### PR TITLE
Update PAT input files (drop missing files at T2_CH_CERN, add new)

### DIFF
--- a/PhysicsTools/PatAlgos/python/patInputFiles_cff.py
+++ b/PhysicsTools/PatAlgos/python/patInputFiles_cff.py
@@ -39,7 +39,5 @@ filesSingleMuRECO = cms.untracked.vstring(
     # only one block available at CERN
     # FIXME: need to fix DBS query in 'pickRelValInputFiles' to identify them properly
     # ==> query for file requiring dataset AND site does not work in DBS :-(
-       '/store/relval/CMSSW_6_2_0_pre4/SingleMu/RECO/PRE_61_V1_RelVal_mu2012D-v1/00000/003C223A-CD92-E211-B862-0025905964A6.root',
-       '/store/relval/CMSSW_6_2_0_pre4/SingleMu/RECO/PRE_61_V1_RelVal_mu2012D-v1/00000/0069FCF4-C992-E211-ACFF-003048679266.root',
-       '/store/relval/CMSSW_6_2_0_pre4/SingleMu/RECO/PRE_61_V1_RelVal_mu2012D-v1/00000/007CE5CD-CC92-E211-A36F-00259059649C.root',
+       '/store/relval/CMSSW_6_2_0_pre4/SingleMu/RECO/PRE_61_V1_RelVal_mu2012D-v1/00000/2A8716C9-3492-E211-8E04-0025905938A4.root',
     )


### PR DESCRIPTION
The /SingleMu/CMSSW_6_2_0_pre4-PRE_61_V1_RelVal_mu2012D-v1/RECO#
472c929e-92ee-11e2-9f9b-00221959e7c0 is not available at T2_CH_CERN.
The size of block is 622.0 GB for 2 unit tests. Replacement block
is /SingleMu/CMSSW_6_2_0_pre4-PRE_61_V1_RelVal_mu2012D-v1/RECO#
5dee2ea8-92a7-11e2-9f9b-00221959e7c0 at just 4.4 GB and a single
file with 3000+ events.

Should resolve two failing unit tests:
- PhysicsTools/PatAlgos (runtestPhysicsToolsPatAlgos)
- TopQuarkAnalysis/TopEventProducers (runtestTqafTopEventProducers)

Goes together with transfers request under IB RelVals.
https://cmsweb.cern.ch/phedex/prod/Request::View?request=402534

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
