### PR TITLE
Bugfix for the GenParticles2HepMCConverter

### DIFF
--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -124,6 +124,7 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
   {
     const reco::Candidate* p = &genParticlesHandle->at(i);
     HepMC::GenParticle* hepmc_particle = new HepMC::GenParticle(FourVector(p->p4()), p->pdgId(), p->status());
+    hepmc_particle->suggest_barcode(i+1);
 
     // Assign particle's generated mass from the standard particle data table
     double particleMass = pTable_->particle(p->pdgId())->mass();

--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -98,6 +98,8 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
   hepmc_event->set_alphaQED(genEventInfoHandle->alphaQED());
   hepmc_event->set_alphaQCD(genEventInfoHandle->alphaQCD());
 
+  hepmc_event->weights() = genEventInfoHandle->weights();
+
   // Set PDF
   const gen::PdfInfo* pdf = genEventInfoHandle->pdf();
   const int pdf_id1 = pdf->id.first, pdf_id2 = pdf->id.second;

--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -76,8 +76,6 @@ void GenParticles2HepMCConverter::beginRun(edm::Run& run, const edm::EventSetup&
   // const double xsecLOErr = genRunInfoHandle->externalXSecLO().error();
   // const double xsecNLO = genRunInfoHandle->externalXSecNLO().value();
   // const double xsecNLOErr = genRunInfoHandle->externalXSecNLO().error();
-  
-  eventSetup.getData(pTable_);
 }
 
 void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSetup& eventSetup)
@@ -90,6 +88,8 @@ void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSet
 
   edm::Handle<GenEventInfoProduct> genEventInfoHandle;
   event.getByLabel(genEventInfoLabel_, genEventInfoHandle);
+
+  eventSetup.getData(pTable_);
 
   HepMC::GenEvent* hepmc_event = new HepMC::GenEvent();
   hepmc_event->set_event_number(event.id().event());


### PR DESCRIPTION
Bugfix version of GenParticles2HepMCConverter.
1. Orphan gluons are also kept in the event.
2. Avoid crash while reading HepPDT
3. Particles' barcode and weights are included
