### PR TITLE
Removed respondTo(Open/Close)OutputFile transitions

### DIFF
--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -49,8 +49,6 @@ namespace edm {
 		   CurrentProcessingContext const* cpc);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
-    void doRespondToOpenOutputFiles(FileBlock const& fb);
-    void doRespondToCloseOutputFiles(FileBlock const& fb);
     void doPreForkReleaseResources();
     void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
     void registerProductsAndCallbacks(EDAnalyzer const*, ProductRegistry* reg);
@@ -64,8 +62,6 @@ namespace edm {
     virtual void endLuminosityBlock(LuminosityBlock const&, EventSetup const&){}
     virtual void respondToOpenInputFile(FileBlock const&) {}
     virtual void respondToCloseInputFile(FileBlock const&) {}
-    virtual void respondToOpenOutputFiles(FileBlock const&) {}
-    virtual void respondToCloseOutputFiles(FileBlock const&) {}
     virtual void preForkReleaseResources() {}
     virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
 

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -58,8 +58,6 @@ namespace edm {
 		   CurrentProcessingContext const* cpc);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
-    void doRespondToOpenOutputFiles(FileBlock const& fb);
-    void doRespondToCloseOutputFiles(FileBlock const& fb);
     void doPreForkReleaseResources();
     void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
 
@@ -79,8 +77,6 @@ namespace edm {
     virtual void endLuminosityBlock(LuminosityBlock const& iL, EventSetup const& iE){}
     virtual void respondToOpenInputFile(FileBlock const&) {}
     virtual void respondToCloseInputFile(FileBlock const&) {}
-    virtual void respondToOpenOutputFiles(FileBlock const&) {}
-    virtual void respondToCloseOutputFiles(FileBlock const&) {}
     virtual void preForkReleaseResources() {}
     virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
      

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -52,8 +52,6 @@ namespace edm {
 		   CurrentProcessingContext const* cpc);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
-    void doRespondToOpenOutputFiles(FileBlock const& fb);
-    void doRespondToCloseOutputFiles(FileBlock const& fb);
     void doPreForkReleaseResources();
     void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
     void registerProductsAndCallbacks(EDProducer* module, ProductRegistry* reg) {
@@ -72,8 +70,6 @@ namespace edm {
     virtual void endLuminosityBlock(LuminosityBlock const& iL, EventSetup const& iE){}
     virtual void respondToOpenInputFile(FileBlock const&) {}
     virtual void respondToCloseInputFile(FileBlock const&) {}
-    virtual void respondToOpenOutputFiles(FileBlock const&) {}
-    virtual void respondToCloseOutputFiles(FileBlock const&) {}
     virtual void preForkReleaseResources() {}
     virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
 

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -238,8 +238,6 @@ namespace edm {
 
     virtual void respondToOpenInputFile();
     virtual void respondToCloseInputFile();
-    virtual void respondToOpenOutputFiles();
-    virtual void respondToCloseOutputFiles();
 
     virtual void startingNewLoop();
     virtual bool endOfLoop();

--- a/FWCore/Framework/interface/IEventProcessor.h
+++ b/FWCore/Framework/interface/IEventProcessor.h
@@ -49,8 +49,6 @@ namespace edm {
 
     virtual void respondToOpenInputFile() = 0;
     virtual void respondToCloseInputFile() = 0;
-    virtual void respondToOpenOutputFiles() = 0;
-    virtual void respondToCloseOutputFiles() = 0;
 
     virtual void startingNewLoop() = 0;
     virtual bool endOfLoop() = 0;

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -170,8 +170,6 @@ namespace edm {
     void doOpenFile(FileBlock const& fb);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
-    void doRespondToOpenOutputFiles(FileBlock const& fb);
-    void doRespondToCloseOutputFiles(FileBlock const& fb);
     void doPreForkReleaseResources();
     void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
 
@@ -206,8 +204,6 @@ namespace edm {
     virtual void openFile(FileBlock const&) {}
     virtual void respondToOpenInputFile(FileBlock const&) {}
     virtual void respondToCloseInputFile(FileBlock const&) {}
-    virtual void respondToOpenOutputFiles(FileBlock const&) {}
-    virtual void respondToCloseOutputFiles(FileBlock const&) {}
     virtual void preForkReleaseResources() {}
     virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
 

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -160,12 +160,6 @@ namespace edm {
     // Call respondToCloseInputFile() on all Modules
     void respondToCloseInputFile(FileBlock const& fb);
 
-    // Call respondToOpenOutputFiles() on all Modules
-    void respondToOpenOutputFiles(FileBlock const& fb);
-
-    // Call respondToCloseOutputFiles() on all Modules
-    void respondToCloseOutputFiles(FileBlock const& fb);
-
     // Call shouldWeCloseFile() on all OutputModules.
     bool shouldWeCloseOutput() const;
 

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -112,20 +112,6 @@ namespace edm {
       if(subProcess_.get()) subProcess_->respondToCloseInputFile(fb);
     }
 
-    // Call respondToOpenOutputFiles() on all Modules
-    void respondToOpenOutputFiles(FileBlock const& fb) {
-      ServiceRegistry::Operate operate(serviceToken_);
-      schedule_->respondToOpenOutputFiles(fb);
-      if(subProcess_.get()) subProcess_->respondToOpenOutputFiles(fb);
-    }
-
-    // Call respondToCloseOutputFiles() on all Modules
-    void respondToCloseOutputFiles(FileBlock const& fb) {
-      ServiceRegistry::Operate operate(serviceToken_);
-      schedule_->respondToCloseOutputFiles(fb);
-      if(subProcess_.get()) subProcess_->respondToCloseOutputFiles(fb);
-    }
-
     // Call shouldWeCloseFile() on all OutputModules.
     bool shouldWeCloseOutput() const {
       ServiceRegistry::Operate operate(serviceToken_);

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -16,7 +16,6 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Thu, 02 May 2013 21:21:21 GMT
-// $Id$
 //
 
 // system include files
@@ -71,8 +70,6 @@ namespace edm {
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
-      void doRespondToOpenOutputFiles(FileBlock const& fb);
-      void doRespondToCloseOutputFiles(FileBlock const& fb);
       void doPreForkReleaseResources();
       void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
 

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -16,7 +16,6 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Thu, 02 May 2013 21:21:21 GMT
-// $Id$
 //
 
 // system include files
@@ -71,8 +70,6 @@ namespace edm {
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
-      void doRespondToOpenOutputFiles(FileBlock const& fb);
-      void doRespondToCloseOutputFiles(FileBlock const& fb);
       void doPreForkReleaseResources();
       void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
 

--- a/FWCore/Framework/src/EDAnalyzer.cc
+++ b/FWCore/Framework/src/EDAnalyzer.cc
@@ -92,16 +92,6 @@ namespace edm {
     respondToCloseInputFile(fb);
   }
 
-  void
-  EDAnalyzer::doRespondToOpenOutputFiles(FileBlock const& fb) {
-    respondToOpenOutputFiles(fb);
-  }
-
-  void
-  EDAnalyzer::doRespondToCloseOutputFiles(FileBlock const& fb) {
-    respondToCloseOutputFiles(fb);
-  }
-
   void 
   EDAnalyzer::doPreForkReleaseResources() {
     preForkReleaseResources();

--- a/FWCore/Framework/src/EDFilter.cc
+++ b/FWCore/Framework/src/EDFilter.cc
@@ -95,16 +95,6 @@ namespace edm {
     respondToCloseInputFile(fb);
   }
 
-  void
-  EDFilter::doRespondToOpenOutputFiles(FileBlock const& fb) {
-    respondToOpenOutputFiles(fb);
-  }
-
-  void
-  EDFilter::doRespondToCloseOutputFiles(FileBlock const& fb) {
-    respondToCloseOutputFiles(fb);
-  }
-
   void 
   EDFilter::doPreForkReleaseResources() {
     preForkReleaseResources();

--- a/FWCore/Framework/src/EDProducer.cc
+++ b/FWCore/Framework/src/EDProducer.cc
@@ -99,16 +99,6 @@ namespace edm {
   }
 
   void 
-  EDProducer::doRespondToOpenOutputFiles(FileBlock const& fb) {
-    respondToOpenOutputFiles(fb);
-  }
-
-  void
-  EDProducer::doRespondToCloseOutputFiles(FileBlock const& fb) {
-    respondToCloseOutputFiles(fb);
-  }
-
-  void 
   EDProducer::doPreForkReleaseResources() {
     preForkReleaseResources();
   }

--- a/FWCore/Framework/src/EPStates.cc
+++ b/FWCore/Framework/src/EPStates.cc
@@ -78,7 +78,6 @@ namespace statemachine {
   void HandleFiles::closeFiles(bool cleaningUpAfterException) {
     ep_.respondToCloseInputFile();
     ep_.closeInputFile(cleaningUpAfterException);
-    ep_.respondToCloseOutputFiles();
     ep_.closeOutputFiles();
   }
 
@@ -141,7 +140,6 @@ namespace statemachine {
     ep_.respondToOpenInputFile();
 
     ep_.openOutputFiles();
-    ep_.respondToOpenOutputFiles();
   }
 
   HandleNewInputFile1::HandleNewInputFile1(my_context ctx) :
@@ -179,14 +177,12 @@ namespace statemachine {
     ep_.respondToCloseInputFile();
     ep_.closeInputFile(false);
 
-    ep_.respondToCloseOutputFiles();
     ep_.closeOutputFiles();
 
     ep_.readFile();
     ep_.respondToOpenInputFile();
 
     ep_.openOutputFiles();
-    ep_.respondToOpenOutputFiles();
   }
 
   HandleRuns::HandleRuns(my_context ctx) :

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1897,22 +1897,6 @@ namespace edm {
     FDEBUG(1) << "\trespondToCloseInputFile\n";
   }
 
-  void EventProcessor::respondToOpenOutputFiles() {
-    if (fb_.get() != nullptr) {
-      schedule_->respondToOpenOutputFiles(*fb_);
-      if(hasSubProcess()) subProcess_->respondToOpenOutputFiles(*fb_);
-    }
-    FDEBUG(1) << "\trespondToOpenOutputFiles\n";
-  }
-
-  void EventProcessor::respondToCloseOutputFiles() {
-    if (fb_.get() != nullptr) {
-      schedule_->respondToCloseOutputFiles(*fb_);
-      if(hasSubProcess()) subProcess_->respondToCloseOutputFiles(*fb_);
-    }
-    FDEBUG(1) << "\trespondToCloseOutputFiles\n";
-  }
-
   void EventProcessor::startingNewLoop() {
     shouldWeStop_ = false;
     //NOTE: for first loop, need to delay calling 'doStartingNewLoop'

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -274,14 +274,6 @@ namespace edm {
     respondToCloseInputFile(fb);
   }
 
-  void OutputModule::doRespondToOpenOutputFiles(FileBlock const& fb) {
-    respondToOpenOutputFiles(fb);
-  }
-
-  void OutputModule::doRespondToCloseOutputFiles(FileBlock const& fb) {
-    respondToCloseOutputFiles(fb);
-  }
-
   void
   OutputModule::doPreForkReleaseResources() {
     preForkReleaseResources();

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -1248,14 +1248,6 @@ namespace edm {
     for_all(allWorkers(), boost::bind(&Worker::respondToCloseInputFile, _1, boost::cref(fb)));
   }
 
-  void Schedule::respondToOpenOutputFiles(FileBlock const& fb) {
-    for_all(allWorkers(), boost::bind(&Worker::respondToOpenOutputFiles, _1, boost::cref(fb)));
-  }
-
-  void Schedule::respondToCloseOutputFiles(FileBlock const& fb) {
-    for_all(allWorkers(), boost::bind(&Worker::respondToCloseOutputFiles, _1, boost::cref(fb)));
-  }
-
   void Schedule::beginJob(ProductRegistry const& iRegistry) {
     workerManager_.beginJob(iRegistry);
   }

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -74,8 +74,6 @@ namespace edm {
     void endStream(StreamID id);
     void respondToOpenInputFile(FileBlock const& fb) {implRespondToOpenInputFile(fb);}
     void respondToCloseInputFile(FileBlock const& fb) {implRespondToCloseInputFile(fb);}
-    void respondToOpenOutputFiles(FileBlock const& fb) {implRespondToOpenOutputFiles(fb);}
-    void respondToCloseOutputFiles(FileBlock const& fb) {implRespondToCloseOutputFiles(fb);}
 
     void preForkReleaseResources() {implPreForkReleaseResources();}
     void postForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren) {implPostForkReacquireResources(iChildIndex, iNumberOfChildren);}
@@ -151,8 +149,6 @@ namespace edm {
   private:
     virtual void implRespondToOpenInputFile(FileBlock const& fb) = 0;
     virtual void implRespondToCloseInputFile(FileBlock const& fb) = 0;
-    virtual void implRespondToOpenOutputFiles(FileBlock const& fb) = 0;
-    virtual void implRespondToCloseOutputFiles(FileBlock const& fb) = 0;
 
     virtual void implPreForkReleaseResources() = 0;
     virtual void implPostForkReacquireResources(unsigned int iChildIndex,

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -153,20 +153,6 @@ namespace edm{
   template<typename T>
   inline
   void
-  WorkerT<T>::implRespondToOpenOutputFiles(FileBlock const& fb) {
-    module_->doRespondToOpenOutputFiles(fb);
-  }
-  
-  template<typename T>
-  inline
-  void
-  WorkerT<T>::implRespondToCloseOutputFiles(FileBlock const& fb) {
-    module_->doRespondToCloseOutputFiles(fb);
-  }
-  
-  template<typename T>
-  inline
-  void
   WorkerT<T>::implPreForkReleaseResources() {
     module_->doPreForkReleaseResources();
   }

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -76,8 +76,6 @@ namespace edm {
     virtual void implEndStream(StreamID) override;
     virtual void implRespondToOpenInputFile(FileBlock const& fb) override;
     virtual void implRespondToCloseInputFile(FileBlock const& fb) override;
-    virtual void implRespondToOpenOutputFiles(FileBlock const& fb) override;
-    virtual void implRespondToCloseOutputFiles(FileBlock const& fb) override;
     virtual void implPreForkReleaseResources() override;
     virtual void implPostForkReacquireResources(unsigned int iChildIndex, 
                                                unsigned int iNumberOfChildren) override;

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -8,7 +8,6 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Thu, 02 May 2013 21:56:04 GMT
-// $Id$
 //
 
 // system include files
@@ -126,16 +125,6 @@ namespace edm {
     void
     EDFilterBase::doRespondToCloseInputFile(FileBlock const& fb) {
       //respondToCloseInputFile(fb);
-    }
-    
-    void
-    EDFilterBase::doRespondToOpenOutputFiles(FileBlock const& fb) {
-      //respondToOpenOutputFiles(fb);
-    }
-    
-    void
-    EDFilterBase::doRespondToCloseOutputFiles(FileBlock const& fb) {
-      //respondToCloseOutputFiles(fb);
     }
     
     void

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -8,7 +8,6 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Thu, 02 May 2013 21:56:04 GMT
-// $Id$
 //
 
 // system include files
@@ -126,16 +125,6 @@ namespace edm {
     void
     EDProducerBase::doRespondToCloseInputFile(FileBlock const& fb) {
       //respondToCloseInputFile(fb);
-    }
-    
-    void
-    EDProducerBase::doRespondToOpenOutputFiles(FileBlock const& fb) {
-      //respondToOpenOutputFiles(fb);
-    }
-    
-    void
-    EDProducerBase::doRespondToCloseOutputFiles(FileBlock const& fb) {
-      //respondToCloseOutputFiles(fb);
     }
     
     void

--- a/FWCore/Framework/test/MockEventProcessor.cc
+++ b/FWCore/Framework/test/MockEventProcessor.cc
@@ -116,14 +116,6 @@ namespace edm {
     output_ << "\trespondToCloseInputFile\n";
   }
 
-  void MockEventProcessor::respondToOpenOutputFiles() {
-    output_ << "\trespondToOpenOutputFiles\n";
-  }
-
-  void MockEventProcessor::respondToCloseOutputFiles() {
-    output_ << "\trespondToCloseOutputFiles\n";
-  }
-
   void MockEventProcessor::startingNewLoop() {
     output_ << "\tstartingNewLoop\n";
   }

--- a/FWCore/Framework/test/MockEventProcessor.h
+++ b/FWCore/Framework/test/MockEventProcessor.h
@@ -33,8 +33,6 @@ namespace edm {
 
     virtual void respondToOpenInputFile();
     virtual void respondToCloseInputFile();
-    virtual void respondToOpenOutputFiles();
-    virtual void respondToCloseOutputFiles();
 
     virtual void startingNewLoop();
     virtual bool endOfLoop();

--- a/FWCore/Framework/test/stubs/TestMergeResults.cc
+++ b/FWCore/Framework/test/stubs/TestMergeResults.cc
@@ -54,8 +54,6 @@ namespace edmtest {
     virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
     virtual void respondToOpenInputFile(edm::FileBlock const& fb);
     virtual void respondToCloseInputFile(edm::FileBlock const& fb);
-    virtual void respondToOpenOutputFiles(edm::FileBlock const& fb);
-    virtual void respondToCloseOutputFiles(edm::FileBlock const& fb);
     void endJob();
 
   private:
@@ -97,12 +95,8 @@ namespace edmtest {
 
     int nRespondToOpenInputFile_;
     int nRespondToCloseInputFile_;
-    int nRespondToOpenOutputFiles_;
-    int nRespondToCloseOutputFiles_;
     int expectedRespondToOpenInputFile_;
     int expectedRespondToCloseInputFile_;
-    int expectedRespondToOpenOutputFiles_;
-    int expectedRespondToCloseOutputFiles_;
 
     std::vector<std::string> expectedInputFileNames_;
 
@@ -150,12 +144,8 @@ namespace edmtest {
 
     nRespondToOpenInputFile_(0),
     nRespondToCloseInputFile_(0),
-    nRespondToOpenOutputFiles_(0),
-    nRespondToCloseOutputFiles_(0),
     expectedRespondToOpenInputFile_(ps.getUntrackedParameter<int>("expectedRespondToOpenInputFile", -1)),
     expectedRespondToCloseInputFile_(ps.getUntrackedParameter<int>("expectedRespondToCloseInputFile", -1)),
-    expectedRespondToOpenOutputFiles_(ps.getUntrackedParameter<int>("expectedRespondToOpenOutputFiles", -1)),
-    expectedRespondToCloseOutputFiles_(ps.getUntrackedParameter<int>("expectedRespondToCloseOutputFiles", -1)),
 
     expectedInputFileNames_(ps.getUntrackedParameter<std::vector<std::string> >("expectedInputFileNames", defaultvstring_)),
 
@@ -529,16 +519,6 @@ namespace edmtest {
     ++droppedIndex1_;
   }
 
-  void TestMergeResults::respondToOpenOutputFiles(edm::FileBlock const&) {
-    if(verbose_) edm::LogInfo("TestMergeResults") << "respondToOpenOutputFiles";
-    ++nRespondToOpenOutputFiles_;
-  }
-
-  void TestMergeResults::respondToCloseOutputFiles(edm::FileBlock const&) {
-    if(verbose_) edm::LogInfo("TestMergeResults") << "respondToCloseOutputFiles";
-    ++nRespondToCloseOutputFiles_;
-  }
-
   void TestMergeResults::endJob() {
     if(verbose_) edm::LogInfo("TestMergeResults") << "endJob";
 
@@ -551,18 +531,6 @@ namespace edmtest {
     if(expectedRespondToCloseInputFile_ > -1 && nRespondToCloseInputFile_ != expectedRespondToCloseInputFile_) {
       std::cerr << "Error while testing merging of run/lumi products in TestMergeResults.cc\n"
                 << "Unexpected number of calls to the function respondToCloseInputFile" << std::endl;
-      abort();
-    }
-
-    if(expectedRespondToOpenOutputFiles_ > -1 && nRespondToOpenOutputFiles_ != expectedRespondToOpenOutputFiles_) {
-      std::cerr << "Error while testing merging of run/lumi products in TestMergeResults.cc\n"
-                << "Unexpected number of calls to the function respondToOpenOutputFiles" << std::endl;
-      abort();
-    }
-
-    if(expectedRespondToCloseOutputFiles_ > -1 && nRespondToCloseOutputFiles_ != expectedRespondToCloseOutputFiles_) {
-      std::cerr << "Error while testing merging of run/lumi products in TestMergeResults.cc\n"
-                << "Unexpected number of calls to the function respondToCloseOutputFiles" << std::endl;
       abort();
     }
   }

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_1.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_1.txt
@@ -5,7 +5,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -55,7 +54,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 3
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -66,7 +64,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -110,7 +107,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 3
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -121,7 +117,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Run 2 ***
@@ -161,7 +156,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 3
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -172,7 +166,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -222,7 +215,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 3
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -233,7 +225,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -277,7 +268,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 3
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -288,7 +278,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Run 2 ***
@@ -328,7 +317,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 3
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_11.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_11.txt
@@ -10,11 +10,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Restart 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -25,11 +23,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Lumi 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -40,11 +36,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Event ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -55,16 +49,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 9 ***
 	readAndCacheRun 9
 	beginRun 9
@@ -74,12 +65,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 9
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -89,12 +78,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -110,12 +97,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -125,12 +110,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -146,12 +129,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -173,12 +154,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -188,12 +167,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -209,16 +186,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Lumi 4 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -229,7 +203,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 5 ***
 	readAndCacheRun 5
 	beginRun 5
@@ -245,16 +218,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 5
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Event ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -265,7 +235,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 6 ***
 	readAndCacheRun 6
 	beginRun 6
@@ -281,7 +250,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 6
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -303,11 +271,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Restart 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -318,11 +284,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Lumi 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -333,11 +297,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Event ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -348,16 +310,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 9 ***
 	readAndCacheRun 9
 	beginRun 9
@@ -367,12 +326,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 9
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -382,12 +339,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -403,12 +358,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -418,12 +371,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -437,12 +388,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -460,12 +409,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -475,12 +422,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -494,16 +439,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Lumi 4 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -514,7 +456,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 5 ***
 	readAndCacheRun 5
 	beginRun 5
@@ -528,16 +469,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 5
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Event ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -548,7 +486,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 6 ***
 	readAndCacheRun 6
 	beginRun 6
@@ -562,7 +499,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 6
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -584,11 +520,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Restart 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -599,11 +533,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Lumi 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -614,11 +546,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Event ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -629,16 +559,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 9 ***
 	readAndCacheRun 9
     *** nextItemType: File 0 ***
@@ -646,12 +573,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 9
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: File 0 ***
@@ -659,12 +584,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Run 2 ***
@@ -676,12 +599,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
     *** nextItemType: File 0 ***
@@ -689,12 +610,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
     *** nextItemType: Lumi 1 ***
@@ -706,12 +625,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
     *** nextItemType: Lumi 2 ***
@@ -727,12 +644,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
     *** nextItemType: File 0 ***
@@ -740,12 +655,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
     *** nextItemType: Lumi 3 ***
@@ -757,16 +670,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Lumi 4 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -777,7 +687,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 5 ***
 	readAndCacheRun 5
     *** nextItemType: Lumi 1 ***
@@ -789,16 +698,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 5
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Event ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -809,7 +715,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 6 ***
 	readAndCacheRun 6
     *** nextItemType: Lumi 1 ***
@@ -821,7 +726,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 6
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -843,11 +747,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Restart 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -858,11 +760,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Lumi 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -873,11 +773,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Event ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -888,7 +786,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -996,7 +893,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1007,7 +903,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 5 ***
 	readAndCacheRun 5
 	beginRun 5
@@ -1029,7 +924,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 5
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1040,7 +934,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 6 ***
 	readAndCacheRun 6
 	beginRun 6
@@ -1056,7 +949,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 6
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1078,11 +970,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Restart 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1093,11 +983,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Lumi 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1108,11 +996,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Event ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1123,7 +1009,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -1225,7 +1110,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1236,7 +1120,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 5 ***
 	readAndCacheRun 5
 	beginRun 5
@@ -1256,7 +1139,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 5
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1267,7 +1149,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 6 ***
 	readAndCacheRun 6
 	beginRun 6
@@ -1281,7 +1162,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 6
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1303,11 +1183,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Restart 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1318,11 +1196,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Lumi 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1333,11 +1209,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Event ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1348,7 +1222,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -1444,7 +1317,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1455,7 +1327,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 5 ***
 	readAndCacheRun 5
     *** nextItemType: Lumi 1 ***
@@ -1473,7 +1344,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 5
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1484,7 +1354,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 6 ***
 	readAndCacheRun 6
     *** nextItemType: Lumi 1 ***
@@ -1496,7 +1365,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 6
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_12.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_12.txt
@@ -5,7 +5,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -25,12 +24,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -50,12 +47,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -75,7 +70,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -86,7 +80,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -106,12 +99,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -131,12 +122,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -156,7 +145,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -167,7 +155,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -187,12 +174,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 2 ***
@@ -212,12 +197,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -237,7 +220,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -248,7 +230,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -304,7 +285,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -315,7 +295,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -371,7 +350,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -382,7 +360,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -438,7 +415,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_2.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_2.txt
@@ -5,52 +5,41 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -60,30 +49,24 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -99,34 +82,27 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Stop 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -137,52 +113,41 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -192,30 +157,24 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -229,34 +188,27 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Stop 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -267,52 +219,41 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: File 0 ***
@@ -320,30 +261,24 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
     *** nextItemType: Lumi 1 ***
@@ -355,34 +290,27 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Stop 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -393,27 +321,22 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -430,12 +353,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	shouldWeCloseOutput
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -458,12 +379,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -492,16 +411,13 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Stop 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -512,27 +428,22 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -549,12 +460,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	shouldWeCloseOutput
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -577,12 +486,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -609,16 +516,13 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Stop 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -629,27 +533,22 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -666,12 +565,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	shouldWeCloseOutput
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: File 0 ***
@@ -692,12 +589,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
     *** nextItemType: Lumi 1 ***
@@ -722,16 +617,13 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Stop 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_3.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_3.txt
@@ -5,7 +5,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -25,12 +24,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -50,12 +47,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -75,7 +70,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -86,7 +80,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -106,12 +99,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -131,12 +122,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -156,7 +145,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -167,7 +155,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -187,12 +174,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
     *** nextItemType: Lumi 1 ***
@@ -212,12 +197,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 2 ***
@@ -237,7 +220,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -248,7 +230,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -312,7 +293,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -323,7 +303,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -387,7 +366,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -398,7 +376,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -462,7 +439,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_4.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_4.txt
@@ -5,7 +5,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -41,12 +40,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -66,7 +63,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -77,7 +73,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -113,12 +108,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -138,7 +131,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -149,7 +141,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -185,12 +176,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 2 ***
@@ -210,7 +199,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -221,7 +209,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -279,7 +266,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -290,7 +276,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -348,7 +333,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -359,7 +343,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -417,7 +400,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_5.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_5.txt
@@ -5,7 +5,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -31,12 +30,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -56,7 +53,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -67,7 +63,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -91,12 +86,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -116,7 +109,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -127,7 +119,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -151,12 +142,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 2 ***
@@ -176,7 +165,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -187,7 +175,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -227,7 +214,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -238,7 +224,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -278,7 +263,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -289,7 +273,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -329,7 +312,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_6.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_6.txt
@@ -5,7 +5,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -35,12 +34,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -60,7 +57,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -71,7 +67,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -101,12 +96,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -126,7 +119,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -137,7 +129,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -167,12 +158,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 2 ***
@@ -192,7 +181,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -203,7 +191,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -247,7 +234,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -258,7 +244,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -302,7 +287,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -313,7 +297,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -357,7 +340,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_7.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_7.txt
@@ -5,7 +5,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -35,12 +34,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -66,7 +63,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -77,7 +73,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -107,12 +102,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -136,7 +129,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -147,7 +139,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -177,12 +168,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 2 ***
@@ -206,7 +195,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -217,7 +205,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -267,7 +254,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -278,7 +264,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -328,7 +313,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -339,7 +323,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -389,7 +372,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_8.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_8.txt
@@ -5,7 +5,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -31,12 +30,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -62,7 +59,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -73,7 +69,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -97,12 +92,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -126,7 +119,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -137,7 +129,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -161,12 +152,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 2 ***
@@ -190,7 +179,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -201,7 +189,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -247,7 +234,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -258,7 +244,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -302,7 +287,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -313,7 +297,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -357,7 +340,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_9.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_9.txt
@@ -5,7 +5,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -33,12 +32,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -62,12 +59,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -91,7 +86,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -106,7 +100,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -134,12 +127,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -163,12 +154,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -192,7 +181,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -207,7 +195,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -235,12 +222,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -264,12 +249,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -293,7 +276,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -308,7 +290,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -372,7 +353,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -387,7 +367,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -451,7 +430,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -466,7 +444,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -530,7 +507,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Integration/test/testRunMergeMERGE2_cfg.py
+++ b/FWCore/Integration/test/testRunMergeMERGE2_cfg.py
@@ -241,8 +241,6 @@ process.test = cms.EDAnalyzer("TestMergeResults",
 
     expectedRespondToOpenInputFile = cms.untracked.int32(6),
     expectedRespondToCloseInputFile = cms.untracked.int32(6),
-    expectedRespondToOpenOutputFiles = cms.untracked.int32(1),
-    expectedRespondToCloseOutputFiles = cms.untracked.int32(1),
 
     expectedInputFileNames = cms.untracked.vstring(
         'file:testRunMerge0.root', 

--- a/FWCore/Integration/test/testRunMergeMERGE4_cfg.py
+++ b/FWCore/Integration/test/testRunMergeMERGE4_cfg.py
@@ -183,8 +183,6 @@ process.test = cms.EDAnalyzer("TestMergeResults",
 
     expectedRespondToOpenInputFile = cms.untracked.int32(5),
     expectedRespondToCloseInputFile = cms.untracked.int32(5),
-    expectedRespondToOpenOutputFiles = cms.untracked.int32(1),
-    expectedRespondToCloseOutputFiles = cms.untracked.int32(1),
 
     expectedInputFileNames = cms.untracked.vstring(
         'file:testRunMerge1.root', 

--- a/FWCore/Integration/test/testRunMergeMERGE_cfg.py
+++ b/FWCore/Integration/test/testRunMergeMERGE_cfg.py
@@ -183,8 +183,6 @@ process.test = cms.EDAnalyzer("TestMergeResults",
 
     expectedRespondToOpenInputFile = cms.untracked.int32(5),
     expectedRespondToCloseInputFile = cms.untracked.int32(5),
-    expectedRespondToOpenOutputFiles = cms.untracked.int32(1),
-    expectedRespondToCloseOutputFiles = cms.untracked.int32(1),
 
     expectedInputFileNames = cms.untracked.vstring(
         'file:testRunMerge1.root', 


### PR DESCRIPTION
Removed the respondTo(Open/Close)OutputFile transitions since they were never used, had a confusing argument and complicated creating new types of modules.
