### PR TITLE
Tp sim hit assoc

### DIFF
--- a/CommonTools/RecoAlgos/interface/CosmicTrackingParticleSelector.h
+++ b/CommonTools/RecoAlgos/interface/CosmicTrackingParticleSelector.h
@@ -4,8 +4,8 @@
  *
  * \author Yanyan Gao, FNAL
  *
- *  $Date: 2013/05/14 14:26:32 $
- *  $Revision: 1.4.4.1 $
+ *  $Date: 2013/06/24 12:25:14 $
+ *  $Revision: 1.5 $
  *
  */
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
@@ -26,6 +26,9 @@
 #include <Geometry/CommonDetUnit/interface/GeomDet.h>
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+
+#include "SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 class TrajectoryStateClosestToBeamLineBuilder;
 
@@ -62,22 +65,26 @@ public:
 	event.getByLabel(edm::InputTag("offlineBeamSpot"), beamSpot); 
 	for( TrackingParticleCollection::const_iterator itp = c->begin(); 
 	     itp != c->end(); ++ itp )
-	  if ( operator()(*itp,beamSpot.product(),event,setup) ) {
+	  if ( operator()(TrackingParticleRef(c,itp-c->begin()),beamSpot.product(),event,setup) ) {
 	    selected_.push_back( & * itp );
 	  }
       }
       
     const_iterator begin() const { return selected_.begin(); }
     const_iterator end() const { return selected_.end(); }
-    
+
+    void initEvent(edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssocToSet) const {
+      simHitsTPAssoc = simHitsTPAssocToSet;
+    }
+
     // Operator() performs the selection: e.g. if (tPSelector(tp, bs, event, evtsetup)) {...
-    bool operator()( const TrackingParticle & tp, const reco::BeamSpot* bs, const edm::Event &iEvent, const edm::EventSetup& iSetup ) const { 
-      if (chargedOnly_ && tp.charge()==0) return false;//select only if charge!=0
+    bool operator()( const TrackingParticleRef tpr, const reco::BeamSpot* bs, const edm::Event &iEvent, const edm::EventSetup& iSetup ) const { 
+      if (chargedOnly_ && tpr->charge()==0) return false;//select only if charge!=0
       //bool testId = false;
       //unsigned int idSize = pdgId_.size();
       //if (idSize==0) testId = true;
       //else for (unsigned int it=0;it!=idSize;++it){
-	//if (tp.pdgId()==pdgId_[it]) testId = true;
+	//if (tpr->pdgId()==pdgId_[it]) testId = true;
       //}
       
       edm::ESHandle<TrackerGeometry> tracker;
@@ -90,16 +97,20 @@ public:
       GlobalPoint finalGP(0,0,0);      
       GlobalVector momentum(0,0,0);//At the PCA
       GlobalPoint vertex(0,0,0);//At the PCA
-#warning "This file has been modified just to get it to compile without any regard as to whether it still functions as intended"
-#ifdef REMOVED_JUST_TO_GET_IT_TO_COMPILE__THIS_CODE_NEEDS_TO_BE_CHECKED
       double radius(9999);
-#endif
       bool found(0);
-      
-#warning "This file has been modified just to get it to compile without any regard as to whether it still functions as intended"
-#ifdef REMOVED_JUST_TO_GET_IT_TO_COMPILE__THIS_CODE_NEEDS_TO_BE_CHECKED
-      const std::vector<PSimHit> & simHits = tp.trackPSimHit(DetId::Tracker);
-      for(std::vector<PSimHit>::const_iterator it=simHits.begin(); it!=simHits.end(); ++it){
+
+
+      if (simHitsTPAssoc.isValid()==0) {
+	edm::LogError("TrackAssociation") << "Invalid handle!";
+	return false;
+      }
+      std::pair<TrackingParticleRef, TrackPSimHitRef> clusterTPpairWithDummyTP(tpr,TrackPSimHitRef());//SimHit is dummy: for simHitTPAssociationListGreater 
+                                                                                                      // sorting only the cluster is needed
+      auto range = std::equal_range(simHitsTPAssoc->begin(), simHitsTPAssoc->end(), 
+				    clusterTPpairWithDummyTP, SimHitTPAssociationProducer::simHitTPAssociationListGreater);
+      for(auto ip = range.first; ip != range.second; ++ip) {
+	TrackPSimHitRef it = ip->second;
 	const GeomDet* tmpDet  = tracker->idToDet( DetId(it->detUnitId()) ) ;
 	LocalVector  lv = it->momentumAtEntry();
 	Local3DPoint lp = it->localPosition ();
@@ -112,11 +123,10 @@ public:
 	  finalGP = gp;
 	}
       }
-#endif
       if(!found) return 0;
       else
 	{
-	  FreeTrajectoryState ftsAtProduction(finalGP,finalGV,TrackCharge(tp.charge()),theMF.product());
+	  FreeTrajectoryState ftsAtProduction(finalGP,finalGV,TrackCharge(tpr->charge()),theMF.product());
 	  TSCBLBuilderNoMaterial tscblBuilder;
 	  TrajectoryStateClosestToBeamLine tsAtClosestApproach = tscblBuilder(ftsAtProduction,*bs);//as in TrackProducerAlgorithm
 	  if(!tsAtClosestApproach.isValid()){
@@ -128,7 +138,7 @@ public:
 	      momentum = tsAtClosestApproach.trackStateAtPCA().momentum();
 	      vertex = tsAtClosestApproach.trackStateAtPCA().position();
 	      return (
-		      tp.numberOfTrackerLayers() >= minHit_ &&
+		      tpr->numberOfTrackerLayers() >= minHit_ &&
 		      sqrt(momentum.perp2()) >= ptMin_ && 
 		      momentum.eta() >= minRapidity_ && momentum.eta() <= maxRapidity_ && 
 		      sqrt(vertex.perp2()) <= tip_ &&
@@ -151,7 +161,8 @@ public:
     bool chargedOnly_;
       std::vector<int> pdgId_;
       container selected_;
-      
+
+    mutable edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;      
       
 };
 

--- a/SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h
+++ b/SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h
@@ -1,0 +1,35 @@
+#ifndef SimGeneral_TrackingAnalysis_SimHitTPAssociationProducer_h
+#define SimGeneral_TrackingAnalysis_SimHitTPAssociationProducer_h
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+
+class SimHitTPAssociationProducer : public edm::EDProducer 
+{
+public:
+
+  typedef std::pair<TrackingParticleRef, TrackPSimHitRef> SimHitTPPair;
+  typedef std::vector<SimHitTPPair> SimHitTPAssociationList;
+
+  explicit SimHitTPAssociationProducer(const edm::ParameterSet&);
+  ~SimHitTPAssociationProducer();
+
+private:
+  virtual void beginJob() {}
+  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void endJob() {}
+
+  static bool simHitTPAssociationListGreater(SimHitTPPair i,SimHitTPPair j) { return (i.first.key()>j.first.key()); }
+
+  std::vector<edm::InputTag> _simHitSrc;
+  edm::InputTag _trackingParticleSrc;
+};
+#endif

--- a/SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h
+++ b/SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h
@@ -6,7 +6,6 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
-#include "DataFormats/Candidate/interface/CandidateFwd.h"
 
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
@@ -22,12 +21,12 @@ public:
   explicit SimHitTPAssociationProducer(const edm::ParameterSet&);
   ~SimHitTPAssociationProducer();
 
+  static bool simHitTPAssociationListGreater(SimHitTPPair i,SimHitTPPair j) { return (i.first.key()>j.first.key()); }
+
 private:
   virtual void beginJob() {}
   virtual void produce(edm::Event&, const edm::EventSetup&);
   virtual void endJob() {}
-
-  static bool simHitTPAssociationListGreater(SimHitTPPair i,SimHitTPPair j) { return (i.first.key()>j.first.key()); }
 
   std::vector<edm::InputTag> _simHitSrc;
   edm::InputTag _trackingParticleSrc;

--- a/SimGeneral/TrackingAnalysis/plugins/SimHitTPAssociationProducer.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/SimHitTPAssociationProducer.cc
@@ -1,0 +1,169 @@
+#include <memory>
+#include <vector>
+#include <iostream>
+#include <fstream>
+#include <utility>
+
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/LeafCandidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/SiPixelDetId/interface/PixelChannelIdentifier.h"
+
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
+#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
+#include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
+
+#include "SimTracker/TrackerHitAssociation/interface/ClusterTPAssociationProducer.h"
+
+ClusterTPAssociationProducer::ClusterTPAssociationProducer(const edm::ParameterSet & cfg) 
+  : _verbose(cfg.getParameter<bool>("verbose")),
+    _pixelSimLinkSrc(cfg.getParameter<edm::InputTag>("pixelSimLinkSrc")),
+    _stripSimLinkSrc(cfg.getParameter<edm::InputTag>("stripSimLinkSrc")),
+    _pixelClusterSrc(cfg.getParameter<edm::InputTag>("pixelClusterSrc")),
+    _stripClusterSrc(cfg.getParameter<edm::InputTag>("stripClusterSrc")),
+    _trackingParticleSrc(cfg.getParameter<edm::InputTag>("trackingParticleSrc"))
+{
+  produces<ClusterTPAssociationList>();
+}
+
+ClusterTPAssociationProducer::~ClusterTPAssociationProducer() {
+}
+		
+void ClusterTPAssociationProducer::produce(edm::Event& iEvent, const edm::EventSetup& es) {
+  std::auto_ptr<ClusterTPAssociationList> clusterTPList(new ClusterTPAssociationList);
+ 
+  // Pixel DigiSimLink
+  edm::Handle<edm::DetSetVector<PixelDigiSimLink> > sipixelSimLinks;
+  iEvent.getByLabel(_pixelSimLinkSrc, sipixelSimLinks);
+
+  // SiStrip DigiSimLink
+  edm::Handle<edm::DetSetVector<StripDigiSimLink> > sistripSimLinks;
+  iEvent.getByLabel(_stripSimLinkSrc, sistripSimLinks);
+
+  // Pixel Cluster
+  edm::Handle<edmNew::DetSetVector<SiPixelCluster> > pixelClusters;
+  iEvent.getByLabel(_pixelClusterSrc, pixelClusters);
+
+  // Strip Cluster
+  edm::Handle<edmNew::DetSetVector<SiStripCluster> > stripClusters;
+  iEvent.getByLabel(_stripClusterSrc, stripClusters);
+
+  // TrackingParticle
+  edm::Handle<TrackingParticleCollection>  TPCollectionH;
+  iEvent.getByLabel(_trackingParticleSrc,  TPCollectionH);
+
+  // prepare temporary map between SimTrackId and TrackingParticle index
+  std::map<std::pair<size_t, EncodedEventId>, TrackingParticleRef> mapping;
+  for (TrackingParticleCollection::size_type itp = 0;
+                                             itp < TPCollectionH.product()->size(); ++itp) {
+    TrackingParticleRef trackingParticle(TPCollectionH, itp);
+
+    // SimTracks inside TrackingParticle
+    EncodedEventId eid(trackingParticle->eventId());
+    //size_t index = 0;
+    for (std::vector<SimTrack>::const_iterator itrk  = trackingParticle->g4Track_begin(); 
+                                               itrk != trackingParticle->g4Track_end(); ++itrk) {
+      std::pair<uint32_t, EncodedEventId> trkid(itrk->trackId(), eid);
+      mapping.insert(std::make_pair(trkid, trackingParticle));
+    }
+  }
+
+  // Pixel Clusters 
+  for (edmNew::DetSetVector<SiPixelCluster>::const_iterator iter  = pixelClusters->begin(); 
+                                                            iter != pixelClusters->end(); ++iter) 
+  {
+    uint32_t detid = iter->id(); 
+    DetId detId(detid);
+    edmNew::DetSet<SiPixelCluster> link_pixel = (*iter);
+    for (edmNew::DetSet<SiPixelCluster>::const_iterator di  = link_pixel.begin(); 
+	                                                di != link_pixel.end(); ++di) 
+    {
+      const SiPixelCluster& cluster = (*di);
+      edm::Ref<edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster> c_ref = 
+          edmNew::makeRefTo(pixelClusters, di);
+
+      std::set<std::pair<uint32_t, EncodedEventId> > simTkIds; 
+      for (int irow = cluster.minPixelRow(); irow <= cluster.maxPixelRow(); ++irow) {
+	for (int icol = cluster.minPixelCol(); icol <= cluster.maxPixelCol(); ++icol) {
+	  uint32_t channel = PixelChannelIdentifier::pixelToChannel(irow, icol);
+          std::pair<uint32_t, EncodedEventId> trkid(getSimTrackId<PixelDigiSimLink>(sipixelSimLinks, detId, channel));
+          if (!trkid.first) continue; 
+          simTkIds.insert(trkid);
+	}
+      }
+      for (std::set<std::pair<uint32_t, EncodedEventId> >::const_iterator iset  = simTkIds.begin(); 
+                                                                          iset != simTkIds.end(); iset++) {
+	auto ipos = mapping.find(*iset);
+        if (ipos != mapping.end()) {
+          clusterTPList->push_back(std::make_pair(OmniClusterRef(c_ref), ipos->second));
+        }
+      }
+    } 
+  }
+
+  // Strip Clusters
+  for (edmNew::DetSetVector<SiStripCluster>::const_iterator iter  = stripClusters->begin(); 
+                                                            iter != stripClusters->end(); ++iter) {
+    uint32_t detid = iter->id();  
+    DetId detId(detid);
+    edmNew::DetSet<SiStripCluster> link_strip = (*iter);
+    for (edmNew::DetSet<SiStripCluster>::const_iterator di  = link_strip.begin(); 
+	                                                di != link_strip.end(); di++) {
+      const SiStripCluster& cluster = (*di);
+      edm::Ref<edmNew::DetSetVector<SiStripCluster>, SiStripCluster> c_ref = 
+        edmNew::makeRefTo(stripClusters, di);
+
+      std::set<std::pair<uint32_t, EncodedEventId> > simTkIds; 
+      int first  = cluster.firstStrip();     
+      int last   = first + cluster.amplitudes().size();
+   
+      for (int istr = first; istr <= last; ++istr) {
+        std::pair<uint32_t, EncodedEventId> trkid(getSimTrackId<StripDigiSimLink>(sistripSimLinks, detId, istr));
+        if (!trkid.first) continue; 
+        simTkIds.insert(trkid);
+      }
+      for (std::set<std::pair<uint32_t, EncodedEventId> >::const_iterator iset  = simTkIds.begin(); 
+                                                                          iset != simTkIds.end(); iset++) {
+	auto ipos = mapping.find(*iset);
+        if (ipos != mapping.end()) {
+          clusterTPList->push_back(std::make_pair(OmniClusterRef(c_ref), ipos->second));
+        } 
+      }
+    } 
+  }
+  iEvent.put(clusterTPList);
+}
+template <typename T>
+std::pair<uint32_t, EncodedEventId> 
+ClusterTPAssociationProducer::getSimTrackId(const edm::Handle<edm::DetSetVector<T> >& simLinks,
+                                            const DetId& detId, uint32_t channel) const 
+{
+  std::pair<uint32_t, EncodedEventId> simTrkId;
+  auto isearch = simLinks->find(detId);
+  if (isearch != simLinks->end()) {
+    // Loop over DigiSimLink in this det unit
+    edm::DetSet<T> link_detset = (*isearch);
+    for (typename edm::DetSet<T>::const_iterator it  = link_detset.data.begin(); 
+                                                 it != link_detset.data.end(); ++it) {
+      if (channel == it->channel()) {
+        simTrkId = std::make_pair(it->SimTrackId(), it->eventId());
+        break;        
+      } 
+    }
+  }
+  return simTrkId;
+}
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+DEFINE_FWK_MODULE(ClusterTPAssociationProducer);

--- a/SimGeneral/TrackingAnalysis/plugins/SimHitTPAssociationProducer.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/SimHitTPAssociationProducer.cc
@@ -8,162 +8,61 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/Candidate/interface/Candidate.h"
-#include "DataFormats/Candidate/interface/LeafCandidate.h"
-#include "DataFormats/Candidate/interface/CandidateFwd.h"
-#include "DataFormats/SiPixelDetId/interface/PixelChannelIdentifier.h"
 
-#include "SimDataFormats/Track/interface/SimTrackContainer.h"
-#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
-#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
-#include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
-#include "SimDataFormats/TrackerDigiSimLink/interface/PixelDigiSimLink.h"
+#include "SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h"
 
-#include "SimTracker/TrackerHitAssociation/interface/ClusterTPAssociationProducer.h"
-
-ClusterTPAssociationProducer::ClusterTPAssociationProducer(const edm::ParameterSet & cfg) 
-  : _verbose(cfg.getParameter<bool>("verbose")),
-    _pixelSimLinkSrc(cfg.getParameter<edm::InputTag>("pixelSimLinkSrc")),
-    _stripSimLinkSrc(cfg.getParameter<edm::InputTag>("stripSimLinkSrc")),
-    _pixelClusterSrc(cfg.getParameter<edm::InputTag>("pixelClusterSrc")),
-    _stripClusterSrc(cfg.getParameter<edm::InputTag>("stripClusterSrc")),
+SimHitTPAssociationProducer::SimHitTPAssociationProducer(const edm::ParameterSet & cfg) 
+  : _simHitSrc(cfg.getParameter<std::vector<edm::InputTag> >("simHitSrc")),
     _trackingParticleSrc(cfg.getParameter<edm::InputTag>("trackingParticleSrc"))
 {
-  produces<ClusterTPAssociationList>();
+  produces<SimHitTPAssociationList>();
 }
 
-ClusterTPAssociationProducer::~ClusterTPAssociationProducer() {
+SimHitTPAssociationProducer::~SimHitTPAssociationProducer() {
 }
 		
-void ClusterTPAssociationProducer::produce(edm::Event& iEvent, const edm::EventSetup& es) {
-  std::auto_ptr<ClusterTPAssociationList> clusterTPList(new ClusterTPAssociationList);
+void SimHitTPAssociationProducer::produce(edm::Event& iEvent, const edm::EventSetup& es) {
+  std::auto_ptr<SimHitTPAssociationList> simHitTPList(new SimHitTPAssociationList);
  
-  // Pixel DigiSimLink
-  edm::Handle<edm::DetSetVector<PixelDigiSimLink> > sipixelSimLinks;
-  iEvent.getByLabel(_pixelSimLinkSrc, sipixelSimLinks);
-
-  // SiStrip DigiSimLink
-  edm::Handle<edm::DetSetVector<StripDigiSimLink> > sistripSimLinks;
-  iEvent.getByLabel(_stripSimLinkSrc, sistripSimLinks);
-
-  // Pixel Cluster
-  edm::Handle<edmNew::DetSetVector<SiPixelCluster> > pixelClusters;
-  iEvent.getByLabel(_pixelClusterSrc, pixelClusters);
-
-  // Strip Cluster
-  edm::Handle<edmNew::DetSetVector<SiStripCluster> > stripClusters;
-  iEvent.getByLabel(_stripClusterSrc, stripClusters);
-
   // TrackingParticle
   edm::Handle<TrackingParticleCollection>  TPCollectionH;
   iEvent.getByLabel(_trackingParticleSrc,  TPCollectionH);
 
   // prepare temporary map between SimTrackId and TrackingParticle index
   std::map<std::pair<size_t, EncodedEventId>, TrackingParticleRef> mapping;
-  for (TrackingParticleCollection::size_type itp = 0;
-                                             itp < TPCollectionH.product()->size(); ++itp) {
+  for (TrackingParticleCollection::size_type itp = 0; itp < TPCollectionH.product()->size(); ++itp) {
     TrackingParticleRef trackingParticle(TPCollectionH, itp);
-
     // SimTracks inside TrackingParticle
     EncodedEventId eid(trackingParticle->eventId());
-    //size_t index = 0;
-    for (std::vector<SimTrack>::const_iterator itrk  = trackingParticle->g4Track_begin(); 
-                                               itrk != trackingParticle->g4Track_end(); ++itrk) {
+    for (auto itrk  = trackingParticle->g4Track_begin(); itrk != trackingParticle->g4Track_end(); ++itrk) {
       std::pair<uint32_t, EncodedEventId> trkid(itrk->trackId(), eid);
       mapping.insert(std::make_pair(trkid, trackingParticle));
     }
   }
 
-  // Pixel Clusters 
-  for (edmNew::DetSetVector<SiPixelCluster>::const_iterator iter  = pixelClusters->begin(); 
-                                                            iter != pixelClusters->end(); ++iter) 
-  {
-    uint32_t detid = iter->id(); 
-    DetId detId(detid);
-    edmNew::DetSet<SiPixelCluster> link_pixel = (*iter);
-    for (edmNew::DetSet<SiPixelCluster>::const_iterator di  = link_pixel.begin(); 
-	                                                di != link_pixel.end(); ++di) 
-    {
-      const SiPixelCluster& cluster = (*di);
-      edm::Ref<edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster> c_ref = 
-          edmNew::makeRefTo(pixelClusters, di);
-
-      std::set<std::pair<uint32_t, EncodedEventId> > simTkIds; 
-      for (int irow = cluster.minPixelRow(); irow <= cluster.maxPixelRow(); ++irow) {
-	for (int icol = cluster.minPixelCol(); icol <= cluster.maxPixelCol(); ++icol) {
-	  uint32_t channel = PixelChannelIdentifier::pixelToChannel(irow, icol);
-          std::pair<uint32_t, EncodedEventId> trkid(getSimTrackId<PixelDigiSimLink>(sipixelSimLinks, detId, channel));
-          if (!trkid.first) continue; 
-          simTkIds.insert(trkid);
-	}
+  // PSimHits
+  for (auto psit=_simHitSrc.begin();psit<_simHitSrc.end();++psit) {
+    edm::Handle<edm::PSimHitContainer>  PSimHitCollectionH;
+    iEvent.getByLabel(*psit,  PSimHitCollectionH);
+    for (unsigned int psimHit = 0;psimHit != PSimHitCollectionH->size();++psimHit) {
+      TrackPSimHitRef pSimHitRef(PSimHitCollectionH,psimHit);
+      std::pair<uint32_t, EncodedEventId> simTkIds(pSimHitRef->trackId(),pSimHitRef->eventId()); 
+      auto ipos = mapping.find(simTkIds);
+      if (ipos != mapping.end()) {
+	simHitTPList->push_back(std::make_pair(ipos->second,pSimHitRef));
       }
-      for (std::set<std::pair<uint32_t, EncodedEventId> >::const_iterator iset  = simTkIds.begin(); 
-                                                                          iset != simTkIds.end(); iset++) {
-	auto ipos = mapping.find(*iset);
-        if (ipos != mapping.end()) {
-          clusterTPList->push_back(std::make_pair(OmniClusterRef(c_ref), ipos->second));
-        }
-      }
-    } 
-  }
-
-  // Strip Clusters
-  for (edmNew::DetSetVector<SiStripCluster>::const_iterator iter  = stripClusters->begin(); 
-                                                            iter != stripClusters->end(); ++iter) {
-    uint32_t detid = iter->id();  
-    DetId detId(detid);
-    edmNew::DetSet<SiStripCluster> link_strip = (*iter);
-    for (edmNew::DetSet<SiStripCluster>::const_iterator di  = link_strip.begin(); 
-	                                                di != link_strip.end(); di++) {
-      const SiStripCluster& cluster = (*di);
-      edm::Ref<edmNew::DetSetVector<SiStripCluster>, SiStripCluster> c_ref = 
-        edmNew::makeRefTo(stripClusters, di);
-
-      std::set<std::pair<uint32_t, EncodedEventId> > simTkIds; 
-      int first  = cluster.firstStrip();     
-      int last   = first + cluster.amplitudes().size();
-   
-      for (int istr = first; istr <= last; ++istr) {
-        std::pair<uint32_t, EncodedEventId> trkid(getSimTrackId<StripDigiSimLink>(sistripSimLinks, detId, istr));
-        if (!trkid.first) continue; 
-        simTkIds.insert(trkid);
-      }
-      for (std::set<std::pair<uint32_t, EncodedEventId> >::const_iterator iset  = simTkIds.begin(); 
-                                                                          iset != simTkIds.end(); iset++) {
-	auto ipos = mapping.find(*iset);
-        if (ipos != mapping.end()) {
-          clusterTPList->push_back(std::make_pair(OmniClusterRef(c_ref), ipos->second));
-        } 
-      }
-    } 
-  }
-  iEvent.put(clusterTPList);
-}
-template <typename T>
-std::pair<uint32_t, EncodedEventId> 
-ClusterTPAssociationProducer::getSimTrackId(const edm::Handle<edm::DetSetVector<T> >& simLinks,
-                                            const DetId& detId, uint32_t channel) const 
-{
-  std::pair<uint32_t, EncodedEventId> simTrkId;
-  auto isearch = simLinks->find(detId);
-  if (isearch != simLinks->end()) {
-    // Loop over DigiSimLink in this det unit
-    edm::DetSet<T> link_detset = (*isearch);
-    for (typename edm::DetSet<T>::const_iterator it  = link_detset.data.begin(); 
-                                                 it != link_detset.data.end(); ++it) {
-      if (channel == it->channel()) {
-        simTrkId = std::make_pair(it->SimTrackId(), it->eventId());
-        break;        
-      } 
     }
-  }
-  return simTrkId;
+  } 
+  
+  std::sort(simHitTPList->begin(),simHitTPList->end(),simHitTPAssociationListGreater);
+  iEvent.put(simHitTPList);
+
 }
+
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-DEFINE_FWK_MODULE(ClusterTPAssociationProducer);
+DEFINE_FWK_MODULE(SimHitTPAssociationProducer);

--- a/SimGeneral/TrackingAnalysis/python/simHitTPAssociation_cfi.py
+++ b/SimGeneral/TrackingAnalysis/python/simHitTPAssociation_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+tpClusterProducer = cms.EDProducer("ClusterTPAssociationProducer",
+  verbose = cms.bool(False),
+  simTrackSrc     = cms.InputTag("g4SimHits"),
+  pixelSimLinkSrc = cms.InputTag("simSiPixelDigis"),
+  stripSimLinkSrc = cms.InputTag("simSiStripDigis"),
+  pixelClusterSrc = cms.InputTag("siPixelClusters"),
+  stripClusterSrc = cms.InputTag("siStripClusters"),
+  trackingParticleSrc = cms.InputTag('mix', 'MergedTrackTruth')
+)

--- a/SimGeneral/TrackingAnalysis/python/simHitTPAssociation_cfi.py
+++ b/SimGeneral/TrackingAnalysis/python/simHitTPAssociation_cfi.py
@@ -1,11 +1,20 @@
 import FWCore.ParameterSet.Config as cms
 
 tpClusterProducer = cms.EDProducer("ClusterTPAssociationProducer",
-  verbose = cms.bool(False),
-  simTrackSrc     = cms.InputTag("g4SimHits"),
-  pixelSimLinkSrc = cms.InputTag("simSiPixelDigis"),
-  stripSimLinkSrc = cms.InputTag("simSiStripDigis"),
-  pixelClusterSrc = cms.InputTag("siPixelClusters"),
-  stripClusterSrc = cms.InputTag("siStripClusters"),
+  simHitSrc = cms.VInputTag(cms.InputTag('g4SimHits','MuonDTHits'),
+                            cms.InputTag('g4SimHits','MuonCSCHits'),
+                            cms.InputTag('g4SimHits','MuonRPCHits'),
+                            cms.InputTag('g4SimHits','TrackerHitsTIBLowTof'),
+                            cms.InputTag('g4SimHits','TrackerHitsTIBHighTof'),
+                            cms.InputTag('g4SimHits','TrackerHitsTIDLowTof'),
+                            cms.InputTag('g4SimHits','TrackerHitsTIDHighTof'),
+                            cms.InputTag('g4SimHits','TrackerHitsTOBLowTof'),
+                            cms.InputTag('g4SimHits','TrackerHitsTOBHighTof'),
+                            cms.InputTag('g4SimHits','TrackerHitsTECLowTof'),
+                            cms.InputTag('g4SimHits','TrackerHitsTECHighTof'),
+                            cms.InputTag( 'g4SimHits','TrackerHitsPixelBarrelLowTof'),
+                            cms.InputTag('g4SimHits','TrackerHitsPixelBarrelHighTof'),
+                            cms.InputTag('g4SimHits','TrackerHitsPixelEndcapLowTof'),
+                            cms.InputTag('g4SimHits','TrackerHitsPixelEndcapHighTof') ),
   trackingParticleSrc = cms.InputTag('mix', 'MergedTrackTruth')
 )

--- a/SimGeneral/TrackingAnalysis/python/simHitTPAssociation_cfi.py
+++ b/SimGeneral/TrackingAnalysis/python/simHitTPAssociation_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-tpClusterProducer = cms.EDProducer("ClusterTPAssociationProducer",
+simHitTPAssocProducer = cms.EDProducer("SimHitTPAssociationProducer",
   simHitSrc = cms.VInputTag(cms.InputTag('g4SimHits','MuonDTHits'),
                             cms.InputTag('g4SimHits','MuonCSCHits'),
                             cms.InputTag('g4SimHits','MuonRPCHits'),

--- a/SimGeneral/TrackingAnalysis/src/classes.h
+++ b/SimGeneral/TrackingAnalysis/src/classes.h
@@ -1,0 +1,26 @@
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
+#include "DataFormats/Common/interface/AssociationMap.h"
+#include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
+
+#include "DataFormats/Common/interface/AssociationMap.h"
+namespace {
+  struct dictionary {
+    edm::AssociationMap<edm::OneToMany<std::vector<SimTrack>, std::vector<OmniClusterRef>, unsigned int > > dummy01;
+    edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<SimTrack>, std::vector<OmniClusterRef>, unsigned int > > > dummy02;
+    edm::helpers::KeyVal<edm::RefProd<std::vector<SimTrack> >, edm::RefProd<std::vector<OmniClusterRef> > > dummy03;
+    edm::Wrapper<edm::helpers::KeyVal<edm::RefProd<std::vector<SimTrack> >, edm::RefProd<std::vector<OmniClusterRef> > > > dummy04;
+    std::vector<OmniClusterRef> dummy05;
+    edm::Wrapper<std::vector<OmniClusterRef> > dummy06;
+    std::pair<OmniClusterRef, TrackingParticleRef> dummy13;
+    edm::Wrapper<std::pair<OmniClusterRef, TrackingParticleRef> > dummy14;
+    std::vector<std::pair<OmniClusterRef, TrackingParticleRef> > dummy07;
+    edm::Wrapper<std::vector<std::pair<OmniClusterRef, TrackingParticleRef> > > dummy08;
+    std::map<TrackingParticleRef, std::vector<OmniClusterRef> > dummy09;
+    edm::Wrapper<std::map<TrackingParticleRef, std::vector<OmniClusterRef> > > dummy10;
+    std::map<OmniClusterRef, std::vector<TrackingParticleRef> > dummy11;
+    edm::Wrapper<std::map<OmniClusterRef, std::vector<TrackingParticleRef> > > dummy12;
+  };
+}

--- a/SimGeneral/TrackingAnalysis/src/classes.h
+++ b/SimGeneral/TrackingAnalysis/src/classes.h
@@ -1,26 +1,13 @@
 #include "DataFormats/Common/interface/Wrapper.h"
-#include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
-#include "DataFormats/Common/interface/AssociationMap.h"
-#include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
-#include "DataFormats/Common/interface/AssociationMap.h"
 namespace {
   struct dictionary {
-    edm::AssociationMap<edm::OneToMany<std::vector<SimTrack>, std::vector<OmniClusterRef>, unsigned int > > dummy01;
-    edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<SimTrack>, std::vector<OmniClusterRef>, unsigned int > > > dummy02;
-    edm::helpers::KeyVal<edm::RefProd<std::vector<SimTrack> >, edm::RefProd<std::vector<OmniClusterRef> > > dummy03;
-    edm::Wrapper<edm::helpers::KeyVal<edm::RefProd<std::vector<SimTrack> >, edm::RefProd<std::vector<OmniClusterRef> > > > dummy04;
-    std::vector<OmniClusterRef> dummy05;
-    edm::Wrapper<std::vector<OmniClusterRef> > dummy06;
-    std::pair<OmniClusterRef, TrackingParticleRef> dummy13;
-    edm::Wrapper<std::pair<OmniClusterRef, TrackingParticleRef> > dummy14;
-    std::vector<std::pair<OmniClusterRef, TrackingParticleRef> > dummy07;
-    edm::Wrapper<std::vector<std::pair<OmniClusterRef, TrackingParticleRef> > > dummy08;
-    std::map<TrackingParticleRef, std::vector<OmniClusterRef> > dummy09;
-    edm::Wrapper<std::map<TrackingParticleRef, std::vector<OmniClusterRef> > > dummy10;
-    std::map<OmniClusterRef, std::vector<TrackingParticleRef> > dummy11;
-    edm::Wrapper<std::map<OmniClusterRef, std::vector<TrackingParticleRef> > > dummy12;
+    std::pair<TrackingParticleRef, TrackPSimHitRef> dummy13;
+    edm::Wrapper<std::pair<TrackingParticleRef, TrackPSimHitRef> > dummy14;
+    std::vector<std::pair<TrackingParticleRef, TrackPSimHitRef> > dummy07;
+    edm::Wrapper<std::vector<std::pair<TrackingParticleRef, TrackPSimHitRef> > > dummy08;
   };
 }

--- a/SimGeneral/TrackingAnalysis/src/classes_def.xml
+++ b/SimGeneral/TrackingAnalysis/src/classes_def.xml
@@ -1,0 +1,20 @@
+<lcgdict>
+ <class name="std::vector<OmniClusterRef>" persistent="true" /> 
+ <class name="edm::RefProd<std::vector<OmniClusterRef> >" />
+ <class name="edm::Wrapper<std::vector<OmniClusterRef> >" persistent="true" />
+ <class name="edm::AssociationMap<edm::OneToMany<std::vector<SimTrack>, std::vector<OmniClusterRef>, unsigned int > >" persistent="true" /> 
+ <class name="edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<SimTrack>, std::vector<OmniClusterRef>, unsigned int > > >" persistent="true" /> 
+ <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<SimTrack> >,edm::RefProd<std::vector<OmniClusterRef> > >" />
+ <class name="edm::Wrapper<edm::helpers::KeyVal<edm::RefProd<std::vector<SimTrack> >,edm::RefProd<std::vector<OmniClusterRef> > > >"  persistent="true" />
+ <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<SimTrack>,SimTrack,edm::refhelper::FindUsingAdvance<std::vector<SimTrack>,SimTrack> >,edm::RefVector<std::vector<OmniClusterRef>,OmniClusterRef,edm::refhelper::FindUsingAdvance<std::vector<OmniClusterRef>,OmniClusterRef> > > >" />
+ <class name="edm::helpers::KeyVal<edm::Ref<std::vector<SimTrack>,SimTrack,edm::refhelper::FindUsingAdvance<std::vector<SimTrack>,SimTrack> >,edm::RefVector<std::vector<OmniClusterRef>,OmniClusterRef,edm::refhelper::FindUsingAdvance<std::vector<OmniClusterRef>,OmniClusterRef> > >" />
+ <class name="edm::RefVector<std::vector<OmniClusterRef>,OmniClusterRef,edm::refhelper::FindUsingAdvance<std::vector<OmniClusterRef>,OmniClusterRef> >" />
+
+  <class name="std::pair<OmniClusterRef, TrackingParticleRef>" persistent="true" /> 
+  <class name="std::vector<std::pair<OmniClusterRef, TrackingParticleRef> >" persistent="true" /> 
+  <class name="edm::Wrapper<std::vector<std::pair<OmniClusterRef,TrackingParticleRef> > >" />
+  <class name="std::map<TrackingParticleRef, std::vector<OmniClusterRef> >" persistent="false" /> 
+  <class name="edm::Wrapper<std::map<TrackingParticleRef, std::vector<OmniClusterRef> > >" persistent="false" /> 
+  <class name="std::map<OmniClusterRef, std::vector<TrackingParticleRef> >" persistent="false" /> 
+  <class name="edm::Wrapper<std::map<OmniClusterRef, std::vector<TrackingParticleRef> > >" persistent="false" /> 
+</lcgdict>

--- a/SimGeneral/TrackingAnalysis/src/classes_def.xml
+++ b/SimGeneral/TrackingAnalysis/src/classes_def.xml
@@ -1,20 +1,5 @@
 <lcgdict>
- <class name="std::vector<OmniClusterRef>" persistent="true" /> 
- <class name="edm::RefProd<std::vector<OmniClusterRef> >" />
- <class name="edm::Wrapper<std::vector<OmniClusterRef> >" persistent="true" />
- <class name="edm::AssociationMap<edm::OneToMany<std::vector<SimTrack>, std::vector<OmniClusterRef>, unsigned int > >" persistent="true" /> 
- <class name="edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<SimTrack>, std::vector<OmniClusterRef>, unsigned int > > >" persistent="true" /> 
- <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<SimTrack> >,edm::RefProd<std::vector<OmniClusterRef> > >" />
- <class name="edm::Wrapper<edm::helpers::KeyVal<edm::RefProd<std::vector<SimTrack> >,edm::RefProd<std::vector<OmniClusterRef> > > >"  persistent="true" />
- <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<SimTrack>,SimTrack,edm::refhelper::FindUsingAdvance<std::vector<SimTrack>,SimTrack> >,edm::RefVector<std::vector<OmniClusterRef>,OmniClusterRef,edm::refhelper::FindUsingAdvance<std::vector<OmniClusterRef>,OmniClusterRef> > > >" />
- <class name="edm::helpers::KeyVal<edm::Ref<std::vector<SimTrack>,SimTrack,edm::refhelper::FindUsingAdvance<std::vector<SimTrack>,SimTrack> >,edm::RefVector<std::vector<OmniClusterRef>,OmniClusterRef,edm::refhelper::FindUsingAdvance<std::vector<OmniClusterRef>,OmniClusterRef> > >" />
- <class name="edm::RefVector<std::vector<OmniClusterRef>,OmniClusterRef,edm::refhelper::FindUsingAdvance<std::vector<OmniClusterRef>,OmniClusterRef> >" />
-
-  <class name="std::pair<OmniClusterRef, TrackingParticleRef>" persistent="true" /> 
-  <class name="std::vector<std::pair<OmniClusterRef, TrackingParticleRef> >" persistent="true" /> 
-  <class name="edm::Wrapper<std::vector<std::pair<OmniClusterRef,TrackingParticleRef> > >" />
-  <class name="std::map<TrackingParticleRef, std::vector<OmniClusterRef> >" persistent="false" /> 
-  <class name="edm::Wrapper<std::map<TrackingParticleRef, std::vector<OmniClusterRef> > >" persistent="false" /> 
-  <class name="std::map<OmniClusterRef, std::vector<TrackingParticleRef> >" persistent="false" /> 
-  <class name="edm::Wrapper<std::map<OmniClusterRef, std::vector<TrackingParticleRef> > >" persistent="false" /> 
+  <class name="std::pair<TrackingParticleRef, TrackPSimHitRef>" persistent="true" /> 
+  <class name="std::vector<std::pair<TrackingParticleRef, TrackPSimHitRef> >" persistent="true" /> 
+  <class name="edm::Wrapper<std::vector<std::pair<TrackingParticleRef, TrackPSimHitRef> > >" />
 </lcgdict>

--- a/SimTracker/TrackAssociation/interface/CosmicParametersDefinerForTP.h
+++ b/SimTracker/TrackAssociation/interface/CosmicParametersDefinerForTP.h
@@ -16,8 +16,8 @@ class CosmicParametersDefinerForTP : public ParametersDefinerForTP {
   CosmicParametersDefinerForTP(){};
   virtual ~CosmicParametersDefinerForTP() {};
 
-  virtual TrackingParticle::Vector momentum(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticle& tp) const;
-  virtual TrackingParticle::Point vertex(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticle& tp) const;
+  virtual TrackingParticle::Vector momentum(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticleRef tpr) const;
+  virtual TrackingParticle::Point vertex(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticleRef tpr) const;
 
   virtual TrackingParticle::Vector momentum(const edm::Event& iEvent, const edm::EventSetup& iSetup, 
 	const Charge ch, const Point & vertex, const LorentzVector& lv) const {
@@ -29,7 +29,12 @@ class CosmicParametersDefinerForTP : public ParametersDefinerForTP {
     return TrackingParticle::Point();
   }
 
+  void initEvent(edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssocToSet) const {
+    simHitsTPAssoc = simHitsTPAssocToSet;
+  }
 
+ private:
+  mutable edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;
 };
 
 

--- a/SimTracker/TrackAssociation/interface/ParametersDefinerForTP.h
+++ b/SimTracker/TrackAssociation/interface/ParametersDefinerForTP.h
@@ -8,6 +8,7 @@
  */
 
 #include <SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h>
+#include "SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"      
@@ -23,12 +24,11 @@ class ParametersDefinerForTP {
     typedef math::XYZPointD Point; ///< point in the space
     typedef math::XYZTLorentzVectorD LorentzVector; ///< Lorentz vector
 
-
   virtual TrackingParticle::Vector momentum(const edm::Event& iEvent, const edm::EventSetup& iSetup, 
 	const Charge ch, const Point & vtx, const LorentzVector& lv) const;
 
-  virtual TrackingParticle::Vector momentum(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticle& tp) const{
-    return momentum(iEvent, iSetup, tp.charge(),tp.vertex(),tp.p4());
+  virtual TrackingParticle::Vector momentum(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticleRef tpr) const{
+    return momentum(iEvent, iSetup, tpr->charge(),tpr->vertex(),tpr->p4());
   }
 
   virtual TrackingParticle::Vector momentum(const edm::Event& iEvent, const edm::EventSetup& iSetup, const reco::Candidate& tp) const {
@@ -37,14 +37,17 @@ class ParametersDefinerForTP {
 
   virtual TrackingParticle::Point vertex(const edm::Event& iEvent, const edm::EventSetup& iSetup,
 	const Charge ch, const Point & vtx, const LorentzVector& lv) const;
-
-  virtual TrackingParticle::Point vertex(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticle& tp) const{
-    return vertex(iEvent, iSetup, tp.charge(),tp.vertex(),tp.p4());
+ 
+  virtual TrackingParticle::Point vertex(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticleRef& tpr) const{
+    return vertex(iEvent, iSetup, tpr->charge(),tpr->vertex(),tpr->p4());
   }
 
   virtual TrackingParticle::Point vertex(const edm::Event& iEvent, const edm::EventSetup& iSetup, const reco::Candidate& tp) const {
     return vertex(iEvent, iSetup, tp.charge(),tp.vertex(),tp.p4());
   }
+
+  virtual void initEvent(edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssocToSet) const { }
+
 
 };
 

--- a/SimTracker/TrackAssociation/interface/ParametersDefinerForTP.h
+++ b/SimTracker/TrackAssociation/interface/ParametersDefinerForTP.h
@@ -48,7 +48,6 @@ class ParametersDefinerForTP {
 
   virtual void initEvent(edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssocToSet) const { }
 
-
 };
 
 

--- a/SimTracker/TrackAssociation/interface/TrackAssociatorByHits.h
+++ b/SimTracker/TrackAssociation/interface/TrackAssociatorByHits.h
@@ -96,6 +96,8 @@ class TrackAssociatorByHits : public TrackAssociatorBase {
 
   const TrackingRecHit* getHitPtr(edm::OwnVector<TrackingRecHit>::const_iterator iter) const {return &*iter;}
   const TrackingRecHit* getHitPtr(trackingRecHit_iterator iter) const {return &**iter;}
+
+  edm::InputTag _simHitTpMapTag;
 };
 
 #endif

--- a/SimTracker/TrackAssociation/interface/TrackAssociatorByPosition.h
+++ b/SimTracker/TrackAssociation/interface/TrackAssociatorByPosition.h
@@ -22,6 +22,8 @@
 
 #include <TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h>
 
+#include "SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h"
+
 #include<map>
 
 //Note that the Association Map is filled with -ch2 and not chi2 because it is ordered using std::greater:
@@ -50,6 +52,7 @@ class TrackAssociatorByPosition : public TrackAssociatorBase {
        edm::LogError("TrackAssociatorByPosition")<<meth<<" mothed not recognized. Use dr or chi2.";     }
 
      theConsiderAllSimHits = iConfig.getParameter<bool>("ConsiderAllSimHits");
+     _simHitTpMapTag = iConfig.getParameter<edm::InputTag>("simHitTpMapTag");
    };
 
 
@@ -84,8 +87,9 @@ class TrackAssociatorByPosition : public TrackAssociatorBase {
   bool theConsiderAllSimHits;
   
   FreeTrajectoryState getState(const reco::Track &) const;
-  TrajectoryStateOnSurface getState(const TrackingParticle &)const;
-
+  TrajectoryStateOnSurface getState(const TrackingParticleRef)const;
+  mutable edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;
+  edm::InputTag _simHitTpMapTag;
 };
 
 #endif

--- a/SimTracker/TrackAssociation/plugins/MCTrackMatcher.cc
+++ b/SimTracker/TrackAssociation/plugins/MCTrackMatcher.cc
@@ -66,25 +66,13 @@ void MCTrackMatcher::produce(Event& evt, const EventSetup& es) {
     RecoToSimCollection::const_iterator f = associations.find(track);
     if ( f != associations.end() ) {
       TrackingParticleRef tp = f->val.front().first;
-      const HepMC::GenParticle * particle = 0;
       TrackingParticle::genp_iterator j, b = tp->genParticle_begin(), e = tp->genParticle_end();
       for( j = b; j != e; ++ j ) {
-#warning "This file has been modified just to get it to compile without any regard as to whether it still functions as intended"
-#ifdef REMOVED_JUST_TO_GET_IT_TO_COMPILE__THIS_CODE_NEEDS_TO_BE_CHECKED
-	const HepMC::GenParticle * p = j->get();
+	const reco::GenParticle * p = j->get();
 	if (p->status() == 1) {
-	  particle = p; break;
+	  indices[i] = j->key();
+	  break;
 	}
-#endif
-      }
-      if( particle != 0 ) {
-	int barCode = particle->barcode();
-	vector<int>::const_iterator 
-	  b = barCodes->begin(), e = barCodes->end(), f = find( b, e, barCode );
-	if(f == e) throw edm::Exception(errors::InvalidReference)
-	  << "found matching particle with barcode" << *f
-	  << " which has not been found in " << genParticles_;
-	indices[i] = *f;
       }
     }
   }

--- a/SimTracker/TrackAssociation/python/TrackAssociatorByHits_cfi.py
+++ b/SimTracker/TrackAssociation/python/TrackAssociatorByHits_cfi.py
@@ -25,8 +25,8 @@ TrackAssociatorByHits = cms.ESProducer("TrackAssociatorByHitsESProducer",
     associateStrip = cms.bool(True),
     Purity_SimToReco = cms.double(0.75),
     Cut_RecoToSim = cms.double(0.75),
-    SimToRecoDenominator = cms.string('sim') ##"reco"
-
-)
+    SimToRecoDenominator = cms.string('sim'), ##"reco"
+    simHitTpMapTag = cms.InputTag("simHitTPAssocProducer")
+ )
 
 

--- a/SimTracker/TrackAssociation/python/TrackAssociatorByPosition_cfi.py
+++ b/SimTracker/TrackAssociation/python/TrackAssociatorByPosition_cfi.py
@@ -17,7 +17,8 @@ TrackAssociatorByPosition = cms.ESProducer("TrackAssociatorByPositionESProducer"
     method = cms.string('dist'),
     QCut = cms.double(10.0),
     # False is the old behavior, True will use also the muon simhits to do the matching.                                       
-    ConsiderAllSimHits = cms.bool(False)
+    ConsiderAllSimHits = cms.bool(False),
+    simHitTpMapTag = cms.InputTag("simHitTPAssocProducer")
 )
 
 

--- a/SimTracker/TrackAssociation/src/TrackAssociatorByPosition.cc
+++ b/SimTracker/TrackAssociation/src/TrackAssociatorByPosition.cc
@@ -10,9 +10,13 @@
 using namespace edm;
 using namespace reco;
 
-TrajectoryStateOnSurface TrackAssociatorByPosition::getState(const TrackingParticle & st)const{
-#warning "This file has been modified just to get it to compile without any regard as to whether it still functions as intended"
-#ifdef REMOVED_JUST_TO_GET_IT_TO_COMPILE__THIS_CODE_NEEDS_TO_BE_CHECKED
+TrajectoryStateOnSurface TrackAssociatorByPosition::getState(const TrackingParticleRef st)const{
+
+  std::pair<TrackingParticleRef, TrackPSimHitRef> clusterTPpairWithDummyTP(st,TrackPSimHitRef());//SimHit is dummy: for simHitTPAssociationListGreater 
+	                                                                                         // sorting only the cluster is needed
+  auto range = std::equal_range(simHitsTPAssoc->begin(), simHitsTPAssoc->end(), 
+				clusterTPpairWithDummyTP, SimHitTPAssociationProducer::simHitTPAssociationListGreater);
+
   //  TrackingParticle* simtrack = const_cast<TrackingParticle*>(&st);
   //loop over PSimHits
   const PSimHit * psimhit=0;
@@ -20,16 +24,20 @@ TrajectoryStateOnSurface TrackAssociatorByPosition::getState(const TrackingParti
   double dLim=thePositionMinimumDistance;
 
   //    look for the further most hit beyond a certain limit
-  std::vector<PSimHit> pSimHit = st.trackPSimHit();
-  if (!theConsiderAllSimHits) pSimHit=st.trackPSimHit(DetId::Tracker);
-  std::vector<PSimHit> ::const_iterator start=pSimHit.begin();
-  std::vector<PSimHit> ::const_iterator end=pSimHit.end();
-  LogDebug("TrackAssociatorByPosition")<<pSimHit.size()<<" PSimHits.";
+  auto start=range.first;
+  auto end=range.second;
+  LogDebug("TrackAssociatorByPosition")<<range.second-range.first<<" PSimHits.";
 
   unsigned int count=0;
-  for (std::vector<PSimHit> ::const_iterator psit=start;psit!=end;++psit){    
+  for (auto ip=start;ip!=end;++ip){    
+
+    TrackPSimHitRef psit = ip->second;
+
     //get the detid
     DetId dd(psit->detUnitId());
+
+    if (!theConsiderAllSimHits && dd.det()!=DetId::Tracker) continue; 
+
     LogDebug("TrackAssociatorByPosition")<<count++<<"] PSimHit on: "<<dd.rawId();
     //get the surface from the global geometry
     const GeomDet * gd=theGeometry->idToDet(dd);
@@ -55,9 +63,6 @@ TrajectoryStateOnSurface TrackAssociatorByPosition::getState(const TrackingParti
   else{
     //    edm::LogError("TrackAssociatorByPosition")<<"no corresponding PSimHit for a tracking particle. will fail.";
     return TrajectoryStateOnSurface();}
-#else
-  return TrajectoryStateOnSurface();
-#endif
 }
 
 FreeTrajectoryState TrackAssociatorByPosition::getState(const reco::Track & track)const{
@@ -110,6 +115,10 @@ RecoToSimCollection TrackAssociatorByPosition::associateRecoToSim(const edm::Ref
   std::pair<unsigned int,unsigned int> minPair;
   const double dQmin_default=1542543;
   double dQmin=dQmin_default;
+
+  //warning: make sure the TP collection used in the map is the same used in the associator!
+  e->getByLabel(_simHitTpMapTag,simHitsTPAssoc);
+
   for (unsigned int Ti=0; Ti!=tCH.size();++Ti){
     //initial state (initial OR inner OR outter)
     FreeTrajectoryState iState = getState(*(tCH)[Ti]);
@@ -118,7 +127,7 @@ RecoToSimCollection TrackAssociatorByPosition::associateRecoToSim(const edm::Ref
     //    for each tracking particle, find a state position and the plane to propagate the track to.
     for (unsigned int TPi=0;TPi!=tPCH.size();++TPi) {
       //get a state in the muon system 
-      TrajectoryStateOnSurface simReferenceState = getState(*(tPCH)[TPi]);
+      TrajectoryStateOnSurface simReferenceState = getState((tPCH)[TPi]);
       if (!simReferenceState.isValid()) continue;
 
       //propagate the TRACK to the surface
@@ -158,9 +167,13 @@ SimToRecoCollection TrackAssociatorByPosition::associateSimToReco(const edm::Ref
   std::pair<unsigned int,unsigned int> minPair;
   const double dQmin_default=1542543;
   double dQmin=dQmin_default;
+
+  //warning: make sure the TP collection used in the map is the same used in the associator!
+  e->getByLabel(_simHitTpMapTag,simHitsTPAssoc);
+
   for (unsigned int TPi=0;TPi!=tPCH.size();++TPi){
     //get a state in the muon system
-    TrajectoryStateOnSurface simReferenceState= getState(*(tPCH)[TPi]);
+    TrajectoryStateOnSurface simReferenceState= getState((tPCH)[TPi]);
       
     if (!simReferenceState.isValid()) continue; 
     bool atLeastOne=false;

--- a/Validation/Configuration/python/globalValidation_cff.py
+++ b/Validation/Configuration/python/globalValidation_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
+from SimGeneral.TrackingAnalysis.simHitTPAssociation_cfi import *
 from Validation.TrackerHits.trackerHitsValidation_cff import *
 from Validation.TrackerDigis.trackerDigisValidation_cff import *
 from Validation.TrackerRecHits.trackerRecHitsValidation_cff import *
@@ -36,7 +37,8 @@ from DQMOffline.RecoB.dqmAnalyzer_cff import *
 
 # filter/producer "pre-" sequence for globalValidation
 globalPrevalidation = cms.Sequence( 
-    tracksValidationSelectors
+    simHitTPAssocProducer
+  * tracksValidationSelectors
   * photonPrevalidationSequence
   * produceDenoms
   * prebTagSequence

--- a/Validation/RecoMuon/plugins/MuonTrackValidator.cc
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.cc
@@ -337,17 +337,17 @@ void MuonTrackValidator::analyze(const edm::Event& event, const edm::EventSetup&
 	    momentumTP = tp->momentum();
 	    vertexTP = tp->vertex();
 	    //Calcualte the impact parameters w.r.t. PCA
-	    TrackingParticle::Vector momentum = parametersDefinerTP->momentum(event,setup,*tp);
-	    TrackingParticle::Point vertex = parametersDefinerTP->vertex(event,setup,*tp);
+	    TrackingParticle::Vector momentum = parametersDefinerTP->momentum(event,setup,tpr);
+	    TrackingParticle::Point vertex = parametersDefinerTP->vertex(event,setup,tpr);
 	    dxySim = (-vertex.x()*sin(momentum.phi())+vertex.y()*cos(momentum.phi()));
 	    dzSim = vertex.z() - (vertex.x()*momentum.x()+vertex.y()*momentum.y())/sqrt(momentum.perp2()) * momentum.z()/sqrt(momentum.perp2());
 	  }
 	//If the TrackingParticle is comics, get the momentum and vertex at PCA
 	if(parametersDefiner=="CosmicParametersDefinerForTP")
 	  {
-	    if(! cosmictpSelector(*tp,&bs,event,setup)) continue;	
-	    momentumTP = parametersDefinerTP->momentum(event,setup,*tp);
-	    vertexTP = parametersDefinerTP->vertex(event,setup,*tp);
+	    if(! cosmictpSelector(tpr,&bs,event,setup)) continue;	
+	    momentumTP = parametersDefinerTP->momentum(event,setup,tpr);
+	    vertexTP = parametersDefinerTP->vertex(event,setup,tpr);
 	    dxySim = (-vertexTP.x()*sin(momentumTP.phi())+vertexTP.y()*cos(momentumTP.phi()));
 	    dzSim = vertexTP.z() - (vertexTP.x()*momentumTP.x()+vertexTP.y()*momentumTP.y())/sqrt(momentumTP.perp2()) * momentumTP.z()/sqrt(momentumTP.perp2());
 	  }
@@ -667,8 +667,8 @@ void MuonTrackValidator::analyze(const edm::Event& event, const edm::EventSetup&
 	  h_charge[w]->Fill( track->charge() );
 	  
 	  //Get tracking particle parameters at point of closest approach to the beamline
-	  TrackingParticle::Vector momentumTP = parametersDefinerTP->momentum(event,setup,*(tpr.get()));
-	  TrackingParticle::Point vertexTP = parametersDefinerTP->vertex(event,setup,*(tpr.get()));
+	  TrackingParticle::Vector momentumTP = parametersDefinerTP->momentum(event,setup,tpr) ;
+	  TrackingParticle::Point vertexTP = parametersDefinerTP->vertex(event,setup,tpr);
 	  double ptSim = sqrt(momentumTP.perp2());
 	  double qoverpSim = tpr->charge()/sqrt(momentumTP.x()*momentumTP.x()+momentumTP.y()*momentumTP.y()+momentumTP.z()*momentumTP.z());
 	  double thetaSim = momentumTP.theta();

--- a/Validation/RecoTrack/interface/MultiTrackValidator.h
+++ b/Validation/RecoTrack/interface/MultiTrackValidator.h
@@ -46,6 +46,7 @@ class MultiTrackValidator : public edm::EDAnalyzer, protected MultiTrackValidato
   //(i.e. "denominator" of the efficiency ratio)
   TrackingParticleSelector tpSelector;				      
   CosmicTrackingParticleSelector cosmictpSelector;
+  edm::InputTag _simHitTpMapTag;
 };
 
 

--- a/Validation/RecoTrack/plugins/TrackerSeedValidator.cc
+++ b/Validation/RecoTrack/plugins/TrackerSeedValidator.cc
@@ -201,8 +201,8 @@ void TrackerSeedValidator::analyze(const edm::Event& event, const edm::EventSetu
 	TrackingParticle::Vector momentumTP = tp->momentum();
 	TrackingParticle::Point vertexTP = tp->vertex();
 	//Calcualte the impact parameters w.r.t. PCA
-	TrackingParticle::Vector momentum = parametersDefinerTP->momentum(event,setup,*tp);
-	TrackingParticle::Point vertex = parametersDefinerTP->vertex(event,setup,*tp);
+	TrackingParticle::Vector momentum = parametersDefinerTP->momentum(event,setup,tp);
+	TrackingParticle::Point vertex = parametersDefinerTP->vertex(event,setup,tp);
 	double dxySim = (-vertex.x()*sin(momentum.phi())+vertex.y()*cos(momentum.phi()));
 	double dzSim = vertex.z() - (vertex.x()*momentum.x()+vertex.y()*momentum.y())/sqrt(momentum.perp2()) 
 	  * momentum.z()/sqrt(momentum.perp2());
@@ -359,8 +359,8 @@ void TrackerSeedValidator::analyze(const edm::Event& event, const edm::EventSetu
 	  TrackingParticleRef tpr = tp.begin()->first;
 	
 	  //compute tracking particle parameters at point of closest approach to the beamline
-	  TrackingParticle::Vector momentumTP = parametersDefinerTP->momentum(event,setup,*(tpr.get()));
-	  TrackingParticle::Point vertexTP = parametersDefinerTP->vertex(event,setup,*(tpr.get()));		 	 
+	  TrackingParticle::Vector momentumTP = parametersDefinerTP->momentum(event,setup,tpr);
+	  TrackingParticle::Point vertexTP = parametersDefinerTP->vertex(event,setup,tpr);		 	 
 
 	  // 	  LogTrace("SeedValidatorTEST") << "assocChi2=" << tp.begin()->second << "\n"
 	  // 					 << "" <<  "\n"

--- a/Validation/RecoTrack/python/MultiTrackValidator_cfi.py
+++ b/Validation/RecoTrack/python/MultiTrackValidator_cfi.py
@@ -44,6 +44,7 @@ multiTrackValidator = cms.EDAnalyzer(
     sim = cms.string('g4SimHits'),
     parametersDefiner = cms.string('LhcParametersDefinerForTP'),          # collision like tracks
     # parametersDefiner = cms.string('CosmicParametersDefinerForTP'),     # cosmics tracks
+    simHitTpMapTag = cms.InputTag("simHitTPAssocProducer"),               # needed by CosmicParametersDefinerForTP
 
     ### reco input configuration ###
     label = cms.VInputTag(cms.InputTag("generalTracks")),


### PR DESCRIPTION
Adding the PSimHit-TrackingParticle association so that compilation warnings due to the new TP can be fixed.
A new producer is added to the pre-validation sequence.
Warnings in SimTracker and in CommonTools are fixed.
