### PR TITLE
Switch to LogInfo when GEM geometry is not defined

### DIFF
--- a/Geometry/GlobalTrackingGeometryBuilder/plugins/GlobalTrackingGeometryESProducer.cc
+++ b/Geometry/GlobalTrackingGeometryBuilder/plugins/GlobalTrackingGeometryESProducer.cc
@@ -72,7 +72,7 @@ GlobalTrackingGeometryESProducer::produce(const GlobalTrackingGeometryRecord& re
       record.getRecord<MuonGeometryRecord>().get(gem);      
     } catch (edm::eventsetup::NoProxyException<GEMGeometry>& e) {
       // No GEM geo available
-      LogWarning("GeometryGlobalTrackingGeometryBuilder") << "No GEM geometry is available.";
+      LogInfo("GeometryGlobalTrackingGeometryBuilder") << "No GEM geometry is available.";
     }
 
   } catch (edm::eventsetup::NoRecordException<MuonGeometryRecord>& e){


### PR DESCRIPTION
- Switch to LogInfo when GEM geometry is missing. It's valid for current detector.
