### PR TITLE
Tracking getByToken migration, part 1 (RecoTracker/CkfPattern and RecoTracker/DebugTools)

### DIFF
--- a/Alignment/KalmanAlignmentAlgorithm/src/KalmanAlignmentTrackRefitter.cc
+++ b/Alignment/KalmanAlignmentAlgorithm/src/KalmanAlignmentTrackRefitter.cc
@@ -30,8 +30,10 @@ KalmanAlignmentTrackRefitter::KalmanAlignmentTrackRefitter( const edm::Parameter
   theDebugFlag( config.getUntrackedParameter<bool>( "debug", true ) )
 {
   TrackProducerBase< reco::Track >::setConf( config );
-  TrackProducerBase< reco::Track >::setSrc( config.getParameter< edm::InputTag >( "src" ),
-					    config.getParameter< edm::InputTag >( "bsSrc" ) );
+  // --- GPetrucc: I can't understand where anything is read from the event, and who's the consumer.
+  //               If there is one anywhere, it should do the consumes<T> calls and pass that to the setSrc
+  //TrackProducerBase< reco::Track >::setSrc( consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>( "src" )), 
+  //                                          consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>( "beamSpot" )));
 }
 
 

--- a/RecoEgamma/EgammaPhotonProducers/src/TrackProducerWithSCAssociation.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/TrackProducerWithSCAssociation.cc
@@ -22,8 +22,8 @@ TrackProducerWithSCAssociation::TrackProducerWithSCAssociation(const edm::Parame
   theAlgo(iConfig)
 {
   setConf(iConfig);
-  setSrc( iConfig.getParameter<edm::InputTag>( "src" ), 
-  iConfig.getParameter<edm::InputTag>( "beamSpot" ));
+  setSrc( consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>( "src" )), 
+          consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>( "beamSpot" )));
   setAlias( iConfig.getParameter<std::string>( "@module_label" ) );
 
   if ( iConfig.exists("clusterRemovalInfo") ) {

--- a/RecoTracker/CkfPattern/interface/CkfTrackCandidateMaker.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrackCandidateMaker.h
@@ -24,7 +24,7 @@ class TransientInitialStateEstimator;
 
 namespace cms
 {
-  class CkfTrackCandidateMaker : public CkfTrackCandidateMakerBase, public edm::EDProducer
+  class CkfTrackCandidateMaker : public edm::EDProducer, public CkfTrackCandidateMakerBase
   {
   public:
 

--- a/RecoTracker/CkfPattern/interface/CkfTrackCandidateMaker.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrackCandidateMaker.h
@@ -29,7 +29,7 @@ namespace cms
   public:
 
     explicit CkfTrackCandidateMaker(const edm::ParameterSet& conf):
-      CkfTrackCandidateMakerBase(conf){
+      CkfTrackCandidateMakerBase(conf, consumesCollector()){
       produces<TrackCandidateCollection>();
     }
 

--- a/RecoTracker/CkfPattern/interface/CkfTrackCandidateMakerBase.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrackCandidateMakerBase.h
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -28,7 +29,7 @@ namespace cms
   class CkfTrackCandidateMakerBase  {
   public:
 
-    explicit CkfTrackCandidateMakerBase(const edm::ParameterSet& conf);
+    explicit CkfTrackCandidateMakerBase(const edm::ParameterSet& conf, edm::ConsumesCollector && iC);
 
     virtual ~CkfTrackCandidateMakerBase();
 
@@ -65,7 +66,7 @@ namespace cms
     
     RedundantSeedCleaner*  theSeedCleaner;
     
-    edm::InputTag theSeedLabel;
+    edm::EDGetTokenT<edm::View<TrajectorySeed> >  theSeedLabel;
 
     unsigned int maxSeedsBeforeCleaning_;
     // methods for debugging

--- a/RecoTracker/CkfPattern/interface/CkfTrajectoryMaker.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrajectoryMaker.h
@@ -24,7 +24,7 @@ class TransientInitialStateEstimator;
 
 namespace cms
 {
-  class CkfTrajectoryMaker : public CkfTrackCandidateMakerBase, public edm::EDProducer
+  class CkfTrajectoryMaker : public edm::EDProducer, public CkfTrackCandidateMakerBase
   {
   public:
     typedef std::vector<Trajectory> TrajectoryCollection;

--- a/RecoTracker/CkfPattern/interface/CkfTrajectoryMaker.h
+++ b/RecoTracker/CkfPattern/interface/CkfTrajectoryMaker.h
@@ -30,7 +30,7 @@ namespace cms
     typedef std::vector<Trajectory> TrajectoryCollection;
 
     explicit CkfTrajectoryMaker(const edm::ParameterSet& conf):
-      CkfTrackCandidateMakerBase(conf)
+      CkfTrackCandidateMakerBase(conf, consumesCollector())
     {
       theTrackCandidateOutput=conf.getParameter<bool>("trackCandidateAlso");
       theTrajectoryOutput=true;

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -41,7 +41,7 @@ using namespace edm;
 using namespace std;
 
 namespace cms{
-  CkfTrackCandidateMakerBase::CkfTrackCandidateMakerBase(edm::ParameterSet const& conf) : 
+  CkfTrackCandidateMakerBase::CkfTrackCandidateMakerBase(edm::ParameterSet const& conf, edm::ConsumesCollector && iC) : 
 
     conf_(conf),
     theTrackCandidateOutput(true),
@@ -66,7 +66,7 @@ namespace cms{
     //    if (!conf.exists("src"))
     //      theSeedLabel = InputTag(conf_.getParameter<std::string>("SeedProducer"),conf_.getParameter<std::string>("SeedLabel"));
     //    else
-      theSeedLabel= conf.getParameter<edm::InputTag>("src");
+      theSeedLabel= iC.consumes<edm::View<TrajectorySeed> >(conf.getParameter<edm::InputTag>("src"));
       if ( conf.exists("maxSeedsBeforeCleaning") ) 
 	   maxSeedsBeforeCleaning_=conf.getParameter<unsigned int>("maxSeedsBeforeCleaning");
 
@@ -157,7 +157,7 @@ namespace cms{
     // Step B: Retrieve seeds
     
     edm::Handle<View<TrajectorySeed> > collseed;
-    e.getByLabel(theSeedLabel, collseed);
+    e.getByToken(theSeedLabel, collseed);
     
     // Step C: Create empty output collection
     std::auto_ptr<TrackCandidateCollection> output(new TrackCandidateCollection);    

--- a/RecoTracker/DeDx/plugins/DeDxDiscriminatorLearner.cc
+++ b/RecoTracker/DeDx/plugins/DeDxDiscriminatorLearner.cc
@@ -35,8 +35,8 @@ using namespace edm;
 
 DeDxDiscriminatorLearner::DeDxDiscriminatorLearner(const edm::ParameterSet& iConfig) : ConditionDBWriter<PhysicsTools::Calibration::HistogramD3D>(iConfig)
 {
-   m_tracksTag                 = iConfig.getParameter<edm::InputTag>("tracks");
-   m_trajTrackAssociationTag   = iConfig.getParameter<edm::InputTag>("trajectoryTrackAssociation");
+   m_tracksTag                 = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
+   m_trajTrackAssociationTag   = consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("trajectoryTrackAssociation"));
 
    usePixel = iConfig.getParameter<bool>("UsePixel"); 
    useStrip = iConfig.getParameter<bool>("UseStrip");
@@ -137,11 +137,11 @@ void DeDxDiscriminatorLearner::algoAnalyze(const edm::Event& iEvent, const edm::
 
 
   Handle<TrajTrackAssociationCollection> trajTrackAssociationHandle;
-  iEvent.getByLabel(m_trajTrackAssociationTag, trajTrackAssociationHandle);
+  iEvent.getByToken(m_trajTrackAssociationTag, trajTrackAssociationHandle);
   const TrajTrackAssociationCollection TrajToTrackMap = *trajTrackAssociationHandle.product();
 
   edm::Handle<reco::TrackCollection> trackCollectionHandle;
-  iEvent.getByLabel(m_tracksTag,trackCollectionHandle);
+  iEvent.getByToken(m_tracksTag,trackCollectionHandle);
 
   unsigned track_index = 0;
   for(TrajTrackAssociationCollection::const_iterator it = TrajToTrackMap.begin(); it!=TrajToTrackMap.end(); ++it, track_index++) {

--- a/RecoTracker/DeDx/plugins/DeDxDiscriminatorLearner.h
+++ b/RecoTracker/DeDx/plugins/DeDxDiscriminatorLearner.h
@@ -47,8 +47,8 @@ private:
 
 
   // ----------member data ---------------------------
-  edm::InputTag                     m_trajTrackAssociationTag;
-  edm::InputTag                     m_tracksTag;
+  edm::EDGetTokenT<TrajTrackAssociationCollection>   m_trajTrackAssociationTag;
+  edm::EDGetTokenT<reco::TrackCollection>  m_tracksTag;
 
   bool   usePixel;
   bool   useStrip;

--- a/RecoTracker/DeDx/plugins/DeDxDiscriminatorLearnerFromCalibTree.h
+++ b/RecoTracker/DeDx/plugins/DeDxDiscriminatorLearnerFromCalibTree.h
@@ -50,8 +50,8 @@ private:
 
 
   // ----------member data ---------------------------
-  edm::InputTag                     m_trajTrackAssociationTag;
-  edm::InputTag                     m_tracksTag;
+  edm::EDGetTokenT<TrajTrackAssociationCollection>   m_trajTrackAssociationTag;
+  edm::EDGetTokenT<reco::TrackCollection>  m_tracksTag;
 
   bool   usePixel;
   bool   useStrip;

--- a/RecoTracker/DeDx/plugins/DeDxDiscriminatorProducer.cc
+++ b/RecoTracker/DeDx/plugins/DeDxDiscriminatorProducer.cc
@@ -51,8 +51,8 @@ DeDxDiscriminatorProducer::DeDxDiscriminatorProducer(const edm::ParameterSet& iC
 
    produces<ValueMap<DeDxData> >();
 
-   m_tracksTag = iConfig.getParameter<edm::InputTag>("tracks");
-   m_trajTrackAssociationTag   = iConfig.getParameter<edm::InputTag>("trajectoryTrackAssociation");
+   m_tracksTag                 = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
+   m_trajTrackAssociationTag   = consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("trajectoryTrackAssociation"));
 
    usePixel = iConfig.getParameter<bool>("UsePixel"); 
    useStrip = iConfig.getParameter<bool>("UseStrip");
@@ -231,11 +231,11 @@ void DeDxDiscriminatorProducer::produce(edm::Event& iEvent, const edm::EventSetu
   ValueMap<DeDxData>::Filler filler(*trackDeDxDiscrimAssociation);
 
   Handle<TrajTrackAssociationCollection> trajTrackAssociationHandle;
-  iEvent.getByLabel(m_trajTrackAssociationTag, trajTrackAssociationHandle);
+  iEvent.getByToken(m_trajTrackAssociationTag, trajTrackAssociationHandle);
   const TrajTrackAssociationCollection TrajToTrackMap = *trajTrackAssociationHandle.product();
 
   edm::Handle<reco::TrackCollection> trackCollectionHandle;
-  iEvent.getByLabel(m_tracksTag,trackCollectionHandle);
+  iEvent.getByToken(m_tracksTag,trackCollectionHandle);
 
    edm::ESHandle<TrackerGeometry> tkGeom;
    iSetup.get<TrackerDigiGeometryRecord>().get( tkGeom );

--- a/RecoTracker/DeDx/plugins/DeDxDiscriminatorProducer.h
+++ b/RecoTracker/DeDx/plugins/DeDxDiscriminatorProducer.h
@@ -65,8 +65,8 @@ private:
 
 
   // ----------member data ---------------------------
-  edm::InputTag                     m_trajTrackAssociationTag;
-  edm::InputTag                     m_tracksTag;
+  edm::EDGetTokenT<TrajTrackAssociationCollection>   m_trajTrackAssociationTag;
+  edm::EDGetTokenT<reco::TrackCollection>  m_tracksTag;
 
   bool usePixel;
   bool useStrip;

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
@@ -63,8 +63,8 @@ DeDxEstimatorProducer::DeDxEstimatorProducer(const edm::ParameterSet& iConfig)
    MaxNrStrips         = iConfig.getUntrackedParameter<unsigned>("maxNrStrips"        ,  255);
    MinTrackHits        = iConfig.getUntrackedParameter<unsigned>("MinTrackHits"       ,  4);
 
-   m_tracksTag = iConfig.getParameter<edm::InputTag>("tracks");
-   m_trajTrackAssociationTag   = iConfig.getParameter<edm::InputTag>("trajectoryTrackAssociation");
+   m_tracksTag = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
+   m_trajTrackAssociationTag   = consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("trajectoryTrackAssociation"));
 
    usePixel = iConfig.getParameter<bool>("UsePixel"); 
    useStrip = iConfig.getParameter<bool>("UseStrip");
@@ -138,11 +138,11 @@ void DeDxEstimatorProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
   ValueMap<DeDxData>::Filler filler(*trackDeDxEstimateAssociation);
 
   Handle<TrajTrackAssociationCollection> trajTrackAssociationHandle;
-  iEvent.getByLabel(m_trajTrackAssociationTag, trajTrackAssociationHandle);
+  iEvent.getByToken(m_trajTrackAssociationTag, trajTrackAssociationHandle);
   const TrajTrackAssociationCollection & TrajToTrackMap = *trajTrackAssociationHandle.product();
 
   edm::Handle<reco::TrackCollection> trackCollectionHandle;
-  iEvent.getByLabel(m_tracksTag,trackCollectionHandle);
+  iEvent.getByToken(m_tracksTag,trackCollectionHandle);
 
   size_t n =  TrajToTrackMap.size();
   std::vector<DeDxData> dedxEstimate(n);

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.h
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.h
@@ -21,6 +21,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 
 #include "TFile.h"
 #include "TChain.h"
@@ -50,8 +51,8 @@ private:
   // ----------member data ---------------------------
   BaseDeDxEstimator*                m_estimator;
 
-  edm::InputTag                     m_trajTrackAssociationTag;
-  edm::InputTag                     m_tracksTag;
+  edm::EDGetTokenT<TrajTrackAssociationCollection>   m_trajTrackAssociationTag;
+  edm::EDGetTokenT<reco::TrackCollection>  m_tracksTag;
 
   bool usePixel;
   bool useStrip;

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducerPixelTripplet.cc
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducerPixelTripplet.cc
@@ -58,8 +58,8 @@ DeDxEstimatorProducerPixelTripplet::DeDxEstimatorProducerPixelTripplet(const edm
    MaxNrStrips         = iConfig.getUntrackedParameter<unsigned>("maxNrStrips"        ,  255);
    MinTrackHits        = iConfig.getUntrackedParameter<unsigned>("MinTrackHits"       ,  4);
 
-   m_tracksTag = iConfig.getParameter<edm::InputTag>("tracks");
-   m_trajTrackAssociationTag   = iConfig.getParameter<edm::InputTag>("trajectoryTrackAssociation");
+   m_tracksTag = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
+   m_trajTrackAssociationTag   = consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("trajectoryTrackAssociation"));
 
    usePixel = iConfig.getParameter<bool>("UsePixel"); 
    useStrip = iConfig.getParameter<bool>("UseStrip");
@@ -137,7 +137,7 @@ void DeDxEstimatorProducerPixelTripplet::produce(edm::Event& iEvent, const edm::
   ValueMap<DeDxData>::Filler filler(*trackDeDxEstimateAssociation);
 
   Handle<TrackCollection> trackCollHandle;
-  iEvent.getByLabel(m_trajTrackAssociationTag, trackCollHandle);
+  iEvent.getByToken(m_trajTrackAssociationTag, trackCollHandle);
   const TrackCollection trackColl = *trackCollHandle.product();
 
   size_t n =  trackColl.size();

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducerPixelTripplet.h
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducerPixelTripplet.h
@@ -15,6 +15,7 @@
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h" 
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 
 #include <ext/hash_map>
 
@@ -48,8 +49,8 @@ private:
   // ----------member data ---------------------------
   BaseDeDxEstimator*                m_estimator;
 
-  edm::InputTag                     m_trajTrackAssociationTag;
-  edm::InputTag                     m_tracksTag;
+  edm::EDGetTokenT<TrajTrackAssociationCollection>   m_trajTrackAssociationTag;
+  edm::EDGetTokenT<reco::TrackCollection>  m_tracksTag;
 
   bool usePixel;
   bool useStrip;

--- a/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
+++ b/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
@@ -40,6 +40,8 @@ HLTDeDxFilter::HLTDeDxFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConf
   maxETA_       = iConfig.getParameter<double> ("maxETA");
   inputTracksTag_ = iConfig.getParameter< edm::InputTag > ("inputTracksTag");
   inputdedxTag_   = iConfig.getParameter< edm::InputTag > ("inputDeDxTag");
+  inputTracksToken_ = consumes<reco::TrackCollection>(iConfig.getParameter< edm::InputTag > ("inputTracksTag"));
+  inputdedxToken_   = consumes<edm::ValueMap<reco::DeDxData> >(iConfig.getParameter< edm::InputTag > ("inputDeDxTag"));
 
   thisModuleTag_ = edm::InputTag(iConfig.getParameter<std::string>("@module_label")); 
  
@@ -83,11 +85,11 @@ bool
   }
 
   edm::Handle<reco::TrackCollection> trackCollectionHandle;
-  iEvent.getByLabel(inputTracksTag_,trackCollectionHandle);
+  iEvent.getByToken(inputTracksToken_,trackCollectionHandle);
   reco::TrackCollection trackCollection = *trackCollectionHandle.product();
   
   edm::Handle<edm::ValueMap<reco::DeDxData> > dEdxTrackHandle;
-  iEvent.getByLabel(inputdedxTag_, dEdxTrackHandle);
+  iEvent.getByToken(inputdedxToken_, dEdxTrackHandle);
   const edm::ValueMap<reco::DeDxData> dEdxTrack = *dEdxTrackHandle.product();
 
   bool accept=false;

--- a/RecoTracker/DeDx/plugins/HLTDeDxFilter.h
+++ b/RecoTracker/DeDx/plugins/HLTDeDxFilter.h
@@ -8,6 +8,7 @@
  */
 
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 namespace edm {
    class ConfigurationDescriptions;
@@ -32,6 +33,8 @@ class HLTDeDxFilter : public HLTFilter {
       double minPT_;
       double minNOM_;
       double maxETA_;
+      edm::EDGetToken inputTracksToken_;
+      edm::EDGetToken inputdedxToken_;
       edm::InputTag inputTracksTag_;
       edm::InputTag inputdedxTag_;
       edm::InputTag thisModuleTag_;

--- a/RecoTracker/DebugTools/interface/CkfDebugTrackCandidateMaker.h
+++ b/RecoTracker/DebugTools/interface/CkfDebugTrackCandidateMaker.h
@@ -7,7 +7,7 @@
 #include "FWCore/Framework/interface/EDProducer.h"
 
 namespace cms {
-  class CkfDebugTrackCandidateMaker : public CkfTrackCandidateMakerBase, public edm::EDProducer {
+  class CkfDebugTrackCandidateMaker : public edm::EDProducer, public CkfTrackCandidateMakerBase {
   public:
     CkfDebugTrackCandidateMaker(const edm::ParameterSet& conf) : CkfTrackCandidateMakerBase(conf, consumesCollector()) {
       produces<TrackCandidateCollection>();

--- a/RecoTracker/DebugTools/interface/CkfDebugTrackCandidateMaker.h
+++ b/RecoTracker/DebugTools/interface/CkfDebugTrackCandidateMaker.h
@@ -9,7 +9,7 @@
 namespace cms {
   class CkfDebugTrackCandidateMaker : public CkfTrackCandidateMakerBase, public edm::EDProducer {
   public:
-    CkfDebugTrackCandidateMaker(const edm::ParameterSet& conf) : CkfTrackCandidateMakerBase(conf) {
+    CkfDebugTrackCandidateMaker(const edm::ParameterSet& conf) : CkfTrackCandidateMakerBase(conf, consumesCollector()) {
       produces<TrackCandidateCollection>();
     }
 

--- a/RecoTracker/FinalTrackSelectors/interface/AnalyticalTrackSelector.h
+++ b/RecoTracker/FinalTrackSelectors/interface/AnalyticalTrackSelector.h
@@ -58,6 +58,9 @@ namespace reco { namespace modules {
             /// eta restrictions
             double minEta_;
 	    double maxEta_;
+
+            edm::EDGetTokenT<std::vector<Trajectory> >        srcTraj_;
+            edm::EDGetTokenT<TrajTrackAssociationCollection > srcTass_;
 			
             /// storage
             std::auto_ptr<reco::TrackCollection> selTracks_;

--- a/RecoTracker/FinalTrackSelectors/interface/CosmicTrackSelector.h
+++ b/RecoTracker/FinalTrackSelectors/interface/CosmicTrackSelector.h
@@ -49,12 +49,14 @@ namespace reco { namespace modules {
 		     // return class, or -1 if rejected
 		     bool select (const reco::BeamSpot &vertexBeamSpot, const reco::Track &tk);
 		     // source collection label
-		     edm::InputTag src_;
-		     edm::InputTag beamspot_;
+                     edm::EDGetTokenT<reco::TrackCollection> src_;
+                     edm::EDGetTokenT<reco::BeamSpot> beamspot_;
 		     // copy only the tracks, not extras and rechits (for AOD)
 		     bool copyExtras_;
 		     // copy also trajectories and trajectory->track associations
 		     bool copyTrajectories_;
+                     edm::EDGetTokenT<std::vector<Trajectory> >        srcTraj_;
+                     edm::EDGetTokenT<TrajTrackAssociationCollection > srcTass_;
 		     
 		     // save all the tracks
 		     bool keepAllTracks_;

--- a/RecoTracker/FinalTrackSelectors/interface/DuplicateListMerger.h
+++ b/RecoTracker/FinalTrackSelectors/interface/DuplicateListMerger.h
@@ -25,6 +25,7 @@
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
+#include "DataFormats/Common/interface/ValueMap.h"
 #include <vector>
 #include <algorithm>
 #include <string>
@@ -56,12 +57,25 @@ namespace reco { namespace modules {
 	 }
 
 	 /// track input collection
-	 edm::InputTag mergedTrackSource_;
-	 edm::InputTag originalTrackSource_;
-	 edm::InputTag candidateSource_;
+         struct ThreeTokens {
+            edm::InputTag tag;
+            edm::EDGetTokenT<reco::TrackCollection> tk;
+            edm::EDGetTokenT<std::vector<Trajectory> >        traj;
+            edm::EDGetTokenT<TrajTrackAssociationCollection > tass;
+            ThreeTokens() {}
+            ThreeTokens(const edm::InputTag &tag_, edm::EDGetTokenT<reco::TrackCollection> && tk_, edm::EDGetTokenT<std::vector<Trajectory> > && traj_, edm::EDGetTokenT<TrajTrackAssociationCollection > && tass_) :
+                tag(tag_), tk(tk_), traj(traj_), tass(tass_) {}
+         };
+         ThreeTokens threeTokens(const edm::InputTag &tag) {
+            return ThreeTokens(tag, consumes<reco::TrackCollection>(tag), consumes<std::vector<Trajectory> >(tag), consumes<TrajTrackAssociationCollection >(tag));
+         }
+         ThreeTokens mergedTrackSource_, originalTrackSource_;
+         edm::EDGetTokenT<edm::View<DuplicateRecord> > candidateSource_;
 
-	 edm::InputTag originalMVAVals_;
-	 edm::InputTag mergedMVAVals_;
+         edm::InputTag originalMVAVals_;
+         edm::InputTag mergedMVAVals_;
+         edm::EDGetTokenT<edm::ValueMap<float> > originalMVAValsToken_;
+         edm::EDGetTokenT<edm::ValueMap<float> > mergedMVAValsToken_;
 
 	 reco::TrackBase::TrackQuality qualityToSet_;
 	 unsigned int diffHitsCut_;

--- a/RecoTracker/FinalTrackSelectors/interface/DuplicateTrackMerger.h
+++ b/RecoTracker/FinalTrackSelectors/interface/DuplicateTrackMerger.h
@@ -62,7 +62,7 @@ namespace reco { namespace modules {
 	 float* gbrVals_;
 
 	 /// track input collection
-	 edm::InputTag trackSource_;
+	 edm::EDGetTokenT<reco::TrackCollection> trackSource_;
 	 /// MVA weights file
 	 std::string dbFileName_;
 	 bool useForestFromDB_;

--- a/RecoTracker/FinalTrackSelectors/src/DuplicateTrackMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/src/DuplicateTrackMerger.cc
@@ -36,7 +36,7 @@ DuplicateTrackMerger::DuplicateTrackMerger(const edm::ParameterSet& iPara) : mer
   if(iPara.exists("maxDdsz"))maxDdsz_ = iPara.getParameter<double>("maxDdsz");
   if(iPara.exists("maxDdxy"))maxDdxy_ = iPara.getParameter<double>("maxDdxy");
   if(iPara.exists("maxDQoP"))maxDQoP_ = iPara.getParameter<double>("maxDQoP");
-  if(iPara.exists("source"))trackSource_ = iPara.getParameter<edm::InputTag>("source");
+  if(iPara.exists("source"))trackSource_ = consumes<reco::TrackCollection>(iPara.getParameter<edm::InputTag>("source"));
   if(iPara.exists("minDeltaR3d"))minDeltaR3d_ = iPara.getParameter<double>("minDeltaR3d");
   if(iPara.exists("minBDTG"))minBDTG_ = iPara.getParameter<double>("minBDTG");
 
@@ -95,7 +95,7 @@ void DuplicateTrackMerger::produce(edm::Event& iEvent, const edm::EventSetup& iS
 
   //edm::Handle<edm::View<reco::Track> >handle;
   edm::Handle<reco::TrackCollection >handle;
-  iEvent.getByLabel(trackSource_,handle);
+  iEvent.getByToken(trackSource_,handle);
   reco::TrackRefProd refTrks(handle);
 
   iSetup.get<IdealMagneticFieldRecord>().get(magfield_);

--- a/RecoTracker/FinalTrackSelectors/src/MultiTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/src/MultiTrackSelector.cc
@@ -21,13 +21,13 @@ MultiTrackSelector::MultiTrackSelector()
 }
 
 MultiTrackSelector::MultiTrackSelector( const edm::ParameterSet & cfg ) :
-  src_( cfg.getParameter<edm::InputTag>( "src" ) ),
-  beamspot_( cfg.getParameter<edm::InputTag>( "beamspot" ) ),
+  src_( consumes<reco::TrackCollection>( cfg.getParameter<edm::InputTag>( "src" ) ) ),
+  beamspot_( consumes<reco::BeamSpot>( cfg.getParameter<edm::InputTag>( "beamspot" ) ) ),
   useVertices_( cfg.getParameter<bool>( "useVertices" ) ),
-  useVtxError_( cfg.getParameter<bool>( "useVtxError" ) ),
-  vertices_( useVertices_ ? cfg.getParameter<edm::InputTag>( "vertices" ) : edm::InputTag("NONE"))
+  useVtxError_( cfg.getParameter<bool>( "useVtxError" ) )
   // now get the pset for each selector
 {
+  if (useVertices_) vertices_ = consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>( "vertices" ));
 
   useAnyMVA_ = false;
   forestLabel_ = "MVASelectorIter0";
@@ -199,18 +199,18 @@ void MultiTrackSelector::produce( edm::Event& evt, const edm::EventSetup& es )
 
   // Get tracks 
   Handle<TrackCollection> hSrcTrack;
-  evt.getByLabel( src_, hSrcTrack );
+  evt.getByToken( src_, hSrcTrack );
   const TrackCollection& srcTracks(*hSrcTrack);
 
   // looking for the beam spot
   edm::Handle<reco::BeamSpot> hBsp;
-  evt.getByLabel(beamspot_, hBsp);
+  evt.getByToken(beamspot_, hBsp);
   const reco::BeamSpot& vertexBeamSpot(*hBsp);
 
 	
   // Select good primary vertices for use in subsequent track selection
   edm::Handle<reco::VertexCollection> hVtx;
-  if (useVertices_) evt.getByLabel(vertices_, hVtx);
+  if (useVertices_) evt.getByToken(vertices_, hVtx);
 
   unsigned int trkSize=srcTracks.size();
   std::vector<int> selTracksSave( qualityToSet_.size()*trkSize,0);
@@ -469,7 +469,7 @@ void MultiTrackSelector::processMVA(edm::Event& evt, const edm::EventSetup& es)
 
   // Get tracks 
   Handle<TrackCollection> hSrcTrack;
-  evt.getByLabel( src_, hSrcTrack );
+  evt.getByToken( src_, hSrcTrack );
   const TrackCollection& srcTracks(*hSrcTrack);
 
   auto_ptr<edm::ValueMap<float> >mvaValValueMap = auto_ptr<edm::ValueMap<float> >(new edm::ValueMap<float>);

--- a/RecoTracker/FinalTrackSelectors/src/MultiTrackSelector.h
+++ b/RecoTracker/FinalTrackSelectors/src/MultiTrackSelector.h
@@ -66,12 +66,12 @@ namespace reco { namespace modules {
 	    void processMVA(edm::Event& evt, const edm::EventSetup& es);
 
             /// source collection label
-            edm::InputTag src_;
-            edm::InputTag beamspot_;
+            edm::EDGetTokenT<reco::TrackCollection> src_;
+            edm::EDGetTokenT<reco::BeamSpot> beamspot_;
             bool          useVertices_;
             bool          useVtxError_;
 	    bool          useAnyMVA_;
-            edm::InputTag vertices_;
+            edm::EDGetTokenT<reco::VertexCollection> vertices_;
             
             /// do I have to set a quality bit?
 	    std::vector<bool> setQualityBit_;

--- a/RecoTracker/FinalTrackSelectors/src/TrackListMerger.h
+++ b/RecoTracker/FinalTrackSelectors/src/TrackListMerger.h
@@ -30,6 +30,7 @@
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/Common/interface/ValueMap.h"
 
 namespace cms
 {
@@ -60,7 +61,31 @@ namespace cms
     bool copyExtras_;
     bool makeReKeyedSeeds_;
 
-    std::vector<edm::InputTag> trackProducers_;
+    struct TkEDGetTokenss  {
+        edm::InputTag tag;
+        edm::EDGetTokenT<reco::TrackCollection> tk;
+        edm::EDGetTokenT<std::vector<Trajectory> >        traj;
+        edm::EDGetTokenT<TrajTrackAssociationCollection > tass;
+        edm::EDGetTokenT<edm::ValueMap<int>   > tsel;
+        edm::EDGetTokenT<edm::ValueMap<float> > tmva;
+        TkEDGetTokenss() {}
+        TkEDGetTokenss(const edm::InputTag &tag_, edm::EDGetTokenT<reco::TrackCollection> && tk_, 
+                 edm::EDGetTokenT<std::vector<Trajectory> > && traj_, edm::EDGetTokenT<TrajTrackAssociationCollection > && tass_,
+                 edm::EDGetTokenT<edm::ValueMap<int> > &&tsel_, edm::EDGetTokenT<edm::ValueMap<float> > && tmva_) :
+            tag(tag_), tk(tk_), traj(traj_), tass(tass_), tsel(tsel_), tmva(tmva_) {}
+    };
+    TkEDGetTokenss edTokens(const edm::InputTag &tag, const edm::InputTag &seltag, const edm::InputTag &mvatag) {
+        return TkEDGetTokenss(tag, consumes<reco::TrackCollection>(tag), 
+                                consumes<std::vector<Trajectory> >(tag), consumes<TrajTrackAssociationCollection >(tag),
+                                consumes<edm::ValueMap<int> >(seltag), consumes<edm::ValueMap<float> >(mvatag));
+    }
+    TkEDGetTokenss edTokens(const edm::InputTag &tag, const edm::InputTag &mvatag) {
+        return TkEDGetTokenss(tag, consumes<reco::TrackCollection>(tag), 
+                                consumes<std::vector<Trajectory> >(tag), consumes<TrajTrackAssociationCollection >(tag),
+                                edm::EDGetTokenT<edm::ValueMap<int> >(), consumes<edm::ValueMap<float> >(mvatag));
+    }
+    std::vector<TkEDGetTokenss>      trackProducers_;
+
     double maxNormalizedChisq_;
     double minPT_;
     unsigned int minFound_;
@@ -73,8 +98,6 @@ namespace cms
     std::vector< std::vector< int> > listsToMerge_;
     std::vector<bool> promoteQuality_;
     std::vector<int> hasSelector_;
-    std::vector<edm::InputTag> selectors_;
-    std::vector<edm::InputTag> mvaStores_;
 
     bool allowFirstHitShare_;
     reco::TrackBase::TrackQuality qualityToSet_;

--- a/RecoTracker/IterativeTracking/interface/QualityFilter.h
+++ b/RecoTracker/IterativeTracking/interface/QualityFilter.h
@@ -6,6 +6,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 
 class QualityFilter : public edm::EDProducer {
  public:
@@ -19,7 +20,8 @@ class QualityFilter : public edm::EDProducer {
   // ----------member data ---------------------------
  private:
   
-  edm::InputTag tkTag; 
+  edm::EDGetTokenT<std::vector<Trajectory> >       trajTag; 
+  edm::EDGetTokenT<TrajTrackAssociationCollection> tassTag; 
   reco::TrackBase::TrackQuality trackQuality_;
   bool copyExtras_;  
 };

--- a/RecoTracker/IterativeTracking/src/QualityFilter.cc
+++ b/RecoTracker/IterativeTracking/src/QualityFilter.cc
@@ -26,7 +26,8 @@ QualityFilter::QualityFilter(const edm::ParameterSet& iConfig)
   produces<std::vector<Trajectory> >();
   produces<TrajTrackAssociationCollection>();
 
-  tkTag  = iConfig.getParameter<edm::InputTag>("recTracks");
+  trajTag = consumes<std::vector<Trajectory> >(iConfig.getParameter<edm::InputTag>("recTracks"));
+  tassTag = consumes<TrajTrackAssociationCollection>(iConfig.getParameter<edm::InputTag>("recTracks"));
   trackQuality_=TrackBase::qualityByName(iConfig.getParameter<std::string>("TrackQuality"));
 }
 
@@ -67,8 +68,8 @@ QualityFilter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   Handle<std::vector<Trajectory> > TrajectoryCollection;
   Handle<TrajTrackAssociationCollection> assoMap;
   
-  iEvent.getByLabel(tkTag,TrajectoryCollection);
-  iEvent.getByLabel(tkTag,assoMap);
+  iEvent.getByToken(trajTag,TrajectoryCollection);
+  iEvent.getByToken(tassTag,assoMap);
 
 
 

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.h
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.h
@@ -69,7 +69,7 @@ public:
   void setConf(const edm::ParameterSet& conf){conf_=conf;}
 
   /// set label of source collection
-  void setSrc(const edm::InputTag& src, const edm::InputTag& bsSrc){src_=src;bsSrc_=bsSrc;}
+  void setSrc(const edm::EDGetToken& src, const edm::EDGetTokenT<reco::BeamSpot>& bsSrc){src_=src;bsSrc_=bsSrc;}
 
   /// set the aliases of produced collections
   void setAlias(std::string alias){
@@ -89,12 +89,12 @@ public:
   const edm::ParameterSet& getConf() const {return conf_;}
  private:
   edm::ParameterSet conf_;
-  edm::InputTag src_;
+  edm::EDGetToken src_;
  protected:
   std::string alias_;
   bool trajectoryInEvent_;
   edm::OrphanHandle<TrackCollection> rTracks_;
-  edm::InputTag bsSrc_;
+  edm::EDGetTokenT<reco::BeamSpot> bsSrc_;
 
   bool rekeyClusterRefs_;
   edm::InputTag clusterRemovalInfo_;

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
@@ -105,11 +105,11 @@ TrackProducerBase<T>::getFromEvt(edm::Event& theEvent,edm::Handle<TrackCandidate
   //
   LogDebug("TrackProducer") << 
     "get the TrackCandidateCollection from the event, source is " << src_<<"\n";
-    theEvent.getByLabel(src_,theTCCollection );  
+    theEvent.getByToken(src_,theTCCollection );  
 
   //get the BeamSpot
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-  theEvent.getByLabel(bsSrc_,recoBeamSpotHandle);
+  theEvent.getByToken(bsSrc_,recoBeamSpotHandle);
   bs = *recoBeamSpotHandle;
 }
 
@@ -121,11 +121,11 @@ TrackProducerBase<T>::getFromEvt(edm::Event& theEvent,edm::Handle<TrackCollectio
   //
   LogDebug("TrackProducer") << 
     "get the TrackCollection from the event, source is " << src_<<"\n";
-    theEvent.getByLabel(src_,theTCollection );  
+    theEvent.getByToken(src_,theTCollection );  
 
   //get the BeamSpot
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-  theEvent.getByLabel(bsSrc_,recoBeamSpotHandle);
+  theEvent.getByToken(bsSrc_,recoBeamSpotHandle);
   bs = *recoBeamSpotHandle;
 }
 

--- a/RecoTracker/TrackProducer/plugins/GsfTrackProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackProducer.cc
@@ -21,7 +21,8 @@ GsfTrackProducer::GsfTrackProducer(const edm::ParameterSet& iConfig):
   theAlgo(iConfig)
 {
   setConf(iConfig);
-  setSrc( iConfig.getParameter<edm::InputTag>( "src" ), iConfig.getParameter<edm::InputTag>( "beamSpot" ));
+  setSrc( consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>( "src" )), 
+          consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>( "beamSpot" )));
   setAlias( iConfig.getParameter<std::string>( "@module_label" ) );
 //   string a = alias_;
 //   a.erase(a.size()-6,a.size());

--- a/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.cc
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.cc
@@ -18,7 +18,8 @@ GsfTrackRefitter::GsfTrackRefitter(const edm::ParameterSet& iConfig):
   theAlgo(iConfig)
 {
   setConf(iConfig);
-  setSrc( iConfig.getParameter<edm::InputTag>( "src" ), iConfig.getParameter<edm::InputTag>( "beamSpot" ));
+  setSrc( consumes<reco::GsfTrackCollection>(iConfig.getParameter<edm::InputTag>( "src" )), 
+          consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>( "beamSpot" )));
   setAlias( iConfig.getParameter<std::string>( "@module_label" ) );
   std::string  constraint_str = iConfig.getParameter<std::string>( "constraint" );
 
@@ -26,7 +27,7 @@ GsfTrackRefitter::GsfTrackRefitter(const edm::ParameterSet& iConfig):
 //   else if (constraint_str == "momentum") constraint_ = momentum;
   else if (constraint_str == "vertex") {
     constraint_ = vertex;
-    gsfTrackVtxConstraintTag_ = iConfig.getParameter<edm::InputTag>("gsfTrackVtxConstraintTag");
+    gsfTrackVtxConstraintTag_ = consumes<GsfTrackVtxConstraintAssociationCollection>(iConfig.getParameter<edm::InputTag>("gsfTrackVtxConstraintTag"));
   } else {
     edm::LogError("GsfTrackRefitter")<<"constraint: "<<constraint_str<<" not understood. Set it to 'momentum', 'vertex' or leave it empty";    
     throw cms::Exception("GsfTrackRefitter") << "unknown type of contraint! Set it to 'momentum', 'vertex' or leave it empty";    
@@ -89,9 +90,9 @@ void GsfTrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setu
   case vertex :
     {
       edm::Handle<GsfTrackVtxConstraintAssociationCollection> theTCollectionWithConstraint;
-      theEvent.getByLabel(gsfTrackVtxConstraintTag_, theTCollectionWithConstraint);
+      theEvent.getByToken(gsfTrackVtxConstraintTag_, theTCollectionWithConstraint);
       edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-      theEvent.getByLabel(bsSrc_,recoBeamSpotHandle);
+      theEvent.getByToken(bsSrc_,recoBeamSpotHandle);
       bs = *recoBeamSpotHandle;      
       if (theTCollectionWithConstraint.failedToGet()){
 	edm::LogError("TrackRefitter")<<"could not get TrackVtxConstraintAssociationCollection product."; break;}

--- a/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.h
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.h
@@ -8,6 +8,7 @@
 #include "RecoTracker/TrackProducer/interface/GsfTrackProducerBase.h"
 #include "RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "TrackingTools/GsfTracking/interface/GsfTrackConstraintAssociation.h"
 
 class GsfTrackRefitter : public GsfTrackProducerBase, public edm::EDProducer {
 public:
@@ -24,7 +25,7 @@ private:
 // 		    momentum, 
 		    vertex };
   Constraint constraint_;
-  edm::InputTag gsfTrackVtxConstraintTag_;
+  edm::EDGetTokenT<GsfTrackVtxConstraintAssociationCollection> gsfTrackVtxConstraintTag_;
 };
 
 #endif

--- a/RecoTracker/TrackProducer/plugins/TrackProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackProducer.cc
@@ -18,7 +18,8 @@ TrackProducer::TrackProducer(const edm::ParameterSet& iConfig):
   theAlgo(iConfig)
 {
   setConf(iConfig);
-  setSrc( iConfig.getParameter<edm::InputTag>( "src" ), iConfig.getParameter<edm::InputTag>( "beamSpot" ));
+  setSrc( consumes<TrackCandidateCollection>(iConfig.getParameter<edm::InputTag>( "src" )), 
+          consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>( "beamSpot" )));
   setAlias( iConfig.getParameter<std::string>( "@module_label" ) );
 
   if ( iConfig.exists("clusterRemovalInfo") ) {

--- a/RecoTracker/TrackProducer/plugins/TrackRefitter.h
+++ b/RecoTracker/TrackProducer/plugins/TrackRefitter.h
@@ -25,7 +25,7 @@ private:
   TrackProducerAlgorithm<reco::Track> theAlgo;
   enum Constraint { none, momentum, vertex, trackParameters };
   Constraint constraint_;
-  edm::InputTag trkconstrcoll_;
+  edm::EDGetToken trkconstrcoll_;
 
 };
 


### PR DESCRIPTION
Migration also of CkfPattern, on top of 555
Notes:
- the data access through the MeasurementTracker is not yet migrated (requires a major redesign of the MT class)
- some non-production code in DebugTools has not been migrated, will do later
