### PR TITLE
Don't modify parameter set registry.

### DIFF
--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
@@ -60,9 +60,7 @@ namespace sistrip {
       eventPrincipal_()
   {
     // Use the empty parameter set for the parameter set ID of our "@MIXING" process.
-    edm::ParameterSet emptyPSet;
-    emptyPSet.registerIt();
-    processConfiguration_->setParameterSetID(emptyPSet.id());
+    processConfiguration_->setParameterSetID(ParameterSet::emptyParameterSetID());
     productRegistry_->setFrozen();
 
     eventPrincipal_.reset(new edm::EventPrincipal(source_->productRegistry(),


### PR DESCRIPTION
Don't modify parameter set registry by possibly registering the empty parameter set.  This is an improvement for the multithreaded framework.
