### PR TITLE
Migrating the EITopPAG changes to 700pre2

### DIFF
--- a/CommonTools/ParticleFlow/python/EITopPAG_EventContent_cff.py
+++ b/CommonTools/ParticleFlow/python/EITopPAG_EventContent_cff.py
@@ -9,6 +9,11 @@ EITopPAGEventContent = cms.PSet(
     'keep *_pfIsolatedMuonsEI_*_*',
     # jets
     'keep recoPFJets_pfJetsEI_*_*',
+    # btags
+    'keep *_pfJetTrackAssociatorEI_*_*',
+    'keep *_impactParameterTagInfosEI_*_*',
+    'keep *_secondaryVertexTagInfosEI_*_*',
+    'keep *_combinedSecondaryVertexBJetTagsEI_*_*',
     # taus 
     'keep recoPFTaus_pfTausEI_*_*',
     'keep recoPFTauDiscriminator_pfTausDiscrimination*_*_*',

--- a/CommonTools/ParticleFlow/python/EITopPAG_cff.py
+++ b/CommonTools/ParticleFlow/python/EITopPAG_cff.py
@@ -15,6 +15,12 @@ from CommonTools.ParticleFlow.TopProjectors.pfNoElectron_cfi import *
 from CommonTools.ParticleFlow.TopProjectors.pfNoJet_cfi import *
 from CommonTools.ParticleFlow.TopProjectors.pfNoTau_cfi import *
 
+# b-tagging
+from RecoJets.JetAssociationProducers.ak5JTA_cff import ak5JetTracksAssociatorAtVertex
+from RecoBTag.ImpactParameter.impactParameter_cfi import impactParameterTagInfos
+from RecoBTag.SecondaryVertex.secondaryVertexTagInfos_cfi import secondaryVertexTagInfos
+from RecoBTag.SecondaryVertex.combinedSecondaryVertexBJetTags_cfi import combinedSecondaryVertexBJetTags
+
 
 #### PU Again... need to do this twice because the "linking" stage of PF reco ####
 #### condenses information into the new "particleFlow" collection.            ####
@@ -44,12 +50,13 @@ pfMuonsFromVertexEI = pfMuonsFromVertex.clone( src = cms.InputTag('pfAllMuonsEI'
 pfIsolatedMuonsEI = cms.EDFilter(
     "PFCandidateFwdPtrCollectionStringFilter",
     src = cms.InputTag("pfMuonsFromVertexEI"),
-    cut = cms.string("pt > 5 & muonRef.isAvailable() & "\
-                     "muonRef.pfIsolationR04().sumChargedHadronPt + "\
-                     "muonRef.pfIsolationR04().sumNeutralHadronEt + "\
-                     "muonRef.pfIsolationR04().sumPhotonEt "\
-                     " < 0.15 * pt "
-        ),
+    cut = cms.string('''abs(eta)<2.5 && pt>10. && muonRef.isAvailable() &&
+    (muonRef.pfIsolationR04().sumChargedHadronPt+
+    max(0.,muonRef.pfIsolationR04().sumNeutralHadronEt+
+    muonRef.pfIsolationR04().sumPhotonEt-
+    0.50*muonRef.pfIsolationR04().sumPUPt))/pt < 0.20 && 
+    (muonRef.isPFMuon && (muonRef.isGlobalMuon || muonRef.isTrackerMuon) )'''
+    ),
     makeClones = cms.bool(True)
 )
 
@@ -78,12 +85,14 @@ pfElectronsFromVertexEI = pfElectronsFromVertex.clone( src = cms.InputTag('pfAll
 pfIsolatedElectronsEI = cms.EDFilter(
     "PFCandidateFwdPtrCollectionStringFilter",
     src = cms.InputTag("pfElectronsFromVertexEI"),
-    cut = cms.string(" pt > 5 & gsfElectronRef.isAvailable() & gsfTrackRef.trackerExpectedHitsInner.numberOfLostHits<2 & "\
-                     "gsfElectronRef.pfIsolationVariables().chargedHadronIso + "\
-                     "gsfElectronRef.pfIsolationVariables().neutralHadronIso + "\
-                     "gsfElectronRef.pfIsolationVariables().photonIso "\
-                     " < 0.2 * pt "
-        ),
+    cut = cms.string('''abs(eta)<2.5 && pt>20. &&
+    gsfTrackRef.isAvailable() &&
+    gsfTrackRef.trackerExpectedHitsInner.numberOfLostHits<2 &&
+    (gsfElectronRef.pfIsolationVariables().chargedHadronIso+
+    max(0.,gsfElectronRef.pfIsolationVariables().neutralHadronIso+
+    gsfElectronRef.pfIsolationVariables().photonIso-
+    0.5*gsfElectronRef.pfIsolationVariables().puIso))/pt < 0.15
+    '''),
     makeClones = cms.bool(True)
 )
 
@@ -122,6 +131,22 @@ pfTauEISequence = cms.Sequence(
     pfTausPtrsEI
     )
 
+#### B-tagging ####
+pfJetTrackAssociatorEI = ak5JetTracksAssociatorAtVertex.clone (
+    src = cms.InputTag("pfJetsEI")
+    )
+impactParameterTagInfosEI = impactParameterTagInfos.clone(
+    jetTracks = cms.InputTag( 'pfJetTrackAssociatorEI' )
+    )
+secondaryVertexTagInfosEI = secondaryVertexTagInfos.clone(
+    trackIPTagInfos = cms.InputTag( 'impactParameterTagInfosEI' )
+    )
+combinedSecondaryVertexBJetTagsEI = combinedSecondaryVertexBJetTags.clone(
+    tagInfos = cms.VInputTag(cms.InputTag("impactParameterTagInfosEI"),
+                             cms.InputTag("secondaryVertexTagInfosEI"))    
+    )
+
+
 #### MET ####
 pfMetEI = pfMET.clone(jets=cms.InputTag("pfJetsEI"))
 
@@ -145,6 +170,10 @@ EIsequence = cms.Sequence(
     pfNoJetEI + 
     pfTauEISequence +
     pfNoTauEI +
-    pfMetEI
+    pfMetEI+
+    pfJetTrackAssociatorEI+
+    impactParameterTagInfosEI+
+    secondaryVertexTagInfosEI+
+    combinedSecondaryVertexBJetTagsEI
     )
 

--- a/DataFormats/EgammaCandidates/interface/GsfElectron.h
+++ b/DataFormats/EgammaCandidates/interface/GsfElectron.h
@@ -517,8 +517,9 @@ class GsfElectron : public RecoCandidate
        float chargedHadronIso ;
        float neutralHadronIso ;
        float photonIso ;
+       float puIso;
        PflowIsolationVariables()
-        : chargedHadronIso(0.), neutralHadronIso(0.), photonIso(0.)
+        : chargedHadronIso(0.), neutralHadronIso(0.), photonIso(0.), puIso(0.)
         {}
       } ;
 

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -93,8 +93,8 @@
 
 
 
-  <class name="reco::GsfElectronCore" ClassVersion="10">
-   <version ClassVersion="10" checksum="2226610106"/>
+  <class name="reco::GsfElectronCore" ClassVersion="11">
+   <version ClassVersion="11" checksum="2226610106"/>
   </class>
   <class name="std::vector<reco::GsfElectronCore>"/>  
   <class name="edm::reftobase::BaseHolder<reco::GsfElectronCore>"/>
@@ -138,8 +138,8 @@
   <class name="reco::GsfElectron::ChargeInfo" ClassVersion="10">
    <version ClassVersion="10" checksum="1415326811"/>
   </class>
-  <class name="reco::GsfElectron::PflowIsolationVariables" ClassVersion="10">
-   <version ClassVersion="10" checksum="4270399196"/>
+  <class name="reco::GsfElectron::PflowIsolationVariables" ClassVersion="11">
+   <version ClassVersion="11" checksum="980464324"/>
   </class>
   <class name="reco::GsfElectron::MvaInput" ClassVersion="11">
    <version ClassVersion="11" checksum="2106253688"/>

--- a/RecoParticleFlow/PFProducer/plugins/PFElectronTranslator.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFElectronTranslator.cc
@@ -41,6 +41,9 @@ PFElectronTranslator::PFElectronTranslator(const edm::ParameterSet & iConfig) {
 			(isoVals.getParameter<edm::InputTag>("pfPhotons"));
   		inputTagIsoVals_.push_back
 			(isoVals.getParameter<edm::InputTag>("pfNeutralHadrons"));
+  		inputTagIsoVals_.push_back
+			(isoVals.getParameter<edm::InputTag>("pfPU"));
+
 	}
   }
 
@@ -633,6 +636,7 @@ void PFElectronTranslator::createGsfElectrons(const reco::PFCandidateCollection 
       	myPFIso.chargedHadronIso=(*isolationValues[0])[CandidatePtr_[iGSF]];
       	myPFIso.photonIso=(*isolationValues[1])[CandidatePtr_[iGSF]];
       	myPFIso.neutralHadronIso=(*isolationValues[2])[CandidatePtr_[iGSF]];      
+      	myPFIso.puIso=(*isolationValues[3])[CandidatePtr_[iGSF]];      
       	myElectron.setPfIsolationVariables(myPFIso);
       }
 

--- a/RecoParticleFlow/PFProducer/python/pfElectronTranslator_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/pfElectronTranslator_cfi.py
@@ -20,5 +20,7 @@ pfElectronTranslator = cms.EDProducer("PFElectronTranslator",
                                       isolationValues = cms.PSet(
                                                pfChargedHadrons = cms.InputTag('elPFIsoValueCharged04PFId'),
                                                pfPhotons = cms.InputTag('elPFIsoValueGamma04PFId'),
-                                               pfNeutralHadrons= cms.InputTag('elPFIsoValueNeutral04PFId'))
+                                               pfNeutralHadrons= cms.InputTag('elPFIsoValueNeutral04PFId'),
+                                               pfPUChargedHadrons= cms.InputTag('elPFIsoValuePU04PFId')
+                                          )
                                       )


### PR DESCRIPTION
This is to fix the mangled tag here : 

https://github.com/cms-sw/cmssw/pull/346#issuecomment-22686647

Please take this one for pull request. 

The changes include : 
- Changes to the EITopPAG sequence to account for latest top PAG request : 
  - Use delta-beta corrections in top projection for electrons
  - Add b-tagging. 
  - This necessitates a dataformat change to GsfElectron to add the PU isolation that is computed in RECO
