### PR TITLE
Utilities static analyzer update

### DIFF
--- a/Utilities/StaticAnalyzers/src/ClassChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ClassChecker.cpp
@@ -171,6 +171,24 @@ if (BO->isAssignmentOp()) {
 		} else
 	if (clang::MemberExpr * ME = dyn_cast<clang::MemberExpr>(BO->getLHS())){
 			if (ME->isImplicitAccess()) ReportMember(ME);
+		} else
+	if (clang::UnaryOperator * UO = llvm::dyn_cast<clang::UnaryOperator>(BO->getLHS()->IgnoreParenImpCasts()) ) {
+		if (UO->getOpcode() == clang::UnaryOperatorKind::UO_Deref) {
+			if (clang::MemberExpr * ME = dyn_cast<clang::MemberExpr>(UO->getSubExpr()->IgnoreParenImpCasts())){
+				if (ME->isImplicitAccess()) ReportMember(ME);
+				}
+			if (clang::DeclRefExpr * DRE =dyn_cast<clang::DeclRefExpr>(UO->getSubExpr()->IgnoreParenImpCasts())){
+				if (const clang::VarDecl * D = llvm::dyn_cast<clang::VarDecl>(DRE->getDecl())) {
+					clang::QualType t =  D->getType();
+					const clang::Expr * E = llvm::dyn_cast<clang::Expr>(D->getInit());
+					if (E && t->isPointerType() ) {
+						const clang::MemberExpr * ME = dyn_cast<clang::MemberExpr>(E->IgnoreParenImpCasts());
+						if (ME && ME->isImplicitAccess()) ReportMember(ME);
+						}	
+						
+					} 		
+				}
+			}
 		}
 	}
 }

--- a/Utilities/StaticAnalyzers/test/class_checker.cpp
+++ b/Utilities/StaticAnalyzers/test/class_checker.cpp
@@ -9,7 +9,38 @@ static int const* g_ptr_staticConst = &g_staticConst;
 static int g_static;
 static int * g_ptr_static = &g_static;
 
+class ClassTest {
+   public:
+      explicit ClassTest();
+      ~ClassTest();
 
+void testConst() const;
+
+   private:
+
+      mutable int m_testMutable;
+      int * m_testPointer;
+      int m_testInteger;
+
+};
+
+void
+ClassTest::testConst() const
+{
+    // 1) reported by class checker
+    m_testMutable = 23;
+
+    // 2) compiles, not reported
+    (*m_testPointer) = 23;
+
+    // 3) compiles, not reported
+    int * localPtr = m_testPointer;
+    (*localPtr) = 23;
+
+    // 4) will not compile
+    // error: invalid conversion from 'const int*' to 'int*'
+    //int * localPtrToInt = &m_testInteger;
+} 
 
 class Foo
 {


### PR DESCRIPTION
Add a check for the case where member data is modified through a derefenced pointer in a const function.
