### PR TITLE
[RFC] Add RefToBase member `holder_'  in Reflex dicts.

### DIFF
--- a/AnalysisDataFormats/EWK/src/classes_def.xml
+++ b/AnalysisDataFormats/EWK/src/classes_def.xml
@@ -9,7 +9,9 @@
    <class name="edm::RefProd<std::vector<reco::WMuNuCandidatePtr> >"/>
    <class name="edm::helpers::Key<edm::RefProd<std::vector<reco::WMuNuCandidatePtr> > >"/>
 
-   <class name="edm::RefToBase<reco::WMuNuCandidatePtr>" />
+   <class name="edm::RefToBase<reco::WMuNuCandidatePtr>">
+     <field name="holder_" transient="true"/>
+   </class>
    <class name="edm::reftobase::IndirectHolder<reco::WMuNuCandidatePtr>" />
    <class name="edm::RefToBaseProd<reco::WMuNuCandidatePtr>" />
    <class name="edm::RefToBaseVector<reco::WMuNuCandidatePtr>" />
@@ -26,7 +28,9 @@
    <class name="edm::RefProd<std::vector<reco::WMuNuCandidate> >"/>
    <class name="edm::helpers::Key<edm::RefProd<std::vector<reco::WMuNuCandidate> > >"/>
 
-   <class name="edm::RefToBase<reco::WMuNuCandidate>" />
+   <class name="edm::RefToBase<reco::WMuNuCandidate>">
+     <field name="holder_" transient="true"/>
+   </class>
    <class name="edm::reftobase::IndirectHolder<reco::WMuNuCandidate>" />
    <class name="edm::RefToBaseProd<reco::WMuNuCandidate>" />
    <class name="edm::RefToBaseVector<reco::WMuNuCandidate>" />

--- a/AnalysisDataFormats/EWK/src/classes_def.xml
+++ b/AnalysisDataFormats/EWK/src/classes_def.xml
@@ -9,9 +9,8 @@
    <class name="edm::RefProd<std::vector<reco::WMuNuCandidatePtr> >"/>
    <class name="edm::helpers::Key<edm::RefProd<std::vector<reco::WMuNuCandidatePtr> > >"/>
 
-   <class name="edm::RefToBase<reco::WMuNuCandidatePtr>">
-     <field name="holder_" transient="true"/>
-   </class>
+   <class name="edm::reftobase::BaseHolder<reco::WMuNuCandidatePtr>"/>
+   <class name="edm::RefToBase<reco::WMuNuCandidatePtr>"/>
    <class name="edm::reftobase::IndirectHolder<reco::WMuNuCandidatePtr>" />
    <class name="edm::RefToBaseProd<reco::WMuNuCandidatePtr>" />
    <class name="edm::RefToBaseVector<reco::WMuNuCandidatePtr>" />
@@ -28,9 +27,8 @@
    <class name="edm::RefProd<std::vector<reco::WMuNuCandidate> >"/>
    <class name="edm::helpers::Key<edm::RefProd<std::vector<reco::WMuNuCandidate> > >"/>
 
-   <class name="edm::RefToBase<reco::WMuNuCandidate>">
-     <field name="holder_" transient="true"/>
-   </class>
+   <class name="edm::reftobase::BaseHolder<reco::WMuNuCandidate>"/>
+   <class name="edm::RefToBase<reco::WMuNuCandidate>"/>
    <class name="edm::reftobase::IndirectHolder<reco::WMuNuCandidate>" />
    <class name="edm::RefToBaseProd<reco::WMuNuCandidate>" />
    <class name="edm::RefToBaseVector<reco::WMuNuCandidate>" />

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -42,9 +42,8 @@
 
  
   <class name="std::vector<reco::PhotonCore>"/>  
-  <class name="edm::RefToBase<reco::PhotonCore>">
-    <field name="holder_" transient="true"/> 
-  </class>
+  <class name="edm::reftobase::BaseHolder<reco::PhotonCore>"/>
+  <class name="edm::RefToBase<reco::PhotonCore>"/>
   <class name="edm::reftobase::IndirectHolder<reco::PhotonCore>" />
   <class name="edm::RefToBaseProd<reco::PhotonCore>" />
   <class name="edm::RefToBaseVector<reco::PhotonCore>" />
@@ -64,9 +63,8 @@
   <class name="edm::RefProd<std::vector<reco::Photon> >"/>
   <class name="edm::RefVector<std::vector<reco::Photon>,reco::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::Photon>,reco::Photon> >"/>
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::Photon>,reco::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::Photon>,reco::Photon> > >"/>
-  <class name="edm::RefToBase<reco::Photon>">
-    <field name="holder_" transient="true"/>
-  </class>
+  <class name="edm::reftobase::BaseHolder<reco::Photon>"/>
+  <class name="edm::RefToBase<reco::Photon>"/>
   <class name="edm::reftobase::IndirectHolder<reco::Photon>" />
   <class name="edm::RefToBaseProd<reco::Photon>" />
   <class name="edm::RefToBaseVector<reco::Photon>" />
@@ -83,9 +81,8 @@
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::Electron>,reco::Electron,edm::refhelper::FindUsingAdvance<std::vector<reco::Electron>,reco::Electron> > >"/>
 
 
-  <class name="edm::RefToBase<reco::Electron>">
-    <field name="holder_" transient="true"/>
-  </class>
+  <class name="edm::reftobase::BaseHolder<reco::Electron>"/>
+  <class name="edm::RefToBase<reco::Electron>"/>
   <class name="edm::reftobase::IndirectHolder<reco::Electron>" />
   <class name="edm::RefToBaseProd<reco::Electron>" />
   <class name="edm::RefToBaseVector<reco::Electron>" />
@@ -100,9 +97,8 @@
    <version ClassVersion="10" checksum="2226610106"/>
   </class>
   <class name="std::vector<reco::GsfElectronCore>"/>  
-  <class name="edm::RefToBase<reco::GsfElectronCore>">
-    <field name="holder_" transient="true"/>
-  </class>
+  <class name="edm::reftobase::BaseHolder<reco::GsfElectronCore>"/>
+  <class name="edm::RefToBase<reco::GsfElectronCore>"/>
   <class name="edm::reftobase::IndirectHolder<reco::GsfElectronCore>" />
   <class name="edm::RefToBaseProd<reco::GsfElectronCore>" />
   <class name="edm::RefToBaseVector<reco::GsfElectronCore>" />
@@ -163,9 +159,8 @@
    <version ClassVersion="11" checksum="1755683850"/>
   </class>
   <class name="std::vector<reco::GsfElectron>"/>  
-  <class name="edm::RefToBase<reco::GsfElectron>">
-    <field name="holder_" transient="true"/>
-  </class>
+  <class name="edm::reftobase::BaseHolder<reco::GsfElectron>"/>
+  <class name="edm::RefToBase<reco::GsfElectron>"/>
   <class name="edm::reftobase::IndirectHolder<reco::GsfElectron>" />
   <class name="edm::RefToBaseProd<reco::GsfElectron>" />
   <class name="edm::RefToBaseVector<reco::GsfElectron>" />

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -42,7 +42,9 @@
 
  
   <class name="std::vector<reco::PhotonCore>"/>  
-  <class name="edm::RefToBase<reco::PhotonCore>" />
+  <class name="edm::RefToBase<reco::PhotonCore>">
+    <field name="holder_" transient="true"/> 
+  </class>
   <class name="edm::reftobase::IndirectHolder<reco::PhotonCore>" />
   <class name="edm::RefToBaseProd<reco::PhotonCore>" />
   <class name="edm::RefToBaseVector<reco::PhotonCore>" />
@@ -62,7 +64,9 @@
   <class name="edm::RefProd<std::vector<reco::Photon> >"/>
   <class name="edm::RefVector<std::vector<reco::Photon>,reco::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::Photon>,reco::Photon> >"/>
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::Photon>,reco::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::Photon>,reco::Photon> > >"/>
-  <class name="edm::RefToBase<reco::Photon>" />
+  <class name="edm::RefToBase<reco::Photon>">
+    <field name="holder_" transient="true"/>
+  </class>
   <class name="edm::reftobase::IndirectHolder<reco::Photon>" />
   <class name="edm::RefToBaseProd<reco::Photon>" />
   <class name="edm::RefToBaseVector<reco::Photon>" />
@@ -79,7 +83,9 @@
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::Electron>,reco::Electron,edm::refhelper::FindUsingAdvance<std::vector<reco::Electron>,reco::Electron> > >"/>
 
 
-  <class name="edm::RefToBase<reco::Electron>" />
+  <class name="edm::RefToBase<reco::Electron>">
+    <field name="holder_" transient="true"/>
+  </class>
   <class name="edm::reftobase::IndirectHolder<reco::Electron>" />
   <class name="edm::RefToBaseProd<reco::Electron>" />
   <class name="edm::RefToBaseVector<reco::Electron>" />
@@ -94,7 +100,9 @@
    <version ClassVersion="10" checksum="2226610106"/>
   </class>
   <class name="std::vector<reco::GsfElectronCore>"/>  
-  <class name="edm::RefToBase<reco::GsfElectronCore>" />
+  <class name="edm::RefToBase<reco::GsfElectronCore>">
+    <field name="holder_" transient="true"/>
+  </class>
   <class name="edm::reftobase::IndirectHolder<reco::GsfElectronCore>" />
   <class name="edm::RefToBaseProd<reco::GsfElectronCore>" />
   <class name="edm::RefToBaseVector<reco::GsfElectronCore>" />
@@ -155,7 +163,9 @@
    <version ClassVersion="11" checksum="1755683850"/>
   </class>
   <class name="std::vector<reco::GsfElectron>"/>  
-  <class name="edm::RefToBase<reco::GsfElectron>" />
+  <class name="edm::RefToBase<reco::GsfElectron>">
+    <field name="holder_" transient="true"/>
+  </class>
   <class name="edm::reftobase::IndirectHolder<reco::GsfElectron>" />
   <class name="edm::RefToBaseProd<reco::GsfElectron>" />
   <class name="edm::RefToBaseVector<reco::GsfElectron>" />

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -75,7 +75,9 @@
   <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::MuonRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::MuonRefVector>" />
 
-  <class name="edm::RefToBase<reco::Muon>" />
+  <class name="edm::RefToBase<reco::Muon>">
+    <field name="holder_" transient="true"/>
+  </class>
   <class name="edm::reftobase::IndirectHolder<reco::Muon>" />
   <class name="edm::RefToBaseProd<reco::Muon>" />
   <class name="edm::RefToBaseVector<reco::Muon>" />

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -75,9 +75,8 @@
   <class name="edm::reftobase::VectorHolder<reco::Candidate, reco::MuonRefVector>" />
   <class name="edm::reftobase::RefVectorHolder<reco::MuonRefVector>" />
 
-  <class name="edm::RefToBase<reco::Muon>">
-    <field name="holder_" transient="true"/>
-  </class>
+  <class name="edm::reftobase::BaseHolder<reco::Muon>"/>
+  <class name="edm::RefToBase<reco::Muon>"/>
   <class name="edm::reftobase::IndirectHolder<reco::Muon>" />
   <class name="edm::RefToBaseProd<reco::Muon>" />
   <class name="edm::RefToBaseVector<reco::Muon>" />

--- a/SimDataFormats/TrackingHit/src/classes_def.xml
+++ b/SimDataFormats/TrackingHit/src/classes_def.xml
@@ -8,7 +8,9 @@
   <class name="edm::RefProd<std::vector<PSimHit> >"/>
   <class name="edm::Ref<std::vector<PSimHit>,PSimHit,edm::refhelper::FindUsingAdvance<std::vector<PSimHit>,PSimHit> >"/>
 
-  <class name="edm::RefToBase<PSimHit>"/>
+  <class name="edm::RefToBase<PSimHit>">
+    <field name="holder_" transient="true"/>
+  </class>
   <class name="std::vector<edm::RefToBase<PSimHit> >"/>
   <class name="edm::reftobase::Holder<PSimHit,edm::Ref<std::vector<PSimHit>,PSimHit,edm::refhelper::FindUsingAdvance<std::vector<PSimHit>,PSimHit> > >"/>
 

--- a/SimDataFormats/TrackingHit/src/classes_def.xml
+++ b/SimDataFormats/TrackingHit/src/classes_def.xml
@@ -8,9 +8,8 @@
   <class name="edm::RefProd<std::vector<PSimHit> >"/>
   <class name="edm::Ref<std::vector<PSimHit>,PSimHit,edm::refhelper::FindUsingAdvance<std::vector<PSimHit>,PSimHit> >"/>
 
-  <class name="edm::RefToBase<PSimHit>">
-    <field name="holder_" transient="true"/>
-  </class>
+  <class name="edm::reftobase::BaseHolder<PSimHit>"/>
+  <class name="edm::RefToBase<PSimHit>"/>
   <class name="std::vector<edm::RefToBase<PSimHit> >"/>
   <class name="edm::reftobase::Holder<PSimHit,edm::Ref<std::vector<PSimHit>,PSimHit,edm::refhelper::FindUsingAdvance<std::vector<PSimHit>,PSimHit> > >"/>
 


### PR DESCRIPTION
RefToBase is a templated class with a private memeber `holder_` of `reftobase::BaseHolder<value_type>*` type. The following type is not part of any dictionary, thus `holder_` is not serialized.

There are two options:
1. Make `holder_` transient, which would match the current behavior (not saving it), I assume.
2. Adding a dictionary for `reftobase::BaseHolder<value_type>*` to make `holder_` serializable by ROOT.

Example error generated by ROOT:

```
Error in <TStreamerInfo::Build:>: edm::RefToBase<reco::Electron>:
edm::reftobase::BaseHolder<reco::Electron>* has no streamer or
dictionary, data member holder_ will not be saved
```

The following should resolve errors for 9 dictionaries:
- `edm::RefToBase<reco::WMuNuCandidatePtr>`
- `edm::RefToBase<reco::WMuNuCandidate>`
- `edm::RefToBase<reco::PhotonCore>`
- `edm::RefToBase<reco::Photon>`
- `edm::RefToBase<reco::Muon>`
- `edm::RefToBase<reco::GsfElectronCore>`
- `edm::RefToBase<reco::GsfElectron>`
- `edm::RefToBase<reco::Electron>`
- `edm::RefToBase<PSimHit>`

You can test using `edmClassStorageSize`, e.g.:

```
edmClassStorageSize 'edm::RefToBase<reco::GsfElectronCore>'
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
