### PR TITLE
Updated skeleton code generator to remove CVSisms

### DIFF
--- a/FWCore/Skeletons/python/pkg.py
+++ b/FWCore/Skeletons/python/pkg.py
@@ -47,7 +47,6 @@ class AbstractPkg(object):
         self.tdir   = self.config.get('tmpl_dir')
         self.author = user_info(self.config.get('author', None))
         self.date   = time.strftime("%a, %d %b %Y %H:%M:%S GMT", time.gmtime())
-        self.rcsid  = '$%s$' % 'Id' # CVS commit is too smart
         self.not_in_dir = self.config.get('not_in_dir', [])
         
     def tmpl_etags(self):
@@ -148,7 +147,6 @@ class AbstractPkg(object):
                  '__date__': self.date,
                  '__class__': self.pname,
                  '__name__': self.pname,
-                 '__rcsid__': self.rcsid,
                  '__subsys__': self.config.get('subsystem', 'Subsystem')}
         args = self.config.get('args', None)
         kwds.update(args)

--- a/FWCore/Skeletons/scripts/mkTemplates/EDAnalyzer/EDAnalyzer.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/EDAnalyzer/EDAnalyzer.cc
@@ -1,6 +1,6 @@
 // -*- C++ -*-
 //
-// Package:    __pkgname__
+// Package:    __subsys__/__pkgname__
 // Class:      __class__
 // 
 /**\class __class__ __class__.cc __subsys__/__pkgname__/plugins/__class__.cc
@@ -13,7 +13,6 @@
 //
 // Original Author:  __author__
 //         Created:  __date__
-// __rcsid__
 //
 //
 

--- a/FWCore/Skeletons/scripts/mkTemplates/EDFilter/EDFilter.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/EDFilter/EDFilter.cc
@@ -1,6 +1,6 @@
 // -*- C++ -*-
 //
-// Package:    __pkgname__
+// Package:    __subsys__/__pkgname__
 // Class:      __class__
 // 
 /**\class __class__ __class__.cc __subsys__/__pkgname__/plugins/__class__.cc
@@ -13,7 +13,6 @@
 //
 // Original Author:  __author__
 //         Created:  __date__
-// __rcsid__
 //
 //
 

--- a/FWCore/Skeletons/scripts/mkTemplates/EDLooper/EDLooper.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/EDLooper/EDLooper.cc
@@ -1,6 +1,6 @@
 // -*- C++ -*-
 //
-// Package:    __pkgname__
+// Package:    __subsys__/__pkgname__
 // Class:      __class__
 // 
 /**\class __class__ __class__.cc __subsys__/__pkgname__/plugins/__class__.cc
@@ -13,7 +13,6 @@
 //
 // Original Author:  __author__
 //         Created:  __date__
-// __rcsid__
 //
 //
 

--- a/FWCore/Skeletons/scripts/mkTemplates/EDProducer/EDProducer.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/EDProducer/EDProducer.cc
@@ -1,6 +1,6 @@
 // -*- C++ -*-
 //
-// Package:    __pkgname__
+// Package:    __subsys__/__pkgname__
 // Class:      __class__
 // 
 /**\class __class__ __class__.cc __subsys__/__pkgname__/plugins/__class__.cc
@@ -13,7 +13,6 @@
 //
 // Original Author:  __author__
 //         Created:  __date__
-// __rcsid__
 //
 //
 

--- a/FWCore/Skeletons/scripts/mkTemplates/ESProducer/ESProducer.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/ESProducer/ESProducer.cc
@@ -1,6 +1,6 @@
 // -*- C++ -*-
 //
-// Package:    __pkgname__
+// Package:    __subsys__/__pkgname__
 // Class:      __class__
 // 
 /**\class __class__ __class__.h __subsys__/__pkgname__/plugins/__class__.cc
@@ -13,7 +13,6 @@
 //
 // Original Author:  __author__
 //         Created:  __date__
-// __rcsid__
 //
 //
 

--- a/FWCore/Skeletons/scripts/mkTemplates/EventHypothesis/EventHypothesis.h
+++ b/FWCore/Skeletons/scripts/mkTemplates/EventHypothesis/EventHypothesis.h
@@ -22,7 +22,6 @@
 //
 // Original Author:  __author__
 //         Created:  __date__
-// __rcsid__
 //
 
 #include "DataFormats/PatCandidates/interface/HardEventHypothesis.h"

--- a/FWCore/Skeletons/scripts/mkTemplates/EventHypothesis/EventHypothesisProducer.h
+++ b/FWCore/Skeletons/scripts/mkTemplates/EventHypothesis/EventHypothesisProducer.h
@@ -19,7 +19,6 @@
 //
 // Original Author:  __author__
 //         Created:  __date__
-// __rcsid__
 //
 
 

--- a/FWCore/Skeletons/scripts/mkTemplates/Record/Record.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/Record/Record.cc
@@ -1,6 +1,6 @@
 // -*- C++ -*-
 //
-// Package:     __pkgname__
+// Package:     __subsys__/__pkgname__
 // Class  :     __class__
 // 
 // Implementation:
@@ -8,7 +8,6 @@
 //
 // Author:      __author__
 // Created:     __date__
-// __rcsid__
 
 #include "__subsys__/__pkgname__/interface/__class__.h"
 #include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"

--- a/FWCore/Skeletons/scripts/mkTemplates/Record/Record.h
+++ b/FWCore/Skeletons/scripts/mkTemplates/Record/Record.h
@@ -2,7 +2,7 @@
 #define __class_____class___h
 // -*- C++ -*-
 //
-// Package:     __pkgname__
+// Package:     __subsys__/__pkgname__
 // Class  :     __class__
 // 
 /**\class __class__ __class__.h __subsys__/__pkgname__/interface/__class__.h
@@ -16,7 +16,6 @@
 //
 // Author:      __author__
 // Created:     __date__
-// __rcsid__
 //
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"

--- a/FWCore/Skeletons/scripts/mkTemplates/Skeleton/Skeleton.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/Skeleton/Skeleton.cc
@@ -1,6 +1,6 @@
 // -*- C++ -*-
 //
-// Package:     __pkgname__
+// Package:     __subsys__/__pkgname__
 // Class  :     __class__
 // 
 // Implementation:
@@ -8,7 +8,6 @@
 //
 // Original Author:  __author__
 //         Created:  __date__
-// __rcsid__
 //
 
 // system include files

--- a/FWCore/Skeletons/scripts/mkTemplates/Skeleton/Skeleton.h
+++ b/FWCore/Skeletons/scripts/mkTemplates/Skeleton/Skeleton.h
@@ -2,7 +2,7 @@
 #define __subsys_____pkgname_____class___h
 // -*- C++ -*-
 //
-// Package:     __pkgname__
+// Package:     __subsys__/__pkgname__
 // Class  :     __class__
 // 
 /**\class __class__ __class__.h "__incdir____class__.h"
@@ -16,7 +16,6 @@
 //
 // Original Author:  __author__
 //         Created:  __date__
-// __rcsid__
 //
 
 // system include files

--- a/FWCore/Skeletons/scripts/mkTemplates/TSelector/TSelector.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/TSelector/TSelector.cc
@@ -1,6 +1,6 @@
 // -*- C++ -*-
 //
-// Package:    __pkgname__
+// Package:    __subsys__/__pkgname__
 // Class:      __class__
 // 
 /*
@@ -13,7 +13,6 @@
 //
 // Original Author:  __author__
 //         Created:  __date__
-// __rcsid__
 //
 //
 

--- a/FWCore/Skeletons/scripts/mkTemplates/TSelector/TSelector.h
+++ b/FWCore/Skeletons/scripts/mkTemplates/TSelector/TSelector.h
@@ -2,7 +2,7 @@
 #define __subsys_____pkgname_____class___h
 // -*- C++ -*-
 //
-// Package:    __pkgname__
+// Package:    __subsys__/__pkgname__
 // Class:      __class__
 // 
 /**\class __class__ __class__.h __subsys__/__pkgname__/plugins/__class__.h
@@ -15,7 +15,6 @@ Implementation:
 //
 // Original Author:  __author__
 //         Created:  __date__
-// __rcsid__
 //
 //
 #include <TH1.h>


### PR DESCRIPTION
Removed CVSism from skeletons and always specify **subsys** when **pkgname** is used.
