### PR TITLE
Correcting the partitioning of 8-etaPartition GEM chamber

### DIFF
--- a/Geometry/GEMGeometry/python/GeometryExtendedPostLS2plusGEM_cff.py
+++ b/Geometry/GEMGeometry/python/GeometryExtendedPostLS2plusGEM_cff.py
@@ -4,6 +4,6 @@ import FWCore.ParameterSet.Config as cms
 # Geometry master configuration
 #
 # Ideal geometry, needed for simulation
-from Geometry.GEMGeometry.cmsExtendedGeometryPostLS2plusGEMXML_cfi import *
+from Geometry.GEMGeometry.cmsExtendedGeometryPostLS1plusGEMr08v01XML_cfi.py import *
 from Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi import *
 

--- a/Geometry/MuonCommonData/data/v4/gemf_r08_v01.xml
+++ b/Geometry/MuonCommonData/data/v4/gemf_r08_v01.xml
@@ -4,14 +4,14 @@
 <ConstantsSection label="gemf.xml" eval="true">
   <Constant name="dzTot" value="50.820*cm"/>
   <Constant name="rPos"  value="(1338*mm+[dzTot])"/>
-  <Constant name="dzS1"  value="5.056*cm"/>
-  <Constant name="dzS2"  value="5.056*cm"/>
-  <Constant name="dzS3"  value="5.190*cm"/>
-  <Constant name="dzS4"  value="5.190*cm"/>
-  <Constant name="dzS5"  value="6.188*cm"/>
-  <Constant name="dzS6"  value="6.188*cm"/>
-  <Constant name="dzS7"  value="7.630*cm"/>
-  <Constant name="dzS8"  value="7.630*cm"/>
+  <Constant name="dzS1"  value="7.630*cm"/>
+  <Constant name="dzS2"  value="7.630*cm"/>
+  <Constant name="dzS3"  value="6.188*cm"/>
+  <Constant name="dzS4"  value="6.188*cm"/>
+  <Constant name="dzS5"  value="5.190*cm"/>
+  <Constant name="dzS6"  value="5.190*cm"/>
+  <Constant name="dzS7"  value="5.056*cm"/>
+  <Constant name="dzS8"  value="5.056*cm"/>
   <Constant name="dzGap" value="0.2500*cm"/>
   <Constant name="dzIn"  value="([dzS1]+[dzS2]+[dzS3]+[dzS4]+[dzS5]+[dzS6]+[dzS7]+[dzS8]+7*[dzGap])"/>
   <Constant name="z10"   value="([dzIn]-[dzS1])"/> 


### PR DESCRIPTION
Hi,

This is to correct the 8 partition GEM geometry in CMSSW. Marcello Maggi made the changes a couple of weeks ago, but the changes were never queued or published in CVS. Could you add this fix please?

Thanks,
Sven
