### PR TITLE
Add missing #includes

### DIFF
--- a/Alignment/SurveyAnalysis/interface/Chi2.h
+++ b/Alignment/SurveyAnalysis/interface/Chi2.h
@@ -11,7 +11,7 @@
 #ifndef Alignment_SurveyAnalysis_Chi2_H
 #define Alignment_SurveyAnalysis_Chi2_H
 
-#include <TMatrixD.h>
+#include "TMatrixD.h"
 
 
 class Chi2 {

--- a/Alignment/SurveyAnalysis/interface/SurveyPxbDicer.h
+++ b/Alignment/SurveyAnalysis/interface/SurveyPxbDicer.h
@@ -9,8 +9,8 @@
 #include "Alignment/SurveyAnalysis/interface/SurveyPxbImage.h"
 #include "Math/SMatrix.h"
 #include "Math/SVector.h"
-#include <CLHEP/Random/RandGauss.h>
-#include <CLHEP/Random/Random.h>
+#include "CLHEP/Random/RandGauss.h"
+#include "CLHEP/Random/Random.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include <iostream>

--- a/Alignment/SurveyAnalysis/plugins/SurveyInputCSCfromPins.cc
+++ b/Alignment/SurveyAnalysis/plugins/SurveyInputCSCfromPins.cc
@@ -3,7 +3,7 @@
 #include "Geometry/DTGeometry/interface/DTGeometry.h"
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 #include "Alignment/MuonAlignment/interface/AlignableMuon.h"
-#include <FWCore/Framework/interface/ESHandle.h> 
+#include "FWCore/Framework/interface/ESHandle.h" 
 #include "Alignment/CommonAlignment/interface/AlignableNavigator.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"

--- a/Alignment/SurveyAnalysis/src/SurveyPxbDicer.cc
+++ b/Alignment/SurveyAnalysis/src/SurveyPxbDicer.cc
@@ -12,8 +12,8 @@
 #include "DataFormats/GeometryVector/interface/Point3DBase.h"
 #include "Math/SMatrix.h"
 #include "Math/SVector.h"
-#include <CLHEP/Random/RandGauss.h>
-#include <CLHEP/Random/Random.h>
+#include "CLHEP/Random/RandGauss.h"
+#include "CLHEP/Random/Random.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include <iostream>

--- a/Alignment/SurveyAnalysis/test/SurveyInputDummy.h
+++ b/Alignment/SurveyAnalysis/test/SurveyInputDummy.h
@@ -24,13 +24,13 @@
  *  The covariance matrix for all structures of a level will be diagonal
  *  given by value^2 * identity.
  *
- *  $Date: 2007/11/15 10:22:42 $
- *  $Revision: 1.4 $
  *  \author Chung Khim Lae
  */
 
 #include "Alignment/CommonAlignment/interface/StructureType.h"
 #include "Alignment/SurveyAnalysis/interface/SurveyInputBase.h"
+
+#include <map>
 
 class SurveyInputDummy:
   public SurveyInputBase

--- a/Alignment/SurveyAnalysis/test/TestConverter.cpp
+++ b/Alignment/SurveyAnalysis/test/TestConverter.cpp
@@ -14,9 +14,9 @@
 
 // system include files
 #include <string>
-#include <TTree.h>
-#include <TFile.h>
-// #include <TRotMatrix.h>
+#include "TTree.h"
+#include "TFile.h"
+// #include "TRotMatrix.h"
 
 // user include files
 #include "FWCore/Framework/interface/EDAnalyzer.h"

--- a/Alignment/SurveyAnalysis/test/TestConverter2.cpp
+++ b/Alignment/SurveyAnalysis/test/TestConverter2.cpp
@@ -14,9 +14,9 @@
 
 // system include files
 #include <string>
-#include <TTree.h>
-#include <TFile.h>
-// #include <TRotMatrix.h>
+#include "TTree.h"
+#include "TFile.h"
+// #include "TRotMatrix.h"
 
 // user include files
 #include "FWCore/Framework/interface/EDAnalyzer.h"

--- a/Alignment/SurveyAnalysis/test/TestIdealGeometry.cpp
+++ b/Alignment/SurveyAnalysis/test/TestIdealGeometry.cpp
@@ -13,9 +13,9 @@
 
 
 // system include files
-#include <TTree.h>
-#include <TFile.h>
-// #include <TRotMatrix.h>
+#include "TTree.h"
+#include "TFile.h"
+// #include "TRotMatrix.h"
 
 // user include files
 #include "FWCore/Framework/interface/EDAnalyzer.h"

--- a/Alignment/SurveyAnalysis/test/TestIdealGeometry2.cpp
+++ b/Alignment/SurveyAnalysis/test/TestIdealGeometry2.cpp
@@ -14,9 +14,9 @@
 
 // system include files
 #include <string>
-#include <TTree.h>
-#include <TFile.h>
-// #include <TRotMatrix.h>
+#include "TTree.h"
+#include "TFile.h"
+// #include "TRotMatrix.h"
 
 // user include files
 #include "FWCore/Framework/interface/EDAnalyzer.h"

--- a/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h
@@ -1,6 +1,7 @@
 #ifndef CALIBCALORIMETRY_HCALALGOS_HCALPULSESHAPES_H
 #define CALIBCALORIMETRY_HCALALGOS_HCALPULSESHAPES_H 1
 
+#include <map>
 #include <vector>
 #include "CalibCalorimetry/HcalAlgos/interface/HcalPulseShape.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
@@ -8,8 +9,6 @@
 
 /** \class HcalPulseShapes
   *  
-  * $Date: 2011/11/23 13:48:27 $
-  * $Revision: 1.6 $
   * \author J. Mans - Minnesota
   */
 class HcalMCParams;

--- a/CalibCalorimetry/HcalAlgos/interface/genlkupmap.h
+++ b/CalibCalorimetry/HcalAlgos/interface/genlkupmap.h
@@ -1,7 +1,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalShapeIntegrator.h"
 #include <algorithm> // for "max","min"
-#include <math.h>
+#include <cmath>
 #include <iostream>
 #include <boost/scoped_ptr.hpp>
 

--- a/CalibCalorimetry/HcalAlgos/src/HcalAlgoUtils.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalAlgoUtils.cc
@@ -1,5 +1,5 @@
 #include "CalibCalorimetry/HcalAlgos/interface/HcalAlgoUtils.h"
-#include <math.h>
+#include <cmath>
 
 void getLinearizedADC(const HcalQIEShape& shape,
 		      const HcalQIECoder* coder,

--- a/CalibCalorimetry/HcalAlgos/src/HcalLedAnalysis.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalLedAnalysis.cc
@@ -5,7 +5,7 @@
 
 #include "CalibCalorimetry/HcalAlgos/interface/HcalLedAnalysis.h"
 #include "TFile.h"
-#include <math.h>
+#include <cmath>
 using namespace std;
 
 

--- a/CalibCalorimetry/HcalAlgos/src/HcalLogicalMapGenerator.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalLogicalMapGenerator.cc
@@ -7,7 +7,7 @@
 
 #include <string>
 #include <sstream>
-#include <stdio.h>
+#include <cstdio>
 #include <iostream>
 #include <cstring>
 

--- a/CalibCalorimetry/HcalAlgos/src/HcalPedestalAnalysis.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPedestalAnalysis.cc
@@ -5,7 +5,7 @@
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalPedestalAnalysis.h"
 #include "TFile.h"
-#include <math.h>
+#include <cmath>
 
 //
 // Michal Szleper, Mar 30, 2007

--- a/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentAlgo.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentAlgo.cc
@@ -1,7 +1,7 @@
 #include "CalibCalorimetry/HcalAlgos/src/HcalPulseContainmentAlgo.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalTimeSlew.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h"
-#include <math.h>
+#include <cmath>
 #include <iostream>
 
 // Function generates a lookup map for a passed-in function (via templated object algoObject,

--- a/CalibCalorimetry/HcalAlgos/src/HcalTimeSlew.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalTimeSlew.cc
@@ -1,5 +1,5 @@
 #include "CalibCalorimetry/HcalAlgos/interface/HcalTimeSlew.h"
-#include <math.h>
+#include <cmath>
 
 static const double tzero[3]= {23.960177, 13.307784, 9.109694};
 static const double slope[3] = {-3.178648,  -1.556668, -1.075824 };

--- a/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
+++ b/CalibMuon/DTCalibration/plugins/DTFakeT0ESProducer.cc
@@ -23,7 +23,7 @@
 #include "DataFormats/MuonDetId/interface/DTLayerId.h"
 
 #include "Geometry/MuonNumbering/interface/MuonDDDConstants.h"
-#include <DetectorDescription/Core/interface/DDCompactView.h>
+#include "DetectorDescription/Core/interface/DDCompactView.h"
 #include "CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.h"
 
 using namespace std;

--- a/CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.h
+++ b/CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.h
@@ -8,9 +8,9 @@
  *  $Revision: 1.0 $
  *  \author S. Bolognesi - INFN Torino
  */
-#include <DetectorDescription/Core/interface/DDFilter.h>
-#include <DetectorDescription/Core/interface/DDFilteredView.h>
-#include <DetectorDescription/Core/interface/DDSolid.h>
+#include "DetectorDescription/Core/interface/DDFilter.h"
+#include "DetectorDescription/Core/interface/DDFilteredView.h"
+#include "DetectorDescription/Core/interface/DDSolid.h"
 #include "Geometry/MuonNumbering/interface/MuonDDDNumbering.h"
 #include "Geometry/MuonNumbering/interface/MuonBaseNumber.h"
 #include "Geometry/MuonNumbering/interface/MuonDDDConstants.h"

--- a/CalibMuon/DTCalibration/plugins/DTNoiseComputation.cc
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseComputation.cc
@@ -15,7 +15,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-#include <FWCore/Framework/interface/MakerMacros.h>
+#include "FWCore/Framework/interface/MakerMacros.h"
 
 // Geometry
 #include "Geometry/DTGeometry/interface/DTLayer.h"
@@ -24,7 +24,7 @@
 #include "Geometry/Records/interface/MuonGeometryRecord.h"
 
 // Digis
-#include <DataFormats/DTDigi/interface/DTDigi.h>
+#include "DataFormats/DTDigi/interface/DTDigi.h"
 #include "DataFormats/DTDigi/interface/DTDigiCollection.h"
 #include "CondFormats/DataRecord/interface/DTStatusFlagRcd.h"
 #include "CondFormats/DTObjects/interface/DTStatusFlag.h"

--- a/CalibMuon/DTCalibration/plugins/DTNoiseComputation.h
+++ b/CalibMuon/DTCalibration/plugins/DTNoiseComputation.h
@@ -10,12 +10,12 @@
  *
 */
 
-#include <FWCore/Framework/interface/EDAnalyzer.h>
-#include <FWCore/Framework/interface/EventSetup.h>
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "DataFormats/MuonDetId/interface/DTLayerId.h"
 #include "DataFormats/MuonDetId/interface/DTWireId.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
-#include <FWCore/Framework/interface/ESHandle.h>
+#include "FWCore/Framework/interface/ESHandle.h"
 
 
 

--- a/CalibMuon/DTCalibration/plugins/DTT0CalibrationNew.cc
+++ b/CalibMuon/DTCalibration/plugins/DTT0CalibrationNew.cc
@@ -19,8 +19,8 @@
 #include "DataFormats/DTDigi/interface/DTDigiCollection.h"
 #include "CondFormats/DTObjects/interface/DTT0.h"
 
-#include <CondFormats/DTObjects/interface/DTTtrig.h>
-#include <CondFormats/DataRecord/interface/DTTtrigRcd.h>
+#include "CondFormats/DTObjects/interface/DTTtrig.h"
+#include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
 
 #include "TH1I.h"
 #include "TFile.h"

--- a/CalibMuon/DTCalibration/plugins/DTTTrigConstantShift.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigConstantShift.cc
@@ -16,7 +16,7 @@
 #include "CondFormats/DTObjects/interface/DTTtrig.h"
 #include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
 
-#include <math.h>
+#include <cmath>
 
 using namespace std;
 using namespace edm;

--- a/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.h
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigCorrectionFirst.h
@@ -12,7 +12,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include <FWCore/Framework/interface/ESHandle.h>
+#include "FWCore/Framework/interface/ESHandle.h"
 
 #include <string>
 

--- a/CalibMuon/DTCalibration/plugins/DTTTrigMatchRPhi.cc
+++ b/CalibMuon/DTCalibration/plugins/DTTTrigMatchRPhi.cc
@@ -14,7 +14,7 @@
 #include "CondFormats/DTObjects/interface/DTTtrig.h"
 #include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
 
-#include <math.h>
+#include <cmath>
 
 using namespace std;
 using namespace edm;

--- a/CalibMuon/DTCalibration/test/DBTools/DTTTrigAnalyzer.h
+++ b/CalibMuon/DTCalibration/test/DBTools/DTTTrigAnalyzer.h
@@ -4,8 +4,6 @@
 /** \class DTTTrigAnalyzer
  *  Plot the ttrig from the DB
  *
- *  $Date: 2009/07/17 09:15:48 $
- *  $Revision: 1.3 $
  *  \author S. Bolognesi - INFN Torino
  */
 
@@ -16,6 +14,7 @@
 
 #include <string>
 #include <fstream>
+#include <map>
 #include <vector>
 
 class DTTtrig;

--- a/CalibMuon/DTCalibration/test/DBTools/DTVDriftAnalyzer.h
+++ b/CalibMuon/DTCalibration/test/DBTools/DTVDriftAnalyzer.h
@@ -4,8 +4,6 @@
 /** \class DTVDriftAnalyzer
  *  Plot the vdrift from the DB
  *
- *  $Date: 2008/09/19 14:25:42 $
- *  $Revision: 1.2 $
  *  \author S. Bolognesi - INFN Torino
  */
 
@@ -16,6 +14,7 @@
 
 #include <string>
 #include <fstream>
+#include <map>
 #include <vector>
 
 class DTMtime;

--- a/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.cc
@@ -26,11 +26,11 @@
 
 // Database
 #include "CondFormats/DTObjects/interface/DTTtrig.h"
-#include <CondFormats/DataRecord/interface/DTTtrigRcd.h>
+#include "CondFormats/DataRecord/interface/DTTtrigRcd.h"
 
 //Random generator
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
-#include <CLHEP/Random/RandGaussQ.h>
+#include "CLHEP/Random/RandGaussQ.h"
 
 // DTDigitizer
 #include "CalibMuon/DTDigiSync/interface/DTTTrigSyncFactory.h"

--- a/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.h
+++ b/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.h
@@ -15,7 +15,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include <FWCore/Framework/interface/ESHandle.h>
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 namespace CLHEP {

--- a/CalibMuon/DTCalibration/test/DBTools/ProduceFakeDB.h
+++ b/CalibMuon/DTCalibration/test/DBTools/ProduceFakeDB.h
@@ -11,7 +11,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include <FWCore/Framework/interface/ESHandle.h>
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include <string>

--- a/CalibMuon/DTCalibration/test/DBTools/ShiftTTrigDB.h
+++ b/CalibMuon/DTCalibration/test/DBTools/ShiftTTrigDB.h
@@ -10,7 +10,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include <FWCore/Framework/interface/ESHandle.h>
+#include "FWCore/Framework/interface/ESHandle.h"
 
 #include <map>
 #include <string>

--- a/CalibMuon/DTCalibration/test/DBTools/ShiftTTrigDB.h
+++ b/CalibMuon/DTCalibration/test/DBTools/ShiftTTrigDB.h
@@ -5,8 +5,6 @@
  *  Class which read a ttrig DB and modifies it introducing
  *  shifts with chamber granularity
  *
- *  $Date: 2010/01/19 09:51:31 $
- *  $Revision: 1.2 $
  *  \author S. Bolognesi - INFN Torino
  */
 
@@ -14,7 +12,9 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include <FWCore/Framework/interface/ESHandle.h>
 
+#include <map>
 #include <string>
+#include <vector>
 
 class DTTtrig;
 class DTGeometry;

--- a/CalibMuon/DTCalibration/test/stubs/DTMeanTimerPlotter.cc
+++ b/CalibMuon/DTCalibration/test/stubs/DTMeanTimerPlotter.cc
@@ -10,10 +10,10 @@
 //#include "CalibMuon/DTCalibration/src/vDriftHistos.h"
 
 #include <iostream>
-#include <stdio.h>
+#include <cstdio>
 #include <sstream>
 #include <string>
-#include <math.h>
+#include <cmath>
 
 #include "TFile.h"
 #include "TCanvas.h"

--- a/CalibMuon/DTCalibration/test/stubs/DTTimeBoxPlotter.cc
+++ b/CalibMuon/DTCalibration/test/stubs/DTTimeBoxPlotter.cc
@@ -12,7 +12,7 @@
 
 
 #include <iostream>
-#include <stdio.h>
+#include <cstdio>
 #include <sstream>
 #include <string>
 

--- a/CalibMuon/DTCalibration/test/stubs/NoiseAnalyzer.c
+++ b/CalibMuon/DTCalibration/test/stubs/NoiseAnalyzer.c
@@ -1,17 +1,17 @@
-#include <TROOT.h>
-#include <TSystem.h>
-#include <TH1D.h>
-#include <THStack.h>
-#include <TChain.h>
-#include <TTree.h>
-#include <TLegend.h>
-#include <TFile.h>
-#include <TCanvas.h>
-#include <TLorentzVector.h>
+#include "TROOT.h"
+#include "TSystem.h"
+#include "TH1D.h"
+#include "THStack.h"
+#include "TChain.h"
+#include "TTree.h"
+#include "TLegend.h"
+#include "TFile.h"
+#include "TCanvas.h"
+#include "TLorentzVector.h"
 #include <iostream>
 #include <sstream>
 #include <fstream.h>
-#include <TPostScript.h>
+#include "TPostScript.h"
 using namespace std;
 
 void NoiseAnalyzer();

--- a/DataFormats/Common/interface/AssociativeIterator.h
+++ b/DataFormats/Common/interface/AssociativeIterator.h
@@ -39,7 +39,7 @@
  */
 
 #include "DataFormats/Provenance/interface/ProductID.h"
-#include <DataFormats/Common/interface/EDProductGetter.h>
+#include "DataFormats/Common/interface/EDProductGetter.h"
 
 namespace edm {
     struct Event;

--- a/DataFormats/Common/interface/PtrVector.h
+++ b/DataFormats/Common/interface/PtrVector.h
@@ -24,6 +24,7 @@
 #include "DataFormats/Common/interface/PtrVectorBase.h"
 
 // system include files
+#include "boost/static_assert.hpp"
 #include "boost/type_traits/is_base_of.hpp"
 #include <typeinfo>
 #include <vector>

--- a/DataFormats/Common/test/DataFrame_t.cpp
+++ b/DataFormats/Common/test/DataFrame_t.cpp
@@ -1,5 +1,5 @@
-#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
-#include <cppunit/extensions/HelperMacros.h>
+#include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
+#include "cppunit/extensions/HelperMacros.h"
 
 #define private public
 #include "DataFormats/Common/interface/DataFrame.h"

--- a/DataFormats/Common/test/DetSetLazyVector_t.cppunit.cc
+++ b/DataFormats/Common/test/DetSetLazyVector_t.cppunit.cc
@@ -1,4 +1,4 @@
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include "DataFormats/Common/interface/DetSetLazyVector.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
 

--- a/DataFormats/Common/test/DetSetNew_t.cpp
+++ b/DataFormats/Common/test/DetSetNew_t.cpp
@@ -1,5 +1,5 @@
-#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
-#include <cppunit/extensions/HelperMacros.h>
+#include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
+#include "cppunit/extensions/HelperMacros.h"
 
 #define private public
 #include "DataFormats/Common/interface/DetSetNew.h"

--- a/DataFormats/Common/test/DetSetRefVector_t.cppunit.cc
+++ b/DataFormats/Common/test/DetSetRefVector_t.cppunit.cc
@@ -1,4 +1,4 @@
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
 #include "DataFormats/Common/interface/DetSetRefVector.h"
 #include "DataFormats/Common/interface/TestHandle.h"

--- a/DataFormats/Common/test/MapOfVectors_t.cpp
+++ b/DataFormats/Common/test/MapOfVectors_t.cpp
@@ -1,5 +1,5 @@
-#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
-#include <cppunit/extensions/HelperMacros.h>
+#include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
+#include "cppunit/extensions/HelperMacros.h"
 
 #define private public
 #include "DataFormats/Common/interface/MapOfVectors.h"

--- a/DataFormats/Common/test/RefCore_t.cpp
+++ b/DataFormats/Common/test/RefCore_t.cpp
@@ -1,5 +1,5 @@
-#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
-#include <cppunit/extensions/HelperMacros.h>
+#include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "DataFormats/Common/interface/RefCore.h"
 #include "DataFormats/Common/interface/RefCoreWithIndex.h"

--- a/DataFormats/Common/test/RefVector_t.cpp
+++ b/DataFormats/Common/test/RefVector_t.cpp
@@ -1,8 +1,8 @@
 #include <map>
 #include <string>
 
-#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
-#include <cppunit/extensions/HelperMacros.h>
+#include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefVector.h"

--- a/DataFormats/Common/test/Ref_t.cpp
+++ b/DataFormats/Common/test/Ref_t.cpp
@@ -3,9 +3,9 @@
 #include "DataFormats/Common/interface/EDProductGetter.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "FWCore/Utilities/interface/EDMException.h"
-#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
+#include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include <iostream>
 #include <string>

--- a/DataFormats/Common/test/Trie_t.cpp
+++ b/DataFormats/Common/test/Trie_t.cpp
@@ -19,8 +19,8 @@
 **   modified by Vincenzo Innocente on 15/08/2007
 */
 
-#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
-#include <cppunit/extensions/HelperMacros.h>
+#include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
+#include "cppunit/extensions/HelperMacros.h"
 
   /**
    *

--- a/DataFormats/Common/test/cloningptr_t.cppunit.cc
+++ b/DataFormats/Common/test/cloningptr_t.cppunit.cc
@@ -1,4 +1,4 @@
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include "DataFormats/Common/interface/CloningPtr.h"
 
 #include <vector>

--- a/DataFormats/Common/test/containermask_t.cppunit.cc
+++ b/DataFormats/Common/test/containermask_t.cppunit.cc
@@ -1,7 +1,7 @@
 
 #include <algorithm>
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include "DataFormats/Common/interface/TestHandle.h"
 #include "DataFormats/Common/interface/ContainerMask.h"
 #include "DataFormats/Common/interface/RefProd.h"

--- a/DataFormats/Common/test/ptr_t.cppunit.cc
+++ b/DataFormats/Common/test/ptr_t.cppunit.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include <vector>
 #include <set>
 #include <list>

--- a/DataFormats/Common/test/ptrvector_t.cppunit.cc
+++ b/DataFormats/Common/test/ptrvector_t.cppunit.cc
@@ -5,7 +5,7 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/IntValues.h"
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include <algorithm>
 #include <iostream>

--- a/DataFormats/Common/test/ref_t.cppunit.cc
+++ b/DataFormats/Common/test/ref_t.cppunit.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include <vector>
 #include "DataFormats/Common/interface/EDProductGetter.h"
 #include "DataFormats/Common/interface/OrphanHandle.h"

--- a/DataFormats/Common/test/reftobase_t.cppunit.cc
+++ b/DataFormats/Common/test/reftobase_t.cppunit.cc
@@ -1,4 +1,4 @@
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include "DataFormats/Common/interface/RefToBase.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/TestHandle.h"

--- a/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
+++ b/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include <vector>
 #include <set>
 #include <list>

--- a/DataFormats/Common/test/reftobasevector_t.cppunit.cc
+++ b/DataFormats/Common/test/reftobasevector_t.cppunit.cc
@@ -1,7 +1,7 @@
 
 #include <algorithm>
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include "DataFormats/Common/interface/TestHandle.h"
 #include "DataFormats/Common/interface/RefToBaseVector.h"
 #include "DataFormats/Common/interface/RefVector.h"

--- a/DataFormats/Common/test/testAssociationNew.cc
+++ b/DataFormats/Common/test/testAssociationNew.cc
@@ -1,4 +1,4 @@
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include <algorithm>
 #include <iterator>
 #include <iostream>

--- a/DataFormats/Common/test/testAssociationVector.cc
+++ b/DataFormats/Common/test/testAssociationVector.cc
@@ -1,4 +1,4 @@
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include <algorithm>
 #include <iterator>
 #include <iostream>

--- a/DataFormats/Common/test/testIDVectorMap.cc
+++ b/DataFormats/Common/test/testIDVectorMap.cc
@@ -1,4 +1,4 @@
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include "DataFormats/Common/interface/IDVectorMap.h"
 #include "DataFormats/Common/interface/CopyPolicy.h"
 

--- a/DataFormats/Common/test/testMultiAssociation.cc
+++ b/DataFormats/Common/test/testMultiAssociation.cc
@@ -4,7 +4,7 @@
 #include "DataFormats/Common/interface/TestHandle.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "boost/lambda/bind.hpp"
 #include "boost/lambda/lambda.hpp"

--- a/DataFormats/Common/test/testOneToManyAssociation.cc
+++ b/DataFormats/Common/test/testOneToManyAssociation.cc
@@ -1,4 +1,4 @@
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include <algorithm>
 #include <iterator>
 #include <iostream>

--- a/DataFormats/Common/test/testOneToOneAssociation.cc
+++ b/DataFormats/Common/test/testOneToOneAssociation.cc
@@ -1,4 +1,4 @@
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include <algorithm>
 #include <iterator>
 #include <iostream>

--- a/DataFormats/Common/test/testOwnArray.cc
+++ b/DataFormats/Common/test/testOwnArray.cc
@@ -1,5 +1,5 @@
 // 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include <algorithm>
 #include <iterator>
 #include <iostream>

--- a/DataFormats/Common/test/testOwnVector.cc
+++ b/DataFormats/Common/test/testOwnVector.cc
@@ -1,4 +1,4 @@
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include <algorithm>
 #include <iterator>
 #include <iostream>

--- a/DataFormats/Common/test/testRangeMap.cc
+++ b/DataFormats/Common/test/testRangeMap.cc
@@ -1,4 +1,4 @@
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include "DataFormats/Common/interface/RangeMap.h"
 #include "DataFormats/Common/interface/CopyPolicy.h"
 

--- a/DataFormats/Common/test/testValueMap.cc
+++ b/DataFormats/Common/test/testValueMap.cc
@@ -1,4 +1,4 @@
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include <algorithm>
 #include <iterator>
 #include <iostream>

--- a/DataFormats/Common/test/testValueMapNew.cc
+++ b/DataFormats/Common/test/testValueMapNew.cc
@@ -1,4 +1,4 @@
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include <algorithm>
 #include <iterator>
 #include <iostream>

--- a/DataFormats/Common/test/traits_t.cpp
+++ b/DataFormats/Common/test/traits_t.cpp
@@ -2,8 +2,8 @@
 #include <string>
 #include <vector>
 
-#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
-#include <cppunit/extensions/HelperMacros.h>
+#include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "DataFormats/Common/interface/traits.h"
 

--- a/DataFormats/Provenance/src/BranchDescription.cc
+++ b/DataFormats/Provenance/src/BranchDescription.cc
@@ -8,7 +8,7 @@
 #include <cassert>
 #include <ostream>
 #include <sstream>
-#include <stdlib.h>
+#include <cstdlib>
 
 class TClass;
 /*----------------------------------------------------------------------

--- a/DataFormats/Provenance/test/eventid_t.cppunit.cc
+++ b/DataFormats/Provenance/test/eventid_t.cppunit.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "DataFormats/Provenance/interface/EventID.h"
 

--- a/DataFormats/Provenance/test/eventrange_t.cppunit.cc
+++ b/DataFormats/Provenance/test/eventrange_t.cppunit.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "DataFormats/Provenance/interface/EventRange.h"
 #include "DataFormats/Provenance/interface/EventID.h"

--- a/DataFormats/Provenance/test/indexIntoFile1_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile1_t.cppunit.cc
@@ -2,7 +2,7 @@
  *  indexIntoFile_t.cppunit.cc
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"

--- a/DataFormats/Provenance/test/indexIntoFile2_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile2_t.cppunit.cc
@@ -2,7 +2,7 @@
  *  indexIntoFile_t.cppunit.cc
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"

--- a/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
@@ -2,7 +2,7 @@
  *  indexIntoFile_t.cppunit.cc
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"

--- a/DataFormats/Provenance/test/indexIntoFile4_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile4_t.cppunit.cc
@@ -2,7 +2,7 @@
  *  indexIntoFile_t.cppunit.cc
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"

--- a/DataFormats/Provenance/test/indexIntoFile5_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile5_t.cppunit.cc
@@ -2,7 +2,7 @@
  *  indexIntoFile_t.cppunit.cc
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"

--- a/DataFormats/Provenance/test/indexIntoFile_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile_t.cppunit.cc
@@ -2,7 +2,7 @@
  *  indexIntoFile_t.cppunit.cc
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"

--- a/DataFormats/Provenance/test/lumirange_t.cppunit.cc
+++ b/DataFormats/Provenance/test/lumirange_t.cppunit.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "DataFormats/Provenance/interface/LuminosityBlockRange.h"
 

--- a/DataFormats/Provenance/test/parametersetid_t.cppunit.cc
+++ b/DataFormats/Provenance/test/parametersetid_t.cppunit.cc
@@ -7,7 +7,7 @@
 #include <map>
 #include <string>
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "FWCore/Utilities/interface/EDMException.h"

--- a/DataFormats/Provenance/test/productHolderIndexHelper_t.cppunit.cc
+++ b/DataFormats/Provenance/test/productHolderIndexHelper_t.cppunit.cc
@@ -2,7 +2,7 @@
  *  productHolderIndexHelper_t.cppunit.cc
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/ProductID.h"

--- a/DataFormats/Provenance/test/testRunner.cpp
+++ b/DataFormats/Provenance/test/testRunner.cpp
@@ -1,1 +1,1 @@
-#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
+#include "Utilities/Testing/interface/CppUnit_testdriver.icpp"

--- a/DataFormats/Provenance/test/timestamp_t.cppunit.cc
+++ b/DataFormats/Provenance/test/timestamp_t.cppunit.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "DataFormats/Provenance/interface/Timestamp.h"
 

--- a/EventFilter/RawDataCollector/interface/RawDataFEDSelector.h
+++ b/EventFilter/RawDataCollector/interface/RawDataFEDSelector.h
@@ -6,7 +6,7 @@
  * \author M. Zanetti CERN
  */
 
-#include <DataFormats/Common/interface/Handle.h>
+#include "DataFormats/Common/interface/Handle.h"
 
 #include <memory>
 #include <utility>

--- a/EventFilter/RawDataCollector/src/RawDataCollectorByLabel.cc
+++ b/EventFilter/RawDataCollector/src/RawDataCollectorByLabel.cc
@@ -4,12 +4,12 @@
  */
 
 #include "EventFilter/RawDataCollector/src/RawDataCollectorByLabel.h"
-#include <DataFormats/FEDRawData/interface/FEDRawDataCollection.h> 
-#include <DataFormats/FEDRawData/interface/FEDRawData.h>
-#include <DataFormats/FEDRawData/interface/FEDNumbering.h>
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h" 
+#include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
-#include <DataFormats/Common/interface/Handle.h>
-#include <FWCore/Framework/interface/Event.h>
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h" 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"

--- a/EventFilter/RawDataCollector/src/RawDataCollectorByLabel.h
+++ b/EventFilter/RawDataCollector/src/RawDataCollectorByLabel.h
@@ -6,11 +6,11 @@
  *
  */
 
-#include <FWCore/Framework/interface/MakerMacros.h>
-#include <FWCore/Framework/interface/EDProducer.h>
-#include <DataFormats/FEDRawData/interface/FEDRawDataCollection.h> 
-#include <DataFormats/Common/interface/Handle.h>
-#include <FWCore/Utilities/interface/InputTag.h>
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h" 
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 
 class RawDataCollectorByLabel: public edm::EDProducer {
 public:

--- a/EventFilter/RawDataCollector/src/RawDataFEDSelector.cc
+++ b/EventFilter/RawDataCollector/src/RawDataFEDSelector.cc
@@ -3,14 +3,14 @@
 //         Created:  Mon Jan 28 18:22:13 CET 2008
 
 
-#include <EventFilter/RawDataCollector/interface/RawDataFEDSelector.h>
+#include "EventFilter/RawDataCollector/interface/RawDataFEDSelector.h"
 
-#include <DataFormats/FEDRawData/interface/FEDRawDataCollection.h> 
-#include <DataFormats/FEDRawData/interface/FEDRawData.h>
-#include <DataFormats/FEDRawData/interface/FEDNumbering.h>
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
-#include <stdio.h>
-#include <string.h>
+#include <cstdio>
+#include <cstring>
 
 using namespace std;
 using namespace edm;

--- a/EventFilter/RawDataCollector/src/RawDataFEDSelector.cc
+++ b/EventFilter/RawDataCollector/src/RawDataFEDSelector.cc
@@ -10,6 +10,7 @@
 #include <DataFormats/FEDRawData/interface/FEDNumbering.h>
 
 #include <stdio.h>
+#include <string.h>
 
 using namespace std;
 using namespace edm;

--- a/EventFilter/RawDataCollector/src/RawDataSelector.cc
+++ b/EventFilter/RawDataCollector/src/RawDataSelector.cc
@@ -13,11 +13,11 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include <DataFormats/FEDRawData/interface/FEDRawDataCollection.h> 
-#include <DataFormats/FEDRawData/interface/FEDRawData.h>
-#include <DataFormats/FEDRawData/interface/FEDNumbering.h>
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
-#include <EventFilter/RawDataCollector/interface/RawDataFEDSelector.h>
+#include "EventFilter/RawDataCollector/interface/RawDataFEDSelector.h"
 
 class RawDataSelector : public edm::EDProducer {
 

--- a/FWCore/Framework/src/MessageForParent.h
+++ b/FWCore/Framework/src/MessageForParent.h
@@ -20,7 +20,7 @@
 //
 
 // system include files
-#include <stddef.h>
+#include <cstddef>
 
 // user include files
 

--- a/FWCore/Framework/src/MessageReceiverForSource.cc
+++ b/FWCore/Framework/src/MessageReceiverForSource.cc
@@ -15,8 +15,8 @@
 #include <sys/ipc.h>
 #include <sys/msg.h>
 #include <sys/socket.h>
-#include <errno.h>
-#include <string.h>
+#include <cerrno>
+#include <cstring>
 
 // user include files
 #include "FWCore/Framework/interface/MessageReceiverForSource.h"

--- a/FWCore/Framework/src/NoDataException.cc
+++ b/FWCore/Framework/src/NoDataException.cc
@@ -1,4 +1,4 @@
-#include <FWCore/Framework/interface/NoDataException.h>
+#include "FWCore/Framework/interface/NoDataException.h"
 
 namespace edm {
   namespace eventsetup {

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -40,7 +40,7 @@ Test program for edm::Event.
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 #include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "Cintex/Cintex.h"
 

--- a/FWCore/Framework/test/View_t.cpp
+++ b/FWCore/Framework/test/View_t.cpp
@@ -1,5 +1,5 @@
-#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
-#include <cppunit/extensions/HelperMacros.h>
+#include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "DataFormats/Common/interface/View.h"
 

--- a/FWCore/Framework/test/callback_t.cppunit.cc
+++ b/FWCore/Framework/test/callback_t.cppunit.cc
@@ -7,7 +7,7 @@
  */
 
 #include <memory>
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include "FWCore/Framework/interface/Callback.h"
 #include "FWCore/Framework/interface/ESProducts.h"
 #include <cassert>

--- a/FWCore/Framework/test/datakey_t.cppunit.cc
+++ b/FWCore/Framework/test/datakey_t.cppunit.cc
@@ -6,7 +6,7 @@
  *  Changed by Viji Sundararajan on 24-Jun-2005.
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include <cstring>
 #include "FWCore/Framework/interface/DataKey.h"
 #include "FWCore/Framework/interface/HCTypeTag.h"

--- a/FWCore/Framework/test/dependentrecord_t.cppunit.cc
+++ b/FWCore/Framework/test/dependentrecord_t.cppunit.cc
@@ -22,8 +22,8 @@
 #include "FWCore/Framework/interface/NoRecordException.h"
 #include "FWCore/Framework/interface/print_eventsetup_record_dependencies.h"
 
-#include <cppunit/extensions/HelperMacros.h>
-#include <string.h>
+#include "cppunit/extensions/HelperMacros.h"
+#include <cstring>
 
 
 using namespace edm::eventsetup;

--- a/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
+++ b/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
@@ -15,7 +15,7 @@
 #include <iostream>
 
 // user include files
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 

--- a/FWCore/Framework/test/edproducer_productregistry_callback.cc
+++ b/FWCore/Framework/test/edproducer_productregistry_callback.cc
@@ -8,7 +8,7 @@
 
 
 #include <iostream>
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include "boost/shared_ptr.hpp"
 #include "FWCore/Utilities/interface/GetPassID.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -14,7 +14,7 @@
 #include "FWCore/Framework/interface/EventSetupProvider.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESProducts.h"
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
 using edm::eventsetup::test::DummyData;

--- a/FWCore/Framework/test/esproducts_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducts_t.cppunit.cc
@@ -7,7 +7,7 @@
  *
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "FWCore/Framework/interface/ESProducts.h"
 using edm::ESProducts;

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -26,7 +26,7 @@ Test of the EventPrincipal class.
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "boost/shared_ptr.hpp"
 

--- a/FWCore/Framework/test/eventprincipal_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprincipal_t.cppunit.cc
@@ -34,7 +34,7 @@ Test of the EventPrincipal class.
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "boost/shared_ptr.hpp"
 

--- a/FWCore/Framework/test/eventprocessor2_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprocessor2_t.cppunit.cc
@@ -9,7 +9,7 @@ Test of the EventProcessor class.
 #include <stdexcept>
 #include "FWCore/Framework/interface/EventProcessor.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
 #include "FWCore/RootAutoLibraryLoader/interface/RootAutoLibraryLoader.h"

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -9,7 +9,7 @@
 
 #include <iostream>
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/FWCore/Framework/test/eventsetupplugin_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetupplugin_t.cppunit.cc
@@ -12,7 +12,7 @@
 //
 
 // system include files
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 // user include files
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -6,7 +6,7 @@
  *  Changed by Viji on 06/07/2005
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
 #include "FWCore/Framework/interface/EventSetupRecordProviderTemplate.h"

--- a/FWCore/Framework/test/eventsetupscontroller_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetupscontroller_t.cppunit.cc
@@ -2,7 +2,7 @@
  *  eventsetupscontroller_t.cc
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "FWCore/Framework/interface/EventSetupProvider.h"
 #include "FWCore/Framework/src/EventSetupsController.h"

--- a/FWCore/Framework/test/fullchain_t.cppunit.cc
+++ b/FWCore/Framework/test/fullchain_t.cppunit.cc
@@ -16,7 +16,7 @@
 #include "FWCore/Framework/test/DummyData.h"
 #include "FWCore/Framework/test/DummyFinder.h"
 #include "FWCore/Framework/test/DummyProxyProvider.h"
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 using namespace edm;
 using namespace edm::eventsetup;

--- a/FWCore/Framework/test/generichandle_t.cppunit.cc
+++ b/FWCore/Framework/test/generichandle_t.cppunit.cc
@@ -28,7 +28,7 @@ Test of GenericHandle class.
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include <iostream>
 #include <memory>

--- a/FWCore/Framework/test/global_module_t.cppunit.cc
+++ b/FWCore/Framework/test/global_module_t.cppunit.cc
@@ -23,7 +23,7 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 class testGlobalModule: public CppUnit::TestFixture 
 {

--- a/FWCore/Framework/test/intersectingiovrecordintervalfinder_t.cppunit.cc
+++ b/FWCore/Framework/test/intersectingiovrecordintervalfinder_t.cppunit.cc
@@ -17,7 +17,7 @@
 #include "FWCore/Framework/test/DummyRecord.h"
 #include "FWCore/Framework/test/DummyFinder.h"
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 using namespace edm::eventsetup;
 
 class testintersectingiovrecordintervalfinder: public CppUnit::TestFixture

--- a/FWCore/Framework/test/interval_t.cppunit.cc
+++ b/FWCore/Framework/test/interval_t.cppunit.cc
@@ -9,7 +9,7 @@
 
 #include "FWCore/Framework/interface/IOVSyncValue.h"
 #include "FWCore/Framework/interface/ValidityInterval.h"
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 using edm::Timestamp;
 using edm::IOVSyncValue;

--- a/FWCore/Framework/test/iovsyncvalue_t.cppunit.cc
+++ b/FWCore/Framework/test/iovsyncvalue_t.cppunit.cc
@@ -6,7 +6,7 @@
  *
  */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "FWCore/Framework/interface/IOVSyncValue.h"
 #include "FWCore/Utilities/interface/Exception.h"

--- a/FWCore/Framework/test/maker2_t.cppunit.cc
+++ b/FWCore/Framework/test/maker2_t.cppunit.cc
@@ -16,7 +16,7 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 using namespace edm;
 

--- a/FWCore/Framework/test/maker_t.cppunit.cc
+++ b/FWCore/Framework/test/maker_t.cppunit.cc
@@ -2,7 +2,7 @@
 #include <iostream>
 
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 // ----------------------------------------------
 class testmaker: public CppUnit::TestFixture

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -27,7 +27,7 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 namespace edm {
   class ModuleCallingContext;

--- a/FWCore/Framework/test/productregistry.cppunit.cc
+++ b/FWCore/Framework/test/productregistry.cppunit.cc
@@ -18,7 +18,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 #include "boost/shared_ptr.hpp"
 

--- a/FWCore/Framework/test/proxyfactoryproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/proxyfactoryproducer_t.cppunit.cc
@@ -7,7 +7,7 @@
 
 */
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include "FWCore/Framework/interface/ESProxyFactoryProducer.h"
 #include "FWCore/Framework/interface/ProxyFactoryTemplate.h"
 #include "FWCore/Framework/interface/DataProxyTemplate.h"

--- a/FWCore/Framework/test/stream_module_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_module_t.cppunit.cc
@@ -24,7 +24,7 @@
 
 #include "FWCore/Utilities/interface/Exception.h"
 
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 
 class testStreamModule: public CppUnit::TestFixture 
 {

--- a/FWCore/Framework/test/stubs/TestPRegisterModule2.cc
+++ b/FWCore/Framework/test/stubs/TestPRegisterModule2.cc
@@ -12,7 +12,7 @@
 #include "FWCore/Framework/test/stubs/TestPRegisterModule2.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
-#include <cppunit/extensions/HelperMacros.h>
+#include "cppunit/extensions/HelperMacros.h"
 #include <cassert>
 #include <memory>
 #include <string>

--- a/FWCore/Framework/test/testRunner.cpp
+++ b/FWCore/Framework/test/testRunner.cpp
@@ -1,1 +1,1 @@
-#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
+#include "Utilities/Testing/interface/CppUnit_testdriver.icpp"

--- a/FWCore/Sources/src/ProducerSourceBase.cc
+++ b/FWCore/Sources/src/ProducerSourceBase.cc
@@ -1,7 +1,7 @@
 /*----------------------------------------------------------------------
 ----------------------------------------------------------------------*/
 
-#include <errno.h>
+#include <cerrno>
 
 #include "DataFormats/Provenance/interface/LuminosityBlockAuxiliary.h"
 #include "DataFormats/Provenance/interface/RunAuxiliary.h"

--- a/Fireworks/Electrons/plugins/FWConvTrackHitsDetailView.cc
+++ b/Fireworks/Electrons/plugins/FWConvTrackHitsDetailView.cc
@@ -36,6 +36,9 @@
 #include "DataFormats/EgammaCandidates/interface/Conversion.h"
 #include "Fireworks/Tracks/interface/TrackUtils.h"
 
+// boost includes
+#include "boost/bind.hpp"
+
 FWConvTrackHitsDetailView::FWConvTrackHitsDetailView ():
   m_modules(0),
   m_moduleLabels(0),

--- a/Fireworks/Tracks/plugins/FWItemTrackAccessors.cc
+++ b/Fireworks/Tracks/plugins/FWItemTrackAccessors.cc
@@ -10,7 +10,7 @@
 // $Id: FWItemTrackAccessors.cc,v 1.8 2010/06/18 12:44:47 yana Exp $
 //
 
-#include <assert.h>
+#include <cassert>
 
 #include "TClass.h"
 

--- a/Fireworks/Tracks/plugins/FWTrackHitsDetailView.cc
+++ b/Fireworks/Tracks/plugins/FWTrackHitsDetailView.cc
@@ -37,6 +37,9 @@
 #include "Fireworks/Tracks/plugins/FWTrackHitsDetailView.h"
 #include "Fireworks/Tracks/interface/TrackUtils.h"
 
+// boost includes
+#include "boost/bind.hpp"
+
 FWTrackHitsDetailView::FWTrackHitsDetailView ():
   m_modules(0),
   m_moduleLabels(0),

--- a/Fireworks/Tracks/plugins/FWTrackResidualDetailView.cc
+++ b/Fireworks/Tracks/plugins/FWTrackResidualDetailView.cc
@@ -1,11 +1,11 @@
 
 #include "TVector3.h"
-#include <TH2.h>
-#include <TLine.h>
-#include <TLatex.h>
-#include <TPaveText.h>
-#include <TCanvas.h>
-#include <TEveWindow.h>
+#include "TH2.h"
+#include "TLine.h"
+#include "TLatex.h"
+#include "TPaveText.h"
+#include "TCanvas.h"
+#include "TEveWindow.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/HitPattern.h"

--- a/GeneratorInterface/LHEInterface/interface/Hadronisation.h
+++ b/GeneratorInterface/LHEInterface/interface/Hadronisation.h
@@ -8,7 +8,7 @@
 #include <boost/shared_ptr.hpp>
 #include <sigc++/signal.h>
 
-#include <HepMC/GenEvent.h>
+#include "HepMC/GenEvent.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"

--- a/GeneratorInterface/LHEInterface/interface/JetClustering.h
+++ b/GeneratorInterface/LHEInterface/interface/JetClustering.h
@@ -4,7 +4,7 @@
 #include <memory>
 #include <vector>
 
-#include <Math/GenVector/PxPyPzE4D.h>
+#include "Math/GenVector/PxPyPzE4D.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/GeneratorInterface/LHEInterface/interface/JetInput.h
+++ b/GeneratorInterface/LHEInterface/interface/JetInput.h
@@ -3,9 +3,9 @@
 
 #include <vector>
 
-#include <HepMC/GenEvent.h>
-#include <HepMC/GenParticle.h>
-#include <HepMC/GenVertex.h>
+#include "HepMC/GenEvent.h"
+#include "HepMC/GenParticle.h"
+#include "HepMC/GenVertex.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/GeneratorInterface/LHEInterface/interface/JetMatching.h
+++ b/GeneratorInterface/LHEInterface/interface/JetMatching.h
@@ -8,8 +8,8 @@
 
 #include <boost/shared_ptr.hpp>
 
-#include <HepMC/GenEvent.h>
-#include <HepMC/SimpleVector.h>
+#include "HepMC/GenEvent.h"
+#include "HepMC/SimpleVector.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/PluginManager/interface/PluginFactory.h"

--- a/GeneratorInterface/LHEInterface/interface/JetMatchingMLM.h
+++ b/GeneratorInterface/LHEInterface/interface/JetMatchingMLM.h
@@ -4,8 +4,8 @@
 #include <memory>
 #include <vector>
 
-#include <HepMC/GenEvent.h>
-#include <HepMC/SimpleVector.h>
+#include "HepMC/GenEvent.h"
+#include "HepMC/SimpleVector.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/GeneratorInterface/LHEInterface/interface/LHEEvent.h
+++ b/GeneratorInterface/LHEInterface/interface/LHEEvent.h
@@ -9,9 +9,9 @@
 
 #include <boost/shared_ptr.hpp>
 
-#include <HepMC/GenEvent.h>
-#include <HepMC/GenVertex.h>
-#include <HepMC/PdfInfo.h>
+#include "HepMC/GenEvent.h"
+#include "HepMC/GenVertex.h"
+#include "HepMC/PdfInfo.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 

--- a/GeneratorInterface/LHEInterface/plugins/JetMatchingMadgraph.cc
+++ b/GeneratorInterface/LHEInterface/plugins/JetMatchingMadgraph.cc
@@ -12,7 +12,7 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/algorithm/string/trim.hpp>
 
-#include <HepMC/GenEvent.h>
+#include "HepMC/GenEvent.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"

--- a/GeneratorInterface/LHEInterface/plugins/LHEAnalyzer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHEAnalyzer.cc
@@ -11,10 +11,10 @@
 #include <boost/bind.hpp>
 #include <boost/ptr_container/ptr_vector.hpp>
 
-#include <TH1.h>
+#include "TH1.h"
 
-#include <HepMC/GenEvent.h>
-#include <HepMC/SimpleVector.h>
+#include "HepMC/GenEvent.h"
+#include "HepMC/SimpleVector.h"
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/GeneratorInterface/LHEInterface/plugins/LHEFilter.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHEFilter.cc
@@ -4,8 +4,8 @@
 
 #include <boost/shared_ptr.hpp>
 
-#include <HepMC/GenEvent.h>
-#include <HepMC/SimpleVector.h>
+#include "HepMC/GenEvent.h"
+#include "HepMC/SimpleVector.h"
 
 #include "FWCore/Framework/interface/EDFilter.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/GeneratorInterface/LHEInterface/plugins/LHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHEProducer.cc
@@ -4,8 +4,8 @@
 #include <boost/shared_ptr.hpp>
 #include <sigc++/signal.h>
 
-#include <HepMC/GenEvent.h>
-#include <HepMC/SimpleVector.h>
+#include "HepMC/GenEvent.h"
+#include "HepMC/SimpleVector.h"
 
 #include "FWCore/Framework/interface/one/EDFilter.h"
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/GeneratorInterface/LHEInterface/plugins/Pythia8Hadronisation.cc
+++ b/GeneratorInterface/LHEInterface/plugins/Pythia8Hadronisation.cc
@@ -4,16 +4,16 @@
 #include <sstream>
 #include <string>
 #include <memory>
-#include <assert.h>
+#include <cassert>
 
 #include <boost/shared_ptr.hpp>
 
-#include <HepMC/GenEvent.h>
-#include <HepMC/GenParticle.h>
+#include "HepMC/GenEvent.h"
+#include "HepMC/GenParticle.h"
 
-#include <Pythia.h>
-#include <LesHouches.h>
-#include <HepMCInterface.h>
+#include "Pythia.h"
+#include "LesHouches.h"
+#include "HepMCInterface.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"

--- a/GeneratorInterface/LHEInterface/src/Hadronisation.cc
+++ b/GeneratorInterface/LHEInterface/src/Hadronisation.cc
@@ -3,7 +3,7 @@
 
 #include <boost/shared_ptr.hpp>
 
-#include <HepMC/GenEvent.h>
+#include "HepMC/GenEvent.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"

--- a/GeneratorInterface/LHEInterface/src/JetInput.cc
+++ b/GeneratorInterface/LHEInterface/src/JetInput.cc
@@ -1,11 +1,11 @@
 #include <algorithm>
 #include <vector>
 
-#include <Math/GenVector/PxPyPzE4D.h>
+#include "Math/GenVector/PxPyPzE4D.h"
 
-#include <HepMC/GenEvent.h>
-#include <HepMC/GenParticle.h>
-#include <HepMC/GenVertex.h>
+#include "HepMC/GenEvent.h"
+#include "HepMC/GenParticle.h"
+#include "HepMC/GenVertex.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Exception.h"

--- a/GeneratorInterface/LHEInterface/src/JetMatchingMLM.cc
+++ b/GeneratorInterface/LHEInterface/src/JetMatchingMLM.cc
@@ -7,11 +7,11 @@
 
 #include <boost/bind.hpp>
 
-#include <Math/GenVector/Cartesian3D.h>
-#include <Math/GenVector/VectorUtil.h>
+#include "Math/GenVector/Cartesian3D.h"
+#include "Math/GenVector/VectorUtil.h"
 
-#include <HepMC/GenEvent.h>
-#include <HepMC/SimpleVector.h>
+#include "HepMC/GenEvent.h"
+#include "HepMC/SimpleVector.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Exception.h"

--- a/GeneratorInterface/LHEInterface/src/LHEEvent.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEEvent.cc
@@ -8,10 +8,10 @@
 #include <memory>
 #include <cmath>
 
-#include <HepMC/GenEvent.h>
-#include <HepMC/GenVertex.h>
-#include <HepMC/GenParticle.h>
-#include <HepMC/SimpleVector.h>
+#include "HepMC/GenEvent.h"
+#include "HepMC/GenVertex.h"
+#include "HepMC/GenParticle.h"
+#include "HepMC/SimpleVector.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 

--- a/GeneratorInterface/LHEInterface/test/DummyLHEAnalyzer.cc
+++ b/GeneratorInterface/LHEInterface/test/DummyLHEAnalyzer.cc
@@ -9,6 +9,7 @@
 #include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include <iomanip>
 #include <iostream>
 using namespace std;
 using namespace edm;

--- a/GeneratorInterface/Pythia6Interface/plugins/Pythia6Hadronizer.cc
+++ b/GeneratorInterface/Pythia6Interface/plugins/Pythia6Hadronizer.cc
@@ -30,6 +30,8 @@ HepMC::IO_HEPEVT conv;
 #include "GeneratorInterface/Pythia6Interface/interface/Pythia6Service.h"
 #include "GeneratorInterface/Pythia6Interface/interface/Pythia6Declarations.h"
 
+#include <iomanip>
+
 namespace gen
 {
 

--- a/GeneratorInterface/Pythia6Interface/src/Pythia6Service.cc
+++ b/GeneratorInterface/Pythia6Interface/src/Pythia6Service.cc
@@ -11,7 +11,7 @@
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 
-#include <CLHEP/Random/RandomEngine.h>
+#include "CLHEP/Random/RandomEngine.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 

--- a/IOPool/Streamer/bin/CalcAdler32.cpp
+++ b/IOPool/Streamer/bin/CalcAdler32.cpp
@@ -5,7 +5,7 @@
 
 #include <fstream>
 #include <iostream>
-#include <stdint.h>
+#include <cstdint>
 
 int main(int argc, char* argv[]) {
 

--- a/IOPool/Streamer/interface/DQMEventMessage.h
+++ b/IOPool/Streamer/interface/DQMEventMessage.h
@@ -41,7 +41,7 @@
 #include "IOPool/Streamer/interface/MsgTools.h"
 #include "IOPool/Streamer/interface/MsgHeader.h"
 #include "boost/shared_ptr.hpp"
-#include <TObject.h>
+#include "TObject.h"
 #include <map>
 
 #include "DataFormats/Provenance/interface/Timestamp.h"

--- a/IOPool/Streamer/interface/StreamDQMSerializer.h
+++ b/IOPool/Streamer/interface/StreamDQMSerializer.h
@@ -11,7 +11,7 @@
 #include "TBufferFile.h"
 
 #include "IOPool/Streamer/interface/DQMEventMsgBuilder.h"
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 namespace edm

--- a/IOPool/Streamer/interface/StreamSerializer.h
+++ b/IOPool/Streamer/interface/StreamSerializer.h
@@ -10,7 +10,7 @@
 
 #include "TBufferFile.h"
 
-#include <stdint.h>
+#include <cstdint>
 #include <vector>
 
 #include "DataFormats/Provenance/interface/BranchIDList.h"

--- a/IOPool/Streamer/src/InitMsgBuilder.cc
+++ b/IOPool/Streamer/src/InitMsgBuilder.cc
@@ -3,7 +3,7 @@
 #include "IOPool/Streamer/interface/MsgHeader.h"
 #include <cassert>
 #include <cstring>
-#include <stdint.h>
+#include <cstdint>
 #include <unistd.h>
 
 #define MAX_INITHOSTNAME_LEN 25

--- a/IOPool/Streamer/test/Eventmsg_t.cppunit.cpp
+++ b/IOPool/Streamer/test/Eventmsg_t.cppunit.cpp
@@ -170,4 +170,4 @@ void testeventmsg::eventMsg()
   CPPUNIT_ASSERT( from_new.getRunNumber() == 2 );
 
 }
-#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>
+#include "Utilities/Testing/interface/CppUnit_testdriver.icpp"

--- a/IOPool/Streamer/test/WriteDQMToFile.cpp
+++ b/IOPool/Streamer/test/WriteDQMToFile.cpp
@@ -5,7 +5,7 @@ Example code to write DQM Event Message to file
 */
 
 #include <iostream>
-#include <stdint.h>
+#include <cstdint>
 
 #include "IOPool/Streamer/interface/MsgTools.h"
 #include "FWCore/Utilities/interface/Exception.h"

--- a/SimG4Core/Watcher/interface/SimProducer.h
+++ b/SimG4Core/Watcher/interface/SimProducer.h
@@ -16,12 +16,12 @@
 //
 // Original Author:  Chris D. Jones
 //         Created:  Mon Nov 28 16:02:21 EST 2005
-// $Id: SimProducer.h,v 1.1 2005/11/29 18:40:25 chrjones Exp $
 //
 
 // system include files
 #include <string>
 #include <vector>
+#include "boost/bind.hpp"
 #include "boost/shared_ptr.hpp"
 
 // user include files


### PR DESCRIPTION
This is an important purely technical change that is needed quickly to support the multithreaded framework.
Please bypass signatures and merge if this is not signed promptly.

In attempting to make a framework change for multithreading by removing the header ProcessConfigurationRegistry.h, I discovered many missing #includes of system headers  in other packages that now compile only due to a chain of includes going through this header.  This pull request adds the missing includes of system or boost headers that should have been there in the first place.
The only other change in this package is the removal of CVS tags ($Date, #Id, and $Revision) in files I was modifying anyway.
