### PR TITLE
Make all registry data members non-mutable

### DIFF
--- a/DataFormats/FWLite/src/Event.cc
+++ b/DataFormats/FWLite/src/Event.cc
@@ -347,9 +347,8 @@ Event::history() const {
         TBranch* b = meta->GetBranch(edm::poolNames::processHistoryBranchName().c_str());
         b->SetAddress(&pPhv);
         b->GetEntry(0);
-        for (edm::ProcessHistoryVector::const_iterator i = historyVector.begin(), e = historyVector.end();
-            i != e; ++i) {
-          historyMap_.insert(std::make_pair(i->id(), *i));
+        for (auto& history : historyVector) {
+          historyMap_.insert(std::make_pair(history.setProcessHistoryID(), history));
         }
       }
     }

--- a/DataFormats/FWLite/src/LuminosityBlock.cc
+++ b/DataFormats/FWLite/src/LuminosityBlock.cc
@@ -298,9 +298,8 @@ LuminosityBlock::history() const
         TBranch* b = meta->GetBranch(edm::poolNames::processHistoryBranchName().c_str());
         b->SetAddress(&pPhv);
         b->GetEntry(0);
-        for (edm::ProcessHistoryVector::const_iterator i = historyVector.begin(), e = historyVector.end();
-            i != e; ++i) {
-          historyMap_.insert(std::make_pair(i->id(), *i));
+        for (auto& history : historyVector) {
+          historyMap_.insert(std::make_pair(history.setProcessHistoryID(), history));
         }
       }
     }

--- a/DataFormats/FWLite/src/Run.cc
+++ b/DataFormats/FWLite/src/Run.cc
@@ -295,9 +295,8 @@ Run::history() const
         TBranch* b = meta->GetBranch(edm::poolNames::processHistoryBranchName().c_str());
         b->SetAddress(&pPhv);
         b->GetEntry(0);
-        for (edm::ProcessHistoryVector::const_iterator i = historyVector.begin(), e = historyVector.end();
-            i != e; ++i) {
-          historyMap_.insert(std::make_pair(i->id(), *i));
+        for (auto& history : historyVector) {
+          historyMap_.insert(std::make_pair(history.setProcessHistoryID(), history));
         }
       }
     }

--- a/DataFormats/Provenance/interface/EventEntryDescription.h
+++ b/DataFormats/Provenance/interface/EventEntryDescription.h
@@ -37,7 +37,8 @@ namespace edm {
     void write(std::ostream& os) const;
 
     std::vector<BranchID> const& parents() const {return parents_;}
-    std::vector<BranchID> & parents() {return parents_;}
+    
+    void setParents(std::vector<BranchID> const& parents) {parents_ = parents;} 
 
   private:
 

--- a/DataFormats/Provenance/interface/Parentage.h
+++ b/DataFormats/Provenance/interface/Parentage.h
@@ -30,30 +30,24 @@ namespace edm {
 
     ~Parentage() {}
 
-    // Only the 'salient attributes' are encoded into the ID.
     ParentageID id() const;
 
     void write(std::ostream& os) const;
 
     std::vector<BranchID> const& parents() const {return parents_;}
-    std::vector<BranchID> & parents() {return parents_;}
-    void swap(Parentage& other) {parents_.swap(other.parents_); parentageID().swap(other.parentageID());}
-
+    std::vector<BranchID>& parentsForUpdate() {return parents_;}
+    void setParents(std::vector<BranchID> const& parents) {parents_ = parents;}
+    void swap(Parentage& other) {parents_.swap(other.parents_);}
     void initializeTransients() {transient_.reset();}
-
     struct Transients {
-      Transients() : parentageID_() {}
-      void reset() {parentageID_.reset();}
-      mutable ParentageID parentageID_;
+      Transients() {}
+      void reset() {}
     };
 
-
   private:
-    ParentageID& parentageID() const {return transient_.parentageID_;}
     // The Branch IDs of the parents
     std::vector<BranchID> parents_;
     Transients transient_;
-
   };
 
   // Free swap function

--- a/DataFormats/Provenance/interface/ProcessConfiguration.h
+++ b/DataFormats/Provenance/interface/ProcessConfiguration.h
@@ -31,6 +31,8 @@ namespace edm {
 
     void setParameterSetID(ParameterSetID const& pSetID);
 
+    ProcessConfigurationID setProcessConfigurationID();
+
     void reduce();
 
     void initializeTransients() {transient_.reset();}
@@ -42,12 +44,11 @@ namespace edm {
         pcid_.reset();
         isCurrentProcess_ = false;
       }
-      mutable ProcessConfigurationID pcid_;
+      ProcessConfigurationID pcid_;
       bool isCurrentProcess_;
     };
 
   private:
-    ProcessConfigurationID const& pcid() const {return transient_.pcid_;}
     void setPCID(ProcessConfigurationID const& pcid) {transient_.pcid_ = pcid;}
     bool isCurrentProcess() const {return transient_.isCurrentProcess_;}
     void setCurrentProcess() {transient_.isCurrentProcess_ = true;}

--- a/DataFormats/Provenance/interface/ProcessHistory.h
+++ b/DataFormats/Provenance/interface/ProcessHistory.h
@@ -63,6 +63,7 @@ namespace edm {
 
     collection_type const& data() const {return data_;}
     ProcessHistoryID id() const;
+    ProcessHistoryID setProcessHistoryID();
 
     // Return true, and fill in config appropriately, if the a process
     // with the given name is recorded in this ProcessHistory. Return
@@ -82,11 +83,11 @@ namespace edm {
     struct Transients {
       Transients() : phid_() {}
       void reset() {phid_.reset();}
-      mutable ProcessHistoryID phid_;
+      ProcessHistoryID phid_;
     };
 
   private:
-    ProcessHistoryID& phid() const {return transient_.phid_;}
+    ProcessHistoryID& phid() {return transient_.phid_;}
     collection_type data_;
     Transients transient_;
   };

--- a/DataFormats/Provenance/src/FullHistoryToReducedHistoryMap.cc
+++ b/DataFormats/Provenance/src/FullHistoryToReducedHistoryMap.cc
@@ -14,6 +14,7 @@ namespace edm {
     // ProcessHistoryID is strangely also defined as the ID of the empty
     // Process History (maybe that should be fixed ...).
     ProcessHistory ph;
+    ph.setProcessHistoryID();
     std::pair<ProcessHistoryID, ProcessHistoryID> newEntry(ph.id(), ph.id());
     std::pair<Map::iterator, bool> result = cache_.insert(newEntry);
     previous_ = result.first;
@@ -36,7 +37,7 @@ namespace edm {
         << "Contact a Framework developer\n";
     }
     ph.reduce();
-    std::pair<ProcessHistoryID, ProcessHistoryID> newEntry(fullID, ph.id());
+    std::pair<ProcessHistoryID, ProcessHistoryID> newEntry(fullID, ph.setProcessHistoryID());
     std::pair<Map::iterator, bool> result = cache_.insert(newEntry);
     previous_ = result.first;
     return result.first->second;

--- a/DataFormats/Provenance/src/Parentage.cc
+++ b/DataFormats/Provenance/src/Parentage.cc
@@ -8,35 +8,24 @@
 ----------------------------------------------------------------------*/
 
 namespace edm {
-  Parentage::Parentage() :
-    parents_()
-  {}
+  Parentage::Parentage() : parents_() {
+  }
 
   Parentage::Parentage(std::vector<BranchID> const& parents) :
-    parents_(parents)
-  {}
+    parents_(parents) {
+  }
 
   ParentageID
   Parentage::id() const {
-    // This implementation is ripe for optimization.
-    if(parentageID().isValid()) {
-      return parentageID();
-    }
     std::ostringstream oss;
-    for (std::vector<BranchID>::const_iterator 
-	   i = parents_.begin(),
-	   e = parents_.end();
-	 i != e;
-	 ++i)
-      {
-	oss << *i << ' ';
-      }
+    for (auto const& parent : parents_) {
+      oss << parent << ' ';
+    }
     
     std::string stringrep = oss.str();
     cms::Digest md5alg(stringrep);
-    ParentageID tmp(md5alg.digest().toString());
-    parentageID().swap(tmp);
-    return parentageID();
+    ParentageID id(md5alg.digest().toString());
+    return id;
   }
 
   void
@@ -47,7 +36,6 @@ namespace edm {
     
   bool
   operator==(Parentage const& a, Parentage const& b) {
-    return
-      a.parents() == b.parents();
+    return a.parents() == b.parents();
   }
 }

--- a/DataFormats/Provenance/src/ProcessConfiguration.cc
+++ b/DataFormats/Provenance/src/ProcessConfiguration.cc
@@ -52,23 +52,30 @@ namespace edm {
 
   ProcessConfigurationID
   ProcessConfiguration::id() const {
-    if(pcid().isValid()) {
-      return pcid();
+    if(transient_.pcid_.isValid()) {
+      return transient_.pcid_; 
     }
     // This implementation is ripe for optimization.
     std::ostringstream oss;
     oss << *this;
     std::string stringrep = oss.str();
     cms::Digest md5alg(stringrep);
-    ProcessConfigurationID tmp(md5alg.digest().toString());
-    transient_.pcid_.swap(tmp);
-    return pcid();
+    ProcessConfigurationID pcid(md5alg.digest().toString());
+    return pcid;
   }
 
   void
   ProcessConfiguration::setParameterSetID(ParameterSetID const& pSetID) {
     assert(parameterSetID_ == ParameterSetID());
     parameterSetID_ = pSetID;
+  }
+
+  ProcessConfigurationID
+  ProcessConfiguration::setProcessConfigurationID() {
+    if(!transient_.pcid_.isValid()) {
+      transient_.pcid_ = id();
+    }
+    return transient_.pcid_;
   }
 
   void
@@ -82,7 +89,7 @@ namespace edm {
     while(iter != iEnd && isdigit(*iter) == 0) ++iter;
     while(iter != iEnd && isdigit(*iter) != 0) ++iter;
     if (iter == iEnd) return;
-    setPCID(ProcessConfigurationID());
+    transient_.pcid_ = ProcessConfigurationID();
     releaseVersion_.erase(iter,iEnd);
   }
 

--- a/DataFormats/Provenance/src/ProcessHistory.cc
+++ b/DataFormats/Provenance/src/ProcessHistory.cc
@@ -6,12 +6,11 @@
 
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 
-
 namespace edm {
   ProcessHistoryID
   ProcessHistory::id() const {
-    if(phid().isValid()) {
-      return phid();
+    if(transient_.phid_.isValid()) {
+      return transient_.phid_;
     }
     // This implementation is ripe for optimization.
     // We do not use operator<< because it does not write out everything.
@@ -24,9 +23,16 @@ namespace edm {
     }
     std::string stringrep = oss.str();
     cms::Digest md5alg(stringrep);
-    ProcessHistoryID tmp(md5alg.digest().toString());
-    phid().swap(tmp);
-    return phid();
+    ProcessHistoryID phID(md5alg.digest().toString());
+    return phID;
+  }
+
+  ProcessHistoryID
+  ProcessHistory::setProcessHistoryID() {
+    if(!transient_.phid_.isValid()) {
+      transient_.phid_ = id();
+    }
+    return transient_.phid_;
   }
 
   bool

--- a/DataFormats/Provenance/src/ProductProvenance.cc
+++ b/DataFormats/Provenance/src/ProductProvenance.cc
@@ -54,7 +54,7 @@ namespace edm {
     parentageID_(),
     transient_() {
       parentagePtr() = boost::shared_ptr<Parentage>(new Parentage);
-      parentagePtr()->parents() = parents;
+      parentagePtr()->setParents(parents);
       parentageID_ = parentagePtr()->id();
       ParentageRegistry::instance()->insertMapped(*parentagePtr());
   }

--- a/DataFormats/Provenance/test/EntryDescription_t.cpp
+++ b/DataFormats/Provenance/test/EntryDescription_t.cpp
@@ -10,9 +10,9 @@ int main() {
   edm::Parentage ed2;
   assert(ed1 == ed2);
 
-  ed2.parents() = std::vector<edm::BranchID>(1);
+  ed2.setParents(std::vector<edm::BranchID>(1));
   edm::Parentage ed3;
-  ed3.parents() = std::vector<edm::BranchID>(2);
+  ed3.setParents(std::vector<edm::BranchID>(2));
 
   try {
     edm::ParentageID id1 = ed1.id();
@@ -27,7 +27,7 @@ int main() {
     assert(ed2 != ed3);
 
     edm::Parentage ed4;
-    ed4.parents() = std::vector<edm::BranchID>(1);
+    ed4.setParents(std::vector<edm::BranchID>(1));
     edm::ParentageID id4 = ed4.id();
     assert(ed4 == ed2);
     assert (id4 == id2);

--- a/FWCore/Framework/src/HistoryAppender.cc
+++ b/FWCore/Framework/src/HistoryAppender.cc
@@ -39,7 +39,7 @@ namespace edm {
     checkProcessHistory(newProcessHistory, pc);
     newProcessHistory.push_back(pc);
     registry->insertMapped(newProcessHistory);
-    ProcessHistoryID newProcessHistoryID = newProcessHistory.id();
+    ProcessHistoryID newProcessHistoryID = newProcessHistory.setProcessHistoryID();
     CachedHistory newValue(inputProcessHistory,
                            registry->getMapped(newProcessHistoryID),
                            newProcessHistoryID);

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -395,6 +395,7 @@ namespace edm {
     proc_pset.registerIt();
     pset::Registry::instance()->extra().setID(proc_pset.id());
     processConfiguration->setParameterSetID(proc_pset.id());
+    processConfiguration->setProcessConfigurationID();
 
     initializeEarlyDelete(opts,preg,subProcPSet);
     

--- a/FWCore/Integration/test/ProcessHistory_t.cpp
+++ b/FWCore/Integration/test/ProcessHistory_t.cpp
@@ -51,9 +51,9 @@ int main() try {
   pnl3.push_back(iHLT);
   pnl3.push_back(iRECO);
 
-  edm::ProcessHistoryID id1 = pnl1.id();
-  edm::ProcessHistoryID id2 = pnl2.id();
-  edm::ProcessHistoryID id3 = pnl3.id();
+  edm::ProcessHistoryID id1 = pnl1.setProcessHistoryID();
+  edm::ProcessHistoryID id2 = pnl2.setProcessHistoryID();
+  edm::ProcessHistoryID id3 = pnl3.setProcessHistoryID();
 
   assert(id1 != id2);
   assert(id2 != id3);
@@ -61,7 +61,7 @@ int main() try {
 
   edm::ProcessHistory pnl4;
   pnl4.push_back(iHLT);
-  edm::ProcessHistoryID id4 = pnl4.id();
+  edm::ProcessHistoryID id4 = pnl4.setProcessHistoryID();
   assert(pnl4 == pnl2);
   assert (id4 == id2);
 
@@ -80,14 +80,14 @@ int main() try {
   edm::ProcessConfiguration pc7(std::string("HLT"), psetID, std::string("xb500yz872djk999patch10"), edm::getPassID());
   edm::ProcessConfiguration pc8(std::string("HLT"), psetID, std::string("CMSSW_4_4_0_pre5"), edm::getPassID());
 
-  pc1.id();
-  pc2.id();
-  pc3.id();
-  pc4.id();
-  pc5.id();
-  pc6.id();
-  pc7.id();
-  pc8.id();
+  pc1.setProcessConfigurationID();
+  pc2.setProcessConfigurationID();
+  pc3.setProcessConfigurationID();
+  pc4.setProcessConfigurationID();
+  pc5.setProcessConfigurationID();
+  pc6.setProcessConfigurationID();
+  pc7.setProcessConfigurationID();
+  pc8.setProcessConfigurationID();
 
   pc1.reduce();
   pc2.reduce();
@@ -134,7 +134,7 @@ int main() try {
   phTestExpected.push_back(iRECOreduced);
 
   edm::ProcessHistory phTest = pnl3;
-  phTest.id();
+  phTest.setProcessHistoryID();
   phTest.reduce();
   assert(phTest == phTestExpected);
   assert(phTest.id() == phTestExpected.id());
@@ -189,14 +189,14 @@ int main() try {
     ph3.push_back(pc3);
     ph4.push_back(pc4);
 
-    edm::ProcessHistoryID phid1 = ph1.id();
-    edm::ProcessHistoryID phid1a = ph1a.id();
-    edm::ProcessHistoryID phid1b = ph1b.id();
-    edm::ProcessHistoryID phid2 = ph2.id();
-    edm::ProcessHistoryID phid2a = ph2a.id();
-    edm::ProcessHistoryID phid2b = ph2b.id();
-    edm::ProcessHistoryID phid3 = ph3.id();
-    edm::ProcessHistoryID phid4 = ph4.id();
+    edm::ProcessHistoryID phid1 = ph1.setProcessHistoryID();
+    edm::ProcessHistoryID phid1a = ph1a.setProcessHistoryID();
+    edm::ProcessHistoryID phid1b = ph1b.setProcessHistoryID();
+    edm::ProcessHistoryID phid2 = ph2.setProcessHistoryID();
+    edm::ProcessHistoryID phid2a = ph2a.setProcessHistoryID();
+    edm::ProcessHistoryID phid2b = ph2b.setProcessHistoryID();
+    edm::ProcessHistoryID phid3 = ph3.setProcessHistoryID();
+    edm::ProcessHistoryID phid4 = ph4.setProcessHistoryID();
 
     edm::ProcessHistoryRegistry::instance()->insertMapped(ph1);
     edm::ProcessHistoryRegistry::instance()->insertMapped(ph1a);

--- a/FWCore/ParameterSet/src/FillProductRegistryTransients.cc
+++ b/FWCore/ParameterSet/src/FillProductRegistryTransients.cc
@@ -27,7 +27,7 @@ namespace edm {
     std::string const& processName = pc.processName();
     ParameterSetID const& processParameterSetID = pc.parameterSetID();
     ParameterSet const* processParameterSet = pset::Registry::instance()->getMapped(processParameterSetID);
-    if(0 == processParameterSet || processParameterSet->empty()) {
+    if(nullptr == processParameterSet || processParameterSet->empty()) {
       return;
     }
     for(ProductRegistry::ProductList::iterator it = preg.productListUpdator().begin(),

--- a/FWCore/Sources/src/DaqProvenanceHelper.cc
+++ b/FWCore/Sources/src/DaqProvenanceHelper.cc
@@ -89,7 +89,7 @@ namespace edm {
     ProcessConfigurationRegistry::instance()->insertMapped(pc);
 
     // Save the process history ID for use every event.
-    return ph.id();
+    return ph.setProcessHistoryID();
   }
 
   bool

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -502,10 +502,10 @@ namespace edm {
       }
       oldregistry.insertMapped(entryDescriptionBuffer);
       Parentage parents;
-      parents.parents() = entryDescriptionBuffer.parents();
+      parents.setParents(entryDescriptionBuffer.parents());
       if(daqProvenanceHelper_) {
         ParentageID const oldID = parents.id();
-        daqProvenanceHelper_->fixMetaData(parents.parents());
+        daqProvenanceHelper_->fixMetaData(parents.parentsForUpdate());
         ParentageID newID = parents.id();
         if(newID != oldID) {
           daqProvenanceHelper_->parentageIDMap_.insert(std::make_pair(oldID, newID));
@@ -543,7 +543,7 @@ namespace edm {
       roottree::getEntry(parentageTree.get(), i);
       if(daqProvenanceHelper_) {
         ParentageID const oldID = parents.id();
-        daqProvenanceHelper_->fixMetaData(parents.parents());
+        daqProvenanceHelper_->fixMetaData(parents.parentsForUpdate());
         ParentageID newID = parents.id();
         if(newID != oldID) {
           daqProvenanceHelper_->parentageIDMap_.insert(std::make_pair(oldID, newID));

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -54,6 +54,7 @@ namespace edm {
     ParameterSet emptyPSet;
     emptyPSet.registerIt();
     processConfiguration_->setParameterSetID(emptyPSet.id());
+    processConfiguration_->setProcessConfigurationID();
  
     productRegistry_->setFrozen();
 


### PR DESCRIPTION
This pull request is another small step towards the multithreaded framework.  It eliminates the last three mutable data members from registries.  The Parentage, ProcessConfiguration, and ProcessHistory classes each contained a mutable cached hash id used for storage in a registry.  In the case of Parentage, the cached ID is simply removed, because it is not needed.  In the case of the other two classes, the cached ID is made non mutable.  The "id()" function remains const, because, while it still reads from the cache, it no longer fills the cache.  A new "set" function fills the cache when needed.
Also, in the case of Parentage, a non-const function with the same name as a const function is removed and replaced with other functions.
Also, "for" loops affected by this change are changed to C++11 range for loops.
This code has been fully tested with checkdeps -a.  All framework unit tests and relval matrix tests pass.
