### PR TITLE
Add missing dictionaries (132522, 132552, 132467)

### DIFF
--- a/CondFormats/CSCObjects/src/classes_def.xml
+++ b/CondFormats/CSCObjects/src/classes_def.xml
@@ -2,6 +2,7 @@
  <class name="CSCPedestals" id="7C1F7D6C-BE30-DA11-95EF-0008743F7CC7"/>
  <class name="CSCPedestals::Item"/>
  <class name="std::vector<CSCPedestals::Item>"/>
+ <class name="std::map<int,std::vector<CSCPedestals::Item> >"/>
 
  <class name="CSCDBPedestals">
    <field name = "pedestals" mapping = "blob"/>
@@ -24,6 +25,7 @@
  <class name="CSCGains" id="24647172-BE30-DA11-888A-0008743F7CC7"/>
  <class name="CSCGains::Item"/>
  <class name="std::vector<CSCGains::Item>"/>
+ <class name="std::map<int, std::vector<CSCGains::Item> >"/>
 
  <class name="CSCDBGains">
    <field name = "gains" mapping = "blob"/>
@@ -34,6 +36,7 @@
  <class name="CSCNoiseMatrix" id="E885ACBB-5EA8-DA11-A44A-001320A4DDB1"/>
  <class name="CSCNoiseMatrix::Item"/>
  <class name="std::vector<CSCNoiseMatrix::Item>"/>
+ <class name="std::map<int, std::vector<CSCNoiseMatrix::Item> >"/>
 
  <class name="CSCDBNoiseMatrix">
    <field name = "matrix" mapping = "blob"/>
@@ -44,6 +47,7 @@
  <class name="CSCcrosstalk" id="DA52D078-BE30-DA11-9387-0008743F7CC7"/>
  <class name="CSCcrosstalk::Item"/>
  <class name="std::vector<CSCcrosstalk::Item>"/>
+ <class name="std::map<int,std::vector<CSCcrosstalk::Item> >"/>
 
  <class name="CSCDBCrosstalk">
    <field name = "crosstalk" mapping = "blob"/>

--- a/CondFormats/Calibration/src/classes.h
+++ b/CondFormats/Calibration/src/classes.h
@@ -4,7 +4,7 @@
 #include "CondFormats/Calibration/interface/BlobComplex.h"
 #include "CondFormats/Calibration/interface/mySiStripNoises.h"
 #include "CondFormats/Calibration/interface/CalibHistograms.h"
-#include<bitset>
+#include <bitset>
 #include "CondFormats/Calibration/interface/boostTypeObj.h"
 #include "CondFormats/Calibration/interface/mypt.h"
 #include "CondFormats/Calibration/interface/fakeMenu.h"
@@ -19,5 +19,8 @@ namespace {
   struct dictionary {
     fixedArray<unsigned short,2097> d;
     std::map<std::string, Algo> e;
+    std::pair<std::string, Algo> e1;
+    std::map<std::string, Algob> e2;
+    std::pair<std::string, Algob> e3;
   };
 }

--- a/CondFormats/Calibration/src/classes_def.xml
+++ b/CondFormats/Calibration/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
  <class name="Pedestals::Item"/>
  <class name="std::vector<Pedestals::Item>"/>
+ <class name="std::vector<Pedestals::Item>::const_iterator"/>
  <class name="Pedestals" class_version="0"/>
 
  <class name="BlobPedestals" class_version="0">
@@ -44,6 +45,10 @@
  <class name="boostTypeObj"/>
  <class name="fixedArray<unsigned short,2097>"/>
  <class name="mypt"/>
+ <class name="std::pair<std::string,Algo>"/>
+ <class name="std::map<std::string,Algo>"/>
+ <class name="std::pair<std::string,Algob>"/>
+ <class name="std::map<std::string,Algob>"/>
  <class name="Algo"/>
  <class name="AlgoMap"/>
  <class name="fakeMenu"/>

--- a/CondFormats/SiPixelObjects/src/classes.h
+++ b/CondFormats/SiPixelObjects/src/classes.h
@@ -1,5 +1,5 @@
 #include "CondFormats/SiPixelObjects/interface/PixelROC.h"
-
+#include "CondFormats/SiPixelObjects/interface/SiPixelDbItem.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelFedCablingMap.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelCPEGenericErrorParm.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelPedestals.h"
@@ -39,6 +39,7 @@ namespace {
  
     std::vector<SiPixelQuality::disabledModuleType>::iterator p9;
     std::vector<SiPixelQuality::disabledModuleType>::const_iterator p10;
+    std::vector<SiPixelDbItem> p11;
   };
 }
 

--- a/CondFormats/SiPixelObjects/src/classes_def.xml
+++ b/CondFormats/SiPixelObjects/src/classes_def.xml
@@ -38,9 +38,10 @@
   <class name="SiPixelGainCalibrationOffline::DetRegistry"/>
   <class name="std::vector<SiPixelGainCalibrationOffline::DetRegistry>"/>
      
-  <class name="SiPixelPedestals" id="5bfc61c7aebd27b50882b745cb0d5365" class_version="0"/>
   <class name="SiPixelDbItem"/>
   <class name="std::vector<SiPixelDbItem>"/>
+  <class name="std::map<int,std::vector<SiPixelDbItem> >"/>
+  <class name="SiPixelPedestals" id="5bfc61c7aebd27b50882b745cb0d5365" class_version="0"/>
 
   <class name="SiPixelLorentzAngle" class_version="0"/>
 

--- a/CondTools/Utilities/test/classes_def.xml
+++ b/CondTools/Utilities/test/classes_def.xml
@@ -1,16 +1,27 @@
  <lcgdict>
 <!-- the class you need -->
-  <class name="CondCachedIter<Pedestals>"/>
-  <class name="CondCachedIter<AlignmentErrors>"/>
-  <class name="CondCachedIter<EcalPedestals>"/>
-  <class name="CondCachedIter<EcalLaserAPDPNRatios>"/>
-  <class name="CondCachedIter<SiPixelGainCalibration>"/>    
-  <class name="CondCachedIter<SiStripFedCabling>"/>   
-  <class name="CondCachedIter<DTReadOutMapping>"/>   
-  
-  <class name="CondCachedIter<mySiStripNoises>"/>
-   
+  <class name="std::vector<cond::PayloadRef<Pedestals> >"/>
   <class name="CondIter<Pedestals>"/>
+  <class name="CondCachedIter<Pedestals>"/>
+  <class name="std::vector<cond::PayloadRef<AlignmentErrors> >"/>
+  <class name="CondIter<AlignmentErrors>"/>
+  <class name="CondCachedIter<AlignmentErrors>"/>
+  <class name="std::vector<cond::PayloadRef<EcalPedestals> >"/>
   <class name="CondIter<EcalPedestals>"/>
-
+  <class name="CondCachedIter<EcalPedestals>"/>
+  <class name="std::vector<cond::PayloadRef<EcalLaserAPDPNRatios> >"/>
+  <class name="CondIter<EcalLaserAPDPNRatios>"/>
+  <class name="CondCachedIter<EcalLaserAPDPNRatios>"/>
+  <class name="std::vector<cond::PayloadRef<SiPixelGainCalibration> >"/>
+  <class name="CondIter<SiPixelGainCalibration>"/>
+  <class name="CondCachedIter<SiPixelGainCalibration>"/>    
+  <class name="std::vector<cond::PayloadRef<SiStripFedCabling> >"/>
+  <class name="CondIter<SiStripFedCabling>"/>
+  <class name="CondCachedIter<SiStripFedCabling>"/>   
+  <class name="std::vector<cond::PayloadRef<DTReadOutMapping> >"/>
+  <class name="CondIter<DTReadOutMapping>"/>
+  <class name="CondCachedIter<DTReadOutMapping>"/>   
+  <class name="std::vector<cond::PayloadRef<mySiStripNoises> >"/>
+  <class name="CondIter<mySiStripNoises>"/>
+  <class name="CondCachedIter<mySiStripNoises>"/>
 </lcgdict>   

--- a/DataFormats/HepMCCandidate/src/classes_def.xml
+++ b/DataFormats/HepMCCandidate/src/classes_def.xml
@@ -39,5 +39,6 @@
   <class name="edm::ValueMap<reco::FlavorHistoryEvent >" />
   <class name="edm::Wrapper<edm::ValueMap<reco::FlavorHistoryEvent > >" />
   <class name="edm::RefVectorIterator<std::vector<reco::GenParticle>,reco::GenParticle,edm::refhelper::FindUsingAdvance<std::vector<reco::GenParticle>,reco::GenParticle> >"/>
+  <class pattern="std::iterator<*edm::Ref*GenParticle*>"/>
 </lcgdict>
  

--- a/DataFormats/PatCandidates/src/classes_def_trigger.xml
+++ b/DataFormats/PatCandidates/src/classes_def_trigger.xml
@@ -4,98 +4,104 @@
   <class name="pat::TriggerObject"  ClassVersion="10">
    <version ClassVersion="10" checksum="2299474032"/>
   </class>
-  <class name="std::vector<pat::TriggerObject>" />
-  <class name="std::vector<pat::TriggerObject>::const_iterator" />
-  <class name="edm::Wrapper<std::vector<pat::TriggerObject> >" />
+  <class name="std::vector&lt;pat::TriggerObject&gt;" />
+  <class name="std::vector&lt;pat::TriggerObject&gt;::const_iterator" />
+  <class name="edm::Wrapper&lt;std::vector&lt;pat::TriggerObject&gt; &gt;" />
   <class name="pat::TriggerObjectRef" />
-  <class name="std::pair<std::string, pat::TriggerObjectRef>" />
-  <class name="std::map<std::string, pat::TriggerObjectRef>" />
+  <class name="std::pair&lt;std::string, pat::TriggerObjectRef&gt;" />
+  <class name="std::map&lt;std::string, pat::TriggerObjectRef&gt;" />
   <class name="pat::TriggerObjectRefProd" />
-  <class name="edm::Wrapper<pat::TriggerObjectRefProd>" />
+  <class name="edm::Wrapper&lt;pat::TriggerObjectRefProd&gt;" />
   <class name="pat::TriggerObjectRefVector" />
   <class name="pat::TriggerObjectRefVectorIterator" />
-  <class name="edm::Association<std::vector<pat::TriggerObject> >" />
-  <class name="edm::reftobase::Holder<reco::Candidate,pat::TriggerObjectRef>" />
-  <class name="edm::reftobase::RefHolder<pat::TriggerObjectRef>" />
-  <class name="edm::Wrapper<edm::Association<std::vector<pat::TriggerObject> > >" />
-  <class name="edm::RefProd<edm::Association<std::vector<pat::TriggerObject> > >" />
-  <class name="std::pair<std::string, edm::RefProd<edm::Association<std::vector<pat::TriggerObject> > > >" />
-  <class name="std::map<std::string, edm::RefProd<edm::Association<std::vector<pat::TriggerObject> > > >" />
-  <class name="std::map<std::string, edm::RefProd<edm::Association<std::vector<pat::TriggerObject> > > >::const_iterator" />
-  <class name="edm::Wrapper<std::map<std::string, edm::RefProd<edm::Association<std::vector<pat::TriggerObject> > > > >" />
+  <class name="edm::Association&lt;std::vector&lt;pat::TriggerObject&gt; &gt;" />
+  <class name="edm::reftobase::Holder&lt;reco::Candidate,pat::TriggerObjectRef&gt;" />
+  <class name="edm::reftobase::RefHolder&lt;pat::TriggerObjectRef&gt;" />
+  <class name="edm::Wrapper&lt;edm::Association&lt;std::vector&lt;pat::TriggerObject&gt; &gt; &gt;" />
+  <class name="edm::RefProd&lt;edm::Association&lt;std::vector&lt;pat::TriggerObject&gt; &gt; &gt;" />
+  <class name="std::pair&lt;std::string, edm::RefProd&lt;edm::Association&lt;std::vector&lt;pat::TriggerObject&gt; &gt; &gt; &gt;" />
+  <class name="std::map&lt;std::string, edm::RefProd&lt;edm::Association&lt;std::vector&lt;pat::TriggerObject&gt; &gt; &gt; &gt;" />
+  <class name="std::map&lt;std::string, edm::RefProd&lt;edm::Association&lt;std::vector&lt;pat::TriggerObject&gt; &gt; &gt; &gt;::const_iterator" />
+  <class name="edm::Wrapper&lt;std::map&lt;std::string, edm::RefProd&lt;edm::Association&lt;std::vector&lt;pat::TriggerObject&gt; &gt; &gt; &gt; &gt;" />
 
   <class name="pat::TriggerObjectStandAlone"  ClassVersion="10">
    <version ClassVersion="10" checksum="3478292234"/>
   </class>
-  <class name="std::vector<pat::TriggerObjectStandAlone>" />
-  <class name="std::vector<pat::TriggerObjectStandAlone>::const_iterator" />
-  <class name="edm::Wrapper<std::vector<pat::TriggerObjectStandAlone> >" />
+  <class name="std::vector&lt;pat::TriggerObjectStandAlone&gt;" />
+  <class name="std::vector&lt;pat::TriggerObjectStandAlone&gt;::const_iterator" />
+  <class name="edm::Wrapper&lt;std::vector&lt;pat::TriggerObjectStandAlone&gt; &gt;" />
   <class name="pat::TriggerObjectStandAloneRef" />
   <class name="pat::TriggerObjectStandAloneRefProd" />
-  <class name="edm::Wrapper<pat::TriggerObjectStandAloneRefProd>" />
+  <class name="edm::Wrapper&lt;pat::TriggerObjectStandAloneRefProd&gt;" />
   <class name="pat::TriggerObjectStandAloneRefVector" />
   <class name="pat::TriggerObjectStandAloneRefVectorIterator" />
-  <class name="edm::Association<std::vector<pat::TriggerObjectStandAlone> >" />
-  <class name="edm::reftobase::Holder<reco::Candidate,pat::TriggerObjectStandAloneRef>" />
-  <class name="edm::reftobase::RefHolder<pat::TriggerObjectStandAloneRef>" />
-  <class name="edm::Wrapper<edm::Association<std::vector<pat::TriggerObjectStandAlone> > >" />
+  <class name="edm::Association&lt;std::vector&lt;pat::TriggerObjectStandAlone&gt; &gt;" />
+  <class name="edm::reftobase::Holder&lt;reco::Candidate,pat::TriggerObjectStandAloneRef&gt;" />
+  <class name="edm::reftobase::RefHolder&lt;pat::TriggerObjectStandAloneRef&gt;" />
+  <class name="edm::Wrapper&lt;edm::Association&lt;std::vector&lt;pat::TriggerObjectStandAlone&gt; &gt; &gt;" />
 
   <class name="pat::TriggerFilter"  ClassVersion="10">
    <version ClassVersion="10" checksum="2906762000"/>
   </class>
-  <class name="std::vector<pat::TriggerFilter>" />
-  <class name="std::vector<pat::TriggerFilter>::const_iterator" />
-  <class name="edm::Wrapper<std::vector<pat::TriggerFilter> >" />
+  <class name="std::vector&lt;pat::TriggerFilter&gt;" />
+  <class name="std::vector&lt;pat::TriggerFilter&gt;::const_iterator" />
+  <class name="edm::Wrapper&lt;std::vector&lt;pat::TriggerFilter&gt; &gt;" />
   <class name="pat::TriggerFilterRef" />
   <class name="pat::TriggerFilterRefProd" />
-  <class name="edm::Wrapper<pat::TriggerFilterRefProd >" />
+  <class name="edm::Wrapper&lt;pat::TriggerFilterRefProd &gt;" />
   <class name="pat::TriggerFilterRefVector" />
   <class name="pat::TriggerFilterRefVectorIterator" />
 
   <class name="pat::TriggerPath"  ClassVersion="10">
    <version ClassVersion="10" checksum="2458567651"/>
   </class>
-  <class name="std::vector<pat::TriggerPath>" />
-  <class name="std::vector<pat::TriggerPath>::const_iterator" />
-  <class name="edm::Wrapper<std::vector<pat::TriggerPath> >" />
+  <class name="std::vector&lt;pat::TriggerPath&gt;" />
+  <class name="std::vector&lt;pat::TriggerPath&gt;::const_iterator" />
+  <class name="edm::Wrapper&lt;std::vector&lt;pat::TriggerPath&gt; &gt;" />
   <class name="pat::TriggerPathRef" />
   <class name="pat::TriggerPathRefProd" />
-  <class name="edm::Wrapper<pat::TriggerPathRefProd >" />
+  <class name="edm::Wrapper&lt;pat::TriggerPathRefProd &gt;" />
   <class name="pat::TriggerPathRefVector" />
   <class name="pat::TriggerPathRefVectorIterator" />
   <class name="pat::L1Seed" />
-  <class name="std::vector<pat::L1Seed>" />
-  <class name="std::vector<pat::L1Seed>::const_iterator" />
+  <class name="std::vector&lt;pat::L1Seed&gt;" />
+  <class name="std::vector&lt;pat::L1Seed&gt;::const_iterator" />
 
   <class name="pat::TriggerCondition"  ClassVersion="10">
    <version ClassVersion="10" checksum="4134787846"/>
   </class>
-  <class name="std::vector<pat::TriggerCondition>" />
-  <class name="std::vector<pat::TriggerCondition>::const_iterator" />
-  <class name="edm::Wrapper<std::vector<pat::TriggerCondition> >" />
+  <class name="std::vector&lt;pat::TriggerCondition&gt;" />
+  <class name="std::vector&lt;pat::TriggerCondition&gt;::const_iterator" />
+  <class name="edm::Wrapper&lt;std::vector&lt;pat::TriggerCondition&gt; &gt;" />
   <class name="pat::TriggerConditionRef" />
   <class name="pat::TriggerConditionRefProd" />
-  <class name="edm::Wrapper<pat::TriggerConditionRefProd >" />
+  <class name="edm::Wrapper&lt;pat::TriggerConditionRefProd &gt;" />
   <class name="pat::TriggerConditionRefVector" />
   <class name="pat::TriggerConditionRefVectorIterator" />
 
   <class name="pat::TriggerAlgorithm"  ClassVersion="10">
    <version ClassVersion="10" checksum="1625162602"/>
   </class>
-  <class name="std::vector<pat::TriggerAlgorithm>" />
-  <class name="std::vector<pat::TriggerAlgorithm>::const_iterator" />
-  <class name="edm::Wrapper<std::vector<pat::TriggerAlgorithm> >" />
+  <class name="std::vector&lt;pat::TriggerAlgorithm&gt;" />
+  <class name="std::vector&lt;pat::TriggerAlgorithm&gt;::const_iterator" />
+  <class name="edm::Wrapper&lt;std::vector&lt;pat::TriggerAlgorithm&gt; &gt;" />
   <class name="pat::TriggerAlgorithmRef" />
   <class name="pat::TriggerAlgorithmRefProd" />
-  <class name="edm::Wrapper<pat::TriggerAlgorithmRefProd >" />
+  <class name="edm::Wrapper&lt;pat::TriggerAlgorithmRefProd &gt;" />
   <class name="pat::TriggerAlgorithmRefVector" />
   <class name="pat::TriggerAlgorithmRefVectorIterator" />
 
   <class name="pat::TriggerEvent"  ClassVersion="10">
    <version ClassVersion="10" checksum="174329539"/>
   </class>
-  <class name="edm::Wrapper<pat::TriggerEvent>" />
+  <class name="edm::Wrapper&lt;pat::TriggerEvent&gt;" />
 
+  <class pattern="std::iterator&lt;std::random_access_iterator_tag,edm::Ref&lt;std::vector&lt;pat::TriggerPath&gt;,pat::TriggerPath,edm::refhelper::FindUsingAdvance&lt;std::vector&lt;pat::TriggerPath&gt;,pat::TriggerPath&gt; &gt;,*,edm::Ref&lt;std::vector&lt;pat::TriggerPath&gt;,pat::TriggerPath,edm::refhelper::FindUsingAdvance&lt;std::vector&lt;pat::TriggerPath&gt;,pat::TriggerPath&gt; &gt;*,edm::Ref&lt;std::vector&lt;pat::TriggerPath&gt;,pat::TriggerPath,edm::refhelper::FindUsingAdvance&lt;std::vector&lt;pat::TriggerPath&gt;,pat::TriggerPath&gt; &gt;&amp;&gt;"/>
+  <class pattern="std::iterator&lt;std::random_access_iterator_tag,edm::Ref&lt;std::vector&lt;pat::TriggerObjectStandAlone&gt;,pat::TriggerObjectStandAlone,edm::refhelper::FindUsingAdvance&lt;std::vector&lt;pat::TriggerObjectStandAlone&gt;,pat::TriggerObjectStandAlone&gt; &gt;,*,edm::Ref&lt;std::vector&lt;pat::TriggerObjectStandAlone&gt;,pat::TriggerObjectStandAlone,edm::refhelper::FindUsingAdvance&lt;std::vector&lt;pat::TriggerObjectStandAlone&gt;,pat::TriggerObjectStandAlone&gt; &gt;*,edm::Ref&lt;std::vector&lt;pat::TriggerObjectStandAlone&gt;,pat::TriggerObjectStandAlone,edm::refhelper::FindUsingAdvance&lt;std::vector&lt;pat::TriggerObjectStandAlone&gt;,pat::TriggerObjectStandAlone&gt; &gt;&amp;&gt;"/>
+  <class pattern="std::iterator&lt;std::random_access_iterator_tag,edm::Ref&lt;std::vector&lt;pat::TriggerFilter&gt;,pat::TriggerFilter,edm::refhelper::FindUsingAdvance&lt;std::vector&lt;pat::TriggerFilter&gt;,pat::TriggerFilter&gt; &gt;,*,edm::Ref&lt;std::vector&lt;pat::TriggerFilter&gt;,pat::TriggerFilter,edm::refhelper::FindUsingAdvance&lt;std::vector&lt;pat::TriggerFilter&gt;,pat::TriggerFilter&gt; &gt;*,edm::Ref&lt;std::vector&lt;pat::TriggerFilter&gt;,pat::TriggerFilter,edm::refhelper::FindUsingAdvance&lt;std::vector&lt;pat::TriggerFilter&gt;,pat::TriggerFilter&gt; &gt;&amp;&gt;"/>
+  <class pattern="std::iterator&lt;std::random_access_iterator_tag,edm::Ref&lt;std::vector&lt;pat::TriggerObject&gt;,pat::TriggerObject,edm::refhelper::FindUsingAdvance&lt;std::vector&lt;pat::TriggerObject&gt;,pat::TriggerObject&gt; &gt;,*,edm::Ref&lt;std::vector&lt;pat::TriggerObject&gt;,pat::TriggerObject,edm::refhelper::FindUsingAdvance&lt;std::vector&lt;pat::TriggerObject&gt;,pat::TriggerObject&gt; &gt;*,edm::Ref&lt;std::vector&lt;pat::TriggerObject&gt;,pat::TriggerObject,edm::refhelper::FindUsingAdvance&lt;std::vector&lt;pat::TriggerObject&gt;,pat::TriggerObject&gt; &gt;&amp;&gt;"/>
+  <class pattern="std::iterator&lt;std::random_access_iterator_tag,edm::Ref&lt;std::vector&lt;pat::TriggerCondition&gt;,pat::TriggerCondition,edm::refhelper::FindUsingAdvance&lt;std::vector&lt;pat::TriggerCondition&gt;,pat::TriggerCondition&gt; &gt;,*,edm::Ref&lt;std::vector&lt;pat::TriggerCondition&gt;,pat::TriggerCondition,edm::refhelper::FindUsingAdvance&lt;std::vector&lt;pat::TriggerCondition&gt;,pat::TriggerCondition&gt; &gt;*,edm::Ref&lt;std::vector&lt;pat::TriggerCondition&gt;,pat::TriggerCondition,edm::refhelper::FindUsingAdvance&lt;std::vector&lt;pat::TriggerCondition&gt;,pat::TriggerCondition&gt; &gt;&amp;&gt;"/>
+  <class pattern="std::iterator&lt;std::random_access_iterator_tag,edm::Ref&lt;std::vector&lt;pat::TriggerAlgorithm&gt;,pat::TriggerAlgorithm,edm::refhelper::FindUsingAdvance&lt;std::vector&lt;pat::TriggerAlgorithm&gt;,pat::TriggerAlgorithm&gt; &gt;,*,edm::Ref&lt;std::vector&lt;pat::TriggerAlgorithm&gt;,pat::TriggerAlgorithm,edm::refhelper::FindUsingAdvance&lt;std::vector&lt;pat::TriggerAlgorithm&gt;,pat::TriggerAlgorithm&gt; &gt;*,edm::Ref&lt;std::vector&lt;pat::TriggerAlgorithm&gt;,pat::TriggerAlgorithm,edm::refhelper::FindUsingAdvance&lt;std::vector&lt;pat::TriggerAlgorithm&gt;,pat::TriggerAlgorithm&gt; &gt;&amp;&gt;"/>
   </selection>
  <exclusion>
  </exclusion>

--- a/DataFormats/PatCandidates/src/classes_trigger.h
+++ b/DataFormats/PatCandidates/src/classes_trigger.h
@@ -5,6 +5,8 @@
 
 #include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
 #include "DataFormats/PatCandidates/interface/TriggerEvent.h"
+#include <iterator>
+#include <vector>
 
 namespace {
   struct dictionary {
@@ -87,6 +89,17 @@ namespace {
 
   edm::Wrapper<pat::TriggerEvent> w_p_te;
 
+  std::iterator<std::random_access_iterator_tag,edm::Ref<std::vector<pat::TriggerPath>,pat::TriggerPath,edm::refhelper::FindUsingAdvance<std::vector<pat::TriggerPath>,pat::TriggerPath> >,long,edm::Ref<std::vector<pat::TriggerPath>,pat::TriggerPath,edm::refhelper::FindUsingAdvance<std::vector<pat::TriggerPath>,pat::TriggerPath> >*,edm::Ref<std::vector<pat::TriggerPath>,pat::TriggerPath,edm::refhelper::FindUsingAdvance<std::vector<pat::TriggerPath>,pat::TriggerPath> >&> iter_big_1;
+
+  std::iterator<std::random_access_iterator_tag,edm::Ref<std::vector<pat::TriggerObjectStandAlone>,pat::TriggerObjectStandAlone,edm::refhelper::FindUsingAdvance<std::vector<pat::TriggerObjectStandAlone>,pat::TriggerObjectStandAlone> >,long,edm::Ref<std::vector<pat::TriggerObjectStandAlone>,pat::TriggerObjectStandAlone,edm::refhelper::FindUsingAdvance<std::vector<pat::TriggerObjectStandAlone>,pat::TriggerObjectStandAlone> >*,edm::Ref<std::vector<pat::TriggerObjectStandAlone>,pat::TriggerObjectStandAlone,edm::refhelper::FindUsingAdvance<std::vector<pat::TriggerObjectStandAlone>,pat::TriggerObjectStandAlone> >&> iter_big_2;
+
+  std::iterator<std::random_access_iterator_tag,edm::Ref<std::vector<pat::TriggerFilter>,pat::TriggerFilter,edm::refhelper::FindUsingAdvance<std::vector<pat::TriggerFilter>,pat::TriggerFilter> >,long,edm::Ref<std::vector<pat::TriggerFilter>,pat::TriggerFilter,edm::refhelper::FindUsingAdvance<std::vector<pat::TriggerFilter>,pat::TriggerFilter> >*,edm::Ref<std::vector<pat::TriggerFilter>,pat::TriggerFilter,edm::refhelper::FindUsingAdvance<std::vector<pat::TriggerFilter>,pat::TriggerFilter> >&> iter_big_3;
+
+  std::iterator<std::random_access_iterator_tag,edm::Ref<std::vector<pat::TriggerObject>,pat::TriggerObject,edm::refhelper::FindUsingAdvance<std::vector<pat::TriggerObject>,pat::TriggerObject> >,long,edm::Ref<std::vector<pat::TriggerObject>,pat::TriggerObject,edm::refhelper::FindUsingAdvance<std::vector<pat::TriggerObject>,pat::TriggerObject> >*,edm::Ref<std::vector<pat::TriggerObject>,pat::TriggerObject,edm::refhelper::FindUsingAdvance<std::vector<pat::TriggerObject>,pat::TriggerObject> >&> iter_big_4;
+
+  std::iterator<std::random_access_iterator_tag,edm::Ref<std::vector<pat::TriggerCondition>,pat::TriggerCondition,edm::refhelper::FindUsingAdvance<std::vector<pat::TriggerCondition>,pat::TriggerCondition> >,long,edm::Ref<std::vector<pat::TriggerCondition>,pat::TriggerCondition,edm::refhelper::FindUsingAdvance<std::vector<pat::TriggerCondition>,pat::TriggerCondition> >*,edm::Ref<std::vector<pat::TriggerCondition>,pat::TriggerCondition,edm::refhelper::FindUsingAdvance<std::vector<pat::TriggerCondition>,pat::TriggerCondition> >&> iter_big_5;
+
+  std::iterator<std::random_access_iterator_tag,edm::Ref<std::vector<pat::TriggerAlgorithm>,pat::TriggerAlgorithm,edm::refhelper::FindUsingAdvance<std::vector<pat::TriggerAlgorithm>,pat::TriggerAlgorithm> >,long,edm::Ref<std::vector<pat::TriggerAlgorithm>,pat::TriggerAlgorithm,edm::refhelper::FindUsingAdvance<std::vector<pat::TriggerAlgorithm>,pat::TriggerAlgorithm> >*,edm::Ref<std::vector<pat::TriggerAlgorithm>,pat::TriggerAlgorithm,edm::refhelper::FindUsingAdvance<std::vector<pat::TriggerAlgorithm>,pat::TriggerAlgorithm> >&> iter_big_6;
   };
 
 }

--- a/DataFormats/StdDictionaries/src/classes_def_others.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_others.xml
@@ -16,4 +16,9 @@
  <class name="std::random_access_iterator_tag"/>
  <class name="std::set<int>"/>
  <class name="std::set<std::basic_string<char> >"/>
+ <class name="__gnu_cxx::new_allocator<char>"/>
+ <class name="__gnu_cxx::new_allocator<double>"/>
+ <class name="__gnu_cxx::new_allocator<int>"/>
+ <class name="__gnu_cxx::new_allocator<short>"/>
+ <class name="std::binary_function<int,int,bool>"/>
 </lcgdict>

--- a/DataFormats/StdDictionaries/src/classes_others.h
+++ b/DataFormats/StdDictionaries/src/classes_others.h
@@ -5,6 +5,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <functional>
 
 namespace {
   struct dictionary {
@@ -25,5 +26,10 @@ namespace {
   std::random_access_iterator_tag randaccitertag;
   std::set<int> dummy19;
   std::set<std::basic_string<char> > dummy20;
+  __gnu_cxx::new_allocator<char> dummy21;
+  __gnu_cxx::new_allocator<double> dummy22;
+  __gnu_cxx::new_allocator<int> dummy23;
+  __gnu_cxx::new_allocator<short> dummy24;
+  std::binary_function<int,int,bool> dummy25;
   };
 }


### PR DESCRIPTION
The following brings back 132522, 132552, and 132467 tagsets from `CMSSW_6_2_X` with dictionary modifications to remove some errors from ROOT I/O noticed on `edmClassStorageSize` usage. They were already signed in `CMSSW_6_2_X`.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
