### PR TITLE
Updated to the POSTLS161_V1 adding the GBRForest tags.

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -13,7 +13,7 @@ autoCond = {
     # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
     'hltonline'         :   'PRE_P62_V8::All',
     # GlobalTag for POSTLS1 upgrade studies:
-    'upgradePLS1'       :   'PRE_PO62_V7::All',
+    'upgradePLS1'       :   'POSTLS162_V1::All',
     'upgrade2017'       :   'DES17_61_V5::All', # placeholder (GT not meant for 62X)
     'upgrade2019'       :   'DES19_61_V5::All', # placeholder (GT not meant for 62X)
     'upgradePLS3'       :   'POSTLS261_V2::All' # placeholder (GT not meant for 62X)


### PR DESCRIPTION
This commit fixes a crash due to the missing GBRForest tags in the upgradePLS1 GT.
The change has been tested in CMSSW_6_2_0 with the command runTheMatrix.py -l 3200 -w upgrade.
