### PR TITLE
[CMSSW_7_0_X] Fix maybe-uninitialized errors in RecoEcal/EgammaClusterAlgos

### DIFF
--- a/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
@@ -106,7 +106,7 @@ namespace {
     const CalibClusterPtr the_seed;    
     PFECALSuperClusterAlgo::clustering_type _type;
     bool dynamic_dphi;
-    double etawidthSuperCluster_, phiwidthSuperCluster_;
+    double etawidthSuperCluster_ = .0 , phiwidthSuperCluster_ = .0;
     IsClustered(const CalibClusterPtr s, 
 		PFECALSuperClusterAlgo::clustering_type ct,
 		const bool dyn_dphi) : 


### PR DESCRIPTION
Fix the following two errors on slc6_amd64_gcc481:

```
RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc:276:15: error:
'IsClusteredWithSeed.{anonymous}::IsClustered::phiwidthSuperCluster_'
may be used uninitialized in this function [-Werror=maybe-uninitialized]
   IsClustered IsClusteredWithSeed(seed,_clustype,_useDynamicDPhi);

RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc:276:15: error:
'IsClusteredWithSeed.{anonymous}::IsClustered::etawidthSuperCluster_'
may be used uninitialized in this function [-Werror=maybe-uninitialized]

In PFECALSuperClusterAlgo::buildSuperCluster we only check for
PFLayer::ECAL_BARREL and PFLayer::ECAL_ENDCAP. If any other
PFLayer::Layer is returned by seed->the_ptr()->layer()
phiwidthSuperCluster_ and etawidthSuperCluster_ are uninitialized.
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
