### PR TITLE
Fixes to cms ewk 11 021

### DIFF
--- a/GeneratorInterface/RivetInterface/data/CMS_EWK_11_021.aida
+++ b/GeneratorInterface/RivetInterface/data/CMS_EWK_11_021.aida
@@ -1027,10 +1027,6 @@
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
       <item key="AidaPath" value="/REF/thrust_inclusive" sticky="true"/>
     </annotation>
-        <dataPoint>
-      <measurement errorPlus="3.187500e-01" value="-1.406875e+01" errorMinus="3.187500e-01"/>
-      <measurement errorPlus="1.900000e-03" value="1.390000e-02" errorMinus="1.900000e-03"/>
-    </dataPoint>
     <dataPoint>
       <measurement errorPlus="3.187500e-01" value="-1.343125e+01" errorMinus="3.187500e-01"/>
       <measurement errorPlus="6.500000e-04" value="5.420000e-03" errorMinus="6.500000e-04"/>
@@ -1119,10 +1115,6 @@
       <item key="AidaPath" value="/REF/d10-x01-y01" sticky="true"/>
     </annotation>
     <dataPoint>
-      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
-      <measurement value="6.248654e-04" errorPlus="1.877970e-04" errorMinus="1.877970e-04"/>
-    </dataPoint>
-    <dataPoint>
       <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
       <measurement value="3.248128e-03" errorPlus="8.562022e-04" errorMinus="8.562022e-04"/>
     </dataPoint>
@@ -1165,10 +1157,6 @@
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
       <item key="AidaPath" value="/REF/d11-x01-y01" sticky="true"/>
     </annotation>
-    <dataPoint>
-      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
-      <measurement value="1.922091e-03" errorPlus="5.364213e-04" errorMinus="5.364213e-04"/>
-    </dataPoint>
     <dataPoint>
       <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
       <measurement value="7.439200e-03" errorPlus="1.979564e-03" errorMinus="1.979564e-03"/>
@@ -1213,10 +1201,6 @@
       <item key="AidaPath" value="/REF/ZJ2_3j_boosted" sticky="true"/>
     </annotation>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.107080e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.306794e-02" value="2.439245e-01" errorMinus="5.306794e-02"/>
-    </dataPoint>
-    <dataPoint>
       <measurement errorPlus="1.070800e-01" value="1.321240e+00" errorMinus="1.070800e-01"/>
       <measurement errorPlus="3.697542e-02" value="2.203887e-01" errorMinus="3.697542e-02"/>
     </dataPoint>
@@ -1259,11 +1243,6 @@
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
       <item key="AidaPath" value="/REF/ZJ0_3j_boosted" sticky="true"/>
     </annotation>
-    
-    <dataPoint>
-      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
-      <measurement value="2.678993e-03" errorPlus="1.252005e-03" errorMinus="1.252005e-03"/>
-    </dataPoint>
     <dataPoint>
       <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
       <measurement value="2.338446e-02" errorPlus="1.019354e-02" errorMinus="1.019354e-02"/>
@@ -1308,10 +1287,6 @@
       <item key="AidaPath" value="/REF/ZJ1_3j_boosted" sticky="true"/>
     </annotation>
     <dataPoint>
-      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
-      <measurement value="2.636743e-01" errorPlus="4.656380e-02" errorMinus="4.656380e-02"/>
-    </dataPoint>
-    <dataPoint>
       <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
       <measurement value="3.345433e-01" errorPlus="4.579215e-02" errorMinus="4.579215e-02"/>
     </dataPoint>
@@ -1354,10 +1329,6 @@
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
       <item key="AidaPath" value="/REF/J1J2_3j_boosted" sticky="true"/>
     </annotation>
-    <dataPoint>
-      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
-      <measurement value="4.291077e-01" errorPlus="6.868231e-02" errorMinus="6.868231e-02"/>
-    </dataPoint>
     <dataPoint>
       <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
       <measurement value="3.457126e-01" errorPlus="4.855760e-02" errorMinus="4.855760e-02"/>
@@ -1402,10 +1373,6 @@
       <item key="AidaPath" value="/REF/J1J3_3j_boosted" sticky="true"/>
     </annotation>  
     <dataPoint>
-      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
-      <measurement value="4.646603e-01" errorPlus="8.810881e-02" errorMinus="8.810881e-02"/>
-    </dataPoint>
-    <dataPoint>
       <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
       <measurement value="4.562352e-01" errorPlus="6.118763e-02" errorMinus="6.118763e-02"/>
     </dataPoint>
@@ -1448,11 +1415,6 @@
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
       <item key="AidaPath" value="/REF/J2J3_3j_boosted" sticky="true"/>
     </annotation>
-    
-    <dataPoint>
-      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
-      <measurement value="4.614759e-01" errorPlus="6.810186e-02" errorMinus="6.810186e-02"/>
-    </dataPoint>
     <dataPoint>
       <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
       <measurement value="4.410187e-01" errorPlus="5.255285e-02" errorMinus="5.255285e-02"/>
@@ -1496,10 +1458,6 @@
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
       <item key="AidaPath" value="/REF/thrust_boosted" sticky="true"/>
     </annotation>
-    <dataPoint>
-      <measurement errorPlus="3.984500e-01" value="-1.414845e+01" errorMinus="3.984500e-01"/>
-      <measurement errorPlus="4.700000e-03" value="2.080000e-02" errorMinus="4.700000e-03"/>
-    </dataPoint>
     <dataPoint>
       <measurement errorPlus="3.984500e-01" value="-1.335155e+01" errorMinus="3.984500e-01"/>
       <measurement errorPlus="1.600000e-03" value="9.650000e-03" errorMinus="1.600000e-03"/>

--- a/GeneratorInterface/RivetInterface/data/CMS_EWK_11_021.aida
+++ b/GeneratorInterface/RivetInterface/data/CMS_EWK_11_021.aida
@@ -1115,6 +1115,10 @@
       <item key="AidaPath" value="/REF/d10-x01-y01" sticky="true"/>
     </annotation>
     <dataPoint>
+      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="6.248654e-04" errorPlus="1.0e10" errorMinus="1.0e10"/>
+    </dataPoint>
+    <dataPoint>
       <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
       <measurement value="3.248128e-03" errorPlus="8.562022e-04" errorMinus="8.562022e-04"/>
     </dataPoint>
@@ -1157,6 +1161,10 @@
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
       <item key="AidaPath" value="/REF/d11-x01-y01" sticky="true"/>
     </annotation>
+    <dataPoint>
+      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="1.922091e-03" errorPlus="1.0e10" errorMinus="1.0e10"/>
+    </dataPoint>
     <dataPoint>
       <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
       <measurement value="7.439200e-03" errorPlus="1.979564e-03" errorMinus="1.979564e-03"/>
@@ -1201,6 +1209,10 @@
       <item key="AidaPath" value="/REF/ZJ2_3j_boosted" sticky="true"/>
     </annotation>
     <dataPoint>
+      <measurement errorPlus="1.070800e-01" value="1.107080e+00" errorMinus="1.070800e-01"/>
+      <measurement errorPlus="1.0e10" value="2.439245e-01" errorMinus="1.0e10"/>
+    </dataPoint>
+    <dataPoint>
       <measurement errorPlus="1.070800e-01" value="1.321240e+00" errorMinus="1.070800e-01"/>
       <measurement errorPlus="3.697542e-02" value="2.203887e-01" errorMinus="3.697542e-02"/>
     </dataPoint>
@@ -1243,6 +1255,10 @@
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
       <item key="AidaPath" value="/REF/ZJ0_3j_boosted" sticky="true"/>
     </annotation>
+    <dataPoint>
+      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="2.678993e-03" errorPlus="1.0e10" errorMinus="1.0e10"/>
+    </dataPoint>
     <dataPoint>
       <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
       <measurement value="2.338446e-02" errorPlus="1.019354e-02" errorMinus="1.019354e-02"/>
@@ -1287,6 +1303,10 @@
       <item key="AidaPath" value="/REF/ZJ1_3j_boosted" sticky="true"/>
     </annotation>
     <dataPoint>
+      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="2.636743e-01" errorPlus="1.0e10" errorMinus="1.0e10"/>
+    </dataPoint>
+    <dataPoint>
       <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
       <measurement value="3.345433e-01" errorPlus="4.579215e-02" errorMinus="4.579215e-02"/>
     </dataPoint>
@@ -1329,6 +1349,10 @@
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
       <item key="AidaPath" value="/REF/J1J2_3j_boosted" sticky="true"/>
     </annotation>
+    <dataPoint>
+      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.291077e-01" errorPlus="1.0e10" errorMinus="1.0e10"/>
+    </dataPoint>
     <dataPoint>
       <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
       <measurement value="3.457126e-01" errorPlus="4.855760e-02" errorMinus="4.855760e-02"/>
@@ -1373,6 +1397,10 @@
       <item key="AidaPath" value="/REF/J1J3_3j_boosted" sticky="true"/>
     </annotation>  
     <dataPoint>
+      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.646603e-01" errorPlus="1.0e10" errorMinus="1.0e10"/>
+    </dataPoint>
+    <dataPoint>
       <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
       <measurement value="4.562352e-01" errorPlus="6.118763e-02" errorMinus="6.118763e-02"/>
     </dataPoint>
@@ -1415,6 +1443,10 @@
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
       <item key="AidaPath" value="/REF/J2J3_3j_boosted" sticky="true"/>
     </annotation>
+    <dataPoint>
+      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.614759e-01" errorPlus="1.0e10" errorMinus="1.0e10"/>
+    </dataPoint>
     <dataPoint>
       <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
       <measurement value="4.410187e-01" errorPlus="5.255285e-02" errorMinus="5.255285e-02"/>

--- a/GeneratorInterface/RivetInterface/data/CMS_EWK_11_021.aida
+++ b/GeneratorInterface/RivetInterface/data/CMS_EWK_11_021.aida
@@ -6,304 +6,257 @@
       path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
     <annotation>
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
-      <item key="AidaPath" value="/REF/ZJ0_2j_inclusive" sticky="true"/>
+      <item key="AidaPath" value="/REF/ZJ0_1j_inclusive" sticky="true"/>
     </annotation>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="5.236000e-02" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="5.248959e-03" value="5.150229e-02" errorMinus="5.248959e-03"/>
+    <measurement value="5.236000e-02" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="1.642816e-02" errorPlus="1.195198e-03" errorMinus="1.195198e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.570800e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="4.836991e-03" value="5.421510e-02" errorMinus="4.836991e-03"/>
+    <measurement value="1.570800e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="1.665056e-02" errorPlus="1.038756e-03" errorMinus="1.038756e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.618000e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="4.136355e-03" value="5.268721e-02" errorMinus="4.136355e-03"/>
+    <measurement value="2.618000e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="1.765461e-02" errorPlus="9.370419e-04" errorMinus="9.370419e-04"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="3.665200e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.810597e-03" value="4.989988e-02" errorMinus="3.810597e-03"/>
+    <measurement value="3.665200e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="1.609122e-02" errorPlus="8.037327e-04" errorMinus="8.037327e-04"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="4.712400e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.829694e-03" value="5.037485e-02" errorMinus="3.829694e-03"/>
+    <measurement value="4.712400e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="1.681694e-02" errorPlus="8.396394e-04" errorMinus="8.396394e-04"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="5.759600e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.793356e-03" value="5.095087e-02" errorMinus="3.793356e-03"/>
+    <measurement value="5.759600e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="1.867247e-02" errorPlus="9.308867e-04" errorMinus="9.308867e-04"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="6.806800e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="4.199466e-03" value="5.739523e-02" errorMinus="4.199466e-03"/>
+    <measurement value="6.806800e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="1.928808e-02" errorPlus="9.539662e-04" errorMinus="9.539662e-04"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="7.854000e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="4.808424e-03" value="6.698780e-02" errorMinus="4.808424e-03"/>
+    <measurement value="7.854000e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="2.105247e-02" errorPlus="1.022601e-03" errorMinus="1.022601e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="8.901200e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="4.337453e-03" value="6.520227e-02" errorMinus="4.337453e-03"/>
+    <measurement value="8.901200e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="2.159342e-02" errorPlus="9.841808e-04" errorMinus="9.841808e-04"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="9.948400e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="4.721696e-03" value="7.752990e-02" errorMinus="4.721696e-03"/>
+    <measurement value="9.948400e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="2.406701e-02" errorPlus="1.027936e-03" errorMinus="1.027936e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.099560e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="4.867087e-03" value="8.702406e-02" errorMinus="4.867087e-03"/>
+    <measurement value="1.099560e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="2.610875e-02" errorPlus="1.045581e-03" errorMinus="1.045581e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.204280e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="5.108922e-03" value="9.374917e-02" errorMinus="5.108922e-03"/>
+    <measurement value="1.204280e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="2.910903e-02" errorPlus="1.116437e-03" errorMinus="1.116437e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="1.309000e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="5.825636e-03" value="1.104797e-01" errorMinus="5.825636e-03"/>
+    <measurement value="1.309000e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+    <measurement value="3.415366e-02" errorPlus="1.239917e-03" errorMinus="1.239917e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.413720e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="6.411058e-03" value="1.268316e-01" errorMinus="6.411058e-03"/>
+    <measurement value="1.413720e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="4.003407e-02" errorPlus="1.354863e-03" errorMinus="1.354863e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.518440e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="6.805899e-03" value="1.447402e-01" errorMinus="6.805899e-03"/>
+    <measurement value="1.518440e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="4.710770e-02" errorPlus="1.460135e-03" errorMinus="1.460135e-03"/>
+  </dataPoint>
+  <dataPoint>
+    <measurement value="1.623160e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+    <measurement value="5.556934e-02" errorPlus="1.564592e-03" errorMinus="1.564592e-03"/>
+  </dataPoint>
+  <dataPoint>
+    <measurement value="1.727880e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="6.583458e-02" errorPlus="1.697321e-03" errorMinus="1.697321e-03"/>
+  </dataPoint>
+  <dataPoint>
+    <measurement value="1.832600e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="8.373436e-02" errorPlus="1.960181e-03" errorMinus="1.960181e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="1.623160e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="7.043961e-03" value="1.665944e-01" errorMinus="7.043961e-03"/>
+    <measurement value="1.937320e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="1.075217e-01" errorPlus="2.226638e-03" errorMinus="2.226638e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.727880e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="7.917743e-03" value="2.090574e-01" errorMinus="7.917743e-03"/>
+    <measurement value="2.042040e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="1.342234e-01" errorPlus="2.650916e-03" errorMinus="2.650916e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.832600e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="8.837340e-03" value="2.556838e-01" errorMinus="8.837340e-03"/>
+    <measurement value="2.146760e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="1.684270e-01" errorPlus="2.977314e-03" errorMinus="2.977314e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.937320e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.028762e-02" value="3.274968e-01" errorMinus="1.028762e-02"/>
+    <measurement value="2.251480e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+    <measurement value="2.109429e-01" errorPlus="3.474436e-03" errorMinus="3.474436e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.042040e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.191960e-02" value="3.896631e-01" errorMinus="1.191960e-02"/>
+    <measurement value="2.356200e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="2.577692e-01" errorPlus="3.871585e-03" errorMinus="3.871585e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.146760e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.323545e-02" value="4.698397e-01" errorMinus="1.323545e-02"/>
+    <measurement value="2.460920e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+    <measurement value="3.413768e-01" errorPlus="4.709881e-03" errorMinus="4.709881e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.251480e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="1.478741e-02" value="5.466833e-01" errorMinus="1.478741e-02"/>
+    <measurement value="2.565640e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="4.412457e-01" errorPlus="5.384109e-03" errorMinus="5.384109e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.356200e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.508832e-02" value="5.807526e-01" errorMinus="1.508832e-02"/>
+    <measurement value="2.670360e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="5.742317e-01" errorPlus="6.640554e-03" errorMinus="6.640554e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.460920e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="1.678939e-02" value="6.975838e-01" errorMinus="1.678939e-02"/>
+    <measurement value="2.775080e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+    <measurement value="8.219324e-01" errorPlus="8.236108e-03" errorMinus="8.236108e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.565640e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.733747e-02" value="7.585345e-01" errorMinus="1.733747e-02"/>
+    <measurement value="2.879800e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="1.178616e+00" errorPlus="1.030722e-02" errorMinus="1.030722e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.670360e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.855293e-02" value="7.776198e-01" errorMinus="1.855293e-02"/>
+    <measurement value="2.984520e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+    <measurement value="1.833936e+00" errorPlus="1.316110e-02" errorMinus="1.316110e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.775080e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="1.919735e-02" value="8.185792e-01" errorMinus="1.919735e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.879800e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.899364e-02" value="8.340747e-01" errorMinus="1.899364e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.984520e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.789140e-02" value="8.160720e-01" errorMinus="1.789140e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="3.089240e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="2.068537e-02" value="7.614693e-01" errorMinus="2.068537e-02"/>
+    <measurement value="3.089240e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+    <measurement value="2.909085e+00" errorPlus="1.462483e-02" errorMinus="1.462483e-02"/>
     </dataPoint>
   </dataPointSet>
   <dataPointSet name="d02-x01-y01" dimension="2"
       path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
     <annotation>
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
-      <item key="AidaPath" value="/REF/d02-x01-y01" sticky="true"/>
+      <item key="AidaPath" value="/REF/ZJ0_2j_inclusive" sticky="true"/>
     </annotation>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.107080e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.364214e-04" value="1.922091e-03" errorMinus="5.364214e-04"/>
+      <measurement value="5.236000e-02" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="5.150229e-02" errorPlus="5.248959e-03" errorMinus="5.248959e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.321240e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="1.979564e-03" value="7.439200e-03" errorMinus="1.979564e-03"/>
+      <measurement value="1.570800e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="5.421510e-02" errorPlus="4.836991e-03" errorMinus="4.836991e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.535400e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="2.111886e-03" value="1.237227e-02" errorMinus="2.111886e-03"/>
+      <measurement value="2.618000e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="5.268722e-02" errorPlus="4.136355e-03" errorMinus="4.136355e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.749560e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="3.800077e-03" value="3.287302e-02" errorMinus="3.800077e-03"/>
+      <measurement value="3.665200e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="4.989987e-02" errorPlus="3.810597e-03" errorMinus="3.810597e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.963720e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="6.862234e-03" value="8.208545e-02" errorMinus="6.862234e-03"/>
+      <measurement value="4.712400e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="5.037485e-02" errorPlus="3.829694e-03" errorMinus="3.829694e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.177880e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="1.171742e-02" value="1.911198e-01" errorMinus="1.171742e-02"/>
+      <measurement value="5.759600e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="5.095087e-02" errorPlus="3.793356e-03" errorMinus="3.793356e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.392040e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="1.938971e-02" value="4.459043e-01" errorMinus="1.938971e-02"/>
+      <measurement value="6.806800e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="5.739523e-02" errorPlus="4.199466e-03" errorMinus="4.199466e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.606200e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="3.046013e-02" value="8.323865e-01" errorMinus="3.046013e-02"/>
+      <measurement value="7.854000e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="6.698781e-02" errorPlus="4.808425e-03" errorMinus="4.808425e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.820360e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="4.403180e-02" value="1.496108e+00" errorMinus="4.403180e-02"/>
+      <measurement value="8.901200e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="6.520227e-02" errorPlus="4.337454e-03" errorMinus="4.337454e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="3.034520e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.114092e-02" value="1.567196e+00" errorMinus="5.114092e-02"/>
+      <measurement value="9.948400e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="7.752991e-02" errorPlus="4.721696e-03" errorMinus="4.721696e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.099560e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="8.702406e-02" errorPlus="4.867088e-03" errorMinus="4.867088e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.204280e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="9.374917e-02" errorPlus="5.108922e-03" errorMinus="5.108922e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.309000e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="1.104797e-01" errorPlus="5.825636e-03" errorMinus="5.825636e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.413720e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.268316e-01" errorPlus="6.411059e-03" errorMinus="6.411059e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.518440e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.447401e-01" errorPlus="6.805899e-03" errorMinus="6.805899e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.623160e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="1.665944e-01" errorPlus="7.043962e-03" errorMinus="7.043962e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.727880e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.090574e-01" errorPlus="7.917743e-03" errorMinus="7.917743e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.832600e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.556838e-01" errorPlus="8.837339e-03" errorMinus="8.837339e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.937320e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.274969e-01" errorPlus="1.028762e-02" errorMinus="1.028762e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.042040e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.896632e-01" errorPlus="1.191959e-02" errorMinus="1.191959e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.146760e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="4.698398e-01" errorPlus="1.323545e-02" errorMinus="1.323545e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.251480e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="5.466833e-01" errorPlus="1.478742e-02" errorMinus="1.478742e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.356200e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="5.807526e-01" errorPlus="1.508833e-02" errorMinus="1.508833e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.460920e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="6.975838e-01" errorPlus="1.678939e-02" errorMinus="1.678939e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.565640e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="7.585344e-01" errorPlus="1.733748e-02" errorMinus="1.733748e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.670360e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="7.776198e-01" errorPlus="1.855293e-02" errorMinus="1.855293e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.775080e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="8.185791e-01" errorPlus="1.919735e-02" errorMinus="1.919735e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.879800e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="8.340748e-01" errorPlus="1.899364e-02" errorMinus="1.899364e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.984520e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="8.160721e-01" errorPlus="1.789139e-02" errorMinus="1.789139e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="3.089240e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="7.614693e-01" errorPlus="2.068537e-02" errorMinus="2.068537e-02"/>
     </dataPoint>
   </dataPointSet>
   <dataPointSet name="d03-x01-y01" dimension="2"
-      path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
-    <annotation>
-      <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
-      <item key="AidaPath" value="/REF/J1J2_3j_inclusive" sticky="true"/>
-    </annotation>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="5.236000e-02" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.735183e-02" value="7.840841e-02" errorMinus="1.735183e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.570800e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.940878e-02" value="1.036595e-01" errorMinus="1.940878e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.618000e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.640669e-02" value="1.055035e-01" errorMinus="1.640669e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="3.665200e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.354214e-02" value="9.398698e-02" errorMinus="1.354214e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="4.712400e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.768854e-02" value="1.319386e-01" errorMinus="1.768854e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="5.759600e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.078331e-02" value="1.524703e-01" errorMinus="2.078331e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="6.806800e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.081396e-02" value="1.389394e-01" errorMinus="2.081396e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="7.854000e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.864774e-02" value="1.174922e-01" errorMinus="1.864774e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="8.901200e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.970507e-02" value="1.218571e-01" errorMinus="1.970507e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="9.948400e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.614899e-02" value="1.141973e-01" errorMinus="1.614899e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.099560e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.781584e-02" value="1.364099e-01" errorMinus="1.781584e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.204280e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.759766e-02" value="1.336769e-01" errorMinus="1.759766e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="1.309000e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="1.775138e-02" value="1.345082e-01" errorMinus="1.775138e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.413720e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.153568e-02" value="1.623442e-01" errorMinus="2.153568e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.518440e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.262472e-02" value="1.775221e-01" errorMinus="2.262472e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="1.623160e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="2.214940e-02" value="1.790094e-01" errorMinus="2.214940e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.727880e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.512130e-02" value="2.261253e-01" errorMinus="2.512130e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.832600e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.718337e-02" value="2.548918e-01" errorMinus="2.718337e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.937320e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.649286e-02" value="2.537082e-01" errorMinus="2.649286e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.042040e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.349113e-02" value="3.035561e-01" errorMinus="3.349113e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.146760e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.039979e-02" value="3.197505e-01" errorMinus="3.039979e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.251480e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="3.745280e-02" value="4.356945e-01" errorMinus="3.745280e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.356200e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="4.118603e-02" value="5.128316e-01" errorMinus="4.118603e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.460920e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="4.547737e-02" value="5.978102e-01" errorMinus="4.547737e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.565640e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="4.777412e-02" value="6.596887e-01" errorMinus="4.777412e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.670360e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="5.085555e-02" value="6.749511e-01" errorMinus="5.085555e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.775080e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="5.313880e-02" value="7.533648e-01" errorMinus="5.313880e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.879800e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="5.523311e-02" value="7.881661e-01" errorMinus="5.523311e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.984520e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="5.693664e-02" value="8.899205e-01" errorMinus="5.693664e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="3.089240e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="6.800551e-02" value="7.968916e-01" errorMinus="6.800551e-02"/>
-    </dataPoint>
-  </dataPointSet>
-  <dataPointSet name="d04-x01-y01" dimension="2"
       path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
     <annotation>
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
@@ -430,1091 +383,830 @@
       <measurement errorPlus="5.564204e-02" value="5.471836e-01" errorMinus="5.564204e-02"/>
     </dataPoint>
   </dataPointSet>
+  <dataPointSet name="d04-x01-y01" dimension="2"
+      path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
+    <annotation>
+      <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
+      <item key="AidaPath" value="/REF/ZJ0_3j_inclusive" sticky="true"/>
+    </annotation> 
+    <dataPoint>
+      <measurement value="5.236000e-02" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.120061e-01" errorPlus="2.193904e-02" errorMinus="2.193904e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.570800e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.088667e-01" errorPlus="1.807787e-02" errorMinus="1.807787e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.618000e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.109672e-01" errorPlus="1.762636e-02" errorMinus="1.762636e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="3.665200e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.015390e-01" errorPlus="1.603971e-02" errorMinus="1.603971e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="4.712400e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="8.919204e-02" errorPlus="1.420441e-02" errorMinus="1.420441e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="5.759600e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="9.257576e-02" errorPlus="1.363335e-02" errorMinus="1.363335e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="6.806800e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.178599e-01" errorPlus="1.574825e-02" errorMinus="1.574825e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="7.854000e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.545665e-01" errorPlus="2.000633e-02" errorMinus="2.000633e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="8.901200e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.156163e-01" errorPlus="1.542021e-02" errorMinus="1.542021e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="9.948400e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.219300e-01" errorPlus="1.695047e-02" errorMinus="1.695047e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.099560e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.550339e-01" errorPlus="2.015500e-02" errorMinus="2.015500e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.204280e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.224293e-01" errorPlus="1.638940e-02" errorMinus="1.638940e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.309000e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="1.650032e-01" errorPlus="2.183081e-02" errorMinus="2.183081e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.413720e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.711129e-01" errorPlus="2.178488e-02" errorMinus="2.178488e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.518440e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.252576e-01" errorPlus="2.308674e-02" errorMinus="2.308674e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.623160e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="2.445951e-01" errorPlus="2.322560e-02" errorMinus="2.322560e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.727880e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.177333e-01" errorPlus="2.229323e-02" errorMinus="2.229323e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.832600e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.790697e-01" errorPlus="2.694146e-02" errorMinus="2.694146e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.937320e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.415442e-01" errorPlus="2.853336e-02" errorMinus="2.853336e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.042040e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="4.041606e-01" errorPlus="3.295277e-02" errorMinus="3.295277e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.146760e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="4.195887e-01" errorPlus="3.145031e-02" errorMinus="3.145031e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.251480e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="4.674118e-01" errorPlus="3.557287e-02" errorMinus="3.557287e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.356200e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="4.631480e-01" errorPlus="3.730945e-02" errorMinus="3.730945e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.460920e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="5.185344e-01" errorPlus="3.958726e-02" errorMinus="3.958726e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.565640e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="5.346193e-01" errorPlus="4.168359e-02" errorMinus="4.168359e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.670360e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="5.809458e-01" errorPlus="4.527264e-02" errorMinus="4.527264e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.775080e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="6.841940e-01" errorPlus="4.710375e-02" errorMinus="4.710375e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.879800e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="7.335244e-01" errorPlus="5.079084e-02" errorMinus="5.079084e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.984520e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="7.802082e-01" errorPlus="5.000141e-02" errorMinus="5.000141e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="3.089240e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="9.160405e-01" errorPlus="6.661010e-02" errorMinus="6.661010e-02"/>
+    </dataPoint> 
+  </dataPointSet>
   <dataPointSet name="d05-x01-y01" dimension="2"
       path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
     <annotation>
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
-      <item key="AidaPath" value="/REF/J1J3_3j_inclusive" sticky="true"/>
+      <item key="AidaPath" value="/REF/ZJ1_3j_inclusive" sticky="true"/>
     </annotation>
+  
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="5.236000e-02" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.046557e-02" value="1.900858e-01" errorMinus="3.046557e-02"/>
+      <measurement value="5.236000e-02" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.780959e-01" errorPlus="3.466390e-02" errorMinus="3.466390e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.570800e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.573739e-02" value="1.778805e-01" errorMinus="2.573739e-02"/>
+      <measurement value="1.570800e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.091850e-01" errorPlus="2.485255e-02" errorMinus="2.485255e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.618000e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.109730e-02" value="1.401701e-01" errorMinus="2.109730e-02"/>
+      <measurement value="2.618000e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.369341e-01" errorPlus="2.775946e-02" errorMinus="2.775946e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="3.665200e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.145963e-02" value="1.292108e-01" errorMinus="2.145963e-02"/>
+      <measurement value="3.665200e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.401135e-01" errorPlus="2.776589e-02" errorMinus="2.776589e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="4.712400e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.636196e-02" value="1.672547e-01" errorMinus="2.636196e-02"/>
+      <measurement value="4.712400e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.585014e-01" errorPlus="2.910420e-02" errorMinus="2.910420e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="5.759600e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.890327e-02" value="2.059059e-01" errorMinus="2.890327e-02"/>
+      <measurement value="5.759600e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.684506e-01" errorPlus="2.971547e-02" errorMinus="2.971547e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="6.806800e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.906703e-02" value="2.015156e-01" errorMinus="2.906703e-02"/>
+      <measurement value="6.806800e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.349995e-01" errorPlus="2.726309e-02" errorMinus="2.726309e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="7.854000e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.880854e-02" value="1.965473e-01" errorMinus="2.880854e-02"/>
+      <measurement value="7.854000e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.687504e-01" errorPlus="2.966743e-02" errorMinus="2.966743e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="8.901200e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.479429e-02" value="1.970752e-01" errorMinus="2.479429e-02"/>
+      <measurement value="8.901200e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.878233e-01" errorPlus="2.786550e-02" errorMinus="2.786550e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="9.948400e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.387006e-02" value="2.080570e-01" errorMinus="2.387006e-02"/>
+      <measurement value="9.948400e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.318311e-01" errorPlus="3.122236e-02" errorMinus="3.122236e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.099560e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.675583e-02" value="2.218247e-01" errorMinus="2.675583e-02"/>
+      <measurement value="1.099560e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.796393e-01" errorPlus="2.723893e-02" errorMinus="2.723893e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.204280e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.796312e-02" value="2.038144e-01" errorMinus="2.796312e-02"/>
+      <measurement value="1.204280e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.587777e-01" errorPlus="2.669250e-02" errorMinus="2.669250e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="1.309000e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="2.750323e-02" value="2.007463e-01" errorMinus="2.750323e-02"/>
+      <measurement value="1.309000e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="3.057591e-01" errorPlus="3.036902e-02" errorMinus="3.036902e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.413720e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.701073e-02" value="2.192382e-01" errorMinus="2.701073e-02"/>
+      <measurement value="1.413720e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.594433e-01" errorPlus="3.339034e-02" errorMinus="3.339034e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.518440e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.671127e-02" value="2.466464e-01" errorMinus="2.671127e-02"/>
+      <measurement value="1.518440e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.229112e-01" errorPlus="3.080273e-02" errorMinus="3.080273e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="1.623160e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="3.171018e-02" value="3.400382e-01" errorMinus="3.171018e-02"/>
+      <measurement value="1.623160e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="2.961657e-01" errorPlus="2.979156e-02" errorMinus="2.979156e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.727880e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.933037e-02" value="3.245859e-01" errorMinus="2.933037e-02"/>
+      <measurement value="1.727880e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.516357e-01" errorPlus="3.238943e-02" errorMinus="3.238943e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.832600e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.269132e-02" value="3.272117e-01" errorMinus="3.269132e-02"/>
+      <measurement value="1.832600e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.801629e-01" errorPlus="3.496870e-02" errorMinus="3.496870e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.937320e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.472652e-02" value="3.126084e-01" errorMinus="3.472652e-02"/>
+      <measurement value="1.937320e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.655124e-01" errorPlus="3.172628e-02" errorMinus="3.172628e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.042040e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.623764e-02" value="3.228979e-01" errorMinus="3.623764e-02"/>
+      <measurement value="2.042040e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.882974e-01" errorPlus="3.570265e-02" errorMinus="3.570265e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.146760e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.975286e-02" value="3.730506e-01" errorMinus="3.975286e-02"/>
+      <measurement value="2.146760e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.576466e-01" errorPlus="3.362131e-02" errorMinus="3.362131e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.251480e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="4.305113e-02" value="3.839296e-01" errorMinus="4.305113e-02"/>
+      <measurement value="2.251480e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="3.809968e-01" errorPlus="3.691779e-02" errorMinus="3.691779e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.356200e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="4.018246e-02" value="4.121540e-01" errorMinus="4.018246e-02"/>
+      <measurement value="2.356200e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.745245e-01" errorPlus="3.597023e-02" errorMinus="3.597023e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.460920e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="4.299477e-02" value="5.054114e-01" errorMinus="4.299477e-02"/>
+      <measurement value="2.460920e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="3.894881e-01" errorPlus="3.688830e-02" errorMinus="3.688830e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.565640e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="4.383419e-02" value="5.470615e-01" errorMinus="4.383419e-02"/>
+      <measurement value="2.565640e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.979021e-01" errorPlus="4.103914e-02" errorMinus="4.103914e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.670360e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="4.832441e-02" value="5.594768e-01" errorMinus="4.832441e-02"/>
+      <measurement value="2.670360e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.411593e-01" errorPlus="3.910241e-02" errorMinus="3.910241e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.775080e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="4.811353e-02" value="5.727788e-01" errorMinus="4.811353e-02"/>
+      <measurement value="2.775080e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="3.785490e-01" errorPlus="4.106688e-02" errorMinus="4.106688e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.879800e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="4.804978e-02" value="6.023063e-01" errorMinus="4.804978e-02"/>
+      <measurement value="2.879800e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.747356e-01" errorPlus="4.015665e-02" errorMinus="4.015665e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.984520e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="4.544927e-02" value="5.233807e-01" errorMinus="4.544927e-02"/>
+      <measurement value="2.984520e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.359133e-01" errorPlus="3.522790e-02" errorMinus="3.522790e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="3.089240e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="6.023095e-02" value="5.364095e-01" errorMinus="6.023095e-02"/>
-    </dataPoint>
+      <measurement value="3.089240e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="3.953698e-01" errorPlus="4.994667e-02" errorMinus="4.994667e-02"/>
+    </dataPoint> 
   </dataPointSet>
   <dataPointSet name="d06-x01-y01" dimension="2"
       path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
     <annotation>
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
-      <item key="AidaPath" value="/REF/ZJ0_3j_boosted" sticky="true"/>
-    </annotation>
+      <item key="AidaPath" value="/REF/J1J2_3j_inclusive" sticky="true"/>
+    </annotation> 
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.107080e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="1.252005e-03" value="2.678993e-03" errorMinus="1.252005e-03"/>
+      <measurement value="5.236000e-02" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="7.840842e-02" errorPlus="1.735184e-02" errorMinus="1.735184e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.321240e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="1.019354e-02" value="2.338446e-02" errorMinus="1.019354e-02"/>
+      <measurement value="1.570800e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.036595e-01" errorPlus="1.940878e-02" errorMinus="1.940878e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.535400e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="1.034789e-02" value="4.748380e-02" errorMinus="1.034789e-02"/>
+      <measurement value="2.618000e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.055035e-01" errorPlus="1.640669e-02" errorMinus="1.640669e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.749560e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="1.723031e-02" value="1.191777e-01" errorMinus="1.723031e-02"/>
+      <measurement value="3.665200e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="9.398699e-02" errorPlus="1.354214e-02" errorMinus="1.354214e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.963720e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="2.771097e-02" value="2.481718e-01" errorMinus="2.771097e-02"/>
+      <measurement value="4.712400e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.319386e-01" errorPlus="1.768854e-02" errorMinus="1.768854e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.177880e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="3.634801e-02" value="3.920558e-01" errorMinus="3.634801e-02"/>
+      <measurement value="5.759600e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.524703e-01" errorPlus="2.078331e-02" errorMinus="2.078331e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.392040e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.581985e-02" value="6.663355e-01" errorMinus="5.581985e-02"/>
+      <measurement value="6.806800e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.389393e-01" errorPlus="2.081397e-02" errorMinus="2.081397e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.606200e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="7.009540e-02" value="7.730855e-01" errorMinus="7.009540e-02"/>
+      <measurement value="7.854000e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.174922e-01" errorPlus="1.864774e-02" errorMinus="1.864774e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.820360e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="7.548324e-02" value="1.025160e+00" errorMinus="7.548324e-02"/>
+      <measurement value="8.901200e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.218571e-01" errorPlus="1.970507e-02" errorMinus="1.970507e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="3.034520e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="1.132023e-01" value="1.371873e+00" errorMinus="1.132023e-01"/>
+      <measurement value="9.948400e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.141973e-01" errorPlus="1.614898e-02" errorMinus="1.614898e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.099560e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.364099e-01" errorPlus="1.781584e-02" errorMinus="1.781584e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.204280e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.336769e-01" errorPlus="1.759766e-02" errorMinus="1.759766e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.309000e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="1.345082e-01" errorPlus="1.775139e-02" errorMinus="1.775139e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.413720e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.623441e-01" errorPlus="2.153567e-02" errorMinus="2.153567e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.518440e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.775220e-01" errorPlus="2.262473e-02" errorMinus="2.262473e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.623160e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="1.790094e-01" errorPlus="2.214940e-02" errorMinus="2.214940e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.727880e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.261253e-01" errorPlus="2.512131e-02" errorMinus="2.512131e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.832600e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.548918e-01" errorPlus="2.718337e-02" errorMinus="2.718337e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.937320e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.537082e-01" errorPlus="2.649286e-02" errorMinus="2.649286e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.042040e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.035561e-01" errorPlus="3.349113e-02" errorMinus="3.349113e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.146760e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.197505e-01" errorPlus="3.039979e-02" errorMinus="3.039979e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.251480e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="4.356945e-01" errorPlus="3.745280e-02" errorMinus="3.745280e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.356200e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="5.128316e-01" errorPlus="4.118603e-02" errorMinus="4.118603e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.460920e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="5.978101e-01" errorPlus="4.547737e-02" errorMinus="4.547737e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.565640e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="6.596887e-01" errorPlus="4.777412e-02" errorMinus="4.777412e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.670360e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="6.749512e-01" errorPlus="5.085555e-02" errorMinus="5.085555e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.775080e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="7.533648e-01" errorPlus="5.313880e-02" errorMinus="5.313880e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.879800e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="7.881660e-01" errorPlus="5.523311e-02" errorMinus="5.523311e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.984520e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="8.899205e-01" errorPlus="5.693664e-02" errorMinus="5.693664e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="3.089240e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="7.968916e-01" errorPlus="6.800551e-02" errorMinus="6.800551e-02"/>
     </dataPoint>
   </dataPointSet>
   <dataPointSet name="d07-x01-y01" dimension="2"
       path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
     <annotation>
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
-      <item key="AidaPath" value="/REF/ZJ1_3j_boosted" sticky="true"/>
+      <item key="AidaPath" value="/REF/J1J3_3j_inclusive" sticky="true"/>
     </annotation>
+    
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.107080e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="4.656379e-02" value="2.636742e-01" errorMinus="4.656379e-02"/>
+      <measurement value="5.236000e-02" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.900858e-01" errorPlus="3.046558e-02" errorMinus="3.046558e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.321240e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="4.579215e-02" value="3.345433e-01" errorMinus="4.579215e-02"/>
+      <measurement value="1.570800e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.778805e-01" errorPlus="2.573740e-02" errorMinus="2.573740e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.535400e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="4.098865e-02" value="3.500321e-01" errorMinus="4.098865e-02"/>
+      <measurement value="2.618000e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.401701e-01" errorPlus="2.109729e-02" errorMinus="2.109729e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.749560e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="4.927013e-02" value="4.369330e-01" errorMinus="4.927013e-02"/>
+      <measurement value="3.665200e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.292108e-01" errorPlus="2.145962e-02" errorMinus="2.145962e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.963720e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="4.740544e-02" value="4.206321e-01" errorMinus="4.740544e-02"/>
+      <measurement value="4.712400e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.672547e-01" errorPlus="2.636196e-02" errorMinus="2.636196e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.177880e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.442006e-02" value="4.874841e-01" errorMinus="5.442006e-02"/>
+      <measurement value="5.759600e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.059059e-01" errorPlus="2.890327e-02" errorMinus="2.890327e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.392040e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="6.041693e-02" value="5.871479e-01" errorMinus="6.041693e-02"/>
+      <measurement value="6.806800e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.015156e-01" errorPlus="2.906702e-02" errorMinus="2.906702e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.606200e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="6.079198e-02" value="5.874949e-01" errorMinus="6.079198e-02"/>
+      <measurement value="7.854000e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.965473e-01" errorPlus="2.880854e-02" errorMinus="2.880854e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.820360e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="6.064583e-02" value="5.526415e-01" errorMinus="6.064583e-02"/>
+      <measurement value="8.901200e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="1.970752e-01" errorPlus="2.479429e-02" errorMinus="2.479429e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="3.034520e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="8.954417e-02" value="6.488233e-01" errorMinus="8.954417e-02"/>
+      <measurement value="9.948400e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.080570e-01" errorPlus="2.387007e-02" errorMinus="2.387007e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.099560e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.218247e-01" errorPlus="2.675584e-02" errorMinus="2.675584e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.204280e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.038144e-01" errorPlus="2.796312e-02" errorMinus="2.796312e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.309000e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="2.007463e-01" errorPlus="2.750323e-02" errorMinus="2.750323e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.413720e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.192382e-01" errorPlus="2.701074e-02" errorMinus="2.701074e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.518440e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.466464e-01" errorPlus="2.671127e-02" errorMinus="2.671127e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.623160e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="3.400382e-01" errorPlus="3.171018e-02" errorMinus="3.171018e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.727880e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.245859e-01" errorPlus="2.933037e-02" errorMinus="2.933037e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.832600e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.272117e-01" errorPlus="3.269132e-02" errorMinus="3.269132e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.937320e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.126084e-01" errorPlus="3.472652e-02" errorMinus="3.472652e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.042040e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.228979e-01" errorPlus="3.623764e-02" errorMinus="3.623764e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.146760e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.730506e-01" errorPlus="3.975285e-02" errorMinus="3.975285e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.251480e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="3.839296e-01" errorPlus="4.305113e-02" errorMinus="4.305113e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.356200e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="4.121540e-01" errorPlus="4.018246e-02" errorMinus="4.018246e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.460920e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="5.054114e-01" errorPlus="4.299477e-02" errorMinus="4.299477e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.565640e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="5.470616e-01" errorPlus="4.383419e-02" errorMinus="4.383419e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.670360e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="5.594769e-01" errorPlus="4.832441e-02" errorMinus="4.832441e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.775080e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="5.727789e-01" errorPlus="4.811353e-02" errorMinus="4.811353e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.879800e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="6.023064e-01" errorPlus="4.804978e-02" errorMinus="4.804978e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.984520e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="5.233808e-01" errorPlus="4.544927e-02" errorMinus="4.544927e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="3.089240e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="5.364096e-01" errorPlus="6.023095e-02" errorMinus="6.023095e-02"/>
     </dataPoint>
   </dataPointSet>
   <dataPointSet name="d08-x01-y01" dimension="2"
       path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
     <annotation>
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
-      <item key="AidaPath" value="/REF/ZJ0_3j_inclusive" sticky="true"/>
-    </annotation>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="5.236000e-02" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.193904e-02" value="1.120061e-01" errorMinus="2.193904e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.570800e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.807787e-02" value="1.088667e-01" errorMinus="1.807787e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.618000e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.762636e-02" value="1.109672e-01" errorMinus="1.762636e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="3.665200e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.603971e-02" value="1.015390e-01" errorMinus="1.603971e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="4.712400e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.420441e-02" value="8.919204e-02" errorMinus="1.420441e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="5.759600e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.363335e-02" value="9.257575e-02" errorMinus="1.363335e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="6.806800e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.574825e-02" value="1.178599e-01" errorMinus="1.574825e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="7.854000e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.000633e-02" value="1.545666e-01" errorMinus="2.000633e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="8.901200e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.542021e-02" value="1.156163e-01" errorMinus="1.542021e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="9.948400e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.695047e-02" value="1.219300e-01" errorMinus="1.695047e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.099560e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.015500e-02" value="1.550339e-01" errorMinus="2.015500e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.204280e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.638940e-02" value="1.224293e-01" errorMinus="1.638940e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="1.309000e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="2.183082e-02" value="1.650032e-01" errorMinus="2.183082e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.413720e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.178488e-02" value="1.711129e-01" errorMinus="2.178488e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.518440e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.308675e-02" value="2.252575e-01" errorMinus="2.308675e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="1.623160e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="2.322560e-02" value="2.445950e-01" errorMinus="2.322560e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.727880e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.229323e-02" value="2.177333e-01" errorMinus="2.229323e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.832600e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.694146e-02" value="2.790697e-01" errorMinus="2.694146e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.937320e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.853336e-02" value="3.415442e-01" errorMinus="2.853336e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.042040e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.295277e-02" value="4.041606e-01" errorMinus="3.295277e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.146760e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.145031e-02" value="4.195887e-01" errorMinus="3.145031e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.251480e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="3.557287e-02" value="4.674118e-01" errorMinus="3.557287e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.356200e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.730944e-02" value="4.631480e-01" errorMinus="3.730944e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.460920e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="3.958726e-02" value="5.185345e-01" errorMinus="3.958726e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.565640e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="4.168359e-02" value="5.346193e-01" errorMinus="4.168359e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.670360e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="4.527263e-02" value="5.809458e-01" errorMinus="4.527263e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.775080e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="4.710375e-02" value="6.841939e-01" errorMinus="4.710375e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.879800e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="5.079084e-02" value="7.335244e-01" errorMinus="5.079084e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.984520e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="5.000141e-02" value="7.802083e-01" errorMinus="5.000141e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="3.089240e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="6.661009e-02" value="9.160404e-01" errorMinus="6.661009e-02"/>
-    </dataPoint>
-  </dataPointSet>
-    <dataPointSet name="d09-x01-y01" dimension="2"
-      path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
-    <annotation>
-      <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
-      <item key="AidaPath" value="/REF/d09-x01-y01" sticky="true"/>
-    </annotation>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.107080e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="1.877970e-04" value="6.248655e-04" errorMinus="1.877970e-04"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.321240e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="8.562019e-04" value="3.248128e-03" errorMinus="8.562019e-04"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.535400e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="8.268673e-04" value="4.725397e-03" errorMinus="8.268673e-04"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.749560e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="1.554031e-03" value="1.350962e-02" errorMinus="1.554031e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.963720e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="2.604822e-03" value="3.129802e-02" errorMinus="2.604822e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.177880e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="4.453100e-03" value="7.530837e-02" errorMinus="4.453100e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.392040e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="7.478493e-03" value="1.849592e-01" errorMinus="7.478493e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.606200e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="1.212792e-02" value="3.762660e-01" errorMinus="1.212792e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.820360e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="2.031572e-02" value="9.233587e-01" errorMinus="2.031572e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="3.034520e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="3.720059e-02" value="3.056108e+00" errorMinus="3.720059e-02"/>
-    </dataPoint>
-  </dataPointSet>  
-  <dataPointSet name="d10-x01-y01" dimension="2"
-      path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
-    <annotation>
-      <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
-      <item key="AidaPath" value="/REF/ZJ0_1j_inclusive" sticky="true"/>
-    </annotation>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="5.236000e-02" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.195198e-03" value="1.642816e-02" errorMinus="1.195198e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.570800e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.038756e-03" value="1.665056e-02" errorMinus="1.038756e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.618000e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="9.370418e-04" value="1.765460e-02" errorMinus="9.370418e-04"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="3.665200e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="8.037326e-04" value="1.609121e-02" errorMinus="8.037326e-04"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="4.712400e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="8.396393e-04" value="1.681694e-02" errorMinus="8.396393e-04"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="5.759600e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="9.308867e-04" value="1.867247e-02" errorMinus="9.308867e-04"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="6.806800e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="9.539662e-04" value="1.928807e-02" errorMinus="9.539662e-04"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="7.854000e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.022600e-03" value="2.105246e-02" errorMinus="1.022600e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="8.901200e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="9.841807e-04" value="2.159342e-02" errorMinus="9.841807e-04"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="9.948400e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.027936e-03" value="2.406701e-02" errorMinus="1.027936e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.099560e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.045582e-03" value="2.610876e-02" errorMinus="1.045582e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.204280e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.116436e-03" value="2.910903e-02" errorMinus="1.116436e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="1.309000e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="1.239917e-03" value="3.415366e-02" errorMinus="1.239917e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.413720e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.354863e-03" value="4.003407e-02" errorMinus="1.354863e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.518440e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.460135e-03" value="4.710770e-02" errorMinus="1.460135e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="1.623160e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="1.564592e-03" value="5.556934e-02" errorMinus="1.564592e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.727880e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.697321e-03" value="6.583458e-02" errorMinus="1.697321e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.832600e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.960181e-03" value="8.373436e-02" errorMinus="1.960181e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.937320e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.226639e-03" value="1.075217e-01" errorMinus="2.226639e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.042040e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.650916e-03" value="1.342234e-01" errorMinus="2.650916e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.146760e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.977314e-03" value="1.684270e-01" errorMinus="2.977314e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.251480e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="3.474437e-03" value="2.109429e-01" errorMinus="3.474437e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.356200e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.871585e-03" value="2.577692e-01" errorMinus="3.871585e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.460920e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="4.709881e-03" value="3.413768e-01" errorMinus="4.709881e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.565640e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="5.384109e-03" value="4.412457e-01" errorMinus="5.384109e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.670360e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="6.640554e-03" value="5.742318e-01" errorMinus="6.640554e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.775080e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="8.236108e-03" value="8.219323e-01" errorMinus="8.236108e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.879800e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.030723e-02" value="1.178616e+00" errorMinus="1.030723e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.984520e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="1.316110e-02" value="1.833936e+00" errorMinus="1.316110e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="3.089240e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="1.462483e-02" value="2.909085e+00" errorMinus="1.462483e-02"/>
-    </dataPoint>
-  </dataPointSet>
-  <dataPointSet name="d11-x01-y01" dimension="2"
-      path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
-    <annotation>
-      <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
-      <item key="AidaPath" value="/REF/J2J3_3j_boosted" sticky="true"/>
-    </annotation>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.107080e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="6.810184e-02" value="4.614759e-01" errorMinus="6.810184e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.321240e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.255286e-02" value="4.410186e-01" errorMinus="5.255286e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.535400e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.041053e-02" value="4.719509e-01" errorMinus="5.041053e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.749560e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="4.836197e-02" value="4.603043e-01" errorMinus="4.836197e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.963720e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.632041e-02" value="5.357364e-01" errorMinus="5.632041e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.177880e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.135800e-02" value="4.827479e-01" errorMinus="5.135800e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.392040e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.844411e-02" value="5.075719e-01" errorMinus="5.844411e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.606200e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.391885e-02" value="4.745018e-01" errorMinus="5.391885e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.820360e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="4.864190e-02" value="4.237874e-01" errorMinus="4.864190e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="3.034520e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="7.348030e-02" value="4.103109e-01" errorMinus="7.348030e-02"/>
-
-    </dataPoint>
-  </dataPointSet>
-  <dataPointSet name="d12-x01-y01" dimension="2"
-      path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
-    <annotation>
-      <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
       <item key="AidaPath" value="/REF/J2J3_3j_inclusive" sticky="true"/>
     </annotation>
+    
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="5.236000e-02" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.218762e-02" value="2.738889e-01" errorMinus="3.218762e-02"/>
+      <measurement value="5.236000e-02" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.738890e-01" errorPlus="3.218763e-02" errorMinus="3.218763e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.570800e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.544623e-02" value="2.876828e-01" errorMinus="2.544623e-02"/>
+      <measurement value="1.570800e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.876828e-01" errorPlus="2.544623e-02" errorMinus="2.544623e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.618000e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.702147e-02" value="3.157044e-01" errorMinus="2.702147e-02"/>
+      <measurement value="2.618000e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.157044e-01" errorPlus="2.702147e-02" errorMinus="2.702147e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="3.665200e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.024739e-02" value="3.804289e-01" errorMinus="3.024739e-02"/>
+      <measurement value="3.665200e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.804289e-01" errorPlus="3.024739e-02" errorMinus="3.024739e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="4.712400e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.332569e-02" value="4.015128e-01" errorMinus="3.332569e-02"/>
+      <measurement value="4.712400e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="4.015128e-01" errorPlus="3.332569e-02" errorMinus="3.332569e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="5.759600e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.418200e-02" value="4.032207e-01" errorMinus="3.418200e-02"/>
+      <measurement value="5.759600e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="4.032207e-01" errorPlus="3.418200e-02" errorMinus="3.418200e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="6.806800e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.038539e-02" value="3.521418e-01" errorMinus="3.038539e-02"/>
+      <measurement value="6.806800e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.521419e-01" errorPlus="3.038539e-02" errorMinus="3.038539e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="7.854000e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.308180e-02" value="3.428525e-01" errorMinus="3.308180e-02"/>
+      <measurement value="7.854000e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.428525e-01" errorPlus="3.308180e-02" errorMinus="3.308180e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="8.901200e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.841112e-02" value="3.017885e-01" errorMinus="2.841112e-02"/>
+      <measurement value="8.901200e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.017885e-01" errorPlus="2.841112e-02" errorMinus="2.841112e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="9.948400e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.743727e-02" value="3.033532e-01" errorMinus="2.743727e-02"/>
+      <measurement value="9.948400e-01" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.033533e-01" errorPlus="2.743727e-02" errorMinus="2.743727e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.099560e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.849799e-02" value="3.432380e-01" errorMinus="2.849799e-02"/>
+      <measurement value="1.099560e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.432380e-01" errorPlus="2.849800e-02" errorMinus="2.849800e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.204280e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.548793e-02" value="3.016538e-01" errorMinus="2.548793e-02"/>
+      <measurement value="1.204280e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.016539e-01" errorPlus="2.548793e-02" errorMinus="2.548793e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="1.309000e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="2.701565e-02" value="3.018116e-01" errorMinus="2.701565e-02"/>
+      <measurement value="1.309000e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="3.018116e-01" errorPlus="2.701565e-02" errorMinus="2.701565e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.413720e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.744769e-02" value="2.971007e-01" errorMinus="2.744769e-02"/>
+      <measurement value="1.413720e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.971008e-01" errorPlus="2.744769e-02" errorMinus="2.744769e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.518440e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.964241e-02" value="3.115460e-01" errorMinus="2.964241e-02"/>
+      <measurement value="1.518440e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.115460e-01" errorPlus="2.964241e-02" errorMinus="2.964241e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="1.623160e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="2.405658e-02" value="2.915713e-01" errorMinus="2.405658e-02"/>
+      <measurement value="1.623160e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="2.915714e-01" errorPlus="2.405658e-02" errorMinus="2.405658e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.727880e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.937166e-02" value="3.824497e-01" errorMinus="2.937166e-02"/>
+      <measurement value="1.727880e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.824497e-01" errorPlus="2.937166e-02" errorMinus="2.937166e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.832600e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.812035e-02" value="3.535595e-01" errorMinus="2.812035e-02"/>
+      <measurement value="1.832600e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.535596e-01" errorPlus="2.812035e-02" errorMinus="2.812035e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.937320e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.745391e-02" value="3.055595e-01" errorMinus="2.745391e-02"/>
+      <measurement value="1.937320e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.055595e-01" errorPlus="2.745390e-02" errorMinus="2.745390e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.042040e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.051934e-02" value="2.734301e-01" errorMinus="3.051934e-02"/>
+      <measurement value="2.042040e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.734301e-01" errorPlus="3.051934e-02" errorMinus="3.051934e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.146760e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.840120e-02" value="2.727617e-01" errorMinus="2.840120e-02"/>
+      <measurement value="2.146760e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.727616e-01" errorPlus="2.840120e-02" errorMinus="2.840120e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.251480e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="2.711715e-02" value="2.608626e-01" errorMinus="2.711715e-02"/>
+      <measurement value="2.251480e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="2.608626e-01" errorPlus="2.711716e-02" errorMinus="2.711716e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.356200e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.972559e-02" value="2.937417e-01" errorMinus="2.972559e-02"/>
+      <measurement value="2.356200e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.937417e-01" errorPlus="2.972559e-02" errorMinus="2.972559e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.460920e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="3.184518e-02" value="3.265637e-01" errorMinus="3.184518e-02"/>
+      <measurement value="2.460920e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="3.265637e-01" errorPlus="3.184518e-02" errorMinus="3.184518e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.565640e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.171946e-02" value="3.276770e-01" errorMinus="3.171946e-02"/>
+      <measurement value="2.565640e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.276771e-01" errorPlus="3.171946e-02" errorMinus="3.171946e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.670360e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.112278e-02" value="3.023471e-01" errorMinus="3.112278e-02"/>
+      <measurement value="2.670360e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.023471e-01" errorPlus="3.112278e-02" errorMinus="3.112278e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.775080e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="2.977767e-02" value="2.844249e-01" errorMinus="2.977767e-02"/>
+      <measurement value="2.775080e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="2.844250e-01" errorPlus="2.977767e-02" errorMinus="2.977767e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.879800e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.074293e-02" value="3.007172e-01" errorMinus="3.074293e-02"/>
+      <measurement value="2.879800e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="3.007171e-01" errorPlus="3.074293e-02" errorMinus="3.074293e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.984520e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.982351e-02" value="2.992140e-01" errorMinus="2.982351e-02"/>
+      <measurement value="2.984520e+00" errorPlus="5.236000e-02" errorMinus="5.236000e-02"/>
+      <measurement value="2.992140e-01" errorPlus="2.982351e-02" errorMinus="2.982351e-02"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="3.089240e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="4.137636e-02" value="3.564693e-01" errorMinus="4.137636e-02"/>
-    </dataPoint>
-  </dataPointSet>
-  <dataPointSet name="d13-x01-y01" dimension="2"
-      path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
-    <annotation>
-      <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
-      <item key="AidaPath" value="/REF/J1J3_3j_boosted" sticky="true"/>
-    </annotation>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.107080e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="8.810880e-02" value="4.646603e-01" errorMinus="8.810880e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.321240e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="6.118762e-02" value="4.562352e-01" errorMinus="6.118762e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.535400e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.405846e-02" value="4.841558e-01" errorMinus="5.405846e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.749560e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.628553e-02" value="5.031229e-01" errorMinus="5.628553e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.963720e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="6.116679e-02" value="4.915115e-01" errorMinus="6.116679e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.177880e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.891969e-02" value="4.475524e-01" errorMinus="5.891969e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.392040e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.086389e-02" value="4.071429e-01" errorMinus="5.086389e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.606200e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.931617e-02" value="5.003530e-01" errorMinus="5.931617e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.820360e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.162995e-02" value="4.628421e-01" errorMinus="5.162995e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="3.034520e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="6.981439e-02" value="4.518306e-01" errorMinus="6.981439e-02"/>
+      <measurement value="3.089240e+00" errorPlus="5.235999e-02" errorMinus="5.235999e-02"/>
+      <measurement value="3.564693e-01" errorPlus="4.137636e-02" errorMinus="4.137636e-02"/>
     </dataPoint>
   </dataPointSet>
-  <dataPointSet name="d14-x01-y01" dimension="2"
-      path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
-    <annotation>
-      <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
-      <item key="AidaPath" value="/REF/ZJ1_3j_inclusive" sticky="true"/>
-    </annotation>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="5.236000e-02" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.466389e-02" value="1.780959e-01" errorMinus="3.466389e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.570800e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.485255e-02" value="2.091851e-01" errorMinus="2.485255e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.618000e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.775945e-02" value="2.369341e-01" errorMinus="2.775945e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="3.665200e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.776589e-02" value="2.401134e-01" errorMinus="2.776589e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="4.712400e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.910419e-02" value="2.585013e-01" errorMinus="2.910419e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="5.759600e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.971547e-02" value="2.684506e-01" errorMinus="2.971547e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="6.806800e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.726308e-02" value="2.349995e-01" errorMinus="2.726308e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="7.854000e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.966743e-02" value="2.687504e-01" errorMinus="2.966743e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="8.901200e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.786550e-02" value="2.878233e-01" errorMinus="2.786550e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="9.948400e-01" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.122235e-02" value="3.318311e-01" errorMinus="3.122235e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.099560e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.723893e-02" value="2.796392e-01" errorMinus="2.723893e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.204280e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="2.669249e-02" value="2.587777e-01" errorMinus="2.669249e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="1.309000e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="3.036902e-02" value="3.057591e-01" errorMinus="3.036902e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.413720e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.339035e-02" value="3.594433e-01" errorMinus="3.339035e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.518440e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.080273e-02" value="3.229112e-01" errorMinus="3.080273e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="1.623160e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="2.979156e-02" value="2.961658e-01" errorMinus="2.979156e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.727880e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.238943e-02" value="3.516357e-01" errorMinus="3.238943e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.832600e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.496870e-02" value="3.801629e-01" errorMinus="3.496870e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="1.937320e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.172628e-02" value="3.655124e-01" errorMinus="3.172628e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.042040e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.570265e-02" value="3.882974e-01" errorMinus="3.570265e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.146760e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.362130e-02" value="3.576466e-01" errorMinus="3.362130e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.251480e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="3.691779e-02" value="3.809968e-01" errorMinus="3.691779e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.356200e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.597023e-02" value="3.745245e-01" errorMinus="3.597023e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.460920e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="3.688830e-02" value="3.894881e-01" errorMinus="3.688830e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.565640e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="4.103913e-02" value="3.979021e-01" errorMinus="4.103913e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.670360e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.910242e-02" value="3.411593e-01" errorMinus="3.910242e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="2.775080e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="4.106687e-02" value="3.785490e-01" errorMinus="4.106687e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.879800e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="4.015665e-02" value="3.747356e-01" errorMinus="4.015665e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.236000e-02" value="2.984520e+00" errorMinus="5.236000e-02"/>
-      <measurement errorPlus="3.522789e-02" value="3.359133e-01" errorMinus="3.522789e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="5.235999e-02" value="3.089240e+00" errorMinus="5.235999e-02"/>
-      <measurement errorPlus="4.994667e-02" value="3.953697e-01" errorMinus="4.994667e-02"/>
-    </dataPoint>
-  </dataPointSet>
-  <dataPointSet name="d15-x01-y01" dimension="2"
-      path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
-    <annotation>
-      <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
-      <item key="AidaPath" value="/REF/J1J2_3j_boosted" sticky="true"/>
-    </annotation>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.107080e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="6.868229e-02" value="4.291077e-01" errorMinus="6.868229e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.321240e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="4.855762e-02" value="3.457126e-01" errorMinus="4.855762e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.535400e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="4.840717e-02" value="3.658830e-01" errorMinus="4.840717e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.749560e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.137098e-02" value="4.135758e-01" errorMinus="5.137098e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="1.963720e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.146787e-02" value="4.490587e-01" errorMinus="5.146787e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.177880e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.161818e-02" value="5.035996e-01" errorMinus="5.161818e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.392040e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="6.175121e-02" value="6.249897e-01" errorMinus="6.175121e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.606200e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.091586e-02" value="5.356855e-01" errorMinus="5.091586e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="2.820360e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.494476e-02" value="5.604076e-01" errorMinus="5.494476e-02"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="1.070800e-01" value="3.034520e+00" errorMinus="1.070800e-01"/>
-      <measurement errorPlus="5.791698e-02" value="4.413854e-01" errorMinus="5.791698e-02"/>
-    </dataPoint>
-  </dataPointSet>
-  <dataPointSet name="d16-x01-y01" dimension="2"
-      path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
-    <annotation>
-      <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
-      <item key="AidaPath" value="/REF/thrust_boosted" sticky="true"/>
-    </annotation>
-    <dataPoint>
-      <measurement errorPlus="4.140500e-01" value="-1.416405e+01" errorMinus="4.140500e-01"/>
-      <measurement errorPlus="4.275660e-03" value="2.101300e-02" errorMinus="4.275660e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="4.140500e-01" value="-1.333595e+01" errorMinus="4.140500e-01"/>
-      <measurement errorPlus="1.531200e-03" value="1.078200e-02" errorMinus="1.531200e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="4.140500e-01" value="-1.250785e+01" errorMinus="4.140500e-01"/>
-      <measurement errorPlus="1.260870e-03" value="1.372490e-02" errorMinus="1.260870e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="4.141000e-01" value="-1.167970e+01" errorMinus="4.141000e-01"/>
-      <measurement errorPlus="2.069870e-03" value="1.963490e-02" errorMinus="2.069870e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="4.140500e-01" value="-1.085155e+01" errorMinus="4.140500e-01"/>
-      <measurement errorPlus="3.196850e-03" value="2.694290e-02" errorMinus="3.196850e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="4.140600e-01" value="-1.002344e+01" errorMinus="4.140600e-01"/>
-      <measurement errorPlus="3.998020e-03" value="4.297670e-02" errorMinus="3.998020e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="4.140650e-01" value="-9.195315e+00" errorMinus="4.140650e-01"/>
-      <measurement errorPlus="3.764310e-03" value="6.622890e-02" errorMinus="3.764310e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="4.140650e-01" value="-8.367185e+00" errorMinus="4.140650e-01"/>
-      <measurement errorPlus="5.064700e-03" value="9.605810e-02" errorMinus="5.064700e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="4.140600e-01" value="-7.539060e+00" errorMinus="4.140600e-01"/>
-      <measurement errorPlus="5.211920e-03" value="1.005750e-01" errorMinus="5.211920e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="4.140600e-01" value="-6.710940e+00" errorMinus="4.140600e-01"/>
-      <measurement errorPlus="5.665090e-03" value="1.240970e-01" errorMinus="5.665090e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="4.140650e-01" value="-5.882815e+00" errorMinus="4.140650e-01"/>
-      <measurement errorPlus="6.120810e-03" value="1.220020e-01" errorMinus="6.120810e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="4.140650e-01" value="-5.054685e+00" errorMinus="4.140650e-01"/>
-      <measurement errorPlus="5.984860e-03" value="1.086820e-01" errorMinus="5.984860e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="4.140600e-01" value="-4.226560e+00" errorMinus="4.140600e-01"/>
-      <measurement errorPlus="5.277780e-03" value="9.817730e-02" errorMinus="5.277780e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="4.140600e-01" value="-3.398440e+00" errorMinus="4.140600e-01"/>
-      <measurement errorPlus="5.376940e-03" value="1.056930e-01" errorMinus="5.376940e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="4.140650e-01" value="-2.570315e+00" errorMinus="4.140650e-01"/>
-      <measurement errorPlus="6.812520e-03" value="1.282780e-01" errorMinus="6.812520e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="4.140650e-01" value="-1.742185e+00" errorMinus="4.140650e-01"/>
-      <measurement errorPlus="6.097560e-03" value="1.136750e-01" errorMinus="6.097560e-03"/>
-    </dataPoint>
-    <dataPoint>
-      <measurement errorPlus="4.140600e-01" value="-9.140600e-01" errorMinus="4.140600e-01"/>
-      <measurement errorPlus="1.016800e-03" value="9.007160e-03" errorMinus="1.016800e-03"/>
-    </dataPoint>
-  </dataPointSet>
-  <dataPointSet name="d17-x01-y01" dimension="2"
+  <dataPointSet name="d09-x01-y01" dimension="2"
       path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
     <annotation>
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
       <item key="AidaPath" value="/REF/thrust_inclusive" sticky="true"/>
     </annotation>
-    <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-1.408125e+01" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="2.050450e-03" value="1.283410e-02" errorMinus="2.050450e-03"/>
+        <dataPoint>
+      <measurement errorPlus="3.187500e-01" value="-1.406875e+01" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="1.900000e-03" value="1.390000e-02" errorMinus="1.900000e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-1.341875e+01" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="7.076630e-04" value="5.278790e-03" errorMinus="7.076630e-04"/>
+      <measurement errorPlus="3.187500e-01" value="-1.343125e+01" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="6.500000e-04" value="5.420000e-03" errorMinus="6.500000e-04"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-1.275625e+01" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="7.003930e-04" value="7.490170e-03" errorMinus="7.003930e-04"/>
+      <measurement errorPlus="3.187500e-01" value="-1.279375e+01" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="6.800000e-04" value="7.600000e-03" errorMinus="6.800000e-04"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-1.209375e+01" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="6.634360e-04" value="1.068510e-02" errorMinus="6.634360e-04"/>
+      <measurement errorPlus="3.187500e-01" value="-1.215625e+01" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="6.500000e-04" value="1.040000e-02" errorMinus="6.500000e-04"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-1.143125e+01" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="8.627300e-04" value="1.493440e-02" errorMinus="8.627300e-04"/>
+      <measurement errorPlus="3.187500e-01" value="-1.151875e+01" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="7.500000e-04" value="1.420000e-02" errorMinus="7.500000e-04"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-1.076875e+01" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="1.519420e-03" value="2.202540e-02" errorMinus="1.519420e-03"/>
+      <measurement errorPlus="3.187500e-01" value="-1.088125e+01" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="1.200000e-03" value="2.010000e-02" errorMinus="1.200000e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-1.010625e+01" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="2.199590e-03" value="3.044030e-02" errorMinus="2.199590e-03"/>
+      <measurement errorPlus="3.187500e-01" value="-1.024375e+01" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="1.900000e-03" value="2.800000e-02" errorMinus="1.900000e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-9.443750e+00" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="2.560680e-03" value="4.128610e-02" errorMinus="2.560680e-03"/>
+      <measurement errorPlus="3.187500e-01" value="-9.606250e+00" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="2.400000e-03" value="3.780000e-02" errorMinus="2.400000e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-8.781250e+00" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="2.994250e-03" value="5.676880e-02" errorMinus="2.994250e-03"/>
+      <measurement errorPlus="3.187500e-01" value="-8.968750e+00" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="2.700000e-03" value="5.240000e-02" errorMinus="2.700000e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-8.118750e+00" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="3.407360e-03" value="7.312010e-02" errorMinus="3.407360e-03"/>
+      <measurement errorPlus="3.187500e-01" value="-8.331250e+00" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="3.100000e-03" value="6.790000e-02" errorMinus="3.100000e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-7.456250e+00" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="3.495530e-03" value="9.269200e-02" errorMinus="3.495530e-03"/>
+      <measurement errorPlus="3.187500e-01" value="-7.693750e+00" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="3.400000e-03" value="8.570000e-02" errorMinus="3.400000e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-6.793750e+00" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="3.457380e-03" value="1.142370e-01" errorMinus="3.457380e-03"/>
+      <measurement errorPlus="3.187500e-01" value="-7.056250e+00" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="3.400000e-03" value="1.054000e-01" errorMinus="3.400000e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-6.131250e+00" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="3.601130e-03" value="1.301310e-01" errorMinus="3.601130e-03"/>
+      <measurement errorPlus="3.187500e-01" value="-6.418750e+00" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="3.400000e-03" value="1.236000e-01" errorMinus="3.400000e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-5.468750e+00" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="3.925550e-03" value="1.478740e-01" errorMinus="3.925550e-03"/>
+      <measurement errorPlus="3.187500e-01" value="-5.781250e+00" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="3.700000e-03" value="1.417000e-01" errorMinus="3.700000e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-4.806250e+00" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="4.380630e-03" value="1.497340e-01" errorMinus="4.380630e-03"/>
+      <measurement errorPlus="3.187500e-01" value="-5.143750e+00" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="3.900000e-03" value="1.478000e-01" errorMinus="3.900000e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-4.143750e+00" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="5.433390e-03" value="1.470840e-01" errorMinus="5.433390e-03"/>
+      <measurement errorPlus="3.187500e-01" value="-4.506250e+00" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="4.600000e-03" value="1.500000e-01" errorMinus="4.600000e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-3.481250e+00" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="5.960570e-03" value="1.341710e-01" errorMinus="5.960570e-03"/>
+      <measurement errorPlus="3.187000e-01" value="-3.868700e+00" errorMinus="3.187000e-01"/>
+      <measurement errorPlus="5.600000e-03" value="1.428000e-01" errorMinus="5.600000e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-2.818750e+00" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="5.034730e-03" value="1.214070e-01" errorMinus="5.034730e-03"/>
+      <measurement errorPlus="3.187500e-01" value="-3.231250e+00" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="5.900000e-03" value="1.302000e-01" errorMinus="5.900000e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-2.156250e+00" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="4.033100e-03" value="1.122340e-01" errorMinus="4.033100e-03"/>
+      <measurement errorPlus="3.187500e-01" value="-2.593750e+00" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="4.600000e-03" value="1.181000e-01" errorMinus="4.600000e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-1.493750e+00" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="4.190200e-03" value="8.423850e-02" errorMinus="4.190200e-03"/>
+      <measurement errorPlus="3.187500e-01" value="-1.956250e+00" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="3.900000e-03" value="1.092000e-01" errorMinus="3.900000e-03"/>
     </dataPoint>
     <dataPoint>
-      <measurement errorPlus="3.312500e-01" value="-8.312500e-01" errorMinus="3.312500e-01"/>
-      <measurement errorPlus="8.055410e-05" value="7.688620e-04" errorMinus="8.055410e-05"/>
+      <measurement errorPlus="3.187500e-01" value="-1.318750e+00" errorMinus="3.187500e-01"/>
+      <measurement errorPlus="3.000000e-03" value="5.630000e-02" errorMinus="3.000000e-03"/>
+    </dataPoint> 
+  </dataPointSet>
+  <dataPointSet name="d10-x01-y01" dimension="2"
+      path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
+    <annotation>
+      <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
+      <item key="AidaPath" value="/REF/d10-x01-y01" sticky="true"/>
+    </annotation>
+    <dataPoint>
+      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="6.248654e-04" errorPlus="1.877970e-04" errorMinus="1.877970e-04"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="3.248128e-03" errorPlus="8.562022e-04" errorMinus="8.562022e-04"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.535400e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.725397e-03" errorPlus="8.268675e-04" errorMinus="8.268675e-04"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.749560e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="1.350963e-02" errorPlus="1.554031e-03" errorMinus="1.554031e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.963720e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="3.129802e-02" errorPlus="2.604822e-03" errorMinus="2.604822e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.177880e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="7.530836e-02" errorPlus="4.453100e-03" errorMinus="4.453100e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.392040e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="1.849592e-01" errorPlus="7.478493e-03" errorMinus="7.478493e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.606200e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="3.762660e-01" errorPlus="1.212792e-02" errorMinus="1.212792e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.820360e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="9.233586e-01" errorPlus="2.031572e-02" errorMinus="2.031572e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="3.034520e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="3.056108e+00" errorPlus="3.720059e-02" errorMinus="3.720059e-02"/>
+    </dataPoint>
+  </dataPointSet>  
+  <dataPointSet name="d11-x01-y01" dimension="2"
+      path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
+    <annotation>
+      <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
+      <item key="AidaPath" value="/REF/d11-x01-y01" sticky="true"/>
+    </annotation>
+    <dataPoint>
+      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="1.922091e-03" errorPlus="5.364213e-04" errorMinus="5.364213e-04"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="7.439200e-03" errorPlus="1.979564e-03" errorMinus="1.979564e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.535400e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="1.237227e-02" errorPlus="2.111886e-03" errorMinus="2.111886e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.749560e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="3.287302e-02" errorPlus="3.800077e-03" errorMinus="3.800077e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.963720e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="8.208545e-02" errorPlus="6.862232e-03" errorMinus="6.862232e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.177880e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="1.911198e-01" errorPlus="1.171742e-02" errorMinus="1.171742e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.392040e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.459043e-01" errorPlus="1.938971e-02" errorMinus="1.938971e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.606200e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="8.323865e-01" errorPlus="3.046013e-02" errorMinus="3.046013e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.820360e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="1.496108e+00" errorPlus="4.403180e-02" errorMinus="4.403180e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="3.034520e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="1.567196e+00" errorPlus="5.114093e-02" errorMinus="5.114093e-02"/>
     </dataPoint>
   </dataPointSet>
-  <dataPointSet name="d18-x01-y01" dimension="2"
+  <dataPointSet name="d12-x01-y01" dimension="2"
       path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
     <annotation>
       <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
@@ -1561,4 +1253,316 @@
       <measurement errorPlus="7.912860e-02" value="6.509273e-01" errorMinus="7.912860e-02"/>
     </dataPoint>
   </dataPointSet>
-</aida>
+  <dataPointSet name="d13-x01-y01" dimension="2"
+      path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
+    <annotation>
+      <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
+      <item key="AidaPath" value="/REF/ZJ0_3j_boosted" sticky="true"/>
+    </annotation>
+    
+    <dataPoint>
+      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="2.678993e-03" errorPlus="1.252005e-03" errorMinus="1.252005e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="2.338446e-02" errorPlus="1.019354e-02" errorMinus="1.019354e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.535400e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.748378e-02" errorPlus="1.034789e-02" errorMinus="1.034789e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.749560e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="1.191777e-01" errorPlus="1.723032e-02" errorMinus="1.723032e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.963720e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="2.481718e-01" errorPlus="2.771097e-02" errorMinus="2.771097e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.177880e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="3.920558e-01" errorPlus="3.634801e-02" errorMinus="3.634801e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.392040e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="6.663357e-01" errorPlus="5.581988e-02" errorMinus="5.581988e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.606200e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="7.730854e-01" errorPlus="7.009541e-02" errorMinus="7.009541e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.820360e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="1.025160e+00" errorPlus="7.548324e-02" errorMinus="7.548324e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="3.034520e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="1.371873e+00" errorPlus="1.132023e-01" errorMinus="1.132023e-01"/>
+    </dataPoint>
+  </dataPointSet>
+  <dataPointSet name="d14-x01-y01" dimension="2"
+      path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
+    <annotation>
+      <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
+      <item key="AidaPath" value="/REF/ZJ1_3j_boosted" sticky="true"/>
+    </annotation>
+    <dataPoint>
+      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="2.636743e-01" errorPlus="4.656380e-02" errorMinus="4.656380e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="3.345433e-01" errorPlus="4.579215e-02" errorMinus="4.579215e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.535400e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="3.500322e-01" errorPlus="4.098865e-02" errorMinus="4.098865e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.749560e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.369331e-01" errorPlus="4.927013e-02" errorMinus="4.927013e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.963720e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.206322e-01" errorPlus="4.740547e-02" errorMinus="4.740547e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.177880e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.874840e-01" errorPlus="5.442006e-02" errorMinus="5.442006e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.392040e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="5.871479e-01" errorPlus="6.041694e-02" errorMinus="6.041694e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.606200e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="5.874949e-01" errorPlus="6.079197e-02" errorMinus="6.079197e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.820360e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="5.526414e-01" errorPlus="6.064583e-02" errorMinus="6.064583e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="3.034520e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="6.488231e-01" errorPlus="8.954420e-02" errorMinus="8.954420e-02"/>
+    </dataPoint>
+  </dataPointSet>
+  <dataPointSet name="d15-x01-y01" dimension="2"
+      path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
+    <annotation>
+      <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
+      <item key="AidaPath" value="/REF/J1J2_3j_boosted" sticky="true"/>
+    </annotation>
+    <dataPoint>
+      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.291077e-01" errorPlus="6.868231e-02" errorMinus="6.868231e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="3.457126e-01" errorPlus="4.855760e-02" errorMinus="4.855760e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.535400e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="3.658830e-01" errorPlus="4.840718e-02" errorMinus="4.840718e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.749560e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.135759e-01" errorPlus="5.137097e-02" errorMinus="5.137097e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.963720e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.490587e-01" errorPlus="5.146788e-02" errorMinus="5.146788e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.177880e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="5.035996e-01" errorPlus="5.161819e-02" errorMinus="5.161819e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.392040e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="6.249899e-01" errorPlus="6.175124e-02" errorMinus="6.175124e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.606200e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="5.356856e-01" errorPlus="5.091588e-02" errorMinus="5.091588e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.820360e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="5.604079e-01" errorPlus="5.494477e-02" errorMinus="5.494477e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="3.034520e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.413854e-01" errorPlus="5.791700e-02" errorMinus="5.791700e-02"/>
+    </dataPoint>
+  </dataPointSet>
+  <dataPointSet name="d16-x01-y01" dimension="2"
+      path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
+    <annotation>
+      <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
+      <item key="AidaPath" value="/REF/J1J3_3j_boosted" sticky="true"/>
+    </annotation>  
+    <dataPoint>
+      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.646603e-01" errorPlus="8.810881e-02" errorMinus="8.810881e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.562352e-01" errorPlus="6.118763e-02" errorMinus="6.118763e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.535400e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.841556e-01" errorPlus="5.405846e-02" errorMinus="5.405846e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.749560e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="5.031230e-01" errorPlus="5.628552e-02" errorMinus="5.628552e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.963720e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.915113e-01" errorPlus="6.116681e-02" errorMinus="6.116681e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.177880e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.475524e-01" errorPlus="5.891971e-02" errorMinus="5.891971e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.392040e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.071429e-01" errorPlus="5.086387e-02" errorMinus="5.086387e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.606200e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="5.003528e-01" errorPlus="5.931619e-02" errorMinus="5.931619e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.820360e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.628421e-01" errorPlus="5.162997e-02" errorMinus="5.162997e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="3.034520e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.518306e-01" errorPlus="6.981439e-02" errorMinus="6.981439e-02"/>
+    </dataPoint>
+  </dataPointSet>
+  <dataPointSet name="d17-x01-y01" dimension="2"
+      path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
+    <annotation>
+      <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
+      <item key="AidaPath" value="/REF/J2J3_3j_boosted" sticky="true"/>
+    </annotation>
+    
+    <dataPoint>
+      <measurement value="1.107080e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.614759e-01" errorPlus="6.810186e-02" errorMinus="6.810186e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.321240e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.410187e-01" errorPlus="5.255285e-02" errorMinus="5.255285e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.535400e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.719511e-01" errorPlus="5.041056e-02" errorMinus="5.041056e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.749560e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.603043e-01" errorPlus="4.836195e-02" errorMinus="4.836195e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="1.963720e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="5.357364e-01" errorPlus="5.632043e-02" errorMinus="5.632043e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.177880e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.827478e-01" errorPlus="5.135800e-02" errorMinus="5.135800e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.392040e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="5.075720e-01" errorPlus="5.844413e-02" errorMinus="5.844413e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.606200e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.745017e-01" errorPlus="5.391884e-02" errorMinus="5.391884e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="2.820360e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.237875e-01" errorPlus="4.864190e-02" errorMinus="4.864190e-02"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement value="3.034520e+00" errorPlus="1.070800e-01" errorMinus="1.070800e-01"/>
+      <measurement value="4.103109e-01" errorPlus="7.348031e-02" errorMinus="7.348031e-02"/>
+    </dataPoint>
+  </dataPointSet>
+  <dataPointSet name="d18-x01-y01" dimension="2"
+      path="/REF/CMS_EWK_11_021" title="Unfold Response aux \rightarrow aux">
+    <annotation>
+      <item key="Title" value="Unfold Response aux \rightarrow aux" sticky="true"/>
+      <item key="AidaPath" value="/REF/thrust_boosted" sticky="true"/>
+    </annotation>
+    <dataPoint>
+      <measurement errorPlus="3.984500e-01" value="-1.414845e+01" errorMinus="3.984500e-01"/>
+      <measurement errorPlus="4.700000e-03" value="2.080000e-02" errorMinus="4.700000e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement errorPlus="3.984500e-01" value="-1.335155e+01" errorMinus="3.984500e-01"/>
+      <measurement errorPlus="1.600000e-03" value="9.650000e-03" errorMinus="1.600000e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement errorPlus="3.984500e-01" value="-1.255465e+01" errorMinus="3.984500e-01"/>
+      <measurement errorPlus="1.400000e-03" value="1.350000e-02" errorMinus="1.400000e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement errorPlus="3.984000e-01" value="-1.175780e+01" errorMinus="3.984000e-01"/>
+      <measurement errorPlus="2.300000e-03" value="1.920000e-02" errorMinus="2.300000e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement errorPlus="3.984500e-01" value="-1.096095e+01" errorMinus="3.984500e-01"/>
+      <measurement errorPlus="3.700000e-03" value="2.700000e-02" errorMinus="3.700000e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement errorPlus="3.984400e-01" value="-1.016406e+01" errorMinus="3.984400e-01"/>
+      <measurement errorPlus="4.500000e-03" value="4.240000e-02" errorMinus="4.500000e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement errorPlus="3.984350e-01" value="-9.367185e+00" errorMinus="3.984350e-01"/>
+      <measurement errorPlus="3.900000e-03" value="6.140000e-02" errorMinus="3.900000e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement errorPlus="3.984350e-01" value="-8.570315e+00" errorMinus="3.984350e-01"/>
+      <measurement errorPlus="5.100000e-03" value="8.560000e-02" errorMinus="5.100000e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement errorPlus="3.984400e-01" value="-7.773440e+00" errorMinus="3.984400e-01"/>
+      <measurement errorPlus="5.700000e-03" value="9.840000e-02" errorMinus="5.700000e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement errorPlus="3.984400e-01" value="-6.976560e+00" errorMinus="3.984400e-01"/>
+      <measurement errorPlus="6.300000e-03" value="1.205000e-01" errorMinus="6.300000e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement errorPlus="3.984350e-01" value="-6.179685e+00" errorMinus="3.984350e-01"/>
+      <measurement errorPlus="6.300000e-03" value="1.207000e-01" errorMinus="6.300000e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement errorPlus="3.984350e-01" value="-5.382815e+00" errorMinus="3.984350e-01"/>
+      <measurement errorPlus="6.100000e-03" value="1.175000e-01" errorMinus="6.100000e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement errorPlus="3.984400e-01" value="-4.585940e+00" errorMinus="3.984400e-01"/>
+      <measurement errorPlus="5.500000e-03" value="1.048000e-01" errorMinus="5.500000e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement errorPlus="3.984400e-01" value="-3.789060e+00" errorMinus="3.984400e-01"/>
+      <measurement errorPlus="5.300000e-03" value="1.007000e-01" errorMinus="5.300000e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement errorPlus="3.984350e-01" value="-2.992185e+00" errorMinus="3.984350e-01"/>
+      <measurement errorPlus="5.900000e-03" value="1.104000e-01" errorMinus="5.900000e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement errorPlus="3.984350e-01" value="-2.195315e+00" errorMinus="3.984350e-01"/>
+      <measurement errorPlus="7.400000e-03" value="1.342000e-01" errorMinus="7.400000e-03"/>
+    </dataPoint>
+    <dataPoint>
+      <measurement errorPlus="3.984400e-01" value="-1.398440e+00" errorMinus="3.984400e-01"/>
+      <measurement errorPlus="3.900000e-03" value="6.790000e-02" errorMinus="3.900000e-03"/>
+    </dataPoint>
+  </dataPointSet>
+</aida>  

--- a/GeneratorInterface/RivetInterface/data/CMS_EWK_11_021.info
+++ b/GeneratorInterface/RivetInterface/data/CMS_EWK_11_021.info
@@ -1,24 +1,27 @@
 Name: CMS_EWK_11_021
 Year: 2011
-Summary: Azimuthal correlations and event shapes in Z + jets in pp collisions at sqrt(s) = 7 TeV
-
+Summary: 'Azimuthal correlations and event shapes in Z + jets in pp collisions at sqrt(s) = 7 TeV'
 Experiment: CMS
 Collider: LHC
-SpiresID: 
+SpiresID: 1209721
 Status: UNVALIDATED
 Authors:
  - Io Odderskov <io.odderskov@gmail.com> 
 References:
  - http://cms.cern.ch/iCMS/analysisadmin/cadi?ancode=EWK-11-021 
+ - https://cds.cern.ch/record/1503578
+ - http://inspirehep.net/record/1209721
+ - arXiv:1301.1646 [hep-ex] (http://arxiv.org/abs/arXiv:1301.1646)
+ - Submitted to Phys. Lett. B
 RunInfo:
    Run MC generators with Z decaying to leptonic modes at 7TeV comEnergy
 NumEvents: 100k
 Beams: [p+, p+]
 Energies: [7000]
 PtCuts: 
-  leptons Pt>20GeV and |leptons_eta|<2.4,| Jets>50GeV
+  leptons Pt>20GeV and |leptons_eta|<2.4, Jets>50GeV
 Description:
-  Measurements are presented of event shapes and azimuthal correlations in the inclu-
+  'Measurements are presented of event shapes and azimuthal correlations in the inclu-
   sive production of a Z boson in association with jets in proton-proton collisions. The
   data correspond to an integrated luminosity of 5.0 fb1, collected with the CMS detec-
   tor at the CERN LHC at sqrt(s) = 7 TeV. This to test perturbative QCD predictions
@@ -28,11 +31,21 @@ Description:
   Carlo event generators that include leading-order multiparton matrix-element (with
   up to four hard partons in the final state) and next-to-leading-order simulations of
   Z + 1-jet events. The results are corrected for detector effects, and can therefore be
-  used as input to improve models for describing these processes.
-BibKey: 
-   '<Insert SPIRES BibTeX key>'
-BibTeX: 
-   '<Insert SPIRES BibTeX block>'
-ToDo:
- - update reference when paper published
-
+  used as input to improve models for describing these processes.'
+BibKey: 'Chatrchyan:2013tna'
+BibTeX: '@article{Chatrchyan:2013tna,
+      author         = "Chatrchyan, Serguei and others",
+      title          = "{Event shapes and azimuthal correlations in $Z$ + jets
+                        events in $pp$ collisions at $\sqrt{s}=7$ TeV}",
+      collaboration  = "CMS Collaboration",
+      journal        = "Phys.Lett.",
+      volume         = "B722",
+      pages          = "238-261",
+      doi            = "10.1016/j.physletb.2013.04.025",
+      year           = "2013",
+      eprint         = "1301.1646",
+      archivePrefix  = "arXiv",
+      primaryClass   = "hep-ex",
+      reportNumber   = "CMS-EWK-11-021, CERN-PH-EP-2013-001",
+      SLACcitation   = "%%CITATION = ARXIV:1301.1646;%%",
+}'

--- a/GeneratorInterface/RivetInterface/data/CMS_EWK_11_021.plot
+++ b/GeneratorInterface/RivetInterface/data/CMS_EWK_11_021.plot
@@ -1,256 +1,88 @@
-# BEGIN PLOT /CMS_EWK_11_021/Mll
-Title=CMS $\text{M}_{ll}$, $\sqrt{s}=7$~TeV 
-XLabel=$\text{M}_{ll}$ [GeV]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{dM}$
+# BEGIN PLOT /CMS_EWK_11_021/d
 FullRange=1
-LogY=1
 LegendXPos=0.1
 # END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/Njets
-Title=CMS Number of jets, $\sqrt{s}=7$~TeV 
-XLabel=#Jets$(50\text{GeV})$
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{dN}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/Ptll
-Title=CMS $\text{P}_T^{ll}$, $\sqrt{s}=7$~TeV 
-XLabel=$\text{P}_T^{ll}$ [GeV]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{dP_t}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/Mjj
-Title=CMS $\text{M}_{jj}$, $\sqrt{s}=7$~TeV 
-XLabel=$\text{M}_{jj}$ [GeV]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{dM}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/PtJet1
-Title=CMS $\text{P}_T^{1\text{st jet}}$, $\sqrt{s}=7$~TeV 
-XLabel=$\text{P}_T^{1\text{st jet}}$ [GeV]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{dP_t}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/PtJet2
-Title=CMS $\text{P}_T^{2\text{nd jet}}$, $\sqrt{s}=7$~TeV 
-XLabel=$\text{P}_T^{2\text{nd jet}}$ [GeV]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{dP_t}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/PtJet3
-Title=CMS $\text{P}_T^{3\text{rd jet}}$, $\sqrt{s}=7$~TeV 
-XLabel=$\text{P}_T^{3\text{rd jet}}$ [GeV]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{dP_t}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/PtJet4
-Title=CMS $\text{P}_T^{4\text{th jet}}$, $\sqrt{s}=7$~TeV 
-XLabel=$\text{P}_T^{4\text{th jet}}$ [GeV]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{dP_t}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/d10-x01-y01
-Title=CMS, $\Delta\phi(\text{Z},\text{J1})$, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{Z},\text{J1})$ [rad]
+
+# BEGIN PLOT /CMS_EWK_11_021/d(0[1-8]|1[0-7])
 YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
 LogY=1
-LegendXPos=0.1
 # END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/DeltaPhiZJ2
-Title=CMS, $\Delta\phi(\text{Z},\text{J2})$, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{Z},\text{J2})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/d04-x01-y01
-Title=CMS, $\Delta\phi(\text{Z},\text{J3})$, $\geq$ 3 Jets, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{Z},\text{J3})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/d01-x01-y01
-Title=CMS, $\Delta\phi(\text{Z},\text{J1})$, $\geq$ 2 Jets, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{Z}\text{J1})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/d08-x01-y01
-Title=CMS, $\Delta\phi(\text{Z},\text{J1})$, $\geq$ 3 Jets, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{Z},\text{J1})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/d14-x01-y01
-Title=CMS, $\Delta\phi(\text{Z},\text{J2})$, $\geq$ 3 Jets, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{Z},\text{J2})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/DeltaPhiJ1J2_2
-Title=CMS, $\Delta\phi(\text{J1},\text{J2})$, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{J1},\text{J2})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/d03-x01-y01
-Title=CMS, $\Delta\phi(\text{J1},\text{J2})$, $\geq$ 3 Jets, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{J1},\text{J2})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/SumDeltaPhi
-Title=CMS, $\Sigma\Delta\phi$, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{J1},\text{J2})+\Delta\phi(\text{J1},\text{J3})+\Delta\phi(\text{J2},\text{J3})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/d17-x01-y01
-Title=CMS, Thrust, $\sqrt{s}=7$~TeV 
+
+# BEGIN PLOT /CMS_EWK_11_021/d(09|18)
 XLabel=$\ln{\tau_{\perp}}$
 YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\ln{\tau_{\perp}}}$
-FullRange=1
 LogY=0
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/d09-x01-y01
-Title=CMS, $\Delta\phi(\text{Z},\text{J1})$, Boosted regime, $\sqrt{s}=7$~TeV 
+# END PLOT 
+
+# BEGIN PLOT /CMS_EWK_11_021/d(0[14]|1[0134])
 XLabel=$\Delta\phi(\text{Z},\text{J1})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/BoostedDeltaPhiZJ2
-Title=CMS, $\Delta\phi(\text{Z},\text{J2})$, Boosted regime, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{Z},\text{J2})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/d18-x01-y01
-Title=CMS, $\Delta\phi(\text{Z},\text{J3})$, $\geq$ 3 Jets, Boosted regime, $\sqrt{s}=7$~TeV 
+# END PLOT 
+# BEGIN PLOT /CMS_EWK_11_021/d(03|12)
 XLabel=$\Delta\phi(\text{Z},\text{J3})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
+# END PLOT 
+# BEGIN PLOT /CMS_EWK_11_021/d(06|15)
+XLabel=$\Delta\phi(\text{J1},\text{J2})$ [rad]
+# END PLOT
+# BEGIN PLOT /CMS_EWK_11_021/d(07|16)
+XLabel=$\Delta\phi(\text{J1},\text{J3})$ [rad]
+# END PLOT
+# BEGIN PLOT /CMS_EWK_11_021/d(08|17)
+XLabel=$\Delta\phi(\text{J2},\text{J3})$ [rad]
+# END PLOT
+
+# BEGIN PLOT /CMS_EWK_11_021/d01-x01-y01
+Title=CMS, $\Delta\phi(\text{Z},\text{J1})$, $\sqrt{s}=7$~TeV 
 # END PLOT
 # BEGIN PLOT /CMS_EWK_11_021/d02-x01-y01
-Title=CMS, $\Delta\phi(\text{Z},\text{J1})$, $\geq$ 2 Jets, Boosted regime, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{Z},\text{J1})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
+Title=CMS, $\Delta\phi(\text{Z},\text{J1})$, $\geq$ 2 Jets, $\sqrt{s}=7$~TeV
+XLabel=$\Delta\phi(\text{Z}\text{J1})$ [rad]
+# END PLOT
+# BEGIN PLOT /CMS_EWK_11_021/d03-x01-y01
+Title=CMS, $\Delta\phi(\text{Z},\text{J3})$, $\geq$ 3 Jets, $\sqrt{s}=7$~TeV 
+# END PLOT
+# BEGIN PLOT /CMS_EWK_11_021/d04-x01-y01
+Title=CMS, $\Delta\phi(\text{Z},\text{J1})$, $\geq$ 3 Jets, $\sqrt{s}=7$~TeV 
+# END PLOT
+# BEGIN PLOT /CMS_EWK_11_021/d05-x01-y01
+Title=CMS, $\Delta\phi(\text{Z},\text{J2})$, $\geq$ 3 Jets, $\sqrt{s}=7$~TeV 
+XLabel=$\Delta\phi(\text{Z},\text{J2})$ [rad]
 # END PLOT
 # BEGIN PLOT /CMS_EWK_11_021/d06-x01-y01
-Title=CMS, $\Delta\phi(\text{Z},\text{J1})$, $\geq$ 3 Jets, Boosted regime, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{Z},\text{J1})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
+Title=CMS, $\Delta\phi(\text{J1},\text{J2})$, $\geq$ 3 Jets, $\sqrt{s}=7$~TeV 
 # END PLOT
 # BEGIN PLOT /CMS_EWK_11_021/d07-x01-y01
-Title=CMS, $\Delta\phi(\text{Z},\text{J2})$, $\geq$ 3 Jets, Boosted regime, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{Z},\text{J1})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
+Title=CMS, $\Delta\phi(\text{J1},\text{J3})$, $\geq$ 3 Jets, $\sqrt{s}=7$~TeV 
 # END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/BoostedDeltaPhiJ1J2_2
-Title=CMS, $\Delta\phi(\text{J1},\text{J2})$, $\geq$ 2 Jets, Boosted regime, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{J1},\text{J2})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
+# BEGIN PLOT /CMS_EWK_11_021/d08-x01-y01
+Title=CMS, $\Delta\phi(\text{J2},\text{J3})$, $\geq$ 3 Jets, $\sqrt{s}=7$~TeV 
+# END PLOT
+# BEGIN PLOT /CMS_EWK_11_021/d09-x01-y01
+Title=CMS, Thrust, $\sqrt{s}=7$~TeV 
+# END PLOT
+# BEGIN PLOT /CMS_EWK_11_021/d10-x01-y01
+Title=CMS, $\Delta\phi(\text{Z},\text{J1})$, Boosted regime, $\sqrt{s}=7$~TeV 
+# END PLOT
+# BEGIN PLOT /CMS_EWK_11_021/d11-x01-y01
+Title=CMS, $\Delta\phi(\text{Z},\text{J1})$, $\geq$ 2 Jets, Boosted regime, $\sqrt{s}=7$~TeV 
+# END PLOT
+# BEGIN PLOT /CMS_EWK_11_021/d12-x01-y01
+Title=CMS, $\Delta\phi(\text{Z},\text{J3})$, $\geq$ 3 Jets, Boosted regime, $\sqrt{s}=7$~TeV 
+# END PLOT
+# BEGIN PLOT /CMS_EWK_11_021/d13-x01-y01
+Title=CMS, $\Delta\phi(\text{Z},\text{J1})$, $\geq$ 3 Jets, Boosted regime, $\sqrt{s}=7$~TeV 
+# END PLOT
+# BEGIN PLOT /CMS_EWK_11_021/d14-x01-y01
+Title=CMS, $\Delta\phi(\text{Z},\text{J2})$, $\geq$ 3 Jets, Boosted regime, $\sqrt{s}=7$~TeV 
 # END PLOT
 # BEGIN PLOT /CMS_EWK_11_021/d15-x01-y01
 Title=CMS, $\Delta\phi(\text{J1},\text{J2})$, $\geq$ 3 Jets, Boosted regime, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{J1},\text{J2})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/BoostedSumDeltaPhi
-Title=CMS, $\Sigma\Delta\phi$, Boosted regime, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi\text{J1}\text{J2}+\Delta\phi\text{J1}\text{J3}+\Delta\phi\text{J2}\text{J3}$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
 # END PLOT
 # BEGIN PLOT /CMS_EWK_11_021/d16-x01-y01
-Title=CMS, Thrust, Boosted regime, $\sqrt{s}=7$~TeV 
-XLabel=$\ln{\tau_{\perp}}$
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\ln{\tau_{\perp}}}$
-FullRange=1
-LogY=0
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/d13-x01-y01
 Title=CMS, $\Delta\phi(\text{J1}\text{J3})$, $\geq$ 3 Jets, Boosted regime, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{J1},\text{J3})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
 # END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/d05-x01-y01
-Title=CMS, $\Delta\phi(\text{J1},\text{J3})$, $\geq$ 3 Jets, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{J1},\text{J3})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
-# END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/d11-x01-y01
+# BEGIN PLOT /CMS_EWK_11_021/d17-x01-y01
 Title=CMS, $\Delta\phi(\text{J2},{J3})$, $\geq$ 3 Jets, Boosted regime, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{J2},\text{J3})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
 # END PLOT
-# BEGIN PLOT /CMS_EWK_11_021/d12-x01-y01
-Title=CMS, $\Delta\phi(\text{J2},\text{J3})$, $\geq$ 3 Jets, $\sqrt{s}=7$~TeV 
-XLabel=$\Delta\phi(\text{J2},\text{J3})$ [rad]
-YLabel=$\frac{1}{\sigma}\frac{d\sigma}{d\phi}$
-FullRange=1
-LogY=1
-LegendXPos=0.1
+# BEGIN PLOT /CMS_EWK_11_021/d18-x01-y01
+Title=CMS, Thrust, Boosted regime, $\sqrt{s}=7$~TeV 
 # END PLOT

--- a/GeneratorInterface/RivetInterface/src/CMS_EWK_11_021.cc
+++ b/GeneratorInterface/RivetInterface/src/CMS_EWK_11_021.cc
@@ -4,8 +4,7 @@
 #include "Rivet/Tools/BinnedHistogram.hh"
 #include "Rivet/Projections/FinalState.hh"
 #include "Rivet/Projections/FastJets.hh"
-#include "Rivet/Projections/ChargedFinalState.hh"
-#include "Rivet/Projections/InvMassFinalState.hh"
+#include "Rivet/Projections/ZFinder.hh"
 #include "Rivet/Tools/ParticleIdUtils.hh"
 #include "Rivet/Math/Vector4.hh"
 #include "Rivet/Projections/Thrust.hh"
@@ -27,467 +26,195 @@ namespace Rivet {
     void init()
       {
 
+      //full final state
       const FinalState fs(-5.0,5.0);
       addProjection(fs, "FS");
-
-      // Histograms without data
-      _histMll            = bookHistogram1D("Mll", 60, 50., 130.);
-      _histNjets          = bookHistogram1D("Njets", 5, -0.5, 4.5);
-      _histPtll           = bookHistogram1D("Ptll", 50, 0., 1000.);
-      _histMjj            = bookHistogram1D("Mjj", 70, 0., 1400.);   
-      _histPtJet1         = bookHistogram1D("PtJet1", 45, 50., 500.);
-      _histPtJet2         = bookHistogram1D("PtJet2", 45, 50., 500.);
-      _histPtJet3         = bookHistogram1D("PtJet3", 45, 50., 500.);
-      _histPtJet4         = bookHistogram1D("PtJet4", 45, 50., 500.);
-      _histDeltaPhiZJ2    = bookHistogram1D("DeltaPhiZJ2", 32, 0., 3.15);
-      _histDeltaPhiJ1J2_2 = bookHistogram1D("DeltaPhiJ1J2_2", 32, 0., 3.15);
-      _histSumDeltaPhi    = bookHistogram1D("SumDeltaPhi", 32, 0, 6.30);
-      // Boosted regime
-      _histBoostedDeltaPhiZJ2    = bookHistogram1D("BoostedDeltaPhiZJ2", 32, 0., 3.15);
-      _histBoostedDeltaPhiJ1J2_2 = bookHistogram1D("BoostedDeltaPhiJ1J2_2", 32, 0., 3.15);
-      _histBoostedSumDeltaPhi    = bookHistogram1D("BoostedSumDeltaPhi", 32, 0, 6.30);
-
+      //Z finders for electrons and muons
+      const ZFinder zfe(fs, -2.4, 2.4, 20*GeV, 11, 71*GeV, 111.*GeV, 0.1, true, false);
+      const ZFinder zfm(fs, -2.4, 2.4, 20*GeV, 13, 71*GeV, 111.*GeV, 0.1, true, false);
+      addProjection(zfe, "ZFE");
+      addProjection(zfm, "ZFM");
+      //jets  
+      const FastJets jets(fs, FastJets::ANTIKT, 0.5);
+      addProjection(jets, "JETS");
 
       //Histograms with data
-      _histDeltaPhiZJ1    = bookHistogram1D(10, 1, 1);
-      _histDeltaPhiZJ3    = bookHistogram1D(4, 1, 1);
-      _histDeltaPhiZJ1_2  = bookHistogram1D(1, 1, 1);
-      _histDeltaPhiZJ1_3  = bookHistogram1D(8, 1, 1);
-      _histDeltaPhiZJ2_3  = bookHistogram1D(14, 1, 1);
-      _histDeltaPhiJ1J2_3 = bookHistogram1D(3, 1, 1);
-      _histDeltaPhiJ1J3_3 = bookHistogram1D(5, 1, 1);   	
-      _histDeltaPhiJ2J3_3 = bookHistogram1D(12, 1, 1);   	
-      _histTransvThrust   = bookHistogram1D(17, 1, 1);
+      _histDeltaPhiZJ1    = bookHistogram1D(1, 1, 1); //10, 1, 1); 
+      _histDeltaPhiZJ1_2  = bookHistogram1D(2, 1, 1); //1, 1, 1);  
+      _histDeltaPhiZJ3    = bookHistogram1D(3, 1, 1); //4, 1, 1);  
+      _histDeltaPhiZJ1_3  = bookHistogram1D(4, 1, 1);  //8, 1, 1);
+      _histDeltaPhiZJ2_3  = bookHistogram1D(5, 1, 1); //14, 1, 1);
+      _histDeltaPhiJ1J2_3 = bookHistogram1D(6, 1, 1); //3, 1, 1);
+      _histDeltaPhiJ1J3_3 = bookHistogram1D(7, 1, 1); //5, 1, 1);   	
+      _histDeltaPhiJ2J3_3 = bookHistogram1D(8, 1, 1); //12, 1, 1);   	
+      _histTransvThrust   = bookHistogram1D(9, 1, 1); //17, 1, 1);
       // Boosted regime
-      _histBoostedDeltaPhiZJ1    = bookHistogram1D(9, 1, 1);
-      _histBoostedDeltaPhiZJ3    = bookHistogram1D(18, 1, 1);
-      _histBoostedDeltaPhiZJ1_2  = bookHistogram1D(2, 1, 1);
-      _histBoostedDeltaPhiZJ1_3  = bookHistogram1D(6, 1, 1);
-      _histBoostedDeltaPhiZJ2_3  = bookHistogram1D(7, 1, 1);
-      _histBoostedDeltaPhiJ1J2_3 = bookHistogram1D(15, 1, 1);
-      _histBoostedDeltaPhiJ1J3_3 = bookHistogram1D(13, 1, 1);    
-      _histBoostedDeltaPhiJ2J3_3 = bookHistogram1D(11, 1, 1);    
-      _histBoostedTransvThrust   = bookHistogram1D(16, 1, 1);
+      _histBoostedDeltaPhiZJ1    = bookHistogram1D(10, 1, 1); //9, 1, 1);
+      _histBoostedDeltaPhiZJ1_2  = bookHistogram1D(11, 1, 1); //2, 1, 1);
+      _histBoostedDeltaPhiZJ3    = bookHistogram1D(12, 1, 1); //18, 1, 1);
+      _histBoostedDeltaPhiZJ1_3  = bookHistogram1D(13, 1, 1); //6, 1, 1);
+      _histBoostedDeltaPhiZJ2_3  = bookHistogram1D(14, 1, 1); //7, 1, 1);
+      _histBoostedDeltaPhiJ1J2_3 = bookHistogram1D(15, 1, 1);  //15, 1, 1);
+      _histBoostedDeltaPhiJ1J3_3 = bookHistogram1D(16, 1, 1); //13, 1, 1);    
+      _histBoostedDeltaPhiJ2J3_3 = bookHistogram1D(17, 1, 1); //11, 1, 1);    
+      _histBoostedTransvThrust   = bookHistogram1D(18, 1, 1); //16, 1, 1);
 
       }
 
-    // Function that finds all photons, and particles and antiparticles of a specified type:
-    void FindPhoParParbar(ParticleVector FPtcls, int Par, vector<unsigned int>& PhoIndex, vector<unsigned int>& ParIndex, vector<unsigned int>& ParbarIndex)
-      {
-      for(unsigned int i(0); i!=FPtcls.size(); ++i)
-        {
-        FourMomentum p(FPtcls[i].momentum());
-        double eta = p.eta();
-        int Id = FPtcls[i].pdgId();
-
-        if( Id==22 ) PhoIndex.push_back(i);
-        if( Id==Par && fabs(eta) < 2.4 ) ParIndex.push_back(i); // && (fabs(eta) < 1.4442 || fabs(eta) > 1.5660)
-        if( Id==-Par && fabs(eta) < 2.4 ) ParbarIndex.push_back(i); // && (fabs(eta) < 1.4442 || fabs(eta) > 1.5660)  
-        }
-        return;
-      }
-
-
-
-    //Function that convolutes a particle (or antiparticle) with the surrounding photons:
-    void ConvPar(vector<unsigned int> PhoIndex, vector<unsigned int> ParIndex, FourMomentum& par_conv, vector<unsigned int>& par_del, ParticleVector FPtcls, bool& is_par)
-      {
-
-      vector<unsigned int> tmp_par_del;
-      FourMomentum tmp_par_conv;
-      FourMomentum tmp_test_conv;
-
-      for(unsigned int i(0); i != ParIndex.size(); ++i)
-        {
-        double R;
-        double mass;
-        FourMomentum par_4p (FPtcls.at( ParIndex[i]).momentum());
-        double par_eta (par_4p.eta());
-        double par_phi (par_4p.phi());
-        
-        tmp_par_del.clear();
-        tmp_par_del.push_back(ParIndex[i]);
-        tmp_par_conv = par_4p;
-        tmp_test_conv = par_4p;
-       
-        for(unsigned int j(0); j != PhoIndex.size(); ++j)
-          {
-          FourMomentum pho_4p (FPtcls.at(PhoIndex[j]).momentum());
-          double pho_eta (pho_4p.eta());
-          double pho_phi (pho_4p.phi());
-    
-          if (fabs(par_eta) < 1.4442) R = 0.05;
-          else R=0.07;
-
-          if (sqrt( (par_eta-pho_eta)*(par_eta-pho_eta) + (par_phi-pho_phi)*(par_phi-pho_phi)) < R )
-            {
-            tmp_par_conv += pho_4p;
-            tmp_par_del.push_back( PhoIndex[j]);
-
-            if (tmp_test_conv.mass2() < 0. ) mass = 0;
-            else mass = tmp_test_conv.mass();
-
-            double E_sum = tmp_test_conv.E() + pho_4p.E();
-            double px_tmp = tmp_test_conv.px() * sqrt( E_sum*E_sum - mass*mass) / tmp_test_conv.p().mod();
-            double py_tmp = tmp_test_conv.py() * sqrt( E_sum*E_sum - mass*mass) / tmp_test_conv.p().mod();
-            double pz_tmp = tmp_test_conv.pz() * sqrt( E_sum*E_sum - mass*mass) / tmp_test_conv.p().mod();
-
-            tmp_test_conv.setPx(px_tmp);
-            tmp_test_conv.setPy(py_tmp);
-            tmp_test_conv.setPz(pz_tmp);
-            tmp_test_conv.setE(E_sum);
-            }
-          }
-
-        if ((tmp_par_conv.pT() > 20.0) && (tmp_par_conv.pT() > par_conv.pT()))
-          {
-          par_conv = tmp_par_conv;
-          par_del = tmp_par_del;
-          is_par = true;
-          }
-        }
-      return;
-      }
-
-
-    void GetPtEtaPhi(FourMomentum p1, double& pt, double& eta, double& phi)
-      {
-      pt = p1.pT();
-      eta = p1.eta();
-      phi = p1.phi();
-      return;
-      }
-
-
-    void analyze(const Event& event)
-      {
+    void analyze(const Event& event){
       const double weight = event.weight();
-      bool is_ele = false;
-      bool is_pos = false;
-      bool is_mu = false;
-      bool is_mubar = false;
-      bool Zee = false;
-      bool Zmm = false;
-      bool is_boosted = false;
+      //apply the Z finders
+      const ZFinder& zfe = applyProjection<ZFinder>(event, "ZFE");
+      const ZFinder& zfm = applyProjection<ZFinder>(event, "ZFM");
 
-      vector<unsigned int> pho_index;
+      //if no Z found, veto
+      if (zfe.empty() && zfm.empty())
+        vetoEvent;
 
-      vector<unsigned int> ele_index;
-      vector<unsigned int> pos_index;
-      vector<unsigned int> ele_del;
-      vector<unsigned int> pos_del;
-
-      vector<unsigned int> mu_index;
-      vector<unsigned int> mubar_index;
-      vector<unsigned int> mu_del;
-      vector<unsigned int> mubar_del;
-  
-      vector<unsigned int> total_del;
-
-
-      FourMomentum ele_conv (0,0,0,0);  
-      FourMomentum pos_conv (0,0,0,0);
-
-      FourMomentum mu_conv (0,0,0,0);  
-      FourMomentum mubar_conv (0,0,0,0);
-
-      ParticleVector final_ptcls;
-      std::vector<fastjet::PseudoJet> vecs;
-
-      const FinalState& fs = applyProjection<FinalState>(event, "FS");
-      final_ptcls = fs.particlesByPt();
-
-      // Find all electrons (muons), positrons (antimuons) and photons
-      FindPhoParParbar(final_ptcls, 11, pho_index, ele_index, pos_index);
-      pho_index.clear();
-      FindPhoParParbar(final_ptcls, 13, pho_index, mu_index, mubar_index);      
-
-      // Convolute electrons with surrounding photons
-      ConvPar(pho_index, ele_index, ele_conv, ele_del, final_ptcls, is_ele);
-      // Convolute muons with surrounding photons
-      ConvPar(pho_index, mu_index, mu_conv, mu_del, final_ptcls, is_mu);
-
-      if ((!is_ele) && (!is_mu)) vetoEvent;
-
-      // Convolute positrons with surrounding photons
-      ConvPar(pho_index, pos_index, pos_conv, pos_del, final_ptcls, is_pos);
-      // Convolute anti muons with surrounding photons
-      ConvPar(pho_index, mubar_index, mubar_conv, mubar_del, final_ptcls, is_mubar);
-
-
-      if ((!is_pos) && (!is_mubar)) vetoEvent;
-
-      FourMomentum Z_momentum;
-      FourMomentum Zee_momentum(add(pos_conv, ele_conv));
-      FourMomentum Zmm_momentum(add(mubar_conv, mu_conv));
- 
-      if (Zee_momentum.mass2() >= 0. )
-        {
-        if (Zee_momentum.mass() > 71.11 && Zee_momentum.mass() < 111.) { Z_momentum = Zee_momentum; Zee = true; }
-        }
-
-      if ( (!Zee) && Zmm_momentum.mass2() >= 0. )
-        {
-        if ( Zmm_momentum.mass() > 71.11 && Zmm_momentum.mass() < 111.) { Z_momentum = Zmm_momentum; Zmm = true; }
-        else vetoEvent;
-        }      
+      //Choose the Z candidate
+      const ParticleVector& z = !zfm.empty() ? zfm.bosons() : zfe.bosons();
+      const ParticleVector& clusteredConstituents = !zfm.empty() ? zfm.constituents() : zfe.constituents();
       
-      if ( (!Zee) && (!Zmm) ) vetoEvent;
+      //determine whether we are in boosted regime
+      bool is_boosted = false;
+      if (z[0].momentum().pT()>150*GeV)
+        is_boosted = true;
 
-      if (Z_momentum.pT() > 150) is_boosted = true;
+      //build the jets
+      const FastJets& jetfs = applyProjection<FastJets>(event, "JETS");
+      Jets jets = jetfs.jetsByPt(50.*GeV, MAXDOUBLE, -2.5, 2.5);
 
-      double par_pt, par_eta, par_phi;
-      double parbar_pt, parbar_eta, parbar_phi;
-
-      if (Zee)
-        {
-        GetPtEtaPhi(ele_conv, par_pt, par_eta, par_phi);
-        GetPtEtaPhi(pos_conv, parbar_pt, parbar_eta, parbar_phi);
-        
-        total_del.reserve(ele_del.size()+pos_del.size() );
-        total_del.insert(total_del.end(), ele_del.begin(), ele_del.end());
-        total_del.insert(total_del.end(), pos_del.begin(), pos_del.end());
-        sort(total_del.begin(), total_del.end());
-        }
-
-      if (Zmm)
-        {
-        GetPtEtaPhi(mu_conv, par_pt, par_eta, par_phi);
-        GetPtEtaPhi(mubar_conv, parbar_pt, parbar_eta, parbar_phi);
-        
-        total_del.reserve(mu_del.size()+mubar_del.size() );
-        total_del.insert(total_del.end(), mu_del.begin(), mu_del.end());
-        total_del.insert(total_del.end(), mubar_del.begin(), mubar_del.end());
-        sort(total_del.begin(), total_del.end());
-        }
-
-      for(unsigned int i(total_del.size()); i !=0; --i)
-        final_ptcls.erase(final_ptcls.begin()+total_del.at(i-1));
-
-    _histMll->fill( Z_momentum.mass(), weight);
-
-     
-      for(unsigned int i(0); i != final_ptcls.size(); ++i)
-        {
-        if (fabs(final_ptcls[i].pdgId()) == 12 || fabs(final_ptcls[i].pdgId()) == 14 || fabs(final_ptcls[i].pdgId()) == 16 ) continue;
-        if (PID::threeCharge (final_ptcls[i].pdgId()) != 0)
-          {
-          if (final_ptcls[i].momentum().E() < 0.25) continue;
-          }
-
-        fastjet::PseudoJet pseudoJet(final_ptcls[i].momentum().px(), final_ptcls[i].momentum().py(), final_ptcls[i].momentum().pz(), final_ptcls[i].momentum().E());
-        pseudoJet.set_user_index(i);
-        vecs.push_back(pseudoJet);
-        }
-
-      vector<fastjet::PseudoJet> jet_list;
-      fastjet::ClusterSequence cseq(vecs, fastjet::JetDefinition(fastjet::antikt_algorithm, 0.5));
-      vector<fastjet::PseudoJet> jets = sorted_by_pt(cseq.inclusive_jets(50.0));                  // In draft, the jet-treshold is 50 GeV
-
-      for(unsigned int i(0); i<jets.size(); ++i)
-        {
-        double j_eta = jets[i].eta();
-        double j_phi = jets[i].phi();
-        double j_pt = jets[i].pt();
-
-        if (fabs(j_eta) <2.5) 
-          {
-          if(j_pt > 50.0)
-            {
-            if (deltaR(par_pt, par_phi, j_eta, j_phi) > 0.4 && deltaR(parbar_pt, parbar_phi, j_eta, j_phi) > 0.4)
-              jet_list.push_back(jets[i]);
-            continue;
-            }
+      //clean the jets against the lepton candidates, as in the paper, with a DeltaR cut of 0.4 against the clustered leptons
+      std::vector<const Jet*> cleanedJets;
+      for (unsigned int i = 0; i < jets.size(); ++i){
+        bool isolated = true; 
+        for (unsigned j = 0; j < clusteredConstituents.size(); ++j){
+          if (deltaR(clusteredConstituents[j].momentum().vector3(), jets[i].momentum().vector3()) < 0.4){
+            isolated=false;
+            break;
           }
         }
+        if (isolated)
+          cleanedJets.push_back(&jets[i]);
+      }
 
-      double Njets = jet_list.size();
+      unsigned int Njets = cleanedJets.size();
+      //require at least 1 jet
+      if (Njets < 1)
+        vetoEvent;
 
-      if (Njets) 
-        {
+      //now compute Thrust
+      // Collect Z and jets transverse momenta to calculate transverse thrust
+      std::vector<Vector3> momenta;
+      momenta.clear();
+      Vector3 mom = z[0].momentum().p();
+      mom.setZ(0.0);
+      momenta.push_back(mom);
 
-        // Collect Z and jets transverse momenta to calculate transverse thrust
-        std::vector<Vector3> momenta;
-        momenta.clear();
-        Vector3 mom = Z_momentum.p();
-        mom.setZ(0.0);
-        momenta.push_back(mom);
+      for (unsigned int i = 0; i < cleanedJets.size(); ++i){
+        Vector3 mj = cleanedJets[i]->momentum().vector3();
+        mj.setZ(0.0);
+        momenta.push_back(mj);
+      }
+      if (momenta.size() <= 2){ 
+        // We need to use a ghost so that Thrust.calc() doesn't return 1.
+        momenta.push_back(Vector3(0.0000001,0.0000001,0.));
+      }
 
-        for (unsigned int i(0); i != jet_list.size(); ++i)
-          {
-	  double momX = 0;
-	  double momY = 0;
-            for (unsigned int j(0); j != cseq.constituents(jet_list[i]).size(); ++j)
-            {
-            std::valarray<double> mom_4 = cseq.constituents(jet_list[i])[j].four_mom();
-            momX += mom_4[0];        
-            momY += mom_4[1];
-            }
-          mom.setX(momX);        
-          mom.setY(momY);
-          mom.setZ(0.0);
-          momenta.push_back(mom);
-          }
-
-        if (momenta.size() <= 2) 
-          {
-          // We need to use a ghost so that Thrust.calc() doesn't return 1.
-          momenta.push_back(Vector3(0.0000001,0.0000001,0.0000001));
-          }
-
-        Thrust thrust;
-        thrust.calc(momenta);    
-        _histTransvThrust->fill(max(log( 1-thrust.thrust() ), -14.), weight); // d17
+      Thrust thrust;
+      thrust.calc(momenta);    
+      _histTransvThrust->fill(max(log( 1-thrust.thrust() ), -14.), weight); // d17
 
 
-        if (is_boosted) _histBoostedTransvThrust->fill(max(log( 1-thrust.thrust() ), -14.), weight); // d16 
+      if (is_boosted) _histBoostedTransvThrust->fill(max(log( 1-thrust.thrust() ), -14.), weight); // d16 
     
-        double Ptll = Z_momentum.pT();
-        double PhiZ = Z_momentum.phi();
-        double PtJet1 = jet_list[0].pt();
-        double PhiJet1 = jet_list[0].phi();
+      double PhiZ = z[0].momentum().phi();
+      double PhiJet1 = cleanedJets[0]->phi();
 
-        _histNjets->fill(Njets, weight);
-        _histPtll->fill(Ptll, weight);
-        _histPtJet1->fill(PtJet1, weight);
-        _histDeltaPhiZJ1->fill(deltaPhi(PhiJet1,PhiZ), weight); // d10 300*0.10472*
+      _histDeltaPhiZJ1->fill(deltaPhi(PhiJet1,PhiZ), weight); // d10 300*0.10472*
 
-        if (is_boosted) _histBoostedDeltaPhiZJ1->fill(deltaPhi(PhiJet1,PhiZ), weight); // d09 300*0.10472*
+      if (is_boosted) _histBoostedDeltaPhiZJ1->fill(deltaPhi(PhiJet1,PhiZ), weight); // d09 300*0.10472*
  
-        if (Njets > 1)
-          {
-          FourMomentum J1_4p (jet_list[0].E(), jet_list[0].px(), jet_list[0].py(), jet_list[0].pz());
-          FourMomentum J2_4p (jet_list[1].E(), jet_list[1].px(), jet_list[1].py(), jet_list[1].pz());
-          FourMomentum pJ1J2(add(J1_4p,J2_4p)); 
+      if (Njets > 1){
+        double PhiJet2 = cleanedJets[1]->phi();
 
-          double Mjj;
-          //if (pJ1J2.mass2() < 0. ) Mjj = 0;
-          //else 
-          Mjj = pJ1J2.mass(); // pJ1J2.mass() gives error message.
-          double PtJet2 = jet_list[1].pt();
-          double PhiJet2 = jet_list[1].phi();
+	_histDeltaPhiZJ1_2->fill(deltaPhi(PhiJet1,PhiZ), weight);	// d01 10*0.10472
 
-          _histMjj->fill(Mjj, weight);
-          _histPtJet2->fill(PtJet2, weight);
-          _histDeltaPhiZJ2->fill(deltaPhi(PhiJet2, PhiZ), weight);
-	  _histDeltaPhiZJ1_2->fill(deltaPhi(PhiJet1,PhiZ), weight);	// d01 10*0.10472
-	  _histDeltaPhiJ1J2_2->fill(deltaPhi(PhiJet1,PhiJet2), weight);
+        if (is_boosted){
+      	  _histBoostedDeltaPhiZJ1_2->fill(deltaPhi(PhiJet1,PhiZ), weight);	// d02 30*0.10472*
+        } 
 
-          if (is_boosted)
-            {
-            _histBoostedDeltaPhiZJ2->fill(deltaPhi(PhiJet2, PhiZ), weight);
-      	    _histBoostedDeltaPhiZJ1_2->fill(deltaPhi(PhiJet1,PhiZ), weight);	// d02 30*0.10472*
-	    _histBoostedDeltaPhiJ1J2_2->fill(deltaPhi(PhiJet1,PhiJet2), weight);
-            } 
-
-           if (Njets > 2)
-             {
-             double PtJet3 = jet_list[2].pt();
-             double PhiJet3 = jet_list[2].phi();
-             double SumDeltaPhi = deltaPhi(PhiJet1,PhiJet2) + deltaPhi(PhiJet1,PhiJet3) + deltaPhi(PhiJet2,PhiJet3);
-	     _histPtJet3->fill(PtJet3, weight);
-	     _histDeltaPhiZJ1_3->fill(deltaPhi(PhiJet1,PhiZ), weight);	// d08 0.10472*
-	     _histDeltaPhiZJ2_3->fill(deltaPhi(PhiJet2,PhiZ), weight); // d14 10*0.10472*
-	     _histDeltaPhiJ1J2_3->fill(deltaPhi(PhiJet1,PhiJet2), weight);	// d03 100*0.10472*
-	     _histDeltaPhiJ1J3_3->fill(deltaPhi(PhiJet1,PhiJet3), weight);	// d05 10*0.10472*
-	     _histDeltaPhiJ2J3_3->fill(deltaPhi(PhiJet2,PhiJet3), weight);	// d12 0.10472*
-	     _histDeltaPhiZJ3->fill(deltaPhi(PhiZ,PhiJet3), weight);	// d04 0.10472*
-	     _histSumDeltaPhi->fill(SumDeltaPhi, weight);
+        if (Njets > 2){
+          double PhiJet3 = cleanedJets[2]->phi();
+	  _histDeltaPhiZJ1_3->fill(deltaPhi(PhiJet1,PhiZ), weight);	// d08 0.10472*
+	  _histDeltaPhiZJ2_3->fill(deltaPhi(PhiJet2,PhiZ), weight); // d14 10*0.10472*
+	  _histDeltaPhiJ1J2_3->fill(deltaPhi(PhiJet1,PhiJet2), weight);	// d03 100*0.10472*
+	  _histDeltaPhiJ1J3_3->fill(deltaPhi(PhiJet1,PhiJet3), weight);	// d05 10*0.10472*
+	  _histDeltaPhiJ2J3_3->fill(deltaPhi(PhiJet2,PhiJet3), weight);	// d12 0.10472*
+	  _histDeltaPhiZJ3->fill(deltaPhi(PhiZ,PhiJet3), weight);	// d04 0.10472*
 
 
-             if (is_boosted)
-               {
+          if (is_boosted) {
   	       _histBoostedDeltaPhiZJ1_3->fill(deltaPhi(PhiJet1,PhiZ), weight); // d06 0.21416*
 	       _histBoostedDeltaPhiZJ2_3->fill(deltaPhi(PhiJet2,PhiZ), weight); // d07 10*0.21416*
 	       _histBoostedDeltaPhiJ1J2_3->fill(deltaPhi(PhiJet1,PhiJet2), weight); // d15 100*0.21416*
     	       _histBoostedDeltaPhiJ1J3_3->fill(deltaPhi(PhiJet1,PhiJet3), weight); // d13 10*0.21416*
 	       _histBoostedDeltaPhiJ2J3_3->fill(deltaPhi(PhiJet2,PhiJet3), weight);	// d11 0.21416*
 	       _histBoostedDeltaPhiZJ3->fill(deltaPhi(PhiZ,PhiJet3), weight); // d18 0.21416*
-	       _histBoostedSumDeltaPhi->fill(SumDeltaPhi, weight);
-
-               }
-
-	      if(Njets>3)
-                {
-	        double PtJet4  = jet_list[3].pt();
-	        _histPtJet4->fill(PtJet4, weight);
-
-                }
-              }
-            }
           }
+        }
       }
+    }  
+
+    void normalizeNoOverflows(AIDA::IHistogram1D* plot, double integral){
+      double factor=1.;
+      if (plot->sumBinHeights()>0 && plot->sumAllBinHeights()>0)
+        factor = plot->sumAllBinHeights()/plot->sumBinHeights();
+      normalize(plot, factor*integral);  
+    }
 
     void finalize() 
       {
-      normalize(_histMll,1.);
-      normalize(_histNjets,1.);
-      normalize(_histPtll,1.);
-      normalize(_histMjj,1.);   
-      normalize(_histPtJet1,1.);
-      normalize(_histPtJet2,1.);
-      normalize(_histPtJet3,1.);
-      normalize(_histPtJet4,1.);
-      normalize(_histDeltaPhiZJ1,1.); // d10 300.
-      normalize(_histDeltaPhiZJ2,1.);
-      normalize(_histDeltaPhiZJ3,1.); // d04
-      normalize(_histDeltaPhiZJ1_2,1.); // d01 10.
-      normalize(_histDeltaPhiZJ1_3,1.); // d08 100.
-      normalize(_histDeltaPhiZJ2_3,1.); // d14
-      normalize(_histDeltaPhiJ1J2_2,1.);
-      normalize(_histDeltaPhiJ1J2_3,1.); // d03 100.
-      normalize(_histSumDeltaPhi,1.);
-      normalize(_histTransvThrust,1); // d17. They have apparently remembered to multiply by the binsize.
-      normalize(_histDeltaPhiJ1J3_3, 1.); // d05 10.
-      normalize(_histDeltaPhiJ2J3_3, 1.); // d12
+      normalizeNoOverflows(_histDeltaPhiZJ1,1.);
+      normalizeNoOverflows(_histDeltaPhiZJ3,1.);
+      normalizeNoOverflows(_histDeltaPhiZJ1_2,1.);
+      normalizeNoOverflows(_histDeltaPhiZJ1_3,1.);
+      normalizeNoOverflows(_histDeltaPhiZJ2_3,1.);
+      normalizeNoOverflows(_histDeltaPhiJ1J2_3,1.);
+      normalizeNoOverflows(_histTransvThrust,1.);
+      normalizeNoOverflows(_histDeltaPhiJ1J3_3, 1.);
+      normalizeNoOverflows(_histDeltaPhiJ2J3_3, 1.);
       // Boosted
-      normalize(_histBoostedDeltaPhiZJ1,1.); // d09 300.
-      normalize(_histBoostedDeltaPhiZJ2,1.);
-      normalize(_histBoostedDeltaPhiZJ3,1.); // d18
-      normalize(_histBoostedDeltaPhiZJ1_2,1.); // d02 30.
-      normalize(_histBoostedDeltaPhiZJ1_3,1.); // d06 300.
-      normalize(_histBoostedDeltaPhiZJ2_3,1.); // d07 10.
-      normalize(_histBoostedDeltaPhiJ1J2_2,1.);
-      normalize(_histBoostedDeltaPhiJ1J2_3,1.); // d15 100.
-      normalize(_histBoostedSumDeltaPhi,1.);
-      normalize(_histBoostedTransvThrust,1); // d16. They have apparently remembered to multiply by the binsize.
-      normalize(_histBoostedDeltaPhiJ1J3_3, 1.); // d13 10.
-      normalize(_histBoostedDeltaPhiJ2J3_3, 1.); // d11
+      normalizeNoOverflows(_histBoostedDeltaPhiZJ1,1.);
+      normalizeNoOverflows(_histBoostedDeltaPhiZJ3,1.);
+      normalizeNoOverflows(_histBoostedDeltaPhiZJ1_2,1.);
+      normalizeNoOverflows(_histBoostedDeltaPhiZJ1_3,1.);
+      normalizeNoOverflows(_histBoostedDeltaPhiZJ2_3,1.);
+      normalizeNoOverflows(_histBoostedDeltaPhiJ1J2_3,1.);
+      normalizeNoOverflows(_histBoostedTransvThrust,1.);
+      normalizeNoOverflows(_histBoostedDeltaPhiJ1J3_3, 1.);
+      normalizeNoOverflows(_histBoostedDeltaPhiJ2J3_3, 1.);
      }
 
 
   private:
 
-    AIDA::IHistogram1D* _histMll;            
-    AIDA::IHistogram1D* _histNjets;          
-    AIDA::IHistogram1D* _histPtll;           
-    AIDA::IHistogram1D* _histMjj;            
-    AIDA::IHistogram1D* _histPtJet1;         
-    AIDA::IHistogram1D* _histPtJet2;         
-    AIDA::IHistogram1D* _histPtJet3;         
-    AIDA::IHistogram1D* _histPtJet4;         
     AIDA::IHistogram1D* _histDeltaPhiZJ1;    
-    AIDA::IHistogram1D* _histDeltaPhiZJ2;    
     AIDA::IHistogram1D* _histDeltaPhiZJ3;    
     AIDA::IHistogram1D* _histDeltaPhiZJ1_2;  
     AIDA::IHistogram1D* _histDeltaPhiZJ1_3;  
     AIDA::IHistogram1D* _histDeltaPhiZJ2_3;  
-    AIDA::IHistogram1D* _histDeltaPhiJ1J2_2; 
     AIDA::IHistogram1D* _histDeltaPhiJ1J2_3; 
-    AIDA::IHistogram1D* _histSumDeltaPhi;
     AIDA::IHistogram1D* _histTransvThrust; 
     AIDA::IHistogram1D* _histDeltaPhiJ1J3_3;
     AIDA::IHistogram1D* _histDeltaPhiJ2J3_3;
     // Boosted
     AIDA::IHistogram1D* _histBoostedDeltaPhiZJ1;   
-    AIDA::IHistogram1D* _histBoostedDeltaPhiZJ2;    
     AIDA::IHistogram1D* _histBoostedDeltaPhiZJ3;    
     AIDA::IHistogram1D* _histBoostedDeltaPhiZJ1_2;  
     AIDA::IHistogram1D* _histBoostedDeltaPhiZJ1_3;  
     AIDA::IHistogram1D* _histBoostedDeltaPhiZJ2_3;  
-    AIDA::IHistogram1D* _histBoostedDeltaPhiJ1J2_2; 
     AIDA::IHistogram1D* _histBoostedDeltaPhiJ1J2_3; 
-    AIDA::IHistogram1D* _histBoostedSumDeltaPhi;
     AIDA::IHistogram1D* _histBoostedTransvThrust;
     AIDA::IHistogram1D* _histBoostedDeltaPhiJ1J3_3;
     AIDA::IHistogram1D* _histBoostedDeltaPhiJ2J3_3;  
@@ -496,7 +223,3 @@ namespace Rivet {
   AnalysisBuilder<CMS_EWK_11_021> plugin_CMS_EWK_11_021;
   
 }
-
-
-
-   

--- a/GeneratorInterface/RivetInterface/src/CMS_EWK_11_021.cc
+++ b/GeneratorInterface/RivetInterface/src/CMS_EWK_11_021.cc
@@ -166,7 +166,7 @@ namespace Rivet {
       }
     }  
 
-    void normalizeNoOverflows(AIDA::IHistogram1D* plot, double integral){
+    void normalize(AIDA::IHistogram1D* plot, double integral){
       double factor=1.;
       if (plot->sumBinHeights()>0 && plot->sumAllBinHeights()>0)
         factor = plot->sumAllBinHeights()/plot->sumBinHeights();
@@ -175,25 +175,25 @@ namespace Rivet {
 
     void finalize() 
       {
-      normalizeNoOverflows(_histDeltaPhiZJ1,1.);
-      normalizeNoOverflows(_histDeltaPhiZJ3,1.);
-      normalizeNoOverflows(_histDeltaPhiZJ1_2,1.);
-      normalizeNoOverflows(_histDeltaPhiZJ1_3,1.);
-      normalizeNoOverflows(_histDeltaPhiZJ2_3,1.);
-      normalizeNoOverflows(_histDeltaPhiJ1J2_3,1.);
-      normalizeNoOverflows(_histTransvThrust,1.);
-      normalizeNoOverflows(_histDeltaPhiJ1J3_3, 1.);
-      normalizeNoOverflows(_histDeltaPhiJ2J3_3, 1.);
+      normalize(_histDeltaPhiZJ1,1.);
+      normalize(_histDeltaPhiZJ3,1.);
+      normalize(_histDeltaPhiZJ1_2,1.);
+      normalize(_histDeltaPhiZJ1_3,1.);
+      normalize(_histDeltaPhiZJ2_3,1.);
+      normalize(_histDeltaPhiJ1J2_3,1.);
+      normalize(_histTransvThrust,1.);
+      normalize(_histDeltaPhiJ1J3_3, 1.);
+      normalize(_histDeltaPhiJ2J3_3, 1.);
       // Boosted
-      normalizeNoOverflows(_histBoostedDeltaPhiZJ1,1.);
-      normalizeNoOverflows(_histBoostedDeltaPhiZJ3,1.);
-      normalizeNoOverflows(_histBoostedDeltaPhiZJ1_2,1.);
-      normalizeNoOverflows(_histBoostedDeltaPhiZJ1_3,1.);
-      normalizeNoOverflows(_histBoostedDeltaPhiZJ2_3,1.);
-      normalizeNoOverflows(_histBoostedDeltaPhiJ1J2_3,1.);
-      normalizeNoOverflows(_histBoostedTransvThrust,1.);
-      normalizeNoOverflows(_histBoostedDeltaPhiJ1J3_3, 1.);
-      normalizeNoOverflows(_histBoostedDeltaPhiJ2J3_3, 1.);
+      normalize(_histBoostedDeltaPhiZJ1,1.);
+      normalize(_histBoostedDeltaPhiZJ3,1.);
+      normalize(_histBoostedDeltaPhiZJ1_2,1.);
+      normalize(_histBoostedDeltaPhiZJ1_3,1.);
+      normalize(_histBoostedDeltaPhiZJ2_3,1.);
+      normalize(_histBoostedDeltaPhiJ1J2_3,1.);
+      normalize(_histBoostedTransvThrust,1.);
+      normalize(_histBoostedDeltaPhiJ1J3_3, 1.);
+      normalize(_histBoostedDeltaPhiJ2J3_3, 1.);
      }
 
 

--- a/GeneratorInterface/RivetInterface/src/CMS_EWK_11_021.cc
+++ b/GeneratorInterface/RivetInterface/src/CMS_EWK_11_021.cc
@@ -166,7 +166,7 @@ namespace Rivet {
       }
     }  
 
-    void normalize(AIDA::IHistogram1D* plot, double integral){
+    void normalizeNoOverflows(AIDA::IHistogram1D* plot, double integral){
       double factor=1.;
       if (plot->sumBinHeights()>0 && plot->sumAllBinHeights()>0)
         factor = plot->sumAllBinHeights()/plot->sumBinHeights();
@@ -175,25 +175,25 @@ namespace Rivet {
 
     void finalize() 
       {
-      normalize(_histDeltaPhiZJ1,1.);
-      normalize(_histDeltaPhiZJ3,1.);
-      normalize(_histDeltaPhiZJ1_2,1.);
-      normalize(_histDeltaPhiZJ1_3,1.);
-      normalize(_histDeltaPhiZJ2_3,1.);
-      normalize(_histDeltaPhiJ1J2_3,1.);
+      normalizeNoOverflows(_histDeltaPhiZJ1,1.);
+      normalizeNoOverflows(_histDeltaPhiZJ3,1.);
+      normalizeNoOverflows(_histDeltaPhiZJ1_2,1.);
+      normalizeNoOverflows(_histDeltaPhiZJ1_3,1.);
+      normalizeNoOverflows(_histDeltaPhiZJ2_3,1.);
+      normalizeNoOverflows(_histDeltaPhiJ1J2_3,1.);
       normalize(_histTransvThrust,1.);
-      normalize(_histDeltaPhiJ1J3_3, 1.);
-      normalize(_histDeltaPhiJ2J3_3, 1.);
+      normalizeNoOverflows(_histDeltaPhiJ1J3_3, 1.);
+      normalizeNoOverflows(_histDeltaPhiJ2J3_3, 1.);
       // Boosted
-      normalize(_histBoostedDeltaPhiZJ1,1.);
-      normalize(_histBoostedDeltaPhiZJ3,1.);
-      normalize(_histBoostedDeltaPhiZJ1_2,1.);
-      normalize(_histBoostedDeltaPhiZJ1_3,1.);
-      normalize(_histBoostedDeltaPhiZJ2_3,1.);
-      normalize(_histBoostedDeltaPhiJ1J2_3,1.);
+      normalizeNoOverflows(_histBoostedDeltaPhiZJ1,1.);
+      normalizeNoOverflows(_histBoostedDeltaPhiZJ3,1.);
+      normalizeNoOverflows(_histBoostedDeltaPhiZJ1_2,1.);
+      normalizeNoOverflows(_histBoostedDeltaPhiZJ1_3,1.);
+      normalizeNoOverflows(_histBoostedDeltaPhiZJ2_3,1.);
+      normalizeNoOverflows(_histBoostedDeltaPhiJ1J2_3,1.);
       normalize(_histBoostedTransvThrust,1.);
-      normalize(_histBoostedDeltaPhiJ1J3_3, 1.);
-      normalize(_histBoostedDeltaPhiJ2J3_3, 1.);
+      normalizeNoOverflows(_histBoostedDeltaPhiJ1J3_3, 1.);
+      normalizeNoOverflows(_histBoostedDeltaPhiJ2J3_3, 1.);
      }
 
 

--- a/GeneratorInterface/RivetInterface/test/rivetSetup.sh
+++ b/GeneratorInterface/RivetInterface/test/rivetSetup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
-export RIVET_REF_PATH=$CMSSW_BASE/src/GeneratorInterface/RivetInterface/data:$CMSSW_RELEASE_BASE/src/GeneratorInterface/RivetInterface/data
-export RIVET_INFO_PATH=$CMSSW_BASE/src/GeneratorInterface/RivetInterface/data:$CMSSW_RELEASE_BASE/src/GeneratorInterface/RivetInterface/data
-export RIVET_PLOT_PATH=$CMSSW_BASE/src/GeneratorInterface/RivetInterface/data:$CMSSW_RELEASE_BASE/src/GeneratorInterface/RivetInterface/data
+export RIVET_REF_PATH=$CMSSW_BASE/src/GeneratorInterface/RivetInterface/data
+export RIVET_INFO_PATH=$CMSSW_BASE/src/GeneratorInterface/RivetInterface/data
+export RIVET_PLOT_PATH=$CMSSW_BASE/src/GeneratorInterface/RivetInterface/data


### PR DESCRIPTION
This is a set of fixes to the rivet analysis EWK-11-021.
It includes fixes to the reference data, to be consistent with the paper content.
