### PR TITLE
Fixed problem handling pass by value arguments.

### DIFF
--- a/FWCore/PluginManager/interface/PluginFactory.h
+++ b/FWCore/PluginManager/interface/PluginFactory.h
@@ -39,7 +39,7 @@ class PluginFactory<R*(Args...)> : public PluginFactoryBase
       typedef R* TemplateArgType(Args...);
 
       struct PMakerBase {
-        virtual R* create(Args&&...) const = 0;
+        virtual R* create(Args...) const = 0;
         virtual ~PMakerBase() {}
       };
       template<class TPlug>
@@ -47,7 +47,7 @@ class PluginFactory<R*(Args...)> : public PluginFactoryBase
         PMaker(const std::string& iName) {
           PluginFactory<R*(Args...)>::get()->registerPMaker(this,iName);
         }
-        virtual R* create(Args&&... args) const {
+        virtual R* create(Args... args) const {
           return new TPlug(std::forward<Args>(args)...);
         }
       };
@@ -55,12 +55,12 @@ class PluginFactory<R*(Args...)> : public PluginFactoryBase
       // ---------- const member functions ---------------------
       virtual const std::string& category() const ;
       
-      R* create(const std::string& iName, Args&&... args) const {
+      R* create(const std::string& iName, Args... args) const {
         return reinterpret_cast<PMakerBase*>(PluginFactoryBase::findPMaker(iName)->second.front().first)->create(std::forward<Args>(args)...);
       }
 
       ///like above but returns 0 if iName is unknown
-      R* tryToCreate(const std::string& iName, Args&&... args) const {
+      R* tryToCreate(const std::string& iName, Args... args) const {
         typename Plugins::const_iterator itFound = PluginFactoryBase::tryToFindPMaker(iName);
         if(itFound ==m_plugins.end() ) {
           return 0;


### PR DESCRIPTION
Changing all the arguments to rvalue references failed to handle arguments which are passed by value.
Instead, we keep the arguments as their regular type and just use std::forward<> to move the values
to the constructors.
