### PR TITLE
SubProcess no longer an OutputModule

### DIFF
--- a/Calibration/EcalCalibAlgos/src/ZeeCalibration.cc
+++ b/Calibration/EcalCalibAlgos/src/ZeeCalibration.cc
@@ -48,7 +48,6 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/CachedProducts.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
 

--- a/FWCore/Framework/interface/CachedProducts.h
+++ b/FWCore/Framework/interface/CachedProducts.h
@@ -76,10 +76,6 @@ namespace edm
 
       bool wantEvent(Event const& e);
 
-      // Get all TriggerResults objects for the process names we're
-      // interested in.
-      size_type fill(Event const& ev);
-      
       handle_t getOneTriggerResults(Event const& e);
 
       // Clear the cache
@@ -88,9 +84,10 @@ namespace edm
     private:
       typedef selectors_t::iterator iter;
 
-      // Return the number of cached TriggerResult handles
-      //size_type size() const { return numberFound_; }
-
+      // Get all TriggerResults objects for the process names we're
+      // interested in.
+      size_type fill(Event const& ev);
+      
       // If we have only one handle cached, return it; otherwise throw.
       handle_t returnOneHandleOrThrow();
 

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -20,6 +20,7 @@ output stream.
 #include "FWCore/Framework/interface/ProductSelectorRules.h"
 #include "FWCore/Framework/interface/ProductSelector.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
+#include "FWCore/Framework/interface/getAllTriggerNames.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
 #include <array>
@@ -30,8 +31,6 @@ output stream.
 namespace edm {
 
   typedef detail::TriggerResultsBasedEventSelector::handle_t Trig;
-
-  std::vector<std::string> const& getAllTriggerNames();
 
   class OutputModule : public EDConsumerBase {
   public:

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -15,7 +15,7 @@ output stream.
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "DataFormats/Provenance/interface/Selections.h"
 
-#include "FWCore/Framework/interface/CachedProducts.h"
+#include "FWCore/Framework/interface/TriggerResultsBasedEventSelector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ProductSelectorRules.h"
 #include "FWCore/Framework/interface/ProductSelector.h"
@@ -29,7 +29,7 @@ output stream.
 
 namespace edm {
 
-  typedef detail::CachedProducts::handle_t Trig;
+  typedef detail::TriggerResultsBasedEventSelector::handle_t Trig;
 
   std::vector<std::string> const& getAllTriggerNames();
 
@@ -73,9 +73,6 @@ namespace edm {
     BranchIDLists const* branchIDLists() const;
 
   protected:
-
-    //Trig const& getTriggerResults(Event const& ep) const;
-    Trig getTriggerResults(Event const& ep) const;
 
     // This function is needed for compatibility with older code. We
     // need to clean up the use of Event and EventPrincipal, to avoid
@@ -148,12 +145,8 @@ namespace edm {
     // We do not own the pointed-to CurrentProcessingContext.
     CurrentProcessingContext const* current_context_;
 
-    //This will store TriggerResults objects for the current event.
-    // mutable std::vector<Trig> prods_;
-    mutable bool prodsValid_;
-
     bool wantAllEvents_;
-    mutable detail::CachedProducts selectors_;
+    mutable detail::TriggerResultsBasedEventSelector selectors_;
     // ID of the ParameterSet that configured the event selector
     // subsystem.
     ParameterSetID selector_config_id_;

--- a/FWCore/Framework/interface/ScheduleItems.h
+++ b/FWCore/Framework/interface/ScheduleItems.h
@@ -14,7 +14,7 @@ namespace edm {
   class ActivityRegistry;
   class BranchIDListHelper;
   class CommonParams;
-  class OutputModule;
+  class SubProcess;
   class ParameterSet;
   class ProcessConfiguration;
   class ProductRegistry;
@@ -25,7 +25,7 @@ namespace edm {
   struct ScheduleItems {
     ScheduleItems();
 
-    ScheduleItems(ProductRegistry const& preg, BranchIDListHelper const& branchIDListHelper, OutputModule const& om);
+    ScheduleItems(ProductRegistry const& preg, BranchIDListHelper const& branchIDListHelper, SubProcess const& om);
 
     ScheduleItems(ScheduleItems const&) = delete; // Disallow copying and moving
     ScheduleItems& operator=(ScheduleItems const&) = delete; // Disallow copying and moving

--- a/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
+++ b/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <map>
 
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/EventSelector.h"
@@ -55,7 +56,6 @@ namespace edm
       handle_t            product_;
     };
 
-
     class TriggerResultsBasedEventSelector
     {
     public:
@@ -93,6 +93,36 @@ namespace edm
       size_type   numberFound_;
       selectors_t selectors_;
     };
+    
+    class  TRBESSentry {
+    public:
+      TRBESSentry(detail::TriggerResultsBasedEventSelector& prods) : p(prods) {}
+      ~TRBESSentry() {
+        p.clear();
+      }
+    private:
+      detail::TriggerResultsBasedEventSelector& p;
+      
+      TRBESSentry(TRBESSentry const&) = delete;
+      TRBESSentry& operator=(TRBESSentry const&) = delete;
+    };
+
+
+    /** Handles the final initialization of the TriggerResutsBasedEventSelector
+     \return true if all events will be selected
+     */
+    bool configureEventSelector(edm::ParameterSet const& iPSet,
+                                std::string const& iProcessName,
+                                std::vector<std::string> const& iAllTriggerNames,
+                                edm::detail::TriggerResultsBasedEventSelector& oSelector);
+    /** Takes the user specified SelectEvents PSet and creates a new one
+     which conforms to the canonical format required for provenance
+     */
+    ParameterSetID registerProperSelectionInfo(edm::ParameterSet const& iInitial,
+                                               std::string const& iLabel,
+                                               std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
+                                               bool anyProductProduced);
+
   }
 }
 

--- a/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
+++ b/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
@@ -1,9 +1,9 @@
-#ifndef Framework_CachedProducts_h
-#define Framework_CachedProducts_h
+#ifndef FWCore_Framework_TriggerResultsBasedEventSelector_h
+#define FWCore_Framework_TriggerResultsBasedEventSelector_h
 
 // -------------------------------------------------------------------
 //
-// CachedProducts: This class is used by OutputModule to interact with
+// TriggerResultsBasedEventSelector: This class is used by OutputModule to interact with
 // the TriggerResults objects upon which the decision to write out an
 // event is made.
 //
@@ -59,10 +59,10 @@ namespace edm
     };
 
 
-    class CachedProducts
+    class TriggerResultsBasedEventSelector
     {
     public:
-      CachedProducts();
+      TriggerResultsBasedEventSelector();
       typedef detail::handle_t                    handle_t;
       typedef std::vector<NamedEventSelector>     selectors_t;
       typedef selectors_t::size_type              size_type;

--- a/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
+++ b/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
@@ -12,7 +12,7 @@
 #include <utility>
 #include <vector>
 
-#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/EventSelector.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -32,10 +32,7 @@ namespace edm
 	product_() 
       { }
 
-      void fill(Event const& e)
-      {
-	e.getByLabel(inputTag_, product_);
-      }
+      void fill(EventPrincipal const& e);
 
       bool match()
       {
@@ -74,9 +71,9 @@ namespace edm
 		 std::vector<std::string> const& triggernames,
                  const std::string& process_name);
 
-      bool wantEvent(Event const& e);
+      bool wantEvent(EventPrincipal const& e);
 
-      handle_t getOneTriggerResults(Event const& e);
+      handle_t getOneTriggerResults(EventPrincipal const& e);
 
       // Clear the cache
       void clear();
@@ -86,7 +83,7 @@ namespace edm
 
       // Get all TriggerResults objects for the process names we're
       // interested in.
-      size_type fill(Event const& ev);
+      size_type fill(EventPrincipal const& ev);
       
       // If we have only one handle cached, return it; otherwise throw.
       handle_t returnOneHandleOrThrow();

--- a/FWCore/Framework/interface/getAllTriggerNames.h
+++ b/FWCore/Framework/interface/getAllTriggerNames.h
@@ -1,0 +1,31 @@
+#ifndef FWCore_Framework_getAllTriggerNames_h
+#define FWCore_Framework_getAllTriggerNames_h
+// -*- C++ -*-
+//
+// Package:     Framework
+// Class  :     getAllTriggerNames
+// 
+/**\function getAllTriggerNames getAllTriggerNames.h "FWCore/Framework/interface/getAllTriggerNames.h"
+
+ Description: Returns a list of all the trigger names in the current process
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Fri, 26 Jul 2013 20:40:50 GMT
+// $Id$
+//
+
+// system include files
+#include <vector>
+#include <string>
+
+// user include files
+
+// forward declarations
+namespace edm {
+  std::vector<std::string> const& getAllTriggerNames();
+}
+#endif

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -25,82 +25,6 @@
 
 namespace edm {
 
-  std::vector<std::string> const& getAllTriggerNames() {
-    Service<service::TriggerNamesService> tns;
-    return tns->getTrigPaths();
-  }
-}
-
-namespace {
-  //--------------------------------------------------------
-  // Remove whitespace (spaces and tabs) from a std::string.
-  void remove_whitespace(std::string& s) {
-    s.erase(std::remove(s.begin(), s.end(), ' '), s.end());
-    s.erase(std::remove(s.begin(), s.end(), '\t'), s.end());
-  }
-
-  void test_remove_whitespace() {
-    std::string a("noblanks");
-    std::string b("\t   no   blanks    \t");
-
-    remove_whitespace(b);
-    assert(a == b);
-  }
-
-  //--------------------------------------------------------
-  // Given a path-spec (std::string of the form "a:b", where the ":b" is
-  // optional), return a parsed_path_spec_t containing "a" and "b".
-
-  typedef std::pair<std::string, std::string> parsed_path_spec_t;
-  void parse_path_spec(std::string const& path_spec,
-                       parsed_path_spec_t& output) {
-    std::string trimmed_path_spec(path_spec);
-    remove_whitespace(trimmed_path_spec);
-
-    std::string::size_type colon = trimmed_path_spec.find(":");
-    if(colon == std::string::npos) {
-        output.first = trimmed_path_spec;
-    } else {
-        output.first  = trimmed_path_spec.substr(0, colon);
-        output.second = trimmed_path_spec.substr(colon + 1,
-                                                 trimmed_path_spec.size());
-    }
-  }
-
-  void test_parse_path_spec() {
-    std::vector<std::string> paths;
-    paths.push_back("a:p1");
-    paths.push_back("b:p2");
-    paths.push_back("  c");
-    paths.push_back("ddd\t:p3");
-    paths.push_back("eee:  p4  ");
-
-    std::vector<parsed_path_spec_t> parsed(paths.size());
-    for(size_t i = 0; i < paths.size(); ++i) {
-      parse_path_spec(paths[i], parsed[i]);
-    }
-
-    assert(parsed[0].first  == "a");
-    assert(parsed[0].second == "p1");
-    assert(parsed[1].first  == "b");
-    assert(parsed[1].second == "p2");
-    assert(parsed[2].first  == "c");
-    assert(parsed[2].second == "");
-    assert(parsed[3].first  == "ddd");
-    assert(parsed[3].second == "p3");
-    assert(parsed[4].first  == "eee");
-    assert(parsed[4].second == "p4");
-  }
-}
-
-namespace edm {
-  namespace test {
-    void run_all_output_module_tests() {
-      test_remove_whitespace();
-      test_parse_path_spec();
-    }
-  }
-
   // -------------------------------------------------------
   OutputModule::OutputModule(ParameterSet const& pset) :
     maxEvents_(-1),
@@ -133,32 +57,10 @@ namespace edm {
     selectevents.registerIt(); // Just in case this PSet is not registered
 
     selector_config_id_ = selectevents.id();
-    // If selectevents is an emtpy ParameterSet, then we are to write
-    // all events, or one which contains a vstrig 'SelectEvents' that
-    // is empty, we are to write all events. We have no need for any
-    // EventSelectors.
-    if(selectevents.empty()) {
-        wantAllEvents_ = true;
-        selectors_.setupDefault(getAllTriggerNames());
-        return;
-    }
-
-    std::vector<std::string> path_specs =
-      selectevents.getParameter<std::vector<std::string> >("SelectEvents");
-
-    if(path_specs.empty()) {
-        wantAllEvents_ = true;
-        selectors_.setupDefault(getAllTriggerNames());
-        return;
-    }
-
-    // If we get here, we have the possibility of having to deal with
-    // path_specs that look at more than one process.
-    std::vector<parsed_path_spec_t> parsed_paths(path_specs.size());
-    for(size_t i = 0; i < path_specs.size(); ++i) {
-      parse_path_spec(path_specs[i], parsed_paths[i]);
-    }
-    selectors_.setup(parsed_paths, getAllTriggerNames(), process_name_);
+    wantAllEvents_ = detail::configureEventSelector(selectevents,
+                                                    process_name_,
+                                                    getAllTriggerNames(),
+                                                    selectors_);
   }
 
   void OutputModule::configure(OutputModuleDescription const& desc) {
@@ -269,18 +171,6 @@ namespace edm {
     return selectors_.getOneTriggerResults(ep);  }
 
   namespace {
-    class  PVSentry {
-    public:
-      PVSentry(detail::TriggerResultsBasedEventSelector& prods) : p(prods) {}
-      ~PVSentry() {
-        p.clear();
-      }
-    private:
-      detail::TriggerResultsBasedEventSelector& p;
-
-      PVSentry(PVSentry const&) = delete;
-      PVSentry& operator=(PVSentry const&) = delete;
-    };
   }
 
   bool
@@ -288,7 +178,7 @@ namespace edm {
                         EventSetup const&,
                         CurrentProcessingContext const* cpc) {
     detail::CPCSentry sentry(current_context_, cpc);
-    PVSentry          products_sentry(selectors_);
+    detail::TRBESSentry products_sentry(selectors_);
 
     FDEBUG(2) << "writeEvent called\n";
 
@@ -492,37 +382,14 @@ namespace edm {
   OutputModule::baseType() {
     return kBaseType;
   }
-
+  
   void
   OutputModule::setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
                                       bool anyProductProduced) {
-
-    ParameterSet selectEventsInfo;
-    selectEventsInfo.copyForModify(getParameterSet(selector_config_id_));
-    selectEventsInfo.addParameter<bool>("InProcessHistory", anyProductProduced);
-    std::string const& label = description().moduleLabel();
-    std::vector<std::string> endPaths;
-    std::vector<int> endPathPositions;
-
-    // The label will be empty if and only if this is a SubProcess
-    // SubProcess's do not appear on any end path
-    if (!label.empty()) {
-      std::map<std::string, std::vector<std::pair<std::string, int> > >::const_iterator iter = outputModulePathPositions.find(label);
-      assert(iter != outputModulePathPositions.end());
-      for (std::vector<std::pair<std::string, int> >::const_iterator i = iter->second.begin(), e = iter->second.end();
-           i != e; ++i) {
-        endPaths.push_back(i->first);
-        endPathPositions.push_back(i->second);
-      }
-    }
-    selectEventsInfo.addParameter<std::vector<std::string> >("EndPaths", endPaths);
-    selectEventsInfo.addParameter<std::vector<int> >("EndPathPositions", endPathPositions);
-    if (!selectEventsInfo.exists("SelectEvents")) {
-      selectEventsInfo.addParameter<std::vector<std::string> >("SelectEvents", std::vector<std::string>());
-    }
-    selectEventsInfo.registerIt();
-
-    selector_config_id_ = selectEventsInfo.id();
+    selector_config_id_ = detail::registerProperSelectionInfo(getParameterSet(selector_config_id_),
+                                      description().moduleLabel(),
+                                                      outputModulePathPositions,
+                                                      anyProductProduced);
   }
 
   void

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -7,7 +7,7 @@
 #include "FWCore/Framework/interface/Actions.h"
 #include "FWCore/Framework/interface/CommonParams.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
-#include "FWCore/Framework/interface/OutputModule.h"
+#include "FWCore/Framework/interface/SubProcess.h"
 #include "FWCore/Framework/interface/Schedule.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
 #include "FWCore/Framework/src/SignallingProductRegistry.h"
@@ -29,7 +29,7 @@ namespace edm {
       processConfiguration_() {
   }
 
-  ScheduleItems::ScheduleItems(ProductRegistry const& preg, BranchIDListHelper const& branchIDListHelper, OutputModule const& om) :
+  ScheduleItems::ScheduleItems(ProductRegistry const& preg, BranchIDListHelper const& branchIDListHelper, SubProcess const& om) :
       actReg_(new ActivityRegistry),
       preg_(new SignallingProductRegistry(preg)),
       branchIDListHelper_(new BranchIDListHelper(branchIDListHelper)),

--- a/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
+++ b/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
@@ -5,10 +5,20 @@
 #include "FWCore/Framework/interface/TriggerResultsBasedEventSelector.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 
+static const edm::TypeID s_TrigResultsType(typeid(edm::TriggerResults));
+
 namespace edm 
 {
   namespace detail
   {
+    void NamedEventSelector::fill(EventPrincipal const& e) {
+      edm::BasicHandle h = e.getByLabel(PRODUCT_TYPE,
+                                        s_TrigResultsType,
+                                        inputTag_,
+                                        nullptr);
+      convert_handle(h,product_);
+    }
+    
     typedef detail::NamedEventSelector NES;
 
 
@@ -75,14 +85,14 @@ namespace edm
     }
 
     TriggerResultsBasedEventSelector::handle_t
-    TriggerResultsBasedEventSelector::getOneTriggerResults(Event const& ev)
+    TriggerResultsBasedEventSelector::getOneTriggerResults(EventPrincipal const& ev)
     {
       fill(ev);
       return returnOneHandleOrThrow();
     }
 
     bool
-    TriggerResultsBasedEventSelector::wantEvent(Event const& ev)
+    TriggerResultsBasedEventSelector::wantEvent(EventPrincipal const& ev)
     {
       // We have to get all the TriggerResults objects before we test
       // any for a match, because we have to deal with the possibility
@@ -131,7 +141,7 @@ namespace edm
     }
 
     TriggerResultsBasedEventSelector::size_type
-    TriggerResultsBasedEventSelector::fill(Event const& ev)
+    TriggerResultsBasedEventSelector::fill(EventPrincipal const& ev)
     {
       if (!fillDone_)
 	{

--- a/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
+++ b/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
@@ -3,14 +3,118 @@
 #include "boost/bind.hpp"
 
 #include "FWCore/Framework/interface/TriggerResultsBasedEventSelector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 
 static const edm::TypeID s_TrigResultsType(typeid(edm::TriggerResults));
 
+namespace {
+  //--------------------------------------------------------
+  // Remove whitespace (spaces and tabs) from a std::string.
+  void remove_whitespace(std::string& s) {
+    s.erase(std::remove(s.begin(), s.end(), ' '), s.end());
+    s.erase(std::remove(s.begin(), s.end(), '\t'), s.end());
+  }
+  
+  void test_remove_whitespace() {
+    std::string a("noblanks");
+    std::string b("\t   no   blanks    \t");
+    
+    remove_whitespace(b);
+    assert(a == b);
+  }
+  
+  //--------------------------------------------------------
+  // Given a path-spec (std::string of the form "a:b", where the ":b" is
+  // optional), return a parsed_path_spec_t containing "a" and "b".
+  
+  typedef std::pair<std::string, std::string> parsed_path_spec_t;
+  void parse_path_spec(std::string const& path_spec,
+                       parsed_path_spec_t& output) {
+    std::string trimmed_path_spec(path_spec);
+    remove_whitespace(trimmed_path_spec);
+    
+    std::string::size_type colon = trimmed_path_spec.find(":");
+    if(colon == std::string::npos) {
+      output.first = trimmed_path_spec;
+    } else {
+      output.first  = trimmed_path_spec.substr(0, colon);
+      output.second = trimmed_path_spec.substr(colon + 1,
+                                               trimmed_path_spec.size());
+    }
+  }
+  
+  void test_parse_path_spec() {
+    std::vector<std::string> paths;
+    paths.push_back("a:p1");
+    paths.push_back("b:p2");
+    paths.push_back("  c");
+    paths.push_back("ddd\t:p3");
+    paths.push_back("eee:  p4  ");
+    
+    std::vector<parsed_path_spec_t> parsed(paths.size());
+    for(size_t i = 0; i < paths.size(); ++i) {
+      parse_path_spec(paths[i], parsed[i]);
+    }
+    
+    assert(parsed[0].first  == "a");
+    assert(parsed[0].second == "p1");
+    assert(parsed[1].first  == "b");
+    assert(parsed[1].second == "p2");
+    assert(parsed[2].first  == "c");
+    assert(parsed[2].second == "");
+    assert(parsed[3].first  == "ddd");
+    assert(parsed[3].second == "p3");
+    assert(parsed[4].first  == "eee");
+    assert(parsed[4].second == "p4");
+  }
+}
+
 namespace edm 
 {
+  namespace test {
+    void run_all_output_module_tests() {
+      test_remove_whitespace();
+      test_parse_path_spec();
+    }
+  }
+
   namespace detail
   {
+    
+    bool configureEventSelector(edm::ParameterSet const& iPSet,
+                                std::string const& iProcessName,
+                                std::vector<std::string> const& iAllTriggerNames,
+                                edm::detail::TriggerResultsBasedEventSelector& oSelector) {
+      // If selectevents is an emtpy ParameterSet, then we are to write
+      // all events, or one which contains a vstrig 'SelectEvents' that
+      // is empty, we are to write all events. We have no need for any
+      // EventSelectors.
+      if(iPSet.empty()) {
+        oSelector.setupDefault(iAllTriggerNames);
+        return true;
+      }
+      
+      std::vector<std::string> path_specs =
+      iPSet.getParameter<std::vector<std::string> >("SelectEvents");
+      
+      if(path_specs.empty()) {
+        oSelector.setupDefault(iAllTriggerNames);
+        return true;
+      }
+      
+      // If we get here, we have the possibility of having to deal with
+      // path_specs that look at more than one process.
+      std::vector<parsed_path_spec_t> parsed_paths(path_specs.size());
+      for(size_t i = 0; i < path_specs.size(); ++i) {
+        parse_path_spec(path_specs[i], parsed_paths[i]);
+      }
+      oSelector.setup(parsed_paths, iAllTriggerNames, iProcessName);
+      
+      return false;
+    }
+
+    
     void NamedEventSelector::fill(EventPrincipal const& e) {
       edm::BasicHandle h = e.getByLabel(PRODUCT_TYPE,
                                         s_TrigResultsType,
@@ -164,6 +268,40 @@ namespace edm
       numberFound_ = 0;
     }
 
+
+    
+    ParameterSetID
+    registerProperSelectionInfo(edm::ParameterSet const& iInitial,
+                                std::string const& iLabel,
+                                std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
+                                bool anyProductProduced) {
+      ParameterSet selectEventsInfo;
+      selectEventsInfo.copyForModify(iInitial);
+      selectEventsInfo.addParameter<bool>("InProcessHistory", anyProductProduced);
+      std::vector<std::string> endPaths;
+      std::vector<int> endPathPositions;
+      
+      // The label will be empty if and only if this is a SubProcess
+      // SubProcess's do not appear on any end path
+      if (!iLabel.empty()) {
+        std::map<std::string, std::vector<std::pair<std::string, int> > >::const_iterator iter = outputModulePathPositions.find(iLabel);
+        assert(iter != outputModulePathPositions.end());
+        for (std::vector<std::pair<std::string, int> >::const_iterator i = iter->second.begin(), e = iter->second.end();
+             i != e; ++i) {
+          endPaths.push_back(i->first);
+          endPathPositions.push_back(i->second);
+        }
+      }
+      selectEventsInfo.addParameter<std::vector<std::string> >("EndPaths", endPaths);
+      selectEventsInfo.addParameter<std::vector<int> >("EndPathPositions", endPathPositions);
+      if (!selectEventsInfo.exists("SelectEvents")) {
+        selectEventsInfo.addParameter<std::vector<std::string> >("SelectEvents", std::vector<std::string>());
+      }
+      selectEventsInfo.registerIt();
+      
+      return selectEventsInfo.id();
+    }
+    
 
   } // namespace detail
 } // namespace edm

--- a/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
+++ b/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
@@ -2,7 +2,7 @@
 
 #include "boost/bind.hpp"
 
-#include "FWCore/Framework/interface/CachedProducts.h"
+#include "FWCore/Framework/interface/TriggerResultsBasedEventSelector.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 
 namespace edm 
@@ -12,14 +12,14 @@ namespace edm
     typedef detail::NamedEventSelector NES;
 
 
-    CachedProducts::CachedProducts() :
+    TriggerResultsBasedEventSelector::TriggerResultsBasedEventSelector() :
       fillDone_(false),
       numberFound_(0),
       selectors_()
     { }
 
     void
-    CachedProducts::setupDefault(std::vector<std::string> const& triggernames)
+    TriggerResultsBasedEventSelector::setupDefault(std::vector<std::string> const& triggernames)
     {
 
       // Set up one NamedEventSelector, with default configuration
@@ -30,7 +30,7 @@ namespace edm
     }
 
     void
-    CachedProducts::setup(std::vector<parsed_path_spec_t> const& path_specs,
+    TriggerResultsBasedEventSelector::setup(std::vector<parsed_path_spec_t> const& path_specs,
 			  std::vector<std::string> const& triggernames,
                           const std::string& process_name)
     {
@@ -74,15 +74,15 @@ namespace edm
 	}
     }
 
-    CachedProducts::handle_t
-    CachedProducts::getOneTriggerResults(Event const& ev)
+    TriggerResultsBasedEventSelector::handle_t
+    TriggerResultsBasedEventSelector::getOneTriggerResults(Event const& ev)
     {
       fill(ev);
       return returnOneHandleOrThrow();
     }
 
     bool
-    CachedProducts::wantEvent(Event const& ev)
+    TriggerResultsBasedEventSelector::wantEvent(Event const& ev)
     {
       // We have to get all the TriggerResults objects before we test
       // any for a match, because we have to deal with the possibility
@@ -106,15 +106,15 @@ namespace edm
       return match_found;
     }
     
-    CachedProducts::handle_t
-    CachedProducts::returnOneHandleOrThrow()
+    TriggerResultsBasedEventSelector::handle_t
+    TriggerResultsBasedEventSelector::returnOneHandleOrThrow()
     {
       switch (numberFound_)
 	{
 	case 0:
 	  throw edm::Exception(edm::errors::ProductNotFound,
 			       "TooFewProducts")
-	    << "CachedProducts::returnOneHandleOrThrow: "
+	    << "TriggerResultsBasedEventSelector::returnOneHandleOrThrow: "
 	    << " too few products found, "
 	    << "exepcted one, got zero\n";
 	case 1:
@@ -123,15 +123,15 @@ namespace edm
 	default:
 	  throw edm::Exception(edm::errors::ProductNotFound,
 			       "TooManyMatches")
-	    << "CachedProducts::returnOneHandleOrThrow: "
+	    << "TriggerResultsBasedEventSelector::returnOneHandleOrThrow: "
 	    << "too many products found, "
 	    << "expected one, got " << numberFound_ << '\n';
 	}
       return selectors_[0].product();
     }
 
-    CachedProducts::size_type
-    CachedProducts::fill(Event const& ev)
+    TriggerResultsBasedEventSelector::size_type
+    TriggerResultsBasedEventSelector::fill(Event const& ev)
     {
       if (!fillDone_)
 	{
@@ -147,7 +147,7 @@ namespace edm
     }
 
     void
-    CachedProducts::clear()
+    TriggerResultsBasedEventSelector::clear()
     { 
       for_all(selectors_, boost::bind(&NamedEventSelector::clear, _1));
       fillDone_ = false;

--- a/FWCore/Framework/src/getAllTriggerNames.cc
+++ b/FWCore/Framework/src/getAllTriggerNames.cc
@@ -1,0 +1,28 @@
+// -*- C++ -*-
+//
+// Package:     Package
+// Class  :     getAllTriggerNames
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  Fri, 26 Jul 2013 20:43:45 GMT
+// $Id$
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/getAllTriggerNames.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/TriggerNamesService.h"
+
+
+namespace edm {
+  
+  std::vector<std::string> const& getAllTriggerNames() {
+    Service<service::TriggerNamesService> tns;
+    return tns->getTrigPaths();
+  }
+}


### PR DESCRIPTION
To facilitate the addition of the new thread safe module types, the SubProcess class no longer inherits from edm::OutputModule. It was never actually used as an OutputModule and only wanted to share some of its implementation. The common code was moved different source files to allow sharing.
