### PR TITLE
Simplified OutputModule base class

### DIFF
--- a/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
@@ -182,15 +182,15 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void write(edm::EventPrincipal const& e);
-  virtual void writeLuminosityBlock(edm::LuminosityBlockPrincipal const&);
-  virtual void writeRun(edm::RunPrincipal const&);
-  virtual bool isFileOpen() const;
-  virtual void openFile(edm::FileBlock const&);
+  virtual void write(edm::EventPrincipal const& e) override;
+  virtual void writeLuminosityBlock(edm::LuminosityBlockPrincipal const&) override;
+  virtual void writeRun(edm::RunPrincipal const&) override;
+  virtual bool isFileOpen() const override;
+  virtual void openFile(edm::FileBlock const&) override;
+  virtual void reallyCloseFile() override;
 
-
-  virtual void startEndFile();
-  virtual void finishEndFile();
+  void startEndFile();
+  void finishEndFile();
   std::string m_fileName;
   std::string m_logicalFileName;
   std::auto_ptr<TFile> m_file;
@@ -474,6 +474,13 @@ void DQMRootOutputModule::writeRun(edm::RunPrincipal const& iRun){
   edm::Service<edm::JobReport> jr;
   jr->reportRunNumber(m_run);  
 }
+
+void 
+DQMRootOutputModule::reallyCloseFile() {
+   startEndFile();
+   finishEndFile();
+}
+
 
 void DQMRootOutputModule::startEndFile() {
   //std::cout << "DQMRootOutputModule::startEndFile"<< std::endl;

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -187,7 +187,7 @@ namespace edm {
 
     // Do the end-of-file tasks; this is only called internally, after
     // the appropriate tests have been done.
-    void reallyCloseFile();
+    virtual void reallyCloseFile();
 
     void registerProductsAndCallbacks(OutputModule const*, ProductRegistry const*) {}
 
@@ -223,23 +223,6 @@ namespace edm {
     void fillDependencyGraph();
 
     bool limitReached() const {return remainingEvents_ == 0;}
-
-    // The following member functions are part of the Template Method
-    // pattern, used for implementing doCloseFile() and maybeEndFile().
-
-    virtual void startEndFile() {}
-    virtual void writeFileFormatVersion() {}
-    virtual void writeFileIdentifier() {}
-    virtual void writeIndexIntoFile() {}
-    virtual void writeProcessConfigurationRegistry() {}
-    virtual void writeProcessHistoryRegistry() {}
-    virtual void writeParameterSetRegistry() {}
-    virtual void writeBranchIDListRegistry() {}
-    virtual void writeParentageRegistry() {}
-    virtual void writeProductDescriptionRegistry() {}
-    virtual void writeProductDependencies() {}
-    virtual void writeBranchMapper() {}
-    virtual void finishEndFile() {}
   };
 }
 

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -297,26 +297,15 @@ namespace edm {
   }
 
   void OutputModule::doCloseFile() {
-    if(isFileOpen()) reallyCloseFile();
+    if(isFileOpen()) {
+      fillDependencyGraph();
+      reallyCloseFile();
+      branchParents_.clear();
+      branchChildren_.clear();
+    }
   }
 
   void OutputModule::reallyCloseFile() {
-    fillDependencyGraph();
-    startEndFile();
-    writeFileFormatVersion();
-    writeFileIdentifier();
-    writeIndexIntoFile();
-    writeProcessConfigurationRegistry();
-    writeProcessHistoryRegistry();
-    writeParameterSetRegistry();
-    writeProductDescriptionRegistry();
-    writeParentageRegistry();
-    writeBranchIDListRegistry();
-    writeProductDependencies();
-    writeBranchMapper();
-    finishEndFile();
-    branchParents_.clear();
-    branchChildren_.clear();
   }
 
   BranchIDLists const*

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -99,31 +99,32 @@ namespace edm {
 
   protected:
     ///allow inheriting classes to override but still be able to call this method in the overridden version
-    virtual bool shouldWeCloseFile() const;
-    virtual void write(EventPrincipal const& e);
+    virtual bool shouldWeCloseFile() const override;
+    virtual void write(EventPrincipal const& e) override;
   private:
-    virtual void openFile(FileBlock const& fb);
-    virtual void respondToOpenInputFile(FileBlock const& fb);
-    virtual void respondToCloseInputFile(FileBlock const& fb);
-    virtual void writeLuminosityBlock(LuminosityBlockPrincipal const& lb);
-    virtual void writeRun(RunPrincipal const& r);
-    virtual void postForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
-    virtual bool isFileOpen() const;
-    virtual void reallyOpenFile();
-    virtual void beginJob();
+    virtual void openFile(FileBlock const& fb) override;
+    virtual void respondToOpenInputFile(FileBlock const& fb) override;
+    virtual void respondToCloseInputFile(FileBlock const& fb) override;
+    virtual void writeLuminosityBlock(LuminosityBlockPrincipal const& lb) override;
+    virtual void writeRun(RunPrincipal const& r) override;
+    virtual void postForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren) override;
+    virtual bool isFileOpen() const override;
+    virtual void reallyOpenFile() override;
+    virtual void reallyCloseFile() override;
+    virtual void beginJob() override;
 
-    virtual void startEndFile();
-    virtual void writeFileFormatVersion();
-    virtual void writeFileIdentifier();
-    virtual void writeIndexIntoFile();
-    virtual void writeProcessConfigurationRegistry();
-    virtual void writeProcessHistoryRegistry();
-    virtual void writeParameterSetRegistry();
-    virtual void writeProductDescriptionRegistry();
-    virtual void writeParentageRegistry();
-    virtual void writeBranchIDListRegistry();
-    virtual void writeProductDependencies();
-    virtual void finishEndFile();
+    void startEndFile();
+    void writeFileFormatVersion();
+    void writeFileIdentifier();
+    void writeIndexIntoFile();
+    void writeProcessConfigurationRegistry();
+    void writeProcessHistoryRegistry();
+    void writeParameterSetRegistry();
+    void writeProductDescriptionRegistry();
+    void writeParentageRegistry();
+    void writeBranchIDListRegistry();
+    void writeProductDependencies();
+    void finishEndFile();
 
     void fillSelectedItemList(BranchType branchtype, TTree* theInputTree);
     void beginInputFile(FileBlock const& fb);

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -260,6 +260,22 @@ namespace edm {
       reportSvc->reportRunNumber(r.run());
   }
 
+  void PoolOutputModule::reallyCloseFile() {
+    startEndFile();
+    writeFileFormatVersion();
+    writeFileIdentifier();
+    writeIndexIntoFile();
+    writeProcessConfigurationRegistry();
+    writeProcessHistoryRegistry();
+    writeParameterSetRegistry();
+    writeProductDescriptionRegistry();
+    writeParentageRegistry();
+    writeBranchIDListRegistry();
+    writeProductDependencies();
+    finishEndFile();
+  }
+
+  
   // At some later date, we may move functionality from finishEndFile() to here.
   void PoolOutputModule::startEndFile() { }
 


### PR DESCRIPTION
Removed from edm::OutputModule base class virtual functions which were only used by one derived class and moved the functionality into the derived class.
