### PR TITLE
Fix for a bug affecting CaloMode=0,1

### DIFF
--- a/FastSimulation/Configuration/python/FamosSequences_cff.py
+++ b/FastSimulation/Configuration/python/FamosSequences_cff.py
@@ -272,6 +272,7 @@ if(CaloMode==0):
         cms.SequencePlaceholder("mix")
         )
     lowLevelRecoSequence = cms.Sequence(
+        siTrackerGaussianSmearingRecHits+
         caloRecHits
         )
     famosSimulationSequence = cms.Sequence(
@@ -295,6 +296,7 @@ elif(CaloMode==1):
         cms.SequencePlaceholder("mix")
         )
     lowLevelRecoSequence = cms.Sequence(
+        siTrackerGaussianSmearingRecHits+
         caloDigis+
         caloRecHits 
         )


### PR DESCRIPTION
Add the SimHit->RecHit converter of the tracker in the LocalReco sequence for CaloMode=0,1. No change for the default mode (CaloMode=3).
