### PR TITLE
Have TriggerResults see all transitions

### DIFF
--- a/FWCore/Framework/src/GlobalSchedule.cc
+++ b/FWCore/Framework/src/GlobalSchedule.cc
@@ -1,5 +1,6 @@
 #include "FWCore/Framework/src/GlobalSchedule.h"
 #include "FWCore/Framework/src/WorkerMaker.h"
+#include "FWCore/Framework/src/TriggerResultInserter.h"
 
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
@@ -15,7 +16,8 @@
 #include <map>
 
 namespace edm {
-  GlobalSchedule::GlobalSchedule(boost::shared_ptr<ModuleRegistry> modReg,
+  GlobalSchedule::GlobalSchedule(TriggerResultInserter* inserter,
+                                 boost::shared_ptr<ModuleRegistry> modReg,
                                  std::vector<std::string> const& iModulesToUse,
                                  ParameterSet& proc_pset,
                                  ProductRegistry& pregistry,
@@ -39,6 +41,12 @@ namespace edm {
       
       //side effect keeps this module around
       addToAllWorkers(workerManager_.getWorker(*modpset, pregistry, processConfiguration, moduleLabel));
+
+    }
+    if(inserter) {
+      results_inserter_.reset(new edm::WorkerT<TriggerResultInserter::ModuleType>(inserter, inserter->moduleDescription(), &actions));
+      results_inserter_->setActivityRegistry(actReg_);
+      addToAllWorkers(results_inserter_.get());
     }
 
   } // GlobalSchedule::GlobalSchedule

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -58,15 +58,17 @@ namespace edm {
   class ProcessContext;
   class PreallocationConfiguration;
   class ModuleRegistry;
+  class TriggerResultInserter;
   
   class GlobalSchedule {
   public:
     typedef std::vector<std::string> vstring;
     typedef std::vector<Worker*> AllWorkers;
-
+    typedef boost::shared_ptr<Worker> WorkerPtr;
     typedef std::vector<Worker*> Workers;
 
-    GlobalSchedule(boost::shared_ptr<ModuleRegistry> modReg,
+    GlobalSchedule(TriggerResultInserter* inserter,
+                   boost::shared_ptr<ModuleRegistry> modReg,
                    std::vector<std::string> const& modulesToUse,
                    ParameterSet& proc_pset,
                    ProductRegistry& pregistry,
@@ -120,10 +122,12 @@ namespace edm {
     
     void addToAllWorkers(Worker* w);
     
-    WorkerManager            workerManager_;
-    boost::shared_ptr<ActivityRegistry>           actReg_;
+    WorkerManager                         workerManager_;
+    boost::shared_ptr<ActivityRegistry>   actReg_;
+    WorkerPtr                             results_inserter_;
 
-    ProcessContext const*          processContext_;
+
+    ProcessContext const*                 processContext_;
   };
 
 

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -374,14 +374,19 @@ namespace edm {
       std::copy(modulesToUse.begin(),itBeginUnscheduled,std::back_inserter(temp));
       temp.swap(modulesToUse);
     }
-    globalSchedule_.reset( new GlobalSchedule{ moduleRegistry_,
+    globalSchedule_.reset( new GlobalSchedule{ resultsInserter_.get(),
+      moduleRegistry_,
       modulesToUse,
       proc_pset, preg,
       actions,areg,processConfiguration,processContext });
     
+    //TriggerResults is not in the top level ParameterSet so the call to
+    // reduceParameterSet would fail to find it. Just remove it up front.
     std::set<std::string> usedModuleLabels;
     for( auto const worker: allWorkers()) {
-      usedModuleLabels.insert(worker->description().moduleLabel());
+      if(worker->description().moduleLabel() != kTriggerResults) {
+        usedModuleLabels.insert(worker->description().moduleLabel());
+      }
     }
     std::vector<std::string> modulesInConfig(proc_pset.getParameter<std::vector<std::string> >("@all_modules"));
     std::map<std::string, std::vector<std::pair<std::string, int> > > outputModulePathPositions;

--- a/FWCore/Framework/test/eventprocessor_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprocessor_t.cppunit.cc
@@ -608,7 +608,7 @@ testeventprocessor::activityRegistryTest() {
 
   typedef std::vector<edm::ModuleDescription const*> ModuleDescs;
   ModuleDescs allModules = proc.getAllModuleDescriptions();
-  CPPUNIT_ASSERT(1 == allModules.size()); // TestMod
+  CPPUNIT_ASSERT(2 == allModules.size()); // TestMod & TriggerResults
   //std::cout << "\nModuleDescriptions in testeventprocessor::activityRegistryTest()---\n";
   for (ModuleDescs::const_iterator i = allModules.begin(), e = allModules.end();
        i != e ;

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -40,6 +40,8 @@ Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e81
 ++ ModuleBeginJob finished: a3
 ++ ModuleBeginJob: out
 ++ ModuleBeginJob finished: out
+++ ModuleBeginJob: TriggerResults
+++ ModuleBeginJob finished: TriggerResults
 ++ Job started
 ++++ ModuleBeginStream: intProducer
 ++++ ModuleBeginStream finished
@@ -112,6 +114,8 @@ ModuleCallingContext state = Running
 ++++++ ModuleGlobalBeginRun finished: a3
 ++++++ ModuleGlobalBeginRun: out
 ++++++ ModuleGlobalBeginRun finished: out
+++++++ ModuleGlobalBeginRun: TriggerResults
+++++++ ModuleGlobalBeginRun finished: TriggerResults
 ++++ GlobalBeginRun finished
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
@@ -230,6 +234,8 @@ ModuleCallingContext state = Running
 ++++++ ModuleGlobalBeginLumi finished: a3
 ++++++ ModuleGlobalBeginLumi: out
 ++++++ ModuleGlobalBeginLumi finished: out
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -736,6 +742,8 @@ ModuleCallingContext state = Running
 ++++++ ModuleGlobalEndLumi finished: a3
 ++++++ ModuleGlobalEndLumi: out
 ++++++ ModuleGlobalEndLumi finished: out
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -852,6 +860,8 @@ ModuleCallingContext state = Running
 ++++++ ModuleGlobalEndRun finished: a3
 ++++++ ModuleGlobalEndRun: out
 ++++++ ModuleGlobalEndRun finished: out
+++++++ ModuleGlobalEndRun: TriggerResults
+++++++ ModuleGlobalEndRun finished: TriggerResults
 ++++ GlobalEndRun finished
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
@@ -918,4 +928,6 @@ TestFindProduct sum = 300
 ++ ModuleEndJob finished: a3
 ++ ModuleEndJob: out
 ++ ModuleEndJob finished: out
+++ ModuleEndJob: TriggerResults
+++ ModuleEndJob finished: TriggerResults
 ++ Job ended

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -26,6 +26,8 @@ Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196e
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
 ++ ModuleBeginJob: out
 ++ ModuleBeginJob finished: out
+++ ModuleBeginJob: TriggerResults
+++ ModuleBeginJob finished: TriggerResults
 ++ Job started
 ++++ ModuleBeginStream: intProducer
 StreamContext: StreamID = 0 transition = BeginStream
@@ -82,6 +84,8 @@ ModuleCallingContext state = Running
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 ++++++ ModuleGlobalBeginRun: out
 ++++++ ModuleGlobalBeginRun finished: out
+++++++ ModuleGlobalBeginRun: TriggerResults
+++++++ ModuleGlobalBeginRun finished: TriggerResults
 ++++ GlobalBeginRun finished
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
@@ -160,6 +164,8 @@ ModuleCallingContext state = Running
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 ++++++ ModuleGlobalBeginLumi: out
 ++++++ ModuleGlobalBeginLumi finished: out
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -533,6 +539,8 @@ ModuleCallingContext state = Running
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 ++++++ ModuleGlobalEndLumi: out
 ++++++ ModuleGlobalEndLumi finished: out
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -609,6 +617,8 @@ ModuleCallingContext state = Running
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 ++++++ ModuleGlobalEndRun: out
 ++++++ ModuleGlobalEndRun finished: out
+++++++ ModuleGlobalEndRun: TriggerResults
+++++++ ModuleGlobalEndRun finished: TriggerResults
 ++++ GlobalEndRun finished
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
@@ -646,4 +656,6 @@ Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196e
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
 ++ ModuleEndJob: out
 ++ ModuleEndJob finished: out
+++ ModuleEndJob: TriggerResults
+++ ModuleEndJob finished: TriggerResults
 ++ Job ended

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -46,6 +46,8 @@
 ++ ModuleBeginJob finished: getInt
 ++ ModuleBeginJob: noPut
 ++ ModuleBeginJob finished: noPut
+++ ModuleBeginJob: TriggerResults
+++ ModuleBeginJob finished: TriggerResults
 ++ ModuleBeginJob: thingWithMergeProducer
 ++ ModuleBeginJob finished: thingWithMergeProducer
 ++ ModuleBeginJob: test
@@ -60,6 +62,8 @@
 ++ ModuleBeginJob finished: dependsOnNoPut
 ++ ModuleBeginJob: out
 ++ ModuleBeginJob finished: out
+++ ModuleBeginJob: TriggerResults
+++ ModuleBeginJob finished: TriggerResults
 ++ Job started
 ++++ ModuleBeginStream: thingWithMergeProducer
 ++++ ModuleBeginStream finished
@@ -114,6 +118,8 @@
 ++++++ ModuleGlobalBeginRun finished: getInt
 ++++++ ModuleGlobalBeginRun: noPut
 ++++++ ModuleGlobalBeginRun finished: noPut
+++++++ ModuleGlobalBeginRun: TriggerResults
+++++++ ModuleGlobalBeginRun finished: TriggerResults
 ++++ GlobalBeginRun finished
 ++++ GlobalBeginRun run: 1 time: 1
 ++++ GlobalBeginRun finished
@@ -132,6 +138,8 @@
 ++++++ ModuleGlobalBeginRun finished: dependsOnNoPut
 ++++++ ModuleGlobalBeginRun: out
 ++++++ ModuleGlobalBeginRun finished: out
+++++++ ModuleGlobalBeginRun: TriggerResults
+++++++ ModuleGlobalBeginRun finished: TriggerResults
 ++++ GlobalBeginRun finished
 ++++ StreamBeginRun run: 1 time: 1
 ++++ StreamBeginRun finished
@@ -192,6 +200,8 @@
 ++++++ ModuleGlobalBeginLumi finished: getInt
 ++++++ ModuleGlobalBeginLumi: noPut
 ++++++ ModuleGlobalBeginLumi finished: noPut
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 ++++ GlobalBeginLumi run: 1 lumi: 1 time: 1
 ++++ GlobalBeginLumi finished
@@ -210,6 +220,8 @@
 ++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
 ++++++ ModuleGlobalBeginLumi: out
 ++++++ ModuleGlobalBeginLumi finished: out
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 ++++ StreamBeginLumi run: 1 lumi: 1 time: 1
 ++++ StreamBeginLumi finished
@@ -546,6 +558,8 @@
 ++++++ ModuleGlobalEndLumi finished: getInt
 ++++++ ModuleGlobalEndLumi: noPut
 ++++++ ModuleGlobalEndLumi finished: noPut
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 ++++ GlobalEndLumi run: 1 lumi: 1 time: 1
 ++++ GlobalEndLumi finished
@@ -564,6 +578,8 @@
 ++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
 ++++++ ModuleGlobalEndLumi: out
 ++++++ ModuleGlobalEndLumi finished: out
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 ++++ source lumi
 ++++ finished: source lumi
@@ -586,6 +602,8 @@
 ++++++ ModuleGlobalBeginLumi finished: getInt
 ++++++ ModuleGlobalBeginLumi: noPut
 ++++++ ModuleGlobalBeginLumi finished: noPut
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 ++++ GlobalBeginLumi run: 1 lumi: 2 time: 25000001
 ++++ GlobalBeginLumi finished
@@ -604,6 +622,8 @@
 ++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
 ++++++ ModuleGlobalBeginLumi: out
 ++++++ ModuleGlobalBeginLumi finished: out
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 ++++ StreamBeginLumi run: 1 lumi: 2 time: 25000001
 ++++ StreamBeginLumi finished
@@ -940,6 +960,8 @@
 ++++++ ModuleGlobalEndLumi finished: getInt
 ++++++ ModuleGlobalEndLumi: noPut
 ++++++ ModuleGlobalEndLumi finished: noPut
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 ++++ GlobalEndLumi run: 1 lumi: 2 time: 25000001
 ++++ GlobalEndLumi finished
@@ -958,6 +980,8 @@
 ++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
 ++++++ ModuleGlobalEndLumi: out
 ++++++ ModuleGlobalEndLumi finished: out
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 ++++ source lumi
 ++++ finished: source lumi
@@ -980,6 +1004,8 @@
 ++++++ ModuleGlobalBeginLumi finished: getInt
 ++++++ ModuleGlobalBeginLumi: noPut
 ++++++ ModuleGlobalBeginLumi finished: noPut
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 ++++ GlobalBeginLumi run: 1 lumi: 3 time: 45000001
 ++++ GlobalBeginLumi finished
@@ -998,6 +1024,8 @@
 ++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
 ++++++ ModuleGlobalBeginLumi: out
 ++++++ ModuleGlobalBeginLumi finished: out
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 ++++ StreamBeginLumi run: 1 lumi: 3 time: 45000001
 ++++ StreamBeginLumi finished
@@ -1214,6 +1242,8 @@
 ++++++ ModuleGlobalEndLumi finished: getInt
 ++++++ ModuleGlobalEndLumi: noPut
 ++++++ ModuleGlobalEndLumi finished: noPut
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 ++++ GlobalEndLumi run: 1 lumi: 3 time: 45000001
 ++++ GlobalEndLumi finished
@@ -1232,6 +1262,8 @@
 ++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
 ++++++ ModuleGlobalEndLumi: out
 ++++++ ModuleGlobalEndLumi finished: out
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 ++++ StreamEndRun run: 1 time: 50000001
 ++++ StreamEndRun finished
@@ -1290,6 +1322,8 @@
 ++++++ ModuleGlobalEndRun finished: getInt
 ++++++ ModuleGlobalEndRun: noPut
 ++++++ ModuleGlobalEndRun finished: noPut
+++++++ ModuleGlobalEndRun: TriggerResults
+++++++ ModuleGlobalEndRun finished: TriggerResults
 ++++ GlobalEndRun finished
 ++++ GlobalEndRun run: 1 time: 0
 ++++ GlobalEndRun finished
@@ -1308,6 +1342,8 @@
 ++++++ ModuleGlobalEndRun finished: dependsOnNoPut
 ++++++ ModuleGlobalEndRun: out
 ++++++ ModuleGlobalEndRun finished: out
+++++++ ModuleGlobalEndRun: TriggerResults
+++++++ ModuleGlobalEndRun finished: TriggerResults
 ++++ GlobalEndRun finished
 ++++ source run
 ++++ finished: source run
@@ -1330,6 +1366,8 @@
 ++++++ ModuleGlobalBeginRun finished: getInt
 ++++++ ModuleGlobalBeginRun: noPut
 ++++++ ModuleGlobalBeginRun finished: noPut
+++++++ ModuleGlobalBeginRun: TriggerResults
+++++++ ModuleGlobalBeginRun finished: TriggerResults
 ++++ GlobalBeginRun finished
 ++++ GlobalBeginRun run: 2 time: 55000001
 ++++ GlobalBeginRun finished
@@ -1348,6 +1386,8 @@
 ++++++ ModuleGlobalBeginRun finished: dependsOnNoPut
 ++++++ ModuleGlobalBeginRun: out
 ++++++ ModuleGlobalBeginRun finished: out
+++++++ ModuleGlobalBeginRun: TriggerResults
+++++++ ModuleGlobalBeginRun finished: TriggerResults
 ++++ GlobalBeginRun finished
 ++++ StreamBeginRun run: 2 time: 55000001
 ++++ StreamBeginRun finished
@@ -1408,6 +1448,8 @@
 ++++++ ModuleGlobalBeginLumi finished: getInt
 ++++++ ModuleGlobalBeginLumi: noPut
 ++++++ ModuleGlobalBeginLumi finished: noPut
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 ++++ GlobalBeginLumi run: 2 lumi: 1 time: 55000001
 ++++ GlobalBeginLumi finished
@@ -1426,6 +1468,8 @@
 ++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
 ++++++ ModuleGlobalBeginLumi: out
 ++++++ ModuleGlobalBeginLumi finished: out
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 ++++ StreamBeginLumi run: 2 lumi: 1 time: 55000001
 ++++ StreamBeginLumi finished
@@ -1762,6 +1806,8 @@
 ++++++ ModuleGlobalEndLumi finished: getInt
 ++++++ ModuleGlobalEndLumi: noPut
 ++++++ ModuleGlobalEndLumi finished: noPut
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 ++++ GlobalEndLumi run: 2 lumi: 1 time: 55000001
 ++++ GlobalEndLumi finished
@@ -1780,6 +1826,8 @@
 ++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
 ++++++ ModuleGlobalEndLumi: out
 ++++++ ModuleGlobalEndLumi finished: out
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 ++++ source lumi
 ++++ finished: source lumi
@@ -1802,6 +1850,8 @@
 ++++++ ModuleGlobalBeginLumi finished: getInt
 ++++++ ModuleGlobalBeginLumi: noPut
 ++++++ ModuleGlobalBeginLumi finished: noPut
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 ++++ GlobalBeginLumi run: 2 lumi: 2 time: 75000001
 ++++ GlobalBeginLumi finished
@@ -1820,6 +1870,8 @@
 ++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
 ++++++ ModuleGlobalBeginLumi: out
 ++++++ ModuleGlobalBeginLumi finished: out
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 ++++ StreamBeginLumi run: 2 lumi: 2 time: 75000001
 ++++ StreamBeginLumi finished
@@ -2156,6 +2208,8 @@
 ++++++ ModuleGlobalEndLumi finished: getInt
 ++++++ ModuleGlobalEndLumi: noPut
 ++++++ ModuleGlobalEndLumi finished: noPut
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 ++++ GlobalEndLumi run: 2 lumi: 2 time: 75000001
 ++++ GlobalEndLumi finished
@@ -2174,6 +2228,8 @@
 ++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
 ++++++ ModuleGlobalEndLumi: out
 ++++++ ModuleGlobalEndLumi finished: out
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 ++++ source lumi
 ++++ finished: source lumi
@@ -2196,6 +2252,8 @@
 ++++++ ModuleGlobalBeginLumi finished: getInt
 ++++++ ModuleGlobalBeginLumi: noPut
 ++++++ ModuleGlobalBeginLumi finished: noPut
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 ++++ GlobalBeginLumi run: 2 lumi: 3 time: 95000001
 ++++ GlobalBeginLumi finished
@@ -2214,6 +2272,8 @@
 ++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
 ++++++ ModuleGlobalBeginLumi: out
 ++++++ ModuleGlobalBeginLumi finished: out
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 ++++ StreamBeginLumi run: 2 lumi: 3 time: 95000001
 ++++ StreamBeginLumi finished
@@ -2430,6 +2490,8 @@
 ++++++ ModuleGlobalEndLumi finished: getInt
 ++++++ ModuleGlobalEndLumi: noPut
 ++++++ ModuleGlobalEndLumi finished: noPut
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 ++++ GlobalEndLumi run: 2 lumi: 3 time: 95000001
 ++++ GlobalEndLumi finished
@@ -2448,6 +2510,8 @@
 ++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
 ++++++ ModuleGlobalEndLumi: out
 ++++++ ModuleGlobalEndLumi finished: out
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 ++++ StreamEndRun run: 2 time: 100000001
 ++++ StreamEndRun finished
@@ -2506,6 +2570,8 @@
 ++++++ ModuleGlobalEndRun finished: getInt
 ++++++ ModuleGlobalEndRun: noPut
 ++++++ ModuleGlobalEndRun finished: noPut
+++++++ ModuleGlobalEndRun: TriggerResults
+++++++ ModuleGlobalEndRun finished: TriggerResults
 ++++ GlobalEndRun finished
 ++++ GlobalEndRun run: 2 time: 0
 ++++ GlobalEndRun finished
@@ -2524,6 +2590,8 @@
 ++++++ ModuleGlobalEndRun finished: dependsOnNoPut
 ++++++ ModuleGlobalEndRun: out
 ++++++ ModuleGlobalEndRun finished: out
+++++++ ModuleGlobalEndRun: TriggerResults
+++++++ ModuleGlobalEndRun finished: TriggerResults
 ++++ GlobalEndRun finished
 ++++ source run
 ++++ finished: source run
@@ -2546,6 +2614,8 @@
 ++++++ ModuleGlobalBeginRun finished: getInt
 ++++++ ModuleGlobalBeginRun: noPut
 ++++++ ModuleGlobalBeginRun finished: noPut
+++++++ ModuleGlobalBeginRun: TriggerResults
+++++++ ModuleGlobalBeginRun finished: TriggerResults
 ++++ GlobalBeginRun finished
 ++++ GlobalBeginRun run: 3 time: 105000001
 ++++ GlobalBeginRun finished
@@ -2564,6 +2634,8 @@
 ++++++ ModuleGlobalBeginRun finished: dependsOnNoPut
 ++++++ ModuleGlobalBeginRun: out
 ++++++ ModuleGlobalBeginRun finished: out
+++++++ ModuleGlobalBeginRun: TriggerResults
+++++++ ModuleGlobalBeginRun finished: TriggerResults
 ++++ GlobalBeginRun finished
 ++++ StreamBeginRun run: 3 time: 105000001
 ++++ StreamBeginRun finished
@@ -2624,6 +2696,8 @@
 ++++++ ModuleGlobalBeginLumi finished: getInt
 ++++++ ModuleGlobalBeginLumi: noPut
 ++++++ ModuleGlobalBeginLumi finished: noPut
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 ++++ GlobalBeginLumi run: 3 lumi: 1 time: 105000001
 ++++ GlobalBeginLumi finished
@@ -2642,6 +2716,8 @@
 ++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
 ++++++ ModuleGlobalBeginLumi: out
 ++++++ ModuleGlobalBeginLumi finished: out
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 ++++ StreamBeginLumi run: 3 lumi: 1 time: 105000001
 ++++ StreamBeginLumi finished
@@ -2978,6 +3054,8 @@
 ++++++ ModuleGlobalEndLumi finished: getInt
 ++++++ ModuleGlobalEndLumi: noPut
 ++++++ ModuleGlobalEndLumi finished: noPut
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 ++++ GlobalEndLumi run: 3 lumi: 1 time: 105000001
 ++++ GlobalEndLumi finished
@@ -2996,6 +3074,8 @@
 ++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
 ++++++ ModuleGlobalEndLumi: out
 ++++++ ModuleGlobalEndLumi finished: out
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 ++++ source lumi
 ++++ finished: source lumi
@@ -3018,6 +3098,8 @@
 ++++++ ModuleGlobalBeginLumi finished: getInt
 ++++++ ModuleGlobalBeginLumi: noPut
 ++++++ ModuleGlobalBeginLumi finished: noPut
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 ++++ GlobalBeginLumi run: 3 lumi: 2 time: 125000001
 ++++ GlobalBeginLumi finished
@@ -3036,6 +3118,8 @@
 ++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
 ++++++ ModuleGlobalBeginLumi: out
 ++++++ ModuleGlobalBeginLumi finished: out
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 ++++ StreamBeginLumi run: 3 lumi: 2 time: 125000001
 ++++ StreamBeginLumi finished
@@ -3372,6 +3456,8 @@
 ++++++ ModuleGlobalEndLumi finished: getInt
 ++++++ ModuleGlobalEndLumi: noPut
 ++++++ ModuleGlobalEndLumi finished: noPut
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 ++++ GlobalEndLumi run: 3 lumi: 2 time: 125000001
 ++++ GlobalEndLumi finished
@@ -3390,6 +3476,8 @@
 ++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
 ++++++ ModuleGlobalEndLumi: out
 ++++++ ModuleGlobalEndLumi finished: out
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 ++++ source lumi
 ++++ finished: source lumi
@@ -3412,6 +3500,8 @@
 ++++++ ModuleGlobalBeginLumi finished: getInt
 ++++++ ModuleGlobalBeginLumi: noPut
 ++++++ ModuleGlobalBeginLumi finished: noPut
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 ++++ GlobalBeginLumi run: 3 lumi: 3 time: 145000001
 ++++ GlobalBeginLumi finished
@@ -3430,6 +3520,8 @@
 ++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
 ++++++ ModuleGlobalBeginLumi: out
 ++++++ ModuleGlobalBeginLumi finished: out
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
 ++++ GlobalBeginLumi finished
 ++++ StreamBeginLumi run: 3 lumi: 3 time: 145000001
 ++++ StreamBeginLumi finished
@@ -3646,6 +3738,8 @@
 ++++++ ModuleGlobalEndLumi finished: getInt
 ++++++ ModuleGlobalEndLumi: noPut
 ++++++ ModuleGlobalEndLumi finished: noPut
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 ++++ GlobalEndLumi run: 3 lumi: 3 time: 145000001
 ++++ GlobalEndLumi finished
@@ -3664,6 +3758,8 @@
 ++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
 ++++++ ModuleGlobalEndLumi: out
 ++++++ ModuleGlobalEndLumi finished: out
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
 ++++ GlobalEndLumi finished
 ++++ StreamEndRun run: 3 time: 150000001
 ++++ StreamEndRun finished
@@ -3722,6 +3818,8 @@
 ++++++ ModuleGlobalEndRun finished: getInt
 ++++++ ModuleGlobalEndRun: noPut
 ++++++ ModuleGlobalEndRun finished: noPut
+++++++ ModuleGlobalEndRun: TriggerResults
+++++++ ModuleGlobalEndRun finished: TriggerResults
 ++++ GlobalEndRun finished
 ++++ GlobalEndRun run: 3 time: 0
 ++++ GlobalEndRun finished
@@ -3740,6 +3838,8 @@
 ++++++ ModuleGlobalEndRun finished: dependsOnNoPut
 ++++++ ModuleGlobalEndRun: out
 ++++++ ModuleGlobalEndRun finished: out
+++++++ ModuleGlobalEndRun: TriggerResults
+++++++ ModuleGlobalEndRun finished: TriggerResults
 ++++ GlobalEndRun finished
 ++++ ModuleEndStream: 
 ++++ ModuleEndStream finished
@@ -3787,6 +3887,8 @@
 ++ ModuleEndJob finished: getInt
 ++ ModuleEndJob: noPut
 ++ ModuleEndJob finished: noPut
+++ ModuleEndJob: TriggerResults
+++ ModuleEndJob finished: TriggerResults
 ++ ModuleEndJob: thingWithMergeProducer
 ++ ModuleEndJob finished: thingWithMergeProducer
 ++ ModuleEndJob: test
@@ -3801,4 +3903,6 @@
 ++ ModuleEndJob finished: dependsOnNoPut
 ++ ModuleEndJob: out
 ++ ModuleEndJob finished: out
+++ ModuleEndJob: TriggerResults
+++ ModuleEndJob finished: TriggerResults
 ++ Job ended


### PR DESCRIPTION
The FastTimerService requires that all modules see the beginJob transition
in order for it to register that module. A recent change to the framework made
the TriggerResults only see Stream based transitions since that is all it needed.
This change makes TriggerResults see all transitions again.
