### PR TITLE
Consumes interface changes for b-tagging and vertex reco

### DIFF
--- a/RecoBTag/ImpactParameter/plugins/TrackIPProducer.cc
+++ b/RecoBTag/ImpactParameter/plugins/TrackIPProducer.cc
@@ -67,8 +67,9 @@ TrackIPProducer::TrackIPProducer(const edm::ParameterSet& iConfig) :
   m_calibrationCacheId3D = 0;
   m_calibrationCacheId2D = 0;
 
-  m_associator              = m_config.getParameter<InputTag>("jetTracks");
-  m_primaryVertexProducer   = m_config.getParameter<InputTag>("primaryVertex");
+  token_associator          = consumes<reco::JetTracksAssociationCollection>(m_config.getParameter<edm::InputTag>("jetTracks"));
+  token_primaryVertex       = consumes<reco::VertexCollection>(m_config.getParameter<edm::InputTag>("primaryVertex"));
+
   m_computeProbabilities    = m_config.getParameter<bool>("computeProbabilities");
   m_computeGhostTrack       = m_config.getParameter<bool>("computeGhostTrack");
   m_ghostTrackPriorDeltaR   = m_config.getParameter<double>("ghostTrackPriorDeltaR");
@@ -104,10 +105,10 @@ TrackIPProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
  
    //input objects 
    Handle<reco::JetTracksAssociationCollection> jetTracksAssociation;
-   iEvent.getByLabel(m_associator, jetTracksAssociation);
+   iEvent.getByToken(token_associator, jetTracksAssociation);
    
    Handle<reco::VertexCollection> primaryVertex;
-   iEvent.getByLabel(m_primaryVertexProducer, primaryVertex);
+   iEvent.getByToken(token_primaryVertex, primaryVertex);
 
    edm::ESHandle<TransientTrackBuilder> builder;
    iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", builder);

--- a/RecoBTag/ImpactParameter/plugins/TrackIPProducer.h
+++ b/RecoBTag/ImpactParameter/plugins/TrackIPProducer.h
@@ -22,8 +22,9 @@ class TrackIPProducer : public edm::EDProducer {
     void  checkEventSetup(const edm::EventSetup & iSetup);
 
     const edm::ParameterSet& m_config;
-    edm::InputTag m_associator;
-    edm::InputTag m_primaryVertexProducer;
+    edm::EDGetTokenT<reco::VertexCollection> token_primaryVertex;
+    edm::EDGetTokenT<reco::JetTracksAssociationCollection> token_associator;
+
     bool m_computeProbabilities;
     bool m_computeGhostTrack;
     double m_ghostTrackPriorDeltaR;

--- a/RecoBTag/ImpactParameter/test/IPAnalyzer.cc
+++ b/RecoBTag/ImpactParameter/test/IPAnalyzer.cc
@@ -60,9 +60,9 @@ class IPAnalyzer : public edm::EDAnalyzer {
       virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
 
    private:
-     edm::InputTag m_ipassoc;
      edm::InputTag m_assoc;
      edm::InputTag m_jets;
+     edm::EDGetTokenT<reco::TrackIPTagInfoCollection> token_ipassoc;
 };
 
 //
@@ -72,7 +72,7 @@ IPAnalyzer::IPAnalyzer(const edm::ParameterSet& iConfig)
 {
   m_jets  = iConfig.getParameter<edm::InputTag>("jets");
   m_assoc = iConfig.getParameter<edm::InputTag>("association");
-  m_ipassoc = iConfig.getParameter<edm::InputTag>("ipassociation");
+  token_ipassoc = consumes<reco::TrackIPTagInfoCollection>(iConfig.getParameter<edm::InputTag>("ipassociation"));
 }
 
 void
@@ -82,7 +82,7 @@ IPAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   using namespace reco;
 
   Handle<TrackIPTagInfoCollection> ipHandle;
-  iEvent.getByLabel(m_ipassoc, ipHandle);
+  iEvent.getByToken(token_ipassoc, ipHandle);
   const TrackIPTagInfoCollection & ip = *(ipHandle.product());
   cout << "Found " << ip.size() << " TagInfo" << endl;
 

--- a/RecoBTag/ImpactParameterLearning/plugins/ImpactParameterCalibration.cc
+++ b/RecoBTag/ImpactParameterLearning/plugins/ImpactParameterCalibration.cc
@@ -101,8 +101,8 @@ class ImpactParameterCalibration : public edm::EDAnalyzer {
  }
 
    TrackProbabilityCalibration * m_calibration[2];
-   edm::InputTag m_iptaginfo;
-   edm::InputTag m_pv;
+   edm::EDGetTokenT<reco::TrackIPTagInfoCollection> token_trackIPTagInfo;
+   edm::EDGetTokenT<reco::VertexCollection> token_primaryVertex;
   unsigned int minLoop, maxLoop;
 
 };
@@ -110,8 +110,8 @@ class ImpactParameterCalibration : public edm::EDAnalyzer {
 ImpactParameterCalibration::ImpactParameterCalibration(const edm::ParameterSet& iConfig):config(iConfig)
 {
   m_needInitFromES = false;
-  m_iptaginfo = iConfig.getParameter<edm::InputTag>("tagInfoSrc");
-  m_pv = iConfig.getParameter<edm::InputTag>("primaryVertexSrc");
+  token_trackIPTagInfo =  consumes<reco::TrackIPTagInfoCollection>(iConfig.getParameter<edm::InputTag>("tagInfoSrc"));
+  token_primaryVertex = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("primaryVertexSrc"));
   bool createOnlyOne = iConfig.getUntrackedParameter<bool>("createOnlyOneCalibration", false);
   minLoop=0;
   maxLoop=1;
@@ -146,13 +146,13 @@ ImpactParameterCalibration::analyze(const edm::Event& iEvent, const edm::EventSe
   using namespace reco;
 
   Handle<TrackIPTagInfoCollection> ipHandle;
-  iEvent.getByLabel(m_iptaginfo, ipHandle);
+  iEvent.getByToken(token_trackIPTagInfo, ipHandle);
   const TrackIPTagInfoCollection & ip = *(ipHandle.product());
 
 //  cout << "Found " << ip.size() << " TagInfo" << endl;
 
   Handle<reco::VertexCollection> primaryVertex;
-  iEvent.getByLabel(m_pv,primaryVertex);
+  iEvent.getByToken(token_primaryVertex,primaryVertex);
 
   vector<TrackProbabilityCalibration::Entry>::iterator found;
   vector<TrackProbabilityCalibration::Entry>::iterator it_begin;

--- a/RecoBTag/SecondaryVertex/plugins/BVertexFilter.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BVertexFilter.cc
@@ -45,8 +45,8 @@ class BVertexFilter : public edm::EDFilter {
 
    private:
       virtual bool filter(edm::Event&, const edm::EventSetup&);
-      edm::InputTag                           primaryVertexCollection;
-      edm::InputTag                           secondaryVertexCollection;
+      edm::EDGetTokenT<reco::VertexCollection> token_primaryVertex;
+      edm::EDGetTokenT<reco::VertexCollection> token_secondaryVertex;
       reco::VertexFilter                      svFilter;
       bool                                    useVertexKinematicAsJetAxis;
       int                                     minVertices;
@@ -54,13 +54,13 @@ class BVertexFilter : public edm::EDFilter {
 
 
 BVertexFilter::BVertexFilter(const edm::ParameterSet& params):
-      primaryVertexCollection(params.getParameter<edm::InputTag>("primaryVertices")),
-      secondaryVertexCollection(params.getParameter<edm::InputTag>("secondaryVertices")),
       svFilter(params.getParameter<edm::ParameterSet>("vertexFilter")),
       useVertexKinematicAsJetAxis(params.getParameter<bool>("useVertexKinematicAsJetAxis")),
       minVertices(params.getParameter<int>("minVertices"))
 
 {
+	token_primaryVertex = consumes<reco::VertexCollection>(params.getParameter<edm::InputTag>("primaryVertices"));
+	token_secondaryVertex = consumes<reco::VertexCollection>(params.getParameter<edm::InputTag>("secondaryVertices"));
         produces<reco::VertexCollection>();
 
 }
@@ -75,9 +75,9 @@ BVertexFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
  int count = 0; 
  edm::Handle<reco::VertexCollection> pvHandle; 
- iEvent.getByLabel(primaryVertexCollection,pvHandle);
+ iEvent.getByToken(token_primaryVertex, pvHandle);
  edm::Handle<reco::VertexCollection> svHandle; 
- iEvent.getByLabel(secondaryVertexCollection,svHandle);
+ iEvent.getByToken(token_secondaryVertex, svHandle);
  const reco::Vertex & primary = (*pvHandle.product())[0];
  const reco::VertexCollection & vertices = *svHandle.product();
  std::auto_ptr<reco::VertexCollection> recoVertices(new reco::VertexCollection);

--- a/RecoBTag/SoftLepton/plugins/SoftPFElectronTagInfoProducer.cc
+++ b/RecoBTag/SoftLepton/plugins/SoftPFElectronTagInfoProducer.cc
@@ -25,10 +25,13 @@
 #include <cmath>
 #include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
 
-SoftPFElectronTagInfoProducer::SoftPFElectronTagInfoProducer (const edm::ParameterSet& conf):
- PVerTag_(conf.getParameter<edm::InputTag>("primaryVertex") ),
- PFJet_  (conf.getParameter<edm::InputTag>("jets")  )
+SoftPFElectronTagInfoProducer::SoftPFElectronTagInfoProducer (const edm::ParameterSet& conf)
 {
+	token_jets          = consumes<edm::View<reco::Jet> >(conf.getParameter<edm::InputTag>("jets"));
+	token_primaryVertex = consumes<reco::VertexCollection>(conf.getParameter<edm::InputTag>("primaryVertex"));
+	token_BeamSpot      = consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"));
+	token_allConversions= consumes<reco::ConversionCollection>(edm::InputTag("allConversions"));
+
         produces<reco::SoftLeptonTagInfoCollection>();
 }
 
@@ -46,7 +49,7 @@ void SoftPFElectronTagInfoProducer::produce(edm::Event& iEvent, const edm::Event
  	transientTrackBuilder=builder.product();
  
  	edm::Handle<reco::VertexCollection> PVCollection;
- 	iEvent.getByLabel(PVerTag_, PVCollection);
+	iEvent.getByToken(token_primaryVertex, PVCollection);
 // 	if(!PVCollection.isValid() || PVCollection->empty()) return;
  	if(!PVCollection.isValid()) return;
  	if(!PVCollection->empty()){
@@ -55,16 +58,16 @@ void SoftPFElectronTagInfoProducer::produce(edm::Event& iEvent, const edm::Event
 	}else goodvertex = false; 
 	
   edm::Handle<reco::BeamSpot> bsHandle;
-  iEvent.getByLabel("offlineBeamSpot", bsHandle);
+  iEvent.getByToken(token_BeamSpot, bsHandle);
   const reco::BeamSpot &beamspot = *bsHandle.product();
 
   edm::Handle<reco::ConversionCollection> hConversions;
-  iEvent.getByLabel("allConversions", hConversions);
+  iEvent.getByToken(token_allConversions, hConversions);
  
  	std::vector<edm::RefToBase<reco::Jet> > jets;
  
  	edm::Handle<edm::View<reco::Jet> > inputJets;
- 	iEvent.getByLabel(PFJet_, inputJets);
+ 	iEvent.getByToken(token_jets, inputJets);
  	unsigned int size = inputJets->size();
  	jets.resize(size);
  	for (unsigned int i = 0; i < size; i++){

--- a/RecoBTag/SoftLepton/plugins/SoftPFElectronTagInfoProducer.h
+++ b/RecoBTag/SoftLepton/plugins/SoftPFElectronTagInfoProducer.h
@@ -42,7 +42,11 @@ class SoftPFElectronTagInfoProducer : public edm::EDProducer
     
     // service used to make transient tracks from tracks
     const TransientTrackBuilder* transientTrackBuilder;
-    edm::InputTag PVerTag_,PFJet_;
+    edm::EDGetTokenT<reco::VertexCollection> token_primaryVertex;
+    edm::EDGetTokenT<edm::View<reco::Jet> > token_jets;
+    edm::EDGetTokenT<reco::BeamSpot> token_BeamSpot;
+    edm::EDGetTokenT<reco::ConversionCollection> token_allConversions;
+
     bool goodvertex;
 
     const reco::Vertex* vertex;

--- a/RecoBTag/SoftLepton/plugins/SoftPFMuonTagInfoProducer.cc
+++ b/RecoBTag/SoftLepton/plugins/SoftPFMuonTagInfoProducer.cc
@@ -27,10 +27,10 @@
 #include <cmath>
 
 SoftPFMuonTagInfoProducer::SoftPFMuonTagInfoProducer (const edm::ParameterSet& conf):
- PVerTag_(conf.getParameter<edm::InputTag>("primaryVertex") ),
- PFJet_  (conf.getParameter<edm::InputTag>("jets")  ),
  MuonId_ (conf.getParameter<int>          ("MuonId") )
 {
+	token_jets          = consumes<edm::View<reco::Jet> >(conf.getParameter<edm::InputTag>("jets"));
+	token_primaryVertex = consumes<reco::VertexCollection>(conf.getParameter<edm::InputTag>("primaryVertex"));
 	muonId=MuonId_;
 	produces<reco::SoftLeptonTagInfoCollection>();
 }
@@ -49,7 +49,7 @@ void SoftPFMuonTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSetu
  	transientTrackBuilder=builder.product();
  
  	edm::Handle<reco::VertexCollection> PVCollection;
- 	iEvent.getByLabel(PVerTag_, PVCollection);
+	iEvent.getByToken(token_primaryVertex, PVCollection);
 // 	if(!PVCollection.isValid() || PVCollection->empty()) return;
  	if(!PVCollection.isValid()) return;
  	if(!PVCollection->empty()){
@@ -60,7 +60,7 @@ void SoftPFMuonTagInfoProducer::produce(edm::Event& iEvent, const edm::EventSetu
  	std::vector<edm::RefToBase<reco::Jet> > jets;
  
  	edm::Handle<edm::View<reco::Jet> > inputJets;
- 	iEvent.getByLabel(PFJet_, inputJets);
+ 	iEvent.getByToken(token_jets, inputJets);
  	unsigned int size = inputJets->size();
  	jets.resize(size);
  	for (unsigned int i = 0; i < size; i++){

--- a/RecoBTag/SoftLepton/plugins/SoftPFMuonTagInfoProducer.h
+++ b/RecoBTag/SoftLepton/plugins/SoftPFMuonTagInfoProducer.h
@@ -51,7 +51,8 @@ class SoftPFMuonTagInfoProducer : public edm::EDProducer
 	
     // service used to make transient tracks from tracks
     const TransientTrackBuilder* transientTrackBuilder;
-    edm::InputTag PVerTag_,PFJet_;
+    edm::EDGetTokenT<reco::VertexCollection> token_primaryVertex;
+    edm::EDGetTokenT<edm::View<reco::Jet> > token_jets;
     bool goodvertex;
     int MuonId_,muonId;
 

--- a/RecoBTau/JetTagComputer/plugins/JetTagProducer.h
+++ b/RecoBTau/JetTagComputer/plugins/JetTagProducer.h
@@ -12,6 +12,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/BTauReco/interface/BaseTagInfo.h"
 
 class JetTagProducer : public edm::EDProducer {
     public:
@@ -25,7 +27,8 @@ class JetTagProducer : public edm::EDProducer {
 
 	const JetTagComputer			*m_computer;
 	std::string				m_jetTagComputer;
-	std::vector<edm::InputTag>		m_tagInfos;
+	std::vector<edm::EDGetTokenT<edm::View<reco::BaseTagInfo> > > token_tagInfos;
+	unsigned int nTagInfos;
 };
 
 #endif // RecoBTag_JetTagComputer_JetTagProducer_h

--- a/RecoVertex/AdaptiveVertexFinder/plugins/DoubleVertexFilter.cc
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/DoubleVertexFilter.cc
@@ -22,16 +22,16 @@ class DoubleVertexFilter : public edm::EDProducer {
     private:
 	bool trackFilter(const reco::TrackRef &track) const;
 
-	edm::InputTag				primaryVertexCollection;
-	edm::InputTag				secondaryVertexCollection;
+	edm::EDGetTokenT<reco::VertexCollection> token_primaryVertex;
+	edm::EDGetTokenT<reco::VertexCollection> token_secondaryVertex;
 	double					maxFraction;
 };
 
 DoubleVertexFilter::DoubleVertexFilter(const edm::ParameterSet &params) :
-	primaryVertexCollection(params.getParameter<edm::InputTag>("primaryVertices")),
-	secondaryVertexCollection(params.getParameter<edm::InputTag>("secondaryVertices")),
 	maxFraction(params.getParameter<double>("maxFraction"))
 {
+	token_primaryVertex = consumes<reco::VertexCollection>(params.getParameter<edm::InputTag>("primaryVertices"));
+	token_secondaryVertex = consumes<reco::VertexCollection>(params.getParameter<edm::InputTag>("secondaryVertices"));
 	produces<reco::VertexCollection>();
 }
 
@@ -62,10 +62,10 @@ void DoubleVertexFilter::produce(edm::Event &event, const edm::EventSetup &es)
 	using namespace reco;
 
 	edm::Handle<VertexCollection> primaryVertices;
-	event.getByLabel(primaryVertexCollection, primaryVertices);
+	event.getByToken(token_primaryVertex, primaryVertices);
 
 	edm::Handle<VertexCollection> secondaryVertices;
-	event.getByLabel(secondaryVertexCollection, secondaryVertices);
+	event.getByToken(token_secondaryVertex, secondaryVertices);
 
 	std::vector<reco::Vertex>::const_iterator pv = primaryVertices->begin();
 

--- a/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.cc
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/InclusiveVertexFinder.cc
@@ -40,9 +40,9 @@ class InclusiveVertexFinder : public edm::EDProducer {
 	bool trackFilter(const reco::TrackRef &track) const;
         std::pair<std::vector<reco::TransientTrack>,GlobalPoint> nearTracks(const reco::TransientTrack &seed, const std::vector<reco::TransientTrack> & tracks, const reco::Vertex & primaryVertex) const;
 
-	edm::InputTag				beamSpotCollection;
-	edm::InputTag				primaryVertexCollection;
-	edm::InputTag				trackCollection;
+	edm::EDGetTokenT<reco::BeamSpot> 	token_beamSpot; 
+	edm::EDGetTokenT<reco::VertexCollection> token_primaryVertex;
+	edm::EDGetTokenT<reco::TrackCollection>	token_tracks; 
 	unsigned int				minHits;
 	unsigned int				maxNTracks;
 	double					maxLIP;
@@ -57,9 +57,6 @@ class InclusiveVertexFinder : public edm::EDProducer {
 };
 
 InclusiveVertexFinder::InclusiveVertexFinder(const edm::ParameterSet &params) :
-	beamSpotCollection(params.getParameter<edm::InputTag>("beamSpot")),
-	primaryVertexCollection(params.getParameter<edm::InputTag>("primaryVertices")),
-	trackCollection(params.getParameter<edm::InputTag>("tracks")),
 	minHits(params.getParameter<unsigned int>("minHits")),
 	maxNTracks(params.getParameter<unsigned int>("maxNTracks")),
        	maxLIP(params.getParameter<double>("maximumLongitudinalImpactParameter")),
@@ -71,6 +68,9 @@ InclusiveVertexFinder::InclusiveVertexFinder(const edm::ParameterSet &params) :
         clusterizer(new TracksClusteringFromDisplacedSeed(params.getParameter<edm::ParameterSet>("clusterizer")))
 
 {
+	token_beamSpot = consumes<reco::BeamSpot>(params.getParameter<edm::InputTag>("beamSpot"));
+	token_primaryVertex = consumes<reco::VertexCollection>(params.getParameter<edm::InputTag>("primaryVertices"));
+	token_tracks = consumes<reco::TrackCollection>(params.getParameter<edm::InputTag>("tracks"));
 	produces<reco::VertexCollection>();
 	//produces<reco::VertexCollection>("multi");
 }
@@ -105,13 +105,13 @@ void InclusiveVertexFinder::produce(edm::Event &event, const edm::EventSetup &es
 
 
 	edm::Handle<BeamSpot> beamSpot;
-	event.getByLabel(beamSpotCollection, beamSpot);
+	event.getByToken(token_beamSpot,beamSpot);
 
 	edm::Handle<VertexCollection> primaryVertices;
-	event.getByLabel(primaryVertexCollection, primaryVertices);
+	event.getByToken(token_primaryVertex, primaryVertices);
 
 	edm::Handle<TrackCollection> tracks;
-	event.getByLabel(trackCollection, tracks);
+	event.getByToken(token_tracks, tracks);
 
 	edm::ESHandle<TransientTrackBuilder> trackBuilder;
 	es.get<TransientTrackRecord>().get("TransientTrackBuilder",

--- a/RecoVertex/AdaptiveVertexFinder/plugins/VertexMerger.cc
+++ b/RecoVertex/AdaptiveVertexFinder/plugins/VertexMerger.cc
@@ -23,18 +23,16 @@ class VertexMerger : public edm::EDProducer {
     private:
 	bool trackFilter(const reco::TrackRef &track) const;
 
-//	edm::InputTag				primaryVertexCollection;
-	edm::InputTag				secondaryVertexCollection;
+	edm::EDGetTokenT<reco::VertexCollection> token_secondaryVertex;
 	double					maxFraction;
 	double					minSignificance;
 };
 
 VertexMerger::VertexMerger(const edm::ParameterSet &params) :
-//	primaryVertexCollection(params.getParameter<edm::InputTag>("primaryVertices")),
-	secondaryVertexCollection(params.getParameter<edm::InputTag>("secondaryVertices")),
 	maxFraction(params.getParameter<double>("maxFraction")),
 	minSignificance(params.getParameter<double>("minSignificance"))
 {
+	token_secondaryVertex = consumes<reco::VertexCollection>(params.getParameter<edm::InputTag>("secondaryVertices"));
 	produces<reco::VertexCollection>();
 }
 
@@ -65,7 +63,7 @@ void VertexMerger::produce(edm::Event &event, const edm::EventSetup &es)
 	using namespace reco;
 
 	edm::Handle<VertexCollection> secondaryVertices;
-	event.getByLabel(secondaryVertexCollection, secondaryVertices);
+	event.getByToken(token_secondaryVertex, secondaryVertices);
 
         VertexDistance3D dist;
 	std::auto_ptr<VertexCollection> recoVertices(new VertexCollection);

--- a/RecoVertex/GaussianSumVertexFit/test/GsfTest.cc
+++ b/RecoVertex/GaussianSumVertexFit/test/GsfTest.cc
@@ -26,12 +26,14 @@ using namespace std;
 GsfTest::GsfTest(const edm::ParameterSet& iConfig)
   : theConfig(iConfig), associatorForParamAtPca(0), tree(0)
 {
-  trackLabel_ = iConfig.getParameter<std::string>("TrackLabel");
+  token_tracks = consumes<TrackCollection>(iConfig.getParameter<string>("TrackLabel"));
   outputFile_ = iConfig.getUntrackedParameter<std::string>("outputFile");
   gsfPSet = iConfig.getParameter<edm::ParameterSet>("GsfParameters");
   rootFile_ = TFile::Open(outputFile_.c_str(),"RECREATE"); 
   edm::LogInfo("RecoVertex/GsfTest") 
     << "Initializing KVF TEST analyser  - Output file: " << outputFile_ <<"\n";
+//   token_TrackTruth = consumes<TrackingParticleCollection>(edm::InputTag("trackingtruth", "TrackTruth"));
+  token_VertexTruth = consumes<TrackingVertexCollection>(edm::InputTag("trackingtruth", "VertexTruth"));
 }
 
 
@@ -71,7 +73,7 @@ GsfTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     // get RECO tracks from the event
     // `tks` can be used as a ptr to a reco::TrackCollection
     edm::Handle<edm::View<reco::Track> > tks;
-    iEvent.getByLabel(trackLabel_, tks);
+    iEvent.getByToken(token_tracks, tks);
 
     edm::LogInfo("RecoVertex/GsfTest") 
       << "Found: " << (*tks).size() << " reconstructed tracks" << "\n";
@@ -106,7 +108,7 @@ GsfTest::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 
 
 //   edm::Handle<TrackingParticleCollection>  TPCollectionH ;
-//   iEvent.getByLabel("trackingtruth","TrackTruth",TPCollectionH);
+//   iEvent.getByToken(token_TrackTruth, TPCollectionH);
 //   const TrackingParticleCollection tPC = *(TPCollectionH.product());
 //       reco::RecoToSimCollection recSimColl=associatorForParamAtPca->associateRecoToSim(tks,
 // 									      TPCollectionH,
@@ -132,7 +134,7 @@ TrackingVertex GsfTest::getSimVertex(const edm::Event& iEvent) const
 {
    // get the simulated vertices
   edm::Handle<TrackingVertexCollection>  TVCollectionH ;
-  iEvent.getByLabel("trackingtruth","VertexTruth",TVCollectionH);
+  iEvent.getByToken(token_VertexTruth,TVCollectionH);
   const TrackingVertexCollection tPC = *(TVCollectionH.product());
 
 //    Handle<edm::SimVertexContainer> simVtcs;

--- a/RecoVertex/GaussianSumVertexFit/test/GsfTest.h
+++ b/RecoVertex/GaussianSumVertexFit/test/GsfTest.h
@@ -10,12 +10,6 @@
  Implementation:
      <Notes on implementation>
 */
-//
-// Original Author:  Pascal Vanlaer
-//         Created:  Tue Feb 28 11:06:34 CET 2006
-// $Id: GsfTest.h,v 1.2 2007/12/20 09:52:08 speer Exp $
-//
-//
 
 
 // system include files
@@ -60,5 +54,7 @@ private:
   TFile*  rootFile_;
 
   std::string outputFile_; // output file
-  std::string trackLabel_; // label of track producer
+  edm::EDGetTokenT<reco::TrackCollection> token_tracks; 
+//   edm::EDGetTokenT<TrackingParticleCollection> token_TrackTruth;
+  edm::EDGetTokenT<TrackingVertexCollection> token_VertexTruth;
 };

--- a/RecoVertex/GaussianSumVertexFit/test/TrackMix.cc
+++ b/RecoVertex/GaussianSumVertexFit/test/TrackMix.cc
@@ -3,7 +3,6 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -26,8 +25,8 @@ using namespace std;
 TrackMix::TrackMix(const edm::ParameterSet& iConfig)
   : theConfig(iConfig)
 {
-  gsfTrackLabel_ = iConfig.getParameter<std::string>("gsfTrackLabel");
-  ckfTrackLabel_ = iConfig.getParameter<std::string>("ckfTrackLabel");
+  token_gsf = consumes<edm::View<reco::Track> >(iConfig.getParameter<string>("gsfTrackLabel"));
+  token_ckf = consumes<edm::View<reco::Track> >(iConfig.getParameter<string>("ckfTrackLabel"));
 }
 
 
@@ -53,9 +52,9 @@ TrackMix::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     // get RECO tracks from the event
     // `tks` can be used as a ptr to a reco::TrackCollection
     edm::Handle<edm::View<reco::Track> > tks;
-    iEvent.getByLabel(gsfTrackLabel_, tks);
+    iEvent.getByToken(token_gsf, tks);
     edm::Handle<edm::View<reco::Track> > tks2;
-    iEvent.getByLabel(ckfTrackLabel_, tks2);
+    iEvent.getByToken(token_ckf, tks2);
 
     cout << "got " << (*tks).size() << " gsf tracks " << endl;
     cout << "got " << (*tks2).size()<< " ckf tracks " << endl;

--- a/RecoVertex/GaussianSumVertexFit/test/TrackMix.h
+++ b/RecoVertex/GaussianSumVertexFit/test/TrackMix.h
@@ -15,6 +15,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include <TFile.h>
 
   /**
@@ -34,5 +35,5 @@ public:
 private:
 
   edm::ParameterSet theConfig;
-  std::string gsfTrackLabel_, ckfTrackLabel_ ; // label of track producers
+  edm::EDGetTokenT<edm::View<reco::Track> > token_gsf, token_ckf;
 };

--- a/RecoVertex/KalmanVertexFit/plugins/KVFTest.h
+++ b/RecoVertex/KalmanVertexFit/plugins/KVFTest.h
@@ -10,12 +10,6 @@
  Implementation:
      <Notes on implementation>
 */
-//
-// Original Author:  Pascal Vanlaer
-//         Created:  Tue Feb 28 11:06:34 CET 2006
-// $Id: KVFTest.h,v 1.2 2007/12/20 10:33:10 speer Exp $
-//
-//
 
 
 // system include files
@@ -33,6 +27,7 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
 #include "RecoVertex/KalmanVertexFit/interface/SimpleVertexTree.h"
 #include "SimTracker/TrackAssociation/interface/TrackAssociatorByChi2.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include <TFile.h>
 
   /**
@@ -60,5 +55,8 @@ private:
   TFile*  rootFile_;
 
   std::string outputFile_; // output file
-  std::string trackLabel_; // label of track producer
+  edm::EDGetTokenT<reco::TrackCollection> token_tracks; 
+  edm::EDGetTokenT<TrackingParticleCollection> token_TrackTruth;
+  edm::EDGetTokenT<TrackingVertexCollection> token_VertexTruth;
+
 };

--- a/RecoVertex/KalmanVertexFit/plugins/KVFTrackUpdate.cc
+++ b/RecoVertex/KalmanVertexFit/plugins/KVFTrackUpdate.cc
@@ -3,7 +3,6 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -16,6 +15,7 @@
 #include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
 #include "SimTracker/Records/interface/TrackAssociatorRecord.h"
 #include "RecoVertex/KalmanVertexFit/interface/SingleTrackVertexConstraint.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 
 #include <iostream>
 
@@ -25,8 +25,8 @@ using namespace std;
 
 KVFTrackUpdate::KVFTrackUpdate(const edm::ParameterSet& iConfig)
 {
-  trackLabel_ = iConfig.getParameter<edm::InputTag>("TrackLabel");
-  beamSpotLabel = iConfig.getParameter<edm::InputTag>("beamSpotLabel");
+  token_tracks = consumes<TrackCollection>(iConfig.getParameter<InputTag>("TrackLabel"));
+  token_beamSpot = consumes<BeamSpot>(iConfig.getParameter<InputTag>("beamSpotLabel"));
 }
 
 
@@ -57,7 +57,7 @@ KVFTrackUpdate::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     // get RECO tracks from the event
     // `tks` can be used as a ptr to a reco::TrackCollection
     edm::Handle<reco::TrackCollection> tks;
-    iEvent.getByLabel(trackLabel_, tks);
+    iEvent.getByToken(token_tracks, tks);
 
     edm::LogInfo("RecoVertex/KVFTrackUpdate") 
       << "Found: " << (*tks).size() << " reconstructed tracks" << "\n";
@@ -84,7 +84,7 @@ KVFTrackUpdate::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 
     reco::BeamSpot vertexBeamSpot;
     edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-    iEvent.getByLabel(beamSpotLabel,recoBeamSpotHandle);
+    iEvent.getByToken(token_beamSpot,recoBeamSpotHandle);
 
 
     SingleTrackVertexConstraint stvc;

--- a/RecoVertex/KalmanVertexFit/plugins/KVFTrackUpdate.h
+++ b/RecoVertex/KalmanVertexFit/plugins/KVFTrackUpdate.h
@@ -9,7 +9,8 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
   /**
    * This is a very simple test analyzer to test the update of a track with
@@ -28,6 +29,7 @@ public:
 
 private:
 
-  edm::InputTag trackLabel_, beamSpotLabel;
+  edm::EDGetTokenT<reco::TrackCollection>	 token_tracks; 
+  edm::EDGetTokenT<reco::BeamSpot> 	 token_beamSpot; 
 
 };

--- a/RecoVertex/KinematicFit/plugins/KineExample.cc
+++ b/RecoVertex/KinematicFit/plugins/KineExample.cc
@@ -35,12 +35,14 @@ using namespace std;
 KineExample::KineExample(const edm::ParameterSet& iConfig)
   : theConfig(iConfig)
 {
-  trackLabel_ = iConfig.getParameter<std::string>("TrackLabel");
+  token_tracks = consumes<TrackCollection>(iConfig.getParameter<string>("TrackLabel"));
   outputFile_ = iConfig.getUntrackedParameter<std::string>("outputFile");
   kvfPSet = iConfig.getParameter<edm::ParameterSet>("KVFParameters");
 //   rootFile_ = TFile::Open(outputFile_.c_str(),"RECREATE");
   edm::LogInfo("RecoVertex/KineExample")
     << "Initializing KVF TEST analyser  - Output file: " << outputFile_ <<"\n";
+//   token_TrackTruth = consumes<TrackingParticleCollection>(edm::InputTag("trackingtruth", "TrackTruth"));
+  token_VertexTruth = consumes<TrackingVertexCollection>(edm::InputTag("trackingtruth", "VertexTruth"));
 }
 
 
@@ -75,7 +77,7 @@ KineExample::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   // get RECO tracks from the event
   // `tks` can be used as a ptr to a reco::TrackCollection
   edm::Handle<reco::TrackCollection> tks;
-  iEvent.getByLabel(trackLabel_, tks);
+  iEvent.getByToken(token_tracks, tks);
   if (!tks.isValid()) {
     cout
       << "Couln't find track collection: " << iEvent.id()
@@ -208,7 +210,7 @@ KineExample::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 //       // For the analysis: compare to your SimVertex
 //       TrackingVertex sv = getSimVertex(iEvent);
 //   edm::Handle<TrackingParticleCollection>  TPCollectionH ;
-//   iEvent.getByLabel("trackingtruth","TrackTruth",TPCollectionH);
+//   iEvent.getByToken(token_TrackTruth, TPCollectionH);
 //   const TrackingParticleCollection tPC = *(TPCollectionH.product());
 //       reco::RecoToSimCollection recSimColl=associatorForParamAtPca->associateRecoToSim(tks,
 // 									      TPCollectionH,
@@ -288,7 +290,7 @@ TrackingVertex KineExample::getSimVertex(const edm::Event& iEvent) const
 {
    // get the simulated vertices
   edm::Handle<TrackingVertexCollection>  TVCollectionH ;
-  iEvent.getByLabel("trackingtruth","VertexTruth",TVCollectionH);
+  iEvent.getByToken(token_VertexTruth,TVCollectionH);
   const TrackingVertexCollection tPC = *(TVCollectionH.product());
 
 //    Handle<edm::SimVertexContainer> simVtcs;

--- a/RecoVertex/KinematicFit/plugins/KineExample.h
+++ b/RecoVertex/KinematicFit/plugins/KineExample.h
@@ -10,12 +10,6 @@
  Implementation:
      <Notes on implementation>
 */
-//
-// Original Author:  Pascal Vanlaer
-//         Created:  Tue Feb 28 11:06:34 CET 2006
-// $Id: KineExample.h,v 1.3 2012/10/23 02:20:37 slava77 Exp $
-//
-//
 
 
 // system include files
@@ -68,5 +62,7 @@ private:
 //   TFile*  rootFile_;
 
   std::string outputFile_; // output file
-  std::string trackLabel_; // label of track producer
+  edm::EDGetTokenT<reco::TrackCollection> token_tracks; 
+//   edm::EDGetTokenT<TrackingParticleCollection> token_TrackTruth;
+  edm::EDGetTokenT<TrackingVertexCollection> token_VertexTruth;
 };

--- a/RecoVertex/NuclearInteractionProducer/interface/NuclearInteractionEDProducer.h
+++ b/RecoVertex/NuclearInteractionProducer/interface/NuclearInteractionEDProducer.h
@@ -40,6 +40,7 @@
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "RecoTracker/NuclearSeedGenerator/interface/TrajectoryToSeedMap.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 
 #include "DataFormats/VertexReco/interface/NuclearInteraction.h"
 
@@ -65,10 +66,12 @@ public:
 
       // ----------member data ---------------------------
       edm::ParameterSet conf_;
-      std::string primaryProducer_;
-      std::string seedsProducer_;
-      std::string secondaryProducer_;
-      std::string additionalSecondaryProducer_;
+      edm::EDGetTokenT<reco::TrackCollection>	 token_primaryTrack; 
+      edm::EDGetTokenT<reco::TrackCollection>	 token_secondaryTrack; 
+      edm::EDGetTokenT<reco::TrackCollection>	 token_additionalSecTracks; 
+      edm::EDGetTokenT<TrajectoryCollection> token_primaryTrajectory; 
+      edm::EDGetTokenT<TrajTrackAssociationCollection> token_refMapH; 
+      edm::EDGetTokenT<TrajectoryToSeedsMap> token_nuclMapH; 
 
       std::auto_ptr< NuclearVertexBuilder >  vertexBuilder;
       std::auto_ptr< NuclearLikelihood >     likelihoodCalculator;

--- a/RecoVertex/V0Producer/interface/V0Fitter.h
+++ b/RecoVertex/V0Producer/interface/V0Fitter.h
@@ -47,8 +47,10 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/GluedGeomDet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
 #include <string>
 #include <fstream>
@@ -57,7 +59,8 @@
 class V0Fitter {
  public:
   V0Fitter(const edm::ParameterSet& theParams,
-	   const edm::Event& iEvent, const edm::EventSetup& iSetup);
+	   const edm::Event& iEvent, const edm::EventSetup& iSetup,
+	   edm::ConsumesCollector && iC);
   ~V0Fitter();
 
   // Switching to L. Lista's reco::Candidate infrastructure for V0 storage
@@ -74,7 +77,6 @@ class V0Fitter {
 
   const MagneticField* magField;
 
-  edm::InputTag recoAlg;
   bool useRefTrax;
   bool storeRefTrax;
   bool doKshorts;
@@ -100,6 +102,8 @@ class V0Fitter {
 
   std::vector<reco::TrackBase::TrackQuality> qualities;
 
+  edm::EDGetTokenT<reco::TrackCollection>	 token_tracks; 
+  edm::EDGetTokenT<reco::BeamSpot> 	 token_beamSpot; 
   edm::InputTag vtxFitter;
 
   // Helper method that does the actual fitting using the KalmanVertexFitter

--- a/RecoVertex/V0Producer/interface/V0Fitter.h
+++ b/RecoVertex/V0Producer/interface/V0Fitter.h
@@ -59,13 +59,13 @@
 class V0Fitter {
  public:
   V0Fitter(const edm::ParameterSet& theParams,
-	   const edm::Event& iEvent, const edm::EventSetup& iSetup,
 	   edm::ConsumesCollector && iC);
   ~V0Fitter();
 
   // Switching to L. Lista's reco::Candidate infrastructure for V0 storage
   const reco::VertexCompositeCandidateCollection& getKshorts() const;
   const reco::VertexCompositeCandidateCollection& getLambdas() const;
+  void fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup);
 
  private:
   // STL vector of VertexCompositeCandidate that will be filled with VertexCompositeCandidates by fitAll()
@@ -107,7 +107,6 @@ class V0Fitter {
   edm::InputTag vtxFitter;
 
   // Helper method that does the actual fitting using the KalmanVertexFitter
-  void fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup);
   double findV0MassError(const GlobalPoint &vtxPos, const std::vector<reco::TransientTrack> &dauTracks);
 
   // Applies cuts to the VertexCompositeCandidates after they are fitted/created.

--- a/RecoVertex/V0Producer/interface/V0Producer.h
+++ b/RecoVertex/V0Producer/interface/V0Producer.h
@@ -52,7 +52,7 @@ private:
   virtual void endJob() ;
 
   edm::ParameterSet theParams;
-      
+  V0Fitter * theVees;      
 };
 
 #endif

--- a/RecoVertex/V0Producer/src/V0Fitter.cc
+++ b/RecoVertex/V0Producer/src/V0Fitter.cc
@@ -45,7 +45,6 @@ const double lambdaMass = 1.115683;
 
 // Constructor and (empty) destructor
 V0Fitter::V0Fitter(const edm::ParameterSet& theParameters,
-		   const edm::Event& iEvent, const edm::EventSetup& iSetup,
 		   edm::ConsumesCollector && iC) {
   using std::string;
 
@@ -91,7 +90,6 @@ V0Fitter::V0Fitter(const edm::ParameterSet& theParameters,
 
   //std::cout << "Entering V0Producer" << std::endl;
 
-  fitAll(iEvent, iSetup);
 
   // FOR DEBUG:
   //cleanupFileOutput();
@@ -110,6 +108,9 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using std::endl;
   using namespace reco;
   using namespace edm;
+
+  theKshorts.clear();
+  theLambdas.clear();
 
   // Create std::vectors for Tracks and TrackRefs (required for
   //  passing to the KalmanVertexFitter)

--- a/RecoVertex/V0Producer/src/V0Fitter.cc
+++ b/RecoVertex/V0Producer/src/V0Fitter.cc
@@ -28,8 +28,6 @@
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
 
-#include "DataFormats/BeamSpot/interface/BeamSpot.h"
-
 #include <Math/Functions.h>
 #include <Math/SVector.h>
 #include <Math/SMatrix.h>
@@ -47,11 +45,13 @@ const double lambdaMass = 1.115683;
 
 // Constructor and (empty) destructor
 V0Fitter::V0Fitter(const edm::ParameterSet& theParameters,
-		   const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+		   const edm::Event& iEvent, const edm::EventSetup& iSetup,
+		   edm::ConsumesCollector && iC) {
   using std::string;
 
   // Get the track reco algorithm from the ParameterSet
-  recoAlg = theParameters.getParameter<edm::InputTag>("trackRecoAlgorithm");
+  token_beamSpot = iC.consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"));
+  token_tracks = iC.consumes<reco::TrackCollection>(theParameters.getParameter<edm::InputTag>("trackRecoAlgorithm"));
 
   // ------> Initialize parameters from PSet. ALL TRACKED, so no defaults.
   // First set bits to do various things:
@@ -126,8 +126,8 @@ void V0Fitter::fitAll(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
   // Get the tracks from the event, and get the B-field record
   //  from the EventSetup
-  iEvent.getByLabel(recoAlg, theTrackHandle);
-  iEvent.getByLabel(std::string("offlineBeamSpot"), theBeamSpotHandle);
+  iEvent.getByToken(token_tracks, theTrackHandle);
+  iEvent.getByToken(token_beamSpot,theBeamSpotHandle);
   if( !theTrackHandle->size() ) return;
   iSetup.get<IdealMagneticFieldRecord>().get(bFieldHandle);
   iSetup.get<TrackerDigiGeometryRecord>().get(trackerGeomHandle);

--- a/RecoVertex/V0Producer/src/V0Producer.cc
+++ b/RecoVertex/V0Producer/src/V0Producer.cc
@@ -55,7 +55,7 @@ void V0Producer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
    // Create V0Fitter object which reconstructs the vertices and creates
    //  (and contains) collections of Kshorts, Lambda0s
-   V0Fitter theVees(theParams, iEvent, iSetup);
+   V0Fitter theVees(theParams, iEvent, iSetup, consumesCollector());
 
    // Create auto_ptr for each collection to be stored in the Event
    std::auto_ptr< reco::VertexCompositeCandidateCollection > 

--- a/RecoVertex/V0Producer/src/V0Producer.cc
+++ b/RecoVertex/V0Producer/src/V0Producer.cc
@@ -25,7 +25,9 @@
 
 // Constructor
 V0Producer::V0Producer(const edm::ParameterSet& iConfig) :
-  theParams(iConfig) {
+  theParams(iConfig) 
+{
+  theVees = new V0Fitter(theParams, consumesCollector());
 
    // Registering V0 Collections
   //produces<reco::VertexCollection>("Kshort");
@@ -55,22 +57,22 @@ void V0Producer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
    // Create V0Fitter object which reconstructs the vertices and creates
    //  (and contains) collections of Kshorts, Lambda0s
-   V0Fitter theVees(theParams, iEvent, iSetup, consumesCollector());
+   theVees->fitAll(iEvent, iSetup);
 
    // Create auto_ptr for each collection to be stored in the Event
    std::auto_ptr< reco::VertexCompositeCandidateCollection > 
      kShortCandidates( new reco::VertexCompositeCandidateCollection );
-   kShortCandidates->reserve( theVees.getKshorts().size() ); 
+   kShortCandidates->reserve( theVees->getKshorts().size() ); 
 
    std::auto_ptr< reco::VertexCompositeCandidateCollection >
      lambdaCandidates( new reco::VertexCompositeCandidateCollection );
-   lambdaCandidates->reserve( theVees.getLambdas().size() );
+   lambdaCandidates->reserve( theVees->getLambdas().size() );
 
-   std::copy( theVees.getKshorts().begin(),
-	      theVees.getKshorts().end(),
+   std::copy( theVees->getKshorts().begin(),
+	      theVees->getKshorts().end(),
 	      std::back_inserter(*kShortCandidates) );
-   std::copy( theVees.getLambdas().begin(),
-	      theVees.getLambdas().end(),
+   std::copy( theVees->getLambdas().begin(),
+	      theVees->getLambdas().end(),
 	      std::back_inserter(*lambdaCandidates) );
 
    // Write the collections to the Event


### PR DESCRIPTION
Changes to b-tagging and vertex reco to implement the consumes interface. No further change, all results are identical.
