### PR TITLE
build a vector applying a transformation to each element of an input vector

### DIFF
--- a/FWCore/Utilities/interface/transform.h
+++ b/FWCore/Utilities/interface/transform.h
@@ -1,0 +1,21 @@
+#ifndef FWCore_Utilities_transform_h
+#define FWCore_Utilities_transform_h
+
+#include <vector>
+
+namespace edm {
+
+  // helper template function to build a vector applying a transformation to the elements of an input vector
+  template <typename ReturnType, typename InputType, typename Function>
+  std::vector<ReturnType> vector_transform(std::vector<InputType> const & input, Function predicate)
+  {
+    std::vector<ReturnType> output;
+    output.reserve( input.size() );
+    for (auto const & element : input)
+      output.push_back(predicate(element));
+    return output;
+  }
+
+} // namespace edm
+
+#endif // FWCore_Utilities_transform_h

--- a/FWCore/Utilities/interface/transform.h
+++ b/FWCore/Utilities/interface/transform.h
@@ -6,9 +6,10 @@
 namespace edm {
 
   // helper template function to build a vector applying a transformation to the elements of an input vector
-  template <typename ReturnType, typename InputType, typename Function>
-  std::vector<ReturnType> vector_transform(std::vector<InputType> const & input, Function predicate)
+  template <typename InputType, typename Function>
+  auto vector_transform(std::vector<InputType> const & input, Function predicate) -> std::vector<decltype(predicate(input.front()))>
   {
+    using ReturnType = decltype(predicate(input.front()));
     std::vector<ReturnType> output;
     output.reserve( input.size() );
     for (auto const & element : input)

--- a/FWCore/Utilities/interface/transform.h
+++ b/FWCore/Utilities/interface/transform.h
@@ -2,14 +2,15 @@
 #define FWCore_Utilities_transform_h
 
 #include <vector>
+#include <type_traits>
 
 namespace edm {
 
   // helper template function to build a vector applying a transformation to the elements of an input vector
   template <typename InputType, typename Function>
-  auto vector_transform(std::vector<InputType> const & input, Function predicate) -> std::vector<decltype(predicate(input.front()))>
+  auto vector_transform(std::vector<InputType> const & input, Function predicate) -> std::vector<typename std::remove_cv<typename std::remove_reference<decltype(predicate(input.front()))>::type>::type>
   {
-    using ReturnType = decltype(predicate(input.front()));
+    using ReturnType = typename std::remove_cv<typename std::remove_reference<decltype(predicate(input.front()))>::type>::type;
     std::vector<ReturnType> output;
     output.reserve( input.size() );
     for (auto const & element : input)

--- a/FWCore/Utilities/test/BuildFile.xml
+++ b/FWCore/Utilities/test/BuildFile.xml
@@ -35,7 +35,7 @@
 <bin   file="MallocOpts_t.cpp">
   <use   name="cppunit"/>
 </bin>
-<bin   name="testFWCoreUtilities" file="typeidbase_t.cppunit.cpp,typeid_t.cppunit.cpp,cputimer_t.cppunit.cpp,extensioncord_t.cppunit.cpp,friendlyname_t.cppunit.cpp,signal_t.cppunit.cpp,soatuple_t.cppunit.cpp">
+<bin   name="testFWCoreUtilities" file="typeidbase_t.cppunit.cpp,typeid_t.cppunit.cpp,cputimer_t.cppunit.cpp,extensioncord_t.cppunit.cpp,friendlyname_t.cppunit.cpp,signal_t.cppunit.cpp,soatuple_t.cppunit.cpp,transform.cppunit.cpp">
   <use   name="cppunit"/>
 </bin>
 

--- a/FWCore/Utilities/test/transform.cppunit.cpp
+++ b/FWCore/Utilities/test/transform.cppunit.cpp
@@ -1,0 +1,68 @@
+/*----------------------------------------------------------------------
+
+Test program for edm::vector_transform class.
+
+ ----------------------------------------------------------------------*/
+
+#include <cassert>
+#include <iostream>
+#include <string>
+#include <boost/algorithm/string.hpp>
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "FWCore/Utilities/interface/transform.h"
+
+
+class testTransform: public CppUnit::TestFixture
+{
+  CPPUNIT_TEST_SUITE(testTransform);
+
+  CPPUNIT_TEST(valueTest);
+
+  CPPUNIT_TEST_SUITE_END();
+
+public:
+  void setUp() {}
+  void tearDown() {}
+
+  void valueTest();
+};
+
+// register the test so that the runner can find it
+CPPUNIT_TEST_SUITE_REGISTRATION(testTransform);
+
+
+std::string byvalue_toupper(std::string const & value)
+{
+  return boost::to_upper_copy( value );
+}
+
+const std::string byconstvalue_toupper(std::string const & value)
+{
+  return boost::to_upper_copy( value );
+}
+
+std::string & byref_toupper(std::string const & value)
+{
+  return * new std::string(boost::to_upper_copy( value ));
+}
+
+std::string & byconstref_toupper(std::string const & value)
+{
+  return * new std::string(boost::to_upper_copy( value ));
+}
+
+void testTransform::valueTest()
+{
+  const std::vector<std::string> input { "Hello", "World" };
+  const std::vector<std::string> upper { "HELLO", "WORLD" };
+  const std::vector<std::string::size_type> size  { 5, 5 };
+
+  auto test_lambda = edm::vector_transform( input, [](std::string const & value) { return value.size(); } );
+  CPPUNIT_ASSERT( size  == test_lambda );
+
+  CPPUNIT_ASSERT( upper == edm::vector_transform(input, byvalue_toupper) );
+  CPPUNIT_ASSERT( upper == edm::vector_transform(input, byconstvalue_toupper) );
+  CPPUNIT_ASSERT( upper == edm::vector_transform(input, byref_toupper) );
+  CPPUNIT_ASSERT( upper == edm::vector_transform(input, byconstref_toupper) );
+}


### PR DESCRIPTION
helper template function to build a vector by applying a transformation function to each elements of an input vector
- return type deduction by @makortel 
- reference and cv-qualified return types should be properly handled
