### PR TITLE
Add process history map entry immediately on registration

### DIFF
--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -833,8 +833,8 @@ DQMRootSource::setupFile(unsigned int iIndex)
         if(not configs.empty()) {
           edm::ProcessHistory ph(configs);
           m_historyIDs.push_back(ph.id());
-          phr->insertMapped(ph);
-          m_reducedHistoryIDs.push_back(phr->extraForUpdate().reduceProcessHistoryID(ph.id()));
+          registerProcessHistory(ph);
+          m_reducedHistoryIDs.push_back(phr->extra().reducedProcessHistoryID(ph.id()));
         }
         configs.clear();
       }
@@ -845,8 +845,8 @@ DQMRootSource::setupFile(unsigned int iIndex)
     if(not configs.empty()) {
       edm::ProcessHistory ph(configs);
       m_historyIDs.push_back(ph.id());
-      phr->insertMapped( ph);
-      m_reducedHistoryIDs.push_back(phr->extraForUpdate().reduceProcessHistoryID(ph.id()));
+      registerProcessHistory(ph);
+      m_reducedHistoryIDs.push_back(phr->extra().reducedProcessHistoryID(ph.id()));
       //std::cout <<"inserted "<<ph.id()<<std::endl;
     }
   }

--- a/DataFormats/Provenance/interface/FullHistoryToReducedHistoryMap.h
+++ b/DataFormats/Provenance/interface/FullHistoryToReducedHistoryMap.h
@@ -6,24 +6,12 @@
 Used to convert the ProcessHistoryID of a full ProcessHistory
 to the ProcessHistoryID of the corresponding reduced ProcessHistory.
 
-Includes optimizations to cache the result so the same conversion
-need not be repeated many times.
-
 The ProcessHistoryRegistry includes an instance of this class
-as its "extra" data member.  That instance should be used.
-It would be a waste of memory and cpu to instantiate other
-instances of this class. The syntax should look something
-like the following:
-
-  edm::ProcessHistoryID reducedPHID = edm::ProcessHistoryRegistry::instance()->extra().reduceProcessHistoryID(fullID);
-
-Note that the above function will throw an exception if the
-full ProcessHistory is not already in the ProcessHistoryRegistry.
-We expect that the reduced ProcessHistory will not ever be
-in the registry (although there is nothing prevents that).
+as its "extra" data member.
+An entry will be added when an entry is added to the registry.
 
 \author W. David Dagenhart, created 2 August, 2011
-
+\author Bill Tanenbaum, modified 22 August, 2013 
 */
 
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
@@ -32,21 +20,21 @@ in the registry (although there is nothing prevents that).
 
 namespace edm {
 
+  class ProcessHistory;
   class FullHistoryToReducedHistoryMap {
   public:
-
     FullHistoryToReducedHistoryMap();
-
+#ifndef __GCCXML__
+    FullHistoryToReducedHistoryMap(FullHistoryToReducedHistoryMap const&) = delete; // Disallow copying and moving
+    FullHistoryToReducedHistoryMap& operator=(FullHistoryToReducedHistoryMap const&) = delete; // Disallow copying and moving
+#endif
     /// Use to obtain reduced ProcessHistoryID's from full ProcessHistoryID's
-    ProcessHistoryID const& reduceProcessHistoryID(ProcessHistoryID const& fullID);
+    ProcessHistoryID const& reducedProcessHistoryID(ProcessHistoryID const& fullID) const;
+    void insertMapping(ProcessHistory const& processHistory); 
 
   private:
-    FullHistoryToReducedHistoryMap(FullHistoryToReducedHistoryMap const&);
-    FullHistoryToReducedHistoryMap& operator=(FullHistoryToReducedHistoryMap const&);
-
     typedef std::map<ProcessHistoryID, ProcessHistoryID> Map;
-    Map cache_;
-    Map::const_iterator previous_;
+    Map fullHistoryToReducedHistoryMap_;
   };
 }
 #endif

--- a/DataFormats/Provenance/interface/ProcessHistoryRegistry.h
+++ b/DataFormats/Provenance/interface/ProcessHistoryRegistry.h
@@ -6,11 +6,12 @@
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/FullHistoryToReducedHistoryMap.h"
 
-namespace edm
-{
+namespace edm {
   typedef edm::detail::ThreadSafeRegistry<edm::ProcessHistoryID,edm::ProcessHistory,edm::FullHistoryToReducedHistoryMap> ProcessHistoryRegistry;
   typedef ProcessHistoryRegistry::collection_type ProcessHistoryMap;
   typedef ProcessHistoryRegistry::vector_type ProcessHistoryVector;
+
+  bool registerProcessHistory(ProcessHistory const& processHistory);
 }
 
 #endif

--- a/DataFormats/Provenance/src/FullHistoryToReducedHistoryMap.cc
+++ b/DataFormats/Provenance/src/FullHistoryToReducedHistoryMap.cc
@@ -6,40 +6,22 @@
 namespace edm {
 
   FullHistoryToReducedHistoryMap::FullHistoryToReducedHistoryMap() {
-    // Put in the conversion for the ID of an empty process history.
-    // It always maps onto itself, often is needed, and gives
-    // us something valid to initialize the iterator with. That removes
-    // the need to check for its validity and also for the validity
-    // of the fullID argument to the reduce function, because the invalid
-    // ProcessHistoryID is strangely also defined as the ID of the empty
-    // Process History (maybe that should be fixed ...).
-    ProcessHistory ph;
-    ph.setProcessHistoryID();
-    std::pair<ProcessHistoryID, ProcessHistoryID> newEntry(ph.id(), ph.id());
-    std::pair<Map::iterator, bool> result = cache_.insert(newEntry);
-    previous_ = result.first;
+    // We need to map the empty process history ID.
+    insertMapping(ProcessHistory());
   }
 
   ProcessHistoryID const&
-  FullHistoryToReducedHistoryMap::reduceProcessHistoryID(ProcessHistoryID const& fullID) {
-    if (previous_->first == fullID) return previous_->second;
-    Map::const_iterator iter = cache_.find(fullID);
-    if (iter != cache_.end()) {
-      previous_ = iter;
-      return iter->second;
-    }
-    ProcessHistoryRegistry* registry = ProcessHistoryRegistry::instance();
-    ProcessHistory ph;
-    if (!registry->getMapped(fullID, ph)) {
-      throw Exception(errors::LogicError)
-        << "FullHistoryToReducedHistoryMap::reduceProcessHistoryID\n"
-        << "ProcessHistory not found in registry\n"
-        << "Contact a Framework developer\n";
-    }
+  FullHistoryToReducedHistoryMap::reducedProcessHistoryID(ProcessHistoryID const& fullID) const {
+    Map::const_iterator iter = fullHistoryToReducedHistoryMap_.find(fullID);
+    assert(iter != fullHistoryToReducedHistoryMap_.end());
+    return iter->second;
+  }
+
+  void
+  FullHistoryToReducedHistoryMap::insertMapping(ProcessHistory const& processHistory) {
+    ProcessHistory ph(processHistory);
     ph.reduce();
-    std::pair<ProcessHistoryID, ProcessHistoryID> newEntry(fullID, ph.setProcessHistoryID());
-    std::pair<Map::iterator, bool> result = cache_.insert(newEntry);
-    previous_ = result.first;
-    return result.first->second;
+    std::pair<ProcessHistoryID, ProcessHistoryID> newEntry(processHistory.id(), ph.setProcessHistoryID());
+    fullHistoryToReducedHistoryMap_.insert(newEntry);
   }
 }

--- a/DataFormats/Provenance/src/IndexIntoFile.cc
+++ b/DataFormats/Provenance/src/IndexIntoFile.cc
@@ -151,14 +151,12 @@ namespace edm {
     runOrLumiIndexes().reserve(runOrLumiEntries_.size());
 
     int index = 0;
-    for(std::vector<RunOrLumiEntry>::const_iterator iter = runOrLumiEntries_.begin(),
-                                                    iEnd = runOrLumiEntries_.end();
-         iter != iEnd;
-         ++iter, ++index) {
-      runOrLumiIndexes().emplace_back(iter->processHistoryIDIndex(),
-                                      iter->run(),
-                                      iter->lumi(),
+    for(RunOrLumiEntry const& item : runOrLumiEntries_) {
+      runOrLumiIndexes().emplace_back(item.processHistoryIDIndex(),
+                                      item.run(),
+                                      item.lumi(),
                                       index);
+      ++index;
     }
     stable_sort_all(runOrLumiIndexes());
 
@@ -325,7 +323,7 @@ namespace edm {
   void
   IndexIntoFile::reduceProcessHistoryIDs() {
 
-    FullHistoryToReducedHistoryMap& phidConverter(ProcessHistoryRegistry::instance()->extraForUpdate());
+    FullHistoryToReducedHistoryMap const& phidConverter(ProcessHistoryRegistry::instance()->extra());
 
     std::vector<ProcessHistoryID> reducedPHIDs;
 
@@ -334,11 +332,9 @@ namespace edm {
     std::pair<std::map<ProcessHistoryID, int>::iterator, bool> insertResult;
 
     std::vector<int> phidIndexConverter;
-    for(std::vector<ProcessHistoryID>::const_iterator phid = processHistoryIDs_.begin(),
-         iEnd = processHistoryIDs_.end();
-         phid != iEnd; ++phid) {
+    for(auto const& phid : processHistoryIDs_) {
 
-      ProcessHistoryID const& reducedPHID = phidConverter.reduceProcessHistoryID(*phid);
+      ProcessHistoryID const& reducedPHID = phidConverter.reducedProcessHistoryID(phid);
       mapEntry.first = reducedPHID;
       insertResult = reducedPHIDToIndex.insert(mapEntry);
 
@@ -364,30 +360,28 @@ namespace edm {
     std::pair<std::map<IndexIntoFile::IndexRunLumiKey, int>::iterator, bool> lumiInsertResult;
 
     // loop over all the RunOrLumiEntry's
-    for(std::vector<RunOrLumiEntry>::iterator i = runOrLumiEntries_.begin(),
-         iterEnd = runOrLumiEntries_.end();
-         i != iterEnd; ++i) {
+    for(auto& item : runOrLumiEntries_) {
 
       // Convert the process history index so it points into the new vector of reduced IDs
-      i->setProcessHistoryIDIndex(phidIndexConverter.at(i->processHistoryIDIndex()));
+      item.setProcessHistoryIDIndex(phidIndexConverter.at(item.processHistoryIDIndex()));
 
       // Convert the phid-run order
-      IndexIntoFile::IndexRunKey runKey(i->processHistoryIDIndex(), i->run());
+      IndexIntoFile::IndexRunKey runKey(item.processHistoryIDIndex(), item.run());
       runInsertResult = runOrderMap.insert(std::pair<IndexIntoFile::IndexRunKey, int>(runKey,0));
       if(runInsertResult.second) {
-        runInsertResult.first->second = i->orderPHIDRun();
+        runInsertResult.first->second = item.orderPHIDRun();
       } else {
-        i->setOrderPHIDRun(runInsertResult.first->second);
+        item.setOrderPHIDRun(runInsertResult.first->second);
       }
 
       // Convert the phid-run-lumi order for the lumi entries
-      if(i->lumi() != 0) {
-        IndexIntoFile::IndexRunLumiKey lumiKey(i->processHistoryIDIndex(), i->run(), i->lumi());
+      if(item.lumi() != 0) {
+        IndexIntoFile::IndexRunLumiKey lumiKey(item.processHistoryIDIndex(), item.run(), item.lumi());
         lumiInsertResult = lumiOrderMap.insert(std::pair<IndexIntoFile::IndexRunLumiKey, int>(lumiKey,0));
         if(lumiInsertResult.second) {
-          lumiInsertResult.first->second = i->orderPHIDRunLumi();
+          lumiInsertResult.first->second = item.orderPHIDRunLumi();
         } else {
-          i->setOrderPHIDRunLumi(lumiInsertResult.first->second);
+          item.setOrderPHIDRunLumi(lumiInsertResult.first->second);
         }
       }
     }
@@ -413,21 +407,15 @@ namespace edm {
     }
     processHistoryIDs_ = processHistoryIDs;
 
-    for(std::vector<RunOrLumiEntry>::iterator iter = runOrLumiEntries_.begin(),
-                                               iEnd = runOrLumiEntries_.end();
-         iter != iEnd;
-         ++iter) {
-      iter->setProcessHistoryIDIndex(oldToNewIndex[iter->processHistoryIDIndex()]);
+    for(RunOrLumiEntry& item : runOrLumiEntries_) {
+      item.setProcessHistoryIDIndex(oldToNewIndex[item.processHistoryIDIndex()]);
     }
   }
 
   void IndexIntoFile::sortVector_Run_Or_Lumi_Entries() {
-    for(std::vector<RunOrLumiEntry>::iterator iter = runOrLumiEntries_.begin(),
-                                               iEnd = runOrLumiEntries_.end();
-         iter != iEnd;
-         ++iter) {
+    for(RunOrLumiEntry& item : runOrLumiEntries_) {
       std::map<IndexRunKey, EntryNumber_t>::const_iterator firstRunEntry =
-        runToFirstEntry().find(IndexRunKey(iter->processHistoryIDIndex(), iter->run()));
+        runToFirstEntry().find(IndexRunKey(item.processHistoryIDIndex(), item.run()));
       if(firstRunEntry == runToFirstEntry().end()) {
         throw Exception(errors::LogicError)
           << "In IndexIntoFile::sortVector_Run_Or_Lumi_Entries. A run entry is missing.\n"
@@ -438,7 +426,7 @@ namespace edm {
           << "the primary exception. This is an expected side effect.\n"
           << "Otherwise please report this to the core framework developers\n";
       }
-      iter->setOrderPHIDRun(firstRunEntry->second);
+      item.setOrderPHIDRun(firstRunEntry->second);
     }
     stable_sort_all(runOrLumiEntries_);
   }
@@ -847,13 +835,11 @@ namespace edm {
                                   indexIntoFile.eventEntries().begin() + beginEventNumbers2,
                                   indexIntoFile.eventEntries().begin() + endEventNumbers2,
                                   insertIter);
-            for(std::vector<EventEntry>::const_iterator iEvent = matchingEvents.begin(),
-                                                           iEnd = matchingEvents.end();
-                 iEvent != iEnd; ++iEvent) {
+            for(EventEntry const& entry : matchingEvents) {
               intersection.insert(IndexRunLumiEventKey(indexes1.processHistoryIDIndex(),
                                                        indexes1.run(),
                                                        indexes1.lumi(),
-                                                       iEvent->event()));
+                                                       entry.event()));
             }
           } else {
             fillEventNumbers();
@@ -865,13 +851,11 @@ namespace edm {
                                   indexIntoFile.eventNumbers().begin() + beginEventNumbers2,
                                   indexIntoFile.eventNumbers().begin() + endEventNumbers2,
                                   insertIter);
-            for(std::vector<EventNumber_t>::const_iterator iEvent = matchingEvents.begin(),
-                                                              iEnd = matchingEvents.end();
-                 iEvent != iEnd; ++iEvent) {
+            for(EventNumber_t const& eventNumber : matchingEvents) {
               intersection.insert(IndexRunLumiEventKey(indexes1.processHistoryIDIndex(),
                                                        indexes1.run(),
                                                        indexes1.lumi(),
-                                                       *iEvent));
+                                                       eventNumber));
             }
           }
         }

--- a/DataFormats/Provenance/src/ProcessHistory.cc
+++ b/DataFormats/Provenance/src/ProcessHistory.cc
@@ -15,11 +15,11 @@ namespace edm {
     // This implementation is ripe for optimization.
     // We do not use operator<< because it does not write out everything.
     std::ostringstream oss;
-    for (const_iterator i = begin(), e = end(); i != e; ++i) {
-      oss << i->processName() << ' '
-	  << i->parameterSetID() << ' ' 
-	  << i->releaseVersion() << ' '
-	  << i->passID() << ' ';
+    for(auto const& item : *this) {
+      oss << item.processName() << ' '
+	  << item.parameterSetID() << ' ' 
+	  << item.releaseVersion() << ' '
+	  << item.passID() << ' ';
     }
     std::string stringrep = oss.str();
     cms::Digest md5alg(stringrep);
@@ -38,9 +38,9 @@ namespace edm {
   bool
   ProcessHistory::getConfigurationForProcess(std::string const& name, 
 					     ProcessConfiguration& config) const {
-    for (const_iterator i = begin(), e = end(); i != e; ++i) {
-      if (i->processName() == name) {
-	config = *i;
+    for(auto const& item : *this) {
+      if (item.processName() == name) {
+	config = item;
 	return true;
       }
     }
@@ -51,8 +51,8 @@ namespace edm {
   void
   ProcessHistory::reduce() {
     phid() = ProcessHistoryID();
-    for (iterator i = data_.begin(), e = data_.end(); i != e; ++i) {
-      i->reduce();
+    for(auto& item : data_) {
+      item.reduce();
     }
   }
 

--- a/DataFormats/Provenance/src/ProcessHistoryRegistry.cc
+++ b/DataFormats/Provenance/src/ProcessHistoryRegistry.cc
@@ -1,4 +1,17 @@
 #include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
+#include "DataFormats/Provenance/interface/FullHistoryToReducedHistoryMap.h"
 #include "FWCore/Utilities/interface/ThreadSafeRegistry.icc"
+
+namespace edm {
+  bool
+  registerProcessHistory(ProcessHistory const& processHistory) {
+    ProcessHistoryRegistry& registry = *ProcessHistoryRegistry::instance();
+    bool newlyAdded = registry.insertMapped(processHistory);
+    if(newlyAdded) {
+      registry.extraForUpdate().insertMapping(processHistory); 
+    }
+    return newlyAdded;
+  }
+}
 
 DEFINE_THREAD_SAFE_REGISTRY_INSTANCE(ProcessHistoryRegistry)

--- a/DataFormats/Provenance/test/indexIntoFile1_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile1_t.cppunit.cc
@@ -45,14 +45,14 @@ public:
     std::unique_ptr<ProcessHistory> processHistory1(new ProcessHistory);
     ProcessHistory& ph1 = *processHistory1;
     processHistory1->push_back(pc);
-    ProcessHistoryRegistry::instance()->insertMapped(ph1);
+    registerProcessHistory(ph1);
     fakePHID1 = ph1.id();
 
     std::unique_ptr<ProcessHistory> processHistory2(new ProcessHistory);
     ProcessHistory& ph2 = *processHistory2;
     processHistory2->push_back(pc);
     processHistory2->push_back(pc);
-    ProcessHistoryRegistry::instance()->insertMapped(ph2);
+    registerProcessHistory(ph2);
     fakePHID2 = ph2.id();
 
     std::unique_ptr<ProcessHistory> processHistory3(new ProcessHistory);
@@ -60,7 +60,7 @@ public:
     processHistory3->push_back(pc);
     processHistory3->push_back(pc);
     processHistory3->push_back(pc);
-    ProcessHistoryRegistry::instance()->insertMapped(ph3);
+    registerProcessHistory(ph3);
     fakePHID3 = ph3.id();
   }
 

--- a/DataFormats/Provenance/test/indexIntoFile2_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile2_t.cppunit.cc
@@ -41,14 +41,14 @@ public:
     std::unique_ptr<ProcessHistory> processHistory1(new ProcessHistory);
     ProcessHistory& ph1 = *processHistory1;
     processHistory1->push_back(pc);
-    ProcessHistoryRegistry::instance()->insertMapped(ph1);
+    registerProcessHistory(ph1);
     fakePHID1 = ph1.id();
 
     std::unique_ptr<ProcessHistory> processHistory2(new ProcessHistory);
     ProcessHistory& ph2 = *processHistory2;
     processHistory2->push_back(pc);
     processHistory2->push_back(pc);
-    ProcessHistoryRegistry::instance()->insertMapped(ph2);
+    registerProcessHistory(ph2);
     fakePHID2 = ph2.id();
 
     std::unique_ptr<ProcessHistory> processHistory3(new ProcessHistory);
@@ -56,7 +56,7 @@ public:
     processHistory3->push_back(pc);
     processHistory3->push_back(pc);
     processHistory3->push_back(pc);
-    ProcessHistoryRegistry::instance()->insertMapped(ph3);
+    registerProcessHistory(ph3);
     fakePHID3 = ph3.id();
   }
 

--- a/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile3_t.cppunit.cc
@@ -55,14 +55,14 @@ public:
     std::unique_ptr<ProcessHistory> processHistory1(new ProcessHistory);
     ProcessHistory& ph1 = *processHistory1;
     processHistory1->push_back(pc);
-    ProcessHistoryRegistry::instance()->insertMapped(ph1);
+    registerProcessHistory(ph1);
     fakePHID1 = ph1.id();
 
     std::unique_ptr<ProcessHistory> processHistory2(new ProcessHistory);
     ProcessHistory& ph2 = *processHistory2;
     processHistory2->push_back(pc);
     processHistory2->push_back(pc);
-    ProcessHistoryRegistry::instance()->insertMapped(ph2);
+    registerProcessHistory(ph2);
     fakePHID2 = ph2.id();
 
     std::unique_ptr<ProcessHistory> processHistory3(new ProcessHistory);
@@ -70,7 +70,7 @@ public:
     processHistory3->push_back(pc);
     processHistory3->push_back(pc);
     processHistory3->push_back(pc);
-    ProcessHistoryRegistry::instance()->insertMapped(ph3);
+    registerProcessHistory(ph3);
     fakePHID3 = ph3.id();
   }
 

--- a/DataFormats/Provenance/test/indexIntoFile4_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile4_t.cppunit.cc
@@ -55,14 +55,14 @@ public:
     std::unique_ptr<ProcessHistory> processHistory1(new ProcessHistory);
     ProcessHistory& ph1 = *processHistory1;
     processHistory1->push_back(pc);
-    ProcessHistoryRegistry::instance()->insertMapped(ph1);
+    registerProcessHistory(ph1);
     fakePHID1 = ph1.id();
 
     std::unique_ptr<ProcessHistory> processHistory2(new ProcessHistory);
     ProcessHistory& ph2 = *processHistory2;
     processHistory2->push_back(pc);
     processHistory2->push_back(pc);
-    ProcessHistoryRegistry::instance()->insertMapped(ph2);
+    registerProcessHistory(ph2);
     fakePHID2 = ph2.id();
 
     std::unique_ptr<ProcessHistory> processHistory3(new ProcessHistory);
@@ -70,7 +70,7 @@ public:
     processHistory3->push_back(pc);
     processHistory3->push_back(pc);
     processHistory3->push_back(pc);
-    ProcessHistoryRegistry::instance()->insertMapped(ph3);
+    registerProcessHistory(ph3);
     fakePHID3 = ph3.id();
   }
 

--- a/DataFormats/Provenance/test/indexIntoFile5_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile5_t.cppunit.cc
@@ -55,14 +55,14 @@ public:
     std::unique_ptr<ProcessHistory> processHistory1(new ProcessHistory);
     ProcessHistory& ph1 = *processHistory1;
     processHistory1->push_back(pc);
-    ProcessHistoryRegistry::instance()->insertMapped(ph1);
+    registerProcessHistory(ph1);
     fakePHID1 = ph1.id();
 
     std::unique_ptr<ProcessHistory> processHistory2(new ProcessHistory);
     ProcessHistory& ph2 = *processHistory2;
     processHistory2->push_back(pc);
     processHistory2->push_back(pc);
-    ProcessHistoryRegistry::instance()->insertMapped(ph2);
+    registerProcessHistory(ph2);
     fakePHID2 = ph2.id();
 
     std::unique_ptr<ProcessHistory> processHistory3(new ProcessHistory);
@@ -70,7 +70,7 @@ public:
     processHistory3->push_back(pc);
     processHistory3->push_back(pc);
     processHistory3->push_back(pc);
-    ProcessHistoryRegistry::instance()->insertMapped(ph3);
+    registerProcessHistory(ph3);
     fakePHID3 = ph3.id();
   }
 

--- a/DataFormats/Provenance/test/indexIntoFile_t.cppunit.cc
+++ b/DataFormats/Provenance/test/indexIntoFile_t.cppunit.cc
@@ -61,14 +61,14 @@ public:
     std::unique_ptr<ProcessHistory> processHistory1(new ProcessHistory);
     ProcessHistory& ph1 = *processHistory1;
     processHistory1->push_back(pc);
-    ProcessHistoryRegistry::instance()->insertMapped(ph1);
+    registerProcessHistory(ph1);
     fakePHID1 = ph1.id();
 
     std::unique_ptr<ProcessHistory> processHistory2(new ProcessHistory);
     ProcessHistory& ph2 = *processHistory2;
     processHistory2->push_back(pc);
     processHistory2->push_back(pc);
-    ProcessHistoryRegistry::instance()->insertMapped(ph2);
+    registerProcessHistory(ph2);
     fakePHID2 = ph2.id();
 
     std::unique_ptr<ProcessHistory> processHistory3(new ProcessHistory);
@@ -76,7 +76,7 @@ public:
     processHistory3->push_back(pc);
     processHistory3->push_back(pc);
     processHistory3->push_back(pc);
-    ProcessHistoryRegistry::instance()->insertMapped(ph3);
+    registerProcessHistory(ph3);
     fakePHID3 = ph3.id();
   }
 

--- a/FWCore/Framework/src/HistoryAppender.cc
+++ b/FWCore/Framework/src/HistoryAppender.cc
@@ -26,7 +26,7 @@ namespace edm {
 
     if (inputPHID.isValid()) {
       inputProcessHistory = registry->getMapped(inputPHID);
-      if (inputProcessHistory == 0) {
+      if (inputProcessHistory == nullptr) {
         throw Exception(errors::LogicError)
           << "HistoryAppender::appendToProcessHistory\n"
           << "Input ProcessHistory not found in registry\n"
@@ -38,7 +38,7 @@ namespace edm {
     newProcessHistory = *inputProcessHistory;
     checkProcessHistory(newProcessHistory, pc);
     newProcessHistory.push_back(pc);
-    registry->insertMapped(newProcessHistory);
+    registerProcessHistory(newProcessHistory);
     ProcessHistoryID newProcessHistoryID = newProcessHistory.setProcessHistoryID();
     CachedHistory newValue(inputProcessHistory,
                            registry->getMapped(newProcessHistoryID),
@@ -53,8 +53,8 @@ namespace edm {
   HistoryAppender::checkProcessHistory(ProcessHistory const& ph,
                                        ProcessConfiguration const& pc) const {
     std::string const& processName = pc.processName();
-    for (ProcessHistory::const_iterator it = ph.begin(), itEnd = ph.end(); it != itEnd; ++it) {
-      if (processName == it->processName()) {
+    for (auto const& process : ph) {
+      if (processName == process.processName()) {
         throw edm::Exception(errors::Configuration, "Duplicate Process.")
           << "The process name " << processName << " was already in the ProcessHistory.\n"
           << "Please modify the configuration file to use a distinct process name.\n";

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -601,7 +601,7 @@ namespace edm {
   InputSource::reducedProcessHistoryID() const {
     assert(runAuxiliary());
     //THREADUNSAFE this is modifying global state
-    return ProcessHistoryRegistry::instance()->extraForUpdate().reduceProcessHistoryID(runAuxiliary()->processHistoryID());
+    return ProcessHistoryRegistry::instance()->extra().reducedProcessHistoryID(runAuxiliary()->processHistoryID());
   }
 
   RunNumber_t

--- a/FWCore/Framework/src/PrincipalCache.cc
+++ b/FWCore/Framework/src/PrincipalCache.cc
@@ -98,7 +98,7 @@ namespace edm {
         << "Contact a Framework Developer\n";
     }
     if (inputProcessHistoryID_ != aux->processHistoryID()) {
-      if (reducedInputProcessHistoryID_ != ProcessHistoryRegistry::instance()->extraForUpdate().reduceProcessHistoryID(aux->processHistoryID())) {
+      if (reducedInputProcessHistoryID_ != ProcessHistoryRegistry::instance()->extra().reducedProcessHistoryID(aux->processHistoryID())) {
         throw edm::Exception(edm::errors::LogicError)
           << "PrincipalCache::merge\n"
           << "Illegal attempt to merge run into cache\n"
@@ -128,7 +128,7 @@ namespace edm {
         << "Contact a Framework Developer\n";
     }
     if (inputProcessHistoryID_ != aux->processHistoryID()) {
-      if (reducedInputProcessHistoryID_ != ProcessHistoryRegistry::instance()->extraForUpdate().reduceProcessHistoryID(aux->processHistoryID())) {
+      if (reducedInputProcessHistoryID_ != ProcessHistoryRegistry::instance()->extra().reducedProcessHistoryID(aux->processHistoryID())) {
         throw edm::Exception(edm::errors::LogicError)
           << "PrincipalCache::merge\n"
           << "Illegal attempt to merge run into cache\n"
@@ -158,7 +158,7 @@ namespace edm {
         << "Contact a Framework Developer\n";
     }
     if (inputProcessHistoryID_ != rp->aux().processHistoryID()) {
-      reducedInputProcessHistoryID_ = ProcessHistoryRegistry::instance()->extraForUpdate().reduceProcessHistoryID(rp->aux().processHistoryID());
+      reducedInputProcessHistoryID_ = ProcessHistoryRegistry::instance()->extra().reducedProcessHistoryID(rp->aux().processHistoryID());
       inputProcessHistoryID_ = rp->aux().processHistoryID();
     }
     run_ = rp->run();
@@ -180,7 +180,7 @@ namespace edm {
         << "Contact a Framework Developer\n";
     }
     if (inputProcessHistoryID_ != lbp->aux().processHistoryID()) {
-      if (reducedInputProcessHistoryID_ != ProcessHistoryRegistry::instance()->extraForUpdate().reduceProcessHistoryID(lbp->aux().processHistoryID())) {
+      if (reducedInputProcessHistoryID_ != ProcessHistoryRegistry::instance()->extra().reducedProcessHistoryID(lbp->aux().processHistoryID())) {
         throw edm::Exception(edm::errors::LogicError)
           << "PrincipalCache::insert\n"
           << "Illegal attempt to insert lumi into cache\n"

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -310,9 +310,9 @@ namespace edm {
     rpp->fillRunPrincipal(principal.reader());
     principalCache_.insert(rpp);
 
-    FullHistoryToReducedHistoryMap& phidConverter(ProcessHistoryRegistry::instance()->extraForUpdate());
-    ProcessHistoryID const& parentInputReducedPHID = phidConverter.reduceProcessHistoryID(principal.aux().processHistoryID());
-    ProcessHistoryID const& inputReducedPHID       = phidConverter.reduceProcessHistoryID(principal.processHistoryID());
+    FullHistoryToReducedHistoryMap const& phidConverter(ProcessHistoryRegistry::instance()->extra());
+    ProcessHistoryID const& parentInputReducedPHID = phidConverter.reducedProcessHistoryID(principal.aux().processHistoryID());
+    ProcessHistoryID const& inputReducedPHID       = phidConverter.reducedProcessHistoryID(principal.processHistoryID());
 
     parentToChildPhID_.insert(std::make_pair(parentInputReducedPHID,inputReducedPHID));
 
@@ -470,12 +470,12 @@ namespace edm {
   void
   SubProcess::propagateProducts(BranchType type, Principal const& parentPrincipal, Principal& principal) const {
     SelectedProducts const& keptVector = keptProducts()[type];
-    for(SelectedProducts::const_iterator it = keptVector.begin(), itEnd = keptVector.end(); it != itEnd; ++it) {
-      ProductHolderBase const* parentProductHolder = parentPrincipal.getProductHolder((*it)->branchID(), false, false, nullptr);
-      if(parentProductHolder != 0) {
+    for(auto const& item : keptVector) {
+      ProductHolderBase const* parentProductHolder = parentPrincipal.getProductHolder(item->branchID(), false, false, nullptr);
+      if(parentProductHolder != nullptr) {
         ProductData const& parentData = parentProductHolder->productData();
-        ProductHolderBase const* productHolder = principal.getProductHolder((*it)->branchID(), false, false, nullptr);
-        if(productHolder != 0) {
+        ProductHolderBase const* productHolder = principal.getProductHolder(item->branchID(), false, false, nullptr);
+        if(productHolder != nullptr) {
           ProductData& thisData = const_cast<ProductData&>(productHolder->productData());
           //Propagate the per event(run)(lumi) data for this product to the subprocess.
           //First, the product itself.

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -342,7 +342,7 @@ void testEvent::setUp() {
   processHistory->push_back(processEarly);
   processHistory->push_back(processLate);
 
-  ProcessHistoryRegistry::instance()->insertMapped(ph);
+  registerProcessHistory(ph);
 
   ProcessHistoryID processHistoryID = ph.id();
 

--- a/FWCore/Integration/test/ProcessHistory_t.cpp
+++ b/FWCore/Integration/test/ProcessHistory_t.cpp
@@ -140,22 +140,14 @@ int main() try {
   assert(phTest.id() == phTestExpected.id());
   assert(phTest.id() != pnl3.id());
 
-  edm::ProcessHistoryRegistry::instance()->insertMapped(pnl3);
-  edm::ProcessHistoryID reducedPHID = edm::ProcessHistoryRegistry::instance()->extraForUpdate().reduceProcessHistoryID(pnl3.id());
+  registerProcessHistory(pnl3);
+  edm::ProcessHistoryID reducedPHID = edm::ProcessHistoryRegistry::instance()->extra().reducedProcessHistoryID(pnl3.id());
   assert(reducedPHID == phTest.id());
 
-  // Repeat a few times to test the caching optimization in FullHistoryToReducedHistoryMap
-  // (You have to watch in a debugger to really verify it is working properly)
-  reducedPHID = edm::ProcessHistoryRegistry::instance()->extraForUpdate().reduceProcessHistoryID(pnl3.id());
-  assert(reducedPHID == phTest.id());
-
-  edm::ProcessHistoryRegistry::instance()->insertMapped(pnl2);
-  reducedPHID = edm::ProcessHistoryRegistry::instance()->extraForUpdate().reduceProcessHistoryID(pnl2.id());
+  registerProcessHistory(pnl2);
+  reducedPHID = edm::ProcessHistoryRegistry::instance()->extra().reducedProcessHistoryID(pnl2.id());
   pnl2.reduce();
   assert(reducedPHID == pnl2.id());
-
-  reducedPHID = edm::ProcessHistoryRegistry::instance()->extraForUpdate().reduceProcessHistoryID(pnl3.id());
-  assert(reducedPHID == phTest.id());
 
   {
     edm::ProcessHistory ph1;
@@ -198,14 +190,14 @@ int main() try {
     edm::ProcessHistoryID phid3 = ph3.setProcessHistoryID();
     edm::ProcessHistoryID phid4 = ph4.setProcessHistoryID();
 
-    edm::ProcessHistoryRegistry::instance()->insertMapped(ph1);
-    edm::ProcessHistoryRegistry::instance()->insertMapped(ph1a);
-    edm::ProcessHistoryRegistry::instance()->insertMapped(ph1b);
-    edm::ProcessHistoryRegistry::instance()->insertMapped(ph2);
-    edm::ProcessHistoryRegistry::instance()->insertMapped(ph2a);
-    edm::ProcessHistoryRegistry::instance()->insertMapped(ph2b);
-    edm::ProcessHistoryRegistry::instance()->insertMapped(ph3);
-    edm::ProcessHistoryRegistry::instance()->insertMapped(ph4);
+    edm::registerProcessHistory(ph1);
+    edm::registerProcessHistory(ph1a);
+    edm::registerProcessHistory(ph1b);
+    edm::registerProcessHistory(ph2);
+    edm::registerProcessHistory(ph2a);
+    edm::registerProcessHistory(ph2b);
+    edm::registerProcessHistory(ph3);
+    edm::registerProcessHistory(ph4);
 
     edm::IndexIntoFile indexIntoFile;
     indexIntoFile.addEntry(phid1, 1, 0, 0, 0);
@@ -288,17 +280,15 @@ int main() try {
     std::cout << rv1[2] << "  " << rph3 << "\n";
     std::cout << rv1[3] << "  " << rph4 << "\n";
 
-    for (std::vector<edm::IndexIntoFile::RunOrLumiEntry>::const_iterator iter = runOrLumiEntries.begin(),
-         iEnd = runOrLumiEntries.end();
-         iter != iEnd; ++iter) {
-      std::cout << iter->orderPHIDRun() << "  "
-                << iter->orderPHIDRunLumi() << "  "
-                << iter->entry() << "  "
-                << iter->processHistoryIDIndex() << "  "
-                << iter->run() << "  "
-                << iter->lumi() << "  "
-                << iter->beginEvents() << "  "
-                << iter->endEvents() << "\n";
+    for (auto const& item : runOrLumiEntries) {
+      std::cout << item.orderPHIDRun() << "  "
+                << item.orderPHIDRunLumi() << "  "
+                << item.entry() << "  "
+                << item.processHistoryIDIndex() << "  "
+                << item.run() << "  "
+                << item.lumi() << "  "
+                << item.beginEvents() << "  "
+                << item.endEvents() << "\n";
 
     }
     */

--- a/FWCore/Sources/src/DaqProvenanceHelper.cc
+++ b/FWCore/Sources/src/DaqProvenanceHelper.cc
@@ -81,7 +81,7 @@ namespace edm {
     // Insert an entry for this process in the process history registry
     ProcessHistory ph;
     ph.emplace_back(constBranchDescription_.processName(), processParameterSet_.id(), getReleaseVersion(), getPassID());
-    ProcessHistoryRegistry::instance()->insertMapped(ph);
+    registerProcessHistory(ph);
 
     // Save the process history ID for use every event.
     return ph.setProcessHistoryID();

--- a/GeneratorInterface/LHEInterface/plugins/LHEProvenanceHelper.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHEProvenanceHelper.cc
@@ -111,7 +111,7 @@ namespace edm {
     // Insert an entry for this process in the process history registry
     ProcessHistory ph;
     ph.emplace_back(eventProductBranchDescription_.processName(), processParameterSet_.id(), getReleaseVersion(), getPassID());
-    ProcessHistoryRegistry::instance()->insertMapped(ph);
+    registerProcessHistory(ph);
 
     // Save the process history ID for use every event.
     return ph.id();

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -394,7 +394,9 @@ namespace edm {
       }
     }
 
-    ProcessHistoryRegistry::instance()->insertCollection(pHistVector);
+    for(auto const& history : pHistVector) {
+      registerProcessHistory(history);
+    }
 
     eventTree_.trainCache(BranchTypeToAuxiliaryBranchName(InEvent).c_str());
 
@@ -865,7 +867,7 @@ namespace edm {
       // are not actually used in this function, but could be needed elsewhere.
       indexIntoFile_.unsortedEventNumbers().push_back(eventAux().event());
 
-      ProcessHistoryID reducedPHID = ProcessHistoryRegistry::instance()->extraForUpdate().reduceProcessHistoryID(eventAux().processHistoryID());
+      ProcessHistoryID reducedPHID = ProcessHistoryRegistry::instance()->extra().reducedProcessHistoryID(eventAux().processHistoryID());
 
       if(iFirst || prevPhid != reducedPHID || prevRun != eventAux().run()) {
         iFirst = false;
@@ -913,7 +915,7 @@ namespace edm {
         // Note: adjacent duplicates will be skipped without an explicit check.
 
         boost::shared_ptr<RunAuxiliary> runAux = fillRunAuxiliary();
-        ProcessHistoryID reducedPHID = ProcessHistoryRegistry::instance()->extraForUpdate().reduceProcessHistoryID(runAux->processHistoryID());
+        ProcessHistoryID reducedPHID = ProcessHistoryRegistry::instance()->extra().reducedProcessHistoryID(runAux->processHistoryID());
 
         if(runSet.insert(runAux->run()).second) { // (check 4, insert 4)
           // This run was not associated with any events.
@@ -1362,7 +1364,7 @@ namespace edm {
     // If this next assert shows up in performance profiling or significantly affects memory, then these three lines should be deleted.
     // The IndexIntoFile should guarantee that it never fails.
     ProcessHistoryID idToCheck = (daqProvenanceHelper_ && fileFormatVersion().useReducedProcessHistoryID() ? *daqProvenanceHelper_->oldProcessHistoryID_ : eventAux().processHistoryID());
-    ProcessHistoryID const& reducedPHID = ProcessHistoryRegistry::instance()->extraForUpdate().reduceProcessHistoryID(idToCheck);
+    ProcessHistoryID const& reducedPHID = ProcessHistoryRegistry::instance()->extra().reducedProcessHistoryID(idToCheck);
     assert(reducedPHID == indexIntoFile_.processHistoryID(indexIntoFileIter_.processHistoryIDIndex()));
 
     ++indexIntoFileIter_;

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -409,7 +409,7 @@ namespace edm {
     }
 
     // Store the reduced ID in the IndexIntoFile
-    ProcessHistoryID reducedPHID = ProcessHistoryRegistry::instance()->extraForUpdate().reduceProcessHistoryID(e.processHistoryID());
+    ProcessHistoryID reducedPHID = ProcessHistoryRegistry::instance()->extra().reducedProcessHistoryID(e.processHistoryID());
     // Add event to index
     indexIntoFile_.addEntry(reducedPHID, pEventAux_->run(), pEventAux_->luminosityBlock(), pEventAux_->event(), eventEntryNumber_);
     ++eventEntryNumber_;
@@ -426,7 +426,7 @@ namespace edm {
     // Use the updated process historyID
     lumiAux_.setProcessHistoryID(lb.processHistoryID());
     // Store the reduced ID in the IndexIntoFile
-    ProcessHistoryID reducedPHID = ProcessHistoryRegistry::instance()->extraForUpdate().reduceProcessHistoryID(lb.processHistoryID());
+    ProcessHistoryID reducedPHID = ProcessHistoryRegistry::instance()->extra().reducedProcessHistoryID(lb.processHistoryID());
     // Add lumi to index.
     indexIntoFile_.addEntry(reducedPHID, lumiAux_.run(), lumiAux_.luminosityBlock(), 0U, lumiEntryNumber_);
     ++lumiEntryNumber_;
@@ -441,7 +441,7 @@ namespace edm {
     // Use the updated process historyID
     runAux_.setProcessHistoryID(r.processHistoryID());
     // Store the reduced ID in the IndexIntoFile
-    ProcessHistoryID reducedPHID = ProcessHistoryRegistry::instance()->extraForUpdate().reduceProcessHistoryID(r.processHistoryID());
+    ProcessHistoryID reducedPHID = ProcessHistoryRegistry::instance()->extra().reducedProcessHistoryID(r.processHistoryID());
     // Add run to index.
     indexIntoFile_.addEntry(reducedPHID, runAux_.run(), 0U, 0U, runEntryNumber_);
     ++runEntryNumber_;


### PR DESCRIPTION
This is a merge of #598 by Bill. The only change was to rebase on top of CMSSW_7_0_X and then change `Selections` to `SelectedProducts` as Chris did. Find below the result of:

`diff -Naur =(git show cms-sw/refs/pull/598/head) =(git show HEAD)`

```
--- /tmp/zshL4mFUZ      2013-08-27 23:35:30.000000000 +0200
+++ /tmp/zshUwMkgU      2013-08-27 23:35:30.000000000 +0200
@@ -1,4 +1,4 @@
-commit 34485e93d5e3524bb155d9697d1f300c0a7b968b
+commit cc5726f06f205a3b460fbd8210eebf53ac2e98d6
 Author: wmtan <wmtan@fnal.gov>
 Date:   Fri Aug 23 17:38:11 2013 +0200

@@ -604,10 +604,10 @@
            << "The process name " << processName << " was already in the ProcessHistory.\n"
            << "Please modify the configuration file to use a distinct process name.\n";
 diff --git a/FWCore/Framework/src/InputSource.cc b/FWCore/Framework/src/InputSource.cc
-index d32c40d..ce3157d 100644
+index e2efbb3..0f61fe1 100644
 --- a/FWCore/Framework/src/InputSource.cc
 +++ b/FWCore/Framework/src/InputSource.cc
-@@ -604,7 +604,7 @@ namespace edm {
+@@ -601,7 +601,7 @@ namespace edm {
    InputSource::reducedProcessHistoryID() const {
      assert(runAuxiliary());
      //THREADUNSAFE this is modifying global state
@@ -657,10 +657,10 @@
            << "PrincipalCache::insert\n"
            << "Illegal attempt to insert lumi into cache\n"
 diff --git a/FWCore/Framework/src/SubProcess.cc b/FWCore/Framework/src/SubProcess.cc
-index 5de5572..5adab1d 100644
+index 0773add..c309401 100644
 --- a/FWCore/Framework/src/SubProcess.cc
 +++ b/FWCore/Framework/src/SubProcess.cc
-@@ -309,9 +309,9 @@ namespace edm {
+@@ -310,9 +310,9 @@ namespace edm {
      rpp->fillRunPrincipal(principal.reader());
      principalCache_.insert(rpp);

@@ -673,11 +673,11 @@

      parentToChildPhID_.insert(std::make_pair(parentInputReducedPHID,inputReducedPHID));

-@@ -471,12 +471,12 @@ namespace edm {
+@@ -470,12 +470,12 @@ namespace edm {
    void
    SubProcess::propagateProducts(BranchType type, Principal const& parentPrincipal, Principal& principal) const {
-     Selections const& keptVector = keptProducts()[type];
--    for(Selections::const_iterator it = keptVector.begin(), itEnd = keptVector.end(); it != itEnd; ++it) {
+     SelectedProducts const& keptVector = keptProducts()[type];
+-    for(SelectedProducts::const_iterator it = keptVector.begin(), itEnd = keptVector.end(); it != itEnd; ++it) {
 -      ProductHolderBase const* parentProductHolder = parentPrincipal.getProductHolder((*it)->branchID(), false, false, nullptr);
 -      if(parentProductHolder != 0) {
 +    for(auto const& item : keptVector) {
@@ -855,7 +855,7 @@

      ++indexIntoFileIter_;
 diff --git a/IOPool/Output/src/RootOutputFile.cc b/IOPool/Output/src/RootOutputFile.cc
-index a25500c..b183cad 100644
+index 57e754b..ae309ad 100644
 --- a/IOPool/Output/src/RootOutputFile.cc
 +++ b/IOPool/Output/src/RootOutputFile.cc
 @@ -409,7 +409,7 @@ namespace edm {
```
