### PR TITLE
getParameterNames is really a const function

### DIFF
--- a/FWCore/ParameterSet/interface/ParameterSet.h
+++ b/FWCore/ParameterSet/interface/ParameterSet.h
@@ -229,7 +229,7 @@ namespace edm {
     // untracked parameters.
     size_t getParameterSetNames(std::vector<std::string>& output,
                                 bool trackiness = true) const;
-    size_t getParameterSetNames(std::vector<std::string>& output);
+    size_t getParameterSetNames(std::vector<std::string>& output) const;
     // Return the names of all parameters of type
     // vector<ParameterSet>, pushing the names into the argument
     // 'output'. Return the number of names pushed into the vector. If

--- a/FWCore/ParameterSet/src/ParameterSet.cc
+++ b/FWCore/ParameterSet/src/ParameterSet.cc
@@ -775,7 +775,7 @@ namespace edm {
   }
 
   size_t
-  ParameterSet::getParameterSetNames(std::vector<std::string>& output) {
+  ParameterSet::getParameterSetNames(std::vector<std::string>& output) const {
     std::transform(psetTable_.begin(), psetTable_.end(), back_inserter(output),
                    boost::bind(&std::pair<std::string const, ParameterSetEntry>::first, _1));
     return output.size();


### PR DESCRIPTION
I happened to notice that both functions in the ParameterSet::getParameterSetNames overload set are really const functions, but only one of them has const in its signature.  This simple pull request adds const to the signature of the other function, which should also have it.  This makes one fewer non-const function of class ParameterSet.
