### PR TITLE
Don't return pointer to principal

### DIFF
--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -348,9 +348,9 @@ class DQMRootSource : public edm::InputSource
       //NOTE: the following is really read next run auxiliary
       virtual boost::shared_ptr<edm::RunAuxiliary> readRunAuxiliary_() override ;
       virtual boost::shared_ptr<edm::LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override ;
-      virtual boost::shared_ptr<edm::RunPrincipal> readRun_(boost::shared_ptr<edm::RunPrincipal> rpCache) override;
-      virtual boost::shared_ptr<edm::LuminosityBlockPrincipal> readLuminosityBlock_( boost::shared_ptr<edm::LuminosityBlockPrincipal> lbCache) override;
-      virtual edm::EventPrincipal* readEvent_(edm::EventPrincipal&) override ;
+      virtual void readRun_(boost::shared_ptr<edm::RunPrincipal> rpCache) override;
+      virtual void readLuminosityBlock_( boost::shared_ptr<edm::LuminosityBlockPrincipal> lbCache) override;
+      virtual void readEvent_(edm::EventPrincipal&) override ;
       
       virtual std::unique_ptr<edm::FileBlock> readFile_() override;
       virtual void closeFile_() override;
@@ -482,9 +482,8 @@ DQMRootSource::~DQMRootSource()
 //
 // member functions
 //
-edm::EventPrincipal* DQMRootSource::readEvent_(edm::EventPrincipal&)
+void DQMRootSource::readEvent_(edm::EventPrincipal&)
 {
-  return 0;
 }
 
 edm::InputSource::ItemType DQMRootSource::getNextItemType()
@@ -524,7 +523,7 @@ DQMRootSource::readLuminosityBlockAuxiliary_()
   return boost::shared_ptr<edm::LuminosityBlockAuxiliary>(new edm::LuminosityBlockAuxiliary(m_lumiAux));
 }
 
-boost::shared_ptr<edm::RunPrincipal>
+void
 DQMRootSource::readRun_(boost::shared_ptr<edm::RunPrincipal> rpCache)
 {
   assert(m_presentIndexItr != m_orderedIndices.end());
@@ -578,10 +577,9 @@ DQMRootSource::readRun_(boost::shared_ptr<edm::RunPrincipal> rpCache)
   jr->reportInputRunNumber(rpCache->id().run());
 
   rpCache->fillRunPrincipal();
-  return rpCache;
 }
 
-boost::shared_ptr<edm::LuminosityBlockPrincipal>
+void
 DQMRootSource::readLuminosityBlock_( boost::shared_ptr<edm::LuminosityBlockPrincipal> lbCache)
 {
   assert(m_presentIndexItr != m_orderedIndices.end());
@@ -616,7 +614,6 @@ DQMRootSource::readLuminosityBlock_( boost::shared_ptr<edm::LuminosityBlockPrinc
   jr->reportInputLumiSection(lbCache->id().run(),lbCache->id().luminosityBlock());
 
   lbCache->fillLuminosityBlockPrincipal();
-  return lbCache;
 }
 
 std::unique_ptr<edm::FileBlock>

--- a/EventFilter/StorageManager/src/DQMHttpSource.cc
+++ b/EventFilter/StorageManager/src/DQMHttpSource.cc
@@ -61,16 +61,14 @@ namespace edm
     return true;
   }
 
-  EventPrincipal* DQMHttpSource::read(EventPrincipal& eventPrincipal)
+  void DQMHttpSource::read(EventPrincipal& eventPrincipal)
   {
     // make a fake event principal containing no data but the evId and runId from DQMEvent
     // and the time stamp from the event at update
-    EventPrincipal* e = makeEvent(
+    makeEvent(
       eventPrincipal,
       eventAuxiliary()
     );
-
-    return e;
   }
 
   

--- a/EventFilter/StorageManager/src/DQMHttpSource.h
+++ b/EventFilter/StorageManager/src/DQMHttpSource.h
@@ -54,7 +54,7 @@ namespace edm
     void setEventAuxiliary(std::unique_ptr<EventAuxiliary> aux) {
       eventAuxiliary_ = std::move(aux);
     }
-    virtual EventPrincipal* read(EventPrincipal& eventPrincipal);
+    virtual void read(EventPrincipal& eventPrincipal);
     virtual bool checkNextEvent();
     void initializeDQMStore();
 

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -255,9 +255,9 @@ namespace edm {
     virtual void beginLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi);
     virtual void endLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi, bool cleaningUpAfterException);
 
-    virtual statemachine::Run readAndCacheRun();
+    virtual statemachine::Run readRun();
     virtual statemachine::Run readAndMergeRun();
-    virtual int readAndCacheLumi();
+    virtual int readLuminosityBlock();
     virtual int readAndMergeLumi();
     virtual void writeRun(statemachine::Run const& run);
     virtual void deleteRunFromCache(statemachine::Run const& run);

--- a/FWCore/Framework/interface/IEventProcessor.h
+++ b/FWCore/Framework/interface/IEventProcessor.h
@@ -64,9 +64,9 @@ namespace edm {
     virtual void beginLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi) = 0;
     virtual void endLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi, bool cleaningUpAfterException) = 0;
 
-    virtual statemachine::Run readAndCacheRun() = 0;
+    virtual statemachine::Run readRun() = 0;
     virtual statemachine::Run readAndMergeRun() = 0;
-    virtual int readAndCacheLumi() = 0;
+    virtual int readLuminosityBlock() = 0;
     virtual int readAndMergeLumi() = 0;
     virtual void writeRun(statemachine::Run const& run) = 0;
     virtual void deleteRunFromCache(statemachine::Run const& run) = 0;

--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -106,10 +106,10 @@ namespace edm {
 
     /// Read next event
     /// Indicate inability to get a new event by returning a null ptr.
-    EventPrincipal* readEvent(EventPrincipal& ep, StreamContext *);
+    void readEvent(EventPrincipal& ep, StreamContext *);
 
     /// Read a specific event
-    EventPrincipal* readEvent(EventPrincipal& ep, EventID const&, StreamContext *);
+    bool readEvent(EventPrincipal& ep, EventID const&, StreamContext *);
 
     /// Read next luminosity block Auxilary
     boost::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary();
@@ -118,13 +118,13 @@ namespace edm {
     boost::shared_ptr<RunAuxiliary> readRunAuxiliary();
 
     /// Read next run (new run)
-    boost::shared_ptr<RunPrincipal> readAndCacheRun(HistoryAppender& historyAppender);
+    void readRun(boost::shared_ptr<RunPrincipal> runPrincipal, HistoryAppender& historyAppender);
 
     /// Read next run (same as a prior run)
     void readAndMergeRun(boost::shared_ptr<RunPrincipal> rp);
 
     /// Read next luminosity block (new lumi)
-    boost::shared_ptr<LuminosityBlockPrincipal> readAndCacheLumi(HistoryAppender& historyAppender);
+    void readLuminosityBlock(boost::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal, HistoryAppender& historyAppender);
 
     /// Read next luminosity block (same as a prior lumi)
     void readAndMergeLumi(boost::shared_ptr<LuminosityBlockPrincipal> lbp);
@@ -373,11 +373,10 @@ namespace edm {
     ItemType nextItemType_();
     virtual boost::shared_ptr<RunAuxiliary> readRunAuxiliary_() = 0;
     virtual boost::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() = 0;
-    virtual boost::shared_ptr<RunPrincipal> readRun_(boost::shared_ptr<RunPrincipal> runPrincipal);
-    virtual boost::shared_ptr<LuminosityBlockPrincipal> readLuminosityBlock_(
-        boost::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal);
-    virtual EventPrincipal* readEvent_(EventPrincipal& eventPrincipal) = 0;
-    virtual EventPrincipal* readIt(EventID const&, EventPrincipal& eventPrincipal);
+    virtual void readRun_(boost::shared_ptr<RunPrincipal> runPrincipal);
+    virtual void readLuminosityBlock_(boost::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal);
+    virtual void readEvent_(EventPrincipal& eventPrincipal) = 0;
+    virtual bool readIt(EventID const&, EventPrincipal& eventPrincipal);
     virtual std::unique_ptr<FileBlock> readFile_();
     virtual void closeFile_() {}
     virtual bool goToEvent_(EventID const& eventID);

--- a/FWCore/Framework/src/EPStates.cc
+++ b/FWCore/Framework/src/EPStates.cc
@@ -218,7 +218,7 @@ namespace statemachine {
   void HandleRuns::setupCurrentRun() {
 
     runException_ = true;
-    currentRun_ = ep_.readAndCacheRun();
+    currentRun_ = ep_.readRun();
     runException_ = false;
 
     if(context<Machine>().emptyRunLumiMode() != doNotHandleEmptyRunsAndLumis) {
@@ -410,7 +410,7 @@ namespace statemachine {
     Run const& run = context<HandleRuns>().currentRun();
     assert(run != INVALID_RUN);
     lumiException_ = true;
-    currentLumi_ = HandleLumis::LumiID(run.processHistoryID(), run.runNumber(), ep_.readAndCacheLumi());
+    currentLumi_ = HandleLumis::LumiID(run.processHistoryID(), run.runNumber(), ep_.readLuminosityBlock());
 
     if(context<Machine>().emptyRunLumiMode() == handleEmptyRunsAndLumis) {
       assert(context<HandleRuns>().beginRunCalled());

--- a/FWCore/Framework/test/MockEventProcessor.cc
+++ b/FWCore/Framework/test/MockEventProcessor.cc
@@ -158,8 +158,8 @@ namespace edm {
     output_ << "\tendLumi " << run << "/" << lumi << "\n";
   }
 
-  statemachine::Run MockEventProcessor::readAndCacheRun() {
-    output_ << "\treadAndCacheRun " << run_ << "\n";
+  statemachine::Run MockEventProcessor::readRun() {
+    output_ << "\treadRun " << run_ << "\n";
     return statemachine::Run(ProcessHistoryID(), run_);
   }
 
@@ -168,8 +168,8 @@ namespace edm {
     return statemachine::Run(ProcessHistoryID(), run_);
   }
 
-  int MockEventProcessor::readAndCacheLumi() {
-    output_ << "\treadAndCacheLumi " << lumi_ << "\n";
+  int MockEventProcessor::readLuminosityBlock() {
+    output_ << "\treadLuminosityBlock " << lumi_ << "\n";
     return lumi_;
   }
 

--- a/FWCore/Framework/test/MockEventProcessor.h
+++ b/FWCore/Framework/test/MockEventProcessor.h
@@ -48,9 +48,9 @@ namespace edm {
     virtual void beginLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi);
     virtual void endLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi, bool cleaningUpAfterException);
 
-    virtual statemachine::Run readAndCacheRun();
+    virtual statemachine::Run readRun();
     virtual statemachine::Run readAndMergeRun();
-    virtual int readAndCacheLumi();
+    virtual int readLuminosityBlock();
     virtual int readAndMergeLumi();
     virtual void writeRun(statemachine::Run const& run);
     virtual void deleteRunFromCache(statemachine::Run const& run);

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_1.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_1.txt
@@ -6,22 +6,22 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Run 2 ***
 	endRun 1
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 2/1
     *** nextItemType: Lumi 2 ***
 	endLumi 2/1
 	writeLumi 2/1
 	deleteLumiFromCache 2/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 2/2
     *** nextItemType: Event ***
 	readEvent
@@ -31,7 +31,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	endLumi 2/2
 	writeLumi 2/2
 	deleteLumiFromCache 2/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
 	beginLumi 2/3
     *** nextItemType: Run 3 ***
 	endLumi 2/3
@@ -40,10 +40,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	endRun 2
 	writeRun 2
 	deleteRunFromCache 2
-	readAndCacheRun 3
+	readRun 3
 	beginRun 3
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 3/1
     *** nextItemType: Stop 1 ***
 	endLumi 3/1
@@ -65,20 +65,20 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Run 2 ***
 	endRun 1
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Lumi 2 ***
 	writeLumi 2/1
 	deleteLumiFromCache 2/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 2/2
 	readEvent
@@ -88,17 +88,17 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	endLumi 2/2
 	writeLumi 2/2
 	deleteLumiFromCache 2/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
     *** nextItemType: Run 3 ***
 	writeLumi 2/3
 	deleteLumiFromCache 2/3
 	endRun 2
 	writeRun 2
 	deleteRunFromCache 2
-	readAndCacheRun 3
+	readRun 3
 	beginRun 3
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Stop 1 ***
 	writeLumi 3/1
 	deleteLumiFromCache 3/1
@@ -118,17 +118,17 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Run 2 ***
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Lumi 2 ***
 	writeLumi 2/1
 	deleteLumiFromCache 2/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginRun 2
 	beginLumi 2/2
@@ -139,16 +139,16 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	endLumi 2/2
 	writeLumi 2/2
 	deleteLumiFromCache 2/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
     *** nextItemType: Run 3 ***
 	writeLumi 2/3
 	deleteLumiFromCache 2/3
 	endRun 2
 	writeRun 2
 	deleteRunFromCache 2
-	readAndCacheRun 3
+	readRun 3
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Stop 1 ***
 	writeLumi 3/1
 	deleteLumiFromCache 3/1
@@ -167,22 +167,22 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Run 2 ***
 	endRun 1
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 2/1
     *** nextItemType: Lumi 2 ***
 	endLumi 2/1
 	writeLumi 2/1
 	deleteLumiFromCache 2/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 2/2
     *** nextItemType: Event ***
 	readEvent
@@ -192,7 +192,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	endLumi 2/2
 	writeLumi 2/2
 	deleteLumiFromCache 2/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
 	beginLumi 2/3
     *** nextItemType: Run 3 ***
 	endLumi 2/3
@@ -201,10 +201,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	endRun 2
 	writeRun 2
 	deleteRunFromCache 2
-	readAndCacheRun 3
+	readRun 3
 	beginRun 3
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 3/1
     *** nextItemType: Stop 1 ***
 	endLumi 3/1
@@ -226,20 +226,20 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Run 2 ***
 	endRun 1
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Lumi 2 ***
 	writeLumi 2/1
 	deleteLumiFromCache 2/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 2/2
 	readEvent
@@ -249,17 +249,17 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	endLumi 2/2
 	writeLumi 2/2
 	deleteLumiFromCache 2/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
     *** nextItemType: Run 3 ***
 	writeLumi 2/3
 	deleteLumiFromCache 2/3
 	endRun 2
 	writeRun 2
 	deleteRunFromCache 2
-	readAndCacheRun 3
+	readRun 3
 	beginRun 3
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Stop 1 ***
 	writeLumi 3/1
 	deleteLumiFromCache 3/1
@@ -279,17 +279,17 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Run 2 ***
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Lumi 2 ***
 	writeLumi 2/1
 	deleteLumiFromCache 2/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginRun 2
 	beginLumi 2/2
@@ -300,16 +300,16 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	endLumi 2/2
 	writeLumi 2/2
 	deleteLumiFromCache 2/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
     *** nextItemType: Run 3 ***
 	writeLumi 2/3
 	deleteLumiFromCache 2/3
 	endRun 2
 	writeRun 2
 	deleteRunFromCache 2
-	readAndCacheRun 3
+	readRun 3
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Stop 1 ***
 	writeLumi 3/1
 	deleteLumiFromCache 3/1

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_11.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_11.txt
@@ -57,7 +57,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 9 ***
-	readAndCacheRun 9
+	readRun 9
 	beginRun 9
     *** nextItemType: File 0 ***
 	endRun 9
@@ -70,7 +70,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: File 0 ***
 	endRun 1
@@ -83,13 +83,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Run 2 ***
 	endRun 1
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: File 0 ***
 	endRun 2
@@ -102,7 +102,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: File 0 ***
 	endRun 2
@@ -115,10 +115,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 2/1
     *** nextItemType: File 0 ***
 	endLumi 2/1
@@ -134,16 +134,16 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 2/2
     *** nextItemType: Lumi 3 ***
 	endLumi 2/2
 	writeLumi 2/2
 	deleteLumiFromCache 2/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
 	beginLumi 2/3
     *** nextItemType: File 0 ***
 	endLumi 2/3
@@ -159,7 +159,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: File 0 ***
 	endRun 2
@@ -172,10 +172,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 3 ***
-	readAndCacheLumi 3
+	readLuminosityBlock 3
 	beginLumi 2/3
     *** nextItemType: File 0 ***
 	endLumi 2/3
@@ -204,10 +204,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 5 ***
-	readAndCacheRun 5
+	readRun 5
 	beginRun 5
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 5/1
     *** nextItemType: File 0 ***
 	endLumi 5/1
@@ -236,10 +236,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 6 ***
-	readAndCacheRun 6
+	readRun 6
 	beginRun 6
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 6/1
     *** nextItemType: Restart 0 ***
 	endLumi 6/1
@@ -318,7 +318,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 9 ***
-	readAndCacheRun 9
+	readRun 9
 	beginRun 9
     *** nextItemType: File 0 ***
 	endRun 9
@@ -331,7 +331,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: File 0 ***
 	endRun 1
@@ -344,13 +344,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Run 2 ***
 	endRun 1
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: File 0 ***
 	endRun 2
@@ -363,7 +363,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: File 0 ***
 	endRun 2
@@ -376,10 +376,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: File 0 ***
 	writeLumi 2/1
 	deleteLumiFromCache 2/1
@@ -393,14 +393,14 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Lumi 3 ***
 	writeLumi 2/2
 	deleteLumiFromCache 2/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
     *** nextItemType: File 0 ***
 	writeLumi 2/3
 	deleteLumiFromCache 2/3
@@ -414,7 +414,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: File 0 ***
 	endRun 2
@@ -427,10 +427,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 3 ***
-	readAndCacheLumi 3
+	readLuminosityBlock 3
     *** nextItemType: File 0 ***
 	writeLumi 2/3
 	deleteLumiFromCache 2/3
@@ -457,10 +457,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 5 ***
-	readAndCacheRun 5
+	readRun 5
 	beginRun 5
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: File 0 ***
 	writeLumi 5/1
 	deleteLumiFromCache 5/1
@@ -487,10 +487,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 6 ***
-	readAndCacheRun 6
+	readRun 6
 	beginRun 6
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Restart 0 ***
 	writeLumi 6/1
 	deleteLumiFromCache 6/1
@@ -567,7 +567,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 9 ***
-	readAndCacheRun 9
+	readRun 9
     *** nextItemType: File 0 ***
 	writeRun 9
 	deleteRunFromCache 9
@@ -578,7 +578,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: File 0 ***
 	writeRun 1
 	deleteRunFromCache 1
@@ -589,11 +589,11 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Run 2 ***
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
     *** nextItemType: File 0 ***
 	writeRun 2
 	deleteRunFromCache 2
@@ -604,7 +604,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
     *** nextItemType: File 0 ***
 	writeRun 2
 	deleteRunFromCache 2
@@ -615,9 +615,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: File 0 ***
 	writeLumi 2/1
 	deleteLumiFromCache 2/1
@@ -630,13 +630,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Lumi 3 ***
 	writeLumi 2/2
 	deleteLumiFromCache 2/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
     *** nextItemType: File 0 ***
 	writeLumi 2/3
 	deleteLumiFromCache 2/3
@@ -649,7 +649,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
     *** nextItemType: File 0 ***
 	writeRun 2
 	deleteRunFromCache 2
@@ -660,9 +660,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
     *** nextItemType: Lumi 3 ***
-	readAndCacheLumi 3
+	readLuminosityBlock 3
     *** nextItemType: File 0 ***
 	writeLumi 2/3
 	deleteLumiFromCache 2/3
@@ -688,9 +688,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 5 ***
-	readAndCacheRun 5
+	readRun 5
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: File 0 ***
 	writeLumi 5/1
 	deleteLumiFromCache 5/1
@@ -716,9 +716,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 6 ***
-	readAndCacheRun 6
+	readRun 6
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Restart 0 ***
 	writeLumi 6/1
 	deleteLumiFromCache 6/1
@@ -793,7 +793,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
  	readFile
 	respondToOpenInputFile
     *** nextItemType: Run 9 ***
-	readAndCacheRun 9
+	readRun 9
 	beginRun 9
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
@@ -805,7 +805,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	endRun 9
 	writeRun 9
 	deleteRunFromCache 9
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
@@ -819,7 +819,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	endRun 1
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
@@ -838,7 +838,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
     *** nextItemType: Run 2 ***
 	readAndMergeRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 2/1
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
@@ -852,13 +852,13 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	endLumi 2/1
 	writeLumi 2/1
 	deleteLumiFromCache 2/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 2/2
     *** nextItemType: Lumi 3 ***
 	endLumi 2/2
 	writeLumi 2/2
 	deleteLumiFromCache 2/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
 	beginLumi 2/3
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
@@ -904,10 +904,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 5 ***
-	readAndCacheRun 5
+	readRun 5
 	beginRun 5
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 5/1
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
@@ -935,10 +935,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 6 ***
-	readAndCacheRun 6
+	readRun 6
 	beginRun 6
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 6/1
     *** nextItemType: Restart 0 ***
 	endLumi 6/1
@@ -1016,7 +1016,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
  	readFile
 	respondToOpenInputFile
     *** nextItemType: Run 9 ***
-	readAndCacheRun 9
+	readRun 9
 	beginRun 9
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
@@ -1028,7 +1028,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	endRun 9
 	writeRun 9
 	deleteRunFromCache 9
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
@@ -1042,7 +1042,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	endRun 1
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
@@ -1061,7 +1061,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
     *** nextItemType: Run 2 ***
 	readAndMergeRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -1073,11 +1073,11 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
     *** nextItemType: Lumi 2 ***
 	writeLumi 2/1
 	deleteLumiFromCache 2/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Lumi 3 ***
 	writeLumi 2/2
 	deleteLumiFromCache 2/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -1121,10 +1121,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 5 ***
-	readAndCacheRun 5
+	readRun 5
 	beginRun 5
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -1150,10 +1150,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 6 ***
-	readAndCacheRun 6
+	readRun 6
 	beginRun 6
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Restart 0 ***
 	writeLumi 6/1
 	deleteLumiFromCache 6/1
@@ -1229,7 +1229,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
  	readFile
 	respondToOpenInputFile
     *** nextItemType: Run 9 ***
-	readAndCacheRun 9
+	readRun 9
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -1239,7 +1239,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
     *** nextItemType: Run 1 ***
 	writeRun 9
 	deleteRunFromCache 9
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -1251,7 +1251,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
     *** nextItemType: Run 2 ***
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -1269,7 +1269,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
     *** nextItemType: Run 2 ***
 	readAndMergeRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -1281,11 +1281,11 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
     *** nextItemType: Lumi 2 ***
 	writeLumi 2/1
 	deleteLumiFromCache 2/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Lumi 3 ***
 	writeLumi 2/2
 	deleteLumiFromCache 2/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -1328,9 +1328,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 5 ***
-	readAndCacheRun 5
+	readRun 5
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -1355,9 +1355,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 6 ***
-	readAndCacheRun 6
+	readRun 6
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Restart 0 ***
 	writeLumi 6/1
 	deleteLumiFromCache 6/1

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_12.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_12.txt
@@ -6,10 +6,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -29,10 +29,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Event ***
 	readEvent
@@ -52,10 +52,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -81,10 +81,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -104,10 +104,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 1/2
 	readEvent
@@ -127,10 +127,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -156,9 +156,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1
@@ -179,9 +179,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/2
@@ -202,9 +202,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1
@@ -231,10 +231,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -252,7 +252,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Event ***
 	readEvent
@@ -270,7 +270,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	endLumi 1/2
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -296,10 +296,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -317,7 +317,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 1/2
 	readEvent
@@ -335,7 +335,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	endLumi 1/2
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -361,9 +361,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1
@@ -382,7 +382,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 1/2
 	readEvent
@@ -400,7 +400,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	endLumi 1/2
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_2.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_2.txt
@@ -41,7 +41,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: File 0 ***
 	endRun 1
@@ -68,10 +68,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 2/1
     *** nextItemType: File 0 ***
 	endLumi 2/1
@@ -149,7 +149,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: File 0 ***
 	endRun 1
@@ -176,10 +176,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: File 0 ***
 	writeLumi 2/1
 	deleteLumiFromCache 2/1
@@ -255,7 +255,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: File 0 ***
 	writeRun 1
 	deleteRunFromCache 1
@@ -280,9 +280,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: File 0 ***
 	writeLumi 2/1
 	deleteLumiFromCache 2/1
@@ -358,7 +358,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
@@ -384,10 +384,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 2/1
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
@@ -465,7 +465,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
@@ -491,10 +491,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -570,7 +570,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -594,9 +594,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_3.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_3.txt
@@ -6,10 +6,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -29,10 +29,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 2/1
     *** nextItemType: Event ***
 	readEvent
@@ -52,10 +52,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Event ***
 	readEvent
@@ -81,10 +81,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -104,10 +104,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 2/1
 	readEvent
@@ -127,10 +127,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 1/2
 	readEvent
@@ -156,9 +156,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1
@@ -179,9 +179,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 2 ***
-	readAndCacheRun 2
+	readRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 2
 	beginLumi 2/1
@@ -202,9 +202,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/2
@@ -231,10 +231,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -253,10 +253,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	endRun 1
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 2/1
     *** nextItemType: Event ***
 	readEvent
@@ -275,10 +275,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	endRun 2
 	writeRun 2
 	deleteRunFromCache 2
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Event ***
 	readEvent
@@ -304,10 +304,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -326,10 +326,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	endRun 1
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 2/1
 	readEvent
@@ -348,10 +348,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	endRun 2
 	writeRun 2
 	deleteRunFromCache 2
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 1/2
 	readEvent
@@ -377,9 +377,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1
@@ -399,9 +399,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	endRun 1
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 2
 	beginLumi 2/1
@@ -421,9 +421,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	endRun 2
 	writeRun 2
 	deleteRunFromCache 2
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/2

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_4.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_4.txt
@@ -6,10 +6,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -22,10 +22,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	endRun 1
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 2/1
     *** nextItemType: Event ***
 	readEvent
@@ -45,10 +45,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Event ***
 	readEvent
@@ -74,10 +74,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -90,10 +90,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	endRun 1
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 2/1
 	readEvent
@@ -113,10 +113,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 1/2
 	readEvent
@@ -142,9 +142,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1
@@ -158,9 +158,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	endRun 1
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 2
 	beginLumi 2/1
@@ -181,9 +181,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/2
@@ -210,10 +210,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -226,10 +226,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	endRun 1
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 2/1
     *** nextItemType: Event ***
 	readEvent
@@ -248,10 +248,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	endRun 2
 	writeRun 2
 	deleteRunFromCache 2
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Event ***
 	readEvent
@@ -277,10 +277,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -293,10 +293,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	endRun 1
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
 	beginRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 2/1
 	readEvent
@@ -315,10 +315,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	endRun 2
 	writeRun 2
 	deleteRunFromCache 2
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 1/2
 	readEvent
@@ -344,9 +344,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1
@@ -360,9 +360,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	endRun 1
 	writeRun 1
 	deleteRunFromCache 1
-	readAndCacheRun 2
+	readRun 2
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 2
 	beginLumi 2/1
@@ -382,9 +382,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	endRun 2
 	writeRun 2
 	deleteRunFromCache 2
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/2

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_5.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_5.txt
@@ -6,10 +6,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -19,7 +19,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: File 0 ***
 	endLumi 1/2
@@ -35,10 +35,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Event ***
 	readEvent
@@ -64,10 +64,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -77,7 +77,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: File 0 ***
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
@@ -91,10 +91,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 1/2
 	readEvent
@@ -120,9 +120,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1
@@ -133,7 +133,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: File 0 ***
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
@@ -147,9 +147,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/2
@@ -176,10 +176,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -189,7 +189,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
@@ -225,10 +225,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -238,7 +238,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -274,9 +274,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1
@@ -287,7 +287,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_6.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_6.txt
@@ -6,10 +6,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -19,7 +19,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Event ***
 	readEvent
@@ -39,10 +39,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Event ***
 	readEvent
@@ -68,10 +68,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -81,7 +81,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 1/2
 	readEvent
@@ -101,10 +101,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 1/2
 	readEvent
@@ -130,9 +130,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1
@@ -143,7 +143,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 1/2
 	readEvent
@@ -163,9 +163,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/2
@@ -192,10 +192,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -205,7 +205,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Event ***
 	readEvent
@@ -245,10 +245,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -258,7 +258,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 1/2
 	readEvent
@@ -298,9 +298,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1
@@ -311,7 +311,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 1/2
 	readEvent

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_7.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_7.txt
@@ -6,10 +6,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -19,7 +19,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Event ***
 	readEvent
@@ -39,16 +39,16 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Lumi 3 ***
 	endLumi 1/2
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
 	beginLumi 1/3
     *** nextItemType: Event ***
 	readEvent
@@ -74,10 +74,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -87,7 +87,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 1/2
 	readEvent
@@ -107,14 +107,14 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Lumi 3 ***
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
     *** nextItemType: Event ***
 	beginLumi 1/3
 	readEvent
@@ -140,9 +140,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1
@@ -153,7 +153,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 1/2
 	readEvent
@@ -173,13 +173,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Lumi 3 ***
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/3
@@ -206,10 +206,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -219,7 +219,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Event ***
 	readEvent
@@ -239,7 +239,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	endLumi 1/2
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
 	beginLumi 1/3
     *** nextItemType: Event ***
 	readEvent
@@ -265,10 +265,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -278,7 +278,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 1/2
 	readEvent
@@ -298,7 +298,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	endLumi 1/2
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
     *** nextItemType: Event ***
 	beginLumi 1/3
 	readEvent
@@ -324,9 +324,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1
@@ -337,7 +337,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Event ***
 	beginLumi 1/2
 	readEvent
@@ -357,7 +357,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	endLumi 1/2
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
     *** nextItemType: Event ***
 	beginLumi 1/3
 	readEvent

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_8.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_8.txt
@@ -6,10 +6,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -19,7 +19,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: File 0 ***
 	endLumi 1/2
@@ -35,16 +35,16 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: Lumi 3 ***
 	endLumi 1/2
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
 	beginLumi 1/3
     *** nextItemType: Event ***
 	readEvent
@@ -70,10 +70,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -83,7 +83,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: File 0 ***
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
@@ -97,14 +97,14 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Lumi 3 ***
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
     *** nextItemType: Event ***
 	beginLumi 1/3
 	readEvent
@@ -130,9 +130,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1
@@ -143,7 +143,7 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: File 0 ***
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
@@ -157,13 +157,13 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 2 ***
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: Lumi 3 ***
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/3
@@ -190,10 +190,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -203,7 +203,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
 	beginLumi 1/2
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
@@ -219,7 +219,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	endLumi 1/2
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
 	beginLumi 1/3
     *** nextItemType: Event ***
 	readEvent
@@ -245,10 +245,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -258,7 +258,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -272,7 +272,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
     *** nextItemType: Lumi 3 ***
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
     *** nextItemType: Event ***
 	beginLumi 1/3
 	readEvent
@@ -298,9 +298,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1
@@ -311,7 +311,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	endLumi 1/1
 	writeLumi 1/1
 	deleteLumiFromCache 1/1
-	readAndCacheLumi 2
+	readLuminosityBlock 2
     *** nextItemType: File 0 ***
 	shouldWeCloseOutput
 	respondToCloseInputFile
@@ -325,7 +325,7 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
     *** nextItemType: Lumi 3 ***
 	writeLumi 1/2
 	deleteLumiFromCache 1/2
-	readAndCacheLumi 3
+	readLuminosityBlock 3
     *** nextItemType: Event ***
 	beginLumi 1/3
 	readEvent

--- a/FWCore/Framework/test/unit_test_outputs/statemachine_output_9.txt
+++ b/FWCore/Framework/test/unit_test_outputs/statemachine_output_9.txt
@@ -6,10 +6,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -37,10 +37,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -64,10 +64,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRunsAndLumis
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -101,10 +101,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -132,10 +132,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -159,10 +159,10 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -196,9 +196,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1
@@ -227,9 +227,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1
@@ -254,9 +254,9 @@ Machine parameters:  mode = NOMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAndL
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1
@@ -291,10 +291,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRunsAndLumi
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
 	beginLumi 1/1
     *** nextItemType: Event ***
 	readEvent
@@ -368,10 +368,10 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = handleEmptyRuns
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
 	beginRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginLumi 1/1
 	readEvent
@@ -445,9 +445,9 @@ Machine parameters:  mode = FULLMERGE  emptyRunLumiMode = doNotHandleEmptyRunsAn
 	respondToOpenInputFile
 	openOutputFiles
     *** nextItemType: Run 1 ***
-	readAndCacheRun 1
+	readRun 1
     *** nextItemType: Lumi 1 ***
-	readAndCacheLumi 1
+	readLuminosityBlock 1
     *** nextItemType: Event ***
 	beginRun 1
 	beginLumi 1/1

--- a/FWCore/Integration/test/ThrowingSource.cc
+++ b/FWCore/Integration/test/ThrowingSource.cc
@@ -22,7 +22,7 @@ namespace edm {
     virtual void closeFile_();
     virtual boost::shared_ptr<edm::RunAuxiliary> readRunAuxiliary_();
     virtual boost::shared_ptr<edm::LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_();
-    virtual edm::EventPrincipal* readEvent_(edm::EventPrincipal&);
+    virtual void readEvent_(edm::EventPrincipal&);
   private:
     enum {
       kDoNotThrow  = 0,
@@ -126,14 +126,13 @@ namespace edm {
     return boost::shared_ptr<LuminosityBlockAuxiliary>(new LuminosityBlockAuxiliary(eventID().run(), eventID().luminosityBlock(), ts, Timestamp::invalidTimestamp()));
   }
 
-  EventPrincipal*
+  void
   ThrowingSource::readEvent_(EventPrincipal& eventPrincipal) {
     if (whenToThrow_ == kReadEvent) throw cms::Exception("TestThrow") << "ThrowingSource::readEvent_";
     assert(eventCached() || processingMode() != RunsLumisAndEvents);
     EventSourceSentry sentry(*this);
     EventAuxiliary aux(eventID(), processGUID(), Timestamp(presentTime()), false, EventAuxiliary::Undefined);
     eventPrincipal.fillEventPrincipal(aux);
-    return &eventPrincipal;
   }
 }
 

--- a/FWCore/Sources/interface/ProducerSourceBase.h
+++ b/FWCore/Sources/interface/ProducerSourceBase.h
@@ -49,7 +49,7 @@ namespace edm {
     virtual void endRun(Run&) override;
     virtual void beginLuminosityBlock(LuminosityBlock&) override;
     virtual void endLuminosityBlock(LuminosityBlock&) override;
-    virtual EventPrincipal* readEvent_(EventPrincipal& eventPrincipal) override;
+    virtual void readEvent_(EventPrincipal& eventPrincipal) override;
     virtual boost::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
     virtual boost::shared_ptr<RunAuxiliary> readRunAuxiliary_() override;
     virtual void skip(int offset) override;

--- a/FWCore/Sources/interface/RawInputSource.h
+++ b/FWCore/Sources/interface/RawInputSource.h
@@ -23,13 +23,13 @@ namespace edm {
     static void fillDescription(ParameterSetDescription& description);
 
   protected:
-    EventPrincipal* makeEvent(EventPrincipal& eventPrincipal, EventAuxiliary const& eventAuxiliary);
+    void makeEvent(EventPrincipal& eventPrincipal, EventAuxiliary const& eventAuxiliary);
     virtual bool checkNextEvent() = 0;
-    virtual EventPrincipal* read(EventPrincipal& eventPrincipal) = 0;
+    virtual void read(EventPrincipal& eventPrincipal) = 0;
     void setInputFileTransitionsEachEvent() {inputFileTransitionsEachEvent_ = true;}
 
   private:
-    virtual EventPrincipal* readEvent_(EventPrincipal& eventPrincipal) override;
+    virtual void readEvent_(EventPrincipal& eventPrincipal) override;
     virtual boost::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_() override;
     virtual boost::shared_ptr<RunAuxiliary> readRunAuxiliary_() override;
     virtual void reset_();

--- a/FWCore/Sources/interface/VectorInputSource.h
+++ b/FWCore/Sources/interface/VectorInputSource.h
@@ -37,11 +37,11 @@ namespace edm {
   private:
 
     void clearEventPrincipal(EventPrincipal& cache);
-    virtual EventPrincipal* readOneRandom(EventPrincipal& cache) = 0;
-    virtual EventPrincipal* readOneRandomWithID(EventPrincipal& cache, LuminosityBlockID const& id) = 0;
-    virtual EventPrincipal* readOneSequential(EventPrincipal& cache) = 0;
-    virtual EventPrincipal* readOneSequentialWithID(EventPrincipal& cache, LuminosityBlockID const& id) = 0;
-    virtual EventPrincipal* readOneSpecified(EventPrincipal& cache, EventID const& event) = 0;
+    virtual void readOneRandom(EventPrincipal& cache) = 0;
+    virtual bool readOneRandomWithID(EventPrincipal& cache, LuminosityBlockID const& id) = 0;
+    virtual bool readOneSequential(EventPrincipal& cache) = 0;
+    virtual bool readOneSequentialWithID(EventPrincipal& cache, LuminosityBlockID const& id) = 0;
+    virtual void readOneSpecified(EventPrincipal& cache, EventID const& event) = 0;
 
     virtual void dropUnwantedBranches_(std::vector<std::string> const& wantedBranches) = 0;
   };
@@ -51,9 +51,8 @@ namespace edm {
     size_t i = 0U;
     for(; i < number; ++i) {
       clearEventPrincipal(cache);
-      EventPrincipal* ep = readOneRandom(cache);
-      if(!ep) break;
-      eventOperator(*ep);
+      readOneRandom(cache);
+      eventOperator(cache);
     }
     return i;
   }
@@ -63,9 +62,9 @@ namespace edm {
     size_t i = 0U;
     for(; i < number; ++i) {
       clearEventPrincipal(cache);
-      EventPrincipal* ep = readOneSequential(cache);
-      if(!ep) break;
-      eventOperator(*ep);
+      bool found = readOneSequential(cache);
+      if(!found) break;
+      eventOperator(cache);
     }
     return i;
   }
@@ -75,9 +74,9 @@ namespace edm {
     size_t i = 0U;
     for(; i < number; ++i) {
       clearEventPrincipal(cache);
-      EventPrincipal* ep = readOneRandomWithID(cache, id);
-      if(!ep) break;
-      eventOperator(*ep);
+      bool found = readOneRandomWithID(cache, id);
+      if(!found) break;
+      eventOperator(cache);
     }
     return i;
   }
@@ -87,9 +86,9 @@ namespace edm {
     size_t i = 0U;
     for(; i < number; ++i) {
       clearEventPrincipal(cache);
-      EventPrincipal* ep = readOneSequentialWithID(cache, id);
-      if(!ep) break;
-      eventOperator(*ep);
+      bool found = readOneSequentialWithID(cache, id);
+      if(!found) break;
+      eventOperator(cache);
     }
     return i;
   }
@@ -99,9 +98,8 @@ namespace edm {
     size_t i = 0U;
     for(typename Collection::const_iterator it = events.begin(), itEnd = events.end(); it != itEnd; ++it) {
       clearEventPrincipal(cache);
-      EventPrincipal* ep = readOneSpecified(cache, *it);
-      if(!ep) break;
-      eventOperator(*ep);
+      readOneSpecified(cache, *it);
+      eventOperator(cache);
       ++i;
     }
     return i;

--- a/FWCore/Sources/src/ProducerSourceBase.cc
+++ b/FWCore/Sources/src/ProducerSourceBase.cc
@@ -56,7 +56,7 @@ namespace edm {
     return boost::shared_ptr<LuminosityBlockAuxiliary>(new LuminosityBlockAuxiliary(eventID_.run(), eventID_.luminosityBlock(), ts, Timestamp::invalidTimestamp()));
   }
 
-  EventPrincipal *
+  void
   ProducerSourceBase::readEvent_(EventPrincipal& eventPrincipal) {
     assert(eventCached() || processingMode() != RunsLumisAndEvents);
     EventSourceSentry sentry(*this);
@@ -66,7 +66,6 @@ namespace edm {
     produce(e);
     e.commit_();
     resetEventCached();
-    return &eventPrincipal;
   }
 
   void

--- a/FWCore/Sources/src/RawInputSource.cc
+++ b/FWCore/Sources/src/RawInputSource.cc
@@ -40,20 +40,19 @@ namespace edm {
     return luminosityBlockAuxiliary();
   }
 
-  EventPrincipal*
+  void
   RawInputSource::readEvent_(EventPrincipal& eventPrincipal) {
     assert(!newRun());
     assert(!newLumi());
     assert(eventCached());
     resetEventCached();
-    return read(eventPrincipal);
+    read(eventPrincipal);
   }
 
-  EventPrincipal*
+  void
   RawInputSource::makeEvent(EventPrincipal& eventPrincipal, EventAuxiliary const& eventAuxiliary) {
     EventSourceSentry sentry(*this);
     eventPrincipal.fillEventPrincipal(eventAuxiliary);
-    return &eventPrincipal;
   }
 
   void

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.cc
@@ -79,19 +79,17 @@ void LHESource::nextEvent()
 }
 
 // This is the only way we can now access the run principal.
-boost::shared_ptr<edm::RunPrincipal>
+void
 LHESource::readRun_(boost::shared_ptr<edm::RunPrincipal> runPrincipal) {
   runAuxiliary()->setProcessHistoryID(phid_);
   runPrincipal->fillRunPrincipal();
   runPrincipal_ = runPrincipal;
-  return runPrincipal;
 }
 
-boost::shared_ptr<edm::LuminosityBlockPrincipal>
+void
 LHESource::readLuminosityBlock_(boost::shared_ptr<edm::LuminosityBlockPrincipal> lumiPrincipal) {
   luminosityBlockAuxiliary()->setProcessHistoryID(phid_);
   lumiPrincipal->fillLuminosityBlockPrincipal();
-  return lumiPrincipal;
 }
 
 void LHESource::beginRun(edm::Run&)
@@ -142,7 +140,7 @@ bool LHESource::setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&)
         return true;
 }
 
-edm::EventPrincipal*
+void
 LHESource::readEvent_(edm::EventPrincipal& eventPrincipal) {
 	assert(eventCached() || processingMode() != RunsLumisAndEvents);
 	EventSourceSentry sentry(*this);
@@ -191,7 +189,6 @@ LHESource::readEvent_(edm::EventPrincipal& eventPrincipal) {
 	partonLevel.reset();
 
 	resetEventCached();
-	return &eventPrincipal;
 }
 
 DEFINE_FWK_INPUT_SOURCE(LHESource);

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.h
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.h
@@ -39,9 +39,9 @@ class LHERunInfoProduct;
 	virtual void beginRun(edm::Run &run) override;
 	virtual void endRun(edm::Run &run) override;
  	virtual bool setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&) override;
-	virtual boost::shared_ptr<edm::RunPrincipal> readRun_(boost::shared_ptr<edm::RunPrincipal> runPrincipal) override;
-	virtual boost::shared_ptr<edm::LuminosityBlockPrincipal> readLuminosityBlock_(boost::shared_ptr<edm::LuminosityBlockPrincipal> lumiPrincipal) override;
-	virtual edm::EventPrincipal* readEvent_(edm::EventPrincipal& eventPrincipal) override;
+	virtual void readRun_(boost::shared_ptr<edm::RunPrincipal> runPrincipal) override;
+	virtual void readLuminosityBlock_(boost::shared_ptr<edm::LuminosityBlockPrincipal> lumiPrincipal) override;
+	virtual void readEvent_(edm::EventPrincipal& eventPrincipal) override;
         virtual void produce(edm::Event&) {}
 
 	void nextEvent();

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -130,79 +130,75 @@ namespace edm {
     return primaryFileSequence_->readLuminosityBlockAuxiliary_();
   }
 
-  boost::shared_ptr<RunPrincipal>
+  void
   PoolSource::readRun_(boost::shared_ptr<RunPrincipal> runPrincipal) {
+    primaryFileSequence_->readRun_(runPrincipal);
     if(secondaryFileSequence_ && !branchIDsToReplace_[InRun].empty()) {
-      boost::shared_ptr<RunPrincipal> primaryPrincipal = primaryFileSequence_->readRun_(runPrincipal);
-      bool found = secondaryFileSequence_->skipToItem(primaryPrincipal->run(), 0U, 0U);
+      bool found = secondaryFileSequence_->skipToItem(runPrincipal->run(), 0U, 0U);
       if(found) {
         boost::shared_ptr<RunAuxiliary> secondaryAuxiliary = secondaryFileSequence_->readRunAuxiliary_();
-        checkConsistency(primaryPrincipal->aux(), *secondaryAuxiliary);
-        boost::shared_ptr<RunPrincipal> rp(new RunPrincipal(secondaryAuxiliary, secondaryFileSequence_->fileProductRegistry(), processConfiguration(), nullptr,runPrincipal->index()));
-        secondaryRunPrincipal_ = secondaryFileSequence_->readRun_(rp);
-        checkHistoryConsistency(*primaryPrincipal, *secondaryRunPrincipal_);
-        primaryPrincipal->recombine(*secondaryRunPrincipal_, branchIDsToReplace_[InRun]);
+        checkConsistency(runPrincipal->aux(), *secondaryAuxiliary);
+        secondaryRunPrincipal_.reset(new RunPrincipal(secondaryAuxiliary, secondaryFileSequence_->fileProductRegistry(), processConfiguration(), nullptr,runPrincipal->index()));
+        secondaryFileSequence_->readRun_(secondaryRunPrincipal_);
+        checkHistoryConsistency(*runPrincipal, *secondaryRunPrincipal_);
+        runPrincipal->recombine(*secondaryRunPrincipal_, branchIDsToReplace_[InRun]);
       } else {
         throw Exception(errors::MismatchedInputFiles, "PoolSource::readRun_")
-          << " Run " << primaryPrincipal->run()
+          << " Run " << runPrincipal->run()
           << " is not found in the secondary input files\n";
       }
-      return primaryPrincipal;
     }
-    return primaryFileSequence_->readRun_(runPrincipal);
   }
 
-  boost::shared_ptr<LuminosityBlockPrincipal>
+  void
   PoolSource::readLuminosityBlock_(boost::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal) {
+    primaryFileSequence_->readLuminosityBlock_(lumiPrincipal);
     if(secondaryFileSequence_ && !branchIDsToReplace_[InLumi].empty()) {
-      boost::shared_ptr<LuminosityBlockPrincipal> primaryPrincipal = primaryFileSequence_->readLuminosityBlock_(lumiPrincipal);
-      bool found = secondaryFileSequence_->skipToItem(primaryPrincipal->run(), primaryPrincipal->luminosityBlock(), 0U);
+      bool found = secondaryFileSequence_->skipToItem(lumiPrincipal->run(), lumiPrincipal->luminosityBlock(), 0U);
       if(found) {
         boost::shared_ptr<LuminosityBlockAuxiliary> secondaryAuxiliary = secondaryFileSequence_->readLuminosityBlockAuxiliary_();
-        checkConsistency(primaryPrincipal->aux(), *secondaryAuxiliary);
-        boost::shared_ptr<LuminosityBlockPrincipal> lbp(new LuminosityBlockPrincipal(secondaryAuxiliary, secondaryFileSequence_->fileProductRegistry(), processConfiguration(), nullptr,lumiPrincipal->index()));
-        secondaryLumiPrincipal_ = secondaryFileSequence_->readLuminosityBlock_(lbp);
-        checkHistoryConsistency(*primaryPrincipal, *secondaryLumiPrincipal_);
-        primaryPrincipal->recombine(*secondaryLumiPrincipal_, branchIDsToReplace_[InLumi]);
+        checkConsistency(lumiPrincipal->aux(), *secondaryAuxiliary);
+        secondaryLumiPrincipal_.reset(new LuminosityBlockPrincipal(secondaryAuxiliary, secondaryFileSequence_->fileProductRegistry(), processConfiguration(), nullptr,lumiPrincipal->index()));
+        secondaryFileSequence_->readLuminosityBlock_(secondaryLumiPrincipal_);
+        checkHistoryConsistency(*lumiPrincipal, *secondaryLumiPrincipal_);
+        lumiPrincipal->recombine(*secondaryLumiPrincipal_, branchIDsToReplace_[InLumi]);
       } else {
         throw Exception(errors::MismatchedInputFiles, "PoolSource::readLuminosityBlock_")
-          << " Run " << primaryPrincipal->run()
-          << " LuminosityBlock " << primaryPrincipal->luminosityBlock()
+          << " Run " << lumiPrincipal->run()
+          << " LuminosityBlock " << lumiPrincipal->luminosityBlock()
           << " is not found in the secondary input files\n";
       }
-      return primaryPrincipal;
     }
-    return primaryFileSequence_->readLuminosityBlock_(lumiPrincipal);
   }
 
-  EventPrincipal*
+  void
   PoolSource::readEvent_(EventPrincipal& eventPrincipal) {
     EventSourceSentry sentry{*this};
-    EventPrincipal* primaryPrincipal = primaryFileSequence_->readEvent(eventPrincipal);
+    primaryFileSequence_->readEvent(eventPrincipal);
     if(secondaryFileSequence_ && !branchIDsToReplace_[InEvent].empty()) {
-      bool found = secondaryFileSequence_->skipToItem(primaryPrincipal->run(),
-                                                      primaryPrincipal->luminosityBlock(),
-                                                      primaryPrincipal->id().event());
+      bool found = secondaryFileSequence_->skipToItem(eventPrincipal.run(),
+                                                      eventPrincipal.luminosityBlock(),
+                                                      eventPrincipal.id().event());
       if(found) {
-        EventPrincipal* secondaryPrincipal = secondaryFileSequence_->readEvent(*secondaryEventPrincipal_);
-        checkConsistency(*primaryPrincipal, *secondaryPrincipal);
-        checkHistoryConsistency(*primaryPrincipal, *secondaryPrincipal);
-        primaryPrincipal->recombine(*secondaryPrincipal, branchIDsToReplace_[InEvent]);
-        primaryPrincipal->mergeMappers(*secondaryPrincipal);
+        secondaryFileSequence_->readEvent(*secondaryEventPrincipal_);
+        checkConsistency(eventPrincipal, *secondaryEventPrincipal_);
+        checkHistoryConsistency(eventPrincipal, *secondaryEventPrincipal_);
+        eventPrincipal.recombine(*secondaryEventPrincipal_, branchIDsToReplace_[InEvent]);
+        eventPrincipal.mergeMappers(*secondaryEventPrincipal_);
         secondaryEventPrincipal_->clearPrincipal();
       } else {
         throw Exception(errors::MismatchedInputFiles, "PoolSource::readEvent_") <<
-          primaryPrincipal->id() << " is not found in the secondary input files\n";
+          eventPrincipal.id() << " is not found in the secondary input files\n";
       }
     }
-    return primaryPrincipal;
   }
 
-  EventPrincipal*
+  bool
   PoolSource::readIt(EventID const& id, EventPrincipal& eventPrincipal) {
     bool found = primaryFileSequence_->skipToItem(id.run(), id.luminosityBlock(), id.event());
-    if(!found) return 0;
-    return readEvent_(eventPrincipal);
+    if(!found) return false;
+    readEvent_(eventPrincipal);
+    return true;
   }
 
   InputSource::ItemType
@@ -232,34 +228,34 @@ namespace edm {
     return primaryFileSequence_->goToEvent(eventID);
   }
 
-  EventPrincipal*
+  void
   PoolSource::readOneRandom(EventPrincipal& cache) {
     assert(!secondaryFileSequence_);
-    return primaryFileSequence_->readOneRandom(cache);
+    primaryFileSequence_->readOneRandom(cache);
   }
 
-  EventPrincipal*
+  bool
   PoolSource::readOneRandomWithID(EventPrincipal& cache, LuminosityBlockID const& lumiID) {
     assert(!secondaryFileSequence_);
     return primaryFileSequence_->readOneRandomWithID(cache, lumiID);
   }
 
-  EventPrincipal*
+  bool
   PoolSource::readOneSequential(EventPrincipal& cache) {
     assert(!secondaryFileSequence_);
     return primaryFileSequence_->readOneSequential(cache);
   }
 
-  EventPrincipal*
+  bool
   PoolSource::readOneSequentialWithID(EventPrincipal& cache, LuminosityBlockID const& lumiID) {
     assert(!secondaryFileSequence_);
     return primaryFileSequence_->readOneSequentialWithID(cache, lumiID);
   }
 
-  EventPrincipal*
+  void
   PoolSource::readOneSpecified(EventPrincipal& cache, EventID const& id) {
     assert(!secondaryFileSequence_);
-    return primaryFileSequence_->readOneSpecified(cache, id);
+    primaryFileSequence_->readOneSpecified(cache, id);
   }
 
   void

--- a/IOPool/Input/src/PoolSource.h
+++ b/IOPool/Input/src/PoolSource.h
@@ -35,24 +35,24 @@ namespace edm {
     static void fillDescriptions(ConfigurationDescriptions & descriptions);
 
   private:
-    virtual EventPrincipal* readEvent_(EventPrincipal& eventPrincipal);
+    virtual void readEvent_(EventPrincipal& eventPrincipal);
     virtual boost::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_();
-    virtual boost::shared_ptr<LuminosityBlockPrincipal> readLuminosityBlock_(boost::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal);
+    virtual void readLuminosityBlock_(boost::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal);
     virtual boost::shared_ptr<RunAuxiliary> readRunAuxiliary_();
-    virtual boost::shared_ptr<RunPrincipal> readRun_(boost::shared_ptr<RunPrincipal> runPrincipal);
+    virtual void readRun_(boost::shared_ptr<RunPrincipal> runPrincipal);
     virtual std::unique_ptr<FileBlock> readFile_();
     virtual void closeFile_();
     virtual void endJob();
     virtual ItemType getNextItemType();
-    virtual EventPrincipal* readIt(EventID const& id, EventPrincipal& eventPrincipal);
+    virtual bool readIt(EventID const& id, EventPrincipal& eventPrincipal);
     virtual void skip(int offset);
     virtual bool goToEvent_(EventID const& eventID);
     virtual void rewind_();
-    virtual EventPrincipal* readOneRandom(EventPrincipal& cache);
-    virtual EventPrincipal* readOneRandomWithID(EventPrincipal& cache, LuminosityBlockID const& lumiID);
-    virtual EventPrincipal* readOneSequential(EventPrincipal& cache);
-    virtual EventPrincipal* readOneSequentialWithID(EventPrincipal& cache, LuminosityBlockID const& lumiID);
-    virtual EventPrincipal* readOneSpecified(EventPrincipal& cache, EventID const& id);
+    virtual void readOneRandom(EventPrincipal& cache);
+    virtual bool readOneRandomWithID(EventPrincipal& cache, LuminosityBlockID const& lumiID);
+    virtual bool readOneSequential(EventPrincipal& cache);
+    virtual bool readOneSequentialWithID(EventPrincipal& cache, LuminosityBlockID const& lumiID);
+    virtual void readOneSpecified(EventPrincipal& cache, EventID const& id);
     virtual void dropUnwantedBranches_(std::vector<std::string> const& wantedBranches);
     virtual void preForkReleaseResources();
     virtual bool randomAccess_() const;

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -85,13 +85,13 @@ namespace edm {
 
     void reportOpened(std::string const& inputType);
     void close();
-    EventPrincipal* readCurrentEvent(EventPrincipal& cache);
-    EventPrincipal* readEvent(EventPrincipal& cache);
+    bool readCurrentEvent(EventPrincipal& cache);
+    void readEvent(EventPrincipal& cache);
 
     boost::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_();
     boost::shared_ptr<RunAuxiliary> readRunAuxiliary_();
-    boost::shared_ptr<RunPrincipal> readRun_(boost::shared_ptr<RunPrincipal> runPrincipal);
-    boost::shared_ptr<LuminosityBlockPrincipal> readLumi(boost::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal);
+    void readRun_(boost::shared_ptr<RunPrincipal> runPrincipal);
+    void readLuminosityBlock_(boost::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal);
     std::string const& file() const {return file_;}
     boost::shared_ptr<ProductRegistry const> productRegistry() const {return productRegistry_;}
     boost::shared_ptr<BranchIDListHelper const> branchIDListHelper() const {return branchIDListHelper_;}

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -352,14 +352,14 @@ namespace edm {
     return rootFile_->readLuminosityBlockAuxiliary_();
   }
 
-  boost::shared_ptr<RunPrincipal>
+  void
   RootInputFileSequence::readRun_(boost::shared_ptr<RunPrincipal> runPrincipal) {
-    return rootFile_->readRun_(runPrincipal);
+    rootFile_->readRun_(runPrincipal);
   }
 
-  boost::shared_ptr<LuminosityBlockPrincipal>
+  void
   RootInputFileSequence::readLuminosityBlock_(boost::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal) {
-    return rootFile_->readLumi(lumiPrincipal);
+    rootFile_->readLuminosityBlock_(lumiPrincipal);
   }
 
   // readEvent() is responsible for setting up the EventPrincipal.
@@ -375,9 +375,9 @@ namespace edm {
   //  when it is asked to do so.
   //
 
-  EventPrincipal*
+  void
   RootInputFileSequence::readEvent(EventPrincipal& eventPrincipal) {
-    return rootFile_->readEvent(eventPrincipal);
+    rootFile_->readEvent(eventPrincipal);
   }
 
   InputSource::ItemType
@@ -472,7 +472,7 @@ namespace edm {
           initFile(false);
           // Now get the item from the correct file.
           bool found = rootFile_->goToEvent(eventID);
-          assert (found);
+          assert(found);
           return true;
         }
       }
@@ -537,7 +537,7 @@ namespace edm {
           }
           // Now get the item from the correct file.
           found = rootFile_->setEntryAtItem(run, lumi, event);
-          assert (found);
+          assert(found);
           return true;
         }
       }
@@ -586,7 +586,7 @@ namespace edm {
     productSelectorRules_ = ProductSelectorRules(pset, "inputCommands", "InputSource");
   }
 
-  EventPrincipal*
+  bool
   RootInputFileSequence::readOneSequential(EventPrincipal& cache) {
     skipBadFiles_ = false;
     if(fileIter_ == fileIterEnd_ || !rootFile_) {
@@ -598,20 +598,20 @@ namespace edm {
       rootFile_->setAtEventEntry(-1);
     }
     rootFile_->nextEventEntry();
-    EventPrincipal* ep = rootFile_->readCurrentEvent(cache);
-    if(ep == 0) {
+    bool found = rootFile_->readCurrentEvent(cache);
+    if(!found) {
       ++fileIter_;
       if(fileIter_ == fileIterEnd_) {
-        return 0;
+        return false;
       }
       initFile(false);
       rootFile_->setAtEventEntry(-1);
       return readOneSequential(cache);
     }
-    return ep;
+    return true;
   }
 
-  EventPrincipal*
+  bool
   RootInputFileSequence::readOneSequentialWithID(EventPrincipal& cache, LuminosityBlockID const& id) {
     if(fileIterEnd_ == fileIterBegin_) {
       throw Exception(errors::Configuration) << "RootInputFileSequence::readOneSequentialWithID(): no input files specified.\n";
@@ -622,21 +622,24 @@ namespace edm {
         rootFile_->indexIntoFileIter().lumi() != id.luminosityBlock()) {
       bool found = skipToItem(id.run(), id.luminosityBlock(), 0, false);
       if(!found) {
-        return 0;
+        return false;
       }
     }
-    bool nextFound = rootFile_->setEntryAtNextEventInLumi(id.run(), id.luminosityBlock());
-    EventPrincipal* ep = (nextFound ? rootFile_->readCurrentEvent(cache) : 0);
-    if(ep == 0) {
-      bool found = skipToItemInNewFile(id.run(), id.luminosityBlock(), 0);
-      if(found) {
-        return readOneSequentialWithID(cache, id);
-      }
+    bool found = rootFile_->setEntryAtNextEventInLumi(id.run(), id.luminosityBlock());
+    if(found) {
+      found = rootFile_->readCurrentEvent(cache);
     }
-    return ep;
+    if(!found) {
+      found = skipToItemInNewFile(id.run(), id.luminosityBlock(), 0);
+      if(!found) {
+        return false; 
+      }
+      return readOneSequentialWithID(cache, id);
+    }
+    return true;
   }
 
-  EventPrincipal*
+  void
   RootInputFileSequence::readOneSpecified(EventPrincipal& cache, EventID const& id) {
     skipBadFiles_ = false;
     bool found = skipToItem(id.run(), id.luminosityBlock(), id.event());
@@ -646,12 +649,11 @@ namespace edm {
          fileIter_->fileName() <<
          " does not contain specified event:\n" << id << "\n";
     }
-    EventPrincipal* ep = rootFile_->readCurrentEvent(cache);
-    assert(ep != 0);
-    return ep;
+    found = rootFile_->readCurrentEvent(cache);
+    assert(found);
   }
 
-  EventPrincipal*
+  void
   RootInputFileSequence::readOneRandom(EventPrincipal& cache) {
     if(fileIterEnd_ == fileIterBegin_) {
       throw Exception(errors::Configuration) << "RootInputFileSequence::readOneRandom(): no input files specified.\n";
@@ -679,19 +681,18 @@ namespace edm {
     }
     rootFile_->nextEventEntry();
 
-    EventPrincipal* ep = rootFile_->readCurrentEvent(cache);
-    if(ep == 0) {
+    bool found = rootFile_->readCurrentEvent(cache);
+    if(!found) {
       rootFile_->setAtEventEntry(0);
-      ep = rootFile_->readCurrentEvent(cache);
-      assert(ep != 0);
+      bool found = rootFile_->readCurrentEvent(cache);
+      assert(found);
     }
     --eventsRemainingInFile_;
-    return ep;
   }
 
   // bool RootFile::setEntryAtNextEventInLumi(RunNumber_t run, LuminosityBlockNumber_t lumi) {
 
-  EventPrincipal*
+  bool
   RootInputFileSequence::readOneRandomWithID(EventPrincipal& cache, LuminosityBlockID const& id) {
     if(fileIterEnd_ == fileIterBegin_) {
       throw Exception(errors::Configuration) << "RootInputFileSequence::readOneRandomWithID(): no input files specified.\n";
@@ -707,7 +708,7 @@ namespace edm {
         rootFile_->indexIntoFileIter().lumi() != id.luminosityBlock()) {
       bool found = skipToItem(id.run(), id.luminosityBlock(), 0);
       if(!found) {
-        return 0;
+        return false;
       }
       int eventsInLumi = 0;
       while(rootFile_->setEntryAtNextEventInLumi(id.run(), id.luminosityBlock())) ++eventsInLumi;
@@ -719,15 +720,18 @@ namespace edm {
         assert(found);
       }
     }
-    bool nextFound = rootFile_->setEntryAtNextEventInLumi(id.run(), id.luminosityBlock());
-    EventPrincipal* ep = (nextFound ? rootFile_->readCurrentEvent(cache) : 0);
-    if(ep == 0) {
-      bool found = rootFile_->setEntryAtItem(id.run(), id.luminosityBlock(), 0);
-      if(found) {
-        return readOneRandomWithID(cache, id);
-      }
+    bool found = rootFile_->setEntryAtNextEventInLumi(id.run(), id.luminosityBlock());
+    if(found) {
+      found = rootFile_->readCurrentEvent(cache);
     }
-    return ep;
+    if(!found) {
+      bool found = rootFile_->setEntryAtItem(id.run(), id.luminosityBlock(), 0);
+      if(!found) {
+        return false;
+      }
+      return readOneRandomWithID(cache, id);
+    }
+    return true;
   }
 
   void

--- a/IOPool/Input/src/RootInputFileSequence.h
+++ b/IOPool/Input/src/RootInputFileSequence.h
@@ -44,11 +44,11 @@ namespace edm {
     RootInputFileSequence& operator=(RootInputFileSequence const&) = delete; // Disallow copying and moving
 
     typedef boost::shared_ptr<RootFile> RootFileSharedPtr;
-    EventPrincipal* readEvent(EventPrincipal& cache);
+    void readEvent(EventPrincipal& cache);
     boost::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_();
-    boost::shared_ptr<LuminosityBlockPrincipal> readLuminosityBlock_(boost::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal);
+    void readLuminosityBlock_(boost::shared_ptr<LuminosityBlockPrincipal> lumiPrincipal);
     boost::shared_ptr<RunAuxiliary> readRunAuxiliary_();
-    boost::shared_ptr<RunPrincipal> readRun_(boost::shared_ptr<RunPrincipal> runPrincipal);
+    void readRun_(boost::shared_ptr<RunPrincipal> runPrincipal);
     std::unique_ptr<FileBlock> readFile_();
     void closeFile_();
     void endJob();
@@ -58,11 +58,11 @@ namespace edm {
     bool skipToItem(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event, bool currentFileFirst = true);
     bool skipToItemInNewFile(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event);
     void rewind_();
-    EventPrincipal* readOneRandom(EventPrincipal& cache);
-    EventPrincipal* readOneRandomWithID(EventPrincipal& cache, LuminosityBlockID const& id);
-    EventPrincipal* readOneSequential(EventPrincipal& cache);
-    EventPrincipal* readOneSequentialWithID(EventPrincipal& cache, LuminosityBlockID const& id);
-    EventPrincipal* readOneSpecified(EventPrincipal& cache, EventID const& id);
+    void readOneRandom(EventPrincipal& cache);
+    bool readOneRandomWithID(EventPrincipal& cache, LuminosityBlockID const& id);
+    bool readOneSequential(EventPrincipal& cache);
+    bool readOneSequentialWithID(EventPrincipal& cache, LuminosityBlockID const& id);
+    void readOneSpecified(EventPrincipal& cache, EventID const& id);
 
     void dropUnwantedBranches_(std::vector<std::string> const& wantedBranches);
     boost::shared_ptr<ProductRegistry const> fileProductRegistry() const;

--- a/IOPool/Streamer/interface/StreamerInputSource.h
+++ b/IOPool/Streamer/interface/StreamerInputSource.h
@@ -69,14 +69,14 @@ namespace edm {
 
       virtual WrapperHolder getIt(edm::ProductID const& id) const;
 
-      void setEventPrincipal(EventPrincipal *ep);
+      void setEventPrincipal(EventPrincipal* ep);
 
     private:
       // We don't own the principal.  The lifetime must be managed externally.
       EventPrincipal const* eventPrincipal_;
     };
 
-    virtual EventPrincipal* read(EventPrincipal& eventPrincipal);
+    virtual void read(EventPrincipal& eventPrincipal);
 
     virtual void setRun(RunNumber_t r);
 

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -263,7 +263,7 @@ namespace edm {
     setEventCached();
   }
 
-  EventPrincipal *
+  void
   StreamerInputSource::read(EventPrincipal& eventPrincipal) {
     if(adjustEventToNewProductRegistry_) {
       eventPrincipal.adjustIndexesAfterProductRegistryAddition();
@@ -307,8 +307,6 @@ namespace edm {
     }
 
     FDEBUG(10) << "Size = " << eventPrincipal.size() << std::endl;
-
-    return &eventPrincipal;
   }
 
   /**
@@ -383,7 +381,7 @@ namespace edm {
   }
 
   void
-  StreamerInputSource::ProductGetter::setEventPrincipal(EventPrincipal *ep) {
+  StreamerInputSource::ProductGetter::setEventPrincipal(EventPrincipal* ep) {
     eventPrincipal_ = ep;
   }
 

--- a/IORawData/DaqSource/plugins/DaqSource.cc
+++ b/IORawData/DaqSource/plugins/DaqSource.cc
@@ -589,7 +589,7 @@ namespace edm {
     return luminosityBlockAuxiliary();
   }
 
-  EventPrincipal*
+  void
   DaqSource::readEvent_(EventPrincipal& eventPrincipal) {
     //    std::cout << "assert not newRun " << std::endl;
     assert(!newRun());
@@ -628,7 +628,6 @@ namespace edm {
     // The commit is needed to complete the "put" transaction.
     e.commit_();
 */
-    return &eventPrincipal;
   }
 
   void
@@ -638,7 +637,7 @@ namespace edm {
         << "Contact a Framework developer.\n";
   }
 
-  EventPrincipal*
+  bool
   DaqSource::readIt(EventID const&) {
       throw edm::Exception(errors::LogicError,"DaqSource::readIt(EventID const& eventID)")
         << "Random access read cannot be used for DaqSource.\n"

--- a/IORawData/DaqSource/plugins/DaqSource.h
+++ b/IORawData/DaqSource/plugins/DaqSource.h
@@ -47,10 +47,10 @@ namespace edm {
    private:
 
     void defaultWebPage(xgi::Input *in, xgi::Output *out); 
-    virtual EventPrincipal* readEvent_(EventPrincipal& eventPrincipal);
+    virtual void readEvent_(EventPrincipal& eventPrincipal);
     virtual boost::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_();
     virtual boost::shared_ptr<RunAuxiliary> readRunAuxiliary_();
-    virtual EventPrincipal* readIt(EventID const& eventID);
+    virtual bool readIt(EventID const& eventID);
     virtual void skip(int offset);
     virtual void setLumi(LuminosityBlockNumber_t lb);
     virtual void setRun(RunNumber_t r);


### PR DESCRIPTION
Functions that read a run, lumi, or an event principal  fill in the principal that is passed in by reference.  These functions no longer create the principal. Therefore, there is no need for them to return a pointer to the principal.
With this pull request, these functions now return void or bool, as appropriate.
Also, the functions readAndCacheRun and readAndCacheLumi were modified to fill in the principal rather than creating it, and were renamed readRun and readLuminosityBlock respectively, because the caching of the principal
has been moved outside these functions.

The changes outside the framework are just minimal adaptions to the framework changes.

These changes have been tested by runTheMatrix.py -s and unit tests.  The full runTheMatrix.py is in progress.
