### PR TITLE
Removed use of ConstProductRegistry since the function is deprecated

### DIFF
--- a/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimProducer.h
+++ b/SimCalorimetry/EcalTrigPrimProducers/plugins/EcalTrigPrimProducer.h
@@ -17,6 +17,7 @@
  *
  ************************************************************/
 
+#include <memory>
  
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -26,8 +27,6 @@
  
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
   
-class TFile;
-class TTree;
 class EcalTrigPrimFunctionalAlgo;
  
 class EcalTrigPrimProducer : public edm::EDProducer
@@ -38,24 +37,24 @@ class EcalTrigPrimProducer : public edm::EDProducer
   
   virtual ~EcalTrigPrimProducer();
   
-  void beginJob();
   void beginRun(const edm::Run& run, const edm::EventSetup& es) override;
   void endRun(const edm::Run&, const edm::EventSetup&) override;
-  virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
+  void produce(edm::Event& e, const edm::EventSetup& c) override;
+
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
  private:
-  EcalTrigPrimFunctionalAlgo *algo_;
-  TFile *histfile_;
+  std::unique_ptr<EcalTrigPrimFunctionalAlgo> algo_;
   bool barrelOnly_;
   bool tcpFormat_;
   bool debug_;
+  bool famos_;
   std::string label_;
   std::string instanceNameEB_;
   std::string instanceNameEE_;
 
   int binOfMaximum_;
-
-  const edm::ParameterSet ps_;
+  bool fillBinOfMaximumFromHistory_;
 
   //method to get EventSetupRecords
   unsigned long long getRecords(edm::EventSetup const& setup);


### PR DESCRIPTION
The code was attempting to lookup a value for a ParameterSet for another module via the ConstProductRegistry.
The particular function being called will be going away for thread safety reasons. The code was changes to
instead use the ProcessHistory at beginRun to lookup the same information. This is actually superior since
the ConstProductRegistry call could have caused an exception if different jobs were using different configurations
for the module being searched.
In addition to the above I removed unused member data, fixed an end of job memory leak and added a
'fillDescriptions' to properly handle the case where a tracked parameter was allowed to not be specified.
