### PR TITLE
Update from CVS HEAD and bugfix for calorimeter RecHit visualization

### DIFF
--- a/Fireworks/Calo/interface/FWCaloDataProxyBuilderBase.h
+++ b/Fireworks/Calo/interface/FWCaloDataProxyBuilderBase.h
@@ -16,7 +16,7 @@
 //
 // Original Author:  
 //         Created:  Mon May 31 15:09:19 CEST 2010
-// $Id: FWCaloDataProxyBuilderBase.h,v 1.4 2010/10/22 15:34:16 amraktad Exp $
+// $Id: FWCaloDataProxyBuilderBase.h,v 1.3 2010/06/14 16:58:15 amraktad Exp $
 //
 
 // system include files

--- a/Fireworks/Calo/interface/FWECALDetailViewBuilder.h
+++ b/Fireworks/Calo/interface/FWECALDetailViewBuilder.h
@@ -45,6 +45,8 @@ public:
    // draw the ecal information with the preset colors
    // (if any colors have been preset)
    TEveCaloLego* build();
+   
+   TEveCaloData* buildCaloData(bool xyEE);
 
    // set colors of some predefined detids
    void setColor(Color_t color, const std::vector<DetId> &detIds);
@@ -65,7 +67,7 @@ private:
 
    // fill data
    void fillData(const EcalRecHitCollection *hits,
-                 TEveCaloDataVec *data);
+                 TEveCaloDataVec *data, bool xyEE);
    const edm::EventBase *m_event;                               // the event
    const FWGeometry     *m_geom;                                // the geometry
    float m_eta;                                                 // eta position view centred on

--- a/Fireworks/Calo/interface/FWTauProxyBuilderBase.h
+++ b/Fireworks/Calo/interface/FWTauProxyBuilderBase.h
@@ -17,7 +17,7 @@
 //
 // Original Author:  Alja Mrak-Tadel 
 //         Created:  Thu Oct 21 20:40:32 CEST 2010
-// $Id: FWTauProxyBuilderBase.h,v 1.2 2012/03/23 00:08:28 amraktad Exp $
+// $Id: FWTauProxyBuilderBase.h,v 1.1 2010/10/22 14:34:44 amraktad Exp $
 //
 
 #include "Fireworks/Core/interface/FWProxyBuilderBase.h"

--- a/Fireworks/Calo/interface/makeEveJetCone.h
+++ b/Fireworks/Calo/interface/makeEveJetCone.h
@@ -16,7 +16,7 @@
 //
 // Original Author:  Alja Mrak-Tadel
 //         Created:  Thu Oct 22 22:59:29 EST 20q0
-// $Id: makeEveJetCone.h,v 1.1 2010/10/22 14:34:44 amraktad Exp $
+// $Id: makeEveJetCone.h,v 1.2 2009/01/23 21:35:39 amraktad Exp $
 //
 
 // system include files

--- a/Fireworks/Calo/interface/scaleMarker.h
+++ b/Fireworks/Calo/interface/scaleMarker.h
@@ -16,7 +16,7 @@
 //
 // Original Author:  Alja Mrak-Tadel
 //         Created:  Fri Oct 22 15:53:19 CEST 2010
-// $Id: scaleMarker.h,v 1.1 2010/10/22 14:34:44 amraktad Exp $
+// $Id$
 //
 
 class TEveScalableStraightLineSet;

--- a/Fireworks/Calo/interface/thetaBins.h
+++ b/Fireworks/Calo/interface/thetaBins.h
@@ -16,7 +16,7 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Thu Dec 11 22:59:29 EST 2008
-// $Id: thetaBins.h,v 1.2 2009/01/23 21:35:39 amraktad Exp $
+// $Id: thetaBins.h,v 1.1 2008/12/12 04:16:10 chrjones Exp $
 //
 
 // system include files

--- a/Fireworks/Calo/plugins/FWCaloRecHitDigitSetProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWCaloRecHitDigitSetProxyBuilder.cc
@@ -1,0 +1,174 @@
+#include "Fireworks/Calo/plugins/FWCaloRecHitDigitSetProxyBuilder.h"
+#include "TEveBoxSet.h"
+#include "FWCaloRecHitDigitSetProxyBuilder.h"
+#include "Fireworks/Core/interface/FWDigitSetProxyBuilder.h"
+#include "Fireworks/Core/interface/FWEventItem.h"
+#include "Fireworks/Core/interface/FWGeometry.h"
+#include "Fireworks/Core/interface/BuilderUtils.h"
+#include "Fireworks/Core/interface/FWViewEnergyScale.h"
+#include "DataFormats/CaloRecHit/interface/CaloRecHit.h"
+
+#include "Fireworks/Core/interface/FWProxyBuilderConfiguration.h"
+
+FWCaloRecHitDigitSetProxyBuilder::FWCaloRecHitDigitSetProxyBuilder()
+   : m_invertBox(false), m_ignoreGeoShapeSize(false) 
+{} 
+
+//______________________________________________________________________________
+
+void FWCaloRecHitDigitSetProxyBuilder::setItem(const FWEventItem* iItem)
+{
+   FWProxyBuilderBase::setItem(iItem);
+   // if (iItem) iItem->getConfig()->assertParam( "IgnoreShapeSize", false);
+}
+//______________________________________________________________________________
+
+void FWCaloRecHitDigitSetProxyBuilder::viewContextBoxScale( const float* corners, float scale, bool plotEt, std::vector<float>& scaledCorners, const CaloRecHit*)
+{
+   if ( m_ignoreGeoShapeSize)
+   {
+      // Same functionality as fireworks::energyTower3DCorners()
+
+      for( int i = 0; i < 24; ++i )
+         scaledCorners[i] = corners[i];
+
+      // Coordinates of a front face scaled 
+      if( m_invertBox )
+      {
+         // We know, that an ES rechit geometry in -Z needs correction. 
+         // The back face is actually its front face.
+         for( unsigned int i = 0; i < 12; i += 3 )
+         {
+            m_vector.Set( corners[i] - corners[i + 12], corners[i + 1] - corners[i + 13], corners[i + 2] - corners[i + 14] );
+            m_vector.Normalize();
+            m_vector *= scale;
+	    
+            scaledCorners[i] = corners[i] + m_vector.fX;
+            scaledCorners[i + 1] = corners[i + 1] + m_vector.fY;
+            scaledCorners[i + 2] = corners[i + 2] + m_vector.fZ;
+         }
+      } 
+      else
+      {
+         for( unsigned int i = 0; i < 12; i += 3 )
+         {
+            m_vector.Set( corners[i + 12] - corners[i], corners[i + 13] - corners[i + 1], corners[i + 14] - corners[i + 2] );
+            m_vector.Normalize();
+            m_vector *= scale;
+	    
+            scaledCorners[i] = corners[i + 12];
+            scaledCorners[i + 1] = corners[i + 13];
+            scaledCorners[i + 2] = corners[i + 14];
+	    
+            scaledCorners[i + 12] = corners[i + 12] + m_vector.fX;
+            scaledCorners[i + 13] = corners[i + 13] + m_vector.fY;
+            scaledCorners[i + 14] = corners[i + 14] + m_vector.fZ;
+         }
+      }
+   }
+   else {
+
+      // Same functionality as fireworks::energyScaledBox3DCorners().
+
+      m_vector.Set(0.f, 0.f, 0.f);
+      for( unsigned int i = 0; i < 24; i += 3 )
+      {	 
+         m_vector[0] += corners[i];
+         m_vector[1] += corners[i + 1];
+         m_vector[2] += corners[i + 2];
+      }
+      m_vector *= 1.f/8.f;
+
+      if (plotEt)
+      {
+         scale *= m_vector.Perp()/m_vector.Mag();
+      }
+
+      // Coordinates for a scaled version of the original box
+      for( unsigned int i = 0; i < 24; i += 3 )
+      {	
+         scaledCorners[i] = m_vector[0] + ( corners[i] - m_vector[0] ) * scale;
+         scaledCorners[i + 1] = m_vector[1] + ( corners[i + 1] - m_vector[1] ) * scale;
+         scaledCorners[i + 2] = m_vector[2] + ( corners[i + 2] - m_vector[2] ) * scale;
+      }
+      
+      if( m_invertBox )
+         fireworks::invertBox( scaledCorners );
+   }
+}
+//_____________________________________________________________________________
+
+float  FWCaloRecHitDigitSetProxyBuilder::scaleFactor(const FWViewContext* vc)
+{
+   // printf("scale face %f \n", vc->getEnergyScale()->getScaleFactor3D());
+     return vc->getEnergyScale()->getScaleFactor3D()/50;
+}
+
+//______________________________________________________________________________
+
+void
+FWCaloRecHitDigitSetProxyBuilder::scaleProduct(TEveElementList* parent, FWViewType::EType type, const FWViewContext* vc)
+{
+   size_t size = item()->size();
+   if (!size) return;
+
+
+   std::vector<float> scaledCorners(24);
+   float scale = scaleFactor(vc);
+
+   assert(parent->NumChildren() == 1);
+   TEveBoxSet* boxSet = static_cast<TEveBoxSet*>(*parent->BeginChildren());
+
+   for (int index = 0; index < static_cast<int>(size); ++index)
+   {
+      const CaloRecHit* hit = (const CaloRecHit*)item()->modelData(index);
+      const float* corners = item()->getGeom()->getCorners(hit->detid());
+      if (corners == 0)  continue;
+
+      FWDigitSetProxyBuilder::BFreeBox_t* b = (FWDigitSetProxyBuilder::BFreeBox_t*)boxSet->GetPlex()->Atom(index);
+
+      viewContextBoxScale(corners, hit->energy()*scale, vc->getEnergyScale()->getPlotEt(), scaledCorners, hit);
+      memcpy(b->fVertices, &scaledCorners[0], sizeof(b->fVertices));
+   }
+   boxSet->ElementChanged();
+}
+//______________________________________________________________________________
+
+void
+FWCaloRecHitDigitSetProxyBuilder::build( const FWEventItem* iItem, TEveElementList* product, const FWViewContext* vc)
+{
+   size_t size = iItem->size();
+   if (!size) return;
+
+   // m_ignoreGeoShapeSize = item()->getConfig()->value<bool>("IgnoreShapeSize");
+
+   std::vector<float> scaledCorners(24);
+
+   float scale = scaleFactor(vc);
+
+   TEveBoxSet* boxSet = addBoxSetToProduct(product);
+   boxSet->SetAntiFlick(kTRUE);
+   for (int index = 0; index < static_cast<int>(size); ++index)
+   {  
+      const CaloRecHit* hit = (const CaloRecHit*)item()->modelData(index);
+
+      const float* corners = context().getGeom()->getCorners(hit->detid());
+      if (corners)
+      {
+         m_vector.Set(0.f, 0.f, 0.f);
+         for( unsigned int i = 0; i < 24; i += 3 )
+         {	 
+            m_vector[0] += corners[i];
+            m_vector[1] += corners[i + 1];
+            m_vector[2] += corners[i + 2];
+         }
+         m_vector.Normalize();
+         context().voteMaxEtAndEnergy( m_vector.Perp() *hit->energy(), hit->energy());
+         viewContextBoxScale( corners, hit->energy()*scale, vc->getEnergyScale()->getPlotEt(), scaledCorners, hit);
+      }
+
+      addBox(boxSet, &scaledCorners[0], iItem->modelInfo(index).displayProperties());
+   }
+}
+
+

--- a/Fireworks/Calo/plugins/FWCaloRecHitDigitSetProxyBuilder.h
+++ b/Fireworks/Calo/plugins/FWCaloRecHitDigitSetProxyBuilder.h
@@ -1,0 +1,34 @@
+#ifndef Fireworks_Calo_FWCaloRecHitDigitSetProxyBuilder_h
+#define Fireworks_Calo_FWCaloRecHitDigitSetProxyBuilder_h
+
+#include "TEveVector.h"
+#include "Fireworks/Core/interface/FWDigitSetProxyBuilder.h"
+
+class CaloRecHit;
+
+class FWCaloRecHitDigitSetProxyBuilder : public FWDigitSetProxyBuilder
+{
+public:
+   FWCaloRecHitDigitSetProxyBuilder();
+   virtual ~FWCaloRecHitDigitSetProxyBuilder( void ) {}
+
+   virtual void    setItem(const FWEventItem* iItem);
+
+   virtual bool havePerViewProduct(FWViewType::EType) const { return true; }
+   virtual void scaleProduct(TEveElementList* parent, FWViewType::EType, const FWViewContext* vc);
+   virtual void build( const FWEventItem* iItem, TEveElementList* product, const FWViewContext* );
+   
+   virtual float scaleFactor(const FWViewContext* vc);
+   virtual void  invertBox(bool x ) { m_invertBox = x ;}
+   virtual void  viewContextBoxScale( const float* corners, float scale, bool plotEt, std::vector<float>& scaledCorners, const CaloRecHit*);
+
+private:
+
+   FWCaloRecHitDigitSetProxyBuilder( const FWCaloRecHitDigitSetProxyBuilder& );
+   const FWCaloRecHitDigitSetProxyBuilder& operator=( const FWCaloRecHitDigitSetProxyBuilder& );
+
+   bool m_invertBox;
+   bool m_ignoreGeoShapeSize;
+   TEveVector m_vector; // internal memeber, to avoid constant recreation
+};
+#endif

--- a/Fireworks/Calo/plugins/FWCaloTauProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWCaloTauProxyBuilder.cc
@@ -8,7 +8,7 @@
 //
 // Original Author:
 //         Created:  Sun Jan  6 23:57:00 EST 2008
-// $Id: FWCaloTauProxyBuilder.cc,v 1.17 2012/03/23 00:08:29 amraktad Exp $
+// $Id: FWCaloTauProxyBuilder.cc,v 1.16 2010/10/22 14:34:44 amraktad Exp $
 //
 
 // system include files

--- a/Fireworks/Calo/plugins/FWCaloTowerDetailView.h
+++ b/Fireworks/Calo/plugins/FWCaloTowerDetailView.h
@@ -5,7 +5,7 @@
 //
 // Package:     Electrons
 // Class  :     FWHCalTowerDetailView
-// $Id: FWCaloTowerDetailView.h,v 1.2 2010/05/25 14:42:03 dmytro Exp $
+// $Id: FWCaloTowerDetailView.h,v 1.1 2010/03/09 21:49:34 amraktad Exp $
 //
 
 // user include files

--- a/Fireworks/Calo/plugins/FWCaloTowerProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWCaloTowerProxyBuilder.cc
@@ -8,7 +8,7 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Wed Dec  3 11:28:28 EST 2008
-// $Id: FWCaloTowerProxyBuilder.cc,v 1.25 2011/02/23 11:34:52 amraktad Exp $
+// $Id: FWCaloTowerProxyBuilder.cc,v 1.24 2010/12/16 11:39:38 amraktad Exp $
 //
 
 // system includes

--- a/Fireworks/Calo/plugins/FWCaloTowerProxyBuilder.h
+++ b/Fireworks/Calo/plugins/FWCaloTowerProxyBuilder.h
@@ -16,7 +16,7 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Wed Dec  3 11:28:08 EST 2008
-// $Id: FWCaloTowerProxyBuilder.h,v 1.16 2010/12/16 11:39:38 amraktad Exp $
+// $Id: FWCaloTowerProxyBuilder.h,v 1.15 2010/06/14 16:58:15 amraktad Exp $
 //
 
 #include "Rtypes.h"

--- a/Fireworks/Calo/plugins/FWCaloTowerSliceSelector.cc
+++ b/Fireworks/Calo/plugins/FWCaloTowerSliceSelector.cc
@@ -8,7 +8,7 @@
 //
 // Original Author:  Alja Mrak-Tadel
 //         Created:  Wed Jun  2 17:36:23 CEST 2010
-// $Id: FWCaloTowerSliceSelector.cc,v 1.3 2010/12/01 21:40:31 amraktad Exp $
+// $Id: FWCaloTowerSliceSelector.cc,v 1.2 2010/06/07 17:54:00 amraktad Exp $
 //
 
 // system include files

--- a/Fireworks/Calo/plugins/FWCaloTowerSliceSelector.h
+++ b/Fireworks/Calo/plugins/FWCaloTowerSliceSelector.h
@@ -16,7 +16,7 @@
 //
 // Original Author:  Alja Mrak-Tadel
 //         Created:  Wed Jun  2 19:21:19 CEST 2010
-// $Id: FWCaloTowerSliceSelector.h,v 1.3 2010/12/01 21:40:31 amraktad Exp $
+// $Id: FWCaloTowerSliceSelector.h,v 1.2 2010/06/07 17:54:00 amraktad Exp $
 //
 
 // system include files

--- a/Fireworks/Calo/plugins/FWCastorRecHitProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWCastorRecHitProxyBuilder.cc
@@ -5,29 +5,30 @@
  *  Created by Ianna Osborne on 7/8/10.
  *
  */
-
-#include "Fireworks/Core/interface/FWDigitSetProxyBuilder.h"
-#include "Fireworks/Core/interface/FWEventItem.h"
-#include "Fireworks/Core/interface/FWGeometry.h"
-#include "Fireworks/Core/interface/BuilderUtils.h"
-#include "DataFormats/HcalRecHit/interface/CastorRecHit.h"
+#include "Fireworks/Calo/plugins/FWCaloRecHitDigitSetProxyBuilder.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 
-class FWCastorRecHitProxyBuilder : public FWDigitSetProxyBuilder
+class FWCastorRecHitProxyBuilder : public FWCaloRecHitDigitSetProxyBuilder
 {
 public:
    FWCastorRecHitProxyBuilder( void ) {}  
    virtual ~FWCastorRecHitProxyBuilder( void ) {}
+
+
+   virtual float scaleFactor(const FWViewContext* vc) { return 10 * FWCaloRecHitDigitSetProxyBuilder::scaleFactor(vc); } 
 
    REGISTER_PROXYBUILDER_METHODS();
 
 private:
    FWCastorRecHitProxyBuilder( const FWCastorRecHitProxyBuilder& );
    const FWCastorRecHitProxyBuilder& operator=( const FWCastorRecHitProxyBuilder& );
-
-   virtual void build( const FWEventItem* iItem, TEveElementList* product, const FWViewContext* );	
 };
 
+REGISTER_FWPROXYBUILDER( FWCastorRecHitProxyBuilder, CastorRecHitCollection, "Castor RecHit", FWViewType::kISpyBit );
+
+// AMT:: scale box round center. Scaleing and e/et added now. Previously used fireworks::energyTower3DCorners();
+
+/*
 void FWCastorRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*)
 {
    const CastorRecHitCollection* collection = 0;
@@ -50,5 +51,4 @@ void FWCastorRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList
       addBox(boxSet, &scaledCorners[0], iItem->modelInfo(index++).displayProperties());
    }
 }
-
-REGISTER_FWPROXYBUILDER( FWCastorRecHitProxyBuilder, CastorRecHitCollection, "Castor RecHit", FWViewType::kISpyBit );
+*/

--- a/Fireworks/Calo/plugins/FWEcalRecHitProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWEcalRecHitProxyBuilder.cc
@@ -5,94 +5,40 @@
  *  Created by Ianna Osborne on 5/28/10.
  *
  */
-#include "TEveBoxSet.h"
-#include "TEveChunkManager.h"
-#include "Fireworks/Core/interface/FWDigitSetProxyBuilder.h"
-#include "Fireworks/Core/interface/FWEventItem.h"
-#include "Fireworks/Core/interface/FWGeometry.h"
-#include "Fireworks/Core/interface/FWViewEnergyScale.h"
-#include "Fireworks/Core/interface/BuilderUtils.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
+#include "Fireworks/Calo/plugins/FWCaloRecHitDigitSetProxyBuilder.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
-class FWEcalRecHitProxyBuilder : public FWDigitSetProxyBuilder
+class FWEcalRecHitProxyBuilder : public FWCaloRecHitDigitSetProxyBuilder
 {
 public:
-   FWEcalRecHitProxyBuilder():FWDigitSetProxyBuilder(), m_plotEt(true) {}
+   FWEcalRecHitProxyBuilder() {}
    virtual ~FWEcalRecHitProxyBuilder() {}
  
-   virtual bool havePerViewProduct(FWViewType::EType) const { return true; }
-   virtual void scaleProduct(TEveElementList* parent, FWViewType::EType, const FWViewContext* vc);
+   virtual void viewContextBoxScale( const float* corners, float scale, bool plotEt, std::vector<float>& scaledCorners, const CaloRecHit*);
 	
    REGISTER_PROXYBUILDER_METHODS();
 	
 private:
    FWEcalRecHitProxyBuilder( const FWEcalRecHitProxyBuilder& );
    const FWEcalRecHitProxyBuilder& operator=( const FWEcalRecHitProxyBuilder& );
-
-   virtual void build( const FWEventItem* iItem, TEveElementList* product, const FWViewContext* );	
-
-   bool m_plotEt;
 };
 
-//______________________________________________________________________________
 
-
-void
-FWEcalRecHitProxyBuilder::scaleProduct(TEveElementList* parent, FWViewType::EType type, const FWViewContext* vc)
-{
- 
-   if (m_plotEt != vc->getEnergyScale()->getPlotEt() )
-   {
-      m_plotEt = !m_plotEt;
-
-      const EcalRecHitCollection* collection = 0;
-      item()->get( collection );
-      if (! collection)
-         return;
-
-      int index = 0;
-      std::vector<float> scaledCorners(24);
-      for (std::vector<EcalRecHit>::const_iterator it = collection->begin() ; it != collection->end(); ++it, ++index)
-      {
-         const float* corners = item()->getGeom()->getCorners((*it).detid());
-         if (corners == 0) 
-            continue;
-
-         Float_t scale = 10.0;
-         bool reflect = false;
-         if (EcalSubdetector( (*it).detid().subdetId() ) == EcalPreshower)
-         {
-            scale = 1000.0; 	// FIXME: The scale should be taken form somewhere else
-            reflect = corners[2] < 0;
-         }
-
-         FWDigitSetProxyBuilder::BFreeBox_t* b = (FWDigitSetProxyBuilder::BFreeBox_t*)getBoxSet()->GetPlex()->Atom(index);
-         /*
-           printf("--------------------scale product \n");
-           for (int i = 0; i < 8 ; ++i)
-           printf("[%f %f %f ]\n",b->fVertices[i][0], b->fVertices[i][1],b->fVertices[i][2] );
-         */
-
-         if (m_plotEt)
-            fireworks::etTower3DCorners(corners, (*it).energy() * scale,  scaledCorners, reflect);
-         else
-            fireworks::energyTower3DCorners(corners, (*it).energy() * scale,  scaledCorners, reflect);
-
-         memcpy(b->fVertices, &scaledCorners[0], sizeof(b->fVertices));
-
-         /*
-           printf("after \n");
-           for (int i = 0; i < 8 ; ++i)
-           printf("[%f %f %f ]\n",b->fVertices[i][0], b->fVertices[i][1],b->fVertices[i][2] );
-         */
-      }
-      getBoxSet()->ElementChanged();
-   }
+void FWEcalRecHitProxyBuilder::viewContextBoxScale( const float* corners, float scale, bool plotEt, std::vector<float>& scaledCorners, const CaloRecHit* hit)
+{ 
+   invertBox((EcalSubdetector( hit->detid().subdetId() ) == EcalPreshower) && (corners[2] < 0));
+   FWCaloRecHitDigitSetProxyBuilder::viewContextBoxScale(corners, scale, plotEt, scaledCorners, hit );
 }
 
-//______________________________________________________________________________
 
+REGISTER_FWPROXYBUILDER( FWEcalRecHitProxyBuilder, EcalRecHitCollection, "Ecal RecHit", FWViewType::kISpyBit );
+
+// AMT: Scale box round cener. Prviousy used fireworks::energyTower3DCorners().
+// Why differnt scale factor in  EcalPreShower ???
+
+
+/*
 void FWEcalRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext* vc)
 {
    m_plotEt = vc->getEnergyScale()->getPlotEt();
@@ -127,5 +73,4 @@ void FWEcalRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* 
       addBox(boxSet, &scaledCorners[0], iItem->modelInfo(index++).displayProperties());
    }
 }
-
-REGISTER_FWPROXYBUILDER( FWEcalRecHitProxyBuilder, EcalRecHitCollection, "Ecal RecHit", FWViewType::kISpyBit );
+*/

--- a/Fireworks/Calo/plugins/FWHBHERecHitProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWHBHERecHitProxyBuilder.cc
@@ -1,85 +1,25 @@
-#include "TEveCompound.h"
-#include "TEveBoxSet.h"
-
-#include "Fireworks/Core/interface/FWDigitSetProxyBuilder.h"
-#include "Fireworks/Core/interface/FWEventItem.h"
-#include "Fireworks/Core/interface/FWGeometry.h"
-#include "Fireworks/Core/interface/BuilderUtils.h"
-#include "Fireworks/Core/interface/FWViewEnergyScale.h"
-#include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
+#include "Fireworks/Calo/plugins/FWCaloRecHitDigitSetProxyBuilder.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 
-class FWHBHERecHitProxyBuilder : public FWDigitSetProxyBuilder
+class FWHBHERecHitProxyBuilder : public FWCaloRecHitDigitSetProxyBuilder
 {
 public:
-   FWHBHERecHitProxyBuilder( void )
-      : m_maxEnergy( 0.85 ), m_plotEt(true)
-    {}
-  
-   virtual ~FWHBHERecHitProxyBuilder( void ) 
-    {}
-
-   virtual bool havePerViewProduct(FWViewType::EType) const { return true; }
-   virtual void scaleProduct(TEveElementList* parent, FWViewType::EType, const FWViewContext* vc);
+   FWHBHERecHitProxyBuilder( void ) { invertBox(true); }
+   virtual ~FWHBHERecHitProxyBuilder( void ) {}
 
    REGISTER_PROXYBUILDER_METHODS();
 
 private:
-   virtual void build( const FWEventItem* iItem, TEveElementList* product, const FWViewContext* );
-
-   Float_t m_maxEnergy;
-   bool m_plotEt;
-
    FWHBHERecHitProxyBuilder( const FWHBHERecHitProxyBuilder& );
    const FWHBHERecHitProxyBuilder& operator=( const FWHBHERecHitProxyBuilder& );
 };
 
-void
-FWHBHERecHitProxyBuilder::scaleProduct(TEveElementList* parent, FWViewType::EType type, const FWViewContext* vc)
-{
-   if (m_plotEt != vc->getEnergyScale()->getPlotEt() )
-   {
-      m_plotEt = !m_plotEt;
+REGISTER_FWPROXYBUILDER( FWHBHERecHitProxyBuilder, HBHERecHitCollection, "HBHE RecHit", FWViewType::kISpyBit );
 
-      const HBHERecHitCollection* collection = 0;
-      item()->get( collection );
-      if (! collection)
-         return;
 
-      int index = 0;
-      std::vector<float> scaledCorners(24);
-      for (std::vector<HBHERecHit>::const_iterator it = collection->begin() ; it != collection->end(); ++it, ++index)
-      {
-         const float* corners = item()->getGeom()->getCorners((*it).detid());
-         if (corners == 0) 
-            continue;
-         FWDigitSetProxyBuilder::BFreeBox_t* b = (FWDigitSetProxyBuilder::BFreeBox_t*)getBoxSet()->GetPlex()->Atom(index);
+// AMT: Refelct box. Previously used energyScaledBox3DCorners()
 
-         /*          
-         printf("--------------------scale product \n");
-         for (int i = 0; i < 8 ; ++i)
-            printf("[%f %f %f ]\n",b->fVertices[i][0], b->fVertices[i][1],b->fVertices[i][2] );
-         */
-
-         if (m_plotEt)
-            fireworks::etScaledBox3DCorners(corners, (*it).energy(),  m_maxEnergy, scaledCorners, true);
-         else
-            fireworks::energyScaledBox3DCorners(corners, (*it).energy() / m_maxEnergy, scaledCorners, true);
-         
-         /*
-         printf("after \n");
-         for (int i = 0; i < 8 ; ++i)
-            printf("[%f %f %f ]\n",b->fVertices[i][0], b->fVertices[i][1],b->fVertices[i][2] );        
-         */
-         memcpy(b->fVertices, &scaledCorners[0], sizeof(b->fVertices));
-
-      }
-      getBoxSet()->ElementChanged();
-   }
-}
-
-//______________________________________________________________________________
-
+/*
 void
 FWHBHERecHitProxyBuilder::build( const FWEventItem* iItem, TEveElementList* product, const FWViewContext* vc)
 {
@@ -117,5 +57,4 @@ FWHBHERecHitProxyBuilder::build( const FWEventItem* iItem, TEveElementList* prod
       addBox(boxSet, &scaledCorners[0], iItem->modelInfo(index++).displayProperties());
    }
 }
-
-REGISTER_FWPROXYBUILDER( FWHBHERecHitProxyBuilder, HBHERecHitCollection, "HBHE RecHit", FWViewType::kISpyBit );
+*/

--- a/Fireworks/Calo/plugins/FWHFRecHitProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWHFRecHitProxyBuilder.cc
@@ -1,33 +1,25 @@
-#include "Fireworks/Core/interface/FWDigitSetProxyBuilder.h"
-#include "Fireworks/Core/interface/FWEventItem.h"
-#include "Fireworks/Core/interface/FWGeometry.h"
-#include "Fireworks/Core/interface/BuilderUtils.h"
-#include "Fireworks/Core/interface/fwLog.h"
-#include "DataFormats/HcalRecHit/interface/HFRecHit.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
-#include "TEveCompound.h"
+#include "Fireworks/Calo/plugins/FWCaloRecHitDigitSetProxyBuilder.h"
 
-class FWHFRecHitProxyBuilder : public FWDigitSetProxyBuilder
+class FWHFRecHitProxyBuilder : public FWCaloRecHitDigitSetProxyBuilder
 {
 public:
-   FWHFRecHitProxyBuilder( void ) 
-     : m_maxEnergy( 5.0 )
-    {}
-  
-   virtual ~FWHFRecHitProxyBuilder( void ) 
-    {}
+   FWHFRecHitProxyBuilder( void ) {invertBox(true); }
+   virtual ~FWHFRecHitProxyBuilder( void ) {}
 
    REGISTER_PROXYBUILDER_METHODS();
 
 private:
-   virtual void build( const FWEventItem* iItem, TEveElementList* product, const FWViewContext* );
-
-   Float_t m_maxEnergy;
-
    FWHFRecHitProxyBuilder( const FWHFRecHitProxyBuilder& );
    const FWHFRecHitProxyBuilder& operator=( const FWHFRecHitProxyBuilder& );
 };
 
+
+REGISTER_FWPROXYBUILDER( FWHFRecHitProxyBuilder, HFRecHitCollection, "HF RecHit", FWViewType::kISpyBit );
+
+// AMT: Reflect box. Previously used energyScaledBox3DCorners(). Scaling and e/et mode added now.
+
+/*
 void
 FWHFRecHitProxyBuilder::build( const FWEventItem* iItem, TEveElementList* product, const FWViewContext* )
 {
@@ -66,5 +58,4 @@ FWHFRecHitProxyBuilder::build( const FWEventItem* iItem, TEveElementList* produc
       addBox(boxSet, &scaledCorners[0], iItem->modelInfo(index++).displayProperties());
    }
 }
-
-REGISTER_FWPROXYBUILDER( FWHFRecHitProxyBuilder, HFRecHitCollection, "HF RecHit", FWViewType::kISpyBit );
+*/

--- a/Fireworks/Calo/plugins/FWHFTowerProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWHFTowerProxyBuilder.cc
@@ -8,7 +8,7 @@
 //
 // Original Author:  
 //         Created:  Mon May 31 16:41:27 CEST 2010
-// $Id: FWHFTowerProxyBuilder.cc,v 1.22 2011/09/06 15:07:30 yana Exp $
+// $Id: FWHFTowerProxyBuilder.cc,v 1.21 2011/02/23 11:34:52 amraktad Exp $
 //
 
 // system include files

--- a/Fireworks/Calo/plugins/FWHFTowerProxyBuilder.h
+++ b/Fireworks/Calo/plugins/FWHFTowerProxyBuilder.h
@@ -16,7 +16,7 @@
 //
 // Original Author:  
 //         Created:  Mon May 31 16:41:23 CEST 2010
-// $Id: FWHFTowerProxyBuilder.h,v 1.8 2010/09/20 15:58:18 yana Exp $
+// $Id: FWHFTowerProxyBuilder.h,v 1.7 2010/06/14 16:58:15 amraktad Exp $
 //
 
 // system include files

--- a/Fireworks/Calo/plugins/FWHFTowerSliceSelector.cc
+++ b/Fireworks/Calo/plugins/FWHFTowerSliceSelector.cc
@@ -8,7 +8,7 @@
 //
 // Original Author:  Alja Mrak-Tadel
 //         Created:  Wed Jun  2 17:39:44 CEST 2010
-// $Id: FWHFTowerSliceSelector.cc,v 1.9 2010/09/07 15:46:45 yana Exp $
+// $Id: FWHFTowerSliceSelector.cc,v 1.8 2010/08/23 15:26:23 yana Exp $
 //
 
 // system include files

--- a/Fireworks/Calo/plugins/FWHFTowerSliceSelector.h
+++ b/Fireworks/Calo/plugins/FWHFTowerSliceSelector.h
@@ -16,7 +16,7 @@
 //
 // Original Author:  Alja Mrak-Tadel
 //         Created:  Wed Jun  2 19:21:13 CEST 2010
-// $Id: FWHFTowerSliceSelector.h,v 1.3 2010/06/07 17:54:00 amraktad Exp $
+// $Id: FWHFTowerSliceSelector.h,v 1.2 2010/06/03 14:48:22 amraktad Exp $
 //
 
 // system include files

--- a/Fireworks/Calo/plugins/FWHORecHitProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWHORecHitProxyBuilder.cc
@@ -1,32 +1,25 @@
-#include "Fireworks/Core/interface/FWDigitSetProxyBuilder.h"
-#include "Fireworks/Core/interface/FWEventItem.h"
-#include "Fireworks/Core/interface/FWGeometry.h"
-#include "Fireworks/Core/interface/BuilderUtils.h"
-#include "DataFormats/HcalRecHit/interface/HORecHit.h"
+#include "Fireworks/Calo/plugins/FWCaloRecHitDigitSetProxyBuilder.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
-#include "TEveCompound.h"
 
-class FWHORecHitProxyBuilder : public FWDigitSetProxyBuilder
+
+class FWHORecHitProxyBuilder : public FWCaloRecHitDigitSetProxyBuilder
 {
 public:
-   FWHORecHitProxyBuilder( void ) 
-     : m_maxEnergy( 1.0 )
-    {}
-  
-   virtual ~FWHORecHitProxyBuilder( void ) 
-    {}
+   FWHORecHitProxyBuilder( void ) { invertBox(true); }
+   virtual ~FWHORecHitProxyBuilder( void ) {}
 
    REGISTER_PROXYBUILDER_METHODS();
 
 private:
-   virtual void build( const FWEventItem* iItem, TEveElementList* product, const FWViewContext* );
-
-   Float_t m_maxEnergy;
-
    FWHORecHitProxyBuilder( const FWHORecHitProxyBuilder& );
    const FWHORecHitProxyBuilder& operator=( const FWHORecHitProxyBuilder& );
 };
 
+REGISTER_FWPROXYBUILDER( FWHORecHitProxyBuilder, HORecHitCollection, "HO RecHit", FWViewType::kISpyBit );
+
+// AMT scale around center, box is inverted. Scaling and e/et mode added now. Previously used fireworks::energyScaledBox3DCorners().
+
+/*
 void
 FWHORecHitProxyBuilder::build( const FWEventItem* iItem, TEveElementList* product, const FWViewContext* )
 {
@@ -57,5 +50,4 @@ FWHORecHitProxyBuilder::build( const FWEventItem* iItem, TEveElementList* produc
       addBox(boxSet, &scaledCorners[0], iItem->modelInfo(index++).displayProperties());
    }
 }
-
-REGISTER_FWPROXYBUILDER( FWHORecHitProxyBuilder, HORecHitCollection, "HO RecHit", FWViewType::kISpyBit );
+*/

--- a/Fireworks/Calo/plugins/FWJetProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWJetProxyBuilder.cc
@@ -8,7 +8,7 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Tue Dec  2 14:17:03 EST 2008
-// $Id: FWJetProxyBuilder.cc,v 1.35 2011/11/21 08:36:37 amraktad Exp $
+// $Id: FWJetProxyBuilder.cc,v 1.34 2011/08/20 03:50:05 amraktad Exp $
 //
 
 #include "TEveJetCone.h"

--- a/Fireworks/Calo/plugins/FWL1EmParticleProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWL1EmParticleProxyBuilder.cc
@@ -8,7 +8,7 @@
 //
 // Original Author:
 //         Created:  Sun Jan  6 23:57:00 EST 2008
-// $Id: FWL1EmParticleProxyBuilder.cc,v 1.7 2010/09/16 15:42:20 yana Exp $
+// $Id: FWL1EmParticleProxyBuilder.cc,v 1.6 2010/09/03 10:20:04 yana Exp $
 //
 
 #include "Fireworks/Core/interface/FWSimpleProxyBuilderTemplate.h"

--- a/Fireworks/Calo/plugins/FWL1EtMissParticleProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWL1EtMissParticleProxyBuilder.cc
@@ -8,7 +8,7 @@
 //
 // Original Author:
 //         Created:  Sun Jan  6 23:57:00 EST 2008
-// $Id: FWL1EtMissParticleProxyBuilder.cc,v 1.9 2010/09/16 15:42:20 yana Exp $
+// $Id: FWL1EtMissParticleProxyBuilder.cc,v 1.8 2010/09/03 10:20:05 yana Exp $
 //
 
 #include "Fireworks/Core/interface/FWSimpleProxyBuilderTemplate.h"

--- a/Fireworks/Calo/plugins/FWL1JetParticleProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWL1JetParticleProxyBuilder.cc
@@ -8,7 +8,7 @@
 //
 // Original Author:
 //         Created:  Sun Jan  6 23:57:00 EST 2008
-// $Id: FWL1JetParticleProxyBuilder.cc,v 1.9 2010/09/16 15:42:20 yana Exp $
+// $Id: FWL1JetParticleProxyBuilder.cc,v 1.8 2010/09/03 10:20:05 yana Exp $
 //
 
 #include "Fireworks/Core/interface/FWSimpleProxyBuilderTemplate.h"

--- a/Fireworks/Calo/plugins/FWL1MuonParticleProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWL1MuonParticleProxyBuilder.cc
@@ -8,7 +8,7 @@
 //
 // Original Author:
 //         Created:  Sun Jan  6 23:57:00 EST 2008
-// $Id: FWL1MuonParticleProxyBuilder.cc,v 1.10 2010/09/16 15:42:20 yana Exp $
+// $Id: FWL1MuonParticleProxyBuilder.cc,v 1.9 2010/09/03 10:20:05 yana Exp $
 //
 
 #include "Fireworks/Core/interface/FWSimpleProxyBuilderTemplate.h"

--- a/Fireworks/Calo/plugins/FWMETProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWMETProxyBuilder.cc
@@ -8,7 +8,7 @@
 //
 // Original Author:
 //         Created:  Sun Jan  6 23:57:00 EST 2008
-// $Id: FWMETProxyBuilder.cc,v 1.31 2011/02/03 15:15:12 amraktad Exp $
+// $Id: FWMETProxyBuilder.cc,v 1.30 2011/01/17 14:11:43 amraktad Exp $
 //
 
 // system include files

--- a/Fireworks/Calo/plugins/FWPFTauProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWPFTauProxyBuilder.cc
@@ -8,7 +8,7 @@
 //
 // Original Author:
 //         Created:  Sun Jan  6 23:57:00 EST 2008
-// $Id: FWPFTauProxyBuilder.cc,v 1.17 2012/03/23 00:08:29 amraktad Exp $
+// $Id: FWPFTauProxyBuilder.cc,v 1.16 2010/11/05 10:54:33 amraktad Exp $
 //
 
 // system include files

--- a/Fireworks/Calo/plugins/FWZDCRecHitProxyBuilder.cc
+++ b/Fireworks/Calo/plugins/FWZDCRecHitProxyBuilder.cc
@@ -5,15 +5,12 @@
  *  Created by Ianna Osborne on 7/8/10.
  *
  */
-#include "Fireworks/Core/interface/FWDigitSetProxyBuilder.h"
-#include "Fireworks/Core/interface/FWEventItem.h"
-#include "Fireworks/Core/interface/FWGeometry.h"
-#include "Fireworks/Core/interface/BuilderUtils.h"
+#include "Fireworks/Calo/plugins/FWCaloRecHitDigitSetProxyBuilder.h"
 #include "DataFormats/HcalRecHit/interface/ZDCRecHit.h"
 #include "DataFormats/Common/interface/SortedCollection.h"
-#include "TEveBoxSet.h"
 
-class FWZDCRecHitProxyBuilder :  public FWDigitSetProxyBuilder
+
+class FWZDCRecHitProxyBuilder :  public FWCaloRecHitDigitSetProxyBuilder
 {
 public:
    FWZDCRecHitProxyBuilder( void ) {}  
@@ -23,11 +20,15 @@ public:
 
 private:
    FWZDCRecHitProxyBuilder( const FWZDCRecHitProxyBuilder& );
-
-   const FWZDCRecHitProxyBuilder& operator=( const FWZDCRecHitProxyBuilder& );
-   virtual void build( const FWEventItem* iItem, TEveElementList* product, const FWViewContext* );	
+   const FWZDCRecHitProxyBuilder& operator=( const FWZDCRecHitProxyBuilder& );	
 };
 
+
+REGISTER_FWPROXYBUILDER( FWZDCRecHitProxyBuilder,  edm::SortedCollection<ZDCRecHit> , "ZDC RecHit", FWViewType::kISpyBit );
+
+// AMT scale box round center. Scaling and e/et mode added now. Previusly used energyTower3DCorners().
+
+/*
 void FWZDCRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*)
 {
    const edm::SortedCollection<ZDCRecHit> *collection = 0;
@@ -53,6 +54,4 @@ void FWZDCRecHitProxyBuilder::build(const FWEventItem* iItem, TEveElementList* p
 
       addBox(boxSet, &scaledCorners[0], iItem->modelInfo(index++).displayProperties());
    }
-}
-
-REGISTER_FWPROXYBUILDER( FWZDCRecHitProxyBuilder,  edm::SortedCollection<ZDCRecHit> , "ZDC RecHit", FWViewType::kISpyBit );
+   }*/

--- a/Fireworks/Calo/src/FWCaloDataProxyBuilderBase.cc
+++ b/Fireworks/Calo/src/FWCaloDataProxyBuilderBase.cc
@@ -8,7 +8,7 @@
 //
 // Original Author:  
 //         Created:  Mon May 31 15:09:39 CEST 2010
-// $Id: FWCaloDataProxyBuilderBase.cc,v 1.5 2010/11/09 16:56:23 amraktad Exp $
+// $Id: FWCaloDataProxyBuilderBase.cc,v 1.4 2010/10/22 15:34:16 amraktad Exp $
 //
 
 // system include files

--- a/Fireworks/Calo/src/FWFromSliceSelector.cc
+++ b/Fireworks/Calo/src/FWFromSliceSelector.cc
@@ -8,7 +8,7 @@
 //
 // Original Author:  
 //         Created:  Wed Jun  2 17:30:49 CEST 2010
-// $Id: FWFromSliceSelector.cc,v 1.4 2010/06/18 10:17:51 yana Exp $
+// $Id: FWFromSliceSelector.cc,v 1.3 2010/06/07 17:54:00 amraktad Exp $
 //
 
 // system include files

--- a/Fireworks/Calo/src/FWFromSliceSelector.h
+++ b/Fireworks/Calo/src/FWFromSliceSelector.h
@@ -16,7 +16,7 @@
 //
 // Original Author:  Alja Mrak-Tadel
 //         Created:  Wed Jun  2 17:30:39 CEST 2010
-// $Id: FWFromSliceSelector.h,v 1.2 2010/06/07 17:54:00 amraktad Exp $
+// $Id: FWFromSliceSelector.h,v 1.1 2010/06/02 17:34:03 amraktad Exp $
 //
 
 // system include files

--- a/Fireworks/Calo/src/FWFromTEveCaloDataSelector.cc
+++ b/Fireworks/Calo/src/FWFromTEveCaloDataSelector.cc
@@ -8,7 +8,7 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Fri Oct 23 14:44:33 CDT 2009
-// $Id: FWFromTEveCaloDataSelector.cc,v 1.13 2012/09/20 20:09:10 eulisse Exp $
+// $Id: FWFromTEveCaloDataSelector.cc,v 1.12 2010/06/07 17:54:00 amraktad Exp $
 //
 
 // system include files

--- a/Fireworks/Calo/src/FWFromTEveCaloDataSelector.h
+++ b/Fireworks/Calo/src/FWFromTEveCaloDataSelector.h
@@ -16,7 +16,7 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Fri Oct 23 14:44:32 CDT 2009
-// $Id: FWFromTEveCaloDataSelector.h,v 1.7 2010/06/02 18:49:07 amraktad Exp $
+// $Id: FWFromTEveCaloDataSelector.h,v 1.6 2010/06/02 17:34:04 amraktad Exp $
 //
 
 // system include files

--- a/Fireworks/Calo/src/FWTauProxyBuilderBase.cc
+++ b/Fireworks/Calo/src/FWTauProxyBuilderBase.cc
@@ -8,7 +8,7 @@
 //
 // Original Author:  Alja Mrak-Tadel
 //         Created:  Thu Oct 21 20:40:28 CEST 2010
-// $Id: FWTauProxyBuilderBase.cc,v 1.5 2012/03/23 00:08:29 amraktad Exp $
+// $Id: FWTauProxyBuilderBase.cc,v 1.4 2011/02/23 11:34:52 amraktad Exp $
 //
 
 // system include files

--- a/Fireworks/Calo/src/thetaBins.cc
+++ b/Fireworks/Calo/src/thetaBins.cc
@@ -8,7 +8,7 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Thu Dec 11 22:59:38 EST 2008
-// $Id: thetaBins.cc,v 1.4 2010/06/07 18:58:16 matevz Exp $
+// $Id: thetaBins.cc,v 1.3 2009/01/23 21:35:40 amraktad Exp $
 //
 
 // system include files

--- a/Fireworks/Core/src/FWProxyBuilderConfiguration.cc
+++ b/Fireworks/Core/src/FWProxyBuilderConfiguration.cc
@@ -147,7 +147,10 @@ template <class T> T FWProxyBuilderConfiguration::value(const std::string& pname
 template bool FWProxyBuilderConfiguration::value<bool>(const std::string& name);
 template long FWProxyBuilderConfiguration::value<long>(const std::string& name);
 template double FWProxyBuilderConfiguration::value<double>(const std::string& name);
+template std::string FWProxyBuilderConfiguration::value<std::string>(const std::string& name);
 
 template FWGenericParameter<bool>* FWProxyBuilderConfiguration::assertParam(const std::string& name, bool def);
 template FWGenericParameterWithRange<long>* FWProxyBuilderConfiguration::assertParam(const std::string& name, long def,long min, long max);
 template FWGenericParameterWithRange<double>* FWProxyBuilderConfiguration::assertParam(const std::string& name, double def,double min, double max);
+template FWGenericParameter<std::string>* FWProxyBuilderConfiguration::assertParam(const std::string& name, std::string def);
+

--- a/Fireworks/ParticleFlow/plugins/FWPFCandidateWithHitsProxyBuilder.cc
+++ b/Fireworks/ParticleFlow/plugins/FWPFCandidateWithHitsProxyBuilder.cc
@@ -1,0 +1,359 @@
+
+#define protected public
+#include "TEveBoxSet.h"
+#undef protected
+#include "TEveTrack.h"
+#include "TEveTrackPropagator.h"
+#include "TEveCompound.h"
+#include "TEveStraightLineSet.h"
+#include "TEveProjectionBases.h"
+
+#include "Fireworks/ParticleFlow/plugins/FWPFCandidateWithHitsProxyBuilder.h"
+#include "Fireworks/Core/interface/FWEventItem.h"
+#include "Fireworks/Core/interface/FWGeometry.h"
+#include "Fireworks/Core/interface/BuilderUtils.h"
+#include "Fireworks/Core/interface/fwLog.h"
+#include "Fireworks/Core/interface/FWViewEnergyScale.h"
+#include "Fireworks/Core/interface/FWProxyBuilderConfiguration.h"
+#include "Fireworks/ParticleFlow/interface/setTrackTypePF.h"
+
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
+#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
+
+#include "DataFormats/FWLite/interface/Handle.h"
+
+namespace
+{
+static std::string kRecHitCollectionName = "RecHitCollection";
+void  addLineToLineSet(TEveStraightLineSet* ls, const float* p, int i1, int i2)
+{
+   i1 *= 3;
+   i2 *= 3;
+   ls->AddLine(p[i1], p[i1+1], p[i1+2], p[i2], p[i2+1], p[i2+2]);
+}
+
+
+void addBoxAsLines(TEveStraightLineSet* lineset, const float* p)
+{
+   for (int l = 0; l < 5; l+=4)
+   {
+      addLineToLineSet(lineset, p, 0+l, 1+l);
+      addLineToLineSet(lineset, p, 1+l, 2+l);
+      addLineToLineSet(lineset, p, 2+l, 3+l);
+      addLineToLineSet(lineset, p, 3+l, 0+l);
+   }
+   for (int l = 0; l < 4; ++l)
+      addLineToLineSet(lineset, p, 0+l, 4+l);
+}
+
+void  editLineInLineSet(TEveChunkManager::iterator& li, const float* p, int i1, int i2)
+{
+   TEveStraightLineSet::Line_t& line = * (TEveStraightLineSet::Line_t*) li();
+   i1 *= 3;
+   i2 *= 3;
+   for (int i = 0; i < 3 ; ++i) {
+      line.fV1[0+i] = p[i1+i];
+      line.fV2[0+i] = p[i2+i];
+   }
+
+   li.next();
+}
+
+void editBoxInLineSet(TEveChunkManager::iterator& li, const float* p)
+{
+    
+   for (int i = 0; i < 5; i+=4)
+   {
+      editLineInLineSet(li, p, 0+i, 1+i);
+
+      editLineInLineSet(li, p, 1+i, 2+i);
+      editLineInLineSet(li, p, 2+i, 3+i);
+      editLineInLineSet(li, p, 3+i, 0+i);
+   }
+   for (int i = 0; i < 4; ++i)
+      editLineInLineSet(li, p, 0+i, 4+i);
+}
+}
+
+ //______________________________________________________________________________
+
+void FWPFCandidateWithHitsProxyBuilder::setItem(const FWEventItem* iItem)
+{
+
+   FWProxyBuilderBase::setItem(iItem);
+   if (iItem) {
+      std::string defn =  "particleFlowRecHitHCAL";
+      iItem->getConfig()->assertParam(kRecHitCollectionName, defn);
+   }
+}
+
+//______________________________________________________________________________
+void 
+FWPFCandidateWithHitsProxyBuilder::build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext* vc)
+{
+   // init PFCandiate collection
+   reco::PFCandidateCollection const * candidates = 0;
+   iItem->get( candidates );
+   if( candidates == 0 ) return;
+
+   Int_t idx = 0;
+   initPFRecHitsCollections();
+   for( reco::PFCandidateCollection::const_iterator it = candidates->begin(), itEnd = candidates->end(); it != itEnd; ++it, ++idx)
+   {  
+      TEveCompound* comp = createCompound();
+      setupAddElement( comp, product );
+      // printf("products size %d/%d \n", (int)iItem->size(), product->NumChildren());
+
+      const reco::PFCandidate& cand = *it;
+      
+      // track
+      {
+         TEveRecTrack t;
+         t.fBeta = 1.;
+         t.fP = TEveVector( cand.px(), cand.py(), cand.pz() );
+         t.fV = TEveVector( cand.vertex().x(), cand.vertex().y(), cand.vertex().z() );
+         t.fSign = cand.charge();
+         TEveTrack* trk = new TEveTrack(&t, context().getTrackPropagator() );
+         trk->MakeTrack();
+         fireworks::setTrackTypePF( cand, trk );
+         setupAddElement( trk, comp);
+      }
+      // hits
+      {
+         comp->SetMainColor(iItem->defaultDisplayProperties().color());
+         addHitsForCandidate(cand, comp, vc);
+      }
+
+   }
+}
+
+//______________________________________________________________________________
+void FWPFCandidateWithHitsProxyBuilder::initPFRecHitsCollections()
+{  
+   // ref hcal collections
+   edm::Handle<reco::PFRecHitCollection> handle_hits;
+
+
+   m_collectionHCAL =0;
+   try
+   {
+      std::string scc = item()->getConfig()->value<std::string>(kRecHitCollectionName);
+      edm::InputTag tag(scc);
+      item()->getEvent()->getByLabel(tag, handle_hits);
+      if (handle_hits.isValid())
+      {
+         m_collectionHCAL = &*handle_hits;
+         fwLog(fwlog::kInfo) <<"FWPFCandidateWithHitsProxyBuilder, item " << item()->name() <<": Accessed collection with name " << scc << "." << std::endl;
+      }
+      else
+      {
+         fwLog(fwlog::kError) <<"FWPFCandidateWithHitsProxyBuilder, item " << item()->name() <<": Failed to access collection with name " << scc << "." << std::endl;
+      }
+   }
+   catch (...)
+   {
+      fwLog(fwlog::kError) <<"FWPFCandidateWithHitsProxyBuilder, item " << item()->name() <<": Failed to access rechit collection \n";
+   }
+}
+
+//______________________________________________________________________________
+void FWPFCandidateWithHitsProxyBuilder::viewContextBoxScale( const float* corners, float scale, bool plotEt, std::vector<float>& scaledCorners, const reco::PFRecHit*)
+{
+   static TEveVector vtmp;
+   vtmp.Set(0.f, 0.f, 0.f);
+   for( unsigned int i = 0; i < 24; i += 3 )
+   {	 
+      vtmp[0] += corners[i];
+      vtmp[1] += corners[i + 1];
+      vtmp[2] += corners[i + 2];
+   }
+   vtmp *= 1.f/8.f;
+
+   if (plotEt)
+   {
+      scale *= vtmp.Perp()/vtmp.Mag();
+   }
+
+   // Coordinates for a scaled version of the original box
+   for( unsigned int i = 0; i < 24; i += 3 )
+   {	
+      scaledCorners[i] = vtmp[0] + ( corners[i] - vtmp[0] ) * scale;
+      scaledCorners[i + 1] = vtmp[1] + ( corners[i + 1] - vtmp[1] ) * scale;
+      scaledCorners[i + 2] = vtmp[2] + ( corners[i + 2] - vtmp[2] ) * scale;
+   }
+}
+
+//______________________________________________________________________________
+const reco::PFRecHit* FWPFCandidateWithHitsProxyBuilder::getHitForDetId(unsigned candIdx)
+{
+
+   for (reco::PFRecHitCollection::const_iterator it = m_collectionHCAL->begin(); it != m_collectionHCAL->end(); ++it)
+   {
+
+      if ( it->detId() == candIdx)
+      {
+         return  &(*it);
+      }
+   }
+   return 0;
+}
+
+//______________________________________________________________________________
+void FWPFCandidateWithHitsProxyBuilder::scaleProduct(TEveElementList* parent, FWViewType::EType type, const FWViewContext* vc)
+{
+   std::vector<float> scaledCorners(24);
+
+   float scale = vc->getEnergyScale()->getScaleFactor3D()/50;
+   for (TEveElement::List_i i=parent->BeginChildren(); i!=parent->EndChildren(); ++i)
+   {
+      if ((*i)->NumChildren() > 1)
+      {
+         TEveElement::List_i xx =  (*i)->BeginChildren(); ++xx;
+         TEveBoxSet* boxset = dynamic_cast<TEveBoxSet*>(*xx);
+         ++xx;
+         TEveStraightLineSet* lineset = dynamic_cast<TEveStraightLineSet*>(*xx);
+         TEveChunkManager::iterator li(lineset->GetLinePlex());
+         li.next();
+
+
+         TEveChunkManager* plex = boxset->GetPlex();
+         if (plex->N())
+         {
+            for (int atomIdx=0; atomIdx < plex->Size(); ++atomIdx)
+            {
+              
+               TEveBoxSet::BFreeBox_t* atom = (TEveBoxSet::BFreeBox_t*)boxset->GetPlex()->Atom(atomIdx);
+               reco::PFRecHit* hit = (reco::PFRecHit*)boxset->GetUserData(atomIdx);
+               const float* corners = item()->getGeom()->getCorners(hit->detId());
+               viewContextBoxScale(corners, hit->energy()*scale, vc->getEnergyScale()->getPlotEt(), scaledCorners, hit);
+               memcpy(atom->fVertices, &scaledCorners[0], sizeof(atom->fVertices));
+
+               editBoxInLineSet(li, &scaledCorners[0]);
+            }
+
+            for (TEveProjectable::ProjList_i p = lineset->BeginProjecteds(); p != lineset->EndProjecteds(); ++p)
+            {
+               TEveStraightLineSetProjected* projLineSet = (TEveStraightLineSetProjected*)(*p);
+               projLineSet->UpdateProjection();
+            }
+         }
+      }
+   }
+}  
+//______________________________________________________________________________
+namespace {
+TString boxset_tooltip_callback(TEveDigitSet* ds, Int_t idx)
+{
+   void* ud = ds->GetUserData(idx);
+   if (ud);
+   {
+      reco::PFRecHit* hit = (reco::PFRecHit*) ud;
+      // printf("idx %d %p hit data %p\n", idx, (void*)hit, ud);
+      if (hit)
+         return TString::Format("RecHit %d energy '%f'", idx,  hit->energy());
+      else
+         return "ERROR";
+   }
+}
+}
+//______________________________________________________________________________
+void FWPFCandidateWithHitsProxyBuilder::addHitsForCandidate(const reco::PFCandidate& cand, TEveElement* holder, const FWViewContext* vc)
+{ 
+   reco::PFCandidate::ElementsInBlocks eleInBlocks = cand.elementsInBlocks();
+
+   TEveBoxSet* boxset = 0;
+   TEveStraightLineSet* lineset = 0;
+
+   for(unsigned elIdx=0; elIdx<eleInBlocks.size(); elIdx++)
+   {
+      // unsigned ieTrack = 0;
+      // unsigned ieECAL = 0;
+      unsigned ieHCAL = 0;
+
+      reco::PFBlockRef blockRef = eleInBlocks[elIdx].first;
+      unsigned indexInBlock = eleInBlocks[elIdx].second;
+      edm::Ptr<reco::PFBlock> myBlock(blockRef.id(),blockRef.get(), blockRef.key());
+      /*
+        if (myBlock->elements()[indexInBlock].type() == 1)
+        ieTrack = indexInBlock;
+        if (myBlock->elements()[indexInBlock].type() == 4)
+        ieECAL = indexInBlock;
+      */
+      if (myBlock->elements()[indexInBlock].type() == 5)
+         ieHCAL = indexInBlock;
+   
+ 
+      std::vector<float> scaledCorners(24);
+      float scale = vc->getEnergyScale()->getScaleFactor3D()/50;
+      if (ieHCAL &&  m_collectionHCAL) {
+         reco::PFClusterRef hcalclusterRef=myBlock->elements()[ieHCAL].clusterRef();
+         edm::Ptr<reco::PFCluster> myCluster(hcalclusterRef.id(),hcalclusterRef.get(), hcalclusterRef.key());
+         if (myCluster.get())
+         {
+            const std::vector< std::pair<DetId, float> > & hitsandfracs = myCluster->hitsAndFractions();
+
+            if (!boxset)
+            {
+               boxset = new TEveBoxSet();
+               boxset->Reset(TEveBoxSet::kBT_FreeBox, true, hitsandfracs.size());
+               boxset->SetAntiFlick(true);
+               boxset->SetAlwaysSecSelect(1);
+               boxset->SetPickable(1);
+               boxset->SetTooltipCBFoo(boxset_tooltip_callback);
+            }
+
+            if (!lineset)
+            {
+               lineset = new TEveStraightLineSet();
+            }
+
+            bool hitsFound = false;
+            for ( int ihandf=0, lastIdx=(int)(hitsandfracs.size()); ihandf<lastIdx; ihandf++) 
+            {
+               unsigned int hitDetId = hitsandfracs[ihandf].first;
+               const float* corners = context().getGeom()->getCorners(hitDetId);
+               const reco::PFRecHit* hit = getHitForDetId(hitDetId);
+               if (hit)
+               {
+                  viewContextBoxScale( corners, hit->energy()*scale, vc->getEnergyScale()->getPlotEt(), scaledCorners, hit);
+                  boxset->AddBox( &scaledCorners[0]);
+                  // setup last box
+                  boxset->DigitColor(holder->GetMainColor());
+                  boxset->DigitUserData((void*)hit);
+                  addBoxAsLines(lineset, &scaledCorners[0]);
+                  hitsFound = true;
+               }
+               /*
+               // AMT: don't add lines if hit is not found becuse of unconsistency of scaling.
+               else
+               {
+                  addBoxAsLines(lineset, corners);
+               }
+               */
+            }
+            if (!hitsFound)
+               fwLog(fwlog::kWarning) << Form("Can't find matching hits with for HCAL block %d in RecHit collection. Number of hits %d.\n", elIdx, (int)hitsandfracs.size());
+
+
+         }
+         else
+         {
+            fwLog(fwlog::kInfo) << "empty cluster \n";
+         }
+      }
+   } // endloop cand.elementsInBlocks();
+
+
+   if (boxset) {
+      boxset->RefitPlex();
+      setupAddElement(boxset, holder);
+   }
+
+   if (lineset) {
+      setupAddElement(lineset, holder);
+   }
+}
+
+REGISTER_FWPROXYBUILDER(FWPFCandidateWithHitsProxyBuilder, reco::PFCandidateCollection,"PF CandidatesWithHits", FWViewType::kAll3DBits | FWViewType::kAllRPZBits );

--- a/Fireworks/ParticleFlow/plugins/FWPFCandidateWithHitsProxyBuilder.h
+++ b/Fireworks/ParticleFlow/plugins/FWPFCandidateWithHitsProxyBuilder.h
@@ -1,0 +1,39 @@
+#include "Fireworks/Core/interface/FWProxyBuilderBase.h"
+//#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
+#include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
+#include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
+namespace reco 
+{
+class PFCandidate;
+class PFRecHit;
+}
+class CaloRecHit;
+
+class FWPFCandidateWithHitsProxyBuilder : public FWProxyBuilderBase
+{
+public:
+   FWPFCandidateWithHitsProxyBuilder() {}
+   virtual ~FWPFCandidateWithHitsProxyBuilder(){}
+
+   virtual void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*);
+   
+   virtual bool havePerViewProduct(FWViewType::EType) const { return true; }
+
+   virtual void scaleProduct(TEveElementList* parent, FWViewType::EType type, const FWViewContext* vc);
+
+   virtual void setItem(const FWEventItem* iItem);
+
+   REGISTER_PROXYBUILDER_METHODS();
+
+private:
+   FWPFCandidateWithHitsProxyBuilder( const FWPFCandidateWithHitsProxyBuilder& );                    // Stop default
+   const FWPFCandidateWithHitsProxyBuilder& operator=( const FWPFCandidateWithHitsProxyBuilder& );   // Stop default
+
+   void addHitsForCandidate(const reco::PFCandidate& c, TEveElement* holder, const FWViewContext* vc);
+   void initPFRecHitsCollections();
+   const reco::PFRecHit* getHitForDetId(unsigned detId);
+   void viewContextBoxScale( const float* corners, float scale, bool plotEt, std::vector<float>& scaledCorners, const reco::PFRecHit*);
+
+   const reco::PFRecHitCollection *m_collectionHCAL;
+
+};

--- a/Tutorial/Test/bin/BuildFile.xml
+++ b/Tutorial/Test/bin/BuildFile.xml
@@ -1,3 +1,2 @@
 <bin file="*.cc" name="git-tutorial-test">
-iiiiiiiiiiiiiii</bin>
-addmore stuff ...
+</bin>

--- a/Tutorial/Test/bin/BuildFile.xml
+++ b/Tutorial/Test/bin/BuildFile.xml
@@ -1,0 +1,2 @@
+<bin file="*.cc" name="git-tutorial-test">
+</bin>

--- a/Tutorial/Test/bin/BuildFile.xml
+++ b/Tutorial/Test/bin/BuildFile.xml
@@ -1,2 +1,3 @@
 <bin file="*.cc" name="git-tutorial-test">
 iiiiiiiiiiiiiii</bin>
+addmore stuff ...

--- a/Tutorial/Test/bin/BuildFile.xml
+++ b/Tutorial/Test/bin/BuildFile.xml
@@ -1,2 +1,2 @@
 <bin file="*.cc" name="git-tutorial-test">
-</bin>
+iiiiiiiiiiiiiii</bin>

--- a/Tutorial/Test/bin/xx.cc
+++ b/Tutorial/Test/bin/xx.cc
@@ -1,0 +1,23 @@
+
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <time.h>
+#include <unistd.h>
+
+int main (int argc, char* argv[]) {
+
+   FILE* fp=    fopen(argv[1], "a+");
+   if (fp == NULL) {
+      printf("CANT topen file !!\n");
+   }
+   printf("test test \n");
+   fprintf(fp, "test test \n");
+
+   fflush(fp);
+   // fclose(fp);
+
+   return 0;
+}


### PR DESCRIPTION
Fireworks/Core: 
add string type to proxy builder configuration

Fireworks/Calo: 
updates from CVS HEAD, bugfix in calo rec-hit scaling when multiple views of  same type are added

Fireworks/ParticleFlow:
make rec-hit collection configurable in FWPFcandidatesWithHits proxy builder

Tutorial/Test:
remainings of my tutorial
