### PR TITLE
Seeding layer cache

### DIFF
--- a/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
+++ b/RecoTracker/TkHitPairs/interface/LayerHitMapCache.h
@@ -29,7 +29,7 @@ private:
       theContainer[key]=value;
     }
     /// emptify cache, delete values associated to Key
-    void clear() {
+    void clear() {      
       for ( auto & v : theContainer)  { delete v; v=nullptr;}
     }
   private:
@@ -48,7 +48,7 @@ public:
   const RecHitsSortedInPhi & 
   operator()(const ctfseeding::SeedingLayer * layer, const TrackingRegion & region, 
 	     const edm::Event & iEvent, const edm::EventSetup & iSetup) {
-    int key = layer->detLayer()->seqNum();
+    int key = layer->seqNum();
     assert (key>=0);
     const RecHitsSortedInPhi * lhm = theCache.get(key);
     if (lhm==nullptr) {

--- a/RecoTracker/TkSeedingLayers/interface/SeedingLayer.h
+++ b/RecoTracker/TkSeedingLayers/interface/SeedingLayer.h
@@ -23,13 +23,14 @@ public:
   
   SeedingLayer(){}
 
-  SeedingLayer( const std::string & name,
+  SeedingLayer( const std::string & name, int seqNum,
                 const DetLayer* layer,
                 const TransientTrackingRecHitBuilder * hitBuilder,
                 const HitExtractor * hitExtractor,  
                 bool usePredefinedErrors = false, float hitErrorRZ = 0., float hitErrorRPhi=0.);
 
   std::string name() const;
+  int seqNum() const;
 
   void hits(const edm::Event& ev, const edm::EventSetup& es, Hits &) const;
   Hits hits(const edm::Event& ev, const edm::EventSetup& es) const;

--- a/RecoTracker/TkSeedingLayers/interface/SeedingLayerSetsBuilder.h
+++ b/RecoTracker/TkSeedingLayers/interface/SeedingLayerSetsBuilder.h
@@ -24,6 +24,7 @@ private:
   std::vector<std::vector<std::string> > layerNamesInSets(
     const std::vector<std::string> & namesPSet) ;
   edm::ParameterSet layerConfig(const std::string & nameLayer,const edm::ParameterSet& cfg) const;
+  std::map<std::string,int> nameToId;
 
 private:
   struct LayerSpec { 
@@ -36,6 +37,7 @@ private:
     bool useSimpleRphiHitsCleaner;
     bool skipClusters; edm::InputTag clustersToSkip;
     bool useProjection;
+    double minAbsZ;
     std::string print() const;
   }; 
   std::vector<std::vector<LayerSpec> > theLayersInSets;

--- a/RecoTracker/TkSeedingLayers/src/HitExtractorSTRP.h
+++ b/RecoTracker/TkSeedingLayers/src/HitExtractorSTRP.h
@@ -44,6 +44,7 @@ public:
 	       const SiStripRecHit2D * hit,
 	       TransientTrackingRecHit::ConstRecHitPointer & replaceMe) const;
   void setNoProjection() const {failProjection=true;};
+  void setMinAbsZ(double minZToSet) {minAbsZ=minZToSet;}
 private:
   bool ringRange(int ring) const;
 private:
@@ -56,6 +57,7 @@ private:
   bool hasStereoHits;  edm::InputTag theStereoHits;
   bool hasRingSelector; int theMinRing, theMaxRing; 
   bool hasSimpleRphiHitsCleaner;
+  double minAbsZ;
   mutable bool failProjection;
 };
 

--- a/RecoTracker/TkSeedingLayers/src/SeedingLayer.cc
+++ b/RecoTracker/TkSeedingLayers/src/SeedingLayer.cc
@@ -9,23 +9,24 @@ using namespace std;
 class SeedingLayer::SeedingLayerImpl {
 public:
   SeedingLayerImpl(
-                const std::string & name,
+                const std::string & name, int seqNum,
                 const DetLayer* layer,
                 const TransientTrackingRecHitBuilder * hitBuilder,
                 const HitExtractor * hitExtractor)
   : theName(name),
+    theSeqNum(seqNum),
     theLayer(layer),
     theTTRHBuilder(hitBuilder),
     theHitExtractor(hitExtractor),
     theHasPredefinedHitErrors(false),thePredefinedHitErrorRZ(0.),thePredefinedHitErrorRPhi(0.) { }
 
   SeedingLayerImpl(
-    const string & name,
+    const string & name, int seqNum,
     const DetLayer* layer,
     const TransientTrackingRecHitBuilder * hitBuilder,
     const HitExtractor * hitExtractor,
     float hitErrorRZ, float hitErrorRPhi)
-  : theName(name), theLayer(layer),
+  : theName(name), theSeqNum(seqNum), theLayer(layer),
     theTTRHBuilder(hitBuilder), theHitExtractor(hitExtractor),
     theHasPredefinedHitErrors(true),
     thePredefinedHitErrorRZ(hitErrorRZ), thePredefinedHitErrorRPhi(hitErrorRPhi) { }
@@ -36,6 +37,8 @@ public:
 			  const edm::EventSetup& es) const { return theHitExtractor->hits(sl,ev,es);  }
 
   std::string name() const { return theName; }
+
+  int seqNum() const { return theSeqNum; }
 
   const DetLayer*  detLayer() const { return theLayer; }
   const TransientTrackingRecHitBuilder * hitBuilder() const { return theTTRHBuilder; }
@@ -49,6 +52,7 @@ private:
 
 private:
   std::string theName;
+  int theSeqNum;
   const DetLayer* theLayer;
   const TransientTrackingRecHitBuilder *theTTRHBuilder;
   const HitExtractor * theHitExtractor;
@@ -60,21 +64,26 @@ private:
 
 
 SeedingLayer::SeedingLayer( 
-    const std::string & name, 
+    const std::string & name, int seqNum,
     const DetLayer* layer, 
     const TransientTrackingRecHitBuilder * hitBuilder,
     const HitExtractor * hitExtractor,
     bool usePredefinedErrors, float hitErrorRZ, float hitErrorRPhi)
 {
   SeedingLayerImpl * l = usePredefinedErrors ? 
-      new SeedingLayerImpl(name,layer,hitBuilder,hitExtractor,hitErrorRZ,hitErrorRPhi)
-    : new SeedingLayerImpl(name,layer,hitBuilder,hitExtractor);
+      new SeedingLayerImpl(name,seqNum,layer,hitBuilder,hitExtractor,hitErrorRZ,hitErrorRPhi)
+    : new SeedingLayerImpl(name,seqNum,layer,hitBuilder,hitExtractor);
   theImpl = boost::shared_ptr<SeedingLayerImpl> (l);
 }
 
 std::string SeedingLayer::name() const
 {
   return theImpl->name();
+}
+
+int SeedingLayer::seqNum() const
+{
+  return theImpl->seqNum();
 }
 
 const DetLayer*  SeedingLayer::detLayer() const

--- a/RecoTracker/TkSeedingLayers/src/SeedingLayerSetsBuilder.cc
+++ b/RecoTracker/TkSeedingLayers/src/SeedingLayerSetsBuilder.cc
@@ -289,20 +289,6 @@ SeedingLayerSets SeedingLayerSetsBuilder::layers(const edm::EventSetup& es) cons
           extractor = new HitExtractorPIX(side,idLayer,layer.pixelHitProducer);
         } else {
           HitExtractorSTRP extSTRP(detLayer,side,idLayer);
-	  /*
-	  if (layer.useMatchedRecHits) {//fixme
-	    if (idLayer<3 || (detLayer->subDetector() != GeomDetEnumerators::TIB && detLayer->subDetector() != GeomDetEnumerators::TOB) ) {
-	      //cout << "useMatchedRecHits for this layer: " << detLayer->subDetector() << " " << idLayer << endl;
-	      extSTRP.useMatchedHits(layer.matchedRecHits);
-	    }
-	  }
-	  if (layer.useRPhiRecHits)    {
-	    if (idLayer>=3 || (detLayer->subDetector() != GeomDetEnumerators::TIB && detLayer->subDetector() != GeomDetEnumerators::TOB) ) {
-	      //cout << "useRPhiRecHits for this layer: " << detLayer->subDetector() << " " << idLayer << endl;
-	      extSTRP.useRPhiHits(layer.rphiRecHits);
-	    }
-	  }
-	  */
 	  if (layer.useMatchedRecHits) extSTRP.useMatchedHits(layer.matchedRecHits);
 	  if (layer.useRPhiRecHits)    extSTRP.useRPhiHits(layer.rphiRecHits);
           if (layer.useStereoRecHits)  extSTRP.useStereoHits(layer.stereoRecHits);

--- a/RecoTracker/TkSeedingLayers/src/SeedingLayerSetsBuilder.cc
+++ b/RecoTracker/TkSeedingLayers/src/SeedingLayerSetsBuilder.cc
@@ -64,6 +64,7 @@ SeedingLayerSetsBuilder::SeedingLayerSetsBuilder(const edm::ParameterSet & cfg)
 
   map<string,LayerSpec> mapConfig; // for debug printout only!
 
+  int layerSetId = 0;
   for (IT it = layerNamesInSets.begin(); it != layerNamesInSets.end(); it++) {
     vector<LayerSpec> layersInSet;
     for (IS is = it->begin(); is != it->end(); is++) {
@@ -129,8 +130,15 @@ SeedingLayerSetsBuilder::SeedingLayerSetsBuilder(const edm::ParameterSet & cfg)
 
       layer.useSimpleRphiHitsCleaner = cfgLayer.exists("useSimpleRphiHitsCleaner") ? cfgLayer.getParameter<bool>("useSimpleRphiHitsCleaner") : true; 
 
+      layer.minAbsZ = cfgLayer.exists("MinAbsZ") ? cfgLayer.getParameter<double>("MinAbsZ") : 0.;
+
       layersInSet.push_back(layer);
       mapConfig[layer.name]=layer;
+      if (nameToId.find(layer.name)==nameToId.end()) {
+	std::string name = layer.name;
+	nameToId.insert( std::pair<std::string,int>(name,layerSetId) );
+	layerSetId++;	
+      }
     }
     theLayersInSets.push_back(layersInSet);
   }
@@ -210,16 +218,16 @@ SeedingLayerSets SeedingLayerSetsBuilder::layers(const edm::EventSetup& es) cons
       //
       // BPIX
       //
-      if (name.substr(0,4) == "BPix") {
-        idLayer = atoi(name.substr(4,1).c_str());
+      if (name.find("BPix") != string::npos) {
+        idLayer = atoi(name.substr(name.find("BPix")+4,1).c_str());
         side=SeedingLayer::Barrel;
         detLayer=bpx[idLayer-1]; 
       }
       //
       // FPIX
       //
-      else if (name.substr(0,4) == "FPix") {
-        idLayer = atoi(name.substr(4,1).c_str());
+      else if (name.find("FPix") != string::npos) {
+        idLayer = atoi(name.substr(name.find("FPix")+4,1).c_str());
         if ( name.find("pos") != string::npos ) {
           side = SeedingLayer::PosEndcap;
           detLayer = fpx_pos[idLayer-1];
@@ -231,16 +239,16 @@ SeedingLayerSets SeedingLayerSetsBuilder::layers(const edm::EventSetup& es) cons
       //
       // TIB
       //
-      else if (name.substr(0,3) == "TIB") {
-        idLayer = atoi(name.substr(3,1).c_str());
+      else if (name.find("TIB") != string::npos) {
+        idLayer = atoi(name.substr(name.find("TIB")+3,1).c_str());
         side=SeedingLayer::Barrel;
         detLayer=tib[idLayer-1];
       }
       //
       // TID
       //
-      else if (name.substr(0,3) == "TID") {
-        idLayer = atoi(name.substr(3,1).c_str());
+      else if (name.find("TID") != string::npos) {
+        idLayer = atoi(name.substr(name.find("TID")+3,1).c_str());
         if ( name.find("pos") != string::npos ) {
           side = SeedingLayer::PosEndcap;
           detLayer = tid_pos[idLayer-1];
@@ -252,16 +260,16 @@ SeedingLayerSets SeedingLayerSetsBuilder::layers(const edm::EventSetup& es) cons
       //
       // TOB
       //
-      else if (name.substr(0,3) == "TOB") {
-        idLayer = atoi(name.substr(3,1).c_str());
+      else if (name.find("TOB") != string::npos) {
+        idLayer = atoi(name.substr(name.find("TOB")+3,1).c_str());
         side=SeedingLayer::Barrel;
         detLayer=tob[idLayer-1];
       }
       //
       // TEC
       //
-      else if (name.substr(0,3) == "TEC") {
-        idLayer = atoi(name.substr(3,1).c_str());
+      else if (name.find("TEC") != string::npos) {
+        idLayer = atoi(name.substr(name.find("TEC")+3,1).c_str());
         if ( name.find("pos") != string::npos ) {
           side = SeedingLayer::PosEndcap;
           detLayer = tec_pos[idLayer-1];
@@ -281,11 +289,26 @@ SeedingLayerSets SeedingLayerSetsBuilder::layers(const edm::EventSetup& es) cons
           extractor = new HitExtractorPIX(side,idLayer,layer.pixelHitProducer);
         } else {
           HitExtractorSTRP extSTRP(detLayer,side,idLayer);
-          if (layer.useMatchedRecHits) extSTRP.useMatchedHits(layer.matchedRecHits);
-          if (layer.useRPhiRecHits)    extSTRP.useRPhiHits(layer.rphiRecHits);
+	  /*
+	  if (layer.useMatchedRecHits) {//fixme
+	    if (idLayer<3 || (detLayer->subDetector() != GeomDetEnumerators::TIB && detLayer->subDetector() != GeomDetEnumerators::TOB) ) {
+	      //cout << "useMatchedRecHits for this layer: " << detLayer->subDetector() << " " << idLayer << endl;
+	      extSTRP.useMatchedHits(layer.matchedRecHits);
+	    }
+	  }
+	  if (layer.useRPhiRecHits)    {
+	    if (idLayer>=3 || (detLayer->subDetector() != GeomDetEnumerators::TIB && detLayer->subDetector() != GeomDetEnumerators::TOB) ) {
+	      //cout << "useRPhiRecHits for this layer: " << detLayer->subDetector() << " " << idLayer << endl;
+	      extSTRP.useRPhiHits(layer.rphiRecHits);
+	    }
+	  }
+	  */
+	  if (layer.useMatchedRecHits) extSTRP.useMatchedHits(layer.matchedRecHits);
+	  if (layer.useRPhiRecHits)    extSTRP.useRPhiHits(layer.rphiRecHits);
           if (layer.useStereoRecHits)  extSTRP.useStereoHits(layer.stereoRecHits);
           if (layer.useRingSelector)   extSTRP.useRingSelector(layer.minRing,layer.maxRing);
 	  extSTRP.useSimpleRphiHitsCleaner(layer.useSimpleRphiHitsCleaner);
+	  if (layer.minAbsZ>0.) extSTRP.setMinAbsZ(layer.minAbsZ);
 	  if (layer.skipClusters && !layer.useProjection)
 	    extSTRP.setNoProjection();
           extractor = extSTRP.clone();
@@ -301,11 +324,17 @@ SeedingLayerSets SeedingLayerSetsBuilder::layers(const edm::EventSetup& es) cons
         edm::ESHandle<TransientTrackingRecHitBuilder> builder;
         es.get<TransientRecHitRecord>().get(layer.hitBuilder, builder);
 
+	auto it = nameToId.find(name);
+	if (it==nameToId.end()) {
+	  edm::LogError("SeedingLayerSetsBuilder")<<"nameToId map mismatch! Could not find: "<<name;
+	  return result;
+	}
+	int layerSetId = it->second;
         if (layer.useErrorsFromParam) {
-          set.push_back( SeedingLayer( name, detLayer, builder.product(), 
-                                       extractor, true, layer.hitErrorRPhi,layer.hitErrorRZ));
+          set.push_back( SeedingLayer( name, layerSetId, detLayer, builder.product(), 
+                                       extractor, true, layer.hitErrorRPhi,layer.hitErrorRZ));	  
         } else {
-          set.push_back( SeedingLayer( name, detLayer, builder.product(), extractor));
+          set.push_back( SeedingLayer( name, layerSetId, detLayer, builder.product(), extractor));
         }
       }
     


### PR DESCRIPTION
a few changes related to seeding layers:
- switch from cache based on DetLayers to cache based on SeedingLayers
- fix small bug in HitExtractorSTRP
- add possibility to set minAbsZ for TOB hits
- add possibility to have multiple SeedingLayers per DetLayer

tracking results expected to be unchanged (functionalities to be used in the future by strip triplet seeding)
