### PR TITLE
Add missing includes of <cassert>

### DIFF
--- a/DataFormats/Common/interface/HandleBase.h
+++ b/DataFormats/Common/interface/HandleBase.h
@@ -25,6 +25,7 @@ If failedToGet() returns false but isValid() is also false then no attempt
 
 ----------------------------------------------------------------------*/
 
+#include <cassert>
 #include "DataFormats/Provenance/interface/ProductID.h"
 #include "DataFormats/Provenance/interface/ProvenanceFwd.h"
 

--- a/DataFormats/Common/interface/RefCoreStreamer.h
+++ b/DataFormats/Common/interface/RefCoreStreamer.h
@@ -3,7 +3,7 @@
 
 #include "TClassStreamer.h"
 #include "TClassRef.h"
-#include <assert.h>
+#include <cassert>
 
 class TBuffer;
 

--- a/DataFormats/Provenance/src/BranchDescription.cc
+++ b/DataFormats/Provenance/src/BranchDescription.cc
@@ -5,6 +5,7 @@
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include "FWCore/Utilities/interface/WrappedClassName.h"
 
+#include <cassert>
 #include <ostream>
 #include <sstream>
 #include <stdlib.h>

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -18,6 +18,7 @@
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include "FWCore/Utilities/interface/WrappedClassName.h"
 
+#include <cassert>
 #include <iterator>
 #include <limits>
 #include <sstream>

--- a/DataFormats/Provenance/test/EntryDescription_t.cpp
+++ b/DataFormats/Provenance/test/EntryDescription_t.cpp
@@ -1,7 +1,7 @@
 #include "DataFormats/Provenance/interface/Parentage.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 
 int main() {

--- a/DataFormats/Streamer/src/StreamedProductStreamer.cc
+++ b/DataFormats/Streamer/src/StreamedProductStreamer.cc
@@ -3,6 +3,8 @@
 
 #include "TROOT.h"
 
+#include <cassert>
+
 namespace edm {
   void 
   StreamedProductStreamer::operator()(TBuffer& R__b, void *objp) {

--- a/FWCore/FWLite/src/BranchMapReader.cc
+++ b/FWCore/FWLite/src/BranchMapReader.cc
@@ -30,6 +30,8 @@
 #include "TFile.h"
 #include "TTree.h"
 
+#include <cassert>
+
 namespace fwlite {
   namespace internal {
 

--- a/FWCore/FWLite/src/RefStreamer.cc
+++ b/FWCore/FWLite/src/RefStreamer.cc
@@ -1,7 +1,7 @@
 #include "DataFormats/Common/interface/RefCore.h"
 #include "DataFormats/Common/interface/RefCoreStreamer.h"
 #include "TROOT.h"
-#include <assert.h>
+#include <cassert>
 #include <ostream>
 
 class TBuffer;

--- a/FWCore/Framework/src/CurrentProcessingContext.cc
+++ b/FWCore/Framework/src/CurrentProcessingContext.cc
@@ -2,6 +2,8 @@
 
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 
+#include <cassert>
+
 namespace edm {
   CurrentProcessingContext::CurrentProcessingContext() :
     pathInSchedule_(0),

--- a/FWCore/Framework/src/EventSetupRecord.cc
+++ b/FWCore/Framework/src/EventSetupRecord.cc
@@ -11,7 +11,7 @@
 //
 
 // system include files
-#include <assert.h>
+#include <cassert>
 #include <string>
 #include <exception>
 

--- a/FWCore/Integration/test/ProcessConfiguration_t.cpp
+++ b/FWCore/Integration/test/ProcessConfiguration_t.cpp
@@ -3,7 +3,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 #include <string>
 

--- a/FWCore/ParameterSet/src/Entry.cc
+++ b/FWCore/ParameterSet/src/Entry.cc
@@ -16,7 +16,7 @@
 #include <map>
 #include <sstream>
 #include <ostream>
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 
 enum {

--- a/FWCore/ParameterSet/test/ps_t.cppunit.cc
+++ b/FWCore/ParameterSet/test/ps_t.cppunit.cc
@@ -7,7 +7,7 @@
 #include <iostream>
 #include <limits>
 #include <string>
-#include <assert.h>
+#include <cassert>
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDMException.h"

--- a/IOPool/Common/bin/EdmProvDump.cc
+++ b/IOPool/Common/bin/EdmProvDump.cc
@@ -28,7 +28,7 @@
 
 #include "boost/program_options.hpp"
 
-#include <assert.h>
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <map>

--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -8,6 +8,7 @@
 #include "TTreeIndex.h"
 #include "TTreeCache.h"
 
+#include <cassert>
 #include <iostream>
 
 namespace edm {

--- a/IOPool/TFileAdaptor/src/ReadRepacker.cc
+++ b/IOPool/TFileAdaptor/src/ReadRepacker.cc
@@ -1,5 +1,5 @@
 
-#include <assert.h>
+#include <cassert>
 #include <string.h>
 
 #include "ReadRepacker.h"


### PR DESCRIPTION
In investigating the possibility of removing the process configuration registry to enhance thread safety, I discovered that many files that call assert() were missing an #include of cassert, and only compiled because cassert was included indirectly through a chain of #includes that involves ProcessConfigurationRegistry.h.
This pull request adds an #include of cassert to those framework  files that fail to compile due to assert() being undefined if ProcessConfigurationRegistry.h is removed.  For standardization, it also replaces assert.h by cassert in all framework C++ files except C files and third party files, 
