### PR TITLE
Remove some const_cast's

### DIFF
--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -313,7 +313,7 @@ namespace edm {
     /// To set the current time, as seen by the input source
     void setTimestamp(Timestamp const& theTime) {time_ = theTime;}
 
-    ProductRegistry& productRegistryUpdate() const {return const_cast<ProductRegistry&>(*productRegistry_);}
+    ProductRegistry& productRegistryUpdate() const {return *productRegistry_;}
     ItemType state() const{return state_;}
     void setRunAuxiliary(RunAuxiliary* rp) {
       runAuxiliary_.reset(rp);
@@ -395,7 +395,7 @@ namespace edm {
     int readCount_;
     ProcessingMode processingMode_;
     ModuleDescription const moduleDescription_;
-    boost::shared_ptr<ProductRegistry const> productRegistry_;
+    boost::shared_ptr<ProductRegistry> productRegistry_;
     boost::shared_ptr<BranchIDListHelper> branchIDListHelper_;
     bool const primary_;
     std::string processGUID_;

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -62,7 +62,7 @@ namespace edm {
       readCount_(0),
       processingMode_(RunsLumisAndEvents),
       moduleDescription_(desc.moduleDescription_),
-      productRegistry_(createSharedPtrToStatic<ProductRegistry const>(desc.productRegistry_)),
+      productRegistry_(createSharedPtrToStatic<ProductRegistry>(desc.productRegistry_)),
       branchIDListHelper_(desc.branchIDListHelper_),
       primary_(pset.getParameter<std::string>("@module_label") == std::string("@main_input")),
       processGUID_(primary_ ? createGlobalIdentifier() : std::string()),

--- a/IOPool/Common/bin/EdmProvDump.cc
+++ b/IOPool/Common/bin/EdmProvDump.cc
@@ -879,7 +879,7 @@ ProvenanceDumper::work_() {
        it != itEnd;
        ++it) {
     //force it to rebuild the branch name
-    const_cast<edm::BranchDescription&>(it->second).init();
+    it->second.init();
 
     if(showDependencies_ || extendedAncestors_ || extendedDescendants_) {
       branchIDToBranchName[it->second.branchID()] = it->second.branchName();


### PR DESCRIPTION
Remove two more instances of const_cast in code that accesses the product registry.  This makes it easier to tell where the product registry is modified, which is important for the multithreaded framework.
