### PR TITLE
Make RecHit1D thread safe.

### DIFF
--- a/DataFormats/TrackingRecHit/interface/RecHit1D.h
+++ b/DataFormats/TrackingRecHit/interface/RecHit1D.h
@@ -39,10 +39,8 @@ class RecHit1D : public TrackingRecHit {
 
   ///Return the projection matrix
   virtual AlgebraicMatrix projectionMatrix() const {
-    if ( !isInitialized) initialize();
     return theProjectionMatrix;
   }
-
 
   /// Return the RecHit dimension
   virtual int dimension() const {
@@ -59,17 +57,6 @@ class RecHit1D : public TrackingRecHit {
 
 
  private:
-
-  static bool isInitialized;
-
-  static AlgebraicMatrix theProjectionMatrix;
-
-  void initialize() const;
-
+  static const AlgebraicMatrix theProjectionMatrix;
 };
 #endif
-
-
-
-
-

--- a/DataFormats/TrackingRecHit/src/RecHit1D.cc
+++ b/DataFormats/TrackingRecHit/src/RecHit1D.cc
@@ -38,21 +38,11 @@ AlgebraicSymMatrix RecHit1D::parametersError() const {
   return m;
 }
 
-
-
-// Initialize the projection matrix
-void RecHit1D::initialize() const {
-  theProjectionMatrix = AlgebraicMatrix( 1, 5, 0);
-  theProjectionMatrix[0][3] = 1;
-  
-  isInitialized = true;
+// Return an initialized matrix.
+static const AlgebraicMatrix initializeMatrix() {
+  AlgebraicMatrix matrix( 1, 5, 0);
+  matrix[0][3] = 1;
+  return matrix;
 }
 
-
-
-bool RecHit1D::isInitialized(false);
-
-
-
-AlgebraicMatrix RecHit1D::theProjectionMatrix;
-
+const AlgebraicMatrix RecHit1D::theProjectionMatrix(initializeMatrix());


### PR DESCRIPTION
By initializing theProjectionMatrix at load time and making it const, we ensure
thread safety.
