### PR TITLE
Secondary input sources should not register anything when opening a file

### DIFF
--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -337,7 +337,10 @@ namespace edm {
       for(auto const& psetEntry : psetMap) {
         ParameterSet pset(psetEntry.second.pset());
         pset.setID(psetEntry.first);
-        psetRegistry.insertMapped(pset);
+        // For thread safety, don't update registries when a secondary source opens a file.
+        if(inputType != InputType::SecondarySource) {
+          psetRegistry.insertMapped(pset);
+        }
       }
     }
     if(!fileFormatVersion().splitProductIDs()) {
@@ -394,7 +397,10 @@ namespace edm {
       }
     }
 
-    ProcessHistoryRegistry::instance()->insertCollection(pHistVector);
+    // For thread safety, don't update registries when a secondary source opens a file.
+    if(inputType != InputType::SecondarySource) {
+      ProcessHistoryRegistry::instance()->insertCollection(pHistVector);
+    }
 
     eventTree_.trainCache(BranchTypeToAuxiliaryBranchName(InEvent).c_str());
 
@@ -402,7 +408,7 @@ namespace edm {
 
     // Here, we make the class that will make the ProvenanceReader
     // It reads whatever trees it needs.
-    provenanceReaderMaker_.reset(makeProvenanceReaderMaker().release());
+    provenanceReaderMaker_.reset(makeProvenanceReaderMaker(inputType).release());
 
     // Merge into the hashed registries.
     if(eventSkipperByID_ && eventSkipperByID_->somethingToSkip()) {
@@ -484,7 +490,7 @@ namespace edm {
   }
 
   void
-  RootFile::readEntryDescriptionTree(EntryDescriptionMap& entryDescriptionMap) {
+  RootFile::readEntryDescriptionTree(EntryDescriptionMap& entryDescriptionMap, InputType::InputType inputType) {
     // Called only for old format files.
     // We use a smart pointer so the tree will be deleted after use, and not kept for the life of the file.
     std::unique_ptr<TTree> entryDescriptionTree(dynamic_cast<TTree*>(filePtr_->Get(poolNames::entryDescriptionTreeName().c_str())));
@@ -520,14 +526,17 @@ namespace edm {
           daqProvenanceHelper_->parentageIDMap_.insert(std::make_pair(oldID, newID));
         }
       }
-      registry.insertMapped(parents);
+      // For thread safety, don't update registries when a secondary source opens a file.
+      if(inputType != InputType::SecondarySource) {
+        registry.insertMapped(parents);
+      }
     }
     entryDescriptionTree->SetBranchAddress(poolNames::entryDescriptionIDBranchName().c_str(), nullptr);
     entryDescriptionTree->SetBranchAddress(poolNames::entryDescriptionBranchName().c_str(), nullptr);
   }
 
   void
-  RootFile::readParentageTree() {
+  RootFile::readParentageTree(InputType::InputType inputType) {
     // New format file
     // We use a smart pointer so the tree will be deleted after use, and not kept for the life of the file.
     std::unique_ptr<TTree> parentageTree(dynamic_cast<TTree*>(filePtr_->Get(poolNames::parentageTreeName().c_str())));
@@ -553,7 +562,10 @@ namespace edm {
           daqProvenanceHelper_->parentageIDMap_.insert(std::make_pair(oldID, newID));
         }
       }
-      registry.insertMapped(parents);
+      // For thread safety, don't update registries when a secondary source opens a file.
+      if(inputType != InputType::SecondarySource) {
+        registry.insertMapped(parents);
+      }
       parentageIDLookup_.push_back(parents.id());
     }
     parentageTree->SetBranchAddress(poolNames::parentageBranchName().c_str(), nullptr);
@@ -1712,16 +1724,16 @@ namespace edm {
   }
 
   std::unique_ptr<MakeProvenanceReader>
-  RootFile::makeProvenanceReaderMaker() {
+  RootFile::makeProvenanceReaderMaker(InputType::InputType inputType) {
     if(fileFormatVersion_.storedProductProvenanceUsed()) {
-      readParentageTree();
+      readParentageTree(inputType);
       return std::unique_ptr<MakeProvenanceReader>(new MakeReducedProvenanceReader(parentageIDLookup_));
     } else if(fileFormatVersion_.splitProductIDs()) {
-      readParentageTree();
+      readParentageTree(inputType);
       return std::unique_ptr<MakeProvenanceReader>(new MakeFullProvenanceReader);
     } else if(fileFormatVersion_.perEventProductIDs()) {
       std::unique_ptr<EntryDescriptionMap> entryDescriptionMap(new EntryDescriptionMap);
-      readEntryDescriptionTree(*entryDescriptionMap);
+      readEntryDescriptionTree(*entryDescriptionMap, inputType);
       return std::unique_ptr<MakeProvenanceReader>(new MakeOldProvenanceReader(std::move(entryDescriptionMap)));
     } else {
       return std::unique_ptr<MakeProvenanceReader>(new MakeDummyProvenanceReader);

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -158,15 +158,15 @@ namespace edm {
     void overrideRunNumber(EventID& id, bool isRealData);
     std::string const& newBranchToOldBranch(std::string const& newBranch) const;
     void dropOnInput(ProductRegistry& reg, ProductSelectorRules const& rules, bool dropDescendants, InputType::InputType inputType);
-    void readParentageTree();
-    void readEntryDescriptionTree(EntryDescriptionMap&); // backward compatibility
+    void readParentageTree(InputType::InputType inputType);
+    void readEntryDescriptionTree(EntryDescriptionMap&, InputType::InputType inputType); // backward compatibility
     void readEventHistoryTree();
     bool isDuplicateEvent();
 
     void initializeDuplicateChecker(std::vector<boost::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
                                     std::vector<boost::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile);
 
-    std::unique_ptr<MakeProvenanceReader> makeProvenanceReaderMaker();
+    std::unique_ptr<MakeProvenanceReader> makeProvenanceReaderMaker(InputType::InputType inputType);
     boost::shared_ptr<BranchMapper> makeBranchMapper();
 
     std::string const file_;


### PR DESCRIPTION
Currently, input sources may insert objects into global registries when a new input file is opened.  This is OK for phase 1 of the multithreaded framework, except in the case of a secondary input source. This is because a secondary input source may open a new input file during any primary event.  This pull request modifies the ROOT/EDM input source so that it registers nothing if it is being used as a secondary input source.  This request does nothing for other input sources, but this is OK for now as the ROOT/EDM input source is the only source currently used for secondary input.
