### PR TITLE
New DataFormat for the new Jet Reconstruction method in Heavy Ions

### DIFF
--- a/DataFormats/HeavyIonEvent/BuildFile.xml
+++ b/DataFormats/HeavyIonEvent/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="root"/>
 <use   name="rootrflx"/>
 <use   name="DataFormats/Common"/>
+<use   name="DataFormats/ParticleFlowCandidate"/>
 <use   name="CondFormats/HIObjects"/>
 <use   name="CondFormats/DataRecord"/>
 <export>

--- a/DataFormats/HeavyIonEvent/interface/Centrality.h
+++ b/DataFormats/HeavyIonEvent/interface/Centrality.h
@@ -1,5 +1,5 @@
 //
-// $Id: Centrality.h,v 1.11 2010/08/14 17:06:50 nart Exp $
+// $Id: Centrality.h,v 1.12 2010/08/23 16:42:01 nart Exp $
 //
 
 #ifndef DataFormats_Centrality_h

--- a/DataFormats/HeavyIonEvent/interface/CentralityProvider.h
+++ b/DataFormats/HeavyIonEvent/interface/CentralityProvider.h
@@ -8,6 +8,7 @@
 #include "CondFormats/HIObjects/interface/CentralityTable.h"
 #include "CondFormats/DataRecord/interface/HeavyIonRcd.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 class CentralityProvider : public CentralityBins {
 
@@ -15,7 +16,7 @@ class CentralityProvider : public CentralityBins {
   CentralityProvider(const edm::EventSetup& iSetup);
   ~CentralityProvider(){;}
 
-  enum VariableType {HFtowers,HFhits,PixelHits,PixelTracks,Tracks,EB,EE,Missing};
+  enum VariableType {HFtowers, HFtowersPlus, HFtowersMinus, HFtowersTrunc, HFtowersPlusTrunc, HFtowersMinusTrunc, HFhits, PixelHits, PixelTracks, Tracks, EB, EE, Missing};
 
   int getNbins() const {return table_.size();}
   double centralityValue() const;
@@ -43,6 +44,7 @@ class CentralityProvider : public CentralityBins {
   unsigned int prevRun_;
   mutable edm::Handle<reco::Centrality> chandle_;
   VariableType varType_;
+  unsigned int pPbRunFlip_;
 };
 
 #endif

--- a/DataFormats/HeavyIonEvent/interface/EvtPlane.h
+++ b/DataFormats/HeavyIonEvent/interface/EvtPlane.h
@@ -1,6 +1,6 @@
 
 //
-// $Id: EvtPlane.h,v 1.3 2009/09/08 10:50:57 edwenger Exp $
+// $Id: EvtPlane.h,v 1.4 2009/09/08 12:33:11 edwenger Exp $
 //
 
 #ifndef DataFormats_EvtPlane_h

--- a/DataFormats/HeavyIonEvent/interface/VoronoiBackground.h
+++ b/DataFormats/HeavyIonEvent/interface/VoronoiBackground.h
@@ -7,7 +7,7 @@
 
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "DataFormats/Common/interface/AssociationMap.h"
+#include "DataFormats/Common/interface/ValueMap.h"
 
 #include <string>
 #include <vector>
@@ -37,15 +37,8 @@ protected:
 
 };
 
-
- // typedef edm::AssociationMap<edm::OneToValue<reco::PFCandidateCollection, reco::VoronoiBackground> > VoronoiBackgroundMap;
- // typedef edm::AssociationMap<edm::OneToValue<reco::CandidateCollection, reco::VoronoiBackground> > VoronoiBackgroundMap;
-
- typedef edm::AssociationMap<edm::OneToValue<reco::CandidateView, reco::VoronoiBackground> > VoronoiBackgroundMap;
- typedef edm::AssociationMap<edm::OneToValue<reco::PFCandidateCollection, reco::VoronoiBackground> > PFVoronoiBackgroundMap;
-
+ typedef edm::ValueMap<reco::VoronoiBackground> VoronoiMap;
  typedef edm::Ref<reco::CandidateView> CandidateViewRef;
-
 
 
 }

--- a/DataFormats/HeavyIonEvent/interface/VoronoiBackground.h
+++ b/DataFormats/HeavyIonEvent/interface/VoronoiBackground.h
@@ -1,0 +1,55 @@
+//
+// $Id: VoronoiBackground.h,v 1.12 2010/08/23 16:42:01 nart Exp $
+//
+
+#ifndef DataFormats_VoronoiBackground_h
+#define DataFormats_VoronoiBackground_h
+
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/Common/interface/AssociationMap.h"
+
+#include <string>
+#include <vector>
+
+namespace reco { class VoronoiBackground {
+public:
+      VoronoiBackground();
+      VoronoiBackground(double pt0, double pt1, double pt2, double mt0, double mt1, double mt2);
+      virtual ~VoronoiBackground();
+
+  double pt() const{
+     return pt_corrected;
+  }
+
+protected:
+
+  double pt_preeq;
+  double pt_posteq;
+  double pt_corrected;
+
+  double mt_preeq;
+  double mt_posteq;
+  double mt_corrected;
+
+  double voronoi_area;
+  //RefVector of neighbors...
+
+};
+
+
+ // typedef edm::AssociationMap<edm::OneToValue<reco::PFCandidateCollection, reco::VoronoiBackground> > VoronoiBackgroundMap;
+ // typedef edm::AssociationMap<edm::OneToValue<reco::CandidateCollection, reco::VoronoiBackground> > VoronoiBackgroundMap;
+
+ typedef edm::AssociationMap<edm::OneToValue<reco::CandidateView, reco::VoronoiBackground> > VoronoiBackgroundMap;
+ typedef edm::AssociationMap<edm::OneToValue<reco::PFCandidateCollection, reco::VoronoiBackground> > PFVoronoiBackgroundMap;
+
+ typedef edm::Ref<reco::CandidateView> CandidateViewRef;
+
+
+
+}
+
+#endif 
+
+

--- a/DataFormats/HeavyIonEvent/src/Centrality.cc
+++ b/DataFormats/HeavyIonEvent/src/Centrality.cc
@@ -1,5 +1,5 @@
 //
-// $Id: Centrality.cc,v 1.13 2010/08/31 18:07:51 edwenger Exp $
+// $Id: Centrality.cc,v 1.14 2010/10/16 17:09:34 yilmaz Exp $
 //
 
 #include "DataFormats/HeavyIonEvent/interface/Centrality.h"

--- a/DataFormats/HeavyIonEvent/src/CentralityProvider.cc
+++ b/DataFormats/HeavyIonEvent/src/CentralityProvider.cc
@@ -9,7 +9,13 @@ CentralityProvider::CentralityProvider(const edm::EventSetup& iSetup) :
       edm::ParameterSet hiPset = thepset.getParameter<edm::ParameterSet>("HeavyIonGlobalParameters");
       tag_ = hiPset.getParameter<edm::InputTag>("centralitySrc");
       centralityVariable_ = hiPset.getParameter<std::string>("centralityVariable");
+      pPbRunFlip_ = hiPset.getUntrackedParameter<unsigned int>("pPbRunFlip",99999999);
       if(centralityVariable_.compare("HFtowers") == 0) varType_ = HFtowers;
+      if(centralityVariable_.compare("HFtowersPlus") == 0) varType_ = HFtowersPlus;
+      if(centralityVariable_.compare("HFtowersMinus") == 0) varType_ = HFtowersMinus;
+      if(centralityVariable_.compare("HFtowersTrunc") == 0) varType_ = HFtowersTrunc;
+      if(centralityVariable_.compare("HFtowersPlusTrunc") == 0) varType_ = HFtowersPlusTrunc;
+      if(centralityVariable_.compare("HFtowersMinusTrunc") == 0) varType_ = HFtowersMinusTrunc;
       if(centralityVariable_.compare("HFhits") == 0) varType_ = HFhits;
       if(centralityVariable_.compare("PixelHits") == 0) varType_ = PixelHits;
       if(centralityVariable_.compare("PixelTracks") == 0) varType_ = PixelTracks;
@@ -18,7 +24,7 @@ CentralityProvider::CentralityProvider(const edm::EventSetup& iSetup) :
       if(centralityVariable_.compare("EE") == 0) varType_ = EE;
       if(varType_ == Missing){
 	 std::string errorMessage="Requested Centrality variable does not exist : "+centralityVariable_+"\n" +
-	    "Supported variables are: \n" + "HFtowers HFhits PixelHits PixelTracks Tracks EB EE" + "\n";
+	    "Supported variables are: \n" + "HFtowers HFtowersPlus HFtowersMinus HFtowersTrunc HFtowersPlusTrunc HFtowersMinusTrunc HFhits PixelHits PixelTracks Tracks EB EE" + "\n";
 	 throw cms::Exception("Configuration",errorMessage);
       }
       if(hiPset.exists("nonDefaultGlauberModel")){
@@ -34,7 +40,15 @@ CentralityProvider::CentralityProvider(const edm::EventSetup& iSetup) :
 void CentralityProvider::newEvent(const edm::Event& ev,const edm::EventSetup& iSetup){
    ev.getByLabel(tag_,chandle_);
    if(ev.id().run() == prevRun_) return;
+   if(prevRun_ < pPbRunFlip_ && ev.id().run() >= pPbRunFlip_){
+     LogDebug("CentralityProvider") << "Attention, the sides are flipped from this run on!\n";
+     if(centralityVariable_.compare("HFtowersPlus") == 0) varType_ = HFtowersMinus;
+     if(centralityVariable_.compare("HFtowersMinus") == 0) varType_ = HFtowersPlus;
+     if(centralityVariable_.compare("HFtowersPlusTrunc") == 0) varType_ = HFtowersMinusTrunc;
+     if(centralityVariable_.compare("HFtowersMinusTrunc") == 0) varType_ = HFtowersPlusTrunc;
+   }
    prevRun_ = ev.id().run();
+
    newRun(iSetup);
 }
 
@@ -91,6 +105,11 @@ double CentralityProvider::centralityValue() const {
    double var = -99;
    if(varType_ == HFhits) var = chandle_->EtHFhitSum();
    if(varType_ == HFtowers) var = chandle_->EtHFtowerSum();
+   if(varType_ == HFtowersPlus) var = chandle_->EtHFtowerSumPlus();
+   if(varType_ == HFtowersMinus) var = chandle_->EtHFtowerSumMinus();
+   if(varType_ == HFtowersTrunc) var = chandle_->EtHFtruncated();
+   if(varType_ == HFtowersPlusTrunc) var = chandle_->EtHFtruncatedPlus();
+   if(varType_ == HFtowersMinusTrunc) var = chandle_->EtHFtruncatedMinus();
    if(varType_ == PixelHits) var = chandle_->multiplicityPixel();
    if(varType_ == PixelTracks) var = chandle_->NpixelTracks();
    if(varType_ == Tracks) var = chandle_->Ntracks();

--- a/DataFormats/HeavyIonEvent/src/EvtPlane.cc
+++ b/DataFormats/HeavyIonEvent/src/EvtPlane.cc
@@ -1,5 +1,5 @@
 // //
-// // $Id: EvtPlane.cc,v 1.3 2009/09/08 10:50:57 edwenger Exp $
+// // $Id: EvtPlane.cc,v 1.4 2009/09/08 12:33:12 edwenger Exp $
 // //
 // 
 // #include "DataFormats/HeavyIonEvent/interface/EvtPlane.h"
@@ -23,7 +23,7 @@
 
 
 //
-// $Id: EvtPlane.cc,v 1.3 2009/09/08 10:50:57 edwenger Exp $
+// $Id: EvtPlane.cc,v 1.4 2009/09/08 12:33:12 edwenger Exp $
 //
 
 #include "DataFormats/HeavyIonEvent/interface/EvtPlane.h"

--- a/DataFormats/HeavyIonEvent/src/VoronoiBackground.cc
+++ b/DataFormats/HeavyIonEvent/src/VoronoiBackground.cc
@@ -1,0 +1,38 @@
+//
+// $Id: VoronoiBackground.cc,v 1.14 2010/10/16 17:09:34 yilmaz Exp $
+//
+
+#include "DataFormats/HeavyIonEvent/interface/VoronoiBackground.h"
+#include "FWCore/ParameterSet/interface/Registry.h"
+
+#include <iostream>
+using namespace std;
+using namespace reco;
+
+VoronoiBackground::VoronoiBackground()
+  : 
+pt_preeq(0),
+pt_posteq(0),
+pt_corrected(0),
+mt_preeq(0),
+mt_posteq(0),
+mt_corrected(0)
+{
+}
+
+VoronoiBackground::VoronoiBackground(double pt0, double pt1, double pt2, double mt0, double mt1, double mt2) 
+   :
+   pt_preeq(pt0),
+   pt_posteq(pt1),
+   pt_corrected(pt2),
+   mt_preeq(mt0),
+   mt_posteq(mt1),
+   mt_corrected(mt2)
+{
+}
+
+VoronoiBackground::~VoronoiBackground()
+{
+}
+
+

--- a/DataFormats/HeavyIonEvent/src/classes.h
+++ b/DataFormats/HeavyIonEvent/src/classes.h
@@ -21,17 +21,9 @@ namespace {
 
      reco::VoronoiBackground vor;
      edm::Wrapper<reco::VoronoiBackground> wvor;
-     reco::VoronoiBackgroundMap vormap;
-     edm::Wrapper<reco::VoronoiBackgroundMap> wvormap;
 
-     edm::AssociationMap<edm::OneToValue<std::vector<reco::PFCandidate>, reco::VoronoiBackground, unsigned int > > y1;
-     edm::Wrapper<edm::AssociationMap<edm::OneToValue<std::vector<reco::PFCandidate>, reco::VoronoiBackground, unsigned int > > > y2;
-
-     edm::AssociationMap<edm::OneToValue<edm::View<reco::Candidate>, reco::VoronoiBackground, unsigned int > > y3;
-     edm::Wrapper<edm::AssociationMap<edm::OneToValue<edm::View<reco::Candidate>, reco::VoronoiBackground, unsigned int > > > y4;
-
-     reco::PFVoronoiBackgroundMap pfvormap;
-     edm::Wrapper<reco::PFVoronoiBackgroundMap> pfwvormap;
+     reco::VoronoiMap pfvorvmap;
+     edm::Wrapper<reco::VoronoiMap> pfwvorvmap;
 
      edm::Wrapper<pat::HeavyIon >              w_v_p_hi;
 

--- a/DataFormats/HeavyIonEvent/src/classes.h
+++ b/DataFormats/HeavyIonEvent/src/classes.h
@@ -1,6 +1,7 @@
 #include "DataFormats/HeavyIonEvent/interface/Centrality.h"
 #include "DataFormats/HeavyIonEvent/interface/EvtPlane.h"
 #include "DataFormats/HeavyIonEvent/interface/HeavyIon.h"
+#include "DataFormats/HeavyIonEvent/interface/VoronoiBackground.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
 namespace { 
@@ -17,6 +18,20 @@ namespace {
 
      reco::EvtPlaneCollection evcol;
      edm::Wrapper<reco::EvtPlaneCollection> wevcol;
+
+     reco::VoronoiBackground vor;
+     edm::Wrapper<reco::VoronoiBackground> wvor;
+     reco::VoronoiBackgroundMap vormap;
+     edm::Wrapper<reco::VoronoiBackgroundMap> wvormap;
+
+     edm::AssociationMap<edm::OneToValue<std::vector<reco::PFCandidate>, reco::VoronoiBackground, unsigned int > > y1;
+     edm::Wrapper<edm::AssociationMap<edm::OneToValue<std::vector<reco::PFCandidate>, reco::VoronoiBackground, unsigned int > > > y2;
+
+     edm::AssociationMap<edm::OneToValue<edm::View<reco::Candidate>, reco::VoronoiBackground, unsigned int > > y3;
+     edm::Wrapper<edm::AssociationMap<edm::OneToValue<edm::View<reco::Candidate>, reco::VoronoiBackground, unsigned int > > > y4;
+
+     reco::PFVoronoiBackgroundMap pfvormap;
+     edm::Wrapper<reco::PFVoronoiBackgroundMap> pfwvormap;
 
      edm::Wrapper<pat::HeavyIon >              w_v_p_hi;
 

--- a/DataFormats/HeavyIonEvent/src/classes_def.xml
+++ b/DataFormats/HeavyIonEvent/src/classes_def.xml
@@ -16,12 +16,7 @@
 </class>
 <class name="reco::VoronoiBackground" />
 <class name="edm::Wrapper<reco::VoronoiBackground>"/>
-<class name="edm::AssociationMap<edm::OneToValue<std::vector<reco::PFCandidate>, reco::VoronoiBackground, unsigned int> >" />
-<class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<std::vector<reco::PFCandidate>, reco::VoronoiBackground, unsigned int> > >" />
-<class name="edm::AssociationMap<edm::OneToValue<edm::View<reco::Candidate>, reco::VoronoiBackground, unsigned int> >" >
-<field name="transientMap_" transient="true" />
-</class>
-<class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<edm::View<reco::Candidate>, reco::VoronoiBackground, unsigned int> > >" />
-<class name="std::map<unsigned int, reco::VoronoiBackground>" />
+<class name="edm::ValueMap<reco::VoronoiBackground>" />
+<class name="edm::Wrapper<edm::ValueMap<reco::VoronoiBackground> >" />
 <class name="edm::Wrapper<pat::HeavyIon >" />
 </lcgdict>

--- a/DataFormats/HeavyIonEvent/src/classes_def.xml
+++ b/DataFormats/HeavyIonEvent/src/classes_def.xml
@@ -14,5 +14,14 @@
 <class name="pat::HeavyIon"  ClassVersion="10">
  <version ClassVersion="10" checksum="934677092"/>
 </class>
+<class name="reco::VoronoiBackground" />
+<class name="edm::Wrapper<reco::VoronoiBackground>"/>
+<class name="edm::AssociationMap<edm::OneToValue<std::vector<reco::PFCandidate>, reco::VoronoiBackground, unsigned int> >" />
+<class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<std::vector<reco::PFCandidate>, reco::VoronoiBackground, unsigned int> > >" />
+<class name="edm::AssociationMap<edm::OneToValue<edm::View<reco::Candidate>, reco::VoronoiBackground, unsigned int> >" >
+<field name="transientMap_" transient="true" />
+</class>
+<class name="edm::Wrapper<edm::AssociationMap<edm::OneToValue<edm::View<reco::Candidate>, reco::VoronoiBackground, unsigned int> > >" />
+<class name="std::map<unsigned int, reco::VoronoiBackground>" />
 <class name="edm::Wrapper<pat::HeavyIon >" />
 </lcgdict>


### PR DESCRIPTION
Part of the implementation for the new jet reconstruction (UE subtraction) software, presented in:
https://indico.cern.ch/conferenceDisplay.py?confId=254369

This is just the new data format (candidate-to-background map), independent of other packages. The actual producers are to be requested in a later pull request.
