### PR TITLE
Don't register default values of untracked parameter sets

### DIFF
--- a/FWCore/ParameterSet/src/ParameterSet.cc
+++ b/FWCore/ParameterSet/src/ParameterSet.cc
@@ -2357,9 +2357,6 @@ namespace edm {
   ParameterSet::getUntrackedParameterSet(char const* name, ParameterSet const& defaultValue) const {
     ParameterSetEntry const* entryPtr = retrieveUntrackedParameterSet(name);
     if(entryPtr == 0) {
-      if(!defaultValue.isRegistered()) {
-        const_cast<ParameterSet&>(defaultValue).registerIt();
-      }
       return defaultValue;
     }
     return entryPtr->pset();


### PR DESCRIPTION
The function ParameterSet::getUntrackedParameterSet registers the passed in default value argument.  This is not thread safe, and is totally unnecesary, This pull request removes the registration. This is a step toward the multithreaded framework.
