### PR TITLE
Revert "getParameterSetNames is really a const function"

### DIFF
--- a/FWCore/ParameterSet/interface/ParameterSet.h
+++ b/FWCore/ParameterSet/interface/ParameterSet.h
@@ -228,8 +228,8 @@ namespace edm {
     // return tracked parameters; if 'trackiness' is false, w return
     // untracked parameters.
     size_t getParameterSetNames(std::vector<std::string>& output,
-                                bool trackiness) const;
-    size_t getParameterSetNames(std::vector<std::string>& output) const;
+                                bool trackiness = true) const;
+    size_t getParameterSetNames(std::vector<std::string>& output);
     // Return the names of all parameters of type
     // vector<ParameterSet>, pushing the names into the argument
     // 'output'. Return the number of names pushed into the vector. If

--- a/FWCore/ParameterSet/src/ParameterSet.cc
+++ b/FWCore/ParameterSet/src/ParameterSet.cc
@@ -775,7 +775,7 @@ namespace edm {
   }
 
   size_t
-  ParameterSet::getParameterSetNames(std::vector<std::string>& output) const {
+  ParameterSet::getParameterSetNames(std::vector<std::string>& output) {
     std::transform(psetTable_.begin(), psetTable_.end(), back_inserter(output),
                    boost::bind(&std::pair<std::string const, ParameterSetEntry>::first, _1));
     return output.size();


### PR DESCRIPTION
This reverts commit 0b66b481fe846e5f5d7122c6fe329e73ff79b051.

Again... @Dr15Jones does not agree as suggested in #230, hence I revert it.
