### PR TITLE
comment out unneeded function

### DIFF
--- a/FWCore/ParameterSet/interface/ParameterSet.h
+++ b/FWCore/ParameterSet/interface/ParameterSet.h
@@ -229,7 +229,7 @@ namespace edm {
     // untracked parameters.
     size_t getParameterSetNames(std::vector<std::string>& output,
                                 bool trackiness = true) const;
-    size_t getParameterSetNames(std::vector<std::string>& output);
+
     // Return the names of all parameters of type
     // vector<ParameterSet>, pushing the names into the argument
     // 'output'. Return the number of names pushed into the vector. If

--- a/FWCore/ParameterSet/src/ParameterSet.cc
+++ b/FWCore/ParameterSet/src/ParameterSet.cc
@@ -775,12 +775,15 @@ namespace edm {
     return result;
   }
 
+/*
+  // Comment out unneeded function
   size_t
-  ParameterSet::getParameterSetNames(std::vector<std::string>& output) {
+  ParameterSet::getAllParameterSetNames(std::vector<std::string>& output) const {
     std::transform(psetTable_.begin(), psetTable_.end(), back_inserter(output),
                    boost::bind(&std::pair<std::string const, ParameterSetEntry>::first, _1));
     return output.size();
   }
+*/
 
   size_t
   ParameterSet::getParameterSetNames(std::vector<std::string>& output,


### PR DESCRIPTION
FWCoreParameterset has two functions named getParameterSetNames.  The function taking one argument has several problems: 1) It is not marked const even though it is really a const function, 2) It can be confused with the function taking two arguments, because the two argument function has a default for the second argument.

The two argument function with the second argument defaulted returns the names of all tracked parameters in the parameter set, while the one argument function returns the names of all parameters, tracked and untracked.  However a case by case study of every use of the function taking one argument shows that, in every case, the two argument function can be used instead, because only the names of tracked parameters are needed.

Therefore, this pull request removes the unneeded one argument function, by commenting it out.  Inside the comment, the function is made const and renamed to getAllParameterSetNames, just in case it is ever needed in the future.
