### PR TITLE
Do not register parameter set in a constructor

### DIFF
--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -800,9 +800,7 @@ DQMRootSource::setupFile(unsigned int iIndex)
     for(unsigned int index = 0; index != parameterSetTree->GetEntries();++index)
     {
       parameterSetTree->GetEntry(index);
-      cms::Digest dg(blob);
-      edm::ParameterSetID psID(dg.digest().toString());
-      edm::ParameterSet temp(blob,psID);
+      edm::ParameterSet::registerFromString(blob);
     } 
   }
 

--- a/FWCore/ParameterSet/interface/ParameterSet.h
+++ b/FWCore/ParameterSet/interface/ParameterSet.h
@@ -46,9 +46,6 @@ namespace edm {
     // construct from coded string.
     explicit ParameterSet(std::string const& rep);
 
-    // construct from coded string and id.  Will cause registration
-    ParameterSet(std::string const& rep, ParameterSetID const& id);
-
     ~ParameterSet();
 
     // instantiate in this library, so these methods don't cause code bloat
@@ -272,7 +269,15 @@ namespace edm {
     VParameterSetEntry*
     getPSetVectorForUpdate(std::string const& name);
 
+    // construct from coded string and register it.
+    static
+    void
+    registerFromString(std::string const& rep);
+
   private:
+    // construct from coded string and id.
+    ParameterSet(std::string const& rep, ParameterSetID const& id);
+
     // decode
     bool fromString(std::string const&);
 

--- a/FWCore/ParameterSet/src/ParameterSet.cc
+++ b/FWCore/ParameterSet/src/ParameterSet.cc
@@ -74,7 +74,7 @@ namespace edm {
   }
 
   // ----------------------------------------------------------------------
-  // from coded string and ID.  Will cause registration
+  // from coded string and ID.
 
   ParameterSet::ParameterSet(std::string const& code, ParameterSetID const& id) :
     tbl_(),
@@ -87,10 +87,18 @@ namespace edm {
         << "passed to a ParameterSet during construction is invalid:\n"
         << code;
     }
-    pset::Registry::instance()->insertMapped(*this);
   }
 
   ParameterSet::~ParameterSet() {}
+
+  void
+  ParameterSet::registerFromString(std::string const& rep) {
+    // from coded string.  Will cause registration
+    cms::Digest dg(rep);
+    edm::ParameterSetID psID(dg.digest().toString());
+    edm::ParameterSet ps(rep, psID);
+    pset::Registry::instance()->insertMapped(ps);
+  }
 
   ParameterSet::ParameterSet(ParameterSet const& other)
   : tbl_(other.tbl_),


### PR DESCRIPTION
There is a public constructor of ParameterSet that registers the constructed parameter set.  This complicates thread safety, because it is hard to find instances of this particular constructor.
This pull request makes this constructor private, and removes the registration from this constructor.   It adds a new public static function of ParameterSet (registerfromString) that invokes this constructor and registers the constructed parameter set.
The only place in CMSSW where this constructor is called is modified to call the new static function.
The new static function has the same thread safety issues as the constructor had previously, but it is much easier to find, and much less likely to be used inappropriately.
