### PR TITLE
Implemented global EDProducer, EDFilter and EDAnalyzer

### DIFF
--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -49,8 +49,6 @@ namespace edm {
 		   CurrentProcessingContext const* cpc);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
-    void doRespondToOpenOutputFiles(FileBlock const& fb);
-    void doRespondToCloseOutputFiles(FileBlock const& fb);
     void doPreForkReleaseResources();
     void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
     void registerProductsAndCallbacks(EDAnalyzer const*, ProductRegistry* reg);
@@ -64,8 +62,6 @@ namespace edm {
     virtual void endLuminosityBlock(LuminosityBlock const&, EventSetup const&){}
     virtual void respondToOpenInputFile(FileBlock const&) {}
     virtual void respondToCloseInputFile(FileBlock const&) {}
-    virtual void respondToOpenOutputFiles(FileBlock const&) {}
-    virtual void respondToCloseOutputFiles(FileBlock const&) {}
     virtual void preForkReleaseResources() {}
     virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
 

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -58,8 +58,6 @@ namespace edm {
 		   CurrentProcessingContext const* cpc);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
-    void doRespondToOpenOutputFiles(FileBlock const& fb);
-    void doRespondToCloseOutputFiles(FileBlock const& fb);
     void doPreForkReleaseResources();
     void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
 
@@ -79,8 +77,6 @@ namespace edm {
     virtual void endLuminosityBlock(LuminosityBlock const& iL, EventSetup const& iE){}
     virtual void respondToOpenInputFile(FileBlock const&) {}
     virtual void respondToCloseInputFile(FileBlock const&) {}
-    virtual void respondToOpenOutputFiles(FileBlock const&) {}
-    virtual void respondToCloseOutputFiles(FileBlock const&) {}
     virtual void preForkReleaseResources() {}
     virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
      

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -52,8 +52,6 @@ namespace edm {
 		   CurrentProcessingContext const* cpc);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
-    void doRespondToOpenOutputFiles(FileBlock const& fb);
-    void doRespondToCloseOutputFiles(FileBlock const& fb);
     void doPreForkReleaseResources();
     void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
     void registerProductsAndCallbacks(EDProducer* module, ProductRegistry* reg) {
@@ -72,8 +70,6 @@ namespace edm {
     virtual void endLuminosityBlock(LuminosityBlock const& iL, EventSetup const& iE){}
     virtual void respondToOpenInputFile(FileBlock const&) {}
     virtual void respondToCloseInputFile(FileBlock const&) {}
-    virtual void respondToOpenOutputFiles(FileBlock const&) {}
-    virtual void respondToCloseOutputFiles(FileBlock const&) {}
     virtual void preForkReleaseResources() {}
     virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
 

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -238,8 +238,6 @@ namespace edm {
 
     virtual void respondToOpenInputFile();
     virtual void respondToCloseInputFile();
-    virtual void respondToOpenOutputFiles();
-    virtual void respondToCloseOutputFiles();
 
     virtual void startingNewLoop();
     virtual bool endOfLoop();

--- a/FWCore/Framework/interface/IEventProcessor.h
+++ b/FWCore/Framework/interface/IEventProcessor.h
@@ -49,8 +49,6 @@ namespace edm {
 
     virtual void respondToOpenInputFile() = 0;
     virtual void respondToCloseInputFile() = 0;
-    virtual void respondToOpenOutputFiles() = 0;
-    virtual void respondToCloseOutputFiles() = 0;
 
     virtual void startingNewLoop() = 0;
     virtual bool endOfLoop() = 0;

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -170,8 +170,6 @@ namespace edm {
     void doOpenFile(FileBlock const& fb);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
-    void doRespondToOpenOutputFiles(FileBlock const& fb);
-    void doRespondToCloseOutputFiles(FileBlock const& fb);
     void doPreForkReleaseResources();
     void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
 
@@ -206,8 +204,6 @@ namespace edm {
     virtual void openFile(FileBlock const&) {}
     virtual void respondToOpenInputFile(FileBlock const&) {}
     virtual void respondToCloseInputFile(FileBlock const&) {}
-    virtual void respondToOpenOutputFiles(FileBlock const&) {}
-    virtual void respondToCloseOutputFiles(FileBlock const&) {}
     virtual void preForkReleaseResources() {}
     virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
 

--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -23,6 +23,10 @@ namespace edm {
     class EDProducerBase;
     class EDFilterBase;
   }
+  namespace global {
+    class EDProducerBase;
+    class EDFilterBase;
+  }
   
   class ProducerBase : private ProductRegistryHelper {
   public:
@@ -50,6 +54,8 @@ namespace edm {
     friend class EDFilter;
     friend class one::EDProducerBase;
     friend class one::EDFilterBase;
+    friend class global::EDProducerBase;
+    friend class global::EDFilterBase;
     
     template< typename P>
     void commit_(P& iPrincipal) {

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -160,12 +160,6 @@ namespace edm {
     // Call respondToCloseInputFile() on all Modules
     void respondToCloseInputFile(FileBlock const& fb);
 
-    // Call respondToOpenOutputFiles() on all Modules
-    void respondToOpenOutputFiles(FileBlock const& fb);
-
-    // Call respondToCloseOutputFiles() on all Modules
-    void respondToCloseOutputFiles(FileBlock const& fb);
-
     // Call shouldWeCloseFile() on all OutputModules.
     bool shouldWeCloseOutput() const;
 

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -112,20 +112,6 @@ namespace edm {
       if(subProcess_.get()) subProcess_->respondToCloseInputFile(fb);
     }
 
-    // Call respondToOpenOutputFiles() on all Modules
-    void respondToOpenOutputFiles(FileBlock const& fb) {
-      ServiceRegistry::Operate operate(serviceToken_);
-      schedule_->respondToOpenOutputFiles(fb);
-      if(subProcess_.get()) subProcess_->respondToOpenOutputFiles(fb);
-    }
-
-    // Call respondToCloseOutputFiles() on all Modules
-    void respondToCloseOutputFiles(FileBlock const& fb) {
-      ServiceRegistry::Operate operate(serviceToken_);
-      schedule_->respondToCloseOutputFiles(fb);
-      if(subProcess_.get()) subProcess_->respondToCloseOutputFiles(fb);
-    }
-
     // Call shouldWeCloseFile() on all OutputModules.
     bool shouldWeCloseOutput() const {
       ServiceRegistry::Operate operate(serviceToken_);

--- a/FWCore/Framework/interface/global/EDAnalyzer.h
+++ b/FWCore/Framework/interface/global/EDAnalyzer.h
@@ -1,0 +1,57 @@
+#ifndef FWCore_Framework_global_EDAnalyzer_h
+#define FWCore_Framework_global_EDAnalyzer_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     edm::global::EDAnalyzer
+// 
+/**\class edm::global::EDAnalyzer EDAnalyzer.h "FWCore/Framework/interface/global/EDAnalyzer.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 18 Jul 2013 11:51:07 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/global/analyzerAbilityToImplementor.h"
+#include "FWCore/Framework/interface/moduleAbilities.h"
+
+// forward declarations
+
+namespace edm {
+  namespace global {
+    template< typename... T>
+    class EDAnalyzer : public analyzer::AbilityToImplementor<T>::Type...,
+                       public virtual EDAnalyzerBase
+    {
+      
+    public:
+      EDAnalyzer() = default;
+      
+      // ---------- const member functions ---------------------
+      
+      // ---------- static member functions --------------------
+      
+      // ---------- member functions ---------------------------
+      
+    private:
+      EDAnalyzer(const EDAnalyzer&) = delete;
+      
+      const EDAnalyzer& operator=(const EDAnalyzer&) = delete;
+      
+      // ---------- member data --------------------------------
+      
+    };
+
+  }
+}
+
+#endif

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -1,0 +1,136 @@
+#ifndef FWCore_Framework_global_EDAnalyzerBase_h
+#define FWCore_Framework_global_EDAnalyzerBase_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     EDAnalyzerBase
+// 
+/**\class EDAnalyzerBase EDAnalyzerBase.h "EDAnalyzerBase.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 18 Jul 2013 11:51:14 GMT
+// $Id$
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/EDConsumerBase.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+
+// forward declarations
+
+namespace edm {
+  class StreamID;
+  
+  namespace global {
+    
+    class EDAnalyzerBase : public EDConsumerBase
+    {
+      
+    public:
+      template <typename T> friend class edm::WorkerT;
+      typedef EDAnalyzerBase ModuleType;
+      typedef WorkerT<EDAnalyzerBase> WorkerType;
+
+      EDAnalyzerBase();
+      virtual ~EDAnalyzerBase();
+
+      static void fillDescriptions(ConfigurationDescriptions& descriptions);
+      static void prevalidate(ConfigurationDescriptions& descriptions);
+      static const std::string& baseType();
+
+    protected:
+      // The returned pointer will be null unless the this is currently
+      // executing its event loop function ('produce').
+      CurrentProcessingContext const* currentContext() const;
+      
+    private:
+      bool doEvent(EventPrincipal& ep, EventSetup const& c,
+                   CurrentProcessingContext const* cpcp);
+      void doBeginJob();
+      void doEndJob();
+      
+      void doBeginStream(StreamID id);
+      void doEndStream(StreamID id);
+      void doStreamBeginRun(StreamID id,
+                            RunPrincipal& ep,
+                            EventSetup const& c,
+                            CurrentProcessingContext const* cpcp);
+      void doStreamEndRun(StreamID id,
+                          RunPrincipal& ep,
+                          EventSetup const& c,
+                          CurrentProcessingContext const* cpcp);
+      void doStreamBeginLuminosityBlock(StreamID id,
+                                        LuminosityBlockPrincipal& ep,
+                                        EventSetup const& c,
+                                        CurrentProcessingContext const* cpcp);
+      void doStreamEndLuminosityBlock(StreamID id,
+                                      LuminosityBlockPrincipal& ep,
+                                      EventSetup const& c,
+                                      CurrentProcessingContext const* cpcp);
+
+      
+      void doBeginRun(RunPrincipal& rp, EventSetup const& c,
+                      CurrentProcessingContext const* cpc);
+      void doEndRun(RunPrincipal& rp, EventSetup const& c,
+                    CurrentProcessingContext const* cpc);
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+                                  CurrentProcessingContext const* cpc);
+      void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+                                CurrentProcessingContext const* cpc);
+      
+      //For now, the following are just dummy implemenations with no ability for users to override
+      void doRespondToOpenInputFile(FileBlock const& fb);
+      void doRespondToCloseInputFile(FileBlock const& fb);
+      void doPreForkReleaseResources();
+      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
+      
+      
+      void registerProductsAndCallbacks(EDAnalyzerBase* module, ProductRegistry* reg);
+      std::string workerType() const {return "WorkerT<EDAnalyzer>";}
+      
+      virtual void analyze(StreamID, Event const& , EventSetup const&) const= 0;
+      virtual void beginJob() {}
+      virtual void endJob(){}
+
+      virtual void doBeginStream_(StreamID id);
+      virtual void doEndStream_(StreamID id);
+      virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c);
+      virtual void doStreamEndRun_(StreamID id, Run const& rp, EventSetup const& c);
+      virtual void doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c);
+      virtual void doStreamBeginLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
+      virtual void doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
+      virtual void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
+
+      virtual void doBeginRun_(Run const& rp, EventSetup const& c);
+      virtual void doBeginRunSummary_(Run const& rp, EventSetup const& c);
+      virtual void doEndRunSummary_(Run const& rp, EventSetup const& c);
+      virtual void doEndRun_(Run const& rp, EventSetup const& c);
+      virtual void doBeginLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c);
+      virtual void doBeginLuminosityBlockSummary_(LuminosityBlock const& rp, EventSetup const& c);
+      virtual void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c);
+      virtual void doEndLuminosityBlock_(LuminosityBlock const& lb, EventSetup const& c);
+      
+      void setModuleDescription(ModuleDescription const& md) {
+        moduleDescription_ = md;
+      }
+      ModuleDescription moduleDescription_;
+      CurrentProcessingContext const* current_context_; //Change in future
+
+      std::function<void(BranchDescription const&)> callWhenNewProductsRegistered_;
+    };
+
+  }
+}
+
+#endif

--- a/FWCore/Framework/interface/global/EDFilter.h
+++ b/FWCore/Framework/interface/global/EDFilter.h
@@ -1,0 +1,60 @@
+#ifndef FWCore_Framework_global_EDFilter_h
+#define FWCore_Framework_global_EDFilter_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     edm::global::EDFilter
+// 
+/**\class edm::global::EDFilter EDFilter.h "FWCore/Framework/interface/global/EDFilter.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Tue, 23 Jul 2013 11:51:07 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/global/filterAbilityToImplementor.h"
+#include "FWCore/Framework/interface/moduleAbilities.h"
+
+// forward declarations
+
+namespace edm {
+  namespace global {
+    template< typename... T>
+    class EDFilter : public filter::SpecializeAbilityToImplementor<
+        CheckAbility<edm::module::Abilities::kRunSummaryCache,T...>::kHasIt & CheckAbility<edm::module::Abilities::kEndRunProducer,T...>::kHasIt,
+        CheckAbility<edm::module::Abilities::kLuminosityBlockSummaryCache,T...>::kHasIt & CheckAbility<edm::module::Abilities::kEndLuminosityBlockProducer,T...>::kHasIt,
+        T>::Type...,
+                       public virtual EDFilterBase
+    {
+      
+    public:
+      EDFilter() = default;
+      
+      // ---------- const member functions ---------------------
+      
+      // ---------- static member functions --------------------
+      
+      // ---------- member functions ---------------------------
+      
+    private:
+      EDFilter(const EDFilter&) = delete;
+      
+      const EDFilter& operator=(const EDFilter&) = delete;
+      
+      // ---------- member data --------------------------------
+      
+    };
+
+  }
+}
+
+#endif

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -1,0 +1,145 @@
+#ifndef FWCore_Framework_global_EDFilterBase_h
+#define FWCore_Framework_global_EDFilterBase_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     EDFilterBase
+// 
+/**\class EDFilterBase EDFilterBase.h "EDFilterBase.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 18 Jul 2013 11:51:14 GMT
+// $Id$
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/EDConsumerBase.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+
+// forward declarations
+
+namespace edm {
+  class StreamID;
+  
+  namespace global {
+    
+    class EDFilterBase : public ProducerBase, public EDConsumerBase
+    {
+      
+    public:
+      template <typename T> friend class edm::WorkerT;
+      typedef EDFilterBase ModuleType;
+      typedef WorkerT<EDFilterBase> WorkerType;
+
+      EDFilterBase();
+      virtual ~EDFilterBase();
+
+      static void fillDescriptions(ConfigurationDescriptions& descriptions);
+      static void prevalidate(ConfigurationDescriptions& descriptions);
+      static const std::string& baseType();
+
+    protected:
+      // The returned pointer will be null unless the this is currently
+      // executing its event loop function ('produce').
+      CurrentProcessingContext const* currentContext() const;
+      
+    private:
+      bool doEvent(EventPrincipal& ep, EventSetup const& c,
+                   CurrentProcessingContext const* cpcp);
+      void doBeginJob();
+      void doEndJob();
+      
+      void doBeginStream(StreamID id);
+      void doEndStream(StreamID id);
+      void doStreamBeginRun(StreamID id,
+                            RunPrincipal& ep,
+                            EventSetup const& c,
+                            CurrentProcessingContext const* cpcp);
+      void doStreamEndRun(StreamID id,
+                          RunPrincipal& ep,
+                          EventSetup const& c,
+                          CurrentProcessingContext const* cpcp);
+      void doStreamBeginLuminosityBlock(StreamID id,
+                                        LuminosityBlockPrincipal& ep,
+                                        EventSetup const& c,
+                                        CurrentProcessingContext const* cpcp);
+      void doStreamEndLuminosityBlock(StreamID id,
+                                      LuminosityBlockPrincipal& ep,
+                                      EventSetup const& c,
+                                      CurrentProcessingContext const* cpcp);
+
+      
+      void doBeginRun(RunPrincipal& rp, EventSetup const& c,
+                      CurrentProcessingContext const* cpc);
+      void doEndRun(RunPrincipal& rp, EventSetup const& c,
+                    CurrentProcessingContext const* cpc);
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+                                  CurrentProcessingContext const* cpc);
+      void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+                                CurrentProcessingContext const* cpc);
+      
+      //For now, the following are just dummy implemenations with no ability for users to override
+      void doRespondToOpenInputFile(FileBlock const& fb);
+      void doRespondToCloseInputFile(FileBlock const& fb);
+      void doPreForkReleaseResources();
+      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
+      
+      
+      void registerProductsAndCallbacks(EDFilterBase* module, ProductRegistry* reg) {
+        registerProducts(module, reg, moduleDescription_);
+      }
+      std::string workerType() const {return "WorkerT<EDProducer>";}
+      
+      virtual bool filter(StreamID, Event&, EventSetup const&) const= 0;
+      virtual void beginJob() {}
+      virtual void endJob(){}
+
+      virtual void doBeginStream_(StreamID id);
+      virtual void doEndStream_(StreamID id);
+      virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c);
+      virtual void doStreamEndRun_(StreamID id, Run const& rp, EventSetup const& c);
+      virtual void doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c);
+      virtual void doStreamBeginLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
+      virtual void doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
+      virtual void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
+
+      virtual void doBeginRun_(Run const& rp, EventSetup const& c);
+      virtual void doBeginRunSummary_(Run const& rp, EventSetup const& c);
+      virtual void doEndRunSummary_(Run const& rp, EventSetup const& c);
+      virtual void doEndRun_(Run const& rp, EventSetup const& c);
+      virtual void doBeginLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c);
+      virtual void doBeginLuminosityBlockSummary_(LuminosityBlock const& rp, EventSetup const& c);
+      virtual void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c);
+      virtual void doEndLuminosityBlock_(LuminosityBlock const& lb, EventSetup const& c);
+      
+      virtual void doBeginRunProduce_(Run& rp, EventSetup const& c);
+      virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
+      virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
+      virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
+      
+      
+      void setModuleDescription(ModuleDescription const& md) {
+        moduleDescription_ = md;
+      }
+      ModuleDescription moduleDescription_;
+      CurrentProcessingContext const* current_context_; //Change in future
+      std::vector<BranchID> previousParentage_; //Per stream in the future?
+      ParentageID previousParentageId_;
+    };
+
+  }
+}
+
+#endif

--- a/FWCore/Framework/interface/global/EDProducer.h
+++ b/FWCore/Framework/interface/global/EDProducer.h
@@ -1,0 +1,60 @@
+#ifndef FWCore_Framework_global_EDProducer_h
+#define FWCore_Framework_global_EDProducer_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     edm::global::EDProducer
+// 
+/**\class edm::global::EDProducer EDProducer.h "FWCore/Framework/interface/global/EDProducer.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 18 Jul 2013 11:51:07 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/global/producerAbilityToImplementor.h"
+#include "FWCore/Framework/interface/moduleAbilities.h"
+
+// forward declarations
+
+namespace edm {
+  namespace global {
+    template< typename... T>
+    class EDProducer : public producer::SpecializeAbilityToImplementor<
+        CheckAbility<edm::module::Abilities::kRunSummaryCache,T...>::kHasIt & CheckAbility<edm::module::Abilities::kEndRunProducer,T...>::kHasIt,
+        CheckAbility<edm::module::Abilities::kLuminosityBlockSummaryCache,T...>::kHasIt & CheckAbility<edm::module::Abilities::kEndLuminosityBlockProducer,T...>::kHasIt,
+        T>::Type...,
+                       public virtual EDProducerBase
+    {
+      
+    public:
+      EDProducer() = default;
+      
+      // ---------- const member functions ---------------------
+      
+      // ---------- static member functions --------------------
+      
+      // ---------- member functions ---------------------------
+      
+    private:
+      EDProducer(const EDProducer&) = delete;
+      
+      const EDProducer& operator=(const EDProducer&) = delete;
+      
+      // ---------- member data --------------------------------
+      
+    };
+
+  }
+}
+
+#endif

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -1,0 +1,145 @@
+#ifndef FWCore_Framework_global_EDProducerBase_h
+#define FWCore_Framework_global_EDProducerBase_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     EDProducerBase
+// 
+/**\class EDProducerBase EDProducerBase.h "EDProducerBase.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 18 Jul 2013 11:51:14 GMT
+// $Id$
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/ProducerBase.h"
+#include "FWCore/Framework/interface/EDConsumerBase.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+
+// forward declarations
+
+namespace edm {
+  class StreamID;
+  
+  namespace global {
+    
+    class EDProducerBase : public ProducerBase, public EDConsumerBase
+    {
+      
+    public:
+      template <typename T> friend class edm::WorkerT;
+      typedef EDProducerBase ModuleType;
+      typedef WorkerT<EDProducerBase> WorkerType;
+
+      EDProducerBase();
+      virtual ~EDProducerBase();
+
+      static void fillDescriptions(ConfigurationDescriptions& descriptions);
+      static void prevalidate(ConfigurationDescriptions& descriptions);
+      static const std::string& baseType();
+
+    protected:
+      // The returned pointer will be null unless the this is currently
+      // executing its event loop function ('produce').
+      CurrentProcessingContext const* currentContext() const;
+      
+    private:
+      bool doEvent(EventPrincipal& ep, EventSetup const& c,
+                   CurrentProcessingContext const* cpcp);
+      void doBeginJob();
+      void doEndJob();
+      
+      void doBeginStream(StreamID id);
+      void doEndStream(StreamID id);
+      void doStreamBeginRun(StreamID id,
+                            RunPrincipal& ep,
+                            EventSetup const& c,
+                            CurrentProcessingContext const* cpcp);
+      void doStreamEndRun(StreamID id,
+                          RunPrincipal& ep,
+                          EventSetup const& c,
+                          CurrentProcessingContext const* cpcp);
+      void doStreamBeginLuminosityBlock(StreamID id,
+                                        LuminosityBlockPrincipal& ep,
+                                        EventSetup const& c,
+                                        CurrentProcessingContext const* cpcp);
+      void doStreamEndLuminosityBlock(StreamID id,
+                                      LuminosityBlockPrincipal& ep,
+                                      EventSetup const& c,
+                                      CurrentProcessingContext const* cpcp);
+
+      
+      void doBeginRun(RunPrincipal& rp, EventSetup const& c,
+                      CurrentProcessingContext const* cpc);
+      void doEndRun(RunPrincipal& rp, EventSetup const& c,
+                    CurrentProcessingContext const* cpc);
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+                                  CurrentProcessingContext const* cpc);
+      void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+                                CurrentProcessingContext const* cpc);
+      
+      //For now, the following are just dummy implemenations with no ability for users to override
+      void doRespondToOpenInputFile(FileBlock const& fb);
+      void doRespondToCloseInputFile(FileBlock const& fb);
+      void doPreForkReleaseResources();
+      void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
+      
+      
+      void registerProductsAndCallbacks(EDProducerBase* module, ProductRegistry* reg) {
+        registerProducts(module, reg, moduleDescription_);
+      }
+      std::string workerType() const {return "WorkerT<EDProducer>";}
+      
+      virtual void produce(StreamID, Event&, EventSetup const&) const= 0;
+      virtual void beginJob() {}
+      virtual void endJob(){}
+
+      virtual void doBeginStream_(StreamID id);
+      virtual void doEndStream_(StreamID id);
+      virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c);
+      virtual void doStreamEndRun_(StreamID id, Run const& rp, EventSetup const& c);
+      virtual void doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c);
+      virtual void doStreamBeginLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
+      virtual void doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
+      virtual void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c);
+
+      virtual void doBeginRun_(Run const& rp, EventSetup const& c);
+      virtual void doBeginRunSummary_(Run const& rp, EventSetup const& c);
+      virtual void doEndRunSummary_(Run const& rp, EventSetup const& c);
+      virtual void doEndRun_(Run const& rp, EventSetup const& c);
+      virtual void doBeginLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c);
+      virtual void doBeginLuminosityBlockSummary_(LuminosityBlock const& rp, EventSetup const& c);
+      virtual void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c);
+      virtual void doEndLuminosityBlock_(LuminosityBlock const& lb, EventSetup const& c);
+      
+      virtual void doBeginRunProduce_(Run& rp, EventSetup const& c);
+      virtual void doEndRunProduce_(Run& rp, EventSetup const& c);
+      virtual void doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
+      virtual void doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c);
+      
+      
+      void setModuleDescription(ModuleDescription const& md) {
+        moduleDescription_ = md;
+      }
+      ModuleDescription moduleDescription_;
+      CurrentProcessingContext const* current_context_; //Change in future
+      std::vector<BranchID> previousParentage_; //Per stream in the future?
+      ParentageID previousParentageId_;
+    };
+
+  }
+}
+
+#endif

--- a/FWCore/Framework/interface/global/analyzerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/global/analyzerAbilityToImplementor.h
@@ -1,0 +1,63 @@
+#ifndef FWCore_Framework_global_analyzerAbilityToImplementor_h
+#define FWCore_Framework_global_analyzerAbilityToImplementor_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// File  :     analyzerAbilityToImplementor
+// 
+/**\file  analyzerAbilityToImplementor.h "FWCore/Framework/interface/global/analyzerAbilityToImplementor.h"
+
+ Description: Class used to pair a module Ability to the actual base class used to implement that ability
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 18 Jul 2013 11:51:33 GMT
+// $Id$
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/moduleAbilities.h"
+#include "FWCore/Framework/interface/global/implementors.h"
+#include "FWCore/Framework/interface/global/EDAnalyzerBase.h"
+
+// forward declarations
+namespace edm {
+  namespace global {
+    namespace analyzer {
+      template<typename T> struct AbilityToImplementor;
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::StreamCache<C>> {
+        typedef edm::global::impl::StreamCacheHolder<edm::global::EDAnalyzerBase,C> Type;
+      };
+
+      template<typename C>
+      struct AbilityToImplementor<edm::RunCache<C>> {
+        typedef edm::global::impl::RunCacheHolder<edm::global::EDAnalyzerBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::RunSummaryCache<C>> {
+        typedef edm::global::impl::RunSummaryCacheHolder<edm::global::EDAnalyzerBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::LuminosityBlockCache<C>> {
+        typedef edm::global::impl::LuminosityBlockCacheHolder<edm::global::EDAnalyzerBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
+        typedef edm::global::impl::LuminosityBlockSummaryCacheHolder<edm::global::EDAnalyzerBase,C> Type;
+      };
+    }
+  }
+}
+
+#endif

--- a/FWCore/Framework/interface/global/filterAbilityToImplementor.h
+++ b/FWCore/Framework/interface/global/filterAbilityToImplementor.h
@@ -1,0 +1,103 @@
+#ifndef FWCore_Framework_global_filterAbilityToImplementor_h
+#define FWCore_Framework_global_filterAbilityToImplementor_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// File  :     filterAbilityToImplementor
+// 
+/**\file  filterAbilityToImplementor.h "FWCore/Framework/interface/global/filterAbilityToImplementor.h"
+
+ Description: Class used to pair a module Ability to the actual base class used to implement that ability
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 18 Jul 2013 11:51:33 GMT
+// $Id$
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/moduleAbilities.h"
+#include "FWCore/Framework/interface/global/implementors.h"
+#include "FWCore/Framework/interface/global/EDFilterBase.h"
+
+// forward declarations
+namespace edm {
+  namespace global {
+    namespace filter {
+      template<typename T> struct AbilityToImplementor;
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::StreamCache<C>> {
+        typedef edm::global::impl::StreamCacheHolder<edm::global::EDFilterBase,C> Type;
+      };
+
+      template<typename C>
+      struct AbilityToImplementor<edm::RunCache<C>> {
+        typedef edm::global::impl::RunCacheHolder<edm::global::EDFilterBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::RunSummaryCache<C>> {
+        typedef edm::global::impl::RunSummaryCacheHolder<edm::global::EDFilterBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::LuminosityBlockCache<C>> {
+        typedef edm::global::impl::LuminosityBlockCacheHolder<edm::global::EDFilterBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
+        typedef edm::global::impl::LuminosityBlockSummaryCacheHolder<edm::global::EDFilterBase,C> Type;
+      };
+      
+      template<>
+      struct AbilityToImplementor<edm::BeginRunProducer> {
+        typedef edm::global::impl::BeginRunProducer<edm::global::EDFilterBase> Type;
+      };
+      
+      template<>
+      struct AbilityToImplementor<edm::EndRunProducer> {
+        typedef edm::global::impl::EndRunProducer<edm::global::EDFilterBase> Type;
+      };
+      
+      template<>
+      struct AbilityToImplementor<edm::BeginLuminosityBlockProducer> {
+        typedef edm::global::impl::BeginLuminosityBlockProducer<edm::global::EDFilterBase> Type;
+      };
+      
+      template<>
+      struct AbilityToImplementor<edm::EndLuminosityBlockProducer> {
+        typedef edm::global::impl::EndLuminosityBlockProducer<edm::global::EDFilterBase> Type;
+      };
+      
+      template<bool,bool,typename T> struct SpecializeAbilityToImplementor {
+        typedef typename AbilityToImplementor<T>::Type Type;
+      };
+      
+      template<bool B,typename C> struct SpecializeAbilityToImplementor<true,B,edm::RunSummaryCache<C>> {
+        typedef typename edm::global::impl::EndRunSummaryProducer<edm::global::EDFilterBase,C> Type;
+      };
+      
+      template<bool B> struct SpecializeAbilityToImplementor<true,B,edm::EndRunProducer> {
+        typedef typename edm::global::impl::EmptyType Type;
+      };
+
+      template<bool B,typename C> struct SpecializeAbilityToImplementor<B,true,edm::LuminosityBlockSummaryCache<C>> {
+        typedef typename edm::global::impl::EndLuminosityBlockSummaryProducer<edm::global::EDFilterBase,C> Type;
+      };
+      
+      template<bool B> struct SpecializeAbilityToImplementor<B,true,edm::EndLuminosityBlockProducer> {
+        typedef typename edm::global::impl::EmptyType Type;
+      };
+    }
+  }
+}
+
+#endif

--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -1,0 +1,274 @@
+#ifndef FWCore_Framework_global_implementors_h
+#define FWCore_Framework_global_implementors_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     implementors
+// 
+/**\file implementors.h "FWCore/Framework/interface/global/implementors.h"
+
+ Description: Base classes used to implement the interfaces for the edm::global::* module  abilities
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 18 Jul 2013 11:52:34 GMT
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/RunIndex.h"
+#include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
+
+// forward declarations
+namespace edm {
+  
+  namespace global {
+    namespace impl {
+      class EmptyType {};
+      
+      
+      template <typename T, typename C>
+      class StreamCacheHolder : public virtual T {
+      public:
+        StreamCacheHolder() = default;
+        StreamCacheHolder( StreamCacheHolder<T,C> const&) = delete;
+        StreamCacheHolder<T,C>& operator=(StreamCacheHolder<T,C> const&) = delete;
+      protected:
+        T * streamCache(edm::StreamID iID) const { return cache_.get(); }
+      private:
+        virtual void doBeginStream_(StreamID id) override final {
+          cache_ = beginStream(id);
+        }
+        virtual void doEndStream_(StreamID id) override final {
+          endStream(id);
+          cache_.reset();
+        }
+        virtual void doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) override final {
+          streamBeginRun(id,rp,c);
+        }
+        virtual void doStreamEndRun_(StreamID id, Run const& rp, EventSetup const& c) override final {
+          streamEndRun(id,rp,c);
+        }
+        virtual void doStreamBeginLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) override final {
+          streamBeginLuminosityBlock(id,lbp,c);
+        }
+        virtual void doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) override final {
+          streamEndLuminosityBlock(id,lbp,c);
+        }
+
+        virtual std::unique_ptr<C> beginStream(edm::StreamID) const = 0;
+        virtual void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const  {}
+        virtual void streamBeginLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const {}
+        virtual void streamEndLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const {}
+        virtual void streamEndRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const {}
+        virtual void endStream(edm::StreamID) const {}
+
+        //When threaded we will have a container for N items whre N is # of streams
+        std::unique_ptr<C> cache_;
+      };
+      
+      template <typename T, typename C>
+      class RunCacheHolder : public virtual T {
+      public:
+        RunCacheHolder() = default;
+        RunCacheHolder( RunCacheHolder<T,C> const&) = delete;
+        RunCacheHolder<T,C>& operator=(RunCacheHolder<T,C> const&) = delete;
+      protected:
+        C const* runCache(edm::RunIndex iID) const { return cache_.get(); }
+      private:
+        void doBeginRun_(Run const& rp, EventSetup const& c) override final {
+          cache_ = globalBeginRun(rp,c);
+        }
+        void doEndRun_(Run const& rp, EventSetup const& c) override final {
+          globalEndRun(rp,c);
+          cache_.reset();
+        }
+        
+        virtual std::shared_ptr<C> globalBeginRun(edm::Run const&, edm::EventSetup const&) const = 0;
+        virtual void globalEndRun(edm::Run const&, edm::EventSetup const&) const = 0;
+        //When threaded we will have a container for N items whre N is # of simultaneous runs
+        std::shared_ptr<C> cache_;
+      };
+      
+      template <typename T, typename C>
+      class LuminosityBlockCacheHolder : public virtual T {
+      public:
+        LuminosityBlockCacheHolder() = default;
+        LuminosityBlockCacheHolder( LuminosityBlockCacheHolder<T,C> const&) = delete;
+        LuminosityBlockCacheHolder<T,C>& operator=(LuminosityBlockCacheHolder<T,C> const&) = delete;
+      protected:
+        C const* luminosityBlockCache(edm::LuminosityBlockIndex iID) const { return cache_.get(); }
+      private:
+        void doBeginLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) override final {
+          cache_ = globalBeginLuminosityBlock(rp,c);
+        }
+        void doEndLuminosityBlock_(LuminosityBlock const& rp, EventSetup const& c) override final {
+          globalEndLuminosityBlock(rp,c);
+          cache_.reset();
+        }
+        
+        virtual std::shared_ptr<C> globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const = 0;
+        virtual void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const = 0;
+        //When threaded we will have a container for N items whre N is # of simultaneous runs
+        std::shared_ptr<C> cache_;
+      };
+      
+      template<typename T, typename C> class EndRunSummaryProducer;
+      
+      template <typename T, typename C>
+      class RunSummaryCacheHolder : public virtual T {
+      public:
+        RunSummaryCacheHolder() = default;
+        RunSummaryCacheHolder( RunSummaryCacheHolder<T,C> const&) = delete;
+        RunSummaryCacheHolder<T,C>& operator=(RunSummaryCacheHolder<T,C> const&) = delete;
+      private:
+        friend class EndRunSummaryProducer<T,C>;
+        void doBeginRunSummary_(edm::Run const& rp, EventSetup const& c) override final {
+          cache_ = globalBeginRunSummary(rp,c);
+        }
+        void doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c) override final {
+          //NOTE: in future this will need to be serialized
+          streamEndRunSummary(id,rp,c,cache_.get());
+        }
+        void doEndRunSummary_(Run const& rp, EventSetup const& c) override final {
+          globalEndRunSummary(rp,c,cache_.get());
+        }
+
+        virtual std::shared_ptr<C> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const = 0;
+        virtual void streamEndRunSummary(StreamID, edm::Run const&, edm::EventSetup const&, C*) const = 0;
+
+        virtual void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, C*) const = 0;
+
+        //When threaded we will have a container for N items where N is # of simultaneous runs
+        std::shared_ptr<C> cache_;
+      };
+
+      template<typename T, typename C> class EndLuminosityBlockSummaryProducer;
+
+      
+      template <typename T, typename C>
+      class LuminosityBlockSummaryCacheHolder : public virtual T {
+      public:
+        LuminosityBlockSummaryCacheHolder() = default;
+        LuminosityBlockSummaryCacheHolder( LuminosityBlockSummaryCacheHolder<T,C> const&) = delete;
+        LuminosityBlockSummaryCacheHolder<T,C>& operator=(LuminosityBlockSummaryCacheHolder<T,C> const&) = delete;
+      private:
+        friend class EndLuminosityBlockSummaryProducer<T,C>;
+        
+        void doBeginLuminosityBlockSummary_(edm::LuminosityBlock const& lb, EventSetup const& c) override final {
+          cache_ = globalBeginLuminosityBlockSummary(lb,c);
+        }
+
+        virtual void doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lb, EventSetup const& c) override final
+        {
+          streamEndLuminosityBlockSummary(id,lb,c,cache_.get());
+        }
+        void doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c) override final {
+          globalEndLuminosityBlockSummary(lb,c,cache_.get());
+        }
+
+        virtual std::shared_ptr<C> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&) const = 0;
+        virtual void streamEndLuminosityBlockSummary(StreamID, edm::LuminosityBlock const&, edm::EventSetup const&, C*) const = 0;
+        
+        virtual void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, C*) const = 0;
+        
+        //When threaded we will have a container for N items where N is # of simultaneous Lumis
+        std::shared_ptr<C> cache_;
+      };
+
+      
+      template <typename T>
+      class BeginRunProducer : public virtual T {
+      public:
+        BeginRunProducer() = default;
+        BeginRunProducer( BeginRunProducer const&) = delete;
+        BeginRunProducer& operator=(BeginRunProducer const&) = delete;
+        
+      private:
+        void doBeginRunProduce_(Run& rp, EventSetup const& c) override final;
+        
+        virtual void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const = 0;
+      };
+      
+      template <typename T>
+      class EndRunProducer : public virtual T {
+      public:
+        EndRunProducer() = default;
+        EndRunProducer( EndRunProducer const&) = delete;
+        EndRunProducer& operator=(EndRunProducer const&) = delete;
+        
+      private:
+        
+        void doEndRunProduce_(Run& rp, EventSetup const& c) override final;
+        
+        virtual void globalEndRunProduce(edm::Run&, edm::EventSetup const&) const = 0;
+      };
+
+      template <typename T, typename C>
+      class EndRunSummaryProducer : public RunSummaryCacheHolder<T,C> {
+      public:
+        EndRunSummaryProducer() = default;
+        EndRunSummaryProducer( EndRunSummaryProducer const&) = delete;
+        EndRunSummaryProducer& operator=(EndRunSummaryProducer const&) = delete;
+        
+      private:
+        
+        void doEndRunProduce_(Run& rp, EventSetup const& c) override final {
+          globalEndRunProduce(rp,c,RunSummaryCacheHolder<T,C>::cache_.get());
+        }
+        
+        virtual void globalEndRunProduce(edm::Run&, edm::EventSetup const&, C const*) const = 0;
+      };
+
+      template <typename T>
+      class BeginLuminosityBlockProducer : public virtual T {
+      public:
+        BeginLuminosityBlockProducer() = default;
+        BeginLuminosityBlockProducer( BeginLuminosityBlockProducer const&) = delete;
+        BeginLuminosityBlockProducer& operator=(BeginLuminosityBlockProducer const&) = delete;
+        
+      private:
+        void doBeginLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) override final;
+        virtual void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const = 0;
+      };
+      
+      template <typename T>
+      class EndLuminosityBlockProducer : public virtual T {
+      public:
+        EndLuminosityBlockProducer() = default;
+        EndLuminosityBlockProducer( EndLuminosityBlockProducer const&) = delete;
+        EndLuminosityBlockProducer& operator=(EndLuminosityBlockProducer const&) = delete;
+        
+      private:
+        void doEndLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) override final;
+        virtual void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const = 0;
+      };
+
+      template <typename T, typename S>
+      class EndLuminosityBlockSummaryProducer : public LuminosityBlockSummaryCacheHolder<T,S> {
+      public:
+        EndLuminosityBlockSummaryProducer() = default;
+        EndLuminosityBlockSummaryProducer( EndLuminosityBlockSummaryProducer const&) = delete;
+        EndLuminosityBlockSummaryProducer& operator=(EndLuminosityBlockSummaryProducer const&) = delete;
+        
+      private:
+        void doEndLuminosityBlockProduce_(LuminosityBlock& lb, EventSetup const& c) override final {
+          globalEndLuminosityBlockProduce(lb,c,LuminosityBlockSummaryCacheHolder<T,S>::cache_.get());
+        }
+        
+        virtual void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&, S const*) const = 0;
+      };
+    }
+  }
+}
+
+
+#endif

--- a/FWCore/Framework/interface/global/producerAbilityToImplementor.h
+++ b/FWCore/Framework/interface/global/producerAbilityToImplementor.h
@@ -1,0 +1,103 @@
+#ifndef FWCore_Framework_global_producerAbilityToImplementor_h
+#define FWCore_Framework_global_producerAbilityToImplementor_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// File  :     producerAbilityToImplementor
+// 
+/**\file  producerAbilityToImplementor.h "FWCore/Framework/interface/global/producerAbilityToImplementor.h"
+
+ Description: Class used to pair a module Ability to the actual base class used to implement that ability
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 18 Jul 2013 11:51:33 GMT
+// $Id$
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/moduleAbilities.h"
+#include "FWCore/Framework/interface/global/implementors.h"
+#include "FWCore/Framework/interface/global/EDProducerBase.h"
+
+// forward declarations
+namespace edm {
+  namespace global {
+    namespace producer {
+      template<typename T> struct AbilityToImplementor;
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::StreamCache<C>> {
+        typedef edm::global::impl::StreamCacheHolder<edm::global::EDProducerBase,C> Type;
+      };
+
+      template<typename C>
+      struct AbilityToImplementor<edm::RunCache<C>> {
+        typedef edm::global::impl::RunCacheHolder<edm::global::EDProducerBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::RunSummaryCache<C>> {
+        typedef edm::global::impl::RunSummaryCacheHolder<edm::global::EDProducerBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::LuminosityBlockCache<C>> {
+        typedef edm::global::impl::LuminosityBlockCacheHolder<edm::global::EDProducerBase,C> Type;
+      };
+      
+      template<typename C>
+      struct AbilityToImplementor<edm::LuminosityBlockSummaryCache<C>> {
+        typedef edm::global::impl::LuminosityBlockSummaryCacheHolder<edm::global::EDProducerBase,C> Type;
+      };
+      
+      template<>
+      struct AbilityToImplementor<edm::BeginRunProducer> {
+        typedef edm::global::impl::BeginRunProducer<edm::global::EDProducerBase> Type;
+      };
+      
+      template<>
+      struct AbilityToImplementor<edm::EndRunProducer> {
+        typedef edm::global::impl::EndRunProducer<edm::global::EDProducerBase> Type;
+      };
+      
+      template<>
+      struct AbilityToImplementor<edm::BeginLuminosityBlockProducer> {
+        typedef edm::global::impl::BeginLuminosityBlockProducer<edm::global::EDProducerBase> Type;
+      };
+      
+      template<>
+      struct AbilityToImplementor<edm::EndLuminosityBlockProducer> {
+        typedef edm::global::impl::EndLuminosityBlockProducer<edm::global::EDProducerBase> Type;
+      };
+      
+      template<bool,bool,typename T> struct SpecializeAbilityToImplementor {
+        typedef typename AbilityToImplementor<T>::Type Type;
+      };
+      
+      template<bool B,typename C> struct SpecializeAbilityToImplementor<true,B,edm::RunSummaryCache<C>> {
+        typedef typename edm::global::impl::EndRunSummaryProducer<edm::global::EDProducerBase,C> Type;
+      };
+      
+      template<bool B> struct SpecializeAbilityToImplementor<true,B,edm::EndRunProducer> {
+        typedef typename edm::global::impl::EmptyType Type;
+      };
+
+      template<bool B,typename C> struct SpecializeAbilityToImplementor<B,true,edm::LuminosityBlockSummaryCache<C>> {
+        typedef typename edm::global::impl::EndLuminosityBlockSummaryProducer<edm::global::EDProducerBase,C> Type;
+      };
+      
+      template<bool B> struct SpecializeAbilityToImplementor<B,true,edm::EndLuminosityBlockProducer> {
+        typedef typename edm::global::impl::EmptyType Type;
+      };
+    }
+  }
+}
+
+#endif

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -16,7 +16,6 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Thu, 02 May 2013 21:21:21 GMT
-// $Id$
 //
 
 // system include files
@@ -71,8 +70,6 @@ namespace edm {
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
-      void doRespondToOpenOutputFiles(FileBlock const& fb);
-      void doRespondToCloseOutputFiles(FileBlock const& fb);
       void doPreForkReleaseResources();
       void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
 

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -16,7 +16,6 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Thu, 02 May 2013 21:21:21 GMT
-// $Id$
 //
 
 // system include files
@@ -71,8 +70,6 @@ namespace edm {
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
-      void doRespondToOpenOutputFiles(FileBlock const& fb);
-      void doRespondToCloseOutputFiles(FileBlock const& fb);
       void doPreForkReleaseResources();
       void doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren);
 

--- a/FWCore/Framework/interface/one/implementors.h
+++ b/FWCore/Framework/interface/one/implementors.h
@@ -3,9 +3,9 @@
 // -*- C++ -*-
 //
 // Package:     FWCore/Framework
-// Class  :     producerAbilities
+// Class  :     implementors
 // 
-/**\file producerAbilities.h "FWCore/Framework/interface/one/implementors"
+/**\file implementors.h "FWCore/Framework/interface/one/implementors.h"
 
  Description: Base classes used to implement the interfaces for the edm::one::* module  abilities
 
@@ -16,7 +16,6 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Thu, 09 May 2013 18:40:17 GMT
-// $Id$
 //
 
 // system include files

--- a/FWCore/Framework/src/EDAnalyzer.cc
+++ b/FWCore/Framework/src/EDAnalyzer.cc
@@ -92,16 +92,6 @@ namespace edm {
     respondToCloseInputFile(fb);
   }
 
-  void
-  EDAnalyzer::doRespondToOpenOutputFiles(FileBlock const& fb) {
-    respondToOpenOutputFiles(fb);
-  }
-
-  void
-  EDAnalyzer::doRespondToCloseOutputFiles(FileBlock const& fb) {
-    respondToCloseOutputFiles(fb);
-  }
-
   void 
   EDAnalyzer::doPreForkReleaseResources() {
     preForkReleaseResources();

--- a/FWCore/Framework/src/EDFilter.cc
+++ b/FWCore/Framework/src/EDFilter.cc
@@ -95,16 +95,6 @@ namespace edm {
     respondToCloseInputFile(fb);
   }
 
-  void
-  EDFilter::doRespondToOpenOutputFiles(FileBlock const& fb) {
-    respondToOpenOutputFiles(fb);
-  }
-
-  void
-  EDFilter::doRespondToCloseOutputFiles(FileBlock const& fb) {
-    respondToCloseOutputFiles(fb);
-  }
-
   void 
   EDFilter::doPreForkReleaseResources() {
     preForkReleaseResources();

--- a/FWCore/Framework/src/EDProducer.cc
+++ b/FWCore/Framework/src/EDProducer.cc
@@ -99,16 +99,6 @@ namespace edm {
   }
 
   void 
-  EDProducer::doRespondToOpenOutputFiles(FileBlock const& fb) {
-    respondToOpenOutputFiles(fb);
-  }
-
-  void
-  EDProducer::doRespondToCloseOutputFiles(FileBlock const& fb) {
-    respondToCloseOutputFiles(fb);
-  }
-
-  void 
   EDProducer::doPreForkReleaseResources() {
     preForkReleaseResources();
   }

--- a/FWCore/Framework/src/EPStates.cc
+++ b/FWCore/Framework/src/EPStates.cc
@@ -78,7 +78,6 @@ namespace statemachine {
   void HandleFiles::closeFiles(bool cleaningUpAfterException) {
     ep_.respondToCloseInputFile();
     ep_.closeInputFile(cleaningUpAfterException);
-    ep_.respondToCloseOutputFiles();
     ep_.closeOutputFiles();
   }
 
@@ -141,7 +140,6 @@ namespace statemachine {
     ep_.respondToOpenInputFile();
 
     ep_.openOutputFiles();
-    ep_.respondToOpenOutputFiles();
   }
 
   HandleNewInputFile1::HandleNewInputFile1(my_context ctx) :
@@ -179,14 +177,12 @@ namespace statemachine {
     ep_.respondToCloseInputFile();
     ep_.closeInputFile(false);
 
-    ep_.respondToCloseOutputFiles();
     ep_.closeOutputFiles();
 
     ep_.readFile();
     ep_.respondToOpenInputFile();
 
     ep_.openOutputFiles();
-    ep_.respondToOpenOutputFiles();
   }
 
   HandleRuns::HandleRuns(my_context ctx) :

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1897,22 +1897,6 @@ namespace edm {
     FDEBUG(1) << "\trespondToCloseInputFile\n";
   }
 
-  void EventProcessor::respondToOpenOutputFiles() {
-    if (fb_.get() != nullptr) {
-      schedule_->respondToOpenOutputFiles(*fb_);
-      if(hasSubProcess()) subProcess_->respondToOpenOutputFiles(*fb_);
-    }
-    FDEBUG(1) << "\trespondToOpenOutputFiles\n";
-  }
-
-  void EventProcessor::respondToCloseOutputFiles() {
-    if (fb_.get() != nullptr) {
-      schedule_->respondToCloseOutputFiles(*fb_);
-      if(hasSubProcess()) subProcess_->respondToCloseOutputFiles(*fb_);
-    }
-    FDEBUG(1) << "\trespondToCloseOutputFiles\n";
-  }
-
   void EventProcessor::startingNewLoop() {
     shouldWeStop_ = false;
     //NOTE: for first loop, need to delay calling 'doStartingNewLoop'

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -274,14 +274,6 @@ namespace edm {
     respondToCloseInputFile(fb);
   }
 
-  void OutputModule::doRespondToOpenOutputFiles(FileBlock const& fb) {
-    respondToOpenOutputFiles(fb);
-  }
-
-  void OutputModule::doRespondToCloseOutputFiles(FileBlock const& fb) {
-    respondToCloseOutputFiles(fb);
-  }
-
   void
   OutputModule::doPreForkReleaseResources() {
     preForkReleaseResources();

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -1248,14 +1248,6 @@ namespace edm {
     for_all(allWorkers(), boost::bind(&Worker::respondToCloseInputFile, _1, boost::cref(fb)));
   }
 
-  void Schedule::respondToOpenOutputFiles(FileBlock const& fb) {
-    for_all(allWorkers(), boost::bind(&Worker::respondToOpenOutputFiles, _1, boost::cref(fb)));
-  }
-
-  void Schedule::respondToCloseOutputFiles(FileBlock const& fb) {
-    for_all(allWorkers(), boost::bind(&Worker::respondToCloseOutputFiles, _1, boost::cref(fb)));
-  }
-
   void Schedule::beginJob(ProductRegistry const& iRegistry) {
     workerManager_.beginJob(iRegistry);
   }

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -74,8 +74,6 @@ namespace edm {
     void endStream(StreamID id);
     void respondToOpenInputFile(FileBlock const& fb) {implRespondToOpenInputFile(fb);}
     void respondToCloseInputFile(FileBlock const& fb) {implRespondToCloseInputFile(fb);}
-    void respondToOpenOutputFiles(FileBlock const& fb) {implRespondToOpenOutputFiles(fb);}
-    void respondToCloseOutputFiles(FileBlock const& fb) {implRespondToCloseOutputFiles(fb);}
 
     void preForkReleaseResources() {implPreForkReleaseResources();}
     void postForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren) {implPostForkReacquireResources(iChildIndex, iNumberOfChildren);}
@@ -151,8 +149,6 @@ namespace edm {
   private:
     virtual void implRespondToOpenInputFile(FileBlock const& fb) = 0;
     virtual void implRespondToCloseInputFile(FileBlock const& fb) = 0;
-    virtual void implRespondToOpenOutputFiles(FileBlock const& fb) = 0;
-    virtual void implRespondToCloseOutputFiles(FileBlock const& fb) = 0;
 
     virtual void implPreForkReleaseResources() = 0;
     virtual void implPostForkReacquireResources(unsigned int iChildIndex,

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -153,20 +153,6 @@ namespace edm{
   template<typename T>
   inline
   void
-  WorkerT<T>::implRespondToOpenOutputFiles(FileBlock const& fb) {
-    module_->doRespondToOpenOutputFiles(fb);
-  }
-  
-  template<typename T>
-  inline
-  void
-  WorkerT<T>::implRespondToCloseOutputFiles(FileBlock const& fb) {
-    module_->doRespondToCloseOutputFiles(fb);
-  }
-  
-  template<typename T>
-  inline
-  void
   WorkerT<T>::implPreForkReleaseResources() {
     module_->doPreForkReleaseResources();
   }

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -1,3 +1,5 @@
+#include "boost/mpl/if.hpp"
+
 #include "FWCore/Framework/src/WorkerT.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
 
@@ -7,8 +9,70 @@
 #include "FWCore/Framework/interface/OutputModule.h"
 #include "FWCore/Framework/interface/one/EDProducerBase.h"
 #include "FWCore/Framework/interface/one/EDFilterBase.h"
+#include "FWCore/Framework/interface/global/EDProducerBase.h"
+#include "FWCore/Framework/interface/global/EDFilterBase.h"
+#include "FWCore/Framework/interface/global/EDAnalyzerBase.h"
 
 namespace edm{
+  namespace workerimpl {
+    template<typename T>
+    struct has_stream_functions {
+      static bool constexpr value = false;
+    };
+
+    template<>
+    struct has_stream_functions<edm::global::EDProducerBase> {
+      static bool constexpr value = true;
+    };
+    
+    template<>
+    struct has_stream_functions<edm::global::EDFilterBase> {
+      static bool constexpr value = true;
+    };
+    
+    template<>
+    struct has_stream_functions<edm::global::EDAnalyzerBase> {
+      static bool constexpr value = true;
+    };
+    
+    struct DoNothing {
+      template< typename... T>
+      inline void operator()(const T&...) {}
+    };
+    
+    template<typename T>
+    struct DoBeginStream {
+      inline void operator()(WorkerT<T>* iWorker, StreamID id) {
+        iWorker->callWorkerBeginStream(0,id);
+      }
+    };
+
+    template<typename T>
+    struct DoEndStream {
+      inline void operator()(WorkerT<T>* iWorker, StreamID id) {
+        iWorker->callWorkerEndStream(0,id);
+      }
+    };
+
+    template<typename T, typename P>
+    struct DoStreamBeginTrans {
+      inline void operator() (WorkerT<T>* iWorker, StreamID id, P& rp,
+                            EventSetup const& c,
+                            CurrentProcessingContext const* cpc) {
+        iWorker->callWorkerStreamBegin(0,id,rp,c,cpc);
+      }
+    };
+
+    template<typename T, typename P>
+    struct DoStreamEndTrans {
+      inline void operator() (WorkerT<T>* iWorker, StreamID id, P& rp,
+                              EventSetup const& c,
+                              CurrentProcessingContext const* cpc) {
+        iWorker->callWorkerStreamEnd(0,id,rp,c,cpc);
+      }
+    };
+  }
+  
   UnscheduledHandler* getUnscheduledHandler(EventPrincipal const& ep) {
     return ep.unscheduledHandler().get();
   }
@@ -46,9 +110,32 @@ namespace edm{
   }
   
   template<typename T>
+  template<typename D>
+  void
+  WorkerT<T>::callWorkerStreamBegin(D, StreamID id, RunPrincipal& rp,
+                                    EventSetup const& c,
+                                    CurrentProcessingContext const* cpc) {
+    module_->doStreamBeginRun(id, rp, c, cpc);
+  }
+
+  template<typename T>
+  template<typename D>
+  void
+  WorkerT<T>::callWorkerStreamEnd(D, StreamID id, RunPrincipal& rp,
+                                    EventSetup const& c,
+                                    CurrentProcessingContext const* cpc) {
+    module_->doStreamEndRun(id, rp, c, cpc);
+  }
+
+  
+  template<typename T>
   inline
   bool
   WorkerT<T>::implDoStreamBegin(StreamID id, RunPrincipal& rp, EventSetup const& c, CurrentProcessingContext const* cpc) {
+    typename boost::mpl::if_c<workerimpl::has_stream_functions<T>::value,
+    workerimpl::DoStreamBeginTrans<T,RunPrincipal>,
+    workerimpl::DoNothing>::type might_call;
+    might_call(this,id,rp,c,cpc);
     //module_->doStreamBeginRun(id, rp, c, cpc);
     return true;
   }
@@ -57,6 +144,10 @@ namespace edm{
   inline
   bool
   WorkerT<T>::implDoStreamEnd(StreamID id, RunPrincipal& rp, EventSetup const& c, CurrentProcessingContext const* cpc) {
+    typename boost::mpl::if_c<workerimpl::has_stream_functions<T>::value,
+    workerimpl::DoStreamEndTrans<T,RunPrincipal>,
+    workerimpl::DoNothing>::type might_call;
+    might_call(this,id,rp,c,cpc);
     //module_->doStreamEndRun(id, rp, c, cpc);
     return true;
   }
@@ -78,9 +169,32 @@ namespace edm{
   }
   
   template<typename T>
+  template<typename D>
+  void
+  WorkerT<T>::callWorkerStreamBegin(D, StreamID id, LuminosityBlockPrincipal& rp,
+                                    EventSetup const& c,
+                                    CurrentProcessingContext const* cpc) {
+    module_->doStreamBeginLuminosityBlock(id, rp, c, cpc);
+  }
+  
+  template<typename T>
+  template<typename D>
+  void
+  WorkerT<T>::callWorkerStreamEnd(D, StreamID id, LuminosityBlockPrincipal& rp,
+                                  EventSetup const& c,
+                                  CurrentProcessingContext const* cpc) {
+    module_->doStreamEndLuminosityBlock(id, rp, c, cpc);
+  }
+
+  
+  template<typename T>
   inline
   bool
   WorkerT<T>::implDoStreamBegin(StreamID id, LuminosityBlockPrincipal& lbp, EventSetup const& c, CurrentProcessingContext const* cpc) {
+    typename boost::mpl::if_c<workerimpl::has_stream_functions<T>::value,
+    workerimpl::DoStreamBeginTrans<T,LuminosityBlockPrincipal>,
+    workerimpl::DoNothing>::type might_call;
+    might_call(this,id,lbp,c,cpc);
     //module_->doStreamBeginLuminosityBlock(id, lbp, c, cpc);
     return true;
   }
@@ -89,6 +203,11 @@ namespace edm{
   inline
   bool
   WorkerT<T>::implDoStreamEnd(StreamID id, LuminosityBlockPrincipal& lbp, EventSetup const& c, CurrentProcessingContext const* cpc) {
+    typename boost::mpl::if_c<workerimpl::has_stream_functions<T>::value,
+    workerimpl::DoStreamEndTrans<T,LuminosityBlockPrincipal>,
+    workerimpl::DoNothing>::type might_call;
+    might_call(this,id,lbp,c,cpc);
+
     //module_->doStreamEndLuminosityBlock(id, lbp, c, cpc);
     return true;
   }
@@ -121,19 +240,37 @@ namespace edm{
   WorkerT<T>::implEndJob() {
     module_->doEndJob();
   }
-  
+
+  template<typename T>
+  template<typename D>
+  void WorkerT<T>::callWorkerBeginStream(D, StreamID id) {
+    module_->doBeginStream(id);
+  }
+
   template<typename T>
   inline
   void
   WorkerT<T>::implBeginStream(StreamID id) {
-    //module_->doBeginStream(id);
+    typename boost::mpl::if_c<workerimpl::has_stream_functions<T>::value,
+    workerimpl::DoBeginStream<T>,
+    workerimpl::DoNothing>::type might_call;
+    might_call(this,id);
+  }
+  
+  template<typename T>
+  template<typename D>
+  void WorkerT<T>::callWorkerEndStream(D, StreamID id) {
+    module_->doEndStream(id);
   }
   
   template<typename T>
   inline
   void
   WorkerT<T>::implEndStream(StreamID id) {
-    //module_->doEndStream(id);
+    typename boost::mpl::if_c<workerimpl::has_stream_functions<T>::value,
+    workerimpl::DoEndStream<T>,
+    workerimpl::DoNothing>::type might_call;
+    might_call(this,id);
   }
 
   template<typename T>
@@ -184,6 +321,13 @@ namespace edm{
   template<>
   Worker::Types WorkerT<edm::one::EDFilterBase>::moduleType() const { return Worker::kFilter;}
 
+  template<>
+  Worker::Types WorkerT<edm::global::EDProducerBase>::moduleType() const { return Worker::kProducer;}
+  template<>
+  Worker::Types WorkerT<edm::global::EDFilterBase>::moduleType() const { return Worker::kFilter;}
+  template<>
+  Worker::Types WorkerT<edm::global::EDAnalyzerBase>::moduleType() const { return Worker::kAnalyzer;}
+
   
   //Explicitly instantiate our needed templates to avoid having the compiler
   // instantiate them in all of our libraries
@@ -193,4 +337,7 @@ namespace edm{
   template class WorkerT<OutputModule>;
   template class WorkerT<one::EDProducerBase>;
   template class WorkerT<one::EDFilterBase>;
+  template class WorkerT<global::EDProducerBase>;
+  template class WorkerT<global::EDFilterBase>;
+  template class WorkerT<global::EDAnalyzerBase>;
 }

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -47,6 +47,27 @@ namespace edm {
                               ProductHolderIndexHelper const&) override;
 
 
+    template<typename D>
+    void callWorkerBeginStream(D, StreamID);
+    template<typename D>
+    void callWorkerEndStream(D, StreamID);
+    template<typename D>
+    void callWorkerStreamBegin(D, StreamID id, RunPrincipal& rp,
+                               EventSetup const& c,
+                               CurrentProcessingContext const* cpc);
+    template<typename D>
+    void callWorkerStreamEnd(D, StreamID id, RunPrincipal& rp,
+                             EventSetup const& c,
+                             CurrentProcessingContext const* cpc);
+    template<typename D>
+    void callWorkerStreamBegin(D, StreamID id, LuminosityBlockPrincipal& rp,
+                               EventSetup const& c,
+                               CurrentProcessingContext const* cpc);
+    template<typename D>
+    void callWorkerStreamEnd(D, StreamID id, LuminosityBlockPrincipal& rp,
+                             EventSetup const& c,
+                             CurrentProcessingContext const* cpc);
+    
   protected:
     T& module() {return *module_;}
     T const& module() const {return *module_;}

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -76,8 +76,6 @@ namespace edm {
     virtual void implEndStream(StreamID) override;
     virtual void implRespondToOpenInputFile(FileBlock const& fb) override;
     virtual void implRespondToCloseInputFile(FileBlock const& fb) override;
-    virtual void implRespondToOpenOutputFiles(FileBlock const& fb) override;
-    virtual void implRespondToCloseOutputFiles(FileBlock const& fb) override;
     virtual void implPreForkReleaseResources() override;
     virtual void implPostForkReacquireResources(unsigned int iChildIndex, 
                                                unsigned int iNumberOfChildren) override;

--- a/FWCore/Framework/src/global/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/global/EDAnalyzerBase.cc
@@ -1,0 +1,248 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     global::EDAnalyzerBase
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 02 May 2013 21:56:04 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/global/EDAnalyzerBase.h"
+#include "FWCore/Framework/src/CPCSentry.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/src/edmodule_mightGet_config.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/ConstProductRegistry.h"
+
+
+//
+// constants, enums and typedefs
+//
+namespace edm {
+  namespace global {
+    //
+    // static data member definitions
+    //
+    
+    //
+    // constructors and destructor
+    //
+    EDAnalyzerBase::EDAnalyzerBase():
+    moduleDescription_(),
+    current_context_(nullptr) { }
+    
+    EDAnalyzerBase::~EDAnalyzerBase()
+    {
+    }
+    
+    bool
+    EDAnalyzerBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+                        CurrentProcessingContext const* cpc) {
+      detail::CPCSentry sentry(current_context_, cpc);
+      Event e(ep, moduleDescription_);
+      e.setConsumer(this);
+      this->analyze(e.streamID(), e, c);
+      return true;
+    }
+    
+    void
+    EDAnalyzerBase::doBeginJob() {
+      this->beginJob();
+    }
+    
+    void
+    EDAnalyzerBase::doEndJob() {
+      this->endJob();
+    }
+    
+    void
+    EDAnalyzerBase::doBeginRun(RunPrincipal& rp, EventSetup const& c,
+                           CurrentProcessingContext const* cpc) {
+      
+      detail::CPCSentry sentry(current_context_, cpc);
+      Run r(rp, moduleDescription_);
+      r.setConsumer(this);
+      Run const& cnstR = r;
+      this->doBeginRun_(cnstR, c);
+      this->doBeginRunSummary_(cnstR, c);
+    }
+    
+    void
+    EDAnalyzerBase::doEndRun(RunPrincipal& rp, EventSetup const& c,
+                         CurrentProcessingContext const* cpc) {
+      detail::CPCSentry sentry(current_context_, cpc);
+      Run r(rp, moduleDescription_);
+      r.setConsumer(this);
+      Run const& cnstR = r;
+      this->doEndRunSummary_(r,c);
+      this->doEndRun_(cnstR, c);
+    }
+    
+    void
+    EDAnalyzerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+                                       CurrentProcessingContext const* cpc) {
+      detail::CPCSentry sentry(current_context_, cpc);
+      LuminosityBlock lb(lbp, moduleDescription_);
+      lb.setConsumer(this);
+      LuminosityBlock const& cnstLb = lb;
+      this->doBeginLuminosityBlock_(cnstLb, c);
+      this->doBeginLuminosityBlockSummary_(cnstLb, c);
+    }
+    
+    void
+    EDAnalyzerBase::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+                                     CurrentProcessingContext const* cpc) {
+      detail::CPCSentry sentry(current_context_, cpc);
+      LuminosityBlock lb(lbp, moduleDescription_);
+      lb.setConsumer(this);
+      LuminosityBlock const& cnstLb = lb;
+      this->doEndLuminosityBlockSummary_(cnstLb,c);
+      this->doEndLuminosityBlock_(cnstLb, c);
+    }
+    
+    void
+    EDAnalyzerBase::doBeginStream(StreamID id) {
+      doBeginStream_(id);
+    }
+    void
+    EDAnalyzerBase::doEndStream(StreamID id) {
+      doEndStream_(id);
+    }
+    void
+    EDAnalyzerBase::doStreamBeginRun(StreamID id,
+                                     RunPrincipal& rp,
+                                     EventSetup const& c,
+                                     CurrentProcessingContext const* cpcp)
+    {
+      detail::CPCSentry sentry(current_context_, cpcp);
+      Run r(rp, moduleDescription_);
+      r.setConsumer(this);
+      this->doStreamBeginRun_(id, r, c);
+    }
+    void
+    EDAnalyzerBase::doStreamEndRun(StreamID id,
+                                   RunPrincipal& rp,
+                                   EventSetup const& c,
+                                   CurrentProcessingContext const* cpcp) {
+      detail::CPCSentry sentry(current_context_, cpcp);
+      Run r(rp, moduleDescription_);
+      r.setConsumer(this);
+      this->doStreamEndRun_(id, r, c);
+      this->doStreamEndRunSummary_(id, r, c);
+    }
+    void
+    EDAnalyzerBase::doStreamBeginLuminosityBlock(StreamID id,
+                                                 LuminosityBlockPrincipal& lbp,
+                                                 EventSetup const& c,
+                                                 CurrentProcessingContext const* cpcp) {
+      detail::CPCSentry sentry(current_context_, cpcp);
+      LuminosityBlock lb(lbp, moduleDescription_);
+      lb.setConsumer(this);
+      this->doStreamBeginLuminosityBlock_(id,lb, c);
+    }
+    
+    void
+    EDAnalyzerBase::doStreamEndLuminosityBlock(StreamID id,
+                                               LuminosityBlockPrincipal& lbp,
+                                               EventSetup const& c,
+                                               CurrentProcessingContext const* cpcp) {
+      detail::CPCSentry sentry(current_context_, cpcp);
+      LuminosityBlock lb(lbp, moduleDescription_);
+      lb.setConsumer(this);
+      this->doStreamEndLuminosityBlock_(id,lb, c);
+      this->doStreamEndLuminosityBlockSummary_(id,lb, c);
+    }
+    
+    
+    
+    void
+    EDAnalyzerBase::doRespondToOpenInputFile(FileBlock const& fb) {
+      //respondToOpenInputFile(fb);
+    }
+    
+    void
+    EDAnalyzerBase::doRespondToCloseInputFile(FileBlock const& fb) {
+      //respondToCloseInputFile(fb);
+    }
+    
+    void
+    EDAnalyzerBase::doPreForkReleaseResources() {
+      //preForkReleaseResources();
+    }
+    
+    void
+    EDAnalyzerBase::doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren) {
+      //postForkReacquireResources(iChildIndex, iNumberOfChildren);
+    }
+    
+    void EDAnalyzerBase::doBeginStream_(StreamID id){}
+    void EDAnalyzerBase::doEndStream_(StreamID id) {}
+    void EDAnalyzerBase::doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) {}
+    void EDAnalyzerBase::doStreamEndRun_(StreamID id, Run const& rp, EventSetup const& c) {}
+    void EDAnalyzerBase::doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c) {}
+    void EDAnalyzerBase::doStreamBeginLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDAnalyzerBase::doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDAnalyzerBase::doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) {}
+    
+    
+    void EDAnalyzerBase::doBeginRun_(Run const& rp, EventSetup const& c) {}
+    void EDAnalyzerBase::doEndRun_(Run const& rp, EventSetup const& c) {}
+    void EDAnalyzerBase::doBeginRunSummary_(Run const& rp, EventSetup const& c) {}
+    void EDAnalyzerBase::doEndRunSummary_(Run const& rp, EventSetup const& c) {}
+    
+    void EDAnalyzerBase::doBeginLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDAnalyzerBase::doEndLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDAnalyzerBase::doBeginLuminosityBlockSummary_(LuminosityBlock const& rp, EventSetup const& c) {}
+    void EDAnalyzerBase::doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c) {}
+    
+    CurrentProcessingContext const*
+    EDAnalyzerBase::currentContext() const {
+      return current_context_;
+    }
+    
+    void
+    EDAnalyzerBase::fillDescriptions(ConfigurationDescriptions& descriptions) {
+      ParameterSetDescription desc;
+      desc.setUnknown();
+      descriptions.addDefault(desc);
+    }
+    
+    void
+    EDAnalyzerBase::prevalidate(ConfigurationDescriptions& iConfig) {
+      edmodule_mightGet_config(iConfig);
+    }
+    
+    void
+    EDAnalyzerBase::registerProductsAndCallbacks(EDAnalyzerBase*, ProductRegistry* reg) {
+      
+      if (callWhenNewProductsRegistered_) {
+        
+        reg->callForEachBranch(callWhenNewProductsRegistered_);
+        
+        Service<ConstProductRegistry> regService;
+        regService->watchProductAdditions(callWhenNewProductsRegistered_);
+      }
+    }
+    static const std::string kBaseType("EDAnalyzer");
+    
+    const std::string&
+    EDAnalyzerBase::baseType() {
+      return kBaseType;
+    }
+
+  }
+}

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -1,0 +1,249 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     global::EDFilterBase
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 02 May 2013 21:56:04 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/global/EDFilterBase.h"
+#include "FWCore/Framework/src/CPCSentry.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/src/edmodule_mightGet_config.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+
+//
+// constants, enums and typedefs
+//
+namespace edm {
+  namespace global {
+    //
+    // static data member definitions
+    //
+    
+    //
+    // constructors and destructor
+    //
+    EDFilterBase::EDFilterBase():
+    ProducerBase(),
+    moduleDescription_(),
+    current_context_(nullptr),
+    previousParentage_(),
+    previousParentageId_() { }
+    
+    EDFilterBase::~EDFilterBase()
+    {
+    }
+    
+    bool
+    EDFilterBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+                        CurrentProcessingContext const* cpc) {
+      detail::CPCSentry sentry(current_context_, cpc);
+      Event e(ep, moduleDescription_);
+      e.setConsumer(this);
+      bool returnValue = this->filter(e.streamID(), e, c);
+      commit_(e,&previousParentage_, &previousParentageId_);
+      return returnValue;
+    }
+    
+    void
+    EDFilterBase::doBeginJob() {
+      this->beginJob();
+    }
+    
+    void
+    EDFilterBase::doEndJob() {
+      this->endJob();
+    }
+    
+    void
+    EDFilterBase::doBeginRun(RunPrincipal& rp, EventSetup const& c,
+                           CurrentProcessingContext const* cpc) {
+      
+      detail::CPCSentry sentry(current_context_, cpc);
+      Run r(rp, moduleDescription_);
+      r.setConsumer(this);
+      Run const& cnstR = r;
+      this->doBeginRun_(cnstR, c);
+      this->doBeginRunSummary_(cnstR, c);
+      this->doBeginRunProduce_(r,c);
+      commit_(r);
+    }
+    
+    void
+    EDFilterBase::doEndRun(RunPrincipal& rp, EventSetup const& c,
+                         CurrentProcessingContext const* cpc) {
+      detail::CPCSentry sentry(current_context_, cpc);
+      Run r(rp, moduleDescription_);
+      r.setConsumer(this);
+      Run const& cnstR = r;
+      this->doEndRunProduce_(r, c);
+      this->doEndRunSummary_(r,c);
+      this->doEndRun_(cnstR, c);
+      commit_(r);
+    }
+    
+    void
+    EDFilterBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+                                       CurrentProcessingContext const* cpc) {
+      detail::CPCSentry sentry(current_context_, cpc);
+      LuminosityBlock lb(lbp, moduleDescription_);
+      lb.setConsumer(this);
+      LuminosityBlock const& cnstLb = lb;
+      this->doBeginLuminosityBlock_(cnstLb, c);
+      this->doBeginLuminosityBlockSummary_(cnstLb, c);
+      this->doBeginLuminosityBlockProduce_(lb, c);
+      commit_(lb);
+    }
+    
+    void
+    EDFilterBase::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+                                     CurrentProcessingContext const* cpc) {
+      detail::CPCSentry sentry(current_context_, cpc);
+      LuminosityBlock lb(lbp, moduleDescription_);
+      lb.setConsumer(this);
+      LuminosityBlock const& cnstLb = lb;
+      this->doEndLuminosityBlockProduce_(lb, c);
+      this->doEndLuminosityBlockSummary_(cnstLb,c);
+      this->doEndLuminosityBlock_(cnstLb, c);
+      commit_(lb);
+    }
+    
+    void
+    EDFilterBase::doBeginStream(StreamID id) {
+      doBeginStream_(id);
+    }
+    void
+    EDFilterBase::doEndStream(StreamID id) {
+      doEndStream_(id);
+    }
+    void
+    EDFilterBase::doStreamBeginRun(StreamID id,
+                                     RunPrincipal& rp,
+                                     EventSetup const& c,
+                                     CurrentProcessingContext const* cpcp)
+    {
+      detail::CPCSentry sentry(current_context_, cpcp);
+      Run r(rp, moduleDescription_);
+      r.setConsumer(this);
+      this->doStreamBeginRun_(id, r, c);
+    }
+    void
+    EDFilterBase::doStreamEndRun(StreamID id,
+                                   RunPrincipal& rp,
+                                   EventSetup const& c,
+                                   CurrentProcessingContext const* cpcp) {
+      detail::CPCSentry sentry(current_context_, cpcp);
+      Run r(rp, moduleDescription_);
+      r.setConsumer(this);
+      this->doStreamEndRun_(id, r, c);
+      this->doStreamEndRunSummary_(id, r, c);
+    }
+    void
+    EDFilterBase::doStreamBeginLuminosityBlock(StreamID id,
+                                                 LuminosityBlockPrincipal& lbp,
+                                                 EventSetup const& c,
+                                                 CurrentProcessingContext const* cpcp) {
+      detail::CPCSentry sentry(current_context_, cpcp);
+      LuminosityBlock lb(lbp, moduleDescription_);
+      lb.setConsumer(this);
+      this->doStreamBeginLuminosityBlock_(id,lb, c);
+    }
+    
+    void
+    EDFilterBase::doStreamEndLuminosityBlock(StreamID id,
+                                               LuminosityBlockPrincipal& lbp,
+                                               EventSetup const& c,
+                                               CurrentProcessingContext const* cpcp) {
+      detail::CPCSentry sentry(current_context_, cpcp);
+      LuminosityBlock lb(lbp, moduleDescription_);
+      lb.setConsumer(this);
+      this->doStreamEndLuminosityBlock_(id,lb, c);
+      this->doStreamEndLuminosityBlockSummary_(id,lb, c);
+    }
+    
+    
+    
+    void
+    EDFilterBase::doRespondToOpenInputFile(FileBlock const& fb) {
+      //respondToOpenInputFile(fb);
+    }
+    
+    void
+    EDFilterBase::doRespondToCloseInputFile(FileBlock const& fb) {
+      //respondToCloseInputFile(fb);
+    }
+    
+    void
+    EDFilterBase::doPreForkReleaseResources() {
+      //preForkReleaseResources();
+    }
+    
+    void
+    EDFilterBase::doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren) {
+      //postForkReacquireResources(iChildIndex, iNumberOfChildren);
+    }
+    
+    void EDFilterBase::doBeginStream_(StreamID id){}
+    void EDFilterBase::doEndStream_(StreamID id) {}
+    void EDFilterBase::doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) {}
+    void EDFilterBase::doStreamEndRun_(StreamID id, Run const& rp, EventSetup const& c) {}
+    void EDFilterBase::doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c) {}
+    void EDFilterBase::doStreamBeginLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDFilterBase::doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDFilterBase::doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) {}
+    
+    
+    void EDFilterBase::doBeginRun_(Run const& rp, EventSetup const& c) {}
+    void EDFilterBase::doEndRun_(Run const& rp, EventSetup const& c) {}
+    void EDFilterBase::doBeginRunSummary_(Run const& rp, EventSetup const& c) {}
+    void EDFilterBase::doEndRunSummary_(Run const& rp, EventSetup const& c) {}
+    
+    void EDFilterBase::doBeginLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDFilterBase::doEndLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDFilterBase::doBeginLuminosityBlockSummary_(LuminosityBlock const& rp, EventSetup const& c) {}
+    void EDFilterBase::doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c) {}
+    
+    void EDFilterBase::doBeginRunProduce_(Run& rp, EventSetup const& c) {}
+    void EDFilterBase::doEndRunProduce_(Run& rp, EventSetup const& c) {}
+    void EDFilterBase::doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) {}
+    void EDFilterBase::doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) {}
+    
+    CurrentProcessingContext const*
+    EDFilterBase::currentContext() const {
+      return current_context_;
+    }
+    
+    void
+    EDFilterBase::fillDescriptions(ConfigurationDescriptions& descriptions) {
+      ParameterSetDescription desc;
+      desc.setUnknown();
+      descriptions.addDefault(desc);
+    }
+    
+    void
+    EDFilterBase::prevalidate(ConfigurationDescriptions& iConfig) {
+      edmodule_mightGet_config(iConfig);
+    }
+    
+    static const std::string kBaseType("EDFilter");
+    
+    const std::string&
+    EDFilterBase::baseType() {
+      return kBaseType;
+    }
+
+  }
+}

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -1,0 +1,249 @@
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     global::EDProducerBase
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 02 May 2013 21:56:04 GMT
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/global/EDProducerBase.h"
+#include "FWCore/Framework/src/CPCSentry.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/src/edmodule_mightGet_config.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+
+//
+// constants, enums and typedefs
+//
+namespace edm {
+  namespace global {
+    //
+    // static data member definitions
+    //
+    
+    //
+    // constructors and destructor
+    //
+    EDProducerBase::EDProducerBase():
+    ProducerBase(),
+    moduleDescription_(),
+    current_context_(nullptr),
+    previousParentage_(),
+    previousParentageId_() { }
+    
+    EDProducerBase::~EDProducerBase()
+    {
+    }
+    
+    bool
+    EDProducerBase::doEvent(EventPrincipal& ep, EventSetup const& c,
+                        CurrentProcessingContext const* cpc) {
+      detail::CPCSentry sentry(current_context_, cpc);
+      Event e(ep, moduleDescription_);
+      e.setConsumer(this);
+      this->produce(e.streamID(), e, c);
+      commit_(e,&previousParentage_, &previousParentageId_);
+      return true;
+    }
+    
+    void
+    EDProducerBase::doBeginJob() {
+      this->beginJob();
+    }
+    
+    void
+    EDProducerBase::doEndJob() {
+      this->endJob();
+    }
+    
+    void
+    EDProducerBase::doBeginRun(RunPrincipal& rp, EventSetup const& c,
+                           CurrentProcessingContext const* cpc) {
+      
+      detail::CPCSentry sentry(current_context_, cpc);
+      Run r(rp, moduleDescription_);
+      r.setConsumer(this);
+      Run const& cnstR = r;
+      this->doBeginRun_(cnstR, c);
+      this->doBeginRunSummary_(cnstR, c);
+      this->doBeginRunProduce_(r,c);
+      commit_(r);
+    }
+    
+    void
+    EDProducerBase::doEndRun(RunPrincipal& rp, EventSetup const& c,
+                         CurrentProcessingContext const* cpc) {
+      detail::CPCSentry sentry(current_context_, cpc);
+      Run r(rp, moduleDescription_);
+      r.setConsumer(this);
+      Run const& cnstR = r;
+      this->doEndRunProduce_(r, c);
+      this->doEndRunSummary_(r,c);
+      this->doEndRun_(cnstR, c);
+      commit_(r);
+    }
+    
+    void
+    EDProducerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+                                       CurrentProcessingContext const* cpc) {
+      detail::CPCSentry sentry(current_context_, cpc);
+      LuminosityBlock lb(lbp, moduleDescription_);
+      lb.setConsumer(this);
+      LuminosityBlock const& cnstLb = lb;
+      this->doBeginLuminosityBlock_(cnstLb, c);
+      this->doBeginLuminosityBlockSummary_(cnstLb, c);
+      this->doBeginLuminosityBlockProduce_(lb, c);
+      commit_(lb);
+    }
+    
+    void
+    EDProducerBase::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
+                                     CurrentProcessingContext const* cpc) {
+      detail::CPCSentry sentry(current_context_, cpc);
+      LuminosityBlock lb(lbp, moduleDescription_);
+      lb.setConsumer(this);
+      LuminosityBlock const& cnstLb = lb;
+      this->doEndLuminosityBlockProduce_(lb, c);
+      this->doEndLuminosityBlockSummary_(cnstLb,c);
+      this->doEndLuminosityBlock_(cnstLb, c);
+      commit_(lb);
+    }
+    
+    void
+    EDProducerBase::doBeginStream(StreamID id) {
+      doBeginStream_(id);
+    }
+    void
+    EDProducerBase::doEndStream(StreamID id) {
+      doEndStream_(id);
+    }
+    void
+    EDProducerBase::doStreamBeginRun(StreamID id,
+                                     RunPrincipal& rp,
+                                     EventSetup const& c,
+                                     CurrentProcessingContext const* cpcp)
+    {
+      detail::CPCSentry sentry(current_context_, cpcp);
+      Run r(rp, moduleDescription_);
+      r.setConsumer(this);
+      this->doStreamBeginRun_(id, r, c);
+    }
+    void
+    EDProducerBase::doStreamEndRun(StreamID id,
+                                   RunPrincipal& rp,
+                                   EventSetup const& c,
+                                   CurrentProcessingContext const* cpcp) {
+      detail::CPCSentry sentry(current_context_, cpcp);
+      Run r(rp, moduleDescription_);
+      r.setConsumer(this);
+      this->doStreamEndRun_(id, r, c);
+      this->doStreamEndRunSummary_(id, r, c);
+    }
+    void
+    EDProducerBase::doStreamBeginLuminosityBlock(StreamID id,
+                                                 LuminosityBlockPrincipal& lbp,
+                                                 EventSetup const& c,
+                                                 CurrentProcessingContext const* cpcp) {
+      detail::CPCSentry sentry(current_context_, cpcp);
+      LuminosityBlock lb(lbp, moduleDescription_);
+      lb.setConsumer(this);
+      this->doStreamBeginLuminosityBlock_(id,lb, c);
+    }
+    
+    void
+    EDProducerBase::doStreamEndLuminosityBlock(StreamID id,
+                                               LuminosityBlockPrincipal& lbp,
+                                               EventSetup const& c,
+                                               CurrentProcessingContext const* cpcp) {
+      detail::CPCSentry sentry(current_context_, cpcp);
+      LuminosityBlock lb(lbp, moduleDescription_);
+      lb.setConsumer(this);
+      this->doStreamEndLuminosityBlock_(id,lb, c);
+      this->doStreamEndLuminosityBlockSummary_(id,lb, c);
+    }
+    
+    
+    
+    void
+    EDProducerBase::doRespondToOpenInputFile(FileBlock const& fb) {
+      //respondToOpenInputFile(fb);
+    }
+    
+    void
+    EDProducerBase::doRespondToCloseInputFile(FileBlock const& fb) {
+      //respondToCloseInputFile(fb);
+    }
+    
+    void
+    EDProducerBase::doPreForkReleaseResources() {
+      //preForkReleaseResources();
+    }
+    
+    void
+    EDProducerBase::doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren) {
+      //postForkReacquireResources(iChildIndex, iNumberOfChildren);
+    }
+    
+    void EDProducerBase::doBeginStream_(StreamID id){}
+    void EDProducerBase::doEndStream_(StreamID id) {}
+    void EDProducerBase::doStreamBeginRun_(StreamID id, Run const& rp, EventSetup const& c) {}
+    void EDProducerBase::doStreamEndRun_(StreamID id, Run const& rp, EventSetup const& c) {}
+    void EDProducerBase::doStreamEndRunSummary_(StreamID id, Run const& rp, EventSetup const& c) {}
+    void EDProducerBase::doStreamBeginLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDProducerBase::doStreamEndLuminosityBlock_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDProducerBase::doStreamEndLuminosityBlockSummary_(StreamID id, LuminosityBlock const& lbp, EventSetup const& c) {}
+    
+    
+    void EDProducerBase::doBeginRun_(Run const& rp, EventSetup const& c) {}
+    void EDProducerBase::doEndRun_(Run const& rp, EventSetup const& c) {}
+    void EDProducerBase::doBeginRunSummary_(Run const& rp, EventSetup const& c) {}
+    void EDProducerBase::doEndRunSummary_(Run const& rp, EventSetup const& c) {}
+    
+    void EDProducerBase::doBeginLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDProducerBase::doEndLuminosityBlock_(LuminosityBlock const& lbp, EventSetup const& c) {}
+    void EDProducerBase::doBeginLuminosityBlockSummary_(LuminosityBlock const& rp, EventSetup const& c) {}
+    void EDProducerBase::doEndLuminosityBlockSummary_(LuminosityBlock const& lb, EventSetup const& c) {}
+    
+    void EDProducerBase::doBeginRunProduce_(Run& rp, EventSetup const& c) {}
+    void EDProducerBase::doEndRunProduce_(Run& rp, EventSetup const& c) {}
+    void EDProducerBase::doBeginLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) {}
+    void EDProducerBase::doEndLuminosityBlockProduce_(LuminosityBlock& lbp, EventSetup const& c) {}
+    
+    CurrentProcessingContext const*
+    EDProducerBase::currentContext() const {
+      return current_context_;
+    }
+    
+    void
+    EDProducerBase::fillDescriptions(ConfigurationDescriptions& descriptions) {
+      ParameterSetDescription desc;
+      desc.setUnknown();
+      descriptions.addDefault(desc);
+    }
+    
+    void
+    EDProducerBase::prevalidate(ConfigurationDescriptions& iConfig) {
+      edmodule_mightGet_config(iConfig);
+    }
+    
+    static const std::string kBaseType("EDProducer");
+    
+    const std::string&
+    EDProducerBase::baseType() {
+      return kBaseType;
+    }
+
+  }
+}

--- a/FWCore/Framework/src/global/filterImplementors.cc
+++ b/FWCore/Framework/src/global/filterImplementors.cc
@@ -1,0 +1,29 @@
+// -*- C++ -*-
+//
+// Package:     Package
+// Class  :     filterImplementors
+// 
+// Implementation:
+//     Explicitly instantiate implementor templates for EDFilterBase
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 09 May 2013 20:14:06 GMT
+// $Id$
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/src/global/implementorsMethods.h"
+#include "FWCore/Framework/interface/global/EDFilterBase.h"
+
+namespace edm {
+  namespace global {
+    namespace impl {
+      template class BeginRunProducer<edm::global::EDFilterBase>;
+      template class EndRunProducer<edm::global::EDFilterBase>;
+      template class BeginLuminosityBlockProducer<edm::global::EDFilterBase>;
+      template class EndLuminosityBlockProducer<edm::global::EDFilterBase>;
+    }
+  }
+}

--- a/FWCore/Framework/src/global/implementorsMethods.h
+++ b/FWCore/Framework/src/global/implementorsMethods.h
@@ -1,0 +1,56 @@
+#ifndef FWCore_Framework_global_implementorsMethods_h
+#define FWCore_Framework_global_implementorsMethods_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// File  :     implementorsMethods
+// 
+/**\file implementorsMethods.h "FWCore/Framework/src/global/implementorsMethods.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 09 May 2013 20:13:53 GMT
+// $Id$
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/interface/global/implementors.h"
+
+// forward declarations
+
+namespace edm {
+  namespace global {
+    namespace impl {
+      template< typename T>
+      void BeginRunProducer<T>::doBeginRunProduce_(Run& rp, EventSetup const& c) {
+        this->globalBeginRunProduce(rp,c);
+      }
+
+      template< typename T>
+      void EndRunProducer<T>::doEndRunProduce_(Run& rp, EventSetup const& c) {
+        this->globalEndRunProduce(rp,c);
+      }
+
+      template< typename T>
+      void BeginLuminosityBlockProducer<T>::doBeginLuminosityBlockProduce_(LuminosityBlock& rp, EventSetup const& c) {
+        this->globalBeginLuminosityBlockProduce(rp,c);
+      }
+      
+      template< typename T>
+      void EndLuminosityBlockProducer<T>::doEndLuminosityBlockProduce_(LuminosityBlock& rp, EventSetup const& c) {
+        this->globalEndLuminosityBlockProduce(rp,c);
+      }
+    }
+  }
+}
+
+
+#endif

--- a/FWCore/Framework/src/global/producerImplementors.cc
+++ b/FWCore/Framework/src/global/producerImplementors.cc
@@ -1,0 +1,29 @@
+// -*- C++ -*-
+//
+// Package:     Package
+// Class  :     producerImplementors
+// 
+// Implementation:
+//     Explicitly instantiate implementor templates for EDProducerBase
+//
+// Original Author:  Chris Jones
+//         Created:  Thu, 09 May 2013 20:14:06 GMT
+// $Id$
+//
+
+// system include files
+
+// user include files
+#include "FWCore/Framework/src/global/implementorsMethods.h"
+#include "FWCore/Framework/interface/global/EDProducerBase.h"
+
+namespace edm {
+  namespace global {
+    namespace impl {
+      template class BeginRunProducer<edm::global::EDProducerBase>;
+      template class EndRunProducer<edm::global::EDProducerBase>;
+      template class BeginLuminosityBlockProducer<edm::global::EDProducerBase>;
+      template class EndLuminosityBlockProducer<edm::global::EDProducerBase>;
+    }
+  }
+}

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -8,7 +8,6 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Thu, 02 May 2013 21:56:04 GMT
-// $Id$
 //
 
 // system include files
@@ -126,16 +125,6 @@ namespace edm {
     void
     EDFilterBase::doRespondToCloseInputFile(FileBlock const& fb) {
       //respondToCloseInputFile(fb);
-    }
-    
-    void
-    EDFilterBase::doRespondToOpenOutputFiles(FileBlock const& fb) {
-      //respondToOpenOutputFiles(fb);
-    }
-    
-    void
-    EDFilterBase::doRespondToCloseOutputFiles(FileBlock const& fb) {
-      //respondToCloseOutputFiles(fb);
     }
     
     void

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -8,7 +8,6 @@
 //
 // Original Author:  Chris Jones
 //         Created:  Thu, 02 May 2013 21:56:04 GMT
-// $Id$
 //
 
 // system include files
@@ -126,16 +125,6 @@ namespace edm {
     void
     EDProducerBase::doRespondToCloseInputFile(FileBlock const& fb) {
       //respondToCloseInputFile(fb);
-    }
-    
-    void
-    EDProducerBase::doRespondToOpenOutputFiles(FileBlock const& fb) {
-      //respondToOpenOutputFiles(fb);
-    }
-    
-    void
-    EDProducerBase::doRespondToCloseOutputFiles(FileBlock const& fb) {
-      //respondToCloseOutputFiles(fb);
     }
     
     void

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -130,7 +130,7 @@
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/ParameterSet"/>
 </library>
-<bin   name="TestFWCoreFramework" file="testRunner.cpp,maker2_t.cppunit.cc,maker_t.cppunit.cc,productregistry.cppunit.cc,edproducer_productregistry_callback.cc,event_getrefbeforeput_t.cppunit.cc,generichandle_t.cppunit.cc,edconsumerbase_t.cppunit.cc">
+<bin   name="TestFWCoreFramework" file="testRunner.cpp,maker2_t.cppunit.cc,maker_t.cppunit.cc,productregistry.cppunit.cc,edproducer_productregistry_callback.cc,event_getrefbeforeput_t.cppunit.cc,generichandle_t.cppunit.cc,edconsumerbase_t.cppunit.cc,global_module_t.cppunit.cc">
   <use   name="DataFormats/Common"/>
   <use   name="DataFormats/Provenance"/>
   <use   name="DataFormats/TestObjects"/>

--- a/FWCore/Framework/test/MockEventProcessor.cc
+++ b/FWCore/Framework/test/MockEventProcessor.cc
@@ -116,14 +116,6 @@ namespace edm {
     output_ << "\trespondToCloseInputFile\n";
   }
 
-  void MockEventProcessor::respondToOpenOutputFiles() {
-    output_ << "\trespondToOpenOutputFiles\n";
-  }
-
-  void MockEventProcessor::respondToCloseOutputFiles() {
-    output_ << "\trespondToCloseOutputFiles\n";
-  }
-
   void MockEventProcessor::startingNewLoop() {
     output_ << "\tstartingNewLoop\n";
   }

--- a/FWCore/Framework/test/MockEventProcessor.h
+++ b/FWCore/Framework/test/MockEventProcessor.h
@@ -33,8 +33,6 @@ namespace edm {
 
     virtual void respondToOpenInputFile();
     virtual void respondToCloseInputFile();
-    virtual void respondToOpenOutputFiles();
-    virtual void respondToCloseOutputFiles();
 
     virtual void startingNewLoop();
     virtual bool endOfLoop();

--- a/FWCore/Framework/test/global_module_t.cppunit.cc
+++ b/FWCore/Framework/test/global_module_t.cppunit.cc
@@ -1,0 +1,508 @@
+/*
+ *  proxyfactoryproducer_t.cc
+ *  EDMProto
+ *
+ *  Created by Chris Jones on 4/8/05.
+ *  Changed by Viji Sundararajan on 28-Jun-05
+ */
+#include <iostream>
+#include <atomic>
+#include <vector>
+#include <map>
+#include <functional>
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/src/WorkerT.h"
+#include "FWCore/Framework/interface/OccurrenceTraits.h"
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "DataFormats/Provenance/interface/BranchIDListHelper.h"
+#include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
+
+
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include <cppunit/extensions/HelperMacros.h>
+
+class testGlobalModule: public CppUnit::TestFixture 
+{
+  CPPUNIT_TEST_SUITE(testGlobalModule);
+  
+  CPPUNIT_TEST(basicTest);
+  CPPUNIT_TEST(streamTest);
+  CPPUNIT_TEST(runTest);
+  CPPUNIT_TEST(runSummaryTest);
+  CPPUNIT_TEST(lumiTest);
+  CPPUNIT_TEST(lumiSummaryTest);
+  CPPUNIT_TEST(beginRunProdTest);
+  CPPUNIT_TEST(beginLumiProdTest);
+  CPPUNIT_TEST(endRunProdTest);
+  CPPUNIT_TEST(endLumiProdTest);
+  CPPUNIT_TEST(endRunSummaryProdTest);
+  CPPUNIT_TEST(endLumiSummaryProdTest);
+  
+  CPPUNIT_TEST_SUITE_END();
+public:
+  testGlobalModule();
+  
+  void setUp(){}
+  void tearDown(){}
+
+  void basicTest();
+  void streamTest();
+  void runTest();
+  void runSummaryTest();
+  void lumiTest();
+  void lumiSummaryTest();
+  void beginRunProdTest();
+  void beginLumiProdTest();
+  void endRunProdTest();
+  void endLumiProdTest();
+  void endRunSummaryProdTest();
+  void endLumiSummaryProdTest();
+
+private:
+
+  enum class Trans {
+    kBeginJob,
+    kBeginStream,
+    kGlobalBeginRun,
+    kGlobalBeginRunProduce,
+    kStreamBeginRun,
+    kGlobalBeginLuminosityBlock,
+    kStreamBeginLuminosityBlock,
+    kEvent,
+    kStreamEndLuminosityBlock,
+    kGlobalEndLuminosityBlock,
+    kStreamEndRun,
+    kGlobalEndRun,
+    kEndStream,
+    kEndJob
+  };
+  
+  std::map<Trans,std::function<void(edm::Worker*)>> m_transToFunc;
+  typedef std::vector<Trans> Expectations;
+  
+  edm::ProcessConfiguration m_procConfig;
+  boost::shared_ptr<edm::ProductRegistry> m_prodReg;
+  boost::shared_ptr<edm::BranchIDListHelper> m_idHelper;
+  std::unique_ptr<edm::EventPrincipal> m_ep;
+  edm::HistoryAppender historyAppender_;
+  boost::shared_ptr<edm::LuminosityBlockPrincipal> m_lbp;
+  boost::shared_ptr<edm::RunPrincipal> m_rp;
+  edm::EventSetup* m_es = nullptr;
+  edm::CurrentProcessingContext* m_context = nullptr;
+  edm::ModuleDescription m_desc = {"Dummy","dummy"};
+  edm::CPUTimer* m_timer = nullptr;
+  edm::WorkerParams m_params;
+  
+  template<typename T>
+  void testTransitions(std::unique_ptr<T>&& iMod, Expectations const& iExpect);
+  
+  class BasicProd : public edm::global::EDProducer<> {
+  public:
+    mutable unsigned int m_count = 0; //[[cms-thread-safe]]
+    
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+  };
+  class StreamProd : public edm::global::EDProducer<edm::StreamCache<int>> {
+  public:
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    
+    std::unique_ptr<int> beginStream(edm::StreamID) const override {
+      ++m_count;
+      return std::unique_ptr<int>{};
+    }
+    
+    virtual void streamBeginRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const  override{
+      ++m_count;
+    }
+    virtual void streamBeginLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    virtual void streamEndLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    virtual void streamEndRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    void endStream(edm::StreamID) const override {
+      ++m_count;
+    }
+  };
+  
+  class RunProd : public edm::global::EDProducer<edm::RunCache<int>> {
+  public:
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    
+    std::shared_ptr<int> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::shared_ptr<int>{};
+    }
+
+    void globalEndRun(edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+  };
+
+
+  class LumiProd : public edm::global::EDProducer<edm::LuminosityBlockCache<int>> {
+  public:
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    
+    std::shared_ptr<int> globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::shared_ptr<int>{};
+    }
+    
+    void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+  };
+  
+  class RunSummaryProd : public edm::global::EDProducer<edm::RunSummaryCache<int>> {
+  public:
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    
+    std::shared_ptr<int> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::shared_ptr<int>{};
+    }
+    
+    void streamEndRunSummary(edm::StreamID, edm::Run const&, edm::EventSetup const&, int*) const override {
+      ++m_count;
+    }
+    
+    void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, int*) const override {
+      ++m_count;
+    }
+  };
+
+  class LumiSummaryProd : public edm::global::EDProducer<edm::LuminosityBlockSummaryCache<int>> {
+  public:
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    
+    std::shared_ptr<int> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::shared_ptr<int>{};
+    }
+    
+    void streamEndLuminosityBlockSummary(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&, int*) const override {
+      ++m_count;
+    }
+    
+    void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, int*) const override {
+      ++m_count;
+    }
+  };
+
+  class BeginRunProd : public edm::global::EDProducer<edm::BeginRunProducer> {
+  public:
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+
+    void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+  };
+
+  class BeginLumiProd : public edm::global::EDProducer<edm::BeginLuminosityBlockProducer> {
+  public:
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    
+    void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+  };
+
+  class EndRunProd : public edm::global::EDProducer<edm::EndRunProducer> {
+  public:
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    
+    void globalEndRunProduce(edm::Run&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+  };
+  
+  class EndLumiProd : public edm::global::EDProducer<edm::EndLuminosityBlockProducer> {
+  public:
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    
+    void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+  };
+
+
+  class EndRunSummaryProd : public edm::global::EDProducer<edm::EndRunProducer, edm::RunSummaryCache<int>> {
+  public:
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+    
+    std::shared_ptr<int> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::shared_ptr<int>{};
+    }
+    
+    void streamEndRunSummary(edm::StreamID, edm::Run const&, edm::EventSetup const&, int*) const override {
+      ++m_count;
+    }
+    
+    void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, int*) const override {
+      ++m_count;
+    }
+
+    void globalEndRunProduce(edm::Run&, edm::EventSetup const&, int const*) const override {
+      ++m_count;
+    }
+  };
+  
+  class EndLumiSummaryProd : public edm::global::EDProducer<edm::EndLuminosityBlockProducer, edm::LuminosityBlockSummaryCache<int>> {
+  public:
+    mutable unsigned int m_count = 0;
+    void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+
+    std::shared_ptr<int> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::shared_ptr<int>{};
+    }
+    
+    void streamEndLuminosityBlockSummary(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&, int*) const override {
+      ++m_count;
+    }
+    
+    void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, int*) const override {
+      ++m_count;
+    }
+
+    void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&, int const*) const override {
+      ++m_count;
+    }
+  };
+};
+
+///registration of the test so that the runner can find it
+CPPUNIT_TEST_SUITE_REGISTRATION(testGlobalModule);
+
+testGlobalModule::testGlobalModule():
+m_prodReg(new edm::ProductRegistry{}),
+m_idHelper(new edm::BranchIDListHelper{}),
+m_ep()
+{
+  //Setup the principals
+  m_prodReg->setFrozen();
+  m_idHelper->updateRegistries(*m_prodReg);
+  edm::EventID eventID;
+  
+  std::string uuid = edm::createGlobalIdentifier();
+  edm::Timestamp now(1234567UL);
+  boost::shared_ptr<edm::RunAuxiliary> runAux(new edm::RunAuxiliary(eventID.run(), now, now));
+  m_rp.reset(new edm::RunPrincipal(runAux, m_prodReg, m_procConfig, &historyAppender_,0));
+  boost::shared_ptr<edm::LuminosityBlockAuxiliary> lumiAux(new edm::LuminosityBlockAuxiliary(m_rp->run(), 1, now, now));
+  m_lbp.reset(new edm::LuminosityBlockPrincipal(lumiAux, m_prodReg, m_procConfig, &historyAppender_,0));
+  m_lbp->setRunPrincipal(m_rp);
+  edm::EventAuxiliary eventAux(eventID, uuid, now, true);
+
+  m_ep.reset(new edm::EventPrincipal(m_prodReg,
+                                     m_idHelper,
+                                     m_procConfig,nullptr));
+  m_ep->fillEventPrincipal(eventAux);
+  m_ep->setLuminosityBlockPrincipal(m_lbp);
+
+  //For each transition, bind a lambda which will call the proper method of the Worker
+  m_transToFunc[Trans::kBeginStream] = [this](edm::Worker* iBase) {
+    iBase->beginStream(edm::StreamID::invalidStreamID()); };
+  
+  m_transToFunc[Trans::kGlobalBeginRun] = [this](edm::Worker* iBase) {
+    typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
+    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID()); };
+  m_transToFunc[Trans::kStreamBeginRun] = [this](edm::Worker* iBase) {
+    typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamBegin> Traits;
+    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID()); };
+  
+  m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase) {
+    typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
+    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID()); };
+  m_transToFunc[Trans::kStreamBeginLuminosityBlock] = [this](edm::Worker* iBase) {
+    typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamBegin> Traits;
+    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID()); };
+  
+  m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase) {
+    typedef edm::OccurrenceTraits<edm::EventPrincipal, edm::BranchActionStreamBegin> Traits;
+    iBase->doWork<Traits>(*m_ep,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID()); };
+
+  m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this](edm::Worker* iBase) {
+    typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamEnd> Traits;
+    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID()); };
+  m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase) {
+    typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
+    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID()); };
+
+  m_transToFunc[Trans::kStreamEndRun] = [this](edm::Worker* iBase) {
+    typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamEnd> Traits;
+    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID()); };
+  m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase) {
+    typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
+    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID()); };
+
+  m_transToFunc[Trans::kEndStream] = [this](edm::Worker* iBase) {
+    iBase->endStream(edm::StreamID::invalidStreamID()); };
+
+}
+
+
+namespace {
+  template<typename T>
+  void
+  testTransition(T* iMod, edm::Worker* iWorker, testGlobalModule::Trans iTrans, testGlobalModule::Expectations const& iExpect, std::function<void(edm::Worker*)> iFunc) {
+    assert(0==iMod->m_count);
+    iFunc(iWorker);
+    auto count = std::count(iExpect.begin(),iExpect.end(),iTrans);
+    if(count != iMod->m_count) {
+      std::cout<<"For trans " <<static_cast<std::underlying_type<testGlobalModule::Trans>::type >(iTrans)<< " expected "<<count<<" and got "<<iMod->m_count<<std::endl;
+    }
+    CPPUNIT_ASSERT(iMod->m_count == count);
+    iMod->m_count = 0;
+    iWorker->reset();
+  }
+}
+
+template<typename T>
+void
+testGlobalModule::testTransitions(std::unique_ptr<T>&& iMod, Expectations const& iExpect) {
+  T* pMod = iMod.get();
+  edm::WorkerT<edm::global::EDProducerBase> w{std::move(iMod),m_desc,m_params};
+  for(auto& keyVal: m_transToFunc) {
+    testTransition(pMod,&w,keyVal.first,iExpect,keyVal.second);
+  }
+}
+
+
+void testGlobalModule::basicTest()
+{
+  std::unique_ptr<BasicProd> testProd{ new BasicProd };
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(std::move(testProd), {Trans::kEvent});
+}
+
+void testGlobalModule::streamTest()
+{
+  std::unique_ptr<StreamProd> testProd{ new StreamProd };
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(std::move(testProd), {Trans::kBeginStream, Trans::kStreamBeginRun, Trans::kStreamBeginLuminosityBlock, Trans::kEvent,
+    Trans::kStreamEndLuminosityBlock,Trans::kStreamEndRun,Trans::kEndStream});
+}
+
+void testGlobalModule::runTest()
+{
+  std::unique_ptr<RunProd> testProd{ new RunProd };
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(std::move(testProd), {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kGlobalEndRun});
+}
+
+void testGlobalModule::runSummaryTest()
+{
+  std::unique_ptr<RunSummaryProd> testProd{ new RunSummaryProd };
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(std::move(testProd), {Trans::kGlobalBeginRun, Trans::kEvent, Trans::kStreamEndRun, Trans::kGlobalEndRun});
+}
+
+void testGlobalModule::lumiTest()
+{
+  std::unique_ptr<LumiProd> testProd{ new LumiProd };
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(std::move(testProd), {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kGlobalEndLuminosityBlock});
+}
+
+void testGlobalModule::lumiSummaryTest()
+{
+  std::unique_ptr<LumiSummaryProd> testProd{ new LumiSummaryProd };
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(std::move(testProd), {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent, Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock});
+}
+
+void testGlobalModule::beginRunProdTest()
+{
+  std::unique_ptr<BeginRunProd> testProd{ new BeginRunProd };
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(std::move(testProd), {Trans::kGlobalBeginRun, Trans::kEvent});
+}
+
+void testGlobalModule::beginLumiProdTest()
+{
+  std::unique_ptr<BeginLumiProd> testProd{ new BeginLumiProd };
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(std::move(testProd), {Trans::kGlobalBeginLuminosityBlock, Trans::kEvent});
+}
+
+void testGlobalModule::endRunProdTest()
+{
+  std::unique_ptr<EndRunProd> testProd{ new EndRunProd };
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(std::move(testProd), {Trans::kGlobalEndRun, Trans::kEvent});
+}
+
+void testGlobalModule::endLumiProdTest()
+{
+  std::unique_ptr<EndLumiProd> testProd{ new EndLumiProd };
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(std::move(testProd), {Trans::kGlobalEndLuminosityBlock, Trans::kEvent});
+}
+
+void testGlobalModule::endRunSummaryProdTest()
+{
+  std::unique_ptr<EndRunSummaryProd> testProd{ new EndRunSummaryProd };
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(std::move(testProd), {Trans::kGlobalEndRun, Trans::kEvent, Trans::kGlobalBeginRun, Trans::kStreamEndRun, Trans::kGlobalEndRun});
+}
+
+void testGlobalModule::endLumiSummaryProdTest()
+{
+  std::unique_ptr<EndLumiSummaryProd> testProd{ new EndLumiSummaryProd };
+  
+  CPPUNIT_ASSERT(0 == testProd->m_count);
+  testTransitions(std::move(testProd), {Trans::kGlobalEndLuminosityBlock, Trans::kEvent, Trans::kGlobalBeginLuminosityBlock, Trans::kStreamEndLuminosityBlock, Trans::kGlobalEndLuminosityBlock}); 
+}
+

--- a/FWCore/Framework/test/stubs/TestMergeResults.cc
+++ b/FWCore/Framework/test/stubs/TestMergeResults.cc
@@ -54,8 +54,6 @@ namespace edmtest {
     virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
     virtual void respondToOpenInputFile(edm::FileBlock const& fb);
     virtual void respondToCloseInputFile(edm::FileBlock const& fb);
-    virtual void respondToOpenOutputFiles(edm::FileBlock const& fb);
-    virtual void respondToCloseOutputFiles(edm::FileBlock const& fb);
     void endJob();
 
   private:
@@ -97,12 +95,8 @@ namespace edmtest {
 
     int nRespondToOpenInputFile_;
     int nRespondToCloseInputFile_;
-    int nRespondToOpenOutputFiles_;
-    int nRespondToCloseOutputFiles_;
     int expectedRespondToOpenInputFile_;
     int expectedRespondToCloseInputFile_;
-    int expectedRespondToOpenOutputFiles_;
-    int expectedRespondToCloseOutputFiles_;
 
     std::vector<std::string> expectedInputFileNames_;
 
@@ -150,12 +144,8 @@ namespace edmtest {
 
     nRespondToOpenInputFile_(0),
     nRespondToCloseInputFile_(0),
-    nRespondToOpenOutputFiles_(0),
-    nRespondToCloseOutputFiles_(0),
     expectedRespondToOpenInputFile_(ps.getUntrackedParameter<int>("expectedRespondToOpenInputFile", -1)),
     expectedRespondToCloseInputFile_(ps.getUntrackedParameter<int>("expectedRespondToCloseInputFile", -1)),
-    expectedRespondToOpenOutputFiles_(ps.getUntrackedParameter<int>("expectedRespondToOpenOutputFiles", -1)),
-    expectedRespondToCloseOutputFiles_(ps.getUntrackedParameter<int>("expectedRespondToCloseOutputFiles", -1)),
 
     expectedInputFileNames_(ps.getUntrackedParameter<std::vector<std::string> >("expectedInputFileNames", defaultvstring_)),
 
@@ -529,16 +519,6 @@ namespace edmtest {
     ++droppedIndex1_;
   }
 
-  void TestMergeResults::respondToOpenOutputFiles(edm::FileBlock const&) {
-    if(verbose_) edm::LogInfo("TestMergeResults") << "respondToOpenOutputFiles";
-    ++nRespondToOpenOutputFiles_;
-  }
-
-  void TestMergeResults::respondToCloseOutputFiles(edm::FileBlock const&) {
-    if(verbose_) edm::LogInfo("TestMergeResults") << "respondToCloseOutputFiles";
-    ++nRespondToCloseOutputFiles_;
-  }
-
   void TestMergeResults::endJob() {
     if(verbose_) edm::LogInfo("TestMergeResults") << "endJob";
 
@@ -551,18 +531,6 @@ namespace edmtest {
     if(expectedRespondToCloseInputFile_ > -1 && nRespondToCloseInputFile_ != expectedRespondToCloseInputFile_) {
       std::cerr << "Error while testing merging of run/lumi products in TestMergeResults.cc\n"
                 << "Unexpected number of calls to the function respondToCloseInputFile" << std::endl;
-      abort();
-    }
-
-    if(expectedRespondToOpenOutputFiles_ > -1 && nRespondToOpenOutputFiles_ != expectedRespondToOpenOutputFiles_) {
-      std::cerr << "Error while testing merging of run/lumi products in TestMergeResults.cc\n"
-                << "Unexpected number of calls to the function respondToOpenOutputFiles" << std::endl;
-      abort();
-    }
-
-    if(expectedRespondToCloseOutputFiles_ > -1 && nRespondToCloseOutputFiles_ != expectedRespondToCloseOutputFiles_) {
-      std::cerr << "Error while testing merging of run/lumi products in TestMergeResults.cc\n"
-                << "Unexpected number of calls to the function respondToCloseOutputFiles" << std::endl;
       abort();
     }
   }

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_1.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_1.txt
@@ -5,7 +5,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -55,7 +54,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 3
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -66,7 +64,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -110,7 +107,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 3
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -121,7 +117,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Run 2 ***
@@ -161,7 +156,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 3
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -172,7 +166,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -222,7 +215,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 3
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -233,7 +225,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -277,7 +268,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 3
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -288,7 +278,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Run 2 ***
@@ -328,7 +317,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 3
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_11.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_11.txt
@@ -10,11 +10,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Restart 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -25,11 +23,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Lumi 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -40,11 +36,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Event ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -55,16 +49,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 9 ***
 	readAndCacheRun 9
 	beginRun 9
@@ -74,12 +65,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 9
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -89,12 +78,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -110,12 +97,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -125,12 +110,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -146,12 +129,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -173,12 +154,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -188,12 +167,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -209,16 +186,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Lumi 4 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -229,7 +203,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 5 ***
 	readAndCacheRun 5
 	beginRun 5
@@ -245,16 +218,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 5
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Event ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -265,7 +235,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 6 ***
 	readAndCacheRun 6
 	beginRun 6
@@ -281,7 +250,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 6
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -303,11 +271,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Restart 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -318,11 +284,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Lumi 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -333,11 +297,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Event ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -348,16 +310,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 9 ***
 	readAndCacheRun 9
 	beginRun 9
@@ -367,12 +326,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 9
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -382,12 +339,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -403,12 +358,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -418,12 +371,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -437,12 +388,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -460,12 +409,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -475,12 +422,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -494,16 +439,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Lumi 4 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -514,7 +456,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 5 ***
 	readAndCacheRun 5
 	beginRun 5
@@ -528,16 +469,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 5
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Event ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -548,7 +486,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 6 ***
 	readAndCacheRun 6
 	beginRun 6
@@ -562,7 +499,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 6
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -584,11 +520,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Restart 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -599,11 +533,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Lumi 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -614,11 +546,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Event ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -629,16 +559,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 9 ***
 	readAndCacheRun 9
     *** nextItemType: File 0 ***
@@ -646,12 +573,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 9
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: File 0 ***
@@ -659,12 +584,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Run 2 ***
@@ -676,12 +599,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
     *** nextItemType: File 0 ***
@@ -689,12 +610,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
     *** nextItemType: Lumi 1 ***
@@ -706,12 +625,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
     *** nextItemType: Lumi 2 ***
@@ -727,12 +644,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
     *** nextItemType: File 0 ***
@@ -740,12 +655,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
     *** nextItemType: Lumi 3 ***
@@ -757,16 +670,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Lumi 4 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -777,7 +687,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 5 ***
 	readAndCacheRun 5
     *** nextItemType: Lumi 1 ***
@@ -789,16 +698,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 5
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Event ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -809,7 +715,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 6 ***
 	readAndCacheRun 6
     *** nextItemType: Lumi 1 ***
@@ -821,7 +726,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 6
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -843,11 +747,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Restart 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -858,11 +760,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Lumi 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -873,11 +773,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Event ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -888,7 +786,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -996,7 +893,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1007,7 +903,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 5 ***
 	readAndCacheRun 5
 	beginRun 5
@@ -1029,7 +924,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 5
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1040,7 +934,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 6 ***
 	readAndCacheRun 6
 	beginRun 6
@@ -1056,7 +949,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 6
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1078,11 +970,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Restart 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1093,11 +983,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Lumi 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1108,11 +996,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Event ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1123,7 +1009,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -1225,7 +1110,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1236,7 +1120,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 5 ***
 	readAndCacheRun 5
 	beginRun 5
@@ -1256,7 +1139,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 5
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1267,7 +1149,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 6 ***
 	readAndCacheRun 6
 	beginRun 6
@@ -1281,7 +1162,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 6
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1303,11 +1183,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Restart 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1318,11 +1196,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Lumi 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1333,11 +1209,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Event ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1348,7 +1222,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -1444,7 +1317,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1455,7 +1327,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 5 ***
 	readAndCacheRun 5
     *** nextItemType: Lumi 1 ***
@@ -1473,7 +1344,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 5
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop
@@ -1484,7 +1354,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 6 ***
 	readAndCacheRun 6
     *** nextItemType: Lumi 1 ***
@@ -1496,7 +1365,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 6
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	doErrorStuff
 	endOfLoop

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_12.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_12.txt
@@ -5,7 +5,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -25,12 +24,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -50,12 +47,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -75,7 +70,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -86,7 +80,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -106,12 +99,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -131,12 +122,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -156,7 +145,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -167,7 +155,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -187,12 +174,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 2 ***
@@ -212,12 +197,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -237,7 +220,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -248,7 +230,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -304,7 +285,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -315,7 +295,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -371,7 +350,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -382,7 +360,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -438,7 +415,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_2.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_2.txt
@@ -5,52 +5,41 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -60,30 +49,24 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -99,34 +82,27 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Stop 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -137,52 +113,41 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -192,30 +157,24 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -229,34 +188,27 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Stop 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -267,52 +219,41 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: File 0 ***
@@ -320,30 +261,24 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
     *** nextItemType: Lumi 1 ***
@@ -355,34 +290,27 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Stop 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -393,27 +321,22 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -430,12 +353,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	shouldWeCloseOutput
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -458,12 +379,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -492,16 +411,13 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Stop 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -512,27 +428,22 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -549,12 +460,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	shouldWeCloseOutput
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -577,12 +486,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -609,16 +516,13 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Stop 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -629,27 +533,22 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 1 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -666,12 +565,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	shouldWeCloseOutput
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: File 0 ***
@@ -692,12 +589,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
     *** nextItemType: Lumi 1 ***
@@ -722,16 +617,13 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Stop 1 ***
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_3.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_3.txt
@@ -5,7 +5,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -25,12 +24,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -50,12 +47,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -75,7 +70,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -86,7 +80,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -106,12 +99,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
 	beginRun 2
@@ -131,12 +122,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -156,7 +145,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -167,7 +155,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -187,12 +174,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 2 ***
 	readAndCacheRun 2
     *** nextItemType: Lumi 1 ***
@@ -212,12 +197,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 2 ***
@@ -237,7 +220,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -248,7 +230,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -312,7 +293,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -323,7 +303,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -387,7 +366,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -398,7 +376,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -462,7 +439,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_4.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_4.txt
@@ -5,7 +5,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -41,12 +40,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -66,7 +63,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -77,7 +73,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -113,12 +108,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -138,7 +131,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -149,7 +141,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -185,12 +176,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 2
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 2 ***
@@ -210,7 +199,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -221,7 +209,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -279,7 +266,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -290,7 +276,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -348,7 +333,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -359,7 +343,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -417,7 +400,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_5.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_5.txt
@@ -5,7 +5,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -31,12 +30,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -56,7 +53,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -67,7 +63,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -91,12 +86,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -116,7 +109,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -127,7 +119,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -151,12 +142,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 2 ***
@@ -176,7 +165,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -187,7 +175,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -227,7 +214,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -238,7 +224,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -278,7 +263,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -289,7 +273,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -329,7 +312,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_6.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_6.txt
@@ -5,7 +5,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -35,12 +34,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -60,7 +57,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -71,7 +67,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -101,12 +96,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -126,7 +119,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -137,7 +129,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -167,12 +158,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 2 ***
@@ -192,7 +181,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -203,7 +191,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -247,7 +234,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -258,7 +244,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -302,7 +287,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -313,7 +297,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -357,7 +340,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_7.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_7.txt
@@ -5,7 +5,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -35,12 +34,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -66,7 +63,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -77,7 +73,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -107,12 +102,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -136,7 +129,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -147,7 +139,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -177,12 +168,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 2 ***
@@ -206,7 +195,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -217,7 +205,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -267,7 +254,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -278,7 +264,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -328,7 +313,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -339,7 +323,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -389,7 +372,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_8.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_8.txt
@@ -5,7 +5,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -31,12 +30,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -62,7 +59,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -73,7 +69,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -97,12 +92,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -126,7 +119,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -137,7 +129,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -161,12 +152,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 2 ***
@@ -190,7 +179,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -201,7 +189,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -247,7 +234,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -258,7 +244,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -302,7 +287,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -313,7 +297,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -357,7 +340,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_9.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_9.txt
@@ -5,7 +5,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -33,12 +32,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -62,12 +59,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -91,7 +86,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -106,7 +100,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -134,12 +127,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -163,12 +154,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -192,7 +181,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -207,7 +195,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -235,12 +222,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -264,12 +249,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -293,7 +276,6 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -308,7 +290,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -372,7 +353,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -387,7 +367,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
 	beginRun 1
@@ -451,7 +430,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated
@@ -466,7 +444,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
 	openOutputFiles
-	respondToOpenOutputFiles
     *** nextItemType: Run 1 ***
 	readAndCacheRun 1
     *** nextItemType: Lumi 1 ***
@@ -530,7 +507,6 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	deleteRunFromCache 1
 	respondToCloseInputFile
 	closeInputFile
-	respondToCloseOutputFiles
 	closeOutputFiles
 	endOfLoop
 The state machine reports it has been terminated

--- a/FWCore/Integration/test/testRunMergeMERGE2_cfg.py
+++ b/FWCore/Integration/test/testRunMergeMERGE2_cfg.py
@@ -241,8 +241,6 @@ process.test = cms.EDAnalyzer("TestMergeResults",
 
     expectedRespondToOpenInputFile = cms.untracked.int32(6),
     expectedRespondToCloseInputFile = cms.untracked.int32(6),
-    expectedRespondToOpenOutputFiles = cms.untracked.int32(1),
-    expectedRespondToCloseOutputFiles = cms.untracked.int32(1),
 
     expectedInputFileNames = cms.untracked.vstring(
         'file:testRunMerge0.root', 

--- a/FWCore/Integration/test/testRunMergeMERGE4_cfg.py
+++ b/FWCore/Integration/test/testRunMergeMERGE4_cfg.py
@@ -183,8 +183,6 @@ process.test = cms.EDAnalyzer("TestMergeResults",
 
     expectedRespondToOpenInputFile = cms.untracked.int32(5),
     expectedRespondToCloseInputFile = cms.untracked.int32(5),
-    expectedRespondToOpenOutputFiles = cms.untracked.int32(1),
-    expectedRespondToCloseOutputFiles = cms.untracked.int32(1),
 
     expectedInputFileNames = cms.untracked.vstring(
         'file:testRunMerge1.root', 

--- a/FWCore/Integration/test/testRunMergeMERGE_cfg.py
+++ b/FWCore/Integration/test/testRunMergeMERGE_cfg.py
@@ -183,8 +183,6 @@ process.test = cms.EDAnalyzer("TestMergeResults",
 
     expectedRespondToOpenInputFile = cms.untracked.int32(5),
     expectedRespondToCloseInputFile = cms.untracked.int32(5),
-    expectedRespondToOpenOutputFiles = cms.untracked.int32(1),
-    expectedRespondToCloseOutputFiles = cms.untracked.int32(1),
 
     expectedInputFileNames = cms.untracked.vstring(
         'file:testRunMerge1.root', 


### PR DESCRIPTION
Implemented and incorporated into the framework the global modules EDProducer, EDFilter and EDAnalyzer.
The OutputModule was postponed because some of the functions encorporated into the classic OutputModule
base class are not thread safe and need to be reviewed.

This pull builds on pull request #197.
