### PR TITLE
Add function to calculate ID of empty parameter set without registering ...

### DIFF
--- a/FWCore/ParameterSet/interface/ParameterSet.h
+++ b/FWCore/ParameterSet/interface/ParameterSet.h
@@ -274,6 +274,11 @@ namespace edm {
     void
     registerFromString(std::string const& rep);
 
+    // return ID of empty parameter set without registering it.
+    static
+    ParameterSetID
+    emptyParameterSetID();
+
   private:
     // construct from coded string and id.
     ParameterSet(std::string const& rep, ParameterSetID const& id);

--- a/FWCore/ParameterSet/src/ParameterSet.cc
+++ b/FWCore/ParameterSet/src/ParameterSet.cc
@@ -100,6 +100,13 @@ namespace edm {
     pset::Registry::instance()->insertMapped(ps);
   }
 
+  ParameterSetID
+  ParameterSet::emptyParameterSetID() {  // const
+    cms::Digest newDigest;
+    ParameterSet().toDigest(newDigest);
+    return ParameterSetID(newDigest.digest().toString());
+  }
+
   ParameterSet::ParameterSet(ParameterSet const& other)
   : tbl_(other.tbl_),
     psetTable_(other.psetTable_),

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -51,9 +51,7 @@ namespace edm {
         firstEvent_(true),
         firstLoop_(true),
         expectedEventNumber_(1) {
-    ParameterSet emptyPSet;
-    emptyPSet.registerIt();
-    processConfiguration_->setParameterSetID(emptyPSet.id());
+    processConfiguration_->setParameterSetID(ParameterSet::emptyParameterSetID());
     processConfiguration_->setProcessConfigurationID();
  
     productRegistry_->setFrozen();


### PR DESCRIPTION
There are at least three different places in CMSSW outside the framework, where the empty parameter set is explicitly registered. A previously merged pull request registered the empty parameter set up front during the initialization of the EventProcessor.
Unfortunately, there is currently no public member function of ParameterSet that calculates the ID of a given parameter set without attempting to register it, even if the empty parameter set is already registered.  Some places outside  the framework need the ability to get the ID of the empty parameter set without attempting to register it.
This pull request adds a static function of ParameterSet that returns the ID of the empty parameter set without registering it.  This pull request also replaces a registration of the empty parameter set in a unit test in the framework.
After this request is merged, I will remove the  explicit registrations of the empty parameter set outside the framework.
This will reduce the number of places in the code where the registries are updated.
