### PR TITLE
Really make reco::TrackBase destructor virtual

### DIFF
--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -46,8 +46,6 @@
  * 
  * \author Thomas Speer, Luca Lista, Pascal Vanlaer, Juan Alcaraz
  *
- * \version $Id: TrackBase.h,v 1.86 2012/03/16 18:16:21 mangano Exp $
- *
  */
 
 #include "DataFormats/Math/interface/Vector.h"
@@ -102,7 +100,7 @@ namespace reco {
 	       const Vector & momentum, int charge, const CovarianceMatrix &,
 	       TrackAlgorithm=undefAlgorithm, TrackQuality quality=undefQuality,signed char nloops=0);
     /// virtual destructor   
-    ~TrackBase();
+    virtual ~TrackBase();
     /// chi-squared of the fit
     double chi2() const { return chi2_; }
     /// number of degrees of freedom of the fit

--- a/Fireworks/Core/BuildFile.xml
+++ b/Fireworks/Core/BuildFile.xml
@@ -10,6 +10,7 @@
 <use name="DataFormats/MuonDetId"/>
 <use name="DataFormats/SiPixelDetId"/>
 <use name="DataFormats/Scalers"/>
+<use name="DataFormats/TrackReco"/>
 <use name="FWCore/Common"/>
 <use name="FWCore/FWLite"/>
 <use name="FWCore/PluginManager"/>


### PR DESCRIPTION
Back in January 2008, an attempt was made to add a virtual destructor to reco::TrackBase and its derived classes, such as reco::Track.  Unfortunately, the virtual keyword was not added in TrackBase, just a comment stating (incorrectly) that the destructor was virtual.  This is a bug, as the class needs a virtual destructor.
This request merely adds the virtual keyword to the destructor to fix the bug.  It was tested with checkdeps -a, and the unit tests pass.

This is a trivial C++ bug fix that has nothing really to do with RECO, so if it is not signed in a timely manner, I suggest that the signature be bypassed.

The bug causes a unit test failure in CommonTools/Utils when the Reflex functionality for invoking functions is replaced by ROOT.  So, this fix is needed.
