### PR TITLE
add dummy file to avoid empty python sub-directory

### DIFF
--- a/HLTrigger/HLTfilters/python/_dummy.py
+++ b/HLTrigger/HLTfilters/python/_dummy.py
@@ -1,0 +1,1 @@
+# https://hypernews.cern.ch/HyperNews/CMS/get/sw-develtools/1894.html


### PR DESCRIPTION
Add dummy file to avoid empty python sub-directory
(https://hypernews.cern.ch/HyperNews/CMS/get/sw-develtools/1894.html)
