### PR TITLE
Fix for api changes in llvm 3.3

### DIFF
--- a/Utilities/StaticAnalyzers/src/CmsException.h
+++ b/Utilities/StaticAnalyzers/src/CmsException.h
@@ -8,7 +8,7 @@
 #define LLVM_CLANG_STATICANALYZER_CMS_CMSEXCEPTION_H
 
 #include <llvm/Support/Regex.h>
-
+#include <llvm/Support/raw_ostream.h>
 #include "clang/AST/Type.h"
 #include "clang/Basic/SourceManager.h"
 #include "clang/StaticAnalyzer/Core/BugReporter/BugReporter.h"

--- a/Utilities/StaticAnalyzers/src/UsingNamespace.h
+++ b/Utilities/StaticAnalyzers/src/UsingNamespace.h
@@ -9,6 +9,7 @@
 #include <clang/StaticAnalyzer/Core/Checker.h>
 #include <clang/StaticAnalyzer/Core/PathSensitive/CheckerContext.h>
 #include <clang/AST/DeclCXX.h>
+#include <llvm/Support/raw_ostream.h>
 
 namespace clangcms {
   class UsingNamespace : public clang::ento::Checker< clang::ento::check::ASTDecl <clang::UsingDirectiveDecl>,clang::ento::check::ASTDecl <clang::UsingDecl> >

--- a/Utilities/StaticAnalyzers/src/getByChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/getByChecker.cpp
@@ -52,9 +52,9 @@ void Walker::VisitCXXMemberCallExpr( CXXMemberCallExpr *CE ) {
 //				llvm::errs()<<"class "<<RD->getQualifiedNameAsString()<<"\n";
 //				llvm::errs()<<"\n";
 //				}
-			std::string tname;
-			llvm::dyn_cast<CXXMethodDecl>(D)->getNameForDiagnostic(tname,Policy,1);
-			os<<"function '"<<tname<<"' ";
+			os<<"function '";
+			llvm::dyn_cast<CXXMethodDecl>(D)->getNameForDiagnostic(os,Policy,1);
+			os<<"' ";
 //			os<<"call expression '";
 //			CE->printPretty(os,0,Policy);
 //			os<<"' ";
@@ -118,9 +118,10 @@ void Walker::VisitCXXMemberCallExpr( CXXMemberCallExpr *CE ) {
 			if ( qtname=="edm::Event" || qtname=="const edm::Event" ||
 				qtname=="edm::Event *" || qtname=="const edm::Event *" )  {
 				std::string tname;
-				MD->getNameForDiagnostic(tname,Policy,1);
 				os<<"function '"<<dname<<"' ";
-				os<<"calls '"<<tname<<"' with argument of type '"<<qtname<<"'\n";
+				os<<"calls '";
+				MD->getNameForDiagnostic(os,Policy,1);
+				os<<"' with argument of type '"<<qtname<<"'\n";
 //				llvm::errs()<<"\n";
 //				llvm::errs()<<"call expression passed edm::Event ";
 //				CE->printPretty(llvm::errs(),0,Policy);


### PR DESCRIPTION
Explicitly include raw_ostream.h for llvm 3.3
change in FunctionDecl::getNameForDiagnostic interface for clang 3.3
