### PR TITLE
Fixed ambiguity with Selections

### DIFF
--- a/PhysicsTools/UtilAlgos/plugins/ConfigurableAnalysis.cc
+++ b/PhysicsTools/UtilAlgos/plugins/ConfigurableAnalysis.cc
@@ -127,8 +127,6 @@ ConfigurableAnalysis::~ConfigurableAnalysis()
 // ------------ method called to produce the data  ------------
 bool ConfigurableAnalysis::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  using namespace edm;
-
   //will the filter pass or not.
   bool majorGlobalAccept=false;
 


### PR DESCRIPTION
Framework changes brought the forward declaration of edm::Selections
into this code. However a ::Selections was begin used and with the
'using namespace edm' caused an ambiguity. However, the 'using namespace edm'
was unnecessary in the code and therefore was removed.
