### PR TITLE
Add a new entry to the list of EDProducers whose use a string configurat...

### DIFF
--- a/FWCore/ParameterSet/python/Utilities.py
+++ b/FWCore/ParameterSet/python/Utilities.py
@@ -135,6 +135,7 @@ def convertToUnscheduled(proc):
   knownStringInputLabels['KProd'] = ['xSrc'] # a fake entry for a unit test below
   knownStringInputLabels['SeedGeneratorFromRegionHitsEDProducer'] = ['vertexSrc']
   knownStringInputLabels['PixelTrackProducer'] = ['vertexSrc']
+  knownStringInputLabels['PixelTracksProducer'] = ['vertexSrc']
   knownStringInputLabels['SimpleTrackListMerger'] = ['TrackProducer1', 'TrackProducer2']
 
   allEDFilters = set(proc.filters_().keys())


### PR DESCRIPTION
...ion

parameter as an InputTag. This only affects the python function that converts
scheduled configurations to unscheduled which is not currently used by anything
in the release.
