### PR TITLE
Print Error message when a module requests a data product without first registering the request via 'consumes'

### DIFF
--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -52,6 +52,12 @@ namespace edm {
     void itemsToGet(BranchType, std::vector<ProductHolderIndex>&) const;
     void itemsMayGet(BranchType, std::vector<ProductHolderIndex>&) const;
     
+
+    ///\return true if the product corresponding to the index was registered via consumes or mayConsume call
+    bool registeredToConsume(ProductHolderIndex, BranchType) const;
+    
+    ///\return true of TypeID corresponds to a type specified in a consumesMany call
+    bool registeredToConsumeMany(TypeID const&, BranchType) const;
     // ---------- static member functions --------------------
     
     // ---------- member functions ---------------------------

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -44,6 +44,7 @@ namespace edm {
 
   class HistoryAppender;
   class ProductHolderIndexHelper;
+  class EDConsumerBase;
 
   struct FilledProductPtr {
     bool operator()(boost::shared_ptr<ProductHolderBase> const& iObj) { return bool(iObj);}
@@ -106,14 +107,14 @@ namespace edm {
     BasicHandle  getByLabel(KindOfType kindOfType,
                             TypeID const& typeID,
                             InputTag const& inputTag,
-                            ProductHolderIndex& oIndex) const;
+                            EDConsumerBase const* consumes) const;
 
     BasicHandle  getByLabel(KindOfType kindOfType,
                             TypeID const& typeID,
                             std::string const& label,
                             std::string const& instance,
                             std::string const& process,
-                            ProductHolderIndex& oIndex) const;
+                            EDConsumerBase const* consumes) const;
     
     BasicHandle getByToken(KindOfType kindOfType,
                            TypeID const& typeID,
@@ -122,7 +123,8 @@ namespace edm {
                            bool& ambiguous) const;
 
     void getManyByType(TypeID const& typeID,
-                       BasicHandleVec& results) const;
+                       BasicHandleVec& results,
+                       EDConsumerBase const* consumes) const;
 
     ProcessHistory const& processHistory() const {
       return *processHistoryPtr_;
@@ -205,14 +207,14 @@ namespace edm {
     ProductData const* findProductByLabel(KindOfType kindOfType,
                                           TypeID const& typeID,
                                           InputTag const& inputTag,
-                                          ProductHolderIndex& oIndex) const;
+                                          EDConsumerBase const* consumer) const;
 
     ProductData const* findProductByLabel(KindOfType kindOfType,
                                           TypeID const& typeID,
                                           std::string const& label,
                                           std::string const& instance,
                                           std::string const& process,
-                                          ProductHolderIndex& oIndex) const;
+                                          EDConsumerBase const* consumer) const;
 
     // defaults to no-op unless overridden in derived class.
     virtual void resolveProduct_(ProductHolderBase const&, bool /*fillOnDemand*/) const {}

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -105,13 +105,15 @@ namespace edm {
 
     BasicHandle  getByLabel(KindOfType kindOfType,
                             TypeID const& typeID,
-                            InputTag const& inputTag) const;
+                            InputTag const& inputTag,
+                            ProductHolderIndex& oIndex) const;
 
     BasicHandle  getByLabel(KindOfType kindOfType,
                             TypeID const& typeID,
                             std::string const& label,
                             std::string const& instance,
-                            std::string const& process) const;
+                            std::string const& process,
+                            ProductHolderIndex& oIndex) const;
     
     BasicHandle getByToken(KindOfType kindOfType,
                            TypeID const& typeID,
@@ -202,13 +204,15 @@ namespace edm {
 
     ProductData const* findProductByLabel(KindOfType kindOfType,
                                           TypeID const& typeID,
-                                          InputTag const& inputTag) const;
+                                          InputTag const& inputTag,
+                                          ProductHolderIndex& oIndex) const;
 
     ProductData const* findProductByLabel(KindOfType kindOfType,
                                           TypeID const& typeID,
                                           std::string const& label,
                                           std::string const& instance,
-                                          std::string const& process) const;
+                                          std::string const& process,
+                                          ProductHolderIndex& oIndex) const;
 
     // defaults to no-op unless overridden in derived class.
     virtual void resolveProduct_(ProductHolderBase const&, bool /*fillOnDemand*/) const {}

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -270,6 +270,37 @@ EDConsumerBase::labelsForToken(EDGetToken iToken, Labels& oLabels) const
   oLabels.process = oLabels.module+labels.m_deltaToProcessName;
 }
 
+bool
+EDConsumerBase::registeredToConsume(ProductHolderIndex iIndex, BranchType iBranch) const
+{
+  for(auto it = m_tokenInfo.begin<kLookupInfo>(),
+      itEnd = m_tokenInfo.end<kLookupInfo>();
+      it != itEnd; ++it) {
+    if(it->m_index == iIndex and
+       it->m_branchType == iBranch) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool
+EDConsumerBase::registeredToConsumeMany(TypeID const& iType, BranchType iBranch) const
+{
+  for(auto it = m_tokenInfo.begin<kLookupInfo>(),
+      itEnd = m_tokenInfo.end<kLookupInfo>();
+      it != itEnd; ++it) {
+    //consumesMany entries do not have their index resolved
+    if(it->m_index == ProductHolderIndexInvalid and
+       it->m_type == iType and
+       it->m_branchType == iBranch) {
+      return true;
+    }
+  }
+  return false;
+  
+}
+
 
 void
 EDConsumerBase::throwTypeMismatch(edm::TypeID const& iType, EDGetToken iToken) const

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -281,6 +281,14 @@ EDConsumerBase::registeredToConsume(ProductHolderIndex iIndex, BranchType iBranc
       return true;
     }
   }
+  //TEMPORARY: Remember so we do not have to do this again
+  //non thread-safe
+  EDConsumerBase* nonConstThis = const_cast<EDConsumerBase*>(this);
+  nonConstThis->m_tokenInfo.emplace_back(TokenLookupInfo{TypeID{},iIndex,iBranch},
+                                         true,
+                                         LabelPlacement{0,0,0},
+                                         PRODUCT_TYPE);
+
   return false;
 }
 
@@ -297,6 +305,13 @@ EDConsumerBase::registeredToConsumeMany(TypeID const& iType, BranchType iBranch)
       return true;
     }
   }
+  //TEMPORARY: Remember so we do not have to do this again
+  //non thread-safe
+  EDConsumerBase* nonConstThis = const_cast<EDConsumerBase*>(this);
+  nonConstThis->m_tokenInfo.emplace_back(TokenLookupInfo{iType,ProductHolderIndexInvalid,iBranch},
+                           true,
+                           LabelPlacement{0,0,0},
+                           PRODUCT_TYPE);
   return false;
   
 }

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -574,11 +574,10 @@ void testEvent::getByLabel() {
 
   }
 
-  edm::ProductHolderIndex index;
-  BasicHandle bh = principal_->getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)), "modMulti", "int1", "LATE",index);
+  BasicHandle bh = principal_->getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)), "modMulti", "int1", "LATE",nullptr);
   convert_handle(bh, h);
   CPPUNIT_ASSERT(h->value == 100);
-  BasicHandle bh2(principal_->getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)), "modMulti", "int1", "nomatch",index));
+  BasicHandle bh2(principal_->getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)), "modMulti", "int1", "nomatch",nullptr));
   CPPUNIT_ASSERT(!bh2.isValid());
 
   boost::shared_ptr<Wrapper<edmtest::IntProduct> const> ptr = getProductByTag<edmtest::IntProduct>(*principal_, inputTag);

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -574,10 +574,11 @@ void testEvent::getByLabel() {
 
   }
 
-  BasicHandle bh = principal_->getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)), "modMulti", "int1", "LATE");
+  edm::ProductHolderIndex index;
+  BasicHandle bh = principal_->getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)), "modMulti", "int1", "LATE",index);
   convert_handle(bh, h);
   CPPUNIT_ASSERT(h->value == 100);
-  BasicHandle bh2(principal_->getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)), "modMulti", "int1", "nomatch"));
+  BasicHandle bh2(principal_->getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)), "modMulti", "int1", "nomatch",index));
   CPPUNIT_ASSERT(!bh2.isValid());
 
   boost::shared_ptr<Wrapper<edmtest::IntProduct> const> ptr = getProductByTag<edmtest::IntProduct>(*principal_, inputTag);

--- a/FWCore/Framework/test/eventprincipal_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprincipal_t.cppunit.cc
@@ -235,7 +235,8 @@ void test_ep::failgetbyLabelTest() {
 
   std::string label("this does not exist");
 
-  edm::BasicHandle h(pEvent_->getByLabel(edm::PRODUCT_TYPE, tid, label, std::string(), std::string()));
+  edm::ProductHolderIndex index;
+  edm::BasicHandle h(pEvent_->getByLabel(edm::PRODUCT_TYPE, tid, label, std::string(), std::string(),index));
   CPPUNIT_ASSERT(h.failedToGet());
 }
 

--- a/FWCore/Framework/test/eventprincipal_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprincipal_t.cppunit.cc
@@ -235,8 +235,7 @@ void test_ep::failgetbyLabelTest() {
 
   std::string label("this does not exist");
 
-  edm::ProductHolderIndex index;
-  edm::BasicHandle h(pEvent_->getByLabel(edm::PRODUCT_TYPE, tid, label, std::string(), std::string(),index));
+  edm::BasicHandle h(pEvent_->getByLabel(edm::PRODUCT_TYPE, tid, label, std::string(), std::string(),nullptr));
   CPPUNIT_ASSERT(h.failedToGet());
 }
 
@@ -245,7 +244,7 @@ void test_ep::failgetManybyTypeTest() {
   edm::TypeID tid(dummy);
   std::vector<edm::BasicHandle > handles;
 
-  pEvent_->getManyByType(tid, handles);
+  pEvent_->getManyByType(tid, handles,nullptr);
   CPPUNIT_ASSERT(handles.empty());
 }
 

--- a/FWCore/Modules/src/GetProductCheckerOutputModule.cc
+++ b/FWCore/Modules/src/GetProductCheckerOutputModule.cc
@@ -91,13 +91,12 @@ namespace edm {
                throw cms::Exception("BranchIDMissMatch") << "While processing " << id << " request for BranchID " << branchID << " returned BranchID " << oh.desc()->branchID() << "\n";
             }
            
-            ProductHolderIndex index;
             TypeID const& tid((*it)->branchDescription().unwrappedTypeID());
             BasicHandle bh = p.getByLabel(PRODUCT_TYPE, tid,
             (*it)->branchDescription().moduleLabel(),
             (*it)->branchDescription().productInstanceName(),
             (*it)->branchDescription().processName(),
-            index);
+            nullptr);
             
             /*This doesn't appear to be an error, it just means the Product isn't available, which can be legitimate
             if(!bh.product()) {

--- a/FWCore/Modules/src/GetProductCheckerOutputModule.cc
+++ b/FWCore/Modules/src/GetProductCheckerOutputModule.cc
@@ -90,12 +90,14 @@ namespace edm {
             if(0 != oh.desc() && oh.desc()->branchID() != branchID) {
                throw cms::Exception("BranchIDMissMatch") << "While processing " << id << " request for BranchID " << branchID << " returned BranchID " << oh.desc()->branchID() << "\n";
             }
-            
+           
+            ProductHolderIndex index;
             TypeID const& tid((*it)->branchDescription().unwrappedTypeID());
             BasicHandle bh = p.getByLabel(PRODUCT_TYPE, tid,
             (*it)->branchDescription().moduleLabel(),
             (*it)->branchDescription().productInstanceName(),
-            (*it)->branchDescription().processName());
+            (*it)->branchDescription().processName(),
+            index);
             
             /*This doesn't appear to be an error, it just means the Product isn't available, which can be legitimate
             if(!bh.product()) {

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -101,10 +101,12 @@ namespace edm {
 
     EventNumber_t en = eventPrincipal.id().event();
     // Check that secondary source products are retrieved from the same event as the EventAuxiliary
+    ProductHolderIndex index;
     BasicHandle bhandle = eventPrincipal.getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)),
                                                     "EventNumber",
                                                     "",
-                                                    "");
+                                                    "",
+                                                    index);
     assert(bhandle.isValid());
     Handle<edmtest::IntProduct> handle;
     convert_handle<edmtest::IntProduct>(bhandle, handle);
@@ -117,7 +119,8 @@ namespace edm {
     BasicHandle bh = eventPrincipal.getByLabel(PRODUCT_TYPE, TypeID(typeid(TC)),
                                                "Thing",
                                                "",
-                                               "");
+                                               "",
+                                               index);
     assert(bh.isValid());
     if(!(bh.interface()->dynamicTypeInfo() == typeid(TC))) {
       handleimpl::throwConvertTypeError(typeid(TC), bh.interface()->dynamicTypeInfo());

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -101,12 +101,11 @@ namespace edm {
 
     EventNumber_t en = eventPrincipal.id().event();
     // Check that secondary source products are retrieved from the same event as the EventAuxiliary
-    ProductHolderIndex index;
     BasicHandle bhandle = eventPrincipal.getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)),
                                                     "EventNumber",
                                                     "",
                                                     "",
-                                                    index);
+                                                    nullptr);
     assert(bhandle.isValid());
     Handle<edmtest::IntProduct> handle;
     convert_handle<edmtest::IntProduct>(bhandle, handle);
@@ -120,7 +119,7 @@ namespace edm {
                                                "Thing",
                                                "",
                                                "",
-                                               index);
+                                               nullptr);
     assert(bh.isValid());
     if(!(bh.interface()->dynamicTypeInfo() == typeid(TC))) {
       handleimpl::throwConvertTypeError(typeid(TC), bh.interface()->dynamicTypeInfo());

--- a/SimGeneral/MixingModule/interface/PileUpEventPrincipal.h
+++ b/SimGeneral/MixingModule/interface/PileUpEventPrincipal.h
@@ -50,7 +50,7 @@ public:
     getByLabel(edm::InputTag const& tag, edm::Handle<T>& result) const {
     typedef typename T::value_type ItemType;
     typedef typename T::iterator iterator;
-    edm::BasicHandle bh = principal_.getByLabel(edm::PRODUCT_TYPE, edm::TypeID(typeid(T)), tag);
+    edm::BasicHandle bh = principal_.getByLabel(edm::PRODUCT_TYPE, edm::TypeID(typeid(T)), tag, nullptr);
     convert_handle(bh, result);
     if(result.isValid() && addLabel(edm::TypeID(typeid(T)), tag.label())) {
       T& product = const_cast<T&>(*result.product());


### PR DESCRIPTION
The threaded framework requires that all modules register what data they may request by calling 'consumes', 'mayConsume' or 'consumesMany' in the module's constructor. This change will catch the cases where this was not done and on the first such request it will print an Error message to the MessageLogger.

When we move to the threaded framework all such unregistered data requests will cause a fatal exception to be thrown.
