### PR TITLE
Remove obsolete link dependency on Reflex

### DIFF
--- a/FWCore/PluginManager/BuildFile.xml
+++ b/FWCore/PluginManager/BuildFile.xml
@@ -1,6 +1,5 @@
 <use   name="boost"/>
 <use   name="boost_filesystem"/>
-<use   name="rootrflx"/>
 <use   name="FWCore/Utilities"/>
 <export>
   <lib   name="1"/>


### PR DESCRIPTION
The dependency of FWCore/PluginManager on Reflex was removed recently, but I forgot to remove the declaration of the link dependency on Reflex in the package build file. This request removes the obsolete link dependency from the build file.
