### PR TITLE
Tracking getByToken migration, part 0.1 (DeDx, IterativeTracking, FinalTrackSelectors)

### DIFF
--- a/RecoTracker/DeDx/plugins/DeDxDiscriminatorLearner.cc
+++ b/RecoTracker/DeDx/plugins/DeDxDiscriminatorLearner.cc
@@ -35,8 +35,8 @@ using namespace edm;
 
 DeDxDiscriminatorLearner::DeDxDiscriminatorLearner(const edm::ParameterSet& iConfig) : ConditionDBWriter<PhysicsTools::Calibration::HistogramD3D>(iConfig)
 {
-   m_tracksTag                 = iConfig.getParameter<edm::InputTag>("tracks");
-   m_trajTrackAssociationTag   = iConfig.getParameter<edm::InputTag>("trajectoryTrackAssociation");
+   m_tracksTag                 = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
+   m_trajTrackAssociationTag   = consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("trajectoryTrackAssociation"));
 
    usePixel = iConfig.getParameter<bool>("UsePixel"); 
    useStrip = iConfig.getParameter<bool>("UseStrip");
@@ -137,11 +137,11 @@ void DeDxDiscriminatorLearner::algoAnalyze(const edm::Event& iEvent, const edm::
 
 
   Handle<TrajTrackAssociationCollection> trajTrackAssociationHandle;
-  iEvent.getByLabel(m_trajTrackAssociationTag, trajTrackAssociationHandle);
+  iEvent.getByToken(m_trajTrackAssociationTag, trajTrackAssociationHandle);
   const TrajTrackAssociationCollection TrajToTrackMap = *trajTrackAssociationHandle.product();
 
   edm::Handle<reco::TrackCollection> trackCollectionHandle;
-  iEvent.getByLabel(m_tracksTag,trackCollectionHandle);
+  iEvent.getByToken(m_tracksTag,trackCollectionHandle);
 
   unsigned track_index = 0;
   for(TrajTrackAssociationCollection::const_iterator it = TrajToTrackMap.begin(); it!=TrajToTrackMap.end(); ++it, track_index++) {

--- a/RecoTracker/DeDx/plugins/DeDxDiscriminatorLearner.h
+++ b/RecoTracker/DeDx/plugins/DeDxDiscriminatorLearner.h
@@ -47,8 +47,8 @@ private:
 
 
   // ----------member data ---------------------------
-  edm::InputTag                     m_trajTrackAssociationTag;
-  edm::InputTag                     m_tracksTag;
+  edm::EDGetTokenT<TrajTrackAssociationCollection>   m_trajTrackAssociationTag;
+  edm::EDGetTokenT<reco::TrackCollection>  m_tracksTag;
 
   bool   usePixel;
   bool   useStrip;

--- a/RecoTracker/DeDx/plugins/DeDxDiscriminatorLearnerFromCalibTree.h
+++ b/RecoTracker/DeDx/plugins/DeDxDiscriminatorLearnerFromCalibTree.h
@@ -50,8 +50,8 @@ private:
 
 
   // ----------member data ---------------------------
-  edm::InputTag                     m_trajTrackAssociationTag;
-  edm::InputTag                     m_tracksTag;
+  edm::EDGetTokenT<TrajTrackAssociationCollection>   m_trajTrackAssociationTag;
+  edm::EDGetTokenT<reco::TrackCollection>  m_tracksTag;
 
   bool   usePixel;
   bool   useStrip;

--- a/RecoTracker/DeDx/plugins/DeDxDiscriminatorProducer.cc
+++ b/RecoTracker/DeDx/plugins/DeDxDiscriminatorProducer.cc
@@ -51,8 +51,8 @@ DeDxDiscriminatorProducer::DeDxDiscriminatorProducer(const edm::ParameterSet& iC
 
    produces<ValueMap<DeDxData> >();
 
-   m_tracksTag = iConfig.getParameter<edm::InputTag>("tracks");
-   m_trajTrackAssociationTag   = iConfig.getParameter<edm::InputTag>("trajectoryTrackAssociation");
+   m_tracksTag                 = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
+   m_trajTrackAssociationTag   = consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("trajectoryTrackAssociation"));
 
    usePixel = iConfig.getParameter<bool>("UsePixel"); 
    useStrip = iConfig.getParameter<bool>("UseStrip");
@@ -231,11 +231,11 @@ void DeDxDiscriminatorProducer::produce(edm::Event& iEvent, const edm::EventSetu
   ValueMap<DeDxData>::Filler filler(*trackDeDxDiscrimAssociation);
 
   Handle<TrajTrackAssociationCollection> trajTrackAssociationHandle;
-  iEvent.getByLabel(m_trajTrackAssociationTag, trajTrackAssociationHandle);
+  iEvent.getByToken(m_trajTrackAssociationTag, trajTrackAssociationHandle);
   const TrajTrackAssociationCollection TrajToTrackMap = *trajTrackAssociationHandle.product();
 
   edm::Handle<reco::TrackCollection> trackCollectionHandle;
-  iEvent.getByLabel(m_tracksTag,trackCollectionHandle);
+  iEvent.getByToken(m_tracksTag,trackCollectionHandle);
 
    edm::ESHandle<TrackerGeometry> tkGeom;
    iSetup.get<TrackerDigiGeometryRecord>().get( tkGeom );

--- a/RecoTracker/DeDx/plugins/DeDxDiscriminatorProducer.h
+++ b/RecoTracker/DeDx/plugins/DeDxDiscriminatorProducer.h
@@ -65,8 +65,8 @@ private:
 
 
   // ----------member data ---------------------------
-  edm::InputTag                     m_trajTrackAssociationTag;
-  edm::InputTag                     m_tracksTag;
+  edm::EDGetTokenT<TrajTrackAssociationCollection>   m_trajTrackAssociationTag;
+  edm::EDGetTokenT<reco::TrackCollection>  m_tracksTag;
 
   bool usePixel;
   bool useStrip;

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
@@ -63,8 +63,8 @@ DeDxEstimatorProducer::DeDxEstimatorProducer(const edm::ParameterSet& iConfig)
    MaxNrStrips         = iConfig.getUntrackedParameter<unsigned>("maxNrStrips"        ,  255);
    MinTrackHits        = iConfig.getUntrackedParameter<unsigned>("MinTrackHits"       ,  4);
 
-   m_tracksTag = iConfig.getParameter<edm::InputTag>("tracks");
-   m_trajTrackAssociationTag   = iConfig.getParameter<edm::InputTag>("trajectoryTrackAssociation");
+   m_tracksTag = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
+   m_trajTrackAssociationTag   = consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("trajectoryTrackAssociation"));
 
    usePixel = iConfig.getParameter<bool>("UsePixel"); 
    useStrip = iConfig.getParameter<bool>("UseStrip");
@@ -138,11 +138,11 @@ void DeDxEstimatorProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   ValueMap<DeDxData>::Filler filler(*trackDeDxEstimateAssociation);
 
   Handle<TrajTrackAssociationCollection> trajTrackAssociationHandle;
-  iEvent.getByLabel(m_trajTrackAssociationTag, trajTrackAssociationHandle);
+  iEvent.getByToken(m_trajTrackAssociationTag, trajTrackAssociationHandle);
   const TrajTrackAssociationCollection & TrajToTrackMap = *trajTrackAssociationHandle.product();
 
   edm::Handle<reco::TrackCollection> trackCollectionHandle;
-  iEvent.getByLabel(m_tracksTag,trackCollectionHandle);
+  iEvent.getByToken(m_tracksTag,trackCollectionHandle);
 
   size_t n =  TrajToTrackMap.size();
   std::vector<DeDxData> dedxEstimate(n);

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.h
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.h
@@ -21,6 +21,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 
 #include "TFile.h"
 #include "TChain.h"
@@ -50,8 +51,8 @@ private:
   // ----------member data ---------------------------
   BaseDeDxEstimator*                m_estimator;
 
-  edm::InputTag                     m_trajTrackAssociationTag;
-  edm::InputTag                     m_tracksTag;
+  edm::EDGetTokenT<TrajTrackAssociationCollection>   m_trajTrackAssociationTag;
+  edm::EDGetTokenT<reco::TrackCollection>  m_tracksTag;
 
   bool usePixel;
   bool useStrip;

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducerPixelTripplet.cc
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducerPixelTripplet.cc
@@ -58,8 +58,8 @@ DeDxEstimatorProducerPixelTripplet::DeDxEstimatorProducerPixelTripplet(const edm
    MaxNrStrips         = iConfig.getUntrackedParameter<unsigned>("maxNrStrips"        ,  255);
    MinTrackHits        = iConfig.getUntrackedParameter<unsigned>("MinTrackHits"       ,  4);
 
-   m_tracksTag = iConfig.getParameter<edm::InputTag>("tracks");
-   m_trajTrackAssociationTag   = iConfig.getParameter<edm::InputTag>("trajectoryTrackAssociation");
+   m_tracksTag = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
+   m_trajTrackAssociationTag   = consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("trajectoryTrackAssociation"));
 
    usePixel = iConfig.getParameter<bool>("UsePixel"); 
    useStrip = iConfig.getParameter<bool>("UseStrip");
@@ -137,7 +137,7 @@ void DeDxEstimatorProducerPixelTripplet::produce(edm::Event& iEvent, const edm::
   ValueMap<DeDxData>::Filler filler(*trackDeDxEstimateAssociation);
 
   Handle<TrackCollection> trackCollHandle;
-  iEvent.getByLabel(m_trajTrackAssociationTag, trackCollHandle);
+  iEvent.getByToken(m_trajTrackAssociationTag, trackCollHandle);
   const TrackCollection trackColl = *trackCollHandle.product();
 
   size_t n =  trackColl.size();

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducerPixelTripplet.h
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducerPixelTripplet.h
@@ -15,6 +15,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h" 
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 
 #include <ext/hash_map>
 
@@ -48,8 +49,8 @@ private:
   // ----------member data ---------------------------
   BaseDeDxEstimator*                m_estimator;
 
-  edm::InputTag                     m_trajTrackAssociationTag;
-  edm::InputTag                     m_tracksTag;
+  edm::EDGetTokenT<TrajTrackAssociationCollection>   m_trajTrackAssociationTag;
+  edm::EDGetTokenT<reco::TrackCollection>  m_tracksTag;
 
   bool usePixel;
   bool useStrip;

--- a/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
+++ b/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
@@ -40,6 +40,8 @@ HLTDeDxFilter::HLTDeDxFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConf
   maxETA_       = iConfig.getParameter<double> ("maxETA");
   inputTracksTag_ = iConfig.getParameter< edm::InputTag > ("inputTracksTag");
   inputdedxTag_   = iConfig.getParameter< edm::InputTag > ("inputDeDxTag");
+  inputTracksToken_ = consumes<reco::TrackCollection>(iConfig.getParameter< edm::InputTag > ("inputTracksTag"));
+  inputdedxToken_   = consumes<edm::ValueMap<reco::DeDxData> >(iConfig.getParameter< edm::InputTag > ("inputDeDxTag"));
 
   thisModuleTag_ = edm::InputTag(iConfig.getParameter<std::string>("@module_label")); 
  
@@ -83,11 +85,11 @@ bool
   }
 
   edm::Handle<reco::TrackCollection> trackCollectionHandle;
-  iEvent.getByLabel(inputTracksTag_,trackCollectionHandle);
+  iEvent.getByToken(inputTracksToken_,trackCollectionHandle);
   reco::TrackCollection trackCollection = *trackCollectionHandle.product();
   
   edm::Handle<edm::ValueMap<reco::DeDxData> > dEdxTrackHandle;
-  iEvent.getByLabel(inputdedxTag_, dEdxTrackHandle);
+  iEvent.getByToken(inputdedxToken_, dEdxTrackHandle);
   const edm::ValueMap<reco::DeDxData> dEdxTrack = *dEdxTrackHandle.product();
 
   bool accept=false;

--- a/RecoTracker/DeDx/plugins/HLTDeDxFilter.h
+++ b/RecoTracker/DeDx/plugins/HLTDeDxFilter.h
@@ -8,6 +8,7 @@
  */
 
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 namespace edm {
    class ConfigurationDescriptions;
@@ -32,6 +33,8 @@ class HLTDeDxFilter : public HLTFilter {
       double minPT_;
       double minNOM_;
       double maxETA_;
+      edm::EDGetToken inputTracksToken_;
+      edm::EDGetToken inputdedxToken_;
       edm::InputTag inputTracksTag_;
       edm::InputTag inputdedxTag_;
       edm::InputTag thisModuleTag_;

--- a/RecoTracker/FinalTrackSelectors/interface/AnalyticalTrackSelector.h
+++ b/RecoTracker/FinalTrackSelectors/interface/AnalyticalTrackSelector.h
@@ -58,6 +58,9 @@ namespace reco { namespace modules {
             /// eta restrictions
             double minEta_;
 	    double maxEta_;
+
+            edm::EDGetTokenT<std::vector<Trajectory> >        srcTraj_;
+            edm::EDGetTokenT<TrajTrackAssociationCollection > srcTass_;
 			
             /// storage
             std::auto_ptr<reco::TrackCollection> selTracks_;

--- a/RecoTracker/FinalTrackSelectors/interface/CosmicTrackSelector.h
+++ b/RecoTracker/FinalTrackSelectors/interface/CosmicTrackSelector.h
@@ -49,12 +49,14 @@ namespace reco { namespace modules {
 		     // return class, or -1 if rejected
 		     bool select (const reco::BeamSpot &vertexBeamSpot, const reco::Track &tk);
 		     // source collection label
-		     edm::InputTag src_;
-		     edm::InputTag beamspot_;
+                     edm::EDGetTokenT<reco::TrackCollection> src_;
+                     edm::EDGetTokenT<reco::BeamSpot> beamspot_;
 		     // copy only the tracks, not extras and rechits (for AOD)
 		     bool copyExtras_;
 		     // copy also trajectories and trajectory->track associations
 		     bool copyTrajectories_;
+                     edm::EDGetTokenT<std::vector<Trajectory> >        srcTraj_;
+                     edm::EDGetTokenT<TrajTrackAssociationCollection > srcTass_;
 		     
 		     // save all the tracks
 		     bool keepAllTracks_;

--- a/RecoTracker/FinalTrackSelectors/interface/DuplicateListMerger.h
+++ b/RecoTracker/FinalTrackSelectors/interface/DuplicateListMerger.h
@@ -25,6 +25,7 @@
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
+#include "DataFormats/Common/interface/ValueMap.h"
 #include <vector>
 #include <algorithm>
 #include <string>
@@ -56,12 +57,25 @@ namespace reco { namespace modules {
 	 }
 
 	 /// track input collection
-	 edm::InputTag mergedTrackSource_;
-	 edm::InputTag originalTrackSource_;
-	 edm::InputTag candidateSource_;
+         struct ThreeTokens {
+            edm::InputTag tag;
+            edm::EDGetTokenT<reco::TrackCollection> tk;
+            edm::EDGetTokenT<std::vector<Trajectory> >        traj;
+            edm::EDGetTokenT<TrajTrackAssociationCollection > tass;
+            ThreeTokens() {}
+            ThreeTokens(const edm::InputTag &tag_, edm::EDGetTokenT<reco::TrackCollection> && tk_, edm::EDGetTokenT<std::vector<Trajectory> > && traj_, edm::EDGetTokenT<TrajTrackAssociationCollection > && tass_) :
+                tag(tag_), tk(tk_), traj(traj_), tass(tass_) {}
+         };
+         ThreeTokens threeTokens(const edm::InputTag &tag) {
+            return ThreeTokens(tag, consumes<reco::TrackCollection>(tag), consumes<std::vector<Trajectory> >(tag), consumes<TrajTrackAssociationCollection >(tag));
+         }
+         ThreeTokens mergedTrackSource_, originalTrackSource_;
+         edm::EDGetTokenT<edm::View<DuplicateRecord> > candidateSource_;
 
-	 edm::InputTag originalMVAVals_;
-	 edm::InputTag mergedMVAVals_;
+         edm::InputTag originalMVAVals_;
+         edm::InputTag mergedMVAVals_;
+         edm::EDGetTokenT<edm::ValueMap<float> > originalMVAValsToken_;
+         edm::EDGetTokenT<edm::ValueMap<float> > mergedMVAValsToken_;
 
 	 reco::TrackBase::TrackQuality qualityToSet_;
 	 unsigned int diffHitsCut_;

--- a/RecoTracker/FinalTrackSelectors/interface/DuplicateTrackMerger.h
+++ b/RecoTracker/FinalTrackSelectors/interface/DuplicateTrackMerger.h
@@ -62,7 +62,7 @@ namespace reco { namespace modules {
 	 float* gbrVals_;
 
 	 /// track input collection
-	 edm::InputTag trackSource_;
+	 edm::EDGetTokenT<reco::TrackCollection> trackSource_;
 	 /// MVA weights file
 	 std::string dbFileName_;
 	 bool useForestFromDB_;

--- a/RecoTracker/FinalTrackSelectors/src/DuplicateTrackMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/src/DuplicateTrackMerger.cc
@@ -36,7 +36,7 @@ DuplicateTrackMerger::DuplicateTrackMerger(const edm::ParameterSet& iPara) : mer
   if(iPara.exists("maxDdsz"))maxDdsz_ = iPara.getParameter<double>("maxDdsz");
   if(iPara.exists("maxDdxy"))maxDdxy_ = iPara.getParameter<double>("maxDdxy");
   if(iPara.exists("maxDQoP"))maxDQoP_ = iPara.getParameter<double>("maxDQoP");
-  if(iPara.exists("source"))trackSource_ = iPara.getParameter<edm::InputTag>("source");
+  if(iPara.exists("source"))trackSource_ = consumes<reco::TrackCollection>(iPara.getParameter<edm::InputTag>("source"));
   if(iPara.exists("minDeltaR3d"))minDeltaR3d_ = iPara.getParameter<double>("minDeltaR3d");
   if(iPara.exists("minBDTG"))minBDTG_ = iPara.getParameter<double>("minBDTG");
 
@@ -95,7 +95,7 @@ void DuplicateTrackMerger::produce(edm::Event& iEvent, const edm::EventSetup& iS
 
   //edm::Handle<edm::View<reco::Track> >handle;
   edm::Handle<reco::TrackCollection >handle;
-  iEvent.getByLabel(trackSource_,handle);
+  iEvent.getByToken(trackSource_,handle);
   reco::TrackRefProd refTrks(handle);
 
   iSetup.get<IdealMagneticFieldRecord>().get(magfield_);

--- a/RecoTracker/FinalTrackSelectors/src/MultiTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/src/MultiTrackSelector.cc
@@ -21,13 +21,13 @@ MultiTrackSelector::MultiTrackSelector()
 }
 
 MultiTrackSelector::MultiTrackSelector( const edm::ParameterSet & cfg ) :
-  src_( cfg.getParameter<edm::InputTag>( "src" ) ),
-  beamspot_( cfg.getParameter<edm::InputTag>( "beamspot" ) ),
+  src_( consumes<reco::TrackCollection>( cfg.getParameter<edm::InputTag>( "src" ) ) ),
+  beamspot_( consumes<reco::BeamSpot>( cfg.getParameter<edm::InputTag>( "beamspot" ) ) ),
   useVertices_( cfg.getParameter<bool>( "useVertices" ) ),
-  useVtxError_( cfg.getParameter<bool>( "useVtxError" ) ),
-  vertices_( useVertices_ ? cfg.getParameter<edm::InputTag>( "vertices" ) : edm::InputTag("NONE"))
+  useVtxError_( cfg.getParameter<bool>( "useVtxError" ) )
   // now get the pset for each selector
 {
+  if (useVertices_) vertices_ = consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>( "vertices" ));
 
   useAnyMVA_ = false;
   forestLabel_ = "MVASelectorIter0";
@@ -199,18 +199,18 @@ void MultiTrackSelector::produce( edm::Event& evt, const edm::EventSetup& es )
 
   // Get tracks 
   Handle<TrackCollection> hSrcTrack;
-  evt.getByLabel( src_, hSrcTrack );
+  evt.getByToken( src_, hSrcTrack );
   const TrackCollection& srcTracks(*hSrcTrack);
 
   // looking for the beam spot
   edm::Handle<reco::BeamSpot> hBsp;
-  evt.getByLabel(beamspot_, hBsp);
+  evt.getByToken(beamspot_, hBsp);
   const reco::BeamSpot& vertexBeamSpot(*hBsp);
 
 	
   // Select good primary vertices for use in subsequent track selection
   edm::Handle<reco::VertexCollection> hVtx;
-  if (useVertices_) evt.getByLabel(vertices_, hVtx);
+  if (useVertices_) evt.getByToken(vertices_, hVtx);
 
   unsigned int trkSize=srcTracks.size();
   std::vector<int> selTracksSave( qualityToSet_.size()*trkSize,0);
@@ -469,7 +469,7 @@ void MultiTrackSelector::processMVA(edm::Event& evt, const edm::EventSetup& es)
 
   // Get tracks 
   Handle<TrackCollection> hSrcTrack;
-  evt.getByLabel( src_, hSrcTrack );
+  evt.getByToken( src_, hSrcTrack );
   const TrackCollection& srcTracks(*hSrcTrack);
 
   auto_ptr<edm::ValueMap<float> >mvaValValueMap = auto_ptr<edm::ValueMap<float> >(new edm::ValueMap<float>);

--- a/RecoTracker/FinalTrackSelectors/src/MultiTrackSelector.h
+++ b/RecoTracker/FinalTrackSelectors/src/MultiTrackSelector.h
@@ -66,12 +66,12 @@ namespace reco { namespace modules {
 	    void processMVA(edm::Event& evt, const edm::EventSetup& es);
 
             /// source collection label
-            edm::InputTag src_;
-            edm::InputTag beamspot_;
+            edm::EDGetTokenT<reco::TrackCollection> src_;
+            edm::EDGetTokenT<reco::BeamSpot> beamspot_;
             bool          useVertices_;
             bool          useVtxError_;
 	    bool          useAnyMVA_;
-            edm::InputTag vertices_;
+            edm::EDGetTokenT<reco::VertexCollection> vertices_;
             
             /// do I have to set a quality bit?
 	    std::vector<bool> setQualityBit_;

--- a/RecoTracker/FinalTrackSelectors/src/TrackListMerger.h
+++ b/RecoTracker/FinalTrackSelectors/src/TrackListMerger.h
@@ -30,6 +30,7 @@
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/ValueMap.h"
 
 namespace cms
 {
@@ -60,7 +61,31 @@ namespace cms
     bool copyExtras_;
     bool makeReKeyedSeeds_;
 
-    std::vector<edm::InputTag> trackProducers_;
+    struct TkEDGetTokenss  {
+        edm::InputTag tag;
+        edm::EDGetTokenT<reco::TrackCollection> tk;
+        edm::EDGetTokenT<std::vector<Trajectory> >        traj;
+        edm::EDGetTokenT<TrajTrackAssociationCollection > tass;
+        edm::EDGetTokenT<edm::ValueMap<int>   > tsel;
+        edm::EDGetTokenT<edm::ValueMap<float> > tmva;
+        TkEDGetTokenss() {}
+        TkEDGetTokenss(const edm::InputTag &tag_, edm::EDGetTokenT<reco::TrackCollection> && tk_, 
+                 edm::EDGetTokenT<std::vector<Trajectory> > && traj_, edm::EDGetTokenT<TrajTrackAssociationCollection > && tass_,
+                 edm::EDGetTokenT<edm::ValueMap<int> > &&tsel_, edm::EDGetTokenT<edm::ValueMap<float> > && tmva_) :
+            tag(tag_), tk(tk_), traj(traj_), tass(tass_), tsel(tsel_), tmva(tmva_) {}
+    };
+    TkEDGetTokenss edTokens(const edm::InputTag &tag, const edm::InputTag &seltag, const edm::InputTag &mvatag) {
+        return TkEDGetTokenss(tag, consumes<reco::TrackCollection>(tag), 
+                                consumes<std::vector<Trajectory> >(tag), consumes<TrajTrackAssociationCollection >(tag),
+                                consumes<edm::ValueMap<int> >(seltag), consumes<edm::ValueMap<float> >(mvatag));
+    }
+    TkEDGetTokenss edTokens(const edm::InputTag &tag, const edm::InputTag &mvatag) {
+        return TkEDGetTokenss(tag, consumes<reco::TrackCollection>(tag), 
+                                consumes<std::vector<Trajectory> >(tag), consumes<TrajTrackAssociationCollection >(tag),
+                                edm::EDGetTokenT<edm::ValueMap<int> >(), consumes<edm::ValueMap<float> >(mvatag));
+    }
+    std::vector<TkEDGetTokenss>      trackProducers_;
+
     double maxNormalizedChisq_;
     double minPT_;
     unsigned int minFound_;
@@ -73,8 +98,6 @@ namespace cms
     std::vector< std::vector< int> > listsToMerge_;
     std::vector<bool> promoteQuality_;
     std::vector<int> hasSelector_;
-    std::vector<edm::InputTag> selectors_;
-    std::vector<edm::InputTag> mvaStores_;
 
     bool allowFirstHitShare_;
     reco::TrackBase::TrackQuality qualityToSet_;

--- a/RecoTracker/IterativeTracking/interface/QualityFilter.h
+++ b/RecoTracker/IterativeTracking/interface/QualityFilter.h
@@ -6,6 +6,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 
 class QualityFilter : public edm::EDProducer {
  public:
@@ -19,7 +20,8 @@ class QualityFilter : public edm::EDProducer {
   // ----------member data ---------------------------
  private:
   
-  edm::InputTag tkTag; 
+  edm::EDGetTokenT<std::vector<Trajectory> >       trajTag; 
+  edm::EDGetTokenT<TrajTrackAssociationCollection> tassTag; 
   reco::TrackBase::TrackQuality trackQuality_;
   bool copyExtras_;  
 };

--- a/RecoTracker/IterativeTracking/src/QualityFilter.cc
+++ b/RecoTracker/IterativeTracking/src/QualityFilter.cc
@@ -26,7 +26,8 @@ QualityFilter::QualityFilter(const edm::ParameterSet& iConfig)
   produces<std::vector<Trajectory> >();
   produces<TrajTrackAssociationCollection>();
 
-  tkTag  = iConfig.getParameter<edm::InputTag>("recTracks");
+  trajTag = consumes<std::vector<Trajectory> >(iConfig.getParameter<edm::InputTag>("recTracks"));
+  tassTag = consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("recTracks"));
   trackQuality_=TrackBase::qualityByName(iConfig.getParameter<std::string>("TrackQuality"));
 }
 
@@ -67,8 +68,8 @@ QualityFilter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   Handle<std::vector<Trajectory> > TrajectoryCollection;
   Handle<TrajTrackAssociationCollection> assoMap;
   
-  iEvent.getByLabel(tkTag,TrajectoryCollection);
-  iEvent.getByLabel(tkTag,assoMap);
+  iEvent.getByToken(trajTag,TrajectoryCollection);
+  iEvent.getByToken(tassTag,assoMap);
 
 
 


### PR DESCRIPTION
getByToken migration in many tracking modules.

First set of tags, with no external dependencies

Notes:
- some modules not running in the default sequence have not been migrated
- the getByLabels done through the ClusterRemovalRefSetter have not been migrated, as to my knowledge they're obsolete, and they're not trivial to do (the tag is known only at runtime). A call to consumesMany<T> might be added if those are needed. 
