### PR TITLE
Don't use Reflex::SharedLibrary

### DIFF
--- a/FWCore/PluginManager/interface/SharedLibrary.h
+++ b/FWCore/PluginManager/interface/SharedLibrary.h
@@ -25,10 +25,6 @@
 
 // forward declarations
 
-namespace Reflex {
-  class SharedLibrary;
-}
-
 namespace edmplugin {
 class SharedLibrary
 {
@@ -51,7 +47,7 @@ class SharedLibrary
       const SharedLibrary& operator=(const SharedLibrary&); // stop default
 
       // ---------- member data --------------------------------
-      mutable Reflex::SharedLibrary* library_;
+      void* libraryHandle_;
       boost::filesystem::path path_;
 };
 

--- a/FWCore/PluginManager/src/SharedLibrary.cc
+++ b/FWCore/PluginManager/src/SharedLibrary.cc
@@ -8,12 +8,12 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Thu Apr  5 15:30:15 EDT 2007
-// $Id: SharedLibrary.cc,v 1.4 2011/08/24 12:28:53 eulisse Exp $
 //
 
 // system include files
 #include <string> /*needed by the following include*/
-#include "Reflex/SharedLibrary.h"
+#include <dlfcn.h>
+#include <errno.h>
 
 // user include files
 #include "FWCore/PluginManager/interface/SharedLibrary.h"
@@ -32,14 +32,16 @@ namespace edmplugin {
 // constructors and destructor
 //
   SharedLibrary::SharedLibrary(const boost::filesystem::path& iName) :
-  library_(0),
+  libraryHandle_(::dlopen(iName.string().c_str(), RTLD_LAZY | RTLD_GLOBAL)),
   path_(iName)
 {
-    std::auto_ptr<Reflex::SharedLibrary> lib(new Reflex::SharedLibrary(iName.string()));
-    if( !lib->Load() ) {
-      throw cms::Exception("PluginLibraryLoadError")<<"unable to load "<<iName.string()<<" because "<<lib->Error();
+    if(libraryHandle_ == nullptr) {
+      char const* err = dlerror();
+      if(err == nullptr) {
+        throw cms::Exception("PluginLibraryLoadError") << "unable to load " << iName.string();
+      }
+      throw cms::Exception("PluginLibraryLoadError") << "unable to load " << iName.string() << " because " << err;
     }
-    library_ = lib.release();
 }
 
 // SharedLibrary::SharedLibrary(const SharedLibrary& rhs)
@@ -49,7 +51,6 @@ namespace edmplugin {
 
 SharedLibrary::~SharedLibrary()
 {
-  delete library_;
 }
 
 //
@@ -72,9 +73,13 @@ SharedLibrary::~SharedLibrary()
 // const member functions
 //
 bool 
-SharedLibrary::symbol(const std::string& iSymbolName, void* & iSymbol) const
+SharedLibrary::symbol(const std::string& iSymbolName, void*& iSymbol) const
 {
-  return library_->Symbol(iSymbolName,iSymbol);
+  if(libraryHandle_ == nullptr) {
+    return false;
+  }
+  iSymbol = dlsym(libraryHandle_, iSymbolName.c_str());
+  return (iSymbol != nullptr);
 }
 
 //


### PR DESCRIPTION
Since Reflex will not be supported in the next release of ROOT, this pull request removes the usage of the Reflex::SharedLibrary class by moving the needed functionality from Reflex::SharedLibrary into CMSSW, and eliminating redundancy.  The code in question is only a very few lines.  This pull request has been tested.
