### PR TITLE
Moved functionality from OutputWorker to OutputModuleCommunicator 

### DIFF
--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -36,7 +36,7 @@ namespace edm {
   class OutputModule : public EDConsumerBase {
   public:
     template <typename T> friend class WorkerT;
-    friend class OutputWorker;
+    friend class ClassicOutputModuleCommunicator;
     typedef OutputModule ModuleType;
     typedef OutputWorker WorkerType;
 

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -96,7 +96,7 @@ namespace edm {
   class BranchIDListHelper;
   class EventSetup;
   class ExceptionCollector;
-  class OutputWorker;
+  class OutputModuleCommunicator;
   class RunStopwatch;
   class UnscheduledCallProducer;
   class WorkerInPath;
@@ -108,7 +108,7 @@ namespace edm {
     typedef boost::shared_ptr<HLTGlobalStatus> TrigResPtr;
     typedef boost::shared_ptr<Worker> WorkerPtr;
     typedef std::vector<Worker*> AllWorkers;
-    typedef std::vector<OutputWorker*> AllOutputWorkers;
+    typedef std::vector<boost::shared_ptr<OutputModuleCommunicator>> AllOutputModuleCommunicators;
 
     typedef std::vector<Worker*> Workers;
 
@@ -302,7 +302,7 @@ namespace edm {
 
     WorkerPtr                results_inserter_;
     AllWorkers               all_workers_;
-    AllOutputWorkers         all_output_workers_;
+    AllOutputModuleCommunicators         all_output_communicators_;
     TrigPaths                trig_paths_;
     TrigPaths                end_paths_;
     std::vector<int>         empty_trig_paths_;

--- a/FWCore/Framework/src/OutputModuleCommunicator.cc
+++ b/FWCore/Framework/src/OutputModuleCommunicator.cc
@@ -1,0 +1,23 @@
+// -*- C++ -*-
+//
+// Package:     Package
+// Class  :     OutputModuleCommunicator
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  Fri, 05 Jul 2013 17:36:58 GMT
+// $Id$
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/src/OutputModuleCommunicator.h"
+
+using namespace edm;
+
+OutputModuleCommunicator::~OutputModuleCommunicator()
+{
+}

--- a/FWCore/Framework/src/OutputModuleCommunicator.h
+++ b/FWCore/Framework/src/OutputModuleCommunicator.h
@@ -1,0 +1,80 @@
+#ifndef FWCore_Framework_OutputModuleCommunicator_h
+#define FWCore_Framework_OutputModuleCommunicator_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     OutputModuleCommunicator
+// 
+/**\class edm::OutputModuleCommunicator OutputModuleCommunicator.h "FWCore/Framework/interface/OutputModuleCommunicator.h"
+
+ Description: Base class used by the framework to communicate with an OutputModule
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Fri, 05 Jul 2013 17:36:51 GMT
+// $Id$
+//
+
+// system include files
+#include <map>
+#include <string>
+#include <vector>
+
+// user include files
+#include "DataFormats/Provenance/interface/Selections.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+
+// forward declarations
+namespace edm {
+  class OutputModuleCommunicator
+  {
+    
+  public:
+    OutputModuleCommunicator() = default;
+    virtual ~OutputModuleCommunicator();
+    
+    virtual void closeFile() = 0;
+    
+    ///\return true if output module wishes to close its file
+    virtual bool shouldWeCloseFile() const = 0;
+    
+    virtual void openNewFileIfNeeded() = 0;
+    
+    ///\return true if no event filtering is applied to OutputModule
+    virtual bool wantAllEvents() const = 0;
+    
+    virtual void openFile(FileBlock const& fb) = 0;
+    
+    virtual void writeRun(RunPrincipal const& rp) = 0;
+    
+    virtual void writeLumi(LuminosityBlockPrincipal const& lbp) = 0;
+    
+    ///\return true if OutputModule has reached its limit on maximum number of events it wants to see
+    virtual bool limitReached() const = 0;
+    
+    virtual void configure(OutputModuleDescription const& desc) = 0;
+    
+    virtual SelectionsArray const& keptProducts() const = 0;
+    
+    virtual void selectProducts(ProductRegistry const& preg) = 0;
+    
+    virtual void setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
+                                       bool anyProductProduced) = 0;
+
+    virtual ModuleDescription const& description() const = 0;
+    
+  private:
+    OutputModuleCommunicator(const OutputModuleCommunicator&) = delete; // stop default
+    
+    const OutputModuleCommunicator& operator=(const OutputModuleCommunicator&) = delete; // stop default
+    
+    // ---------- member data --------------------------------
+    
+  };
+}
+
+#endif

--- a/FWCore/Framework/src/OutputWorker.cc
+++ b/FWCore/Framework/src/OutputWorker.cc
@@ -6,6 +6,7 @@ $Id: OutputWorker.cc,v 1.41 2013/05/03 18:35:58 chrjones Exp $
 #include "FWCore/Framework/interface/OutputModule.h"
 #include "FWCore/Framework/src/WorkerParams.h"
 #include "FWCore/Framework/src/OutputWorker.h"
+#include "FWCore/Framework/src/OutputModuleCommunicator.h"
 
 namespace edm {
   OutputWorker::OutputWorker(std::unique_ptr<OutputModule>&& mod,
@@ -17,48 +18,105 @@ namespace edm {
 
   OutputWorker::~OutputWorker() {
   }
+  
+  class ClassicOutputModuleCommunicator: public edm::OutputModuleCommunicator {
+  public:
+    ClassicOutputModuleCommunicator(edm::OutputModule* iModule):
+    module_(iModule){}
+    virtual void closeFile() override;
+    
+    ///\return true if output module wishes to close its file
+    virtual bool shouldWeCloseFile() const override;
+    
+    virtual void openNewFileIfNeeded() override;
+    
+    ///\return true if no event filtering is applied to OutputModule
+    virtual bool wantAllEvents() const override;
+    
+    virtual void openFile(edm::FileBlock const& fb) override;
+    
+    virtual void writeRun(edm::RunPrincipal const& rp) override;
+    
+    virtual void writeLumi(edm::LuminosityBlockPrincipal const& lbp) override;
+    
+    ///\return true if OutputModule has reached its limit on maximum number of events it wants to see
+    virtual bool limitReached() const override;
+    
+    virtual void configure(edm::OutputModuleDescription const& desc) override;
+    
+    virtual edm::SelectionsArray const& keptProducts() const override;
+    
+    virtual void selectProducts(edm::ProductRegistry const& preg) override;
+    
+    virtual void setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
+                                       bool anyProductProduced) override;
+    
+    virtual ModuleDescription const& description() const override;
 
+
+  private:
+    inline edm::OutputModule& module() const { return *module_;}
+    edm::OutputModule* module_;
+  };
+  
   void
-  OutputWorker::closeFile() {
+  ClassicOutputModuleCommunicator::closeFile() {
     module().doCloseFile();
   }
-
+  
   bool
-  OutputWorker::shouldWeCloseFile() const {
+  ClassicOutputModuleCommunicator::shouldWeCloseFile() const {
     return module().shouldWeCloseFile();
   }
-
+  
   void
-  OutputWorker::openNewFileIfNeeded() {
+  ClassicOutputModuleCommunicator::openNewFileIfNeeded() {
     module().maybeOpenFile();
   }
-
+  
   void
-  OutputWorker::openFile(FileBlock const& fb) {
+  ClassicOutputModuleCommunicator::openFile(edm::FileBlock const& fb) {
     module().doOpenFile(fb);
   }
-
+  
   void
-  OutputWorker::writeRun(RunPrincipal const& rp) {
+  ClassicOutputModuleCommunicator::writeRun(edm::RunPrincipal const& rp) {
     module().doWriteRun(rp);
   }
-
+  
   void
-  OutputWorker::writeLumi(LuminosityBlockPrincipal const& lbp) {
+  ClassicOutputModuleCommunicator::writeLumi(edm::LuminosityBlockPrincipal const& lbp) {
     module().doWriteLuminosityBlock(lbp);
   }
-
-  bool OutputWorker::wantAllEvents() const {return module().wantAllEvents();}
-
-  bool OutputWorker::limitReached() const {return module().limitReached();}
-
-  void OutputWorker::configure(OutputModuleDescription const& desc) {module().configure(desc);}
   
-  SelectionsArray const& OutputWorker::keptProducts() const {
+  bool ClassicOutputModuleCommunicator::wantAllEvents() const {return module().wantAllEvents();}
+  
+  bool ClassicOutputModuleCommunicator::limitReached() const {return module().limitReached();}
+  
+  void ClassicOutputModuleCommunicator::configure(OutputModuleDescription const& desc) {module().configure(desc);}
+  
+  edm::SelectionsArray const& ClassicOutputModuleCommunicator::keptProducts() const {
     return module().keptProducts();
   }
-
-  void OutputWorker::selectProducts(ProductRegistry const& preg) {
+  
+  void ClassicOutputModuleCommunicator::selectProducts(edm::ProductRegistry const& preg) {
     module().selectProducts(preg);
   }
+  
+  void ClassicOutputModuleCommunicator::setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
+                                                    bool anyProductProduced) {
+    module().setEventSelectionInfo(outputModulePathPositions, anyProductProduced);
+  }
+
+  ModuleDescription const& ClassicOutputModuleCommunicator::description() const {
+    return module().description();
+  }
+
+
+  
+  std::unique_ptr<OutputModuleCommunicator>
+  OutputWorker::createOutputModuleCommunicator() {
+    return std::move(std::unique_ptr<OutputModuleCommunicator>{new ClassicOutputModuleCommunicator{& this->module()}});
+  }
+
 }

--- a/FWCore/Framework/src/OutputWorker.h
+++ b/FWCore/Framework/src/OutputWorker.h
@@ -12,6 +12,7 @@ appear in one worker.
 
 #include <memory>
 
+#include "FWCore/Framework/interface/OutputModule.h"
 #include "FWCore/Framework/src/WorkerT.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
@@ -25,29 +26,8 @@ namespace edm {
 
     virtual ~OutputWorker();
 
-    // Call closeFile() on the controlled OutputModule.
-    void closeFile();
-
-    // Call shouldWeCloseFile() on the controlled OutputModule.
-    bool shouldWeCloseFile() const;
-
-    void openNewFileIfNeeded();
-
-    bool wantAllEvents() const;
-
-    void openFile(FileBlock const& fb);
-
-    void writeRun(RunPrincipal const& rp);
-
-    void writeLumi(LuminosityBlockPrincipal const& lbp);
-
-    bool limitReached() const;
-
-    void configure(OutputModuleDescription const& desc);
+    std::unique_ptr<OutputModuleCommunicator> createOutputModuleCommunicator() override;
     
-    SelectionsArray const& keptProducts() const;
-
-    void selectProducts(ProductRegistry const& preg);
   };
 
 }

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -4,6 +4,7 @@
 
 #include "FWCore/Framework/src/Worker.h"
 #include "FWCore/Framework/src/EarlyDeleteHelper.h"
+#include "FWCore/Framework/src/OutputModuleCommunicator.h"
 
 namespace edm {
   namespace {
@@ -59,6 +60,11 @@ private:
   }
 
   Worker::~Worker() {
+  }
+
+  std::unique_ptr<OutputModuleCommunicator>
+  Worker::createOutputModuleCommunicator() {
+    return std::move(std::unique_ptr<OutputModuleCommunicator>{});
   }
 
   void Worker::setActivityRegistry(boost::shared_ptr<ActivityRegistry> areg) {

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -37,12 +37,14 @@ the worker is reset().
 #include "FWCore/Framework/src/RunStopwatch.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
+#include <memory>
 #include <sstream>
 
 namespace edm {
   class EventPrincipal;
   class EarlyDeleteHelper;
   class ProductHolderIndexHelper;
+  class OutputModuleCommunicator;
 
   class Worker {
   public:
@@ -73,6 +75,9 @@ namespace edm {
 
     void pathFinished(EventPrincipal&);
     void postDoEvent(EventPrincipal&);
+
+    ///\return nullptr if Worker is not wrapping an OutputModule
+    virtual std::unique_ptr<OutputModuleCommunicator> createOutputModuleCommunicator();
     
     ModuleDescription const& description() const {return md_;}
     ModuleDescription const* descPtr() const {return &md_; }

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -146,19 +146,6 @@ namespace edm{
     module_->updateLookup(iBranchType,iHelper);
   }
 
-  template<typename T>
-  void WorkerT<T>::setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
-                             bool anyProductProduced) {
-    //do nothing for the regular case
-  }
-
-
-  template<>
-  void WorkerT<OutputModule>::setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
-                             bool anyProductProduced) {
-    module_->setEventSelectionInfo(outputModulePathPositions, anyProductProduced);
-  }
-
   template<>
   Worker::Types WorkerT<EDAnalyzer>::moduleType() const { return Worker::kAnalyzer;}
   template<>

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -40,9 +40,6 @@ namespace edm {
      module_->setModuleDescription(description());
      
   }
-
-    void setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
-                               bool anyProductProduced);
     
     virtual Types moduleType() const override;
 


### PR DESCRIPTION
The Schedule class was doing a dynamic_cast<OutputWorker> on all workers in order to communicate with the OutputModule. This will not work when we go to the threaded framework since there will be several different OutputModule types with different workers. The solution was to abstract the communication with the OutputModule into a OutputModuleCommunication base class.
