### PR TITLE
Move FWEveDigitSetScalableMarker delcaration in header file. Related to #332

### DIFF
--- a/Fireworks/Core/src/FWEveDigitSetScalableMarker.cc
+++ b/Fireworks/Core/src/FWEveDigitSetScalableMarker.cc
@@ -1,69 +1,42 @@
-#ifndef Fireworks_Core_FWMarkerDigitSetGL_h
-#define Fireworks_Core_FWMarkerDigitSetGL_h
-
-#include "TEveQuadSet.h"
-#include "TEveQuadSetGL.h"
 #include "TGLIncludes.h"
-#include "TGLRnrCtx.h"
-#include "TAttMarker.h"
+#include "Fireworks/Core/src/FWEveDigitSetScalableMarker.h"
 
-class FWEveDigitSetScalableMarker : public TEveQuadSet, public TAttMarker
+void 
+FWEveDigitSetScalableMarkerGL::DirectDraw(TGLRnrCtx & rnrCtx) const
 {
-public:
-   FWEveDigitSetScalableMarker() {}
-   virtual ~FWEveDigitSetScalableMarker() {}
-   
-   ClassDef( FWEveDigitSetScalableMarker, 0);
-};
-
-//--------------------------------------------
-class FWEveDigitSetScalableMarkerGL : public TEveQuadSetGL
-{
-public:
-   FWEveDigitSetScalableMarkerGL() {}
-   virtual ~FWEveDigitSetScalableMarkerGL() {}
-   
-   virtual void DirectDraw(TGLRnrCtx & rnrCtx) const
-   {
-      glPushAttrib(GL_ENABLE_BIT | GL_POLYGON_BIT | GL_POINT_BIT);
-      glEnable(GL_POINT_SMOOTH);
-      glDisable(GL_LIGHTING);
+   glPushAttrib(GL_ENABLE_BIT | GL_POLYGON_BIT | GL_POINT_BIT);
+   glEnable(GL_POINT_SMOOTH);
+   glDisable(GL_LIGHTING);
           
-      TEveChunkManager::iterator qi(fM->GetPlex());
-      if (rnrCtx.Highlight() && fHighlightSet)
-         qi.fSelection = fHighlightSet;
+   TEveChunkManager::iterator qi(fM->GetPlex());
+   if (rnrCtx.Highlight() && fHighlightSet)
+      qi.fSelection = fHighlightSet;
       
-      if (rnrCtx.SecSelection()) glPushName(0);
+   if (rnrCtx.SecSelection()) glPushName(0);
       
-      glPointSize(((FWEveDigitSetScalableMarker*)fM)->GetMarkerSize());
-      while (qi.next()) {
-         TEveQuadSet::QFreeQuad_t* q =  (TEveQuadSet::QFreeQuad_t*) qi();
-         if (q->fValue < 0)
-            continue;
-         TGLUtil::ColorAlpha(Color_t(q->fValue));
-         if (rnrCtx.SecSelection()) glLoadName(qi.index());
-         float* p = &q->fVertices[0];
-         glBegin(GL_LINES);
-         float c[3]  =  {0.5f*(p[0]+p[6]), 0.5f*(p[1]+p[7]), 0.5f*(p[2]+p[8])};
+   glPointSize(((FWEveDigitSetScalableMarker*)fM)->GetMarkerSize());
+   while (qi.next()) {
+      TEveQuadSet::QFreeQuad_t* q =  (TEveQuadSet::QFreeQuad_t*) qi();
+      if (q->fValue < 0)
+         continue;
+      TGLUtil::ColorAlpha(Color_t(q->fValue));
+      if (rnrCtx.SecSelection()) glLoadName(qi.index());
+      float* p = &q->fVertices[0];
+      glBegin(GL_LINES);
+      float c[3]  =  {0.5f*(p[0]+p[6]), 0.5f*(p[1]+p[7]), 0.5f*(p[2]+p[8])};
          
-         float d = p[6] - p[0];
-         glVertex3f( c[0] -d, c[1], c[2]); glVertex3f(c[0] + d, c[1], c[2]);
-         glVertex3f( c[0] , c[1] -d, c[2]); glVertex3f(c[0] , c[1] +d, c[2]);
-         glVertex3f( c[0] , c[1], c[2]-d); glVertex3f(c[0] , c[1], c[2] +d);
+      float d = p[6] - p[0];
+      glVertex3f( c[0] -d, c[1], c[2]); glVertex3f(c[0] + d, c[1], c[2]);
+      glVertex3f( c[0] , c[1] -d, c[2]); glVertex3f(c[0] , c[1] +d, c[2]);
+      glVertex3f( c[0] , c[1], c[2]-d); glVertex3f(c[0] , c[1], c[2] +d);
          
-         glEnd();
+      glEnd();
          
-         glBegin(GL_POINTS);
-         glVertex3fv(&c[0]);
-         glEnd();
+      glBegin(GL_POINTS);
+      glVertex3fv(&c[0]);
+      glEnd();
          
-      }
-      
-      glPopAttrib();
    }
-   
-   ClassDef(FWEveDigitSetScalableMarkerGL, 0);
-};
-
-
-#endif
+      
+   glPopAttrib();
+}

--- a/Fireworks/Core/src/FWEveDigitSetScalableMarker.h
+++ b/Fireworks/Core/src/FWEveDigitSetScalableMarker.h
@@ -1,0 +1,31 @@
+#ifndef Fireworks_Core_FWMarkerDigitSetGL_h
+#define Fireworks_Core_FWMarkerDigitSetGL_h
+
+#include "TEveQuadSet.h"
+#include "TEveQuadSetGL.h"
+#include "TGLRnrCtx.h"
+#include "TAttMarker.h"
+
+class FWEveDigitSetScalableMarker : public TEveQuadSet, public TAttMarker
+{
+public:
+   FWEveDigitSetScalableMarker() {}
+   virtual ~FWEveDigitSetScalableMarker() {}
+   
+   ClassDef( FWEveDigitSetScalableMarker, 0);
+};
+
+//--------------------------------------------
+class FWEveDigitSetScalableMarkerGL : public TEveQuadSetGL
+{
+public:
+   FWEveDigitSetScalableMarkerGL() {}
+   virtual ~FWEveDigitSetScalableMarkerGL() {}
+   
+   void DirectDraw(TGLRnrCtx & rnrCtx) const;
+   
+   ClassDef(FWEveDigitSetScalableMarkerGL, 0);
+};
+
+
+#endif

--- a/Fireworks/Core/src/FWGeometryTableViewBase.cc
+++ b/Fireworks/Core/src/FWGeometryTableViewBase.cc
@@ -14,7 +14,7 @@
 #include "Fireworks/Core/src/FWColorSelect.h"
 #include "Fireworks/Core/src/FWPopupMenu.cc"
 #include "Fireworks/Core/src/FWGeoTopNodeScene.h"
-#include "Fireworks/Core/src/FWEveDigitSetScalableMarker.cc"
+#include "Fireworks/Core/src/FWEveDigitSetScalableMarker.h"
 #include "Fireworks/Core/interface/CmsShowViewPopup.h"
 
 

--- a/Fireworks/Core/src/FWOverlapTableManager.cc
+++ b/Fireworks/Core/src/FWOverlapTableManager.cc
@@ -16,7 +16,7 @@
 // user include files
 #include "Fireworks/Core/src/FWOverlapTableManager.h"
 #include "Fireworks/Core/src/FWOverlapTableView.h"
-#include "Fireworks/Core/src/FWEveDigitSetScalableMarker.cc"
+#include "Fireworks/Core/src/FWEveDigitSetScalableMarker.h"
 #include "Fireworks/Core/interface/FWGeometryTableViewManager.h"
 #include "Fireworks/Core/interface/fwLog.h"
 

--- a/Fireworks/Core/src/FWOverlapTableView.cc
+++ b/Fireworks/Core/src/FWOverlapTableView.cc
@@ -21,13 +21,12 @@
 #include "Fireworks/Core/src/FWEveOverlap.h"
 #include "Fireworks/Core/interface/FWGeometryTableViewManager.h"
 #include "Fireworks/Core/interface/CmsShowViewPopup.h"
-#include "Fireworks/Core/src/FWEveDigitSetScalableMarker.cc"
 #include "Fireworks/Core/src/FWPopupMenu.cc"
 #include "Fireworks/Core/interface/fwLog.h"
 
 #include "Fireworks/Core/src/FWGUIValidatingTextEntry.h"
 #include "Fireworks/Core/src/FWValidatorBase.h"
-#include "Fireworks/Core/src/FWEveDigitSetScalableMarker.cc"
+#include "Fireworks/Core/src/FWEveDigitSetScalableMarker.h"
 
 #include "TEveScene.h"
 #include "TEveSceneInfo.h"

--- a/Fireworks/Core/src/classes.h
+++ b/Fireworks/Core/src/classes.h
@@ -29,7 +29,7 @@
 #include "Fireworks/Core/interface/FWGUIEventSelector.h"
 #include "Fireworks/Core/interface/FWTEventList.h"
 #include "Fireworks/Core/interface/FWTSelectorToEventList.h"
-#include "Fireworks/Core/src/FWEveDigitSetScalableMarker.cc"
+#include "Fireworks/Core/src/FWEveDigitSetScalableMarker.h"
 #include "Fireworks/Core/src/FW3DViewDistanceMeasureTool.h"
 namespace {
    struct Fireworks_Core {


### PR DESCRIPTION
In pull request #332 were problems with dictionary since Fireworks/Core/src/FWEveDigitSetScalableMarker.cc file was included in classes.h. 

I have split the code into source and header so that classes.h include only header files. As I understand a workaround for problem in #332 has already been made, but not included in the official cmssw repository.
