### PR TITLE
Make getObj in the *Generator classes thread safe

### DIFF
--- a/CalibTracker/SiStripESProducers/interface/SiStripApvGainGenerator.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripApvGainGenerator.h
@@ -19,11 +19,11 @@ class SiStripApvGainGenerator : public SiStripCondObjBuilderBase<SiStripApvGain>
   explicit SiStripApvGainGenerator(const edm::ParameterSet&,const edm::ActivityRegistry&);
   ~SiStripApvGainGenerator();
   
-  void getObj(SiStripApvGain* & obj){createObject(); obj=obj_;}
+  void getObj(SiStripApvGain* & obj){obj=createObject();}
 
  private:
   
-  void createObject();
+  SiStripApvGain* createObject();
 
   
 };

--- a/CalibTracker/SiStripESProducers/interface/SiStripBackPlaneCorrectionGenerator.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripBackPlaneCorrectionGenerator.h
@@ -19,11 +19,11 @@ class SiStripBackPlaneCorrectionGenerator : public SiStripCondObjBuilderBase<SiS
   explicit SiStripBackPlaneCorrectionGenerator(const edm::ParameterSet&,const edm::ActivityRegistry&);
   ~SiStripBackPlaneCorrectionGenerator();
   
-  void getObj(SiStripBackPlaneCorrection* & obj){createObject(); obj=obj_;}
+  void getObj(SiStripBackPlaneCorrection* & obj){obj=createObject();}
 
  private:
 
-  void createObject();
+  SiStripBackPlaneCorrection*  createObject();
 };
 
 #endif 

--- a/CalibTracker/SiStripESProducers/interface/SiStripBadModuleGenerator.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripBadModuleGenerator.h
@@ -13,11 +13,11 @@ class SiStripBadModuleGenerator : public SiStripCondObjBuilderBase<SiStripBadStr
   explicit SiStripBadModuleGenerator(const edm::ParameterSet&,const edm::ActivityRegistry&);
   ~SiStripBadModuleGenerator();
   
-  void getObj(SiStripBadStrip* & obj){createObject(); obj=obj_;}
+  void getObj(SiStripBadStrip* & obj){obj=createObject();}
 
  private:
   
-  void createObject();
+  SiStripBadStrip* createObject();
 
   void selectDetectors(const std::vector<uint32_t>& , std::vector<uint32_t>& );
 

--- a/CalibTracker/SiStripESProducers/interface/SiStripBaseDelayGenerator.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripBaseDelayGenerator.h
@@ -17,11 +17,11 @@ class SiStripBaseDelayGenerator : public SiStripCondObjBuilderBase<SiStripBaseDe
   explicit SiStripBaseDelayGenerator(const edm::ParameterSet&,const edm::ActivityRegistry&);
   ~SiStripBaseDelayGenerator();
 
-  void getObj(SiStripBaseDelay* & obj){createObject(); obj=obj_;}
+  void getObj(SiStripBaseDelay* & obj){obj=createObject();}
 
  private:
 
-  void createObject();
+  SiStripBaseDelay* createObject();
 
 };
 

--- a/CalibTracker/SiStripESProducers/interface/SiStripConfObjectGenerator.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripConfObjectGenerator.h
@@ -18,11 +18,11 @@ class SiStripConfObjectGenerator : public SiStripCondObjBuilderBase<SiStripConfO
   explicit SiStripConfObjectGenerator(const edm::ParameterSet&,const edm::ActivityRegistry&);
   ~SiStripConfObjectGenerator();
 
-  void getObj(SiStripConfObject* & obj){createObject(); obj=obj_;}
+  void getObj(SiStripConfObject* & obj){obj=createObject();}
 
  private:
 
-  void createObject();
+  SiStripConfObject*  createObject();
 
   std::vector<edm::ParameterSet> parameters_;
 };

--- a/CalibTracker/SiStripESProducers/interface/SiStripLatencyGenerator.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripLatencyGenerator.h
@@ -17,11 +17,11 @@ class SiStripLatencyGenerator : public SiStripCondObjBuilderBase<SiStripLatency>
   explicit SiStripLatencyGenerator(const edm::ParameterSet&,const edm::ActivityRegistry&);
   ~SiStripLatencyGenerator();
 
-  void getObj(SiStripLatency* & obj){createObject(); obj=obj_;}
+  void getObj(SiStripLatency* & obj){obj=createObject();}
 
  private:
 
-  void createObject();
+  SiStripLatency* createObject();
 
 };
 

--- a/CalibTracker/SiStripESProducers/interface/SiStripLorentzAngleGenerator.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripLorentzAngleGenerator.h
@@ -25,11 +25,11 @@ class SiStripLorentzAngleGenerator : public SiStripCondObjBuilderBase<SiStripLor
   explicit SiStripLorentzAngleGenerator(const edm::ParameterSet&,const edm::ActivityRegistry&);
   ~SiStripLorentzAngleGenerator();
   
-  void getObj(SiStripLorentzAngle* & obj){createObject(); obj=obj_;}
+  void getObj(SiStripLorentzAngle* & obj){obj=createObject();}
 
  private:
 
-  void createObject();
+  SiStripLorentzAngle* createObject();
   float hallMobility_;
   /**
    * This method fills the hallMobility_ variable with different values according to the parameters passed in the cfg. <br>

--- a/CalibTracker/SiStripESProducers/interface/SiStripNoisesGenerator.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripNoisesGenerator.h
@@ -15,11 +15,11 @@ class SiStripNoisesGenerator : public SiStripCondObjBuilderBase<SiStripNoises> {
   explicit SiStripNoisesGenerator(const edm::ParameterSet&,const edm::ActivityRegistry&);
   ~SiStripNoisesGenerator();
   
-  void getObj(SiStripNoises* & obj){createObject(); obj=obj_;}
+  void getObj(SiStripNoises* & obj){obj=createObject();}
 
  private:
 
-  void createObject();
+  SiStripNoises*  createObject();
   /// Given the map and the detid it returns the corresponding layer/ring
   std::pair<int, int> subDetAndLayer(const uint32_t detit) const;
   /// Fills the parameters read from cfg and matching the name in the given map

--- a/CalibTracker/SiStripESProducers/interface/SiStripPedestalsGenerator.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripPedestalsGenerator.h
@@ -13,11 +13,11 @@ class SiStripPedestalsGenerator : public SiStripCondObjBuilderBase<SiStripPedest
   explicit SiStripPedestalsGenerator(const edm::ParameterSet&,const edm::ActivityRegistry&);
   ~SiStripPedestalsGenerator();
   
-  void getObj(SiStripPedestals* & obj){createObject(); obj=obj_;}
+  void getObj(SiStripPedestals* & obj){obj=createObject();}
 
  private:
   
-  void createObject();
+  SiStripPedestals* createObject();
 
   
 };

--- a/CalibTracker/SiStripESProducers/interface/SiStripThresholdGenerator.h
+++ b/CalibTracker/SiStripESProducers/interface/SiStripThresholdGenerator.h
@@ -13,11 +13,11 @@ class SiStripThresholdGenerator : public SiStripCondObjBuilderBase<SiStripThresh
   explicit SiStripThresholdGenerator(const edm::ParameterSet&,const edm::ActivityRegistry&);
   ~SiStripThresholdGenerator();
   
-  void getObj(SiStripThreshold* & obj){createObject(); obj=obj_;}
+  void getObj(SiStripThreshold* & obj){obj=createObject();}
 
  private:
   
-  void createObject();
+  SiStripThreshold* createObject();
 
   
 };

--- a/CalibTracker/SiStripESProducers/src/SiStripApvGainGenerator.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripApvGainGenerator.cc
@@ -17,9 +17,9 @@ SiStripApvGainGenerator::~SiStripApvGainGenerator() {
   edm::LogInfo("SiStripApvGainGenerator") <<  "[SiStripApvGainGenerator::~SiStripApvGainGenerator]";
 }
 
-void SiStripApvGainGenerator::createObject(){
+SiStripApvGain* SiStripApvGainGenerator::createObject(){
     
-  obj_ = new SiStripApvGain();
+  SiStripApvGain* obj = new SiStripApvGain();
 
   std::string genMode = _pset.getParameter<std::string>("genMode");
 
@@ -58,7 +58,8 @@ void SiStripApvGainGenerator::createObject(){
     }
     count++;
     SiStripApvGain::Range range(theSiStripVector.begin(),theSiStripVector.end());
-    if ( ! obj_->put(it->first,range) )
+    if ( ! obj->put(it->first,range) )
       edm::LogError("SiStripApvGainGenerator")<<" detid already exists"<<std::endl;
   }
+  return obj;
 }

--- a/CalibTracker/SiStripESProducers/src/SiStripBackPlaneCorrectionGenerator.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripBackPlaneCorrectionGenerator.cc
@@ -23,9 +23,9 @@ SiStripBackPlaneCorrectionGenerator::~SiStripBackPlaneCorrectionGenerator() {
   edm::LogInfo("SiStripBackPlaneCorrectionGenerator") <<  "[SiStripBackPlaneCorrectionGenerator::~SiStripBackPlaneCorrectionGenerator]";
 }
 
-void SiStripBackPlaneCorrectionGenerator::createObject()
+SiStripBackPlaneCorrection*  SiStripBackPlaneCorrectionGenerator::createObject()
 {
-  obj_ = new SiStripBackPlaneCorrection();
+  SiStripBackPlaneCorrection* obj = new SiStripBackPlaneCorrection();
 
   edm::FileInPath fp_                 = _pset.getParameter<edm::FileInPath>("file");
   std::vector<double> valuePerModuleGeometry(_pset.getParameter<std::vector<double> >("BackPlaneCorrection_PerModuleGeometry"));
@@ -38,8 +38,9 @@ void SiStripBackPlaneCorrectionGenerator::createObject()
     if(moduleGeometry>valuePerModuleGeometry.size())edm::LogError("SiStripBackPlaneCorrectionGenerator")<<" BackPlaneCorrection_PerModuleGeometry only contains "<< valuePerModuleGeometry.size() << "elements and module is out of range"<<std::endl;
     float value =     valuePerModuleGeometry[moduleGeometry];
   
-    if (!obj_->putBackPlaneCorrection(*detit, value) ) {
+    if (!obj->putBackPlaneCorrection(*detit, value) ) {
       edm::LogError("SiStripBackPlaneCorrectionGenerator")<<" detid already exists"<<std::endl;
     }
   }
+  return obj;
 }

--- a/CalibTracker/SiStripESProducers/src/SiStripBadModuleGenerator.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripBadModuleGenerator.cc
@@ -25,7 +25,7 @@ SiStripBadModuleGenerator::~SiStripBadModuleGenerator() {
 }
 
 
-void SiStripBadModuleGenerator::createObject(){
+SiStripBadStrip* SiStripBadModuleGenerator::createObject(){
     
   SiStripQuality* obj  = new SiStripQuality();
 
@@ -79,8 +79,8 @@ void SiStripBadModuleGenerator::createObject(){
     edm::LogInfo("SiStripQualityConfigurableFakeESSource") << ss1.str();
   }
 
-  obj_ = new SiStripBadStrip( *(dynamic_cast<SiStripBadStrip*> (obj)));
-  delete obj;
+//  obj_ = new SiStripBadStrip( *(dynamic_cast<SiStripBadStrip*> (obj)));
+  return obj;
 }
 
 

--- a/CalibTracker/SiStripESProducers/src/SiStripBaseDelayGenerator.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripBaseDelayGenerator.cc
@@ -18,9 +18,9 @@ SiStripBaseDelayGenerator::~SiStripBaseDelayGenerator()
   edm::LogInfo("SiStripBaseDelayGenerator") << "[SiStripBaseDelayGenerator::~SiStripBaseDelayGenerator]";
 }
 
-void SiStripBaseDelayGenerator::createObject()
+SiStripBaseDelay* SiStripBaseDelayGenerator::createObject()
 {
-  obj_ = new SiStripBaseDelay();
+  SiStripBaseDelay* obj = new SiStripBaseDelay();
 
   // Read the full list of detIds
   edm::FileInPath fp_ = _pset.getParameter<edm::FileInPath>("file");
@@ -31,10 +31,11 @@ void SiStripBaseDelayGenerator::createObject()
   if( !detInfos.empty() ) {
     std::map<uint32_t, SiStripDetInfoFileReader::DetInfo>::const_iterator it = detInfos.begin();
     for( ; it != detInfos.end(); ++it ) {
-      obj_->put(it->first, coarseDelay, fineDelay);
+      obj->put(it->first, coarseDelay, fineDelay);
     }
   }
   else {
     edm::LogError("SiStripBaseDelayGenerator") << "Error: detInfo map is empty." << std::endl;
   }
+  return obj;
 }

--- a/CalibTracker/SiStripESProducers/src/SiStripConfObjectGenerator.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripConfObjectGenerator.cc
@@ -12,20 +12,21 @@ SiStripConfObjectGenerator::~SiStripConfObjectGenerator()
   edm::LogInfo("SiStripConfObjectGenerator") << "[SiStripConfObjectGenerator::~SiStripConfObjectGenerator]";
 }
 
-void SiStripConfObjectGenerator::createObject()
+SiStripConfObject* SiStripConfObjectGenerator::createObject()
 {
   parameters_ = _pset.getParameter<std::vector<edm::ParameterSet> >("Parameters");
   std::vector<edm::ParameterSet>::const_iterator parIt = parameters_.begin();
-  obj_ = new SiStripConfObject();
+  SiStripConfObject* obj = new SiStripConfObject();
   for( ; parIt != parameters_.end(); ++parIt ) {
     if( parIt->getParameter<std::string>("ParameterType") == "int" ) {
-      obj_->put(parIt->getParameter<std::string>("ParameterName"), parIt->getParameter<int32_t>("ParameterValue"));
+      obj->put(parIt->getParameter<std::string>("ParameterName"), parIt->getParameter<int32_t>("ParameterValue"));
     }
     else if( parIt->getParameter<std::string>("ParameterType") == "double" ) {
-      obj_->put(parIt->getParameter<std::string>("ParameterName"), parIt->getParameter<double>("ParameterValue"));
+      obj->put(parIt->getParameter<std::string>("ParameterName"), parIt->getParameter<double>("ParameterValue"));
     }
     if( parIt->getParameter<std::string>("ParameterType") == "string" ) {
-      obj_->put(parIt->getParameter<std::string>("ParameterName"), parIt->getParameter<std::string>("ParameterValue"));
+      obj->put(parIt->getParameter<std::string>("ParameterName"), parIt->getParameter<std::string>("ParameterValue"));
     }
   }
+  return obj;
 }

--- a/CalibTracker/SiStripESProducers/src/SiStripLatencyGenerator.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripLatencyGenerator.cc
@@ -18,9 +18,9 @@ SiStripLatencyGenerator::~SiStripLatencyGenerator()
   edm::LogInfo("SiStripLatencyGenerator") << "[SiStripLatencyGenerator::~SiStripLatencyGenerator]";
 }
 
-void SiStripLatencyGenerator::createObject()
+SiStripLatency* SiStripLatencyGenerator::createObject()
 {
-  obj_ = new SiStripLatency();
+  SiStripLatency* obj = new SiStripLatency();
 
   // Read the full list of detIds
   edm::FileInPath fp_ = _pset.getParameter<edm::FileInPath>("file");
@@ -32,12 +32,13 @@ void SiStripLatencyGenerator::createObject()
     edm::LogInfo("SiStripLatencyGenerator") << "detId = " << detInfos.rbegin()->first << " apv = " << 6
                                             << " latency = " << _pset.getParameter<uint32_t>("latency")
                                             << " mode = " << _pset.getParameter<uint32_t>("mode") << std::endl;
-    obj_->put(detInfos.rbegin()->first, 6, _pset.getParameter<uint32_t>("latency"), _pset.getParameter<uint32_t>("mode") );
+    obj->put(detInfos.rbegin()->first, 6, _pset.getParameter<uint32_t>("latency"), _pset.getParameter<uint32_t>("mode") );
 
     // Call this method to collapse all consecutive detIdAndApvs with the same latency and mode to a single entry
-    obj_->compress();
+    obj->compress();
   }
   else {
     edm::LogError("SiStripLatencyGenerator") << "Error: detInfo map is empty. Cannot get the last detId." << std::endl;
   }
+  return obj;
 }

--- a/CalibTracker/SiStripESProducers/src/SiStripLorentzAngleGenerator.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripLorentzAngleGenerator.cc
@@ -47,9 +47,9 @@ void SiStripLorentzAngleGenerator::setUniform(const std::vector<double> & estima
   }
 }
 
-void SiStripLorentzAngleGenerator::createObject()
+SiStripLorentzAngle* SiStripLorentzAngleGenerator::createObject()
 {
-  obj_ = new SiStripLorentzAngle();
+  SiStripLorentzAngle* obj = new SiStripLorentzAngle();
 
   edm::FileInPath fp_                 = _pset.getParameter<edm::FileInPath>("file");
 
@@ -125,8 +125,10 @@ void SiStripLorentzAngleGenerator::createObject()
       }
     }
       
-    if ( ! obj_->putLorentzAngle(*detit, hallMobility_) ) {
+    if ( ! obj->putLorentzAngle(*detit, hallMobility_) ) {
       edm::LogError("SiStripLorentzAngleGenerator")<<" detid already exists"<<std::endl;
     }
   }
+  return obj;
 }
+

--- a/CalibTracker/SiStripESProducers/src/SiStripNoisesGenerator.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripNoisesGenerator.cc
@@ -26,9 +26,9 @@ SiStripNoisesGenerator::~SiStripNoisesGenerator()
   edm::LogInfo("SiStripNoisesGenerator") <<  "[SiStripNoisesGenerator::~SiStripNoisesGenerator]";
 }
 
-void SiStripNoisesGenerator::createObject()
+SiStripNoises* SiStripNoisesGenerator::createObject()
 {    
-  obj_ = new SiStripNoises();
+  SiStripNoises* obj = new SiStripNoises();
 
   stripLengthMode_ = _pset.getParameter<bool>("StripLengthMode");
   
@@ -71,7 +71,7 @@ void SiStripNoisesGenerator::createObject()
       for( unsigned short j=0; j<128*nApvs; ++j ) {
 	noise = ( linearSlope*stripLength + linearQuote) / electronsPerADC_;
         if( count<printDebug_ ) printLog(detId, j, noise);
-        obj_->setData(noise, theSiStripVector);
+        obj->setData(noise, theSiStripVector);
       }
     }
     else {
@@ -82,15 +82,16 @@ void SiStripNoisesGenerator::createObject()
         noise = CLHEP::RandGauss::shoot(meanN, sigmaN);
         if( noise<=minimumPosValue_ ) noise = minimumPosValue_;
         if( count<printDebug_ ) printLog(detId, j, noise);
-        obj_->setData(noise, theSiStripVector);
+        obj->setData(noise, theSiStripVector);
       }
     }
     ++count;
     
-    if ( ! obj_->put(it->first,theSiStripVector) ) {
+    if ( ! obj->put(it->first,theSiStripVector) ) {
       edm::LogError("SiStripNoisesFakeESSource::produce ")<<" detid already exists"<<std::endl;
     }
   }
+  return obj;
 }
 
 std::pair<int, int> SiStripNoisesGenerator::subDetAndLayer( const uint32_t detId ) const

--- a/CalibTracker/SiStripESProducers/src/SiStripPedestalsGenerator.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripPedestalsGenerator.cc
@@ -16,9 +16,9 @@ SiStripPedestalsGenerator::~SiStripPedestalsGenerator() {
 }
 
 
-void SiStripPedestalsGenerator::createObject(){
+SiStripPedestals* SiStripPedestalsGenerator::createObject(){
     
-  obj_ = new SiStripPedestals();
+  SiStripPedestals* obj = new SiStripPedestals();
 
   uint32_t PedestalValue_ = _pset.getParameter<uint32_t>("PedestalsValue");  
   edm::FileInPath fp_ = _pset.getParameter<edm::FileInPath>("file");
@@ -37,10 +37,11 @@ void SiStripPedestalsGenerator::createObject(){
       if (count<printdebug_) {
 	edm::LogInfo("SiStripPedestalsFakeESSource::makePedestals(): ") << "detid: " << it->first  << " strip: " << j <<  " ped: " << PedestalValue_  << std::endl; 	    
       }
-      obj_->setData(PedestalValue_,theSiStripVector);
+      obj->setData(PedestalValue_,theSiStripVector);
     }
     count++;
-    if ( ! obj_->put(it->first, theSiStripVector) )
+    if ( ! obj->put(it->first, theSiStripVector) )
       edm::LogError("SiStripPedestalsFakeESSource::produce ")<<" detid already exists"<<std::endl;
   }
+  return obj;
 }

--- a/CalibTracker/SiStripESProducers/src/SiStripThresholdGenerator.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripThresholdGenerator.cc
@@ -16,9 +16,9 @@ SiStripThresholdGenerator::~SiStripThresholdGenerator() {
 }
 
 
-void SiStripThresholdGenerator::createObject(){
+SiStripThreshold* SiStripThresholdGenerator::createObject(){
     
-  obj_ = new SiStripThreshold();
+  SiStripThreshold* obj = new SiStripThreshold();
 
   edm::FileInPath fp_ = _pset.getParameter<edm::FileInPath>("file");
   float lTh_ = _pset.getParameter<double>("LowTh");
@@ -34,7 +34,7 @@ void SiStripThresholdGenerator::createObject(){
     SiStripThreshold::Container theSiStripVector;   
     uint16_t strip=0;
 
-    obj_->setData(strip,lTh_,hTh_,cTh_,theSiStripVector);
+    obj->setData(strip,lTh_,hTh_,cTh_,theSiStripVector);
     LogDebug("SiStripThresholdFakeESSource::produce") <<"detid: "  << it->first << " \t"
 						      << "firstStrip: " << strip << " \t" << theSiStripVector.back().getFirstStrip() << " \t"
 						      << "lTh: " << lTh_       << " \t" << theSiStripVector.back().getLth() << " \t"
@@ -42,12 +42,12 @@ void SiStripThresholdGenerator::createObject(){
 						      << "FirstStrip_and_Hth: " << theSiStripVector.back().FirstStrip_and_Hth << " \t"
 						      << std::endl; 	    
     
-    if ( ! obj_->put(it->first,theSiStripVector) )
+    if ( ! obj->put(it->first,theSiStripVector) )
       edm::LogError("SiStripThresholdFakeESSource::produce ")<<" detid already exists"<<std::endl;
   }
   
   std::stringstream ss;
-  obj_->printDebug(ss);
+  obj->printDebug(ss);
   LogDebug("SiStripThresholdFakeESSource::produce") <<"printDebug\n" << ss.str() << std::endl;
-
+  return obj;
 }


### PR DESCRIPTION
Make getObj in the *Generator classes thread safe by not returning pointer to member data obj_.
