### PR TITLE
Make branch description non mutable redux

### DIFF
--- a/DataFormats/Provenance/interface/BranchDescription.h
+++ b/DataFormats/Provenance/interface/BranchDescription.h
@@ -58,14 +58,14 @@ namespace edm {
 
     ~BranchDescription() {}
 
-    void init() const {
+    void init() {
       initBranchName();
       initFromDictionary();
     }
 
-    void initBranchName() const;
+    void initBranchName();
 
-    void initFromDictionary() const;
+    void initFromDictionary();
 
     void write(std::ostream& os) const;
 
@@ -81,42 +81,58 @@ namespace edm {
     std::string const& className() const {return fullClassName();}
     std::string const& friendlyClassName() const {return friendlyClassName_;}
     std::string const& productInstanceName() const {return productInstanceName_;}
-    bool& produced() const {return transient_.produced_;}
+    bool produced() const {return transient_.produced_;}
+    bool& produced() {return transient_.produced_;}
     bool present() const {return !transient_.dropped_;}
-    bool& dropped() const {return transient_.dropped_;}
-    bool& onDemand() const {return transient_.onDemand_;}
-    bool& transient() const {return transient_.transient_;}
-    TypeWithDict& wrappedType() const {return transient_.wrappedType_;}
-    TypeWithDict& unwrappedType() const {return transient_.unwrappedType_;}
+    bool dropped() const {return transient_.dropped_;}
+    bool& dropped() {return transient_.dropped_;}
+    bool onDemand() const {return transient_.onDemand_;}
+    bool& onDemand() {return transient_.onDemand_;}
+    bool transient() const {return transient_.transient_;}
+    bool& transient() {return transient_.transient_;}
+    TypeWithDict const& wrappedType() const {return transient_.wrappedType_;}
+    TypeWithDict& wrappedType() {return transient_.wrappedType_;}
+    TypeWithDict const& unwrappedType() const {return transient_.unwrappedType_;}
+    TypeWithDict& unwrappedType() {return transient_.unwrappedType_;}
     TypeID wrappedTypeID() const {return TypeID(transient_.wrappedType_.typeInfo());}
     TypeID unwrappedTypeID() const {return TypeID(transient_.unwrappedType_.typeInfo());}
-    int& splitLevel() const {return transient_.splitLevel_;}
-    int& basketSize() const {return transient_.basketSize_;}
+    int splitLevel() const {return transient_.splitLevel_;}
+    int& splitLevel() {return transient_.splitLevel_;}
+    int basketSize() const {return transient_.basketSize_;}
+    int& basketSize() {return transient_.basketSize_;}
 
     ParameterSetID const& parameterSetID() const {return transient_.parameterSetID_;}
     std::string const& moduleName() const {return transient_.moduleName_;}
 
-    std::map<ProcessConfigurationID, ParameterSetID>& parameterSetIDs() const {
+    std::map<ProcessConfigurationID, ParameterSetID> const& parameterSetIDs() const {
       return transient_.parameterSetIDs_;
     }
-    std::map<ProcessConfigurationID, std::string>& moduleNames() const {
+    std::map<ProcessConfigurationID, ParameterSetID>& parameterSetIDs() {
+      return transient_.parameterSetIDs_;
+    }
+    std::map<ProcessConfigurationID, std::string> const& moduleNames() const {
+      return transient_.moduleNames_;
+    }
+    std::map<ProcessConfigurationID, std::string>& moduleNames() {
       return transient_.moduleNames_;
     }
     ParameterSetID const& psetID() const;
     bool isPsetIDUnique() const {return parameterSetIDs().size() == 1;}
     std::set<std::string> const& branchAliases() const {return branchAliases_;}
     std::set<std::string>& branchAliases() {return branchAliases_;}
-    std::string& branchName() const {return transient_.branchName_;}
+    std::string const& branchName() const {return transient_.branchName_;}
+    std::string& branchName() {return transient_.branchName_;}
     BranchType const& branchType() const {return branchType_;}
-    std::string& wrappedName() const {return transient_.wrappedName_;}
-    WrapperInterfaceBase*& wrapperInterfaceBase() const {return transient_.wrapperInterfaceBase_;}
+    std::string const& wrappedName() const {return transient_.wrappedName_;}
+    std::string& wrappedName() {return transient_.wrappedName_;}
+    WrapperInterfaceBase*& wrapperInterfaceBase() {return transient_.wrapperInterfaceBase_;}
 
     WrapperInterfaceBase const* getInterface() const;
-    void setDropped() const {dropped() = true;}
-    void setOnDemand() const {onDemand() = true;}
+    void setDropped() {dropped() = true;}
+    void setOnDemand() {onDemand() = true;}
     void updateFriendlyClassName();
 
-    void initializeTransients() const {transient_.reset();}
+    void initializeTransients() {transient_.reset();}
 
     struct Transients {
       Transients();
@@ -152,12 +168,12 @@ namespace edm {
       // ID's of process configurations for products on this branch
       //  with corresponding parameter set IDs,
       // This is initialized if and only if produced_ is false.
-      mutable std::map<ProcessConfigurationID, ParameterSetID> parameterSetIDs_;
+      std::map<ProcessConfigurationID, ParameterSetID> parameterSetIDs_;
 
       // ID's of process configurations for products on this branch
       //  with corresponding module names
       // This is initialized if and only if produced_ is false.
-      mutable std::map<ProcessConfigurationID, std::string> moduleNames_;
+      std::map<ProcessConfigurationID, std::string> moduleNames_;
 
       // Is the class of the branch marked as transient
       // in the data dictionary
@@ -170,7 +186,7 @@ namespace edm {
       TypeWithDict unwrappedType_;
 
       // A pointer to a polymorphic object to obtain typed Wrapper.
-      mutable WrapperInterfaceBase* wrapperInterfaceBase_;
+      WrapperInterfaceBase* wrapperInterfaceBase_;
 
       // The split level of the branch, as marked
       // in the data dictionary.
@@ -195,7 +211,7 @@ namespace edm {
     std::string processName_;
 
     // An ID uniquely identifying the branch
-    mutable BranchID branchID_;
+    BranchID branchID_;
 
     // the full name of the type of product this is
     std::string fullClassName_;
@@ -213,9 +229,9 @@ namespace edm {
     // If this branch *is* an EDAlias, this field is the BranchID
     // of the branch for which this branch is an alias.
     // If this branch is not an EDAlias, the normal case, this field is 0.
-    mutable BranchID aliasForBranchID_;
+    BranchID aliasForBranchID_;
 
-    mutable Transients transient_;
+    Transients transient_;
   };
 
   inline

--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -128,6 +128,8 @@ namespace edm {
 
     void initializeTransients() {transient_.reset();}
 
+    bool frozen() const {return transient_.frozen_;}
+
     struct Transients {
       Transients();
       void reset();
@@ -158,7 +160,6 @@ namespace edm {
       transient_.anyProductProduced_ = true;
     }
 
-    bool frozen() const {return transient_.frozen_;}
     void freezeIt(bool frozen = true) {transient_.frozen_ = frozen;}
 
     void updateConstProductRegistry();

--- a/DataFormats/Provenance/src/BranchDescription.cc
+++ b/DataFormats/Provenance/src/BranchDescription.cc
@@ -107,7 +107,7 @@ namespace edm {
   }
 
   void
-  BranchDescription::initBranchName() const {
+  BranchDescription::initBranchName() {
     if(!branchName().empty()) {
       return;  // already called
     }
@@ -155,7 +155,7 @@ namespace edm {
   }
 
   void
-  BranchDescription::initFromDictionary() const {
+  BranchDescription::initFromDictionary() {
     if(bool(wrappedType())) {
       return;  // already initialized;
     }
@@ -179,6 +179,8 @@ namespace edm {
       basketSize() = invalidBasketSize;
       return;
     }
+    wrappedType().invokeByName(wrapperInterfaceBase(), "getInterface");
+    assert(wrapperInterfaceBase() != 0);
     Reflex::PropertyList wp = Reflex::Type::ByTypeInfo(wrappedType().typeInfo()).Properties();
     transient() = (wp.HasProperty("persistent") ? wp.PropertyAsString("persistent") == std::string("false") : false);
     if(transient()) {
@@ -366,12 +368,6 @@ namespace edm {
 
   WrapperInterfaceBase const*
   BranchDescription::getInterface() const {
-    if(wrapperInterfaceBase() == 0) {
-      // This could be done in init(), but we only want to do it on demand, for performance reasons.
-      TypeWithDict type = TypeWithDict::byName(wrappedName());
-      type.invokeByName(wrapperInterfaceBase(), "getInterface");
-      assert(wrapperInterfaceBase() != 0);
-    }
-    return wrapperInterfaceBase();
+    return transient_.wrapperInterfaceBase_;
   }
 }

--- a/DataFormats/Streamer/interface/StreamedProducts.h
+++ b/DataFormats/Streamer/interface/StreamedProducts.h
@@ -49,7 +49,6 @@ namespace edm {
     void allocateForReading();
     void setNewClassType();
     void clearClassType();
-    void initializeTransients();
 
    void clear() {
      prod_= 0;
@@ -92,7 +91,6 @@ namespace edm {
     EventSelectionIDVector const& eventSelectionIDs() const {return eventSelectionIDs_;}
     BranchListIndexes const& branchListIndexes() const {return branchListIndexes_;}
     SendProds& products() {return products_;}
-    void initializeTransients();
   private:
     EventAuxiliary aux_;
     ProcessHistory processHistory_;

--- a/DataFormats/Streamer/src/StreamedProducts.cc
+++ b/DataFormats/Streamer/src/StreamedProducts.cc
@@ -9,7 +9,7 @@ namespace edm {
 		    std::vector<BranchID> const* parents) :
       desc_(&desc), present_(present), parents_(parents), prod_(const_cast<void*>(prod)), classRef_() {
       if(present_ && prod == 0) {
-	desc.init();
+        const_cast<BranchDescription&>(desc).init();
         throw edm::Exception(edm::errors::LogicError, "StreamedProduct::StreamedProduct\n")
            << "A product with a status of 'present' is not actually present.\n"
            << "The branch name is " << desc.branchName() << "\n"
@@ -33,18 +33,6 @@ namespace edm {
       if(prod_ != 0) {
         classRef_->Destructor(prod_);
         prod_ = 0;
-      }
-    }
-
-    void
-    StreamedProduct::initializeTransients() {
-      desc_->init();
-    }
-
-    void
-    SendEvent::initializeTransients() {
-      for(StreamedProduct& prod : products_) {
-        prod.initializeTransients();
       }
     }
 

--- a/FWCore/FWLite/src/BranchMapReader.cc
+++ b/FWCore/FWLite/src/BranchMapReader.cc
@@ -102,7 +102,6 @@ namespace fwlite {
         bReg = metaDataTree->GetBranch(edm::poolNames::productDescriptionBranchName().c_str());
         bReg->SetAddress(ppReg);
         bReg->GetEntry(0);
-        (*ppReg)->setFrozen(false);
       }
       return bReg;
     }
@@ -168,17 +167,19 @@ namespace fwlite {
       TBranch* br = getBranchRegistry(&pReg);
 
       if(0 != br) {
-        edm::ProductRegistry::ProductList const& prodList = reg.productList();
+        edm::ProductRegistry::ProductList& prodList = reg.productListUpdator();
 
-        for(edm::ProductRegistry::ProductList::const_iterator it = prodList.begin(), itEnd = prodList.end(); it != itEnd; ++it) {
-          if(edm::InEvent == it->second.branchType()) {
+        for(auto& item : prodList) {
+          edm::BranchDescription& prod = item.second;
+          if(edm::InEvent == prod.branchType()) {
             // call to regenerate branchName
-            it->second.init();
-            branchDescriptionMap_.insert(bidToDesc::value_type(it->second.branchID(), it->second));
+            prod.init();
+            branchDescriptionMap_.insert(bidToDesc::value_type(prod.branchID(), prod));
           }
         }
         mapperFilled_ = true;
       }
+      reg.setFrozen(false);
       return 0 != br;
     }
 
@@ -265,16 +266,18 @@ namespace fwlite {
       TBranch *br = getBranchRegistry(&pReg);
 
       if(0 != br) {
-        edm::ProductRegistry::ProductList const& prodList = reg.productList();
+        edm::ProductRegistry::ProductList& prodList = reg.productListUpdator();
 
-        for(edm::ProductRegistry::ProductList::const_iterator it = prodList.begin(), itEnd = prodList.end(); it != itEnd; ++it) {
-          if(edm::InEvent == it->second.branchType()) {
+        for(auto& item : prodList) {
+          edm::BranchDescription& prod = item.second;
+          if(edm::InEvent == prod.branchType()) {
             // call to regenerate branchName
-            it->second.init();
-            branchDescriptionMap_.insert(bidToDesc::value_type(it->second.branchID(), it->second));
+            prod.init();
+            branchDescriptionMap_.insert(bidToDesc::value_type(prod.branchID(), prod));
           }
         }
       }
+      reg.setFrozen(false);
       return 0 != br;
     }
 
@@ -375,17 +378,19 @@ namespace fwlite {
       TBranch *br = getBranchRegistry(&pReg);
 
       if(0 != br) {
-        edm::ProductRegistry::ProductList const& prodList = reg.productList();
+        edm::ProductRegistry::ProductList& prodList = reg.productListUpdator();
 
-        for(edm::ProductRegistry::ProductList::const_iterator it = prodList.begin(), itEnd = prodList.end(); it != itEnd; ++it) {
-          if(edm::InEvent == it->second.branchType()) {
+        for(auto& item : prodList) {
+          edm::BranchDescription& prod = item.second;
+          if(edm::InEvent == prod.branchType()) {
             // call to regenerate branchName
-            it->second.init();
-            branchDescriptionMap_.insert(bidToDesc::value_type(it->second.branchID(), it->second));
-//             std::cout << "v11 updatefile " << it->second.branchID() << std::endl;
+            prod.init();
+            branchDescriptionMap_.insert(bidToDesc::value_type(prod.branchID(), prod));
+//             std::cout << "v11 updatefile " << prod.branchID() << std::endl;
                 }
               }
       }
+      reg.setFrozen(false);
       return 0 != br;
     }
 
@@ -488,17 +493,19 @@ namespace fwlite {
       TBranch *br = getBranchRegistry(&pReg);
 
       if(0 != br) {
-        edm::ProductRegistry::ProductList const& prodList = reg.productList();
+        edm::ProductRegistry::ProductList& prodList = reg.productListUpdator();
 
-        for(edm::ProductRegistry::ProductList::const_iterator it = prodList.begin(), itEnd = prodList.end(); it != itEnd; ++it) {
-          if(edm::InEvent == it->second.branchType()) {
+        for(auto& item : prodList) {
+          edm::BranchDescription& prod = item.second;
+          if(edm::InEvent == prod.branchType()) {
             // call to regenerate branchName
-            it->second.init();
-            branchDescriptionMap_.insert(bidToDesc::value_type(it->second.branchID(), it->second));
-//             std::cout << "v11 updatefile " << it->second.branchID() << std::endl;
+            prod.init();
+            branchDescriptionMap_.insert(bidToDesc::value_type(prod.branchID(), prod));
+//             std::cout << "v11 updatefile " << prod.branchID() << std::endl;
                 }
               }
       }
+      reg.setFrozen(false);
       return 0 != br;
     }
 

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -414,13 +414,6 @@ namespace edm {
 
     loadMissingDictionaries();
 
-    preg.setFrozen();
-
-    for (auto c : all_output_communicators_) {
-      c->setEventSelectionInfo(outputModulePathPositions, preg.anyProductProduced());
-      c->selectProducts(preg);
-    }
-
     // Sanity check: make sure nobody has added a worker after we've
     // already relied on the WorkerManager being full.
     assert (all_workers_count == allWorkers().size());
@@ -428,6 +421,14 @@ namespace edm {
     ProcessConfigurationRegistry::instance()->insertMapped(*processConfiguration);
     branchIDListHelper.updateRegistries(preg);
     fillProductRegistryTransients(*processConfiguration, preg);
+
+    preg.setFrozen();
+
+    for (auto c : all_output_communicators_) {
+      c->setEventSelectionInfo(outputModulePathPositions, preg.anyProductProduced());
+      c->selectProducts(preg);
+    }
+
   } // Schedule::Schedule
 
   

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -35,28 +35,31 @@ namespace edm {
       branchIDListHelper_(new BranchIDListHelper(branchIDListHelper)),
       act_table_(),
       processConfiguration_() {
-    for(ProductRegistry::ProductList::iterator it = preg_->productListUpdator().begin(), itEnd = preg_->productListUpdator().end(); it != itEnd; ++it) {
-      it->second.onDemand() = false;
-      it->second.produced() = false;
+
+    for(auto& item : preg_->productListUpdator()) {
+      BranchDescription& prod = item.second;
+      prod.onDemand() = false;
+      prod.produced() = false;
     }
 
     // Mark dropped branches as dropped in the product registry.
     std::set<BranchID> keptBranches;
     Selections const& keptVectorR = om.keptProducts()[InRun];
-    for(Selections::const_iterator it = keptVectorR.begin(), itEnd = keptVectorR.end(); it != itEnd; ++it) {
-      keptBranches.insert((*it)->branchID());
+    for(auto const& item : keptVectorR) {
+      keptBranches.insert(item->branchID());
     }
     Selections const& keptVectorL = om.keptProducts()[InLumi];
-    for(Selections::const_iterator it = keptVectorL.begin(), itEnd = keptVectorL.end(); it != itEnd; ++it) {
-      keptBranches.insert((*it)->branchID());
+    for(auto const& item : keptVectorL) {
+      keptBranches.insert(item->branchID());
     }
     Selections const& keptVectorE = om.keptProducts()[InEvent];
-    for(Selections::const_iterator it = keptVectorE.begin(), itEnd = keptVectorE.end(); it != itEnd; ++it) {
-      keptBranches.insert((*it)->branchID());
+    for(auto const& item : keptVectorE) {
+      keptBranches.insert(item->branchID());
     }
-    for(ProductRegistry::ProductList::const_iterator it = preg_->productList().begin(), itEnd = preg_->productList().end(); it != itEnd; ++it) {
-      if(keptBranches.find(it->second.branchID()) == keptBranches.end()) {
-        it->second.setDropped();
+    for(auto& item : preg_->productListUpdator()) {
+      BranchDescription& prod = item.second;
+      if(keptBranches.find(prod.branchID()) == keptBranches.end()) {
+        prod.setDropped();
       }
     }
   }
@@ -72,11 +75,9 @@ namespace edm {
     ServiceToken token(ServiceRegistry::createSet(pServiceSets, iToken, iLegacy, associate));
 
     //see if any of the Services have to have their PSets stored
-    for(std::vector<ParameterSet>::const_iterator it = pServiceSets.begin(), itEnd = pServiceSets.end();
-        it != itEnd;
-        ++it) {
-      if(it->exists("@save_config")) {
-        parameterSet.addParameter(it->getParameter<std::string>("@service_type"), *it);
+    for(auto const& item : pServiceSets) {
+      if(item.exists("@save_config")) {
+        parameterSet.addParameter(item.getParameter<std::string>("@service_type"), item);
       }
     }
     // Copy slots that hold all the registered callback functions like

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -46,7 +46,7 @@ namespace edm {
   }
 
   void WorkerManager::setOnDemandProducts(ProductRegistry& pregistry, std::set<std::string> const& unscheduledLabels) const {
-    for(auto& prod : pregistry.productList()) {
+    for(auto& prod : pregistry.productListUpdator()) {
       if(prod.second.produced() &&
           prod.second.branchType() == InEvent &&
           unscheduledLabels.end() != unscheduledLabels.find(prod.second.moduleLabel())) {

--- a/FWCore/ParameterSet/interface/FillProductRegistryTransients.h
+++ b/FWCore/ParameterSet/interface/FillProductRegistryTransients.h
@@ -14,8 +14,8 @@ namespace edm {
   class ProcessConfiguration;
 
   void
-  fillProductRegistryTransients(std::vector<ProcessConfiguration> const& pcVec, ProductRegistry const& preg, bool okToRegister = false);
+  fillProductRegistryTransients(std::vector<ProcessConfiguration> const& pcVec, ProductRegistry& preg, bool okToRegister = false);
   void
-  fillProductRegistryTransients(ProcessConfiguration const& pc, ProductRegistry const& preg, bool okToRegister = false);
+  fillProductRegistryTransients(ProcessConfiguration const& pc, ProductRegistry& preg, bool okToRegister = false);
 }
 #endif

--- a/FWCore/ParameterSet/src/FillProductRegistryTransients.cc
+++ b/FWCore/ParameterSet/src/FillProductRegistryTransients.cc
@@ -17,7 +17,7 @@
 
 namespace edm {
   void
-  fillProductRegistryTransients(ProcessConfiguration const& pc, ProductRegistry const& preg, bool okToRegister) {
+  fillProductRegistryTransients(ProcessConfiguration const& pc, ProductRegistry& preg, bool okToRegister) {
     std::string const triggerResults = std::string("TriggerResults");
     std::string const triggerResultsInserter = std::string("TriggerResultsInserter");
     std::string const triggerPaths = std::string("@trigger_paths");
@@ -30,10 +30,10 @@ namespace edm {
     if(0 == processParameterSet || processParameterSet->empty()) {
       return;
     }
-    for(ProductRegistry::ProductList::const_iterator it = preg.productList().begin(),
-        itEnd = preg.productList().end();
+    for(ProductRegistry::ProductList::iterator it = preg.productListUpdator().begin(),
+        itEnd = preg.productListUpdator().end();
         it != itEnd; ++it) {
-      BranchDescription const& bd = it->second;
+      BranchDescription& bd = it->second;
       if(processName != bd.processName()) {
         continue;
       }
@@ -63,7 +63,7 @@ namespace edm {
   }
 
   void
-  fillProductRegistryTransients(std::vector<ProcessConfiguration> const& pcVec, ProductRegistry const& preg, bool okToRegister) {
+  fillProductRegistryTransients(std::vector<ProcessConfiguration> const& pcVec, ProductRegistry& preg, bool okToRegister) {
     typedef std::vector<ProcessConfiguration>::const_iterator PCIter;
     for(PCIter i = pcVec.begin(), iEnd = pcVec.end(); i != iEnd; ++i) {
       fillProductRegistryTransients(*i, preg, okToRegister);

--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -419,7 +419,6 @@ TFWLiteSelectorBasic::setupNewFile(TFile& iFile) {
            edm::BranchDescription newBD(prod);
            newBD.updateFriendlyClassName();
            newReg->copyProduct(newBD);
-           // Need to call init to get old branch name.
          }
          prod.init();
        }

--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -338,8 +338,6 @@ TFWLiteSelectorBasic::setupNewFile(TFile& iFile) {
   edm::ProductRegistry* pReg = &(*m_->reg_);
   metaDataTree->SetBranchAddress(edm::poolNames::productDescriptionBranchName().c_str(), &(pReg));
 
-  m_->reg_->setFrozen();
-
   typedef std::map<edm::ParameterSetID, edm::ParameterSetBlob> PsetMap;
   PsetMap psetMap;
   PsetMap *psetMapPtr = &psetMap;
@@ -382,6 +380,10 @@ TFWLiteSelectorBasic::setupNewFile(TFile& iFile) {
 
   metaDataTree->GetEntry(0);
 
+  for(auto& prod : m_->reg_->productListUpdator()) {
+    prod.second.init();
+  }
+
   // Merge into the registries. For now, we do NOT merge the product registry.
   edm::pset::Registry& psetRegistry = *edm::pset::Registry::instance();
   for(PsetMap::const_iterator i = psetMap.begin(), iEnd = psetMap.end();
@@ -400,12 +402,11 @@ TFWLiteSelectorBasic::setupNewFile(TFile& iFile) {
   fillProductRegistryTransients(procConfigVector, *m_->reg_);
   std::auto_ptr<edm::ProductRegistry> newReg(new edm::ProductRegistry());
 
-  edm::ProductRegistry::ProductList const& prodList = m_->reg_->productList();
+  edm::ProductRegistry::ProductList& prodList = m_->reg_->productListUpdator();
   {
-     for(edm::ProductRegistry::ProductList::const_iterator it = prodList.begin(), itEnd = prodList.end();
-            it != itEnd; ++it) {
-         edm::BranchDescription const& prod = it->second;
-         //std::cout << "productname = " << it->second << " end " << std::endl;
+     for(auto& item : prodList) {
+         edm::BranchDescription& prod = item.second;
+         //std::cout << "productname = " << item.second << " end " << std::endl;
          std::string newFriendlyName = edm::friendlyname::friendlyName(prod.className());
          if(newFriendlyName == prod.friendlyClassName()) {
            newReg->copyProduct(prod);
@@ -419,23 +420,21 @@ TFWLiteSelectorBasic::setupNewFile(TFile& iFile) {
            newBD.updateFriendlyClassName();
            newReg->copyProduct(newBD);
            // Need to call init to get old branch name.
-           prod.init();
          }
+         prod.init();
        }
 
-    newReg->setFrozen();
     m_->reg_.reset(newReg.release());
   }
 
-  edm::ProductRegistry::ProductList const& prodList2 = m_->reg_->productList();
+  edm::ProductRegistry::ProductList& prodList2 = m_->reg_->productListUpdator();
   std::vector<edm::EventEntryDescription> temp(prodList2.size(), edm::EventEntryDescription());
   m_->prov_.swap(temp);
   std::vector<edm::EventEntryDescription>::iterator itB = m_->prov_.begin();
   m_->pointerToBranchBuffer_.reserve(prodList2.size());
 
-  for(edm::ProductRegistry::ProductList::const_iterator it = prodList2.begin(), itEnd = prodList2.end();
-       it != itEnd; ++it, ++itB) {
-    edm::BranchDescription const& prod = it->second;
+  for(auto& item : prodList2) {
+    edm::BranchDescription& prod = item.second;
     if(prod.branchType() == edm::InEvent) {
       prod.init();
       //NEED to do this and check to see if branch exists
@@ -452,6 +451,7 @@ TFWLiteSelectorBasic::setupNewFile(TFile& iFile) {
     }
   }
   m_->branchIDListHelper_->updateFromInput(*branchIDListsPtr);
+  m_->reg_->setFrozen();
   m_->ep_.reset(new edm::EventPrincipal(m_->reg_, m_->branchIDListHelper_, m_->pc_, nullptr,edm::StreamID::invalidStreamID()));
   everythingOK_ = true;
 }

--- a/IOPool/Common/bin/EdmProvDump.cc
+++ b/IOPool/Common/bin/EdmProvDump.cc
@@ -874,8 +874,8 @@ ProvenanceDumper::work_() {
 
   std::map<edm::BranchID, std::string> branchIDToBranchName;
 
-  for(edm::ProductRegistry::ProductList::const_iterator it =
-         reg_.productList().begin(), itEnd = reg_.productList().end();
+  for(edm::ProductRegistry::ProductList::iterator it =
+         reg_.productListUpdator().begin(), itEnd = reg_.productListUpdator().end();
        it != itEnd;
        ++it) {
     //force it to rebuild the branch name

--- a/IOPool/Input/src/ProvenanceAdaptor.cc
+++ b/IOPool/Input/src/ProvenanceAdaptor.cc
@@ -91,19 +91,19 @@ namespace edm {
     }
 
     void
-    fillListsAndIndexes(ProductRegistry const& productRegistry,
+    fillListsAndIndexes(ProductRegistry& productRegistry,
 			ProcessHistoryMap const& pHistMap,
 			boost::shared_ptr<BranchIDLists const>& branchIDLists,
 			std::vector<BranchListIndex>& branchListIndexes) {
       OrderedProducts orderedProducts;
       std::set<std::string> processNamesThatProduced;
-      ProductRegistry::ProductList const& prodList = productRegistry.productList();
-      for (ProductRegistry::ProductList::const_iterator it = prodList.begin(), itEnd = prodList.end();
-	  it != itEnd; ++it) {
-        if (it->second.branchType() == InEvent) {
-	  it->second.init();
-	  processNamesThatProduced.insert(it->second.processName());
-	  orderedProducts.emplace_back(it->second.processName(), it->second.branchID());
+      ProductRegistry::ProductList& prodList = productRegistry.productListUpdator();
+      for (auto& item : prodList) {
+        BranchDescription& prod = item.second;
+        if (prod.branchType() == InEvent) {
+	  prod.init();
+	  processNamesThatProduced.insert(prod.processName());
+	  orderedProducts.emplace_back(prod.processName(), prod.branchID());
         }
       }
       assert (!orderedProducts.empty());

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -362,7 +362,6 @@ namespace edm {
         // Save info from the old and new branch descriptions
         daqProvenanceHelper_->saveInfo(it->second, newBD);
         // Map the new branch name to the old branch name.
-        it->second.init();
         newBranchToOldBranch_.insert(std::make_pair(newBD.branchName(), it->second.branchName()));
         // Remove the old branch description from the product Registry.
         pList.erase(it);
@@ -400,9 +399,9 @@ namespace edm {
     eventProcessHistoryIter_ = eventProcessHistoryIDs_.begin();
 
     // Set product presence information in the product registry.
-    ProductRegistry::ProductList const& pList = inputProdDescReg.productList();
-    for(auto const& product : pList) {
-      BranchDescription const& prod = product.second;
+    ProductRegistry::ProductList& pList = inputProdDescReg.productListUpdator();
+    for(auto& product : pList) {
+      BranchDescription& prod = product.second;
       prod.init();
       treePointers_[prod.branchType()]->setPresence(prod, newBranchToOldBranch(prod.branchName()));
     }

--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -102,9 +102,8 @@ namespace edm {
   }  
 
   void
-  RootTree::setPresence(BranchDescription const& prod, std::string const& oldBranchName) {
+  RootTree::setPresence(BranchDescription& prod, std::string const& oldBranchName) {
       assert(isValid());
-      prod.init();
       if(tree_->GetBranch(oldBranchName.c_str()) == 0){
         prod.setDropped();
       }
@@ -115,7 +114,6 @@ namespace edm {
                       BranchDescription const& prod,
                       std::string const& oldBranchName) {
       assert(isValid());
-      prod.init();
       //use the translated branch name
       TBranch* branch = tree_->GetBranch(oldBranchName.c_str());
       roottree::BranchInfo info = roottree::BranchInfo(ConstBranchDescription(prod));

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -75,7 +75,7 @@ namespace edm {
                    std::string const& oldBranchName);
     void dropBranch(std::string const& oldBranchName);
     void getEntry(TBranch *branch, EntryNumber entry) const;
-    void setPresence(BranchDescription const& prod,
+    void setPresence(BranchDescription& prod,
                    std::string const& oldBranchName);
 
     bool next() {return ++entryNumber_ < entries_;}

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -134,7 +134,6 @@ namespace edm {
           it != itEnd; ++it) {
         it->product_ = 0;
         BranchDescription const& desc = *it->branchDescription_;
-        desc.init();
         theTree->addBranch(desc.branchName(),
                            desc.wrappedName(),
                            desc.getInterface(),

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -85,8 +85,10 @@ namespace edm {
       declareStreamers(descs);
       buildClassCache(descs);
       loadExtraClasses();
-      reg.updateFromInput(descs);
-      fillProductRegistryTransients(header.processConfigurations(), reg);
+      if(!reg.frozen()) {
+        reg.updateFromInput(descs);
+        fillProductRegistryTransients(header.processConfigurations(), reg);
+      }
       branchIDListHelper.updateFromInput(header.branchIDLists());
     }
   }
@@ -161,6 +163,7 @@ namespace edm {
           << "Could not read the initial product registry list\n";
     }
 
+    sd->initializeTransients();
     return sd;
   }
 


### PR DESCRIPTION
This pull request makes all data members of the BranchDescription class non-mutable, and all member functions that modify any member are made non-const. This makes it much easier to identify where any instance of this class is modified. This is important for the multithreaded framework, in that this class is used in the ProductRegistry, which is accessible across threads. This code has been tested. Unit tests and relvals all pass.
This is a repeat of pull request 77 but with the merge conflict resolved.
