### PR TITLE
Multithreaded Framework Service Callbacks

### DIFF
--- a/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
@@ -170,7 +170,11 @@ namespace sistrip {
   template <class T> const T* SpyEventMatcher::getProduct(const edm::EventPrincipal& event, const edm::InputTag& tag)
   {
     LogDebug(mlLabel_) << "Retrieving product " << tag;
-    const boost::shared_ptr< const edm::Wrapper<T> > productWrapper = edm::getProductByTag<T>(event,tag);
+    // Note: The third argument to getProductByTag can be a nullptr
+    // as long as unscheduled execution of an EDProducer cannot occur
+    // as a result of this function call (and with the current implementation
+    // of SpyEventMatcher unscheduled execution never happens).
+    const boost::shared_ptr< const edm::Wrapper<T> > productWrapper = edm::getProductByTag<T>(event,tag,nullptr);
     if (productWrapper) {
       return productWrapper->product();
     } else {

--- a/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootOutputModule.cc
@@ -174,6 +174,9 @@ namespace {
 
 }
 
+namespace edm {
+  class ModuleCallingContext;
+}
 
 class DQMRootOutputModule : public edm::OutputModule {
 public:
@@ -182,9 +185,9 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
 private:
-  virtual void write(edm::EventPrincipal const& e) override;
-  virtual void writeLuminosityBlock(edm::LuminosityBlockPrincipal const&) override;
-  virtual void writeRun(edm::RunPrincipal const&) override;
+  virtual void write(edm::EventPrincipal const& e, edm::ModuleCallingContext const*) override;
+  virtual void writeLuminosityBlock(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*) override;
+  virtual void writeRun(edm::RunPrincipal const&, edm::ModuleCallingContext const*) override;
   virtual bool isFileOpen() const override;
   virtual void openFile(edm::FileBlock const&) override;
   virtual void reallyCloseFile() override;
@@ -363,11 +366,11 @@ DQMRootOutputModule::openFile(edm::FileBlock const&)
 
 
 void 
-DQMRootOutputModule::write(edm::EventPrincipal const& ){
+DQMRootOutputModule::write(edm::EventPrincipal const&, edm::ModuleCallingContext const*){
   
 }
 void 
-DQMRootOutputModule::writeLuminosityBlock(edm::LuminosityBlockPrincipal const& iLumi) {
+DQMRootOutputModule::writeLuminosityBlock(edm::LuminosityBlockPrincipal const& iLumi, edm::ModuleCallingContext const*) {
   //std::cout << "DQMRootOutputModule::writeLuminosityBlock"<< std::endl;
   edm::Service<DQMStore> dstore;
   m_run=iLumi.id().run();
@@ -426,7 +429,7 @@ DQMRootOutputModule::writeLuminosityBlock(edm::LuminosityBlockPrincipal const& i
 }
 
 
-void DQMRootOutputModule::writeRun(edm::RunPrincipal const& iRun){
+void DQMRootOutputModule::writeRun(edm::RunPrincipal const& iRun, edm::ModuleCallingContext const*){
   //std::cout << "DQMRootOutputModule::writeRun"<< std::endl;
   edm::Service<DQMStore> dstore;
   m_run=iRun.id().run();

--- a/FWCore/Framework/interface/EDAnalyzer.h
+++ b/FWCore/Framework/interface/EDAnalyzer.h
@@ -12,6 +12,8 @@
 
 namespace edm {
 
+  class ModuleCallingContext;
+
   class EDAnalyzer : public EDConsumerBase {
   public:
     template <typename T> friend class WorkerT;
@@ -27,6 +29,9 @@ namespace edm {
     static const std::string& baseType();
     static   void prevalidate(ConfigurationDescriptions& );
 
+    // Warning: the returned moduleDescription will be invalid during construction
+    ModuleDescription const& moduleDescription() const { return moduleDescription_; }
+
   protected:
     // The returned pointer will be null unless the this is currently
     // executing its event loop function ('analyze').
@@ -36,17 +41,22 @@ namespace edm {
 
   private:
     bool doEvent(EventPrincipal const& ep, EventSetup const& c,
-		   CurrentProcessingContext const* cpc);
+                 CurrentProcessingContext const* cpc,
+                 ModuleCallingContext const* mcc);
     void doBeginJob();
     void doEndJob();
     bool doBeginRun(RunPrincipal const& rp, EventSetup const& c,
-		   CurrentProcessingContext const* cpc);
+                    CurrentProcessingContext const* cpc,
+                    ModuleCallingContext const* mcc);
     bool doEndRun(RunPrincipal const& rp, EventSetup const& c,
-		   CurrentProcessingContext const* cpc);
+                  CurrentProcessingContext const* cpc,
+                  ModuleCallingContext const* mcc);
     bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
-		   CurrentProcessingContext const* cpc);
+                                CurrentProcessingContext const* cpc,
+                                ModuleCallingContext const* mcc);
     bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
-		   CurrentProcessingContext const* cpc);
+                              CurrentProcessingContext const* cpc,
+                              ModuleCallingContext const* mcc);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
     void doPreForkReleaseResources();

--- a/FWCore/Framework/interface/EDFilter.h
+++ b/FWCore/Framework/interface/EDFilter.h
@@ -22,6 +22,8 @@ These products should be informational products about the filter decision.
 
 namespace edm {
 
+  class ModuleCallingContext;
+
   class EDFilter : public ProducerBase, public EDConsumerBase {
   public:
     template <typename T> friend class WorkerT;
@@ -38,6 +40,9 @@ namespace edm {
 
     static const std::string& baseType();
 
+    // Warning: the returned moduleDescription will be invalid during construction
+    ModuleDescription const& moduleDescription() const { return moduleDescription_; }
+
   protected:
     // The returned pointer will be null unless the this is currently
     // executing its event loop function ('filter').
@@ -45,17 +50,22 @@ namespace edm {
 
   private:    
     bool doEvent(EventPrincipal& ep, EventSetup const& c,
-		  CurrentProcessingContext const* cpc);
+                 CurrentProcessingContext const* cpc,
+                 ModuleCallingContext const* mcc);
     void doBeginJob();
     void doEndJob();    
     void doBeginRun(RunPrincipal& rp, EventSetup const& c,
-		   CurrentProcessingContext const* cpc);
+                    CurrentProcessingContext const* cpc,
+                    ModuleCallingContext const* mcc);
     void doEndRun(RunPrincipal& rp, EventSetup const& c,
-		   CurrentProcessingContext const* cpc);
+                  CurrentProcessingContext const* cpc,
+                  ModuleCallingContext const* mcc);
     void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-		   CurrentProcessingContext const* cpc);
+                                CurrentProcessingContext const* cpc,
+                                ModuleCallingContext const* mcc);
     void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-		   CurrentProcessingContext const* cpc);
+                              CurrentProcessingContext const* cpc,
+                              ModuleCallingContext const* mcc);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
     void doPreForkReleaseResources();

--- a/FWCore/Framework/interface/EDLooperBase.h
+++ b/FWCore/Framework/interface/EDLooperBase.h
@@ -64,7 +64,9 @@ namespace edm {
     class EventSetupProvider;
   }
   class ActionTable;
+  class ProcessContext;
   class ScheduleInfo;
+  class StreamContext;
   class ModuleChanger;
   class ProcessingController;
   class ActivityRegistry;
@@ -80,13 +82,13 @@ namespace edm {
       EDLooperBase& operator=(EDLooperBase const&) = delete; // Disallow copying and moving
 
       void doStartingNewLoop();
-      Status doDuringLoop(EventPrincipal& eventPrincipal, EventSetup const& es, ProcessingController&);
+      Status doDuringLoop(EventPrincipal& eventPrincipal, EventSetup const& es, ProcessingController&, StreamContext*);
       Status doEndOfLoop(EventSetup const& es);
       void prepareForNextLoop(eventsetup::EventSetupProvider* esp);
-      void doBeginRun(RunPrincipal&, EventSetup const&);
-      void doEndRun(RunPrincipal&, EventSetup const&);
-      void doBeginLuminosityBlock(LuminosityBlockPrincipal&, EventSetup const&);
-      void doEndLuminosityBlock(LuminosityBlockPrincipal&, EventSetup const&);
+      void doBeginRun(RunPrincipal&, EventSetup const&, ProcessContext*);
+      void doEndRun(RunPrincipal&, EventSetup const&, ProcessContext*);
+      void doBeginLuminosityBlock(LuminosityBlockPrincipal&, EventSetup const&, ProcessContext*);
+      void doEndLuminosityBlock(LuminosityBlockPrincipal&, EventSetup const&, ProcessContext*);
 
       //This interface is deprecated
       virtual void beginOfJob(EventSetup const&);

--- a/FWCore/Framework/interface/EDProducer.h
+++ b/FWCore/Framework/interface/EDProducer.h
@@ -19,6 +19,9 @@ EDProducts into an Event.
 #include <vector>
 
 namespace edm {
+
+  class ModuleCallingContext;
+
   class EDProducer : public ProducerBase, public EDConsumerBase {
   public:
     template <typename T> friend class WorkerT;
@@ -32,6 +35,9 @@ namespace edm {
     static void prevalidate(ConfigurationDescriptions& descriptions);
     static const std::string& baseType();
 
+    // Warning: the returned moduleDescription will be invalid during construction
+    ModuleDescription const& moduleDescription() const { return moduleDescription_; }
+
   protected:
     // The returned pointer will be null unless the this is currently
     // executing its event loop function ('produce').
@@ -39,17 +45,22 @@ namespace edm {
 
   private:
     bool doEvent(EventPrincipal& ep, EventSetup const& c,
-		   CurrentProcessingContext const* cpcp);
+                 CurrentProcessingContext const* cpcp,
+                 ModuleCallingContext const* mcc);
     void doBeginJob();
     void doEndJob();
     void doBeginRun(RunPrincipal& rp, EventSetup const& c,
-		   CurrentProcessingContext const* cpc);
+                    CurrentProcessingContext const* cpc,
+                    ModuleCallingContext const* mcc);
     void doEndRun(RunPrincipal& rp, EventSetup const& c,
-		   CurrentProcessingContext const* cpc);
+                  CurrentProcessingContext const* cpc,
+                  ModuleCallingContext const* mcc);
     void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-		   CurrentProcessingContext const* cpc);
+                                CurrentProcessingContext const* cpc,
+                                ModuleCallingContext const* mcc);
     void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-		   CurrentProcessingContext const* cpc);
+                              CurrentProcessingContext const* cpc,
+                              ModuleCallingContext const* mcc);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
     void doPreForkReleaseResources();

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -48,6 +48,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 namespace edm {
 
   class ConstBranchDescription;
+  class ModuleCallingContext;
   class TriggerResultsByName;
   class TriggerResults;
   class TriggerNames;
@@ -59,7 +60,8 @@ namespace edm {
 
   class Event : public EventBase {
   public:
-    Event(EventPrincipal& ep, ModuleDescription const& md);
+    Event(EventPrincipal& ep, ModuleDescription const& md,
+          ModuleCallingContext const*);
     virtual ~Event();
     
     //Used in conjunction with EDGetToken
@@ -196,6 +198,8 @@ namespace edm {
     virtual edm::TriggerNames const& triggerNames(edm::TriggerResults const& triggerResults) const;
     virtual TriggerResultsByName triggerResultsByName(std::string const& process) const;
 
+    ModuleCallingContext const* moduleCallingContext() const { return moduleCallingContext_; }
+
     typedef std::vector<std::pair<WrapperOwningHolder, ConstBranchDescription const*> > ProductPtrVec;
 
   private:
@@ -258,6 +262,7 @@ namespace edm {
     mutable std::vector<boost::shared_ptr<ViewBase> > gotViews_;
     
     StreamID streamID_;
+    ModuleCallingContext const* moduleCallingContext_;
 
     static const std::string emptyString_;
   };
@@ -372,7 +377,7 @@ namespace edm {
   bool
   Event::getByLabel(InputTag const& tag, Handle<PROD>& result) const {
     result.clear();
-    BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), tag);
+    BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), tag, moduleCallingContext_);
     convert_handle(bh, result);  // throws on conversion error
     if (bh.failedToGet()) {
       return false;
@@ -387,7 +392,7 @@ namespace edm {
                     std::string const& productInstanceName,
                     Handle<PROD>& result) const {
     result.clear();
-    BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), label, productInstanceName, emptyString_);
+    BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), label, productInstanceName, emptyString_, moduleCallingContext_);
     convert_handle(bh, result);  // throws on conversion error
     if (bh.failedToGet()) {
       return false;
@@ -405,7 +410,7 @@ namespace edm {
   template<typename PROD>
   void
   Event::getManyByType(std::vector<Handle<PROD> >& results) const {
-    provRecorder_.getManyByType(results);
+    provRecorder_.getManyByType(results, moduleCallingContext_);
     for(typename std::vector<Handle<PROD> >::const_iterator it = results.begin(), itEnd = results.end();
         it != itEnd; ++it) {
       addToGotBranchIDs(*it->provenance());
@@ -416,7 +421,7 @@ namespace edm {
   bool
   Event::getByToken(EDGetToken token, Handle<PROD>& result) const {
     result.clear();
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
     convert_handle(bh, result);  // throws on conversion error
     if (bh.failedToGet()) {
       return false;
@@ -429,7 +434,7 @@ namespace edm {
   bool
   Event::getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const {
     result.clear();
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
     convert_handle(bh, result);  // throws on conversion error
     if (bh.failedToGet()) {
       return false;
@@ -443,7 +448,7 @@ namespace edm {
   bool
   Event::getByLabel(InputTag const& tag, Handle<View<ELEMENT> >& result) const {
     result.clear();
-    BasicHandle bh = provRecorder_.getMatchingSequenceByLabel_(TypeID(typeid(ELEMENT)), tag);
+    BasicHandle bh = provRecorder_.getMatchingSequenceByLabel_(TypeID(typeid(ELEMENT)), tag, moduleCallingContext_);
     if(bh.failedToGet()) {
       Handle<View<ELEMENT> > h(bh.whyFailed());
       h.swap(result);
@@ -459,7 +464,7 @@ namespace edm {
                     std::string const& productInstanceName,
                     Handle<View<ELEMENT> >& result) const {
     result.clear();
-    BasicHandle bh = provRecorder_.getMatchingSequenceByLabel_(TypeID(typeid(ELEMENT)), moduleLabel, productInstanceName, emptyString_);
+    BasicHandle bh = provRecorder_.getMatchingSequenceByLabel_(TypeID(typeid(ELEMENT)), moduleLabel, productInstanceName, emptyString_, moduleCallingContext_);
     if(bh.failedToGet()) {
       Handle<View<ELEMENT> > h(bh.whyFailed());
       h.swap(result);
@@ -479,7 +484,7 @@ namespace edm {
   bool
   Event::getByToken(EDGetToken token, Handle<View<ELEMENT>>& result) const {
     result.clear();
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)),ELEMENT_TYPE, token);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)),ELEMENT_TYPE, token, moduleCallingContext_);
     if(bh.failedToGet()) {
       Handle<View<ELEMENT> > h(bh.whyFailed());
       h.swap(result);
@@ -493,7 +498,7 @@ namespace edm {
   bool
   Event::getByToken(EDGetTokenT<View<ELEMENT>> token, Handle<View<ELEMENT>>& result) const {
     result.clear();
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)),ELEMENT_TYPE, token);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)),ELEMENT_TYPE, token, moduleCallingContext_);
     if(bh.failedToGet()) {
       Handle<View<ELEMENT> > h(bh.whyFailed());
       h.swap(result);

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -35,6 +35,7 @@ namespace edm {
   class EventID;
   class HistoryAppender;
   class LuminosityBlockPrincipal;
+  class ModuleCallingContext;
   class RunPrincipal;
   class UnscheduledHandler;
 
@@ -131,7 +132,7 @@ namespace edm {
     BranchListIndexes const& branchListIndexes() const;
 
     Provenance
-    getProvenance(ProductID const& pid) const;
+    getProvenance(ProductID const& pid, ModuleCallingContext const* mcc) const;
 
     BasicHandle
     getByProductID(ProductID const& oid) const;
@@ -160,9 +161,12 @@ namespace edm {
 
     BranchID pidToBid(ProductID const& pid) const;
 
-    virtual bool unscheduledFill(std::string const& moduleLabel) const override;
+    virtual bool unscheduledFill(std::string const& moduleLabel,
+                                 ModuleCallingContext const* mcc) const override;
 
-    virtual void resolveProduct_(ProductHolderBase const& phb, bool fillOnDemand) const override;
+    virtual void resolveProduct_(ProductHolderBase const& phb,
+                                 bool fillOnDemand,
+                                 ModuleCallingContext const* mcc) const override;
 
   private:
 

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -20,6 +20,7 @@ configured in the user's main() function, and is set running.
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ProcessContext.h"
 #include "FWCore/ServiceRegistry/interface/ServiceLegacy.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 
@@ -317,6 +318,7 @@ namespace edm {
     boost::shared_ptr<eventsetup::EventSetupProvider> esp_;
     std::unique_ptr<ActionTable const>          act_table_;
     boost::shared_ptr<ProcessConfiguration const>       processConfiguration_;
+    ProcessContext                                processContext_;
     std::auto_ptr<Schedule>                       schedule_;
     std::auto_ptr<SubProcess>                     subProcess_;
     std::unique_ptr<HistoryAppender>            historyAppender_;

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -37,6 +37,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include <vector>
 
 namespace edm {
+  class ModuleCallingContext;
   class ProducerBase;
   namespace stream {
     template< typename T> class ProducingModuleAdaptorBase;
@@ -45,7 +46,8 @@ namespace edm {
 
   class LuminosityBlock : public LuminosityBlockBase {
   public:
-    LuminosityBlock(LuminosityBlockPrincipal& lbp, ModuleDescription const& md);
+    LuminosityBlock(LuminosityBlockPrincipal& lbp, ModuleDescription const& md,
+                    ModuleCallingContext const*);
     ~LuminosityBlock();
 
     // AUX functions are defined in LuminosityBlockBase
@@ -111,6 +113,8 @@ namespace edm {
     ProcessHistory const&
     processHistory() const;
 
+    ModuleCallingContext const* moduleCallingContext() const { return moduleCallingContext_; }
+
   private:
     LuminosityBlockPrincipal const&
     luminosityBlockPrincipal() const;
@@ -145,6 +149,7 @@ namespace edm {
     boost::shared_ptr<Run const> const run_;
     typedef std::set<BranchID> BranchIDSet;
     mutable BranchIDSet gotBranchIDs_;
+    ModuleCallingContext const* moduleCallingContext_;
 
     static const std::string emptyString_;
   };
@@ -189,7 +194,7 @@ namespace edm {
       principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)), label, productInstanceName);
     }
     result.clear();
-    BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), label, productInstanceName, emptyString_);
+    BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), label, productInstanceName, emptyString_, moduleCallingContext_);
     convert_handle(bh, result);  // throws on conversion error
     if (bh.failedToGet()) {
       return false;
@@ -205,7 +210,7 @@ namespace edm {
       principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)), tag.label(), tag.instance());
     }
     result.clear();
-    BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), tag);
+    BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), tag, moduleCallingContext_);
     convert_handle(bh, result);  // throws on conversion error
     if (bh.failedToGet()) {
       return false;
@@ -220,7 +225,7 @@ namespace edm {
       principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)), token);
     }
     result.clear();
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
     convert_handle(bh, result);  // throws on conversion error
     if (bh.failedToGet()) {
       return false;
@@ -235,7 +240,7 @@ namespace edm {
       principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)), token);
     }
     result.clear();
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
     convert_handle(bh, result);  // throws on conversion error
     if (bh.failedToGet()) {
       return false;
@@ -250,7 +255,7 @@ namespace edm {
     if(!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("Lumi", TypeID(typeid(PROD)));
     }
-    return provRecorder_.getManyByType(results);
+    return provRecorder_.getManyByType(results, moduleCallingContext_);
   }
 
 }

--- a/FWCore/Framework/interface/LuminosityBlockPrincipal.h
+++ b/FWCore/Framework/interface/LuminosityBlockPrincipal.h
@@ -25,6 +25,7 @@ is the DataBlock.
 namespace edm {
 
   class HistoryAppender;
+  class ModuleCallingContext;
   class RunPrincipal;
   class UnscheduledHandler;
 
@@ -107,7 +108,8 @@ namespace edm {
 
     virtual bool isComplete_() const override {return complete_;}
 
-    virtual bool unscheduledFill(std::string const&) const override {return false;}
+    virtual bool unscheduledFill(std::string const&,
+                                 ModuleCallingContext const* mcc) const override {return false;}
 
     void resolveProductImmediate(ProductHolderBase const& phb) const;
 

--- a/FWCore/Framework/interface/OccurrenceTraits.h
+++ b/FWCore/Framework/interface/OccurrenceTraits.h
@@ -16,6 +16,11 @@ OccurrenceTraits:
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/GlobalContext.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/PathContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
 
 #include<string>
 
@@ -26,27 +31,44 @@ namespace edm {
   class OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> {
   public:
     typedef EventPrincipal MyPrincipal;
+    typedef StreamContext Context;
     static BranchType const branchType_ = InEvent;
     static bool const begin_ = true;
     static bool const isEvent_ = true;
-    static void preScheduleSignal(ActivityRegistry *a, EventPrincipal const* ep) {
+
+    static void setStreamContext(StreamContext& streamContext, MyPrincipal const& principal) {
+      streamContext.setTransition(StreamContext::Transition::kEvent);
+      streamContext.setEventID(principal.id());
+      streamContext.setTimestamp(principal.time());
+    }
+
+    static void preScheduleSignal(ActivityRegistry *a, EventPrincipal const* ep, StreamContext const* streamContext) {
       a->preProcessEventSignal_(ep->id(), ep->time()); 
+      a->preEventSignal_(*streamContext); 
     }
-    static void postScheduleSignal(ActivityRegistry *a, EventPrincipal* ep, EventSetup const* es) {
-      Event ev(*ep, ModuleDescription());
+    static void postScheduleSignal(ActivityRegistry *a, EventPrincipal* ep, EventSetup const* es, StreamContext const* streamContext) {
+      edm::ModuleDescription modDesc("postScheduledSignal", "");
+      ParentContext parentContext(streamContext);
+      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+      Event ev(*ep, ModuleDescription(), &moduleCallingContext);
       a->postProcessEventSignal_(ev, *es);
+      a->postEventSignal_(*streamContext, ev, *es);
     }
-    static void prePathSignal(ActivityRegistry *a, std::string const& s) {
-      a->preProcessPathSignal_(s); 
+    static void prePathSignal(ActivityRegistry *a, std::string const& s, PathContext const* pathContext) {
+      a->preProcessPathSignal_(s);
+      a->prePathEventSignal_(*pathContext->streamContext(), *pathContext); 
     }
-    static void postPathSignal(ActivityRegistry *a, std::string const& s, HLTPathStatus const& status) {
+    static void postPathSignal(ActivityRegistry *a, std::string const& s, HLTPathStatus const& status, PathContext const* pathContext) {
       a->postProcessPathSignal_(s, status); 
+      a->postPathEventSignal_(*pathContext->streamContext(), *pathContext, status); 
     }
-    static void preModuleSignal(ActivityRegistry *a, ModuleDescription const* md) {
+    static void preModuleSignal(ActivityRegistry *a, ModuleDescription const* md, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
       a->preModuleSignal_(*md); 
+      a->preModuleEventSignal_(*streamContext, *moduleCallingContext); 
     }
-    static void postModuleSignal(ActivityRegistry *a, ModuleDescription const* md) {
+    static void postModuleSignal(ActivityRegistry *a, ModuleDescription const* md, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
       a->postModuleSignal_(*md); 
+      a->postModuleEventSignal_(*streamContext, *moduleCallingContext); 
     }
   };
 
@@ -54,27 +76,46 @@ namespace edm {
   class OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> {
   public:
     typedef RunPrincipal MyPrincipal;
+    typedef GlobalContext Context;
     static BranchType const branchType_ = InRun;
     static bool const begin_ = true;
     static bool const isEvent_ = false;
-    static void preScheduleSignal(ActivityRegistry *a, RunPrincipal const* ep) {
-      a->preBeginRunSignal_(ep->id(), ep->beginTime()); 
+
+    static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
+      return GlobalContext(GlobalContext::Transition::kBeginRun,
+                           LuminosityBlockID(principal.run(), 0),
+                           principal.index(),
+                           LuminosityBlockIndex::invalidLuminosityBlockIndex(),
+                           principal.beginTime(),
+                           processContext);
     }
-    static void postScheduleSignal(ActivityRegistry *a, RunPrincipal* ep, EventSetup const* es) {
-      Run run(*ep, ModuleDescription());
+
+    static void preScheduleSignal(ActivityRegistry *a, RunPrincipal const* ep, GlobalContext const* globalContext) {
+      a->preBeginRunSignal_(ep->id(), ep->beginTime());
+      a->preGlobalBeginRunSignal_(*globalContext);
+    }
+    static void postScheduleSignal(ActivityRegistry *a, RunPrincipal* ep, EventSetup const* es, GlobalContext const* globalContext) {
+      // Next 4 lines not needed when we go to threaded interface
+      edm::ModuleDescription modDesc("postScheduledSignal", "");
+      ParentContext parentContext(globalContext);
+      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+      Run run(*ep, ModuleDescription(), &moduleCallingContext);
       a->postBeginRunSignal_(run, *es);
+      a->postGlobalBeginRunSignal_(*globalContext);
     }
-    static void prePathSignal(ActivityRegistry *a, std::string const& s) {
+    static void prePathSignal(ActivityRegistry *a, std::string const& s, PathContext const* pathContext) {
       a->prePathBeginRunSignal_(s); 
     }
-    static void postPathSignal(ActivityRegistry *a, std::string const& s, HLTPathStatus const& status) {
+    static void postPathSignal(ActivityRegistry *a, std::string const& s, HLTPathStatus const& status, PathContext const* pathContext) {
       a->postPathBeginRunSignal_(s, status); 
     }
-    static void preModuleSignal(ActivityRegistry *a, ModuleDescription const* md) {
+    static void preModuleSignal(ActivityRegistry *a, ModuleDescription const* md, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
       a->preModuleBeginRunSignal_(*md); 
+      a->preModuleGlobalBeginRunSignal_(*globalContext, *moduleCallingContext);
     }
-    static void postModuleSignal(ActivityRegistry *a, ModuleDescription const* md) {
+    static void postModuleSignal(ActivityRegistry *a, ModuleDescription const* md, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
       a->postModuleBeginRunSignal_(*md); 
+      a->postModuleGlobalBeginRunSignal_(*globalContext, *moduleCallingContext);
     }
   };
 
@@ -82,27 +123,34 @@ namespace edm {
   class OccurrenceTraits<RunPrincipal, BranchActionStreamBegin> {
   public:
     typedef RunPrincipal MyPrincipal;
+    typedef StreamContext Context;
     static BranchType const branchType_ = InRun;
     static bool const begin_ = true;
     static bool const isEvent_ = false;
-    static void preScheduleSignal(ActivityRegistry *a, RunPrincipal const* ep) {
-      //a->preBeginRunSignal_(ep->id(), ep->beginTime());
+
+    static void setStreamContext(StreamContext& streamContext, MyPrincipal const& principal) {
+      streamContext.setTransition(StreamContext::Transition::kBeginRun);
+      streamContext.setEventID(EventID(principal.run(), 0, 0));
+      streamContext.setRunIndex(principal.index());
+      streamContext.setLuminosityBlockIndex(LuminosityBlockIndex::invalidLuminosityBlockIndex());
+      streamContext.setTimestamp(principal.beginTime());
     }
-    static void postScheduleSignal(ActivityRegistry *a, RunPrincipal* ep, EventSetup const* es) {
-      Run run(*ep, ModuleDescription());
-      //a->postBeginRunSignal_(run, *es);
+
+    static void preScheduleSignal(ActivityRegistry *a, RunPrincipal const* ep, StreamContext const* streamContext) {
+      a->preStreamBeginRunSignal_(*streamContext);
     }
-    static void prePathSignal(ActivityRegistry *a, std::string const& s) {
-      //a->prePathBeginRunSignal_(s);
+    static void postScheduleSignal(ActivityRegistry *a, RunPrincipal* ep, EventSetup const* es, StreamContext const* streamContext) {
+      a->postStreamBeginRunSignal_(*streamContext);
     }
-    static void postPathSignal(ActivityRegistry *a, std::string const& s, HLTPathStatus const& status) {
-      //a->postPathBeginRunSignal_(s, status);
+    static void prePathSignal(ActivityRegistry *a, std::string const& s, PathContext const* pathContext) {
     }
-    static void preModuleSignal(ActivityRegistry *a, ModuleDescription const* md) {
-      //a->preModuleBeginRunSignal_(*md);
+    static void postPathSignal(ActivityRegistry *a, std::string const& s, HLTPathStatus const& status, PathContext const* pathContext) {
     }
-    static void postModuleSignal(ActivityRegistry *a, ModuleDescription const* md) {
-      //a->postModuleBeginRunSignal_(*md);
+    static void preModuleSignal(ActivityRegistry *a, ModuleDescription const* md, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
+      a->preModuleStreamBeginRunSignal_(*streamContext, *moduleCallingContext);
+    }
+    static void postModuleSignal(ActivityRegistry *a, ModuleDescription const* md, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
+      a->postModuleStreamBeginRunSignal_(*streamContext, *moduleCallingContext);
     }
   };
 
@@ -110,27 +158,38 @@ namespace edm {
   class OccurrenceTraits<RunPrincipal, BranchActionStreamEnd> {
   public:
     typedef RunPrincipal MyPrincipal;
+    typedef StreamContext Context;
     static BranchType const branchType_ = InRun;
     static bool const begin_ = false;
     static bool const isEvent_ = false;
-    static void preScheduleSignal(ActivityRegistry *a, RunPrincipal const* ep) {
-      //a->preEndRunSignal_(ep->id(), ep->endTime());
+
+    static void setStreamContext(StreamContext& streamContext, MyPrincipal const& principal) {
+      streamContext.setTransition(StreamContext::Transition::kEndRun);
+      streamContext.setEventID(EventID(principal.run(), 0, 0));
+      streamContext.setRunIndex(principal.index());
+      streamContext.setLuminosityBlockIndex(LuminosityBlockIndex::invalidLuminosityBlockIndex());
+      streamContext.setTimestamp(principal.endTime());
     }
-    static void postScheduleSignal(ActivityRegistry *a, RunPrincipal* ep, EventSetup const* es) {
-      //Run run(*ep, ModuleDescription());
-      //a->postEndRunSignal_(run, *es);
+
+    static void preScheduleSignal(ActivityRegistry *a, RunPrincipal const* ep, StreamContext const* streamContext) {
+      a->preStreamEndRunSignal_(*streamContext);
     }
-    static void prePathSignal(ActivityRegistry *a, std::string const& s) {
-      //a->prePathEndRunSignal_(s);
+    static void postScheduleSignal(ActivityRegistry *a, RunPrincipal* ep, EventSetup const* es, StreamContext const* streamContext) {
+      edm::ModuleDescription modDesc("postScheduledSignal", "");
+      ParentContext parentContext(streamContext);
+      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+      Run run(*ep, ModuleDescription(), &moduleCallingContext);
+      a->postStreamEndRunSignal_(*streamContext, run, *es);
     }
-    static void postPathSignal(ActivityRegistry *a, std::string const& s, HLTPathStatus const& status) {
-      //a->postPathEndRunSignal_(s, status);
+    static void prePathSignal(ActivityRegistry *a, std::string const& s, PathContext const* pathContext) {
     }
-    static void preModuleSignal(ActivityRegistry *a, ModuleDescription const* md) {
-      //a->preModuleEndRunSignal_(*md);
+    static void postPathSignal(ActivityRegistry *a, std::string const& s, HLTPathStatus const& status, PathContext const* pathContext) {
     }
-    static void postModuleSignal(ActivityRegistry *a, ModuleDescription const* md) {
-      //a->postModuleEndRunSignal_(*md);
+    static void preModuleSignal(ActivityRegistry *a, ModuleDescription const* md, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
+      a->preModuleStreamEndRunSignal_(*streamContext, *moduleCallingContext);
+    }
+    static void postModuleSignal(ActivityRegistry *a, ModuleDescription const* md, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
+      a->postModuleStreamEndRunSignal_(*streamContext, *moduleCallingContext);
     }
   };
 
@@ -138,27 +197,45 @@ namespace edm {
   class OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> {
   public:
     typedef RunPrincipal MyPrincipal;
+    typedef GlobalContext Context;
     static BranchType const branchType_ = InRun;
     static bool const begin_ = false;
     static bool const isEvent_ = false;
-    static void preScheduleSignal(ActivityRegistry *a, RunPrincipal const* ep) {
+
+    static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
+      return GlobalContext(GlobalContext::Transition::kEndRun,
+                           LuminosityBlockID(principal.run(), 0),
+                           principal.index(),
+                           LuminosityBlockIndex::invalidLuminosityBlockIndex(),
+                           principal.endTime(),
+                           processContext);
+    }
+
+    static void preScheduleSignal(ActivityRegistry *a, RunPrincipal const* ep, GlobalContext const* globalContext) {
       a->preEndRunSignal_(ep->id(), ep->endTime());
+      a->preGlobalEndRunSignal_(*globalContext);
     }
-    static void postScheduleSignal(ActivityRegistry *a, RunPrincipal* ep, EventSetup const* es) {
-      Run run(*ep, ModuleDescription());
+    static void postScheduleSignal(ActivityRegistry *a, RunPrincipal* ep, EventSetup const* es, GlobalContext const* globalContext) {
+      edm::ModuleDescription modDesc("postScheduledSignal", "");
+      ParentContext parentContext(globalContext);
+      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+      Run run(*ep, ModuleDescription(), &moduleCallingContext);
       a->postEndRunSignal_(run, *es);
+      a->postGlobalEndRunSignal_(*globalContext, run, *es);
     }
-    static void prePathSignal(ActivityRegistry *a, std::string const& s) {
+    static void prePathSignal(ActivityRegistry *a, std::string const& s, PathContext const* pathContext) {
       a->prePathEndRunSignal_(s);
     }
-    static void postPathSignal(ActivityRegistry *a, std::string const& s, HLTPathStatus const& status) {
+    static void postPathSignal(ActivityRegistry *a, std::string const& s, HLTPathStatus const& status, PathContext const* pathContext) {
       a->postPathEndRunSignal_(s, status);
     }
-    static void preModuleSignal(ActivityRegistry *a, ModuleDescription const* md) {
+    static void preModuleSignal(ActivityRegistry *a, ModuleDescription const* md, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
       a->preModuleEndRunSignal_(*md);
+      a->preModuleGlobalEndRunSignal_(*globalContext, *moduleCallingContext);
     }
-    static void postModuleSignal(ActivityRegistry *a, ModuleDescription const* md) {
+    static void postModuleSignal(ActivityRegistry *a, ModuleDescription const* md, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
       a->postModuleEndRunSignal_(*md);
+      a->postModuleGlobalEndRunSignal_(*globalContext, *moduleCallingContext);
     }
   };
   
@@ -166,27 +243,46 @@ namespace edm {
   class OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> {
   public:
     typedef LuminosityBlockPrincipal MyPrincipal;
+    typedef GlobalContext Context;
     static BranchType const branchType_ = InLumi;
     static bool const begin_ = true;
     static bool const isEvent_ = false;
-    static void preScheduleSignal(ActivityRegistry *a, LuminosityBlockPrincipal const* ep) {
+
+    static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
+      return GlobalContext(GlobalContext::Transition::kBeginLuminosityBlock,
+                           principal.id(),
+                           principal.runPrincipal().index(),
+                           principal.index(),
+                           principal.beginTime(),
+                           processContext);
+    }
+
+    static void preScheduleSignal(ActivityRegistry *a, LuminosityBlockPrincipal const* ep, GlobalContext const* globalContext) {
       a->preBeginLumiSignal_(ep->id(), ep->beginTime());
+      a->preGlobalBeginLumiSignal_(*globalContext);
     }
-    static void postScheduleSignal(ActivityRegistry *a, LuminosityBlockPrincipal* ep, EventSetup const* es) {
-      LuminosityBlock lumi(*ep, ModuleDescription());
+    static void postScheduleSignal(ActivityRegistry *a, LuminosityBlockPrincipal* ep, EventSetup const* es, GlobalContext const* globalContext) {
+      // Next 4 lines not needed when we go to threaded interface
+      edm::ModuleDescription modDesc("postScheduledSignal", "");
+      ParentContext parentContext(globalContext);
+      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+      LuminosityBlock lumi(*ep, ModuleDescription(), &moduleCallingContext);
       a->postBeginLumiSignal_(lumi, *es);
+      a->postGlobalBeginLumiSignal_(*globalContext);
     }
-    static void prePathSignal(ActivityRegistry *a, std::string const& s) {
+    static void prePathSignal(ActivityRegistry *a, std::string const& s, PathContext const* pathContext) {
       a->prePathBeginLumiSignal_(s);
     }
-    static void postPathSignal(ActivityRegistry *a, std::string const& s, HLTPathStatus const& status) {
+    static void postPathSignal(ActivityRegistry *a, std::string const& s, HLTPathStatus const& status, PathContext const* pathContext) {
       a->postPathBeginLumiSignal_(s, status);
     }
-    static void preModuleSignal(ActivityRegistry *a, ModuleDescription const* md) {
+    static void preModuleSignal(ActivityRegistry *a, ModuleDescription const* md, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
       a->preModuleBeginLumiSignal_(*md);
+      a->preModuleGlobalBeginLumiSignal_(*globalContext, *moduleCallingContext);
     }
-    static void postModuleSignal(ActivityRegistry *a, ModuleDescription const* md) {
+    static void postModuleSignal(ActivityRegistry *a, ModuleDescription const* md, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
       a->postModuleBeginLumiSignal_(*md);
+      a->postModuleGlobalBeginLumiSignal_(*globalContext, *moduleCallingContext);
     }
   };
   
@@ -194,27 +290,34 @@ namespace edm {
   class OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> {
   public:
     typedef LuminosityBlockPrincipal MyPrincipal;
+    typedef StreamContext Context;
     static BranchType const branchType_ = InLumi;
     static bool const begin_ = true;
     static bool const isEvent_ = false;
-    static void preScheduleSignal(ActivityRegistry *a, LuminosityBlockPrincipal const* ep) {
-      //a->preBeginLumiSignal_(ep->id(), ep->beginTime());
+
+    static void setStreamContext(StreamContext& streamContext, MyPrincipal const& principal) {
+      streamContext.setTransition(StreamContext::Transition::kBeginLuminosityBlock);
+      streamContext.setEventID(EventID(principal.run(), principal.luminosityBlock(), 0));
+      streamContext.setRunIndex(principal.runPrincipal().index());
+      streamContext.setLuminosityBlockIndex(principal.index());
+      streamContext.setTimestamp(principal.beginTime());
     }
-    static void postScheduleSignal(ActivityRegistry *a, LuminosityBlockPrincipal* ep, EventSetup const* es) {
-      //LuminosityBlock lumi(*ep, ModuleDescription());
-      //a->postBeginLumiSignal_(lumi, *es);
+
+    static void preScheduleSignal(ActivityRegistry *a, LuminosityBlockPrincipal const* ep, StreamContext const* streamContext) {
+      a->preStreamBeginLumiSignal_(*streamContext);
     }
-    static void prePathSignal(ActivityRegistry *a, std::string const& s) {
-      //a->prePathBeginLumiSignal_(s);
+    static void postScheduleSignal(ActivityRegistry *a, LuminosityBlockPrincipal* ep, EventSetup const* es, StreamContext const* streamContext) {
+      a->postStreamBeginLumiSignal_(*streamContext);
     }
-    static void postPathSignal(ActivityRegistry *a, std::string const& s, HLTPathStatus const& status) {
-      //a->postPathBeginLumiSignal_(s, status);
+    static void prePathSignal(ActivityRegistry *a, std::string const& s, PathContext const* pathContext) {
     }
-    static void preModuleSignal(ActivityRegistry *a, ModuleDescription const* md) {
-      //a->preModuleBeginLumiSignal_(*md);
+    static void postPathSignal(ActivityRegistry *a, std::string const& s, HLTPathStatus const& status, PathContext const* pathContext) {
     }
-    static void postModuleSignal(ActivityRegistry *a, ModuleDescription const* md) {
-      //a->postModuleBeginLumiSignal_(*md);
+    static void preModuleSignal(ActivityRegistry *a, ModuleDescription const* md, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
+      a->preModuleStreamBeginLumiSignal_(*streamContext, *moduleCallingContext);
+    }
+    static void postModuleSignal(ActivityRegistry *a, ModuleDescription const* md, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
+      a->postModuleStreamBeginLumiSignal_(*streamContext, *moduleCallingContext);
     }
   };
 
@@ -222,27 +325,40 @@ namespace edm {
   class OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd> {
   public:
     typedef LuminosityBlockPrincipal MyPrincipal;
+    typedef StreamContext Context;
     static BranchType const branchType_ = InLumi;
     static bool const begin_ = false;
     static bool const isEvent_ = false;
-    static void preScheduleSignal(ActivityRegistry *a, LuminosityBlockPrincipal const* ep) {
-      //a->preEndLumiSignal_(ep->id(), ep->beginTime());
+
+    static StreamContext const* context(StreamContext const* s, GlobalContext const* g) { return s; }
+
+    static void setStreamContext(StreamContext& streamContext, MyPrincipal const& principal) {
+      streamContext.setTransition(StreamContext::Transition::kEndLuminosityBlock);
+      streamContext.setEventID(EventID(principal.run(), principal.luminosityBlock(), 0));
+      streamContext.setRunIndex(principal.runPrincipal().index());
+      streamContext.setLuminosityBlockIndex(principal.index());
+      streamContext.setTimestamp(principal.endTime());
     }
-    static void postScheduleSignal(ActivityRegistry *a, LuminosityBlockPrincipal* ep, EventSetup const* es) {
-      //LuminosityBlock lumi(*ep, ModuleDescription());
-      //a->postEndLumiSignal_(lumi, *es);
+
+    static void preScheduleSignal(ActivityRegistry *a, LuminosityBlockPrincipal const* ep, StreamContext const* streamContext) {
+      a->preStreamEndLumiSignal_(*streamContext);
     }
-    static void prePathSignal(ActivityRegistry *a, std::string const& s) {
-      //a->prePathEndLumiSignal_(s);
+    static void postScheduleSignal(ActivityRegistry *a, LuminosityBlockPrincipal* ep, EventSetup const* es, StreamContext const* streamContext) {
+      edm::ModuleDescription modDesc("postScheduledSignal", "");
+      ParentContext parentContext(streamContext);
+      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+      LuminosityBlock lumi(*ep, ModuleDescription(), &moduleCallingContext);
+      a->postStreamEndLumiSignal_(*streamContext, lumi, *es);
     }
-    static void postPathSignal(ActivityRegistry *a, std::string const& s, HLTPathStatus const& status) {
-      //a->postPathEndLumiSignal_(s, status);
+    static void prePathSignal(ActivityRegistry *a, std::string const& s, PathContext const* pathContext) {
     }
-    static void preModuleSignal(ActivityRegistry *a, ModuleDescription const* md) {
-      //a->preModuleEndLumiSignal_(*md);
+    static void postPathSignal(ActivityRegistry *a, std::string const& s, HLTPathStatus const& status, PathContext const* pathContext) {
     }
-    static void postModuleSignal(ActivityRegistry *a, ModuleDescription const* md) {
-      //a->postModuleEndLumiSignal_(*md);
+    static void preModuleSignal(ActivityRegistry *a, ModuleDescription const* md, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
+      a->preModuleStreamEndLumiSignal_(*streamContext, *moduleCallingContext);
+    }
+    static void postModuleSignal(ActivityRegistry *a, ModuleDescription const* md, StreamContext const* streamContext, ModuleCallingContext const*  moduleCallingContext) {
+      a->postModuleStreamEndLumiSignal_(*streamContext, *moduleCallingContext);
     }
   };
 
@@ -250,27 +366,45 @@ namespace edm {
   class OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> {
   public:
     typedef LuminosityBlockPrincipal MyPrincipal;
+    typedef GlobalContext Context;
     static BranchType const branchType_ = InLumi;
     static bool const begin_ = false;
     static bool const isEvent_ = false;
-    static void preScheduleSignal(ActivityRegistry *a, LuminosityBlockPrincipal const* ep) {
+
+    static GlobalContext makeGlobalContext(MyPrincipal const& principal, ProcessContext const* processContext) {
+      return GlobalContext(GlobalContext::Transition::kEndLuminosityBlock,
+                           principal.id(),
+                           principal.runPrincipal().index(),
+                           principal.index(),
+                           principal.beginTime(),
+                           processContext);
+    }
+
+    static void preScheduleSignal(ActivityRegistry *a, LuminosityBlockPrincipal const* ep, GlobalContext const* globalContext) {
       a->preEndLumiSignal_(ep->id(), ep->beginTime()); 
+      a->preGlobalEndLumiSignal_(*globalContext); 
     }
-    static void postScheduleSignal(ActivityRegistry *a, LuminosityBlockPrincipal* ep, EventSetup const* es) {
-      LuminosityBlock lumi(*ep, ModuleDescription());
+    static void postScheduleSignal(ActivityRegistry *a, LuminosityBlockPrincipal* ep, EventSetup const* es, GlobalContext const* globalContext) {
+      edm::ModuleDescription modDesc("postScheduledSignal", "");
+      ParentContext parentContext(globalContext);
+      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+      LuminosityBlock lumi(*ep, ModuleDescription(), &moduleCallingContext);
       a->postEndLumiSignal_(lumi, *es);
+      a->postGlobalEndLumiSignal_(*globalContext, lumi, *es); 
     }
-    static void prePathSignal(ActivityRegistry *a, std::string const& s) {
+    static void prePathSignal(ActivityRegistry *a, std::string const& s, PathContext const* pathContext) {
       a->prePathEndLumiSignal_(s); 
     }
-    static void postPathSignal(ActivityRegistry *a, std::string const& s, HLTPathStatus const& status) {
+    static void postPathSignal(ActivityRegistry *a, std::string const& s, HLTPathStatus const& status, PathContext const* pathContext) {
       a->postPathEndLumiSignal_(s, status); 
     }
-    static void preModuleSignal(ActivityRegistry *a, ModuleDescription const* md) {
+    static void preModuleSignal(ActivityRegistry *a, ModuleDescription const* md, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
       a->preModuleEndLumiSignal_(*md); 
+      a->preModuleGlobalEndLumiSignal_(*globalContext, *moduleCallingContext);
     }
-    static void postModuleSignal(ActivityRegistry *a, ModuleDescription const* md) {
+    static void postModuleSignal(ActivityRegistry *a, ModuleDescription const* md, GlobalContext const* globalContext, ModuleCallingContext const*  moduleCallingContext) {
       a->postModuleEndLumiSignal_(*md); 
+      a->postModuleGlobalEndLumiSignal_(*globalContext, *moduleCallingContext);
     }
   };
 }

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -30,6 +30,8 @@ output stream.
 
 namespace edm {
 
+  class ModuleCallingContext;
+
   typedef detail::TriggerResultsBasedEventSelector::handle_t Trig;
 
   class OutputModule : public EDConsumerBase {
@@ -77,7 +79,7 @@ namespace edm {
     // need to clean up the use of Event and EventPrincipal, to avoid
     // creation of multiple Event objects when handling a single
     // event.
-    Trig getTriggerResults(EventPrincipal const& ep) const;
+    Trig getTriggerResults(EventPrincipal const& ep, ModuleCallingContext const*) const;
 
     // The returned pointer will be null unless the this is currently
     // executing its event loop function ('write').
@@ -90,15 +92,20 @@ namespace edm {
     void doBeginJob();
     void doEndJob();
     bool doEvent(EventPrincipal const& ep, EventSetup const& c,
-                 CurrentProcessingContext const* cpc);
+                 CurrentProcessingContext const* cpc,
+                 ModuleCallingContext const* mcc);
     bool doBeginRun(RunPrincipal const& rp, EventSetup const& c,
-                 CurrentProcessingContext const* cpc);
+                    CurrentProcessingContext const* cpc,
+                    ModuleCallingContext const* mcc);
     bool doEndRun(RunPrincipal const& rp, EventSetup const& c,
-                 CurrentProcessingContext const* cpc);
+                  CurrentProcessingContext const* cpc,
+                  ModuleCallingContext const* mcc);
     bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
-                 CurrentProcessingContext const* cpc);
+                                CurrentProcessingContext const* cpc,
+                                ModuleCallingContext const* mcc);
     bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
-                 CurrentProcessingContext const* cpc);
+                              CurrentProcessingContext const* cpc,
+                              ModuleCallingContext const* mcc);
 
     void setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
                                bool anyProductProduced);
@@ -165,8 +172,8 @@ namespace edm {
     //------------------------------------------------------------------
     // private member functions
     //------------------------------------------------------------------
-    void doWriteRun(RunPrincipal const& rp);
-    void doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp);
+    void doWriteRun(RunPrincipal const& rp, ModuleCallingContext const* mcc);
+    void doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp, ModuleCallingContext const* mcc);
     void doOpenFile(FileBlock const& fb);
     void doRespondToOpenInputFile(FileBlock const& fb);
     void doRespondToCloseInputFile(FileBlock const& fb);
@@ -192,15 +199,15 @@ namespace edm {
     /// Ask the OutputModule if we should end the current file.
     virtual bool shouldWeCloseFile() const {return false;}
 
-    virtual void write(EventPrincipal const& e) = 0;
+    virtual void write(EventPrincipal const& e, ModuleCallingContext const*) = 0;
     virtual void beginJob(){}
     virtual void endJob(){}
-    virtual void beginRun(RunPrincipal const&){}
-    virtual void endRun(RunPrincipal const&){}
-    virtual void writeRun(RunPrincipal const&) = 0;
-    virtual void beginLuminosityBlock(LuminosityBlockPrincipal const&){}
-    virtual void endLuminosityBlock(LuminosityBlockPrincipal const&){}
-    virtual void writeLuminosityBlock(LuminosityBlockPrincipal const&) = 0;
+    virtual void beginRun(RunPrincipal const&, ModuleCallingContext const*){}
+    virtual void endRun(RunPrincipal const&, ModuleCallingContext const*){}
+    virtual void writeRun(RunPrincipal const&, ModuleCallingContext const*) = 0;
+    virtual void beginLuminosityBlock(LuminosityBlockPrincipal const&, ModuleCallingContext const*){}
+    virtual void endLuminosityBlock(LuminosityBlockPrincipal const&, ModuleCallingContext const*){}
+    virtual void writeLuminosityBlock(LuminosityBlockPrincipal const&, ModuleCallingContext const*) = 0;
     virtual void openFile(FileBlock const&) {}
     virtual void respondToOpenInputFile(FileBlock const&) {}
     virtual void respondToCloseInputFile(FileBlock const&) {}

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -92,7 +92,7 @@ namespace edm {
     
     EDProductGetter const* prodGetter() const {return this;}
 
-    OutputHandle getForOutput(BranchID const& bid, bool getProd) const;
+    OutputHandle getForOutput(BranchID const& bid, bool getProd, ModuleCallingContext const* mcc) const;
 
     // Return a BasicHandle to the product which:
     //   1. matches the given label, instance, and process
@@ -107,24 +107,28 @@ namespace edm {
     BasicHandle  getByLabel(KindOfType kindOfType,
                             TypeID const& typeID,
                             InputTag const& inputTag,
-                            EDConsumerBase const* consumes) const;
+                            EDConsumerBase const* consumes,
+                            ModuleCallingContext const* mcc) const;
 
     BasicHandle  getByLabel(KindOfType kindOfType,
                             TypeID const& typeID,
                             std::string const& label,
                             std::string const& instance,
                             std::string const& process,
-                            EDConsumerBase const* consumes) const;
+                            EDConsumerBase const* consumes,
+                            ModuleCallingContext const* mcc) const;
     
     BasicHandle getByToken(KindOfType kindOfType,
                            TypeID const& typeID,
                            ProductHolderIndex index,
                            bool skipCurrentProcess,
-                           bool& ambiguous) const;
+                           bool& ambiguous,
+                           ModuleCallingContext const* mcc) const;
 
     void getManyByType(TypeID const& typeID,
                        BasicHandleVec& results,
-                       EDConsumerBase const* consumes) const;
+                       EDConsumerBase const* consumes,
+                       ModuleCallingContext const* mcc) const;
 
     ProcessHistory const& processHistory() const {
       return *processHistoryPtr_;
@@ -149,7 +153,8 @@ namespace edm {
     const_iterator begin() const {return boost::make_filter_iterator<FilledProductPtr>(productHolders_.begin(), productHolders_.end());}
     const_iterator end() const {return  boost::make_filter_iterator<FilledProductPtr>(productHolders_.end(), productHolders_.end());}
 
-    Provenance getProvenance(BranchID const& bid) const;
+    Provenance getProvenance(BranchID const& bid,
+                             ModuleCallingContext const* mcc) const;
 
     void getAllProvenance(std::vector<Provenance const*>& provenances) const;
 
@@ -159,24 +164,27 @@ namespace edm {
 
     ConstProductPtr getProductHolder(BranchID const& oid,
                                      bool resolveProd,
-                                     bool fillOnDemand) const;
+                                     bool fillOnDemand,
+                                     ModuleCallingContext const* mcc) const;
 
-    ProductData const* findProductByTag(TypeID const& typeID, InputTag const& tag) const;
+    ProductData const* findProductByTag(TypeID const& typeID, InputTag const& tag, ModuleCallingContext const* mcc) const;
 
     // Make my DelayedReader get the EDProduct for a ProductHolder or
     // trigger unscheduled execution if required.  The ProductHolder is
     // a cache, and so can be modified through the const reference.
     // We do not change the *number* of products through this call, and so
     // *this is const.
-    void resolveProduct(ProductHolderBase const& phb, bool fillOnDemand) const {resolveProduct_(phb, fillOnDemand);}
+    void resolveProduct(ProductHolderBase const& phb, bool fillOnDemand, ModuleCallingContext const* mcc) const {resolveProduct_(phb, fillOnDemand,mcc);}
 
-    virtual bool unscheduledFill(std::string const& moduleLabel) const = 0;
+    virtual bool unscheduledFill(std::string const& moduleLabel,
+                                 ModuleCallingContext const* mcc) const = 0;
 
     std::vector<unsigned int> const& lookupProcessOrder() const { return lookupProcessOrder_; }
 
     ConstProductPtr getProductByIndex(ProductHolderIndex const& oid,
                                       bool resolveProd,
-                                      bool fillOnDemand) const;
+                                      bool fillOnDemand,
+                                      ModuleCallingContext const* mcc) const;
 
     bool isComplete() const {return isComplete_();}
 
@@ -202,22 +210,26 @@ namespace edm {
 
     void findProducts(std::vector<ProductHolderBase const*> const& holders,
                       TypeID const& typeID,
-                      BasicHandleVec& results) const;
+                      BasicHandleVec& results,
+                      ModuleCallingContext const* mcc) const;
 
     ProductData const* findProductByLabel(KindOfType kindOfType,
                                           TypeID const& typeID,
                                           InputTag const& inputTag,
-                                          EDConsumerBase const* consumer) const;
+                                          EDConsumerBase const* consumer,
+                                          ModuleCallingContext const* mcc) const;
 
     ProductData const* findProductByLabel(KindOfType kindOfType,
                                           TypeID const& typeID,
                                           std::string const& label,
                                           std::string const& instance,
                                           std::string const& process,
-                                          EDConsumerBase const* consumer) const;
+                                          EDConsumerBase const* consumer,
+                                          ModuleCallingContext const* mcc) const;
 
     // defaults to no-op unless overridden in derived class.
-    virtual void resolveProduct_(ProductHolderBase const&, bool /*fillOnDemand*/) const {}
+    virtual void resolveProduct_(ProductHolderBase const&, bool /*fillOnDemand*/,
+                                 ModuleCallingContext const*) const {}
 
     virtual bool isComplete_() const {return true;}
 
@@ -258,9 +270,9 @@ namespace edm {
   template <typename PROD>
   inline
   boost::shared_ptr<Wrapper<PROD> const>
-  getProductByTag(Principal const& ep, InputTag const& tag) {
+    getProductByTag(Principal const& ep, InputTag const& tag, ModuleCallingContext const* mcc) {
     TypeID tid = TypeID(typeid(PROD));
-    ProductData const* result = ep.findProductByTag(tid, tag);
+    ProductData const* result = ep.findProductByTag(tid, tag, mcc);
 
     if(result->getInterface() &&
        (!(result->getInterface()->dynamicTypeInfo() == typeid(PROD)))) {

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -108,6 +108,8 @@ edm::Ref<AppleCollection> ref(refApples, index);
 
 namespace edm {
 
+  class ModuleCallingContext;
+
   namespace principal_get_adapter_detail {
     struct deleter {
       void operator()(std::pair<WrapperOwningHolder, ConstBranchDescription const*> const p) const;
@@ -147,7 +149,7 @@ namespace edm {
 
     template <typename PROD>
     void 
-    getManyByType(std::vector<Handle<PROD> >& results) const;
+    getManyByType(std::vector<Handle<PROD> >& results, ModuleCallingContext const* mcc) const;
 
     ProcessHistory const&
     processHistory() const;
@@ -168,30 +170,36 @@ namespace edm {
     // from the Principal class.
 
     BasicHandle 
-    getByLabel_(TypeID const& tid, InputTag const& tag) const;
+    getByLabel_(TypeID const& tid, InputTag const& tag,
+                ModuleCallingContext const* mcc) const;
 
     BasicHandle 
     getByLabel_(TypeID const& tid,
-		std::string const& label,
-		std::string const& instance,
-		std::string const& process) const;
+                std::string const& label,
+                std::string const& instance,
+                std::string const& process,
+                ModuleCallingContext const* mcc) const;
 
     BasicHandle
-    getByToken_(TypeID const& id, KindOfType kindOfType, EDGetToken token) const;
-    
+    getByToken_(TypeID const& id, KindOfType kindOfType, EDGetToken token,
+                ModuleCallingContext const* mcc) const;
+
     BasicHandle
     getMatchingSequenceByLabel_(TypeID const& typeID,
-                                InputTag const& tag) const;
+                                InputTag const& tag,
+                                ModuleCallingContext const* mcc) const;
 
     BasicHandle
     getMatchingSequenceByLabel_(TypeID const& typeID,
                                 std::string const& label,
                                 std::string const& instance,
-                                std::string const& process) const;
+                                std::string const& process,
+                                ModuleCallingContext const* mcc) const;
     
     void 
     getManyByType_(TypeID const& tid, 
-		   BasicHandleVec& results) const;
+		   BasicHandleVec& results,
+                   ModuleCallingContext const* mcc) const;
 
     // Also isolates the PrincipalGetAdapter class
     // from the Principal class.
@@ -307,9 +315,10 @@ namespace edm {
   template <typename PROD>
   inline
   void 
-  PrincipalGetAdapter::getManyByType(std::vector<Handle<PROD> >& results) const { 
+  PrincipalGetAdapter::getManyByType(std::vector<Handle<PROD> >& results,
+                                     ModuleCallingContext const* mcc) const { 
     BasicHandleVec bhv;
-    this->getManyByType_(TypeID(typeid(PROD)), bhv);
+    this->getManyByType_(TypeID(typeid(PROD)), bhv, mcc);
     
     // Go through the returned handles; for each element,
     //   1. create a Handle<PROD> and

--- a/FWCore/Framework/interface/ProductHolder.h
+++ b/FWCore/Framework/interface/ProductHolder.h
@@ -24,6 +24,7 @@ a set of related EDProducts. This is the storage unit of such information.
 namespace edm {
   class BranchMapper;
   class DelayedReader;
+  class ModuleCallingContext;
   class Principal;
   class WrapperInterfaceBase;
 
@@ -46,8 +47,9 @@ namespace edm {
       return getProductData();
     }
 
-    ProductData const* resolveProduct(ResolveStatus& resolveStatus, bool skipCurrentProcess) const {
-      return resolveProduct_(resolveStatus, skipCurrentProcess);
+    ProductData const* resolveProduct(ResolveStatus& resolveStatus, bool skipCurrentProcess,
+                                      ModuleCallingContext const* mcc) const {
+      return resolveProduct_(resolveStatus, skipCurrentProcess, mcc);
     }
 
     void resetStatus () {
@@ -174,7 +176,8 @@ namespace edm {
   private:
     virtual ProductData const& getProductData() const = 0;
     virtual ProductData& getProductData() = 0;
-    virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess) const = 0;
+    virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess,
+                                               ModuleCallingContext const* mcc) const = 0;
     virtual void swap_(ProductHolderBase& rhs) = 0;
     virtual bool onDemand_() const = 0;
     virtual bool productUnavailable_() const = 0;
@@ -225,7 +228,8 @@ namespace edm {
         edm::swap(productData_, other.productData_);
         std::swap(productIsUnavailable_, other.productIsUnavailable_);
       }
-      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess) const;
+      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess,
+                                                 ModuleCallingContext const* mcc) const;
       virtual void putProduct_(WrapperOwningHolder const& edp, ProductProvenance const& productProvenance);
       virtual void putProduct_(WrapperOwningHolder const& edp) const;
       virtual void mergeProduct_(WrapperOwningHolder const& edp, ProductProvenance& productProvenance);
@@ -311,7 +315,8 @@ namespace edm {
         edm::swap(productData_, other.productData_);
         std::swap(theStatus_, other.theStatus_);
       }
-      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess) const;
+      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess,
+                                                 ModuleCallingContext const* mcc) const;
       virtual void resetStatus_() {theStatus_ = NotRun;}
       virtual bool onDemand_() const {return false;}
       virtual ProductData const& getProductData() const {return productData_;}
@@ -338,7 +343,8 @@ namespace edm {
         edm::swap(productData_, other.productData_);
         std::swap(theStatus_, other.theStatus_);
       }
-      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess) const;
+      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess,
+                                                 ModuleCallingContext const* mcc) const;
       virtual void resetStatus_() {theStatus_ = UnscheduledNotRun;}
       virtual bool onDemand_() const {return status() == UnscheduledNotRun;}
       virtual ProductData const& getProductData() const {return productData_;}
@@ -365,7 +371,8 @@ namespace edm {
         edm::swap(productData_, other.productData_);
         std::swap(theStatus_, other.theStatus_);
       }
-      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess) const;
+      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess,
+                                                 ModuleCallingContext const* mcc) const;
       virtual void resetStatus_() {theStatus_ = NotPut;}
       virtual bool onDemand_() const {return false;}
       virtual ProductData const& getProductData() const {return productData_;}
@@ -387,7 +394,8 @@ namespace edm {
         realProduct_.swap(other.realProduct_);
         std::swap(bd_, other.bd_);
       }
-      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess) const {return realProduct_.resolveProduct(resolveStatus, skipCurrentProcess);}
+      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess,
+                                                 ModuleCallingContext const* mcc) const {return realProduct_.resolveProduct(resolveStatus, skipCurrentProcess, mcc);}
       virtual bool onDemand_() const {return realProduct_.onDemand();}
       virtual ProductStatus& status_() const {return realProduct_.status();}
       virtual void resetStatus_() {realProduct_.resetStatus();}
@@ -436,7 +444,8 @@ namespace edm {
     private:
       virtual ProductData const& getProductData() const;
       virtual ProductData& getProductData();
-      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess) const;
+      virtual ProductData const* resolveProduct_(ResolveStatus& resolveStatus, bool skipCurrentProcess,
+                                                 ModuleCallingContext const* mcc) const;
       virtual void swap_(ProductHolderBase& rhs);
       virtual bool onDemand_() const;
       virtual bool productUnavailable_() const;

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -32,6 +32,7 @@ For its usage, see "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include <vector>
 
 namespace edm {
+  class ModuleCallingContext;
   class ProducerBase;
   namespace stream {
     template< typename T> class ProducingModuleAdaptorBase;
@@ -39,7 +40,8 @@ namespace edm {
 
   class Run : public RunBase {
   public:
-    Run(RunPrincipal& rp, ModuleDescription const& md);
+    Run(RunPrincipal& rp, ModuleDescription const& md,
+        ModuleCallingContext const*);
     ~Run();
 
     //Used in conjunction with EDGetToken
@@ -119,6 +121,8 @@ namespace edm {
     ProcessHistory const&
     processHistory() const;
 
+    ModuleCallingContext const* moduleCallingContext() const { return moduleCallingContext_; }
+
   private:
     RunPrincipal const&
     runPrincipal() const;
@@ -151,6 +155,7 @@ namespace edm {
     RunAuxiliary const& aux_;
     typedef std::set<BranchID> BranchIDSet;
     mutable BranchIDSet gotBranchIDs_;
+    ModuleCallingContext const* moduleCallingContext_;
 
     static const std::string emptyString_;
   };
@@ -195,7 +200,7 @@ namespace edm {
       principal_get_adapter_detail::throwOnPrematureRead("Run", TypeID(typeid(PROD)), label, productInstanceName);
     }
     result.clear();
-    BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), label, productInstanceName, emptyString_);
+    BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), label, productInstanceName, emptyString_, moduleCallingContext_);
     convert_handle(bh, result);  // throws on conversion error
     if (bh.failedToGet()) {
       return false;
@@ -211,7 +216,7 @@ namespace edm {
       principal_get_adapter_detail::throwOnPrematureRead("Run", TypeID(typeid(PROD)), tag.label(), tag.instance());
     }
     result.clear();
-    BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), tag);
+    BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), tag, moduleCallingContext_);
     convert_handle(bh, result);  // throws on conversion error
     if (bh.failedToGet()) {
       return false;
@@ -226,7 +231,7 @@ namespace edm {
       principal_get_adapter_detail::throwOnPrematureRead("Run", TypeID(typeid(PROD)), token);
     }
     result.clear();
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
     convert_handle(bh, result);  // throws on conversion error
     if (bh.failedToGet()) {
       return false;
@@ -241,7 +246,7 @@ namespace edm {
       principal_get_adapter_detail::throwOnPrematureRead("Run", TypeID(typeid(PROD)), token);
     }
     result.clear();
-    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token);
+    BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
     convert_handle(bh, result);  // throws on conversion error
     if (bh.failedToGet()) {
       return false;
@@ -255,7 +260,7 @@ namespace edm {
     if(!provRecorder_.checkIfComplete<PROD>()) {
       principal_get_adapter_detail::throwOnPrematureRead("Run", TypeID(typeid(PROD)));
     }
-    return provRecorder_.getManyByType(results);
+    return provRecorder_.getManyByType(results, moduleCallingContext_);
   }
 
 }

--- a/FWCore/Framework/interface/RunPrincipal.h
+++ b/FWCore/Framework/interface/RunPrincipal.h
@@ -96,7 +96,8 @@ namespace edm {
 
     virtual bool isComplete_() const override {return complete_;}
 
-    virtual bool unscheduledFill(std::string const&) const override {return false;}
+    virtual bool unscheduledFill(std::string const&,
+                                 ModuleCallingContext const* mcc) const override {return false;}
 
     void resolveProductImmediate(ProductHolderBase const& phb) const;
 

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -91,6 +91,28 @@
 #include <sstream>
 
 namespace edm {
+
+  namespace {
+    template <typename T>
+    class ScheduleSignalSentry {
+    public:
+      ScheduleSignalSentry(ActivityRegistry* a, typename T::MyPrincipal* principal, EventSetup const* es, typename T::Context const* context) :
+        a_(a), principal_(principal), es_(es), context_(context) {
+        if (a_) T::preScheduleSignal(a_, principal_, context_);
+      }
+      ~ScheduleSignalSentry() {
+        if (a_) if (principal_) T::postScheduleSignal(a_, principal_, es_, context_);
+      }
+
+    private:
+      // We own none of these resources.
+      ActivityRegistry* a_;
+      typename T::MyPrincipal* principal_;
+      EventSetup const* es_;
+      typename T::Context const* context_;
+    };
+  }
+
   namespace service {
     class TriggerNamesService;
   }
@@ -99,6 +121,7 @@ namespace edm {
   class EventSetup;
   class ExceptionCollector;
   class OutputModuleCommunicator;
+  class ProcessContext;
   class RunStopwatch;
   class UnscheduledCallProducer;
   class WorkerInPath;
@@ -124,14 +147,25 @@ namespace edm {
              boost::shared_ptr<ActivityRegistry> areg,
              boost::shared_ptr<ProcessConfiguration> processConfiguration,
              const ParameterSet* subProcPSet,
-             StreamID streamID);
+             StreamID streamID,
+             ProcessContext const* processContext);
 
     enum State { Ready = 0, Running, Latched };
 
     template <typename T>
-    void processOneOccurrence(typename T::MyPrincipal& principal,
-                              EventSetup const& eventSetup,
-                              bool cleaningUpAfterException = false);
+    void processOneEvent(typename T::MyPrincipal& principal,
+                         EventSetup const& eventSetup,
+                         bool cleaningUpAfterException = false);
+
+    template <typename T>
+    void processOneGlobal(typename T::MyPrincipal& principal,
+                          EventSetup const& eventSetup,
+                          bool cleaningUpAfterException = false);
+
+    template <typename T>
+    void processOneStream(typename T::MyPrincipal& principal,
+                          EventSetup const& eventSetup,
+                          bool cleaningUpAfterException = false);
 
     void beginJob(ProductRegistry const&);
     void endJob(ExceptionCollector & collector);
@@ -140,10 +174,10 @@ namespace edm {
     void endStream();
 
     // Write the luminosity block
-    void writeLumi(LuminosityBlockPrincipal const& lbp);
+    void writeLumi(LuminosityBlockPrincipal const& lbp, ProcessContext const*);
 
     // Write the run
-    void writeRun(RunPrincipal const& rp);
+    void writeRun(RunPrincipal const& rp, ProcessContext const*);
 
     // Call closeFile() on all OutputModules.
     void closeOutputFiles();
@@ -243,10 +277,10 @@ namespace edm {
     void resetAll();
 
     template <typename T>
-    bool runTriggerPaths(typename T::MyPrincipal&, EventSetup const&);
+    bool runTriggerPaths(typename T::MyPrincipal&, EventSetup const&, typename T::Context const*);
 
     template <typename T>
-    void runEndPaths(typename T::MyPrincipal&, EventSetup const&);
+    void runEndPaths(typename T::MyPrincipal&, EventSetup const&, typename T::Context const*);
 
     void reportSkipped(EventPrincipal const& ep) const;
     void reportSkipped(LuminosityBlockPrincipal const&) const {}
@@ -321,6 +355,7 @@ namespace edm {
     RunStopwatch::StopwatchPointer stopwatch_;
 
     StreamID                streamID_;
+    StreamContext           streamContext_;
     volatile bool           endpathsAreActive_;
   };
 
@@ -332,8 +367,7 @@ namespace edm {
   }
 
   template <typename T>
-  void
-  Schedule::processOneOccurrence(typename T::MyPrincipal& ep,
+  void Schedule::processOneEvent(typename T::MyPrincipal& ep,
                                  EventSetup const& es,
                                  bool cleaningUpAfterException) {
     this->resetAll();
@@ -342,25 +376,26 @@ namespace edm {
     }
     state_ = Running;
 
+    T::setStreamContext(streamContext_, ep);
+    ScheduleSignalSentry<T> sentry(actReg_.get(), &ep, &es, &streamContext_);
+
     // A RunStopwatch, but only if we are processing an event.
-    RunStopwatch stopwatch(T::isEvent_ ? stopwatch_ : RunStopwatch::StopwatchPointer());
+    RunStopwatch stopwatch(stopwatch_);
 
     // This call takes care of the unscheduled processing.
-    workerManager_.processOneOccurrence<T>(ep, es, streamID_, cleaningUpAfterException);
+    workerManager_.processOneOccurrence<T>(ep, es, streamID_, &streamContext_, &streamContext_, cleaningUpAfterException);
 
-    if (T::isEvent_) {
-      ++total_events_;
-    }
+    ++total_events_;
     try {
       try {
         try {
-          if (runTriggerPaths<T>(ep, es)) {
-            if (T::isEvent_) ++total_passed_;
+          if (runTriggerPaths<T>(ep, es, &streamContext_)) {
+            ++total_passed_;
           }
           state_ = Latched;
         }
         catch(cms::Exception& e) {
-          actions::ActionCodes action = (T::isEvent_ ? actionTable().find(e.category()) : actions::Rethrow);
+          actions::ActionCodes action = actionTable().find(e.category());
           assert (action != actions::IgnoreCompletely);
           assert (action != actions::FailPath);
           if (action == actions::SkipEvent) {
@@ -372,7 +407,8 @@ namespace edm {
 
         try {
           CPUTimer timer;
-          if (results_inserter_.get()) results_inserter_->doWork<T>(ep, es, nullptr, &timer,streamID_);
+          ParentContext parentContext(&streamContext_);
+          if (results_inserter_.get()) results_inserter_->doWork<T>(ep, es, nullptr, &timer,streamID_, parentContext, &streamContext_);
         }
         catch (cms::Exception & ex) {
           if (T::isEvent_) {
@@ -384,8 +420,8 @@ namespace edm {
           throw;
         }
 
-        if (endpathsAreActive_) runEndPaths<T>(ep, es);
-        if(T::isEvent_) resetEarlyDelete();
+        if (endpathsAreActive_) runEndPaths<T>(ep, es, &streamContext_);
+        resetEarlyDelete();
       }
       catch (cms::Exception& e) { throw; }
       catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
@@ -396,7 +432,94 @@ namespace edm {
     }
     catch(cms::Exception& ex) {
       if (ex.context().empty()) {
-        addContextAndPrintException("Calling function Schedule::processOneOccurrence", ex, cleaningUpAfterException);
+        addContextAndPrintException("Calling function Schedule::processOneEvent", ex, cleaningUpAfterException);
+      } else {
+        addContextAndPrintException("", ex, cleaningUpAfterException);
+      }
+      state_ = Ready;
+      throw;
+    }
+    // next thing probably is not needed, the product insertion code clears it
+    state_ = Ready;
+  }
+
+  template <typename T>
+  void Schedule::processOneStream(typename T::MyPrincipal& ep,
+                                  EventSetup const& es,
+                                  bool cleaningUpAfterException) {
+    this->resetAll();
+    for (int empty_trig_path : empty_trig_paths_) {
+      results_->at(empty_trig_path) = HLTPathStatus(hlt::Pass, 0);
+    }
+    state_ = Running;
+
+    T::setStreamContext(streamContext_, ep);
+    ScheduleSignalSentry<T> sentry(actReg_.get(), &ep, &es, &streamContext_);
+
+    // This call takes care of the unscheduled processing.
+    workerManager_.processOneOccurrence<T>(ep, es, streamID_, &streamContext_, &streamContext_, cleaningUpAfterException);
+
+    try {
+      try {
+        runTriggerPaths<T>(ep, es, &streamContext_);
+        state_ = Latched;
+
+        if (endpathsAreActive_) runEndPaths<T>(ep, es, &streamContext_);
+      }
+      catch (cms::Exception& e) { throw; }
+      catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
+      catch (std::exception& e) { convertException::stdToEDM(e); }
+      catch(std::string& s) { convertException::stringToEDM(s); }
+      catch(char const* c) { convertException::charPtrToEDM(c); }
+      catch (...) { convertException::unknownToEDM(); }
+    }
+    catch(cms::Exception& ex) {
+      if (ex.context().empty()) {
+        addContextAndPrintException("Calling function Schedule::processOneStream", ex, cleaningUpAfterException);
+      } else {
+        addContextAndPrintException("", ex, cleaningUpAfterException);
+      }
+      state_ = Ready;
+      throw;
+    }
+    // next thing probably is not needed, the product insertion code clears it
+    state_ = Ready;
+  }
+  template <typename T>
+  void
+  Schedule::processOneGlobal(typename T::MyPrincipal& ep,
+                                 EventSetup const& es,
+                                 bool cleaningUpAfterException) {
+    this->resetAll();
+    for (int empty_trig_path : empty_trig_paths_) {
+      results_->at(empty_trig_path) = HLTPathStatus(hlt::Pass, 0);
+    }
+    state_ = Running;
+
+    GlobalContext globalContext = T::makeGlobalContext(ep, streamContext_.processContext());
+
+    ScheduleSignalSentry<T> sentry(actReg_.get(), &ep, &es, &globalContext);
+
+    // This call takes care of the unscheduled processing.
+    workerManager_.processOneOccurrence<T>(ep, es, streamID_, &globalContext, &globalContext, cleaningUpAfterException);
+
+    try {
+      try {
+        runTriggerPaths<T>(ep, es, &globalContext);
+        state_ = Latched;
+
+        if (endpathsAreActive_) runEndPaths<T>(ep, es, &globalContext);
+      }
+      catch (cms::Exception& e) { throw; }
+      catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
+      catch (std::exception& e) { convertException::stdToEDM(e); }
+      catch(std::string& s) { convertException::stringToEDM(s); }
+      catch(char const* c) { convertException::charPtrToEDM(c); }
+      catch (...) { convertException::unknownToEDM(); }
+    }
+    catch(cms::Exception& ex) {
+      if (ex.context().empty()) {
+        addContextAndPrintException("Calling function Schedule::processOneGlobal", ex, cleaningUpAfterException);
       } else {
         addContextAndPrintException("", ex, cleaningUpAfterException);
       }
@@ -409,33 +532,21 @@ namespace edm {
 
   template <typename T>
   bool
-  Schedule::runTriggerPaths(typename T::MyPrincipal& ep, EventSetup const& es) {
+  Schedule::runTriggerPaths(typename T::MyPrincipal& ep, EventSetup const& es, typename T::Context const* context) {
     for(auto& p : trig_paths_) {
-      p.processOneOccurrence<T>(ep, es, streamID_);
+      p.processOneOccurrence<T>(ep, es, streamID_, context);
     }
     return results_->accept();
   }
 
   template <typename T>
   void
-  Schedule::runEndPaths(typename T::MyPrincipal& ep, EventSetup const& es) {
+  Schedule::runEndPaths(typename T::MyPrincipal& ep, EventSetup const& es, typename T::Context const* context) {
     // Note there is no state-checking safety controlling the
     // activation/deactivation of endpaths.
     for(auto& p : end_paths_) {
-      p.processOneOccurrence<T>(ep, es, streamID_);
+      p.processOneOccurrence<T>(ep, es, streamID_, context);
     }
-
-    // We could get rid of the functor ProcessOneOccurrence if we used
-    // boost::lambda, but the use of lambda with member functions
-    // which take multiple arguments, by both non-const and const
-    // reference, seems much more obscure...
-    //
-    // using namespace boost::lambda;
-    // for_all(end_paths_,
-    //          bind(&Path::processOneOccurrence,
-    //               boost::lambda::_1, // qualification to avoid ambiguity
-    //               var(ep),           //  pass by reference (not copy)
-    //               constant_ref(es))); // pass by const-reference (not copy)
   }
 }
 

--- a/FWCore/Framework/interface/ScheduleItems.h
+++ b/FWCore/Framework/interface/ScheduleItems.h
@@ -17,6 +17,7 @@ namespace edm {
   class SubProcess;
   class ParameterSet;
   class ProcessConfiguration;
+  class ProcessContext;
   class ProductRegistry;
   class Schedule;
   class SignallingProductRegistry;
@@ -46,7 +47,8 @@ namespace edm {
     std::auto_ptr<Schedule>
     initSchedule(ParameterSet& parameterSet,
                  ParameterSet const* subProcessPSet,
-                 StreamID streamID);
+                 StreamID streamID,
+                 ProcessContext const*);
 
     void
     clear();

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -8,6 +8,7 @@
 #include "FWCore/Framework/interface/TriggerResultsBasedEventSelector.h"
 #include "FWCore/Framework/interface/ProductSelectorRules.h"
 #include "FWCore/Framework/interface/ProductSelector.h"
+#include "FWCore/ServiceRegistry/interface/ProcessContext.h"
 #include "FWCore/ServiceRegistry/interface/ServiceLegacy.h"
 #include "FWCore/ServiceRegistry/interface/ServiceToken.h"
 #include "FWCore/Utilities/interface/BranchType.h"
@@ -24,6 +25,7 @@ namespace edm {
   class EDLooperBase;
   class HistoryAppender;
   class IOVSyncValue;
+  class ModuleCallingContext;
   class ParameterSet;
   class ProductRegistry;
   namespace eventsetup {
@@ -38,7 +40,8 @@ namespace edm {
                eventsetup::EventSetupsController& esController,
                ActivityRegistry& parentActReg,
                ServiceToken const& token,
-               serviceregistry::ServiceLegacy iLegacy);
+               serviceregistry::ServiceLegacy iLegacy,
+               ProcessContext const* parentProcessContext);
 
     virtual ~SubProcess();
     
@@ -215,6 +218,7 @@ namespace edm {
     boost::shared_ptr<BranchIDListHelper>         branchIDListHelper_;
     std::unique_ptr<ActionTable const>            act_table_;
     boost::shared_ptr<ProcessConfiguration const> processConfiguration_;
+    ProcessContext                                processContext_;
     PrincipalCache                                principalCache_;
     boost::shared_ptr<eventsetup::EventSetupProvider> esp_;
     std::auto_ptr<Schedule>                       schedule_;

--- a/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
+++ b/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
@@ -20,6 +20,8 @@
 
 namespace edm
 {
+  class ModuleCallingContext;
+
   namespace detail
   {
     typedef edm::Handle<edm::TriggerResults> handle_t;
@@ -33,7 +35,7 @@ namespace edm
 	product_() 
       { }
 
-      void fill(EventPrincipal const& e);
+      void fill(EventPrincipal const& e, ModuleCallingContext const* mcc);
 
       bool match()
       {
@@ -71,9 +73,9 @@ namespace edm
 		 std::vector<std::string> const& triggernames,
                  const std::string& process_name);
 
-      bool wantEvent(EventPrincipal const& e);
+      bool wantEvent(EventPrincipal const& e, ModuleCallingContext const*);
 
-      handle_t getOneTriggerResults(EventPrincipal const& e);
+      handle_t getOneTriggerResults(EventPrincipal const& e, ModuleCallingContext const*);
 
       // Clear the cache
       void clear();
@@ -83,7 +85,7 @@ namespace edm
 
       // Get all TriggerResults objects for the process names we're
       // interested in.
-      size_type fill(EventPrincipal const& ev);
+      size_type fill(EventPrincipal const& ev, ModuleCallingContext const*);
       
       // If we have only one handle cached, return it; otherwise throw.
       handle_t returnOneHandleOrThrow();

--- a/FWCore/Framework/interface/UnscheduledCallProducer.h
+++ b/FWCore/Framework/interface/UnscheduledCallProducer.h
@@ -7,6 +7,8 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/OccurrenceTraits.h"
 #include "FWCore/Framework/src/Worker.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
 
 #include <map>
 #include <string>
@@ -21,8 +23,9 @@ namespace edm {
       labelToWorkers_[aWorker->description().moduleLabel()] = aWorker;
     }
 
-    template <typename T>
-    void runNow(typename T::MyPrincipal& p, EventSetup const& es, StreamID streamID) {
+    template <typename T, typename U>
+    void runNow(typename T::MyPrincipal& p, EventSetup const& es, StreamID streamID,
+                typename T::Context const* topContext, U const* context) {
       //do nothing for event since we will run when requested
       if(!T::isEvent_) {
         for(std::map<std::string, Worker*>::iterator it = labelToWorkers_.begin(), itEnd=labelToWorkers_.end();
@@ -30,7 +33,8 @@ namespace edm {
             ++it) {
           CPUTimer timer;
           try {
-            it->second->doWork<T>(p, es, nullptr, &timer,streamID);
+            ParentContext parentContext(context);
+            it->second->doWork<T>(p, es, nullptr, &timer,streamID, parentContext, topContext);
           }
           catch (cms::Exception & ex) {
 	    std::ostringstream ost;
@@ -69,13 +73,16 @@ namespace edm {
     virtual bool tryToFillImpl(std::string const& moduleLabel,
                                EventPrincipal& event,
                                EventSetup const& eventSetup,
-                               CurrentProcessingContext const* iContext) {
+                               CurrentProcessingContext const* iContext,
+                               ModuleCallingContext const* mcc) {
       std::map<std::string, Worker*>::const_iterator itFound =
         labelToWorkers_.find(moduleLabel);
       if(itFound != labelToWorkers_.end()) {
         CPUTimer timer;
         try {
-          itFound->second->doWork<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> >(event, eventSetup, iContext, &timer,event.streamID());
+          ParentContext parentContext(mcc);
+          itFound->second->doWork<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> >(event,
+              eventSetup, iContext, &timer,event.streamID(), parentContext, mcc->getStreamContext());
         }
         catch (cms::Exception & ex) {
 	  std::ostringstream ost;
@@ -95,3 +102,4 @@ namespace edm {
 }
 
 #endif
+

--- a/FWCore/Framework/interface/UnscheduledHandler.h
+++ b/FWCore/Framework/interface/UnscheduledHandler.h
@@ -28,6 +28,7 @@ to keep the EventPrincipal class from having too much 'physical' coupling with t
 // forward declarations
 namespace edm {
    class CurrentProcessingContext;
+   class ModuleCallingContext;
    class UnscheduledHandlerSentry;
 
    class UnscheduledHandler {
@@ -47,7 +48,8 @@ namespace edm {
       // ---------- member functions ---------------------------
       ///returns true if found an EDProducer and ran it
       bool tryToFill(std::string const& label,
-                     EventPrincipal& iEvent);
+                     EventPrincipal& iEvent,
+                     ModuleCallingContext const* mcc);
 
       void setEventSetup(EventSetup const& iSetup) {
          m_setup = &iSetup;
@@ -59,7 +61,8 @@ namespace edm {
       virtual bool tryToFillImpl(std::string const&,
                                  EventPrincipal&,
                                  EventSetup const&,
-                                 CurrentProcessingContext const*) = 0;
+                                 CurrentProcessingContext const*,
+                                 ModuleCallingContext const* mcc) = 0;
       // ---------- member data --------------------------------
       EventSetup const* m_setup;
       CurrentProcessingContext const* m_context;

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -22,6 +22,7 @@
 namespace edm {
   class ExceptionCollector;
   class StreamID;
+  class StreamContext;
   
   class WorkerManager {
   public:
@@ -39,18 +40,20 @@ namespace edm {
 
     void setOnDemandProducts(ProductRegistry& pregistry, std::set<std::string> const& unscheduledLabels) const;
 
-    template <typename T>
+    template <typename T, typename U>
     void processOneOccurrence(typename T::MyPrincipal& principal,
                               EventSetup const& eventSetup,
                               StreamID streamID,
+                              typename T::Context const* topContext,
+                              U const* context,
                               bool cleaningUpAfterException = false);
 
     void beginJob(ProductRegistry const& iRegistry);
     void endJob();
     void endJob(ExceptionCollector& collector);
 
-    void beginStream(StreamID iID);
-    void endStream(StreamID iID);
+    void beginStream(StreamID iID, StreamContext& streamContext);
+    void endStream(StreamID iID, StreamContext& streamContext);
     
     AllWorkers const& allWorkers() const {return allWorkers_;}
 
@@ -77,11 +80,13 @@ namespace edm {
     boost::shared_ptr<UnscheduledCallProducer> unscheduled_;
   };
 
-  template <typename T>
+  template <typename T, typename U>
   void
   WorkerManager::processOneOccurrence(typename T::MyPrincipal& ep,
                                  EventSetup const& es,
                                  StreamID streamID,
+                                 typename T::Context const* topContext,
+                                 U const* context,
                                  bool cleaningUpAfterException) {
     this->resetAll();
 
@@ -92,7 +97,7 @@ namespace edm {
             setupOnDemandSystem(dynamic_cast<EventPrincipal&>(ep), es);
           } else {
             //make sure the unscheduled items see this run or lumi rtansition
-            unscheduled_->runNow<T>(ep, es,streamID);
+            unscheduled_->runNow<T,U>(ep, es,streamID, topContext, context);
           }
         }
         catch(cms::Exception& e) {

--- a/FWCore/Framework/interface/global/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/global/EDAnalyzerBase.h
@@ -30,6 +30,7 @@
 // forward declarations
 
 namespace edm {
+  class ModuleCallingContext;
   class StreamID;
   
   namespace global {
@@ -49,6 +50,9 @@ namespace edm {
       static void prevalidate(ConfigurationDescriptions& descriptions);
       static const std::string& baseType();
 
+      // Warning: the returned moduleDescription will be invalid during construction
+      ModuleDescription const& moduleDescription() const { return moduleDescription_; }
+
     protected:
       // The returned pointer will be null unless the this is currently
       // executing its event loop function ('produce').
@@ -56,7 +60,8 @@ namespace edm {
       
     private:
       bool doEvent(EventPrincipal& ep, EventSetup const& c,
-                   CurrentProcessingContext const* cpcp);
+                   CurrentProcessingContext const* cpcp,
+                   ModuleCallingContext const*);
       void doBeginJob();
       void doEndJob();
       
@@ -65,29 +70,37 @@ namespace edm {
       void doStreamBeginRun(StreamID id,
                             RunPrincipal& ep,
                             EventSetup const& c,
-                            CurrentProcessingContext const* cpcp);
+                            CurrentProcessingContext const* cpcp,
+                            ModuleCallingContext const*);
       void doStreamEndRun(StreamID id,
                           RunPrincipal& ep,
                           EventSetup const& c,
-                          CurrentProcessingContext const* cpcp);
+                          CurrentProcessingContext const* cpcp,
+                          ModuleCallingContext const*);
       void doStreamBeginLuminosityBlock(StreamID id,
                                         LuminosityBlockPrincipal& ep,
                                         EventSetup const& c,
-                                        CurrentProcessingContext const* cpcp);
+                                        CurrentProcessingContext const* cpcp,
+                                        ModuleCallingContext const*);
       void doStreamEndLuminosityBlock(StreamID id,
                                       LuminosityBlockPrincipal& ep,
                                       EventSetup const& c,
-                                      CurrentProcessingContext const* cpcp);
+                                      CurrentProcessingContext const* cpcp,
+                                      ModuleCallingContext const*);
 
       
       void doBeginRun(RunPrincipal& rp, EventSetup const& c,
-                      CurrentProcessingContext const* cpc);
+                      CurrentProcessingContext const* cpc,
+                      ModuleCallingContext const*);
       void doEndRun(RunPrincipal& rp, EventSetup const& c,
-                    CurrentProcessingContext const* cpc);
+                    CurrentProcessingContext const* cpc,
+                    ModuleCallingContext const*);
       void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                  CurrentProcessingContext const* cpc);
+                                  CurrentProcessingContext const* cpc,
+                                  ModuleCallingContext const*);
       void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                CurrentProcessingContext const* cpc);
+                                CurrentProcessingContext const* cpc,
+                                ModuleCallingContext const*);
       
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -31,6 +31,7 @@
 // forward declarations
 
 namespace edm {
+  class ModuleCallingContext;
   class StreamID;
   
   namespace global {
@@ -50,6 +51,9 @@ namespace edm {
       static void prevalidate(ConfigurationDescriptions& descriptions);
       static const std::string& baseType();
 
+      // Warning: the returned moduleDescription will be invalid during construction
+      ModuleDescription const& moduleDescription() const { return moduleDescription_; }
+
     protected:
       // The returned pointer will be null unless the this is currently
       // executing its event loop function ('produce').
@@ -57,7 +61,8 @@ namespace edm {
       
     private:
       bool doEvent(EventPrincipal& ep, EventSetup const& c,
-                   CurrentProcessingContext const* cpcp);
+                   CurrentProcessingContext const* cpcp,
+                   ModuleCallingContext const*);
       void doBeginJob();
       void doEndJob();
       
@@ -66,29 +71,37 @@ namespace edm {
       void doStreamBeginRun(StreamID id,
                             RunPrincipal& ep,
                             EventSetup const& c,
-                            CurrentProcessingContext const* cpcp);
+                            CurrentProcessingContext const* cpcp,
+                            ModuleCallingContext const*);
       void doStreamEndRun(StreamID id,
                           RunPrincipal& ep,
                           EventSetup const& c,
-                          CurrentProcessingContext const* cpcp);
+                          CurrentProcessingContext const* cpcp,
+                          ModuleCallingContext const*);
       void doStreamBeginLuminosityBlock(StreamID id,
                                         LuminosityBlockPrincipal& ep,
                                         EventSetup const& c,
-                                        CurrentProcessingContext const* cpcp);
+                                        CurrentProcessingContext const* cpcp,
+                                        ModuleCallingContext const*);
       void doStreamEndLuminosityBlock(StreamID id,
                                       LuminosityBlockPrincipal& ep,
                                       EventSetup const& c,
-                                      CurrentProcessingContext const* cpcp);
+                                      CurrentProcessingContext const* cpcp,
+                                      ModuleCallingContext const*);
 
       
       void doBeginRun(RunPrincipal& rp, EventSetup const& c,
-                      CurrentProcessingContext const* cpc);
+                      CurrentProcessingContext const* cpc,
+                      ModuleCallingContext const*);
       void doEndRun(RunPrincipal& rp, EventSetup const& c,
-                    CurrentProcessingContext const* cpc);
+                    CurrentProcessingContext const* cpc,
+                    ModuleCallingContext const*);
       void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                  CurrentProcessingContext const* cpc);
+                                  CurrentProcessingContext const* cpc,
+                                  ModuleCallingContext const*);
       void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                CurrentProcessingContext const* cpc);
+                                CurrentProcessingContext const* cpc,
+                                ModuleCallingContext const*);
       
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -31,6 +31,7 @@
 // forward declarations
 
 namespace edm {
+  class ModuleCallingContext;
   class StreamID;
   
   namespace global {
@@ -50,6 +51,9 @@ namespace edm {
       static void prevalidate(ConfigurationDescriptions& descriptions);
       static const std::string& baseType();
 
+      // Warning: the returned moduleDescription will be invalid during construction
+      ModuleDescription const& moduleDescription() const { return moduleDescription_; }
+
     protected:
       // The returned pointer will be null unless the this is currently
       // executing its event loop function ('produce').
@@ -57,7 +61,8 @@ namespace edm {
       
     private:
       bool doEvent(EventPrincipal& ep, EventSetup const& c,
-                   CurrentProcessingContext const* cpcp);
+                   CurrentProcessingContext const* cpcp,
+                   ModuleCallingContext const*);
       void doBeginJob();
       void doEndJob();
       
@@ -66,29 +71,37 @@ namespace edm {
       void doStreamBeginRun(StreamID id,
                             RunPrincipal& ep,
                             EventSetup const& c,
-                            CurrentProcessingContext const* cpcp);
+                            CurrentProcessingContext const* cpcp,
+                            ModuleCallingContext const*);
       void doStreamEndRun(StreamID id,
                           RunPrincipal& ep,
                           EventSetup const& c,
-                          CurrentProcessingContext const* cpcp);
+                          CurrentProcessingContext const* cpcp,
+                          ModuleCallingContext const*);
       void doStreamBeginLuminosityBlock(StreamID id,
                                         LuminosityBlockPrincipal& ep,
                                         EventSetup const& c,
-                                        CurrentProcessingContext const* cpcp);
+                                        CurrentProcessingContext const* cpcp,
+                                        ModuleCallingContext const*);
       void doStreamEndLuminosityBlock(StreamID id,
                                       LuminosityBlockPrincipal& ep,
                                       EventSetup const& c,
-                                      CurrentProcessingContext const* cpcp);
+                                      CurrentProcessingContext const* cpcp,
+                                      ModuleCallingContext const*);
 
       
       void doBeginRun(RunPrincipal& rp, EventSetup const& c,
-                      CurrentProcessingContext const* cpc);
+                      CurrentProcessingContext const* cpc,
+                      ModuleCallingContext const*);
       void doEndRun(RunPrincipal& rp, EventSetup const& c,
-                    CurrentProcessingContext const* cpc);
+                    CurrentProcessingContext const* cpc,
+                    ModuleCallingContext const*);
       void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                  CurrentProcessingContext const* cpc);
+                                  CurrentProcessingContext const* cpc,
+                                  ModuleCallingContext const*);
       void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                CurrentProcessingContext const* cpc);
+                                CurrentProcessingContext const* cpc,
+                                ModuleCallingContext const*);
       
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -28,6 +28,9 @@
 
 // forward declarations
 namespace edm {
+
+  class ModuleCallingContext;
+
   namespace one {
 
     class EDAnalyzerBase : public EDConsumerBase
@@ -46,6 +49,9 @@ namespace edm {
       static void prevalidate(ConfigurationDescriptions& descriptions);
       static const std::string& baseType();
 
+      // Warning: the returned moduleDescription will be invalid during construction
+      ModuleDescription const& moduleDescription() const { return moduleDescription_; }
+
     protected:
       // The returned pointer will be null unless the this is currently
       // executing its event loop function ('produce').
@@ -55,18 +61,23 @@ namespace edm {
 
     private:
       bool doEvent(EventPrincipal& ep, EventSetup const& c,
-                   CurrentProcessingContext const* cpcp);
+                   CurrentProcessingContext const* cpcp,
+                   ModuleCallingContext const*);
       void doBeginJob();
       void doEndJob();
       
       void doBeginRun(RunPrincipal& rp, EventSetup const& c,
-                      CurrentProcessingContext const* cpc);
+                      CurrentProcessingContext const* cpc,
+                      ModuleCallingContext const*);
       void doEndRun(RunPrincipal& rp, EventSetup const& c,
-                    CurrentProcessingContext const* cpc);
+                    CurrentProcessingContext const* cpc,
+                    ModuleCallingContext const*);
       void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                  CurrentProcessingContext const* cpc);
+                                  CurrentProcessingContext const* cpc,
+                                  ModuleCallingContext const*);
       void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                CurrentProcessingContext const* cpc);
+                                CurrentProcessingContext const* cpc,
+                                ModuleCallingContext const*);
       
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/one/EDFilterBase.h
+++ b/FWCore/Framework/interface/one/EDFilterBase.h
@@ -29,6 +29,9 @@
 
 // forward declarations
 namespace edm {
+
+  class ModuleCallingContext;
+
   namespace one {
 
     class EDFilterBase : public ProducerBase, public EDConsumerBase
@@ -47,6 +50,9 @@ namespace edm {
       static void prevalidate(ConfigurationDescriptions& descriptions);
       static const std::string& baseType();
 
+      // Warning: the returned moduleDescription will be invalid during construction
+      ModuleDescription const& moduleDescription() const { return moduleDescription_; }
+
     protected:
       // The returned pointer will be null unless the this is currently
       // executing its event loop function ('produce').
@@ -54,18 +60,23 @@ namespace edm {
       
     private:
       bool doEvent(EventPrincipal& ep, EventSetup const& c,
-                   CurrentProcessingContext const* cpcp);
+                   CurrentProcessingContext const* cpcp,
+                   ModuleCallingContext const*);
       void doBeginJob();
       void doEndJob();
       
       void doBeginRun(RunPrincipal& rp, EventSetup const& c,
-                      CurrentProcessingContext const* cpc);
+                      CurrentProcessingContext const* cpc,
+                      ModuleCallingContext const*);
       void doEndRun(RunPrincipal& rp, EventSetup const& c,
-                    CurrentProcessingContext const* cpc);
+                    CurrentProcessingContext const* cpc,
+                    ModuleCallingContext const*);
       void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                  CurrentProcessingContext const* cpc);
+                                  CurrentProcessingContext const* cpc,
+                                  ModuleCallingContext const*);
       void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                CurrentProcessingContext const* cpc);
+                                CurrentProcessingContext const* cpc,
+                                ModuleCallingContext const*);
       
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/one/EDProducerBase.h
+++ b/FWCore/Framework/interface/one/EDProducerBase.h
@@ -29,6 +29,9 @@
 
 // forward declarations
 namespace edm {
+
+  class ModuleCallingContext;
+
   namespace one {
 
     class EDProducerBase : public ProducerBase, public EDConsumerBase
@@ -47,6 +50,9 @@ namespace edm {
       static void prevalidate(ConfigurationDescriptions& descriptions);
       static const std::string& baseType();
 
+      // Warning: the returned moduleDescription will be invalid during construction
+      ModuleDescription const& moduleDescription() const { return moduleDescription_; }
+
     protected:
       // The returned pointer will be null unless the this is currently
       // executing its event loop function ('produce').
@@ -54,19 +60,24 @@ namespace edm {
       
     private:
       bool doEvent(EventPrincipal& ep, EventSetup const& c,
-                   CurrentProcessingContext const* cpcp);
+                   CurrentProcessingContext const* cpcp,
+                   ModuleCallingContext const*);
       void doBeginJob();
       void doEndJob();
-      
+
       void doBeginRun(RunPrincipal& rp, EventSetup const& c,
-                      CurrentProcessingContext const* cpc);
+                      CurrentProcessingContext const* cpc,
+                      ModuleCallingContext const*);
       void doEndRun(RunPrincipal& rp, EventSetup const& c,
-                    CurrentProcessingContext const* cpc);
+                    CurrentProcessingContext const* cpc,
+                    ModuleCallingContext const*);
       void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                  CurrentProcessingContext const* cpc);
+                                  CurrentProcessingContext const* cpc,
+                                  ModuleCallingContext const*);
       void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                CurrentProcessingContext const* cpc);
-      
+                                CurrentProcessingContext const* cpc,
+                                ModuleCallingContext const*);
+
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -43,6 +43,9 @@
 
 // forward declarations
 namespace edm {
+
+  class ModuleCallingContext;
+
   namespace one {
     
     typedef detail::TriggerResultsBasedEventSelector::handle_t Trig;
@@ -88,7 +91,7 @@ namespace edm {
       
     protected:
       
-      Trig getTriggerResults(EventPrincipal const& ep) const;
+      Trig getTriggerResults(EventPrincipal const& ep, ModuleCallingContext const*) const;
       
       // The returned pointer will be null unless the this is currently
       // executing its event loop function ('write').
@@ -101,15 +104,15 @@ namespace edm {
       void doBeginJob();
       void doEndJob();
       bool doEvent(EventPrincipal const& ep, EventSetup const& c,
-                   CurrentProcessingContext const* cpc);
+                   CurrentProcessingContext const* cpc, ModuleCallingContext const*);
       bool doBeginRun(RunPrincipal const& rp, EventSetup const& c,
-                      CurrentProcessingContext const* cpc);
+                      CurrentProcessingContext const* cpc, ModuleCallingContext const*);
       bool doEndRun(RunPrincipal const& rp, EventSetup const& c,
-                    CurrentProcessingContext const* cpc);
+                    CurrentProcessingContext const* cpc, ModuleCallingContext const*);
       bool doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
-                                  CurrentProcessingContext const* cpc);
+                                  CurrentProcessingContext const* cpc, ModuleCallingContext const*);
       bool doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
-                                CurrentProcessingContext const* cpc);
+                                CurrentProcessingContext const* cpc, ModuleCallingContext const*);
       
       void setEventSelectionInfo(std::map<std::string, std::vector<std::pair<std::string, int> > > const& outputModulePathPositions,
                                  bool anyProductProduced);
@@ -176,8 +179,8 @@ namespace edm {
       //------------------------------------------------------------------
       // private member functions
       //------------------------------------------------------------------
-      void doWriteRun(RunPrincipal const& rp);
-      void doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp);
+      void doWriteRun(RunPrincipal const& rp, ModuleCallingContext const*);
+      void doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp, ModuleCallingContext const*);
       void doOpenFile(FileBlock const& fb);
       void doRespondToOpenInputFile(FileBlock const& fb);
       void doRespondToCloseInputFile(FileBlock const& fb);
@@ -204,20 +207,20 @@ namespace edm {
       /// Ask the OutputModule if we should end the current file.
       virtual bool shouldWeCloseFile() const {return false;}
       
-      virtual void write(EventPrincipal const& e) = 0;
+      virtual void write(EventPrincipal const& e, ModuleCallingContext const*) = 0;
       virtual void beginJob(){}
       virtual void endJob(){}
-      virtual void writeLuminosityBlock(LuminosityBlockPrincipal const&) = 0;
-      virtual void writeRun(RunPrincipal const&) = 0;
+      virtual void writeLuminosityBlock(LuminosityBlockPrincipal const&, ModuleCallingContext const*) = 0;
+      virtual void writeRun(RunPrincipal const&, ModuleCallingContext const*) = 0;
       virtual void openFile(FileBlock const&) {}
       virtual bool isFileOpen() const { return true; }
       virtual void reallyOpenFile() {}
       
 
-      virtual void doBeginRun_(RunPrincipal const&){}
-      virtual void doEndRun_(RunPrincipal const&){}
-      virtual void doBeginLuminosityBlock_(LuminosityBlockPrincipal const&){}
-      virtual void doEndLuminosityBlock_(LuminosityBlockPrincipal const&){}
+      virtual void doBeginRun_(RunPrincipal const&, ModuleCallingContext const*){}
+      virtual void doEndRun_(RunPrincipal const&, ModuleCallingContext const*){}
+      virtual void doBeginLuminosityBlock_(LuminosityBlockPrincipal const&, ModuleCallingContext const*){}
+      virtual void doEndLuminosityBlock_(LuminosityBlockPrincipal const&, ModuleCallingContext const*){}
       virtual void doRespondToOpenInputFile_(FileBlock const&) {}
       virtual void doRespondToCloseInputFile_(FileBlock const&) {}
       

--- a/FWCore/Framework/interface/one/outputmoduleAbilityToImplementor.h
+++ b/FWCore/Framework/interface/one/outputmoduleAbilityToImplementor.h
@@ -40,12 +40,12 @@ namespace edm {
         RunWatcher& operator=(RunWatcher const&) = delete;
         
       private:
-        void doBeginRun_(RunPrincipal const& rp) override final;
-        void doEndRun_(RunPrincipal const& rp) override final;
+        void doBeginRun_(RunPrincipal const& rp, ModuleCallingContext const*) override final;
+        void doEndRun_(RunPrincipal const& rp, ModuleCallingContext const*) override final;
         
         
-        virtual void beginRun(edm::RunPrincipal const&) = 0;
-        virtual void endRun(edm::RunPrincipal const&) = 0;
+        virtual void beginRun(edm::RunPrincipal const&, ModuleCallingContext const*) = 0;
+        virtual void endRun(edm::RunPrincipal const&, ModuleCallingContext const*) = 0;
       };
       
       class LuminosityBlockWatcher : public virtual OutputModuleBase {
@@ -55,11 +55,11 @@ namespace edm {
         LuminosityBlockWatcher& operator=(LuminosityBlockWatcher const&) = delete;
         
       private:
-        void doBeginLuminosityBlock_(LuminosityBlockPrincipal const& lbp) override final;
-        void doEndLuminosityBlock_(LuminosityBlockPrincipal const& lbp) override final;
+        void doBeginLuminosityBlock_(LuminosityBlockPrincipal const& lbp, ModuleCallingContext const*) override final;
+        void doEndLuminosityBlock_(LuminosityBlockPrincipal const& lbp, ModuleCallingContext const*) override final;
         
-        virtual void beginLuminosityBlock(edm::LuminosityBlockPrincipal const&) = 0;
-        virtual void endLuminosityBlock(edm::LuminosityBlockPrincipal const&) = 0;
+        virtual void beginLuminosityBlock(edm::LuminosityBlockPrincipal const&, ModuleCallingContext const*) = 0;
+        virtual void endLuminosityBlock(edm::LuminosityBlockPrincipal const&, ModuleCallingContext const*) = 0;
       };
 
       class InputFileWatcher : public virtual OutputModuleBase {

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -34,8 +34,10 @@
 // forward declarations
 
 namespace edm {
+  class ModuleCallingContext;
   class ProductHolderIndexHelper;
   class EDConsumerBase;
+
   namespace stream {
     class EDAnalyzerBase;
     class EDAnalyzerAdaptorBase
@@ -75,7 +77,8 @@ namespace edm {
       const EDAnalyzerAdaptorBase& operator=(const EDAnalyzerAdaptorBase&); // stop default
       
       bool doEvent(EventPrincipal& ep, EventSetup const& c,
-                           CurrentProcessingContext const* cpcp) ;
+                   CurrentProcessingContext const* cpcp,
+                   ModuleCallingContext const*) ;
       void doBeginJob();
       virtual void doEndJob() = 0;
       
@@ -84,34 +87,42 @@ namespace edm {
       void doStreamBeginRun(StreamID id,
                             RunPrincipal& ep,
                             EventSetup const& c,
-                            CurrentProcessingContext const* cpcp);
+                            CurrentProcessingContext const* cpcp,
+                            ModuleCallingContext const*);
       virtual void setupRun(EDAnalyzerBase*, RunIndex) = 0;
       void doStreamEndRun(StreamID id,
                           RunPrincipal& ep,
                           EventSetup const& c,
-                          CurrentProcessingContext const* cpcp);
+                          CurrentProcessingContext const* cpcp,
+                          ModuleCallingContext const*);
       virtual void streamEndRunSummary(EDAnalyzerBase*,edm::Run const&, edm::EventSetup const&) = 0;
 
       void doStreamBeginLuminosityBlock(StreamID id,
                                         LuminosityBlockPrincipal& ep,
                                         EventSetup const& c,
-                                        CurrentProcessingContext const* cpcp);
+                                        CurrentProcessingContext const* cpcp,
+                                        ModuleCallingContext const*);
       virtual void setupLuminosityBlock(EDAnalyzerBase*, LuminosityBlockIndex) = 0;
       void doStreamEndLuminosityBlock(StreamID id,
                                       LuminosityBlockPrincipal& ep,
                                       EventSetup const& c,
-                                      CurrentProcessingContext const* cpcp);
+                                      CurrentProcessingContext const* cpcp,
+                                      ModuleCallingContext const*);
       virtual void streamEndLuminosityBlockSummary(EDAnalyzerBase*,edm::LuminosityBlock const&, edm::EventSetup const&) = 0;
       
       
       virtual void doBeginRun(RunPrincipal& rp, EventSetup const& c,
-                              CurrentProcessingContext const* cpc)=0;
+                              CurrentProcessingContext const* cpc,
+                              ModuleCallingContext const*)=0;
       virtual void doEndRun(RunPrincipal& rp, EventSetup const& c,
-                            CurrentProcessingContext const* cpc)=0;
+                            CurrentProcessingContext const* cpc,
+                            ModuleCallingContext const*)=0;
       virtual void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                          CurrentProcessingContext const* cpc)=0;
+                                          CurrentProcessingContext const* cpc,
+                                          ModuleCallingContext const*)=0;
       virtual void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                        CurrentProcessingContext const* cpc)=0;
+                                        CurrentProcessingContext const* cpc,
+                                        ModuleCallingContext const*)=0;
       
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);

--- a/FWCore/Framework/interface/stream/EDFilterAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDFilterAdaptorBase.h
@@ -33,6 +33,9 @@
 // forward declarations
 
 namespace edm {
+
+  class ModuleCallingContext;
+
   namespace stream {
     class EDFilterBase;
     class EDFilterAdaptorBase : public ProducingModuleAdaptorBase<EDFilterBase>
@@ -59,7 +62,8 @@ namespace edm {
       const EDFilterAdaptorBase& operator=(const EDFilterAdaptorBase&) =delete; // stop default
       
       bool doEvent(EventPrincipal& ep, EventSetup const& c,
-                   CurrentProcessingContext const* cpcp) ;
+                   CurrentProcessingContext const* cpcp,
+                   ModuleCallingContext const*) ;
     };
   }
 }

--- a/FWCore/Framework/interface/stream/EDProducerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDProducerAdaptorBase.h
@@ -33,6 +33,9 @@
 // forward declarations
 
 namespace edm {
+
+  class ModuleCallingContext;
+
   namespace stream {
     class EDProducerBase;
     class EDProducerAdaptorBase : public ProducingModuleAdaptorBase<EDProducerBase>
@@ -59,7 +62,8 @@ namespace edm {
       const EDProducerAdaptorBase& operator=(const EDProducerAdaptorBase&) =delete; // stop default
       
       bool doEvent(EventPrincipal& ep, EventSetup const& c,
-                           CurrentProcessingContext const* cpcp) ;
+                   CurrentProcessingContext const* cpcp,
+                   ModuleCallingContext const*) ;
     };
   }
 }

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -118,9 +118,10 @@ namespace edm {
 
       void doBeginRun(RunPrincipal& rp,
                       EventSetup const& c,
-                      CurrentProcessingContext const* cpc)override final {
+                      CurrentProcessingContext const* cpc,
+                      ModuleCallingContext const* mcc) override final {
         if(T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache or T::HasAbility::kBeginRunProducer) {
-          Run r(rp, this->moduleDescription());
+          Run r(rp, this->moduleDescription(), mcc);
           r.setConsumer(this->consumer());
           Run const& cnstR = r;
           RunIndex ri = rp.index();
@@ -135,11 +136,12 @@ namespace edm {
       }
       void doEndRun(RunPrincipal& rp,
                     EventSetup const& c,
-                    CurrentProcessingContext const* cpc)override final
+                    CurrentProcessingContext const* cpc,
+                    ModuleCallingContext const* mcc) override final
       {
         if(T::HasAbility::kRunCache or T::HasAbility::kRunSummaryCache or T::HasAbility::kEndRunProducer) {
           
-          Run r(rp, this->moduleDescription());
+          Run r(rp, this->moduleDescription(), mcc);
           r.setConsumer(this->consumer());
 
           RunIndex ri = rp.index();
@@ -154,10 +156,11 @@ namespace edm {
       }
 
       void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                  CurrentProcessingContext const* cpc)override final
+                                  CurrentProcessingContext const* cpc,
+                                  ModuleCallingContext const* mcc) override final
       {
         if(T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache or T::HasAbility::kBeginLuminosityBlockProducer) {
-          LuminosityBlock lb(lbp, this->moduleDescription());
+          LuminosityBlock lb(lbp, this->moduleDescription(), mcc);
           lb.setConsumer(this->consumer());
           LuminosityBlock const& cnstLb = lb;
           LuminosityBlockIndex li = lbp.index();
@@ -175,10 +178,11 @@ namespace edm {
       }
       void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp,
                                 EventSetup const& c,
-                                CurrentProcessingContext const* cpc)override final {
+                                CurrentProcessingContext const* cpc,
+                                ModuleCallingContext const* mcc) override final {
         if(T::HasAbility::kLuminosityBlockCache or T::HasAbility::kLuminosityBlockSummaryCache or T::HasAbility::kEndLuminosityBlockProducer) {
           
-          LuminosityBlock lb(lbp, this->moduleDescription());
+          LuminosityBlock lb(lbp, this->moduleDescription(), mcc);
           lb.setConsumer(this->consumer());
           
           LuminosityBlockIndex li = lbp.index();

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -37,6 +37,7 @@
 
 namespace edm {
   class Event;
+  class ModuleCallingContext;
   class ProductHolderIndexHelper;
   class EDConsumerBase;
   
@@ -102,36 +103,44 @@ namespace edm {
       void doStreamBeginRun(StreamID id,
                             RunPrincipal& ep,
                             EventSetup const& c,
-                            CurrentProcessingContext const* cpcp);
+                            CurrentProcessingContext const* cpcp,
+                            ModuleCallingContext const*);
       virtual void setupRun(T*, RunIndex) = 0;
       void doStreamEndRun(StreamID id,
                           RunPrincipal& ep,
                           EventSetup const& c,
-                          CurrentProcessingContext const* cpcp);
+                          CurrentProcessingContext const* cpcp,
+                          ModuleCallingContext const*);
       virtual void streamEndRunSummary(T*,edm::Run const&, edm::EventSetup const&) = 0;
 
       void doStreamBeginLuminosityBlock(StreamID id,
                                         LuminosityBlockPrincipal& ep,
                                         EventSetup const& c,
-                                        CurrentProcessingContext const* cpcp);
+                                        CurrentProcessingContext const* cpcp,
+                                        ModuleCallingContext const*);
       virtual void setupLuminosityBlock(T*, LuminosityBlockIndex) = 0;
       void doStreamEndLuminosityBlock(StreamID id,
                                       LuminosityBlockPrincipal& ep,
                                       EventSetup const& c,
-                                      CurrentProcessingContext const* cpcp);
+                                      CurrentProcessingContext const* cpcp,
+                                      ModuleCallingContext const*);
       virtual void streamEndLuminosityBlockSummary(T*,edm::LuminosityBlock const&, edm::EventSetup const&) = 0;
       
       
       virtual void doBeginRun(RunPrincipal& rp, EventSetup const& c,
-                              CurrentProcessingContext const* cpc)=0;
+                              CurrentProcessingContext const* cpc,
+                              ModuleCallingContext const*)=0;
       virtual void doEndRun(RunPrincipal& rp, EventSetup const& c,
-                            CurrentProcessingContext const* cpc)=0;
+                            CurrentProcessingContext const* cpc,
+                            ModuleCallingContext const*)=0;
       virtual void doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp,
                                           EventSetup const& c,
-                                          CurrentProcessingContext const* cpc)=0;
+                                          CurrentProcessingContext const* cpc,
+                                          ModuleCallingContext const*)=0;
       virtual void doEndLuminosityBlock(LuminosityBlockPrincipal& lbp,
                                         EventSetup const& c,
-                                        CurrentProcessingContext const* cpc)=0;
+                                        CurrentProcessingContext const* cpc,
+                                        ModuleCallingContext const*)=0;
       
       //For now, the following are just dummy implemenations with no ability for users to override
       void doRespondToOpenInputFile(FileBlock const& fb);

--- a/FWCore/Framework/src/EDAnalyzer.cc
+++ b/FWCore/Framework/src/EDAnalyzer.cc
@@ -24,9 +24,10 @@ namespace edm {
 
   bool
   EDAnalyzer::doEvent(EventPrincipal const& ep, EventSetup const& c,
-			CurrentProcessingContext const* cpc) {
+		      CurrentProcessingContext const* cpc,
+                      ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
-    Event e(const_cast<EventPrincipal&>(ep), moduleDescription_);
+    Event e(const_cast<EventPrincipal&>(ep), moduleDescription_, mcc);
     e.setConsumer(this);
     this->analyze(e, c);
     return true;
@@ -44,9 +45,10 @@ namespace edm {
 
   bool
   EDAnalyzer::doBeginRun(RunPrincipal const& rp, EventSetup const& c,
-			CurrentProcessingContext const* cpc) {
+			 CurrentProcessingContext const* cpc,
+                         ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
-    Run r(const_cast<RunPrincipal&>(rp), moduleDescription_);
+    Run r(const_cast<RunPrincipal&>(rp), moduleDescription_, mcc);
     r.setConsumer(this);
     this->beginRun(r, c);
     return true;
@@ -54,9 +56,10 @@ namespace edm {
 
   bool
   EDAnalyzer::doEndRun(RunPrincipal const& rp, EventSetup const& c,
-			CurrentProcessingContext const* cpc) {
+		       CurrentProcessingContext const* cpc,
+                       ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
-    Run r(const_cast<RunPrincipal&>(rp), moduleDescription_);
+    Run r(const_cast<RunPrincipal&>(rp), moduleDescription_, mcc);
     r.setConsumer(this);
     this->endRun(r, c);
     return true;
@@ -64,9 +67,10 @@ namespace edm {
 
   bool
   EDAnalyzer::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
-			CurrentProcessingContext const* cpc) {
+			             CurrentProcessingContext const* cpc,
+                                     ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
-    LuminosityBlock lb(const_cast<LuminosityBlockPrincipal&>(lbp), moduleDescription_);
+    LuminosityBlock lb(const_cast<LuminosityBlockPrincipal&>(lbp), moduleDescription_, mcc);
     lb.setConsumer(this);
     this->beginLuminosityBlock(lb, c);
     return true;
@@ -74,9 +78,10 @@ namespace edm {
 
   bool
   EDAnalyzer::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp, EventSetup const& c,
-			CurrentProcessingContext const* cpc) {
+                                   CurrentProcessingContext const* cpc,
+                                   ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
-    LuminosityBlock lb(const_cast<LuminosityBlockPrincipal&>(lbp), moduleDescription_);
+    LuminosityBlock lb(const_cast<LuminosityBlockPrincipal&>(lbp), moduleDescription_, mcc);
     lb.setConsumer(this);
     this->endLuminosityBlock(lb, c);
     return true;

--- a/FWCore/Framework/src/EDFilter.cc
+++ b/FWCore/Framework/src/EDFilter.cc
@@ -19,10 +19,11 @@ namespace edm {
 
   bool
   EDFilter::doEvent(EventPrincipal& ep, EventSetup const& c,
-		     CurrentProcessingContext const* cpc) {
+		    CurrentProcessingContext const* cpc,
+                    ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
     bool rc = false;
-    Event e(ep, moduleDescription_);
+    Event e(ep, moduleDescription_, mcc);
     e.setConsumer(this);
     rc = this->filter(e, c);
     commit_(e,&previousParentage_, &previousParentageId_);
@@ -40,9 +41,10 @@ namespace edm {
 
   void
   EDFilter::doBeginRun(RunPrincipal& rp, EventSetup const& c,
-			CurrentProcessingContext const* cpc) {
+		       CurrentProcessingContext const* cpc,
+                       ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
-    Run r(rp, moduleDescription_);
+    Run r(rp, moduleDescription_, mcc);
     r.setConsumer(this);
     Run const& cnstR=r;
     this->beginRun(cnstR, c);
@@ -52,9 +54,10 @@ namespace edm {
 
   void
   EDFilter::doEndRun(RunPrincipal& rp, EventSetup const& c,
-			CurrentProcessingContext const* cpc) {
+		     CurrentProcessingContext const* cpc,
+                     ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
-    Run r(rp, moduleDescription_);
+    Run r(rp, moduleDescription_, mcc);
     r.setConsumer(this);
     Run const& cnstR=r;
     this->endRun(cnstR, c);
@@ -64,9 +67,10 @@ namespace edm {
 
   void
   EDFilter::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-			CurrentProcessingContext const* cpc) {
+                                   CurrentProcessingContext const* cpc,
+                                   ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
-    LuminosityBlock lb(lbp, moduleDescription_);
+    LuminosityBlock lb(lbp, moduleDescription_, mcc);
     lb.setConsumer(this);
     LuminosityBlock const& cnstLb = lb;
     this->beginLuminosityBlock(cnstLb, c);
@@ -75,9 +79,10 @@ namespace edm {
 
   void
   EDFilter::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-			CurrentProcessingContext const* cpc) {
+			         CurrentProcessingContext const* cpc,
+                                 ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
-    LuminosityBlock lb(lbp, moduleDescription_);
+    LuminosityBlock lb(lbp, moduleDescription_, mcc);
     lb.setConsumer(this);
     LuminosityBlock const& cnstLb = lb;
     this->endLuminosityBlock(cnstLb, c);

--- a/FWCore/Framework/src/EDLooperBase.cc
+++ b/FWCore/Framework/src/EDLooperBase.cc
@@ -8,15 +8,21 @@
 
 #include "FWCore/Framework/interface/EDLooperBase.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/Framework/interface/EventSetupProvider.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/MessageLogger/interface/ExceptionMessages.h"
 #include "FWCore/Framework/interface/Actions.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Framework/interface/ScheduleInfo.h"
+#include "FWCore/ServiceRegistry/interface/GlobalContext.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
 
 #include "boost/bind.hpp"
 
@@ -32,9 +38,18 @@ namespace edm {
   }
 
   EDLooperBase::Status
-  EDLooperBase::doDuringLoop(edm::EventPrincipal& eventPrincipal, const edm::EventSetup& es, edm::ProcessingController& ioController) {
-    edm::ModuleDescription modDesc("EDLooperBase", "");
-    Event event(eventPrincipal, modDesc);
+  EDLooperBase::doDuringLoop(edm::EventPrincipal& eventPrincipal, const edm::EventSetup& es,
+                             edm::ProcessingController& ioController, StreamContext* streamContext) {
+
+    edm::ModuleDescription modDesc("Looper", "looper");
+    streamContext->setTransition(StreamContext::Transition::kEvent);
+    streamContext->setEventID(eventPrincipal.id());
+    streamContext->setRunIndex(eventPrincipal.luminosityBlockPrincipal().runPrincipal().index());
+    streamContext->setLuminosityBlockIndex(eventPrincipal.luminosityBlockPrincipal().index());
+    streamContext->setTimestamp(eventPrincipal.time());
+    ParentContext parentContext(streamContext);
+    ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+    Event event(eventPrincipal, modDesc, &moduleCallingContext);
 
     Status status = kContinue;
     try {
@@ -73,25 +88,57 @@ namespace edm {
 
   void EDLooperBase::endOfJob() { }
 
-  void EDLooperBase::doBeginRun(RunPrincipal& iRP, EventSetup const& iES){
-        edm::ModuleDescription modDesc("EDLooperBase", "");
-	Run run(iRP, modDesc);
+  void EDLooperBase::doBeginRun(RunPrincipal& iRP, EventSetup const& iES, ProcessContext* processContext) {
+        edm::ModuleDescription modDesc("Looper", "looper");
+        GlobalContext globalContext(GlobalContext::Transition::kBeginRun,
+                                    LuminosityBlockID(iRP.run(), 0),
+                                    iRP.index(),
+                                    LuminosityBlockIndex::invalidLuminosityBlockIndex(),
+                                    iRP.beginTime(),
+                                    processContext);
+        ParentContext parentContext(&globalContext);
+        ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+	Run run(iRP, modDesc, &moduleCallingContext);
 	beginRun(run,iES);
   }
 
-  void EDLooperBase::doEndRun(RunPrincipal& iRP, EventSetup const& iES){
-        edm::ModuleDescription modDesc("EDLooperBase", "");
-	Run run(iRP, modDesc);
+  void EDLooperBase::doEndRun(RunPrincipal& iRP, EventSetup const& iES, ProcessContext* processContext){
+        edm::ModuleDescription modDesc("Looper", "looper");
+        GlobalContext globalContext(GlobalContext::Transition::kEndRun,
+                                    LuminosityBlockID(iRP.run(), 0),
+                                    iRP.index(),
+                                    LuminosityBlockIndex::invalidLuminosityBlockIndex(),
+                                    iRP.endTime(),
+                                    processContext);
+        ParentContext parentContext(&globalContext);
+        ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+	Run run(iRP, modDesc, &moduleCallingContext);
 	endRun(run,iES);
   }
-  void EDLooperBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& iLB, EventSetup const& iES){
-    edm::ModuleDescription modDesc("EDLooperBase", "");
-    LuminosityBlock luminosityBlock(iLB, modDesc);
+  void EDLooperBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& iLB, EventSetup const& iES, ProcessContext* processContext){
+    edm::ModuleDescription modDesc("Looper", "looper");
+    GlobalContext globalContext(GlobalContext::Transition::kBeginLuminosityBlock,
+                                iLB.id(),
+                                iLB.runPrincipal().index(),
+                                iLB.index(),
+                                iLB.beginTime(),
+                                processContext);
+    ParentContext parentContext(&globalContext);
+    ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+    LuminosityBlock luminosityBlock(iLB, modDesc, &moduleCallingContext);
     beginLuminosityBlock(luminosityBlock,iES);
   }
-  void EDLooperBase::doEndLuminosityBlock(LuminosityBlockPrincipal& iLB, EventSetup const& iES){
-    edm::ModuleDescription modDesc("EDLooperBase", "");
-    LuminosityBlock luminosityBlock(iLB, modDesc);
+  void EDLooperBase::doEndLuminosityBlock(LuminosityBlockPrincipal& iLB, EventSetup const& iES, ProcessContext* processContext){
+    edm::ModuleDescription modDesc("Looper", "looper");
+    GlobalContext globalContext(GlobalContext::Transition::kEndLuminosityBlock,
+                                iLB.id(),
+                                iLB.runPrincipal().index(),
+                                iLB.index(),
+                                iLB.beginTime(),
+                                processContext);
+    ParentContext parentContext(&globalContext);
+    ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+    LuminosityBlock luminosityBlock(iLB, modDesc, &moduleCallingContext);
     endLuminosityBlock(luminosityBlock,iES);
   }
 

--- a/FWCore/Framework/src/EDProducer.cc
+++ b/FWCore/Framework/src/EDProducer.cc
@@ -25,9 +25,10 @@ namespace edm {
 
   bool
   EDProducer::doEvent(EventPrincipal& ep, EventSetup const& c,
-			     CurrentProcessingContext const* cpc) {
+		      CurrentProcessingContext const* cpc,
+                      ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
-    Event e(ep, moduleDescription_);
+    Event e(ep, moduleDescription_, mcc);
     e.setConsumer(this);
     this->produce(e, c);
     commit_(e, &previousParentage_, &previousParentageId_);
@@ -46,9 +47,10 @@ namespace edm {
 
   void
   EDProducer::doBeginRun(RunPrincipal& rp, EventSetup const& c,
-			CurrentProcessingContext const* cpc) {
+			 CurrentProcessingContext const* cpc,
+                         ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
-    Run r(rp, moduleDescription_);
+    Run r(rp, moduleDescription_, mcc);
     r.setConsumer(this);
     Run const& cnstR = r;
     this->beginRun(cnstR, c);
@@ -57,9 +59,10 @@ namespace edm {
 
   void
   EDProducer::doEndRun(RunPrincipal& rp, EventSetup const& c,
-			CurrentProcessingContext const* cpc) {
+		       CurrentProcessingContext const* cpc,
+                       ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
-    Run r(rp, moduleDescription_);
+    Run r(rp, moduleDescription_, mcc);
     r.setConsumer(this);
     Run const& cnstR = r;
     this->endRun(cnstR, c);
@@ -68,9 +71,10 @@ namespace edm {
 
   void
   EDProducer::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-			CurrentProcessingContext const* cpc) {
+			             CurrentProcessingContext const* cpc,
+                                     ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
-    LuminosityBlock lb(lbp, moduleDescription_);
+    LuminosityBlock lb(lbp, moduleDescription_, mcc);
     lb.setConsumer(this);
     LuminosityBlock const& cnstLb = lb;
     this->beginLuminosityBlock(cnstLb, c);
@@ -79,9 +83,10 @@ namespace edm {
 
   void
   EDProducer::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-			CurrentProcessingContext const* cpc) {
+			           CurrentProcessingContext const* cpc,
+                                   ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
-    LuminosityBlock lb(lbp, moduleDescription_);
+    LuminosityBlock lb(lbp, moduleDescription_, mcc);
     lb.setConsumer(this);
     LuminosityBlock const& cnstLb = lb;
     this->endLuminosityBlock(cnstLb, c);

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -14,13 +14,14 @@ namespace edm {
 
   std::string const Event::emptyString_;
 
-  Event::Event(EventPrincipal& ep, ModuleDescription const& md) :
+  Event::Event(EventPrincipal& ep, ModuleDescription const& md, ModuleCallingContext const* moduleCallingContext) :
       provRecorder_(ep, md),
       aux_(ep.aux()),
-      luminosityBlock_(ep.luminosityBlockPrincipalPtrValid() ? new LuminosityBlock(ep.luminosityBlockPrincipal(), md) : 0),
+      luminosityBlock_(ep.luminosityBlockPrincipalPtrValid() ? new LuminosityBlock(ep.luminosityBlockPrincipal(), md, moduleCallingContext) : 0),
       gotBranchIDs_(),
       gotViews_(),
-      streamID_(ep.streamID())
+      streamID_(ep.streamID()),
+      moduleCallingContext_(moduleCallingContext)
   {
   }
 
@@ -68,12 +69,12 @@ namespace edm {
 
   Provenance
   Event::getProvenance(BranchID const& bid) const {
-    return provRecorder_.principal().getProvenance(bid);
+    return provRecorder_.principal().getProvenance(bid, moduleCallingContext_);
   }
 
   Provenance
   Event::getProvenance(ProductID const& pid) const {
-    return eventPrincipal().getProvenance(pid);
+    return eventPrincipal().getProvenance(pid, moduleCallingContext_);
   }
 
   void
@@ -198,7 +199,7 @@ namespace edm {
 
   BasicHandle
   Event::getByLabelImpl(std::type_info const&, std::type_info const& iProductType, const InputTag& iTag) const {
-    BasicHandle h = provRecorder_.getByLabel_(TypeID(iProductType), iTag);
+    BasicHandle h = provRecorder_.getByLabel_(TypeID(iProductType), iTag, moduleCallingContext_);
     if(h.isValid()) {
       addToGotBranchIDs(*(h.provenance()));
     }

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -46,6 +46,7 @@
 
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
 
 #include "FWCore/Utilities/interface/DebugMacros.h"
 #include "FWCore/Utilities/interface/EDMException.h"
@@ -104,26 +105,6 @@ namespace edm {
   }
 
   using namespace event_processor;
-
-  namespace {
-    template <typename T>
-    class ScheduleSignalSentry {
-    public:
-      ScheduleSignalSentry(ActivityRegistry* a, typename T::MyPrincipal* principal, EventSetup const* es) :
-           a_(a), principal_(principal), es_(es) {
-        if (a_) T::preScheduleSignal(a_, principal_);
-      }
-      ~ScheduleSignalSentry() {
-        if (a_) if (principal_) T::postScheduleSignal(a_, principal_, es_);
-      }
-
-    private:
-      // We own none of these resources.
-      ActivityRegistry* a_;
-      typename T::MyPrincipal* principal_;
-      EventSetup const* es_;
-    };
-  }
 
   namespace {
 
@@ -638,7 +619,7 @@ namespace edm {
     input_ = makeInput(*parameterSet, *common, *items.preg_, items.branchIDListHelper_, items.actReg_, items.processConfiguration_);
 
     // intialize the Schedule
-    schedule_ = items.initSchedule(*parameterSet,subProcessParameterSet.get(),StreamID{0});
+    schedule_ = items.initSchedule(*parameterSet,subProcessParameterSet.get(),StreamID{0},&processContext_);
 
     // set the data members
     act_table_ = std::move(items.act_table_);
@@ -646,6 +627,7 @@ namespace edm {
     preg_.reset(items.preg_.release());
     branchIDListHelper_ = items.branchIDListHelper_;
     processConfiguration_ = items.processConfiguration_;
+    processContext_.setProcessConfiguration(processConfiguration_.get());
 
     FDEBUG(2) << parameterSet << std::endl;
 
@@ -659,7 +641,7 @@ namespace edm {
       
     // initialize the subprocess, if there is one
     if(subProcessParameterSet) {
-      subProcess_.reset(new SubProcess(*subProcessParameterSet, *parameterSet, preg_, branchIDListHelper_, *espController_, *actReg_, token, serviceregistry::kConfigurationOverrides));
+      subProcess_.reset(new SubProcess(*subProcessParameterSet, *parameterSet, preg_, branchIDListHelper_, *espController_, *actReg_, token, serviceregistry::kConfigurationOverrides, &processContext_));
     }
   }
 
@@ -1949,7 +1931,7 @@ namespace edm {
 
   void EventProcessor::beginRun(statemachine::Run const& run) {
     RunPrincipal& runPrincipal = principalCache_.runPrincipal(run.processHistoryID(), run.runNumber());
-    input_->doBeginRun(runPrincipal);
+    input_->doBeginRun(runPrincipal, &processContext_);
     IOVSyncValue ts(EventID(runPrincipal.run(), 0, 0),
                     runPrincipal.beginTime());
     if(forceESCacheClearOnNewRun_){
@@ -1965,20 +1947,18 @@ namespace edm {
     }
     {
       typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> Traits;
-      ScheduleSignalSentry<Traits> sentry(actReg_.get(), &runPrincipal, &es);
-      schedule_->processOneOccurrence<Traits>(runPrincipal, es);
+      schedule_->processOneGlobal<Traits>(runPrincipal, es);
       if(hasSubProcess()) {
         subProcess_->doBeginRun(runPrincipal, ts);
       }
     }
     FDEBUG(1) << "\tbeginRun " << run.runNumber() << "\n";
     if(looper_) {
-      looper_->doBeginRun(runPrincipal, es);
+      looper_->doBeginRun(runPrincipal, es, &processContext_);
     }
     {
       typedef OccurrenceTraits<RunPrincipal, BranchActionStreamBegin> Traits;
-      ScheduleSignalSentry<Traits> sentry(actReg_.get(), &runPrincipal, &es);
-      schedule_->processOneOccurrence<Traits>(runPrincipal, es);
+      schedule_->processOneStream<Traits>(runPrincipal, es);
       if(hasSubProcess()) {
         subProcess_->doStreamBeginRun(schedule_->streamID(), runPrincipal, ts);
       }
@@ -1991,15 +1971,14 @@ namespace edm {
 
   void EventProcessor::endRun(statemachine::Run const& run, bool cleaningUpAfterException) {
     RunPrincipal& runPrincipal = principalCache_.runPrincipal(run.processHistoryID(), run.runNumber());
-    input_->doEndRun(runPrincipal, cleaningUpAfterException);
+    input_->doEndRun(runPrincipal, cleaningUpAfterException, &processContext_);
     IOVSyncValue ts(EventID(runPrincipal.run(), LuminosityBlockID::maxLuminosityBlockNumber(), EventID::maxEventNumber()),
                     runPrincipal.endTime());
     espController_->eventSetupForInstance(ts);
     EventSetup const& es = esp_->eventSetup();
     {
       typedef OccurrenceTraits<RunPrincipal, BranchActionStreamEnd> Traits;
-      ScheduleSignalSentry<Traits> sentry(actReg_.get(), &runPrincipal, &es);
-      schedule_->processOneOccurrence<Traits>(runPrincipal, es, cleaningUpAfterException);
+      schedule_->processOneStream<Traits>(runPrincipal, es, cleaningUpAfterException);
       if(hasSubProcess()) {
         subProcess_->doStreamEndRun(schedule_->streamID(),runPrincipal, ts, cleaningUpAfterException);
       }
@@ -2010,25 +1989,24 @@ namespace edm {
     }
     {
       typedef OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> Traits;
-      ScheduleSignalSentry<Traits> sentry(actReg_.get(), &runPrincipal, &es);
-      schedule_->processOneOccurrence<Traits>(runPrincipal, es, cleaningUpAfterException);
+      schedule_->processOneGlobal<Traits>(runPrincipal, es, cleaningUpAfterException);
       if(hasSubProcess()) {
         subProcess_->doEndRun(runPrincipal, ts, cleaningUpAfterException);
       }
     }
     FDEBUG(1) << "\tendRun " << run.runNumber() << "\n";
     if(looper_) {
-      looper_->doEndRun(runPrincipal, es);
+      looper_->doEndRun(runPrincipal, es, &processContext_);
     }
   }
 
   void EventProcessor::beginLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi) {
     LuminosityBlockPrincipal& lumiPrincipal = principalCache_.lumiPrincipal(phid, run, lumi);
-    input_->doBeginLumi(lumiPrincipal);
+    input_->doBeginLumi(lumiPrincipal, &processContext_);
 
     Service<RandomNumberGenerator> rng;
     if(rng.isAvailable()) {
-      LuminosityBlock lb(lumiPrincipal, ModuleDescription());
+      LuminosityBlock lb(lumiPrincipal, ModuleDescription(), nullptr);
       rng->preBeginLumi(lb);
     }
 
@@ -2039,20 +2017,18 @@ namespace edm {
     EventSetup const& es = esp_->eventSetup();
     {
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> Traits;
-      ScheduleSignalSentry<Traits> sentry(actReg_.get(), &lumiPrincipal, &es);
-      schedule_->processOneOccurrence<Traits>(lumiPrincipal, es);
+      schedule_->processOneGlobal<Traits>(lumiPrincipal, es);
       if(hasSubProcess()) {
         subProcess_->doBeginLuminosityBlock(lumiPrincipal, ts);
       }
     }
     FDEBUG(1) << "\tbeginLumi " << run << "/" << lumi << "\n";
     if(looper_) {
-      looper_->doBeginLuminosityBlock(lumiPrincipal, es);
+      looper_->doBeginLuminosityBlock(lumiPrincipal, es, &processContext_);
     }
     {
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin> Traits;
-      ScheduleSignalSentry<Traits> sentry(actReg_.get(), &lumiPrincipal, &es);
-      schedule_->processOneOccurrence<Traits>(lumiPrincipal, es);
+      schedule_->processOneStream<Traits>(lumiPrincipal, es);
       if(hasSubProcess()) {
         subProcess_->doStreamBeginLuminosityBlock(schedule_->streamID(),lumiPrincipal, ts);
       }
@@ -2065,7 +2041,7 @@ namespace edm {
 
   void EventProcessor::endLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi, bool cleaningUpAfterException) {
     LuminosityBlockPrincipal& lumiPrincipal = principalCache_.lumiPrincipal(phid, run, lumi);
-    input_->doEndLumi(lumiPrincipal, cleaningUpAfterException);
+    input_->doEndLumi(lumiPrincipal, cleaningUpAfterException, &processContext_);
     //NOTE: Using the max event number for the end of a lumi block is a bad idea
     // lumi blocks know their start and end times why not also start and end events?
     IOVSyncValue ts(EventID(lumiPrincipal.run(), lumiPrincipal.luminosityBlock(), EventID::maxEventNumber()),
@@ -2074,8 +2050,7 @@ namespace edm {
     EventSetup const& es = esp_->eventSetup();
     {
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd> Traits;
-      ScheduleSignalSentry<Traits> sentry(actReg_.get(), &lumiPrincipal, &es);
-      schedule_->processOneOccurrence<Traits>(lumiPrincipal, es, cleaningUpAfterException);
+      schedule_->processOneStream<Traits>(lumiPrincipal, es, cleaningUpAfterException);
       if(hasSubProcess()) {
         subProcess_->doStreamEndLuminosityBlock(schedule_->streamID(),lumiPrincipal, ts, cleaningUpAfterException);
       }
@@ -2086,15 +2061,14 @@ namespace edm {
     }
     {
       typedef OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> Traits;
-      ScheduleSignalSentry<Traits> sentry(actReg_.get(), &lumiPrincipal, &es);
-      schedule_->processOneOccurrence<Traits>(lumiPrincipal, es, cleaningUpAfterException);
+      schedule_->processOneGlobal<Traits>(lumiPrincipal, es, cleaningUpAfterException);
       if(hasSubProcess()) {
         subProcess_->doEndLuminosityBlock(lumiPrincipal, ts, cleaningUpAfterException);
       }
     }
     FDEBUG(1) << "\tendLumi " << run << "/" << lumi << "\n";
     if(looper_) {
-      looper_->doEndLuminosityBlock(lumiPrincipal, es);
+      looper_->doEndLuminosityBlock(lumiPrincipal, es, &processContext_);
     }
   }
 
@@ -2141,7 +2115,7 @@ namespace edm {
   }
 
   void EventProcessor::writeRun(statemachine::Run const& run) {
-    schedule_->writeRun(principalCache_.runPrincipal(run.processHistoryID(), run.runNumber()));
+    schedule_->writeRun(principalCache_.runPrincipal(run.processHistoryID(), run.runNumber()), &processContext_);
     if(hasSubProcess()) subProcess_->writeRun(run.processHistoryID(), run.runNumber());
     FDEBUG(1) << "\twriteRun " << run.runNumber() << "\n";
   }
@@ -2153,7 +2127,7 @@ namespace edm {
   }
 
   void EventProcessor::writeLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi) {
-    schedule_->writeLumi(principalCache_.lumiPrincipal(phid, run, lumi));
+    schedule_->writeLumi(principalCache_.lumiPrincipal(phid, run, lumi), &processContext_);
     if(hasSubProcess()) subProcess_->writeLumi(phid, run, lumi);
     FDEBUG(1) << "\twriteLumi " << run << "/" << lumi << "\n";
   }
@@ -2165,7 +2139,8 @@ namespace edm {
   }
 
   void EventProcessor::readAndProcessEvent() {
-    EventPrincipal *pep = input_->readEvent(principalCache_.eventPrincipal());
+    StreamContext streamContext(StreamID{0}, &processContext_);
+    EventPrincipal *pep = input_->readEvent(principalCache_.eventPrincipal(), &streamContext);
     FDEBUG(1) << "\treadEvent\n";
     assert(pep != 0);
     pep->setLuminosityBlockPrincipal(principalCache_.lumiPrincipalPtr());
@@ -2178,8 +2153,7 @@ namespace edm {
     EventSetup const& es = esp_->eventSetup();
     {
       typedef OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> Traits;
-      ScheduleSignalSentry<Traits> sentry(actReg_.get(), pep, &es);
-      schedule_->processOneOccurrence<Traits>(*pep, es);
+      schedule_->processOneEvent<Traits>(*pep, es);
       if(hasSubProcess()) {
         subProcess_->doEvent(*pep, ts);
       }
@@ -2193,7 +2167,9 @@ namespace edm {
 
       EDLooperBase::Status status = EDLooperBase::kContinue;
       do {
-        status = looper_->doDuringLoop(*pep, esp_->eventSetup(), pc);
+
+        StreamContext streamContext(StreamID{0}, &processContext_);
+        status = looper_->doDuringLoop(*pep, esp_->eventSetup(), pc, &streamContext);
 
         bool succeeded = true;
         if(randomAccess) {

--- a/FWCore/Framework/src/GenericHandle.cc
+++ b/FWCore/Framework/src/GenericHandle.cc
@@ -52,7 +52,7 @@ edm::Event::getByLabel<GenericObject>(std::string const& label,
                                       std::string const& productInstanceName,
                                       Handle<GenericObject>& result) const
 {
-  BasicHandle bh = provRecorder_.getByLabel_(TypeID(result.type().typeInfo()), label, productInstanceName, std::string());
+  BasicHandle bh = provRecorder_.getByLabel_(TypeID(result.type().typeInfo()), label, productInstanceName, std::string(), moduleCallingContext_);
   convert_handle(bh, result);  // throws on conversion error
   if(!bh.failedToGet()) {
     addToGotBranchIDs(*bh.provenance());
@@ -69,7 +69,7 @@ edm::Event::getByLabel<GenericObject>(edm::InputTag const& tag,
   if (tag.process().empty()) {
     return this->getByLabel(tag.label(), tag.instance(), result);
   } else {
-    BasicHandle bh = provRecorder_.getByLabel_(TypeID(result.type().typeInfo()), tag.label(), tag.instance(),tag.process());
+    BasicHandle bh = provRecorder_.getByLabel_(TypeID(result.type().typeInfo()), tag.label(), tag.instance(),tag.process(), moduleCallingContext_);
     convert_handle(bh, result);  // throws on conversion error
     if(!bh.failedToGet()) {
       addToGotBranchIDs(*bh.provenance());

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -19,7 +19,10 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/GlobalContext.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/do_nothing_deleter.h"
@@ -339,7 +342,7 @@ namespace edm {
   }
 
   EventPrincipal*
-  InputSource::readEvent(EventPrincipal& ep) {
+  InputSource::readEvent(EventPrincipal& ep, StreamContext* streamContext) {
     assert(state_ == IsEvent);
     assert(!eventLimitReached());
 
@@ -349,7 +352,8 @@ namespace edm {
     }
 
     if(result != 0) {
-      Event event(*result, moduleDescription());
+
+      Event event(*result, moduleDescription(), nullptr);
       postRead(event);
       if(remainingEvents_ > 0) --remainingEvents_;
       ++readCount_;
@@ -360,7 +364,7 @@ namespace edm {
   }
 
   EventPrincipal*
-  InputSource::readEvent(EventPrincipal& ep, EventID const& eventID) {
+  InputSource::readEvent(EventPrincipal& ep, EventID const& eventID, StreamContext* streamContext) {
     EventPrincipal* result = 0;
 
     if(!limitReached()) {
@@ -368,7 +372,8 @@ namespace edm {
       result = readIt(eventID, ep);
 
       if(result != 0) {
-        Event event(*result, moduleDescription());
+
+        Event event(*result, moduleDescription(), nullptr);
         postRead(event);
         if(remainingEvents_ > 0) --remainingEvents_;
         ++readCount_;
@@ -491,33 +496,33 @@ namespace edm {
   }
 
   void
-  InputSource::doBeginRun(RunPrincipal& rp) {
-    Run run(rp, moduleDescription());
+  InputSource::doBeginRun(RunPrincipal& rp, ProcessContext const* processContext) {
+    Run run(rp, moduleDescription(), nullptr);
     callWithTryCatchAndPrint<void>( [this,&run](){ beginRun(run); }, "Calling InputSource::beginRun" );
     run.commit_();
   }
 
   void
-  InputSource::doEndRun(RunPrincipal& rp, bool cleaningUpAfterException) {
+  InputSource::doEndRun(RunPrincipal& rp, bool cleaningUpAfterException, ProcessContext const* processContext) {
     rp.setEndTime(time_);
     rp.setComplete();
-    Run run(rp, moduleDescription());
+    Run run(rp, moduleDescription(), nullptr);
     callWithTryCatchAndPrint<void>( [this,&run](){ endRun(run); }, "Calling InputSource::endRun", cleaningUpAfterException );
     run.commit_();
   }
 
   void
-  InputSource::doBeginLumi(LuminosityBlockPrincipal& lbp) {
-    LuminosityBlock lb(lbp, moduleDescription());
+  InputSource::doBeginLumi(LuminosityBlockPrincipal& lbp, ProcessContext const* processContext) {
+    LuminosityBlock lb(lbp, moduleDescription(), nullptr);
     callWithTryCatchAndPrint<void>( [this,&lb](){ beginLuminosityBlock(lb); }, "Calling InputSource::beginLuminosityBlock" );
     lb.commit_();
   }
 
   void
-  InputSource::doEndLumi(LuminosityBlockPrincipal& lbp, bool cleaningUpAfterException) {
+  InputSource::doEndLumi(LuminosityBlockPrincipal& lbp, bool cleaningUpAfterException, ProcessContext const* processContext) {
     lbp.setEndTime(time_);
     lbp.setComplete();
-    LuminosityBlock lb(lbp, moduleDescription());
+    LuminosityBlock lb(lbp, moduleDescription(), nullptr);
     callWithTryCatchAndPrint<void>( [this,&lb](){ endLuminosityBlock(lb); }, "Calling InputSource::endLuminosityBlock", cleaningUpAfterException );
     lb.commit_();
   }
@@ -634,21 +639,29 @@ namespace edm {
      sentry_(source.actReg()->preSourceRunSignal_, source.actReg()->postSourceRunSignal_) {
   }
 
-  InputSource::FileOpenSentry::FileOpenSentry(InputSource const& source) :
-     sentry_(source.actReg()->preOpenFileSignal_, source.actReg()->postOpenFileSignal_) {
+  InputSource::FileOpenSentry::FileOpenSentry(InputSource const& source,
+                                              std::string const& lfn,
+                                              bool usedFallback) :
+    post_(source.actReg()->postOpenFileSignal_),
+    lfn_(lfn),
+    usedFallback_(usedFallback) {
+     source.actReg()->preOpenFileSignal_(lfn, usedFallback);
   }
 
-  InputSource::FileCloseSentry::FileCloseSentry(InputSource const& source) :
-     post_(source.actReg()->postCloseFileSignal_) {
-     source.actReg()->preCloseFileSignal_("", false);
+  InputSource::FileOpenSentry::~FileOpenSentry() {
+    post_(lfn_, usedFallback_);
   }
 
-  InputSource::FileCloseSentry::FileCloseSentry(InputSource const& source, std::string const& lfn, bool usedFallback) :
-     post_(source.actReg()->postCloseFileSignal_) {
-     source.actReg()->preCloseFileSignal_(lfn, usedFallback);
+  InputSource::FileCloseSentry::FileCloseSentry(InputSource const& source,
+                                                std::string const& lfn,
+                                                bool usedFallback) :
+    post_(source.actReg()->postCloseFileSignal_),
+    lfn_(lfn),
+    usedFallback_(usedFallback) {
+    source.actReg()->preCloseFileSignal_(lfn, usedFallback);
   }
 
   InputSource::FileCloseSentry::~FileCloseSentry() {
-     post_();
+    post_(lfn_, usedFallback_);
   }
 }

--- a/FWCore/Framework/src/LuminosityBlock.cc
+++ b/FWCore/Framework/src/LuminosityBlock.cc
@@ -8,10 +8,12 @@ namespace edm {
 
   std::string const LuminosityBlock::emptyString_;
 
-  LuminosityBlock::LuminosityBlock(LuminosityBlockPrincipal& lbp, ModuleDescription const& md) :
+  LuminosityBlock::LuminosityBlock(LuminosityBlockPrincipal& lbp, ModuleDescription const& md,
+                                   ModuleCallingContext const* moduleCallingContext) :
         provRecorder_(lbp, md),
         aux_(lbp.aux()),
-        run_(new Run(lbp.runPrincipal(), md)) {
+        run_(new Run(lbp.runPrincipal(), md, moduleCallingContext)),
+        moduleCallingContext_(moduleCallingContext) {
   }
 
   LuminosityBlock::~LuminosityBlock() {
@@ -46,7 +48,7 @@ namespace edm {
 
   Provenance
   LuminosityBlock::getProvenance(BranchID const& bid) const {
-    return luminosityBlockPrincipal().getProvenance(bid);
+    return luminosityBlockPrincipal().getProvenance(bid, moduleCallingContext_);
   }
 
   void
@@ -88,7 +90,7 @@ namespace edm {
 
   BasicHandle
   LuminosityBlock::getByLabelImpl(std::type_info const&, std::type_info const& iProductType, const InputTag& iTag) const {
-    BasicHandle h = provRecorder_.getByLabel_(TypeID(iProductType), iTag);
+    BasicHandle h = provRecorder_.getByLabel_(TypeID(iProductType), iTag, moduleCallingContext_);
     if (h.isValid()) {
       addToGotBranchIDs(*(h.provenance()));
     }

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -167,8 +167,8 @@ namespace edm {
   }
 
 
-  Trig OutputModule::getTriggerResults(EventPrincipal const& ep) const {
-    return selectors_.getOneTriggerResults(ep);  }
+  Trig OutputModule::getTriggerResults(EventPrincipal const& ep, ModuleCallingContext const* mcc) const {
+    return selectors_.getOneTriggerResults(ep, mcc);  }
 
   namespace {
   }
@@ -176,18 +176,19 @@ namespace edm {
   bool
   OutputModule::doEvent(EventPrincipal const& ep,
                         EventSetup const&,
-                        CurrentProcessingContext const* cpc) {
+                        CurrentProcessingContext const* cpc,
+                        ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
     detail::TRBESSentry products_sentry(selectors_);
 
     FDEBUG(2) << "writeEvent called\n";
 
     if(!wantAllEvents_) {
-      if(!selectors_.wantEvent(ep)) {
+      if(!selectors_.wantEvent(ep, mcc)) {
         return true;
       }
     }
-    write(ep);
+    write(ep, mcc);
     updateBranchParents(ep);
     if(remainingEvents_ > 0) {
       --remainingEvents_;
@@ -213,53 +214,59 @@ namespace edm {
 
   bool
   OutputModule::doBeginRun(RunPrincipal const& rp,
-                                EventSetup const&,
-                                CurrentProcessingContext const* cpc) {
+                           EventSetup const&,
+                           CurrentProcessingContext const* cpc,
+                           ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
     FDEBUG(2) << "beginRun called\n";
-    beginRun(rp);
+    beginRun(rp, mcc);
     return true;
   }
 
   bool
   OutputModule::doEndRun(RunPrincipal const& rp,
-                              EventSetup const&,
-                              CurrentProcessingContext const* cpc) {
+                         EventSetup const&,
+                         CurrentProcessingContext const* cpc,
+                         ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
     FDEBUG(2) << "endRun called\n";
-    endRun(rp);
+    endRun(rp, mcc);
     return true;
   }
 
   void
-  OutputModule::doWriteRun(RunPrincipal const& rp) {
+  OutputModule::doWriteRun(RunPrincipal const& rp,
+                           ModuleCallingContext const* mcc) {
     FDEBUG(2) << "writeRun called\n";
-    writeRun(rp);
+    writeRun(rp, mcc);
   }
 
   bool
   OutputModule::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                            EventSetup const&,
-                                            CurrentProcessingContext const* cpc) {
+                                       EventSetup const&,
+                                       CurrentProcessingContext const* cpc,
+                                       ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
     FDEBUG(2) << "beginLuminosityBlock called\n";
-    beginLuminosityBlock(lbp);
+    beginLuminosityBlock(lbp, mcc);
     return true;
   }
 
   bool
   OutputModule::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                          EventSetup const&,
-                                          CurrentProcessingContext const* cpc) {
+                                     EventSetup const&,
+                                     CurrentProcessingContext const* cpc,
+                                     ModuleCallingContext const* mcc) {
     detail::CPCSentry sentry(current_context_, cpc);
     FDEBUG(2) << "endLuminosityBlock called\n";
-    endLuminosityBlock(lbp);
+    endLuminosityBlock(lbp, mcc);
     return true;
   }
 
-  void OutputModule::doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp) {
+  void OutputModule::doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                                            ModuleCallingContext const* mcc) {
     FDEBUG(2) << "writeLuminosityBlock called\n";
-    writeLuminosityBlock(lbp);
+    writeLuminosityBlock(lbp, mcc);
   }
 
   void OutputModule::doOpenFile(FileBlock const& fb) {

--- a/FWCore/Framework/src/OutputModuleCommunicator.h
+++ b/FWCore/Framework/src/OutputModuleCommunicator.h
@@ -30,6 +30,9 @@
 
 // forward declarations
 namespace edm {
+
+  class ProcessContext;
+
   class OutputModuleCommunicator
   {
     
@@ -49,9 +52,9 @@ namespace edm {
     
     virtual void openFile(FileBlock const& fb) = 0;
     
-    virtual void writeRun(RunPrincipal const& rp) = 0;
+    virtual void writeRun(RunPrincipal const& rp, ProcessContext const*) = 0;
     
-    virtual void writeLumi(LuminosityBlockPrincipal const& lbp) = 0;
+    virtual void writeLumi(LuminosityBlockPrincipal const& lbp, ProcessContext const*) = 0;
     
     ///\return true if OutputModule has reached its limit on maximum number of events it wants to see
     virtual bool limitReached() const = 0;

--- a/FWCore/Framework/src/Path.cc
+++ b/FWCore/Framework/src/Path.cc
@@ -15,7 +15,8 @@ namespace edm {
 	     TrigResPtr trptr,
 	     ActionTable const& actions,
 	     boost::shared_ptr<ActivityRegistry> areg,
-	     bool isEndPath):
+	     bool isEndPath,
+             StreamContext const* streamContext):
     stopwatch_(),
     timesRun_(),
     timesPassed_(),
@@ -28,7 +29,8 @@ namespace edm {
     actReg_(areg),
     act_table_(&actions),
     workers_(workers),
-    isEndPath_(isEndPath) {
+    isEndPath_(isEndPath),
+    pathContext_(path_name, bitpos, streamContext) {
   }
   
   bool

--- a/FWCore/Framework/src/Path.h
+++ b/FWCore/Framework/src/Path.h
@@ -16,6 +16,7 @@
 #include "FWCore/Framework/src/Worker.h"
 #include "DataFormats/Common/interface/HLTenums.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
+#include "FWCore/ServiceRegistry/interface/PathContext.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
@@ -50,10 +51,12 @@ namespace edm {
          TrigResPtr trptr,
          ActionTable const& actions,
          boost::shared_ptr<ActivityRegistry> reg,
-         bool isEndPath);
+         bool isEndPath,
+         StreamContext const* streamContext);
 
     template <typename T>
-    void processOneOccurrence(typename T::MyPrincipal&, EventSetup const&, StreamID const&);
+    void processOneOccurrence(typename T::MyPrincipal&, EventSetup const&,
+                              StreamID const&, typename T::Context const*);
 
     int bitPosition() const { return bitpos_; }
     std::string const& name() const { return name_; }
@@ -108,6 +111,8 @@ namespace edm {
 
     bool isEndPath_;
 
+    PathContext pathContext_;
+
     // Helper functions
     // nwrwue = numWorkersRunWithoutUnhandledException (really!)
     bool handleWorkerFailure(cms::Exception & e,
@@ -138,29 +143,32 @@ namespace edm {
       PathSignalSentry(ActivityRegistry *a,
                        std::string const& name,
                        int const& nwrwue,
-                       hlt::HLTState const& state) :
-      a_(a), name_(name), nwrwue_(nwrwue), state_(state) {
-        if (a_) T::prePathSignal(a_, name_);
+                       hlt::HLTState const& state,
+                       PathContext const* pathContext) :
+        a_(a), name_(name), nwrwue_(nwrwue), state_(state), pathContext_(pathContext) {
+        if (a_) T::prePathSignal(a_, name_, pathContext_);
       }
       ~PathSignalSentry() {
         HLTPathStatus status(state_, nwrwue_);
-        if(a_) T::postPathSignal(a_, name_, status);
+        if(a_) T::postPathSignal(a_, name_, status, pathContext_);
       }
     private:
       ActivityRegistry* a_;
       std::string const& name_;
       int const& nwrwue_;
       hlt::HLTState const& state_;
+      PathContext const* pathContext_;
     };
   }
 
   template <typename T>
-  void Path::processOneOccurrence(typename T::MyPrincipal& ep, EventSetup const& es, StreamID const& streamID) {
+  void Path::processOneOccurrence(typename T::MyPrincipal& ep, EventSetup const& es,
+                                  StreamID const& streamID, typename T::Context const* context) {
 
     //Create the PathSignalSentry before the RunStopwatch so that
     // we only record the time spent in the path not from the signal
     int nwrwue = -1;
-    PathSignalSentry<T> signaler(actReg_.get(), name_, nwrwue, state_);
+    PathSignalSentry<T> signaler(actReg_.get(), name_, nwrwue, state_, &pathContext_);
 
     // A RunStopwatch, but only if we are processing an event.
     RunStopwatch stopwatch(T::isEvent_ ? stopwatch_ : RunStopwatch::StopwatchPointer());
@@ -185,7 +193,13 @@ namespace edm {
       try {
         try {
           cpc.activate(idx, i->getWorker()->descPtr());
-          should_continue = i->runWorker<T>(ep, es, &cpc, streamID);
+          if(T::isEvent_) {
+            ParentContext parentContext(&pathContext_);
+            should_continue = i->runWorker<T>(ep, es, &cpc, streamID, parentContext, context);
+          } else {
+            ParentContext parentContext(context);
+            should_continue = i->runWorker<T>(ep, es, &cpc, streamID, parentContext, context);
+          }
         }
         catch (cms::Exception& e) { throw; }
         catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -418,23 +418,25 @@ namespace edm {
   }
 
   Principal::ConstProductPtr
-  Principal::getProductHolder(BranchID const& bid, bool resolveProd, bool fillOnDemand) const {
+  Principal::getProductHolder(BranchID const& bid, bool resolveProd, bool fillOnDemand,
+                              ModuleCallingContext const* mcc) const {
     ProductHolderIndex index = preg_->indexFrom(bid);
     if(index == ProductHolderIndexInvalid){
        return ConstProductPtr();
     }
-    return getProductByIndex(index, resolveProd, fillOnDemand);
+    return getProductByIndex(index, resolveProd, fillOnDemand, mcc);
   }
 
   Principal::ConstProductPtr
-  Principal::getProductByIndex(ProductHolderIndex const& index, bool resolveProd, bool fillOnDemand) const {
+  Principal::getProductByIndex(ProductHolderIndex const& index, bool resolveProd, bool fillOnDemand,
+                               ModuleCallingContext const* mcc) const {
 
     ConstProductPtr const phb = productHolders_[index].get();
     if(nullptr == phb) {
       return phb;
     }
     if(resolveProd && !phb->productUnavailable()) {
-      this->resolveProduct(*phb, fillOnDemand);
+      this->resolveProduct(*phb, fillOnDemand, mcc);
     }
     return phb;
   }
@@ -443,9 +445,10 @@ namespace edm {
   Principal::getByLabel(KindOfType kindOfType,
                         TypeID const& typeID,
                         InputTag const& inputTag,
-                        EDConsumerBase const* consumer) const {
+                        EDConsumerBase const* consumer,
+                        ModuleCallingContext const* mcc) const {
 
-    ProductData const* result = findProductByLabel(kindOfType, typeID, inputTag, consumer);
+    ProductData const* result = findProductByLabel(kindOfType, typeID, inputTag, consumer, mcc);
     if(result == 0) {
       boost::shared_ptr<cms::Exception> whyFailed =
         makeNotFoundException("getByLabel", kindOfType, typeID, inputTag.label(), inputTag.instance(), inputTag.process());
@@ -460,9 +463,10 @@ namespace edm {
                         std::string const& label,
                         std::string const& instance,
                         std::string const& process,
-                        EDConsumerBase const* consumer) const {
+                        EDConsumerBase const* consumer,
+                        ModuleCallingContext const* mcc) const {
 
-    ProductData const* result = findProductByLabel(kindOfType, typeID, label, instance, process,consumer);
+    ProductData const* result = findProductByLabel(kindOfType, typeID, label, instance, process,consumer, mcc);
     if(result == 0) {
       boost::shared_ptr<cms::Exception> whyFailed =
         makeNotFoundException("getByLabel", kindOfType, typeID, label, instance, process);
@@ -476,12 +480,13 @@ namespace edm {
                         TypeID const& typeID,
                         ProductHolderIndex index,
                         bool skipCurrentProcess,
-                        bool& ambiguous) const {
+                        bool& ambiguous,
+                        ModuleCallingContext const* mcc) const {
     assert(index !=ProductHolderIndexInvalid);
     boost::shared_ptr<ProductHolderBase> const& productHolder = productHolders_[index];
     assert(0!=productHolder.get());
     ProductHolderBase::ResolveStatus resolveStatus;
-    ProductData const* productData = productHolder->resolveProduct(resolveStatus, skipCurrentProcess);
+    ProductData const* productData = productHolder->resolveProduct(resolveStatus, skipCurrentProcess, mcc);
     if(resolveStatus == ProductHolderBase::Ambiguous) {
       ambiguous = true;
       return BasicHandle();
@@ -495,7 +500,8 @@ namespace edm {
   void
   Principal::getManyByType(TypeID const& typeID,
                            BasicHandleVec& results,
-                           EDConsumerBase const* consumer) const {
+                           EDConsumerBase const* consumer,
+                           ModuleCallingContext const* mcc) const {
 
     assert(results.empty());
 
@@ -546,7 +552,7 @@ namespace edm {
       if(!matches.isFullyResolved(i)) {
         if(!holders.empty()) {
           // Process the ones with a particular module label and instance
-          findProducts(holders, typeID, results);
+          findProducts(holders, typeID, results, mcc);
           holders.clear();
         }
       } else {
@@ -557,7 +563,7 @@ namespace edm {
     }
     // Do not miss the last subset of products
     if(!holders.empty()) {
-      findProducts(holders, typeID, results);
+      findProducts(holders, typeID, results, mcc);
     }
     return;
   }
@@ -565,7 +571,8 @@ namespace edm {
   void
   Principal::findProducts(std::vector<ProductHolderBase const*> const& holders,
                           TypeID const& typeID,
-                          BasicHandleVec& results) const {
+                          BasicHandleVec& results,
+                          ModuleCallingContext const* mcc) const {
 
     for (auto iter = processHistoryPtr_->rbegin(),
               iEnd = processHistoryPtr_->rend();
@@ -592,7 +599,7 @@ namespace edm {
           // Skip product if not available.
           if(!productHolder->productUnavailable()) {
 
-            this->resolveProduct(*productHolder, true);
+            this->resolveProduct(*productHolder, true, mcc);
             // If the product is a dummy filler, product holder will now be marked unavailable.
             // Unscheduled execution can fail to produce the EDProduct so check
             if(productHolder->product() && !productHolder->productUnavailable() && !productHolder->onDemand()) {
@@ -610,7 +617,8 @@ namespace edm {
   Principal::findProductByLabel(KindOfType kindOfType,
                                 TypeID const& typeID,
                                 InputTag const& inputTag,
-                                EDConsumerBase const* consumer) const {
+                                EDConsumerBase const* consumer,
+                                ModuleCallingContext const* mcc) const {
 
     bool skipCurrentProcess = inputTag.willSkipCurrentProcess();
 
@@ -650,7 +658,7 @@ namespace edm {
     boost::shared_ptr<ProductHolderBase> const& productHolder = productHolders_[index];
 
     ProductHolderBase::ResolveStatus resolveStatus;
-    ProductData const* productData = productHolder->resolveProduct(resolveStatus, skipCurrentProcess);
+    ProductData const* productData = productHolder->resolveProduct(resolveStatus, skipCurrentProcess, mcc);
     if(resolveStatus == ProductHolderBase::Ambiguous) {
       throwAmbiguousException("findProductByLabel", typeID, inputTag.label(), inputTag.instance(), inputTag.process());
     }
@@ -663,7 +671,8 @@ namespace edm {
                                 std::string const& label,
                                 std::string const& instance,
                                 std::string const& process,
-                                EDConsumerBase const* consumer) const {
+                                EDConsumerBase const* consumer,
+                                ModuleCallingContext const* mcc) const {
 
     ProductHolderIndex index = productLookup().index(kindOfType,
                                                      typeID,
@@ -690,7 +699,7 @@ namespace edm {
     boost::shared_ptr<ProductHolderBase> const& productHolder = productHolders_[index];
 
     ProductHolderBase::ResolveStatus resolveStatus;
-    ProductData const* productData = productHolder->resolveProduct(resolveStatus, false);
+    ProductData const* productData = productHolder->resolveProduct(resolveStatus, false, mcc);
     if(resolveStatus == ProductHolderBase::Ambiguous) {
       throwAmbiguousException("findProductByLabel", typeID, label, instance, process);
     }
@@ -698,12 +707,13 @@ namespace edm {
   }
 
   ProductData const*
-  Principal::findProductByTag(TypeID const& typeID, InputTag const& tag) const {
+  Principal::findProductByTag(TypeID const& typeID, InputTag const& tag, ModuleCallingContext const* mcc) const {
     ProductData const* productData =
       findProductByLabel(PRODUCT_TYPE,
                          typeID,
                          tag,
-                         nullptr);
+                         nullptr,
+                         mcc);
     if(productData == nullptr) {
       throwNotFoundException("findProductByTag", typeID, tag);
     }
@@ -711,8 +721,9 @@ namespace edm {
   }
 
   OutputHandle
-  Principal::getForOutput(BranchID const& bid, bool getProd) const {
-    ConstProductPtr const phb = getProductHolder(bid, getProd, true);
+  Principal::getForOutput(BranchID const& bid, bool getProd,
+                          ModuleCallingContext const* mcc) const {
+    ConstProductPtr const phb = getProductHolder(bid, getProd, true, mcc);
     if(phb == nullptr) {
       throwProductNotFoundException("getForOutput", errors::LogicError, bid);
     }
@@ -729,14 +740,15 @@ namespace edm {
   }
 
   Provenance
-  Principal::getProvenance(BranchID const& bid) const {
-    ConstProductPtr const phb = getProductHolder(bid, false, true);
+  Principal::getProvenance(BranchID const& bid,
+                           ModuleCallingContext const* mcc) const {
+    ConstProductPtr const phb = getProductHolder(bid, false, true, mcc);
     if(phb == nullptr) {
       throwProductNotFoundException("getProvenance", errors::ProductNotFound, bid);
     }
 
     if(phb->onDemand()) {
-      unscheduledFill(phb->branchDescription().moduleLabel());
+      unscheduledFill(phb->branchDescription().moduleLabel(), mcc);
     }
     // We already tried to produce the unscheduled products above
     // If they still are not there, then throw

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -142,20 +142,23 @@ namespace edm {
 
   BasicHandle
   PrincipalGetAdapter::getByLabel_(TypeID const& typeID,
-                                   InputTag const& tag) const {
-    return principal_.getByLabel(PRODUCT_TYPE, typeID, tag, consumer_);
+                                   InputTag const& tag,
+                                   ModuleCallingContext const* mcc) const {
+    return principal_.getByLabel(PRODUCT_TYPE, typeID, tag, consumer_, mcc);
   }
 
   BasicHandle
   PrincipalGetAdapter::getByLabel_(TypeID const& typeID,
                                    std::string const& label,
   	                           std::string const& instance,
-  	                           std::string const& process) const {
-    return principal_.getByLabel(PRODUCT_TYPE, typeID, label, instance, process, consumer_);
+  	                           std::string const& process,
+                                   ModuleCallingContext const* mcc) const {
+    return principal_.getByLabel(PRODUCT_TYPE, typeID, label, instance, process, consumer_, mcc);
   }
   
   BasicHandle
-  PrincipalGetAdapter::getByToken_(TypeID const& id, KindOfType kindOfType, EDGetToken token) const {
+  PrincipalGetAdapter::getByToken_(TypeID const& id, KindOfType kindOfType, EDGetToken token,
+                                   ModuleCallingContext const* mcc) const {
     ProductHolderIndex index = consumer_->indexFrom(token,InEvent,id);
     if( unlikely(index == ProductHolderIndexInvalid)) {
       return makeFailToGetException(kindOfType,id,token);
@@ -164,7 +167,7 @@ namespace edm {
       throwAmbiguousException(id, token);
     }
     bool ambiguous = false;
-    BasicHandle h = principal_.getByToken(kindOfType,id,index, token.willSkipCurrentProcess(), ambiguous);
+    BasicHandle h = principal_.getByToken(kindOfType,id,index, token.willSkipCurrentProcess(), ambiguous, mcc);
     if (ambiguous) {
       // This deals with ambiguities where the process is not specified
       throwAmbiguousException(id, token);
@@ -176,28 +179,32 @@ namespace edm {
 
   BasicHandle
   PrincipalGetAdapter::getMatchingSequenceByLabel_(TypeID const& typeID,
-                                                   InputTag const& tag) const {
-    return principal_.getByLabel(ELEMENT_TYPE, typeID, tag, consumer_);
+                                                   InputTag const& tag,
+                                                   ModuleCallingContext const* mcc) const {
+    return principal_.getByLabel(ELEMENT_TYPE, typeID, tag, consumer_, mcc);
   }
 
   BasicHandle
   PrincipalGetAdapter::getMatchingSequenceByLabel_(TypeID const& typeID,
                                                    std::string const& label,
                                                    std::string const& instance,
-                                                   std::string const& process) const {
+                                                   std::string const& process,
+                                                   ModuleCallingContext const* mcc) const {
     auto h= principal_.getByLabel(ELEMENT_TYPE,
-                                 typeID,
-                                 label,
-                                 instance,
-                                 process,
-                                 consumer_);
+                                  typeID,
+                                  label,
+                                  instance,
+                                  process,
+                                  consumer_,
+                                  mcc);
     return h;
   }
 
   void
   PrincipalGetAdapter::getManyByType_(TypeID const& tid,
-		  BasicHandleVec& results) const {
-    principal_.getManyByType(tid, results, consumer_);
+                                      BasicHandleVec& results,
+                                      ModuleCallingContext const* mcc) const {
+    principal_.getManyByType(tid, results, consumer_, mcc);
   }
 
   ProcessHistory const&
@@ -207,7 +214,7 @@ namespace edm {
 
   ConstBranchDescription const&
   PrincipalGetAdapter::getBranchDescription(TypeID const& type,
-				     std::string const& productInstanceName) const {
+                                            std::string const& productInstanceName) const {
     ProductHolderIndexHelper const& productHolderIndexHelper = principal_.productLookup();
     ProductHolderIndex index = productHolderIndexHelper.index(PRODUCT_TYPE, type, md_.moduleLabel().c_str(),productInstanceName.c_str(), md_.processName().c_str());
     if(index == ProductHolderIndexInvalid) {
@@ -223,7 +230,7 @@ namespace edm {
 	<< principal_.productRegistry()
 	<< '\n';
     }
-    ProductHolderBase const*  phb = principal_.getProductByIndex(index, false, false);
+    ProductHolderBase const*  phb = principal_.getProductByIndex(index, false, false, nullptr);
     assert(phb != nullptr);
     return phb->branchDescription();
   }

--- a/FWCore/Framework/src/Run.cc
+++ b/FWCore/Framework/src/Run.cc
@@ -7,9 +7,11 @@ namespace edm {
 
   std::string const Run::emptyString_;
 
-  Run::Run(RunPrincipal& rp, ModuleDescription const& md) :
+  Run::Run(RunPrincipal& rp, ModuleDescription const& md,
+           ModuleCallingContext const* moduleCallingContext) :
         provRecorder_(rp, md),
-        aux_(rp.aux()) {
+        aux_(rp.aux()),
+        moduleCallingContext_(moduleCallingContext)  {
   }
 
   Run::~Run() {
@@ -32,7 +34,7 @@ namespace edm {
 
   Provenance
   Run::getProvenance(BranchID const& bid) const {
-    return runPrincipal().getProvenance(bid);
+    return runPrincipal().getProvenance(bid, moduleCallingContext_);
   }
 
   void
@@ -111,7 +113,7 @@ namespace edm {
 
   BasicHandle
   Run::getByLabelImpl(std::type_info const&, std::type_info const& iProductType, const InputTag& iTag) const {
-    BasicHandle h = provRecorder_.getByLabel_(TypeID(iProductType), iTag);
+    BasicHandle h = provRecorder_.getByLabel_(TypeID(iProductType), iTag, moduleCallingContext_);
     if(h.isValid()) {
       addToGotBranchIDs(*(h.provenance()));
     }

--- a/FWCore/Framework/src/ScheduleItems.cc
+++ b/FWCore/Framework/src/ScheduleItems.cc
@@ -127,7 +127,8 @@ namespace edm {
   std::auto_ptr<Schedule>
   ScheduleItems::initSchedule(ParameterSet& parameterSet,
                               ParameterSet const* subProcessPSet,
-                              StreamID streamID) {
+                              StreamID streamID,
+                              ProcessContext const* processContext) {
     std::auto_ptr<Schedule> schedule(
         new Schedule(parameterSet,
                      ServiceRegistry::instance().get<service::TriggerNamesService>(),
@@ -137,7 +138,8 @@ namespace edm {
                      actReg_,
                      processConfiguration_,
                      subProcessPSet,
-                     streamID));
+                     streamID,
+                     processContext));
     return schedule;
   }
 

--- a/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
+++ b/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
@@ -115,11 +115,12 @@ namespace edm
     }
 
     
-    void NamedEventSelector::fill(EventPrincipal const& e) {
+    void NamedEventSelector::fill(EventPrincipal const& e, ModuleCallingContext const* mcc) {
       edm::BasicHandle h = e.getByLabel(PRODUCT_TYPE,
                                         s_TrigResultsType,
                                         inputTag_,
-                                        nullptr);
+                                        nullptr,
+                                        mcc);
       convert_handle(h,product_);
     }
     
@@ -189,14 +190,14 @@ namespace edm
     }
 
     TriggerResultsBasedEventSelector::handle_t
-    TriggerResultsBasedEventSelector::getOneTriggerResults(EventPrincipal const& ev)
+    TriggerResultsBasedEventSelector::getOneTriggerResults(EventPrincipal const& ev, ModuleCallingContext const* mcc)
     {
-      fill(ev);
+      fill(ev, mcc);
       return returnOneHandleOrThrow();
     }
 
     bool
-    TriggerResultsBasedEventSelector::wantEvent(EventPrincipal const& ev)
+    TriggerResultsBasedEventSelector::wantEvent(EventPrincipal const& ev, ModuleCallingContext const* mcc)
     {
       // We have to get all the TriggerResults objects before we test
       // any for a match, because we have to deal with the possibility
@@ -206,7 +207,7 @@ namespace edm
       // configuration has been set to match all events, or the
       // configuration is set to use specific process names.
 
-      fill(ev);
+      fill(ev, mcc);
 
       // Now we go through and see if anyone matches...
       iter i = selectors_.begin();
@@ -245,7 +246,7 @@ namespace edm
     }
 
     TriggerResultsBasedEventSelector::size_type
-    TriggerResultsBasedEventSelector::fill(EventPrincipal const& ev)
+    TriggerResultsBasedEventSelector::fill(EventPrincipal const& ev, ModuleCallingContext const* mcc)
     {
       if (!fillDone_)
 	{
@@ -253,7 +254,7 @@ namespace edm
 	  for (iter i = selectors_.begin(), e = selectors_.end(); 
 	       i != e; ++i)
 	    {
-	      i->fill(ev);     // fill might throw...
+	      i->fill(ev, mcc);     // fill might throw...
 	      ++numberFound_ ; // so numberFound_ might be less than expected
 	    }
 	}

--- a/FWCore/Framework/src/UnscheduledHandler.cc
+++ b/FWCore/Framework/src/UnscheduledHandler.cc
@@ -70,7 +70,8 @@ namespace edm {
 
   bool
   UnscheduledHandler::tryToFill(std::string const& label,
-                                EventPrincipal& iEvent) {
+                                EventPrincipal& iEvent,
+                                ModuleCallingContext const* mcc) {
      assert(m_setup);
      CurrentProcessingContext const* chosen = m_context;
      CurrentProcessingContext temp;
@@ -80,7 +81,7 @@ namespace edm {
         chosen = &temp;
      }
      UnscheduledHandlerSentry sentry(this, chosen);
-     return tryToFillImpl(label, iEvent, *m_setup, chosen);
+     return tryToFillImpl(label, iEvent, *m_setup, chosen, mcc);
   }
 
   //

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -5,6 +5,7 @@
 #include "FWCore/Framework/src/Worker.h"
 #include "FWCore/Framework/src/EarlyDeleteHelper.h"
 #include "FWCore/Framework/src/OutputModuleCommunicator.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
 
 namespace edm {
   namespace {
@@ -33,7 +34,39 @@ private:
       ActivityRegistry* a_;
       ModuleDescription* md_;
     };
-    
+
+    class ModuleBeginStreamSignalSentry {
+    public:
+      ModuleBeginStreamSignalSentry(ActivityRegistry* a,
+                                    StreamContext const& sc,
+                                    ModuleDescription const& md) : a_(a), sc_(sc), md_(md) {
+        if(a_) a_->preModuleBeginStreamSignal_(sc_, md_);
+      }
+      ~ModuleBeginStreamSignalSentry() {
+        if(a_) a_->postModuleBeginStreamSignal_(sc_, md_);
+      }
+    private:
+      ActivityRegistry* a_;
+      StreamContext const& sc_;
+      ModuleDescription const& md_;
+    };
+
+    class ModuleEndStreamSignalSentry {
+    public:
+      ModuleEndStreamSignalSentry(ActivityRegistry* a,
+                                  StreamContext const& sc,
+                                  ModuleDescription const& md) : a_(a), sc_(sc), md_(md) {
+        if(a_) a_->preModuleEndStreamSignal_(sc_, md_);
+      }
+      ~ModuleEndStreamSignalSentry() {
+        if(a_) a_->postModuleEndStreamSignal_(sc_, md_);
+      }
+    private:
+      ActivityRegistry* a_;
+      StreamContext const& sc_;
+      ModuleDescription const& md_;
+    };
+
     cms::Exception& exceptionContext(ModuleDescription const& iMD,
                                      cms::Exception& iEx) {
       iEx << iMD.moduleName() << "/" << iMD.moduleLabel() << "\n";
@@ -52,6 +85,7 @@ private:
     timesExcept_(),
     state_(Ready),
     md_(iMD),
+    moduleCallingContext_(&md_),
     actions_(iWP.actions_),
     cached_exception_(),
     actReg_(),
@@ -119,10 +153,15 @@ private:
     }
   }
 
-  void Worker::beginStream(StreamID id) {
+  void Worker::beginStream(StreamID id, StreamContext& streamContext) {
     try {
       try {
-        //ModuleBeginStreamSignalSentry cpp(actReg_.get(), md_);
+        streamContext.setTransition(StreamContext::Transition::kBeginStream);
+        streamContext.setEventID(EventID(0, 0, 0));
+        streamContext.setRunIndex(RunIndex::invalidRunIndex());
+        streamContext.setLuminosityBlockIndex(LuminosityBlockIndex::invalidLuminosityBlockIndex());
+        streamContext.setTimestamp(Timestamp());
+        ModuleBeginStreamSignalSentry beginSentry(actReg_.get(), streamContext, md_);
         implBeginStream(id);
       }
       catch (cms::Exception& e) { throw; }
@@ -141,10 +180,15 @@ private:
     }
   }
   
-  void Worker::endStream(StreamID id) {
+  void Worker::endStream(StreamID id, StreamContext& streamContext) {
     try {
       try {
-        //ModuleEndStreamSignalSentry cpp(actReg_.get(), md_);
+        streamContext.setTransition(StreamContext::Transition::kEndStream);
+        streamContext.setEventID(EventID(0, 0, 0));
+        streamContext.setRunIndex(RunIndex::invalidRunIndex());
+        streamContext.setLuminosityBlockIndex(LuminosityBlockIndex::invalidLuminosityBlockIndex());
+        streamContext.setTimestamp(Timestamp());
+        ModuleEndStreamSignalSentry endSentry(actReg_.get(), streamContext, md_);
         implEndStream(id);
       }
       catch (cms::Exception& e) { throw; }

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -29,6 +29,7 @@ the worker is reset().
 #include "FWCore/Framework/interface/OccurrenceTraits.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/BranchType.h"
@@ -47,7 +48,9 @@ namespace edm {
   class EarlyDeleteHelper;
   class ProductHolderIndexHelper;
   class StreamID;
+  class StreamContext;
   class OutputModuleCommunicator;
+  class ParentContext;
 
   namespace workerhelper {
     template< typename O> class CallImpl;
@@ -65,13 +68,15 @@ namespace edm {
 
     template <typename T>
     bool doWork(typename T::MyPrincipal&, EventSetup const& c,
-		            CurrentProcessingContext const* cpc,
+		CurrentProcessingContext const* cpc,
                 CPUTimer *const timer,
-                StreamID stream);
+                StreamID stream,
+                ParentContext const& parentContext,
+                typename T::Context const* context);
     void beginJob() ;
     void endJob();
-    void beginStream(StreamID id);
-    void endStream(StreamID id);
+    void beginStream(StreamID id, StreamContext& streamContext);
+    void endStream(StreamID id, StreamContext& streamContext);
     void respondToOpenInputFile(FileBlock const& fb) {implRespondToOpenInputFile(fb);}
     void respondToCloseInputFile(FileBlock const& fb) {implRespondToCloseInputFile(fb);}
 
@@ -124,23 +129,32 @@ namespace edm {
     template<typename O> friend class workerhelper::CallImpl;
     virtual std::string workerType() const = 0;
     virtual bool implDo(EventPrincipal&, EventSetup const& c,
-			    CurrentProcessingContext const* cpc) = 0;
+			    CurrentProcessingContext const* cpc,
+                            ModuleCallingContext const* mcc) = 0;
     virtual bool implDoBegin(RunPrincipal& rp, EventSetup const& c,
-			    CurrentProcessingContext const* cpc) = 0;
+			     CurrentProcessingContext const* cpc,
+                             ModuleCallingContext const* mcc) = 0;
     virtual bool implDoStreamBegin(StreamID id, RunPrincipal& rp, EventSetup const& c,
-                                   CurrentProcessingContext const* cpc) = 0;
+                                   CurrentProcessingContext const* cpc,
+                                   ModuleCallingContext const* mcc) = 0;
     virtual bool implDoStreamEnd(StreamID id, RunPrincipal& rp, EventSetup const& c,
-                                 CurrentProcessingContext const* cpc) = 0;
+                                 CurrentProcessingContext const* cpc,
+                                 ModuleCallingContext const* mcc) = 0;
     virtual bool implDoEnd(RunPrincipal& rp, EventSetup const& c,
-                           CurrentProcessingContext const* cpc) = 0;
+                           CurrentProcessingContext const* cpc,
+                           ModuleCallingContext const* mcc) = 0;
     virtual bool implDoBegin(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                             CurrentProcessingContext const* cpc) = 0;
+                             CurrentProcessingContext const* cpc,
+                             ModuleCallingContext const* mcc) = 0;
     virtual bool implDoStreamBegin(StreamID id, LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                   CurrentProcessingContext const* cpc) = 0;
+                                   CurrentProcessingContext const* cpc,
+                                   ModuleCallingContext const* mcc) = 0;
     virtual bool implDoStreamEnd(StreamID id, LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                 CurrentProcessingContext const* cpc) = 0;
+                                 CurrentProcessingContext const* cpc,
+                                 ModuleCallingContext const* mcc) = 0;
     virtual bool implDoEnd(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                           CurrentProcessingContext const* cpc) = 0;
+                           CurrentProcessingContext const* cpc,
+                           ModuleCallingContext const* mcc) = 0;
     virtual void implBeginJob() = 0;
     virtual void implEndJob() = 0;
     virtual void implBeginStream(StreamID) = 0;
@@ -163,6 +177,8 @@ namespace edm {
     State state_;
 
     ModuleDescription md_;
+    ModuleCallingContext moduleCallingContext_;
+
     ActionTable const* actions_; // memory assumed to be managed elsewhere
     boost::shared_ptr<cms::Exception> cached_exception_; // if state is 'exception'
 
@@ -175,15 +191,27 @@ namespace edm {
     template <typename T>
     class ModuleSignalSentry {
     public:
-      ModuleSignalSentry(ActivityRegistry *a, ModuleDescription& md) : a_(a), md_(&md) {
-	if(a_) T::preModuleSignal(a_, md_);
+      ModuleSignalSentry(ActivityRegistry *a,
+                         ModuleDescription& md,
+                         typename T::Context const* context,
+                         ModuleCallingContext* moduleCallingContext,
+                         ParentContext const& parentContext) :
+        a_(a), md_(&md), context_(context), moduleCallingContext_(moduleCallingContext) {
+
+        moduleCallingContext_->setContext(ModuleCallingContext::State::kRunning, parentContext);
+	if(a_) T::preModuleSignal(a_, md_, context, moduleCallingContext_);
       }
+
       ~ModuleSignalSentry() {
-	if(a_) T::postModuleSignal(a_, md_);
+	if(a_) T::postModuleSignal(a_, md_, context_, moduleCallingContext_);
+        moduleCallingContext_->setContext(ModuleCallingContext::State::kInvalid, ParentContext());
       }
+
     private:
       ActivityRegistry* a_;
       ModuleDescription* md_;
+      typename T::Context const* context_;
+      ModuleCallingContext* moduleCallingContext_;
     };
 
     template <typename T>
@@ -235,8 +263,8 @@ namespace edm {
     class CallImpl<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>> {
     public:
       static bool call(Worker* iWorker, StreamID, EventPrincipal& ep, EventSetup const& es,
-                       CurrentProcessingContext const* cpc) {
-        return iWorker->implDo(ep,es,cpc);
+                       CurrentProcessingContext const* cpc, ModuleCallingContext const* mcc) {
+        return iWorker->implDo(ep,es,cpc, mcc);
       }
     };
     
@@ -244,32 +272,32 @@ namespace edm {
     class CallImpl<OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin>>{
     public:
       static bool call(Worker* iWorker,StreamID, RunPrincipal& ep, EventSetup const& es,
-                       CurrentProcessingContext const* cpc) {
-        return iWorker->implDoBegin(ep,es,cpc);
+                       CurrentProcessingContext const* cpc, ModuleCallingContext const* mcc) {
+        return iWorker->implDoBegin(ep,es,cpc, mcc);
       }
     };
     template<>
     class CallImpl<OccurrenceTraits<RunPrincipal, BranchActionStreamBegin>>{
     public:
       static bool call(Worker* iWorker,StreamID id, RunPrincipal& ep, EventSetup const& es,
-                       CurrentProcessingContext const* cpc) {
-        return iWorker->implDoStreamBegin(id,ep,es,cpc);
+                       CurrentProcessingContext const* cpc, ModuleCallingContext const* mcc) {
+        return iWorker->implDoStreamBegin(id,ep,es,cpc, mcc);
       }
     };
     template<>
     class CallImpl<OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd>>{
     public:
       static bool call(Worker* iWorker,StreamID, RunPrincipal& ep, EventSetup const& es,
-                       CurrentProcessingContext const* cpc) {
-        return iWorker->implDoEnd(ep,es,cpc);
+                       CurrentProcessingContext const* cpc, ModuleCallingContext const* mcc) {
+        return iWorker->implDoEnd(ep,es,cpc, mcc);
       }
     };
     template<>
     class CallImpl<OccurrenceTraits<RunPrincipal, BranchActionStreamEnd>>{
     public:
       static bool call(Worker* iWorker,StreamID id, RunPrincipal& ep, EventSetup const& es,
-                       CurrentProcessingContext const* cpc) {
-        return iWorker->implDoStreamEnd(id,ep,es,cpc);
+                       CurrentProcessingContext const* cpc, ModuleCallingContext const* mcc) {
+        return iWorker->implDoStreamEnd(id,ep,es,cpc, mcc);
       }
     };
     
@@ -277,16 +305,16 @@ namespace edm {
     class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin>>{
     public:
       static bool call(Worker* iWorker,StreamID, LuminosityBlockPrincipal& ep, EventSetup const& es,
-                       CurrentProcessingContext const* cpc) {
-        return iWorker->implDoBegin(ep,es,cpc);
+                       CurrentProcessingContext const* cpc, ModuleCallingContext const* mcc) {
+        return iWorker->implDoBegin(ep,es,cpc, mcc);
       }
     };
     template<>
     class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamBegin>>{
     public:
       static bool call(Worker* iWorker,StreamID id, LuminosityBlockPrincipal& ep, EventSetup const& es,
-                       CurrentProcessingContext const* cpc) {
-        return iWorker->implDoStreamBegin(id,ep,es,cpc);
+                       CurrentProcessingContext const* cpc, ModuleCallingContext const* mcc) {
+        return iWorker->implDoStreamBegin(id,ep,es,cpc, mcc);
       }
     };
     
@@ -294,26 +322,28 @@ namespace edm {
     class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd>>{
     public:
       static bool call(Worker* iWorker,StreamID, LuminosityBlockPrincipal& ep, EventSetup const& es,
-                       CurrentProcessingContext const* cpc) {
-        return iWorker->implDoEnd(ep,es,cpc);
+                       CurrentProcessingContext const* cpc, ModuleCallingContext const* mcc) {
+        return iWorker->implDoEnd(ep,es,cpc, mcc);
       }
     };
     template<>
     class CallImpl<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionStreamEnd>>{
     public:
       static bool call(Worker* iWorker,StreamID id, LuminosityBlockPrincipal& ep, EventSetup const& es,
-                       CurrentProcessingContext const* cpc) {
-        return iWorker->implDoStreamEnd(id,ep,es,cpc);
+                       CurrentProcessingContext const* cpc, ModuleCallingContext const* mcc) {
+        return iWorker->implDoStreamEnd(id,ep,es,cpc, mcc);
       }
     };
   }
   
   template <typename T>
   bool Worker::doWork(typename T::MyPrincipal& ep, 
-                       EventSetup const& es,
-                       CurrentProcessingContext const* cpc,
-                       CPUTimer* const iTimer,
-                       StreamID streamID) {
+                      EventSetup const& es,
+                      CurrentProcessingContext const* cpc,
+                      CPUTimer* const iTimer,
+                      StreamID streamID,
+                      ParentContext const& parentContext,
+                      typename T::Context const* context) {
 
     // A RunStopwatch, but only if we are processing an event.
     RunDualStopwatches stopwatch(T::isEvent_ ? stopwatch_ : RunStopwatch::StopwatchPointer(),
@@ -337,9 +367,8 @@ namespace edm {
 
     try {
       try {
-
-        ModuleSignalSentry<T> cpp(actReg_.get(), md_);
-        rc = workerhelper::CallImpl<T>::call(this,streamID,ep,es,cpc);
+        ModuleSignalSentry<T> cpp(actReg_.get(), md_, context, &moduleCallingContext_, parentContext);
+        rc = workerhelper::CallImpl<T>::call(this,streamID,ep,es,cpc, &moduleCallingContext_);
 
         if (rc) {
           state_ = Pass;

--- a/FWCore/Framework/src/WorkerInPath.h
+++ b/FWCore/Framework/src/WorkerInPath.h
@@ -27,7 +27,9 @@ namespace edm {
 
     template <typename T>
     bool runWorker(typename T::MyPrincipal&, EventSetup const&,
-		   CurrentProcessingContext const* cpc, StreamID streamID);
+		   CurrentProcessingContext const* cpc, StreamID streamID,
+                   ParentContext const& parentContext,
+                   typename T::Context const* context);
 
     std::pair<double,double> timeCpuReal() const {
       if(stopwatch_) {
@@ -63,7 +65,9 @@ namespace edm {
 
   template <typename T>
   bool WorkerInPath::runWorker(typename T::MyPrincipal & ep, EventSetup const & es,
-			       CurrentProcessingContext const* cpc, StreamID streamID) {
+                               CurrentProcessingContext const* cpc, StreamID streamID,
+                               ParentContext const& parentContext,
+                               typename T::Context const* context) {
 
     if (T::isEvent_) {
       ++timesVisited_;
@@ -74,7 +78,7 @@ namespace edm {
 	// may want to change the return value from the worker to be 
 	// the Worker::FilterAction so conditions in the path will be easier to 
 	// identify
-	rc = worker_->doWork<T>(ep, es, cpc,stopwatch_.get(),streamID);
+	rc = worker_->doWork<T>(ep, es, cpc,stopwatch_.get(),streamID, parentContext, context);
 
         // Ignore return code for non-event (e.g. run, lumi) calls
 	if (!T::isEvent_) rc = true;

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -96,16 +96,16 @@ namespace edm {
   }
 
   void
-  WorkerManager::beginStream(StreamID iID) {
+  WorkerManager::beginStream(StreamID iID, StreamContext& streamContext) {
     for(auto& worker: allWorkers_) {
-      worker->beginStream(iID);
+      worker->beginStream(iID, streamContext);
     }
   }
 
   void
-  WorkerManager::endStream(StreamID iID) {
+  WorkerManager::endStream(StreamID iID, StreamContext& streamContext) {
     for(auto& worker: allWorkers_) {
-      worker->endStream(iID);
+      worker->endStream(iID, streamContext);
     }
   }
 

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -78,9 +78,10 @@ namespace edm{
     template<typename T, typename P>
     struct DoStreamBeginTrans {
       inline void operator() (WorkerT<T>* iWorker, StreamID id, P& rp,
-                            EventSetup const& c,
-                            CurrentProcessingContext const* cpc) {
-        iWorker->callWorkerStreamBegin(0,id,rp,c,cpc);
+                              EventSetup const& c,
+                              CurrentProcessingContext const* cpc,
+                              ModuleCallingContext const* mcc) {
+        iWorker->callWorkerStreamBegin(0,id,rp,c,cpc, mcc);
       }
     };
 
@@ -88,8 +89,9 @@ namespace edm{
     struct DoStreamEndTrans {
       inline void operator() (WorkerT<T>* iWorker, StreamID id, P& rp,
                               EventSetup const& c,
-                              CurrentProcessingContext const* cpc) {
-        iWorker->callWorkerStreamEnd(0,id,rp,c,cpc);
+                              CurrentProcessingContext const* cpc,
+                              ModuleCallingContext const* mcc) {
+        iWorker->callWorkerStreamEnd(0,id,rp,c,cpc,mcc);
       }
     };
   }
@@ -116,17 +118,19 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDo(EventPrincipal& ep, EventSetup const& c, CurrentProcessingContext const* cpc) {
+  WorkerT<T>::implDo(EventPrincipal& ep, EventSetup const& c, CurrentProcessingContext const* cpc,
+                     ModuleCallingContext const* mcc) {
     UnscheduledHandlerSentry s(getUnscheduledHandler(ep), cpc);
     boost::shared_ptr<Worker> sentry(this,[&ep](Worker* obj) {obj->postDoEvent(ep);});
-    return module_->doEvent(ep, c, cpc);
+    return module_->doEvent(ep, c, cpc, mcc);
   }
   
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoBegin(RunPrincipal& rp, EventSetup const& c, CurrentProcessingContext const* cpc) {
-    module_->doBeginRun(rp, c, cpc);
+  WorkerT<T>::implDoBegin(RunPrincipal& rp, EventSetup const& c, CurrentProcessingContext const* cpc,
+                          ModuleCallingContext const* mcc) {
+    module_->doBeginRun(rp, c, cpc, mcc);
     return true;
   }
   
@@ -135,8 +139,9 @@ namespace edm{
   void
   WorkerT<T>::callWorkerStreamBegin(D, StreamID id, RunPrincipal& rp,
                                     EventSetup const& c,
-                                    CurrentProcessingContext const* cpc) {
-    module_->doStreamBeginRun(id, rp, c, cpc);
+                                    CurrentProcessingContext const* cpc,
+                                    ModuleCallingContext const* mcc) {
+    module_->doStreamBeginRun(id, rp, c, cpc, mcc);
   }
 
   template<typename T>
@@ -144,46 +149,51 @@ namespace edm{
   void
   WorkerT<T>::callWorkerStreamEnd(D, StreamID id, RunPrincipal& rp,
                                     EventSetup const& c,
-                                    CurrentProcessingContext const* cpc) {
-    module_->doStreamEndRun(id, rp, c, cpc);
+                                    CurrentProcessingContext const* cpc,
+                                    ModuleCallingContext const* mcc) {
+    module_->doStreamEndRun(id, rp, c, cpc, mcc);
   }
 
   
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoStreamBegin(StreamID id, RunPrincipal& rp, EventSetup const& c, CurrentProcessingContext const* cpc) {
+  WorkerT<T>::implDoStreamBegin(StreamID id, RunPrincipal& rp, EventSetup const& c, CurrentProcessingContext const* cpc,
+                                ModuleCallingContext const* mcc) {
     typename boost::mpl::if_c<workerimpl::has_stream_functions<T>::value,
     workerimpl::DoStreamBeginTrans<T,RunPrincipal>,
     workerimpl::DoNothing>::type might_call;
-    might_call(this,id,rp,c,cpc);
+    might_call(this,id,rp,c,cpc, mcc);
     return true;
   }
   
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoStreamEnd(StreamID id, RunPrincipal& rp, EventSetup const& c, CurrentProcessingContext const* cpc) {
+  WorkerT<T>::implDoStreamEnd(StreamID id, RunPrincipal& rp, EventSetup const& c, CurrentProcessingContext const* cpc,
+                              ModuleCallingContext const* mcc) {
     typename boost::mpl::if_c<workerimpl::has_stream_functions<T>::value,
     workerimpl::DoStreamEndTrans<T,RunPrincipal>,
     workerimpl::DoNothing>::type might_call;
-    might_call(this,id,rp,c,cpc);
+    might_call(this,id,rp,c,cpc, mcc);
     return true;
   }
   
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoEnd(RunPrincipal& rp, EventSetup const& c, CurrentProcessingContext const* cpc) {
-    module_->doEndRun(rp, c, cpc);
+  WorkerT<T>::implDoEnd(RunPrincipal& rp, EventSetup const& c, CurrentProcessingContext const* cpc,
+                        ModuleCallingContext const* mcc) {
+    module_->doEndRun(rp, c, cpc, mcc);
     return true;
   }
   
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoBegin(LuminosityBlockPrincipal& lbp, EventSetup const& c, CurrentProcessingContext const* cpc) {
-    module_->doBeginLuminosityBlock(lbp, c, cpc);
+  WorkerT<T>::implDoBegin(LuminosityBlockPrincipal& lbp, EventSetup const& c, CurrentProcessingContext const* cpc,
+                          ModuleCallingContext const* mcc) {
+    module_->doBeginLuminosityBlock(lbp, c, cpc, mcc);
     return true;
   }
   
@@ -192,8 +202,9 @@ namespace edm{
   void
   WorkerT<T>::callWorkerStreamBegin(D, StreamID id, LuminosityBlockPrincipal& rp,
                                     EventSetup const& c,
-                                    CurrentProcessingContext const* cpc) {
-    module_->doStreamBeginLuminosityBlock(id, rp, c, cpc);
+                                    CurrentProcessingContext const* cpc,
+                                    ModuleCallingContext const* mcc) {
+    module_->doStreamBeginLuminosityBlock(id, rp, c, cpc, mcc);
   }
   
   template<typename T>
@@ -201,30 +212,33 @@ namespace edm{
   void
   WorkerT<T>::callWorkerStreamEnd(D, StreamID id, LuminosityBlockPrincipal& rp,
                                   EventSetup const& c,
-                                  CurrentProcessingContext const* cpc) {
-    module_->doStreamEndLuminosityBlock(id, rp, c, cpc);
+                                  CurrentProcessingContext const* cpc,
+                                  ModuleCallingContext const* mcc) {
+    module_->doStreamEndLuminosityBlock(id, rp, c, cpc, mcc);
   }
 
   
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoStreamBegin(StreamID id, LuminosityBlockPrincipal& lbp, EventSetup const& c, CurrentProcessingContext const* cpc) {
+    WorkerT<T>::implDoStreamBegin(StreamID id, LuminosityBlockPrincipal& lbp, EventSetup const& c, CurrentProcessingContext const* cpc,
+                                  ModuleCallingContext const* mcc) {
     typename boost::mpl::if_c<workerimpl::has_stream_functions<T>::value,
     workerimpl::DoStreamBeginTrans<T,LuminosityBlockPrincipal>,
     workerimpl::DoNothing>::type might_call;
-    might_call(this,id,lbp,c,cpc);
+    might_call(this,id,lbp,c,cpc, mcc);
     return true;
   }
   
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoStreamEnd(StreamID id, LuminosityBlockPrincipal& lbp, EventSetup const& c, CurrentProcessingContext const* cpc) {
+  WorkerT<T>::implDoStreamEnd(StreamID id, LuminosityBlockPrincipal& lbp, EventSetup const& c, CurrentProcessingContext const* cpc,
+                              ModuleCallingContext const* mcc) {
     typename boost::mpl::if_c<workerimpl::has_stream_functions<T>::value,
     workerimpl::DoStreamEndTrans<T,LuminosityBlockPrincipal>,
     workerimpl::DoNothing>::type might_call;
-    might_call(this,id,lbp,c,cpc);
+    might_call(this,id,lbp,c,cpc,mcc);
 
     return true;
   }
@@ -232,8 +246,9 @@ namespace edm{
   template<typename T>
   inline
   bool
-  WorkerT<T>::implDoEnd(LuminosityBlockPrincipal& lbp, EventSetup const& c, CurrentProcessingContext const* cpc) {
-    module_->doEndLuminosityBlock(lbp, c, cpc);
+  WorkerT<T>::implDoEnd(LuminosityBlockPrincipal& lbp, EventSetup const& c, CurrentProcessingContext const* cpc,
+                        ModuleCallingContext const* mcc) {
+    module_->doEndLuminosityBlock(lbp, c, cpc, mcc);
     return true;
   }
   

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -54,19 +54,23 @@ namespace edm {
     template<typename D>
     void callWorkerStreamBegin(D, StreamID id, RunPrincipal& rp,
                                EventSetup const& c,
-                               CurrentProcessingContext const* cpc);
+                               CurrentProcessingContext const* cpc,
+                               ModuleCallingContext const* mcc);
     template<typename D>
     void callWorkerStreamEnd(D, StreamID id, RunPrincipal& rp,
                              EventSetup const& c,
-                             CurrentProcessingContext const* cpc);
+                             CurrentProcessingContext const* cpc,
+                             ModuleCallingContext const* mcc);
     template<typename D>
     void callWorkerStreamBegin(D, StreamID id, LuminosityBlockPrincipal& rp,
                                EventSetup const& c,
-                               CurrentProcessingContext const* cpc);
+                               CurrentProcessingContext const* cpc,
+                               ModuleCallingContext const* mcc);
     template<typename D>
     void callWorkerStreamEnd(D, StreamID id, LuminosityBlockPrincipal& rp,
                              EventSetup const& c,
-                             CurrentProcessingContext const* cpc);
+                             CurrentProcessingContext const* cpc,
+                             ModuleCallingContext const* mcc);
     
   protected:
     T& module() {return *module_;}
@@ -74,23 +78,32 @@ namespace edm {
 
   private:
     virtual bool implDo(EventPrincipal& ep, EventSetup const& c,
-                        CurrentProcessingContext const* cpc) override;
+                        CurrentProcessingContext const* cpc,
+                        ModuleCallingContext const* mcc) override;
     virtual bool implDoBegin(RunPrincipal& rp, EventSetup const& c,
-                             CurrentProcessingContext const* cpc) override;
+                             CurrentProcessingContext const* cpc,
+                             ModuleCallingContext const* mcc) override;
     virtual bool implDoStreamBegin(StreamID id, RunPrincipal& rp, EventSetup const& c,
-                                   CurrentProcessingContext const* cpc) override;
+                                   CurrentProcessingContext const* cpc,
+                                   ModuleCallingContext const* mcc) override;
     virtual bool implDoStreamEnd(StreamID id, RunPrincipal& rp, EventSetup const& c,
-                                 CurrentProcessingContext const* cpc) override;
+                                 CurrentProcessingContext const* cpc,
+                                 ModuleCallingContext const* mcc) override;
     virtual bool implDoEnd(RunPrincipal& rp, EventSetup const& c,
-                            CurrentProcessingContext const* cpc) override;
+                           CurrentProcessingContext const* cpc,
+                           ModuleCallingContext const* mcc) override;
     virtual bool implDoBegin(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                            CurrentProcessingContext const* cpc) override;
+                             CurrentProcessingContext const* cpc,
+                             ModuleCallingContext const* mcc) override;
     virtual bool implDoStreamBegin(StreamID id, LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                   CurrentProcessingContext const* cpc) override;
+                                   CurrentProcessingContext const* cpc,
+                                   ModuleCallingContext const* mcc) override;
     virtual bool implDoStreamEnd(StreamID id, LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                 CurrentProcessingContext const* cpc) override;
+                                 CurrentProcessingContext const* cpc,
+                                 ModuleCallingContext const* mcc) override;
     virtual bool implDoEnd(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                           CurrentProcessingContext const* cpc) override;
+                           CurrentProcessingContext const* cpc,
+                           ModuleCallingContext const* mcc) override;
     virtual void implBeginJob() override;
     virtual void implEndJob() override;
     virtual void implBeginStream(StreamID) override;

--- a/FWCore/Framework/src/global/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/global/EDAnalyzerBase.cc
@@ -51,9 +51,10 @@ namespace edm {
     
     bool
     EDAnalyzerBase::doEvent(EventPrincipal& ep, EventSetup const& c,
-                        CurrentProcessingContext const* cpc) {
+                            CurrentProcessingContext const* cpc,
+                            ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      Event e(ep, moduleDescription_);
+      Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       this->analyze(e.streamID(), e, c);
       return true;
@@ -71,10 +72,11 @@ namespace edm {
     
     void
     EDAnalyzerBase::doBeginRun(RunPrincipal& rp, EventSetup const& c,
-                           CurrentProcessingContext const* cpc) {
+                               CurrentProcessingContext const* cpc,
+                               ModuleCallingContext const* mcc) {
       
       detail::CPCSentry sentry(current_context_, cpc);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
       Run const& cnstR = r;
       this->doBeginRun_(cnstR, c);
@@ -83,9 +85,10 @@ namespace edm {
     
     void
     EDAnalyzerBase::doEndRun(RunPrincipal& rp, EventSetup const& c,
-                         CurrentProcessingContext const* cpc) {
+                             CurrentProcessingContext const* cpc,
+                             ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
       Run const& cnstR = r;
       this->doEndRunSummary_(r,c);
@@ -94,9 +97,10 @@ namespace edm {
     
     void
     EDAnalyzerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                       CurrentProcessingContext const* cpc) {
+                                           CurrentProcessingContext const* cpc,
+                                           ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
       this->doBeginLuminosityBlock_(cnstLb, c);
@@ -105,9 +109,10 @@ namespace edm {
     
     void
     EDAnalyzerBase::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                     CurrentProcessingContext const* cpc) {
+                                         CurrentProcessingContext const* cpc,
+                                         ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
       this->doEndLuminosityBlockSummary_(cnstLb,c);
@@ -126,10 +131,11 @@ namespace edm {
     EDAnalyzerBase::doStreamBeginRun(StreamID id,
                                      RunPrincipal& rp,
                                      EventSetup const& c,
-                                     CurrentProcessingContext const* cpcp)
+                                     CurrentProcessingContext const* cpcp,
+                                     ModuleCallingContext const* mcc)
     {
       detail::CPCSentry sentry(current_context_, cpcp);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
       this->doStreamBeginRun_(id, r, c);
     }
@@ -137,9 +143,10 @@ namespace edm {
     EDAnalyzerBase::doStreamEndRun(StreamID id,
                                    RunPrincipal& rp,
                                    EventSetup const& c,
-                                   CurrentProcessingContext const* cpcp) {
+                                   CurrentProcessingContext const* cpcp,
+                                   ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpcp);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
@@ -148,9 +155,10 @@ namespace edm {
     EDAnalyzerBase::doStreamBeginLuminosityBlock(StreamID id,
                                                  LuminosityBlockPrincipal& lbp,
                                                  EventSetup const& c,
-                                                 CurrentProcessingContext const* cpcp) {
+                                                 CurrentProcessingContext const* cpcp,
+                                                 ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpcp);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
       this->doStreamBeginLuminosityBlock_(id,lb, c);
     }
@@ -159,9 +167,10 @@ namespace edm {
     EDAnalyzerBase::doStreamEndLuminosityBlock(StreamID id,
                                                LuminosityBlockPrincipal& lbp,
                                                EventSetup const& c,
-                                               CurrentProcessingContext const* cpcp) {
+                                               CurrentProcessingContext const* cpcp,
+                                               ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpcp);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
       this->doStreamEndLuminosityBlock_(id,lb, c);
       this->doStreamEndLuminosityBlockSummary_(id,lb, c);

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -49,9 +49,10 @@ namespace edm {
     
     bool
     EDFilterBase::doEvent(EventPrincipal& ep, EventSetup const& c,
-                        CurrentProcessingContext const* cpc) {
+                          CurrentProcessingContext const* cpc,
+                          ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      Event e(ep, moduleDescription_);
+      Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       bool returnValue = this->filter(e.streamID(), e, c);
       commit_(e,&previousParentage_, &previousParentageId_);
@@ -70,10 +71,11 @@ namespace edm {
     
     void
     EDFilterBase::doBeginRun(RunPrincipal& rp, EventSetup const& c,
-                           CurrentProcessingContext const* cpc) {
+                             CurrentProcessingContext const* cpc,
+                             ModuleCallingContext const* mcc) {
       
       detail::CPCSentry sentry(current_context_, cpc);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
       Run const& cnstR = r;
       this->doBeginRun_(cnstR, c);
@@ -84,9 +86,10 @@ namespace edm {
     
     void
     EDFilterBase::doEndRun(RunPrincipal& rp, EventSetup const& c,
-                         CurrentProcessingContext const* cpc) {
+                           CurrentProcessingContext const* cpc,
+                           ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
       Run const& cnstR = r;
       this->doEndRunProduce_(r, c);
@@ -97,9 +100,10 @@ namespace edm {
     
     void
     EDFilterBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                       CurrentProcessingContext const* cpc) {
+                                         CurrentProcessingContext const* cpc,
+                                         ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
       this->doBeginLuminosityBlock_(cnstLb, c);
@@ -110,9 +114,10 @@ namespace edm {
     
     void
     EDFilterBase::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                     CurrentProcessingContext const* cpc) {
+                                       CurrentProcessingContext const* cpc,
+                                       ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
       this->doEndLuminosityBlockProduce_(lb, c);
@@ -133,10 +138,11 @@ namespace edm {
     EDFilterBase::doStreamBeginRun(StreamID id,
                                      RunPrincipal& rp,
                                      EventSetup const& c,
-                                     CurrentProcessingContext const* cpcp)
+                                     CurrentProcessingContext const* cpcp,
+                                     ModuleCallingContext const* mcc)
     {
       detail::CPCSentry sentry(current_context_, cpcp);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
       this->doStreamBeginRun_(id, r, c);
     }
@@ -144,9 +150,10 @@ namespace edm {
     EDFilterBase::doStreamEndRun(StreamID id,
                                    RunPrincipal& rp,
                                    EventSetup const& c,
-                                   CurrentProcessingContext const* cpcp) {
+                                   CurrentProcessingContext const* cpcp,
+                                   ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpcp);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
@@ -155,9 +162,10 @@ namespace edm {
     EDFilterBase::doStreamBeginLuminosityBlock(StreamID id,
                                                  LuminosityBlockPrincipal& lbp,
                                                  EventSetup const& c,
-                                                 CurrentProcessingContext const* cpcp) {
+                                                 CurrentProcessingContext const* cpcp,
+                                                 ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpcp);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
       this->doStreamBeginLuminosityBlock_(id,lb, c);
     }
@@ -166,9 +174,10 @@ namespace edm {
     EDFilterBase::doStreamEndLuminosityBlock(StreamID id,
                                                LuminosityBlockPrincipal& lbp,
                                                EventSetup const& c,
-                                               CurrentProcessingContext const* cpcp) {
+                                               CurrentProcessingContext const* cpcp,
+                                               ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpcp);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
       this->doStreamEndLuminosityBlock_(id,lb, c);
       this->doStreamEndLuminosityBlockSummary_(id,lb, c);

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -49,9 +49,10 @@ namespace edm {
     
     bool
     EDProducerBase::doEvent(EventPrincipal& ep, EventSetup const& c,
-                        CurrentProcessingContext const* cpc) {
+                            CurrentProcessingContext const* cpc,
+                            ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      Event e(ep, moduleDescription_);
+      Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       this->produce(e.streamID(), e, c);
       commit_(e,&previousParentage_, &previousParentageId_);
@@ -70,10 +71,11 @@ namespace edm {
     
     void
     EDProducerBase::doBeginRun(RunPrincipal& rp, EventSetup const& c,
-                           CurrentProcessingContext const* cpc) {
+                               CurrentProcessingContext const* cpc,
+                               ModuleCallingContext const* mcc) {
       
       detail::CPCSentry sentry(current_context_, cpc);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
       Run const& cnstR = r;
       this->doBeginRun_(cnstR, c);
@@ -84,9 +86,10 @@ namespace edm {
     
     void
     EDProducerBase::doEndRun(RunPrincipal& rp, EventSetup const& c,
-                         CurrentProcessingContext const* cpc) {
+                             CurrentProcessingContext const* cpc,
+                             ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
       Run const& cnstR = r;
       this->doEndRunProduce_(r, c);
@@ -97,9 +100,10 @@ namespace edm {
     
     void
     EDProducerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                       CurrentProcessingContext const* cpc) {
+                                           CurrentProcessingContext const* cpc,
+                                           ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
       this->doBeginLuminosityBlock_(cnstLb, c);
@@ -110,9 +114,10 @@ namespace edm {
     
     void
     EDProducerBase::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                     CurrentProcessingContext const* cpc) {
+                                         CurrentProcessingContext const* cpc,
+                                         ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
       this->doEndLuminosityBlockProduce_(lb, c);
@@ -133,10 +138,11 @@ namespace edm {
     EDProducerBase::doStreamBeginRun(StreamID id,
                                      RunPrincipal& rp,
                                      EventSetup const& c,
-                                     CurrentProcessingContext const* cpcp)
+                                     CurrentProcessingContext const* cpcp,
+                                     ModuleCallingContext const* mcc)
     {
       detail::CPCSentry sentry(current_context_, cpcp);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
       this->doStreamBeginRun_(id, r, c);
     }
@@ -144,9 +150,10 @@ namespace edm {
     EDProducerBase::doStreamEndRun(StreamID id,
                                    RunPrincipal& rp,
                                    EventSetup const& c,
-                                   CurrentProcessingContext const* cpcp) {
+                                   CurrentProcessingContext const* cpcp,
+                                   ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpcp);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
       this->doStreamEndRun_(id, r, c);
       this->doStreamEndRunSummary_(id, r, c);
@@ -155,9 +162,10 @@ namespace edm {
     EDProducerBase::doStreamBeginLuminosityBlock(StreamID id,
                                                  LuminosityBlockPrincipal& lbp,
                                                  EventSetup const& c,
-                                                 CurrentProcessingContext const* cpcp) {
+                                                 CurrentProcessingContext const* cpcp,
+                                                 ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpcp);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
       this->doStreamBeginLuminosityBlock_(id,lb, c);
     }
@@ -166,9 +174,10 @@ namespace edm {
     EDProducerBase::doStreamEndLuminosityBlock(StreamID id,
                                                LuminosityBlockPrincipal& lbp,
                                                EventSetup const& c,
-                                               CurrentProcessingContext const* cpcp) {
+                                               CurrentProcessingContext const* cpcp,
+                                               ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpcp);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
       this->doStreamEndLuminosityBlock_(id,lb, c);
       this->doStreamEndLuminosityBlockSummary_(id,lb, c);

--- a/FWCore/Framework/src/one/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/one/EDAnalyzerBase.cc
@@ -49,9 +49,10 @@ namespace edm {
     
     bool
     EDAnalyzerBase::doEvent(EventPrincipal& ep, EventSetup const& c,
-                        CurrentProcessingContext const* cpc) {
+                        CurrentProcessingContext const* cpc,
+                        ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      Event e(ep, moduleDescription_);
+      Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       this->analyze(e, c);
       return true;
@@ -69,10 +70,11 @@ namespace edm {
     
     void
     EDAnalyzerBase::doBeginRun(RunPrincipal& rp, EventSetup const& c,
-                           CurrentProcessingContext const* cpc) {
+                               CurrentProcessingContext const* cpc,
+                               ModuleCallingContext const* mcc) {
       
       detail::CPCSentry sentry(current_context_, cpc);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
       Run const& cnstR = r;
       this->doBeginRun_(cnstR, c);
@@ -80,9 +82,10 @@ namespace edm {
     
     void
     EDAnalyzerBase::doEndRun(RunPrincipal& rp, EventSetup const& c,
-                         CurrentProcessingContext const* cpc) {
+                             CurrentProcessingContext const* cpc,
+                             ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
       Run const& cnstR = r;
       this->doEndRun_(cnstR, c);
@@ -90,9 +93,10 @@ namespace edm {
     
     void
     EDAnalyzerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                       CurrentProcessingContext const* cpc) {
+                                           CurrentProcessingContext const* cpc,
+                                           ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
       this->doBeginLuminosityBlock_(cnstLb, c);
@@ -100,9 +104,10 @@ namespace edm {
     
     void
     EDAnalyzerBase::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                     CurrentProcessingContext const* cpc) {
+                                         CurrentProcessingContext const* cpc,
+                                         ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
       this->doEndLuminosityBlock_(cnstLb, c);

--- a/FWCore/Framework/src/one/EDFilterBase.cc
+++ b/FWCore/Framework/src/one/EDFilterBase.cc
@@ -28,6 +28,8 @@
 // constants, enums and typedefs
 //
 namespace edm {
+  class ModuleCallingContext;
+
   namespace one {
     //
     // static data member definitions
@@ -49,9 +51,10 @@ namespace edm {
     
     bool
     EDFilterBase::doEvent(EventPrincipal& ep, EventSetup const& c,
-                        CurrentProcessingContext const* cpc) {
+                          CurrentProcessingContext const* cpc,
+                          ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      Event e(ep, moduleDescription_);
+      Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       bool returnValue = this->filter(e, c);
       commit_(e,&previousParentage_, &previousParentageId_);
@@ -70,10 +73,11 @@ namespace edm {
     
     void
     EDFilterBase::doBeginRun(RunPrincipal& rp, EventSetup const& c,
-                           CurrentProcessingContext const* cpc) {
+                             CurrentProcessingContext const* cpc,
+                             ModuleCallingContext const* mcc) {
       
       detail::CPCSentry sentry(current_context_, cpc);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
       Run const& cnstR = r;
       this->doBeginRun_(cnstR, c);
@@ -83,9 +87,10 @@ namespace edm {
     
     void
     EDFilterBase::doEndRun(RunPrincipal& rp, EventSetup const& c,
-                         CurrentProcessingContext const* cpc) {
+                           CurrentProcessingContext const* cpc,
+                           ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
       Run const& cnstR = r;
       this->doEndRun_(cnstR, c);
@@ -95,9 +100,10 @@ namespace edm {
     
     void
     EDFilterBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                       CurrentProcessingContext const* cpc) {
+                                         CurrentProcessingContext const* cpc,
+                                         ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
       this->doBeginLuminosityBlock_(cnstLb, c);
@@ -107,9 +113,10 @@ namespace edm {
     
     void
     EDFilterBase::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                     CurrentProcessingContext const* cpc) {
+                                       CurrentProcessingContext const* cpc,
+                                       ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
       this->doEndLuminosityBlock_(cnstLb, c);

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -28,6 +28,7 @@
 // constants, enums and typedefs
 //
 namespace edm {
+
   namespace one {
     //
     // static data member definitions
@@ -49,9 +50,10 @@ namespace edm {
     
     bool
     EDProducerBase::doEvent(EventPrincipal& ep, EventSetup const& c,
-                        CurrentProcessingContext const* cpc) {
+                            CurrentProcessingContext const* cpc,
+                            ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      Event e(ep, moduleDescription_);
+      Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       this->produce(e, c);
       commit_(e,&previousParentage_, &previousParentageId_);
@@ -70,10 +72,11 @@ namespace edm {
     
     void
     EDProducerBase::doBeginRun(RunPrincipal& rp, EventSetup const& c,
-                           CurrentProcessingContext const* cpc) {
+                               CurrentProcessingContext const* cpc,
+                               ModuleCallingContext const* mcc) {
       
       detail::CPCSentry sentry(current_context_, cpc);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
       Run const& cnstR = r;
       this->doBeginRun_(cnstR, c);
@@ -83,9 +86,10 @@ namespace edm {
     
     void
     EDProducerBase::doEndRun(RunPrincipal& rp, EventSetup const& c,
-                         CurrentProcessingContext const* cpc) {
+                             CurrentProcessingContext const* cpc,
+                             ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(this);
       Run const& cnstR = r;
       this->doEndRun_(cnstR, c);
@@ -95,9 +99,10 @@ namespace edm {
     
     void
     EDProducerBase::doBeginLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                       CurrentProcessingContext const* cpc) {
+                                           CurrentProcessingContext const* cpc,
+                                           ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
       this->doBeginLuminosityBlock_(cnstLb, c);
@@ -107,9 +112,10 @@ namespace edm {
     
     void
     EDProducerBase::doEndLuminosityBlock(LuminosityBlockPrincipal& lbp, EventSetup const& c,
-                                     CurrentProcessingContext const* cpc) {
+                                         CurrentProcessingContext const* cpc,
+                                         ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(this);
       LuminosityBlock const& cnstLb = lb;
       this->doEndLuminosityBlock_(cnstLb, c);

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -179,22 +179,24 @@ namespace edm {
     }
     
     
-    Trig OutputModuleBase::getTriggerResults(EventPrincipal const& ep) const {
-      return selectors_.getOneTriggerResults(ep);  }
+    Trig OutputModuleBase::getTriggerResults(EventPrincipal const& ep,
+                                             ModuleCallingContext const* mcc) const {
+      return selectors_.getOneTriggerResults(ep, mcc);  }
     
     bool
     OutputModuleBase::doEvent(EventPrincipal const& ep,
-                          EventSetup const&,
-                          CurrentProcessingContext const* cpc) {
+                              EventSetup const&,
+                              CurrentProcessingContext const* cpc,
+                              ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
       detail::TRBESSentry products_sentry(selectors_);
       
       if(!wantAllEvents_) {
-        if(!selectors_.wantEvent(ep)) {
+        if(!selectors_.wantEvent(ep, mcc)) {
           return true;
         }
       }
-      write(ep);
+      write(ep, mcc);
       updateBranchParents(ep);
       if(remainingEvents_ > 0) {
         --remainingEvents_;
@@ -204,47 +206,53 @@ namespace edm {
     
     bool
     OutputModuleBase::doBeginRun(RunPrincipal const& rp,
-                             EventSetup const&,
-                             CurrentProcessingContext const* cpc) {
+                                 EventSetup const&,
+                                 CurrentProcessingContext const* cpc,
+                                 ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      doBeginRun_(rp);
+      doBeginRun_(rp, mcc);
       return true;
     }
     
     bool
     OutputModuleBase::doEndRun(RunPrincipal const& rp,
-                           EventSetup const&,
-                           CurrentProcessingContext const* cpc) {
+                               EventSetup const&,
+                               CurrentProcessingContext const* cpc,
+                               ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      doEndRun_(rp);
+      doEndRun_(rp, mcc);
       return true;
     }
     
     void
-    OutputModuleBase::doWriteRun(RunPrincipal const& rp) {
-      writeRun(rp);
+    OutputModuleBase::doWriteRun(RunPrincipal const& rp,
+                                 ModuleCallingContext const* mcc) {
+      writeRun(rp, mcc);
     }
     
     bool
     OutputModuleBase::doBeginLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                         EventSetup const&,
-                                         CurrentProcessingContext const* cpc) {
+                                             EventSetup const&,
+                                             CurrentProcessingContext const* cpc,
+                                             ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      doBeginLuminosityBlock_(lbp);
+      doBeginLuminosityBlock_(lbp, mcc);
       return true;
     }
     
     bool
     OutputModuleBase::doEndLuminosityBlock(LuminosityBlockPrincipal const& lbp,
-                                       EventSetup const&,
-                                       CurrentProcessingContext const* cpc) {
+                                           EventSetup const&,
+                                           CurrentProcessingContext const* cpc,
+                                           ModuleCallingContext const* mcc) {
       detail::CPCSentry sentry(current_context_, cpc);
-      doEndLuminosityBlock_(lbp);
+      doEndLuminosityBlock_(lbp, mcc);
       return true;
     }
     
-    void OutputModuleBase::doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp) {
-      writeLuminosityBlock(lbp);
+    void OutputModuleBase::doWriteLuminosityBlock(LuminosityBlockPrincipal const& lbp,
+                                                  ModuleCallingContext const* mcc) {
+      writeLuminosityBlock(lbp, mcc);
     }
     
     void OutputModuleBase::doOpenFile(FileBlock const& fb) {

--- a/FWCore/Framework/src/one/outputmoduleImplementors.cc
+++ b/FWCore/Framework/src/one/outputmoduleImplementors.cc
@@ -20,18 +20,18 @@
 namespace edm {
   namespace one {
     namespace outputmodule {
-      void RunWatcher::doBeginRun_(RunPrincipal const& rp) {
-        beginRun(rp);
+      void RunWatcher::doBeginRun_(RunPrincipal const& rp, ModuleCallingContext const* mcc) {
+        beginRun(rp, mcc);
       }
-      void RunWatcher::doEndRun_(RunPrincipal const& rp) {
-        endRun(rp);
+      void RunWatcher::doEndRun_(RunPrincipal const& rp, ModuleCallingContext const* mcc) {
+        endRun(rp, mcc);
       }
       
-      void LuminosityBlockWatcher::doBeginLuminosityBlock_(LuminosityBlockPrincipal const& lbp) {
-        beginLuminosityBlock(lbp);
+      void LuminosityBlockWatcher::doBeginLuminosityBlock_(LuminosityBlockPrincipal const& lbp, ModuleCallingContext const* mcc) {
+        beginLuminosityBlock(lbp, mcc);
       }
-      void LuminosityBlockWatcher::doEndLuminosityBlock_(LuminosityBlockPrincipal const& lbp) {
-        endLuminosityBlock(lbp);
+      void LuminosityBlockWatcher::doEndLuminosityBlock_(LuminosityBlockPrincipal const& lbp, ModuleCallingContext const* mcc) {
+        endLuminosityBlock(lbp, mcc);
       }
       void InputFileWatcher::doRespondToOpenInputFile_(FileBlock const& iB)
       {

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -102,11 +102,12 @@ EDAnalyzerAdaptorBase::consumer() const {
 
 bool
 EDAnalyzerAdaptorBase::doEvent(EventPrincipal& ep, EventSetup const& c,
-                               CurrentProcessingContext const* cpcp) {
+                               CurrentProcessingContext const* cpcp,
+                               ModuleCallingContext const* mcc) {
   assert(ep.streamID()<m_streamModules.size());
   auto mod = m_streamModules[ep.streamID()];
   detail::CPCSentry sentry(mod->current_context_, cpcp);
-  Event e(ep, moduleDescription_);
+  Event e(ep, moduleDescription_, mcc);
   e.setConsumer(mod);
   mod->analyze(e, c);
   return true;
@@ -129,13 +130,14 @@ void
 EDAnalyzerAdaptorBase::doStreamBeginRun(StreamID id,
                                         RunPrincipal& rp,
                                         EventSetup const& c,
-                                        CurrentProcessingContext const* cpcp)
+                                        CurrentProcessingContext const* cpcp,
+                                        ModuleCallingContext const* mcc)
 {
   auto mod = m_streamModules[id];
   detail::CPCSentry sentry(mod->current_context_, cpcp);
   setupRun(mod, rp.index());
   
-  Run r(rp, moduleDescription_);
+  Run r(rp, moduleDescription_, mcc);
   r.setConsumer(mod);
   mod->beginRun(r, c);
 
@@ -145,11 +147,12 @@ void
 EDAnalyzerAdaptorBase::doStreamEndRun(StreamID id,
                     RunPrincipal& rp,
                     EventSetup const& c,
-                    CurrentProcessingContext const* cpcp)
+                    CurrentProcessingContext const* cpcp,
+                    ModuleCallingContext const* mcc)
 {
   auto mod = m_streamModules[id];
   detail::CPCSentry sentry(mod->current_context_, cpcp);
-  Run r(rp, moduleDescription_);
+  Run r(rp, moduleDescription_, mcc);
   r.setConsumer(mod);
   mod->endRun(r, c);
   streamEndRunSummary(mod,r,c);
@@ -159,12 +162,13 @@ void
 EDAnalyzerAdaptorBase::doStreamBeginLuminosityBlock(StreamID id,
                                                     LuminosityBlockPrincipal& lbp,
                                                     EventSetup const& c,
-                                                    CurrentProcessingContext const* cpcp) {
+                                                    CurrentProcessingContext const* cpcp,
+                                                    ModuleCallingContext const* mcc) {
   auto mod = m_streamModules[id];
   detail::CPCSentry sentry(mod->current_context_, cpcp);
   setupLuminosityBlock(mod,lbp.index());
   
-  LuminosityBlock lb(lbp, moduleDescription_);
+  LuminosityBlock lb(lbp, moduleDescription_, mcc);
   lb.setConsumer(mod);
   mod->beginLuminosityBlock(lb, c);
 }
@@ -172,11 +176,12 @@ void
 EDAnalyzerAdaptorBase::doStreamEndLuminosityBlock(StreamID id,
                                 LuminosityBlockPrincipal& lbp,
                                 EventSetup const& c,
-                                CurrentProcessingContext const* cpcp)
+                                CurrentProcessingContext const* cpcp,
+                                ModuleCallingContext const* mcc)
 {
   auto mod = m_streamModules[id];
   detail::CPCSentry sentry(mod->current_context_, cpcp);
-  LuminosityBlock lb(lbp, moduleDescription_);
+  LuminosityBlock lb(lbp, moduleDescription_, mcc);
   lb.setConsumer(mod);
   mod->endLuminosityBlock(lb, c);
   streamEndLuminosityBlockSummary(mod,lb, c);

--- a/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDFilterAdaptorBase.cc
@@ -47,11 +47,12 @@ namespace edm {
     
     bool
     EDFilterAdaptorBase::doEvent(EventPrincipal& ep, EventSetup const& c,
-                                   CurrentProcessingContext const* cpcp) {
+                                 CurrentProcessingContext const* cpcp,
+                                 ModuleCallingContext const* mcc) {
       assert(ep.streamID()<m_streamModules.size());
       auto mod = m_streamModules[ep.streamID()];
       detail::CPCSentry sentry(mod->current_context_, cpcp);
-      Event e(ep, moduleDescription());
+      Event e(ep, moduleDescription(), mcc);
       e.setConsumer(mod);
       bool result = mod->filter(e, c);
       commit(e,&mod->previousParentage_, &mod->previousParentageId_);

--- a/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerAdaptorBase.cc
@@ -47,11 +47,12 @@ namespace edm {
     
     bool
     EDProducerAdaptorBase::doEvent(EventPrincipal& ep, EventSetup const& c,
-                                   CurrentProcessingContext const* cpcp) {
+                                   CurrentProcessingContext const* cpcp,
+                                   ModuleCallingContext const* mcc) {
       assert(ep.streamID()<m_streamModules.size());
       auto mod = m_streamModules[ep.streamID()];
       detail::CPCSentry sentry(mod->current_context_, cpcp);
-      Event e(ep, moduleDescription());
+      Event e(ep, moduleDescription(), mcc);
       e.setConsumer(mod);
       mod->produce(e, c);
       commit(e,&mod->previousParentage_, &mod->previousParentageId_);

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -120,13 +120,14 @@ namespace edm {
     ProducingModuleAdaptorBase<T>::doStreamBeginRun(StreamID id,
                                                     RunPrincipal& rp,
                                                     EventSetup const& c,
-                                                    CurrentProcessingContext const* cpcp)
+                                                    CurrentProcessingContext const* cpcp,
+                                                    ModuleCallingContext const* mcc)
     {
       auto mod = m_streamModules[id];
       detail::CPCSentry sentry(mod->current_context_, cpcp);
       setupRun(mod, rp.index());
       
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(mod);
       mod->beginRun(r, c);
       
@@ -136,11 +137,12 @@ namespace edm {
     ProducingModuleAdaptorBase<T>::doStreamEndRun(StreamID id,
                                                   RunPrincipal& rp,
                                                   EventSetup const& c,
-                                                  CurrentProcessingContext const* cpcp)
+                                                  CurrentProcessingContext const* cpcp,
+                                                  ModuleCallingContext const* mcc)
     {
       auto mod = m_streamModules[id];
       detail::CPCSentry sentry(mod->current_context_, cpcp);
-      Run r(rp, moduleDescription_);
+      Run r(rp, moduleDescription_, mcc);
       r.setConsumer(mod);
       mod->endRun(r, c);
       streamEndRunSummary(mod,r,c);
@@ -151,12 +153,13 @@ namespace edm {
     ProducingModuleAdaptorBase<T>::doStreamBeginLuminosityBlock(StreamID id,
                                                                 LuminosityBlockPrincipal& lbp,
                                                                 EventSetup const& c,
-                                                                CurrentProcessingContext const* cpcp) {
+                                                                CurrentProcessingContext const* cpcp,
+                                                                ModuleCallingContext const* mcc) {
       auto mod = m_streamModules[id];
       detail::CPCSentry sentry(mod->current_context_, cpcp);
       setupLuminosityBlock(mod,lbp.index());
       
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(mod);
       mod->beginLuminosityBlock(lb, c);
     }
@@ -166,11 +169,12 @@ namespace edm {
     ProducingModuleAdaptorBase<T>::doStreamEndLuminosityBlock(StreamID id,
                                                               LuminosityBlockPrincipal& lbp,
                                                               EventSetup const& c,
-                                                              CurrentProcessingContext const* cpcp)
+                                                              CurrentProcessingContext const* cpcp,
+                                                              ModuleCallingContext const* mcc)
     {
       auto mod = m_streamModules[id];
       detail::CPCSentry sentry(mod->current_context_, cpcp);
-      LuminosityBlock lb(lbp, moduleDescription_);
+      LuminosityBlock lb(lbp, moduleDescription_, mcc);
       lb.setConsumer(mod);
       mod->endLuminosityBlock(lb, c);
       streamEndLuminosityBlockSummary(mod,lb, c);

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -87,7 +87,7 @@ void testEventGetRefBeforePut::failGetProductNotRegisteredTest() {
      boost::shared_ptr<edm::ProcessConfiguration> processConfiguration(
       new edm::ProcessConfiguration());
      edm::ModuleDescription modDesc(pset.id(), "Blah", "blahs", processConfiguration.get());
-     edm::Event event(ep, modDesc);
+     edm::Event event(ep, modDesc, nullptr);
 
      std::string label("this does not exist");
      edm::RefProd<edmtest::DummyProduct> ref = event.getRefBeforePut<edmtest::DummyProduct>(label);
@@ -158,7 +158,7 @@ void testEventGetRefBeforePut::getRefTest() {
   try {
     edm::ModuleDescription modDesc("Blah", label, pcPtr.get());
 
-    edm::Event event(ep, modDesc);
+    edm::Event event(ep, modDesc, nullptr);
     std::auto_ptr<edmtest::IntProduct> pr(new edmtest::IntProduct);
     pr->value = 10;
 

--- a/FWCore/Framework/test/eventprincipal_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprincipal_t.cppunit.cc
@@ -235,7 +235,7 @@ void test_ep::failgetbyLabelTest() {
 
   std::string label("this does not exist");
 
-  edm::BasicHandle h(pEvent_->getByLabel(edm::PRODUCT_TYPE, tid, label, std::string(), std::string(),nullptr));
+  edm::BasicHandle h(pEvent_->getByLabel(edm::PRODUCT_TYPE, tid, label, std::string(), std::string(), nullptr, nullptr));
   CPPUNIT_ASSERT(h.failedToGet());
 }
 
@@ -244,7 +244,7 @@ void test_ep::failgetManybyTypeTest() {
   edm::TypeID tid(dummy);
   std::vector<edm::BasicHandle > handles;
 
-  pEvent_->getManyByType(tid, handles,nullptr);
+  pEvent_->getManyByType(tid, handles, nullptr, nullptr);
   CPPUNIT_ASSERT(handles.empty());
 }
 
@@ -258,5 +258,5 @@ void test_ep::failgetbyInvalidIdTest() {
 
 void test_ep::failgetProvenanceTest() {
   edm::BranchID id;
-  CPPUNIT_ASSERT_THROW(pEvent_->getProvenance(id), edm::Exception);
+  CPPUNIT_ASSERT_THROW(pEvent_->getProvenance(id, nullptr), edm::Exception);
 }

--- a/FWCore/Framework/test/generichandle_t.cppunit.cc
+++ b/FWCore/Framework/test/generichandle_t.cppunit.cc
@@ -101,7 +101,7 @@ void testGenericHandle::failgetbyLabelTest() {
      edm::ParameterSet pset;
      pset.registerIt();
      edm::ModuleDescription modDesc(pset.id(), "Blah", "blahs");
-     edm::Event event(ep, modDesc);
+     edm::Event event(ep, modDesc, nullptr);
 
      std::string label("this does not exist");
      event.getByLabel(label,h);
@@ -201,7 +201,7 @@ void testGenericHandle::getbyLabelTest() {
     edm::ParameterSet pset;
     pset.registerIt();
     edm::ModuleDescription modDesc(pset.id(), "Blah", "blahs", processConfiguration.get());
-    edm::Event event(ep, modDesc);
+    edm::Event event(ep, modDesc, nullptr);
 
     event.getByLabel(label, productInstanceName,h);
   }

--- a/FWCore/Framework/test/global_module_t.cppunit.cc
+++ b/FWCore/Framework/test/global_module_t.cppunit.cc
@@ -16,6 +16,8 @@
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 
 
@@ -340,44 +342,48 @@ m_ep()
   m_ep->fillEventPrincipal(eventAux);
   m_ep->setLuminosityBlockPrincipal(m_lbp);
 
+  edm::StreamContext streamContext(edm::StreamID::invalidStreamID(), nullptr);
+
   //For each transition, bind a lambda which will call the proper method of the Worker
-  m_transToFunc[Trans::kBeginStream] = [this](edm::Worker* iBase) {
-    iBase->beginStream(edm::StreamID::invalidStreamID()); };
+  m_transToFunc[Trans::kBeginStream] = [this, &streamContext](edm::Worker* iBase) {
+    iBase->beginStream(edm::StreamID::invalidStreamID(), streamContext); };
+
+  edm::ParentContext nullParentContext;
   
-  m_transToFunc[Trans::kGlobalBeginRun] = [this](edm::Worker* iBase) {
+  m_transToFunc[Trans::kGlobalBeginRun] = [this,&nullParentContext](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
-    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID()); };
-  m_transToFunc[Trans::kStreamBeginRun] = [this](edm::Worker* iBase) {
+    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), nullParentContext, nullptr); };
+  m_transToFunc[Trans::kStreamBeginRun] = [this,&nullParentContext](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamBegin> Traits;
-    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID()); };
+    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), nullParentContext, nullptr); };
   
-  m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase) {
+  m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this,&nullParentContext](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
-    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID()); };
-  m_transToFunc[Trans::kStreamBeginLuminosityBlock] = [this](edm::Worker* iBase) {
+    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), nullParentContext, nullptr); };
+  m_transToFunc[Trans::kStreamBeginLuminosityBlock] = [this,&nullParentContext](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamBegin> Traits;
-    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID()); };
+    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), nullParentContext, nullptr); };
   
-  m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase) {
+  m_transToFunc[Trans::kEvent] = [this,&nullParentContext](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::EventPrincipal, edm::BranchActionStreamBegin> Traits;
-    iBase->doWork<Traits>(*m_ep,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID()); };
+    iBase->doWork<Traits>(*m_ep,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), nullParentContext, nullptr); };
 
-  m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this](edm::Worker* iBase) {
+  m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this,&nullParentContext](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamEnd> Traits;
-    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID()); };
-  m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase) {
+    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), nullParentContext, nullptr); };
+  m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this,&nullParentContext](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
-    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID()); };
+    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), nullParentContext, nullptr); };
 
-  m_transToFunc[Trans::kStreamEndRun] = [this](edm::Worker* iBase) {
+  m_transToFunc[Trans::kStreamEndRun] = [this,&nullParentContext](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamEnd> Traits;
-    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID()); };
-  m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase) {
+    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), nullParentContext, nullptr); };
+  m_transToFunc[Trans::kGlobalEndRun] = [this,&nullParentContext](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
-    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID()); };
+    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), nullParentContext, nullptr); };
 
-  m_transToFunc[Trans::kEndStream] = [this](edm::Worker* iBase) {
-    iBase->endStream(edm::StreamID::invalidStreamID()); };
+  m_transToFunc[Trans::kEndStream] = [this, &streamContext](edm::Worker* iBase) {
+    iBase->endStream(edm::StreamID::invalidStreamID(), streamContext); };
 
 }
 

--- a/FWCore/Framework/test/stream_module_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_module_t.cppunit.cc
@@ -17,6 +17,8 @@
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 
 
@@ -390,44 +392,47 @@ m_ep()
   m_ep->fillEventPrincipal(eventAux);
   m_ep->setLuminosityBlockPrincipal(m_lbp);
 
+  edm::ParentContext parentContext;
+  edm::StreamContext streamContext(s_streamID0, nullptr);
+
   //For each transition, bind a lambda which will call the proper method of the Worker
-  m_transToFunc[Trans::kBeginStream] = [this](edm::Worker* iBase) {
-    iBase->beginStream(s_streamID0); };
+  m_transToFunc[Trans::kBeginStream] = [this, &streamContext](edm::Worker* iBase) {
+    iBase->beginStream(s_streamID0, streamContext); };
   
-  m_transToFunc[Trans::kGlobalBeginRun] = [this](edm::Worker* iBase) {
+  m_transToFunc[Trans::kGlobalBeginRun] = [this,&parentContext](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
-    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, s_streamID0); };
-  m_transToFunc[Trans::kStreamBeginRun] = [this](edm::Worker* iBase) {
+    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, s_streamID0, parentContext, nullptr); };
+  m_transToFunc[Trans::kStreamBeginRun] = [this,&parentContext](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamBegin> Traits;
-    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, s_streamID0); };
+    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, s_streamID0, parentContext, nullptr); };
   
-  m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase) {
+  m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this,&parentContext](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
-    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, s_streamID0); };
-  m_transToFunc[Trans::kStreamBeginLuminosityBlock] = [this](edm::Worker* iBase) {
+    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, s_streamID0, parentContext, nullptr); };
+  m_transToFunc[Trans::kStreamBeginLuminosityBlock] = [this,&parentContext](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamBegin> Traits;
-    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, s_streamID0); };
+    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, s_streamID0, parentContext, nullptr); };
   
-  m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase) {
+  m_transToFunc[Trans::kEvent] = [this,&parentContext](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::EventPrincipal, edm::BranchActionStreamBegin> Traits;
-    iBase->doWork<Traits>(*m_ep,*m_es,m_context,m_timer, s_streamID0); };
+    iBase->doWork<Traits>(*m_ep,*m_es,m_context,m_timer, s_streamID0, parentContext, nullptr); };
 
-  m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this](edm::Worker* iBase) {
+  m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this,&parentContext](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamEnd> Traits;
-    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, s_streamID0); };
-  m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase) {
+    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, s_streamID0, parentContext, nullptr); };
+  m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this,&parentContext](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
-    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, s_streamID0); };
+    iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, s_streamID0, parentContext, nullptr); };
 
-  m_transToFunc[Trans::kStreamEndRun] = [this](edm::Worker* iBase) {
+  m_transToFunc[Trans::kStreamEndRun] = [this,&parentContext](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamEnd> Traits;
-    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, s_streamID0); };
-  m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase) {
+    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, s_streamID0, parentContext, nullptr); };
+  m_transToFunc[Trans::kGlobalEndRun] = [this,&parentContext](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
-    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, s_streamID0); };
+    iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, s_streamID0, parentContext, nullptr); };
 
-  m_transToFunc[Trans::kEndStream] = [this](edm::Worker* iBase) {
-    iBase->endStream(s_streamID0); };
+  m_transToFunc[Trans::kEndStream] = [this, &streamContext](edm::Worker* iBase) {
+    iBase->endStream(s_streamID0, streamContext); };
 
 }
 

--- a/FWCore/Framework/test/stubs/TestFilterModule.cc
+++ b/FWCore/Framework/test/stubs/TestFilterModule.cc
@@ -18,6 +18,10 @@
 
 using namespace edm;
 
+namespace edm {
+  class ModuleCallingContext;
+}
+
 namespace edmtest
 {
 
@@ -27,8 +31,8 @@ namespace edmtest
     explicit TestResultAnalyzer(edm::ParameterSet const&);
     virtual ~TestResultAnalyzer();
 
-    virtual void analyze(edm::Event const& e, edm::EventSetup const& c);
-    void endJob();
+    virtual void analyze(edm::Event const& e, edm::EventSetup const& c) override;
+    void endJob() override;
 
   private:
     int    passed_;
@@ -48,8 +52,8 @@ namespace edmtest
     explicit TestFilterModule(edm::ParameterSet const&);
     virtual ~TestFilterModule();
 
-    virtual bool filter(edm::Event& e, edm::EventSetup const& c);
-    void endJob();
+    virtual bool filter(edm::Event& e, edm::EventSetup const& c) override;
+    void endJob() override;
 
   private:
     int count_;
@@ -66,10 +70,10 @@ namespace edmtest
     virtual ~SewerModule();
 
   private:
-    virtual void write(edm::EventPrincipal const& e);
-    virtual void writeLuminosityBlock(edm::LuminosityBlockPrincipal const&){}
-    virtual void writeRun(edm::RunPrincipal const&){}
-    virtual void endJob();
+    virtual void write(edm::EventPrincipal const& e, ModuleCallingContext const*) override;
+    virtual void writeLuminosityBlock(edm::LuminosityBlockPrincipal const&, ModuleCallingContext const*) override {}
+    virtual void writeRun(edm::RunPrincipal const&, ModuleCallingContext const*) override {}
+    virtual void endJob() override;
 
     std::string name_;
     int num_pass_;
@@ -179,7 +183,7 @@ namespace edmtest
   {
   }
 
-  void SewerModule::write(edm::EventPrincipal const&)
+  void SewerModule::write(edm::EventPrincipal const&, ModuleCallingContext const*)
   {
     ++total_;
     assert(currentContext() != 0);

--- a/FWCore/Framework/test/stubs/TestOutputModule.cc
+++ b/FWCore/Framework/test/stubs/TestOutputModule.cc
@@ -61,10 +61,10 @@ namespace edmtest
     virtual ~TestOutputModule();
 
   private:
-    virtual void write(edm::EventPrincipal const& e);
-    virtual void writeLuminosityBlock(edm::LuminosityBlockPrincipal const&){}
-    virtual void writeRun(edm::RunPrincipal const&){}
-    virtual void endJob();
+    virtual void write(edm::EventPrincipal const& e, ModuleCallingContext const*) override;
+    virtual void writeLuminosityBlock(edm::LuminosityBlockPrincipal const&, ModuleCallingContext const*) override {}
+    virtual void writeRun(edm::RunPrincipal const&, ModuleCallingContext const*) override {}
+    virtual void endJob() override;
 
     std::string name_;
     int bitMask_;
@@ -87,7 +87,7 @@ namespace edmtest
   {
   }
 
-  void TestOutputModule::write(edm::EventPrincipal const& e)
+  void TestOutputModule::write(edm::EventPrincipal const& e, ModuleCallingContext const* mcc)
   {
     assert(currentContext() != 0);
 
@@ -109,7 +109,7 @@ namespace edmtest
     if (!expectTriggerResults_) {
 
       try {
-        prod = getTriggerResults(e);
+        prod = getTriggerResults(e, mcc);
         //throw doesn't happen until we dereference
         *prod;
       }
@@ -126,7 +126,7 @@ namespace edmtest
     // Now deal with the other case where we expect the object
     // to be present.
 
-    prod = getTriggerResults(e);
+    prod = getTriggerResults(e, mcc);
 
     std::vector<unsigned char> vHltState;
 

--- a/FWCore/Integration/test/run_SubProcess.sh
+++ b/FWCore/Integration/test/run_SubProcess.sh
@@ -13,6 +13,8 @@ pushd ${LOCAL_TMP_DIR}
   cmsRun -p ${LOCAL_TEST_DIR}/${test}_cfg.py > ${test}.log 2>&1 || die "cmsRun ${test}_cfg.py" $?
   grep Doodad ${test}.log > testSubProcess.grep.txt
   diff ${LOCAL_TEST_DIR}/unit_test_outputs/testSubProcess.grep.txt testSubProcess.grep.txt || die "comparing testSubProcess.grep.txt" $?
+  grep "++" ${test}.log > testSubProcess.grep2.txt
+  diff ${LOCAL_TEST_DIR}/unit_test_outputs/testSubProcess.grep2.txt testSubProcess.grep2.txt || die "comparing testSubProcess.grep2.txt" $?
 
   echo cmsRun readSubProcessOutput_cfg.py
   cmsRun -p ${LOCAL_TEST_DIR}/readSubProcessOutput_cfg.py || die "cmsRun readSubProcessOutput_cfg.py" $?

--- a/FWCore/Integration/test/run_TestGetBy.sh
+++ b/FWCore/Integration/test/run_TestGetBy.sh
@@ -6,9 +6,11 @@ function die { echo Failure $1: status $2 ; exit $2 ; }
 
 pushd ${LOCAL_TMP_DIR}
 
-  cmsRun -p ${LOCAL_TEST_DIR}/${test}1_cfg.py || die "cmsRun ${test}1_cfg.py" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}1_cfg.py > testGetBy1.log || die "cmsRun ${test}1_cfg.py" $?
+  diff ${LOCAL_TMP_DIR}/testGetBy1.log ${LOCAL_TEST_DIR}/unit_test_outputs/testGetBy1.log || die "comparing testGetBy1.log" $?
 
-  cmsRun -p ${LOCAL_TEST_DIR}/${test}2_cfg.py || die "cmsRun ${test}2_cfg.py" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}2_cfg.py > testGetBy2.log || die "cmsRun ${test}2_cfg.py" $?
+  diff ${LOCAL_TMP_DIR}/testGetBy2.log ${LOCAL_TEST_DIR}/unit_test_outputs/testGetBy2.log || die "comparing testGetBy2.log" $?
 
   cmsRun -p ${LOCAL_TEST_DIR}/${test}3_cfg.py || die "cmsRun ${test}3_cfg.py" $?
 

--- a/FWCore/Integration/test/testGetBy1_cfg.py
+++ b/FWCore/Integration/test/testGetBy1_cfg.py
@@ -2,6 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("PROD1")
 
+process.Tracer = cms.Service('Tracer')
+
 process.options = cms.untracked.PSet( allowUnscheduled = cms.untracked.bool(True) )
 
 process.source = cms.Source("IntSource")

--- a/FWCore/Integration/test/testGetBy2_cfg.py
+++ b/FWCore/Integration/test/testGetBy2_cfg.py
@@ -2,6 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("PROD2")
 
+process.Tracer = cms.Service('Tracer')
+
 process.options = cms.untracked.PSet( allowUnscheduled = cms.untracked.bool(True) )
 
 process.source = cms.Source("PoolSource",

--- a/FWCore/Integration/test/testSubProcess_cfg.py
+++ b/FWCore/Integration/test/testSubProcess_cfg.py
@@ -1,6 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 process = cms.Process("FIRST")
 
+process.Tracer = cms.Service('Tracer')
+
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 process.MessageLogger.cerr.threshold = 'INFO'

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -1,0 +1,323 @@
+++ constructing source:IntSource
+++ construction finished:IntSource
+++ constructing module: intProducer
+++ construction finished: intProducer
+++ constructing module: a1
+++ construction finished: a1
+++ constructing module: a2
+++ construction finished: a2
+++ constructing module: a3
+++ construction finished: a3
+++ constructing module: TriggerResults
+++ construction finished: TriggerResults
+++ constructing module: out
+++ construction finished: out
+++ constructing module: intProducerA
+++ construction finished: intProducerA
+++ constructing module: intProducerU
+++ construction finished: intProducerU
+++ constructing module: intVectorProducer
+++ construction finished: intVectorProducer
+++ ModuleBeginJob: intProducer
+++ ModuleBeginJob finished: intProducer
+++ ModuleBeginJob: a1
+++ ModuleBeginJob finished: a1
+++ ModuleBeginJob: a2
+++ ModuleBeginJob finished: a2
+++ ModuleBeginJob: a3
+++ ModuleBeginJob finished: a3
+++ ModuleBeginJob: TriggerResults
+++ ModuleBeginJob finished: TriggerResults
+++ ModuleBeginJob: out
+++ ModuleBeginJob finished: out
+++ ModuleBeginJob: intProducerA
+++ ModuleBeginJob finished: intProducerA
+++ ModuleBeginJob: intProducerU
+++ ModuleBeginJob finished: intProducerU
+++ ModuleBeginJob: intVectorProducer
+++ ModuleBeginJob finished: intVectorProducer
+++ Job started
+++++ ModuleBeginStream: intProducer
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: a1
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: a2
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: a3
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: TriggerResults
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: out
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: intProducerA
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: intProducerU
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: intVectorProducer
+++++ ModuleBeginStream finished
+++++ source run
+++++ finished: source run
+++++ GlobalBeginRun run: 1 time: 1
+++++++ ModuleGlobalBeginRun: intProducerA
+++++++ ModuleGlobalBeginRun finished: intProducerA
+++++++ ModuleGlobalBeginRun: intProducerU
+++++++ ModuleGlobalBeginRun finished: intProducerU
+++++++ ModuleGlobalBeginRun: intVectorProducer
+++++++ ModuleGlobalBeginRun finished: intVectorProducer
+++++++ ModuleGlobalBeginRun: intProducer
+++++++ ModuleGlobalBeginRun finished: intProducer
+++++++ ModuleGlobalBeginRun: a1
+++++++ ModuleGlobalBeginRun finished: a1
+++++++ ModuleGlobalBeginRun: a2
+++++++ ModuleGlobalBeginRun finished: a2
+++++++ ModuleGlobalBeginRun: a3
+++++++ ModuleGlobalBeginRun finished: a3
+++++++ ModuleGlobalBeginRun: out
+++++++ ModuleGlobalBeginRun finished: out
+++++ GlobalBeginRun finished
+++++ StreamBeginRun run: 1 time: 1
+++++++ ModuleStreamBeginRun: intProducerA
+++++++ ModuleStreamBeginRun finished: intProducerA
+++++++ ModuleStreamBeginRun: intProducerU
+++++++ ModuleStreamBeginRun finished: intProducerU
+++++++ ModuleStreamBeginRun: intVectorProducer
+++++++ ModuleStreamBeginRun finished: intVectorProducer
+++++++ ModuleStreamBeginRun: intProducer
+++++++ ModuleStreamBeginRun finished: intProducer
+++++++ ModuleStreamBeginRun: a1
+++++++ ModuleStreamBeginRun finished: a1
+++++++ ModuleStreamBeginRun: a2
+++++++ ModuleStreamBeginRun finished: a2
+++++++ ModuleStreamBeginRun: a3
+++++++ ModuleStreamBeginRun finished: a3
+++++++ ModuleStreamBeginRun: out
+++++++ ModuleStreamBeginRun finished: out
+++++ StreamBeginRun finished
+++++ source lumi
+++++ finished: source lumi
+++++ GlobalBeginLumi run: 1 lumi: 1 time: 1
+++++++ ModuleGlobalBeginLumi: intProducerA
+++++++ ModuleGlobalBeginLumi finished: intProducerA
+++++++ ModuleGlobalBeginLumi: intProducerU
+++++++ ModuleGlobalBeginLumi finished: intProducerU
+++++++ ModuleGlobalBeginLumi: intVectorProducer
+++++++ ModuleGlobalBeginLumi finished: intVectorProducer
+++++++ ModuleGlobalBeginLumi: intProducer
+++++++ ModuleGlobalBeginLumi finished: intProducer
+++++++ ModuleGlobalBeginLumi: a1
+++++++ ModuleGlobalBeginLumi finished: a1
+++++++ ModuleGlobalBeginLumi: a2
+++++++ ModuleGlobalBeginLumi finished: a2
+++++++ ModuleGlobalBeginLumi: a3
+++++++ ModuleGlobalBeginLumi finished: a3
+++++++ ModuleGlobalBeginLumi: out
+++++++ ModuleGlobalBeginLumi finished: out
+++++ GlobalBeginLumi finished
+++++ StreamBeginLumi run: 1 lumi: 1 time: 1
+++++++ ModuleStreamBeginLumi: intProducerA
+++++++ ModuleStreamBeginLumi finished: intProducerA
+++++++ ModuleStreamBeginLumi: intProducerU
+++++++ ModuleStreamBeginLumi finished: intProducerU
+++++++ ModuleStreamBeginLumi: intVectorProducer
+++++++ ModuleStreamBeginLumi finished: intVectorProducer
+++++++ ModuleStreamBeginLumi: intProducer
+++++++ ModuleStreamBeginLumi finished: intProducer
+++++++ ModuleStreamBeginLumi: a1
+++++++ ModuleStreamBeginLumi finished: a1
+++++++ ModuleStreamBeginLumi: a2
+++++++ ModuleStreamBeginLumi finished: a2
+++++++ ModuleStreamBeginLumi: a3
+++++++ ModuleStreamBeginLumi finished: a3
+++++++ ModuleStreamBeginLumi: out
+++++++ ModuleStreamBeginLumi finished: out
+++++ StreamBeginLumi finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 1 event: 1 time:5000001
+++++++ processing path for event: p
+++++++++ module for event: intProducer
+++++++++ finished module for event: intProducer
+++++++++ module for event: a1
+++++++++ finished module for event: a1
+++++++++ module for event: a2
+++++++++++ module for event: intProducerA
+++++++++++ finished module for event: intProducerA
+++++++++ finished module for event: a2
+++++++++ module for event: a3
+++++++++ finished module for event: a3
+++++++ path for event finished: p
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: e
+++++++++ module for event: out
+++++++++++ module for event: intProducerU
+++++++++++ finished module for event: intProducerU
+++++++++++ module for event: intVectorProducer
+++++++++++ finished module for event: intVectorProducer
+++++++++ finished module for event: out
+++++++ path for event finished: e
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 1 event: 2 time:10000001
+++++++ processing path for event: p
+++++++++ module for event: intProducer
+++++++++ finished module for event: intProducer
+++++++++ module for event: a1
+++++++++ finished module for event: a1
+++++++++ module for event: a2
+++++++++++ module for event: intProducerA
+++++++++++ finished module for event: intProducerA
+++++++++ finished module for event: a2
+++++++++ module for event: a3
+++++++++ finished module for event: a3
+++++++ path for event finished: p
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: e
+++++++++ module for event: out
+++++++++++ module for event: intProducerU
+++++++++++ finished module for event: intProducerU
+++++++++++ module for event: intVectorProducer
+++++++++++ finished module for event: intVectorProducer
+++++++++ finished module for event: out
+++++++ path for event finished: e
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 1 event: 3 time:15000001
+++++++ processing path for event: p
+++++++++ module for event: intProducer
+++++++++ finished module for event: intProducer
+++++++++ module for event: a1
+++++++++ finished module for event: a1
+++++++++ module for event: a2
+++++++++++ module for event: intProducerA
+++++++++++ finished module for event: intProducerA
+++++++++ finished module for event: a2
+++++++++ module for event: a3
+++++++++ finished module for event: a3
+++++++ path for event finished: p
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: e
+++++++++ module for event: out
+++++++++++ module for event: intProducerU
+++++++++++ finished module for event: intProducerU
+++++++++++ module for event: intVectorProducer
+++++++++++ finished module for event: intVectorProducer
+++++++++ finished module for event: out
+++++++ path for event finished: e
+++++ event finished
+++++ StreamEndLumi run: 1 lumi: 1 time: 15000001
+++++++ ModuleStreamEndLumi: intProducerA
+++++++ ModuleStreamEndLumi finished: intProducerA
+++++++ ModuleStreamEndLumi: intProducerU
+++++++ ModuleStreamEndLumi finished: intProducerU
+++++++ ModuleStreamEndLumi: intVectorProducer
+++++++ ModuleStreamEndLumi finished: intVectorProducer
+++++++ ModuleStreamEndLumi: intProducer
+++++++ ModuleStreamEndLumi finished: intProducer
+++++++ ModuleStreamEndLumi: a1
+++++++ ModuleStreamEndLumi finished: a1
+++++++ ModuleStreamEndLumi: a2
+++++++ ModuleStreamEndLumi finished: a2
+++++++ ModuleStreamEndLumi: a3
+++++++ ModuleStreamEndLumi finished: a3
+++++++ ModuleStreamEndLumi: out
+++++++ ModuleStreamEndLumi finished: out
+++++ StreamEndLumi finished
+++++ GlobalEndLumi run: 1 lumi: 1 time: 1
+++++++ ModuleGlobalEndLumi: intProducerA
+++++++ ModuleGlobalEndLumi finished: intProducerA
+++++++ ModuleGlobalEndLumi: intProducerU
+++++++ ModuleGlobalEndLumi finished: intProducerU
+++++++ ModuleGlobalEndLumi: intVectorProducer
+++++++ ModuleGlobalEndLumi finished: intVectorProducer
+++++++ ModuleGlobalEndLumi: intProducer
+++++++ ModuleGlobalEndLumi finished: intProducer
+++++++ ModuleGlobalEndLumi: a1
+++++++ ModuleGlobalEndLumi finished: a1
+++++++ ModuleGlobalEndLumi: a2
+++++++ ModuleGlobalEndLumi finished: a2
+++++++ ModuleGlobalEndLumi: a3
+++++++ ModuleGlobalEndLumi finished: a3
+++++++ ModuleGlobalEndLumi: out
+++++++ ModuleGlobalEndLumi finished: out
+++++ GlobalEndLumi finished
+++++ StreamEndRun run: 1 time: 15000001
+++++++ ModuleStreamEndRun: intProducerA
+++++++ ModuleStreamEndRun finished: intProducerA
+++++++ ModuleStreamEndRun: intProducerU
+++++++ ModuleStreamEndRun finished: intProducerU
+++++++ ModuleStreamEndRun: intVectorProducer
+++++++ ModuleStreamEndRun finished: intVectorProducer
+++++++ ModuleStreamEndRun: intProducer
+++++++ ModuleStreamEndRun finished: intProducer
+++++++ ModuleStreamEndRun: a1
+++++++ ModuleStreamEndRun finished: a1
+++++++ ModuleStreamEndRun: a2
+++++++ ModuleStreamEndRun finished: a2
+++++++ ModuleStreamEndRun: a3
+++++++ ModuleStreamEndRun finished: a3
+++++++ ModuleStreamEndRun: out
+++++++ ModuleStreamEndRun finished: out
+++++ StreamEndRun finished
+++++ GlobalEndRun run: 1 time: 15000001
+++++++ ModuleGlobalEndRun: intProducerA
+++++++ ModuleGlobalEndRun finished: intProducerA
+++++++ ModuleGlobalEndRun: intProducerU
+++++++ ModuleGlobalEndRun finished: intProducerU
+++++++ ModuleGlobalEndRun: intVectorProducer
+++++++ ModuleGlobalEndRun finished: intVectorProducer
+++++++ ModuleGlobalEndRun: intProducer
+++++++ ModuleGlobalEndRun finished: intProducer
+++++++ ModuleGlobalEndRun: a1
+++++++ ModuleGlobalEndRun finished: a1
+++++++ ModuleGlobalEndRun: a2
+++++++ ModuleGlobalEndRun finished: a2
+++++++ ModuleGlobalEndRun: a3
+++++++ ModuleGlobalEndRun finished: a3
+++++++ ModuleGlobalEndRun: out
+++++++ ModuleGlobalEndRun finished: out
+++++ GlobalEndRun finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++ ModuleEndJob: intProducer
+++ ModuleEndJob finished: intProducer
+++ ModuleEndJob: a1
+TestFindProduct sum = 12
+++ ModuleEndJob finished: a1
+++ ModuleEndJob: a2
+TestFindProduct sum = 300
+++ ModuleEndJob finished: a2
+++ ModuleEndJob: a3
+TestFindProduct sum = 300
+++ ModuleEndJob finished: a3
+++ ModuleEndJob: TriggerResults
+++ ModuleEndJob finished: TriggerResults
+++ ModuleEndJob: out
+++ ModuleEndJob finished: out
+++ ModuleEndJob: intProducerA
+++ ModuleEndJob finished: intProducerA
+++ ModuleEndJob: intProducerU
+++ ModuleEndJob finished: intProducerU
+++ ModuleEndJob: intVectorProducer
+++ ModuleEndJob finished: intVectorProducer
+++ Job ended

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -1,0 +1,196 @@
+++ constructing source:PoolSource
+++++ open input file: file:testGetBy1.root
+++++ finished: open input file
+++ construction finished:PoolSource
+++ constructing module: intProducer
+++ construction finished: intProducer
+++ constructing module: TriggerResults
+++ construction finished: TriggerResults
+++ constructing module: out
+++ construction finished: out
+++ constructing module: intProducerU
+++ construction finished: intProducerU
+++ constructing module: intVectorProducer
+++ construction finished: intVectorProducer
+++ ModuleBeginJob: intProducer
+++ ModuleBeginJob finished: intProducer
+++ ModuleBeginJob: TriggerResults
+++ ModuleBeginJob finished: TriggerResults
+++ ModuleBeginJob: out
+++ ModuleBeginJob finished: out
+++ ModuleBeginJob: intProducerU
+++ ModuleBeginJob finished: intProducerU
+++ ModuleBeginJob: intVectorProducer
+++ ModuleBeginJob finished: intVectorProducer
+++ Job started
+++++ ModuleBeginStream: intProducer
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: TriggerResults
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: out
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: intProducerU
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: intVectorProducer
+++++ ModuleBeginStream finished
+++++ source run
+++++ finished: source run
+++++ GlobalBeginRun run: 1 time: 1
+++++++ ModuleGlobalBeginRun: intProducerU
+++++++ ModuleGlobalBeginRun finished: intProducerU
+++++++ ModuleGlobalBeginRun: intVectorProducer
+++++++ ModuleGlobalBeginRun finished: intVectorProducer
+++++++ ModuleGlobalBeginRun: intProducer
+++++++ ModuleGlobalBeginRun finished: intProducer
+++++++ ModuleGlobalBeginRun: out
+++++++ ModuleGlobalBeginRun finished: out
+++++ GlobalBeginRun finished
+++++ StreamBeginRun run: 1 time: 1
+++++++ ModuleStreamBeginRun: intProducerU
+++++++ ModuleStreamBeginRun finished: intProducerU
+++++++ ModuleStreamBeginRun: intVectorProducer
+++++++ ModuleStreamBeginRun finished: intVectorProducer
+++++++ ModuleStreamBeginRun: intProducer
+++++++ ModuleStreamBeginRun finished: intProducer
+++++++ ModuleStreamBeginRun: out
+++++++ ModuleStreamBeginRun finished: out
+++++ StreamBeginRun finished
+++++ source lumi
+++++ finished: source lumi
+++++ GlobalBeginLumi run: 1 lumi: 1 time: 1
+++++++ ModuleGlobalBeginLumi: intProducerU
+++++++ ModuleGlobalBeginLumi finished: intProducerU
+++++++ ModuleGlobalBeginLumi: intVectorProducer
+++++++ ModuleGlobalBeginLumi finished: intVectorProducer
+++++++ ModuleGlobalBeginLumi: intProducer
+++++++ ModuleGlobalBeginLumi finished: intProducer
+++++++ ModuleGlobalBeginLumi: out
+++++++ ModuleGlobalBeginLumi finished: out
+++++ GlobalBeginLumi finished
+++++ StreamBeginLumi run: 1 lumi: 1 time: 1
+++++++ ModuleStreamBeginLumi: intProducerU
+++++++ ModuleStreamBeginLumi finished: intProducerU
+++++++ ModuleStreamBeginLumi: intVectorProducer
+++++++ ModuleStreamBeginLumi finished: intVectorProducer
+++++++ ModuleStreamBeginLumi: intProducer
+++++++ ModuleStreamBeginLumi finished: intProducer
+++++++ ModuleStreamBeginLumi: out
+++++++ ModuleStreamBeginLumi finished: out
+++++ StreamBeginLumi finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 1 event: 1 time:5000001
+++++++ processing path for event: p
+++++++++ module for event: intProducer
+++++++++ finished module for event: intProducer
+++++++ path for event finished: p
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: e
+++++++++ module for event: out
+++++++++++ module for event: intProducerU
+++++++++++ finished module for event: intProducerU
+++++++++++ module for event: intVectorProducer
+++++++++++ finished module for event: intVectorProducer
+++++++++ finished module for event: out
+++++++ path for event finished: e
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 1 event: 2 time:10000001
+++++++ processing path for event: p
+++++++++ module for event: intProducer
+++++++++ finished module for event: intProducer
+++++++ path for event finished: p
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: e
+++++++++ module for event: out
+++++++++++ module for event: intProducerU
+++++++++++ finished module for event: intProducerU
+++++++++++ module for event: intVectorProducer
+++++++++++ finished module for event: intVectorProducer
+++++++++ finished module for event: out
+++++++ path for event finished: e
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 1 event: 3 time:15000001
+++++++ processing path for event: p
+++++++++ module for event: intProducer
+++++++++ finished module for event: intProducer
+++++++ path for event finished: p
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: e
+++++++++ module for event: out
+++++++++++ module for event: intProducerU
+++++++++++ finished module for event: intProducerU
+++++++++++ module for event: intVectorProducer
+++++++++++ finished module for event: intVectorProducer
+++++++++ finished module for event: out
+++++++ path for event finished: e
+++++ event finished
+++++ StreamEndLumi run: 1 lumi: 1 time: 15000001
+++++++ ModuleStreamEndLumi: intProducerU
+++++++ ModuleStreamEndLumi finished: intProducerU
+++++++ ModuleStreamEndLumi: intVectorProducer
+++++++ ModuleStreamEndLumi finished: intVectorProducer
+++++++ ModuleStreamEndLumi: intProducer
+++++++ ModuleStreamEndLumi finished: intProducer
+++++++ ModuleStreamEndLumi: out
+++++++ ModuleStreamEndLumi finished: out
+++++ StreamEndLumi finished
+++++ GlobalEndLumi run: 1 lumi: 1 time: 1
+++++++ ModuleGlobalEndLumi: intProducerU
+++++++ ModuleGlobalEndLumi finished: intProducerU
+++++++ ModuleGlobalEndLumi: intVectorProducer
+++++++ ModuleGlobalEndLumi finished: intVectorProducer
+++++++ ModuleGlobalEndLumi: intProducer
+++++++ ModuleGlobalEndLumi finished: intProducer
+++++++ ModuleGlobalEndLumi: out
+++++++ ModuleGlobalEndLumi finished: out
+++++ GlobalEndLumi finished
+++++ StreamEndRun run: 1 time: 15000001
+++++++ ModuleStreamEndRun: intProducerU
+++++++ ModuleStreamEndRun finished: intProducerU
+++++++ ModuleStreamEndRun: intVectorProducer
+++++++ ModuleStreamEndRun finished: intVectorProducer
+++++++ ModuleStreamEndRun: intProducer
+++++++ ModuleStreamEndRun finished: intProducer
+++++++ ModuleStreamEndRun: out
+++++++ ModuleStreamEndRun finished: out
+++++ StreamEndRun finished
+++++ GlobalEndRun run: 1 time: 15000001
+++++++ ModuleGlobalEndRun: intProducerU
+++++++ ModuleGlobalEndRun finished: intProducerU
+++++++ ModuleGlobalEndRun: intVectorProducer
+++++++ ModuleGlobalEndRun finished: intVectorProducer
+++++++ ModuleGlobalEndRun: intProducer
+++++++ ModuleGlobalEndRun finished: intProducer
+++++++ ModuleGlobalEndRun: out
+++++++ ModuleGlobalEndRun finished: out
+++++ GlobalEndRun finished
+++++ close input file: file:testGetBy1.root
+++++ finished: close input file
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++ ModuleEndJob: intProducer
+++ ModuleEndJob finished: intProducer
+++ ModuleEndJob: TriggerResults
+++ ModuleEndJob finished: TriggerResults
+++ ModuleEndJob: out
+++ ModuleEndJob finished: out
+++ ModuleEndJob: intProducerU
+++ ModuleEndJob finished: intProducerU
+++ ModuleEndJob: intVectorProducer
+++ ModuleEndJob finished: intVectorProducer
+++ Job ended

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -1,0 +1,3812 @@
+++ constructing source:EmptySource
+++ construction finished:EmptySource
+++ constructing module: thingWithMergeProducer
+++ construction finished: thingWithMergeProducer
+++ constructing module: get
+++ construction finished: get
+++ constructing module: putInt
+++ construction finished: putInt
+++ constructing module: putInt2
+++ construction finished: putInt2
+++ constructing module: putInt3
+++ construction finished: putInt3
+++ constructing module: getInt
+++ construction finished: getInt
+++ constructing module: noPut
+++ construction finished: noPut
+++ constructing module: TriggerResults
+++ construction finished: TriggerResults
+++ constructing module: thingWithMergeProducer
+++ construction finished: thingWithMergeProducer
+++ constructing module: test
+++ construction finished: test
+++ constructing module: testmerge
+++ construction finished: testmerge
+++ constructing module: get
+++ construction finished: get
+++ constructing module: getInt
+++ construction finished: getInt
+++ constructing module: dependsOnNoPut
+++ construction finished: dependsOnNoPut
+++ constructing module: TriggerResults
+++ construction finished: TriggerResults
+++ constructing module: out
+++ construction finished: out
+++ ModuleBeginJob: thingWithMergeProducer
+++ ModuleBeginJob finished: thingWithMergeProducer
+++ ModuleBeginJob: get
+++ ModuleBeginJob finished: get
+++ ModuleBeginJob: putInt
+++ ModuleBeginJob finished: putInt
+++ ModuleBeginJob: putInt2
+++ ModuleBeginJob finished: putInt2
+++ ModuleBeginJob: putInt3
+++ ModuleBeginJob finished: putInt3
+++ ModuleBeginJob: getInt
+++ ModuleBeginJob finished: getInt
+++ ModuleBeginJob: noPut
+++ ModuleBeginJob finished: noPut
+++ ModuleBeginJob: TriggerResults
+++ ModuleBeginJob finished: TriggerResults
+++ ModuleBeginJob: thingWithMergeProducer
+++ ModuleBeginJob finished: thingWithMergeProducer
+++ ModuleBeginJob: test
+++ ModuleBeginJob finished: test
+++ ModuleBeginJob: testmerge
+++ ModuleBeginJob finished: testmerge
+++ ModuleBeginJob: get
+++ ModuleBeginJob finished: get
+++ ModuleBeginJob: getInt
+++ ModuleBeginJob finished: getInt
+++ ModuleBeginJob: dependsOnNoPut
+++ ModuleBeginJob finished: dependsOnNoPut
+++ ModuleBeginJob: TriggerResults
+++ ModuleBeginJob finished: TriggerResults
+++ ModuleBeginJob: out
+++ ModuleBeginJob finished: out
+++ Job started
+++++ ModuleBeginStream: thingWithMergeProducer
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: get
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: putInt
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: putInt2
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: putInt3
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: getInt
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: noPut
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: TriggerResults
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: thingWithMergeProducer
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: test
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: testmerge
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: get
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: getInt
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: dependsOnNoPut
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: TriggerResults
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: out
+++++ ModuleBeginStream finished
+++++ source run
+++++ finished: source run
+++++ GlobalBeginRun run: 1 time: 1
+++++ GlobalBeginRun finished
+++++ GlobalBeginRun run: 1 time: 1
+++++ GlobalBeginRun finished
+++++ GlobalBeginRun run: 1 time: 1
+++++++ ModuleGlobalBeginRun: thingWithMergeProducer
+++++++ ModuleGlobalBeginRun finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginRun: get
+++++++ ModuleGlobalBeginRun finished: get
+++++++ ModuleGlobalBeginRun: putInt
+++++++ ModuleGlobalBeginRun finished: putInt
+++++++ ModuleGlobalBeginRun: putInt2
+++++++ ModuleGlobalBeginRun finished: putInt2
+++++++ ModuleGlobalBeginRun: putInt3
+++++++ ModuleGlobalBeginRun finished: putInt3
+++++++ ModuleGlobalBeginRun: getInt
+++++++ ModuleGlobalBeginRun finished: getInt
+++++++ ModuleGlobalBeginRun: noPut
+++++++ ModuleGlobalBeginRun finished: noPut
+++++ GlobalBeginRun finished
+++++ GlobalBeginRun run: 1 time: 1
+++++ GlobalBeginRun finished
+++++ GlobalBeginRun run: 1 time: 1
+++++++ ModuleGlobalBeginRun: thingWithMergeProducer
+++++++ ModuleGlobalBeginRun finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginRun: test
+++++++ ModuleGlobalBeginRun finished: test
+++++++ ModuleGlobalBeginRun: testmerge
+++++++ ModuleGlobalBeginRun finished: testmerge
+++++++ ModuleGlobalBeginRun: get
+++++++ ModuleGlobalBeginRun finished: get
+++++++ ModuleGlobalBeginRun: getInt
+++++++ ModuleGlobalBeginRun finished: getInt
+++++++ ModuleGlobalBeginRun: dependsOnNoPut
+++++++ ModuleGlobalBeginRun finished: dependsOnNoPut
+++++++ ModuleGlobalBeginRun: out
+++++++ ModuleGlobalBeginRun finished: out
+++++ GlobalBeginRun finished
+++++ StreamBeginRun run: 1 time: 1
+++++ StreamBeginRun finished
+++++ StreamBeginRun run: 1 time: 1
+++++ StreamBeginRun finished
+++++ StreamBeginRun run: 1 time: 1
+++++++ ModuleStreamBeginRun: thingWithMergeProducer
+++++++ ModuleStreamBeginRun finished: thingWithMergeProducer
+++++++ ModuleStreamBeginRun: get
+++++++ ModuleStreamBeginRun finished: get
+++++++ ModuleStreamBeginRun: putInt
+++++++ ModuleStreamBeginRun finished: putInt
+++++++ ModuleStreamBeginRun: putInt2
+++++++ ModuleStreamBeginRun finished: putInt2
+++++++ ModuleStreamBeginRun: putInt3
+++++++ ModuleStreamBeginRun finished: putInt3
+++++++ ModuleStreamBeginRun: getInt
+++++++ ModuleStreamBeginRun finished: getInt
+++++++ ModuleStreamBeginRun: noPut
+++++++ ModuleStreamBeginRun finished: noPut
+++++ StreamBeginRun finished
+++++ StreamBeginRun run: 1 time: 1
+++++ StreamBeginRun finished
+++++ StreamBeginRun run: 1 time: 1
+++++++ ModuleStreamBeginRun: thingWithMergeProducer
+++++++ ModuleStreamBeginRun finished: thingWithMergeProducer
+++++++ ModuleStreamBeginRun: test
+++++++ ModuleStreamBeginRun finished: test
+++++++ ModuleStreamBeginRun: testmerge
+++++++ ModuleStreamBeginRun finished: testmerge
+++++++ ModuleStreamBeginRun: get
+++++++ ModuleStreamBeginRun finished: get
+++++++ ModuleStreamBeginRun: getInt
+++++++ ModuleStreamBeginRun finished: getInt
+++++++ ModuleStreamBeginRun: dependsOnNoPut
+++++++ ModuleStreamBeginRun finished: dependsOnNoPut
+++++++ ModuleStreamBeginRun: out
+++++++ ModuleStreamBeginRun finished: out
+++++ StreamBeginRun finished
+++++ source lumi
+++++ finished: source lumi
+++++ GlobalBeginLumi run: 1 lumi: 1 time: 1
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 1 lumi: 1 time: 1
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 1 lumi: 1 time: 1
+++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: putInt
+++++++ ModuleGlobalBeginLumi finished: putInt
+++++++ ModuleGlobalBeginLumi: putInt2
+++++++ ModuleGlobalBeginLumi finished: putInt2
+++++++ ModuleGlobalBeginLumi: putInt3
+++++++ ModuleGlobalBeginLumi finished: putInt3
+++++++ ModuleGlobalBeginLumi: getInt
+++++++ ModuleGlobalBeginLumi finished: getInt
+++++++ ModuleGlobalBeginLumi: noPut
+++++++ ModuleGlobalBeginLumi finished: noPut
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 1 lumi: 1 time: 1
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 1 lumi: 1 time: 1
+++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi: test
+++++++ ModuleGlobalBeginLumi finished: test
+++++++ ModuleGlobalBeginLumi: testmerge
+++++++ ModuleGlobalBeginLumi finished: testmerge
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: getInt
+++++++ ModuleGlobalBeginLumi finished: getInt
+++++++ ModuleGlobalBeginLumi: dependsOnNoPut
+++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
+++++++ ModuleGlobalBeginLumi: out
+++++++ ModuleGlobalBeginLumi finished: out
+++++ GlobalBeginLumi finished
+++++ StreamBeginLumi run: 1 lumi: 1 time: 1
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 1 lumi: 1 time: 1
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 1 lumi: 1 time: 1
+++++++ ModuleStreamBeginLumi: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++++ ModuleStreamBeginLumi: putInt
+++++++ ModuleStreamBeginLumi finished: putInt
+++++++ ModuleStreamBeginLumi: putInt2
+++++++ ModuleStreamBeginLumi finished: putInt2
+++++++ ModuleStreamBeginLumi: putInt3
+++++++ ModuleStreamBeginLumi finished: putInt3
+++++++ ModuleStreamBeginLumi: getInt
+++++++ ModuleStreamBeginLumi finished: getInt
+++++++ ModuleStreamBeginLumi: noPut
+++++++ ModuleStreamBeginLumi finished: noPut
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 1 lumi: 1 time: 1
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 1 lumi: 1 time: 1
+++++++ ModuleStreamBeginLumi: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi: test
+++++++ ModuleStreamBeginLumi finished: test
+++++++ ModuleStreamBeginLumi: testmerge
+++++++ ModuleStreamBeginLumi finished: testmerge
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++++ ModuleStreamBeginLumi: getInt
+++++++ ModuleStreamBeginLumi finished: getInt
+++++++ ModuleStreamBeginLumi: dependsOnNoPut
+++++++ ModuleStreamBeginLumi finished: dependsOnNoPut
+++++++ ModuleStreamBeginLumi: out
+++++++ ModuleStreamBeginLumi finished: out
+++++ StreamBeginLumi finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 1 event: 1 time:5000001
+++++ event finished
+++++ processing event run: 1 lumi: 1 event: 1 time:5000001
+++++ event finished
+++++ processing event run: 1 lumi: 1 event: 1 time:5000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 1 lumi: 1 event: 1 time:5000001
+++++ event finished
+++++ processing event run: 1 lumi: 1 event: 1 time:5000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 1 event: 2 time:10000001
+++++ event finished
+++++ processing event run: 1 lumi: 1 event: 2 time:10000001
+++++ event finished
+++++ processing event run: 1 lumi: 1 event: 2 time:10000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 1 lumi: 1 event: 2 time:10000001
+++++ event finished
+++++ processing event run: 1 lumi: 1 event: 2 time:10000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 1 event: 3 time:15000001
+++++ event finished
+++++ processing event run: 1 lumi: 1 event: 3 time:15000001
+++++ event finished
+++++ processing event run: 1 lumi: 1 event: 3 time:15000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 1 lumi: 1 event: 3 time:15000001
+++++ event finished
+++++ processing event run: 1 lumi: 1 event: 3 time:15000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 1 event: 4 time:20000001
+++++ event finished
+++++ processing event run: 1 lumi: 1 event: 4 time:20000001
+++++ event finished
+++++ processing event run: 1 lumi: 1 event: 4 time:20000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 1 lumi: 1 event: 4 time:20000001
+++++ event finished
+++++ processing event run: 1 lumi: 1 event: 4 time:20000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ StreamEndLumi run: 1 lumi: 1 time: 20000001
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 1 lumi: 1 time: 0
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 1 lumi: 1 time: 0
+++++++ ModuleStreamEndLumi: thingWithMergeProducer
+++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++++ ModuleStreamEndLumi: putInt
+++++++ ModuleStreamEndLumi finished: putInt
+++++++ ModuleStreamEndLumi: putInt2
+++++++ ModuleStreamEndLumi finished: putInt2
+++++++ ModuleStreamEndLumi: putInt3
+++++++ ModuleStreamEndLumi finished: putInt3
+++++++ ModuleStreamEndLumi: getInt
+++++++ ModuleStreamEndLumi finished: getInt
+++++++ ModuleStreamEndLumi: noPut
+++++++ ModuleStreamEndLumi finished: noPut
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 1 lumi: 1 time: 0
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 1 lumi: 1 time: 0
+++++++ ModuleStreamEndLumi: thingWithMergeProducer
+++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
+++++++ ModuleStreamEndLumi: test
+++++++ ModuleStreamEndLumi finished: test
+++++++ ModuleStreamEndLumi: testmerge
+++++++ ModuleStreamEndLumi finished: testmerge
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++++ ModuleStreamEndLumi: getInt
+++++++ ModuleStreamEndLumi finished: getInt
+++++++ ModuleStreamEndLumi: dependsOnNoPut
+++++++ ModuleStreamEndLumi finished: dependsOnNoPut
+++++++ ModuleStreamEndLumi: out
+++++++ ModuleStreamEndLumi finished: out
+++++ StreamEndLumi finished
+++++ GlobalEndLumi run: 1 lumi: 1 time: 1
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 1 lumi: 1 time: 1
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 1 lumi: 1 time: 1
+++++++ ModuleGlobalEndLumi: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: putInt
+++++++ ModuleGlobalEndLumi finished: putInt
+++++++ ModuleGlobalEndLumi: putInt2
+++++++ ModuleGlobalEndLumi finished: putInt2
+++++++ ModuleGlobalEndLumi: putInt3
+++++++ ModuleGlobalEndLumi finished: putInt3
+++++++ ModuleGlobalEndLumi: getInt
+++++++ ModuleGlobalEndLumi finished: getInt
+++++++ ModuleGlobalEndLumi: noPut
+++++++ ModuleGlobalEndLumi finished: noPut
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 1 lumi: 1 time: 1
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 1 lumi: 1 time: 1
+++++++ ModuleGlobalEndLumi: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi: test
+++++++ ModuleGlobalEndLumi finished: test
+++++++ ModuleGlobalEndLumi: testmerge
+++++++ ModuleGlobalEndLumi finished: testmerge
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: getInt
+++++++ ModuleGlobalEndLumi finished: getInt
+++++++ ModuleGlobalEndLumi: dependsOnNoPut
+++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
+++++++ ModuleGlobalEndLumi: out
+++++++ ModuleGlobalEndLumi finished: out
+++++ GlobalEndLumi finished
+++++ source lumi
+++++ finished: source lumi
+++++ GlobalBeginLumi run: 1 lumi: 2 time: 25000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 1 lumi: 2 time: 25000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 1 lumi: 2 time: 25000001
+++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: putInt
+++++++ ModuleGlobalBeginLumi finished: putInt
+++++++ ModuleGlobalBeginLumi: putInt2
+++++++ ModuleGlobalBeginLumi finished: putInt2
+++++++ ModuleGlobalBeginLumi: putInt3
+++++++ ModuleGlobalBeginLumi finished: putInt3
+++++++ ModuleGlobalBeginLumi: getInt
+++++++ ModuleGlobalBeginLumi finished: getInt
+++++++ ModuleGlobalBeginLumi: noPut
+++++++ ModuleGlobalBeginLumi finished: noPut
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 1 lumi: 2 time: 25000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 1 lumi: 2 time: 25000001
+++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi: test
+++++++ ModuleGlobalBeginLumi finished: test
+++++++ ModuleGlobalBeginLumi: testmerge
+++++++ ModuleGlobalBeginLumi finished: testmerge
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: getInt
+++++++ ModuleGlobalBeginLumi finished: getInt
+++++++ ModuleGlobalBeginLumi: dependsOnNoPut
+++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
+++++++ ModuleGlobalBeginLumi: out
+++++++ ModuleGlobalBeginLumi finished: out
+++++ GlobalBeginLumi finished
+++++ StreamBeginLumi run: 1 lumi: 2 time: 25000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 1 lumi: 2 time: 25000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 1 lumi: 2 time: 25000001
+++++++ ModuleStreamBeginLumi: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++++ ModuleStreamBeginLumi: putInt
+++++++ ModuleStreamBeginLumi finished: putInt
+++++++ ModuleStreamBeginLumi: putInt2
+++++++ ModuleStreamBeginLumi finished: putInt2
+++++++ ModuleStreamBeginLumi: putInt3
+++++++ ModuleStreamBeginLumi finished: putInt3
+++++++ ModuleStreamBeginLumi: getInt
+++++++ ModuleStreamBeginLumi finished: getInt
+++++++ ModuleStreamBeginLumi: noPut
+++++++ ModuleStreamBeginLumi finished: noPut
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 1 lumi: 2 time: 25000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 1 lumi: 2 time: 25000001
+++++++ ModuleStreamBeginLumi: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi: test
+++++++ ModuleStreamBeginLumi finished: test
+++++++ ModuleStreamBeginLumi: testmerge
+++++++ ModuleStreamBeginLumi finished: testmerge
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++++ ModuleStreamBeginLumi: getInt
+++++++ ModuleStreamBeginLumi finished: getInt
+++++++ ModuleStreamBeginLumi: dependsOnNoPut
+++++++ ModuleStreamBeginLumi finished: dependsOnNoPut
+++++++ ModuleStreamBeginLumi: out
+++++++ ModuleStreamBeginLumi finished: out
+++++ StreamBeginLumi finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 2 event: 5 time:25000001
+++++ event finished
+++++ processing event run: 1 lumi: 2 event: 5 time:25000001
+++++ event finished
+++++ processing event run: 1 lumi: 2 event: 5 time:25000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 1 lumi: 2 event: 5 time:25000001
+++++ event finished
+++++ processing event run: 1 lumi: 2 event: 5 time:25000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 2 event: 6 time:30000001
+++++ event finished
+++++ processing event run: 1 lumi: 2 event: 6 time:30000001
+++++ event finished
+++++ processing event run: 1 lumi: 2 event: 6 time:30000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 1 lumi: 2 event: 6 time:30000001
+++++ event finished
+++++ processing event run: 1 lumi: 2 event: 6 time:30000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 2 event: 7 time:35000001
+++++ event finished
+++++ processing event run: 1 lumi: 2 event: 7 time:35000001
+++++ event finished
+++++ processing event run: 1 lumi: 2 event: 7 time:35000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 1 lumi: 2 event: 7 time:35000001
+++++ event finished
+++++ processing event run: 1 lumi: 2 event: 7 time:35000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 2 event: 8 time:40000001
+++++ event finished
+++++ processing event run: 1 lumi: 2 event: 8 time:40000001
+++++ event finished
+++++ processing event run: 1 lumi: 2 event: 8 time:40000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 1 lumi: 2 event: 8 time:40000001
+++++ event finished
+++++ processing event run: 1 lumi: 2 event: 8 time:40000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ StreamEndLumi run: 1 lumi: 2 time: 40000001
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 1 lumi: 2 time: 0
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 1 lumi: 2 time: 0
+++++++ ModuleStreamEndLumi: thingWithMergeProducer
+++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++++ ModuleStreamEndLumi: putInt
+++++++ ModuleStreamEndLumi finished: putInt
+++++++ ModuleStreamEndLumi: putInt2
+++++++ ModuleStreamEndLumi finished: putInt2
+++++++ ModuleStreamEndLumi: putInt3
+++++++ ModuleStreamEndLumi finished: putInt3
+++++++ ModuleStreamEndLumi: getInt
+++++++ ModuleStreamEndLumi finished: getInt
+++++++ ModuleStreamEndLumi: noPut
+++++++ ModuleStreamEndLumi finished: noPut
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 1 lumi: 2 time: 0
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 1 lumi: 2 time: 0
+++++++ ModuleStreamEndLumi: thingWithMergeProducer
+++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
+++++++ ModuleStreamEndLumi: test
+++++++ ModuleStreamEndLumi finished: test
+++++++ ModuleStreamEndLumi: testmerge
+++++++ ModuleStreamEndLumi finished: testmerge
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++++ ModuleStreamEndLumi: getInt
+++++++ ModuleStreamEndLumi finished: getInt
+++++++ ModuleStreamEndLumi: dependsOnNoPut
+++++++ ModuleStreamEndLumi finished: dependsOnNoPut
+++++++ ModuleStreamEndLumi: out
+++++++ ModuleStreamEndLumi finished: out
+++++ StreamEndLumi finished
+++++ GlobalEndLumi run: 1 lumi: 2 time: 25000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 1 lumi: 2 time: 25000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 1 lumi: 2 time: 25000001
+++++++ ModuleGlobalEndLumi: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: putInt
+++++++ ModuleGlobalEndLumi finished: putInt
+++++++ ModuleGlobalEndLumi: putInt2
+++++++ ModuleGlobalEndLumi finished: putInt2
+++++++ ModuleGlobalEndLumi: putInt3
+++++++ ModuleGlobalEndLumi finished: putInt3
+++++++ ModuleGlobalEndLumi: getInt
+++++++ ModuleGlobalEndLumi finished: getInt
+++++++ ModuleGlobalEndLumi: noPut
+++++++ ModuleGlobalEndLumi finished: noPut
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 1 lumi: 2 time: 25000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 1 lumi: 2 time: 25000001
+++++++ ModuleGlobalEndLumi: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi: test
+++++++ ModuleGlobalEndLumi finished: test
+++++++ ModuleGlobalEndLumi: testmerge
+++++++ ModuleGlobalEndLumi finished: testmerge
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: getInt
+++++++ ModuleGlobalEndLumi finished: getInt
+++++++ ModuleGlobalEndLumi: dependsOnNoPut
+++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
+++++++ ModuleGlobalEndLumi: out
+++++++ ModuleGlobalEndLumi finished: out
+++++ GlobalEndLumi finished
+++++ source lumi
+++++ finished: source lumi
+++++ GlobalBeginLumi run: 1 lumi: 3 time: 45000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 1 lumi: 3 time: 45000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 1 lumi: 3 time: 45000001
+++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: putInt
+++++++ ModuleGlobalBeginLumi finished: putInt
+++++++ ModuleGlobalBeginLumi: putInt2
+++++++ ModuleGlobalBeginLumi finished: putInt2
+++++++ ModuleGlobalBeginLumi: putInt3
+++++++ ModuleGlobalBeginLumi finished: putInt3
+++++++ ModuleGlobalBeginLumi: getInt
+++++++ ModuleGlobalBeginLumi finished: getInt
+++++++ ModuleGlobalBeginLumi: noPut
+++++++ ModuleGlobalBeginLumi finished: noPut
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 1 lumi: 3 time: 45000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 1 lumi: 3 time: 45000001
+++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi: test
+++++++ ModuleGlobalBeginLumi finished: test
+++++++ ModuleGlobalBeginLumi: testmerge
+++++++ ModuleGlobalBeginLumi finished: testmerge
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: getInt
+++++++ ModuleGlobalBeginLumi finished: getInt
+++++++ ModuleGlobalBeginLumi: dependsOnNoPut
+++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
+++++++ ModuleGlobalBeginLumi: out
+++++++ ModuleGlobalBeginLumi finished: out
+++++ GlobalBeginLumi finished
+++++ StreamBeginLumi run: 1 lumi: 3 time: 45000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 1 lumi: 3 time: 45000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 1 lumi: 3 time: 45000001
+++++++ ModuleStreamBeginLumi: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++++ ModuleStreamBeginLumi: putInt
+++++++ ModuleStreamBeginLumi finished: putInt
+++++++ ModuleStreamBeginLumi: putInt2
+++++++ ModuleStreamBeginLumi finished: putInt2
+++++++ ModuleStreamBeginLumi: putInt3
+++++++ ModuleStreamBeginLumi finished: putInt3
+++++++ ModuleStreamBeginLumi: getInt
+++++++ ModuleStreamBeginLumi finished: getInt
+++++++ ModuleStreamBeginLumi: noPut
+++++++ ModuleStreamBeginLumi finished: noPut
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 1 lumi: 3 time: 45000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 1 lumi: 3 time: 45000001
+++++++ ModuleStreamBeginLumi: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi: test
+++++++ ModuleStreamBeginLumi finished: test
+++++++ ModuleStreamBeginLumi: testmerge
+++++++ ModuleStreamBeginLumi finished: testmerge
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++++ ModuleStreamBeginLumi: getInt
+++++++ ModuleStreamBeginLumi finished: getInt
+++++++ ModuleStreamBeginLumi: dependsOnNoPut
+++++++ ModuleStreamBeginLumi finished: dependsOnNoPut
+++++++ ModuleStreamBeginLumi: out
+++++++ ModuleStreamBeginLumi finished: out
+++++ StreamBeginLumi finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 3 event: 9 time:45000001
+++++ event finished
+++++ processing event run: 1 lumi: 3 event: 9 time:45000001
+++++ event finished
+++++ processing event run: 1 lumi: 3 event: 9 time:45000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 1 lumi: 3 event: 9 time:45000001
+++++ event finished
+++++ processing event run: 1 lumi: 3 event: 9 time:45000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 3 event: 10 time:50000001
+++++ event finished
+++++ processing event run: 1 lumi: 3 event: 10 time:50000001
+++++ event finished
+++++ processing event run: 1 lumi: 3 event: 10 time:50000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 1 lumi: 3 event: 10 time:50000001
+++++ event finished
+++++ processing event run: 1 lumi: 3 event: 10 time:50000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ StreamEndLumi run: 1 lumi: 3 time: 50000001
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 1 lumi: 3 time: 0
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 1 lumi: 3 time: 0
+++++++ ModuleStreamEndLumi: thingWithMergeProducer
+++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++++ ModuleStreamEndLumi: putInt
+++++++ ModuleStreamEndLumi finished: putInt
+++++++ ModuleStreamEndLumi: putInt2
+++++++ ModuleStreamEndLumi finished: putInt2
+++++++ ModuleStreamEndLumi: putInt3
+++++++ ModuleStreamEndLumi finished: putInt3
+++++++ ModuleStreamEndLumi: getInt
+++++++ ModuleStreamEndLumi finished: getInt
+++++++ ModuleStreamEndLumi: noPut
+++++++ ModuleStreamEndLumi finished: noPut
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 1 lumi: 3 time: 0
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 1 lumi: 3 time: 0
+++++++ ModuleStreamEndLumi: thingWithMergeProducer
+++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
+++++++ ModuleStreamEndLumi: test
+++++++ ModuleStreamEndLumi finished: test
+++++++ ModuleStreamEndLumi: testmerge
+++++++ ModuleStreamEndLumi finished: testmerge
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++++ ModuleStreamEndLumi: getInt
+++++++ ModuleStreamEndLumi finished: getInt
+++++++ ModuleStreamEndLumi: dependsOnNoPut
+++++++ ModuleStreamEndLumi finished: dependsOnNoPut
+++++++ ModuleStreamEndLumi: out
+++++++ ModuleStreamEndLumi finished: out
+++++ StreamEndLumi finished
+++++ GlobalEndLumi run: 1 lumi: 3 time: 45000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 1 lumi: 3 time: 45000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 1 lumi: 3 time: 45000001
+++++++ ModuleGlobalEndLumi: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: putInt
+++++++ ModuleGlobalEndLumi finished: putInt
+++++++ ModuleGlobalEndLumi: putInt2
+++++++ ModuleGlobalEndLumi finished: putInt2
+++++++ ModuleGlobalEndLumi: putInt3
+++++++ ModuleGlobalEndLumi finished: putInt3
+++++++ ModuleGlobalEndLumi: getInt
+++++++ ModuleGlobalEndLumi finished: getInt
+++++++ ModuleGlobalEndLumi: noPut
+++++++ ModuleGlobalEndLumi finished: noPut
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 1 lumi: 3 time: 45000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 1 lumi: 3 time: 45000001
+++++++ ModuleGlobalEndLumi: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi: test
+++++++ ModuleGlobalEndLumi finished: test
+++++++ ModuleGlobalEndLumi: testmerge
+++++++ ModuleGlobalEndLumi finished: testmerge
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: getInt
+++++++ ModuleGlobalEndLumi finished: getInt
+++++++ ModuleGlobalEndLumi: dependsOnNoPut
+++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
+++++++ ModuleGlobalEndLumi: out
+++++++ ModuleGlobalEndLumi finished: out
+++++ GlobalEndLumi finished
+++++ StreamEndRun run: 1 time: 50000001
+++++ StreamEndRun finished
+++++ StreamEndRun run: 1 time: 0
+++++ StreamEndRun finished
+++++ StreamEndRun run: 1 time: 0
+++++++ ModuleStreamEndRun: thingWithMergeProducer
+++++++ ModuleStreamEndRun finished: thingWithMergeProducer
+++++++ ModuleStreamEndRun: get
+++++++ ModuleStreamEndRun finished: get
+++++++ ModuleStreamEndRun: putInt
+++++++ ModuleStreamEndRun finished: putInt
+++++++ ModuleStreamEndRun: putInt2
+++++++ ModuleStreamEndRun finished: putInt2
+++++++ ModuleStreamEndRun: putInt3
+++++++ ModuleStreamEndRun finished: putInt3
+++++++ ModuleStreamEndRun: getInt
+++++++ ModuleStreamEndRun finished: getInt
+++++++ ModuleStreamEndRun: noPut
+++++++ ModuleStreamEndRun finished: noPut
+++++ StreamEndRun finished
+++++ StreamEndRun run: 1 time: 0
+++++ StreamEndRun finished
+++++ StreamEndRun run: 1 time: 0
+++++++ ModuleStreamEndRun: thingWithMergeProducer
+++++++ ModuleStreamEndRun finished: thingWithMergeProducer
+++++++ ModuleStreamEndRun: test
+++++++ ModuleStreamEndRun finished: test
+++++++ ModuleStreamEndRun: testmerge
+++++++ ModuleStreamEndRun finished: testmerge
+++++++ ModuleStreamEndRun: get
+++++++ ModuleStreamEndRun finished: get
+++++++ ModuleStreamEndRun: getInt
+++++++ ModuleStreamEndRun finished: getInt
+++++++ ModuleStreamEndRun: dependsOnNoPut
+++++++ ModuleStreamEndRun finished: dependsOnNoPut
+++++++ ModuleStreamEndRun: out
+++++++ ModuleStreamEndRun finished: out
+++++ StreamEndRun finished
+++++ GlobalEndRun run: 1 time: 50000001
+++++ GlobalEndRun finished
+++++ GlobalEndRun run: 1 time: 0
+++++ GlobalEndRun finished
+++++ GlobalEndRun run: 1 time: 0
+++++++ ModuleGlobalEndRun: thingWithMergeProducer
+++++++ ModuleGlobalEndRun finished: thingWithMergeProducer
+++++++ ModuleGlobalEndRun: get
+++++++ ModuleGlobalEndRun finished: get
+++++++ ModuleGlobalEndRun: putInt
+++++++ ModuleGlobalEndRun finished: putInt
+++++++ ModuleGlobalEndRun: putInt2
+++++++ ModuleGlobalEndRun finished: putInt2
+++++++ ModuleGlobalEndRun: putInt3
+++++++ ModuleGlobalEndRun finished: putInt3
+++++++ ModuleGlobalEndRun: getInt
+++++++ ModuleGlobalEndRun finished: getInt
+++++++ ModuleGlobalEndRun: noPut
+++++++ ModuleGlobalEndRun finished: noPut
+++++ GlobalEndRun finished
+++++ GlobalEndRun run: 1 time: 0
+++++ GlobalEndRun finished
+++++ GlobalEndRun run: 1 time: 0
+++++++ ModuleGlobalEndRun: thingWithMergeProducer
+++++++ ModuleGlobalEndRun finished: thingWithMergeProducer
+++++++ ModuleGlobalEndRun: test
+++++++ ModuleGlobalEndRun finished: test
+++++++ ModuleGlobalEndRun: testmerge
+++++++ ModuleGlobalEndRun finished: testmerge
+++++++ ModuleGlobalEndRun: get
+++++++ ModuleGlobalEndRun finished: get
+++++++ ModuleGlobalEndRun: getInt
+++++++ ModuleGlobalEndRun finished: getInt
+++++++ ModuleGlobalEndRun: dependsOnNoPut
+++++++ ModuleGlobalEndRun finished: dependsOnNoPut
+++++++ ModuleGlobalEndRun: out
+++++++ ModuleGlobalEndRun finished: out
+++++ GlobalEndRun finished
+++++ source run
+++++ finished: source run
+++++ GlobalBeginRun run: 2 time: 55000001
+++++ GlobalBeginRun finished
+++++ GlobalBeginRun run: 2 time: 55000001
+++++ GlobalBeginRun finished
+++++ GlobalBeginRun run: 2 time: 55000001
+++++++ ModuleGlobalBeginRun: thingWithMergeProducer
+++++++ ModuleGlobalBeginRun finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginRun: get
+++++++ ModuleGlobalBeginRun finished: get
+++++++ ModuleGlobalBeginRun: putInt
+++++++ ModuleGlobalBeginRun finished: putInt
+++++++ ModuleGlobalBeginRun: putInt2
+++++++ ModuleGlobalBeginRun finished: putInt2
+++++++ ModuleGlobalBeginRun: putInt3
+++++++ ModuleGlobalBeginRun finished: putInt3
+++++++ ModuleGlobalBeginRun: getInt
+++++++ ModuleGlobalBeginRun finished: getInt
+++++++ ModuleGlobalBeginRun: noPut
+++++++ ModuleGlobalBeginRun finished: noPut
+++++ GlobalBeginRun finished
+++++ GlobalBeginRun run: 2 time: 55000001
+++++ GlobalBeginRun finished
+++++ GlobalBeginRun run: 2 time: 55000001
+++++++ ModuleGlobalBeginRun: thingWithMergeProducer
+++++++ ModuleGlobalBeginRun finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginRun: test
+++++++ ModuleGlobalBeginRun finished: test
+++++++ ModuleGlobalBeginRun: testmerge
+++++++ ModuleGlobalBeginRun finished: testmerge
+++++++ ModuleGlobalBeginRun: get
+++++++ ModuleGlobalBeginRun finished: get
+++++++ ModuleGlobalBeginRun: getInt
+++++++ ModuleGlobalBeginRun finished: getInt
+++++++ ModuleGlobalBeginRun: dependsOnNoPut
+++++++ ModuleGlobalBeginRun finished: dependsOnNoPut
+++++++ ModuleGlobalBeginRun: out
+++++++ ModuleGlobalBeginRun finished: out
+++++ GlobalBeginRun finished
+++++ StreamBeginRun run: 2 time: 55000001
+++++ StreamBeginRun finished
+++++ StreamBeginRun run: 2 time: 55000001
+++++ StreamBeginRun finished
+++++ StreamBeginRun run: 2 time: 55000001
+++++++ ModuleStreamBeginRun: thingWithMergeProducer
+++++++ ModuleStreamBeginRun finished: thingWithMergeProducer
+++++++ ModuleStreamBeginRun: get
+++++++ ModuleStreamBeginRun finished: get
+++++++ ModuleStreamBeginRun: putInt
+++++++ ModuleStreamBeginRun finished: putInt
+++++++ ModuleStreamBeginRun: putInt2
+++++++ ModuleStreamBeginRun finished: putInt2
+++++++ ModuleStreamBeginRun: putInt3
+++++++ ModuleStreamBeginRun finished: putInt3
+++++++ ModuleStreamBeginRun: getInt
+++++++ ModuleStreamBeginRun finished: getInt
+++++++ ModuleStreamBeginRun: noPut
+++++++ ModuleStreamBeginRun finished: noPut
+++++ StreamBeginRun finished
+++++ StreamBeginRun run: 2 time: 55000001
+++++ StreamBeginRun finished
+++++ StreamBeginRun run: 2 time: 55000001
+++++++ ModuleStreamBeginRun: thingWithMergeProducer
+++++++ ModuleStreamBeginRun finished: thingWithMergeProducer
+++++++ ModuleStreamBeginRun: test
+++++++ ModuleStreamBeginRun finished: test
+++++++ ModuleStreamBeginRun: testmerge
+++++++ ModuleStreamBeginRun finished: testmerge
+++++++ ModuleStreamBeginRun: get
+++++++ ModuleStreamBeginRun finished: get
+++++++ ModuleStreamBeginRun: getInt
+++++++ ModuleStreamBeginRun finished: getInt
+++++++ ModuleStreamBeginRun: dependsOnNoPut
+++++++ ModuleStreamBeginRun finished: dependsOnNoPut
+++++++ ModuleStreamBeginRun: out
+++++++ ModuleStreamBeginRun finished: out
+++++ StreamBeginRun finished
+++++ source lumi
+++++ finished: source lumi
+++++ GlobalBeginLumi run: 2 lumi: 1 time: 55000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 2 lumi: 1 time: 55000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 2 lumi: 1 time: 55000001
+++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: putInt
+++++++ ModuleGlobalBeginLumi finished: putInt
+++++++ ModuleGlobalBeginLumi: putInt2
+++++++ ModuleGlobalBeginLumi finished: putInt2
+++++++ ModuleGlobalBeginLumi: putInt3
+++++++ ModuleGlobalBeginLumi finished: putInt3
+++++++ ModuleGlobalBeginLumi: getInt
+++++++ ModuleGlobalBeginLumi finished: getInt
+++++++ ModuleGlobalBeginLumi: noPut
+++++++ ModuleGlobalBeginLumi finished: noPut
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 2 lumi: 1 time: 55000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 2 lumi: 1 time: 55000001
+++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi: test
+++++++ ModuleGlobalBeginLumi finished: test
+++++++ ModuleGlobalBeginLumi: testmerge
+++++++ ModuleGlobalBeginLumi finished: testmerge
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: getInt
+++++++ ModuleGlobalBeginLumi finished: getInt
+++++++ ModuleGlobalBeginLumi: dependsOnNoPut
+++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
+++++++ ModuleGlobalBeginLumi: out
+++++++ ModuleGlobalBeginLumi finished: out
+++++ GlobalBeginLumi finished
+++++ StreamBeginLumi run: 2 lumi: 1 time: 55000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 2 lumi: 1 time: 55000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 2 lumi: 1 time: 55000001
+++++++ ModuleStreamBeginLumi: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++++ ModuleStreamBeginLumi: putInt
+++++++ ModuleStreamBeginLumi finished: putInt
+++++++ ModuleStreamBeginLumi: putInt2
+++++++ ModuleStreamBeginLumi finished: putInt2
+++++++ ModuleStreamBeginLumi: putInt3
+++++++ ModuleStreamBeginLumi finished: putInt3
+++++++ ModuleStreamBeginLumi: getInt
+++++++ ModuleStreamBeginLumi finished: getInt
+++++++ ModuleStreamBeginLumi: noPut
+++++++ ModuleStreamBeginLumi finished: noPut
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 2 lumi: 1 time: 55000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 2 lumi: 1 time: 55000001
+++++++ ModuleStreamBeginLumi: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi: test
+++++++ ModuleStreamBeginLumi finished: test
+++++++ ModuleStreamBeginLumi: testmerge
+++++++ ModuleStreamBeginLumi finished: testmerge
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++++ ModuleStreamBeginLumi: getInt
+++++++ ModuleStreamBeginLumi finished: getInt
+++++++ ModuleStreamBeginLumi: dependsOnNoPut
+++++++ ModuleStreamBeginLumi finished: dependsOnNoPut
+++++++ ModuleStreamBeginLumi: out
+++++++ ModuleStreamBeginLumi finished: out
+++++ StreamBeginLumi finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 2 lumi: 1 event: 1 time:55000001
+++++ event finished
+++++ processing event run: 2 lumi: 1 event: 1 time:55000001
+++++ event finished
+++++ processing event run: 2 lumi: 1 event: 1 time:55000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 2 lumi: 1 event: 1 time:55000001
+++++ event finished
+++++ processing event run: 2 lumi: 1 event: 1 time:55000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 2 lumi: 1 event: 2 time:60000001
+++++ event finished
+++++ processing event run: 2 lumi: 1 event: 2 time:60000001
+++++ event finished
+++++ processing event run: 2 lumi: 1 event: 2 time:60000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 2 lumi: 1 event: 2 time:60000001
+++++ event finished
+++++ processing event run: 2 lumi: 1 event: 2 time:60000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 2 lumi: 1 event: 3 time:65000001
+++++ event finished
+++++ processing event run: 2 lumi: 1 event: 3 time:65000001
+++++ event finished
+++++ processing event run: 2 lumi: 1 event: 3 time:65000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 2 lumi: 1 event: 3 time:65000001
+++++ event finished
+++++ processing event run: 2 lumi: 1 event: 3 time:65000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 2 lumi: 1 event: 4 time:70000001
+++++ event finished
+++++ processing event run: 2 lumi: 1 event: 4 time:70000001
+++++ event finished
+++++ processing event run: 2 lumi: 1 event: 4 time:70000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 2 lumi: 1 event: 4 time:70000001
+++++ event finished
+++++ processing event run: 2 lumi: 1 event: 4 time:70000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ StreamEndLumi run: 2 lumi: 1 time: 70000001
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 2 lumi: 1 time: 0
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 2 lumi: 1 time: 0
+++++++ ModuleStreamEndLumi: thingWithMergeProducer
+++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++++ ModuleStreamEndLumi: putInt
+++++++ ModuleStreamEndLumi finished: putInt
+++++++ ModuleStreamEndLumi: putInt2
+++++++ ModuleStreamEndLumi finished: putInt2
+++++++ ModuleStreamEndLumi: putInt3
+++++++ ModuleStreamEndLumi finished: putInt3
+++++++ ModuleStreamEndLumi: getInt
+++++++ ModuleStreamEndLumi finished: getInt
+++++++ ModuleStreamEndLumi: noPut
+++++++ ModuleStreamEndLumi finished: noPut
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 2 lumi: 1 time: 0
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 2 lumi: 1 time: 0
+++++++ ModuleStreamEndLumi: thingWithMergeProducer
+++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
+++++++ ModuleStreamEndLumi: test
+++++++ ModuleStreamEndLumi finished: test
+++++++ ModuleStreamEndLumi: testmerge
+++++++ ModuleStreamEndLumi finished: testmerge
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++++ ModuleStreamEndLumi: getInt
+++++++ ModuleStreamEndLumi finished: getInt
+++++++ ModuleStreamEndLumi: dependsOnNoPut
+++++++ ModuleStreamEndLumi finished: dependsOnNoPut
+++++++ ModuleStreamEndLumi: out
+++++++ ModuleStreamEndLumi finished: out
+++++ StreamEndLumi finished
+++++ GlobalEndLumi run: 2 lumi: 1 time: 55000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 2 lumi: 1 time: 55000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 2 lumi: 1 time: 55000001
+++++++ ModuleGlobalEndLumi: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: putInt
+++++++ ModuleGlobalEndLumi finished: putInt
+++++++ ModuleGlobalEndLumi: putInt2
+++++++ ModuleGlobalEndLumi finished: putInt2
+++++++ ModuleGlobalEndLumi: putInt3
+++++++ ModuleGlobalEndLumi finished: putInt3
+++++++ ModuleGlobalEndLumi: getInt
+++++++ ModuleGlobalEndLumi finished: getInt
+++++++ ModuleGlobalEndLumi: noPut
+++++++ ModuleGlobalEndLumi finished: noPut
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 2 lumi: 1 time: 55000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 2 lumi: 1 time: 55000001
+++++++ ModuleGlobalEndLumi: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi: test
+++++++ ModuleGlobalEndLumi finished: test
+++++++ ModuleGlobalEndLumi: testmerge
+++++++ ModuleGlobalEndLumi finished: testmerge
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: getInt
+++++++ ModuleGlobalEndLumi finished: getInt
+++++++ ModuleGlobalEndLumi: dependsOnNoPut
+++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
+++++++ ModuleGlobalEndLumi: out
+++++++ ModuleGlobalEndLumi finished: out
+++++ GlobalEndLumi finished
+++++ source lumi
+++++ finished: source lumi
+++++ GlobalBeginLumi run: 2 lumi: 2 time: 75000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 2 lumi: 2 time: 75000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 2 lumi: 2 time: 75000001
+++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: putInt
+++++++ ModuleGlobalBeginLumi finished: putInt
+++++++ ModuleGlobalBeginLumi: putInt2
+++++++ ModuleGlobalBeginLumi finished: putInt2
+++++++ ModuleGlobalBeginLumi: putInt3
+++++++ ModuleGlobalBeginLumi finished: putInt3
+++++++ ModuleGlobalBeginLumi: getInt
+++++++ ModuleGlobalBeginLumi finished: getInt
+++++++ ModuleGlobalBeginLumi: noPut
+++++++ ModuleGlobalBeginLumi finished: noPut
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 2 lumi: 2 time: 75000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 2 lumi: 2 time: 75000001
+++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi: test
+++++++ ModuleGlobalBeginLumi finished: test
+++++++ ModuleGlobalBeginLumi: testmerge
+++++++ ModuleGlobalBeginLumi finished: testmerge
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: getInt
+++++++ ModuleGlobalBeginLumi finished: getInt
+++++++ ModuleGlobalBeginLumi: dependsOnNoPut
+++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
+++++++ ModuleGlobalBeginLumi: out
+++++++ ModuleGlobalBeginLumi finished: out
+++++ GlobalBeginLumi finished
+++++ StreamBeginLumi run: 2 lumi: 2 time: 75000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 2 lumi: 2 time: 75000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 2 lumi: 2 time: 75000001
+++++++ ModuleStreamBeginLumi: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++++ ModuleStreamBeginLumi: putInt
+++++++ ModuleStreamBeginLumi finished: putInt
+++++++ ModuleStreamBeginLumi: putInt2
+++++++ ModuleStreamBeginLumi finished: putInt2
+++++++ ModuleStreamBeginLumi: putInt3
+++++++ ModuleStreamBeginLumi finished: putInt3
+++++++ ModuleStreamBeginLumi: getInt
+++++++ ModuleStreamBeginLumi finished: getInt
+++++++ ModuleStreamBeginLumi: noPut
+++++++ ModuleStreamBeginLumi finished: noPut
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 2 lumi: 2 time: 75000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 2 lumi: 2 time: 75000001
+++++++ ModuleStreamBeginLumi: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi: test
+++++++ ModuleStreamBeginLumi finished: test
+++++++ ModuleStreamBeginLumi: testmerge
+++++++ ModuleStreamBeginLumi finished: testmerge
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++++ ModuleStreamBeginLumi: getInt
+++++++ ModuleStreamBeginLumi finished: getInt
+++++++ ModuleStreamBeginLumi: dependsOnNoPut
+++++++ ModuleStreamBeginLumi finished: dependsOnNoPut
+++++++ ModuleStreamBeginLumi: out
+++++++ ModuleStreamBeginLumi finished: out
+++++ StreamBeginLumi finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 2 lumi: 2 event: 5 time:75000001
+++++ event finished
+++++ processing event run: 2 lumi: 2 event: 5 time:75000001
+++++ event finished
+++++ processing event run: 2 lumi: 2 event: 5 time:75000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 2 lumi: 2 event: 5 time:75000001
+++++ event finished
+++++ processing event run: 2 lumi: 2 event: 5 time:75000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 2 lumi: 2 event: 6 time:80000001
+++++ event finished
+++++ processing event run: 2 lumi: 2 event: 6 time:80000001
+++++ event finished
+++++ processing event run: 2 lumi: 2 event: 6 time:80000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 2 lumi: 2 event: 6 time:80000001
+++++ event finished
+++++ processing event run: 2 lumi: 2 event: 6 time:80000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 2 lumi: 2 event: 7 time:85000001
+++++ event finished
+++++ processing event run: 2 lumi: 2 event: 7 time:85000001
+++++ event finished
+++++ processing event run: 2 lumi: 2 event: 7 time:85000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 2 lumi: 2 event: 7 time:85000001
+++++ event finished
+++++ processing event run: 2 lumi: 2 event: 7 time:85000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 2 lumi: 2 event: 8 time:90000001
+++++ event finished
+++++ processing event run: 2 lumi: 2 event: 8 time:90000001
+++++ event finished
+++++ processing event run: 2 lumi: 2 event: 8 time:90000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 2 lumi: 2 event: 8 time:90000001
+++++ event finished
+++++ processing event run: 2 lumi: 2 event: 8 time:90000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ StreamEndLumi run: 2 lumi: 2 time: 90000001
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 2 lumi: 2 time: 0
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 2 lumi: 2 time: 0
+++++++ ModuleStreamEndLumi: thingWithMergeProducer
+++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++++ ModuleStreamEndLumi: putInt
+++++++ ModuleStreamEndLumi finished: putInt
+++++++ ModuleStreamEndLumi: putInt2
+++++++ ModuleStreamEndLumi finished: putInt2
+++++++ ModuleStreamEndLumi: putInt3
+++++++ ModuleStreamEndLumi finished: putInt3
+++++++ ModuleStreamEndLumi: getInt
+++++++ ModuleStreamEndLumi finished: getInt
+++++++ ModuleStreamEndLumi: noPut
+++++++ ModuleStreamEndLumi finished: noPut
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 2 lumi: 2 time: 0
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 2 lumi: 2 time: 0
+++++++ ModuleStreamEndLumi: thingWithMergeProducer
+++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
+++++++ ModuleStreamEndLumi: test
+++++++ ModuleStreamEndLumi finished: test
+++++++ ModuleStreamEndLumi: testmerge
+++++++ ModuleStreamEndLumi finished: testmerge
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++++ ModuleStreamEndLumi: getInt
+++++++ ModuleStreamEndLumi finished: getInt
+++++++ ModuleStreamEndLumi: dependsOnNoPut
+++++++ ModuleStreamEndLumi finished: dependsOnNoPut
+++++++ ModuleStreamEndLumi: out
+++++++ ModuleStreamEndLumi finished: out
+++++ StreamEndLumi finished
+++++ GlobalEndLumi run: 2 lumi: 2 time: 75000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 2 lumi: 2 time: 75000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 2 lumi: 2 time: 75000001
+++++++ ModuleGlobalEndLumi: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: putInt
+++++++ ModuleGlobalEndLumi finished: putInt
+++++++ ModuleGlobalEndLumi: putInt2
+++++++ ModuleGlobalEndLumi finished: putInt2
+++++++ ModuleGlobalEndLumi: putInt3
+++++++ ModuleGlobalEndLumi finished: putInt3
+++++++ ModuleGlobalEndLumi: getInt
+++++++ ModuleGlobalEndLumi finished: getInt
+++++++ ModuleGlobalEndLumi: noPut
+++++++ ModuleGlobalEndLumi finished: noPut
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 2 lumi: 2 time: 75000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 2 lumi: 2 time: 75000001
+++++++ ModuleGlobalEndLumi: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi: test
+++++++ ModuleGlobalEndLumi finished: test
+++++++ ModuleGlobalEndLumi: testmerge
+++++++ ModuleGlobalEndLumi finished: testmerge
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: getInt
+++++++ ModuleGlobalEndLumi finished: getInt
+++++++ ModuleGlobalEndLumi: dependsOnNoPut
+++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
+++++++ ModuleGlobalEndLumi: out
+++++++ ModuleGlobalEndLumi finished: out
+++++ GlobalEndLumi finished
+++++ source lumi
+++++ finished: source lumi
+++++ GlobalBeginLumi run: 2 lumi: 3 time: 95000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 2 lumi: 3 time: 95000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 2 lumi: 3 time: 95000001
+++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: putInt
+++++++ ModuleGlobalBeginLumi finished: putInt
+++++++ ModuleGlobalBeginLumi: putInt2
+++++++ ModuleGlobalBeginLumi finished: putInt2
+++++++ ModuleGlobalBeginLumi: putInt3
+++++++ ModuleGlobalBeginLumi finished: putInt3
+++++++ ModuleGlobalBeginLumi: getInt
+++++++ ModuleGlobalBeginLumi finished: getInt
+++++++ ModuleGlobalBeginLumi: noPut
+++++++ ModuleGlobalBeginLumi finished: noPut
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 2 lumi: 3 time: 95000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 2 lumi: 3 time: 95000001
+++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi: test
+++++++ ModuleGlobalBeginLumi finished: test
+++++++ ModuleGlobalBeginLumi: testmerge
+++++++ ModuleGlobalBeginLumi finished: testmerge
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: getInt
+++++++ ModuleGlobalBeginLumi finished: getInt
+++++++ ModuleGlobalBeginLumi: dependsOnNoPut
+++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
+++++++ ModuleGlobalBeginLumi: out
+++++++ ModuleGlobalBeginLumi finished: out
+++++ GlobalBeginLumi finished
+++++ StreamBeginLumi run: 2 lumi: 3 time: 95000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 2 lumi: 3 time: 95000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 2 lumi: 3 time: 95000001
+++++++ ModuleStreamBeginLumi: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++++ ModuleStreamBeginLumi: putInt
+++++++ ModuleStreamBeginLumi finished: putInt
+++++++ ModuleStreamBeginLumi: putInt2
+++++++ ModuleStreamBeginLumi finished: putInt2
+++++++ ModuleStreamBeginLumi: putInt3
+++++++ ModuleStreamBeginLumi finished: putInt3
+++++++ ModuleStreamBeginLumi: getInt
+++++++ ModuleStreamBeginLumi finished: getInt
+++++++ ModuleStreamBeginLumi: noPut
+++++++ ModuleStreamBeginLumi finished: noPut
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 2 lumi: 3 time: 95000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 2 lumi: 3 time: 95000001
+++++++ ModuleStreamBeginLumi: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi: test
+++++++ ModuleStreamBeginLumi finished: test
+++++++ ModuleStreamBeginLumi: testmerge
+++++++ ModuleStreamBeginLumi finished: testmerge
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++++ ModuleStreamBeginLumi: getInt
+++++++ ModuleStreamBeginLumi finished: getInt
+++++++ ModuleStreamBeginLumi: dependsOnNoPut
+++++++ ModuleStreamBeginLumi finished: dependsOnNoPut
+++++++ ModuleStreamBeginLumi: out
+++++++ ModuleStreamBeginLumi finished: out
+++++ StreamBeginLumi finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 2 lumi: 3 event: 9 time:95000001
+++++ event finished
+++++ processing event run: 2 lumi: 3 event: 9 time:95000001
+++++ event finished
+++++ processing event run: 2 lumi: 3 event: 9 time:95000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 2 lumi: 3 event: 9 time:95000001
+++++ event finished
+++++ processing event run: 2 lumi: 3 event: 9 time:95000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 2 lumi: 3 event: 10 time:100000001
+++++ event finished
+++++ processing event run: 2 lumi: 3 event: 10 time:100000001
+++++ event finished
+++++ processing event run: 2 lumi: 3 event: 10 time:100000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 2 lumi: 3 event: 10 time:100000001
+++++ event finished
+++++ processing event run: 2 lumi: 3 event: 10 time:100000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ StreamEndLumi run: 2 lumi: 3 time: 100000001
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 2 lumi: 3 time: 0
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 2 lumi: 3 time: 0
+++++++ ModuleStreamEndLumi: thingWithMergeProducer
+++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++++ ModuleStreamEndLumi: putInt
+++++++ ModuleStreamEndLumi finished: putInt
+++++++ ModuleStreamEndLumi: putInt2
+++++++ ModuleStreamEndLumi finished: putInt2
+++++++ ModuleStreamEndLumi: putInt3
+++++++ ModuleStreamEndLumi finished: putInt3
+++++++ ModuleStreamEndLumi: getInt
+++++++ ModuleStreamEndLumi finished: getInt
+++++++ ModuleStreamEndLumi: noPut
+++++++ ModuleStreamEndLumi finished: noPut
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 2 lumi: 3 time: 0
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 2 lumi: 3 time: 0
+++++++ ModuleStreamEndLumi: thingWithMergeProducer
+++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
+++++++ ModuleStreamEndLumi: test
+++++++ ModuleStreamEndLumi finished: test
+++++++ ModuleStreamEndLumi: testmerge
+++++++ ModuleStreamEndLumi finished: testmerge
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++++ ModuleStreamEndLumi: getInt
+++++++ ModuleStreamEndLumi finished: getInt
+++++++ ModuleStreamEndLumi: dependsOnNoPut
+++++++ ModuleStreamEndLumi finished: dependsOnNoPut
+++++++ ModuleStreamEndLumi: out
+++++++ ModuleStreamEndLumi finished: out
+++++ StreamEndLumi finished
+++++ GlobalEndLumi run: 2 lumi: 3 time: 95000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 2 lumi: 3 time: 95000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 2 lumi: 3 time: 95000001
+++++++ ModuleGlobalEndLumi: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: putInt
+++++++ ModuleGlobalEndLumi finished: putInt
+++++++ ModuleGlobalEndLumi: putInt2
+++++++ ModuleGlobalEndLumi finished: putInt2
+++++++ ModuleGlobalEndLumi: putInt3
+++++++ ModuleGlobalEndLumi finished: putInt3
+++++++ ModuleGlobalEndLumi: getInt
+++++++ ModuleGlobalEndLumi finished: getInt
+++++++ ModuleGlobalEndLumi: noPut
+++++++ ModuleGlobalEndLumi finished: noPut
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 2 lumi: 3 time: 95000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 2 lumi: 3 time: 95000001
+++++++ ModuleGlobalEndLumi: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi: test
+++++++ ModuleGlobalEndLumi finished: test
+++++++ ModuleGlobalEndLumi: testmerge
+++++++ ModuleGlobalEndLumi finished: testmerge
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: getInt
+++++++ ModuleGlobalEndLumi finished: getInt
+++++++ ModuleGlobalEndLumi: dependsOnNoPut
+++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
+++++++ ModuleGlobalEndLumi: out
+++++++ ModuleGlobalEndLumi finished: out
+++++ GlobalEndLumi finished
+++++ StreamEndRun run: 2 time: 100000001
+++++ StreamEndRun finished
+++++ StreamEndRun run: 2 time: 0
+++++ StreamEndRun finished
+++++ StreamEndRun run: 2 time: 0
+++++++ ModuleStreamEndRun: thingWithMergeProducer
+++++++ ModuleStreamEndRun finished: thingWithMergeProducer
+++++++ ModuleStreamEndRun: get
+++++++ ModuleStreamEndRun finished: get
+++++++ ModuleStreamEndRun: putInt
+++++++ ModuleStreamEndRun finished: putInt
+++++++ ModuleStreamEndRun: putInt2
+++++++ ModuleStreamEndRun finished: putInt2
+++++++ ModuleStreamEndRun: putInt3
+++++++ ModuleStreamEndRun finished: putInt3
+++++++ ModuleStreamEndRun: getInt
+++++++ ModuleStreamEndRun finished: getInt
+++++++ ModuleStreamEndRun: noPut
+++++++ ModuleStreamEndRun finished: noPut
+++++ StreamEndRun finished
+++++ StreamEndRun run: 2 time: 0
+++++ StreamEndRun finished
+++++ StreamEndRun run: 2 time: 0
+++++++ ModuleStreamEndRun: thingWithMergeProducer
+++++++ ModuleStreamEndRun finished: thingWithMergeProducer
+++++++ ModuleStreamEndRun: test
+++++++ ModuleStreamEndRun finished: test
+++++++ ModuleStreamEndRun: testmerge
+++++++ ModuleStreamEndRun finished: testmerge
+++++++ ModuleStreamEndRun: get
+++++++ ModuleStreamEndRun finished: get
+++++++ ModuleStreamEndRun: getInt
+++++++ ModuleStreamEndRun finished: getInt
+++++++ ModuleStreamEndRun: dependsOnNoPut
+++++++ ModuleStreamEndRun finished: dependsOnNoPut
+++++++ ModuleStreamEndRun: out
+++++++ ModuleStreamEndRun finished: out
+++++ StreamEndRun finished
+++++ GlobalEndRun run: 2 time: 100000001
+++++ GlobalEndRun finished
+++++ GlobalEndRun run: 2 time: 0
+++++ GlobalEndRun finished
+++++ GlobalEndRun run: 2 time: 0
+++++++ ModuleGlobalEndRun: thingWithMergeProducer
+++++++ ModuleGlobalEndRun finished: thingWithMergeProducer
+++++++ ModuleGlobalEndRun: get
+++++++ ModuleGlobalEndRun finished: get
+++++++ ModuleGlobalEndRun: putInt
+++++++ ModuleGlobalEndRun finished: putInt
+++++++ ModuleGlobalEndRun: putInt2
+++++++ ModuleGlobalEndRun finished: putInt2
+++++++ ModuleGlobalEndRun: putInt3
+++++++ ModuleGlobalEndRun finished: putInt3
+++++++ ModuleGlobalEndRun: getInt
+++++++ ModuleGlobalEndRun finished: getInt
+++++++ ModuleGlobalEndRun: noPut
+++++++ ModuleGlobalEndRun finished: noPut
+++++ GlobalEndRun finished
+++++ GlobalEndRun run: 2 time: 0
+++++ GlobalEndRun finished
+++++ GlobalEndRun run: 2 time: 0
+++++++ ModuleGlobalEndRun: thingWithMergeProducer
+++++++ ModuleGlobalEndRun finished: thingWithMergeProducer
+++++++ ModuleGlobalEndRun: test
+++++++ ModuleGlobalEndRun finished: test
+++++++ ModuleGlobalEndRun: testmerge
+++++++ ModuleGlobalEndRun finished: testmerge
+++++++ ModuleGlobalEndRun: get
+++++++ ModuleGlobalEndRun finished: get
+++++++ ModuleGlobalEndRun: getInt
+++++++ ModuleGlobalEndRun finished: getInt
+++++++ ModuleGlobalEndRun: dependsOnNoPut
+++++++ ModuleGlobalEndRun finished: dependsOnNoPut
+++++++ ModuleGlobalEndRun: out
+++++++ ModuleGlobalEndRun finished: out
+++++ GlobalEndRun finished
+++++ source run
+++++ finished: source run
+++++ GlobalBeginRun run: 3 time: 105000001
+++++ GlobalBeginRun finished
+++++ GlobalBeginRun run: 3 time: 105000001
+++++ GlobalBeginRun finished
+++++ GlobalBeginRun run: 3 time: 105000001
+++++++ ModuleGlobalBeginRun: thingWithMergeProducer
+++++++ ModuleGlobalBeginRun finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginRun: get
+++++++ ModuleGlobalBeginRun finished: get
+++++++ ModuleGlobalBeginRun: putInt
+++++++ ModuleGlobalBeginRun finished: putInt
+++++++ ModuleGlobalBeginRun: putInt2
+++++++ ModuleGlobalBeginRun finished: putInt2
+++++++ ModuleGlobalBeginRun: putInt3
+++++++ ModuleGlobalBeginRun finished: putInt3
+++++++ ModuleGlobalBeginRun: getInt
+++++++ ModuleGlobalBeginRun finished: getInt
+++++++ ModuleGlobalBeginRun: noPut
+++++++ ModuleGlobalBeginRun finished: noPut
+++++ GlobalBeginRun finished
+++++ GlobalBeginRun run: 3 time: 105000001
+++++ GlobalBeginRun finished
+++++ GlobalBeginRun run: 3 time: 105000001
+++++++ ModuleGlobalBeginRun: thingWithMergeProducer
+++++++ ModuleGlobalBeginRun finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginRun: test
+++++++ ModuleGlobalBeginRun finished: test
+++++++ ModuleGlobalBeginRun: testmerge
+++++++ ModuleGlobalBeginRun finished: testmerge
+++++++ ModuleGlobalBeginRun: get
+++++++ ModuleGlobalBeginRun finished: get
+++++++ ModuleGlobalBeginRun: getInt
+++++++ ModuleGlobalBeginRun finished: getInt
+++++++ ModuleGlobalBeginRun: dependsOnNoPut
+++++++ ModuleGlobalBeginRun finished: dependsOnNoPut
+++++++ ModuleGlobalBeginRun: out
+++++++ ModuleGlobalBeginRun finished: out
+++++ GlobalBeginRun finished
+++++ StreamBeginRun run: 3 time: 105000001
+++++ StreamBeginRun finished
+++++ StreamBeginRun run: 3 time: 105000001
+++++ StreamBeginRun finished
+++++ StreamBeginRun run: 3 time: 105000001
+++++++ ModuleStreamBeginRun: thingWithMergeProducer
+++++++ ModuleStreamBeginRun finished: thingWithMergeProducer
+++++++ ModuleStreamBeginRun: get
+++++++ ModuleStreamBeginRun finished: get
+++++++ ModuleStreamBeginRun: putInt
+++++++ ModuleStreamBeginRun finished: putInt
+++++++ ModuleStreamBeginRun: putInt2
+++++++ ModuleStreamBeginRun finished: putInt2
+++++++ ModuleStreamBeginRun: putInt3
+++++++ ModuleStreamBeginRun finished: putInt3
+++++++ ModuleStreamBeginRun: getInt
+++++++ ModuleStreamBeginRun finished: getInt
+++++++ ModuleStreamBeginRun: noPut
+++++++ ModuleStreamBeginRun finished: noPut
+++++ StreamBeginRun finished
+++++ StreamBeginRun run: 3 time: 105000001
+++++ StreamBeginRun finished
+++++ StreamBeginRun run: 3 time: 105000001
+++++++ ModuleStreamBeginRun: thingWithMergeProducer
+++++++ ModuleStreamBeginRun finished: thingWithMergeProducer
+++++++ ModuleStreamBeginRun: test
+++++++ ModuleStreamBeginRun finished: test
+++++++ ModuleStreamBeginRun: testmerge
+++++++ ModuleStreamBeginRun finished: testmerge
+++++++ ModuleStreamBeginRun: get
+++++++ ModuleStreamBeginRun finished: get
+++++++ ModuleStreamBeginRun: getInt
+++++++ ModuleStreamBeginRun finished: getInt
+++++++ ModuleStreamBeginRun: dependsOnNoPut
+++++++ ModuleStreamBeginRun finished: dependsOnNoPut
+++++++ ModuleStreamBeginRun: out
+++++++ ModuleStreamBeginRun finished: out
+++++ StreamBeginRun finished
+++++ source lumi
+++++ finished: source lumi
+++++ GlobalBeginLumi run: 3 lumi: 1 time: 105000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 3 lumi: 1 time: 105000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 3 lumi: 1 time: 105000001
+++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: putInt
+++++++ ModuleGlobalBeginLumi finished: putInt
+++++++ ModuleGlobalBeginLumi: putInt2
+++++++ ModuleGlobalBeginLumi finished: putInt2
+++++++ ModuleGlobalBeginLumi: putInt3
+++++++ ModuleGlobalBeginLumi finished: putInt3
+++++++ ModuleGlobalBeginLumi: getInt
+++++++ ModuleGlobalBeginLumi finished: getInt
+++++++ ModuleGlobalBeginLumi: noPut
+++++++ ModuleGlobalBeginLumi finished: noPut
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 3 lumi: 1 time: 105000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 3 lumi: 1 time: 105000001
+++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi: test
+++++++ ModuleGlobalBeginLumi finished: test
+++++++ ModuleGlobalBeginLumi: testmerge
+++++++ ModuleGlobalBeginLumi finished: testmerge
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: getInt
+++++++ ModuleGlobalBeginLumi finished: getInt
+++++++ ModuleGlobalBeginLumi: dependsOnNoPut
+++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
+++++++ ModuleGlobalBeginLumi: out
+++++++ ModuleGlobalBeginLumi finished: out
+++++ GlobalBeginLumi finished
+++++ StreamBeginLumi run: 3 lumi: 1 time: 105000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 3 lumi: 1 time: 105000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 3 lumi: 1 time: 105000001
+++++++ ModuleStreamBeginLumi: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++++ ModuleStreamBeginLumi: putInt
+++++++ ModuleStreamBeginLumi finished: putInt
+++++++ ModuleStreamBeginLumi: putInt2
+++++++ ModuleStreamBeginLumi finished: putInt2
+++++++ ModuleStreamBeginLumi: putInt3
+++++++ ModuleStreamBeginLumi finished: putInt3
+++++++ ModuleStreamBeginLumi: getInt
+++++++ ModuleStreamBeginLumi finished: getInt
+++++++ ModuleStreamBeginLumi: noPut
+++++++ ModuleStreamBeginLumi finished: noPut
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 3 lumi: 1 time: 105000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 3 lumi: 1 time: 105000001
+++++++ ModuleStreamBeginLumi: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi: test
+++++++ ModuleStreamBeginLumi finished: test
+++++++ ModuleStreamBeginLumi: testmerge
+++++++ ModuleStreamBeginLumi finished: testmerge
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++++ ModuleStreamBeginLumi: getInt
+++++++ ModuleStreamBeginLumi finished: getInt
+++++++ ModuleStreamBeginLumi: dependsOnNoPut
+++++++ ModuleStreamBeginLumi finished: dependsOnNoPut
+++++++ ModuleStreamBeginLumi: out
+++++++ ModuleStreamBeginLumi finished: out
+++++ StreamBeginLumi finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 3 lumi: 1 event: 1 time:105000001
+++++ event finished
+++++ processing event run: 3 lumi: 1 event: 1 time:105000001
+++++ event finished
+++++ processing event run: 3 lumi: 1 event: 1 time:105000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 3 lumi: 1 event: 1 time:105000001
+++++ event finished
+++++ processing event run: 3 lumi: 1 event: 1 time:105000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 3 lumi: 1 event: 2 time:110000001
+++++ event finished
+++++ processing event run: 3 lumi: 1 event: 2 time:110000001
+++++ event finished
+++++ processing event run: 3 lumi: 1 event: 2 time:110000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 3 lumi: 1 event: 2 time:110000001
+++++ event finished
+++++ processing event run: 3 lumi: 1 event: 2 time:110000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 3 lumi: 1 event: 3 time:115000001
+++++ event finished
+++++ processing event run: 3 lumi: 1 event: 3 time:115000001
+++++ event finished
+++++ processing event run: 3 lumi: 1 event: 3 time:115000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 3 lumi: 1 event: 3 time:115000001
+++++ event finished
+++++ processing event run: 3 lumi: 1 event: 3 time:115000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 3 lumi: 1 event: 4 time:120000001
+++++ event finished
+++++ processing event run: 3 lumi: 1 event: 4 time:120000001
+++++ event finished
+++++ processing event run: 3 lumi: 1 event: 4 time:120000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 3 lumi: 1 event: 4 time:120000001
+++++ event finished
+++++ processing event run: 3 lumi: 1 event: 4 time:120000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ StreamEndLumi run: 3 lumi: 1 time: 120000001
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 3 lumi: 1 time: 0
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 3 lumi: 1 time: 0
+++++++ ModuleStreamEndLumi: thingWithMergeProducer
+++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++++ ModuleStreamEndLumi: putInt
+++++++ ModuleStreamEndLumi finished: putInt
+++++++ ModuleStreamEndLumi: putInt2
+++++++ ModuleStreamEndLumi finished: putInt2
+++++++ ModuleStreamEndLumi: putInt3
+++++++ ModuleStreamEndLumi finished: putInt3
+++++++ ModuleStreamEndLumi: getInt
+++++++ ModuleStreamEndLumi finished: getInt
+++++++ ModuleStreamEndLumi: noPut
+++++++ ModuleStreamEndLumi finished: noPut
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 3 lumi: 1 time: 0
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 3 lumi: 1 time: 0
+++++++ ModuleStreamEndLumi: thingWithMergeProducer
+++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
+++++++ ModuleStreamEndLumi: test
+++++++ ModuleStreamEndLumi finished: test
+++++++ ModuleStreamEndLumi: testmerge
+++++++ ModuleStreamEndLumi finished: testmerge
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++++ ModuleStreamEndLumi: getInt
+++++++ ModuleStreamEndLumi finished: getInt
+++++++ ModuleStreamEndLumi: dependsOnNoPut
+++++++ ModuleStreamEndLumi finished: dependsOnNoPut
+++++++ ModuleStreamEndLumi: out
+++++++ ModuleStreamEndLumi finished: out
+++++ StreamEndLumi finished
+++++ GlobalEndLumi run: 3 lumi: 1 time: 105000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 3 lumi: 1 time: 105000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 3 lumi: 1 time: 105000001
+++++++ ModuleGlobalEndLumi: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: putInt
+++++++ ModuleGlobalEndLumi finished: putInt
+++++++ ModuleGlobalEndLumi: putInt2
+++++++ ModuleGlobalEndLumi finished: putInt2
+++++++ ModuleGlobalEndLumi: putInt3
+++++++ ModuleGlobalEndLumi finished: putInt3
+++++++ ModuleGlobalEndLumi: getInt
+++++++ ModuleGlobalEndLumi finished: getInt
+++++++ ModuleGlobalEndLumi: noPut
+++++++ ModuleGlobalEndLumi finished: noPut
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 3 lumi: 1 time: 105000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 3 lumi: 1 time: 105000001
+++++++ ModuleGlobalEndLumi: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi: test
+++++++ ModuleGlobalEndLumi finished: test
+++++++ ModuleGlobalEndLumi: testmerge
+++++++ ModuleGlobalEndLumi finished: testmerge
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: getInt
+++++++ ModuleGlobalEndLumi finished: getInt
+++++++ ModuleGlobalEndLumi: dependsOnNoPut
+++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
+++++++ ModuleGlobalEndLumi: out
+++++++ ModuleGlobalEndLumi finished: out
+++++ GlobalEndLumi finished
+++++ source lumi
+++++ finished: source lumi
+++++ GlobalBeginLumi run: 3 lumi: 2 time: 125000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 3 lumi: 2 time: 125000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 3 lumi: 2 time: 125000001
+++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: putInt
+++++++ ModuleGlobalBeginLumi finished: putInt
+++++++ ModuleGlobalBeginLumi: putInt2
+++++++ ModuleGlobalBeginLumi finished: putInt2
+++++++ ModuleGlobalBeginLumi: putInt3
+++++++ ModuleGlobalBeginLumi finished: putInt3
+++++++ ModuleGlobalBeginLumi: getInt
+++++++ ModuleGlobalBeginLumi finished: getInt
+++++++ ModuleGlobalBeginLumi: noPut
+++++++ ModuleGlobalBeginLumi finished: noPut
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 3 lumi: 2 time: 125000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 3 lumi: 2 time: 125000001
+++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi: test
+++++++ ModuleGlobalBeginLumi finished: test
+++++++ ModuleGlobalBeginLumi: testmerge
+++++++ ModuleGlobalBeginLumi finished: testmerge
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: getInt
+++++++ ModuleGlobalBeginLumi finished: getInt
+++++++ ModuleGlobalBeginLumi: dependsOnNoPut
+++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
+++++++ ModuleGlobalBeginLumi: out
+++++++ ModuleGlobalBeginLumi finished: out
+++++ GlobalBeginLumi finished
+++++ StreamBeginLumi run: 3 lumi: 2 time: 125000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 3 lumi: 2 time: 125000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 3 lumi: 2 time: 125000001
+++++++ ModuleStreamBeginLumi: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++++ ModuleStreamBeginLumi: putInt
+++++++ ModuleStreamBeginLumi finished: putInt
+++++++ ModuleStreamBeginLumi: putInt2
+++++++ ModuleStreamBeginLumi finished: putInt2
+++++++ ModuleStreamBeginLumi: putInt3
+++++++ ModuleStreamBeginLumi finished: putInt3
+++++++ ModuleStreamBeginLumi: getInt
+++++++ ModuleStreamBeginLumi finished: getInt
+++++++ ModuleStreamBeginLumi: noPut
+++++++ ModuleStreamBeginLumi finished: noPut
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 3 lumi: 2 time: 125000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 3 lumi: 2 time: 125000001
+++++++ ModuleStreamBeginLumi: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi: test
+++++++ ModuleStreamBeginLumi finished: test
+++++++ ModuleStreamBeginLumi: testmerge
+++++++ ModuleStreamBeginLumi finished: testmerge
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++++ ModuleStreamBeginLumi: getInt
+++++++ ModuleStreamBeginLumi finished: getInt
+++++++ ModuleStreamBeginLumi: dependsOnNoPut
+++++++ ModuleStreamBeginLumi finished: dependsOnNoPut
+++++++ ModuleStreamBeginLumi: out
+++++++ ModuleStreamBeginLumi finished: out
+++++ StreamBeginLumi finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 3 lumi: 2 event: 5 time:125000001
+++++ event finished
+++++ processing event run: 3 lumi: 2 event: 5 time:125000001
+++++ event finished
+++++ processing event run: 3 lumi: 2 event: 5 time:125000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 3 lumi: 2 event: 5 time:125000001
+++++ event finished
+++++ processing event run: 3 lumi: 2 event: 5 time:125000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 3 lumi: 2 event: 6 time:130000001
+++++ event finished
+++++ processing event run: 3 lumi: 2 event: 6 time:130000001
+++++ event finished
+++++ processing event run: 3 lumi: 2 event: 6 time:130000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 3 lumi: 2 event: 6 time:130000001
+++++ event finished
+++++ processing event run: 3 lumi: 2 event: 6 time:130000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 3 lumi: 2 event: 7 time:135000001
+++++ event finished
+++++ processing event run: 3 lumi: 2 event: 7 time:135000001
+++++ event finished
+++++ processing event run: 3 lumi: 2 event: 7 time:135000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 3 lumi: 2 event: 7 time:135000001
+++++ event finished
+++++ processing event run: 3 lumi: 2 event: 7 time:135000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 3 lumi: 2 event: 8 time:140000001
+++++ event finished
+++++ processing event run: 3 lumi: 2 event: 8 time:140000001
+++++ event finished
+++++ processing event run: 3 lumi: 2 event: 8 time:140000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 3 lumi: 2 event: 8 time:140000001
+++++ event finished
+++++ processing event run: 3 lumi: 2 event: 8 time:140000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ StreamEndLumi run: 3 lumi: 2 time: 140000001
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 3 lumi: 2 time: 0
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 3 lumi: 2 time: 0
+++++++ ModuleStreamEndLumi: thingWithMergeProducer
+++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++++ ModuleStreamEndLumi: putInt
+++++++ ModuleStreamEndLumi finished: putInt
+++++++ ModuleStreamEndLumi: putInt2
+++++++ ModuleStreamEndLumi finished: putInt2
+++++++ ModuleStreamEndLumi: putInt3
+++++++ ModuleStreamEndLumi finished: putInt3
+++++++ ModuleStreamEndLumi: getInt
+++++++ ModuleStreamEndLumi finished: getInt
+++++++ ModuleStreamEndLumi: noPut
+++++++ ModuleStreamEndLumi finished: noPut
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 3 lumi: 2 time: 0
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 3 lumi: 2 time: 0
+++++++ ModuleStreamEndLumi: thingWithMergeProducer
+++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
+++++++ ModuleStreamEndLumi: test
+++++++ ModuleStreamEndLumi finished: test
+++++++ ModuleStreamEndLumi: testmerge
+++++++ ModuleStreamEndLumi finished: testmerge
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++++ ModuleStreamEndLumi: getInt
+++++++ ModuleStreamEndLumi finished: getInt
+++++++ ModuleStreamEndLumi: dependsOnNoPut
+++++++ ModuleStreamEndLumi finished: dependsOnNoPut
+++++++ ModuleStreamEndLumi: out
+++++++ ModuleStreamEndLumi finished: out
+++++ StreamEndLumi finished
+++++ GlobalEndLumi run: 3 lumi: 2 time: 125000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 3 lumi: 2 time: 125000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 3 lumi: 2 time: 125000001
+++++++ ModuleGlobalEndLumi: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: putInt
+++++++ ModuleGlobalEndLumi finished: putInt
+++++++ ModuleGlobalEndLumi: putInt2
+++++++ ModuleGlobalEndLumi finished: putInt2
+++++++ ModuleGlobalEndLumi: putInt3
+++++++ ModuleGlobalEndLumi finished: putInt3
+++++++ ModuleGlobalEndLumi: getInt
+++++++ ModuleGlobalEndLumi finished: getInt
+++++++ ModuleGlobalEndLumi: noPut
+++++++ ModuleGlobalEndLumi finished: noPut
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 3 lumi: 2 time: 125000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 3 lumi: 2 time: 125000001
+++++++ ModuleGlobalEndLumi: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi: test
+++++++ ModuleGlobalEndLumi finished: test
+++++++ ModuleGlobalEndLumi: testmerge
+++++++ ModuleGlobalEndLumi finished: testmerge
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: getInt
+++++++ ModuleGlobalEndLumi finished: getInt
+++++++ ModuleGlobalEndLumi: dependsOnNoPut
+++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
+++++++ ModuleGlobalEndLumi: out
+++++++ ModuleGlobalEndLumi finished: out
+++++ GlobalEndLumi finished
+++++ source lumi
+++++ finished: source lumi
+++++ GlobalBeginLumi run: 3 lumi: 3 time: 145000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 3 lumi: 3 time: 145000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 3 lumi: 3 time: 145000001
+++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: putInt
+++++++ ModuleGlobalBeginLumi finished: putInt
+++++++ ModuleGlobalBeginLumi: putInt2
+++++++ ModuleGlobalBeginLumi finished: putInt2
+++++++ ModuleGlobalBeginLumi: putInt3
+++++++ ModuleGlobalBeginLumi finished: putInt3
+++++++ ModuleGlobalBeginLumi: getInt
+++++++ ModuleGlobalBeginLumi finished: getInt
+++++++ ModuleGlobalBeginLumi: noPut
+++++++ ModuleGlobalBeginLumi finished: noPut
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 3 lumi: 3 time: 145000001
+++++ GlobalBeginLumi finished
+++++ GlobalBeginLumi run: 3 lumi: 3 time: 145000001
+++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalBeginLumi: test
+++++++ ModuleGlobalBeginLumi finished: test
+++++++ ModuleGlobalBeginLumi: testmerge
+++++++ ModuleGlobalBeginLumi finished: testmerge
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: getInt
+++++++ ModuleGlobalBeginLumi finished: getInt
+++++++ ModuleGlobalBeginLumi: dependsOnNoPut
+++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
+++++++ ModuleGlobalBeginLumi: out
+++++++ ModuleGlobalBeginLumi finished: out
+++++ GlobalBeginLumi finished
+++++ StreamBeginLumi run: 3 lumi: 3 time: 145000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 3 lumi: 3 time: 145000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 3 lumi: 3 time: 145000001
+++++++ ModuleStreamBeginLumi: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++++ ModuleStreamBeginLumi: putInt
+++++++ ModuleStreamBeginLumi finished: putInt
+++++++ ModuleStreamBeginLumi: putInt2
+++++++ ModuleStreamBeginLumi finished: putInt2
+++++++ ModuleStreamBeginLumi: putInt3
+++++++ ModuleStreamBeginLumi finished: putInt3
+++++++ ModuleStreamBeginLumi: getInt
+++++++ ModuleStreamBeginLumi finished: getInt
+++++++ ModuleStreamBeginLumi: noPut
+++++++ ModuleStreamBeginLumi finished: noPut
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 3 lumi: 3 time: 145000001
+++++ StreamBeginLumi finished
+++++ StreamBeginLumi run: 3 lumi: 3 time: 145000001
+++++++ ModuleStreamBeginLumi: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
+++++++ ModuleStreamBeginLumi: test
+++++++ ModuleStreamBeginLumi finished: test
+++++++ ModuleStreamBeginLumi: testmerge
+++++++ ModuleStreamBeginLumi finished: testmerge
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++++ ModuleStreamBeginLumi: getInt
+++++++ ModuleStreamBeginLumi finished: getInt
+++++++ ModuleStreamBeginLumi: dependsOnNoPut
+++++++ ModuleStreamBeginLumi finished: dependsOnNoPut
+++++++ ModuleStreamBeginLumi: out
+++++++ ModuleStreamBeginLumi finished: out
+++++ StreamBeginLumi finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 3 lumi: 3 event: 9 time:145000001
+++++ event finished
+++++ processing event run: 3 lumi: 3 event: 9 time:145000001
+++++ event finished
+++++ processing event run: 3 lumi: 3 event: 9 time:145000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 3 lumi: 3 event: 9 time:145000001
+++++ event finished
+++++ processing event run: 3 lumi: 3 event: 9 time:145000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 3 lumi: 3 event: 10 time:150000001
+++++ event finished
+++++ processing event run: 3 lumi: 3 event: 10 time:150000001
+++++ event finished
+++++ processing event run: 3 lumi: 3 event: 10 time:150000001
+++++++ processing path for event: p1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: p1
+++++++ processing path for event: path1
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: putInt
+++++++++ finished module for event: putInt
+++++++++ module for event: putInt2
+++++++++ finished module for event: putInt2
+++++++++ module for event: putInt3
+++++++++ finished module for event: putInt3
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: noPut
+++++++++ finished module for event: noPut
+++++++ path for event finished: path2
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ processing event run: 3 lumi: 3 event: 10 time:150000001
+++++ event finished
+++++ processing event run: 3 lumi: 3 event: 10 time:150000001
+++++++ processing path for event: path1
+++++++++ module for event: thingWithMergeProducer
+++++++++ finished module for event: thingWithMergeProducer
+++++++ path for event finished: path1
+++++++ processing path for event: path2
+++++++++ module for event: test
+++++++++ finished module for event: test
+++++++++ module for event: testmerge
+++++++++ finished module for event: testmerge
+++++++ path for event finished: path2
+++++++ processing path for event: path3
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++++ module for event: getInt
+++++++++ finished module for event: getInt
+++++++ path for event finished: path3
+++++++ processing path for event: path4
+++++++++ module for event: dependsOnNoPut
+++++++++ finished module for event: dependsOnNoPut
+++++++ path for event finished: path4
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++++ processing path for event: endPath1
+++++++++ module for event: out
+++++++++ finished module for event: out
+++++++ path for event finished: endPath1
+++++ event finished
+++++ StreamEndLumi run: 3 lumi: 3 time: 150000001
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 3 lumi: 3 time: 0
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 3 lumi: 3 time: 0
+++++++ ModuleStreamEndLumi: thingWithMergeProducer
+++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++++ ModuleStreamEndLumi: putInt
+++++++ ModuleStreamEndLumi finished: putInt
+++++++ ModuleStreamEndLumi: putInt2
+++++++ ModuleStreamEndLumi finished: putInt2
+++++++ ModuleStreamEndLumi: putInt3
+++++++ ModuleStreamEndLumi finished: putInt3
+++++++ ModuleStreamEndLumi: getInt
+++++++ ModuleStreamEndLumi finished: getInt
+++++++ ModuleStreamEndLumi: noPut
+++++++ ModuleStreamEndLumi finished: noPut
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 3 lumi: 3 time: 0
+++++ StreamEndLumi finished
+++++ StreamEndLumi run: 3 lumi: 3 time: 0
+++++++ ModuleStreamEndLumi: thingWithMergeProducer
+++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
+++++++ ModuleStreamEndLumi: test
+++++++ ModuleStreamEndLumi finished: test
+++++++ ModuleStreamEndLumi: testmerge
+++++++ ModuleStreamEndLumi finished: testmerge
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++++ ModuleStreamEndLumi: getInt
+++++++ ModuleStreamEndLumi finished: getInt
+++++++ ModuleStreamEndLumi: dependsOnNoPut
+++++++ ModuleStreamEndLumi finished: dependsOnNoPut
+++++++ ModuleStreamEndLumi: out
+++++++ ModuleStreamEndLumi finished: out
+++++ StreamEndLumi finished
+++++ GlobalEndLumi run: 3 lumi: 3 time: 145000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 3 lumi: 3 time: 145000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 3 lumi: 3 time: 145000001
+++++++ ModuleGlobalEndLumi: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: putInt
+++++++ ModuleGlobalEndLumi finished: putInt
+++++++ ModuleGlobalEndLumi: putInt2
+++++++ ModuleGlobalEndLumi finished: putInt2
+++++++ ModuleGlobalEndLumi: putInt3
+++++++ ModuleGlobalEndLumi finished: putInt3
+++++++ ModuleGlobalEndLumi: getInt
+++++++ ModuleGlobalEndLumi finished: getInt
+++++++ ModuleGlobalEndLumi: noPut
+++++++ ModuleGlobalEndLumi finished: noPut
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 3 lumi: 3 time: 145000001
+++++ GlobalEndLumi finished
+++++ GlobalEndLumi run: 3 lumi: 3 time: 145000001
+++++++ ModuleGlobalEndLumi: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
+++++++ ModuleGlobalEndLumi: test
+++++++ ModuleGlobalEndLumi finished: test
+++++++ ModuleGlobalEndLumi: testmerge
+++++++ ModuleGlobalEndLumi finished: testmerge
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: getInt
+++++++ ModuleGlobalEndLumi finished: getInt
+++++++ ModuleGlobalEndLumi: dependsOnNoPut
+++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
+++++++ ModuleGlobalEndLumi: out
+++++++ ModuleGlobalEndLumi finished: out
+++++ GlobalEndLumi finished
+++++ StreamEndRun run: 3 time: 150000001
+++++ StreamEndRun finished
+++++ StreamEndRun run: 3 time: 0
+++++ StreamEndRun finished
+++++ StreamEndRun run: 3 time: 0
+++++++ ModuleStreamEndRun: thingWithMergeProducer
+++++++ ModuleStreamEndRun finished: thingWithMergeProducer
+++++++ ModuleStreamEndRun: get
+++++++ ModuleStreamEndRun finished: get
+++++++ ModuleStreamEndRun: putInt
+++++++ ModuleStreamEndRun finished: putInt
+++++++ ModuleStreamEndRun: putInt2
+++++++ ModuleStreamEndRun finished: putInt2
+++++++ ModuleStreamEndRun: putInt3
+++++++ ModuleStreamEndRun finished: putInt3
+++++++ ModuleStreamEndRun: getInt
+++++++ ModuleStreamEndRun finished: getInt
+++++++ ModuleStreamEndRun: noPut
+++++++ ModuleStreamEndRun finished: noPut
+++++ StreamEndRun finished
+++++ StreamEndRun run: 3 time: 0
+++++ StreamEndRun finished
+++++ StreamEndRun run: 3 time: 0
+++++++ ModuleStreamEndRun: thingWithMergeProducer
+++++++ ModuleStreamEndRun finished: thingWithMergeProducer
+++++++ ModuleStreamEndRun: test
+++++++ ModuleStreamEndRun finished: test
+++++++ ModuleStreamEndRun: testmerge
+++++++ ModuleStreamEndRun finished: testmerge
+++++++ ModuleStreamEndRun: get
+++++++ ModuleStreamEndRun finished: get
+++++++ ModuleStreamEndRun: getInt
+++++++ ModuleStreamEndRun finished: getInt
+++++++ ModuleStreamEndRun: dependsOnNoPut
+++++++ ModuleStreamEndRun finished: dependsOnNoPut
+++++++ ModuleStreamEndRun: out
+++++++ ModuleStreamEndRun finished: out
+++++ StreamEndRun finished
+++++ GlobalEndRun run: 3 time: 150000001
+++++ GlobalEndRun finished
+++++ GlobalEndRun run: 3 time: 0
+++++ GlobalEndRun finished
+++++ GlobalEndRun run: 3 time: 0
+++++++ ModuleGlobalEndRun: thingWithMergeProducer
+++++++ ModuleGlobalEndRun finished: thingWithMergeProducer
+++++++ ModuleGlobalEndRun: get
+++++++ ModuleGlobalEndRun finished: get
+++++++ ModuleGlobalEndRun: putInt
+++++++ ModuleGlobalEndRun finished: putInt
+++++++ ModuleGlobalEndRun: putInt2
+++++++ ModuleGlobalEndRun finished: putInt2
+++++++ ModuleGlobalEndRun: putInt3
+++++++ ModuleGlobalEndRun finished: putInt3
+++++++ ModuleGlobalEndRun: getInt
+++++++ ModuleGlobalEndRun finished: getInt
+++++++ ModuleGlobalEndRun: noPut
+++++++ ModuleGlobalEndRun finished: noPut
+++++ GlobalEndRun finished
+++++ GlobalEndRun run: 3 time: 0
+++++ GlobalEndRun finished
+++++ GlobalEndRun run: 3 time: 0
+++++++ ModuleGlobalEndRun: thingWithMergeProducer
+++++++ ModuleGlobalEndRun finished: thingWithMergeProducer
+++++++ ModuleGlobalEndRun: test
+++++++ ModuleGlobalEndRun finished: test
+++++++ ModuleGlobalEndRun: testmerge
+++++++ ModuleGlobalEndRun finished: testmerge
+++++++ ModuleGlobalEndRun: get
+++++++ ModuleGlobalEndRun finished: get
+++++++ ModuleGlobalEndRun: getInt
+++++++ ModuleGlobalEndRun finished: getInt
+++++++ ModuleGlobalEndRun: dependsOnNoPut
+++++++ ModuleGlobalEndRun finished: dependsOnNoPut
+++++++ ModuleGlobalEndRun: out
+++++++ ModuleGlobalEndRun finished: out
+++++ GlobalEndRun finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++ ModuleEndJob: thingWithMergeProducer
+++ ModuleEndJob finished: thingWithMergeProducer
+++ ModuleEndJob: get
+++ ModuleEndJob finished: get
+++ ModuleEndJob: putInt
+++ ModuleEndJob finished: putInt
+++ ModuleEndJob: putInt2
+++ ModuleEndJob finished: putInt2
+++ ModuleEndJob: putInt3
+++ ModuleEndJob finished: putInt3
+++ ModuleEndJob: getInt
+++ ModuleEndJob finished: getInt
+++ ModuleEndJob: noPut
+++ ModuleEndJob finished: noPut
+++ ModuleEndJob: TriggerResults
+++ ModuleEndJob finished: TriggerResults
+++ ModuleEndJob: thingWithMergeProducer
+++ ModuleEndJob finished: thingWithMergeProducer
+++ ModuleEndJob: test
+++ ModuleEndJob finished: test
+++ ModuleEndJob: testmerge
+++ ModuleEndJob finished: testmerge
+++ ModuleEndJob: get
+++ ModuleEndJob finished: get
+++ ModuleEndJob: getInt
+++ ModuleEndJob finished: getInt
+++ ModuleEndJob: dependsOnNoPut
+++ ModuleEndJob finished: dependsOnNoPut
+++ ModuleEndJob: TriggerResults
+++ ModuleEndJob finished: TriggerResults
+++ ModuleEndJob: out
+++ ModuleEndJob finished: out
+++ Job ended

--- a/FWCore/MessageService/interface/MessageLogger.h
+++ b/FWCore/MessageService/interface/MessageLogger.h
@@ -56,9 +56,9 @@ public:
   void  preSource  ();
   void  postSource ();
 
-  void  preFile       ();
+  void  preFile       ( std::string const &, bool );
   void  preFileClose  ( std::string const&, bool );
-  void  postFile      ();
+  void  postFile      ( std::string const &, bool );
 
   void  preModuleConstruction ( ModuleDescription const & );
   void  postModuleConstruction( ModuleDescription const & );

--- a/FWCore/MessageService/src/MessageLogger.cc
+++ b/FWCore/MessageService/src/MessageLogger.cc
@@ -540,11 +540,11 @@ MessageLogger::preSource()
 void MessageLogger::postSource()
 { unEstablish("AfterSource"); }
 
-void MessageLogger::preFile()
+void MessageLogger::preFile( std::string const &, bool )
 {  establish("file_open"); }
 void MessageLogger::preFileClose( std::string const &, bool )
 {  establish("file_close"); }
-void MessageLogger::postFile()
+void MessageLogger::postFile( std::string const &, bool )
 { unEstablish("AfterFile"); }
 
 

--- a/FWCore/Modules/src/AsciiOutputModule.cc
+++ b/FWCore/Modules/src/AsciiOutputModule.cc
@@ -24,9 +24,9 @@ namespace edm {
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
   private:
-    virtual void write(EventPrincipal const& e);
-    virtual void writeLuminosityBlock(LuminosityBlockPrincipal const&){}
-    virtual void writeRun(RunPrincipal const&){}
+    virtual void write(EventPrincipal const& e, ModuleCallingContext const*) override;
+    virtual void writeLuminosityBlock(LuminosityBlockPrincipal const&, ModuleCallingContext const*) override {}
+    virtual void writeRun(RunPrincipal const&, ModuleCallingContext const*) override {}
     int prescale_;
     int verbosity_;
     int counter_;
@@ -45,7 +45,7 @@ namespace edm {
   }
 
   void
-  AsciiOutputModule::write(EventPrincipal const& e) {
+  AsciiOutputModule::write(EventPrincipal const& e, ModuleCallingContext const*) {
 
     if ((++counter_ % prescale_) != 0 || verbosity_ <= 0) return;
 

--- a/FWCore/Modules/src/GetProductCheckerOutputModule.cc
+++ b/FWCore/Modules/src/GetProductCheckerOutputModule.cc
@@ -27,7 +27,9 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 namespace edm {
+   class ModuleCallingContext;
    class ParameterSet;
+
    class GetProductCheckerOutputModule : public OutputModule {
    public:
       // We do not take ownership of passed stream.
@@ -36,9 +38,9 @@ namespace edm {
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void write(EventPrincipal const& e);
-      virtual void writeLuminosityBlock(LuminosityBlockPrincipal const&);
-      virtual void writeRun(RunPrincipal const&);
+      virtual void write(EventPrincipal const& e, edm::ModuleCallingContext const*) override;
+      virtual void writeLuminosityBlock(LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*) override;
+      virtual void writeRun(RunPrincipal const&, edm::ModuleCallingContext const*) override;
    };
 
 //
@@ -77,7 +79,7 @@ namespace edm {
 //
 // member functions
 //
-   static void check(Principal const& p, std::string const& id) {
+   static void check(Principal const& p, std::string const& id, edm::ModuleCallingContext const* mcc) {
       for(Principal::const_iterator it = p.begin(), itEnd = p.end();
           it != itEnd;
           ++it) {
@@ -85,7 +87,7 @@ namespace edm {
            if (!(*it)->singleProduct()) continue;
 
             BranchID branchID = (*it)->branchDescription().branchID();
-            OutputHandle const oh = p.getForOutput(branchID, false);
+            OutputHandle const oh = p.getForOutput(branchID, false, mcc);
             
             if(0 != oh.desc() && oh.desc()->branchID() != branchID) {
                throw cms::Exception("BranchIDMissMatch") << "While processing " << id << " request for BranchID " << branchID << " returned BranchID " << oh.desc()->branchID() << "\n";
@@ -96,7 +98,7 @@ namespace edm {
             (*it)->branchDescription().moduleLabel(),
             (*it)->branchDescription().productInstanceName(),
             (*it)->branchDescription().processName(),
-            nullptr);
+                                          nullptr, mcc);
             
             /*This doesn't appear to be an error, it just means the Product isn't available, which can be legitimate
             if(!bh.product()) {
@@ -111,20 +113,20 @@ namespace edm {
          }
       }
    }
-   void GetProductCheckerOutputModule::write(EventPrincipal const& e) {
+   void GetProductCheckerOutputModule::write(EventPrincipal const& e, edm::ModuleCallingContext const* mcc) {
       std::ostringstream str;
       str << e.id();
-      check(e, str.str());
+      check(e, str.str(), mcc);
    }
-   void GetProductCheckerOutputModule::writeLuminosityBlock(LuminosityBlockPrincipal const& l) {
+   void GetProductCheckerOutputModule::writeLuminosityBlock(LuminosityBlockPrincipal const& l, edm::ModuleCallingContext const* mcc) {
       std::ostringstream str;
       str << l.id();
-      check(l, str.str());
+      check(l, str.str(), mcc);
    }
-   void GetProductCheckerOutputModule::writeRun(RunPrincipal const& r) {
+   void GetProductCheckerOutputModule::writeRun(RunPrincipal const& r, edm::ModuleCallingContext const* mcc) {
       std::ostringstream str;
       str << r.id();
-      check(r, str.str());
+      check(r, str.str(), mcc);
    }
 
 //

--- a/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
+++ b/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
@@ -33,9 +33,9 @@ namespace edm {
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void write(EventPrincipal const& e);
-      virtual void writeLuminosityBlock(LuminosityBlockPrincipal const&){}
-      virtual void writeRun(RunPrincipal const&){}
+      virtual void write(EventPrincipal const& e, ModuleCallingContext const*) override;
+      virtual void writeLuminosityBlock(LuminosityBlockPrincipal const&, ModuleCallingContext const*) override {}
+      virtual void writeRun(RunPrincipal const&, ModuleCallingContext const*) override {}
    };
 
 
@@ -101,7 +101,7 @@ namespace edm {
    }
 
    void
-   ProvenanceCheckerOutputModule::write(EventPrincipal const& e) {
+   ProvenanceCheckerOutputModule::write(EventPrincipal const& e, ModuleCallingContext const* mcc) {
       //check ProductProvenance's parents to see if they are in the ProductProvenance list
       boost::shared_ptr<BranchMapper> mapperPtr = e.branchMapperPtr();
 
@@ -118,7 +118,7 @@ namespace edm {
             idToProductHolder[branchID] = (*it);
             if((*it)->productUnavailable()) {
                //This call seems to have a side effect of filling the 'ProductProvenance' in the ProductHolder
-               OutputHandle const oh = e.getForOutput(branchID, false);
+              OutputHandle const oh = e.getForOutput(branchID, false, mcc);
 
                bool cannotFindProductProvenance=false;
                if(!(*it)->productProvenancePtr()) {

--- a/FWCore/ServiceRegistry/BuildFile.xml
+++ b/FWCore/ServiceRegistry/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="boost"/>
+<use   name="DataFormats/Provenance"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/PythonParameterSet"/>

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -12,6 +12,16 @@
  Usage:
     Services can connect to the signals distributed by the ActivityRegistry in order to monitor the activity of the application.
 
+There are unit tests for the signals that use the Tracer
+to print out the transitions as they occur and then
+compare to a reference file. One test does this for
+a SubProcess test and the other for a test using
+unscheduled execution. The tests are in FWCore/Integration/test:
+  run_SubProcess.sh
+  testSubProcess_cfg.py
+  run_TestGetBy.sh
+  testGetBy1_cfg.py
+  testGetBy2_cfg.py
 */
 //
 // Original Author:  Chris Jones
@@ -30,6 +40,7 @@
 #define AR_WATCH_USING_METHOD_0(method) template<class TClass, class TMethod> void method (TClass* iObject, TMethod iMethod) { method (boost::bind(boost::mem_fn(iMethod), iObject)); }
 #define AR_WATCH_USING_METHOD_1(method) template<class TClass, class TMethod> void method (TClass* iObject, TMethod iMethod) { method (boost::bind(boost::mem_fn(iMethod), iObject, _1)); }
 #define AR_WATCH_USING_METHOD_2(method) template<class TClass, class TMethod> void method (TClass* iObject, TMethod iMethod) { method (boost::bind(boost::mem_fn(iMethod), iObject, _1, _2)); }
+#define AR_WATCH_USING_METHOD_3(method) template<class TClass, class TMethod> void method (TClass* iObject, TMethod iMethod) { method (boost::bind(boost::mem_fn(iMethod), iObject, _1, _2, _3)); }
 // forward declarations
 namespace edm {
    class EventID;
@@ -42,7 +53,11 @@ namespace edm {
    class Run;
    class EventSetup;
    class HLTPathStatus;
-   
+   class GlobalContext;
+   class StreamContext;
+   class PathContext;
+   class ModuleCallingContext;
+
    class ActivityRegistry : private boost::noncopyable {
    public:
       ActivityRegistry() {}
@@ -124,21 +139,21 @@ namespace edm {
       AR_WATCH_USING_METHOD_0(watchPostSourceRun)
         
       /// signal is emitted before the source opens a file
-      typedef signalslot::Signal<void()> PreOpenFile;
+      typedef signalslot::Signal<void(std::string const&, bool)> PreOpenFile;
       PreOpenFile preOpenFileSignal_;
       void watchPreOpenFile(PreOpenFile::slot_type const& iSlot) {
         preOpenFileSignal_.connect(iSlot);
       }
-      AR_WATCH_USING_METHOD_0(watchPreOpenFile)
+      AR_WATCH_USING_METHOD_2(watchPreOpenFile)
 
       /// signal is emitted after the source opens a file
       //   Note this is only done for a primary file, not a secondary one.
-      typedef signalslot::Signal<void()> PostOpenFile;
+      typedef signalslot::Signal<void(std::string const&, bool)> PostOpenFile;
       PostOpenFile postOpenFileSignal_;
       void watchPostOpenFile(PostOpenFile::slot_type const& iSlot) {
          postOpenFileSignal_.connect_front(iSlot);
       }
-      AR_WATCH_USING_METHOD_0(watchPostOpenFile)
+      AR_WATCH_USING_METHOD_2(watchPostOpenFile)
         
       /// signal is emitted before the Closesource closes a file
       //   First argument is the LFN of the file which is being closed.
@@ -151,13 +166,187 @@ namespace edm {
       AR_WATCH_USING_METHOD_2(watchPreCloseFile)
 
       /// signal is emitted after the source opens a file
-      typedef signalslot::Signal<void()> PostCloseFile;
+      typedef signalslot::Signal<void(std::string const&, bool)> PostCloseFile;
       PostCloseFile postCloseFileSignal_;
       void watchPostCloseFile(PostCloseFile::slot_type const& iSlot) {
          postCloseFileSignal_.connect_front(iSlot);
       }
-      AR_WATCH_USING_METHOD_0(watchPostCloseFile)
+      AR_WATCH_USING_METHOD_2(watchPostCloseFile)
+
+      typedef signalslot::Signal<void(StreamContext const&, ModuleDescription const&)> PreModuleBeginStream;
+      PreModuleBeginStream preModuleBeginStreamSignal_;
+      void watchPreModuleBeginStream(PreModuleBeginStream::slot_type const& iSlot) {
+         preModuleBeginStreamSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPreModuleBeginStream)
         
+      typedef signalslot::Signal<void(StreamContext const&, ModuleDescription const&)> PostModuleBeginStream;
+      PostModuleBeginStream postModuleBeginStreamSignal_;
+      void watchPostModuleBeginStream(PostModuleBeginStream::slot_type const& iSlot) {
+         postModuleBeginStreamSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPostModuleBeginStream)
+        
+      typedef signalslot::Signal<void(StreamContext const&, ModuleDescription const&)> PreModuleEndStream;
+      PreModuleEndStream preModuleEndStreamSignal_;
+      void watchPreModuleEndStream(PreModuleEndStream::slot_type const& iSlot) {
+         preModuleEndStreamSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPreModuleEndStream)
+        
+      typedef signalslot::Signal<void(StreamContext const&, ModuleDescription const&)> PostModuleEndStream;
+      PostModuleEndStream postModuleEndStreamSignal_;
+      void watchPostModuleEndStream(PostModuleEndStream::slot_type const& iSlot) {
+         postModuleEndStreamSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPostModuleEndStream)
+
+      typedef signalslot::Signal<void(GlobalContext const&)> PreGlobalBeginRun;
+      /// signal is emitted after the Run has been created by the InputSource but before any modules have seen the Run
+      PreGlobalBeginRun preGlobalBeginRunSignal_;
+      void watchPreGlobalBeginRun(PreGlobalBeginRun::slot_type const& iSlot) {
+         preGlobalBeginRunSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_1(watchPreGlobalBeginRun)
+
+      typedef signalslot::Signal<void(GlobalContext const&)> PostGlobalBeginRun;
+      PostGlobalBeginRun postGlobalBeginRunSignal_;
+      void watchPostGlobalBeginRun(PostGlobalBeginRun::slot_type const& iSlot) {
+         postGlobalBeginRunSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_1(watchPostGlobalBeginRun)
+      
+      typedef signalslot::Signal<void(GlobalContext const&)> PreGlobalEndRun;
+      PreGlobalEndRun preGlobalEndRunSignal_;
+      void watchPreGlobalEndRun(PreGlobalEndRun::slot_type const& iSlot) {
+         preGlobalEndRunSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_1(watchPreGlobalEndRun)
+
+        typedef signalslot::Signal<void(GlobalContext const&, Run const&, EventSetup const&)> PostGlobalEndRun;
+      PostGlobalEndRun postGlobalEndRunSignal_;
+      void watchPostGlobalEndRun(PostGlobalEndRun::slot_type const& iSlot) {
+         postGlobalEndRunSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_3(watchPostGlobalEndRun)
+      
+      typedef signalslot::Signal<void(StreamContext const&)> PreStreamBeginRun;
+      PreStreamBeginRun preStreamBeginRunSignal_;
+      void watchPreStreamBeginRun(PreStreamBeginRun::slot_type const& iSlot) {
+         preStreamBeginRunSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_1(watchPreStreamBeginRun)
+
+      typedef signalslot::Signal<void(StreamContext const&)> PostStreamBeginRun;
+      PostStreamBeginRun postStreamBeginRunSignal_;
+      void watchPostStreamBeginRun(PostStreamBeginRun::slot_type const& iSlot) {
+         postStreamBeginRunSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_1(watchPostStreamBeginRun)
+      
+      typedef signalslot::Signal<void(StreamContext const&)> PreStreamEndRun;
+      PreStreamEndRun preStreamEndRunSignal_;
+      void watchPreStreamEndRun(PreStreamEndRun::slot_type const& iSlot) {
+         preStreamEndRunSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_1(watchPreStreamEndRun)
+
+      typedef signalslot::Signal<void(StreamContext const&, Run const&, EventSetup const&)> PostStreamEndRun;
+      PostStreamEndRun postStreamEndRunSignal_;
+      void watchPostStreamEndRun(PostStreamEndRun::slot_type const& iSlot) {
+         postStreamEndRunSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_3(watchPostStreamEndRun)
+      
+      typedef signalslot::Signal<void(GlobalContext const&)> PreGlobalBeginLumi;
+      PreGlobalBeginLumi preGlobalBeginLumiSignal_;
+      void watchPreGlobalBeginLumi(PreGlobalBeginLumi::slot_type const& iSlot) {
+         preGlobalBeginLumiSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_1(watchPreGlobalBeginLumi)
+
+      typedef signalslot::Signal<void(GlobalContext const&)> PostGlobalBeginLumi;
+      PostGlobalBeginLumi postGlobalBeginLumiSignal_;
+      void watchPostGlobalBeginLumi(PostGlobalBeginLumi::slot_type const& iSlot) {
+         postGlobalBeginLumiSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_1(watchPostGlobalBeginLumi)
+      
+      typedef signalslot::Signal<void(GlobalContext const&)> PreGlobalEndLumi;
+      PreGlobalEndLumi preGlobalEndLumiSignal_;
+      void watchPreGlobalEndLumi(PreGlobalEndLumi::slot_type const& iSlot) {
+         preGlobalEndLumiSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_1(watchPreGlobalEndLumi)
+
+      typedef signalslot::Signal<void(GlobalContext const&, LuminosityBlock const&, EventSetup const&)> PostGlobalEndLumi;
+      PostGlobalEndLumi postGlobalEndLumiSignal_;
+      void watchPostGlobalEndLumi(PostGlobalEndLumi::slot_type const& iSlot) {
+         postGlobalEndLumiSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_3(watchPostGlobalEndLumi)
+      
+      typedef signalslot::Signal<void(StreamContext const&)> PreStreamBeginLumi;
+      PreStreamBeginLumi preStreamBeginLumiSignal_;
+      void watchPreStreamBeginLumi(PreStreamBeginLumi::slot_type const& iSlot) {
+         preStreamBeginLumiSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_1(watchPreStreamBeginLumi)
+
+      typedef signalslot::Signal<void(StreamContext const&)> PostStreamBeginLumi;
+      PostStreamBeginLumi postStreamBeginLumiSignal_;
+      void watchPostStreamBeginLumi(PostStreamBeginLumi::slot_type const& iSlot) {
+         postStreamBeginLumiSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_1(watchPostStreamBeginLumi)
+      
+      typedef signalslot::Signal<void(StreamContext const&)> PreStreamEndLumi;
+      PreStreamEndLumi preStreamEndLumiSignal_;
+      void watchPreStreamEndLumi(PreStreamEndLumi::slot_type const& iSlot) {
+         preStreamEndLumiSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_1(watchPreStreamEndLumi)
+
+      typedef signalslot::Signal<void(StreamContext const&, LuminosityBlock const&, EventSetup const&)> PostStreamEndLumi;
+      PostStreamEndLumi postStreamEndLumiSignal_;
+      void watchPostStreamEndLumi(PostStreamEndLumi::slot_type const& iSlot) {
+         postStreamEndLumiSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_3(watchPostStreamEndLumi)
+
+      typedef signalslot::Signal<void(StreamContext const&)> PreEvent;
+      /// signal is emitted after the Event has been created by the InputSource but before any modules have seen the Event
+      PreEvent preEventSignal_;
+      void watchPreEvent(PreEvent::slot_type const& iSlot) {
+         preEventSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_1(watchPreEvent)
+
+      typedef signalslot::Signal<void(StreamContext const&, Event const&, EventSetup const&)> PostEvent;
+      /// signal is emitted after all modules have finished processing the Event
+      PostEvent postEventSignal_;
+      void watchPostEvent(PostEvent::slot_type const& iSlot) {
+         postEventSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_3(watchPostEvent)
+
+      /// signal is emitted before starting to process a Path for an event
+        typedef signalslot::Signal<void(StreamContext const&, PathContext const&)> PrePathEvent;
+      PrePathEvent prePathEventSignal_;
+      void watchPrePathEvent(PrePathEvent::slot_type const& iSlot) {
+        prePathEventSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPrePathEvent)
+
+      /// signal is emitted after all modules have finished for the Path for an event
+      typedef signalslot::Signal<void(StreamContext const&, PathContext const&, HLTPathStatus const&)> PostPathEvent;
+      PostPathEvent postPathEventSignal_;
+      void watchPostPathEvent(PostPathEvent::slot_type const& iSlot) {
+         postPathEventSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_3(watchPostPathEvent)
+
+      // OLD DELETE THIS
       typedef signalslot::Signal<void(EventID const&, Timestamp const&)> PreProcessEvent;
       /// signal is emitted after the Event has been created by the InputSource but before any modules have seen the Event
       PreProcessEvent preProcessEventSignal_;
@@ -166,6 +355,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_2(watchPreProcessEvent)
       
+      // OLD DELETE THIS
       typedef signalslot::Signal<void(Event const&, EventSetup const&)> PostProcessEvent;
       /// signal is emitted after all modules have finished processing the Event
       PostProcessEvent postProcessEventSignal_;
@@ -174,6 +364,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_2(watchPostProcessEvent)
 
+      // OLD DELETE THIS
       typedef signalslot::Signal<void(RunID const&, Timestamp const&)> PreBeginRun;
       /// signal is emitted after the Run has been created by the InputSource but before any modules have seen the Run
       PreBeginRun preBeginRunSignal_;
@@ -182,6 +373,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_2(watchPreBeginRun)
       
+      // OLD DELETE THIS
       typedef signalslot::Signal<void(Run const&, EventSetup const&)> PostBeginRun;
       /// signal is emitted after all modules have finished processing the beginRun 
       PostBeginRun postBeginRunSignal_;
@@ -190,6 +382,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_2(watchPostBeginRun)
 
+      // OLD DELETE THIS
       typedef signalslot::Signal<void(RunID const&, Timestamp const&)> PreEndRun;
       /// signal is emitted before the endRun is processed
       PreEndRun preEndRunSignal_;
@@ -198,6 +391,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_2(watchPreEndRun)
       
+      // OLD DELETE THIS
       typedef signalslot::Signal<void(Run const&, EventSetup const&)> PostEndRun;
       /// signal is emitted after all modules have finished processing the Run
       PostEndRun postEndRunSignal_;
@@ -206,6 +400,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_2(watchPostEndRun)
 
+      // OLD DELETE THIS
       typedef signalslot::Signal<void(LuminosityBlockID const&, Timestamp const&)> PreBeginLumi;
       /// signal is emitted after the Lumi has been created by the InputSource but before any modules have seen the Lumi
       PreBeginLumi preBeginLumiSignal_;
@@ -214,6 +409,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_2(watchPreBeginLumi)
       
+      // OLD DELETE THIS
       typedef signalslot::Signal<void(LuminosityBlock const&, EventSetup const&)> PostBeginLumi;
       /// signal is emitted after all modules have finished processing the beginLumi
       PostBeginLumi postBeginLumiSignal_;
@@ -222,6 +418,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_2(watchPostBeginLumi)
 
+      // OLD DELETE THIS
       typedef signalslot::Signal<void(LuminosityBlockID const&, Timestamp const&)> PreEndLumi;
       /// signal is emitted before the endLumi is processed
       PreEndLumi preEndLumiSignal_;
@@ -230,6 +427,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_2(watchPreEndLumi)
       
+      // OLD DELETE THIS
       typedef signalslot::Signal<void(LuminosityBlock const&, EventSetup const&)> PostEndLumi;
       /// signal is emitted after all modules have finished processing the Lumi
       PostEndLumi postEndLumiSignal_;
@@ -238,6 +436,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_2(watchPostEndLumi)
 
+      // OLD DELETE THIS
       /// signal is emitted before starting to process a Path for an event
       typedef signalslot::Signal<void(std::string const&)> PreProcessPath;
       PreProcessPath preProcessPathSignal_;
@@ -246,6 +445,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPreProcessPath)
         
+      // OLD DELETE THIS
       /// signal is emitted after all modules have finished for the Path for an event
       typedef signalslot::Signal<void(std::string const&, HLTPathStatus const&)> PostProcessPath;
       PostProcessPath postProcessPathSignal_;
@@ -254,6 +454,7 @@ namespace edm {
       }  
       AR_WATCH_USING_METHOD_2(watchPostProcessPath)
         
+      // OLD DELETE THIS
       /// signal is emitted before starting to process a Path for beginRun
       typedef signalslot::Signal<void(std::string const&)> PrePathBeginRun;
       PrePathBeginRun prePathBeginRunSignal_;
@@ -262,6 +463,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPrePathBeginRun)
         
+      // OLD DELETE THIS
       /// signal is emitted after all modules have finished for the Path for beginRun
       typedef signalslot::Signal<void(std::string const&, HLTPathStatus const&)> PostPathBeginRun;
       PostPathBeginRun postPathBeginRunSignal_;
@@ -270,6 +472,7 @@ namespace edm {
       }  
       AR_WATCH_USING_METHOD_2(watchPostPathBeginRun)
         
+      // OLD DELETE THIS
       /// signal is emitted before starting to process a Path for endRun
       typedef signalslot::Signal<void(std::string const&)> PrePathEndRun;
       PrePathEndRun prePathEndRunSignal_;
@@ -278,6 +481,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPrePathEndRun)
         
+      // OLD DELETE THIS
       /// signal is emitted after all modules have finished for the Path for endRun
       typedef signalslot::Signal<void(std::string const&, HLTPathStatus const&)> PostPathEndRun;
       PostPathEndRun postPathEndRunSignal_;
@@ -286,6 +490,7 @@ namespace edm {
       }  
       AR_WATCH_USING_METHOD_2(watchPostPathEndRun)
         
+      // OLD DELETE THIS
       /// signal is emitted before starting to process a Path for beginLumi
       typedef signalslot::Signal<void(std::string const&)> PrePathBeginLumi;
       PrePathBeginLumi prePathBeginLumiSignal_;
@@ -294,6 +499,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPrePathBeginLumi)
         
+      // OLD DELETE THIS
       /// signal is emitted after all modules have finished for the Path for beginLumi
       typedef signalslot::Signal<void(std::string const&, HLTPathStatus const&)> PostPathBeginLumi;
       PostPathBeginLumi postPathBeginLumiSignal_;
@@ -302,6 +508,7 @@ namespace edm {
       }  
       AR_WATCH_USING_METHOD_2(watchPostPathBeginLumi)
         
+      // OLD DELETE THIS
       /// signal is emitted before starting to process a Path for endRun
       typedef signalslot::Signal<void(std::string const&)> PrePathEndLumi;
       PrePathEndLumi prePathEndLumiSignal_;
@@ -310,6 +517,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPrePathEndLumi)
         
+      // OLD DELETE THIS
       /// signal is emitted after all modules have finished for the Path for endRun
       typedef signalslot::Signal<void(std::string const&, HLTPathStatus const&)> PostPathEndLumi;
       PostPathEndLumi postPathEndLumiSignal_;
@@ -379,7 +587,136 @@ namespace edm {
          postModuleEndJobSignal_.connect_front(iSlot);
       }
       AR_WATCH_USING_METHOD_1(watchPostModuleEndJob)
-        
+
+      /// signal is emitted before the module starts processing the Event
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleEvent;
+      PreModuleEvent preModuleEventSignal_;
+      void watchPreModuleEvent(PreModuleEvent::slot_type const& iSlot) {
+         preModuleEventSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPreModuleEvent)
+         
+      /// signal is emitted after the module finished processing the Event
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PostModuleEvent;
+      PostModuleEvent postModuleEventSignal_;
+      void watchPostModuleEvent(PostModuleEvent::slot_type const& iSlot) {
+         postModuleEventSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPostModuleEvent)
+
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleStreamBeginRun;
+      PreModuleStreamBeginRun preModuleStreamBeginRunSignal_;
+      void watchPreModuleStreamBeginRun(PreModuleStreamBeginRun::slot_type const& iSlot) {
+         preModuleStreamBeginRunSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPreModuleStreamBeginRun)
+         
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PostModuleStreamBeginRun;
+      PostModuleStreamBeginRun postModuleStreamBeginRunSignal_;
+      void watchPostModuleStreamBeginRun(PostModuleStreamBeginRun::slot_type const& iSlot) {
+         postModuleStreamBeginRunSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPostModuleStreamBeginRun)
+
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleStreamEndRun;
+      PreModuleStreamEndRun preModuleStreamEndRunSignal_;
+      void watchPreModuleStreamEndRun(PreModuleStreamEndRun::slot_type const& iSlot) {
+         preModuleStreamEndRunSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPreModuleStreamEndRun)
+         
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PostModuleStreamEndRun;
+      PostModuleStreamEndRun postModuleStreamEndRunSignal_;
+      void watchPostModuleStreamEndRun(PostModuleStreamEndRun::slot_type const& iSlot) {
+         postModuleStreamEndRunSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPostModuleStreamEndRun)
+
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleStreamBeginLumi;
+      PreModuleStreamBeginLumi preModuleStreamBeginLumiSignal_;
+      void watchPreModuleStreamBeginLumi(PreModuleStreamBeginLumi::slot_type const& iSlot) {
+         preModuleStreamBeginLumiSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPreModuleStreamBeginLumi)
+         
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PostModuleStreamBeginLumi;
+      PostModuleStreamBeginLumi postModuleStreamBeginLumiSignal_;
+      void watchPostModuleStreamBeginLumi(PostModuleStreamBeginLumi::slot_type const& iSlot) {
+         postModuleStreamBeginLumiSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPostModuleStreamBeginLumi)
+
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleStreamEndLumi;
+      PreModuleStreamEndLumi preModuleStreamEndLumiSignal_;
+      void watchPreModuleStreamEndLumi(PreModuleStreamEndLumi::slot_type const& iSlot) {
+         preModuleStreamEndLumiSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPreModuleStreamEndLumi)
+         
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PostModuleStreamEndLumi;
+      PostModuleStreamEndLumi postModuleStreamEndLumiSignal_;
+      void watchPostModuleStreamEndLumi(PostModuleStreamEndLumi::slot_type const& iSlot) {
+         postModuleStreamEndLumiSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPostModuleStreamEndLumi)
+
+      typedef signalslot::Signal<void(GlobalContext const&, ModuleCallingContext const&)> PreModuleGlobalBeginRun;
+      PreModuleGlobalBeginRun preModuleGlobalBeginRunSignal_;
+      void watchPreModuleGlobalBeginRun(PreModuleGlobalBeginRun::slot_type const& iSlot) {
+         preModuleGlobalBeginRunSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPreModuleGlobalBeginRun)
+         
+      typedef signalslot::Signal<void(GlobalContext const&, ModuleCallingContext const&)> PostModuleGlobalBeginRun;
+      PostModuleGlobalBeginRun postModuleGlobalBeginRunSignal_;
+      void watchPostModuleGlobalBeginRun(PostModuleGlobalBeginRun::slot_type const& iSlot) {
+         postModuleGlobalBeginRunSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPostModuleGlobalBeginRun)
+
+      typedef signalslot::Signal<void(GlobalContext const&, ModuleCallingContext const&)> PreModuleGlobalEndRun;
+      PreModuleGlobalEndRun preModuleGlobalEndRunSignal_;
+      void watchPreModuleGlobalEndRun(PreModuleGlobalEndRun::slot_type const& iSlot) {
+         preModuleGlobalEndRunSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPreModuleGlobalEndRun)
+         
+      typedef signalslot::Signal<void(GlobalContext const&, ModuleCallingContext const&)> PostModuleGlobalEndRun;
+      PostModuleGlobalEndRun postModuleGlobalEndRunSignal_;
+      void watchPostModuleGlobalEndRun(PostModuleGlobalEndRun::slot_type const& iSlot) {
+         postModuleGlobalEndRunSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPostModuleGlobalEndRun)
+
+      typedef signalslot::Signal<void(GlobalContext const&, ModuleCallingContext const&)> PreModuleGlobalBeginLumi;
+      PreModuleGlobalBeginLumi preModuleGlobalBeginLumiSignal_;
+      void watchPreModuleGlobalBeginLumi(PreModuleGlobalBeginLumi::slot_type const& iSlot) {
+         preModuleGlobalBeginLumiSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPreModuleGlobalBeginLumi)
+         
+      typedef signalslot::Signal<void(GlobalContext const&, ModuleCallingContext const&)> PostModuleGlobalBeginLumi;
+      PostModuleGlobalBeginLumi postModuleGlobalBeginLumiSignal_;
+      void watchPostModuleGlobalBeginLumi(PostModuleGlobalBeginLumi::slot_type const& iSlot) {
+         postModuleGlobalBeginLumiSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPostModuleGlobalBeginLumi)
+
+      typedef signalslot::Signal<void(GlobalContext const&, ModuleCallingContext const&)> PreModuleGlobalEndLumi;
+      PreModuleGlobalEndLumi preModuleGlobalEndLumiSignal_;
+      void watchPreModuleGlobalEndLumi(PreModuleGlobalEndLumi::slot_type const& iSlot) {
+         preModuleGlobalEndLumiSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPreModuleGlobalEndLumi)
+         
+      typedef signalslot::Signal<void(GlobalContext const&, ModuleCallingContext const&)> PostModuleGlobalEndLumi;
+      PostModuleGlobalEndLumi postModuleGlobalEndLumiSignal_;
+      void watchPostModuleGlobalEndLumi(PostModuleGlobalEndLumi::slot_type const& iSlot) {
+         postModuleGlobalEndLumiSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPostModuleGlobalEndLumi)
+
+      // OLD DELETE THIS
       /// signal is emitted before the module starts processing the Event
       typedef signalslot::Signal<void(ModuleDescription const&)> PreModule;
       PreModule preModuleSignal_;
@@ -388,6 +725,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPreModule)
          
+      // OLD DELETE THIS
       /// signal is emitted after the module finished processing the Event
       typedef signalslot::Signal<void(ModuleDescription const&)> PostModule;
       PostModule postModuleSignal_;
@@ -396,6 +734,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPostModule)
          
+      // OLD DELETE THIS
       /// signal is emitted before the module starts processing beginRun
       typedef signalslot::Signal<void(ModuleDescription const&)> PreModuleBeginRun;
       PreModuleBeginRun preModuleBeginRunSignal_;
@@ -404,6 +743,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPreModuleBeginRun)
          
+      // OLD DELETE THIS
       /// signal is emitted after the module finished processing beginRun
       typedef signalslot::Signal<void(ModuleDescription const&)> PostModuleBeginRun;
       PostModuleBeginRun postModuleBeginRunSignal_;
@@ -413,6 +753,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPostModuleBeginRun)
          
+      // OLD DELETE THIS
       /// signal is emitted before the module starts processing endRun
       typedef signalslot::Signal<void(ModuleDescription const&)> PreModuleEndRun;
       PreModuleEndRun preModuleEndRunSignal_;
@@ -421,6 +762,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPreModuleEndRun)
          
+      // OLD DELETE THIS
       /// signal is emitted after the module finished processing endRun
       typedef signalslot::Signal<void(ModuleDescription const&)> PostModuleEndRun;
       PostModuleEndRun postModuleEndRunSignal_;
@@ -429,6 +771,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPostModuleEndRun)
          
+      // OLD DELETE THIS
       /// signal is emitted before the module starts processing beginLumi
       typedef signalslot::Signal<void(ModuleDescription const&)> PreModuleBeginLumi;
       PreModuleBeginLumi preModuleBeginLumiSignal_;
@@ -437,6 +780,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPreModuleBeginLumi)
          
+      // OLD DELETE THIS
       /// signal is emitted after the module finished processing beginLumi
       typedef signalslot::Signal<void(ModuleDescription const&)> PostModuleBeginLumi;
       PostModuleBeginLumi postModuleBeginLumiSignal_;
@@ -445,6 +789,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPostModuleBeginLumi)
          
+      // OLD DELETE THIS
       /// signal is emitted before the module starts processing endLumi
       typedef signalslot::Signal<void(ModuleDescription const&)> PreModuleEndLumi;
       PreModuleEndLumi preModuleEndLumiSignal_;
@@ -453,6 +798,7 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPreModuleEndLumi)
          
+      // OLD DELETE THIS
       /// signal is emitted after the module finished processing endLumi
       typedef signalslot::Signal<void(ModuleDescription const&)> PostModuleEndLumi;
       PostModuleEndLumi postModuleEndLumiSignal_;
@@ -460,7 +806,7 @@ namespace edm {
          postModuleEndLumiSignal_.connect_front(iSlot);
       }
       AR_WATCH_USING_METHOD_1(watchPostModuleEndLumi)
-         
+
       /// signal is emitted before the source is constructed
       typedef signalslot::Signal<void(ModuleDescription const&)> PreSourceConstruction;
       PreSourceConstruction preSourceConstructionSignal_;

--- a/FWCore/ServiceRegistry/interface/GlobalContext.h
+++ b/FWCore/ServiceRegistry/interface/GlobalContext.h
@@ -1,0 +1,68 @@
+#ifndef FWCore_ServiceRegistry_GlobalContext_h
+#define FWCore_ServiceRegistry_GlobalContext_h
+
+/**\class edm::GlobalContext
+
+ Description: This is intended primarily to be passed to
+Services as an argument to their callback functions. It contains
+information about the current state of global processing.
+
+ Usage:
+
+
+*/
+//
+// Original Author: W. David Dagenhart
+//         Created: 7/10/2013
+
+#include "DataFormats/Provenance/interface/LuminosityBlockID.h"
+#include "DataFormats/Provenance/interface/Timestamp.h"
+#include "FWCore/ServiceRegistry/interface/ProcessContext.h"
+#include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
+#include "FWCore/Utilities/interface/RunIndex.h"
+
+#include <iosfwd>
+
+namespace edm {
+
+  class GlobalContext {
+
+  public:
+
+    enum class Transition {
+      kBeginJob,
+      kBeginRun,
+      kBeginLuminosityBlock,
+      kEndLuminosityBlock,
+      kEndRun,
+      kEndJob,
+      kWriteRun,
+      kWriteLuminosityBlock
+    };
+    
+    GlobalContext(Transition transition,
+                  LuminosityBlockID const& luminosityBlockID,
+                  RunIndex const& runIndex,
+                  LuminosityBlockIndex const& luminosityBlockIndex, 
+                  Timestamp const & timestamp,
+                  ProcessContext const* processContext);
+
+    Transition transition() const { return transition_; }
+    LuminosityBlockID const& luminosityBlockID() const { return luminosityBlockID_; }
+    RunIndex const& runIndex() const { return runIndex_; }
+    LuminosityBlockIndex const& luminosityBlockIndex() const { return luminosityBlockIndex_; }
+    Timestamp const& timestamp() const { return timestamp_; }
+    ProcessContext const* processContext() const { return processContext_; }
+
+  private:
+    Transition transition_;
+    LuminosityBlockID luminosityBlockID_;
+    RunIndex runIndex_;
+    LuminosityBlockIndex luminosityBlockIndex_; 
+    Timestamp timestamp_;
+    ProcessContext const* processContext_;
+  };
+
+  std::ostream& operator<<(std::ostream&, GlobalContext const&);
+}
+#endif

--- a/FWCore/ServiceRegistry/interface/InternalContext.h
+++ b/FWCore/ServiceRegistry/interface/InternalContext.h
@@ -1,0 +1,40 @@
+#ifndef FWCore_ServiceRegistry_InternalContext_h
+#define FWCore_ServiceRegistry_InternalContext_h
+
+/**\class edm::InternalContext
+
+ Description: Holds context information for the link
+ between a MixingModule context and a module called
+ by unscheduled production adding data to a secondary
+ Principal.
+*/
+//
+// Original Author: W. David Dagenhart
+//         Created: 7/31/2013
+
+#include "DataFormats/Provenance/interface/EventID.h"
+
+#include <iosfwd>
+
+namespace edm {
+
+  class ModuleCallingContext;
+
+  class InternalContext {
+
+  public:
+
+    InternalContext(EventID const& eventID,
+                    ModuleCallingContext const*);
+
+    EventID const& eventID() const { return eventID_; } // event#==0 is a lumi, event#==0&lumi#==0 is a run
+    ModuleCallingContext const* moduleCallingContext() const { return moduleCallingContext_; }
+
+  private:
+    EventID eventID_; // event#==0 is a lumi, event#==0&lumi#==0 is a run
+    ModuleCallingContext const* moduleCallingContext_;
+  };
+
+  std::ostream& operator<<(std::ostream&, InternalContext const&);
+}
+#endif

--- a/FWCore/ServiceRegistry/interface/ModuleCallingContext.h
+++ b/FWCore/ServiceRegistry/interface/ModuleCallingContext.h
@@ -1,0 +1,71 @@
+#ifndef FWCore_ServiceRegistry_ModuleCallingContext_h
+#define FWCore_ServiceRegistry_ModuleCallingContext_h
+
+/**\class edm::ModuleCallingContext
+
+ Description: This is intended primarily to be passed to
+Services as an argument to their callback functions.
+
+ Usage:
+
+
+*/
+//
+// Original Author: W. David Dagenhart
+//         Created: 7/11/2013
+
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+
+#include <iosfwd>
+
+namespace edm {
+
+  class GlobalContext;
+  class InternalContext;
+  class ModuleDescription;
+  class PathContext;
+  class StreamContext;
+
+
+  class ModuleCallingContext {
+  public:
+
+    typedef ParentContext::Type Type;
+
+    enum class State {
+      kPrefetching,  // prefetching products before starting to run
+      kRunning,      // module actually running
+      kInvalid
+    };
+
+    ModuleCallingContext(ModuleDescription const* moduleDescription);
+    ModuleCallingContext(ModuleDescription const* moduleDescription, State state, ParentContext const& parent);
+
+    void setContext(State state, ParentContext const& parent);
+
+    ModuleDescription const* moduleDescription() const { return moduleDescription_; }
+    State state() const { return state_; }
+    Type type() const { return parent_.type(); }
+    ParentContext const& parent() const { return parent_; }
+    ModuleCallingContext const* moduleCallingContext() const { return parent_.moduleCallingContext(); }
+    PathContext const* pathContext() const { return parent_.pathContext(); }
+    StreamContext const* streamContext() const { return parent_.streamContext(); }
+    GlobalContext const* globalContext() const { return parent_.globalContext(); }
+    InternalContext const* internalContext() const { return parent_.internalContext(); }
+
+    // These functions will iterate up a series of linked context objects
+    // to find the StreamContext or GlobalContext at the top of the series.
+    // Throws if the top context object does not have that type.
+    StreamContext const* getStreamContext() const;
+    GlobalContext const* getGlobalContext() const;
+
+  private:
+
+    ModuleDescription const* moduleDescription_;
+    ParentContext parent_;
+    State state_;
+  };
+
+  std::ostream& operator<<(std::ostream&, ModuleCallingContext const&);
+}
+#endif

--- a/FWCore/ServiceRegistry/interface/ParentContext.h
+++ b/FWCore/ServiceRegistry/interface/ParentContext.h
@@ -1,0 +1,68 @@
+#ifndef FWCore_ServiceRegistry_ParentContext_h
+#define FWCore_ServiceRegistry_ParentContext_h
+
+/**\class edm::ParentContext
+
+ Description: This is intended to be used as a member
+of ModuleCallingContext.
+
+ Usage:
+
+
+*/
+//
+// Original Author: W. David Dagenhart
+//         Created: 7/11/2013
+
+#include <iosfwd>
+
+namespace edm {
+
+  class GlobalContext;
+  class InternalContext;
+  class ModuleCallingContext;
+  class PathContext;
+  class StreamContext;
+
+  class ParentContext {
+  public:
+
+    enum class Type {
+      kGlobal,
+      kInternal,
+      kModule,
+      kPath,
+      kStream,
+      kInvalid
+    };
+
+    ParentContext();
+    ParentContext(GlobalContext const*);
+    ParentContext(InternalContext const*);
+    ParentContext(ModuleCallingContext const*);
+    ParentContext(PathContext const*);
+    ParentContext(StreamContext const*);
+
+    Type type() const { return type_; }
+
+    GlobalContext const* globalContext() const;
+    InternalContext const* internalContext() const;
+    ModuleCallingContext const* moduleCallingContext() const;
+    PathContext const* pathContext() const;
+    StreamContext const* streamContext() const;
+
+  private:
+    Type type_;
+
+    union Parent {
+      GlobalContext const* global;
+      InternalContext const* internal;
+      ModuleCallingContext const* module;
+      PathContext const* path;
+      StreamContext const* stream;
+    } parent_;
+  };
+
+  std::ostream& operator<<(std::ostream&, ParentContext const&);
+}
+#endif

--- a/FWCore/ServiceRegistry/interface/PathContext.h
+++ b/FWCore/ServiceRegistry/interface/PathContext.h
@@ -1,0 +1,43 @@
+#ifndef FWCore_ServiceRegistry_PathContext_h
+#define FWCore_ServiceRegistry_PathContext_h
+
+/**\class edm::PathContext
+
+ Description: This is intended primarily to be passed to
+Services as an argument to their callback functions.
+
+ Usage:
+
+
+*/
+//
+// Original Author: W. David Dagenhart
+//         Created: 7/10/2013
+
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+
+#include <iosfwd>
+#include <string>
+
+namespace edm {
+
+  class PathContext {
+  public:
+
+    PathContext(std::string const& pathName,
+                unsigned int pathID,
+                StreamContext const* streamContext);
+
+    std::string const& pathName() const { return pathName_; }
+    unsigned int pathID() const { return pathID_; }
+    StreamContext const* streamContext() const { return streamContext_; }
+
+  private:
+    std::string pathName_;
+    unsigned int pathID_;
+    StreamContext const* streamContext_;
+  };
+
+  std::ostream& operator<<(std::ostream&, PathContext const&);
+}
+#endif

--- a/FWCore/ServiceRegistry/interface/ProcessContext.h
+++ b/FWCore/ServiceRegistry/interface/ProcessContext.h
@@ -1,0 +1,53 @@
+#ifndef FWCore_ServiceRegistry_ProcessContext_h
+#define FWCore_ServiceRegistry_ProcessContext_h
+
+/**\class edm::ProcessContext
+
+ Description: Holds pointer to ProcessConfiguration and
+if this is a SubProcess also a pointer to the parent
+ProcessContext. This is intended primarily to be passed
+to Services as an argument to their callback functions.
+
+ Usage:
+
+
+*/
+//
+// Original Author: W. David Dagenhart
+//         Created: 7/2/2013
+
+#include "DataFormats/Provenance/interface/ParameterSetID.h"
+#include "DataFormats/Provenance/interface/ProcessConfiguration.h"
+
+#include <iosfwd>
+#include <string>
+
+namespace edm {
+
+  class ProcessContext {
+
+  public:
+
+    ProcessContext();
+
+    std::string const& processName() const { return processConfiguration_->processName(); }
+    ParameterSetID const& parameterSetID() const { return processConfiguration_->parameterSetID(); }
+    ProcessConfiguration const* processConfiguration() const { return processConfiguration_; }
+    bool isSubProcess() const { return parentProcessContext_ != nullptr; }
+    ProcessContext const& parentProcessContext() const;
+
+    void setProcessConfiguration(ProcessConfiguration const* processConfiguration);
+    void setParentProcessContext(ProcessContext const* parentProcessContext);
+
+  private:
+
+    ProcessConfiguration const* processConfiguration_;
+
+    // If this is a SubProcess this points to the parent process,
+    // otherwise it is null.
+    ProcessContext const* parentProcessContext_;
+  };
+
+  std::ostream& operator<<(std::ostream&, ProcessContext const&);
+}
+#endif

--- a/FWCore/ServiceRegistry/interface/StreamContext.h
+++ b/FWCore/ServiceRegistry/interface/StreamContext.h
@@ -1,0 +1,82 @@
+#ifndef FWCore_ServiceRegistry_StreamContext_h
+#define FWCore_ServiceRegistry_StreamContext_h
+
+/**\class edm::StreamContext
+
+ Description: Holds pointer to ProcessContext, StreamID,
+ transition, EventID and timestamp.
+ This is intended primarily to be passed to Services
+ as an argument to their callback functions.
+
+ Usage:
+
+
+*/
+//
+// Original Author: W. David Dagenhart
+//         Created: 7/8/2013
+
+#include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/Provenance/interface/Timestamp.h"
+#include "FWCore/ServiceRegistry/interface/ProcessContext.h"
+#include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
+#include "FWCore/Utilities/interface/RunIndex.h"
+#include "FWCore/Utilities/interface/StreamID.h"
+
+#include <iosfwd>
+
+namespace edm {
+
+  class StreamContext {
+
+  public:
+
+    enum class Transition {
+      kBeginStream,
+      kBeginRun,
+      kBeginLuminosityBlock,
+      kEvent,
+      kEndLuminosityBlock,
+      kEndRun,
+      kEndStream,
+      kInvalid
+    };
+
+    StreamContext(StreamID const& streamID,
+                  ProcessContext const* processContext);
+    
+    StreamContext(StreamID const& streamID,
+                  Transition transition,
+                  EventID const& eventID,
+                  RunIndex const& runIndex,
+                  LuminosityBlockIndex const& luminosityBlockIndex, 
+                  Timestamp const & timestamp,
+                  ProcessContext const* processContext);
+
+    StreamID const& streamID() const { return streamID_; }
+    Transition transition() const { return transition_; }
+    EventID const& eventID() const { return eventID_; } // event#==0 is a lumi, event#==0&lumi#==0 is a run
+    RunIndex const& runIndex() const { return runIndex_; }
+    LuminosityBlockIndex const& luminosityBlockIndex() const { return luminosityBlockIndex_; }
+    Timestamp const& timestamp() const { return timestamp_; }
+    ProcessContext const* processContext() const { return processContext_; }
+
+    void setTransition(Transition v) { transition_ = v; }
+    void setEventID(EventID const& v) { eventID_ = v; }
+    void setRunIndex(RunIndex const& v) { runIndex_ = v; }
+    void setLuminosityBlockIndex(LuminosityBlockIndex const& v) { luminosityBlockIndex_ = v; }
+    void setTimestamp(Timestamp const& v) { timestamp_ = v; }
+
+  private:
+    StreamID streamID_;
+    Transition transition_;
+    EventID eventID_; // event#==0 is a lumi, event#==0&lumi#==0 is a run
+    RunIndex runIndex_;
+    LuminosityBlockIndex luminosityBlockIndex_; 
+    Timestamp timestamp_;
+    ProcessContext const* processContext_;
+  };
+
+  std::ostream& operator<<(std::ostream&, StreamContext const&);
+}
+#endif

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -110,6 +110,49 @@ namespace edm {
      preSourceConstructionSignal_.connect(std::cref(iOther.preSourceConstructionSignal_));
      postSourceConstructionSignal_.connect(std::cref(iOther.postSourceConstructionSignal_));
 
+     preForkReleaseResourcesSignal_.connect(std::cref(iOther.preForkReleaseResourcesSignal_));
+     postForkReacquireResourcesSignal_.connect(std::cref(iOther.postForkReacquireResourcesSignal_));
+  }
+
+  void
+  ActivityRegistry::connectLocals(ActivityRegistry& iOther) {
+
+     preModuleBeginStreamSignal_.connect(std::cref(iOther.preModuleBeginStreamSignal_));
+     postModuleBeginStreamSignal_.connect(std::cref(iOther.postModuleBeginStreamSignal_));
+
+     preModuleEndStreamSignal_.connect(std::cref(iOther.preModuleEndStreamSignal_));
+     postModuleEndStreamSignal_.connect(std::cref(iOther.postModuleEndStreamSignal_));
+
+     preGlobalBeginRunSignal_.connect(std::cref(iOther.preGlobalBeginRunSignal_));
+     postGlobalBeginRunSignal_.connect(std::cref(iOther.postGlobalBeginRunSignal_));
+
+     preGlobalEndRunSignal_.connect(std::cref(iOther.preGlobalEndRunSignal_));
+     postGlobalEndRunSignal_.connect(std::cref(iOther.postGlobalEndRunSignal_));
+
+     preStreamBeginRunSignal_.connect(std::cref(iOther.preStreamBeginRunSignal_));
+     postStreamBeginRunSignal_.connect(std::cref(iOther.postStreamBeginRunSignal_));
+
+     preStreamEndRunSignal_.connect(std::cref(iOther.preStreamEndRunSignal_));
+     postStreamEndRunSignal_.connect(std::cref(iOther.postStreamEndRunSignal_));
+
+     preGlobalBeginLumiSignal_.connect(std::cref(iOther.preGlobalBeginLumiSignal_));
+     postGlobalBeginLumiSignal_.connect(std::cref(iOther.postGlobalBeginLumiSignal_));
+
+     preGlobalEndLumiSignal_.connect(std::cref(iOther.preGlobalEndLumiSignal_));
+     postGlobalEndLumiSignal_.connect(std::cref(iOther.postGlobalEndLumiSignal_));
+
+     preStreamBeginLumiSignal_.connect(std::cref(iOther.preStreamBeginLumiSignal_));
+     postStreamBeginLumiSignal_.connect(std::cref(iOther.postStreamBeginLumiSignal_));
+
+     preStreamEndLumiSignal_.connect(std::cref(iOther.preStreamEndLumiSignal_));
+     postStreamEndLumiSignal_.connect(std::cref(iOther.postStreamEndLumiSignal_));
+
+     preEventSignal_.connect(std::cref(iOther.preEventSignal_));
+     postEventSignal_.connect(std::cref(iOther.postEventSignal_));
+
+     prePathEventSignal_.connect(std::cref(iOther.prePathEventSignal_));
+     postPathEventSignal_.connect(std::cref(iOther.postPathEventSignal_));
+
      preProcessEventSignal_.connect(std::cref(iOther.preProcessEventSignal_));
      postProcessEventSignal_.connect(std::cref(iOther.postProcessEventSignal_));
 
@@ -124,13 +167,6 @@ namespace edm {
 
      preEndLumiSignal_.connect(std::cref(iOther.preEndLumiSignal_));
      postEndLumiSignal_.connect(std::cref(iOther.postEndLumiSignal_));
-
-     preForkReleaseResourcesSignal_.connect(std::cref(iOther.preForkReleaseResourcesSignal_));
-     postForkReacquireResourcesSignal_.connect(std::cref(iOther.postForkReacquireResourcesSignal_));
-  }
-
-  void
-  ActivityRegistry::connectLocals(ActivityRegistry& iOther) {
 
      preProcessPathSignal_.connect(std::cref(iOther.preProcessPathSignal_));
      postProcessPathSignal_.connect(std::cref(iOther.postProcessPathSignal_));
@@ -147,6 +183,42 @@ namespace edm {
      prePathEndLumiSignal_.connect(std::cref(iOther.prePathEndLumiSignal_));
      postPathEndLumiSignal_.connect(std::cref(iOther.postPathEndLumiSignal_));
 
+     preModuleConstructionSignal_.connect(std::cref(iOther.preModuleConstructionSignal_));
+     postModuleConstructionSignal_.connect(std::cref(iOther.postModuleConstructionSignal_));
+
+     preModuleBeginJobSignal_.connect(std::cref(iOther.preModuleBeginJobSignal_));
+     postModuleBeginJobSignal_.connect(std::cref(iOther.postModuleBeginJobSignal_));
+
+     preModuleEndJobSignal_.connect(std::cref(iOther.preModuleEndJobSignal_));
+     postModuleEndJobSignal_.connect(std::cref(iOther.postModuleEndJobSignal_));
+
+     preModuleEventSignal_.connect(std::cref(iOther.preModuleEventSignal_));
+     postModuleEventSignal_.connect(std::cref(iOther.postModuleEventSignal_));
+
+     preModuleStreamBeginRunSignal_.connect(std::cref(iOther.preModuleStreamBeginRunSignal_));
+     postModuleStreamBeginRunSignal_.connect(std::cref(iOther.postModuleStreamBeginRunSignal_));
+
+     preModuleStreamEndRunSignal_.connect(std::cref(iOther.preModuleStreamEndRunSignal_));
+     postModuleStreamEndRunSignal_.connect(std::cref(iOther.postModuleStreamEndRunSignal_));
+
+     preModuleStreamBeginLumiSignal_.connect(std::cref(iOther.preModuleStreamBeginLumiSignal_));
+     postModuleStreamBeginLumiSignal_.connect(std::cref(iOther.postModuleStreamBeginLumiSignal_));
+
+     preModuleStreamEndLumiSignal_.connect(std::cref(iOther.preModuleStreamEndLumiSignal_));
+     postModuleStreamEndLumiSignal_.connect(std::cref(iOther.postModuleStreamEndLumiSignal_));
+
+     preModuleGlobalBeginRunSignal_.connect(std::cref(iOther.preModuleGlobalBeginRunSignal_));
+     postModuleGlobalBeginRunSignal_.connect(std::cref(iOther.postModuleGlobalBeginRunSignal_));
+
+     preModuleGlobalEndRunSignal_.connect(std::cref(iOther.preModuleGlobalEndRunSignal_));
+     postModuleGlobalEndRunSignal_.connect(std::cref(iOther.postModuleGlobalEndRunSignal_));
+
+     preModuleGlobalBeginLumiSignal_.connect(std::cref(iOther.preModuleGlobalBeginLumiSignal_));
+     postModuleGlobalBeginLumiSignal_.connect(std::cref(iOther.postModuleGlobalBeginLumiSignal_));
+
+     preModuleGlobalEndLumiSignal_.connect(std::cref(iOther.preModuleGlobalEndLumiSignal_));
+     postModuleGlobalEndLumiSignal_.connect(std::cref(iOther.postModuleGlobalEndLumiSignal_));
+
      preModuleSignal_.connect(std::cref(iOther.preModuleSignal_));
      postModuleSignal_.connect(std::cref(iOther.postModuleSignal_));
 
@@ -161,15 +233,6 @@ namespace edm {
 
      preModuleEndLumiSignal_.connect(std::cref(iOther.preModuleEndLumiSignal_));
      postModuleEndLumiSignal_.connect(std::cref(iOther.postModuleEndLumiSignal_));
-
-     preModuleConstructionSignal_.connect(std::cref(iOther.preModuleConstructionSignal_));
-     postModuleConstructionSignal_.connect(std::cref(iOther.postModuleConstructionSignal_));
-
-     preModuleBeginJobSignal_.connect(std::cref(iOther.preModuleBeginJobSignal_));
-     postModuleBeginJobSignal_.connect(std::cref(iOther.postModuleBeginJobSignal_));
-
-     preModuleEndJobSignal_.connect(std::cref(iOther.preModuleEndJobSignal_));
-     postModuleEndJobSignal_.connect(std::cref(iOther.postModuleEndJobSignal_));
   }
 
   void
@@ -180,8 +243,8 @@ namespace edm {
 
   void
   ActivityRegistry::connectToSubProcess(ActivityRegistry& iOther) {
-    connectGlobals(iOther);
-    iOther.connectLocals(*this);
+    connectGlobals(iOther);        // child sees parents global signals
+    iOther.connectLocals(*this);   // parent see childs global signals
   }
 
   void
@@ -205,6 +268,42 @@ namespace edm {
 
     copySlotsToFrom(preCloseFileSignal_, iOther.preCloseFileSignal_);
     copySlotsToFromReverse(postCloseFileSignal_, iOther.postCloseFileSignal_);
+
+    copySlotsToFrom(preModuleBeginStreamSignal_, iOther.preModuleBeginStreamSignal_);
+    copySlotsToFromReverse(postModuleBeginStreamSignal_, iOther.postModuleBeginStreamSignal_);
+
+    copySlotsToFrom(preModuleEndStreamSignal_, iOther.preModuleEndStreamSignal_);
+    copySlotsToFromReverse(postModuleEndStreamSignal_, iOther.postModuleEndStreamSignal_);
+
+    copySlotsToFrom(preGlobalBeginRunSignal_, iOther.preGlobalBeginRunSignal_);
+    copySlotsToFromReverse(postGlobalBeginRunSignal_, iOther.postGlobalBeginRunSignal_);
+
+    copySlotsToFrom(preGlobalEndRunSignal_, iOther.preGlobalEndRunSignal_);
+    copySlotsToFromReverse(postGlobalEndRunSignal_, iOther.postGlobalEndRunSignal_);
+
+    copySlotsToFrom(preStreamBeginRunSignal_, iOther.preStreamBeginRunSignal_);
+    copySlotsToFromReverse(postStreamBeginRunSignal_, iOther.postStreamBeginRunSignal_);
+
+    copySlotsToFrom(preStreamEndRunSignal_, iOther.preStreamEndRunSignal_);
+    copySlotsToFromReverse(postStreamEndRunSignal_, iOther.postStreamEndRunSignal_);
+
+    copySlotsToFrom(preGlobalBeginLumiSignal_, iOther.preGlobalBeginLumiSignal_);
+    copySlotsToFromReverse(postGlobalBeginLumiSignal_, iOther.postGlobalBeginLumiSignal_);
+
+    copySlotsToFrom(preGlobalEndLumiSignal_, iOther.preGlobalEndLumiSignal_);
+    copySlotsToFromReverse(postGlobalEndLumiSignal_, iOther.postGlobalEndLumiSignal_);
+
+    copySlotsToFrom(preStreamBeginLumiSignal_, iOther.preStreamBeginLumiSignal_);
+    copySlotsToFromReverse(postStreamBeginLumiSignal_, iOther.postStreamBeginLumiSignal_);
+
+    copySlotsToFrom(preStreamEndLumiSignal_, iOther.preStreamEndLumiSignal_);
+    copySlotsToFromReverse(postStreamEndLumiSignal_, iOther.postStreamEndLumiSignal_);
+
+    copySlotsToFrom(preEventSignal_, iOther.preEventSignal_);
+    copySlotsToFromReverse(postEventSignal_, iOther.postEventSignal_);
+
+    copySlotsToFrom(prePathEventSignal_, iOther.prePathEventSignal_);
+    copySlotsToFromReverse(postPathEventSignal_, iOther.postPathEventSignal_);
 
     copySlotsToFrom(preProcessEventSignal_, iOther.preProcessEventSignal_);
     copySlotsToFromReverse(postProcessEventSignal_, iOther.postProcessEventSignal_);
@@ -236,6 +335,42 @@ namespace edm {
     copySlotsToFrom(prePathEndLumiSignal_, iOther.prePathEndLumiSignal_);
     copySlotsToFromReverse(postPathEndLumiSignal_, iOther.postPathEndLumiSignal_);
 
+    copySlotsToFrom(preModuleConstructionSignal_, iOther.preModuleConstructionSignal_);
+    copySlotsToFromReverse(postModuleConstructionSignal_, iOther.postModuleConstructionSignal_);
+
+    copySlotsToFrom(preModuleBeginJobSignal_, iOther.preModuleBeginJobSignal_);
+    copySlotsToFromReverse(postModuleBeginJobSignal_, iOther.postModuleBeginJobSignal_);
+
+    copySlotsToFrom(preModuleEndJobSignal_, iOther.preModuleEndJobSignal_);
+    copySlotsToFromReverse(postModuleEndJobSignal_, iOther.postModuleEndJobSignal_);
+
+    copySlotsToFrom(preModuleEventSignal_, iOther.preModuleEventSignal_);
+    copySlotsToFromReverse(postModuleEventSignal_, iOther.postModuleEventSignal_);
+
+    copySlotsToFrom(preModuleStreamBeginRunSignal_, iOther.preModuleStreamBeginRunSignal_);
+    copySlotsToFromReverse(postModuleStreamBeginRunSignal_, iOther.postModuleStreamBeginRunSignal_);
+
+    copySlotsToFrom(preModuleStreamEndRunSignal_, iOther.preModuleStreamEndRunSignal_);
+    copySlotsToFromReverse(postModuleStreamEndRunSignal_, iOther.postModuleStreamEndRunSignal_);
+
+    copySlotsToFrom(preModuleStreamBeginLumiSignal_, iOther.preModuleStreamBeginLumiSignal_);
+    copySlotsToFromReverse(postModuleStreamBeginLumiSignal_, iOther.postModuleStreamBeginLumiSignal_);
+
+    copySlotsToFrom(preModuleStreamEndLumiSignal_, iOther.preModuleStreamEndLumiSignal_);
+    copySlotsToFromReverse(postModuleStreamEndLumiSignal_, iOther.postModuleStreamEndLumiSignal_);
+
+    copySlotsToFrom(preModuleGlobalBeginRunSignal_, iOther.preModuleGlobalBeginRunSignal_);
+    copySlotsToFromReverse(postModuleGlobalBeginRunSignal_, iOther.postModuleGlobalBeginRunSignal_);
+
+    copySlotsToFrom(preModuleGlobalEndRunSignal_, iOther.preModuleGlobalEndRunSignal_);
+    copySlotsToFromReverse(postModuleGlobalEndRunSignal_, iOther.postModuleGlobalEndRunSignal_);
+
+    copySlotsToFrom(preModuleGlobalBeginLumiSignal_, iOther.preModuleGlobalBeginLumiSignal_);
+    copySlotsToFromReverse(postModuleGlobalBeginLumiSignal_, iOther.postModuleGlobalBeginLumiSignal_);
+
+    copySlotsToFrom(preModuleGlobalEndLumiSignal_, iOther.preModuleGlobalEndLumiSignal_);
+    copySlotsToFromReverse(postModuleGlobalEndLumiSignal_, iOther.postModuleGlobalEndLumiSignal_);
+
     copySlotsToFrom(preModuleSignal_, iOther.preModuleSignal_);
     copySlotsToFromReverse(postModuleSignal_, iOther.postModuleSignal_);
 
@@ -250,15 +385,6 @@ namespace edm {
 
     copySlotsToFrom(preModuleEndLumiSignal_, iOther.preModuleEndLumiSignal_);
     copySlotsToFromReverse(postModuleEndLumiSignal_, iOther.postModuleEndLumiSignal_);
-
-    copySlotsToFrom(preModuleConstructionSignal_, iOther.preModuleConstructionSignal_);
-    copySlotsToFromReverse(postModuleConstructionSignal_, iOther.postModuleConstructionSignal_);
-
-    copySlotsToFrom(preModuleBeginJobSignal_, iOther.preModuleBeginJobSignal_);
-    copySlotsToFromReverse(postModuleBeginJobSignal_, iOther.postModuleBeginJobSignal_);
-
-    copySlotsToFrom(preModuleEndJobSignal_, iOther.preModuleEndJobSignal_);
-    copySlotsToFromReverse(postModuleEndJobSignal_, iOther.postModuleEndJobSignal_);
 
     copySlotsToFrom(preSourceConstructionSignal_, iOther.preSourceConstructionSignal_);
     copySlotsToFromReverse(postSourceConstructionSignal_, iOther.postSourceConstructionSignal_);

--- a/FWCore/ServiceRegistry/src/GlobalContext.cc
+++ b/FWCore/ServiceRegistry/src/GlobalContext.cc
@@ -1,0 +1,59 @@
+#include "FWCore/ServiceRegistry/interface/GlobalContext.h"
+
+#include <ostream>
+
+namespace edm {
+
+  GlobalContext::GlobalContext(Transition transition,
+                               LuminosityBlockID const& luminosityBlockID,
+                               RunIndex const& runIndex,
+                               LuminosityBlockIndex const& luminosityBlockIndex, 
+                               Timestamp const & timestamp,
+                               ProcessContext const* processContext) :
+    transition_(transition),
+    luminosityBlockID_(luminosityBlockID),
+    runIndex_(runIndex),
+    luminosityBlockIndex_(luminosityBlockIndex),
+    timestamp_(timestamp),
+    processContext_(processContext) {
+  }
+
+  std::ostream& operator<<(std::ostream& os, GlobalContext const& gc) {
+    os << "GlobalContext: transition = ";
+    switch (gc.transition()) {
+    case GlobalContext::Transition::kBeginJob:
+      os << "BeginJob";
+      break;
+    case GlobalContext::Transition::kBeginRun:
+      os << "BeginRun";
+      break;
+    case GlobalContext::Transition::kBeginLuminosityBlock:
+      os << "BeginLuminosityBlock";
+      break;
+    case GlobalContext::Transition::kEndLuminosityBlock:
+      os << "EndLuminosityBlock";
+      break;
+    case GlobalContext::Transition::kEndRun:
+      os << "EndRun";
+      break;
+    case GlobalContext::Transition::kEndJob:
+      os << "EndJob";
+      break;
+    case GlobalContext::Transition::kWriteRun:
+      os << "WriteRun";
+      break;
+    case GlobalContext::Transition::kWriteLuminosityBlock:
+      os << "WriteLuminosityBlock";
+      break;
+    }
+    os << "\n    " << gc.luminosityBlockID()
+       << "\n    runIndex = " << gc.runIndex().value()
+       << "  luminosityBlockIndex = " << gc.luminosityBlockIndex().value()
+       << "  unixTime = " << gc.timestamp().unixTime()
+       << " microsecondOffset = " << gc.timestamp().microsecondOffset() <<"\n";
+    if(gc.processContext()) {
+      os << "    " << *gc.processContext(); 
+    }
+    return os;
+  }
+}

--- a/FWCore/ServiceRegistry/src/InternalContext.cc
+++ b/FWCore/ServiceRegistry/src/InternalContext.cc
@@ -1,0 +1,21 @@
+#include "FWCore/ServiceRegistry/interface/InternalContext.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+
+#include <ostream>
+
+namespace edm {
+
+  InternalContext::InternalContext(EventID const& eventID,
+                                   ModuleCallingContext const* moduleCallingContext) :
+    eventID_(eventID),
+    moduleCallingContext_(moduleCallingContext) {
+  }
+
+  std::ostream& operator<<(std::ostream& os, InternalContext const& ic) {
+    os << "InternalContext " << ic.eventID() << "\n";
+    if(ic.moduleCallingContext()) {
+      os << "    " << *ic.moduleCallingContext(); 
+    }
+    return os;
+  }
+}

--- a/FWCore/ServiceRegistry/src/ModuleCallingContext.cc
+++ b/FWCore/ServiceRegistry/src/ModuleCallingContext.cc
@@ -1,0 +1,91 @@
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/InternalContext.h"
+#include "FWCore/ServiceRegistry/interface/PathContext.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
+
+#include <ostream>
+
+namespace edm {
+
+  ModuleCallingContext::ModuleCallingContext(ModuleDescription const* moduleDescription) :
+    moduleDescription_(moduleDescription),
+    parent_(),
+    state_(State::kInvalid) {
+  }
+
+  ModuleCallingContext::ModuleCallingContext(ModuleDescription const* moduleDescription, State state, ParentContext const& parent) :
+    moduleDescription_(moduleDescription),
+    parent_(parent),
+    state_(state) {
+  }
+
+  void ModuleCallingContext::setContext(State state, ParentContext const& parent) {
+    state_ = state;
+    parent_ = parent;
+  }
+
+  StreamContext const*
+  ModuleCallingContext::getStreamContext() const {
+    ModuleCallingContext const* mcc = this;
+    while(mcc->type() == ParentContext::Type::kModule) {
+      mcc = mcc->moduleCallingContext();
+    }
+    if(mcc->type() == ParentContext::Type::kInternal) {
+      mcc = mcc->internalContext()->moduleCallingContext();
+    }
+    while(mcc->type() == ParentContext::Type::kModule) {
+      mcc = mcc->moduleCallingContext();
+    }
+    if(mcc->type() == ParentContext::Type::kPath) {
+      return mcc->pathContext()->streamContext();
+    } else if (mcc->type() != ParentContext::Type::kStream) {
+      throw Exception(errors::LogicError)
+        << "ModuleCallingContext::getStreamContext() called in context not linked to a StreamContext\n";
+    }
+    return mcc->streamContext();
+  }
+
+  GlobalContext const*
+  ModuleCallingContext::getGlobalContext() const {
+    ModuleCallingContext const* mcc = this;
+    while(mcc->type() == ParentContext::Type::kModule) {
+      mcc = mcc->moduleCallingContext();
+    }
+    if(mcc->type() == ParentContext::Type::kInternal) {
+      mcc = mcc->internalContext()->moduleCallingContext();
+    }
+    while(mcc->type() == ParentContext::Type::kModule) {
+      mcc = mcc->moduleCallingContext();
+    }
+    if (mcc->type() != ParentContext::Type::kGlobal) {
+      throw Exception(errors::LogicError)
+        << "ModuleCallingContext::getGlobalContext() called in context not linked to a GlobalContext\n";
+    }
+    return mcc->globalContext();
+  }
+
+  std::ostream& operator<<(std::ostream& os, ModuleCallingContext const& mcc) {
+    os << "ModuleCallingContext state = ";
+    switch (mcc.state()) {
+    case ModuleCallingContext::State::kInvalid:
+      os << "Invalid";
+      break;
+    case ModuleCallingContext::State::kPrefetching:
+      os << "Prefetching";
+      break;
+    case ModuleCallingContext::State::kRunning:
+      os << "Running";
+      break;
+    }
+    os << "\n";
+    if(mcc.state() == ModuleCallingContext::State::kInvalid) {
+      return os;
+    }
+    if(mcc.moduleDescription()) {
+      os << "    moduleDescription: " << *mcc.moduleDescription() << "\n";
+    }
+    os << "    " << mcc.parent();
+    return os;
+  }
+}

--- a/FWCore/ServiceRegistry/src/ParentContext.cc
+++ b/FWCore/ServiceRegistry/src/ParentContext.cc
@@ -1,0 +1,105 @@
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/GlobalContext.h"
+#include "FWCore/ServiceRegistry/interface/InternalContext.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/PathContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include <ostream>
+
+namespace edm {
+
+  ParentContext::ParentContext() :
+    type_(Type::kInvalid) {
+    parent_.global = nullptr;
+  }
+
+  ParentContext::ParentContext(GlobalContext const* global) :
+    type_(Type::kGlobal) {
+    parent_.global = global;
+  }
+
+  ParentContext::ParentContext(InternalContext const* internal) :
+    type_(Type::kInternal) {
+    parent_.internal = internal;
+  }
+
+  ParentContext::ParentContext(ModuleCallingContext const* module) :
+    type_(Type::kModule) {
+    parent_.module = module;
+  }
+
+  ParentContext::ParentContext(PathContext const* path) :
+    type_(Type::kPath) {
+    parent_.path = path;
+  }
+
+  ParentContext::ParentContext(StreamContext const* stream) :
+    type_(Type::kStream) {
+    parent_.stream = stream;
+  }
+
+  ModuleCallingContext const*
+  ParentContext::moduleCallingContext() const {
+    if(type_ != Type::kModule) {
+      throw Exception(errors::LogicError)
+        << "ParentContext::moduleCallingContext called for incorrect type of context";
+    }
+    return parent_.module;
+  }
+
+  PathContext const*
+  ParentContext::pathContext() const {
+    if(type_ != Type::kPath) {
+      throw Exception(errors::LogicError)
+        << "ParentContext::pathContext called for incorrect type of context";
+    }
+    return parent_.path;
+  }
+
+  StreamContext const*
+  ParentContext::streamContext() const {
+    if(type_ != Type::kStream) {
+      throw Exception(errors::LogicError)
+        << "ParentContext::streamContext called for incorrect type of context";
+    }
+    return parent_.stream;
+  }
+
+  GlobalContext const*
+  ParentContext::globalContext() const {
+    if(type_ != Type::kGlobal) {
+      throw Exception(errors::LogicError)
+        << "ParentContext::globalContext called for incorrect type of context";
+    }
+    return parent_.global;
+  }
+
+  InternalContext const*
+  ParentContext::internalContext() const {
+    if(type_ != Type::kInternal) {
+      throw Exception(errors::LogicError)
+        << "ParentContext::internalContext called for incorrect type of context";
+    }
+    return parent_.internal;
+  }
+
+  std::ostream& operator<<(std::ostream& os, ParentContext const& pc) {
+    if(pc.type() == ParentContext::Type::kGlobal && pc.globalContext()) {
+      os << *pc.globalContext();
+    } else if (pc.type() == ParentContext::Type::kInternal && pc.internalContext()) {
+      os << *pc.internalContext();
+    } else if (pc.type() == ParentContext::Type::kModule && pc.moduleCallingContext()) {
+      os << *pc.moduleCallingContext();
+    } else if (pc.type() == ParentContext::Type::kPath && pc.pathContext()) {
+      os << *pc.pathContext();
+    } else if (pc.type() == ParentContext::Type::kStream && pc.streamContext()) {
+      os << *pc.streamContext();
+    } else if (pc.type() == ParentContext::Type::kInvalid) {
+      os << "ParentContext invalid\n";
+    }
+    return os;
+  }
+}

--- a/FWCore/ServiceRegistry/src/PathContext.cc
+++ b/FWCore/ServiceRegistry/src/PathContext.cc
@@ -1,0 +1,23 @@
+#include "FWCore/ServiceRegistry/interface/PathContext.h"
+
+#include <ostream>
+
+namespace edm {
+
+  PathContext::PathContext(std::string const& pathName,
+                           unsigned int pathID,
+                           StreamContext const* streamContext) :
+    pathName_(pathName),
+    pathID_(pathID),
+    streamContext_(streamContext) {
+  }
+
+  std::ostream& operator<<(std::ostream& os, PathContext const& pc) {
+    os << "PathContext: pathName = " << pc.pathName()
+       << " pathID = " << pc.pathID() << "\n";
+    if(pc.streamContext()) {
+      os << "    " << *pc.streamContext(); 
+    }
+    return os;
+  }
+}

--- a/FWCore/ServiceRegistry/src/ProcessContext.cc
+++ b/FWCore/ServiceRegistry/src/ProcessContext.cc
@@ -1,0 +1,46 @@
+#include "FWCore/ServiceRegistry/interface/ProcessContext.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include <ostream>
+
+namespace edm {
+
+  ProcessContext::ProcessContext() :
+    processConfiguration_(nullptr),
+    parentProcessContext_(nullptr) {
+  }
+
+  ProcessContext const&
+  ProcessContext::parentProcessContext() const {
+    if (!isSubProcess()) {
+      throw Exception(errors::LogicError)
+        << "ProcessContext::parentProcessContext This function should only be called for SubProcesses.\n"
+        << "If necessary, you can check this by calling isSubProcess first.\n";
+    }
+    return *parentProcessContext_;
+  }
+
+  void
+  ProcessContext::setProcessConfiguration(ProcessConfiguration const* processConfiguration) {
+    processConfiguration_ = processConfiguration;
+  }
+
+  void
+  ProcessContext::setParentProcessContext(ProcessContext const* parentProcessContext) {
+    parentProcessContext_ = parentProcessContext;
+  }
+
+  std::ostream& operator<<(std::ostream& os, ProcessContext const& pc) {
+    os << "ProcessContext: ";
+    if(pc.processConfiguration()) {
+      os << *pc.processConfiguration() << "\n";
+    } else {
+      os << "invalid\n";
+      return os;
+    }
+    if(pc.isSubProcess()) {
+      os << "    parent " << pc.parentProcessContext();
+    }
+    return os;
+  }
+}

--- a/FWCore/ServiceRegistry/src/StreamContext.cc
+++ b/FWCore/ServiceRegistry/src/StreamContext.cc
@@ -1,0 +1,73 @@
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+
+#include <ostream>
+
+namespace edm {
+
+  StreamContext::StreamContext(StreamID const& streamID,
+                               ProcessContext const* processContext) :
+    streamID_(streamID),
+    transition_(Transition::kInvalid),
+    eventID_(EventID(0,0,0)),
+    runIndex_(RunIndex::invalidRunIndex()),
+    luminosityBlockIndex_(LuminosityBlockIndex::invalidLuminosityBlockIndex()),
+    timestamp_(),
+    processContext_(processContext) {
+  }
+
+  StreamContext::StreamContext(StreamID const& streamID,
+                               Transition transition,
+                               EventID const& eventID,
+                               RunIndex const& runIndex,
+                               LuminosityBlockIndex const& luminosityBlockIndex, 
+                               Timestamp const& timestamp,
+                               ProcessContext const* processContext) :
+    streamID_(streamID),
+    transition_(transition),
+    eventID_(eventID),
+    runIndex_(runIndex),
+    luminosityBlockIndex_(luminosityBlockIndex),
+    timestamp_(timestamp),
+    processContext_(processContext) {
+  }
+
+  std::ostream& operator<<(std::ostream& os, StreamContext const& sc) {
+    os << "StreamContext: StreamID = " << sc.streamID()
+       << " transition = ";
+    switch (sc.transition()) {
+    case StreamContext::Transition::kBeginStream:
+      os << "BeginStream";
+      break;
+    case StreamContext::Transition::kBeginRun:
+      os << "BeginRun";
+      break;
+    case StreamContext::Transition::kBeginLuminosityBlock:
+      os << "BeginLuminosityBlock";
+      break;
+    case StreamContext::Transition::kEvent:
+      os << "Event";
+      break;
+    case StreamContext::Transition::kEndLuminosityBlock:
+      os << "EndLuminosityBlock";
+      break;
+    case StreamContext::Transition::kEndRun:
+      os << "EndRun";
+      break;
+    case StreamContext::Transition::kEndStream:
+      os << "EndStream";
+      break;
+    case StreamContext::Transition::kInvalid:
+      os << "Invalid";
+      break;
+    }
+    os << "\n    " << sc.eventID()
+       << "\n    runIndex = " << sc.runIndex().value()
+       << "  luminosityBlockIndex = " << sc.luminosityBlockIndex().value()
+       << "  unixTime = " << sc.timestamp().unixTime()
+       << " microsecondOffset = " << sc.timestamp().microsecondOffset() <<"\n";
+    if(sc.processContext()) {
+      os << "    " << *sc.processContext(); 
+    }
+    return os;
+  }
+}

--- a/FWCore/Services/src/Tracer.cc
+++ b/FWCore/Services/src/Tracer.cc
@@ -21,6 +21,10 @@
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/GlobalContext.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/PathContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
 
 // system include files
 #include <iostream>
@@ -43,11 +47,56 @@ Tracer::Tracer(ParameterSet const& iPS, ActivityRegistry&iRegistry) :
    iRegistry.watchPostBeginJob(this, &Tracer::postBeginJob);
    iRegistry.watchPostEndJob(this, &Tracer::postEndJob);
 
-   iRegistry.watchPreModule(this, &Tracer::preModuleEvent);
-   iRegistry.watchPostModule(this, &Tracer::postModuleEvent);
-   
-   iRegistry.watchPreSourceConstruction(this, &Tracer::preSourceConstruction);
-   iRegistry.watchPostSourceConstruction(this, &Tracer::postSourceConstruction);
+   iRegistry.watchPreSource(this, &Tracer::preSource);
+   iRegistry.watchPostSource(this, &Tracer::postSource);
+
+   iRegistry.watchPreSourceLumi(this, &Tracer::preSourceLumi);
+   iRegistry.watchPostSourceLumi(this, &Tracer::postSourceLumi);
+
+   iRegistry.watchPreSourceRun(this, &Tracer::preSourceRun);
+   iRegistry.watchPostSourceRun(this, &Tracer::postSourceRun);
+
+   iRegistry.watchPreOpenFile(this, &Tracer::preOpenFile);
+   iRegistry.watchPostOpenFile(this, &Tracer::postOpenFile);
+
+   iRegistry.watchPreCloseFile(this, &Tracer::preCloseFile);
+   iRegistry.watchPostCloseFile(this, &Tracer::postCloseFile);
+
+   iRegistry.watchPreModuleBeginStream(this, &Tracer::preModuleBeginStream);
+   iRegistry.watchPostModuleBeginStream(this, &Tracer::postModuleBeginStream);
+
+   iRegistry.watchPreModuleEndStream(this, &Tracer::preModuleEndStream);
+   iRegistry.watchPostModuleEndStream(this, &Tracer::postModuleEndStream);
+
+   iRegistry.watchPreGlobalBeginRun(this, &Tracer::preGlobalBeginRun);
+   iRegistry.watchPostGlobalBeginRun(this, &Tracer::postGlobalBeginRun);
+
+   iRegistry.watchPreGlobalEndRun(this, &Tracer::preGlobalEndRun);
+   iRegistry.watchPostGlobalEndRun(this, &Tracer::postGlobalEndRun);
+
+   iRegistry.watchPreStreamBeginRun(this, &Tracer::preStreamBeginRun);
+   iRegistry.watchPostStreamBeginRun(this, &Tracer::postStreamBeginRun);
+
+   iRegistry.watchPreStreamEndRun(this, &Tracer::preStreamEndRun);
+   iRegistry.watchPostStreamEndRun(this, &Tracer::postStreamEndRun);
+
+   iRegistry.watchPreGlobalBeginLumi(this, &Tracer::preGlobalBeginLumi);
+   iRegistry.watchPostGlobalBeginLumi(this, &Tracer::postGlobalBeginLumi);
+
+   iRegistry.watchPreGlobalEndLumi(this, &Tracer::preGlobalEndLumi);
+   iRegistry.watchPostGlobalEndLumi(this, &Tracer::postGlobalEndLumi);
+
+   iRegistry.watchPreStreamBeginLumi(this, &Tracer::preStreamBeginLumi);
+   iRegistry.watchPostStreamBeginLumi(this, &Tracer::postStreamBeginLumi);
+
+   iRegistry.watchPreStreamEndLumi(this, &Tracer::preStreamEndLumi);
+   iRegistry.watchPostStreamEndLumi(this, &Tracer::postStreamEndLumi);
+
+   iRegistry.watchPreEvent(this, &Tracer::preEvent);
+   iRegistry.watchPostEvent(this, &Tracer::postEvent);
+
+   iRegistry.watchPrePathEvent(this, &Tracer::prePathEvent);
+   iRegistry.watchPostPathEvent(this, &Tracer::postPathEvent);
 
    iRegistry.watchPreModuleConstruction(this, &Tracer::preModuleConstruction);
    iRegistry.watchPostModuleConstruction(this, &Tracer::postModuleConstruction);
@@ -58,63 +107,31 @@ Tracer::Tracer(ParameterSet const& iPS, ActivityRegistry&iRegistry) :
    iRegistry.watchPreModuleEndJob(this, &Tracer::preModuleEndJob);
    iRegistry.watchPostModuleEndJob(this, &Tracer::postModuleEndJob);
 
-   iRegistry.watchPreModuleBeginRun(this, &Tracer::preModuleBeginRun);
-   iRegistry.watchPostModuleBeginRun(this, &Tracer::postModuleBeginRun);
+   iRegistry.watchPreModuleEvent(this, &Tracer::preModuleEvent);
+   iRegistry.watchPostModuleEvent(this, &Tracer::postModuleEvent);
 
-   iRegistry.watchPreModuleEndRun(this, &Tracer::preModuleEndRun);
-   iRegistry.watchPostModuleEndRun(this, &Tracer::postModuleEndRun);
+   iRegistry.watchPreModuleStreamBeginRun(this, &Tracer::preModuleStreamBeginRun);
+   iRegistry.watchPostModuleStreamBeginRun(this, &Tracer::postModuleStreamBeginRun);
+   iRegistry.watchPreModuleStreamEndRun(this, &Tracer::preModuleStreamEndRun);
+   iRegistry.watchPostModuleStreamEndRun(this, &Tracer::postModuleStreamEndRun);
 
-   iRegistry.watchPreModuleBeginLumi(this, &Tracer::preModuleBeginLumi);
-   iRegistry.watchPostModuleBeginLumi(this, &Tracer::postModuleBeginLumi);
+   iRegistry.watchPreModuleStreamBeginLumi(this, &Tracer::preModuleStreamBeginLumi);
+   iRegistry.watchPostModuleStreamBeginLumi(this, &Tracer::postModuleStreamBeginLumi);
+   iRegistry.watchPreModuleStreamEndLumi(this, &Tracer::preModuleStreamEndLumi);
+   iRegistry.watchPostModuleStreamEndLumi(this, &Tracer::postModuleStreamEndLumi);
 
-   iRegistry.watchPreModuleEndLumi(this, &Tracer::preModuleEndLumi);
-   iRegistry.watchPostModuleEndLumi(this, &Tracer::postModuleEndLumi);
+   iRegistry.watchPreModuleGlobalBeginRun(this, &Tracer::preModuleGlobalBeginRun);
+   iRegistry.watchPostModuleGlobalBeginRun(this, &Tracer::postModuleGlobalBeginRun);
+   iRegistry.watchPreModuleGlobalEndRun(this, &Tracer::preModuleGlobalEndRun);
+   iRegistry.watchPostModuleGlobalEndRun(this, &Tracer::postModuleGlobalEndRun);
 
-   iRegistry.watchPreProcessPath(this, &Tracer::prePathEvent);
-   iRegistry.watchPostProcessPath(this, &Tracer::postPathEvent);
+   iRegistry.watchPreModuleGlobalBeginLumi(this, &Tracer::preModuleGlobalBeginLumi);
+   iRegistry.watchPostModuleGlobalBeginLumi(this, &Tracer::postModuleGlobalBeginLumi);
+   iRegistry.watchPreModuleGlobalEndLumi(this, &Tracer::preModuleGlobalEndLumi);
+   iRegistry.watchPostModuleGlobalEndLumi(this, &Tracer::postModuleGlobalEndLumi);
 
-   iRegistry.watchPrePathBeginRun(this, &Tracer::prePathBeginRun);
-   iRegistry.watchPostPathBeginRun(this, &Tracer::postPathBeginRun);
-
-   iRegistry.watchPrePathEndRun(this, &Tracer::prePathEndRun);
-   iRegistry.watchPostPathEndRun(this, &Tracer::postPathEndRun);
-
-   iRegistry.watchPrePathBeginLumi(this, &Tracer::prePathBeginLumi);
-   iRegistry.watchPostPathBeginLumi(this, &Tracer::postPathBeginLumi);
-
-   iRegistry.watchPrePathEndLumi(this, &Tracer::prePathEndLumi);
-   iRegistry.watchPostPathEndLumi(this, &Tracer::postPathEndLumi);
-
-   iRegistry.watchPreProcessEvent(this, &Tracer::preEvent);
-   iRegistry.watchPostProcessEvent(this, &Tracer::postEvent);
-
-   iRegistry.watchPreBeginRun(this, &Tracer::preBeginRun);
-   iRegistry.watchPostBeginRun(this, &Tracer::postBeginRun);
-
-   iRegistry.watchPreEndRun(this, &Tracer::preEndRun);
-   iRegistry.watchPostEndRun(this, &Tracer::postEndRun);
-
-   iRegistry.watchPreBeginLumi(this, &Tracer::preBeginLumi);
-   iRegistry.watchPostBeginLumi(this, &Tracer::postBeginLumi);
-
-   iRegistry.watchPreEndLumi(this, &Tracer::preEndLumi);
-   iRegistry.watchPostEndLumi(this, &Tracer::postEndLumi);
-
-   iRegistry.watchPreSource(this, &Tracer::preSourceEvent);
-   iRegistry.watchPostSource(this, &Tracer::postSourceEvent);
-
-   iRegistry.watchPreOpenFile(this, &Tracer::preOpenFile);
-   iRegistry.watchPostOpenFile(this, &Tracer::postOpenFile);
-
-   iRegistry.watchPreCloseFile(this, &Tracer::preCloseFile);
-   iRegistry.watchPostCloseFile(this, &Tracer::postCloseFile);
-
-   iRegistry.watchPreSourceRun(this, &Tracer::preSourceRun);
-   iRegistry.watchPostSourceRun(this, &Tracer::postSourceRun);
-
-   iRegistry.watchPreSourceLumi(this, &Tracer::preSourceLumi);
-   iRegistry.watchPostSourceLumi(this, &Tracer::postSourceLumi);
-
+   iRegistry.watchPreSourceConstruction(this, &Tracer::preSourceConstruction);
+   iRegistry.watchPostSourceConstruction(this, &Tracer::postSourceConstruction);
 }
 
 // Tracer::Tracer(Tracer const& rhs)
@@ -154,251 +171,404 @@ void
 Tracer::postBeginJob() {
    std::cout << indention_ << " Job started" << std::endl;
 }
+
 void 
 Tracer::postEndJob() {
    std::cout << indention_ << " Job ended" << std::endl;
 }
 
 void
-Tracer::preSourceEvent() {
-  std::cout << indention_ << indention_ << "source event" << std::endl;
+Tracer::preSource() {
+  std::cout << indention_ << indention_ << " source event" << std::endl;
 }
+
 void
-Tracer::postSourceEvent () {
-  std::cout << indention_ << indention_ << "finished: source event" << std::endl;
+Tracer::postSource() {
+  std::cout << indention_ << indention_ << " finished: source event" << std::endl;
 }
 
 void
 Tracer::preSourceLumi() {
-  std::cout << indention_ << indention_ << "source lumi" << std::endl;
+  std::cout << indention_ << indention_ << " source lumi" << std::endl;
 }
+
 void
 Tracer::postSourceLumi () {
-  std::cout << indention_ << indention_ << "finished: source lumi" << std::endl;
+  std::cout << indention_ << indention_ << " finished: source lumi" << std::endl;
 }
 
 void
 Tracer::preSourceRun() {
-  std::cout << indention_ << indention_ << "source run" << std::endl;
-}
-void
-Tracer::postSourceRun () {
-  std::cout << indention_ << indention_ << "finished: source run" << std::endl;
+  std::cout << indention_ << indention_ << " source run" << std::endl;
 }
 
 void
-Tracer::preOpenFile() {
-  std::cout << indention_ << indention_ << "open input file" << std::endl;
+Tracer::postSourceRun () {
+  std::cout << indention_ << indention_ << " finished: source run" << std::endl;
 }
+
 void
-Tracer::postOpenFile () {
-  std::cout << indention_ << indention_ << "finished: open input file" << std::endl;
+Tracer::preOpenFile(std::string const& lfn, bool) {
+  std::cout << indention_ << indention_ << " open input file: " << lfn << std::endl;
+}
+
+void
+Tracer::postOpenFile (std::string const&, bool) {
+  std::cout << indention_ << indention_ << " finished: open input file" << std::endl;
 }
 
 void
 Tracer::preCloseFile(std::string const & lfn, bool) {
-  std::cout << indention_ << indention_ << "close input file " << lfn << std::endl;
+  std::cout << indention_ << indention_ << " close input file: " << lfn << std::endl;
 }
 void
-Tracer::postCloseFile () {
-  std::cout << indention_ << indention_ << "finished: close input file" << std::endl;
+Tracer::postCloseFile (std::string const&, bool) {
+  std::cout << indention_ << indention_ << " finished: close input file" << std::endl;
+}
+
+void
+Tracer::preModuleBeginStream(StreamContext const&, ModuleDescription const& desc) {
+  std::cout << indention_ << indention_ << " ModuleBeginStream: " << desc.moduleLabel() << std::endl; 
+}
+
+void
+Tracer::postModuleBeginStream(StreamContext const&, ModuleDescription const&) {
+  std::cout << indention_ << indention_ << " ModuleBeginStream finished" << std::endl; 
+}
+
+void
+Tracer::preModuleEndStream(StreamContext const&, ModuleDescription const&) {
+  std::cout << indention_ << indention_ << " ModuleEndStream: " << std::endl; 
+}
+
+void
+Tracer::postModuleEndStream(StreamContext const&, ModuleDescription const&) {
+  std::cout << indention_ << indention_ << " ModuleEndStream finished" << std::endl; 
+}
+
+void
+Tracer::preGlobalBeginRun(GlobalContext const& gc) {
+  std::cout << indention_ << indention_ << " GlobalBeginRun run: " << gc.luminosityBlockID().run() 
+            << " time: " << gc.timestamp().value() << std::endl; 
+}
+
+void
+Tracer::postGlobalBeginRun(GlobalContext const&) {
+  std::cout << indention_ << indention_ << " GlobalBeginRun finished" << std::endl; 
+}
+
+void
+Tracer::preGlobalEndRun(GlobalContext const& gc) {
+  std::cout << indention_ << indention_ << " GlobalEndRun run: " << gc.luminosityBlockID().run() 
+            << " time: " << gc.timestamp().value() << std::endl; 
+}
+
+void
+Tracer::postGlobalEndRun(GlobalContext const&, Run const&, EventSetup const&) {
+  std::cout << indention_ << indention_ << " GlobalEndRun finished" << std::endl; 
+}
+
+void
+Tracer::preStreamBeginRun(StreamContext const& sc) {
+  std::cout << indention_ << indention_ << " StreamBeginRun run: " << sc.eventID().run() 
+            << " time: " << sc.timestamp().value() << std::endl; 
+}
+
+void
+Tracer::postStreamBeginRun(StreamContext const&) {
+  std::cout << indention_ << indention_ << " StreamBeginRun finished" << std::endl; 
+}
+
+void
+Tracer::preStreamEndRun(StreamContext const& sc) {
+  std::cout << indention_ << indention_ << " StreamEndRun run: " << sc.eventID().run() 
+            << " time: " << sc.timestamp().value() << std::endl; 
+}
+
+void
+Tracer::postStreamEndRun(StreamContext const&, Run const&, EventSetup const&) {
+  std::cout << indention_ << indention_ << " StreamEndRun finished" << std::endl; 
+}
+
+void
+Tracer::preGlobalBeginLumi(GlobalContext const& gc) {
+  std::cout << indention_ << indention_ << " GlobalBeginLumi run: " << gc.luminosityBlockID().run() 
+            << " lumi: " << gc.luminosityBlockID().luminosityBlock() << " time: " << gc.timestamp().value() << std::endl; 
+}
+
+void
+Tracer::postGlobalBeginLumi(GlobalContext const&) {
+  std::cout << indention_ << indention_ << " GlobalBeginLumi finished" << std::endl; 
+}
+
+void
+Tracer::preGlobalEndLumi(GlobalContext const& gc) {
+  std::cout << indention_ << indention_ << " GlobalEndLumi run: " << gc.luminosityBlockID().run() 
+            << " lumi: " << gc.luminosityBlockID().luminosityBlock() << " time: " << gc.timestamp().value() << std::endl; 
+}
+
+void
+Tracer::postGlobalEndLumi(GlobalContext const&, LuminosityBlock const&, EventSetup const&) {
+  std::cout << indention_ << indention_ << " GlobalEndLumi finished" << std::endl; 
+}
+
+void
+Tracer::preStreamBeginLumi(StreamContext const& sc) {
+  std::cout << indention_ << indention_ << " StreamBeginLumi run: " << sc.eventID().run() 
+            << " lumi: " << sc.eventID().luminosityBlock() << " time: " << sc.timestamp().value() << std::endl; 
+}
+
+void
+Tracer::postStreamBeginLumi(StreamContext const&) {
+  std::cout << indention_ << indention_ << " StreamBeginLumi finished" << std::endl; 
+}
+
+void
+Tracer::preStreamEndLumi(StreamContext const& sc) {
+  std::cout << indention_ << indention_ << " StreamEndLumi run: " << sc.eventID().run() 
+            << " lumi: " << sc.eventID().luminosityBlock() << " time: " << sc.timestamp().value() << std::endl; 
+}
+
+void
+Tracer::postStreamEndLumi(StreamContext const&, LuminosityBlock const&, EventSetup const&) {
+  std::cout << indention_ << indention_ << " StreamEndLumi finished" << std::endl; 
+}
+
+void
+Tracer::preEvent(StreamContext const& sc) {
+  std::cout << indention_ << indention_ << " processing event " << sc.eventID() << " time:" << sc.timestamp().value() << std::endl;
+}
+
+void
+Tracer::postEvent(StreamContext const&, Event const&, EventSetup const&) {
+  std::cout << indention_ << indention_ << " event finished" << std::endl;
+}
+
+void
+Tracer::prePathEvent(StreamContext const&, PathContext const& pc) {
+  std::cout << indention_ << indention_ << indention_ << " processing path for event: " << pc.pathName() << std::endl;
+}
+
+void
+Tracer::postPathEvent(StreamContext const&, PathContext const& pc, HLTPathStatus const&) {
+  std::cout << indention_ << indention_ << indention_ << " path for event finished: " << pc.pathName() << std::endl;
 }
 
 void 
-Tracer::preEvent(EventID const& iID, Timestamp const& iTime) {
-   depth_=0;
-   std::cout << indention_ << indention_ << " processing event:" << iID << " time:" << iTime.value() << std::endl;
-}
-void 
-Tracer::postEvent(Event const&, EventSetup const&) {
-   std::cout << indention_ << indention_ << " finished event:" << std::endl;
+Tracer::preModuleConstruction(ModuleDescription const& desc) {
+  std::cout << indention_;
+  std::cout << " constructing module: " << desc.moduleLabel() << std::endl;
 }
 
 void 
-Tracer::prePathEvent(std::string const& iName) {
-  std::cout << indention_ << indention_ << indention_ << " processing path for event:" << iName << std::endl;
-}
-void 
-Tracer::postPathEvent(std::string const& iName, HLTPathStatus const&) {
-  std::cout << indention_ << indention_ << indention_ << " finished path for event:" << iName << std::endl;
+Tracer::postModuleConstruction(ModuleDescription const& desc) {
+  std::cout << indention_;
+  std::cout << " construction finished: " << desc.moduleLabel() << std::endl;
 }
 
 void 
-Tracer::preModuleEvent(ModuleDescription const& iDescription) {
+Tracer::preModuleBeginJob(ModuleDescription const& desc) {
+  std::cout << indention_;
+  std::cout << " ModuleBeginJob: " << desc.moduleLabel() << std::endl;
+}
+
+void 
+Tracer::postModuleBeginJob(ModuleDescription const& desc) {
+  std::cout << indention_;
+  std::cout << " ModuleBeginJob finished: " << desc.moduleLabel() << std::endl;
+}
+
+void 
+Tracer::preModuleEndJob(ModuleDescription const& iDescription) {
+  std::cout << indention_;
+  std::cout << " ModuleEndJob: " << iDescription.moduleLabel() << std::endl;
+}
+
+void 
+Tracer::postModuleEndJob(ModuleDescription const& iDescription) {
+  std::cout << indention_;
+  std::cout << " ModuleEndJob finished: " << iDescription.moduleLabel() << std::endl;
+}
+
+void 
+Tracer::preModuleEvent(StreamContext const&, ModuleCallingContext const& mcc) {
    ++depth_;
    std::cout << indention_ << indention_ << indention_;
    for(unsigned int depth = 0; depth !=depth_; ++depth) {
       std::cout << indention_;
    }
-   std::cout << " module for event:" << iDescription.moduleLabel() << std::endl;
+   std::cout << " module for event: " << mcc.moduleDescription()->moduleLabel() << std::endl;
 }
+
 void 
-Tracer::postModuleEvent(ModuleDescription const& iDescription) {
+Tracer::postModuleEvent(StreamContext const&, ModuleCallingContext const& mcc) {
    --depth_;
    std::cout << indention_ << indention_ << indention_ << indention_;
    for(unsigned int depth = 0; depth !=depth_; ++depth) {
       std::cout << indention_;
    }
-   
-   std::cout << " finished for event:" << iDescription.moduleLabel() << std::endl;
+   std::cout << " finished module for event: " << mcc.moduleDescription()->moduleLabel() << std::endl;
 }
 
-void 
-Tracer::preBeginRun(RunID const& iID, Timestamp const& iTime) {
-   depth_=0;
-   std::cout << indention_ << indention_ << " processing begin run:" << iID << " time:" << iTime.value() << std::endl;
-}
-void 
-Tracer::postBeginRun(Run const&, EventSetup const&) {
-   std::cout << indention_ << indention_ << " finished begin run:" << std::endl;
-}
 
-void 
-Tracer::prePathBeginRun(std::string const& iName) {
-  std::cout << indention_ << indention_ << indention_ << " processing path for begin run:" << iName << std::endl;
-}
-void 
-Tracer::postPathBeginRun(std::string const& iName, HLTPathStatus const&) {
-  std::cout << indention_ << indention_ << indention_ << " finished path for begin run:" << iName << std::endl;
-}
-
-void 
-Tracer::preModuleBeginRun(ModuleDescription const& iDescription) {
+void
+Tracer::preModuleStreamBeginRun(StreamContext const&, ModuleCallingContext const& mcc) {
    ++depth_;
+   std::cout << indention_ << indention_;
+   for(unsigned int depth = 0; depth !=depth_; ++depth) {
+      std::cout << indention_;
+   }
+   std::cout << " ModuleStreamBeginRun: " << mcc.moduleDescription()->moduleLabel() << std::endl;
+}
+
+void
+Tracer::postModuleStreamBeginRun(StreamContext const&, ModuleCallingContext const& mcc) {
+   --depth_;
    std::cout << indention_ << indention_ << indention_;
    for(unsigned int depth = 0; depth !=depth_; ++depth) {
       std::cout << indention_;
-   }
-   std::cout << " module for begin run:" << iDescription.moduleLabel() << std::endl;
+   }   
+   std::cout << " ModuleStreamBeginRun finished: " << mcc.moduleDescription()->moduleLabel() << std::endl;
 }
-void 
-Tracer::postModuleBeginRun(ModuleDescription const& iDescription) {
-   --depth_;
-   std::cout << indention_ << indention_ << indention_ << indention_;
+
+void
+Tracer::preModuleStreamEndRun(StreamContext const&, ModuleCallingContext const& mcc) {
+   ++depth_;
+   std::cout << indention_ << indention_;
    for(unsigned int depth = 0; depth !=depth_; ++depth) {
       std::cout << indention_;
    }
-   
-   std::cout << " finished for begin run:" << iDescription.moduleLabel() << std::endl;
+   std::cout << " ModuleStreamEndRun: " << mcc.moduleDescription()->moduleLabel() << std::endl;
 }
 
-void 
-Tracer::preEndRun(RunID const& iID, Timestamp const& iTime) {
-   depth_=0;
-   std::cout << indention_ << indention_ << " processing end run:" << iID << " time:" << iTime.value() << std::endl;
-}
-void 
-Tracer::postEndRun(Run const&, EventSetup const&) {
-   std::cout << indention_ << indention_ << " finished end run:" << std::endl;
-}
-
-void 
-Tracer::prePathEndRun(std::string const& iName) {
-  std::cout << indention_ << indention_ << indention_ << " processing path for end run:" << iName << std::endl;
-}
-void 
-Tracer::postPathEndRun(std::string const& iName, HLTPathStatus const&) {
-  std::cout << indention_ << indention_ << indention_ << " finished path for end run:" << iName << std::endl;
-}
-
-void 
-Tracer::preModuleEndRun(ModuleDescription const& iDescription) {
-   ++depth_;
+void
+Tracer::postModuleStreamEndRun(StreamContext const&, ModuleCallingContext const& mcc) {
+   --depth_;
    std::cout << indention_ << indention_ << indention_;
    for(unsigned int depth = 0; depth !=depth_; ++depth) {
       std::cout << indention_;
-   }
-   std::cout << " module for end run:" << iDescription.moduleLabel() << std::endl;
+   }   
+   std::cout << " ModuleStreamEndRun finished: " << mcc.moduleDescription()->moduleLabel() << std::endl;
 }
-void 
-Tracer::postModuleEndRun(ModuleDescription const& iDescription) {
-   --depth_;
-   std::cout << indention_ << indention_ << indention_ << indention_;
+
+void
+Tracer::preModuleStreamBeginLumi(StreamContext const&, ModuleCallingContext const& mcc) {
+   ++depth_;
+   std::cout << indention_ << indention_;
    for(unsigned int depth = 0; depth !=depth_; ++depth) {
       std::cout << indention_;
    }
-   
-   std::cout << " finished for end run:" << iDescription.moduleLabel() << std::endl;
+   std::cout << " ModuleStreamBeginLumi: " << mcc.moduleDescription()->moduleLabel() << std::endl;
 }
 
-void 
-Tracer::preBeginLumi(LuminosityBlockID const& iID, Timestamp const& iTime) {
-   depth_=0;
-   std::cout << indention_ << indention_ << " processing begin lumi:" << iID << " time:" << iTime.value() << std::endl;
-}
-void 
-Tracer::postBeginLumi(LuminosityBlock const&, EventSetup const&) {
-   std::cout << indention_ << indention_ << " finished begin lumi:" << std::endl;
-}
-
-void 
-Tracer::prePathBeginLumi(std::string const& iName) {
-  std::cout << indention_ << indention_ << indention_ << " processing path for begin lumi:" << iName << std::endl;
-}
-void 
-Tracer::postPathBeginLumi(std::string const& iName, HLTPathStatus const&) {
-  std::cout << indention_ << indention_ << indention_ << " finished path for begin lumi:" << iName << std::endl;
-}
-
-void 
-Tracer::preModuleBeginLumi(ModuleDescription const& iDescription) {
-   ++depth_;
+void
+Tracer::postModuleStreamBeginLumi(StreamContext const&, ModuleCallingContext const& mcc) {
+   --depth_;
    std::cout << indention_ << indention_ << indention_;
    for(unsigned int depth = 0; depth !=depth_; ++depth) {
       std::cout << indention_;
-   }
-   std::cout << " module for begin lumi:" << iDescription.moduleLabel() << std::endl;
+   }   
+   std::cout << " ModuleStreamBeginLumi finished: " << mcc.moduleDescription()->moduleLabel() << std::endl;
 }
-void 
-Tracer::postModuleBeginLumi(ModuleDescription const& iDescription) {
-   --depth_;
-   std::cout << indention_ << indention_ << indention_ << indention_;
+
+void
+Tracer::preModuleStreamEndLumi(StreamContext const&, ModuleCallingContext const& mcc) {
+   ++depth_;
+   std::cout << indention_ << indention_;
    for(unsigned int depth = 0; depth !=depth_; ++depth) {
       std::cout << indention_;
    }
-   
-   std::cout << " finished for begin lumi:" << iDescription.moduleLabel() << std::endl;
+   std::cout << " ModuleStreamEndLumi: " << mcc.moduleDescription()->moduleLabel() << std::endl;
 }
 
-void 
-Tracer::preEndLumi(LuminosityBlockID const& iID, Timestamp const& iTime) {
-   depth_ = 0;
-   std::cout << indention_ << indention_ << " processing end lumi:" << iID << " time:" << iTime.value() << std::endl;
-}
-void 
-Tracer::postEndLumi(LuminosityBlock const&, EventSetup const&) {
-   std::cout << indention_ << indention_ << " finished end lumi:" << std::endl;
-}
-
-void 
-Tracer::prePathEndLumi(std::string const& iName) {
-  std::cout << indention_ << indention_ << indention_ << " processing path for end lumi:" << iName << std::endl;
-}
-
-void 
-Tracer::postPathEndLumi(std::string const& iName, HLTPathStatus const&) {
-  std::cout << indention_ << indention_ << indention_ << " finished path for end lumi:" << iName << std::endl;
-}
-
-void 
-Tracer::preModuleEndLumi(ModuleDescription const& iDescription) {
-   ++depth_;
+void
+Tracer::postModuleStreamEndLumi(StreamContext const&, ModuleCallingContext const& mcc) {
+   --depth_;
    std::cout << indention_ << indention_ << indention_;
    for(unsigned int depth = 0; depth !=depth_; ++depth) {
       std::cout << indention_;
-   }
-   std::cout << " module for end lumi:" << iDescription.moduleLabel() << std::endl;
+   }   
+   std::cout << " ModuleStreamEndLumi finished: " << mcc.moduleDescription()->moduleLabel() << std::endl;
 }
 
-void 
-Tracer::postModuleEndLumi(ModuleDescription const& iDescription) {
-   --depth_;
-   std::cout << indention_ << indention_ << indention_ << indention_;
+void
+Tracer::preModuleGlobalBeginRun(GlobalContext const&, ModuleCallingContext const& mcc) {
+   ++depth_;
+   std::cout << indention_ << indention_;
    for(unsigned int depth = 0; depth !=depth_; ++depth) {
       std::cout << indention_;
    }
-   
-   std::cout << " finished for end lumi:" << iDescription.moduleLabel() << std::endl;
+   std::cout << " ModuleGlobalBeginRun: " << mcc.moduleDescription()->moduleLabel() << std::endl;
+}
+
+void
+Tracer::postModuleGlobalBeginRun(GlobalContext const&, ModuleCallingContext const& mcc) {
+   --depth_;
+   std::cout << indention_ << indention_ << indention_;
+   for(unsigned int depth = 0; depth !=depth_; ++depth) {
+      std::cout << indention_;
+   }   
+   std::cout << " ModuleGlobalBeginRun finished: " << mcc.moduleDescription()->moduleLabel() << std::endl;
+}
+
+void
+Tracer::preModuleGlobalEndRun(GlobalContext const&, ModuleCallingContext const& mcc) {
+   ++depth_;
+   std::cout << indention_ << indention_;
+   for(unsigned int depth = 0; depth !=depth_; ++depth) {
+      std::cout << indention_;
+   }
+   std::cout << " ModuleGlobalEndRun: " << mcc.moduleDescription()->moduleLabel() << std::endl;
+}
+
+void
+Tracer::postModuleGlobalEndRun(GlobalContext const&, ModuleCallingContext const& mcc) {
+   --depth_;
+   std::cout << indention_ << indention_ << indention_;
+   for(unsigned int depth = 0; depth !=depth_; ++depth) {
+      std::cout << indention_;
+   }   
+   std::cout << " ModuleGlobalEndRun finished: " << mcc.moduleDescription()->moduleLabel() << std::endl;
+}
+
+void
+Tracer::preModuleGlobalBeginLumi(GlobalContext const&, ModuleCallingContext const& mcc) {
+   ++depth_;
+   std::cout << indention_ << indention_;
+   for(unsigned int depth = 0; depth !=depth_; ++depth) {
+      std::cout << indention_;
+   }
+   std::cout << " ModuleGlobalBeginLumi: " << mcc.moduleDescription()->moduleLabel() << std::endl;
+}
+
+void
+Tracer::postModuleGlobalBeginLumi(GlobalContext const&, ModuleCallingContext const& mcc) {
+   --depth_;
+   std::cout << indention_ << indention_ << indention_;
+   for(unsigned int depth = 0; depth !=depth_; ++depth) {
+      std::cout << indention_;
+   }   
+   std::cout << " ModuleGlobalBeginLumi finished: " << mcc.moduleDescription()->moduleLabel() << std::endl;
+}
+
+void
+Tracer::preModuleGlobalEndLumi(GlobalContext const&, ModuleCallingContext const& mcc) {
+   ++depth_;
+   std::cout << indention_ << indention_;
+   for(unsigned int depth = 0; depth !=depth_; ++depth) {
+      std::cout << indention_;
+   }
+   std::cout << " ModuleGlobalEndLumi: " << mcc.moduleDescription()->moduleLabel() << std::endl;
+}
+
+void
+Tracer::postModuleGlobalEndLumi(GlobalContext const&, ModuleCallingContext const& mcc) {
+   --depth_;
+   std::cout << indention_ << indention_ << indention_;
+   for(unsigned int depth = 0; depth !=depth_; ++depth) {
+      std::cout << indention_;
+   }   
+   std::cout << " ModuleGlobalEndLumi finished: " << mcc.moduleDescription()->moduleLabel() << std::endl;
 }
 
 void 
@@ -412,48 +582,3 @@ Tracer::postSourceConstruction(ModuleDescription const& iDescription) {
   std::cout << indention_;
   std::cout << " construction finished:" << iDescription.moduleName() << std::endl;
 }
-
-void 
-Tracer::preModuleConstruction(ModuleDescription const& iDescription) {
-  std::cout << indention_;
-  std::cout << " constructing module:" << iDescription.moduleLabel() << std::endl;
-}
-
-void 
-Tracer::postModuleConstruction(ModuleDescription const& iDescription) {
-  std::cout << indention_;
-  std::cout << " construction finished:" << iDescription.moduleLabel() << std::endl;
-}
-
-void 
-Tracer::preModuleBeginJob(ModuleDescription const& iDescription) {
-  std::cout << indention_;
-  std::cout << " beginJob module:" << iDescription.moduleLabel() << std::endl;
-}
-
-void 
-Tracer::postModuleBeginJob(ModuleDescription const& iDescription) {
-  std::cout << indention_;
-  std::cout << " beginJob finished:" << iDescription.moduleLabel() << std::endl;
-}
-
-void 
-Tracer::preModuleEndJob(ModuleDescription const& iDescription) {
-  std::cout << indention_;
-  std::cout << " endJob module:" << iDescription.moduleLabel() << std::endl;
-}
-
-void 
-Tracer::postModuleEndJob(ModuleDescription const& iDescription) {
-  std::cout << indention_;
-  std::cout << " endJob finished:" << iDescription.moduleLabel() << std::endl;
-}
-
-//
-// const member functions
-//
-
-//
-// static member functions
-//
-

--- a/FWCore/Services/src/Tracer.h
+++ b/FWCore/Services/src/Tracer.h
@@ -28,9 +28,20 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 
+#include <string>
 
 namespace edm {
    class ConfigurationDescriptions;
+   class Event;
+   class EventSetup;
+   class GlobalContext;
+   class HLTPathStatus;
+   class LuminosityBlock;
+   class ModuleCallingContext;
+   class ModuleDescription;
+   class PathContext;
+   class Run;
+   class StreamContext;
 
    namespace service {
       class Tracer {
@@ -42,50 +53,8 @@ public:
          void postBeginJob();
          void postEndJob();
          
-         void preBeginRun(RunID const& id, Timestamp const& ts);
-         void postBeginRun(Run const& run, EventSetup const& es);
-
-         void preBeginLumi(LuminosityBlockID const& id, Timestamp const& ts);
-         void postBeginLumi(LuminosityBlock const& run, EventSetup const& es);
-
-         void preEvent(EventID const& id, Timestamp const& ts);
-         void postEvent(Event const& ev, EventSetup const& es);
-         
-         void preEndLumi(LuminosityBlockID const& id, Timestamp const& ts);
-         void postEndLumi(LuminosityBlock const& run, EventSetup const& es);
-
-         void preEndRun(RunID const& id, Timestamp const& ts);
-         void postEndRun(Run const& run, EventSetup const& es);
-
-         void preSourceConstruction(ModuleDescription const& md);
-         void postSourceConstruction(ModuleDescription const& md);
-
-         void preModuleConstruction(ModuleDescription const& md);
-         void postModuleConstruction(ModuleDescription const& md);
-
-         void preModuleBeginJob(ModuleDescription const& md);
-         void postModuleBeginJob(ModuleDescription const& md);
-
-         void preModuleBeginRun(ModuleDescription const& md);
-         void postModuleBeginRun(ModuleDescription const& md);
-
-         void preModuleBeginLumi(ModuleDescription const& md);
-         void postModuleBeginLumi(ModuleDescription const& md);
-
-         void preModuleEvent(ModuleDescription const& md);
-         void postModuleEvent(ModuleDescription const& md);
-         
-         void preModuleEndLumi(ModuleDescription const& md);
-         void postModuleEndLumi(ModuleDescription const& md);
-
-         void preModuleEndRun(ModuleDescription const& md);
-         void postModuleEndRun(ModuleDescription const& md);
-
-         void preModuleEndJob(ModuleDescription const& md);
-         void postModuleEndJob(ModuleDescription const& md);
-
-         void preSourceEvent();
-         void postSourceEvent();
+         void preSource();
+         void postSource();
 
          void preSourceLumi();
          void postSourceLumi();
@@ -93,33 +62,87 @@ public:
          void preSourceRun();
          void postSourceRun();
 
-         void preOpenFile();
-         void postOpenFile();
+         void preOpenFile(std::string const&, bool);
+         void postOpenFile(std::string const&, bool);
          
          void preCloseFile(std::string const& lfn, bool primary);
-         void postCloseFile();
+         void postCloseFile(std::string const&, bool);
+
+         void preModuleBeginStream(StreamContext const&, ModuleDescription const&);
+         void postModuleBeginStream(StreamContext const&, ModuleDescription const&);
+
+         void preModuleEndStream(StreamContext const&, ModuleDescription const&);
+         void postModuleEndStream(StreamContext const&, ModuleDescription const&);
+
+         void preGlobalBeginRun(GlobalContext const&);
+         void postGlobalBeginRun(GlobalContext const&);
+
+         void preGlobalEndRun(GlobalContext const&);
+         void postGlobalEndRun(GlobalContext const&, Run const&, EventSetup const&);
+
+         void preStreamBeginRun(StreamContext const&);
+         void postStreamBeginRun(StreamContext const&);
+
+         void preStreamEndRun(StreamContext const&);
+         void postStreamEndRun(StreamContext const&, Run const&, EventSetup const&);
+
+         void preGlobalBeginLumi(GlobalContext const&);
+         void postGlobalBeginLumi(GlobalContext const&);
+
+         void preGlobalEndLumi(GlobalContext const&);
+         void postGlobalEndLumi(GlobalContext const&, LuminosityBlock const&, EventSetup const&);
+
+         void preStreamBeginLumi(StreamContext const&);
+         void postStreamBeginLumi(StreamContext const&);
+
+         void preStreamEndLumi(StreamContext const&);
+         void postStreamEndLumi(StreamContext const&, LuminosityBlock const&, EventSetup const&);
+
+         void preEvent(StreamContext const&);
+         void postEvent(StreamContext const&, Event const&, EventSetup const&);
+
+         void prePathEvent(StreamContext const&, PathContext const&);
+         void postPathEvent(StreamContext const&, PathContext const&, HLTPathStatus const&);
+
+         void preModuleConstruction(ModuleDescription const& md);
+         void postModuleConstruction(ModuleDescription const& md);
+
+         void preModuleBeginJob(ModuleDescription const& md);
+         void postModuleBeginJob(ModuleDescription const& md);
+
+         void preModuleEndJob(ModuleDescription const& md);
+         void postModuleEndJob(ModuleDescription const& md);
+
+         void preModuleEvent(StreamContext const&, ModuleCallingContext const&);
+         void postModuleEvent(StreamContext const&, ModuleCallingContext const&);
          
-         void prePathBeginRun(std::string const& s);
-         void postPathBeginRun(std::string const& s, HLTPathStatus const& hlt);
+         void preModuleStreamBeginRun(StreamContext const&, ModuleCallingContext const&);
+         void postModuleStreamBeginRun(StreamContext const&, ModuleCallingContext const&);
+         void preModuleStreamEndRun(StreamContext const&, ModuleCallingContext const&);
+         void postModuleStreamEndRun(StreamContext const&, ModuleCallingContext const&);
 
-         void prePathBeginLumi(std::string const& s);
-         void postPathBeginLumi(std::string const& s, HLTPathStatus const& hlt);
+         void preModuleStreamBeginLumi(StreamContext const&, ModuleCallingContext const&);
+         void postModuleStreamBeginLumi(StreamContext const&, ModuleCallingContext const&);
+         void preModuleStreamEndLumi(StreamContext const&, ModuleCallingContext const&);
+         void postModuleStreamEndLumi(StreamContext const&, ModuleCallingContext const&);
 
-         void prePathEvent(std::string const& s);
-         void postPathEvent(std::string const& s, HLTPathStatus const& hlt);
+         void preModuleGlobalBeginRun(GlobalContext const&, ModuleCallingContext const&);
+         void postModuleGlobalBeginRun(GlobalContext const&, ModuleCallingContext const&);
+         void preModuleGlobalEndRun(GlobalContext const&, ModuleCallingContext const&);
+         void postModuleGlobalEndRun(GlobalContext const&, ModuleCallingContext const&);
 
-         void prePathEndLumi(std::string const& s);
-         void postPathEndLumi(std::string const& s, HLTPathStatus const& hlt);
+         void preModuleGlobalBeginLumi(GlobalContext const&, ModuleCallingContext const&);
+         void postModuleGlobalBeginLumi(GlobalContext const&, ModuleCallingContext const&);
+         void preModuleGlobalEndLumi(GlobalContext const&, ModuleCallingContext const&);
+         void postModuleGlobalEndLumi(GlobalContext const&, ModuleCallingContext const&);
 
-         void prePathEndRun(std::string const& s);
-         void postPathEndRun(std::string const& s, HLTPathStatus const& hlt);
+         void preSourceConstruction(ModuleDescription const& md);
+         void postSourceConstruction(ModuleDescription const& md);
 
 private:
          std::string indention_;
          unsigned int depth_;
-         
       };
    }
 }
-   
 #endif

--- a/FWCore/Sources/src/ProducerSourceBase.cc
+++ b/FWCore/Sources/src/ProducerSourceBase.cc
@@ -62,7 +62,7 @@ namespace edm {
     EventSourceSentry sentry(*this);
     EventAuxiliary aux(eventID_, processGUID(), Timestamp(presentTime_), isRealData_, eType_);
     eventPrincipal.fillEventPrincipal(aux);
-    Event e(eventPrincipal, moduleDescription());
+    Event e(eventPrincipal, moduleDescription(), nullptr);
     produce(e);
     e.commit_();
     resetEventCached();

--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -292,7 +292,7 @@ TFWLiteSelectorBasic::Process(Long64_t iEntry) {
          m_->ep_->setLuminosityBlockPrincipal(lbp);
          m_->processNames_ = m_->ep_->processHistory();
 
-         edm::Event event(*m_->ep_, m_->md_);
+         edm::Event event(*m_->ep_, m_->md_, nullptr);
 
          //Make the event principal accessible to edm::Ref's
          Operate sentry(m_->ep_->prodGetter());

--- a/FWCore/Utilities/interface/LuminosityBlockIndex.h
+++ b/FWCore/Utilities/interface/LuminosityBlockIndex.h
@@ -52,6 +52,8 @@ namespace edm {
      */
     unsigned int value() const { return value_;}
     
+    static LuminosityBlockIndex invalidLuminosityBlockIndex();
+
   private:
     ///Only the LuminosityBlockPrincipal is allowed to make one of these
     friend class LuminosityBlockPrincipal;
@@ -63,6 +65,7 @@ namespace edm {
     // ---------- member data --------------------------------
     unsigned int value_;
     
+    static const unsigned int invalidValue_;    
   };
 }
 

--- a/FWCore/Utilities/interface/RunIndex.h
+++ b/FWCore/Utilities/interface/RunIndex.h
@@ -49,8 +49,9 @@ namespace edm {
     /** \return value ranging from 0 to one less than max number of simultaneous runs.
      */
     unsigned int value() const { return value_;}
-    
-    
+
+    static RunIndex invalidRunIndex();
+
   private:
     ///Only the RunPrincipal is allowed to make one of these
     friend class RunPrincipal;
@@ -60,7 +61,8 @@ namespace edm {
     
     // ---------- member data --------------------------------
     unsigned int value_;
-    
+
+    static const unsigned int invalidValue_;    
   };
 }
 

--- a/FWCore/Utilities/src/LuminosityBlockIndex.cc
+++ b/FWCore/Utilities/src/LuminosityBlockIndex.cc
@@ -1,0 +1,12 @@
+#include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
+
+#include <limits>
+
+namespace edm {
+
+  const unsigned int LuminosityBlockIndex::invalidValue_ = std::numeric_limits<unsigned int>::max();    
+
+  LuminosityBlockIndex LuminosityBlockIndex::invalidLuminosityBlockIndex() {
+    return LuminosityBlockIndex(invalidValue_);
+  }
+}

--- a/FWCore/Utilities/src/RunIndex.cc
+++ b/FWCore/Utilities/src/RunIndex.cc
@@ -1,0 +1,12 @@
+#include "FWCore/Utilities/interface/RunIndex.h"
+
+#include <limits>
+
+namespace edm {
+
+  const unsigned int RunIndex::invalidValue_ = std::numeric_limits<unsigned int>::max();    
+
+  RunIndex RunIndex::invalidRunIndex() {
+    return RunIndex(invalidValue_);
+  }
+}

--- a/Fireworks/FWInterface/interface/FWFFLooper.h
+++ b/Fireworks/FWInterface/interface/FWFFLooper.h
@@ -57,9 +57,7 @@ public:
    void postBeginJob();
    void postEndJob();
 
-   virtual void beginRun(const edm::Run&, const edm::EventSetup&);
-   virtual void doBeginLuminosityBlock(edm::LuminosityBlockPrincipal&,edm::EventSetup const&);
-   virtual void doEndLuminosityBlock(edm::LuminosityBlockPrincipal&, edm::EventSetup const&);
+   virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
 
    void display(const std::string& info="");
 
@@ -74,9 +72,9 @@ public:
 
    void quit();
 
-   virtual void startingNewLoop(unsigned int);
-   virtual edm::EDLooperBase::Status endOfLoop(const edm::EventSetup&, unsigned int);
-   virtual edm::EDLooperBase::Status duringLoop(const edm::Event&, const edm::EventSetup&, edm::ProcessingController&); 
+   virtual void startingNewLoop(unsigned int) override;
+   virtual edm::EDLooperBase::Status endOfLoop(const edm::EventSetup&, unsigned int) override;
+   virtual edm::EDLooperBase::Status duringLoop(const edm::Event&, const edm::EventSetup&, edm::ProcessingController&) override; 
    void requestChanges(const std::string &, const edm::ParameterSet &);
 
    void remakeGeometry(const DisplayGeomRecord& dgRec);

--- a/Fireworks/FWInterface/src/FWFFLooper.cc
+++ b/Fireworks/FWInterface/src/FWFFLooper.cc
@@ -531,29 +531,6 @@ FWFFLooper::requestChanges(const std::string &moduleLabel, const edm::ParameterS
    m_scheduledChanges[moduleLabel] = ps;
 }
  
-
-//______________________________________________________________________________
-// AMT : I'm not sure if geometry can change in the two functionss. Plese delete
-// them if you think this is impossible
-
-void FWFFLooper::doBeginLuminosityBlock(edm::LuminosityBlockPrincipal& iLB, edm::EventSetup const& iES)
-{
-   try {
-      m_geomWatcher.check(iES);
-   } catch (...) {}
-   
-   EDLooperBase::doBeginLuminosityBlock(iLB, iES);
-}
-
-void FWFFLooper::doEndLuminosityBlock(edm::LuminosityBlockPrincipal& iLB, edm::EventSetup const& iES)
-{
-   try {
-      m_geomWatcher.check(iES);
-   }  catch (...) {}
-   
-   EDLooperBase::doEndLuminosityBlock(iLB, iES);
-}
-
 //______________________________________________________________________________
 
 void

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -191,6 +191,7 @@ namespace edm {
     }
 
     lfn_ = fileIter_->logicalFileName().empty() ? fileIter_->fileName() : fileIter_->logicalFileName();
+    usedFallback_ = false;
 
     // Determine whether we have a fallback URL specified; if so, prepare it;
     // Only valid if it is non-empty and differs from the original filename.
@@ -200,7 +201,7 @@ namespace edm {
     boost::shared_ptr<InputFile> filePtr;
     try {
       std::unique_ptr<InputSource::FileOpenSentry>
-        sentry(inputType_ == InputType::Primary ? new InputSource::FileOpenSentry(input_) : 0);
+        sentry(inputType_ == InputType::Primary ? new InputSource::FileOpenSentry(input_, lfn_, usedFallback_) : 0);
       filePtr.reset(new InputFile(gSystem->ExpandPathName(fileIter_->fileName().c_str()), "  Initiating request to open file "));
     }
     catch (cms::Exception const& e) {
@@ -223,10 +224,10 @@ namespace edm {
     }
     if(!filePtr && (hasFallbackUrl)) {
       try {
-        std::unique_ptr<InputSource::FileOpenSentry>
-          sentry(inputType_ == InputType::Primary ? new InputSource::FileOpenSentry(input_) : 0);
-        filePtr.reset(new InputFile(gSystem->ExpandPathName(fallbackName.c_str()), "  Fallback request to file "));
         usedFallback_ = true;
+        std::unique_ptr<InputSource::FileOpenSentry>
+          sentry(inputType_ == InputType::Primary ? new InputSource::FileOpenSentry(input_, lfn_, usedFallback_) : 0);
+        filePtr.reset(new InputFile(gSystem->ExpandPathName(fallbackName.c_str()), "  Fallback request to file "));
       }
       catch (cms::Exception const& e) {
         if(!skipBadFiles) {

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -100,13 +100,13 @@ namespace edm {
   protected:
     ///allow inheriting classes to override but still be able to call this method in the overridden version
     virtual bool shouldWeCloseFile() const override;
-    virtual void write(EventPrincipal const& e) override;
+    virtual void write(EventPrincipal const& e, ModuleCallingContext const*) override;
   private:
     virtual void openFile(FileBlock const& fb) override;
     virtual void respondToOpenInputFile(FileBlock const& fb) override;
     virtual void respondToCloseInputFile(FileBlock const& fb) override;
-    virtual void writeLuminosityBlock(LuminosityBlockPrincipal const& lb) override;
-    virtual void writeRun(RunPrincipal const& r) override;
+    virtual void writeLuminosityBlock(LuminosityBlockPrincipal const& lb, ModuleCallingContext const*) override;
+    virtual void writeRun(RunPrincipal const& r, ModuleCallingContext const*) override;
     virtual void postForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren) override;
     virtual bool isFileOpen() const override;
     virtual void reallyOpenFile() override;

--- a/IOPool/Output/interface/TimeoutPoolOutputModule.h
+++ b/IOPool/Output/interface/TimeoutPoolOutputModule.h
@@ -26,7 +26,7 @@ namespace edm {
     TimeoutPoolOutputModule& operator=(TimeoutPoolOutputModule const&) = delete; // Disallow copying and moving
   protected:
     virtual bool shouldWeCloseFile() const;
-    virtual void write(EventPrincipal const& e);
+    virtual void write(EventPrincipal const& e, ModuleCallingContext const*) override;
 
   private:
     mutable time_t m_lastEvent;

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -239,8 +239,8 @@ namespace edm {
   PoolOutputModule::~PoolOutputModule() {
   }
 
-  void PoolOutputModule::write(EventPrincipal const& e) {
-      rootOutputFile_->writeOne(e);
+  void PoolOutputModule::write(EventPrincipal const& e, ModuleCallingContext const* mcc) {
+    rootOutputFile_->writeOne(e, mcc);
       if (!statusFileName_.empty()) {
         std::ofstream statusFile(statusFileName_.c_str());
         statusFile << e.id() << " time: " << std::setprecision(3) << TimeOfDay() << '\n';
@@ -248,14 +248,14 @@ namespace edm {
       }
   }
 
-  void PoolOutputModule::writeLuminosityBlock(LuminosityBlockPrincipal const& lb) {
-      rootOutputFile_->writeLuminosityBlock(lb);
+  void PoolOutputModule::writeLuminosityBlock(LuminosityBlockPrincipal const& lb, ModuleCallingContext const* mcc) {
+    rootOutputFile_->writeLuminosityBlock(lb, mcc);
       Service<JobReport> reportSvc;
       reportSvc->reportLumiSection(lb.id().run(), lb.id().luminosityBlock());
   }
 
-  void PoolOutputModule::writeRun(RunPrincipal const& r) {
-      rootOutputFile_->writeRun(r);
+  void PoolOutputModule::writeRun(RunPrincipal const& r, ModuleCallingContext const* mcc) {
+    rootOutputFile_->writeRun(r, mcc);
       Service<JobReport> reportSvc;
       reportSvc->reportRunNumber(r.run());
   }

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -380,7 +380,8 @@ namespace edm {
     return(size >= om_->maxFileSize());
   }
 
-  void RootOutputFile::writeOne(EventPrincipal const& e) {
+  void RootOutputFile::writeOne(EventPrincipal const& e,
+                                ModuleCallingContext const* mcc) {
     // Auxiliary branch
     pEventAux_ = &e.aux();
 
@@ -400,7 +401,7 @@ namespace edm {
       esids.push_back(om_->selectorConfig());
     }
     pEventSelectionIDs_ = &esids;
-    fillBranches(InEvent, e, pEventEntryInfoVector_);
+    fillBranches(InEvent, e, pEventEntryInfoVector_, mcc);
 
     // Add the dataType to the job report if it hasn't already been done
     if(!dataTypeReported_) {
@@ -422,7 +423,7 @@ namespace edm {
     reportSvc->eventWrittenToFile(reportToken_, e.id().run(), e.id().event());
   }
 
-  void RootOutputFile::writeLuminosityBlock(LuminosityBlockPrincipal const& lb) {
+  void RootOutputFile::writeLuminosityBlock(LuminosityBlockPrincipal const& lb, ModuleCallingContext const* mcc) {
     // Auxiliary branch
     // NOTE: lumiAux_ must be filled before calling fillBranches since it gets written out in that routine.
     lumiAux_ = lb.aux();
@@ -433,11 +434,11 @@ namespace edm {
     // Add lumi to index.
     indexIntoFile_.addEntry(reducedPHID, lumiAux_.run(), lumiAux_.luminosityBlock(), 0U, lumiEntryNumber_);
     ++lumiEntryNumber_;
-    fillBranches(InLumi, lb, 0);
+    fillBranches(InLumi, lb, 0, mcc);
     lumiTree_.optimizeBaskets(10ULL*1024*1024);
   }
 
-  void RootOutputFile::writeRun(RunPrincipal const& r) {
+  void RootOutputFile::writeRun(RunPrincipal const& r, ModuleCallingContext const* mcc) {
     // Auxiliary branch
     // NOTE: runAux_ must be filled before calling fillBranches since it gets written out in that routine.
     runAux_ = r.aux();
@@ -448,7 +449,7 @@ namespace edm {
     // Add run to index.
     indexIntoFile_.addEntry(reducedPHID, runAux_.run(), 0U, 0U, runEntryNumber_);
     ++runEntryNumber_;
-    fillBranches(InRun, r, 0);
+    fillBranches(InRun, r, 0, mcc);
     runTree_.optimizeBaskets(10ULL*1024*1024);
   }
 
@@ -663,7 +664,8 @@ namespace edm {
   RootOutputFile::insertAncestors(ProductProvenance const& iGetParents,
                                   EventPrincipal const& principal,
                                   bool produced,
-                                  std::set<StoredProductProvenance>& oToFill) {
+                                  std::set<StoredProductProvenance>& oToFill,
+                                  ModuleCallingContext const* mcc) {
     assert(om_->dropMetaData() != PoolOutputModule::DropAll);
     assert(produced || om_->dropMetaData() != PoolOutputModule::DropPrior);
     if(om_->dropMetaData() == PoolOutputModule::DropDroppedPrior && !produced) return;
@@ -675,10 +677,10 @@ namespace edm {
       ProductProvenance const* info = iMapper.branchIDToProvenance(*it);
       if(info) {
         if(om_->dropMetaData() == PoolOutputModule::DropNone ||
-                 principal.getProvenance(info->branchID()).product().produced()) {
+           principal.getProvenance(info->branchID(), mcc).product().produced()) {
           if(insertProductProvenance(*info,oToFill) ) {
             //haven't seen this one yet
-            insertAncestors(*info, principal, produced, oToFill);
+            insertAncestors(*info, principal, produced, oToFill, mcc);
           }
         }
       }
@@ -688,7 +690,8 @@ namespace edm {
   void RootOutputFile::fillBranches(
                 BranchType const& branchType,
                 Principal const& principal,
-                StoredProductProvenanceVector* productProvenanceVecPtr) {
+                StoredProductProvenanceVector* productProvenanceVecPtr,
+                ModuleCallingContext const* mcc) {
 
     typedef std::vector<std::pair<TClass*, void const*> > Dummies;
     Dummies dummies;
@@ -714,13 +717,13 @@ namespace edm {
          treePointers_[branchType]->uncloned(i->branchDescription_->branchName()));
 
       void const* product = 0;
-      OutputHandle const oh = principal.getForOutput(id, getProd);
+      OutputHandle const oh = principal.getForOutput(id, getProd, mcc);
       if(keepProvenance && oh.productProvenance()) {
         insertProductProvenance(*oh.productProvenance(),provenanceToKeep);
         //provenanceToKeep.insert(*oh.productProvenance());
         EventPrincipal const& eventPrincipal = dynamic_cast<EventPrincipal const&>(principal);
         assert(eventPrincipal.branchMapperPtr());
-        insertAncestors(*oh.productProvenance(), eventPrincipal, produced, provenanceToKeep);
+        insertAncestors(*oh.productProvenance(), eventPrincipal, produced, provenanceToKeep, mcc);
       }
       product = oh.wrapper();
       if(getProd) {

--- a/IOPool/Output/src/RootOutputFile.h
+++ b/IOPool/Output/src/RootOutputFile.h
@@ -35,7 +35,9 @@ class TTree;
 class TFile;
 
 namespace edm {
+  class ModuleCallingContext;
   class PoolOutputModule;
+
 
   class RootOutputFile {
   public:
@@ -45,10 +47,10 @@ namespace edm {
     explicit RootOutputFile(PoolOutputModule* om, std::string const& fileName,
                             std::string const& logicalFileName);
     ~RootOutputFile() {}
-    void writeOne(EventPrincipal const& e);
+    void writeOne(EventPrincipal const& e, ModuleCallingContext const*);
     //void endFile();
-    void writeLuminosityBlock(LuminosityBlockPrincipal const& lb);
-    void writeRun(RunPrincipal const& r);
+    void writeLuminosityBlock(LuminosityBlockPrincipal const& lb, ModuleCallingContext const*);
+    void writeRun(RunPrincipal const& r, ModuleCallingContext const*);
     void writeFileFormatVersion();
     void writeFileIdentifier();
     void writeIndexIntoFile();
@@ -80,12 +82,14 @@ namespace edm {
 
     void fillBranches(BranchType const& branchType,
                       Principal const& principal,
-                      StoredProductProvenanceVector* productProvenanceVecPtr);
+                      StoredProductProvenanceVector* productProvenanceVecPtr,
+                      ModuleCallingContext const*);
 
      void insertAncestors(ProductProvenance const& iGetParents,
                           EventPrincipal const& principal,
                           bool produced,
-                          std::set<StoredProductProvenance>& oToFill);
+                          std::set<StoredProductProvenance>& oToFill,
+                          ModuleCallingContext const*);
 
     bool insertProductProvenance(const ProductProvenance&,
                                  std::set<StoredProductProvenance>& oToInsert);

--- a/IOPool/Output/src/TimeoutPoolOutputModule.cc
+++ b/IOPool/Output/src/TimeoutPoolOutputModule.cc
@@ -3,9 +3,9 @@
 
 namespace edm {
 
-  void TimeoutPoolOutputModule::write(EventPrincipal const& e) {
+  void TimeoutPoolOutputModule::write(EventPrincipal const& e, ModuleCallingContext const* mcc) {
     eventsWrittenInCurrentFile++;
-    PoolOutputModule::write(e);
+    PoolOutputModule::write(e, mcc);
   }
   
   TimeoutPoolOutputModule::TimeoutPoolOutputModule(ParameterSet const& ps):

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -107,6 +107,7 @@ namespace edm {
                                                     "EventNumber",
                                                     "",
                                                     "",
+                                                    nullptr,
                                                     nullptr);
     assert(bhandle.isValid());
     Handle<edmtest::IntProduct> handle;
@@ -121,6 +122,7 @@ namespace edm {
                                                "Thing",
                                                "",
                                                "",
+                                               nullptr,
                                                nullptr);
     assert(bh.isValid());
     if(!(bh.interface()->dynamicTypeInfo() == typeid(TC))) {

--- a/IOPool/Streamer/interface/StreamSerializer.h
+++ b/IOPool/Streamer/interface/StreamSerializer.h
@@ -60,6 +60,7 @@ namespace edm
 {
   
   class EventPrincipal;
+  class ModuleCallingContext;
   class StreamSerializer
   {
 
@@ -71,7 +72,8 @@ namespace edm
     int serializeEvent(EventPrincipal const& eventPrincipal,
                        ParameterSetID const& selectorConfig,
                        bool use_compression, int compression_level,
-                       SerializeDataBuffer &data_buffer);
+                       SerializeDataBuffer &data_buffer,
+                       ModuleCallingContext const* mcc);
 
     /**
      * Compresses the data in the specified input buffer into the

--- a/IOPool/Streamer/interface/StreamerOutputModuleBase.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleBase.h
@@ -10,7 +10,9 @@
 class InitMsgBuilder;
 class EventMsgBuilder;
 namespace edm {
+  class ModuleCallingContext;
   class ParameterSetDescription;
+
   class StreamerOutputModuleBase : public OutputModule {
   public:
     explicit StreamerOutputModuleBase(ParameterSet const& ps);  
@@ -18,13 +20,13 @@ namespace edm {
     static void fillDescription(ParameterSetDescription & desc);
 
   private:
-    virtual void beginRun(RunPrincipal const&);
-    virtual void endRun(RunPrincipal const&);
-    virtual void beginJob();
-    virtual void endJob();
-    virtual void writeRun(RunPrincipal const&);
-    virtual void writeLuminosityBlock(LuminosityBlockPrincipal const&);
-    virtual void write(EventPrincipal const& e);
+    virtual void beginRun(RunPrincipal const&, ModuleCallingContext const*) override;
+    virtual void endRun(RunPrincipal const&, ModuleCallingContext const*) override;
+    virtual void beginJob() override;
+    virtual void endJob() override;
+    virtual void writeRun(RunPrincipal const&, ModuleCallingContext const*) override;
+    virtual void writeLuminosityBlock(LuminosityBlockPrincipal const&, ModuleCallingContext const*) override;
+    virtual void write(EventPrincipal const& e, ModuleCallingContext const*) override;
 
     virtual void start() const = 0;
     virtual void stop() const = 0;
@@ -32,8 +34,8 @@ namespace edm {
     virtual void doOutputEvent(EventMsgBuilder const& msg) const = 0;
 
     std::auto_ptr<InitMsgBuilder> serializeRegistry();
-    std::auto_ptr<EventMsgBuilder> serializeEvent(EventPrincipal const& e); 
-    void setHltMask(EventPrincipal const& e);
+    std::auto_ptr<EventMsgBuilder> serializeEvent(EventPrincipal const& e, ModuleCallingContext const* mcc); 
+    void setHltMask(EventPrincipal const& e, ModuleCallingContext const*);
     void setLumiSection();
 
   private:

--- a/IOPool/Streamer/src/StreamSerializer.cc
+++ b/IOPool/Streamer/src/StreamSerializer.cc
@@ -136,7 +136,8 @@ namespace edm {
   int StreamSerializer::serializeEvent(EventPrincipal const& eventPrincipal,
                                        ParameterSetID const& selectorConfig,
                                        bool use_compression, int compression_level,
-                                       SerializeDataBuffer &data_buffer) {
+                                       SerializeDataBuffer &data_buffer,
+                                       ModuleCallingContext const* mcc) {
     Parentage parentage;
 
     EventSelectionIDVector selectionIDs = eventPrincipal.eventSelectionIDs();
@@ -150,7 +151,7 @@ namespace edm {
       BranchDescription const& desc = **i;
       BranchID const& id = desc.branchID();
 
-      OutputHandle const oh = eventPrincipal.getForOutput(id, true);
+      OutputHandle const oh = eventPrincipal.getForOutput(id, true, mcc);
       if(!oh.productProvenance()) {
         // No product with this ID was put in the event.
         // Create and write the provenance.

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -104,14 +104,14 @@ namespace edm {
   StreamerOutputModuleBase::~StreamerOutputModuleBase() {}
 
   void
-  StreamerOutputModuleBase::beginRun(RunPrincipal const&) {
+  StreamerOutputModuleBase::beginRun(RunPrincipal const&, ModuleCallingContext const*) {
     start();
     std::auto_ptr<InitMsgBuilder>  init_message = serializeRegistry();
     doOutputHeader(*init_message);
   }
 
   void
-  StreamerOutputModuleBase::endRun(RunPrincipal const&) {
+  StreamerOutputModuleBase::endRun(RunPrincipal const&, ModuleCallingContext const*) {
     stop();
   }
 
@@ -124,14 +124,14 @@ namespace edm {
   }
 
   void
-  StreamerOutputModuleBase::writeRun(RunPrincipal const&) {}
+  StreamerOutputModuleBase::writeRun(RunPrincipal const&, ModuleCallingContext const*) {}
 
   void
-  StreamerOutputModuleBase::writeLuminosityBlock(LuminosityBlockPrincipal const&) {}
+  StreamerOutputModuleBase::writeLuminosityBlock(LuminosityBlockPrincipal const&, ModuleCallingContext const*) {}
 
   void
-  StreamerOutputModuleBase::write(EventPrincipal const& e) {
-    std::auto_ptr<EventMsgBuilder> msg = serializeEvent(e);
+  StreamerOutputModuleBase::write(EventPrincipal const& e, ModuleCallingContext const* mcc) {
+    std::auto_ptr<EventMsgBuilder> msg = serializeEvent(e, mcc);
     doOutputEvent(*msg); // You can't use msg in StreamerOutputModuleBase after this point
   }
 
@@ -195,11 +195,11 @@ namespace edm {
   }
 
   void
-  StreamerOutputModuleBase::setHltMask(EventPrincipal const& e) {
+  StreamerOutputModuleBase::setHltMask(EventPrincipal const& e, ModuleCallingContext const* mcc) {
 
     hltbits_.clear();  // If there was something left over from last event
 
-    Handle<TriggerResults> const& prod = getTriggerResults(e);
+    Handle<TriggerResults> const& prod = getTriggerResults(e, mcc);
     //Trig const& prod = getTrigMask(e);
     std::vector<unsigned char> vHltState;
 
@@ -236,7 +236,7 @@ namespace edm {
   }
 
   std::auto_ptr<EventMsgBuilder>
-  StreamerOutputModuleBase::serializeEvent(EventPrincipal const& e) {
+  StreamerOutputModuleBase::serializeEvent(EventPrincipal const& e, ModuleCallingContext const* mcc) {
     //Lets Build the Event Message first
 
     //Following is strictly DUMMY Data for L! Trig and will be replaced with actual
@@ -246,7 +246,7 @@ namespace edm {
     l1bit_.push_back(false);
     //End of dummy data
 
-    setHltMask(e);
+    setHltMask(e, mcc);
 
     if (lumiSectionInterval_ == 0) {
       lumi_ = e.luminosityBlock();
@@ -254,7 +254,7 @@ namespace edm {
       setLumiSection();
     }
 
-    serializer_.serializeEvent(e, selectorConfig(), useCompression_, compressionLevel_, serialize_databuffer);
+    serializer_.serializeEvent(e, selectorConfig(), useCompression_, compressionLevel_, serialize_databuffer, mcc);
 
     // resize bufs_ to reflect space used in serializer_ + header
     // I just added an overhead for header of 50000 for now

--- a/IgTools/IgProf/plugins/IgProfService.cc
+++ b/IgTools/IgProf/plugins/IgProfService.cc
@@ -141,12 +141,12 @@ void IgProfService::postEndJob() {
   makeDump(atPostEndJob_); 
 }
 
-void IgProfService::postOpenFile () {
+void IgProfService::postOpenFile (std::string const&, bool) {
   ++nfileopened_; 
   makeDump(atPostOpenFile_);
 }  
 
-void IgProfService::postCloseFile () {
+void IgProfService::postCloseFile (std::string const&, bool) {
   ++nfileclosed_; 
   makeDump(atPostCloseFile_);
 }  

--- a/IgTools/IgProf/plugins/IgProfService.h
+++ b/IgTools/IgProf/plugins/IgProfService.h
@@ -34,9 +34,9 @@ namespace edm {
 
       void postEndJob();
 
-      void postOpenFile();
+      void postOpenFile(std::string const&, bool);
 
-      void postCloseFile();
+      void postCloseFile(std::string const&, bool);
 
       inline
       bool isProcessWideService(IgProfService const*) {

--- a/Mixing/Base/src/BMixingModule.cc
+++ b/Mixing/Base/src/BMixingModule.cc
@@ -252,7 +252,7 @@ namespace edm {
       addSignals(e,setup);
     }
 
-    doPileUp(e,setup);
+    doPileUp(e, setup);
 
     // Includes putting digi products into the edm::Event.
     finalizeEvent(e, setup);

--- a/Mixing/Base/src/PileUp.cc
+++ b/Mixing/Base/src/PileUp.cc
@@ -174,7 +174,7 @@ namespace edm {
     if (provider_.get() != nullptr) {
       boost::shared_ptr<RunAuxiliary> aux(new RunAuxiliary(run.runAuxiliary()));
       runPrincipal_.reset(new RunPrincipal(aux, productRegistry_, *processConfiguration_, nullptr, 0));
-      provider_->beginRun(*runPrincipal_, setup);
+      provider_->beginRun(*runPrincipal_, setup, run.moduleCallingContext());
     }
   }
   void PileUp::beginLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& setup) {
@@ -182,18 +182,18 @@ namespace edm {
       boost::shared_ptr<LuminosityBlockAuxiliary> aux(new LuminosityBlockAuxiliary(lumi.luminosityBlockAuxiliary()));
       lumiPrincipal_.reset(new LuminosityBlockPrincipal(aux, productRegistry_, *processConfiguration_, nullptr, 0));
       lumiPrincipal_->setRunPrincipal(runPrincipal_);
-      provider_->beginLuminosityBlock(*lumiPrincipal_, setup);
+      provider_->beginLuminosityBlock(*lumiPrincipal_, setup, lumi.moduleCallingContext());
     }
   }
 
   void PileUp::endRun(const edm::Run& run, const edm::EventSetup& setup) {
     if (provider_.get() != nullptr) {
-      provider_->endRun(*runPrincipal_, setup);
+      provider_->endRun(*runPrincipal_, setup, run.moduleCallingContext());
     }
   }
   void PileUp::endLuminosityBlock(const edm::LuminosityBlock& lumi, const edm::EventSetup& setup) {
     if (provider_.get() != nullptr) {
-      provider_->endLuminosityBlock(*lumiPrincipal_, setup);
+      provider_->endLuminosityBlock(*lumiPrincipal_, setup, lumi.moduleCallingContext());
     }
   }
 

--- a/Mixing/Base/src/SecondaryEventProvider.cc
+++ b/Mixing/Base/src/SecondaryEventProvider.cc
@@ -28,23 +28,28 @@ namespace edm {
   
   //NOTE: When the Stream interfaces are propagated to the modules, this code must be updated
   // to also send the stream based transitions
-  void SecondaryEventProvider::beginRun(RunPrincipal& run, const EventSetup& setup) {
-    workerManager_.processOneOccurrence<OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> >(run, setup, StreamID::invalidStreamID());
+  void SecondaryEventProvider::beginRun(RunPrincipal& run, const EventSetup& setup, ModuleCallingContext const* mcc) {
+    workerManager_.processOneOccurrence<OccurrenceTraits<RunPrincipal, BranchActionGlobalBegin> >(run, setup, StreamID::invalidStreamID(),
+                                                                                                  mcc->getGlobalContext(), mcc);
   }
 
-  void SecondaryEventProvider::beginLuminosityBlock(LuminosityBlockPrincipal& lumi, const EventSetup& setup) {
-    workerManager_.processOneOccurrence<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> >(lumi, setup, StreamID::invalidStreamID());
+  void SecondaryEventProvider::beginLuminosityBlock(LuminosityBlockPrincipal& lumi, const EventSetup& setup, ModuleCallingContext const* mcc) {
+    workerManager_.processOneOccurrence<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalBegin> >(lumi, setup, StreamID::invalidStreamID(),
+                                                                                                              mcc->getGlobalContext(), mcc);
   }
 
-  void SecondaryEventProvider::endRun(RunPrincipal& run, const EventSetup& setup) {
-    workerManager_.processOneOccurrence<OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> >(run, setup, StreamID::invalidStreamID());
+  void SecondaryEventProvider::endRun(RunPrincipal& run, const EventSetup& setup, ModuleCallingContext const* mcc) {
+    workerManager_.processOneOccurrence<OccurrenceTraits<RunPrincipal, BranchActionGlobalEnd> >(run, setup, StreamID::invalidStreamID(),
+                                                                                                mcc->getGlobalContext(), mcc);
   }
 
-  void SecondaryEventProvider::endLuminosityBlock(LuminosityBlockPrincipal& lumi, const EventSetup& setup) {
-    workerManager_.processOneOccurrence<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> >(lumi, setup, StreamID::invalidStreamID());
+  void SecondaryEventProvider::endLuminosityBlock(LuminosityBlockPrincipal& lumi, const EventSetup& setup, ModuleCallingContext const* mcc) {
+    workerManager_.processOneOccurrence<OccurrenceTraits<LuminosityBlockPrincipal, BranchActionGlobalEnd> >(lumi, setup, StreamID::invalidStreamID(),
+                                                                                                            mcc->getGlobalContext(), mcc);
   }
 
   void SecondaryEventProvider::setupPileUpEvent(EventPrincipal& ep, const EventSetup& setup) {
-    workerManager_.processOneOccurrence<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin> >(ep, setup, ep.streamID());
+    workerManager_.processOneOccurrence<OccurrenceTraits<EventPrincipal, BranchActionStreamBegin>, StreamContext >(ep, setup, ep.streamID(),
+                                                                                                                   nullptr, nullptr);
   }
 }

--- a/Mixing/Base/src/SecondaryEventProvider.h
+++ b/Mixing/Base/src/SecondaryEventProvider.h
@@ -11,6 +11,8 @@
 #include <vector>
 
 namespace edm {
+  class ModuleCallingContext;
+
   class SecondaryEventProvider {
   public:
     SecondaryEventProvider(std::vector<ParameterSet>& psets,
@@ -18,11 +20,11 @@ namespace edm {
              ActionTable const& actions,
              boost::shared_ptr<ProcessConfiguration> processConfiguration);
 
-    void beginRun(RunPrincipal& run, const edm::EventSetup& setup);
-    void beginLuminosityBlock(LuminosityBlockPrincipal& lumi, const edm::EventSetup& setup);
+    void beginRun(RunPrincipal& run, const edm::EventSetup& setup, ModuleCallingContext const*);
+    void beginLuminosityBlock(LuminosityBlockPrincipal& lumi, const edm::EventSetup& setup, ModuleCallingContext const*);
 
-    void endRun(RunPrincipal& run, const edm::EventSetup& setup);
-    void endLuminosityBlock(LuminosityBlockPrincipal& lumi, const edm::EventSetup& setup);
+    void endRun(RunPrincipal& run, const edm::EventSetup& setup, ModuleCallingContext const*);
+    void endLuminosityBlock(LuminosityBlockPrincipal& lumi, const edm::EventSetup& setup, ModuleCallingContext const*);
 
     void setupPileUpEvent(EventPrincipal& ep, const EventSetup& setup);
 

--- a/SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h
+++ b/SimCalorimetry/HcalSimAlgos/interface/HcalSignalGenerator.h
@@ -20,6 +20,10 @@
 
 #include <iostream>
 
+namespace edm {
+  class ModuleCallingContext;
+}
+
 template<class HCALDIGITIZERTRAITS>
 class HcalSignalGenerator : public HcalBaseSignalGenerator
 {
@@ -47,7 +51,7 @@ public:
     theParameterMap->setDbService(theConditions.product());
   }
 
-  virtual void fill()
+  virtual void fill(edm::ModuleCallingContext const* mcc)
   {
     theNoiseSignals.clear();
     edm::Handle<COLLECTION> pDigis;
@@ -67,7 +71,7 @@ public:
     else if(theEventPrincipal)
     {
        boost::shared_ptr<edm::Wrapper<COLLECTION>  const> digisPTR =
-          edm::getProductByTag<COLLECTION>(*theEventPrincipal, theInputTag );
+          edm::getProductByTag<COLLECTION>(*theEventPrincipal, theInputTag, mcc );
        if(digisPTR) {
           digis = digisPTR->product();
        }

--- a/SimCalorimetry/HcalSimAlgos/test/HcalSignalGeneratorTest.cpp
+++ b/SimCalorimetry/HcalSimAlgos/test/HcalSignalGeneratorTest.cpp
@@ -51,10 +51,10 @@ void HcalSignalGeneratorTest::analyze(const edm::Event& iEvent, const edm::Event
   theHFSignalGenerator.initializeEvent(&iEvent, &iSetup);
   theZDCSignalGenerator.initializeEvent(&iEvent, &iSetup);
 
-  theHBHESignalGenerator.fill();
-  theHOSignalGenerator.fill();
-  theHFSignalGenerator.fill();
-  theZDCSignalGenerator.fill();
+  theHBHESignalGenerator.fill(nullptr);
+  theHOSignalGenerator.fill(nullptr);
+  theHFSignalGenerator.fill(nullptr);
+  theZDCSignalGenerator.fill(nullptr);
 
   //dump(&theHBHESignalGenerator);
 }

--- a/SimGeneral/DataMixingModule/plugins/DataMixingEMDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingEMDigiWorker.cc
@@ -101,9 +101,10 @@ namespace edm
 
 	 EBDigiStorage_.insert(EBDigiMap::value_type( ( it->id() ), *it ));
 #ifdef DEBUG	 
-         LogDebug("DataMixingEMDigiWorker") << "processed EBDigi with rawId: "
-				      << it->id().rawId() << "\n"
-				      << " digi energy: " << it->energy();
+         // Commented out because this does not compile anymore	 
+         // LogDebug("DataMixingEMDigiWorker") << "processed EBDigi with rawId: "
+         //                                    << it->id().rawId() << "\n"
+         //                                    << " digi energy: " << it->energy();
 #endif
        }
      }
@@ -129,9 +130,10 @@ namespace edm
 
 	 EEDigiStorage_.insert(EEDigiMap::value_type( ( it->id() ), *it ));
 #ifdef DEBUG	 
-	 LogDebug("DataMixingEMDigiWorker") << "processed EEDigi with rawId: "
-				      << it->id().rawId() << "\n"
-				      << " digi energy: " << it->energy();
+         // Commented out because this does not compile anymore	 
+	 // LogDebug("DataMixingEMDigiWorker") << "processed EEDigi with rawId: "
+         //                                    << it->id().rawId() << "\n"
+         //                                    << " digi energy: " << it->energy();
 #endif
 
        }
@@ -161,9 +163,10 @@ namespace edm
 	 ESDigiStorage_.insert(ESDigiMap::value_type( ( it->id() ), *it ));
 	 
 #ifdef DEBUG	 
-         LogDebug("DataMixingEMDigiWorker") << "processed ESDigi with rawId: "
-				      << it->id().rawId() << "\n"
-				      << " digi energy: " << it->energy();
+         // Commented out because this does not compile anymore	 
+         // LogDebug("DataMixingEMDigiWorker") << "processed ESDigi with rawId: "
+         //                                    << it->id().rawId() << "\n"
+         //                                    << " digi energy: " << it->energy();
 #endif
 
        }
@@ -171,7 +174,8 @@ namespace edm
     
   } // end of addEMSignals
 
-  void DataMixingEMDigiWorker::addEMPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr, const edm::EventSetup& ES) {
+  void DataMixingEMDigiWorker::addEMPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr, const edm::EventSetup& ES,
+                                            ModuleCallingContext const* mcc) {
   
     LogInfo("DataMixingEMDigiWorker") <<"\n===============> adding pileups from event  "<<ep->id()<<" for bunchcrossing "<<bcr;
 
@@ -180,7 +184,7 @@ namespace edm
     // EB first
 
     boost::shared_ptr<Wrapper<EBDigiCollection>  const> EBDigisPTR = 
-          getProductByTag<EBDigiCollection>(*ep, EBPileInputTag_ );
+      getProductByTag<EBDigiCollection>(*ep, EBPileInputTag_, mcc);
  
    if(EBDigisPTR ) {
 
@@ -195,9 +199,10 @@ namespace edm
        	 EBDigiStorage_.insert(EBDigiMap::value_type( (it->id()), *it ));
 	 
 #ifdef DEBUG	 
-       	 LogDebug("DataMixingEMDigiWorker") << "processed EBDigi with rawId: "
-       		      << it->id().rawId() << "\n"
-       		      << " digi energy: " << it->energy();
+         // Commented out because this does not compile anymore	 
+       	 // LogDebug("DataMixingEMDigiWorker") << "processed EBDigi with rawId: "
+         //                                    << it->id().rawId() << "\n"
+         //                                    << " digi energy: " << it->energy();
 #endif
       }
     }
@@ -205,7 +210,7 @@ namespace edm
     // EE Next
 
     boost::shared_ptr<Wrapper<EEDigiCollection>  const> EEDigisPTR =
-          getProductByTag<EEDigiCollection>(*ep, EEPileInputTag_ );
+      getProductByTag<EEDigiCollection>(*ep, EEPileInputTag_, mcc);
 
     if(EEDigisPTR ) {
 
@@ -219,16 +224,17 @@ namespace edm
        EEDigiStorage_.insert(EEDigiMap::value_type( (it->id()), *it ));
 	 
 #ifdef DEBUG	 
-       LogDebug("DataMixingEMDigiWorker") << "processed EEDigi with rawId: "
-				      << it->id().rawId() << "\n"
-				      << " digi energy: " << it->energy();
+       // Commented out because this does not compile anymore	 
+       // LogDebug("DataMixingEMDigiWorker") << "processed EEDigi with rawId: "
+       //                                    << it->id().rawId() << "\n"
+       //                                    << " digi energy: " << it->energy();
 #endif
      }
    }
     // ES Next
 
     boost::shared_ptr<Wrapper<ESDigiCollection>  const> ESDigisPTR =
-      getProductByTag<ESDigiCollection>(*ep, ESPileInputTag_ );
+      getProductByTag<ESDigiCollection>(*ep, ESPileInputTag_, mcc);
 
     if(ESDigisPTR ) {
 
@@ -242,9 +248,10 @@ namespace edm
 	ESDigiStorage_.insert(ESDigiMap::value_type( (it->id()), *it ));
 
 #ifdef DEBUG
-	LogDebug("DataMixingEMDigiWorker") << "processed ESDigi with rawId: "
-					   << it->id().rawId() << "\n"
-					   << " digi energy: " << it->energy();
+        // Commented out because this does not compile anymore	 
+        // LogDebug("DataMixingEMDigiWorker") << "processed ESDigi with rawId: "
+        //                                    << it->id().rawId() << "\n"
+        //                                    << " digi energy: " << it->energy();
 #endif
       }
     }

--- a/SimGeneral/DataMixingModule/plugins/DataMixingEMDigiWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingEMDigiWorker.h
@@ -37,6 +37,8 @@
 
 namespace edm
 {
+  class ModuleCallingContext;
+
   class DataMixingEMDigiWorker
     {
     public:
@@ -51,7 +53,8 @@ namespace edm
 
       void putEM(edm::Event &e,const edm::EventSetup& ES) ;
       void addEMSignals(const edm::Event &e,const edm::EventSetup& ES); 
-      void addEMPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId,const edm::EventSetup& ES);
+      void addEMPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId,const edm::EventSetup& ES,
+                        ModuleCallingContext const*);
 
 
     private:

--- a/SimGeneral/DataMixingModule/plugins/DataMixingEMWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingEMWorker.cc
@@ -165,7 +165,8 @@ namespace edm
     
   } // end of addEMSignals
 
-  void DataMixingEMWorker::addEMPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr) {
+  void DataMixingEMWorker::addEMPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr,
+                                        ModuleCallingContext const* mcc) {
   
     LogInfo("DataMixingEMWorker") <<"\n===============> adding pileups from event  "<<ep->id()<<" for bunchcrossing "<<bcr;
 
@@ -174,7 +175,7 @@ namespace edm
     // EB first
 
     boost::shared_ptr<Wrapper<EBRecHitCollection>  const> EBRecHitsPTR =
-      getProductByTag<EBRecHitCollection>(*ep, EBPileRecHitInputTag_ );
+      getProductByTag<EBRecHitCollection>(*ep, EBPileRecHitInputTag_, mcc);
 
     if(EBRecHitsPTR ) {
 
@@ -199,7 +200,7 @@ namespace edm
     // EE Next
 
     boost::shared_ptr<Wrapper<EERecHitCollection>  const> EERecHitsPTR =
-      getProductByTag<EERecHitCollection>(*ep, EEPileRecHitInputTag_ );
+      getProductByTag<EERecHitCollection>(*ep, EEPileRecHitInputTag_, mcc);
 
     if(EERecHitsPTR ) {
 
@@ -224,7 +225,7 @@ namespace edm
     // ES Next
 
     boost::shared_ptr<Wrapper<ESRecHitCollection>  const> ESRecHitsPTR =
-      getProductByTag<ESRecHitCollection>(*ep, ESPileRecHitInputTag_ );
+      getProductByTag<ESRecHitCollection>(*ep, ESPileRecHitInputTag_, mcc);
 
     if(ESRecHitsPTR ) {
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingEMWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingEMWorker.h
@@ -33,6 +33,8 @@
 
 namespace edm
 {
+  class ModuleCallingContext;
+
   class DataMixingEMWorker
     {
     public:
@@ -47,7 +49,8 @@ namespace edm
 
       void putEM(edm::Event &e) ;
       void addEMSignals(const edm::Event &e); 
-      void addEMPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId);
+      void addEMPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId,
+                        ModuleCallingContext const*);
 
 
     private:

--- a/SimGeneral/DataMixingModule/plugins/DataMixingGeneralTrackWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingGeneralTrackWorker.cc
@@ -73,12 +73,13 @@ namespace edm
 
 
 
-  void DataMixingGeneralTrackWorker::addGeneralTrackPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr) {
+  void DataMixingGeneralTrackWorker::addGeneralTrackPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr,
+                                                            ModuleCallingContext const* mcc) {
     LogDebug("DataMixingGeneralTrackWorker") <<"\n===============> adding pileups from event  "<<ep->id()<<" for bunchcrossing "<<bcr;
 
 
     boost::shared_ptr<Wrapper<reco::TrackCollection >  const> inputPTR =
-      getProductByTag<reco::TrackCollection >(*ep, GeneralTrackPileInputTag_ );
+      getProductByTag<reco::TrackCollection >(*ep, GeneralTrackPileInputTag_, mcc);
 
     if(inputPTR ) {
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingGeneralTrackWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingGeneralTrackWorker.h
@@ -33,6 +33,8 @@
 
 namespace edm
 {
+  class ModuleCallingContext;
+
   class DataMixingGeneralTrackWorker
     {
     public:
@@ -47,7 +49,7 @@ namespace edm
 
       void putGeneralTrack(edm::Event &e) ;
       void addGeneralTrackSignals(const edm::Event &e); 
-      void addGeneralTrackPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId);
+      void addGeneralTrackPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId, ModuleCallingContext const*);
 
 
     private:

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.cc
@@ -124,9 +124,10 @@ namespace edm
 	 HBHEDigiStorage_.insert(HBHEDigiMap::value_type( ( it->id() ), tool ));
 	 
 #ifdef DEBUG	 
-         LogDebug("DataMixingHcalDigiWorker") << "processed HBHEDigi with rawId: "
-				      << it->id() << "\n"
-				      << " digi energy: " << it->energy();
+         // Commented out because this does not compile anymore	 
+         // LogDebug("DataMixingHcalDigiWorker") << "processed HBHEDigi with rawId: "
+         //                                      << it->id() << "\n"
+         //                                      << " digi energy: " << it->energy();
 #endif
 
        }
@@ -165,9 +166,10 @@ namespace edm
 	 HODigiStorage_.insert(HODigiMap::value_type( ( it->id() ), tool ));
 	 
 #ifdef DEBUG	 
-         LogDebug("DataMixingHcalDigiWorker") << "processed HODigi with rawId: "
-				      << it->id() << "\n"
-				      << " digi energy: " << it->energy();
+         // Commented out because this does not compile anymore	 
+         // LogDebug("DataMixingHcalDigiWorker") << "processed HODigi with rawId: "
+         //                                      << it->id() << "\n"
+         //                                      << " digi energy: " << it->energy();
 #endif
 
        }
@@ -206,9 +208,10 @@ namespace edm
 	 HFDigiStorage_.insert(HFDigiMap::value_type( ( it->id() ), tool ));
 	 
 #ifdef DEBUG	 
-         LogDebug("DataMixingHcalDigiWorker") << "processed HFDigi with rawId: "
-				      << it->id() << "\n"
-				      << " digi energy: " << it->energy();
+         // Commented out because this does not compile anymore	 
+         // LogDebug("DataMixingHcalDigiWorker") << "processed HFDigi with rawId: "
+         //                                      << it->id() << "\n"
+         //                                      << " digi energy: " << it->energy();
 #endif
 
        }
@@ -249,9 +252,10 @@ namespace edm
 	   ZDCDigiStorage_.insert(ZDCDigiMap::value_type( ( it->id() ), tool ));
 	 
 #ifdef DEBUG	 
-	   LogDebug("DataMixingHcalDigiWorker") << "processed ZDCDigi with rawId: "
-						<< it->id() << "\n"
-						<< " digi energy: " << it->energy();
+           // Commented out because this does not compile anymore	 
+           // LogDebug("DataMixingHcalDigiWorker") << "processed ZDCDigi with rawId: "
+           //                                      << it->id() << "\n"
+           //                                      << " digi energy: " << it->energy();
 #endif
 
 	 }
@@ -260,7 +264,8 @@ namespace edm
     
   } // end of addHCalSignals
 
-  void DataMixingHcalDigiWorker::addHcalPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr,const edm::EventSetup& ES) {
+  void DataMixingHcalDigiWorker::addHcalPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr,const edm::EventSetup& ES,
+                                                ModuleCallingContext const* mcc) {
   
     LogDebug("DataMixingHcalDigiWorker") <<"\n===============> adding pileups from event  "<<ep->id()<<" for bunchcrossing "<<bcr;
 
@@ -272,8 +277,9 @@ namespace edm
 
     // HBHE first
 
+
     boost::shared_ptr<Wrapper<HBHEDigiCollection>  const> HBHEDigisPTR = 
-          getProductByTag<HBHEDigiCollection>(*ep, HBHEPileInputTag_ );
+      getProductByTag<HBHEDigiCollection>(*ep, HBHEPileInputTag_, mcc);
  
     if(HBHEDigisPTR ) {
 
@@ -298,16 +304,17 @@ namespace edm
 	 HBHEDigiStorage_.insert(HBHEDigiMap::value_type( (it->id()), tool ));
 	 
 #ifdef DEBUG	 
-	 LogDebug("DataMixingHcalDigiWorker") << "processed HBHEDigi with rawId: "
-				      << it->id() << "\n"
-				      << " digi energy: " << it->energy();
+         // Commented out because this does not compile anymore	 
+	 // LogDebug("DataMixingHcalDigiWorker") << "processed HBHEDigi with rawId: "
+         //                                      << it->id() << "\n"
+         //                                      << " digi energy: " << it->energy();
 #endif
        }
     }
     // HO Next
 
     boost::shared_ptr<Wrapper<HODigiCollection>  const> HODigisPTR = 
-          getProductByTag<HODigiCollection>(*ep, HOPileInputTag_ );
+      getProductByTag<HODigiCollection>(*ep, HOPileInputTag_, mcc);
  
     if(HODigisPTR ) {
 
@@ -332,9 +339,10 @@ namespace edm
 	 HODigiStorage_.insert(HODigiMap::value_type( (it->id()), tool ));
 	 
 #ifdef DEBUG	 
-	 LogDebug("DataMixingHcalDigiWorker") << "processed HODigi with rawId: "
-				      << it->id() << "\n"
-				      << " digi energy: " << it->energy();
+         // Commented out because this does not compile anymore	 
+	 // LogDebug("DataMixingHcalDigiWorker") << "processed HODigi with rawId: "
+         //                                      << it->id() << "\n"
+         //                                      << " digi energy: " << it->energy();
 #endif
        }
     }
@@ -343,7 +351,7 @@ namespace edm
     // HF Next
 
     boost::shared_ptr<Wrapper<HFDigiCollection>  const> HFDigisPTR = 
-          getProductByTag<HFDigiCollection>(*ep, HFPileInputTag_ );
+      getProductByTag<HFDigiCollection>(*ep, HFPileInputTag_, mcc);
  
     if(HFDigisPTR ) {
 
@@ -368,9 +376,10 @@ namespace edm
 	 HFDigiStorage_.insert(HFDigiMap::value_type( (it->id()), tool ));
 	 
 #ifdef DEBUG	 
-	 LogDebug("DataMixingHcalDigiWorker") << "processed HFDigi with rawId: "
-				      << it->id() << "\n"
-				      << " digi energy: " << it->energy();
+         // Commented out because this does not compile anymore	 
+	 // LogDebug("DataMixingHcalDigiWorker") << "processed HFDigi with rawId: "
+         //                                      << it->id() << "\n"
+         //                                      << " digi energy: " << it->energy();
 #endif
        }
     }
@@ -382,7 +391,7 @@ namespace edm
 
 
       boost::shared_ptr<Wrapper<ZDCDigiCollection>  const> ZDCDigisPTR = 
-	getProductByTag<ZDCDigiCollection>(*ep, ZDCPileInputTag_ );
+	getProductByTag<ZDCDigiCollection>(*ep, ZDCPileInputTag_, mcc);
  
       if(ZDCDigisPTR ) {
 
@@ -406,10 +415,11 @@ namespace edm
 
 	  ZDCDigiStorage_.insert(ZDCDigiMap::value_type( (it->id()), tool ));
 	 
-#ifdef DEBUG	 
-	  LogDebug("DataMixingHcalDigiWorker") << "processed ZDCDigi with rawId: "
-					       << it->id() << "\n"
-					       << " digi energy: " << it->energy();
+#ifdef DEBUG
+          // Commented out because this does not compile anymore	 
+	  // LogDebug("DataMixingHcalDigiWorker") << "processed ZDCDigi with rawId: "
+          //                                      << it->id() << "\n"
+          //                                      << " digi energy: " << it->energy();
 #endif
 	}
       }

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorker.h
@@ -35,6 +35,8 @@
 
 namespace edm
 {
+  class ModuleCallingContext;
+
   class DataMixingHcalDigiWorker
     {
     public:
@@ -49,7 +51,8 @@ namespace edm
 
       void putHcal(edm::Event &e,const edm::EventSetup& ES) ;
       void addHcalSignals(const edm::Event &e,const edm::EventSetup& ES); 
-      void addHcalPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId,const edm::EventSetup& ES);
+      void addHcalPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId,const edm::EventSetup& ES,
+                          ModuleCallingContext const*);
 
 
     private:

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.cc
@@ -59,7 +59,8 @@ namespace edm {
 
   } // end of addHcalSignals
 
-  void DataMixingHcalDigiWorkerProd::addHcalPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr,const edm::EventSetup& ES) {
+  void DataMixingHcalDigiWorkerProd::addHcalPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr,const edm::EventSetup& ES,
+                                                    edm::ModuleCallingContext const* mcc) {
   
     LogDebug("DataMixingHcalDigiWorkerProd") <<"\n===============> adding pileups from event  "<<ep->id()<<" for bunchcrossing "<<bcr;
 
@@ -68,9 +69,9 @@ namespace edm {
     theHFSignalGenerator.initializeEvent(ep, &ES);
     theZDCSignalGenerator.initializeEvent(ep, &ES);
 
-    theHBHESignalGenerator.fill();
-    theHOSignalGenerator.fill();
-    theHFSignalGenerator.fill();
+    theHBHESignalGenerator.fill(mcc);
+    theHOSignalGenerator.fill(mcc);
+    theHFSignalGenerator.fill(mcc);
   }
 
   void DataMixingHcalDigiWorkerProd::putHcal(edm::Event &e,const edm::EventSetup& ES) {

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.h
@@ -37,6 +37,8 @@
 
 namespace edm
 {
+  class ModuleCallingContext;
+
   class DataMixingHcalDigiWorkerProd
     {
     public:
@@ -49,7 +51,8 @@ namespace edm
 
       void putHcal(edm::Event &e,const edm::EventSetup& ES);
       void addHcalSignals(const edm::Event &e,const edm::EventSetup& ES); 
-      void addHcalPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId,const edm::EventSetup& ES);
+      void addHcalPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId,
+                          const edm::EventSetup& ES, edm::ModuleCallingContext const*);
 
 
     private:

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalWorker.cc
@@ -190,7 +190,8 @@ namespace edm
     
   } // end of addEMSignals
 
-  void DataMixingHcalWorker::addHcalPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr) {
+  void DataMixingHcalWorker::addHcalPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr,
+                                            ModuleCallingContext const* mcc) {
   
     LogDebug("DataMixingHcalWorker") <<"\n===============> adding pileups from event  "<<ep->id()<<" for bunchcrossing "<<bcr;
 
@@ -199,7 +200,7 @@ namespace edm
     // HBHE first
 
     boost::shared_ptr<Wrapper<HBHERecHitCollection>  const> HBHERecHitsPTR =
-      getProductByTag<HBHERecHitCollection>(*ep, HBHEPileRecHitInputTag_ );
+      getProductByTag<HBHERecHitCollection>(*ep, HBHEPileRecHitInputTag_, mcc);
 
     if(HBHERecHitsPTR ) {
 
@@ -224,7 +225,7 @@ namespace edm
     // HO Next
 
     boost::shared_ptr<Wrapper<HORecHitCollection>  const> HORecHitsPTR =
-      getProductByTag<HORecHitCollection>(*ep, HOPileRecHitInputTag_ );
+      getProductByTag<HORecHitCollection>(*ep, HOPileRecHitInputTag_, mcc);
 
     if(HORecHitsPTR ) {
 
@@ -249,7 +250,7 @@ namespace edm
     // HF Next
 
     boost::shared_ptr<Wrapper<HFRecHitCollection>  const> HFRecHitsPTR =
-      getProductByTag<HFRecHitCollection>(*ep, HFPileRecHitInputTag_ );
+      getProductByTag<HFRecHitCollection>(*ep, HFPileRecHitInputTag_, mcc);
 
     if(HFRecHitsPTR ) {
 
@@ -274,7 +275,7 @@ namespace edm
     // ZDC Next
 
     boost::shared_ptr<Wrapper<ZDCRecHitCollection>  const> ZDCRecHitsPTR =
-      getProductByTag<ZDCRecHitCollection>(*ep, ZDCPileRecHitInputTag_ );
+      getProductByTag<ZDCRecHitCollection>(*ep, ZDCPileRecHitInputTag_, mcc);
 
     if(ZDCRecHitsPTR ) {
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalWorker.h
@@ -29,6 +29,8 @@
 
 namespace edm
 {
+  class ModuleCallingContext;
+
   class DataMixingHcalWorker
     {
     public:
@@ -43,7 +45,8 @@ namespace edm
 
       void putHcal(edm::Event &e) ;
       void addHcalSignals(const edm::Event &e); 
-      void addHcalPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId);
+      void addHcalPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId,
+                          ModuleCallingContext const*);
 
 
     private:

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
@@ -41,8 +41,10 @@
 #include <string>
 
 
-namespace edm
-{
+namespace edm {
+
+  class ModuleCallingContext;
+
   class DataMixingModule : public BMixingModule
     {
     public:
@@ -57,10 +59,10 @@ namespace edm
       virtual void checkSignal(const edm::Event &e) {}
       virtual void createnewEDProduct() {}
       virtual void addSignals(const edm::Event &e, const edm::EventSetup& ES); 
-      virtual void doPileUp(edm::Event &e,const edm::EventSetup& ES);
+      virtual void doPileUp(edm::Event &e,const edm::EventSetup& ES, edm::ModuleCallingContext const* mcc);
       virtual void put(edm::Event &e,const edm::EventSetup& ES) ;
 
-      void pileWorker(const edm::EventPrincipal&, int bcr, int EventId,const edm::EventSetup& ES);
+      void pileWorker(const edm::EventPrincipal&, int bcr, int EventId,const edm::EventSetup& ES, ModuleCallingContext const*);
 
     private:
       // data specifiers

--- a/SimGeneral/DataMixingModule/plugins/DataMixingMuonWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingMuonWorker.cc
@@ -213,7 +213,8 @@ namespace edm
     
   } // end of addMuonSignals
 
-  void DataMixingMuonWorker::addMuonPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr) {
+  void DataMixingMuonWorker::addMuonPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr,
+                                            ModuleCallingContext const* mcc) {
   
     LogDebug("DataMixingMuonWorker") <<"\n===============> adding pileups from event  "<<ep->id()<<" for bunchcrossing "<<bcr;
 
@@ -224,7 +225,7 @@ namespace edm
     // Get the digis from the event
 
    boost::shared_ptr<Wrapper<DTDigiCollection>  const> DTDigisPTR = 
-          getProductByTag<DTDigiCollection>(*ep, DTPileInputTag_ );
+     getProductByTag<DTDigiCollection>(*ep, DTPileInputTag_, mcc);
  
    if(DTDigisPTR ) {
 
@@ -249,7 +250,7 @@ namespace edm
 
 
    boost::shared_ptr<Wrapper<RPCDigiCollection>  const> RPCDigisPTR = 
-          getProductByTag<RPCDigiCollection>(*ep, RPCPileInputTag_ );
+     getProductByTag<RPCDigiCollection>(*ep, RPCPileInputTag_, mcc);
  
    if(RPCDigisPTR ) {
 
@@ -274,7 +275,7 @@ namespace edm
     // Get the digis from the event
 
    boost::shared_ptr<Wrapper<CSCStripDigiCollection>  const> CSCStripDigisPTR = 
-          getProductByTag<CSCStripDigiCollection>(*ep, CSCStripPileInputTag_ );
+     getProductByTag<CSCStripDigiCollection>(*ep, CSCStripPileInputTag_, mcc);
  
    if(CSCStripDigisPTR ) {
 
@@ -299,7 +300,7 @@ namespace edm
     // Get the digis from the event
 
    boost::shared_ptr<Wrapper<CSCWireDigiCollection>  const> CSCWireDigisPTR = 
-          getProductByTag<CSCWireDigiCollection>(*ep, CSCWirePileInputTag_ );
+     getProductByTag<CSCWireDigiCollection>(*ep, CSCWirePileInputTag_, mcc);
  
    if(CSCWireDigisPTR ) {
 
@@ -324,7 +325,7 @@ namespace edm
    // Get the digis from the event
 
    boost::shared_ptr<Wrapper<CSCComparatorDigiCollection>  const> CSCComparatorDigisPTR =
-     getProductByTag<CSCComparatorDigiCollection>(*ep, CSCCompPileInputTag_ );
+     getProductByTag<CSCComparatorDigiCollection>(*ep, CSCCompPileInputTag_, mcc);
 
    if(CSCComparatorDigisPTR ) {
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingMuonWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingMuonWorker.h
@@ -37,6 +37,8 @@
 
 namespace edm
 {
+  class ModuleCallingContext;
+
   class DataMixingMuonWorker
     {
     public:
@@ -51,7 +53,7 @@ namespace edm
 
       void putMuon(edm::Event &e) ;
       void addMuonSignals(const edm::Event &e); 
-      void addMuonPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId);
+      void addMuonPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId, ModuleCallingContext const*);
 
 
     private:

--- a/SimGeneral/DataMixingModule/plugins/DataMixingPileupCopy.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingPileupCopy.cc
@@ -44,7 +44,8 @@ namespace edm
   }  
 
 
-  void DataMixingPileupCopy::addPileupInfo(const EventPrincipal *ep, unsigned int eventNr) {
+  void DataMixingPileupCopy::addPileupInfo(const EventPrincipal *ep, unsigned int eventNr,
+                                           ModuleCallingContext const* mcc) {
   
     LogDebug("DataMixingPileupCopy") <<"\n===============> adding pileup Info from event  "<<ep->id();
 
@@ -53,7 +54,7 @@ namespace edm
     // Pileup info first
 
     boost::shared_ptr<Wrapper< std::vector<PileupSummaryInfo> >  const> PileupInfoPTR =
-      getProductByTag<std::vector<PileupSummaryInfo>>(*ep,PileupInfoInputTag_ );
+      getProductByTag<std::vector<PileupSummaryInfo>>(*ep,PileupInfoInputTag_, mcc);
 
     if(PileupInfoPTR ) {
 
@@ -66,7 +67,7 @@ namespace edm
     // Playback
 
     boost::shared_ptr<Wrapper<CrossingFramePlaybackInfoExtended>  const> PlaybackPTR =
-      getProductByTag<CrossingFramePlaybackInfoExtended>(*ep,CFPlaybackInputTag_ );
+      getProductByTag<CrossingFramePlaybackInfoExtended>(*ep,CFPlaybackInputTag_, mcc);
 
     if(PlaybackPTR ) {
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingPileupCopy.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingPileupCopy.h
@@ -31,6 +31,8 @@
 
 namespace edm
 {
+  class ModuleCallingContext;
+
   class DataMixingPileupCopy
     {
     public:
@@ -44,7 +46,8 @@ namespace edm
       virtual ~DataMixingPileupCopy();
 
       void putPileupInfo(edm::Event &e) ;
-      void addPileupInfo(const edm::EventPrincipal*,unsigned int EventId);
+      void addPileupInfo(const edm::EventPrincipal*,unsigned int EventId,
+                         ModuleCallingContext const* mcc);
 
 
     private:

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelWorker.cc
@@ -89,14 +89,15 @@ namespace edm
 
 
 
-  void DataMixingSiPixelWorker::addSiPixelPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr) {
+  void DataMixingSiPixelWorker::addSiPixelPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr,
+                                                  ModuleCallingContext const* mcc) {
   
     LogDebug("DataMixingSiPixelWorker") <<"\n===============> adding pileups from event  "<<ep->id()<<" for bunchcrossing "<<bcr;
 
     // fill in maps of hits; same code as addSignals, except now applied to the pileup events
 
     boost::shared_ptr<Wrapper<edm::DetSetVector<PixelDigi> >  const> inputPTR =
-      getProductByTag<edm::DetSetVector<PixelDigi> >(*ep, pixeldigi_collectionPile_ );
+      getProductByTag<edm::DetSetVector<PixelDigi> >(*ep, pixeldigi_collectionPile_, mcc);
 
     if(inputPTR ) {
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelWorker.h
@@ -32,6 +32,8 @@
 
 namespace edm
 {
+  class ModuleCallingContext;
+
   class DataMixingSiPixelWorker
     {
     public:
@@ -46,7 +48,7 @@ namespace edm
 
       void putSiPixel(edm::Event &e) ;
       void addSiPixelSignals(const edm::Event &e); 
-      void addSiPixelPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId);
+      void addSiPixelPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId, ModuleCallingContext const*);
 
 
     private:

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiStripRawWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiStripRawWorker.cc
@@ -79,7 +79,8 @@ namespace edm
 
 
 
-  void DataMixingSiStripRawWorker::addSiStripPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr) {
+  void DataMixingSiStripRawWorker::addSiStripPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr,
+                                                     ModuleCallingContext const* mcc) {
     
     LogDebug("DataMixingSiStripRawWorker") << "\n===============> adding pileups from event  "
 					   << ep->id() << " for bunchcrossing " << bcr;
@@ -88,10 +89,10 @@ namespace edm
     boost::shared_ptr<Wrapper<edm::DetSetVector<SiStripRawDigi> > const> pSSRD;
     
     if (SiStripRawDigiSource_=="SIGNAL") {
-      pSSD = getProductByTag<edm::DetSetVector<SiStripDigi> >(*ep, SiStripPileInputTag_);
+      pSSD = getProductByTag<edm::DetSetVector<SiStripDigi> >(*ep, SiStripPileInputTag_, mcc);
       digicollection_ = const_cast< edm::DetSetVector<SiStripDigi> * >(pSSD->product());
     } else if (SiStripRawDigiSource_=="PILEUP") {
-      pSSRD = getProductByTag<edm::DetSetVector<SiStripRawDigi> >(*ep, SiStripRawInputTag_ );
+      pSSRD = getProductByTag<edm::DetSetVector<SiStripRawDigi> >(*ep, SiStripRawInputTag_, mcc);
       rawdigicollection_ = const_cast< edm::DetSetVector<SiStripRawDigi> * >(pSSRD->product());
     } else {
       std::cout << "you shouldn't be here" << std::endl;

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiStripRawWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiStripRawWorker.h
@@ -33,6 +33,8 @@
 
 namespace edm
 {
+  class ModuleCallingContext;
+
   class DataMixingSiStripRawWorker
     {
     public:
@@ -47,7 +49,8 @@ namespace edm
 
       void putSiStrip(edm::Event &e) ;
       void addSiStripSignals(const edm::Event &e); 
-      void addSiStripPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId);
+      void addSiStripPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId,
+                             ModuleCallingContext const*);
 
 
     private:

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiStripWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiStripWorker.cc
@@ -81,13 +81,14 @@ namespace edm
 
 
 
-  void DataMixingSiStripWorker::addSiStripPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr) {
+  void DataMixingSiStripWorker::addSiStripPileups(const int bcr, const EventPrincipal *ep, unsigned int eventNr,
+                                                  ModuleCallingContext const* mcc) {
     LogDebug("DataMixingSiStripWorker") <<"\n===============> adding pileups from event  "<<ep->id()<<" for bunchcrossing "<<bcr;
 
     // fill in maps of hits; same code as addSignals, except now applied to the pileup events
 
     boost::shared_ptr<Wrapper<edm::DetSetVector<SiStripDigi> >  const> inputPTR =
-      getProductByTag<edm::DetSetVector<SiStripDigi> >(*ep, SiStripPileInputTag_ );
+      getProductByTag<edm::DetSetVector<SiStripDigi> >(*ep, SiStripPileInputTag_, mcc);
 
     if(inputPTR ) {
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiStripWorker.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiStripWorker.h
@@ -32,6 +32,8 @@
 
 namespace edm
 {
+  class ModuleCallingContext;
+
   class DataMixingSiStripWorker
     {
     public:
@@ -46,7 +48,8 @@ namespace edm
 
       void putSiStrip(edm::Event &e) ;
       void addSiStripSignals(const edm::Event &e); 
-      void addSiStripPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId);
+      void addSiStripPileups(const int bcr, const edm::EventPrincipal*,unsigned int EventId,
+                             ModuleCallingContext const*);
 
 
     private:

--- a/SimGeneral/MixingModule/interface/PileUpEventPrincipal.h
+++ b/SimGeneral/MixingModule/interface/PileUpEventPrincipal.h
@@ -16,11 +16,15 @@ class PSimHit;
 class SimTrack;
 class SimVertex;
 
+namespace edm {
+  class ModuleCallingContext;
+}
+
 class PileUpEventPrincipal {
 public:
 
-  PileUpEventPrincipal(edm::EventPrincipal const& ep, int bcr, int bsp, int eventId, int vtxOffset) :
-    principal_(ep), bunchCrossing_(bcr), bunchCrossingXbunchSpace_(bcr*bsp), id_(bcr, eventId), vertexOffset_(vtxOffset), labels_() {}
+  PileUpEventPrincipal(edm::EventPrincipal const& ep, edm::ModuleCallingContext const* mcc, int bcr, int bsp, int eventId, int vtxOffset) :
+    principal_(ep), mcc_(mcc), bunchCrossing_(bcr), bunchCrossingXbunchSpace_(bcr*bsp), id_(bcr, eventId), vertexOffset_(vtxOffset), labels_() {}
 
   bool
   addLabel(edm::TypeID const& type, std::string const& label) const {
@@ -47,10 +51,10 @@ public:
 
   template<typename T>
   bool
-    getByLabel(edm::InputTag const& tag, edm::Handle<T>& result) const {
+  getByLabel(edm::InputTag const& tag, edm::Handle<T>& result) const {
     typedef typename T::value_type ItemType;
     typedef typename T::iterator iterator;
-    edm::BasicHandle bh = principal_.getByLabel(edm::PRODUCT_TYPE, edm::TypeID(typeid(T)), tag, nullptr);
+    edm::BasicHandle bh = principal_.getByLabel(edm::PRODUCT_TYPE, edm::TypeID(typeid(T)), tag, nullptr, mcc_);
     convert_handle(bh, result);
     if(result.isValid() && addLabel(edm::TypeID(typeid(T)), tag.label())) {
       T& product = const_cast<T&>(*result.product());
@@ -62,7 +66,8 @@ public:
   }
 
 private: 
-  edm::EventPrincipal const& principal_;  
+  edm::EventPrincipal const& principal_;
+  edm::ModuleCallingContext const* mcc_;
   int bunchCrossing_;
   int bunchCrossingXbunchSpace_;
   EncodedEventId id_;

--- a/SimGeneral/MixingModule/plugins/MixingModule.h
+++ b/SimGeneral/MixingModule/plugins/MixingModule.h
@@ -41,6 +41,7 @@ class PileUpEventPrincipal;
 
 namespace edm {
   class MixingWorkerBase;
+  class ModuleCallingContext;
 
   class MixingModule : public BMixingModule {
     public:
@@ -79,7 +80,7 @@ namespace edm {
       virtual void checkSignal(const edm::Event &e);
       virtual void addSignals(const edm::Event &e, const edm::EventSetup& es); 
       virtual void doPileUp(edm::Event &e, const edm::EventSetup& es);
-      void pileAllWorkers(EventPrincipal const& ep, int bcr, int id, int& offset,
+      void pileAllWorkers(EventPrincipal const& ep, ModuleCallingContext const*, int bcr, int id, int& offset,
 			  const edm::EventSetup& setup);
       void createDigiAccumulators( const edm::ParameterSet& mixingPSet ) ;
 

--- a/SimGeneral/MixingModule/plugins/MixingWorker.cc
+++ b/SimGeneral/MixingModule/plugins/MixingWorker.cc
@@ -9,9 +9,9 @@
 
 namespace edm {
   template <>
-  void MixingWorker<PCaloHit>::addPileups(const int bcr, const EventPrincipal &ep, unsigned int eventNr,int vertexoffset) {
-
-    boost::shared_ptr<Wrapper<std::vector<PCaloHit> > const> shPtr = edm::getProductByTag<std::vector<PCaloHit> >(ep, tag_);
+  void MixingWorker<PCaloHit>::addPileups(const int bcr, const EventPrincipal &ep, ModuleCallingContext const* mcc,
+                                          unsigned int eventNr,int vertexoffset) {
+    boost::shared_ptr<Wrapper<std::vector<PCaloHit> > const> shPtr = edm::getProductByTag<std::vector<PCaloHit> >(ep, tag_, mcc);
 
     if (shPtr) {
       LogDebug("MixingModule") <<shPtr->product()->size()<<"  pileup objects  added, eventNr "<<eventNr;
@@ -21,9 +21,10 @@ namespace edm {
   }
 
   template <>
-  void MixingWorker<PSimHit>::addPileups(const int bcr, const EventPrincipal &ep,unsigned int eventNr,int vertexoffset) {
+  void MixingWorker<PSimHit>::addPileups(const int bcr, const EventPrincipal &ep, ModuleCallingContext const* mcc,
+                                         unsigned int eventNr,int vertexoffset) {
     //    changed for high/low treatment
-    boost::shared_ptr<Wrapper<std::vector<PSimHit> > const> shPtr = getProductByTag<std::vector<PSimHit> >(ep, tag_);
+    boost::shared_ptr<Wrapper<std::vector<PSimHit> > const> shPtr = getProductByTag<std::vector<PSimHit> >(ep, tag_, mcc);
     if (shPtr) {
       LogDebug("MixingModule") <<shPtr->product()->size()<<"  pileup objects  added, eventNr "<<eventNr;
       crFrame_->setPileupPtr(shPtr);
@@ -32,9 +33,10 @@ namespace edm {
   }
 
   template <>
-  void  MixingWorker<SimTrack>::addPileups(const int bcr, const EventPrincipal &ep,unsigned int eventNr,int vertexoffset) { 
+  void  MixingWorker<SimTrack>::addPileups(const int bcr, const EventPrincipal &ep, ModuleCallingContext const* mcc,
+                                           unsigned int eventNr,int vertexoffset) { 
       // changed to transmit vertexoffset
-      boost::shared_ptr<Wrapper<std::vector<SimTrack> > const> shPtr = getProductByTag<std::vector<SimTrack> >(ep, tag_);
+    boost::shared_ptr<Wrapper<std::vector<SimTrack> > const> shPtr = getProductByTag<std::vector<SimTrack> >(ep, tag_, mcc);
       
       if (shPtr) {
 	LogDebug("MixingModule") <<shPtr->product()->size()<<"  pileup objects  added, eventNr "<<eventNr;
@@ -44,10 +46,11 @@ namespace edm {
   }
 
   template <>
-  void MixingWorker<SimVertex>::addPileups(const int bcr, const EventPrincipal &ep,unsigned int eventNr,int vertexoffset) {
+  void MixingWorker<SimVertex>::addPileups(const int bcr, const EventPrincipal &ep, ModuleCallingContext const* mcc,
+                                           unsigned int eventNr,int vertexoffset) {
   
     // changed to take care of vertexoffset
-    boost::shared_ptr<Wrapper<std::vector<SimVertex> > const> shPtr = getProductByTag<std::vector<SimVertex> >(ep, tag_);
+    boost::shared_ptr<Wrapper<std::vector<SimVertex> > const> shPtr = getProductByTag<std::vector<SimVertex> >(ep, tag_, mcc);
         
     if (shPtr) {
       LogDebug("MixingModule") <<shPtr->product()->size()<<"  pileup objects  added, eventNr "<<eventNr;
@@ -58,9 +61,10 @@ namespace edm {
   }
 
   template <>
-  void MixingWorker<HepMCProduct>::addPileups(const int bcr, const EventPrincipal& ep,unsigned int eventNr,int vertexoffset) {
+  void MixingWorker<HepMCProduct>::addPileups(const int bcr, const EventPrincipal& ep, ModuleCallingContext const* mcc,
+                                              unsigned int eventNr,int vertexoffset) {
     // HepMCProduct does not come as a vector....
-    boost::shared_ptr<Wrapper<HepMCProduct> const> shPtr = getProductByTag<HepMCProduct>(ep, tag_);
+    boost::shared_ptr<Wrapper<HepMCProduct> const> shPtr = getProductByTag<HepMCProduct>(ep, tag_, mcc);
     if (shPtr) {
       LogDebug("MixingModule") <<"HepMC pileup objects  added, eventNr "<<eventNr << " Tag " << tag_ << std::endl;
       crFrame_->setPileupPtr(shPtr);

--- a/SimGeneral/MixingModule/plugins/MixingWorker.h
+++ b/SimGeneral/MixingModule/plugins/MixingWorker.h
@@ -118,7 +118,7 @@ namespace edm
       }
 
 
-      virtual void addPileups(const int bcr, const EventPrincipal &ep, unsigned int eventNr,int vertexoffset);
+      virtual void addPileups(const int bcr, const EventPrincipal &ep, ModuleCallingContext const*, unsigned int eventNr,int vertexoffset);
 
       virtual void setBcrOffset() {crFrame_->setBcrOffset();}
       virtual void setSourceOffset(const unsigned int s) {crFrame_->setSourceOffset(s);}
@@ -154,19 +154,24 @@ namespace edm
 //=============== template specializations ====================================================================================
     
 template <>
-    void MixingWorker<PCaloHit>::addPileups(const int bcr, const EventPrincipal &ep, unsigned int eventNr,int vertexoffset);
+    void MixingWorker<PCaloHit>::addPileups(const int bcr, const EventPrincipal &ep, ModuleCallingContext const*,
+                                            unsigned int eventNr,int vertexoffset);
 
 template <>
-    void MixingWorker<PSimHit>::addPileups(const int bcr, const EventPrincipal &ep, unsigned int eventNr,int vertexoffset);
+    void MixingWorker<PSimHit>::addPileups(const int bcr, const EventPrincipal &ep, ModuleCallingContext const*,
+                                           unsigned int eventNr,int vertexoffset);
 
 template <>
-    void MixingWorker<SimTrack>::addPileups(const int bcr, const EventPrincipal &ep, unsigned int eventNr,int vertexoffset);
+    void MixingWorker<SimTrack>::addPileups(const int bcr, const EventPrincipal &ep, ModuleCallingContext const*,
+                                            unsigned int eventNr,int vertexoffset);
 
 template <>
-    void MixingWorker<SimVertex>::addPileups(const int bcr, const EventPrincipal& ep, unsigned int eventNr,int vertexoffset);
+    void MixingWorker<SimVertex>::addPileups(const int bcr, const EventPrincipal& ep, ModuleCallingContext const*,
+                                             unsigned int eventNr,int vertexoffset);
 
 template <>
-    void MixingWorker<HepMCProduct>::addPileups(const int bcr, const EventPrincipal &ep, unsigned int eventNr,int vertexoffset);
+    void MixingWorker<HepMCProduct>::addPileups(const int bcr, const EventPrincipal &ep, ModuleCallingContext const*,
+                                                unsigned int eventNr,int vertexoffset);
 
 template <class T>
     void MixingWorker<T>::setTof() {;}

--- a/SimGeneral/MixingModule/plugins/MixingWorkerBase.h
+++ b/SimGeneral/MixingModule/plugins/MixingWorkerBase.h
@@ -20,6 +20,7 @@
 namespace edm
 {
   class MixingModule;
+  class ModuleCallingContext;
   class EventSetup;
 
   /*! This class allows MixingModule to store a vector of
@@ -40,7 +41,8 @@ namespace edm
       virtual void createnewEDProduct()=0; 
       virtual void addSignals(const edm::Event &e) =0;
       virtual void addPileups(const int bcr, const edm::EventPrincipal&,
-			      unsigned int EventNr, int vertexOffset=0)=0;
+                              ModuleCallingContext const*,
+                              unsigned int EventNr, int vertexOffset=0)=0;
       virtual void setBcrOffset()=0;
       virtual void setSourceOffset(const unsigned int s)=0;
       virtual void setTof()=0;

--- a/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
+++ b/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
@@ -34,6 +34,9 @@
 #include "SimDataFormats/CrossingFrame/interface/PCrossingFrame.h"
 
 #include "FWCore/Framework/interface/InputSourceDescription.h"
+#include "FWCore/ServiceRegistry/interface/InternalContext.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
 #include "FWCore/Sources/interface/VectorInputSourceFactory.h"
 
 #include "FWCore/Sources/interface/VectorInputSource.h"
@@ -100,7 +103,7 @@ SecSourceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 	   input_->readPileUp( iEvent.id(),
                                vectorEventIDs_[ ibx-minBunch_ ],
 			       boost::bind(&SecSourceAnalyzer::getBranches, 
-					   this, _1), ibx
+					   this, _1, iEvent.moduleCallingContext()), ibx
 			       );
 	 }
        else
@@ -120,8 +123,13 @@ SecSourceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 	     << " bunch." << std::endl;
 }
 
-void  SecSourceAnalyzer::getBranches(EventPrincipal const &ep)
+void  SecSourceAnalyzer::getBranches(EventPrincipal const &ep,
+                                     ModuleCallingContext const* mcc)
   { 
+    InternalContext internalContext(ep.id(), mcc);
+    ParentContext parentContext(&internalContext);
+    ModuleCallingContext moduleCallingContext(&moduleDescription(), ModuleCallingContext::State::kRunning, parentContext);
+
     std::cout <<"-> Get the event:  id " << ep.id() << std::endl;
     std::cout << "-> dataStep2_ = " << dataStep2_ << std::endl;
     tag_ = InputTag(label_);
@@ -134,7 +142,7 @@ void  SecSourceAnalyzer::getBranches(EventPrincipal const &ep)
         
 	// default version changed to transmit vertexoffset
         boost::shared_ptr<Wrapper<std::vector<SimTrack> > const> shPtr =
-        getProductByTag<std::vector<SimTrack> >(ep, tag_);
+          getProductByTag<std::vector<SimTrack> >(ep, tag_, &moduleCallingContext);
     
         if (shPtr) 
 		std::cout << "-> Could get SimTrack !" << std::endl;
@@ -148,7 +156,7 @@ void  SecSourceAnalyzer::getBranches(EventPrincipal const &ep)
         // default version changed to transmit vertexoffset
 	tag_ = InputTag("CFwriter","g4SimHits");
         boost::shared_ptr<Wrapper<PCrossingFrame<SimTrack> > const> shPtr =
-        getProductByTag<PCrossingFrame<SimTrack> >(ep, tag_);
+          getProductByTag<PCrossingFrame<SimTrack> >(ep, tag_, &moduleCallingContext);
         
 	if (shPtr) 
 		std::cout << "-> Could get PCrossingFrame<SimTrack> !" << std::endl;

--- a/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.h
+++ b/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.h
@@ -37,36 +37,39 @@
 //
 // class declaration
 //
-namespace edm
-{
-class SecSourceAnalyzer : public edm::EDAnalyzer {
-   public:
+namespace edm {
+
+  class ModuleCallingContext;
+
+  class SecSourceAnalyzer : public edm::EDAnalyzer {
+  public:
    
-      explicit SecSourceAnalyzer(const edm::ParameterSet&);
-      ~SecSourceAnalyzer();
+    explicit SecSourceAnalyzer(const edm::ParameterSet&);
+    ~SecSourceAnalyzer();
 
-      virtual void getBranches(EventPrincipal const& ep);
-      virtual void dummyFunction(EventPrincipal const& ep) {}
+    virtual void getBranches(EventPrincipal const& ep,
+                             ModuleCallingContext const*);
+    virtual void dummyFunction(EventPrincipal const& ep) {}
 
-   private:
-      virtual void beginJob() ;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() ;
+  private:
+    virtual void beginJob() ;
+    virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+    virtual void endJob() ;
 
-      // ----------member data ---------------------------
-     int minBunch_;
-     int maxBunch_;
+    // ----------member data ---------------------------
+    int minBunch_;
+    int maxBunch_;
 
-      bool dataStep2_;
-      edm::InputTag label_;
+    bool dataStep2_;
+    edm::InputTag label_;
       
-      std::vector<std::vector<edm::EventID> > vectorEventIDs_;
+    std::vector<std::vector<edm::EventID> > vectorEventIDs_;
 
-      boost::shared_ptr<PileUp> input_;
-      std::vector< float > TrueNumInteractions_[5];
+    boost::shared_ptr<PileUp> input_;
+    std::vector< float > TrueNumInteractions_[5];
 
-      InputTag tag_;
+    InputTag tag_;
  
-};
+  };
 }//edm
 #endif


### PR DESCRIPTION
Adds new interface for Service callback functions to
support the multithreaded Framework. This interface
passes around a new set of classes which hold the
context at all the important transitions that occur
in the Framework. The new interface supports all the
new transitions which will occur in the multithreaded
Framework, for example global begin run and stream begin
run transitions will replace the old begin run transition.
The Tracer service is modified to use all the new signals
and it is also used in unit tests to test them.
