### PR TITLE
Have Workers for the same module use the same ModuleDescription

### DIFF
--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -95,6 +95,9 @@ namespace edm {
       
       BranchIDLists const* branchIDLists() const;
       
+      const ModuleDescription& moduleDescription() const {
+        return moduleDescription_;
+      }
     protected:
       
       Trig getTriggerResults(EventPrincipal const& ep, ModuleCallingContext const*) const;

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -59,7 +59,7 @@ namespace edm {
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------
-      const ModuleDescription moduleDescription() { return moduleDescription_;}
+      const ModuleDescription& moduleDescription() { return moduleDescription_;}
       
       std::string workerType() const { return "WorkerT<EDAnalyzerAdaptorBase>";}
       void

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -88,8 +88,8 @@ namespace edm {
     void pathFinished(EventPrincipal&);
     void postDoEvent(EventPrincipal&);
 
-    ModuleDescription const& description() const {return md_;}
-    ModuleDescription const* descPtr() const {return &md_; }
+    ModuleDescription const& description() const {return *(moduleCallingContext_.moduleDescription());}
+    ModuleDescription const* descPtr() const {return moduleCallingContext_.moduleDescription(); }
     ///The signals are required to live longer than the last call to 'doWork'
     /// this was done to improve performance based on profiling
     void setActivityRegistry(boost::shared_ptr<ActivityRegistry> areg);
@@ -148,6 +148,7 @@ namespace edm {
     virtual void implBeginStream(StreamID) = 0;
     virtual void implEndStream(StreamID) = 0;
     
+    void resetModuleDescription(ModuleDescription const*);
   private:
     virtual void implRespondToOpenInputFile(FileBlock const& fb) = 0;
     virtual void implRespondToCloseInputFile(FileBlock const& fb) = 0;
@@ -164,7 +165,6 @@ namespace edm {
     int timesExcept_;
     State state_;
 
-    ModuleDescription md_;
     ModuleCallingContext moduleCallingContext_;
 
     ExceptionToActionTable const* actions_; // memory assumed to be managed elsewhere
@@ -180,7 +180,7 @@ namespace edm {
     class ModuleSignalSentry {
     public:
       ModuleSignalSentry(ActivityRegistry *a,
-                         ModuleDescription& md,
+                         ModuleDescription const& md,
                          typename T::Context const* context,
                          ModuleCallingContext* moduleCallingContext) :
         a_(a), md_(&md), context_(context), moduleCallingContext_(moduleCallingContext) {
@@ -194,7 +194,7 @@ namespace edm {
 
     private:
       ActivityRegistry* a_;
-      ModuleDescription* md_;
+      ModuleDescription const* md_;
       typename T::Context const* context_;
       ModuleCallingContext* moduleCallingContext_;
     };
@@ -379,7 +379,7 @@ namespace edm {
     ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
     try {
       try {
-        ModuleSignalSentry<T> cpp(actReg_.get(), md_, context, &moduleCallingContext_);
+        ModuleSignalSentry<T> cpp(actReg_.get(), description(), context, &moduleCallingContext_);
         rc = workerhelper::CallImpl<T>::call(this,streamID,ep,es, &moduleCallingContext_);
 
         if (rc) {

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -39,6 +39,7 @@ namespace edm {
 
   void setModule( T* iModule) {
     module_ = iModule;
+    resetModuleDescription(&(module_->moduleDescription()));
   }
     
     virtual Types moduleType() const override;


### PR DESCRIPTION
The Service system used to guarantee that the address for a module's ModuleDescription would be unique. When we allowed multiple Workers per module that guarantee was broken. We now have the Workers use the ModuleDescription from the module rather than one they hold.

This fixes the problem of the FastTimerService flooding the IB with error messages
