### PR TITLE
Register empty parameter set in initialization

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -584,6 +584,9 @@ namespace edm {
    
     ROOT::Cintex::Cintex::Enable();
 
+    // register the empty parameter set, once and for all.
+    ParameterSet().registerIt();
+
     boost::shared_ptr<ParameterSet> parameterSet = processDesc->getProcessPSet();
     //std::cerr << parameterSet->dump() << std::endl;
 


### PR DESCRIPTION
There are at least three different places in CMSSW, each outside the framework, where the empty parameter set is explicitly registered.  This pull request simply registers the empty parameter set up front during the initialization of the EventProcessor.
After this request is merged, I will remove the other explicit registrations.
This will reduce the number of places in the code where the registries are updated.
