### PR TITLE
Unit tests related to bug fix in tagset 133141.

### DIFF
--- a/FWCore/Framework/interface/ConsumesCollector.h
+++ b/FWCore/Framework/interface/ConsumesCollector.h
@@ -1,0 +1,104 @@
+#ifndef FWCore_Framework_ConsumesCollector_h
+#define FWCore_Framework_ConsumesCollector_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     edm::ConsumesCollector
+// 
+/**\class edm::ConsumesCollector ConsumesCollector.h "FWCore/Framework/interface/ConsumesCollector.h"
+
+ Description: Helper class to gather consumes information for EDConsumerBase class.
+
+ Usage:
+    The constructor of a module can get an instance of edm::ConsumesCollector by calling its
+consumesCollector() method. This instance can then be passed to helper classes in order to register
+the data the helper will request from an Event, LuminosityBlock or Run on behalf of the module.
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Fri, 07 Jun 2013 12:44:47 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/EDConsumerBase.h"
+
+// forward declarations
+namespace edm {
+  class EDConsumerBase;
+  
+  class ConsumesCollector
+  {
+    
+  public:
+    //virtual ~ConsumesCollector();
+    ConsumesCollector(ConsumesCollector&& iOther): m_consumer(iOther.m_consumer){}
+    
+    // ---------- member functions ---------------------------
+    template <typename ProductType, BranchType B=InEvent>
+    EDGetTokenT<ProductType> consumes(edm::InputTag const& tag) {
+      return m_consumer->consumes<ProductType,B>(tag);
+    }
+    
+    EDGetToken consumes(const TypeToGet& id, edm::InputTag const& tag) {
+      return m_consumer->consumes(id,tag);
+    }
+    
+    template <BranchType B>
+    EDGetToken consumes(TypeToGet const& id, edm::InputTag const& tag) {
+      return m_consumer->consumes<B>(id,tag);
+    }
+    
+    template <typename ProductType, BranchType B=InEvent>
+    EDGetTokenT<ProductType> mayConsume(edm::InputTag const& tag) {
+      return m_consumer->mayConsume<ProductType,B>(tag);
+    }
+    
+    
+    EDGetToken mayConsume(const TypeToGet& id, edm::InputTag const& tag) {
+      return m_consumer->mayConsume(id,tag);
+    }
+    
+    template <BranchType B>
+    EDGetToken mayConsume(const TypeToGet& id, edm::InputTag const& tag) {
+      return m_consumer->mayConsume<B>(id,tag);
+    }
+    
+    template <typename ProductType, BranchType B=InEvent>
+    void consumesMany() {
+      m_consumer->consumesMany<ProductType,B>();
+    }
+    
+    
+    void consumesMany(const TypeToGet& id) {
+      m_consumer->consumesMany(id);
+    }
+    
+    template <BranchType B>
+    void consumesMany(const TypeToGet& id) {
+      m_consumer->consumesMany<B>(id);
+    }
+    
+
+  private:
+    //only EDConsumerBase is allowed to make an instance of this class
+    friend class EDConsumerBase;
+    
+    ConsumesCollector(EDConsumerBase* iConsumer):
+    m_consumer(iConsumer) {}
+
+    ConsumesCollector() = delete;
+    ConsumesCollector(const ConsumesCollector&) = delete; // stop default
+    
+    const ConsumesCollector& operator=(const ConsumesCollector&) = delete; // stop default
+    
+    // ---------- member data --------------------------------
+    EDConsumerBase* m_consumer;
+    
+  };
+}
+
+
+#endif

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -16,7 +16,7 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Tue, 02 Apr 2013 21:35:53 GMT
-// $Id: EDConsumerBase.h,v 1.5 2013/06/04 14:59:02 wdd Exp $
+// $Id: EDConsumerBase.h,v 1.6 2013/06/07 17:58:31 chrjones Exp $
 //
 
 // system include files
@@ -37,6 +37,7 @@
 
 namespace edm {
   class ProductHolderIndexHelper;
+  class ConsumesCollector;
   
   class EDConsumerBase
   {
@@ -65,6 +66,9 @@ namespace edm {
     void labelsForToken(EDGetToken iToken, Labels& oLabels) const;
     
   protected:
+    friend class ConsumesCollector;
+    ///Use a ConsumesCollector to gather consumes information from helper functions
+    ConsumesCollector consumesCollector();
     
     template <typename ProductType, BranchType B=InEvent>
     EDGetTokenT<ProductType> consumes(edm::InputTag const& tag) {

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -8,14 +8,16 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Tue, 02 Apr 2013 21:36:06 GMT
-// $Id: EDConsumerBase.cc,v 1.5 2013/06/04 14:59:02 wdd Exp $
+// $Id: EDConsumerBase.cc,v 1.6 2013/06/07 17:58:32 chrjones Exp $
 //
 
 // system include files
 #include <cassert>
+#include <utility>
 
 // user include files
 #include "FWCore/Framework/interface/EDConsumerBase.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Utilities/interface/Likely.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "DataFormats/Provenance/interface/ProductHolderIndexHelper.h"
@@ -61,6 +63,12 @@ EDConsumerBase::~EDConsumerBase()
 //
 // member functions
 //
+ConsumesCollector
+EDConsumerBase::consumesCollector() {
+  ConsumesCollector c{this};
+  return std::move(c);
+}
+
 
 unsigned int
 EDConsumerBase::recordConsumes(BranchType iBranch, TypeToGet const& iType, edm::InputTag const& iTag, bool iAlwaysGets) {

--- a/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
+++ b/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
@@ -8,7 +8,7 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Sat, 06 Apr 2013 16:39:12 GMT
-// $Id: edconsumerbase_t.cppunit.cc,v 1.4 2013/06/04 14:59:02 wdd Exp $
+// $Id: edconsumerbase_t.cppunit.cc,v 1.5 2013/06/07 17:58:32 chrjones Exp $
 //
 
 // system include files
@@ -18,6 +18,7 @@
 // user include files
 #include <cppunit/extensions/HelperMacros.h>
 #include "FWCore/Framework/interface/EDConsumerBase.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/TypeToGet.h"
@@ -110,8 +111,22 @@ namespace {
     
     std::vector<edm::EDGetToken> m_tokens;  
   };
-}
   
+  class IntsConsumesCollectorConsumer : public edm::EDConsumerBase {
+  public:
+    IntsConsumesCollectorConsumer(std::vector<edm::InputTag> const& iTags) {
+      m_tokens.reserve(iTags.size());
+      edm::ConsumesCollector c{ consumesCollector() };
+      for(auto const& tag : iTags) {
+        m_tokens.push_back(c.consumes<std::vector<int>>(tag));
+      }
+    }
+    
+    std::vector<edm::EDGetTokenT<std::vector<int>>> m_tokens;
+  };
+
+}
+
 void
 TestEDConsumerBase::testRegularType()
 {
@@ -171,6 +186,29 @@ TestEDConsumerBase::testRegularType()
 
   }
   {
+    std::vector<edm::InputTag> vTags={ {"label","instance","process"}, {"labelC","instanceC","processC"} };
+    IntsConsumesCollectorConsumer intConsumer{vTags};
+    intConsumer.updateLookup(edm::InEvent,helper);
+    
+    CPPUNIT_ASSERT(intConsumer.m_tokens[0].index()==0);
+    CPPUNIT_ASSERT(intConsumer.m_tokens[1].index()==1);
+    
+    CPPUNIT_ASSERT(vint_c == intConsumer.indexFrom(intConsumer.m_tokens[1],edm::InEvent,typeID_vint));
+    CPPUNIT_ASSERT(vint_blank == intConsumer.indexFrom(intConsumer.m_tokens[0],edm::InEvent,typeID_vint));
+    
+    std::vector<edm::ProductHolderIndex> indices;
+    intConsumer.itemsToGet(edm::InEvent,indices);
+    
+    CPPUNIT_ASSERT(2 == indices.size());
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), vint_c));
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), vint_blank));
+    
+    std::vector<edm::ProductHolderIndex> indicesMay;
+    intConsumer.itemsMayGet(edm::InEvent,indicesMay);
+    CPPUNIT_ASSERT(0 == indicesMay.size());
+    
+  }
+  {
     std::vector<edm::InputTag> vTagsRev={ {"labelC","instanceC","processC"},{"label","instance","process"} };
     IntsConsumer intConsumerRev{vTagsRev};
     intConsumerRev.updateLookup(edm::InEvent,helper);
@@ -192,6 +230,28 @@ TestEDConsumerBase::testRegularType()
     intConsumerRev.itemsMayGet(edm::InEvent,indicesMay);
     CPPUNIT_ASSERT(0 == indicesMay.size());
 }
+  {
+    std::vector<edm::InputTag> vTagsRev={ {"labelC","instanceC","processC"},{"label","instance","process"} };
+    IntsConsumesCollectorConsumer intConsumerRev{vTagsRev};
+    intConsumerRev.updateLookup(edm::InEvent,helper);
+    
+    CPPUNIT_ASSERT(intConsumerRev.m_tokens[0].index()==0);
+    CPPUNIT_ASSERT(intConsumerRev.m_tokens[1].index()==1);
+    
+    CPPUNIT_ASSERT(vint_c == intConsumerRev.indexFrom(intConsumerRev.m_tokens[0],edm::InEvent,typeID_vint));
+    CPPUNIT_ASSERT(vint_blank == intConsumerRev.indexFrom(intConsumerRev.m_tokens[1],edm::InEvent,typeID_vint));
+    
+    std::vector<edm::ProductHolderIndex> indices;
+    intConsumerRev.itemsToGet(edm::InEvent,indices);
+    
+    CPPUNIT_ASSERT(2 == indices.size());
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), vint_c));
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), vint_blank));
+    
+    std::vector<edm::ProductHolderIndex> indicesMay;
+    intConsumerRev.itemsMayGet(edm::InEvent,indicesMay);
+    CPPUNIT_ASSERT(0 == indicesMay.size());
+  }
   {
     //test default process
     std::vector<edm::InputTag> vTags={ {"label","instance"}, {"labelC","instanceC","@skipCurrentProcess"} };

--- a/FWCore/Framework/test/stubs/TestMergeResults.cc
+++ b/FWCore/Framework/test/stubs/TestMergeResults.cc
@@ -10,10 +10,14 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Provenance/interface/BranchID.h"
+#include "DataFormats/Provenance/interface/ConstBranchDescription.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
+#include "DataFormats/Provenance/interface/Provenance.h"
 #include "DataFormats/TestObjects/interface/Thing.h"
 #include "DataFormats/TestObjects/interface/ThingWithIsEqual.h"
 #include "DataFormats/TestObjects/interface/ThingWithMerge.h"
+#include "FWCore/Framework/interface/ConstProductRegistry.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/FileBlock.h"
@@ -22,6 +26,7 @@
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include <cassert>
@@ -253,6 +258,20 @@ namespace edmtest {
       edm::InputTag inputTag("aliasForThingToBeDropped2", "instance2","PROD");
       e.getByLabel(inputTag, h_thing);
       assert(h_thing->a == 11);
+
+      edm::BranchID const& originalBranchID = h_thing.provenance()->constBranchDescription().originalBranchID();
+      bool foundOriginalInRegistry = false;
+      edm::Service<edm::ConstProductRegistry> reg;
+      // Loop over provenance of products in registry.
+      for (edm::ProductRegistry::ProductList::const_iterator it =  reg->productList().begin();
+           it != reg->productList().end(); ++it) {
+        edm::BranchDescription const& desc = it->second;
+        if (desc.branchID() == originalBranchID) {
+          foundOriginalInRegistry = true;
+          break;
+        }
+      }
+      assert(foundOriginalInRegistry);
     }
   }
 
@@ -318,6 +337,20 @@ namespace edmtest {
       edm::InputTag inputTag("aliasForThingToBeDropped2", "endRun2","PROD");
       run.getByLabel(inputTag, h_thing);
       assert(h_thing->a == 100001);
+
+      edm::BranchID const& originalBranchID = h_thing.provenance()->constBranchDescription().originalBranchID();
+      bool foundOriginalInRegistry = false;
+      edm::Service<edm::ConstProductRegistry> reg;
+      // Loop over provenance of products in registry.
+      for (edm::ProductRegistry::ProductList::const_iterator it =  reg->productList().begin();
+           it != reg->productList().end(); ++it) {
+        edm::BranchDescription const& desc = it->second;
+        if (desc.branchID() == originalBranchID) {
+          foundOriginalInRegistry = true;
+          break;
+        }
+      }
+      assert(foundOriginalInRegistry);
     }
   }
 
@@ -373,6 +406,20 @@ namespace edmtest {
       edm::InputTag inputTag("aliasForThingToBeDropped2", "endLumi2","PROD");
       lumi.getByLabel(inputTag, h_thing);
       assert(h_thing->a == 1001);
+
+      edm::BranchID const& originalBranchID = h_thing.provenance()->constBranchDescription().originalBranchID();
+      bool foundOriginalInRegistry = false;
+      edm::Service<edm::ConstProductRegistry> reg;
+      // Loop over provenance of products in registry.
+      for (edm::ProductRegistry::ProductList::const_iterator it =  reg->productList().begin();
+           it != reg->productList().end(); ++it) {
+        edm::BranchDescription const& desc = it->second;
+        if (desc.branchID() == originalBranchID) {
+          foundOriginalInRegistry = true;
+          break;
+        }
+      }
+      assert(foundOriginalInRegistry);
     }
   }
 


### PR DESCRIPTION
I put these in a separate tagset because these unit test changes are dependent on other things waiting in
the tag collector queues, but the bug fix itself is not dependent on anything. However they finally made CMSSW_6_2_0_pre8 and therefore we can now accept them.
