### PR TITLE
Revert "getParameterNames is really a const function"

### DIFF
--- a/FWCore/ParameterSet/interface/ParameterSet.h
+++ b/FWCore/ParameterSet/interface/ParameterSet.h
@@ -229,7 +229,7 @@ namespace edm {
     // untracked parameters.
     size_t getParameterSetNames(std::vector<std::string>& output,
                                 bool trackiness = true) const;
-    size_t getParameterSetNames(std::vector<std::string>& output) const;
+    size_t getParameterSetNames(std::vector<std::string>& output);
     // Return the names of all parameters of type
     // vector<ParameterSet>, pushing the names into the argument
     // 'output'. Return the number of names pushed into the vector. If

--- a/FWCore/ParameterSet/src/ParameterSet.cc
+++ b/FWCore/ParameterSet/src/ParameterSet.cc
@@ -775,7 +775,7 @@ namespace edm {
   }
 
   size_t
-  ParameterSet::getParameterSetNames(std::vector<std::string>& output) const {
+  ParameterSet::getParameterSetNames(std::vector<std::string>& output) {
     std::transform(psetTable_.begin(), psetTable_.end(), back_inserter(output),
                    boost::bind(&std::pair<std::string const, ParameterSetEntry>::first, _1));
     return output.size();


### PR DESCRIPTION
This reverts commit 3979e3d91d4b16a29b9bbe2288e54e27c732f1e4 due to the fact it
breaks CMSSW_7_0_X_2013-08-04-0200. See:

https://cmssdt.cern.ch/SDT/cgi-bin/showBuildLogs.py/slc5_amd64_gcc472/www/sun/7.0-sun-02/CMSSW_7_0_X_2013-08-04-0200/
