### PR TITLE
Properly handle TStreamerInfo object in dqm-access python script. 

### DIFF
--- a/DQMServices/Components/python/ROOTData.py
+++ b/DQMServices/Components/python/ROOTData.py
@@ -2,7 +2,7 @@ from ROOT import *
 from array import array
 
 #-------------------------------------------------------------------------------
-def tfile_cd(dirname,tfile,debug=False):
+def tfile_cd(dirname, tfile, debug=False):
 
   """ Safely re-build and navigate the directory structure. dirname is
   considered to be an absolute path."""
@@ -21,18 +21,50 @@ def tfile_cd(dirname,tfile,debug=False):
   if debug:
     print "Current dir %s" % gDirectory.pwd()
 
-#-------------------------------------------------------------------------------
-def literal2root (literal,rootType,tstreamerinfo=None):
-  """
-  Convert an hexadecimal string into a root-object. The correct TStreamerInfo
-  is passed in order to avoid inconsistencies.
-  """
+def loadStreamerInfo(literal, debug):
+
+  """Decode a literal made of TStreamerInfo informations and load
+  streamers that are not part of the currently used version of
+  ROOT. The implementation is a back-to-bone and simplified version of
+  the one contained in the DQM GUI source code."""
+
   bitsarray = array('B')
   bitsarray.fromstring(literal.decode('hex'))
 
   tbuffer = TBufferFile(TBufferFile.kRead)
-  if tstreamerinfo:
-    tbuffer.IncrementLevel(tstreamerinfo)
+  tbuffer.Reset();
+  tbuffer.SetBuffer(bitsarray, len(bitsarray), False)
+  while tbuffer.Length() != tbuffer.BufferSize():
+    obj = tbuffer.ReadObject(eval("TStreamerInfo.Class()"))
+    v = obj.GetClassVersion()
+    c = TClass.GetClass(obj.GetName(), kTRUE)
+    if c:
+      c.GetStreamerInfo();
+      if c.GetStreamerInfos().At(v):
+        if debug:
+          print "skipping already present streamer info version %d for %s" % (v, obj.GetName())
+        continue
+    if debug:
+      print "Importing streamer info version %d for %s" % (v, obj.GetName())
+    obj.BuildCheck();
+
+#-------------------------------------------------------------------------------
+def literal2root (literal, rootType, debug=False):
+
+  """Convert an hexadecimal string into a root-object. In case a
+  TStreamerInfo object is passed, this will be decoded by the
+  loadStreamerInfo function to handle it properly and a None object
+  will be returned. It is the responsibility of the user not the use
+  the returned object in this very case."""
+
+  if rootType == "TStreamerInfo":
+    loadStreamerInfo(literal, debug)
+    return None
+
+  bitsarray = array('B')
+  bitsarray.fromstring(literal.decode('hex'))
+
+  tbuffer = TBufferFile(TBufferFile.kRead)
   tbuffer.SetBuffer(bitsarray,len(bitsarray),False)
 
   # replace a couple of shortcuts with the real root class name
@@ -41,7 +73,7 @@ def literal2root (literal,rootType,tstreamerinfo=None):
   if rootType == 'TPROF2D':
       rootType = 'TProfile2D'
 
-  root_class=eval(rootType+'.Class()')
+  root_class = eval(rootType+'.Class()')
 
   return tbuffer.ReadObject(root_class)
 

--- a/DQMServices/Components/scripts/dqm-access
+++ b/DQMServices/Components/scripts/dqm-access
@@ -250,6 +250,9 @@ op.add_option("-c", dest = "dqmCompliant",
 op.add_option("-d", "--debug", dest = "debug",
               action = "store_true", default = False,
               help = "Show debug information")
+op.add_option("-k", "--debug-streamers", dest = "debug_streamers",
+              action = "store_true", default = False,
+              help = "Show debug information on StreamerInfo objects")
 op.add_option("-l", dest = "long_listing",
               action = "store_true", default = False,
               help = "Enable long listing")
@@ -320,7 +323,7 @@ for sample in find_matching_samples(options):
   tstreamerinfo = None
   if options.write:
     tstreamerinfo = fetch_tstreamerinfo(options, "%(run)d%(dataset)s" % sample)
-    tstreamerinfo = literal2root(tstreamerinfo, "TStreamerInfo")
+    literal2root(tstreamerinfo, "TStreamerInfo", options.debug_streamers)
 
   nreq = 0
   found = []
@@ -378,7 +381,7 @@ for sample in find_matching_samples(options):
           if cwd != indir:
             tfile_cd(indir, ofile)
             cwd = indir
-          obj = literal2root(item['rootobj'], item['properties']['type'], tstreamerinfo)
+          obj = literal2root(item['rootobj'], item['properties']['type'])
           obj.Write()
 
     if options.write and ofile:


### PR DESCRIPTION
This will allow the user to donwload locally any ROOT object from the DQM GUI servers,
without bothering about which ROOT version was used to register the original
ROOT files into the servers and which version he is currently using via CMSSW.
This was tested in a real case of schema evolution of a TH1 object in going
from ROOT 5.32 (used by DQMGUI) and ROOT 5.34, used by any recent CMSSW.
