### PR TITLE
Fix a bug in consumes handling and dded consumes calls to Framework owned modules

### DIFF
--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -38,6 +38,7 @@
 namespace edm {
   class ProductHolderIndexHelper;
   class ConsumesCollector;
+  template<typename T> class WillGetIfMatch;
   
   class EDConsumerBase
   {
@@ -73,6 +74,7 @@ namespace edm {
     
   protected:
     friend class ConsumesCollector;
+    template<typename T> friend class WillGetIfMatch;
     ///Use a ConsumesCollector to gather consumes information from helper functions
     ConsumesCollector consumesCollector();
     

--- a/FWCore/Framework/interface/GetterOfProducts.h
+++ b/FWCore/Framework/interface/GetterOfProducts.h
@@ -125,7 +125,7 @@ namespace edm {
 
       template <typename U, typename M>
       GetterOfProducts(U const& match, M* module, edm::BranchType branchType = edm::InEvent) : 
-        matcher_(WillGetIfMatch<T, M>(match, module)),
+        matcher_(WillGetIfMatch<T>(match, module)),
         inputTags_(new std::vector<edm::InputTag>),
         branchType_(branchType) {
       }

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -123,13 +123,15 @@ EDConsumerBase::updateLookup(BranchType iBranchType,
     auto itLabels = m_tokenInfo.begin<kLabels>();
     for(auto itInfo = m_tokenInfo.begin<kLookupInfo>(),itEnd = m_tokenInfo.end<kLookupInfo>();
         itInfo != itEnd; ++itInfo,++itKind,++itLabels) {
-      const unsigned int labelStart = itLabels->m_startOfModuleLabel;
-      const char* moduleLabel = &(m_tokenLabels[labelStart]);
-      itInfo->m_index = iHelper.index(*itKind,
-                                      itInfo->m_type,
-                                      moduleLabel,
-                                      moduleLabel+itLabels->m_deltaToProductInstance,
-                                      moduleLabel+itLabels->m_deltaToProcessName);
+      if(itInfo->m_branchType == iBranchType) {
+        const unsigned int labelStart = itLabels->m_startOfModuleLabel;
+        const char* moduleLabel = &(m_tokenLabels[labelStart]);
+        itInfo->m_index = iHelper.index(*itKind,
+                                        itInfo->m_type,
+                                        moduleLabel,
+                                        moduleLabel+itLabels->m_deltaToProductInstance,
+                                        moduleLabel+itLabels->m_deltaToProcessName);
+      }
     }
   }
   

--- a/FWCore/Framework/test/stubs/DeleteEarlyModules.cc
+++ b/FWCore/Framework/test/stubs/DeleteEarlyModules.cc
@@ -44,7 +44,9 @@ namespace edmtest {
   public:
     DeleteEarlyReader(edm::ParameterSet const& pset):
     m_tag(pset.getUntrackedParameter<edm::InputTag>("tag"))
-    {}
+    {
+      consumes<DeleteEarly>(m_tag);
+    }
     
     virtual void analyze(edm::Event const& e, edm::EventSetup const& ) {
       edm::Handle<DeleteEarly> h;

--- a/FWCore/Framework/test/stubs/TestFilterModule.cc
+++ b/FWCore/Framework/test/stubs/TestFilterModule.cc
@@ -87,6 +87,7 @@ namespace edmtest
     expected_pathname_(ps.getUntrackedParameter<std::string>("pathname", "")),
     expected_modulelabel_(ps.getUntrackedParameter<std::string>("modlabel", ""))
   {
+    consumesMany<edm::TriggerResults>();
   }
     
   TestResultAnalyzer::~TestResultAnalyzer()

--- a/FWCore/Framework/test/stubs/TestMergeResults.cc
+++ b/FWCore/Framework/test/stubs/TestMergeResults.cc
@@ -195,6 +195,9 @@ namespace edmtest {
 
       consumes<edmtest::ThingWithIsEqual,edm::InRun>(edm::InputTag{"makeThingToBeDropped", "beginRun", "PROD"});
     }
+    for(auto const& parent : expectedParents_) {
+      mayConsume<edmtest::Thing>(edm::InputTag{parent,"event","PROD"});
+    }
     if(expectedDroppedEvent1_.size() > droppedIndex1_) {
       consumes<edmtest::ThingWithIsEqual>(edm::InputTag{"makeThingToBeDropped1", "event", "PROD"});
     }
@@ -226,7 +229,7 @@ namespace edmtest {
     }
     
     if (testAlias_) {
-      consumes<edmtest::Thing>(edm::InputTag{"aliasForThingToBeDropped2", "endRun2"});
+      consumes<edmtest::Thing,edm::InRun>(edm::InputTag{"aliasForThingToBeDropped2", "endRun2"});
       edm::InputTag tag("aliasForThingToBeDropped2", "endRun2","PROD");
       consumes<edmtest::Thing,edm::InRun>(tag);
     }

--- a/FWCore/Framework/test/stubs/TestMergeResults.cc
+++ b/FWCore/Framework/test/stubs/TestMergeResults.cc
@@ -188,6 +188,78 @@ namespace edmtest {
     edm::Wrapper<edmtest::ThingWithIsEqual> w_thingWithIsEqual(ap_thingwithisequal);
     assert(!w_thingWithIsEqual.isMergeable());
     assert(w_thingWithIsEqual.hasIsProductEqual());
+    
+    if(expectedDroppedEvent_.size() > 0) {
+      consumes<edmtest::ThingWithIsEqual>(edm::InputTag{"makeThingToBeDropped", "event", "PROD"});
+      consumes<edmtest::ThingWithMerge>(edm::InputTag{"makeThingToBeDropped", "event", "PROD"});
+
+      consumes<edmtest::ThingWithIsEqual,edm::InRun>(edm::InputTag{"makeThingToBeDropped", "beginRun", "PROD"});
+    }
+    if(expectedDroppedEvent1_.size() > droppedIndex1_) {
+      consumes<edmtest::ThingWithIsEqual>(edm::InputTag{"makeThingToBeDropped1", "event", "PROD"});
+    }
+    consumes<edmtest::Thing>(edm::InputTag{"thingWithMergeProducer", "event", "PROD"});
+
+    if(testAlias_){
+      consumes<edmtest::Thing>(edm::InputTag{"aliasForThingToBeDropped2", "instance2"});
+      consumes<edmtest::Thing>(edm::InputTag{"aliasForThingToBeDropped2", "instance2","PROD"});
+    }
+
+    {
+      edm::InputTag tag("thingWithMergeProducer", "endRun", "PROD");
+      consumes<edmtest::Thing,edm::InRun>(tag);
+      consumes<edmtest::ThingWithMerge,edm::InRun>(tag);
+      consumes<edmtest::ThingWithIsEqual,edm::InRun>(tag);
+    }
+    
+    {
+      edm::InputTag tag("thingWithMergeProducer", "endRun");
+      consumes<edmtest::Thing,edm::InRun>(tag);
+      consumes<edmtest::ThingWithMerge,edm::InRun>(tag);
+      consumes<edmtest::ThingWithIsEqual,edm::InRun>(tag);
+    }
+    
+    if(expectedDroppedEvent_.size() > 2) {
+      edm::InputTag tag("makeThingToBeDropped", "endRun", "PROD");
+      consumes<edmtest::ThingWithMerge,edm::InRun>(tag);
+      consumes<edmtest::ThingWithIsEqual,edm::InRun>(tag);
+    }
+    
+    if (testAlias_) {
+      consumes<edmtest::Thing>(edm::InputTag{"aliasForThingToBeDropped2", "endRun2"});
+      edm::InputTag tag("aliasForThingToBeDropped2", "endRun2","PROD");
+      consumes<edmtest::Thing,edm::InRun>(tag);
+    }
+  
+    if(expectedDroppedEvent_.size() > 3) {
+      edm::InputTag tag("makeThingToBeDropped", "beginLumi", "PROD");
+      consumes<edmtest::ThingWithIsEqual,edm::InLumi>(tag);
+    }
+    {
+      edm::InputTag tag("thingWithMergeProducer", "endLumi", "PROD");
+      consumes<edmtest::Thing,edm::InLumi>(tag);
+      consumes<edmtest::ThingWithMerge,edm::InLumi>(tag);
+      consumes<edmtest::ThingWithIsEqual,edm::InLumi>(tag);
+    }
+    
+    {
+      edm::InputTag tag("thingWithMergeProducer", "endLumi");
+      consumes<edmtest::Thing,edm::InLumi>(tag);
+      consumes<edmtest::ThingWithMerge,edm::InLumi>(tag);
+      consumes<edmtest::ThingWithIsEqual,edm::InLumi>(tag);
+    }
+    
+    if(expectedDroppedEvent_.size() > 4) {
+      edm::InputTag tag("makeThingToBeDropped", "endLumi", "PROD");
+      consumes<edmtest::ThingWithIsEqual,edm::InLumi>(tag);
+      consumes<edmtest::ThingWithMerge,edm::InLumi>(tag);
+    }
+    
+    if (testAlias_) {
+      consumes<edmtest::Thing,edm::InLumi>(edm::InputTag{"aliasForThingToBeDropped2", "endLumi2"});
+      edm::InputTag tag("aliasForThingToBeDropped2", "endLumi2","PROD");
+      consumes<edmtest::Thing,edm::InLumi>(tag);
+    }
   }
 
   // -----------------------------------------------------------------

--- a/FWCore/Framework/test/stubs/TestPRegisterModule2.cc
+++ b/FWCore/Framework/test/stubs/TestPRegisterModule2.cc
@@ -21,6 +21,7 @@ using namespace edm;
 
 TestPRegisterModule2::TestPRegisterModule2(edm::ParameterSet const&){
    produces<edmtest::DoubleProduct>();
+   consumes<edmtest::StringProduct>(edm::InputTag{"m2"});
 }
 
   void TestPRegisterModule2::produce(Event& e, EventSetup const&)

--- a/FWCore/Framework/test/stubs/TestTriggerNames.cc
+++ b/FWCore/Framework/test/stubs/TestTriggerNames.cc
@@ -62,6 +62,7 @@ namespace edmtest {
     dumpPSetRegistry_(ps.getUntrackedParameter<bool>("dumpPSetRegistry", false)),
     expectedTriggerResultsHLT_(ps.getUntrackedParameter<std::vector<unsigned int> >("expectedTriggerResultsHLT", std::vector<unsigned int>())),
     expectedTriggerResultsPROD_(ps.getUntrackedParameter<std::vector<unsigned int> >("expectedTriggerResultsPROD", std::vector<unsigned int>())) {
+      consumesMany<edm::TriggerResults>();
   }
 
   // -----------------------------------------------------------------

--- a/FWCore/Framework/test/stubs/ToyAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/ToyAnalyzers.cc
@@ -51,6 +51,7 @@ namespace edmtest {
     IntTestAnalyzer(edm::ParameterSet const& iPSet) :
       value_(iPSet.getUntrackedParameter<int>("valueMustMatch")),
       moduleLabel_(iPSet.getUntrackedParameter<std::string>("moduleLabel"), "") {
+      consumes<IntProduct>(moduleLabel_);
     }
 
     void analyze(edm::Event const& iEvent, edm::EventSetup const&) {

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -154,6 +154,7 @@ namespace edmtest {
   public:
     explicit IntProducerFromTransient(edm::ParameterSet const&) {
       produces<IntProduct>();
+      consumes<TransientIntProduct>(edm::InputTag{"TransientThing"});
     }
     explicit IntProducerFromTransient() {
       produces<IntProduct>();
@@ -210,6 +211,9 @@ namespace edmtest {
     explicit AddIntsProducer(edm::ParameterSet const& p) :
         labels_(p.getParameter<std::vector<std::string> >("labels")) {
       produces<IntProduct>();
+      for( auto const& label: labels_) {
+        consumes<IntProduct>(edm::InputTag{label});
+      }
     }
     virtual ~AddIntsProducer() {}
     virtual void produce(edm::Event& e, edm::EventSetup const& c);

--- a/FWCore/Framework/test/stubs/ToyModules.cc
+++ b/FWCore/Framework/test/stubs/ToyModules.cc
@@ -184,6 +184,7 @@ namespace edmtest {
     explicit AVSimpleProducer(edm::ParameterSet const& p) :
     src_(p.getParameter<edm::InputTag>("src")) {
       produces<AVSimpleProduct>();
+      consumes<std::vector<edmtest::Simple>>(src_);
     }
 
     virtual ~AVSimpleProducer() {}
@@ -367,6 +368,7 @@ namespace edmtest {
     explicit ProdigalProducer(edm::ParameterSet const& p) :
       label_(p.getParameter<std::string>("label")) {
       produces<Prodigal>();
+      consumes<IntProduct>(edm::InputTag{label_});
     }
     virtual ~ProdigalProducer() {}
     virtual void produce(edm::Event& e, edm::EventSetup const& c);

--- a/FWCore/Framework/test/stubs/ToyRefProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyRefProducers.cc
@@ -43,6 +43,7 @@ namespace edmtest {
     explicit IntVecRefVectorProducer(edm::ParameterSet const& p) :
         target_(p.getParameter<std::string>("target")) {
       produces<product_type>();
+      consumes<std::vector<int>>(edm::InputTag{target_});
     }
     virtual ~IntVecRefVectorProducer() {}
     virtual void produce(edm::Event& e, edm::EventSetup const& c);
@@ -80,6 +81,7 @@ namespace edmtest {
     explicit IntVecRefToBaseVectorProducer(edm::ParameterSet const& p) :
         target_(p.getParameter<std::string>("target")) {
       produces<product_type>();
+      consumes<edm::View<int>>(edm::InputTag{target_});
     }
     virtual ~IntVecRefToBaseVectorProducer() {}
     virtual void produce(edm::Event& e, edm::EventSetup const& c);
@@ -112,6 +114,7 @@ namespace edmtest {
     explicit IntVecPtrVectorProducer(edm::ParameterSet const& p) :
         target_(p.getParameter<std::string>("target")) {
       produces<product_type>();
+      consumes<edm::View<int>>(edm::InputTag{target_});
     }
     virtual ~IntVecPtrVectorProducer() {}
     virtual void produce(edm::Event& e, edm::EventSetup const& c);

--- a/FWCore/Integration/test/ProdigalAnalyzer.cc
+++ b/FWCore/Integration/test/ProdigalAnalyzer.cc
@@ -9,6 +9,7 @@
 namespace edmtest {
   ProdigalAnalyzer::ProdigalAnalyzer(edm::ParameterSet const& )
   {
+    consumes<Prodigal>(edm::InputTag{"maker"});
   }
 
   void ProdigalAnalyzer::analyze(edm::Event const& e, edm::EventSetup const&) {

--- a/FWCore/Integration/test/ViewAnalyzer.cc
+++ b/FWCore/Integration/test/ViewAnalyzer.cc
@@ -25,6 +25,35 @@ namespace edmtest
 {
 
   ViewAnalyzer::ViewAnalyzer(ParameterSet const&) {
+    consumes<edm::View<int>>(edm::InputTag{"intvec","","TEST"});
+    consumes<edm::View<int>>(edm::InputTag{"intvec",""});
+    consumes<std::vector<int>>(edm::InputTag{"intvec"});
+    consumes<edm::View<int>>(edm::InputTag{"intvec"});
+    consumes<std::list<int>>(edm::InputTag{"intlist"});
+    consumes<edm::View<int>>(edm::InputTag{"intlist"});
+    consumes<std::deque<int>>(edm::InputTag{"intdeque"});
+    consumes<edm::View<int>>(edm::InputTag{"intdeque"});
+    consumes<std::set<int>>(edm::InputTag{"intset"});
+    consumes<edm::View<int>>(edm::InputTag{"intset"});
+    consumes<SCSimpleProduct>(edm::InputTag{"simple"});
+    consumes<edm::View<SCSimpleProduct::value_type>>(edm::InputTag{"simple"});
+    consumes<OVSimpleProduct>(edm::InputTag{"ovsimple"});
+    consumes<edm::View<OVSimpleProduct::value_type>>(edm::InputTag{"ovsimple"});
+    consumes<edmtest::DSVSimpleProduct>(edm::InputTag{"dsvsimple"});
+    consumes<edm::View<edmtest::DSVSimpleProduct::value_type>>(edm::InputTag{"dsvsimple"});
+
+    consumes<OVSimpleDerivedProduct>(edm::InputTag{"ovsimple","derived"});
+    consumes<edm::View<Simple>>(edm::InputTag{"ovsimple","derived"});
+    
+    consumes<RefVector<std::vector<int>>>(edm::InputTag{"intvecrefvec"});
+    consumes<edm::View<int>>(edm::InputTag{"intvecrefvec"});
+    
+    consumes<RefToBaseVector<int>>(edm::InputTag{"intvecreftbvec"});
+    consumes<edm::View<int>>(edm::InputTag{"intvecreftbvec"});
+
+    consumes<PtrVector<int>>(edm::InputTag{"intvecptrvec"});
+    consumes<edm::View<int>>(edm::InputTag{"intvecptrvec"});
+    mayConsume<edm::View<int>>(edm::InputTag{"intvecptrvecdoesNotExist"});
   }
 
   ViewAnalyzer::~ViewAnalyzer() {

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -59,6 +59,7 @@ namespace edm {
 
     produces<edmtest::ThingCollection>();
     produces<edmtest::OtherThingCollection>("testUserTag");
+    consumes<edmtest::IntProduct>(edm::InputTag{"EventNumber"});
   }
 
   void SecondaryProducer::beginJob() {


### PR DESCRIPTION
Fixed a bug in the consumes handling where Run and Lumi consumes registrations were lost.
Added the proper consumes calls to all modules used by the Framework for tests.
