### PR TITLE
[CMSSW_5_3_X] Remove dastest.cern.ch from relval_steps.py

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -58,10 +58,10 @@ class InputInfo(object):
         query_by = "block" if self.ib_block else "dataset"
         query_source = "{0}#{1}".format(self.dataSet, self.ib_block) if self.ib_block else self.dataSet
         if len(self.run) is not 0:
-            command = ";".join(["das_client.py --host='https://dastest.cern.ch' --limit=0 --query 'file {0}={1} run={2}'".format(query_by, query_source, query_run) for query_run in self.run])
+            command = ";".join(["das_client.py --limit=0 --query 'file {0}={1} run={2}'".format(query_by, query_source, query_run) for query_run in self.run])
             command = "({0})".format(command)
         else:
-            command = "das_client.py --host='https://dastest.cern.ch' --limit=0 --query 'file {0}={1} site=T2_CH_CERN'".format(query_by, query_source)
+            command = "das_client.py --limit=0 --query 'file {0}={1} site=T2_CH_CERN'".format(query_by, query_source)
 
         # Run filter on DAS output
         if self.ib_blacklist:


### PR DESCRIPTION
dastest.cern.ch instance was only intended for CMSSW_6_2_X to
gather additional information in DAS system in order to solve a few
issues. CMSSW_6_2_X and CMSSW_7_0_X already use production instance
of DAS.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
