### PR TITLE
DetIdSelector in SiStripBaseCondObjDQM.cc

### DIFF
--- a/DQM/SiStripMonitorSummary/BuildFile.xml
+++ b/DQM/SiStripMonitorSummary/BuildFile.xml
@@ -15,6 +15,7 @@
 <use   name="CalibTracker/SiStripAPVAnalysis"/>
 <use   name="CondCore/DBOutputService"/>
 <use   name="CommonTools/TrackerMap"/>
+<use   name="CommonTools/UtilAlgos"/>
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <export>
   <lib   name="1"/>

--- a/DQM/SiStripMonitorSummary/interface/SiStripBaseCondObjDQM.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripBaseCondObjDQM.h
@@ -160,10 +160,6 @@ class SiStripBaseCondObjDQM {
     SiStripFolderOrganizer folder_organizer;         
     DQMStore* dqmStore_;
 
-    std::map<unsigned int, std::string> m_included_subdets;
-    std::map<unsigned int, DetIdSelector> m_included_subdetsels;
-    std::map<unsigned int, std::string> m_excluded_subdets;
-    std::map<unsigned int, DetIdSelector> m_excluded_subdetsels;
 };
 
 

--- a/DQM/SiStripMonitorSummary/interface/SiStripBaseCondObjDQM.h
+++ b/DQM/SiStripMonitorSummary/interface/SiStripBaseCondObjDQM.h
@@ -30,6 +30,8 @@
 #include "DQM/SiStripCommon/interface/TkHistoMap.h"  /// ADDITON OF TK_HISTO_MAP
 #include "CommonTools/TrackerMap/interface/TrackerMap.h"
 
+#include "CommonTools/UtilAlgos/interface/DetIdSelector.h"
+
 #include <vector>
 #include <map>
 #include <string>
@@ -158,6 +160,10 @@ class SiStripBaseCondObjDQM {
     SiStripFolderOrganizer folder_organizer;         
     DQMStore* dqmStore_;
 
+    std::map<unsigned int, std::string> m_included_subdets;
+    std::map<unsigned int, DetIdSelector> m_included_subdetsels;
+    std::map<unsigned int, std::string> m_excluded_subdets;
+    std::map<unsigned int, DetIdSelector> m_excluded_subdetsels;
 };
 
 

--- a/DQM/SiStripMonitorSummary/python/SiStripMonitorCondData_cfi.py
+++ b/DQM/SiStripMonitorSummary/python/SiStripMonitorCondData_cfi.py
@@ -30,11 +30,10 @@ CondDataMonitoring = cms.EDAnalyzer("SiStripMonitorCondData",
       ActiveDetIds_On         =  cms.bool(False),
       TkMap_On                =  cms.bool(False),
 
-      restrictModules         = cms.bool(True),      
       modulesToBeIncluded = cms.VPSet(
 #         cms.PSet(detSelection = cms.uint32(103), detLabel = cms.string("TIB"), selection=cms.untracked.vstring("0x1e000000-0x16000000")),
 #         cms.PSet(detSelection = cms.uint32(104), detLabel = cms.string("TID"), selection=cms.untracked.vstring("0x1e000000-0x18000000")),
-         cms.PSet(detSelection = cms.uint32(1041),detLabel = cms.string("TIDm"),selection=cms.untracked.vstring("0x1e006000-0x18002000")),
+#         cms.PSet(detSelection = cms.uint32(1041),detLabel = cms.string("TIDm"),selection=cms.untracked.vstring("0x1e006000-0x18002000")),
 #         cms.PSet(detSelection = cms.uint32(1042),detLabel = cms.string("TIDp"),selection=cms.untracked.vstring("0x1e006000-0x18004000")),
 #         cms.PSet(detSelection = cms.uint32(105), detLabel = cms.string("TOB"), selection=cms.untracked.vstring("0x1e000000-0x1a000000")),
 #         cms.PSet(detSelection = cms.uint32(106), detLabel = cms.string("TEC"), selection=cms.untracked.vstring("0x1e000000-0x1c000000")),
@@ -45,15 +44,15 @@ CondDataMonitoring = cms.EDAnalyzer("SiStripMonitorCondData",
 #         cms.PSet(detSelection = cms.uint32(103), detLabel = cms.string("TIB"), selection=cms.untracked.vstring("0x1e000000-0x16000000")),
 #         cms.PSet(detSelection = cms.uint32(104), detLabel = cms.string("TID"), selection=cms.untracked.vstring("0x1e000000-0x18000000")),
 #         cms.PSet(detSelection = cms.uint32(1041),detLabel = cms.string("TIDm"),selection=cms.untracked.vstring("0x1e006000-0x18002000")),
-         cms.PSet(detSelection = cms.uint32(1042),detLabel = cms.string("TIDp"),selection=cms.untracked.vstring("0x1e006000-0x18004000")),
+#         cms.PSet(detSelection = cms.uint32(1042),detLabel = cms.string("TIDp"),selection=cms.untracked.vstring("0x1e006000-0x18004000")),
 #         cms.PSet(detSelection = cms.uint32(105), detLabel = cms.string("TOB"), selection=cms.untracked.vstring("0x1e000000-0x1a000000")),
 #         cms.PSet(detSelection = cms.uint32(106), detLabel = cms.string("TEC"), selection=cms.untracked.vstring("0x1e000000-0x1c000000")),
 #         cms.PSet(detSelection = cms.uint32(1061),detLabel = cms.string("TECm"),selection=cms.untracked.vstring("0x1e0c0000-0x1c040000")),
 #         cms.PSet(detSelection = cms.uint32(1062),detLabel = cms.string("TECp"),selection=cms.untracked.vstring("0x1e0c0000-0x1c080000"))
       ),
       #  exclude OR include a set of modules
-#      restrictModules         = cms.bool(False),
-
+      restrictModules         = cms.bool(False),
+#      restrictModules         = cms.bool(True),      
       ModulesToBeIncluded     = cms.vuint32(), #e.g. {369120277, 369120278, 369120282}
       ModulesToBeExcluded     = cms.vuint32(),
         

--- a/DQM/SiStripMonitorSummary/python/SiStripMonitorCondData_cfi.py
+++ b/DQM/SiStripMonitorSummary/python/SiStripMonitorCondData_cfi.py
@@ -30,7 +30,7 @@ CondDataMonitoring = cms.EDAnalyzer("SiStripMonitorCondData",
       ActiveDetIds_On         =  cms.bool(False),
       TkMap_On                =  cms.bool(False),
 
-      modulesToBeIncluded = cms.VPSet(
+      ModulesToBeIncluded_DetIdSelector = cms.VPSet(
 #         cms.PSet(detSelection = cms.uint32(103), detLabel = cms.string("TIB"), selection=cms.untracked.vstring("0x1e000000-0x16000000")),
 #         cms.PSet(detSelection = cms.uint32(104), detLabel = cms.string("TID"), selection=cms.untracked.vstring("0x1e000000-0x18000000")),
 #         cms.PSet(detSelection = cms.uint32(1041),detLabel = cms.string("TIDm"),selection=cms.untracked.vstring("0x1e006000-0x18002000")),
@@ -40,7 +40,7 @@ CondDataMonitoring = cms.EDAnalyzer("SiStripMonitorCondData",
 #         cms.PSet(detSelection = cms.uint32(1061),detLabel = cms.string("TECm"),selection=cms.untracked.vstring("0x1e0c0000-0x1c040000")),
 #         cms.PSet(detSelection = cms.uint32(1062),detLabel = cms.string("TECp"),selection=cms.untracked.vstring("0x1e0c0000-0x1c080000"))
       ),
-      modulesToBeExcluded = cms.VPSet(
+      ModulesToBeExcluded_DetIdSelector = cms.VPSet(
 #         cms.PSet(detSelection = cms.uint32(103), detLabel = cms.string("TIB"), selection=cms.untracked.vstring("0x1e000000-0x16000000")),
 #         cms.PSet(detSelection = cms.uint32(104), detLabel = cms.string("TID"), selection=cms.untracked.vstring("0x1e000000-0x18000000")),
 #         cms.PSet(detSelection = cms.uint32(1041),detLabel = cms.string("TIDm"),selection=cms.untracked.vstring("0x1e006000-0x18002000")),

--- a/DQM/SiStripMonitorSummary/python/SiStripMonitorCondData_cfi.py
+++ b/DQM/SiStripMonitorSummary/python/SiStripMonitorCondData_cfi.py
@@ -29,9 +29,30 @@ CondDataMonitoring = cms.EDAnalyzer("SiStripMonitorCondData",
 
       ActiveDetIds_On         =  cms.bool(False),
       TkMap_On                =  cms.bool(False),
-        
+
+      restrictModules         = cms.bool(True),      
+      modulesToBeIncluded = cms.VPSet(
+#         cms.PSet(detSelection = cms.uint32(103), detLabel = cms.string("TIB"), selection=cms.untracked.vstring("0x1e000000-0x16000000")),
+#         cms.PSet(detSelection = cms.uint32(104), detLabel = cms.string("TID"), selection=cms.untracked.vstring("0x1e000000-0x18000000")),
+         cms.PSet(detSelection = cms.uint32(1041),detLabel = cms.string("TIDm"),selection=cms.untracked.vstring("0x1e006000-0x18002000")),
+#         cms.PSet(detSelection = cms.uint32(1042),detLabel = cms.string("TIDp"),selection=cms.untracked.vstring("0x1e006000-0x18004000")),
+#         cms.PSet(detSelection = cms.uint32(105), detLabel = cms.string("TOB"), selection=cms.untracked.vstring("0x1e000000-0x1a000000")),
+#         cms.PSet(detSelection = cms.uint32(106), detLabel = cms.string("TEC"), selection=cms.untracked.vstring("0x1e000000-0x1c000000")),
+#         cms.PSet(detSelection = cms.uint32(1061),detLabel = cms.string("TECm"),selection=cms.untracked.vstring("0x1e0c0000-0x1c040000")),
+#         cms.PSet(detSelection = cms.uint32(1062),detLabel = cms.string("TECp"),selection=cms.untracked.vstring("0x1e0c0000-0x1c080000"))
+      ),
+      modulesToBeExcluded = cms.VPSet(
+#         cms.PSet(detSelection = cms.uint32(103), detLabel = cms.string("TIB"), selection=cms.untracked.vstring("0x1e000000-0x16000000")),
+#         cms.PSet(detSelection = cms.uint32(104), detLabel = cms.string("TID"), selection=cms.untracked.vstring("0x1e000000-0x18000000")),
+#         cms.PSet(detSelection = cms.uint32(1041),detLabel = cms.string("TIDm"),selection=cms.untracked.vstring("0x1e006000-0x18002000")),
+         cms.PSet(detSelection = cms.uint32(1042),detLabel = cms.string("TIDp"),selection=cms.untracked.vstring("0x1e006000-0x18004000")),
+#         cms.PSet(detSelection = cms.uint32(105), detLabel = cms.string("TOB"), selection=cms.untracked.vstring("0x1e000000-0x1a000000")),
+#         cms.PSet(detSelection = cms.uint32(106), detLabel = cms.string("TEC"), selection=cms.untracked.vstring("0x1e000000-0x1c000000")),
+#         cms.PSet(detSelection = cms.uint32(1061),detLabel = cms.string("TECm"),selection=cms.untracked.vstring("0x1e0c0000-0x1c040000")),
+#         cms.PSet(detSelection = cms.uint32(1062),detLabel = cms.string("TECp"),selection=cms.untracked.vstring("0x1e0c0000-0x1c080000"))
+      ),
       #  exclude OR include a set of modules
-      restrictModules         = cms.bool(False),
+#      restrictModules         = cms.bool(False),
 
       ModulesToBeIncluded     = cms.vuint32(), #e.g. {369120277, 369120278, 369120282}
       ModulesToBeExcluded     = cms.vuint32(),

--- a/DQM/SiStripMonitorSummary/src/SiStripBaseCondObjDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripBaseCondObjDQM.cc
@@ -29,14 +29,14 @@ SiStripBaseCondObjDQM::SiStripBaseCondObjDQM(const edm::EventSetup & eSetup,
  
 
   //Warning message from wrong input:
-  if(SummaryOnLayerLevel_On_ and SummaryOnStringLevel_On_){
+  if(SummaryOnLayerLevel_On_ && SummaryOnStringLevel_On_){
     edm::LogWarning("SiStripBaseCondObjDQM") 
        << "[SiStripBaseCondObjDQM::SiStripBaseCondObjDQMs] PLEASE CHECK : String and layer level options can not be activated together"
        << std::endl; 
   }
 
   //The OR of the two conditions allow to switch on this feature for all the components (if the FillConditions_PSet has the TkMap_On =true) or for single MEs (if the PSet for a ME has the TkMap_On =true)
-  if(fPSet_.getParameter<bool>("TkMap_On") or hPSet_.getParameter<bool>("TkMap_On")) bookTkMap(hPSet_.getParameter<std::string>("TkMapName"));
+  if(fPSet_.getParameter<bool>("TkMap_On") || hPSet_.getParameter<bool>("TkMap_On")) bookTkMap(hPSet_.getParameter<std::string>("TkMapName"));
 
 
   minValue=hPSet_.getParameter<double>("minValue");
@@ -59,7 +59,7 @@ void SiStripBaseCondObjDQM::analysis(const edm::EventSetup & eSetup_){
   getConditionObject(eSetup_);
 
   //The OR of the two conditions allows to switch on this feature for all the components (if the FillConditions_PSet has the ActiveDetIds_On =true) or for single MEs (if the PSet for a ME has the ActiveDetIds_On =true)
-  if(fPSet_.getParameter<bool>("ActiveDetIds_On") or hPSet_.getParameter<bool>("ActiveDetIds_On"))
+  if(fPSet_.getParameter<bool>("ActiveDetIds_On") || hPSet_.getParameter<bool>("ActiveDetIds_On"))
     getActiveDetIds(eSetup_);
   else
     activeDetIds=reader->getAllDetIds();
@@ -67,7 +67,7 @@ void SiStripBaseCondObjDQM::analysis(const edm::EventSetup & eSetup_){
   selectModules(activeDetIds);
 
   if(Mod_On_ )                                            { fillModMEs    (activeDetIds, eSetup_); }
-  if(SummaryOnLayerLevel_On_ or SummaryOnStringLevel_On_ ){ fillSummaryMEs(activeDetIds, eSetup_); }
+  if(SummaryOnLayerLevel_On_ || SummaryOnStringLevel_On_ ){ fillSummaryMEs(activeDetIds, eSetup_); }
 
   std::string filename = hPSet_.getParameter<std::string>("TkMapName");
   if (filename!=""){
@@ -217,8 +217,8 @@ void SiStripBaseCondObjDQM::selectModules(std::vector<uint32_t> & detIds_){
     std::sort(ModulesToBeExcluded_.begin(),ModulesToBeExcluded_.end());
     std::sort(ModulesToBeIncluded_.begin(),ModulesToBeIncluded_.end());
     
-    if (modulesToBeExcluded.size()==0  and modulesToBeIncluded.size()==0 and
-	ModulesToBeExcluded_.size()==0 and ModulesToBeIncluded_.size()==0 )
+    if (modulesToBeExcluded.size()==0  && modulesToBeIncluded.size()==0 &&
+	ModulesToBeExcluded_.size()==0 && ModulesToBeIncluded_.size()==0 )
       edm::LogWarning("SiStripBaseCondObjDQM") 
 	<< "[SiStripBaseCondObjDQM::selectModules] PLEASE CHECK : no modules to be exclude/included in your cfg"
 	<< std::endl; 
@@ -353,11 +353,11 @@ void SiStripBaseCondObjDQM::getModMEs(ModMEs& CondObj_ME, const uint32_t& detId_
   
     CondObj_ME=ModMEsMap_iter->second;
   
-    if( ( CondObj_fillId_ =="ProfileAndCumul" or CondObj_fillId_ =="onlyProfile") and CondObj_ME.ProfileDistr ) { 
+    if( ( CondObj_fillId_ =="ProfileAndCumul" || CondObj_fillId_ =="onlyProfile") && CondObj_ME.ProfileDistr ) { 
       CondObj_ME.ProfileDistr ->Reset();    
     }
        
-    if( (CondObj_fillId_ =="ProfileAndCumul" or CondObj_fillId_ =="onlyCumul" ) and  CondObj_ME.CumulDistr ){
+    if( (CondObj_fillId_ =="ProfileAndCumul" || CondObj_fillId_ =="onlyCumul" ) &&  CondObj_ME.CumulDistr ){
       CondObj_ME.CumulDistr ->Reset();
     }
     else {
@@ -369,13 +369,13 @@ void SiStripBaseCondObjDQM::getModMEs(ModMEs& CondObj_ME, const uint32_t& detId_
   }
   
   // --> profile defined for all CondData
-  if ( (CondObj_fillId_ =="ProfileAndCumul" or CondObj_fillId_ =="onlyProfile")) {
+  if ( (CondObj_fillId_ =="ProfileAndCumul" || CondObj_fillId_ =="onlyProfile")) {
     bookProfileMEs(CondObj_ME,detId_,tTopo);
   }  
   
   // --> cumul currently only defined for noise and apvgain
-  if( (CondObj_fillId_ =="ProfileAndCumul" or CondObj_fillId_ =="onlyCumul" )
-      and(CondObj_name_ == "noise" or CondObj_name_ == "apvgain")          ) bookCumulMEs(CondObj_ME,detId_,tTopo);
+  if( (CondObj_fillId_ =="ProfileAndCumul" || CondObj_fillId_ =="onlyCumul" )
+      &&(CondObj_name_ == "noise" || CondObj_name_ == "apvgain")          ) bookCumulMEs(CondObj_ME,detId_,tTopo);
   
  
   ModMEsMap_.insert( std::make_pair(detId_,CondObj_ME) );
@@ -390,7 +390,7 @@ void SiStripBaseCondObjDQM::getSummaryMEs(ModMEs& CondObj_ME, const uint32_t& de
 
   std::map<uint32_t, ModMEs>::const_iterator SummaryMEsMap_iter;
 
-  if(CondObj_name_ == "lorentzangle" and SummaryOnStringLevel_On_ ){
+  if(CondObj_name_ == "lorentzangle" && SummaryOnStringLevel_On_ ){
     SummaryMEsMap_iter = SummaryMEsMap_.find(getStringNameAndId(detId_,tTopo).second);
   }
   else {
@@ -402,40 +402,40 @@ void SiStripBaseCondObjDQM::getSummaryMEs(ModMEs& CondObj_ME, const uint32_t& de
   //FIXME t's not good that the base class has to know about which derived class shoudl exist.
   // please modify this part. implement virtual functions, esplicited in the derived classes
   // --> currently only profile summary defined for all condition objects except quality
-  if(  (CondObj_fillId_ =="ProfileAndCumul" or CondObj_fillId_ =="onlyProfile" ) and
+  if(  (CondObj_fillId_ =="ProfileAndCumul" || CondObj_fillId_ =="onlyProfile" ) &&
      (
-      CondObj_name_ == "pedestal"     or 
-      CondObj_name_ == "noise"         or 
-      CondObj_name_ == "lowthreshold"  or 
-      CondObj_name_ == "highthreshold" or 
-      CondObj_name_ == "apvgain"       or 
+      CondObj_name_ == "pedestal"     || 
+      CondObj_name_ == "noise"         || 
+      CondObj_name_ == "lowthreshold"  || 
+      CondObj_name_ == "highthreshold" || 
+      CondObj_name_ == "apvgain"       || 
       CondObj_name_ == "lorentzangle") ) {
     if(hPSet_.getParameter<bool>("FillSummaryProfileAtLayerLevel"))	
       if (!CondObj_ME.SummaryOfProfileDistr) { bookSummaryProfileMEs(CondObj_ME,detId_,tTopo); }
   }    
     
   // --> currently only genuine cumul LA
-  if(   (CondObj_fillId_ =="ProfileAndCumul" or CondObj_fillId_ =="onlyCumul" ) and
+  if(   (CondObj_fillId_ =="ProfileAndCumul" || CondObj_fillId_ =="onlyCumul" ) &&
 	(
-	 CondObj_name_ == "lorentzangle" or  
+	 CondObj_name_ == "lorentzangle" ||  
 	 CondObj_name_ == "noise")  ) {
     if(hPSet_.getParameter<bool>("FillCumulativeSummaryAtLayerLevel"))
       if (!CondObj_ME.SummaryOfCumulDistr) { bookSummaryCumulMEs(CondObj_ME,detId_,tTopo); } 
   } 
                           
   // --> currently only summary as a function of detId for noise, pedestal and apvgain 
-  if(      CondObj_name_ == "noise"         or
-	   CondObj_name_ == "lowthreshold"  or 
-	   CondObj_name_ == "highthreshold" or 
-	   CondObj_name_ == "apvgain"       or 
-	   CondObj_name_ == "pedestal"      or 
+  if(      CondObj_name_ == "noise"         ||
+	   CondObj_name_ == "lowthreshold"  || 
+	   CondObj_name_ == "highthreshold" || 
+	   CondObj_name_ == "apvgain"       || 
+	   CondObj_name_ == "pedestal"      || 
 	   CondObj_name_ == "quality"           ) {
     if(hPSet_.getParameter<bool>("FillSummaryAtLayerLevel"))          
       if (!CondObj_ME.SummaryDistr) { bookSummaryMEs(CondObj_ME,detId_,tTopo); } 
     
   } 
                           
-  if(CondObj_name_ == "lorentzangle" and SummaryOnStringLevel_On_) {
+  if(CondObj_name_ == "lorentzangle" && SummaryOnStringLevel_On_) {
     //FIXME getStringNameandId takes time. not need to call it every timne. put the call at the beginning of the method and caache the string 
     SummaryMEsMap_.insert( std::make_pair(getStringNameAndId(detId_,tTopo).second,CondObj_ME) );
   }
@@ -561,16 +561,16 @@ void SiStripBaseCondObjDQM::bookSummaryProfileMEs(SiStripBaseCondObjDQM::ModMEs&
   
   int nStrip, nApv, layerId_;    
   
-  if(CondObj_name_ == "lorentzangle" and SummaryOnStringLevel_On_) { layerId_= getStringNameAndId(detId_,tTopo).second;}
+  if(CondObj_name_ == "lorentzangle" && SummaryOnStringLevel_On_) { layerId_= getStringNameAndId(detId_,tTopo).second;}
   else                                                            { layerId_= getLayerNameAndId(detId_,tTopo).second;}
 
 
-  if( CondObj_name_ == "pedestal" or CondObj_name_ == "noise" or CondObj_name_ == "lowthreshold" or CondObj_name_ == "highthreshold" ){ // plot in strip number
+  if( CondObj_name_ == "pedestal" || CondObj_name_ == "noise" || CondObj_name_ == "lowthreshold" || CondObj_name_ == "highthreshold" ){ // plot in strip number
     
-    if( (layerId_ > 610 and layerId_ < 620) or // TID & TEC have 768 strips at maximum
-        (layerId_ > 620 and layerId_ < 630) or
-        (layerId_ > 410 and layerId_ < 414) or
-        (layerId_ > 420 and layerId_ < 424) ){ nStrip =768;} 
+    if( (layerId_ > 610 && layerId_ < 620) || // TID & TEC have 768 strips at maximum
+        (layerId_ > 620 && layerId_ < 630) ||
+        (layerId_ > 410 && layerId_ < 414) ||
+        (layerId_ > 420 && layerId_ < 424) ){ nStrip =768;} 
     else { nStrip      = reader->getNumberOfApvsAndStripLength(detId_).first*128;}
     
     hSummaryOfProfile_NchX           = nStrip;
@@ -578,7 +578,7 @@ void SiStripBaseCondObjDQM::bookSummaryProfileMEs(SiStripBaseCondObjDQM::ModMEs&
     hSummaryOfProfile_HighX          = nStrip+0.5;
   
   }  
-  else if( (CondObj_name_ == "lorentzangle" and SummaryOnLayerLevel_On_) or CondObj_name_ == "quality"){ // plot in detId-number
+  else if( (CondObj_name_ == "lorentzangle" && SummaryOnLayerLevel_On_) || CondObj_name_ == "quality"){ // plot in detId-number
 
     // -----
     // get detIds belonging to same layer to fill X-axis with detId-number
@@ -606,7 +606,7 @@ void SiStripBaseCondObjDQM::bookSummaryProfileMEs(SiStripBaseCondObjDQM::ModMEs&
     hSummaryOfProfile_HighX          = sameLayerDetIds_.size()+0.5;
  
   } 
-  else if( CondObj_name_ == "lorentzangle" and SummaryOnStringLevel_On_){ // plot in detId-number
+  else if( CondObj_name_ == "lorentzangle" && SummaryOnStringLevel_On_){ // plot in detId-number
 
     // -----
     // get detIds belonging to same string to fill X-axis with detId-number
@@ -640,10 +640,10 @@ void SiStripBaseCondObjDQM::bookSummaryProfileMEs(SiStripBaseCondObjDQM::ModMEs&
   } 
   else if( CondObj_name_ == "apvgain"){
  
-    if( (layerId_ > 610 and layerId_ < 620) or // TID & TEC have 6 apvs at maximum
-        (layerId_ > 620 and layerId_ < 630) or
-        (layerId_ > 410 and layerId_ < 414) or
-        (layerId_ > 420 and layerId_ < 424) ){ nApv =6;} 
+    if( (layerId_ > 610 && layerId_ < 620) || // TID & TEC have 6 apvs at maximum
+        (layerId_ > 620 && layerId_ < 630) ||
+        (layerId_ > 410 && layerId_ < 414) ||
+        (layerId_ > 420 && layerId_ < 424) ){ nApv =6;} 
     else { nApv     = reader->getNumberOfApvsAndStripLength(detId_).first;}
     
     hSummaryOfProfile_NchX           = nApv;
@@ -669,7 +669,7 @@ void SiStripBaseCondObjDQM::bookSummaryProfileMEs(SiStripBaseCondObjDQM::ModMEs&
   int subdetectorId_ = ((detId_>>25)&0x7);
   
  
-  if( subdetectorId_<3 or subdetectorId_>6 ){ 
+  if( subdetectorId_<3 || subdetectorId_>6 ){ 
     edm::LogError("SiStripBaseCondObjDQM")
        << "[SiStripBaseCondObjDQM::bookSummaryProfileMEs] WRONG INPUT : no such subdetector type : "
        << subdetectorId_ << " no folder set!" 
@@ -678,7 +678,7 @@ void SiStripBaseCondObjDQM::bookSummaryProfileMEs(SiStripBaseCondObjDQM::ModMEs&
   }
   // ---
   
-  if(CondObj_name_ == "lorentzangle" and SummaryOnStringLevel_On_) { 
+  if(CondObj_name_ == "lorentzangle" && SummaryOnStringLevel_On_) { 
     hSummaryOfProfile_name = hidmanager.createHistoLayer(hSummaryOfProfile_description, "layer" , getStringNameAndId(detId_,tTopo).first,"") ;
   }
   else {
@@ -792,7 +792,7 @@ void SiStripBaseCondObjDQM::bookSummaryCumulMEs(SiStripBaseCondObjDQM::ModMEs& C
   // ---
   int subdetectorId_ = ((detId_>>25)&0x7);
   
-  if( subdetectorId_<3 or subdetectorId_>6 ){ 
+  if( subdetectorId_<3 || subdetectorId_>6 ){ 
     edm::LogError("SiStripBaseCondObjDQM")
        << "[SiStripBaseCondObjDQM::bookSummaryCumulMEs] WRONG INPUT : no such subdetector type : "
        << subdetectorId_ << " no folder set!" 
@@ -802,7 +802,7 @@ void SiStripBaseCondObjDQM::bookSummaryCumulMEs(SiStripBaseCondObjDQM::ModMEs& C
   // ---
   
   // LA Histos are plotted for each string:
-  if(CondObj_name_ == "lorentzangle" and SummaryOnStringLevel_On_) { 
+  if(CondObj_name_ == "lorentzangle" && SummaryOnStringLevel_On_) { 
     hSummaryOfCumul_name = hidmanager.createHistoLayer(hSummaryOfCumul_description, "layer" , getStringNameAndId(detId_,tTopo).first, "") ;
   }
   else {  
@@ -876,7 +876,7 @@ void SiStripBaseCondObjDQM::bookSummaryMEs(SiStripBaseCondObjDQM::ModMEs& CondOb
   int subdetectorId_ = ((detId_>>25)&0x7);
   
  
-  if( subdetectorId_<3 or subdetectorId_>6 ){ 
+  if( subdetectorId_<3 || subdetectorId_>6 ){ 
     edm::LogError("SiStripBaseCondObjDQM")
        << "[SiStripBaseCondObjDQM::bookSummaryMEs] WRONG INPUT : no such subdetector type : "
        << subdetectorId_ << " no folder set!" 
@@ -1026,7 +1026,7 @@ std::pair<std::string,uint32_t> SiStripBaseCondObjDQM::getStringNameAndId(const 
   std::stringstream layerStringName;
   
   if( subdetectorId_==3 ){ //TIB
-    if(tTopo->tibLayer(detId_)==1 and tTopo->tibIsInternalString(detId_)){ //1st layer int
+    if(tTopo->tibLayer(detId_)==1 && tTopo->tibIsInternalString(detId_)){ //1st layer int
       for( unsigned int i=1; i < 27 ;i++){
 	if(tTopo->tibString(detId_)==i){  
 	  layerStringName << "TIB_L1_Int_Str_" << i;
@@ -1034,7 +1034,7 @@ std::pair<std::string,uint32_t> SiStripBaseCondObjDQM::getStringNameAndId(const 
 	}
       }      
     }
-    else  if(tTopo->tibLayer(detId_)==1 and tTopo->tibIsExternalString(detId_)){ //1st layer ext
+    else  if(tTopo->tibLayer(detId_)==1 && tTopo->tibIsExternalString(detId_)){ //1st layer ext
       for( unsigned int i=1; i < 31 ;i++){
 	if(tTopo->tibString(detId_)==i){  
 	  layerStringName << "TIB_L1_Ext_Str_" << i;
@@ -1042,7 +1042,7 @@ std::pair<std::string,uint32_t> SiStripBaseCondObjDQM::getStringNameAndId(const 
 	}
       }      
     }
-    else if(tTopo->tibLayer(detId_)==2 and tTopo->tibIsInternalString(detId_)){ //2nd layer int
+    else if(tTopo->tibLayer(detId_)==2 && tTopo->tibIsInternalString(detId_)){ //2nd layer int
       for( unsigned int i=1; i < 35 ;i++){
 	if(tTopo->tibString(detId_)==i){  
 	  layerStringName << "TIB_L2_Int_Str_" << i;
@@ -1050,7 +1050,7 @@ std::pair<std::string,uint32_t> SiStripBaseCondObjDQM::getStringNameAndId(const 
 	}
       }      
     }
-    else if(tTopo->tibLayer(detId_)==2 and tTopo->tibIsExternalString(detId_)){ //2nd layer ext
+    else if(tTopo->tibLayer(detId_)==2 && tTopo->tibIsExternalString(detId_)){ //2nd layer ext
       for( unsigned int i=1; i < 39 ;i++){
 	if(tTopo->tibString(detId_)==i){  
 	  layerStringName << "TIB_L2_Ext_Str_" << i;
@@ -1058,7 +1058,7 @@ std::pair<std::string,uint32_t> SiStripBaseCondObjDQM::getStringNameAndId(const 
 	}
       }      
     }
-    else if(tTopo->tibLayer(detId_)==3 and tTopo->tibIsInternalString(detId_)){ //3rd layer int
+    else if(tTopo->tibLayer(detId_)==3 && tTopo->tibIsInternalString(detId_)){ //3rd layer int
       for( unsigned int i=1; i < 45 ;i++){
 	if(tTopo->tibString(detId_)==i){  
 	  layerStringName << "TIB_L3_Int_Str_" << i;
@@ -1066,7 +1066,7 @@ std::pair<std::string,uint32_t> SiStripBaseCondObjDQM::getStringNameAndId(const 
 	}
       }      
     }
-    else if(tTopo->tibLayer(detId_)==3 and tTopo->tibIsExternalString(detId_)){ //3rd layer ext
+    else if(tTopo->tibLayer(detId_)==3 && tTopo->tibIsExternalString(detId_)){ //3rd layer ext
       for( unsigned int i=1; i < 47 ;i++){
 	if(tTopo->tibString(detId_)==i){  
 	  layerStringName << "TIB_L3_Ext_Str_" << i;
@@ -1074,7 +1074,7 @@ std::pair<std::string,uint32_t> SiStripBaseCondObjDQM::getStringNameAndId(const 
 	}
       }      
     }
-    else if(tTopo->tibLayer(detId_)==4 and tTopo->tibIsInternalString(detId_)){ //4th layer int
+    else if(tTopo->tibLayer(detId_)==4 && tTopo->tibIsInternalString(detId_)){ //4th layer int
       for( unsigned int i=1; i < 53 ;i++){
 	if(tTopo->tibString(detId_)==i){  
 	  layerStringName << "TIB_L4_Int_Str_" << i;
@@ -1082,7 +1082,7 @@ std::pair<std::string,uint32_t> SiStripBaseCondObjDQM::getStringNameAndId(const 
 	}
       }      
     }
-    else if(tTopo->tibLayer(detId_)==4 and tTopo->tibIsExternalString(detId_)){ //4th layer ext
+    else if(tTopo->tibLayer(detId_)==4 && tTopo->tibIsExternalString(detId_)){ //4th layer ext
       for( unsigned int i=1; i < 57 ;i++){
 	if(tTopo->tibString(detId_)==i){  
 	  layerStringName << "TIB_L4_Ext_Str_" << i;
@@ -1204,17 +1204,17 @@ void SiStripBaseCondObjDQM::saveTkMap(const std::string& TkMapname, double minVa
       entries+=tkMapScaler[i];
 
     float min=0 ;
-    for(size_t i=0;(i<tkMapScaler.size()) and (min<th);++i){
+    for(size_t i=0;(i<tkMapScaler.size()) && (min<th);++i){
       min+=tkMapScaler[i]/entries;
       imin=i;
     }
 
     float max=0;
-    // for(size_t i=tkMapScaler.size()-1;(i>=0) and (max<th);--i){ // Wrong
+    // for(size_t i=tkMapScaler.size()-1;(i>=0) && (max<th);--i){ // Wrong
     // Since i is unsigned, i >= 0 is always true,
     // and the loop termination condition is never reached.
     // We offset the loop index by one to fix this.
-    for(size_t j=tkMapScaler.size();(j>0) and (max<th);--j){ 
+    for(size_t j=tkMapScaler.size();(j>0) && (max<th);--j){ 
       size_t i = j - 1;
       max+=tkMapScaler[i]/entries;
       imax=i;
@@ -1286,10 +1286,10 @@ void SiStripBaseCondObjDQM::fillSummaryMEs(const std::vector<uint32_t> & selecte
     ModMEs selME;
     selME = iter->second;
 
-    if(hPSet_.getParameter<bool>("FillSummaryProfileAtLayerLevel") and
+    if(hPSet_.getParameter<bool>("FillSummaryProfileAtLayerLevel") &&
        fPSet_.getParameter<bool>("OutputSummaryProfileAtLayerLevelAsImage")){
 
-      if( CondObj_fillId_ =="onlyProfile" or CondObj_fillId_ =="ProfileAndCumul"){
+      if( CondObj_fillId_ =="onlyProfile" || CondObj_fillId_ =="ProfileAndCumul"){
 
 	TCanvas c1("c1");
 	selME.SummaryOfProfileDistr->getTProfile()->Draw();
@@ -1298,7 +1298,7 @@ void SiStripBaseCondObjDQM::fillSummaryMEs(const std::vector<uint32_t> & selecte
 	c1.Print(name.c_str());
       }
     }
-    if(hPSet_.getParameter<bool>("FillSummaryAtLayerLevel") and
+    if(hPSet_.getParameter<bool>("FillSummaryAtLayerLevel") &&
        fPSet_.getParameter<bool>("OutputSummaryAtLayerLevelAsImage")){
 
       TCanvas c1("c1");
@@ -1307,10 +1307,10 @@ void SiStripBaseCondObjDQM::fillSummaryMEs(const std::vector<uint32_t> & selecte
       name+=".png";
       c1.Print(name.c_str());
     }
-    if(hPSet_.getParameter<bool>("FillCumulativeSummaryAtLayerLevel") and
+    if(hPSet_.getParameter<bool>("FillCumulativeSummaryAtLayerLevel") &&
        fPSet_.getParameter<bool>("OutputCumulativeSummaryAtLayerLevelAsImage")){
 
-      if( CondObj_fillId_ =="onlyCumul" or CondObj_fillId_ =="ProfileAndCumul"){
+      if( CondObj_fillId_ =="onlyCumul" || CondObj_fillId_ =="ProfileAndCumul"){
 
 	TCanvas c1("c1");
 	selME.SummaryOfCumulDistr->getTH1()->Draw();

--- a/DQM/SiStripMonitorSummary/src/SiStripBaseCondObjDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripBaseCondObjDQM.cc
@@ -29,14 +29,14 @@ SiStripBaseCondObjDQM::SiStripBaseCondObjDQM(const edm::EventSetup & eSetup,
  
 
   //Warning message from wrong input:
-  if(SummaryOnLayerLevel_On_ && SummaryOnStringLevel_On_){
+  if(SummaryOnLayerLevel_On_ and SummaryOnStringLevel_On_){
     edm::LogWarning("SiStripBaseCondObjDQM") 
        << "[SiStripBaseCondObjDQM::SiStripBaseCondObjDQMs] PLEASE CHECK : String and layer level options can not be activated together"
        << std::endl; 
   }
 
   //The OR of the two conditions allow to switch on this feature for all the components (if the FillConditions_PSet has the TkMap_On =true) or for single MEs (if the PSet for a ME has the TkMap_On =true)
-  if(fPSet_.getParameter<bool>("TkMap_On") || hPSet_.getParameter<bool>("TkMap_On")) bookTkMap(hPSet_.getParameter<std::string>("TkMapName"));
+  if(fPSet_.getParameter<bool>("TkMap_On") or hPSet_.getParameter<bool>("TkMap_On")) bookTkMap(hPSet_.getParameter<std::string>("TkMapName"));
 
 
   minValue=hPSet_.getParameter<double>("minValue");
@@ -49,6 +49,8 @@ SiStripBaseCondObjDQM::SiStripBaseCondObjDQM(const edm::EventSetup & eSetup,
 //======================================
 // -----
 void SiStripBaseCondObjDQM::analysis(const edm::EventSetup & eSetup_){
+
+  edm::LogInfo("SiStripBaseCondObjDQM") << "[SiStripBaseCondObjDQM::analysis] starting .. " << std::endl;
  
   cacheID_current=  getCache(eSetup_);
   
@@ -57,15 +59,15 @@ void SiStripBaseCondObjDQM::analysis(const edm::EventSetup & eSetup_){
   getConditionObject(eSetup_);
 
   //The OR of the two conditions allows to switch on this feature for all the components (if the FillConditions_PSet has the ActiveDetIds_On =true) or for single MEs (if the PSet for a ME has the ActiveDetIds_On =true)
-  if(fPSet_.getParameter<bool>("ActiveDetIds_On") || hPSet_.getParameter<bool>("ActiveDetIds_On"))
+  if(fPSet_.getParameter<bool>("ActiveDetIds_On") or hPSet_.getParameter<bool>("ActiveDetIds_On"))
     getActiveDetIds(eSetup_);
   else
     activeDetIds=reader->getAllDetIds();
 
   selectModules(activeDetIds);
 
-  if(Mod_On_ )                                            { fillModMEs(activeDetIds, eSetup_); }
-  if(SummaryOnLayerLevel_On_ || SummaryOnStringLevel_On_ ){ fillSummaryMEs(activeDetIds, eSetup_);}
+  if(Mod_On_ )                                            { fillModMEs    (activeDetIds, eSetup_); }
+  if(SummaryOnLayerLevel_On_ or SummaryOnStringLevel_On_ ){ fillSummaryMEs(activeDetIds, eSetup_); }
 
   std::string filename = hPSet_.getParameter<std::string>("TkMapName");
   if (filename!=""){
@@ -164,113 +166,147 @@ std::vector<uint32_t> SiStripBaseCondObjDQM::getCabledModules() {
 //#FIXME : very long method. please factorize it
  
 void SiStripBaseCondObjDQM::selectModules(std::vector<uint32_t> & detIds_){
-   
-  ModulesToBeExcluded_     = fPSet_.getParameter< std::vector<unsigned int> >("ModulesToBeExcluded");
-  ModulesToBeIncluded_     = fPSet_.getParameter< std::vector<unsigned int> >("ModulesToBeIncluded");
-  SubDetectorsToBeExcluded_= fPSet_.getParameter< std::vector<std::string> >("SubDetectorsToBeExcluded");  
-
-  // vectors to be sorted otherwise the intersection is non computed properly
-
-  std::sort(ModulesToBeExcluded_.begin(),ModulesToBeExcluded_.end());
-  std::sort(ModulesToBeIncluded_.begin(),ModulesToBeIncluded_.end());
-
-  if(fPSet_.getParameter<bool>("restrictModules") 
-     && ModulesToBeExcluded_.size()==0 
-     && ModulesToBeIncluded_.size()==0 ){
-    edm::LogWarning("SiStripBaseCondObjDQM") 
-       << "[SiStripBaseCondObjDQM::selectModules] PLEASE CHECK : no modules to be exclude/included in your cfg"
-       << std::endl; 
-  }
-
- 
- 
   
-  // --> detIds to start with
-
+  edm::LogInfo("SiStripBaseCondObjDQM") << "[SiStripBaseCondObjDQM::selectModules] input detIds_: " << detIds_.size() << std::endl;
+  
   if( fPSet_.getParameter<bool>("restrictModules")){
-      
-    if( ModulesToBeIncluded_.size()>0 ){
-     std::vector<uint32_t> tmp;
-     tmp.clear();
-     set_intersection( detIds_.begin(), detIds_.end(),  
-                       ModulesToBeIncluded_.begin(), ModulesToBeIncluded_.end(),
-		       inserter(tmp,tmp.begin()));
-     swap(detIds_,tmp);
-   }
     
-  }
-
-  
-
-  // -----
-  // *** exclude modules ***
-  
-  if( fPSet_.getParameter<bool>("restrictModules") ){
+    std::vector<edm::ParameterSet> included_subdets = fPSet_.getParameter<std::vector<edm::ParameterSet> >("modulesToBeIncluded");
+    for(std::vector<edm::ParameterSet>::const_iterator wsdps = included_subdets.begin();wsdps!=included_subdets.end();++wsdps) {
+      m_included_subdets   [wsdps->getParameter<unsigned int>("detSelection")] = wsdps->getParameter<std::string>("detLabel");
+      m_included_subdetsels[wsdps->getParameter<unsigned int>("detSelection")] = 
+	DetIdSelector(wsdps->getUntrackedParameter<std::vector<std::string> >("selection",std::vector<std::string>()));
+    }
+    
+    std::vector<uint32_t> modulesToBeIncluded;
+    for(std::vector<uint32_t>::const_iterator detid=detIds_.begin();detid!=detIds_.end();++detid) {
+      for(std::map<unsigned int,DetIdSelector>::const_iterator detidsel=m_included_subdetsels.begin();detidsel!=m_included_subdetsels.end();++detidsel) {
+	DetIdSelector detIdSel = detidsel->second;
+	if(detIdSel.isSelected(*detid)) {
+	  modulesToBeIncluded.push_back(*detid);
+	  //	  std::cout << "detId: " << *detid << " is selected" << std::endl;
+	}
+      }
+    }
+    edm::LogInfo("SiStripBaseCondObjDQM") << "[SiStripBaseCondObjDQM::selectModules] modulesToBeIncluded: " << modulesToBeIncluded.size() << std::endl;
+    
+    // -----
+    // *** exclude modules ***
+    std::vector<edm::ParameterSet> excluded_subdets = fPSet_.getParameter<std::vector<edm::ParameterSet> >("modulesToBeExcluded");
+    for(std::vector<edm::ParameterSet>::const_iterator wsdps = excluded_subdets.begin();wsdps!=excluded_subdets.end();++wsdps) {
+      m_excluded_subdets   [wsdps->getParameter<unsigned int>("detSelection")] = wsdps->getParameter<std::string>("detLabel");
+      m_excluded_subdetsels[wsdps->getParameter<unsigned int>("detSelection")] = 
+	DetIdSelector(wsdps->getUntrackedParameter<std::vector<std::string> >("selection",std::vector<std::string>()));
+    }
+    
+    std::vector<uint32_t> modulesToBeExcluded;
+    for(std::vector<uint32_t>::const_iterator detid=detIds_.begin();detid!=detIds_.end();++detid) {
+      for(std::map<unsigned int,DetIdSelector>::const_iterator detidsel=m_excluded_subdetsels.begin();detidsel!=m_excluded_subdetsels.end();++detidsel) {
+	DetIdSelector detIdSel = detidsel->second;
+	if(detIdSel.isSelected(*detid)) {
+	  modulesToBeExcluded.push_back(*detid);
+	}
+      }
+    }
+    edm::LogInfo("SiStripBaseCondObjDQM") << "[SiStripBaseCondObjDQM::selectModules] modulesToBeExcluded: " << modulesToBeExcluded.size() << std::endl;
+    
+    ModulesToBeExcluded_     = fPSet_.getParameter< std::vector<unsigned int> >("ModulesToBeExcluded");
+    ModulesToBeIncluded_     = fPSet_.getParameter< std::vector<unsigned int> >("ModulesToBeIncluded");
+    SubDetectorsToBeExcluded_= fPSet_.getParameter< std::vector<std::string> >("SubDetectorsToBeExcluded");  
+    
+    // vectors to be sorted otherwise the intersection is non computed properly
+    
+    std::sort(ModulesToBeExcluded_.begin(),ModulesToBeExcluded_.end());
+    std::sort(ModulesToBeIncluded_.begin(),ModulesToBeIncluded_.end());
+    
+    if (modulesToBeExcluded.size()==0  and modulesToBeIncluded.size()==0 and
+	ModulesToBeExcluded_.size()==0 and ModulesToBeIncluded_.size()==0 )
+      edm::LogWarning("SiStripBaseCondObjDQM") 
+	<< "[SiStripBaseCondObjDQM::selectModules] PLEASE CHECK : no modules to be exclude/included in your cfg"
+	<< std::endl; 
+    
+    
+    modulesToBeIncluded.insert(modulesToBeIncluded.end(),ModulesToBeIncluded_.begin(),ModulesToBeIncluded_.end());
+    
+    // apply modules selection
+    if( modulesToBeIncluded.size()>0 ){
+      std::vector<uint32_t> tmp;
+      // The intersection of two sets is formed only by the elements that are present in both sets
+      set_intersection( detIds_.begin(), detIds_.end(),  
+			modulesToBeIncluded.begin(), modulesToBeIncluded.end(),
+			inserter(tmp,tmp.begin()));
+      swap(detIds_,tmp);
+    }
+    
+    edm::LogInfo("SiStripBaseCondObjDQM") << "[SiStripBaseCondObjDQM::selectModules] after included detIds_: " << detIds_.size() << std::endl;
+    
     
     std::sort(detIds_.begin(),detIds_.end());
-
-    for( std::vector<uint32_t>::const_iterator modIter_  = ModulesToBeExcluded_.begin(); 
-                                               modIter_ != ModulesToBeExcluded_.end(); modIter_++){
-      
-      std::vector<uint32_t>::iterator detIter_=std::lower_bound(detIds_.begin(),detIds_.end(),*modIter_);
-      detIds_.erase(detIter_);
-      detIter_--;
-     
-    }
-  
-  }
-  // *** exclude modules ***
-  // -----
-   
-
-  // -----
-  // *** restrict to a particular subdetector ***
-   
-  if( *(SubDetectorsToBeExcluded_.begin()) !="none" ){
     
-    std::vector<uint32_t> tmp;
-
-    SiStripSubStructure substructure_;
-    
-    for( std::vector<std::string>::const_iterator modIter_  = SubDetectorsToBeExcluded_.begin(); 
-                                                 modIter_ != SubDetectorsToBeExcluded_.end(); modIter_++){
-      tmp.clear();
-
-      if (*modIter_=="TIB")     { substructure_.getTIBDetectors(detIds_, tmp, 0,0,0,0);}
-      else if (*modIter_=="TOB") { substructure_.getTOBDetectors(detIds_, tmp, 0,0,0);}
-      else if (*modIter_=="TID") { substructure_.getTIDDetectors(detIds_, tmp, 0,0,0,0);}
-      else if (*modIter_=="TEC") { substructure_.getTECDetectors(detIds_, tmp, 0,0,0,0,0,0);}
-      else {
-        edm::LogWarning("SiStripBaseCondObjDQM") 
-       << "[SiStripBaseCondObjDQM::selectModules] PLEASE CHECK : no correct (name) subdetector to be excluded in your cfg"
-       << std::endl; 
+    modulesToBeExcluded.insert(modulesToBeExcluded.end(),ModulesToBeExcluded_.begin(),ModulesToBeExcluded_.end());
+    if(modulesToBeExcluded.size()>0) {
+      for( std::vector<uint32_t>::const_iterator mod = modulesToBeExcluded.begin(); 
+	   mod != modulesToBeExcluded.end(); mod++){
+	
+	std::vector<uint32_t>::iterator detid=std::lower_bound(detIds_.begin(),detIds_.end(),*mod);
+	if (detid!=detIds_.end())
+	  detIds_.erase(detid);
+	detid--;
       }
-
-      std::vector<uint32_t>::iterator iterBegin_=std::lower_bound(detIds_.begin(),
-	                                                          detIds_.end(),
-								  *min_element(tmp.begin(), tmp.end()));
-								  
-      std::vector<uint32_t>::iterator iterEnd_=std::lower_bound(detIds_.begin(),
-	                                                        detIds_.end(),
-								*max_element(tmp.begin(), tmp.end()));
-								
-      for(std::vector<uint32_t>::iterator detIter_ = iterEnd_;
-                                         detIter_!= iterBegin_-1;detIter_--){
+    }
+    edm::LogInfo("SiStripBaseCondObjDQM") << "[SiStripBaseCondObjDQM::selectModules] after excluded detIds_: " << detIds_.size() << std::endl;
+    
+    
+    // -----
+    // *** restrict to a particular subdetector ***
+    
+    if( *(SubDetectorsToBeExcluded_.begin()) !="none" ){
+      
+      std::vector<uint32_t> tmp;
+      
+      SiStripSubStructure substructure_;
+      
+      for( std::vector<std::string>::const_iterator modIter_  = SubDetectorsToBeExcluded_.begin(); 
+	   modIter_ != SubDetectorsToBeExcluded_.end(); modIter_++){
+	tmp.clear();
+	
+	if (*modIter_=="TIB")     { substructure_.getTIBDetectors(detIds_, tmp, 0,0,0,0);}
+	else if (*modIter_=="TOB") { substructure_.getTOBDetectors(detIds_, tmp, 0,0,0);}
+	else if (*modIter_=="TID") { substructure_.getTIDDetectors(detIds_, tmp, 0,0,0,0);}
+	else if (*modIter_=="TEC") { substructure_.getTECDetectors(detIds_, tmp, 0,0,0,0,0,0);}
+	else {
+	  edm::LogWarning("SiStripBaseCondObjDQM") 
+	    << "[SiStripBaseCondObjDQM::selectModules] PLEASE CHECK : no correct (name) subdetector to be excluded in your cfg"
+	    << std::endl; 
+	}
+	
+	std::vector<uint32_t>::iterator iterBegin_=std::lower_bound(detIds_.begin(),
+								    detIds_.end(),
+								    *min_element(tmp.begin(), tmp.end()));
+	
+	std::vector<uint32_t>::iterator iterEnd_=std::lower_bound(detIds_.begin(),
+								  detIds_.end(),
+								  *max_element(tmp.begin(), tmp.end()));
+	
+	for(std::vector<uint32_t>::iterator detIter_ = iterEnd_;
+	    detIter_!= iterBegin_-1;detIter_--){
 	  detIds_.erase(detIter_);
-      } 
-
-    } // loop SubDetectorsToBeExcluded_
+	} 
+	
+      } // loop SubDetectorsToBeExcluded_
+    }
+    
   }
-
+  edm::LogInfo("SiStripBaseCondObjDQM") << "[SiStripBaseCondObjDQM::selectModules] output detIds_: " << detIds_.size() << std::endl;
   
   // -----
   // *** fill only one Module per layer ***
-
+  
   if(fPSet_.getParameter<std::string>("ModulesToBeFilled") == "onlyOneModulePerLayer"){
-   
+    
     std::vector<uint32_t> tmp;
     std::vector<uint32_t> layerDetIds;
-
+    
     SiStripSubStructure substructure_;
     
     for(unsigned int i=1; i<5 ; i++){
@@ -300,11 +336,11 @@ void SiStripBaseCondObjDQM::selectModules(std::vector<uint32_t> & detIds_){
     
     detIds_.clear();
     detIds_=layerDetIds;
-
+    
   }
   // -----
-
-   
+  
+  
 } //selectModules
 // -----
 
@@ -319,11 +355,11 @@ void SiStripBaseCondObjDQM::getModMEs(ModMEs& CondObj_ME, const uint32_t& detId_
   
     CondObj_ME=ModMEsMap_iter->second;
   
-    if( ( CondObj_fillId_ =="ProfileAndCumul" || CondObj_fillId_ =="onlyProfile") && CondObj_ME.ProfileDistr ) { 
+    if( ( CondObj_fillId_ =="ProfileAndCumul" or CondObj_fillId_ =="onlyProfile") and CondObj_ME.ProfileDistr ) { 
       CondObj_ME.ProfileDistr ->Reset();    
     }
        
-    if( (CondObj_fillId_ =="ProfileAndCumul" || CondObj_fillId_ =="onlyCumul" ) &&  CondObj_ME.CumulDistr ){
+    if( (CondObj_fillId_ =="ProfileAndCumul" or CondObj_fillId_ =="onlyCumul" ) and  CondObj_ME.CumulDistr ){
       CondObj_ME.CumulDistr ->Reset();
     }
     else {
@@ -335,13 +371,13 @@ void SiStripBaseCondObjDQM::getModMEs(ModMEs& CondObj_ME, const uint32_t& detId_
   }
   
   // --> profile defined for all CondData
-  if ( (CondObj_fillId_ =="ProfileAndCumul" || CondObj_fillId_ =="onlyProfile")) {
+  if ( (CondObj_fillId_ =="ProfileAndCumul" or CondObj_fillId_ =="onlyProfile")) {
     bookProfileMEs(CondObj_ME,detId_,tTopo);
   }  
   
   // --> cumul currently only defined for noise and apvgain
-  if( (CondObj_fillId_ =="ProfileAndCumul" || CondObj_fillId_ =="onlyCumul" )
-      &&(CondObj_name_ == "noise" || CondObj_name_ == "apvgain")          ) bookCumulMEs(CondObj_ME,detId_,tTopo);
+  if( (CondObj_fillId_ =="ProfileAndCumul" or CondObj_fillId_ =="onlyCumul" )
+      and(CondObj_name_ == "noise" or CondObj_name_ == "apvgain")          ) bookCumulMEs(CondObj_ME,detId_,tTopo);
   
  
   ModMEsMap_.insert( std::make_pair(detId_,CondObj_ME) );
@@ -356,7 +392,7 @@ void SiStripBaseCondObjDQM::getSummaryMEs(ModMEs& CondObj_ME, const uint32_t& de
 
   std::map<uint32_t, ModMEs>::const_iterator SummaryMEsMap_iter;
 
-  if(CondObj_name_ == "lorentzangle" && SummaryOnStringLevel_On_ ){
+  if(CondObj_name_ == "lorentzangle" and SummaryOnStringLevel_On_ ){
     SummaryMEsMap_iter = SummaryMEsMap_.find(getStringNameAndId(detId_,tTopo).second);
   }
   else {
@@ -368,40 +404,40 @@ void SiStripBaseCondObjDQM::getSummaryMEs(ModMEs& CondObj_ME, const uint32_t& de
   //FIXME t's not good that the base class has to know about which derived class shoudl exist.
   // please modify this part. implement virtual functions, esplicited in the derived classes
   // --> currently only profile summary defined for all condition objects except quality
-  if(  (CondObj_fillId_ =="ProfileAndCumul" || CondObj_fillId_ =="onlyProfile" ) &&
+  if(  (CondObj_fillId_ =="ProfileAndCumul" or CondObj_fillId_ =="onlyProfile" ) and
      (
-      CondObj_name_ == "pedestal"     || 
-      CondObj_name_ == "noise"         || 
-      CondObj_name_ == "lowthreshold"  || 
-      CondObj_name_ == "highthreshold" || 
-      CondObj_name_ == "apvgain"       || 
+      CondObj_name_ == "pedestal"     or 
+      CondObj_name_ == "noise"         or 
+      CondObj_name_ == "lowthreshold"  or 
+      CondObj_name_ == "highthreshold" or 
+      CondObj_name_ == "apvgain"       or 
       CondObj_name_ == "lorentzangle") ) {
     if(hPSet_.getParameter<bool>("FillSummaryProfileAtLayerLevel"))	
       if (!CondObj_ME.SummaryOfProfileDistr) { bookSummaryProfileMEs(CondObj_ME,detId_,tTopo); }
   }    
     
   // --> currently only genuine cumul LA
-  if(   (CondObj_fillId_ =="ProfileAndCumul" || CondObj_fillId_ =="onlyCumul" ) &&
+  if(   (CondObj_fillId_ =="ProfileAndCumul" or CondObj_fillId_ =="onlyCumul" ) and
 	(
-	 CondObj_name_ == "lorentzangle" ||  
+	 CondObj_name_ == "lorentzangle" or  
 	 CondObj_name_ == "noise")  ) {
     if(hPSet_.getParameter<bool>("FillCumulativeSummaryAtLayerLevel"))
       if (!CondObj_ME.SummaryOfCumulDistr) { bookSummaryCumulMEs(CondObj_ME,detId_,tTopo); } 
   } 
                           
   // --> currently only summary as a function of detId for noise, pedestal and apvgain 
-  if(      CondObj_name_ == "noise"         ||
-	   CondObj_name_ == "lowthreshold"  || 
-	   CondObj_name_ == "highthreshold" || 
-	   CondObj_name_ == "apvgain"       || 
-	   CondObj_name_ == "pedestal"      || 
+  if(      CondObj_name_ == "noise"         or
+	   CondObj_name_ == "lowthreshold"  or 
+	   CondObj_name_ == "highthreshold" or 
+	   CondObj_name_ == "apvgain"       or 
+	   CondObj_name_ == "pedestal"      or 
 	   CondObj_name_ == "quality"           ) {
     if(hPSet_.getParameter<bool>("FillSummaryAtLayerLevel"))          
       if (!CondObj_ME.SummaryDistr) { bookSummaryMEs(CondObj_ME,detId_,tTopo); } 
     
   } 
                           
-  if(CondObj_name_ == "lorentzangle" && SummaryOnStringLevel_On_) {
+  if(CondObj_name_ == "lorentzangle" and SummaryOnStringLevel_On_) {
     //FIXME getStringNameandId takes time. not need to call it every timne. put the call at the beginning of the method and caache the string 
     SummaryMEsMap_.insert( std::make_pair(getStringNameAndId(detId_,tTopo).second,CondObj_ME) );
   }
@@ -527,16 +563,16 @@ void SiStripBaseCondObjDQM::bookSummaryProfileMEs(SiStripBaseCondObjDQM::ModMEs&
   
   int nStrip, nApv, layerId_;    
   
-  if(CondObj_name_ == "lorentzangle" && SummaryOnStringLevel_On_) { layerId_= getStringNameAndId(detId_,tTopo).second;}
-  else                                                          { layerId_= getLayerNameAndId(detId_,tTopo).second;}
+  if(CondObj_name_ == "lorentzangle" and SummaryOnStringLevel_On_) { layerId_= getStringNameAndId(detId_,tTopo).second;}
+  else                                                            { layerId_= getLayerNameAndId(detId_,tTopo).second;}
 
 
-  if( CondObj_name_ == "pedestal" || CondObj_name_ == "noise"|| CondObj_name_ == "lowthreshold" || CondObj_name_ == "highthreshold" ){ // plot in strip number
+  if( CondObj_name_ == "pedestal" or CondObj_name_ == "noise" or CondObj_name_ == "lowthreshold" or CondObj_name_ == "highthreshold" ){ // plot in strip number
     
-    if( (layerId_ > 610 && layerId_ < 620) || // TID & TEC have 768 strips at maximum
-        (layerId_ > 620 && layerId_ < 630) ||
-        (layerId_ > 410 && layerId_ < 414) ||
-        (layerId_ > 420 && layerId_ < 424) ){ nStrip =768;} 
+    if( (layerId_ > 610 and layerId_ < 620) or // TID & TEC have 768 strips at maximum
+        (layerId_ > 620 and layerId_ < 630) or
+        (layerId_ > 410 and layerId_ < 414) or
+        (layerId_ > 420 and layerId_ < 424) ){ nStrip =768;} 
     else { nStrip      = reader->getNumberOfApvsAndStripLength(detId_).first*128;}
     
     hSummaryOfProfile_NchX           = nStrip;
@@ -544,7 +580,7 @@ void SiStripBaseCondObjDQM::bookSummaryProfileMEs(SiStripBaseCondObjDQM::ModMEs&
     hSummaryOfProfile_HighX          = nStrip+0.5;
   
   }  
-  else if( (CondObj_name_ == "lorentzangle" && SummaryOnLayerLevel_On_) || CondObj_name_ == "quality"){ // plot in detId-number
+  else if( (CondObj_name_ == "lorentzangle" and SummaryOnLayerLevel_On_) or CondObj_name_ == "quality"){ // plot in detId-number
 
     // -----
     // get detIds belonging to same layer to fill X-axis with detId-number
@@ -572,7 +608,7 @@ void SiStripBaseCondObjDQM::bookSummaryProfileMEs(SiStripBaseCondObjDQM::ModMEs&
     hSummaryOfProfile_HighX          = sameLayerDetIds_.size()+0.5;
  
   } 
-  else if( CondObj_name_ == "lorentzangle" && SummaryOnStringLevel_On_){ // plot in detId-number
+  else if( CondObj_name_ == "lorentzangle" and SummaryOnStringLevel_On_){ // plot in detId-number
 
     // -----
     // get detIds belonging to same string to fill X-axis with detId-number
@@ -606,10 +642,10 @@ void SiStripBaseCondObjDQM::bookSummaryProfileMEs(SiStripBaseCondObjDQM::ModMEs&
   } 
   else if( CondObj_name_ == "apvgain"){
  
-    if( (layerId_ > 610 && layerId_ < 620) || // TID & TEC have 6 apvs at maximum
-        (layerId_ > 620 && layerId_ < 630) ||
-        (layerId_ > 410 && layerId_ < 414) ||
-        (layerId_ > 420 && layerId_ < 424) ){ nApv =6;} 
+    if( (layerId_ > 610 and layerId_ < 620) or // TID & TEC have 6 apvs at maximum
+        (layerId_ > 620 and layerId_ < 630) or
+        (layerId_ > 410 and layerId_ < 414) or
+        (layerId_ > 420 and layerId_ < 424) ){ nApv =6;} 
     else { nApv     = reader->getNumberOfApvsAndStripLength(detId_).first;}
     
     hSummaryOfProfile_NchX           = nApv;
@@ -635,7 +671,7 @@ void SiStripBaseCondObjDQM::bookSummaryProfileMEs(SiStripBaseCondObjDQM::ModMEs&
   int subdetectorId_ = ((detId_>>25)&0x7);
   
  
-  if( subdetectorId_<3 ||subdetectorId_>6 ){ 
+  if( subdetectorId_<3 or subdetectorId_>6 ){ 
     edm::LogError("SiStripBaseCondObjDQM")
        << "[SiStripBaseCondObjDQM::bookSummaryProfileMEs] WRONG INPUT : no such subdetector type : "
        << subdetectorId_ << " no folder set!" 
@@ -644,7 +680,7 @@ void SiStripBaseCondObjDQM::bookSummaryProfileMEs(SiStripBaseCondObjDQM::ModMEs&
   }
   // ---
   
-  if(CondObj_name_ == "lorentzangle" && SummaryOnStringLevel_On_) { 
+  if(CondObj_name_ == "lorentzangle" and SummaryOnStringLevel_On_) { 
     hSummaryOfProfile_name = hidmanager.createHistoLayer(hSummaryOfProfile_description, "layer" , getStringNameAndId(detId_,tTopo).first,"") ;
   }
   else {
@@ -758,7 +794,7 @@ void SiStripBaseCondObjDQM::bookSummaryCumulMEs(SiStripBaseCondObjDQM::ModMEs& C
   // ---
   int subdetectorId_ = ((detId_>>25)&0x7);
   
-  if( subdetectorId_<3 || subdetectorId_>6 ){ 
+  if( subdetectorId_<3 or subdetectorId_>6 ){ 
     edm::LogError("SiStripBaseCondObjDQM")
        << "[SiStripBaseCondObjDQM::bookSummaryCumulMEs] WRONG INPUT : no such subdetector type : "
        << subdetectorId_ << " no folder set!" 
@@ -768,7 +804,7 @@ void SiStripBaseCondObjDQM::bookSummaryCumulMEs(SiStripBaseCondObjDQM::ModMEs& C
   // ---
   
   // LA Histos are plotted for each string:
-  if(CondObj_name_ == "lorentzangle" && SummaryOnStringLevel_On_) { 
+  if(CondObj_name_ == "lorentzangle" and SummaryOnStringLevel_On_) { 
     hSummaryOfCumul_name = hidmanager.createHistoLayer(hSummaryOfCumul_description, "layer" , getStringNameAndId(detId_,tTopo).first, "") ;
   }
   else {  
@@ -842,7 +878,7 @@ void SiStripBaseCondObjDQM::bookSummaryMEs(SiStripBaseCondObjDQM::ModMEs& CondOb
   int subdetectorId_ = ((detId_>>25)&0x7);
   
  
-  if( subdetectorId_<3 ||subdetectorId_>6 ){ 
+  if( subdetectorId_<3 or subdetectorId_>6 ){ 
     edm::LogError("SiStripBaseCondObjDQM")
        << "[SiStripBaseCondObjDQM::bookSummaryMEs] WRONG INPUT : no such subdetector type : "
        << subdetectorId_ << " no folder set!" 
@@ -992,7 +1028,7 @@ std::pair<std::string,uint32_t> SiStripBaseCondObjDQM::getStringNameAndId(const 
   std::stringstream layerStringName;
   
   if( subdetectorId_==3 ){ //TIB
-    if(tTopo->tibLayer(detId_)==1 && tTopo->tibIsInternalString(detId_)){ //1st layer int
+    if(tTopo->tibLayer(detId_)==1 and tTopo->tibIsInternalString(detId_)){ //1st layer int
       for( unsigned int i=1; i < 27 ;i++){
 	if(tTopo->tibString(detId_)==i){  
 	  layerStringName << "TIB_L1_Int_Str_" << i;
@@ -1000,7 +1036,7 @@ std::pair<std::string,uint32_t> SiStripBaseCondObjDQM::getStringNameAndId(const 
 	}
       }      
     }
-    else  if(tTopo->tibLayer(detId_)==1 && tTopo->tibIsExternalString(detId_)){ //1st layer ext
+    else  if(tTopo->tibLayer(detId_)==1 and tTopo->tibIsExternalString(detId_)){ //1st layer ext
       for( unsigned int i=1; i < 31 ;i++){
 	if(tTopo->tibString(detId_)==i){  
 	  layerStringName << "TIB_L1_Ext_Str_" << i;
@@ -1008,7 +1044,7 @@ std::pair<std::string,uint32_t> SiStripBaseCondObjDQM::getStringNameAndId(const 
 	}
       }      
     }
-    else if(tTopo->tibLayer(detId_)==2 && tTopo->tibIsInternalString(detId_)){ //2nd layer int
+    else if(tTopo->tibLayer(detId_)==2 and tTopo->tibIsInternalString(detId_)){ //2nd layer int
       for( unsigned int i=1; i < 35 ;i++){
 	if(tTopo->tibString(detId_)==i){  
 	  layerStringName << "TIB_L2_Int_Str_" << i;
@@ -1016,7 +1052,7 @@ std::pair<std::string,uint32_t> SiStripBaseCondObjDQM::getStringNameAndId(const 
 	}
       }      
     }
-    else if(tTopo->tibLayer(detId_)==2 && tTopo->tibIsExternalString(detId_)){ //2nd layer ext
+    else if(tTopo->tibLayer(detId_)==2 and tTopo->tibIsExternalString(detId_)){ //2nd layer ext
       for( unsigned int i=1; i < 39 ;i++){
 	if(tTopo->tibString(detId_)==i){  
 	  layerStringName << "TIB_L2_Ext_Str_" << i;
@@ -1024,7 +1060,7 @@ std::pair<std::string,uint32_t> SiStripBaseCondObjDQM::getStringNameAndId(const 
 	}
       }      
     }
-    else if(tTopo->tibLayer(detId_)==3 && tTopo->tibIsInternalString(detId_)){ //3rd layer int
+    else if(tTopo->tibLayer(detId_)==3 and tTopo->tibIsInternalString(detId_)){ //3rd layer int
       for( unsigned int i=1; i < 45 ;i++){
 	if(tTopo->tibString(detId_)==i){  
 	  layerStringName << "TIB_L3_Int_Str_" << i;
@@ -1032,7 +1068,7 @@ std::pair<std::string,uint32_t> SiStripBaseCondObjDQM::getStringNameAndId(const 
 	}
       }      
     }
-    else if(tTopo->tibLayer(detId_)==3 && tTopo->tibIsExternalString(detId_)){ //3rd layer ext
+    else if(tTopo->tibLayer(detId_)==3 and tTopo->tibIsExternalString(detId_)){ //3rd layer ext
       for( unsigned int i=1; i < 47 ;i++){
 	if(tTopo->tibString(detId_)==i){  
 	  layerStringName << "TIB_L3_Ext_Str_" << i;
@@ -1040,7 +1076,7 @@ std::pair<std::string,uint32_t> SiStripBaseCondObjDQM::getStringNameAndId(const 
 	}
       }      
     }
-    else if(tTopo->tibLayer(detId_)==4 && tTopo->tibIsInternalString(detId_)){ //4th layer int
+    else if(tTopo->tibLayer(detId_)==4 and tTopo->tibIsInternalString(detId_)){ //4th layer int
       for( unsigned int i=1; i < 53 ;i++){
 	if(tTopo->tibString(detId_)==i){  
 	  layerStringName << "TIB_L4_Int_Str_" << i;
@@ -1048,7 +1084,7 @@ std::pair<std::string,uint32_t> SiStripBaseCondObjDQM::getStringNameAndId(const 
 	}
       }      
     }
-    else if(tTopo->tibLayer(detId_)==4 && tTopo->tibIsExternalString(detId_)){ //4th layer ext
+    else if(tTopo->tibLayer(detId_)==4 and tTopo->tibIsExternalString(detId_)){ //4th layer ext
       for( unsigned int i=1; i < 57 ;i++){
 	if(tTopo->tibString(detId_)==i){  
 	  layerStringName << "TIB_L4_Ext_Str_" << i;
@@ -1157,6 +1193,9 @@ void SiStripBaseCondObjDQM::fillTkMap(const uint32_t& detid, const float& value)
 
 //==========================
 void SiStripBaseCondObjDQM::saveTkMap(const std::string& TkMapname, double minValue, double maxValue){
+
+  edm::LogInfo("SiStripBaseCondObjDQM") << "[SiStripBaseCondObjDQM::saveTkMap] starting .. " << std::endl;
+  
   if(tkMapScaler.size()!=0){
     //check that saturation is below x%  below minValue and above minValue, and in case re-arrange.
     float th=hPSet_.getParameter<double>("saturatedFraction");
@@ -1167,17 +1206,17 @@ void SiStripBaseCondObjDQM::saveTkMap(const std::string& TkMapname, double minVa
       entries+=tkMapScaler[i];
 
     float min=0 ;
-    for(size_t i=0;(i<tkMapScaler.size()) && (min<th);++i){
+    for(size_t i=0;(i<tkMapScaler.size()) and (min<th);++i){
       min+=tkMapScaler[i]/entries;
       imin=i;
     }
 
     float max=0;
-    // for(size_t i=tkMapScaler.size()-1;(i>=0) && (max<th);--i){ // Wrong
+    // for(size_t i=tkMapScaler.size()-1;(i>=0) and (max<th);--i){ // Wrong
     // Since i is unsigned, i >= 0 is always true,
     // and the loop termination condition is never reached.
     // We offset the loop index by one to fix this.
-    for(size_t j=tkMapScaler.size();(j>0) && (max<th);--j){ 
+    for(size_t j=tkMapScaler.size();(j>0) and (max<th);--j){ 
       size_t i = j - 1;
       max+=tkMapScaler[i]/entries;
       imax=i;
@@ -1185,31 +1224,34 @@ void SiStripBaseCondObjDQM::saveTkMap(const std::string& TkMapname, double minVa
     
     //reset maxValue;
     if(maxValue<imax){
-      edm::LogInfo("")<< "Resetting TkMap maxValue from " << maxValue << " to " << imax;
+      edm::LogInfo("SiStripBaseCondObjDQM") << "Resetting TkMap maxValue from " << maxValue << " to " << imax;
       maxValue=imax;
     }
     //reset minValue;
     if(minValue>imin){
-      edm::LogInfo("")<< "Resetting TkMap minValue from " << minValue << " to " << imin;
+        edm::LogInfo("SiStripBaseCondObjDQM") << "Resetting TkMap minValue from " << minValue << " to " << imin;
       minValue=imin;
     }
   }
-
+  
   tkMap->save(false, minValue, maxValue, TkMapname.c_str(),4500,2400);
   tkMap->setPalette(1); tkMap->showPalette(true);
-
+  
+  edm::LogInfo("SiStripBaseCondObjDQM") << "[SiStripBaseCondObjDQM::fillModMEs] DONE" << std::endl;
 }
 
 
 //==========================
 void SiStripBaseCondObjDQM::end(){
   edm::LogInfo("SiStripBaseCondObjDQM") 
-    << "SiStripBase::end"
+    << "SiStripBaseCondObjDQM::end"
     << std::endl; 
 }
 
 //==========================
 void SiStripBaseCondObjDQM::fillModMEs(const std::vector<uint32_t> & selectedDetIds, const edm::EventSetup& es){
+
+  edm::LogInfo("SiStripBaseCondObjDQM") << "[SiStripBaseCondObjDQM::fillModMEs] starting .. " << std::endl;
 
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
@@ -1219,13 +1261,16 @@ void SiStripBaseCondObjDQM::fillModMEs(const std::vector<uint32_t> & selectedDet
   ModMEs CondObj_ME;
  
   for(std::vector<uint32_t>::const_iterator detIter_=selectedDetIds.begin();
-                                           detIter_!=selectedDetIds.end();++detIter_){
+      detIter_!=selectedDetIds.end();++detIter_){
     fillMEsForDet(CondObj_ME,*detIter_,tTopo);
   }
+  edm::LogInfo("SiStripBaseCondObjDQM") << "[SiStripBaseCondObjDQM::fillModMEs] DONE" << std::endl;
 }
 
 //==========================
 void SiStripBaseCondObjDQM::fillSummaryMEs(const std::vector<uint32_t> & selectedDetIds, const edm::EventSetup& es){
+
+  edm::LogInfo("SiStripBaseCondObjDQM") << "[SiStripBaseCondObjDQM::fillSummaryMEs] starting .. " << std::endl;
 
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
@@ -1237,14 +1282,16 @@ void SiStripBaseCondObjDQM::fillSummaryMEs(const std::vector<uint32_t> & selecte
     fillMEsForLayer(/*SummaryMEsMap_,*/ *detIter_,tTopo);    
   }
 
-  for (std::map<uint32_t, ModMEs>::iterator iter=SummaryMEsMap_.begin(); iter!=SummaryMEsMap_.end(); iter++){
+  for (std::map<uint32_t, ModMEs>::iterator iter=SummaryMEsMap_.begin();
+       iter!=SummaryMEsMap_.end(); iter++){
 
     ModMEs selME;
     selME = iter->second;
 
-    if(hPSet_.getParameter<bool>("FillSummaryProfileAtLayerLevel") && fPSet_.getParameter<bool>("OutputSummaryProfileAtLayerLevelAsImage")){
+    if(hPSet_.getParameter<bool>("FillSummaryProfileAtLayerLevel") and
+       fPSet_.getParameter<bool>("OutputSummaryProfileAtLayerLevelAsImage")){
 
-      if( CondObj_fillId_ =="onlyProfile" || CondObj_fillId_ =="ProfileAndCumul"){
+      if( CondObj_fillId_ =="onlyProfile" or CondObj_fillId_ =="ProfileAndCumul"){
 
 	TCanvas c1("c1");
 	selME.SummaryOfProfileDistr->getTProfile()->Draw();
@@ -1253,7 +1300,8 @@ void SiStripBaseCondObjDQM::fillSummaryMEs(const std::vector<uint32_t> & selecte
 	c1.Print(name.c_str());
       }
     }
-    if(hPSet_.getParameter<bool>("FillSummaryAtLayerLevel") && fPSet_.getParameter<bool>("OutputSummaryAtLayerLevelAsImage")){
+    if(hPSet_.getParameter<bool>("FillSummaryAtLayerLevel") and
+       fPSet_.getParameter<bool>("OutputSummaryAtLayerLevelAsImage")){
 
       TCanvas c1("c1");
       selME.SummaryDistr->getTH1()->Draw();
@@ -1261,9 +1309,10 @@ void SiStripBaseCondObjDQM::fillSummaryMEs(const std::vector<uint32_t> & selecte
       name+=".png";
       c1.Print(name.c_str());
     }
-    if(hPSet_.getParameter<bool>("FillCumulativeSummaryAtLayerLevel") && fPSet_.getParameter<bool>("OutputCumulativeSummaryAtLayerLevelAsImage")){
+    if(hPSet_.getParameter<bool>("FillCumulativeSummaryAtLayerLevel") and
+       fPSet_.getParameter<bool>("OutputCumulativeSummaryAtLayerLevelAsImage")){
 
-      if( CondObj_fillId_ =="onlyCumul" || CondObj_fillId_ =="ProfileAndCumul"){
+      if( CondObj_fillId_ =="onlyCumul" or CondObj_fillId_ =="ProfileAndCumul"){
 
 	TCanvas c1("c1");
 	selME.SummaryOfCumulDistr->getTH1()->Draw();
@@ -1274,5 +1323,5 @@ void SiStripBaseCondObjDQM::fillSummaryMEs(const std::vector<uint32_t> & selecte
     }
 
   }
- 
+  edm::LogInfo("SiStripBaseCondObjDQM") << "[SiStripBaseCondObjDQM::fillSummaryMEs] DONE" << std::endl;
 }

--- a/DQM/SiStripMonitorSummary/src/SiStripBaseCondObjDQM.cc
+++ b/DQM/SiStripMonitorSummary/src/SiStripBaseCondObjDQM.cc
@@ -188,7 +188,6 @@ void SiStripBaseCondObjDQM::selectModules(std::vector<uint32_t> & detIds_){
 	}
       }
     }
-    edm::LogInfo("SiStripBaseCondObjDQM") << "[SiStripBaseCondObjDQM::selectModules] modulesToBeIncluded: " << modulesToBeIncluded.size() << std::endl;
     
     // -----
     // *** exclude modules ***
@@ -208,7 +207,6 @@ void SiStripBaseCondObjDQM::selectModules(std::vector<uint32_t> & detIds_){
 	}
       }
     }
-    edm::LogInfo("SiStripBaseCondObjDQM") << "[SiStripBaseCondObjDQM::selectModules] modulesToBeExcluded: " << modulesToBeExcluded.size() << std::endl;
     
     ModulesToBeExcluded_     = fPSet_.getParameter< std::vector<unsigned int> >("ModulesToBeExcluded");
     ModulesToBeIncluded_     = fPSet_.getParameter< std::vector<unsigned int> >("ModulesToBeIncluded");
@@ -227,6 +225,9 @@ void SiStripBaseCondObjDQM::selectModules(std::vector<uint32_t> & detIds_){
     
     
     modulesToBeIncluded.insert(modulesToBeIncluded.end(),ModulesToBeIncluded_.begin(),ModulesToBeIncluded_.end());
+    edm::LogInfo("SiStripBaseCondObjDQM") << "[SiStripBaseCondObjDQM::selectModules] modulesToBeIncluded: " << modulesToBeIncluded.size() << std::endl;
+    modulesToBeExcluded.insert(modulesToBeExcluded.end(),ModulesToBeExcluded_.begin(),ModulesToBeExcluded_.end());
+    edm::LogInfo("SiStripBaseCondObjDQM") << "[SiStripBaseCondObjDQM::selectModules] modulesToBeExcluded: " << modulesToBeExcluded.size() << std::endl;
     
     // apply modules selection
     if( modulesToBeIncluded.size()>0 ){
@@ -240,10 +241,7 @@ void SiStripBaseCondObjDQM::selectModules(std::vector<uint32_t> & detIds_){
     
     edm::LogInfo("SiStripBaseCondObjDQM") << "[SiStripBaseCondObjDQM::selectModules] after included detIds_: " << detIds_.size() << std::endl;
     
-    
     std::sort(detIds_.begin(),detIds_.end());
-    
-    modulesToBeExcluded.insert(modulesToBeExcluded.end(),ModulesToBeExcluded_.begin(),ModulesToBeExcluded_.end());
     if(modulesToBeExcluded.size()>0) {
       for( std::vector<uint32_t>::const_iterator mod = modulesToBeExcluded.begin(); 
 	   mod != modulesToBeExcluded.end(); mod++){


### PR DESCRIPTION
rolled back standard C++ "&&" and "||"
plus the adjustment of the input parameters name [modulesToBeIncluded --> ModulesToBeIncluded_DetIdSelector and modulesToBeExcluded --> ModulesToBeExcluded_DetIdSelector]
