### PR TITLE
New plugin module to convert GenParticles to HepMC format for Rivet analysis

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/BuildFile.xml
+++ b/GeneratorInterface/RivetInterface/plugins/BuildFile.xml
@@ -6,6 +6,8 @@
 <use   name="rivet"/>
 <use   name="gsl"/>
 <use   name="DQMServices/Core"/>
+<use   name="SimGeneral/HepPDTRecord"/>
+<use   name="DataFormats/HepMCCandidate"/>
 <library   file="*.cc" name="GeneratorInterfaceRivetInterface_plugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -1,0 +1,200 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticleFwd.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+//#include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
+
+#include <iostream>
+#include <map>
+
+using namespace std;
+
+class GenParticles2HepMCConverter : public edm::EDProducer
+{
+public:
+  explicit GenParticles2HepMCConverter(const edm::ParameterSet& pset);
+  ~GenParticles2HepMCConverter() {};
+
+  void beginRun(edm::Run& run, const edm::EventSetup& eventSetup);
+  void produce(edm::Event& event, const edm::EventSetup& eventSetup);
+
+private:
+//  edm::InputTag lheEventLabel_;
+  edm::InputTag genParticlesLabel_;
+//  edm::InputTag genRunInfoLabel_;
+  edm::InputTag genEventInfoLabel_;
+  edm::ESHandle<ParticleDataTable> pTable_;
+
+private:
+  inline HepMC::FourVector FourVector(const reco::Candidate::Point& point)
+  {
+    return HepMC::FourVector(10*point.x(), 10*point.y(), 10*point.z(), 0);
+  };
+
+  inline HepMC::FourVector FourVector(const reco::Candidate::LorentzVector& lvec)
+  {
+    // Avoid negative mass, set minimum m^2 = 0
+    return HepMC::FourVector(lvec.px(), lvec.py(), lvec.pz(), std::hypot(lvec.P(), std::max(0., lvec.mass())));
+  };
+
+
+};
+
+GenParticles2HepMCConverter::GenParticles2HepMCConverter(const edm::ParameterSet& pset)
+{
+//  lheEventLabel_ = pset.getParameter<edm::InputTag>("lheEvent");
+  genParticlesLabel_ = pset.getParameter<edm::InputTag>("genParticles");
+  //genRunInfoLabel_ = pset.getParameter<edm::InputTag>("genRunInfo");
+  genEventInfoLabel_ = pset.getParameter<edm::InputTag>("genEventInfo");
+
+  produces<edm::HepMCProduct>();
+}
+
+void GenParticles2HepMCConverter::beginRun(edm::Run& run, const edm::EventSetup& eventSetup)
+{
+  //edm::Handle<GenRunInfoProduct> genRunInfoHandle;
+  //event.getByLabel(genRunInfoLabel_, genRunInfoHandle);
+  // const double xsecIn = genRunInfoHandle->internalXSec().value();
+  // const double xsecInErr = genRunInfoHandle->internalXSec().error();
+  // const double xsecLO = genRunInfoHandle->externalXSecLO().value();
+  // const double xsecLOErr = genRunInfoHandle->externalXSecLO().error();
+  // const double xsecNLO = genRunInfoHandle->externalXSecNLO().value();
+  // const double xsecNLOErr = genRunInfoHandle->externalXSecNLO().error();
+  
+  eventSetup.getData(pTable_);
+}
+
+void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSetup& eventSetup)
+{
+//  edm::Handle<LHEEventProduct> lheEventHandle;
+//  event.getByLabel(lheEventLabel_, lheEventHandle);
+
+  edm::Handle<reco::CandidateView> genParticlesHandle;
+  event.getByLabel(genParticlesLabel_, genParticlesHandle);
+
+  edm::Handle<GenEventInfoProduct> genEventInfoHandle;
+  event.getByLabel(genEventInfoLabel_, genEventInfoHandle);
+
+  HepMC::GenEvent* hepmc_event = new HepMC::GenEvent();
+  hepmc_event->set_event_number(event.id().event());
+  hepmc_event->set_signal_process_id(genEventInfoHandle->signalProcessID());
+  hepmc_event->set_event_scale(genEventInfoHandle->qScale());
+  hepmc_event->set_alphaQED(genEventInfoHandle->alphaQED());
+  hepmc_event->set_alphaQCD(genEventInfoHandle->alphaQCD());
+
+  // Set PDF
+  const gen::PdfInfo* pdf = genEventInfoHandle->pdf();
+  const int pdf_id1 = pdf->id.first, pdf_id2 = pdf->id.second;
+  const double pdf_x1 = pdf->x.first, pdf_x2 = pdf->x.second;
+  const double pdf_scalePDF = pdf->scalePDF;
+  const double pdf_xPDF1 = pdf->xPDF.first, pdf_xPDF2 = pdf->xPDF.second;
+  HepMC::PdfInfo hepmc_pdfInfo(pdf_id1, pdf_id2, pdf_x1, pdf_x2, pdf_scalePDF, pdf_xPDF1, pdf_xPDF2);
+  hepmc_event->set_pdf_info(hepmc_pdfInfo);
+
+  // Load LHE
+//  const lhef::HEPEUP& lheEvent = lheEventHandle->hepeup();
+//  std::vector<int> lhe_meIndex; // Particle indices with preserved mass, status=2
+//  for ( int i=0, n=lheEvent.ISTUP.size(); i<n; ++i )
+//  {
+//    if ( lheEvent.ISTUP[i] == 2 ) lhe_meIndex.push_back(i);
+//  }
+
+  // Prepare list of HepMC::GenParticles
+  std::map<const reco::Candidate*, HepMC::GenParticle*> genCandToHepMCMap;
+  std::vector<HepMC::GenParticle*> hepmc_particles;
+  for ( unsigned int i=0, n=genParticlesHandle->size(); i<n; ++i )
+  {
+    const reco::Candidate* p = &genParticlesHandle->at(i);
+    HepMC::GenParticle* hepmc_particle = new HepMC::GenParticle(FourVector(p->p4()), p->pdgId(), p->status());
+
+    // Assign particle's generated mass from the standard particle data table
+    double particleMass = pTable_->particle(p->pdgId())->mass();
+//    // Re-assign generated mass from LHE, find particle among the LHE
+//    for ( unsigned int j=0, m=lhe_meIndex.size(); j<m; ++j )
+//    {
+//      const unsigned int lheIndex = lhe_meIndex[j];
+//      if ( p->pdgId() != lheEvent.IDUP[lheIndex] ) continue;
+//
+//      const lhef::HEPEUP::FiveVector& vp = lheEvent.PUP[lheIndex];
+//      if ( std::abs(vp[0] - p->px()) > 1e-7 or std::abs(vp[1] - p->py()) > 1e-7 ) continue;
+//      if ( std::abs(vp[2] - p->pz()) > 1e-7 or std::abs(vp[3] - p->energy()) > 1e-7 ) continue;
+//
+//      particleMass = vp[4];
+//      break;
+//    }
+    hepmc_particle->set_generated_mass(particleMass);
+
+    hepmc_particles.push_back(hepmc_particle);
+    genCandToHepMCMap[p] = hepmc_particle;
+  }
+
+  // Put incident beam particles : proton -> parton vertex
+  const reco::Candidate* parton1 = genParticlesHandle->at(0).daughter(0);
+  const reco::Candidate* parton2 = genParticlesHandle->at(1).daughter(0);
+  HepMC::GenVertex* vertex1 = new HepMC::GenVertex(FourVector(parton1->vertex()));
+  HepMC::GenVertex* vertex2 = new HepMC::GenVertex(FourVector(parton2->vertex()));
+  hepmc_event->add_vertex(vertex1);
+  hepmc_event->add_vertex(vertex2);
+  //hepmc_particles[0]->set_status(4);
+  //hepmc_particles[1]->set_status(4);
+  vertex1->add_particle_in(hepmc_particles[0]);
+  vertex2->add_particle_in(hepmc_particles[1]);
+  hepmc_event->set_beam_particles(hepmc_particles[0], hepmc_particles[1]);
+
+  // Prepare vertex list
+  typedef std::map<const reco::Candidate*, HepMC::GenVertex*> ParticleToVertexMap;
+  ParticleToVertexMap particleToVertexMap;
+  particleToVertexMap[parton1] = vertex1;
+  particleToVertexMap[parton2] = vertex2;
+  for ( unsigned int i=2, n=genParticlesHandle->size(); i<n; ++i )
+  {
+    const reco::Candidate* p = &genParticlesHandle->at(i);
+    const reco::Candidate* elder = p;
+    if ( p->numberOfMothers() != 0 ) elder = p->mother(0)->daughter(0);
+
+    HepMC::GenVertex* vertex = 0;
+    if ( particleToVertexMap.find(elder) == particleToVertexMap.end() )
+    {
+      vertex = new HepMC::GenVertex(FourVector(elder->vertex()));
+      hepmc_event->add_vertex(vertex);
+      particleToVertexMap[elder] = vertex;
+      for ( unsigned int j=0, m=elder->numberOfMothers(); j<m; ++j )
+      {
+        const reco::Candidate* mother = elder->mother(j);
+        vertex->add_particle_in(genCandToHepMCMap[mother]);
+      }
+    }
+    else
+    {
+      vertex = particleToVertexMap[elder];
+    }
+
+    vertex->add_particle_out(hepmc_particles[i]);
+  }
+
+  // Finalize HepMC event record
+  hepmc_event->set_signal_process_vertex(*(vertex1->vertices_begin()));
+
+  std::auto_ptr<edm::HepMCProduct> hepmc_product(new edm::HepMCProduct());
+  hepmc_product->addHepMCData(hepmc_event);
+  event.put(hepmc_product);
+
+}
+
+DEFINE_FWK_MODULE(GenParticles2HepMCConverter);

--- a/GeneratorInterface/RivetInterface/python/genParticles2HepMC_cfi.py
+++ b/GeneratorInterface/RivetInterface/python/genParticles2HepMC_cfi.py
@@ -1,8 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 generator = cms.EDProducer("GenParticles2HepMCConverter",
-    lheEvent = cms.InputTag("source"),
     genParticles = cms.InputTag("genParticles"),
-#    genRunInfo   = cms.InputTag("generator"),
     genEventInfo = cms.InputTag("generator"),
 )

--- a/GeneratorInterface/RivetInterface/python/genParticles2HepMC_cfi.py
+++ b/GeneratorInterface/RivetInterface/python/genParticles2HepMC_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+generator = cms.EDProducer("GenParticles2HepMCConverter",
+    lheEvent = cms.InputTag("source"),
+    genParticles = cms.InputTag("genParticles"),
+#    genRunInfo   = cms.InputTag("generator"),
+    genEventInfo = cms.InputTag("generator"),
+)


### PR DESCRIPTION
New plugins module to do Rivet analysis with AODSIM data.
This module reproduces HepMC referring genParticles.

See 
  https://twiki.cern.ch/twiki/bin/view/CMS/RivetontoAODSIM
for overall information and links, 
and 
  https://twiki.cern.ch/twiki/bin/viewauth/CMS/GenParticles2HepMCConverter
for full documentation of this module.
