### PR TITLE
Fixed bug where we could return a const & to a temporary from ParameterSet::getUntrackedParameterSet*

### DIFF
--- a/FWCore/ParameterSet/interface/ParameterSet.h
+++ b/FWCore/ParameterSet/interface/ParameterSet.h
@@ -107,10 +107,10 @@ namespace edm {
     ParameterSet const&
     getParameterSet(char const*) const;
 
-    ParameterSet const&
+    ParameterSet
     getUntrackedParameterSet(std::string const& name, ParameterSet const& defaultValue) const;
 
-    ParameterSet const&
+    ParameterSet
     getUntrackedParameterSet(char const* name, ParameterSet const& defaultValue) const;
 
     ParameterSet const&
@@ -125,10 +125,10 @@ namespace edm {
     VParameterSet const&
     getParameterSetVector(char const* name) const;
 
-    VParameterSet const&
+    VParameterSet
     getUntrackedParameterSetVector(std::string const& name, VParameterSet const& defaultValue) const;
 
-    VParameterSet const&
+    VParameterSet
     getUntrackedParameterSetVector(char const* name, VParameterSet const& defaultValue) const;
 
     VParameterSet const&

--- a/FWCore/ParameterSet/src/ParameterSet.cc
+++ b/FWCore/ParameterSet/src/ParameterSet.cc
@@ -2363,12 +2363,12 @@ namespace edm {
     return retrieveParameterSet(name).pset();
   }
 
-  ParameterSet const&
+  ParameterSet
   ParameterSet::getUntrackedParameterSet(std::string const& name, ParameterSet const& defaultValue) const {
     return getUntrackedParameterSet(name.c_str(), defaultValue);
   }
 
-  ParameterSet const&
+  ParameterSet
   ParameterSet::getUntrackedParameterSet(char const* name, ParameterSet const& defaultValue) const {
     ParameterSetEntry const* entryPtr = retrieveUntrackedParameterSet(name);
     if(entryPtr == 0) {
@@ -2401,12 +2401,12 @@ namespace edm {
     return retrieveVParameterSet(name).vpset();
   }
 
-  VParameterSet const&
+  VParameterSet
   ParameterSet::getUntrackedParameterSetVector(std::string const& name, VParameterSet const& defaultValue) const {
     return getUntrackedParameterSetVector(name.c_str(), defaultValue);
   }
 
-  VParameterSet const&
+  VParameterSet
   ParameterSet::getUntrackedParameterSetVector(char const* name, VParameterSet const& defaultValue) const {
     VParameterSetEntry const* entryPtr = retrieveUntrackedVParameterSet(name);
     return entryPtr == 0 ? defaultValue : entryPtr->vpset();


### PR DESCRIPTION
The recent change to getUntrackedParameterSet\* to no longer register the default value
to the Registry lead to the bug where if the user passed in a temporary as the default then
that temporary could be returned by const&. If the user's receiving variable is also a const&
then one has an address to a temporary which the compiler can delete after that C++ line ends.
