### PR TITLE
Remove or replace old-style casts that cast away constness

### DIFF
--- a/IOPool/Streamer/bin/DiagStreamerFile.cpp
+++ b/IOPool/Streamer/bin/DiagStreamerFile.cpp
@@ -287,7 +287,7 @@ bool compares_bad(EventMsgView const* eview1, EventMsgView const* eview2) {
 
 //==========================================================================
 bool test_chksum(EventMsgView const* eview) {
-  uint32_t adler32_chksum = cms::Adler32((char*)eview->eventData(), eview->eventLength());
+  uint32_t adler32_chksum = cms::Adler32((char const*)eview->eventData(), eview->eventLength());
   //std::cout << "Adler32 checksum of event = " << adler32_chksum << std::endl;
   //std::cout << "Adler32 checksum from header = " << eview->adler32_chksum() << std::endl;
   //std::cout << "event from host name = " << eview->hostName() << std::endl;
@@ -307,7 +307,7 @@ bool test_uncompress(EventMsgView const* eview, std::vector<unsigned char> &dest
   if(origsize != 0 && origsize != 78)
   {
     // compressed
-    success = uncompressBuffer((unsigned char*)eview->eventData(),
+    success = uncompressBuffer(const_cast<unsigned char*>((unsigned char const*)eview->eventData()),
                                    eview->eventLength(), dest, origsize);
   } else {
     // uncompressed anyway

--- a/IOPool/Streamer/interface/EOFRecordBuilder.h
+++ b/IOPool/Streamer/interface/EOFRecordBuilder.h
@@ -17,8 +17,8 @@ public:
                    uint64 first_event_offset,
                    uint64 last_event_offset);
 
-  uint8* recAddress() const { return (uint8*) &buf_[0]; }
-  uint32 size() const {return (uint32) buf_.size(); }
+  uint8 const* recAddress() const { return &buf_[0]; }
+  uint32 size() const {return static_cast<uint32>(buf_.size()); }
 
 private:
   std::vector<uint8> buf_;

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -140,7 +140,7 @@ namespace edm {
     }
 
    // calculate the adler32 checksum
-   uint32_t adler32_chksum = cms::Adler32((char*)initView.descData(),initView.descLength());
+   uint32_t adler32_chksum = cms::Adler32((char const*)initView.descData(),initView.descLength());
    //std::cout << "Adler32 checksum of init message = " << adler32_chksum << std::endl;
    //std::cout << "Adler32 checksum of init messsage from header = " << initView.adler32_chksum() << " "
    //          << "host name = " << initView.hostName() << " len = " << initView.hostName_len() << std::endl;
@@ -154,7 +154,7 @@ namespace edm {
     TClass* desc = getTClass(typeid(SendJobHeader));
 
     TBufferFile xbuf(TBuffer::kRead, initView.descLength(),
-                 (char*)initView.descData(),kFALSE);
+                 const_cast<char*>((char const*)initView.descData()),kFALSE);
     RootDebug tracer(10,10);
     std::auto_ptr<SendJobHeader> sd((SendJobHeader*)xbuf.ReadObjectAny(desc));
 
@@ -216,7 +216,7 @@ namespace edm {
     unsigned long origsize = eventView.origDataSize();
     unsigned long dest_size; //(should be >= eventView.origDataSize())
 
-    uint32_t adler32_chksum = cms::Adler32((char*)eventView.eventData(), eventView.eventLength());
+    uint32_t adler32_chksum = cms::Adler32((char const*)eventView.eventData(), eventView.eventLength());
     //std::cout << "Adler32 checksum of event = " << adler32_chksum << std::endl;
     //std::cout << "Adler32 checksum from header = " << eventView.adler32_chksum() << " "
     //          << "host name = " << eventView.hostName() << " len = " << eventView.hostName_len() << std::endl;
@@ -228,20 +228,20 @@ namespace edm {
     }
     if(origsize != 78 && origsize != 0) {
       // compressed
-      dest_size = uncompressBuffer((unsigned char*)eventView.eventData(),
+      dest_size = uncompressBuffer(const_cast<unsigned char*>((unsigned char const*)eventView.eventData()),
                                    eventView.eventLength(), dest_, origsize);
     } else { // not compressed
       // we need to copy anyway the buffer as we are using dest in xbuf
       dest_size = eventView.eventLength();
       dest_.resize(dest_size);
       unsigned char* pos = (unsigned char*) &dest_[0];
-      unsigned char* from = (unsigned char*) eventView.eventData();
+      unsigned char const* from = (unsigned char const*) eventView.eventData();
       std::copy(from,from+dest_size,pos);
     }
     //TBuffer xbuf(TBuffer::kRead, dest_size,
-    //             (char*) &dest[0],kFALSE);
+    //             (char const*) &dest[0],kFALSE);
     //TBuffer xbuf(TBuffer::kRead, eventView.eventLength(),
-    //             (char*) eventView.eventData(),kFALSE);
+    //             (char const*) eventView.eventData(),kFALSE);
     xbuf_.Reset();
     xbuf_.SetBuffer(&dest_[0],dest_size,kFALSE);
     RootDebug tracer(10,10);

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -175,13 +175,13 @@ namespace edm {
 
     std::string moduleLabel = description().moduleLabel();
     uLong crc = crc32(0L, Z_NULL, 0);
-    Bytef* buf = (Bytef*) moduleLabel.data();
+    Bytef const* buf = (Bytef const*)(moduleLabel.data());
     crc = crc32(crc, buf, moduleLabel.length());
     outputModuleId_ = static_cast<uint32>(crc);
 
     std::auto_ptr<InitMsgBuilder> init_message(
         new InitMsgBuilder(&serialize_databuffer.header_buf_[0], serialize_databuffer.header_buf_.size(),
-                           run, Version((uint8*)toplevel.compactForm().c_str()),
+                           run, Version((uint8 const*)toplevel.compactForm().c_str()),
                            getReleaseVersion().c_str() , processName.c_str(),
                            moduleLabel.c_str(), outputModuleId_,
                            hltTriggerNames, hltTriggerSelections_, l1_names,


### PR DESCRIPTION
Ono of the impediments to thread safety is casting away constness.  Old style casts that do this are especially bad because they are harder to find than const_cast.
I ran the clang static analyzer on all the framework code minus the unit tests.  All occurrences of old-style casts that cast away constness were in a single package, IOPool/Streamer.
This pull request makes very simple changes to remove or replace those casts.  In most cases, casting away constness was not needed, and the cast was removed or modified so that it no longer casts away constness.
In the places where it was not trivial to remove the casting away constness, a const_cast is now used to cast away constness, so no old style cast still does.
In a very few cases, some old style casts that did not remove constness were removed or replaced by C++ casts.
