### PR TITLE
Rename function to avoid duplication and confusion

### DIFF
--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -221,7 +221,7 @@ namespace edm {
 
     virtual bool isFileOpen() const { return true; }
 
-    virtual void doOpenFile() { }
+    virtual void reallyOpenFile() {}
 
     void setModuleDescription(ModuleDescription const& md) {
       moduleDescription_ = md;

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -420,7 +420,7 @@ namespace edm {
   }
 
   void OutputModule::maybeOpenFile() {
-    if(!isFileOpen()) doOpenFile();
+    if(!isFileOpen()) reallyOpenFile();
   }
 
   void OutputModule::doCloseFile() {

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -109,7 +109,7 @@ namespace edm {
     virtual void writeRun(RunPrincipal const& r);
     virtual void postForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
     virtual bool isFileOpen() const;
-    virtual void doOpenFile();
+    virtual void reallyOpenFile();
     virtual void beginJob();
 
     virtual void startEndFile();

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -201,7 +201,7 @@ namespace edm {
 
   void PoolOutputModule::openFile(FileBlock const& fb) {
     if(!isFileOpen()) {
-      doOpenFile();
+      reallyOpenFile();
       beginInputFile(fb);
     }
   }
@@ -278,7 +278,7 @@ namespace edm {
   bool PoolOutputModule::isFileOpen() const { return rootOutputFile_.get() != 0; }
   bool PoolOutputModule::shouldWeCloseFile() const { return rootOutputFile_->shouldWeCloseFile(); }
 
-  void PoolOutputModule::doOpenFile() {
+  void PoolOutputModule::reallyOpenFile() {
       if(inputFileCount_ == 0) {
         throw edm::Exception(errors::LogicError)
           << "Attempt to open output file before input file. "


### PR DESCRIPTION
Rename the virtual function OutputModule::doOpenFile() to OutputModule::reallyOpenFile().  This is being done because OutputModule had two member functions with the same name and different signatures, one of them virtual and one of them non-virtual.  The functions had the same name not because they are logically part of an overload set, but because they were written by different developers for different purposes, and the author of the later function did not notice the earlier one.  So, to avoid confusion, one of them is being renamed to something unique and more mnemonic.
