### PR TITLE
Remove CurrentProcessingContext from HLTrigger

### DIFF
--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -325,7 +325,6 @@ namespace edm {
     vstring                  end_path_name_list_;
 
     TrigResPtr               results_;
-    TrigResPtr               endpath_results_;
 
     WorkerPtr                results_inserter_;
     AllOutputModuleCommunicators         all_output_communicators_;

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -19,6 +19,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
+#include "FWCore/ServiceRegistry/interface/PathContext.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/ExceptionCollector.h"
@@ -295,7 +296,6 @@ namespace edm {
     trig_name_list_(tns.getTrigPaths()),
     end_path_name_list_(tns.getEndPaths()),
     results_(new HLTGlobalStatus(trig_name_list_.size())),
-    endpath_results_(), // delay!
     results_inserter_(),
     all_output_communicators_(),
     trig_paths_(),
@@ -312,12 +312,10 @@ namespace edm {
     bool hasPath = false;
 
     int trig_bitpos = 0;
+    trig_paths_.reserve(trig_name_list_.size());
     vstring labelsOnTriggerPaths;
-    for (vstring::const_iterator i = trig_name_list_.begin(),
-           e = trig_name_list_.end();
-         i != e;
-         ++i) {
-      fillTrigPath(proc_pset, preg, processConfiguration, trig_bitpos, *i, results_, &labelsOnTriggerPaths);
+    for(auto const& trig_name : trig_name_list_) {
+      fillTrigPath(proc_pset, preg, processConfiguration, trig_bitpos, trig_name, results_, &labelsOnTriggerPaths);
       ++trig_bitpos;
       hasPath = true;
     }
@@ -330,13 +328,12 @@ namespace edm {
       addToAllWorkers(results_inserter_.get());
     }
 
-    TrigResPtr epptr(new HLTGlobalStatus(end_path_name_list_.size()));
-    endpath_results_ = epptr;
-
     // fill normal endpaths
-    vstring::iterator eib(end_path_name_list_.begin()), eie(end_path_name_list_.end());
-    for (int bitpos = 0; eib != eie; ++eib, ++bitpos) {
-      fillEndPath(proc_pset, preg, processConfiguration, bitpos, *eib);
+    int bitpos = 0;
+    end_paths_.reserve(end_path_name_list_.size());
+    for(auto const& end_path_name : end_path_name_list_) {
+      fillEndPath(proc_pset, preg, processConfiguration, bitpos, end_path_name);
+      ++bitpos;
     }
 
     //See if all modules were used
@@ -768,6 +765,7 @@ namespace edm {
     vstring modnames = proc_pset.getParameter<vstring>(name);
     PathWorkers tmpworkers;
 
+    unsigned int placeInPath = 0;
     for (auto const& name : modnames) {
 
       if (labelsOnPaths) labelsOnPaths->push_back(name);
@@ -808,7 +806,8 @@ namespace edm {
             << "or explicitly ignore it in the configuration by using cms.ignore().\n";
         }
       }
-      tmpworkers.emplace_back(worker, filterAction);
+      tmpworkers.emplace_back(worker, filterAction, placeInPath);
+      ++placeInPath;
     }
 
     out.swap(tmpworkers);
@@ -830,11 +829,10 @@ namespace edm {
 
     // an empty path will cause an extra bit that is not used
     if (!tmpworkers.empty()) {
-      Path p(bitpos, name, tmpworkers, trptr, actionTable(), actReg_, false, &streamContext_);
+      trig_paths_.emplace_back(bitpos, name, tmpworkers, trptr, actionTable(), actReg_, &streamContext_, PathContext::PathType::kPath);
       if (wantSummary_) {
-        p.useStopwatch();
+        trig_paths_.back().useStopwatch();
       }
-      trig_paths_.push_back(p);
     } else {
       empty_trig_paths_.push_back(bitpos);
       empty_trig_path_names_.push_back(name);
@@ -855,11 +853,10 @@ namespace edm {
     }
 
     if (!tmpworkers.empty()) {
-      Path p(bitpos, name, tmpworkers, endpath_results_, actionTable(), actReg_, true, &streamContext_);
+      end_paths_.emplace_back(bitpos, name, tmpworkers, TrigResPtr(), actionTable(), actReg_, &streamContext_, PathContext::PathType::kEndPath);
       if (wantSummary_) {
-        p.useStopwatch();
+        end_paths_.back().useStopwatch();
       }
-      end_paths_.push_back(p);
     }
     for_all(holder, boost::bind(&Schedule::addToAllWorkers, this, _1));
   }
@@ -1405,7 +1402,6 @@ namespace edm {
   void
   Schedule::resetAll() {
     results_->reset();
-    endpath_results_->reset();
   }
 
   void

--- a/FWCore/Framework/src/WorkerInPath.cc
+++ b/FWCore/Framework/src/WorkerInPath.cc
@@ -3,28 +3,18 @@
 #include "FWCore/Framework/src/WorkerInPath.h"
 
 namespace edm {
-  WorkerInPath::WorkerInPath(Worker* w, FilterAction theFilterAction):
+  WorkerInPath::WorkerInPath(Worker* w, FilterAction theFilterAction, unsigned int placeInPath):
     stopwatch_(),
     timesVisited_(),
     timesPassed_(),
     timesFailed_(),
     timesExcept_(),
     filterAction_(theFilterAction),
-    worker_(w)
+    worker_(w),
+    placeInPathContext_(placeInPath)
   {
   }
 
-  WorkerInPath::WorkerInPath(Worker* w):
-    stopwatch_(new RunStopwatch::StopwatchPointer::element_type),
-    timesVisited_(),
-    timesPassed_(),
-    timesFailed_(),
-    timesExcept_(),
-    filterAction_(Normal),
-    worker_(w)
-  {
-  }
-   
    void 
    WorkerInPath::useStopwatch() {
       stopwatch_.reset(new RunStopwatch::StopwatchPointer::element_type);

--- a/FWCore/Framework/src/WorkerInPath.h
+++ b/FWCore/Framework/src/WorkerInPath.h
@@ -13,21 +13,23 @@
 
 #include "FWCore/Framework/src/Worker.h"
 #include "FWCore/Framework/src/RunStopwatch.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/PlaceInPathContext.h"
 
 namespace edm {
+
+  class PathContext;
   class StreamID;
 
   class WorkerInPath {
   public:
     enum FilterAction { Normal=0, Ignore, Veto };
 
-    explicit WorkerInPath(Worker*);
-    WorkerInPath(Worker*, FilterAction theAction);
+    WorkerInPath(Worker*, FilterAction theAction, unsigned int placeInPath);
 
     template <typename T>
     bool runWorker(typename T::MyPrincipal&, EventSetup const&,
 		   CurrentProcessingContext const* cpc, StreamID streamID,
-                   ParentContext const& parentContext,
                    typename T::Context const* context);
 
     std::pair<double,double> timeCpuReal() const {
@@ -50,6 +52,8 @@ namespace edm {
     FilterAction filterAction() const { return filterAction_; }
     Worker* getWorker() const { return worker_; }
 
+    void setPathContext(PathContext const* v) { placeInPathContext_.setPathContext(v); }
+
   private:
     RunStopwatch::StopwatchPointer stopwatch_;
 
@@ -60,12 +64,13 @@ namespace edm {
     
     FilterAction filterAction_;
     Worker* worker_;
+
+    PlaceInPathContext placeInPathContext_;
   };
 
   template <typename T>
   bool WorkerInPath::runWorker(typename T::MyPrincipal & ep, EventSetup const & es,
                                CurrentProcessingContext const* cpc, StreamID streamID,
-                               ParentContext const& parentContext,
                                typename T::Context const* context) {
 
     if (T::isEvent_) {
@@ -77,8 +82,13 @@ namespace edm {
 	// may want to change the return value from the worker to be 
 	// the Worker::FilterAction so conditions in the path will be easier to 
 	// identify
-	rc = worker_->doWork<T>(ep, es, cpc,stopwatch_.get(),streamID, parentContext, context);
-
+        if(T::isEvent_) {
+          ParentContext parentContext(&placeInPathContext_);          
+          rc = worker_->doWork<T>(ep, es, cpc,stopwatch_.get(),streamID, parentContext, context);
+        } else {
+          ParentContext parentContext(context);
+          rc = worker_->doWork<T>(ep, es, cpc,stopwatch_.get(),streamID, parentContext, context);
+        }
         // Ignore return code for non-event (e.g. run, lumi) calls
 	if (!T::isEvent_) rc = true;
 	else if (filterAction_ == Veto) rc = !rc;

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -340,6 +340,7 @@ ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Running
     moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
+    PlaceInPathContext 2
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -354,6 +355,7 @@ ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Running
     moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
+    PlaceInPathContext 2
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -379,7 +381,7 @@ StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-PathContext: pathName = e pathID = 0
+PathContext: pathName = e pathID = 0 (EndPath)
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -395,7 +397,7 @@ StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-PathContext: pathName = e pathID = 0
+PathContext: pathName = e pathID = 0 (EndPath)
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -448,6 +450,7 @@ ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Running
     moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
+    PlaceInPathContext 2
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -462,6 +465,7 @@ ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Running
     moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
+    PlaceInPathContext 2
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -487,7 +491,7 @@ StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-PathContext: pathName = e pathID = 0
+PathContext: pathName = e pathID = 0 (EndPath)
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -503,7 +507,7 @@ StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-PathContext: pathName = e pathID = 0
+PathContext: pathName = e pathID = 0 (EndPath)
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -556,6 +560,7 @@ ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Running
     moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
+    PlaceInPathContext 2
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -570,6 +575,7 @@ ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
     ModuleCallingContext state = Running
     moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
+    PlaceInPathContext 2
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -595,7 +601,7 @@ StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-PathContext: pathName = e pathID = 0
+PathContext: pathName = e pathID = 0 (EndPath)
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -611,7 +617,7 @@ StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-PathContext: pathName = e pathID = 0
+PathContext: pathName = e pathID = 0 (EndPath)
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -230,6 +230,7 @@ StreamContext: StreamID = 0 transition = Event
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    PlaceInPathContext 0
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -242,6 +243,7 @@ StreamContext: StreamID = 0 transition = Event
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    PlaceInPathContext 0
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -264,7 +266,7 @@ StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-PathContext: pathName = e pathID = 0
+PathContext: pathName = e pathID = 0 (EndPath)
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -280,7 +282,7 @@ StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-PathContext: pathName = e pathID = 0
+PathContext: pathName = e pathID = 0 (EndPath)
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -314,6 +316,7 @@ StreamContext: StreamID = 0 transition = Event
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    PlaceInPathContext 0
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -326,6 +329,7 @@ StreamContext: StreamID = 0 transition = Event
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    PlaceInPathContext 0
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -348,7 +352,7 @@ StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-PathContext: pathName = e pathID = 0
+PathContext: pathName = e pathID = 0 (EndPath)
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -364,7 +368,7 @@ StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-PathContext: pathName = e pathID = 0
+PathContext: pathName = e pathID = 0 (EndPath)
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -398,6 +402,7 @@ StreamContext: StreamID = 0 transition = Event
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    PlaceInPathContext 0
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -410,6 +415,7 @@ StreamContext: StreamID = 0 transition = Event
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 ModuleCallingContext state = Running
     moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    PlaceInPathContext 0
     PathContext: pathName = p pathID = 0
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -432,7 +438,7 @@ StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-PathContext: pathName = e pathID = 0
+PathContext: pathName = e pathID = 0 (EndPath)
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -448,7 +454,7 @@ StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-PathContext: pathName = e pathID = 0
+PathContext: pathName = e pathID = 0 (EndPath)
     StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001

--- a/FWCore/ServiceRegistry/interface/GlobalContext.h
+++ b/FWCore/ServiceRegistry/interface/GlobalContext.h
@@ -17,13 +17,14 @@ information about the current state of global processing.
 
 #include "DataFormats/Provenance/interface/LuminosityBlockID.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
-#include "FWCore/ServiceRegistry/interface/ProcessContext.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 
 #include <iosfwd>
 
 namespace edm {
+
+  class ProcessContext;
 
   class GlobalContext {
 

--- a/FWCore/ServiceRegistry/interface/ModuleCallingContext.h
+++ b/FWCore/ServiceRegistry/interface/ModuleCallingContext.h
@@ -23,7 +23,7 @@ namespace edm {
   class GlobalContext;
   class InternalContext;
   class ModuleDescription;
-  class PathContext;
+  class PlaceInPathContext;
   class StreamContext;
 
 
@@ -48,7 +48,7 @@ namespace edm {
     Type type() const { return parent_.type(); }
     ParentContext const& parent() const { return parent_; }
     ModuleCallingContext const* moduleCallingContext() const { return parent_.moduleCallingContext(); }
-    PathContext const* pathContext() const { return parent_.pathContext(); }
+    PlaceInPathContext const* placeInPathContext() const { return parent_.placeInPathContext(); }
     StreamContext const* streamContext() const { return parent_.streamContext(); }
     GlobalContext const* globalContext() const { return parent_.globalContext(); }
     InternalContext const* internalContext() const { return parent_.internalContext(); }

--- a/FWCore/ServiceRegistry/interface/ParentContext.h
+++ b/FWCore/ServiceRegistry/interface/ParentContext.h
@@ -21,7 +21,7 @@ namespace edm {
   class GlobalContext;
   class InternalContext;
   class ModuleCallingContext;
-  class PathContext;
+  class PlaceInPathContext;
   class StreamContext;
 
   class ParentContext {
@@ -31,7 +31,7 @@ namespace edm {
       kGlobal,
       kInternal,
       kModule,
-      kPath,
+      kPlaceInPath,
       kStream,
       kInvalid
     };
@@ -40,7 +40,7 @@ namespace edm {
     ParentContext(GlobalContext const*);
     ParentContext(InternalContext const*);
     ParentContext(ModuleCallingContext const*);
-    ParentContext(PathContext const*);
+    ParentContext(PlaceInPathContext const*);
     ParentContext(StreamContext const*);
 
     Type type() const { return type_; }
@@ -48,7 +48,7 @@ namespace edm {
     GlobalContext const* globalContext() const;
     InternalContext const* internalContext() const;
     ModuleCallingContext const* moduleCallingContext() const;
-    PathContext const* pathContext() const;
+    PlaceInPathContext const* placeInPathContext() const;
     StreamContext const* streamContext() const;
 
   private:
@@ -58,7 +58,7 @@ namespace edm {
       GlobalContext const* global;
       InternalContext const* internal;
       ModuleCallingContext const* module;
-      PathContext const* path;
+      PlaceInPathContext const* placeInPath;
       StreamContext const* stream;
     } parent_;
   };

--- a/FWCore/ServiceRegistry/interface/PathContext.h
+++ b/FWCore/ServiceRegistry/interface/PathContext.h
@@ -14,28 +14,38 @@ Services as an argument to their callback functions.
 // Original Author: W. David Dagenhart
 //         Created: 7/10/2013
 
-#include "FWCore/ServiceRegistry/interface/StreamContext.h"
-
 #include <iosfwd>
 #include <string>
 
 namespace edm {
 
+  class StreamContext;
+
   class PathContext {
   public:
 
+    enum class PathType {
+      kPath,
+      kEndPath
+    };
+
     PathContext(std::string const& pathName,
+                StreamContext const* streamContext,
                 unsigned int pathID,
-                StreamContext const* streamContext);
+                PathType pathType);
 
     std::string const& pathName() const { return pathName_; }
-    unsigned int pathID() const { return pathID_; }
     StreamContext const* streamContext() const { return streamContext_; }
+    unsigned int pathID() const { return pathID_; }
+    PathType pathType() const { return pathType_; }
+
+    bool isEndPath() const { return pathType_ == PathType::kEndPath; }
 
   private:
     std::string pathName_;
-    unsigned int pathID_;
     StreamContext const* streamContext_;
+    unsigned int pathID_;
+    PathType pathType_;
   };
 
   std::ostream& operator<<(std::ostream&, PathContext const&);

--- a/FWCore/ServiceRegistry/interface/PlaceInPathContext.h
+++ b/FWCore/ServiceRegistry/interface/PlaceInPathContext.h
@@ -1,0 +1,37 @@
+#ifndef FWCore_ServiceRegistry_PlaceInPathContext_h
+#define FWCore_ServiceRegistry_PlaceInPathContext_h
+
+/**\class edm::PlaceInPathContext
+
+ Description: Holds context information to indentify
+ the position within a sequence of modules in a path.
+*/
+//
+// Original Author: W. David Dagenhart
+//         Created: 7/31/2013
+
+#include <iosfwd>
+
+namespace edm {
+
+  class PathContext;
+
+  class PlaceInPathContext {
+
+  public:
+
+    PlaceInPathContext(unsigned int);
+
+    unsigned int placeInPath() const { return placeInPath_; }
+    PathContext const* pathContext() const { return pathContext_; }
+
+    void setPathContext(PathContext const* v) { pathContext_ = v; }
+
+  private:
+    unsigned int placeInPath_;
+    PathContext const* pathContext_;
+  };
+
+  std::ostream& operator<<(std::ostream&, PlaceInPathContext const&);
+}
+#endif

--- a/FWCore/ServiceRegistry/interface/StreamContext.h
+++ b/FWCore/ServiceRegistry/interface/StreamContext.h
@@ -18,7 +18,6 @@
 
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
-#include "FWCore/ServiceRegistry/interface/ProcessContext.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/StreamID.h"
@@ -26,6 +25,8 @@
 #include <iosfwd>
 
 namespace edm {
+
+  class ProcessContext;
 
   class StreamContext {
 

--- a/FWCore/ServiceRegistry/src/GlobalContext.cc
+++ b/FWCore/ServiceRegistry/src/GlobalContext.cc
@@ -1,4 +1,5 @@
 #include "FWCore/ServiceRegistry/interface/GlobalContext.h"
+#include "FWCore/ServiceRegistry/interface/ProcessContext.h"
 
 #include <ostream>
 

--- a/FWCore/ServiceRegistry/src/ModuleCallingContext.cc
+++ b/FWCore/ServiceRegistry/src/ModuleCallingContext.cc
@@ -1,6 +1,7 @@
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/ServiceRegistry/interface/InternalContext.h"
 #include "FWCore/ServiceRegistry/interface/PathContext.h"
+#include "FWCore/ServiceRegistry/interface/PlaceInPathContext.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 
@@ -37,8 +38,8 @@ namespace edm {
     while(mcc->type() == ParentContext::Type::kModule) {
       mcc = mcc->moduleCallingContext();
     }
-    if(mcc->type() == ParentContext::Type::kPath) {
-      return mcc->pathContext()->streamContext();
+    if(mcc->type() == ParentContext::Type::kPlaceInPath) {
+      return mcc->placeInPathContext()->pathContext()->streamContext();
     } else if (mcc->type() != ParentContext::Type::kStream) {
       throw Exception(errors::LogicError)
         << "ModuleCallingContext::getStreamContext() called in context not linked to a StreamContext\n";

--- a/FWCore/ServiceRegistry/src/ParentContext.cc
+++ b/FWCore/ServiceRegistry/src/ParentContext.cc
@@ -2,7 +2,7 @@
 #include "FWCore/ServiceRegistry/interface/GlobalContext.h"
 #include "FWCore/ServiceRegistry/interface/InternalContext.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
-#include "FWCore/ServiceRegistry/interface/PathContext.h"
+#include "FWCore/ServiceRegistry/interface/PlaceInPathContext.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 
 #include "FWCore/Utilities/interface/EDMException.h"
@@ -31,9 +31,9 @@ namespace edm {
     parent_.module = module;
   }
 
-  ParentContext::ParentContext(PathContext const* path) :
-    type_(Type::kPath) {
-    parent_.path = path;
+  ParentContext::ParentContext(PlaceInPathContext const* placeInPath) :
+    type_(Type::kPlaceInPath) {
+    parent_.placeInPath = placeInPath;
   }
 
   ParentContext::ParentContext(StreamContext const* stream) :
@@ -50,13 +50,13 @@ namespace edm {
     return parent_.module;
   }
 
-  PathContext const*
-  ParentContext::pathContext() const {
-    if(type_ != Type::kPath) {
+  PlaceInPathContext const*
+  ParentContext::placeInPathContext() const {
+    if(type_ != Type::kPlaceInPath) {
       throw Exception(errors::LogicError)
-        << "ParentContext::pathContext called for incorrect type of context";
+        << "ParentContext::placeInPathContext called for incorrect type of context";
     }
-    return parent_.path;
+    return parent_.placeInPath;
   }
 
   StreamContext const*
@@ -93,8 +93,8 @@ namespace edm {
       os << *pc.internalContext();
     } else if (pc.type() == ParentContext::Type::kModule && pc.moduleCallingContext()) {
       os << *pc.moduleCallingContext();
-    } else if (pc.type() == ParentContext::Type::kPath && pc.pathContext()) {
-      os << *pc.pathContext();
+    } else if (pc.type() == ParentContext::Type::kPlaceInPath && pc.placeInPathContext()) {
+      os << *pc.placeInPathContext();
     } else if (pc.type() == ParentContext::Type::kStream && pc.streamContext()) {
       os << *pc.streamContext();
     } else if (pc.type() == ParentContext::Type::kInvalid) {

--- a/FWCore/ServiceRegistry/src/PathContext.cc
+++ b/FWCore/ServiceRegistry/src/PathContext.cc
@@ -1,20 +1,28 @@
 #include "FWCore/ServiceRegistry/interface/PathContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
 
 #include <ostream>
 
 namespace edm {
 
   PathContext::PathContext(std::string const& pathName,
+                           StreamContext const* streamContext,
                            unsigned int pathID,
-                           StreamContext const* streamContext) :
+                           PathType pathType) :
     pathName_(pathName),
+    streamContext_(streamContext),
     pathID_(pathID),
-    streamContext_(streamContext) {
+    pathType_(pathType) {
   }
 
   std::ostream& operator<<(std::ostream& os, PathContext const& pc) {
     os << "PathContext: pathName = " << pc.pathName()
-       << " pathID = " << pc.pathID() << "\n";
+       << " pathID = " << pc.pathID();
+    if(pc.pathType() == PathContext::PathType::kEndPath) {
+      os << " (EndPath)\n"; 
+    } else {
+      os << "\n";
+    }
     if(pc.streamContext()) {
       os << "    " << *pc.streamContext(); 
     }

--- a/FWCore/ServiceRegistry/src/PlaceInPathContext.cc
+++ b/FWCore/ServiceRegistry/src/PlaceInPathContext.cc
@@ -1,0 +1,20 @@
+#include "FWCore/ServiceRegistry/interface/PlaceInPathContext.h"
+#include "FWCore/ServiceRegistry/interface/PathContext.h"
+
+#include <ostream>
+
+namespace edm {
+
+  PlaceInPathContext::PlaceInPathContext(unsigned int placeInPath) :
+    placeInPath_(placeInPath),
+    pathContext_(nullptr) {
+  }
+
+  std::ostream& operator<<(std::ostream& os, PlaceInPathContext const& ppc) {
+    os << "PlaceInPathContext " << ppc.placeInPath() << "\n";
+    if(ppc.pathContext()) {
+      os << "    " << *ppc.pathContext(); 
+    }
+    return os;
+  }
+}

--- a/FWCore/ServiceRegistry/src/StreamContext.cc
+++ b/FWCore/ServiceRegistry/src/StreamContext.cc
@@ -1,4 +1,5 @@
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/ServiceRegistry/interface/ProcessContext.h"
 
 #include <ostream>
 

--- a/HLTrigger/HLTcore/interface/HLTFilter.h
+++ b/HLTrigger/HLTcore/interface/HLTFilter.h
@@ -16,10 +16,12 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EDFilter.h"
-#include "FWCore/Framework/interface/CurrentProcessingContext.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+
+#include <string>
+#include <utility>
 
 //
 // class decleration
@@ -47,10 +49,10 @@ public:
   }
 
 public:
-  int path() const;
-  int module() const;
-  std::pair<int,int> pmid() const;
-  const std::string* pathName() const;
+  int path(edm::Event const&) const;
+  int module(edm::Event const&) const;
+  std::pair<int,int> pmid(edm::Event const&) const;
+  const std::string* pathName(edm::Event const&) const;
   const std::string* moduleLabel() const;
 };
 

--- a/HLTrigger/HLTcore/plugins/HLTPrescaler.cc
+++ b/HLTrigger/HLTcore/plugins/HLTPrescaler.cc
@@ -7,8 +7,10 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 
-#include "FWCore/Framework/interface/CurrentProcessingContext.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/ServiceRegistry/interface/PathContext.h"
+#include "FWCore/ServiceRegistry/interface/PlaceInPathContext.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
@@ -73,7 +75,7 @@ bool HLTPrescaler::filter(edm::Event& iEvent, const edm::EventSetup&)
     bool needsInit (eventCount_==0);
 
     if (prescaleService_) {
-      std::string const & pathName = * currentContext()->pathName();
+      std::string const & pathName = iEvent.moduleCallingContext()->placeInPathContext()->pathContext()->pathName();
       const unsigned int oldSet(prescaleSet_);
       const unsigned int oldPrescale(prescaleFactor_);
 

--- a/HLTrigger/HLTfilters/interface/HLTHighLevel.h
+++ b/HLTrigger/HLTfilters/interface/HLTHighLevel.h
@@ -21,7 +21,6 @@
 // CMSSW headers
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EDFilter.h"
-#include "FWCore/Framework/interface/CurrentProcessingContext.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Common/interface/TriggerNames.h"
@@ -50,11 +49,13 @@ class HLTHighLevel : public edm::EDFilter {
 
     /// get HLTPaths with key 'key' from EventSetup (AlCaRecoTriggerBitsRcd)
     std::vector<std::string> pathsFromSetup(const std::string &key,
+                                            const edm::Event &,
 					    const edm::EventSetup &iSetup) const;
 
   private:
     /// initialize the trigger conditions (call this if the trigger paths have changed)
     void init(const edm::TriggerResults & results,
+              const edm::Event&,
               const edm::EventSetup &iSetup,
               const edm::TriggerNames & triggerNames);
 
@@ -72,7 +73,7 @@ class HLTHighLevel : public edm::EDFilter {
     bool throw_;
 
     /// stolen from HLTFilter
-    std::string const & pathName() const;
+    std::string const & pathName(const edm::Event &) const;
     std::string const & moduleLabel() const;
 
     /// not empty => use read paths from AlCaRecoTriggerBitsRcd via this key

--- a/HLTrigger/HLTfilters/interface/TriggerResultsFilterFromDB.h
+++ b/HLTrigger/HLTfilters/interface/TriggerResultsFilterFromDB.h
@@ -46,7 +46,7 @@ public:
 
 private:
   /// read the triggerConditions from the database
-  void pathsFromSetup(const edm::EventSetup & setup);
+  void pathsFromSetup(const edm::Event &, const edm::EventSetup & setup);
 
   /// parse the logical expression into functionals
   void parse(const std::string & expression);

--- a/HLTrigger/HLTfilters/src/TriggerResultsFilterFromDB.cc
+++ b/HLTrigger/HLTfilters/src/TriggerResultsFilterFromDB.cc
@@ -91,7 +91,7 @@ void TriggerResultsFilterFromDB::parse(const std::string & expression) {
 }
 
 // read the triggerConditions from the database
-void TriggerResultsFilterFromDB::pathsFromSetup(const edm::EventSetup & setup)
+void TriggerResultsFilterFromDB::pathsFromSetup(const edm::Event & event, const edm::EventSetup & setup)
 {
   // Get map of strings to concatenated list of names of HLT paths from EventSetup:
   edm::ESHandle<AlCaRecoTriggerBits> triggerBits;
@@ -102,7 +102,7 @@ void TriggerResultsFilterFromDB::pathsFromSetup(const edm::EventSetup & setup)
   TriggerMap::const_iterator listIter = triggerMap.find(m_eventSetupPathsKey);
   if (listIter == triggerMap.end()) {
     throw cms::Exception("Configuration") << "TriggerResultsFilterFromDB [instance: " << * moduleLabel() 
-                                          << " - path: " << * pathName() 
+                                          << " - path: " << * pathName(event) 
                                           << "]: No triggerList with key " << m_eventSetupPathsKey << " in AlCaRecoTriggerBitsRcd";
   }
 
@@ -115,7 +115,7 @@ bool TriggerResultsFilterFromDB::hltFilter(edm::Event & event, const edm::EventS
 {
   // if the IOV has changed, re-read the triggerConditions from the database
   if (m_eventSetupWatcher.check(setup))
-    pathsFromSetup(setup);
+    pathsFromSetup(event, setup);
 
   if (not m_expression)
     // no valid expression has been parsed

--- a/HLTrigger/special/interface/HLTCountNumberOfObject.h
+++ b/HLTrigger/special/interface/HLTCountNumberOfObject.h
@@ -42,7 +42,7 @@ private:
     bool answer=true;
     if (minN_!=-1) answer = answer && (s>=minN_);
     if (maxN_!=-1) answer = answer && (s<=maxN_);
-    LogDebug("HLTCountNumberOfObject")<<module()<<" sees: "<<s<<" objects. Filtere answer is: "<<(answer?"true":"false");
+    LogDebug("HLTCountNumberOfObject")<<module(iEvent)<<" sees: "<<s<<" objects. Filtere answer is: "<<(answer?"true":"false");
 
     return answer;
   }

--- a/HLTrigger/special/interface/HLTTrackWithHits.h
+++ b/HLTrigger/special/interface/HLTTrackWithHits.h
@@ -54,7 +54,7 @@ private:
     }
       
     bool answer=(count>=minN_ && count<=maxN_);
-    LogDebug("HLTTrackWithHits")<<module()<<" sees: "<<s<<" objects. Only: "<<count<<" satisfy the hit requirement. Filter answer is: "<<(answer?"true":"false")<<std::endl;
+    LogDebug("HLTTrackWithHits")<<module(iEvent)<<" sees: "<<s<<" objects. Only: "<<count<<" satisfy the hit requirement. Filter answer is: "<<(answer?"true":"false")<<std::endl;
     return answer;
   }
  


### PR DESCRIPTION
Remove all uses of CurrentProcessingContext from HLTrigger
packages. This is replaced by using the new ModuleCallingContext.
There should be no change in behavior. The only interface change
in the HLTrigger code is that the Event is an added argument
to some functions. These functions are only used in a few
places and all uses are fixed. Also in the Framework, the
PlaceInPathContext class is added and used. Removed the unused
filling of TriggerResults for end paths. Some other minor
Framework cleanup and unit tests.
