### PR TITLE
Sources can tell the framework they need to synchronize

### DIFF
--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -78,7 +78,8 @@ namespace edm {
       IsRun,
       IsLumi,
       IsEvent,
-      IsRepeat
+      IsRepeat,
+      IsSynchronize
     };
 
     enum ProcessingMode {
@@ -101,7 +102,8 @@ namespace edm {
     static const std::string& baseType();
     static void fillDescription(ParameterSetDescription& desc);
     static void prevalidate(ConfigurationDescriptions& );
-    
+
+    /// Advances the source to the next item
     ItemType nextItemType();
 
     /// Read next event

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1758,6 +1758,9 @@ namespace edm {
             else if(itemType == InputSource::IsEvent) {
               machine->process_event(statemachine::Event());
             }
+            else if(itemType == InputSource::IsSynchronize) {
+              //For now, we don't have to do anything
+            }
             // This should be impossible
             else {
               throw Exception(errors::LogicError)


### PR DESCRIPTION
Added the potential to allow a Source to tell the framework it needs the
framework to finish any outstanding concurrent work before the Source
can proceed. This allows the Source to handle any cases where it can't
work in parallel. For now, the EventProcessor just ignores the statement
since everything is singled threaded right now.
