### PR TITLE
62X additional b-taggers

### DIFF
--- a/RecoBTag/ImpactParameter/python/impactParameter_cff.py
+++ b/RecoBTag/ImpactParameter/python/impactParameter_cff.py
@@ -8,13 +8,13 @@ from RecoBTau.JetTagComputer.jetTagRecord_cfi import *
 # MVA
 from RecoBTag.ImpactParameter.impactParameterMVAComputer_cfi import *
 from RecoBTag.ImpactParameter.impactParameterMVABJetTags_cfi import *
-#B Jet Prob
+# Jet BProb
 from RecoBTag.ImpactParameter.jetBProbabilityComputer_cfi import *
 from RecoBTag.ImpactParameter.jetBProbabilityBJetTags_cfi import *
-#Jet Prob
+# Jet Prob
 from RecoBTag.ImpactParameter.jetProbabilityComputer_cfi import *
 from RecoBTag.ImpactParameter.jetProbabilityBJetTags_cfi import *
-# HighEff
+# High Eff
 from RecoBTag.ImpactParameter.trackCounting3D2ndComputer_cfi import *
 from RecoBTag.ImpactParameter.trackCountingHighEffBJetTags_cfi import *
 # High Purity
@@ -23,8 +23,26 @@ from RecoBTag.ImpactParameter.trackCountingHighPurBJetTags_cfi import *
 
 # Negative Tags
 
-from RecoBTag.ImpactParameter.negativeTrackCountingHighEffJetTags_cfi import *
-from RecoBTag.ImpactParameter.negativeTrackCountingHighPurJetTags_cfi import *
+# Jet BProb
+from RecoBTag.ImpactParameter.negativeOnlyJetBProbabilityComputer_cfi import *
+from RecoBTag.ImpactParameter.negativeOnlyJetBProbabilityJetTags_cfi import *
+# Jet Prob
+from RecoBTag.ImpactParameter.negativeOnlyJetProbabilityComputer_cfi import *
+from RecoBTag.ImpactParameter.negativeOnlyJetProbabilityJetTags_cfi import *
+# High Eff
 from RecoBTag.ImpactParameter.negativeTrackCounting3D2ndComputer_cfi import *
+from RecoBTag.ImpactParameter.negativeTrackCountingHighEffJetTags_cfi import *
+# High Purity
 from RecoBTag.ImpactParameter.negativeTrackCounting3D3rdComputer_cfi import *
+from RecoBTag.ImpactParameter.negativeTrackCountingHighPurJetTags_cfi import *
+
+# Positive Tags
+
+# Jet BProb
+from RecoBTag.ImpactParameter.positiveOnlyJetBProbabilityComputer_cfi import *
+from RecoBTag.ImpactParameter.positiveOnlyJetBProbabilityJetTags_cfi import *
+# Jet Prob
+from RecoBTag.ImpactParameter.positiveOnlyJetProbabilityComputer_cfi import *
+from RecoBTag.ImpactParameter.positiveOnlyJetProbabilityJetTags_cfi import *
+
 

--- a/RecoBTag/ImpactParameter/python/negativeOnlyJetBProbabilityComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/negativeOnlyJetBProbabilityComputer_cfi.py
@@ -1,7 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoBTag.ImpactParameter.variableJTA_cfi import *
+
 # jetBProbability btag computer
 negativeOnlyJetBProbability = cms.ESProducer("JetBProbabilityESProducer",
+    variableJTAPars,
     impactParameterType = cms.int32(0), ## 0 = 3D, 1 = 2D
 
     deltaR = cms.double(-1.0), ## use cut from JTA
@@ -13,7 +16,8 @@ negativeOnlyJetBProbability = cms.ESProducer("JetBProbabilityESProducer",
     numberOfBTracks = cms.uint32(4),
     maximumDecayLength = cms.double(5.0),
 
-    trackQualityClass = cms.string("any")
+    trackQualityClass = cms.string("any"),
+    useVariableJTA = cms.bool(False)
 )
 
 

--- a/RecoBTag/ImpactParameter/python/negativeOnlyJetProbabilityComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/negativeOnlyJetProbabilityComputer_cfi.py
@@ -1,7 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoBTag.ImpactParameter.variableJTA_cfi import *
+
 # negativeOnlyJetProbability btag computer
 negativeOnlyJetProbability = cms.ESProducer("JetProbabilityESProducer",
+    variableJTAPars,
     impactParameterType = cms.int32(0), ## 0 = 3D, 1 = 2D
 
     deltaR = cms.double(0.3),
@@ -10,7 +13,8 @@ negativeOnlyJetProbability = cms.ESProducer("JetProbabilityESProducer",
 
     minimumProbability = cms.double(0.005),
     maximumDecayLength = cms.double(5.0),
-    trackQualityClass = cms.string("any")                                        
+    trackQualityClass = cms.string("any"),
+    useVariableJTA = cms.bool(False)
 )
 
 

--- a/RecoBTag/ImpactParameter/python/positiveOnlyJetBProbabilityComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/positiveOnlyJetBProbabilityComputer_cfi.py
@@ -1,7 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoBTag.ImpactParameter.variableJTA_cfi import *
+
 # jetBProbability btag computer
 positiveOnlyJetBProbability = cms.ESProducer("JetBProbabilityESProducer",
+    variableJTAPars,
     impactParameterType = cms.int32(0), ## 0 = 3D, 1 = 2D
 
     deltaR = cms.double(-1.0), ## use cut from JTA

--- a/RecoBTag/ImpactParameter/python/positiveOnlyJetProbabilityComputer_cfi.py
+++ b/RecoBTag/ImpactParameter/python/positiveOnlyJetProbabilityComputer_cfi.py
@@ -1,7 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoBTag.ImpactParameter.variableJTA_cfi import *
+
 # positiveOnlyJetProbability btag computer
 positiveOnlyJetProbability = cms.ESProducer("JetProbabilityESProducer",
+    variableJTAPars,
     impactParameterType = cms.int32(0), ## 0 = 3D, 1 = 2D
 
     deltaR = cms.double(0.3),

--- a/RecoBTag/SecondaryVertex/interface/SimpleSecondaryVertexComputer.h
+++ b/RecoBTag/SecondaryVertex/interface/SimpleSecondaryVertexComputer.h
@@ -16,17 +16,22 @@
 class SimpleSecondaryVertexComputer : public JetTagComputer {
     public:
 	SimpleSecondaryVertexComputer(const edm::ParameterSet &parameters) :
-		use2d(!parameters.getParameter<bool>("use3d")),
+	        use2d(!parameters.getParameter<bool>("use3d")),
 		useSig(parameters.getParameter<bool>("useSignificance")),
-		unBoost(parameters.getParameter<bool>("unBoost")),
-		minTracks(parameters.getParameter<unsigned int>("minTracks"))
-	{ uses("svTagInfos"); }
+	        unBoost(parameters.getParameter<bool>("unBoost")),
+	        minTracks(parameters.getParameter<unsigned int>("minTracks")),
+	        minVertices_(1)
+		  { 
+		    uses("svTagInfos"); 
+		    minVertices_    = parameters.existsAs<unsigned int>("minVertices") ?  parameters.getParameter<unsigned int>("minVertices") : 1 ;
+		  }
 
 	float discriminator(const TagInfoHelper &tagInfos) const
 	{
 		const reco::SecondaryVertexTagInfo &info =
 				tagInfos.get<reco::SecondaryVertexTagInfo>();
-		unsigned int idx = 0;
+		if(info.nVertices() < minVertices_) return -1;
+                unsigned int idx = 0;
 		while(idx < info.nVertices()) {
 			if (info.nVertexTracks(idx) >= minTracks)
 				break;
@@ -63,6 +68,7 @@ class SimpleSecondaryVertexComputer : public JetTagComputer {
 	bool		useSig;
 	bool		unBoost;
 	unsigned int	minTracks;
+	unsigned int    minVertices_;
 };
 
 #endif // RecoBTag_SecondaryVertex_SimpleSecondaryVertexComputer_h

--- a/RecoBTag/SecondaryVertex/plugins/BVertexFilter.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BVertexFilter.cc
@@ -13,7 +13,7 @@
 //
 // Original Author:  Andrea RIZZI
 //         Created:  Mon Dec  7 18:02:10 CET 2009
-// $Id: BVertexFilter.cc,v 1.1 2010/06/04 11:36:57 arizzi Exp $
+// $Id: BVertexFilter.cc,v 1.2 2012/10/06 21:17:41 alschmid Exp $
 //
 //
 
@@ -78,25 +78,28 @@ BVertexFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
  iEvent.getByLabel(primaryVertexCollection,pvHandle);
  edm::Handle<reco::VertexCollection> svHandle; 
  iEvent.getByLabel(secondaryVertexCollection,svHandle);
- const reco::Vertex & primary = (*pvHandle.product())[0];
- const reco::VertexCollection & vertices = *svHandle.product();
  std::auto_ptr<reco::VertexCollection> recoVertices(new reco::VertexCollection);
+ if(pvHandle->size()!=0) {
+   const reco::Vertex & primary = (*pvHandle.product())[0];
+   const reco::VertexCollection & vertices = *svHandle.product();
 
- if(! primary.isFake()) 
- {
-   for(reco::VertexCollection::const_iterator it=vertices.begin() ; it!=vertices.end() ; ++it)
-    {
-          GlobalVector axis(0,0,0);
-          if(useVertexKinematicAsJetAxis) axis = GlobalVector(it->p4().X(),it->p4().Y(),it->p4().Z());
-          if(svFilter(primary,reco::SecondaryVertex(primary,*it,axis,true),axis))  {
-                count++;
-                recoVertices->push_back(*it);
+
+   if(! primary.isFake()) 
+     {
+       for(reco::VertexCollection::const_iterator it=vertices.begin() ; it!=vertices.end() ; ++it)
+	 {
+	   GlobalVector axis(0,0,0);
+	   if(useVertexKinematicAsJetAxis) axis = GlobalVector(it->p4().X(),it->p4().Y(),it->p4().Z());
+	   if(svFilter(primary,reco::SecondaryVertex(primary,*it,axis,true),axis))  {
+	     count++;
+	     recoVertices->push_back(*it);
            }
-   }
+	 }
+     }
  }
-   iEvent.put(recoVertices);
-
-   return(count >= minVertices);
+ iEvent.put(recoVertices);
+ 
+ return(count >= minVertices);
 }
 
 

--- a/RecoBTag/SecondaryVertex/plugins/BtoCharmDecayVertexMerger.cc
+++ b/RecoBTag/SecondaryVertex/plugins/BtoCharmDecayVertexMerger.cc
@@ -1,0 +1,244 @@
+// this code is partially taken from BCandidateProducer of L. Wehrli
+
+// first revised prototype version for CMSSW 29.Aug.2012
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "RecoVertex/VertexTools/interface/VertexDistance3D.h"
+#include "RecoBTag/SecondaryVertex/interface/SecondaryVertex.h"
+
+#include "DataFormats/GeometryVector/interface/VectorUtil.h"
+
+#include <algorithm>
+
+class BtoCharmDecayVertexMerger : public edm::EDProducer {
+    public:
+	BtoCharmDecayVertexMerger(const edm::ParameterSet &params);
+
+	virtual void produce(edm::Event &event, const edm::EventSetup &es);
+
+    private:
+
+ 
+  edm::InputTag				primaryVertexCollection;
+  edm::InputTag				secondaryVertexCollection;
+  reco::Vertex pv;
+  //	double					maxFraction;
+  //	double					minSignificance;
+
+  double minDRForUnique, vecSumIMCUTForUnique, minCosPAtomerge, maxPtreltomerge; 
+
+  // a vertex proxy for sorting using stl
+  struct vertexProxy{
+    reco::Vertex vert; 
+    double invm;
+    size_t ntracks;
+  };
+
+  // comparison operator for vertexProxy, used in sorting
+  friend bool operator<(vertexProxy v1, vertexProxy v2){
+    if(v1.ntracks>2 && v2.ntracks<3) return true;
+    if(v1.ntracks<3 && v2.ntracks>2) return false;
+    return (v1.invm>v2.invm);
+  }
+
+  void resolveBtoDchain(std::vector<vertexProxy>& coll, unsigned int i, unsigned int k);
+  GlobalVector flightDirection(reco::Vertex &pv, reco::Vertex &sv);
+};
+
+
+
+BtoCharmDecayVertexMerger::BtoCharmDecayVertexMerger(const edm::ParameterSet &params) :
+	primaryVertexCollection(params.getParameter<edm::InputTag>("primaryVertices")),
+	secondaryVertexCollection(params.getParameter<edm::InputTag>("secondaryVertices")),
+	minDRForUnique(params.getUntrackedParameter<double>("minDRUnique",0.4)),
+	vecSumIMCUTForUnique(params.getUntrackedParameter<double>("minvecSumIMifsmallDRUnique",5.5)), 
+	minCosPAtomerge(params.getUntrackedParameter<double>("minCosPAtomerge",0.99)),
+	maxPtreltomerge(params.getUntrackedParameter<double>("maxPtreltomerge",7777.0))
+						    //	maxFraction(params.getParameter<double>("maxFraction")),
+						    //	minSignificance(params.getParameter<double>("minSignificance"))
+{
+	produces<reco::VertexCollection>();
+}
+//-----------------------
+void BtoCharmDecayVertexMerger::produce(edm::Event &iEvent, const edm::EventSetup &iSetup){
+
+  using namespace reco;
+  // PV
+  edm::Handle<reco::VertexCollection> PVcoll;
+  iEvent.getByLabel(primaryVertexCollection, PVcoll);
+
+  if(PVcoll->size()!=0) {
+
+  const reco::VertexCollection pvc = *( PVcoll.product());
+  pv = pvc[0];
+
+  // get the IVF collection
+  edm::Handle<VertexCollection> secondaryVertices;
+  iEvent.getByLabel(secondaryVertexCollection, secondaryVertices);
+  
+ 
+
+  //loop over vertices,  fill into own collection for sorting 
+  std::vector<vertexProxy> vertexProxyColl; 
+  for(std::vector<reco::Vertex>::const_iterator sv = secondaryVertices->begin();
+      sv != secondaryVertices->end(); ++sv) {
+    vertexProxy vtx = {*sv,(*sv).p4().M(),(*sv).tracksSize()};
+    vertexProxyColl.push_back( vtx );
+  }
+  
+  // sort the vertices by mass and track multiplicity
+  sort( vertexProxyColl.begin(), vertexProxyColl.end()); 
+  
+  
+  // loop forward over all vertices
+  for(unsigned int iVtx=0; iVtx < vertexProxyColl.size(); iVtx++){
+
+    // nested loop backwards (in order to start from light masses)
+    // check all vertices against each other for B->D chain
+    for(unsigned int kVtx=vertexProxyColl.size()-1; kVtx>iVtx; kVtx--){
+      // remove D vertices from the collection and add the tracks to the original one
+      resolveBtoDchain(vertexProxyColl, iVtx, kVtx); 
+    }
+  }
+
+  // now create new vertex collection and add to event
+  VertexCollection *bvertices = new VertexCollection();
+  for(std::vector<vertexProxy>::iterator it=vertexProxyColl.begin(); it!=vertexProxyColl.end(); it++) bvertices->push_back((*it).vert); 
+  std::auto_ptr<VertexCollection> bvertColl(bvertices);
+  iEvent.put(bvertColl);
+  }
+  else{
+    std::auto_ptr<VertexCollection> bvertCollEmpty(new VertexCollection);
+    iEvent.put(bvertCollEmpty);
+  }
+}
+
+
+//------------------------------------
+void BtoCharmDecayVertexMerger::resolveBtoDchain(std::vector<vertexProxy>& coll, unsigned int i, unsigned int k){
+  using namespace reco;
+
+  GlobalVector momentum1 = GlobalVector(coll[i].vert.p4().X(), coll[i].vert.p4().Y(), coll[i].vert.p4().Z());
+  GlobalVector momentum2 = GlobalVector(coll[k].vert.p4().X(), coll[k].vert.p4().Y(), coll[k].vert.p4().Z());
+
+  reco::SecondaryVertex sv1(pv, coll[i].vert, momentum1 , true);
+  reco::SecondaryVertex sv2(pv, coll[k].vert, momentum2 , true);
+
+ 
+  // find out which one is near and far
+  reco::SecondaryVertex svNear = sv1;
+  reco::SecondaryVertex svFar  = sv2;
+  GlobalVector momentumNear  = momentum1;
+  GlobalVector momentumFar   = momentum2;
+  
+  // swap if it is the other way around
+  if(sv1.dist3d().value() >= sv2.dist3d().value()){
+    svNear = sv2;
+    svFar = sv1;
+    momentumNear = momentum2;
+    momentumFar = momentum1;
+  }
+  GlobalVector nearToFar = flightDirection( svNear, svFar);
+  GlobalVector pvToNear  = flightDirection( pv, svNear);
+
+  double cosPA =  nearToFar.dot(momentumFar) / momentumFar.mag()/ nearToFar.mag();  
+  double cosa  =  pvToNear. dot(momentumFar) / pvToNear.mag()   / momentumFar.mag(); 
+  double ptrel = sqrt(1.0 - cosa*cosa)* momentumFar.mag();  
+  
+  double vertexDeltaR = Geom::deltaR(flightDirection(pv, sv1), flightDirection(pv, sv2) );
+
+  // create a set of all tracks from both vertices, avoid double counting by using a std::set<>
+  std::set<reco::TrackRef> trackrefs;
+  // first vertex
+  for(reco::Vertex::trackRef_iterator ti = sv1.tracks_begin(); ti!=sv1.tracks_end(); ti++){
+    if(sv1.trackWeight(*ti)>0.5){
+      reco::TrackRef t = ti->castTo<reco::TrackRef>();
+      trackrefs.insert(t);
+    }
+  }
+  // second vertex
+  for(reco::Vertex::trackRef_iterator ti = sv2.tracks_begin(); ti!=sv2.tracks_end(); ti++){
+    if(sv2.trackWeight(*ti)>0.5){
+      reco::TrackRef t = ti->castTo<reco::TrackRef>();
+      trackrefs.insert(t);
+    }
+  }
+  
+  // now calculate one LorentzVector from the track momenta
+  ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> > mother;
+  for(std::set<reco::TrackRef>::const_iterator it = trackrefs.begin(); it!= trackrefs.end(); it++){
+    ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> >  temp ( (*it)->px(),(*it)->py(),(*it)->pz(), 0.13957 );
+    mother += temp;
+  }
+ 
+
+  //   check if criteria for merging are fulfilled
+  if(vertexDeltaR<minDRForUnique && mother.M()<vecSumIMCUTForUnique && cosPA>minCosPAtomerge && fabs(ptrel)<maxPtreltomerge ) {
+    
+    
+    // add tracks of second vertex which are missing to first vertex
+    // loop over the second
+    bool bFoundDuplicate=false;
+    for(reco::Vertex::trackRef_iterator ti = sv2.tracks_begin(); ti!=sv2.tracks_end(); ti++){
+      reco::Vertex::trackRef_iterator it = find(sv1.tracks_begin(), sv1.tracks_end(), *ti);
+      if (it==sv1.tracks_end()) coll[i].vert.add( *ti, sv2.refittedTrack(*ti), sv2.trackWeight(*ti) );     
+      else bFoundDuplicate=true;
+    }
+    // in case a duplicate track is found, need to create the full track list in the vertex from scratch because we need to modify the weight.
+    // the weight must be the larger one, otherwise we may have outliers which are not real outliers
+    
+    if(bFoundDuplicate){
+      // create backup track containers from main vertex
+      std::vector<TrackBaseRef > tracks_;
+      std::vector<Track> refittedTracks_;
+      std::vector<float> weights_;
+      for(reco::Vertex::trackRef_iterator it = coll[i].vert.tracks_begin(); it!=coll[i].vert.tracks_end(); it++) {
+	tracks_.push_back( *it);
+	refittedTracks_.push_back( coll[i].vert.refittedTrack(*it));
+	weights_.push_back( coll[i].vert.trackWeight(*it) );
+      }
+      // delete tracks and add all tracks back, and check in which vertex the weight is larger
+      coll[i].vert.removeTracks();
+      std::vector<Track>::iterator it2 = refittedTracks_.begin();
+      std::vector<float>::iterator it3 = weights_.begin();
+      for(reco::Vertex::trackRef_iterator it = tracks_.begin(); it!=tracks_.end(); it++, it2++, it3++){
+	float weight = *it3;
+	float weight2= sv2.trackWeight(*it);
+	Track refittedTrackWithLargerWeight = *it2;
+	if( weight2 >weight) { 
+	  weight = weight2;
+	  refittedTrackWithLargerWeight = sv2.refittedTrack(*it);
+	}
+	coll[i].vert.add(*it , refittedTrackWithLargerWeight  , weight);
+      }
+    }
+    
+    // remove the second vertex from the collection
+    coll.erase( coll.begin() + k  );
+  }
+  
+}
+//-------------
+
+
+GlobalVector
+BtoCharmDecayVertexMerger::flightDirection(reco::Vertex &pv, reco::Vertex &sv){
+  GlobalVector res(sv.position().X() - pv.position().X(),
+                    sv.position().Y() - pv.position().Y(),
+                    sv.position().Z() - pv.position().Z());
+  return res;
+}
+
+
+
+DEFINE_FWK_MODULE(BtoCharmDecayVertexMerger);

--- a/RecoBTag/SecondaryVertex/plugins/BuildFile.xml
+++ b/RecoBTag/SecondaryVertex/plugins/BuildFile.xml
@@ -8,7 +8,7 @@
 <use name="DataFormats/BTauReco"/>
 <use name="RecoBTag/SecondaryVertex"/>
 <use name="boost"/>
-<library file="SecondaryVertexProducer.cc BVertexFilter.cc" name="RecoBTagSecondaryVertexProducer">
+<library file="SecondaryVertexProducer.cc BVertexFilter.cc BtoCharmDecayVertexMerger.cc" name="RecoBTagSecondaryVertexProducer">
    <use name="DataFormats/BeamSpot"/>
    <use name="TrackingTools/Records"/>
    <use name="TrackingTools/TransientTrack"/>

--- a/RecoBTag/SecondaryVertex/python/bToCharmDecayVertexMerger_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/bToCharmDecayVertexMerger_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+bToCharmDecayVertexMerged = cms.EDProducer("BtoCharmDecayVertexMerger",
+      primaryVertices  = cms.InputTag("offlinePrimaryVertices"),
+      secondaryVertices = cms.InputTag("inclusiveMergedVerticesFiltered"),
+      minDRUnique = cms.untracked.double(0.4),
+      minvecSumIMifsmallDRUnique = cms.untracked.double(5.5),
+      minCosPAtomerge = cms.untracked.double(0.99),
+      maxPtreltomerge = cms.untracked.double(7777.0)
+)

--- a/RecoBTag/SecondaryVertex/python/combinedInclusiveSecondaryVertexPositiveBJetTags_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/combinedInclusiveSecondaryVertexPositiveBJetTags_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+combinedInclusiveSecondaryVertexPositiveBJetTags = cms.EDProducer("JetTagProducer",
+        jetTagComputer = cms.string('combinedSecondaryVertexPositive'),
+        tagInfos = cms.VInputTag(cms.InputTag("impactParameterTagInfos"),
+                                 cms.InputTag("inclusiveSecondaryVertexFinderTagInfos"))
+)

--- a/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexBJetTags_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexBJetTags_cfi.py
@@ -5,3 +5,9 @@ combinedSecondaryVertexBJetTags = cms.EDProducer("JetTagProducer",
 	tagInfos = cms.VInputTag(cms.InputTag("impactParameterTagInfos"),
 	                         cms.InputTag("secondaryVertexTagInfos"))
 )
+
+combinedSecondaryVertexV1BJetTags = cms.EDProducer("JetTagProducer",
+	jetTagComputer = cms.string('combinedSecondaryVertexV1'),
+	tagInfos = cms.VInputTag(cms.InputTag("impactParameterTagInfos"),
+	                         cms.InputTag("secondaryVertexTagInfos"))
+)

--- a/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexES_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexES_cfi.py
@@ -11,3 +11,13 @@ combinedSecondaryVertex = cms.ESProducer("CombinedSecondaryVertexESProducer",
 		'CombinedSVNoVertex'),
 	categoryVariableName = cms.string('vertexCategory')
 )
+
+combinedSecondaryVertexV1 = cms.ESProducer("CombinedSecondaryVertexESProducer",
+	combinedSecondaryVertexCommon,
+	useCategories = cms.bool(True),
+	calibrationRecords = cms.vstring(
+		'CombinedSVRetrainRecoVertex', 
+		'CombinedSVRetrainPseudoVertex', 
+		'CombinedSVRetrainNoVertex'),
+	categoryVariableName = cms.string('vertexCategory')
+)

--- a/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexNegativeBJetTags_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexNegativeBJetTags_cfi.py
@@ -5,3 +5,9 @@ combinedSecondaryVertexNegativeBJetTags = cms.EDProducer("JetTagProducer",
 	tagInfos = cms.VInputTag(cms.InputTag("impactParameterTagInfos"),
 	                         cms.InputTag("secondaryVertexNegativeTagInfos"))
 )
+
+combinedSecondaryVertexV1NegativeBJetTags = cms.EDProducer("JetTagProducer",
+	jetTagComputer = cms.string('combinedSecondaryVertexV1Negative'),
+	tagInfos = cms.VInputTag(cms.InputTag("impactParameterTagInfos"),
+	                         cms.InputTag("secondaryVertexNegativeTagInfos"))
+)

--- a/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexNegativeES_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexNegativeES_cfi.py
@@ -9,3 +9,11 @@ combinedSecondaryVertexNegative.trackSelection.sip3dSigMax = 0
 combinedSecondaryVertexNegative.trackPseudoSelection.sip3dSigMax = 0
 combinedSecondaryVertexNegative.trackPseudoSelection.sip2dSigMin = -99999.9
 combinedSecondaryVertexNegative.trackPseudoSelection.sip2dSigMax = -2.0
+
+combinedSecondaryVertexV1Negative = RecoBTag.SecondaryVertex.combinedSecondaryVertexES_cfi.combinedSecondaryVertexV1.clone()
+combinedSecondaryVertexV1Negative.vertexFlip = True
+combinedSecondaryVertexV1Negative.trackFlip = True
+combinedSecondaryVertexV1Negative.trackSelection.sip3dSigMax = 0
+combinedSecondaryVertexV1Negative.trackPseudoSelection.sip3dSigMax = 0
+combinedSecondaryVertexV1Negative.trackPseudoSelection.sip2dSigMin = -99999.9
+combinedSecondaryVertexV1Negative.trackPseudoSelection.sip2dSigMax = -2.0

--- a/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexPositiveBJetTags_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexPositiveBJetTags_cfi.py
@@ -5,3 +5,9 @@ combinedSecondaryVertexPositiveBJetTags = cms.EDProducer("JetTagProducer",
 	tagInfos = cms.VInputTag(cms.InputTag("impactParameterTagInfos"),
 	                         cms.InputTag("secondaryVertexTagInfos"))
 )
+
+combinedSecondaryVertexV1PositiveBJetTags = cms.EDProducer("JetTagProducer",
+	jetTagComputer = cms.string('combinedSecondaryVertexV1Positive'),
+	tagInfos = cms.VInputTag(cms.InputTag("impactParameterTagInfos"),
+	                         cms.InputTag("secondaryVertexTagInfos"))
+)

--- a/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexPositiveES_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/combinedSecondaryVertexPositiveES_cfi.py
@@ -5,3 +5,7 @@ import RecoBTag.SecondaryVertex.combinedSecondaryVertexES_cfi
 combinedSecondaryVertexPositive = RecoBTag.SecondaryVertex.combinedSecondaryVertexES_cfi.combinedSecondaryVertex.clone()
 combinedSecondaryVertexPositive.trackSelection.sip3dSigMin = 0
 combinedSecondaryVertexPositive.trackPseudoSelection.sip3dSigMin = 0
+
+combinedSecondaryVertexV1Positive = RecoBTag.SecondaryVertex.combinedSecondaryVertexES_cfi.combinedSecondaryVertexV1.clone()
+combinedSecondaryVertexV1Positive.trackSelection.sip3dSigMin = 0
+combinedSecondaryVertexV1Positive.trackPseudoSelection.sip3dSigMin = 0

--- a/RecoBTag/SecondaryVertex/python/doubleSecondaryVertexHighEffBJetTags_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/doubleSecondaryVertexHighEffBJetTags_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+doubleSecondaryVertexHighEffBJetTags = cms.EDProducer("JetTagProducer",
+	jetTagComputer = cms.string('doubleVertex2Trk'),
+	tagInfos = cms.VInputTag(cms.InputTag("inclusiveSecondaryVertexFinderFilteredTagInfos"))
+)

--- a/RecoBTag/SecondaryVertex/python/doubleVertex2TrkES_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/doubleVertex2TrkES_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+doubleVertex2Trk = cms.ESProducer("SimpleSecondaryVertexESProducer",
+	use3d = cms.bool(True),
+	unBoost = cms.bool(False),
+	useSignificance = cms.bool(True),
+	minTracks = cms.uint32(2),
+        minVertices = cms.uint32(2) 
+)

--- a/RecoBTag/SecondaryVertex/python/inclusiveSecondaryVertexFinderTagInfos_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/inclusiveSecondaryVertexFinderTagInfos_cfi.py
@@ -11,3 +11,15 @@ inclusiveSecondaryVertexFinderTagInfos.useExternalSV = cms.bool(True)
 inclusiveSecondaryVertexFinderTagInfos.vertexCuts.fracPV = 0.79 ## 4 out of 5 is discarded
 inclusiveSecondaryVertexFinderTagInfos.vertexCuts.distSig2dMin = 2.0
 
+
+
+# filtered IVF as used in some analyses
+
+inclusiveSecondaryVertexFinderFilteredTagInfos = secondaryVertexTagInfos.clone()
+
+inclusiveSecondaryVertexFinderFilteredTagInfos.extSVCollection     = cms.InputTag('bToCharmDecayVertexMerged')
+inclusiveSecondaryVertexFinderFilteredTagInfos.extSVDeltaRToJet    = cms.double(0.5)
+inclusiveSecondaryVertexFinderFilteredTagInfos.useExternalSV = cms.bool(True)
+inclusiveSecondaryVertexFinderFilteredTagInfos.vertexCuts.fracPV = 0.79 ## 4 out of 5 is discarded
+inclusiveSecondaryVertexFinderFilteredTagInfos.vertexCuts.distSig2dMin = 2.0
+

--- a/RecoBTag/SecondaryVertex/python/secondaryVertex_cff.py
+++ b/RecoBTag/SecondaryVertex/python/secondaryVertex_cff.py
@@ -15,16 +15,32 @@ from RecoBTag.SecondaryVertex.ghostTrackVertexTagInfos_cfi import *
 from RecoBTag.SecondaryVertex.ghostTrackES_cfi import *
 from RecoBTag.SecondaryVertex.ghostTrackBJetTags_cfi import *
 
-#IVF
+# IVF
 from RecoBTag.SecondaryVertex.inclusiveSecondaryVertexFinderTagInfos_cfi import *
 from RecoBTag.SecondaryVertex.combinedInclusiveSecondaryVertexBJetTags_cfi import *
 #from RecoBTag.SecondaryVertex.combinedIVFES_cfi import * #not yet using dedicated training, share CSV ones
+from RecoBTag.SecondaryVertex.bVertexFilter_cfi import *
+inclusiveMergedVerticesFiltered = bVertexFilter.clone()
+inclusiveMergedVerticesFiltered.vertexFilter.multiplicityMin = 2
+inclusiveMergedVerticesFiltered.secondaryVertices = cms.InputTag("inclusiveMergedVertices")
 
-#negative taggers
+from RecoBTag.SecondaryVertex.bToCharmDecayVertexMerger_cfi import *
+from RecoBTag.SecondaryVertex.simpleInclusiveSecondaryVertexBJetTags_cfi import *
+from RecoBTag.SecondaryVertex.doubleVertex2TrkES_cfi import *
+from RecoBTag.SecondaryVertex.doubleSecondaryVertexHighEffBJetTags_cfi import *
+
+# Negative taggers
 from RecoBTag.SecondaryVertex.secondaryVertexNegativeTagInfos_cfi import *
 from RecoBTag.SecondaryVertex.simpleSecondaryVertexNegativeHighEffBJetTags_cfi import *
 from RecoBTag.SecondaryVertex.simpleSecondaryVertexNegativeHighPurBJetTags_cfi import *
+from RecoBTag.SecondaryVertex.combinedSecondaryVertexNegativeES_cfi import *
+from RecoBTag.SecondaryVertex.combinedSecondaryVertexNegativeBJetTags_cfi import *
 
-# backwards compatibility
+# Positive taggers
+from RecoBTag.SecondaryVertex.combinedSecondaryVertexPositiveES_cfi import *
+from RecoBTag.SecondaryVertex.combinedSecondaryVertexPositiveBJetTags_cfi import *
+from RecoBTag.SecondaryVertex.combinedInclusiveSecondaryVertexPositiveBJetTags_cfi import *
+
+# Backwards compatibility
 
 simpleSecondaryVertexBJetTags = simpleSecondaryVertexHighEffBJetTags.clone()

--- a/RecoBTag/SecondaryVertex/python/simpleInclusiveSecondaryVertexBJetTags_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/simpleInclusiveSecondaryVertexBJetTags_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+
+simpleInclusiveSecondaryVertexHighEffBJetTags = cms.EDProducer("JetTagProducer",
+	jetTagComputer = cms.string('simpleSecondaryVertex2Trk'),
+	tagInfos = cms.VInputTag(cms.InputTag("inclusiveSecondaryVertexFinderFilteredTagInfos"))
+)
+
+simpleInclusiveSecondaryVertexHighPurBJetTags = cms.EDProducer("JetTagProducer",
+	jetTagComputer = cms.string('simpleSecondaryVertex3Trk'),
+	tagInfos = cms.VInputTag(cms.InputTag("inclusiveSecondaryVertexFinderFilteredTagInfos"))
+)

--- a/RecoBTag/SoftLepton/python/muonSelection.py
+++ b/RecoBTag/SoftLepton/python/muonSelection.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+All                              = cms.uint32(0)           # dummy options - always true
+AllGlobalMuons                   = cms.uint32(1)           # checks isGlobalMuon flag
+AllStandAloneMuons               = cms.uint32(2)           # checks isStandAloneMuon flag
+AllTrackerMuons                  = cms.uint32(3)           # checks isTrackerMuon flag
+TrackerMuonArbitrated            = cms.uint32(4)           # resolve ambiguity of sharing segments
+AllArbitrated                    = cms.uint32(5)           # all muons with the tracker muon arbitrated
+GlobalMuonPromptTight            = cms.uint32(6)           # global muons with tighter fit requirements
+TMLastStationLoose               = cms.uint32(7)           # penetration depth loose selector
+TMLastStationTight               = cms.uint32(8)           # penetration depth tight selector
+TM2DCompatibilityLoose           = cms.uint32(9)           # likelihood based loose selector
+TM2DCompatibilityTight           = cms.uint32(10)          # likelihood based tight selector
+TMOneStationLoose                = cms.uint32(11)          # require one well matched segment
+TMOneStationTight                = cms.uint32(12)          # require one well matched segment
+TMLastStationOptimizedLowPtLoose = cms.uint32(13)          # combination of TMLastStation and TMOneStation
+TMLastStationOptimizedLowPtTight = cms.uint32(14)          # combination of TMLastStation and TMOneStation

--- a/RecoBTag/SoftLepton/python/softLepton_cff.py
+++ b/RecoBTag/SoftLepton/python/softLepton_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
 from RecoBTau.JetTagComputer.jetTagRecord_cfi import *
+from RecoBTag.SoftLepton.softMuonTagInfos_cfi import *
 from RecoBTag.SoftLepton.softPFElectronTagInfos_cfi import *
 from RecoBTag.SoftLepton.softPFMuonTagInfos_cfi import *
 from RecoBTag.SoftLepton.SoftLeptonByMLP_cfi import *

--- a/RecoBTag/SoftLepton/python/softMuonTagInfos_cfi.py
+++ b/RecoBTag/SoftLepton/python/softMuonTagInfos_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+import RecoBTag.SoftLepton.muonSelection
+
+# SoftLeptonTagInfo producer for tagging caloJets with global muons 
+softMuonTagInfos = cms.EDProducer("SoftLepton",
+    primaryVertex = cms.InputTag("offlinePrimaryVertices"),
+    jets = cms.InputTag("ak5CaloJets"),
+    leptons = cms.InputTag("muons"),
+    leptonCands = cms.InputTag(""),         # optional
+    leptonId = cms.InputTag(""),            # optional
+    
+    refineJetAxis = cms.uint32(0),          # use calorimetric jet direction by default
+
+    leptonDeltaRCut = cms.double(0.4),      # lepton distance from jet axis
+    leptonChi2Cut = cms.double(9999.0),     # no cut on lepton's track's chi2/ndof
+    
+    muonSelection = RecoBTag.SoftLepton.muonSelection.AllGlobalMuons
+)

--- a/RecoBTau/JetTagComputer/python/combinedMVABJetTags_cfi.py
+++ b/RecoBTau/JetTagComputer/python/combinedMVABJetTags_cfi.py
@@ -5,7 +5,17 @@ combinedMVABJetTags = cms.EDProducer("JetTagProducer",
 	tagInfos = cms.VInputTag(
 		cms.InputTag("impactParameterTagInfos"),
 		cms.InputTag("secondaryVertexTagInfos"),
-		cms.InputTag("softMuonTagInfos"),
-		cms.InputTag("softElectronTagInfos")
+		cms.InputTag("softPFMuonsTagInfos"),
+		cms.InputTag("softPFElectronsTagInfos")
+	)
+)
+
+combinedSecondaryVertexSoftPFLeptonV1BJetTags = cms.EDProducer("JetTagProducer",
+	jetTagComputer = cms.string('combinedSecondaryVertexSoftPFLeptonV1'),
+	tagInfos = cms.VInputTag(
+		cms.InputTag("impactParameterTagInfos"),
+		cms.InputTag("secondaryVertexTagInfos"),
+		cms.InputTag("softPFMuonsTagInfos"),
+		cms.InputTag("softPFElectronsTagInfos")
 	)
 )

--- a/RecoBTau/JetTagComputer/python/combinedMVAES_cfi.py
+++ b/RecoBTau/JetTagComputer/python/combinedMVAES_cfi.py
@@ -17,12 +17,39 @@ combinedMVA = cms.ESProducer("CombinedMVAJetTagESProducer",
 		cms.PSet(
 			discriminator = cms.bool(True),
 			variables = cms.bool(False),
-			jetTagComputer = cms.string('softMuon')
+			jetTagComputer = cms.string('softPFMuon')
 		),
 		cms.PSet(
 			discriminator = cms.bool(True),
 			variables = cms.bool(False),
-			jetTagComputer = cms.string('softElectron')
+			jetTagComputer = cms.string('softPFElectron')
+		)
+	)
+)
+
+combinedSecondaryVertexSoftPFLeptonV1 = cms.ESProducer("CombinedMVAJetTagESProducer",
+	useCategories = cms.bool(False),
+	calibrationRecord = cms.string('CombinedCSVSL'),
+	jetTagComputers = cms.VPSet(
+		cms.PSet(
+			discriminator = cms.bool(True),
+			variables = cms.bool(False),
+			jetTagComputer = cms.string('jetProbability')
+		),
+		cms.PSet(
+			discriminator = cms.bool(True),
+			variables = cms.bool(False),
+			jetTagComputer = cms.string('combinedSecondaryVertexV1')
+		),
+		cms.PSet(
+			discriminator = cms.bool(True),
+			variables = cms.bool(False),
+			jetTagComputer = cms.string('softPFMuon')
+		),
+		cms.PSet(
+			discriminator = cms.bool(True),
+			variables = cms.bool(False),
+			jetTagComputer = cms.string('softPFElectron')
 		)
 	)
 )

--- a/RecoBTau/JetTagComputer/python/combinedMVA_cff.py
+++ b/RecoBTau/JetTagComputer/python/combinedMVA_cff.py
@@ -2,3 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoBTau.JetTagComputer.combinedMVAES_cfi import *
 from RecoBTau.JetTagComputer.combinedMVABJetTags_cfi import *
+from RecoBTau.JetTagComputer.negativeCombinedMVAES_cfi import *
+from RecoBTau.JetTagComputer.negativeCombinedMVABJetTags_cfi import *
+from RecoBTau.JetTagComputer.positiveCombinedMVAES_cfi import *
+from RecoBTau.JetTagComputer.positiveCombinedMVABJetTags_cfi import *

--- a/RecoBTau/JetTagComputer/python/negativeCombinedMVABJetTags_cfi.py
+++ b/RecoBTau/JetTagComputer/python/negativeCombinedMVABJetTags_cfi.py
@@ -4,8 +4,18 @@ negativeCombinedMVABJetTags = cms.EDProducer("JetTagProducer",
 	jetTagComputer = cms.string('negativeCombinedMVA'),
 	tagInfos = cms.VInputTag(
 		cms.InputTag("impactParameterTagInfos"),
-		cms.InputTag("secondaryVertexTagInfos"),
-		cms.InputTag("softMuonTagInfos"),
-		cms.InputTag("softElectronTagInfos")
+		cms.InputTag("secondaryVertexNegativeTagInfos"),
+		cms.InputTag("softPFMuonsTagInfos"),
+		cms.InputTag("softPFElectronsTagInfos")
+	)
+)
+
+negativeCombinedSecondaryVertexSoftPFLeptonV1BJetTags = cms.EDProducer("JetTagProducer",
+	jetTagComputer = cms.string('negativeCombinedSecondaryVertexSoftPFLeptonV1'),
+	tagInfos = cms.VInputTag(
+		cms.InputTag("impactParameterTagInfos"),
+		cms.InputTag("secondaryVertexNegativeTagInfos"),
+		cms.InputTag("softPFMuonsTagInfos"),
+		cms.InputTag("softPFElectronsTagInfos")
 	)
 )

--- a/RecoBTau/JetTagComputer/python/negativeCombinedMVAES_cfi.py
+++ b/RecoBTau/JetTagComputer/python/negativeCombinedMVAES_cfi.py
@@ -7,7 +7,7 @@ negativeCombinedMVA = cms.ESProducer("CombinedMVAJetTagESProducer",
 		cms.PSet(
 			discriminator = cms.bool(True),
 			variables = cms.bool(False),
-			jetTagComputer = cms.string('negativeOnlyJetProbabilityJetTags')
+			jetTagComputer = cms.string('negativeOnlyJetProbability')
 		),
 		cms.PSet(
 			discriminator = cms.bool(True),
@@ -17,12 +17,39 @@ negativeCombinedMVA = cms.ESProducer("CombinedMVAJetTagESProducer",
 		cms.PSet(
 			discriminator = cms.bool(True),
 			variables = cms.bool(False),
-			jetTagComputer = cms.string('negativeSoftMuon')
+			jetTagComputer = cms.string('negativeSoftPFMuon')
 		),
 		cms.PSet(
 			discriminator = cms.bool(True),
 			variables = cms.bool(False),
-			jetTagComputer = cms.string('negativeSoftElectron')
+			jetTagComputer = cms.string('negativeSoftPFElectron')
+		)
+	)
+)
+
+negativeCombinedSecondaryVertexSoftPFLeptonV1 = cms.ESProducer("CombinedMVAJetTagESProducer",
+	useCategories = cms.bool(False),
+	calibrationRecord = cms.string('CombinedCSVSL'),
+	jetTagComputers = cms.VPSet(
+		cms.PSet(
+			discriminator = cms.bool(True),
+			variables = cms.bool(False),
+			jetTagComputer = cms.string('negativeOnlyJetProbability')
+		),
+		cms.PSet(
+			discriminator = cms.bool(True),
+			variables = cms.bool(False),
+			jetTagComputer = cms.string('combinedSecondaryVertexV1Negative')
+		),
+		cms.PSet(
+			discriminator = cms.bool(True),
+			variables = cms.bool(False),
+			jetTagComputer = cms.string('negativeSoftPFMuon')
+		),
+		cms.PSet(
+			discriminator = cms.bool(True),
+			variables = cms.bool(False),
+			jetTagComputer = cms.string('negativeSoftPFElectron')
 		)
 	)
 )

--- a/RecoBTau/JetTagComputer/python/negativeCombinedMVA_cff.py
+++ b/RecoBTau/JetTagComputer/python/negativeCombinedMVA_cff.py
@@ -1,4 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from RecoBTau.JetTagComputer.negativeCombinedMVAES_cfi import *
-from RecoBTau.JetTagComputer.negativeCombinedMVABJetTags_cfi import *

--- a/RecoBTau/JetTagComputer/python/positiveCombinedMVABJetTags_cfi.py
+++ b/RecoBTau/JetTagComputer/python/positiveCombinedMVABJetTags_cfi.py
@@ -5,7 +5,17 @@ positiveCombinedMVABJetTags = cms.EDProducer("JetTagProducer",
 	tagInfos = cms.VInputTag(
 		cms.InputTag("impactParameterTagInfos"),
 		cms.InputTag("secondaryVertexTagInfos"),
-		cms.InputTag("softMuonTagInfos"),
-		cms.InputTag("softElectronTagInfos")
+		cms.InputTag("softPFMuonsTagInfos"),
+		cms.InputTag("softPFElectronsTagInfos")
+	)
+)
+
+positiveCombinedSecondaryVertexSoftPFLeptonV1BJetTags = cms.EDProducer("JetTagProducer",
+	jetTagComputer = cms.string('positiveCombinedSecondaryVertexSoftPFLeptonV1'),
+	tagInfos = cms.VInputTag(
+		cms.InputTag("impactParameterTagInfos"),
+		cms.InputTag("secondaryVertexTagInfos"),
+		cms.InputTag("softPFMuonsTagInfos"),
+		cms.InputTag("softPFElectronsTagInfos")
 	)
 )

--- a/RecoBTau/JetTagComputer/python/positiveCombinedMVAES_cfi.py
+++ b/RecoBTau/JetTagComputer/python/positiveCombinedMVAES_cfi.py
@@ -7,7 +7,7 @@ positiveCombinedMVA = cms.ESProducer("CombinedMVAJetTagESProducer",
 		cms.PSet(
 			discriminator = cms.bool(True),
 			variables = cms.bool(False),
-			jetTagComputer = cms.string('positiveOnlyJetProbabilityJetTags')
+			jetTagComputer = cms.string('positiveOnlyJetProbability')
 		),
 		cms.PSet(
 			discriminator = cms.bool(True),
@@ -17,12 +17,39 @@ positiveCombinedMVA = cms.ESProducer("CombinedMVAJetTagESProducer",
 		cms.PSet(
 			discriminator = cms.bool(True),
 			variables = cms.bool(False),
-			jetTagComputer = cms.string('positiveSoftMuon')
+			jetTagComputer = cms.string('positiveSoftPFMuon')
 		),
 		cms.PSet(
 			discriminator = cms.bool(True),
 			variables = cms.bool(False),
-			jetTagComputer = cms.string('positiveSoftElectron')
+			jetTagComputer = cms.string('positiveSoftPFElectron')
+		)
+	)
+)
+
+positiveCombinedSecondaryVertexSoftPFLeptonV1 = cms.ESProducer("CombinedMVAJetTagESProducer",
+	useCategories = cms.bool(False),
+	calibrationRecord = cms.string('CombinedCSVSL'),
+	jetTagComputers = cms.VPSet(
+		cms.PSet(
+			discriminator = cms.bool(True),
+			variables = cms.bool(False),
+			jetTagComputer = cms.string('positiveOnlyJetProbability')
+		),
+		cms.PSet(
+			discriminator = cms.bool(True),
+			variables = cms.bool(False),
+			jetTagComputer = cms.string('combinedSecondaryVertexV1Positive')
+		),
+		cms.PSet(
+			discriminator = cms.bool(True),
+			variables = cms.bool(False),
+			jetTagComputer = cms.string('positiveSoftPFMuon')
+		),
+		cms.PSet(
+			discriminator = cms.bool(True),
+			variables = cms.bool(False),
+			jetTagComputer = cms.string('positiveSoftPFElectron')
 		)
 	)
 )

--- a/RecoBTau/JetTagComputer/python/positiveCombinedMVA_cff.py
+++ b/RecoBTau/JetTagComputer/python/positiveCombinedMVA_cff.py
@@ -1,4 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from RecoBTau.JetTagComputer.positiveCombinedMVAES_cfi import *
-from RecoBTau.JetTagComputer.positiveCombinedMVABJetTags_cfi import *


### PR DESCRIPTION
Updates corresponding to the CVS tag change V01-04-11 --> V01-04-13 of RecoBTag/ImpactParameter
- additional negative and positive taggers added to RecoBTag/ImpactParameter/python/impactParameter_cff.py
- bugfix for negative and positive jet probability b-taggers (added missing variable JTA parameters)

Updates corresponding to the CVS tag change V01-08-03 --> V01-11-02 of RecoBTag/SecondaryVertex
- added retrained CSV (CSVV1) and double SV taggers

Updates corresponding to the CVS tag change V05-09-10 --> V05-09-11 of RecoBTag/SoftLepton
- recovered softMuonTagInfos

Updates corresponding to the CVS tag change V02-03-00 --> V02-03-02 of RecoBTau/JetTagComputer
- added super-combined CSV + soft lepton (CSVSLV1) tagger
