### PR TITLE
Fixed bug in the unit tests

### DIFF
--- a/FWCore/Framework/test/global_module_t.cppunit.cc
+++ b/FWCore/Framework/test/global_module_t.cppunit.cc
@@ -342,47 +342,56 @@ m_ep()
   m_ep->fillEventPrincipal(eventAux);
   m_ep->setLuminosityBlockPrincipal(m_lbp);
 
-  edm::StreamContext streamContext(edm::StreamID::invalidStreamID(), nullptr);
 
   //For each transition, bind a lambda which will call the proper method of the Worker
-  m_transToFunc[Trans::kBeginStream] = [this, &streamContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kBeginStream] = [this](edm::Worker* iBase) {
+    edm::StreamContext streamContext(edm::StreamID::invalidStreamID(), nullptr);
     iBase->beginStream(edm::StreamID::invalidStreamID(), streamContext); };
 
-  edm::ParentContext nullParentContext;
   
-  m_transToFunc[Trans::kGlobalBeginRun] = [this,&nullParentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kGlobalBeginRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
+    edm::ParentContext nullParentContext;
     iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), nullParentContext, nullptr); };
-  m_transToFunc[Trans::kStreamBeginRun] = [this,&nullParentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kStreamBeginRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamBegin> Traits;
+    edm::ParentContext nullParentContext;
     iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), nullParentContext, nullptr); };
   
-  m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this,&nullParentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
+    edm::ParentContext nullParentContext;
     iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), nullParentContext, nullptr); };
-  m_transToFunc[Trans::kStreamBeginLuminosityBlock] = [this,&nullParentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kStreamBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamBegin> Traits;
+    edm::ParentContext nullParentContext;
     iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), nullParentContext, nullptr); };
   
-  m_transToFunc[Trans::kEvent] = [this,&nullParentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::EventPrincipal, edm::BranchActionStreamBegin> Traits;
+    edm::ParentContext nullParentContext;
     iBase->doWork<Traits>(*m_ep,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), nullParentContext, nullptr); };
 
-  m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this,&nullParentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamEnd> Traits;
+    edm::ParentContext nullParentContext;
     iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), nullParentContext, nullptr); };
-  m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this,&nullParentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
+    edm::ParentContext nullParentContext;
     iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), nullParentContext, nullptr); };
 
-  m_transToFunc[Trans::kStreamEndRun] = [this,&nullParentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kStreamEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamEnd> Traits;
+    edm::ParentContext nullParentContext;
     iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), nullParentContext, nullptr); };
-  m_transToFunc[Trans::kGlobalEndRun] = [this,&nullParentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
+    edm::ParentContext nullParentContext;
     iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), nullParentContext, nullptr); };
 
-  m_transToFunc[Trans::kEndStream] = [this, &streamContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kEndStream] = [this](edm::Worker* iBase) {
+    edm::StreamContext streamContext(edm::StreamID::invalidStreamID(), nullptr);
     iBase->endStream(edm::StreamID::invalidStreamID(), streamContext); };
 
 }

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -238,30 +238,34 @@ m_ep()
     iBase->respondToOpenInputFile(fb);
   };
 
-  edm::ParentContext parentContext;
 
-  m_transToFunc[Trans::kGlobalBeginRun] = [this, &parentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kGlobalBeginRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
+    edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), parentContext, nullptr); };
   
-  m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this, &parentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
+    edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), parentContext, nullptr); };
   
-  m_transToFunc[Trans::kEvent] = [this, &parentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::EventPrincipal, edm::BranchActionStreamBegin> Traits;
+    edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_ep,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), parentContext, nullptr); };
 
-  m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this, &parentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
+    edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), parentContext, nullptr);
     auto b =iBase->createOutputModuleCommunicator();
     CPPUNIT_ASSERT(b.get());
     b->writeLumi(*m_lbp, nullptr);
   };
 
-  m_transToFunc[Trans::kGlobalEndRun] = [this, &parentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
+    edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, edm::StreamID::invalidStreamID(), parentContext, nullptr);
     auto b = iBase->createOutputModuleCommunicator();
     CPPUNIT_ASSERT(b.get());

--- a/FWCore/Framework/test/stream_module_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_module_t.cppunit.cc
@@ -392,46 +392,55 @@ m_ep()
   m_ep->fillEventPrincipal(eventAux);
   m_ep->setLuminosityBlockPrincipal(m_lbp);
 
-  edm::ParentContext parentContext;
-  edm::StreamContext streamContext(s_streamID0, nullptr);
 
   //For each transition, bind a lambda which will call the proper method of the Worker
-  m_transToFunc[Trans::kBeginStream] = [this, &streamContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kBeginStream] = [this](edm::Worker* iBase) {
+    edm::StreamContext streamContext(s_streamID0, nullptr);
     iBase->beginStream(s_streamID0, streamContext); };
   
-  m_transToFunc[Trans::kGlobalBeginRun] = [this,&parentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kGlobalBeginRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalBegin> Traits;
+    edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, s_streamID0, parentContext, nullptr); };
-  m_transToFunc[Trans::kStreamBeginRun] = [this,&parentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kStreamBeginRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamBegin> Traits;
+    edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, s_streamID0, parentContext, nullptr); };
   
-  m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this,&parentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kGlobalBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalBegin> Traits;
+    edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, s_streamID0, parentContext, nullptr); };
-  m_transToFunc[Trans::kStreamBeginLuminosityBlock] = [this,&parentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kStreamBeginLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamBegin> Traits;
+    edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, s_streamID0, parentContext, nullptr); };
   
-  m_transToFunc[Trans::kEvent] = [this,&parentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kEvent] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::EventPrincipal, edm::BranchActionStreamBegin> Traits;
+    edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_ep,*m_es,m_context,m_timer, s_streamID0, parentContext, nullptr); };
 
-  m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this,&parentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kStreamEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionStreamEnd> Traits;
+    edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, s_streamID0, parentContext, nullptr); };
-  m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this,&parentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kGlobalEndLuminosityBlock] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::LuminosityBlockPrincipal, edm::BranchActionGlobalEnd> Traits;
+    edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_lbp,*m_es,m_context,m_timer, s_streamID0, parentContext, nullptr); };
 
-  m_transToFunc[Trans::kStreamEndRun] = [this,&parentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kStreamEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionStreamEnd> Traits;
+    edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, s_streamID0, parentContext, nullptr); };
-  m_transToFunc[Trans::kGlobalEndRun] = [this,&parentContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kGlobalEndRun] = [this](edm::Worker* iBase) {
     typedef edm::OccurrenceTraits<edm::RunPrincipal, edm::BranchActionGlobalEnd> Traits;
+    edm::ParentContext parentContext;
     iBase->doWork<Traits>(*m_rp,*m_es,m_context,m_timer, s_streamID0, parentContext, nullptr); };
 
-  m_transToFunc[Trans::kEndStream] = [this, &streamContext](edm::Worker* iBase) {
+  m_transToFunc[Trans::kEndStream] = [this](edm::Worker* iBase) {
+    edm::StreamContext streamContext(s_streamID0, nullptr);
     iBase->endStream(s_streamID0, streamContext); };
 
 }


### PR DESCRIPTION
A bug was introduced into these unit tests where a reference to a stack
variable was added to a lambda but that lambda was not used from within
the scope of the declaring function. This problem was only seen when
the tests were compiled non-optimized.
