### PR TITLE
Muon Selectors for legacy 53X

### DIFF
--- a/DataFormats/MuonReco/interface/MuonCocktails.h
+++ b/DataFormats/MuonReco/interface/MuonCocktails.h
@@ -106,6 +106,22 @@ namespace muon {
 				    const double tune=4.);
   
   double trackProbability(const reco::TrackRef track);
+ 
+  inline bool cocktailInputIsOK(const reco::TrackRef& combinedTrack,
+				 const reco::TrackRef& trackerTrack,
+				const reco::TrackRef& tpfmsTrack,
+				const reco::TrackRef& pickyTrack){
+    
+    return combinedTrack.isNonnull() && trackerTrack.isNonnull() && tpfmsTrack.isNonnull() && pickyTrack.isNonnull();
+  }
+  
+  inline bool cocktailInputIsOK(const reco::Muon& muon){
+    return cocktailInputIsOK(muon.globalTrack(),
+			     muon.innerTrack(),
+			     muon.tpfmsTrack(),
+			     muon.pickyTrack());
+  }
+  
 }
 
 #endif

--- a/DataFormats/MuonReco/interface/MuonCocktails.h
+++ b/DataFormats/MuonReco/interface/MuonCocktails.h
@@ -12,6 +12,7 @@
  */
 
 #include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackToTrackMap.h"
 
@@ -122,6 +123,6 @@ namespace muon {
 			     muon.pickyTrack());
   }
   
+  reco::Muon::MuonTrackTypePair muonBestTrack(const reco::Muon& muon, reco::TunePType tunePType);
 }
-
 #endif

--- a/DataFormats/MuonReco/interface/MuonFwd.h
+++ b/DataFormats/MuonReco/interface/MuonFwd.h
@@ -27,6 +27,9 @@ namespace reco {
   class CaloMuon;
   /// collection of Muon objects
   typedef std::vector<CaloMuon> CaloMuonCollection;
+
+  // For tuneP selection
+  enum TunePType{defaultTuneP, improvedTuneP};
 }
 
 #endif

--- a/DataFormats/MuonReco/interface/MuonSelectors.h
+++ b/DataFormats/MuonReco/interface/MuonSelectors.h
@@ -85,8 +85,7 @@ namespace muon {
    bool isLooseMuon(const reco::Muon&);
    bool isSoftMuon(const reco::Muon&, const reco::Vertex&);
    enum TunePType{defaultTuneP, improvedTuneP};
-   bool isHighPtMuon(const reco::Muon&, const reco::Vertex&, TunePType = muon::improvedTuneP);
-   reco::TrackRef improvedMuonBestTrack(const reco::Muon&, TunePType);
+   bool isHighPtMuon(const reco::Muon&, const reco::Vertex&, TunePType);
 
    // determine if station was crossed well withing active volume
    unsigned int RequiredStationMask( const reco::Muon& muon,

--- a/DataFormats/MuonReco/interface/MuonSelectors.h
+++ b/DataFormats/MuonReco/interface/MuonSelectors.h
@@ -8,6 +8,7 @@
 // $Id: MuonSelectors.h,v 1.14.2.1.4.1 2013/04/26 11:02:08 bachtis Exp $
 
 #include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "TMath.h"
 #include <string>
 
@@ -84,8 +85,7 @@ namespace muon {
    bool isTightMuon(const reco::Muon&, const reco::Vertex&);
    bool isLooseMuon(const reco::Muon&);
    bool isSoftMuon(const reco::Muon&, const reco::Vertex&);
-   enum TunePType{defaultTuneP, improvedTuneP};
-   bool isHighPtMuon(const reco::Muon&, const reco::Vertex&, TunePType);
+   bool isHighPtMuon(const reco::Muon&, const reco::Vertex&, reco::TunePType);
 
    // determine if station was crossed well withing active volume
    unsigned int RequiredStationMask( const reco::Muon& muon,

--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -740,12 +740,12 @@ bool muon::isSoftMuon(const reco::Muon& muon, const reco::Vertex& vtx){
   return muID && layers && ip && chi2;
 }
 
-bool muon::isHighPtMuon(const reco::Muon& muon, const reco::Vertex& vtx, TunePType tunePType){
+bool muon::isHighPtMuon(const reco::Muon& muon, const reco::Vertex& vtx, reco::TunePType tunePType){
 
   bool muID =  muon.isGlobalMuon() && muon.globalTrack()->hitPattern().numberOfValidMuonHits() >0 && (muon.numberOfMatchedStations() > 1);
   if(!muID) return false;
 
-  if(tunePType == improvedTuneP){ 
+  if(tunePType == reco::improvedTuneP){ 
   // Get the optimized track
     reco::TrackRef cktTrack = (muon::tevOptimized(muon, 200, 17., 40., 0.25)).first;
 
@@ -763,7 +763,7 @@ bool muon::isHighPtMuon(const reco::Muon& muon, const reco::Vertex& vtx, TunePTy
 
     return muID && hits && momQuality && ip;}
 
-  else if(tunePType == defaultTuneP){
+  else if(tunePType == reco::defaultTuneP){
   // Get the optimized track
     reco::TrackRef cktTrack = (muon::tevOptimized(muon, 200, 4., 6., -1)).first;
 

--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -776,14 +776,6 @@ bool muon::isHighPtMuon(const reco::Muon& muon, const reco::Vertex& vtx, TunePTy
   else return false;
 }
 
-reco::TrackRef muon::improvedMuonBestTrack(const reco::Muon& muon, TunePType tunePType){
-  reco::TrackRef cktTrack;
-  if(tunePType == improvedTuneP){ 
-    cktTrack = (muon::tevOptimized(muon, 200, 17., 40., 0.25)).first;}
-  else if (tunePType == defaultTuneP){
-    cktTrack = (muon::tevOptimized(muon, 200, 4., 6., -1)).first;}
-  return cktTrack;
-}
 
 int muon::sharedSegments( const reco::Muon& mu, const reco::Muon& mu2, unsigned int segmentArbitrationMask ) {
     int ret = 0;

--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -52,7 +52,7 @@ namespace pat {
 
     public:
 
-      enum TunePType{defaultTuneP, improvedTuneP};
+    //enum TunePType{defaultTuneP, improvedTuneP};
 
 
       /// default constructor
@@ -83,9 +83,15 @@ namespace pat {
       reco::TrackRef combinedMuon() const;
       /// reference to Track reconstructed in both tracked and muon detector (reimplemented from reco::Muon)
       reco::TrackRef globalTrack() const { return combinedMuon(); }
+      /// reference to the Best Track reconstructed in both tracked and muon detector (reimplemented from reco::Muon), old (default bt deprecated) tuneP
+      reco::TrackRef muonBestTrack() const;
+      /// reference to the Best Track reconstructed in both tracked and muon detector (reimplemented from reco::Muon), after new tuneP
+      reco::TrackRef improvedMuonBestTrack() const;
 
       /// set reference to Track selected to be the best measurement of the muon parameters (reimplemented from reco::Muon)
       void embedMuonBestTrack();
+      /// set reference to Track selected to be the best measurement of the muon parameters (reimplemented from reco::Muon), after new tuneP
+      void embedImprovedMuonBestTrack();
       /// set reference to Track reconstructed in the tracker only (reimplemented from reco::Muon)
       void embedTrack();
       /// set reference to Track reconstructed in the muon detector only (reimplemented from reco::Muon)
@@ -158,7 +164,7 @@ namespace pat {
       /// make sure you know what you are doing. If you use the default tuneP for the momentum assignment 
       /// then use defaultTuneP. Insted if you use the newly optimized version (present in release 537 and above)
       /// then use improvedTuneP. 
-      bool isHighPtMuon(const reco::Vertex&, TunePType) const;
+      bool isHighPtMuon(const reco::Vertex&, muon::TunePType) const;
 
       // ---- overload of isolation functions ----
       /// Overload of pat::Lepton::trackIso(); returns the value of
@@ -240,6 +246,9 @@ namespace pat {
       /// best muon track
       bool embeddedMuonBestTrack_;
       std::vector<reco::Track> muonBestTrack_;
+      /// best muon track, after new tuneP
+      bool embeddedImprovedMuonBestTrack_;
+      std::vector<reco::Track> improvedMuonBestTrack_;
       /// track of inner track detector
       bool embeddedTrack_;
       std::vector<reco::Track> track_;

--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -161,7 +161,7 @@ namespace pat {
       /// make sure you know what you are doing. If you use the default tuneP for the momentum assignment 
       /// then use defaultTuneP. Insted if you use the newly optimized version (present in release 537 and above)
       /// then use improvedTuneP. 
-      bool isHighPtMuon(const reco::Vertex&, muon::TunePType) const;
+      bool isHighPtMuon(const reco::Vertex&, reco::TunePType) const;
 
       // ---- overload of isolation functions ----
       /// Overload of pat::Lepton::trackIso(); returns the value of

--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -81,9 +81,9 @@ namespace pat {
       /// reference to Track reconstructed in both tracked and muon detector (reimplemented from reco::Muon)
       reco::TrackRef globalTrack() const { return combinedMuon(); }
       /// reference to the Best Track reconstructed in both tracked and muon detector (reimplemented from reco::Muon), old (default bt deprecated) tuneP
-      reco::TrackRef muonBestTrack() const;
+      reco::TrackRef muonBestTrack();
       /// reference to the Best Track reconstructed in both tracked and muon detector (reimplemented from reco::Muon), after new tuneP
-      reco::TrackRef improvedMuonBestTrack() const;
+      reco::TrackRef improvedMuonBestTrack();
 
       /// set reference to Track selected to be the best measurement of the muon parameters (reimplemented from reco::Muon)
       void embedMuonBestTrack();

--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -85,6 +85,11 @@ namespace pat {
       /// reference to the Best Track reconstructed in both tracked and muon detector (reimplemented from reco::Muon), after new tuneP
       reco::TrackRef improvedMuonBestTrack();
 
+      // get reference to the Improved Best Track
+      virtual MuonTrackType improvedMuonBestTrackType() const {return improvedMuonBestTrackType_;}
+      // set reference to the Improved Best Track
+      virtual void setImprovedBestTrack(MuonTrackType muonType) {improvedMuonBestTrackType_ = muonType;}
+
       /// set reference to Track selected to be the best measurement of the muon parameters (reimplemented from reco::Muon)
       void embedMuonBestTrack();
       /// set reference to Track selected to be the best measurement of the muon parameters (reimplemented from reco::Muon), after new tuneP
@@ -246,6 +251,7 @@ namespace pat {
       /// best muon track, after new tuneP
       bool embeddedImprovedMuonBestTrack_;
       std::vector<reco::Track> improvedMuonBestTrack_;
+      MuonTrackType improvedMuonBestTrackType_;
       /// track of inner track detector
       bool embeddedTrack_;
       std::vector<reco::Track> track_;

--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -52,9 +52,6 @@ namespace pat {
 
     public:
 
-    //enum TunePType{defaultTuneP, improvedTuneP};
-
-
       /// default constructor
       Muon();
       /// constructor from a reco muon

--- a/DataFormats/PatCandidates/interface/TriggerAlgorithm.h
+++ b/DataFormats/PatCandidates/interface/TriggerAlgorithm.h
@@ -7,7 +7,7 @@
 // Package:    PatCandidates
 // Class:      pat::TriggerAlgorithm
 //
-// $Id: TriggerAlgorithm.h,v 1.4 2011/02/22 18:29:50 vadler Exp $
+// $Id: TriggerAlgorithm.h,v 1.5 2013/06/11 13:24:49 vadler Exp $
 //
 /**
   \class    pat::TriggerAlgorithm TriggerAlgorithm.h "DataFormats/PatCandidates/interface/TriggerAlgorithm.h"
@@ -18,7 +18,7 @@
    https://twiki.cern.ch/twiki/bin/view/CMS/SWGuidePATTrigger#TriggerAlgorithm
 
   \author   Volker Adler
-  \version  $Id: TriggerAlgorithm.h,v 1.4 2011/02/22 18:29:50 vadler Exp $
+  \version  $Id: TriggerAlgorithm.h,v 1.5 2013/06/11 13:24:49 vadler Exp $
 */
 
 
@@ -101,11 +101,11 @@ namespace pat {
       /// Add a new trigger condition collection index
       void addConditionKey( unsigned conditionKey ) { if ( ! hasConditionKey( conditionKey ) ) conditionKeys_.push_back( conditionKey ); };
       /// Get L1 algorithm name
-      std::string name() const { return name_; };
+      const std::string & name() const { return name_; };
       /// Get L1 algorithm alias
-      std::string alias() const { return alias_; };
+      const std::string & alias() const { return alias_; };
       /// Get L1 algorithm logical expression
-      std::string logicalExpression() const { return logic_; };
+      const std::string & logicalExpression() const { return logic_; };
       /// Get flag for technical L1 algorithms
       bool techTrigger() const { return tech_; };
       /// Get L1 algorithm bit number
@@ -124,7 +124,7 @@ namespace pat {
       /// identical to L1 algorithm decision, considering the mask
       bool decision() const { return decisionAfterMask(); };
       /// Get all trigger condition collection indeces
-      std::vector< unsigned > conditionKeys() const { return conditionKeys_; };
+      const std::vector< unsigned > & conditionKeys() const { return conditionKeys_; };
       /// Checks, if a certain trigger condition collection index is assigned
       bool hasConditionKey( unsigned conditionKey ) const;
 

--- a/DataFormats/PatCandidates/interface/TriggerCondition.h
+++ b/DataFormats/PatCandidates/interface/TriggerCondition.h
@@ -7,7 +7,7 @@
 // Package:    PatCandidates
 // Class:      pat::TriggerCondition
 //
-// $Id: TriggerCondition.h,v 1.1 2011/02/22 18:33:05 vadler Exp $
+// $Id: TriggerCondition.h,v 1.2 2013/06/11 13:24:49 vadler Exp $
 //
 /**
   \class    pat::TriggerCondition TriggerCondition.h "DataFormats/PatCandidates/interface/TriggerCondition.h"
@@ -18,7 +18,7 @@
    https://twiki.cern.ch/twiki/bin/view/CMS/SWGuidePATTrigger#TriggerCondition
 
   \author   Volker Adler
-  \version  $Id: TriggerCondition.h,v 1.1 2011/02/22 18:33:05 vadler Exp $
+  \version  $Id: TriggerCondition.h,v 1.2 2013/06/11 13:24:49 vadler Exp $
 */
 
 
@@ -87,7 +87,7 @@ namespace pat {
       /// Add a new trigger object collection index
       void addObjectKey( unsigned objectKey ) { if ( ! hasObjectKey( objectKey ) ) objectKeys_.push_back( objectKey ); };
       /// Get the filter label
-      std::string name() const { return name_; };
+      const std::string & name() const { return name_; };
       /// Get the success flag
       bool wasAccept() const { return accept_; };
       /// Get the condition category
@@ -100,7 +100,7 @@ namespace pat {
       bool hasTriggerObjectType( trigger::TriggerObjectType triggerObjectType ) const;
       bool hasTriggerObjectType( int triggerObjectType ) const { return hasTriggerObjectType( trigger::TriggerObjectType( triggerObjectType ) ); };
       /// Get all trigger object collection indeces
-      std::vector< unsigned > objectKeys() const { return objectKeys_; };
+      const std::vector< unsigned > & objectKeys() const { return objectKeys_; };
       /// Checks, if a certain trigger object collection index is assigned
       bool hasObjectKey( unsigned objectKey ) const;
 

--- a/DataFormats/PatCandidates/interface/TriggerEvent.h
+++ b/DataFormats/PatCandidates/interface/TriggerEvent.h
@@ -7,7 +7,7 @@
 // Package:    PatCandidates
 // Class:      pat::TriggerEvent
 //
-// $Id: TriggerEvent.h,v 1.16 2011/11/30 13:42:55 vadler Exp $
+// $Id: TriggerEvent.h,v 1.17 2013/06/11 13:24:49 vadler Exp $
 //
 /**
   \class    pat::TriggerEvent TriggerEvent.h "DataFormats/PatCandidates/interface/TriggerEvent.h"
@@ -19,7 +19,7 @@
    https://twiki.cern.ch/twiki/bin/view/CMS/SWGuidePATTrigger#TriggerEvent
 
   \author   Volker Adler
-  \version  $Id: TriggerEvent.h,v 1.16 2011/11/30 13:42:55 vadler Exp $
+  \version  $Id: TriggerEvent.h,v 1.17 2013/06/11 13:24:49 vadler Exp $
 */
 
 
@@ -144,9 +144,9 @@ namespace pat {
       /// Set the CMS magnet current averaged over run
       void setBCurrentAvg( float bCurrentAvg ) { bCurrentAvg_  = bCurrentAvg; };
       /// Get the name of the L1 trigger menu
-      std::string nameL1Menu() const { return nameL1Menu_; };
+      const std::string & nameL1Menu() const { return nameL1Menu_; };
       /// Get the name of the HLT trigger table
-      std::string nameHltTable() const { return nameHltTable_; };
+      const std::string & nameHltTable() const { return nameHltTable_; };
       /// Get the run flag
       bool wasRun() const { return run_; };
       /// Get the success flag

--- a/DataFormats/PatCandidates/interface/TriggerFilter.h
+++ b/DataFormats/PatCandidates/interface/TriggerFilter.h
@@ -7,7 +7,7 @@
 // Package:    PatCandidates
 // Class:      pat::TriggerFilter
 //
-// $Id: TriggerFilter.h,v 1.9 2011/05/24 15:56:25 vadler Exp $
+// $Id: TriggerFilter.h,v 1.10 2013/06/11 13:24:49 vadler Exp $
 //
 /**
   \class    pat::TriggerFilter TriggerFilter.h "DataFormats/PatCandidates/interface/TriggerFilter.h"
@@ -18,7 +18,7 @@
    https://twiki.cern.ch/twiki/bin/view/CMS/SWGuidePATTrigger#TriggerFilter
 
   \author   Volker Adler
-  \version  $Id: TriggerFilter.h,v 1.9 2011/05/24 15:56:25 vadler Exp $
+  \version  $Id: TriggerFilter.h,v 1.10 2013/06/11 13:24:49 vadler Exp $
 */
 
 
@@ -88,11 +88,11 @@ namespace pat {
       /// Set the L3 status
       void setSaveTags( bool saveTags ) { saveTags_ = saveTags; };
       /// Get the filter label
-      std::string label() const { return label_; };
+      const std::string & label() const { return label_; };
       /// Get the filter module type
-      std::string type() const { return type_; };
+      const std::string & type() const { return type_; };
       /// Get all trigger object collection indeces
-      std::vector< unsigned > objectKeys() const { return objectKeys_; };
+      const std::vector< unsigned > & objectKeys() const { return objectKeys_; };
       /// Get all trigger object type identifiers
 //       std::vector< trigger::TriggerObjectType > triggerObjectTypes() const { return triggerObjectTypes_; };
 //       std::vector< trigger::TriggerObjectType > objectIds()          const { return triggerObjectTypes(); }; // for backward compatibility

--- a/DataFormats/PatCandidates/interface/TriggerObject.h
+++ b/DataFormats/PatCandidates/interface/TriggerObject.h
@@ -7,7 +7,7 @@
 // Package:    PatCandidates
 // Class:      pat::TriggerObject
 //
-// $Id: TriggerObject.h,v 1.13 2010/12/20 20:05:52 vadler Exp $
+// $Id: TriggerObject.h,v 1.14 2013/06/11 13:24:49 vadler Exp $
 //
 /**
   \class    pat::TriggerObject TriggerObject.h "DataFormats/PatCandidates/interface/TriggerObject.h"
@@ -18,7 +18,7 @@
    https://twiki.cern.ch/twiki/bin/view/CMS/SWGuidePATTrigger#TriggerObject
 
   \author   Volker Adler
-  \version  $Id: TriggerObject.h,v 1.13 2010/12/20 20:05:52 vadler Exp $
+  \version  $Id: TriggerObject.h,v 1.14 2013/06/11 13:24:49 vadler Exp $
 */
 
 
@@ -91,7 +91,7 @@ namespace pat {
       void addFilterId( trigger::TriggerObjectType triggerObjectType ) { addTriggerObjectType( triggerObjectType ); };                               // for backward compatibility
       void addFilterId( int                        triggerObjectType ) { addTriggerObjectType( trigger::TriggerObjectType( triggerObjectType ) ); }; // for backward compatibility
       /// Get the label of the collection the trigger object originates from
-      std::string collection() const { return collection_; };
+      const std::string & collection() const { return collection_; };
       /// Get all trigger object type identifiers
 //       std::vector< trigger::TriggerObjectType > triggerObjectTypes() const { return triggerObjectTypes_; };
 //       std::vector< trigger::TriggerObjectType > filterIds()          const { return triggerObjectTypes(); }; // for backward compatibility

--- a/DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h
+++ b/DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h
@@ -7,7 +7,7 @@
 // Package:    PatCandidates
 // Class:      pat::TriggerObjectStandAlone
 //
-// $Id: TriggerObjectStandAlone.h,v 1.15 2011/05/25 07:14:27 vadler Exp $
+// $Id: TriggerObjectStandAlone.h,v 1.16 2013/06/11 13:24:49 vadler Exp $
 //
 /**
   \class    pat::TriggerObjectStandAlone TriggerObjectStandAlone.h "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
@@ -20,7 +20,7 @@
    https://twiki.cern.ch/twiki/bin/view/CMS/SWGuidePATTrigger#TriggerObjectStandAlone
 
   \author   Volker Adler
-  \version  $Id: TriggerObjectStandAlone.h,v 1.15 2011/05/25 07:14:27 vadler Exp $
+  \version  $Id: TriggerObjectStandAlone.h,v 1.16 2013/06/11 13:24:49 vadler Exp $
 */
 
 
@@ -63,7 +63,7 @@ namespace pat {
       /// Adds a new HLT path or L1 algorithm name
       void addPathOrAlgorithm( const std::string & name, bool pathLastFilterAccepted, bool pathL3FilterAccepted );
       /// Gets all HLT filter labels or L1 condition names
-      std::vector< std::string > filtersOrConditions() const { return filterLabels_; };
+      const std::vector< std::string > & filtersOrConditions() const { return filterLabels_; };
       /// Gets all HLT path or L1 algorithm names
       std::vector< std::string > pathsOrAlgorithms( bool pathLastFilterAccepted, bool pathL3FilterAccepted ) const;
       /// Checks, if a certain HLT filter label or L1 condition name is assigned
@@ -104,9 +104,9 @@ namespace pat {
       /// Adds a new L1 algorithm name
       void addAlgorithmName( const std::string & algorithmName, bool algoCondAccepted = true ) { addPathOrAlgorithm( algorithmName, algoCondAccepted, false ); };
       /// Gets all HLT filter labels
-      std::vector< std::string > filterLabels() const { return filtersOrConditions(); };
+      const std::vector< std::string > & filterLabels() const { return filtersOrConditions(); };
       /// Gets all L1 condition names
-      std::vector< std::string > conditionNames() const { return filtersOrConditions(); };
+      const std::vector< std::string > & conditionNames() const { return filtersOrConditions(); };
       /// Gets all HLT path names
       std::vector< std::string > pathNames( bool pathLastFilterAccepted = false, bool pathL3FilterAccepted = true ) const { return pathsOrAlgorithms( pathLastFilterAccepted, pathL3FilterAccepted ); };
       /// Gets all L1 algorithm names

--- a/DataFormats/PatCandidates/interface/TriggerPath.h
+++ b/DataFormats/PatCandidates/interface/TriggerPath.h
@@ -7,7 +7,7 @@
 // Package:    PatCandidates
 // Class:      pat::TriggerPath
 //
-// $Id: TriggerPath.h,v 1.11 2011/05/28 13:40:57 vadler Exp $
+// $Id: TriggerPath.h,v 1.12 2013/06/11 13:24:49 vadler Exp $
 //
 /**
   \class    pat::TriggerPath TriggerPath.h "DataFormats/PatCandidates/interface/TriggerPath.h"
@@ -18,7 +18,7 @@
    https://twiki.cern.ch/twiki/bin/view/CMS/SWGuidePATTrigger#TriggerPath
 
   \author   Volker Adler
-  \version  $Id: TriggerPath.h,v 1.11 2011/05/28 13:40:57 vadler Exp $
+  \version  $Id: TriggerPath.h,v 1.12 2013/06/11 13:24:49 vadler Exp $
 */
 
 
@@ -112,7 +112,7 @@ namespace pat {
       void addL1Seed( const L1Seed & seed )                           { l1Seeds_.push_back( seed ); };
       void addL1Seed( bool decision, const std::string & expression ) { l1Seeds_.push_back( L1Seed( decision, expression ) ); };
       /// Get the path name
-      std::string name() const { return name_; };
+      const std::string & name() const { return name_; };
       /// Get the path index
       unsigned index() const { return index_; };
       /// Get the path pre-scale
@@ -132,15 +132,15 @@ namespace pat {
       /// available starting from CMSSW_4_2_3
       bool xTrigger() const { return ( l3Filters_ > 2 ); };
       /// Get all module labels
-      std::vector< std::string > modules() const { return modules_; };
+      const std::vector< std::string > & modules() const { return modules_; };
       /// Get all trigger fillter collection indeces
-      std::vector< unsigned > filterIndices() const { return filterIndices_; };
+      const std::vector< unsigned > & filterIndices() const { return filterIndices_; };
       /// Get the index of a certain module;
       /// returns size of 'modules_' ( modules().size() ) if name is unknown
       /// and -1 if list of modules is not filled
       int indexModule( const std::string & name ) const;
       /// Get all L1 seeds
-      L1SeedCollection l1Seeds() const { return l1Seeds_; };
+      const L1SeedCollection & l1Seeds() const { return l1Seeds_; };
       /// Get names of all L1 seeds with a certain decision
       std::vector< std::string > l1Seeds( const bool decision ) const;
       /// Get names of all succeeding L1 seeds

--- a/DataFormats/PatCandidates/src/Muon.cc
+++ b/DataFormats/PatCandidates/src/Muon.cc
@@ -18,6 +18,7 @@ Muon::Muon() :
     Lepton<reco::Muon>(),
     embeddedMuonBestTrack_(false),
     embeddedImprovedMuonBestTrack_(false),
+    improvedMuonBestTrackType_(reco::Muon::None),
     embeddedTrack_(false),
     embeddedStandAloneMuon_(false),
     embeddedCombinedMuon_(false),
@@ -44,6 +45,7 @@ Muon::Muon(const reco::Muon & aMuon) :
     Lepton<reco::Muon>(aMuon),
     embeddedMuonBestTrack_(false),
     embeddedImprovedMuonBestTrack_(false),
+    improvedMuonBestTrackType_(reco::Muon::None),
     embeddedTrack_(false),
     embeddedStandAloneMuon_(false),
     embeddedCombinedMuon_(false),
@@ -70,6 +72,7 @@ Muon::Muon(const edm::RefToBase<reco::Muon> & aMuonRef) :
     Lepton<reco::Muon>(aMuonRef),
     embeddedMuonBestTrack_(false),
     embeddedImprovedMuonBestTrack_(false),
+    improvedMuonBestTrackType_(reco::Muon::None),
     embeddedTrack_(false),
     embeddedStandAloneMuon_(false),
     embeddedCombinedMuon_(false),
@@ -96,6 +99,7 @@ Muon::Muon(const edm::Ptr<reco::Muon> & aMuonRef) :
     Lepton<reco::Muon>(aMuonRef),
     embeddedMuonBestTrack_(false),
     embeddedImprovedMuonBestTrack_(false),
+    improvedMuonBestTrackType_(reco::Muon::None),
     embeddedTrack_(false),
     embeddedStandAloneMuon_(false),
     embeddedCombinedMuon_(false),
@@ -220,7 +224,7 @@ reco::TrackRef Muon::improvedMuonBestTrack() {
     return reco::TrackRef(&improvedMuonBestTrack_,0);
   } else {
     reco::Muon::MuonTrackTypePair newBestTrack = muon::muonBestTrack(*this, reco::improvedTuneP);
-    setBestTrack(newBestTrack.second);
+    setImprovedBestTrack(newBestTrack.second);
     return newBestTrack.first;
   } 
 }

--- a/DataFormats/PatCandidates/src/Muon.cc
+++ b/DataFormats/PatCandidates/src/Muon.cc
@@ -207,33 +207,10 @@ reco::TrackRef Muon::dytTrack() const {
 reco::TrackRef Muon::muonBestTrack(){ 
   if (embeddedMuonBestTrack_) {
     return reco::TrackRef(&muonBestTrack_,0);
-  } else {
-    
-    reco::TrackRef newBestTrack;
-    
-    if(isGlobalMuon()){
-      if(muon::cocktailInputIsOK(*this)){
-	reco::Muon::MuonTrackTypePair tuneP = muon::tevOptimized(*this, 200, 4., 6., -1);   
-	newBestTrack = tuneP.first;
-	setBestTrack(tuneP.second);
-      }
-      else{
-	reco::Muon::MuonTrackTypePair sigmaS = muon::sigmaSwitch(combinedMuon(),innerTrack());
-	newBestTrack = sigmaS.first;
-	setBestTrack(sigmaS.second);	
-      }
-    }
-    else if(!isGlobalMuon() && isTrackerMuon()){
-      newBestTrack = innerTrack();
-      setBestTrack(reco::Muon::InnerTrack);
-    }
-    else if(!isGlobalMuon() && !isTrackerMuon() && isStandAloneMuon()){
-      newBestTrack = outerTrack();
-      setBestTrack(reco::Muon::OuterTrack);
-    }
-    else edm::LogError("PATMuonProducer|improvedMuonBestTrack") << "Orphan best track this must not happend!";
-    
-    return newBestTrack;
+  } else {   
+    reco::Muon::MuonTrackTypePair newBestTrack = muon::muonBestTrack(*this, reco::defaultTuneP);
+    setBestTrack(newBestTrack.second);
+    return newBestTrack.first;
   }
 }
 
@@ -242,33 +219,10 @@ reco::TrackRef Muon::improvedMuonBestTrack() {
   if (embeddedImprovedMuonBestTrack_) {
     return reco::TrackRef(&improvedMuonBestTrack_,0);
   } else {
-    
-    reco::TrackRef newBestTrack;
-    
-    if(isGlobalMuon()){
-      if(muon::cocktailInputIsOK(*this)){
-	reco::Muon::MuonTrackTypePair tuneP = muon::tevOptimized(*this,  200, 17., 40., 0.25);   
-	newBestTrack = tuneP.first;
-	setBestTrack(tuneP.second);
-      }
-      else{
-	reco::Muon::MuonTrackTypePair sigmaS = muon::sigmaSwitch(combinedMuon(),innerTrack());
-	newBestTrack = sigmaS.first;
-	setBestTrack(sigmaS.second);	
-      }
-    }
-    else if(!isGlobalMuon() && isTrackerMuon()){
-      newBestTrack = innerTrack();
-      setBestTrack(reco::Muon::InnerTrack);
-    }
-    else if(!isGlobalMuon() && !isTrackerMuon() && isStandAloneMuon()){
-      newBestTrack = outerTrack();
-      setBestTrack(reco::Muon::OuterTrack);
-    }
-    else edm::LogError("PATMuonProducer|improvedMuonBestTrack") << "Orphan best track this must not happend!";
-    
-    return newBestTrack;
-  }
+    reco::Muon::MuonTrackTypePair newBestTrack = muon::muonBestTrack(*this, reco::improvedTuneP);
+    setBestTrack(newBestTrack.second);
+    return newBestTrack.first;
+  } 
 }
 
 
@@ -497,7 +451,7 @@ bool Muon::isSoftMuon(const reco::Vertex& vtx) const {
 }
 
 
-bool Muon::isHighPtMuon(const reco::Vertex& vtx, muon::TunePType type) const{
+bool Muon::isHighPtMuon(const reco::Vertex& vtx, reco::TunePType type) const{
   return muon::isHighPtMuon(*this, vtx, type);
 }
 

--- a/DataFormats/PatCandidates/src/Muon.cc
+++ b/DataFormats/PatCandidates/src/Muon.cc
@@ -251,11 +251,13 @@ void Muon::embedMuonBestTrack() {
 
 /// embed the Track selected to be the best measurement of the muon parameters
 void Muon::embedImprovedMuonBestTrack() {
-  improvedMuonBestTrack_.clear();
-  reco::TrackRef newBestTrack = muon::tevOptimized(*this,  200, 17., 40., 0.25).first;
-  if (newBestTrack.isNonnull()) {
+  improvedMuonBestTrack_.clear(); 
+  if(muon::cocktailInputIsOK(*this)){
+    reco::TrackRef newBestTrack = muon::tevOptimized(*this,  200, 17., 40., 0.25).first;
+    if(newBestTrack.isNonnull()){
       improvedMuonBestTrack_.push_back(*newBestTrack);
       embeddedImprovedMuonBestTrack_ = true;
+    }
   }
 }
 

--- a/DataFormats/PatCandidates/src/Muon.cc
+++ b/DataFormats/PatCandidates/src/Muon.cc
@@ -266,7 +266,7 @@ void Muon::embedImprovedMuonBestTrack() {
     embeddedImprovedMuonBestTrack_ = true;
   } 
   else
-    edm::LogError("PATMuonProducer|embedImprovedMuonBestTrack") << "Orphan best track this must not happend!";
+    edm::LogError("PATMuon|embedImprovedMuonBestTrack") << "Orphan best track this must not happend!";
 }
 
 

--- a/DataFormats/PatCandidates/src/Muon.cc
+++ b/DataFormats/PatCandidates/src/Muon.cc
@@ -16,6 +16,8 @@ using namespace pat;
 /// default constructor
 Muon::Muon() :
     Lepton<reco::Muon>(),
+    embeddedMuonBestTrack_(false),
+    embeddedImprovedMuonBestTrack_(false),
     embeddedTrack_(false),
     embeddedStandAloneMuon_(false),
     embeddedCombinedMuon_(false),
@@ -40,6 +42,8 @@ Muon::Muon() :
 /// constructor from reco::Muon
 Muon::Muon(const reco::Muon & aMuon) :
     Lepton<reco::Muon>(aMuon),
+    embeddedMuonBestTrack_(false),
+    embeddedImprovedMuonBestTrack_(false),
     embeddedTrack_(false),
     embeddedStandAloneMuon_(false),
     embeddedCombinedMuon_(false),
@@ -64,6 +68,8 @@ Muon::Muon(const reco::Muon & aMuon) :
 /// constructor from ref to reco::Muon
 Muon::Muon(const edm::RefToBase<reco::Muon> & aMuonRef) :
     Lepton<reco::Muon>(aMuonRef),
+    embeddedMuonBestTrack_(false),
+    embeddedImprovedMuonBestTrack_(false),
     embeddedTrack_(false),
     embeddedStandAloneMuon_(false),
     embeddedCombinedMuon_(false),
@@ -88,6 +94,8 @@ Muon::Muon(const edm::RefToBase<reco::Muon> & aMuonRef) :
 /// constructor from ref to reco::Muon
 Muon::Muon(const edm::Ptr<reco::Muon> & aMuonRef) :
     Lepton<reco::Muon>(aMuonRef),
+    embeddedMuonBestTrack_(false),
+    embeddedImprovedMuonBestTrack_(false),
     embeddedTrack_(false),
     embeddedStandAloneMuon_(false),
     embeddedCombinedMuon_(false),
@@ -95,7 +103,7 @@ Muon::Muon(const edm::Ptr<reco::Muon> & aMuonRef) :
     embeddedCaloMETMuonCorrs_(false),
     embeddedPickyMuon_(false),
     embeddedTpfmsMuon_(false),
-    embeddedDytMuon_(false),
+    embeddedDytMuon_(false),    
     embeddedPFCandidate_(false),
     pfCandidateRef_(),
     cachedNormChi2_(false),

--- a/DataFormats/PatCandidates/src/TriggerEvent.cc
+++ b/DataFormats/PatCandidates/src/TriggerEvent.cc
@@ -1,5 +1,5 @@
 //
-// $Id: TriggerEvent.cc,v 1.19 2011/11/30 13:42:16 vadler Exp $
+// $Id: TriggerEvent.cc,v 1.20 2013/06/11 13:24:50 vadler Exp $
 //
 
 
@@ -457,9 +457,9 @@ TriggerObjectRefVector TriggerEvent::objects( trigger::TriggerObjectType trigger
 TriggerConditionRefVector TriggerEvent::algorithmConditions( const std::string & nameAlgorithm ) const
 {
   TriggerConditionRefVector theAlgorithmConditions;
-  if ( algorithm( nameAlgorithm ) ) {
-    for ( unsigned iC = 0; iC < algorithm( nameAlgorithm )->conditionKeys().size(); ++iC ) {
-      const TriggerConditionRef conditionRef( conditions_, algorithm( nameAlgorithm )->conditionKeys().at( iC ) );
+  if ( const TriggerAlgorithm * algorithmPtr = algorithm( nameAlgorithm ) ) {
+    for ( unsigned iC = 0; iC < algorithmPtr->conditionKeys().size(); ++iC ) {
+      const TriggerConditionRef conditionRef( conditions_, algorithmPtr->conditionKeys().at( iC ) );
       theAlgorithmConditions.push_back( conditionRef );
     }
   }
@@ -499,9 +499,9 @@ TriggerAlgorithmRefVector TriggerEvent::conditionAlgorithms( const TriggerCondit
 std::vector< std::string > TriggerEvent::conditionCollections( const std::string & nameCondition ) const
 {
   std::vector< std::string > theConditionCollections;
-  if ( condition( nameCondition ) ) {
+  if ( const TriggerCondition * conditionPtr = condition( nameCondition ) ) {
     for ( unsigned iObject = 0; iObject < objects()->size(); ++iObject ) {
-      if ( condition( nameCondition )->hasObjectKey( iObject ) ) {
+      if ( conditionPtr->hasObjectKey( iObject ) ) {
         bool found( false );
         std::string objectCollection( objects()->at( iObject ).collection() );
         for ( std::vector< std::string >::const_iterator iC = theConditionCollections.begin(); iC != theConditionCollections.end(); ++iC ) {
@@ -524,9 +524,9 @@ std::vector< std::string > TriggerEvent::conditionCollections( const std::string
 TriggerObjectRefVector TriggerEvent::conditionObjects( const std::string & nameCondition ) const
 {
   TriggerObjectRefVector theConditionObjects;
-  if ( condition( nameCondition ) ) {
+  if ( const TriggerCondition * conditionPtr = condition( nameCondition ) ) {
     for ( unsigned iObject = 0; iObject < objects()->size(); ++iObject ) {
-      if ( condition( nameCondition )->hasObjectKey( iObject ) ) {
+      if ( conditionPtr->hasObjectKey( iObject ) ) {
         const TriggerObjectRef objectRef( objects_, iObject );
         theConditionObjects.push_back( objectRef );
       }
@@ -538,7 +538,7 @@ TriggerObjectRefVector TriggerEvent::conditionObjects( const std::string & nameC
 
 // Checks, if an object was used in a certain condition given by name
 bool TriggerEvent::objectInCondition( const TriggerObjectRef & objectRef, const std::string & nameCondition ) const {
-  if ( condition( nameCondition ) ) return condition( nameCondition )->hasObjectKey( objectRef.key() );
+  if ( const TriggerCondition * conditionPtr = condition( nameCondition ) ) return conditionPtr->hasObjectKey( objectRef.key() );
   return false;
 }
 
@@ -604,12 +604,14 @@ TriggerAlgorithmRefVector TriggerEvent::objectAlgorithms( const TriggerObjectRef
 TriggerFilterRefVector TriggerEvent::pathModules( const std::string & namePath, bool all ) const
 {
   TriggerFilterRefVector thePathFilters;
-  if ( path( namePath ) && path( namePath )->modules().size() > 0 ) {
-    const unsigned onePastLastFilter = all ? path( namePath )->modules().size() : path( namePath )->lastActiveFilterSlot() + 1;
-    for ( unsigned iM = 0; iM < onePastLastFilter; ++iM ) {
-      const std::string labelFilter( path( namePath )->modules().at( iM ) );
-      const TriggerFilterRef filterRef( filters_, indexFilter( labelFilter ) );
-      thePathFilters.push_back( filterRef );
+  if ( const TriggerPath * pathPtr = path( namePath ) ) {
+    if ( pathPtr->modules().size() > 0 ) {
+      const unsigned onePastLastFilter = all ? pathPtr->modules().size() : pathPtr->lastActiveFilterSlot() + 1;
+      for ( unsigned iM = 0; iM < onePastLastFilter; ++iM ) {
+        const std::string labelFilter( pathPtr->modules().at( iM ) );
+        const TriggerFilterRef filterRef( filters_, indexFilter( labelFilter ) );
+        thePathFilters.push_back( filterRef );
+      }
     }
   }
   return thePathFilters;
@@ -620,9 +622,9 @@ TriggerFilterRefVector TriggerEvent::pathModules( const std::string & namePath, 
 TriggerFilterRefVector TriggerEvent::pathFilters( const std::string & namePath, bool firing ) const
 {
   TriggerFilterRefVector thePathFilters;
-  if ( path( namePath ) ) {
-    for ( unsigned iF = 0; iF < path( namePath )->filterIndices().size(); ++iF ) {
-      const TriggerFilterRef filterRef( filters_, path( namePath )->filterIndices().at( iF ) );
+  if ( const TriggerPath * pathPtr = path( namePath ) ) {
+    for ( unsigned iF = 0; iF < pathPtr->filterIndices().size(); ++iF ) {
+      const TriggerFilterRef filterRef( filters_, pathPtr->filterIndices().at( iF ) );
       if ( ( ! firing ) || filterRef->isFiring() ) thePathFilters.push_back( filterRef );
     }
   }
@@ -662,11 +664,11 @@ TriggerPathRefVector TriggerEvent::filterPaths( const TriggerFilterRef & filterR
 std::vector< std::string > TriggerEvent::filterCollections( const std::string & labelFilter ) const
 {
   std::vector< std::string > theFilterCollections;
-  if ( filter( labelFilter ) ) {
+  if ( const TriggerFilter * filterPtr = filter( labelFilter ) ) {
     for ( unsigned iObject = 0; iObject < objects()->size(); ++iObject ) {
-      if ( filter( labelFilter )->hasObjectKey( iObject ) ) {
+      if ( filterPtr->hasObjectKey( iObject ) ) {
         bool found( false );
-        std::string objectCollection( objects()->at( iObject ).collection() );
+        const std::string objectCollection( objects()->at( iObject ).collection() );
         for ( std::vector< std::string >::const_iterator iC = theFilterCollections.begin(); iC != theFilterCollections.end(); ++iC ) {
           if ( *iC == objectCollection ) {
             found = true;
@@ -687,9 +689,9 @@ std::vector< std::string > TriggerEvent::filterCollections( const std::string & 
 TriggerObjectRefVector TriggerEvent::filterObjects( const std::string & labelFilter ) const
 {
   TriggerObjectRefVector theFilterObjects;
-  if ( filter( labelFilter ) ) {
+  if ( const TriggerFilter * filterPtr = filter( labelFilter ) ) {
     for ( unsigned iObject = 0; iObject < objects()->size(); ++iObject ) {
-      if ( filter( labelFilter )->hasObjectKey( iObject ) ) {
+      if ( filterPtr->hasObjectKey( iObject ) ) {
         const TriggerObjectRef objectRef( objects_, iObject );
         theFilterObjects.push_back( objectRef );
       }
@@ -701,7 +703,7 @@ TriggerObjectRefVector TriggerEvent::filterObjects( const std::string & labelFil
 
 // Checks, if an object was used in a certain filter given by name
 bool TriggerEvent::objectInFilter( const TriggerObjectRef & objectRef, const std::string & labelFilter ) const {
-  if ( filter( labelFilter ) ) return filter( labelFilter )->hasObjectKey( objectRef.key() );
+  if ( const TriggerFilter * filterPtr = filter( labelFilter ) ) return filterPtr->hasObjectKey( objectRef.key() );
   return false;
 }
 

--- a/DataFormats/PatCandidates/src/classes_def.xml
+++ b/DataFormats/PatCandidates/src/classes_def.xml
@@ -30,7 +30,8 @@
    <version ClassVersion="15" checksum="990589145"/>
    <version ClassVersion="10" checksum="1662079993"/>
   </class>
-  <class name="pat::Muon"  ClassVersion="13">
+  <class name="pat::Muon"  ClassVersion="14">
+   <version ClassVersion="14" checksum="1011546643"/>
    <version ClassVersion="13" checksum="1020022799"/>
    <version ClassVersion="12" checksum="462627330"/>
    <version ClassVersion="11" checksum="489577659"/>

--- a/DataFormats/PatCandidates/src/classes_def.xml
+++ b/DataFormats/PatCandidates/src/classes_def.xml
@@ -30,7 +30,8 @@
    <version ClassVersion="15" checksum="990589145"/>
    <version ClassVersion="10" checksum="1662079993"/>
   </class>
-  <class name="pat::Muon"  ClassVersion="12">
+  <class name="pat::Muon"  ClassVersion="13">
+   <version ClassVersion="13" checksum="1020022799"/>
    <version ClassVersion="12" checksum="462627330"/>
    <version ClassVersion="11" checksum="489577659"/>
    <version ClassVersion="10" checksum="2367573922"/>

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -10,6 +10,7 @@
 
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/MuonReco/interface/MuonCocktails.h"
 
 #include "DataFormats/TrackReco/interface/TrackToTrackMap.h"
 
@@ -212,19 +213,16 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 	// get the tracks
 	reco::TrackRef innerTrack = muonBaseRef->innerTrack();
 	reco::TrackRef globalTrack= muonBaseRef->globalTrack();
-	reco::TrackRef bestTrack  = muonBaseRef->muonBestTrack();
-	reco::TrackRef chosenTrack = innerTrack;
-	// Make sure the collection it points to is there
-	if ( bestTrack.isNonnull() && bestTrack.isAvailable() ) 
-	  chosenTrack = bestTrack;
+	reco::TrackRef bestTrack  = muon::muonBestTrack(*muonBaseRef, reco::defaultTuneP).first;
 
-	if ( chosenTrack.isNonnull() && chosenTrack.isAvailable() ) {
-	  unsigned int nhits = chosenTrack->numberOfValidHits(); // ????
+	// Make sure the collection it points to is there
+	if ( bestTrack.isNonnull() && bestTrack.isAvailable() ) {
+	  unsigned int nhits = bestTrack->numberOfValidHits(); // ????
 	  aMuon.setNumberOfValidHits( nhits );
 
-	  reco::TransientTrack tt = trackBuilder->build(chosenTrack);
+	  reco::TransientTrack tt = trackBuilder->build(bestTrack);
 	  embedHighLevel( aMuon, 
-			  chosenTrack,
+			  bestTrack,
 			  tt,
 			  primaryVertex,
 			  primaryVertexIsValid,
@@ -233,7 +231,7 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 
 	  // Correct to PV, or beam spot
 	  if ( !usePV_ ) {
-	    double corr_d0 = -1.0 * chosenTrack->dxy( beamPoint );
+	    double corr_d0 = -1.0 * bestTrack->dxy( beamPoint );
 	    aMuon.setDB( corr_d0, -1.0 );
 	  } else {
 	    std::pair<bool,Measurement1D> result = IPTools::absoluteTransverseImpactParameter(tt, primaryVertex);
@@ -311,18 +309,16 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 	// get the tracks
 	reco::TrackRef innerTrack = itMuon->innerTrack();
 	reco::TrackRef globalTrack= itMuon->globalTrack();
-	reco::TrackRef bestTrack  = itMuon->muonBestTrack();
-	reco::TrackRef chosenTrack = innerTrack;
+	reco::TrackRef bestTrack  = muon::muonBestTrack(*itMuon, reco::defaultTuneP).first;
+
 	// Make sure the collection it points to is there
-	if ( bestTrack.isNonnull() && bestTrack.isAvailable() )
-	  chosenTrack = bestTrack;
-	if ( chosenTrack.isNonnull() && chosenTrack.isAvailable() ) {
-	  unsigned int nhits = chosenTrack->numberOfValidHits(); // ????
+	if ( bestTrack.isNonnull() && bestTrack.isAvailable() ) {
+	  unsigned int nhits = bestTrack->numberOfValidHits(); // ????
 	  aMuon.setNumberOfValidHits( nhits );
 
-	  reco::TransientTrack tt = trackBuilder->build(chosenTrack);
+	  reco::TransientTrack tt = trackBuilder->build(bestTrack);
 	  embedHighLevel( aMuon, 
-			  chosenTrack,
+			  bestTrack,
 			  tt,
 			  primaryVertex,
 			  primaryVertexIsValid,
@@ -331,7 +327,7 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 
 	  // Correct to PV, or beam spot
 	  if ( !usePV_ ) {
-	    double corr_d0 = -1.0 * chosenTrack->dxy( beamPoint );
+	    double corr_d0 = -1.0 * bestTrack->dxy( beamPoint );
 	    aMuon.setDB( corr_d0, -1.0 );
 	  } else {
 	    std::pair<bool,Measurement1D> result = IPTools::absoluteTransverseImpactParameter(tt, primaryVertex);

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -51,6 +51,7 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet & iConfig) : useUserDat
   muonSrc_ = iConfig.getParameter<edm::InputTag>( "muonSource" );
   // embedding of tracks
   embedBestTrack_ = iConfig.getParameter<bool>( "embedMuonBestTrack" );
+  embedImprovedBestTrack_ = iConfig.getParameter<bool>( "embedImprovedMuonBestTrack" );
   embedTrack_ = iConfig.getParameter<bool>( "embedTrack" );
   embedCombinedMuon_ = iConfig.getParameter<bool>( "embedCombinedMuon"   );
   embedStandAloneMuon_ = iConfig.getParameter<bool>( "embedStandAloneMuon" );
@@ -374,7 +375,8 @@ void PATMuonProducer::fillMuon( Muon& aMuon, const MuonBaseRef& muonRef, const r
   // as the pat::Muon momentum
   if (useParticleFlow_) 
     aMuon.setP4( aMuon.pfCandidateRef()->p4() );
-  if (embedBestTrack_)      aMuon.embedMuonBestTrack();
+  if (embedBestTrack_)         aMuon.embedMuonBestTrack();
+  if (embedImprovedBestTrack_) aMuon.embedImprovedMuonBestTrack();
   if (embedTrack_)          aMuon.embedTrack();
   if (embedStandAloneMuon_) aMuon.embedStandAloneMuon();
   if (embedCombinedMuon_)   aMuon.embedCombinedMuon();
@@ -449,6 +451,7 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
 
   // embedding
   iDesc.add<bool>("embedMuonBestTrack", true)->setComment("embed muon best track");
+  iDesc.add<bool>("embedImprovedMuonBestTrack", true)->setComment("embed muon best track, new tuneP (only 53X)");
   iDesc.add<bool>("embedTrack", true)->setComment("embed external track");
   iDesc.add<bool>("embedStandAloneMuon", true)->setComment("embed external stand-alone muon");
   iDesc.add<bool>("embedCombinedMuon", false)->setComment("embed external combined muon");

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -86,6 +86,8 @@ namespace pat {
 
     /// embed the track from best muon measurement
     bool embedBestTrack_;
+    /// embed the track from best muon measurement, new tuneP, 53X option only
+    bool embedImprovedBestTrack_;
     /// embed the track from inner tracker into the muon
     bool embedTrack_;
     /// embed track from muon system into the muon

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py
@@ -32,7 +32,8 @@ patMuons = cms.EDProducer("PATMuonProducer",
     ),
 
     # embedding objects
-    embedMuonBestTrack  = cms.bool(True),  ## embed in AOD externally stored muon best track
+    embedMuonBestTrack          = cms.bool(True),  ## embed in AOD externally stored muon best track
+    embedImprovedMuonBestTrack  = cms.bool(True),  ## embed in AOD externally stored muon best track, with new tuneP (option available only in 53X)
     embedTrack          = cms.bool(False), ## embed in AOD externally stored tracker track
     embedCombinedMuon   = cms.bool(True),  ## embed in AOD externally stored combined muon track
     embedStandAloneMuon = cms.bool(True),  ## embed in AOD externally stored standalone muon track

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -3,6 +3,140 @@ from FWCore.GuiBrowsers.ConfigToolBase import *
 from PhysicsTools.PatAlgos.tools.helpers import *
 
 
+_defaultBTagInfos =['impactParameterTagInfos'
+                   ,'secondaryVertexTagInfos'
+                   #,'secondaryVertexNegativeTagInfos'
+                   #,'softMuonTagInfos'
+                   #,'softPFMuonsTagInfos'
+                   #,'softPFElectronsTagInfos'
+                   #,'inclusiveSecondaryVertexFinderTagInfos'
+                   #,'inclusiveSecondaryVertexFinderFilteredTagInfos'
+                   ]
+_allowedBTagInfos =['impactParameterTagInfos'
+                   ,'secondaryVertexTagInfos'
+                   ,'secondaryVertexNegativeTagInfos'
+                   ,'softMuonTagInfos'
+                   ,'softPFMuonsTagInfos'
+                   ,'softPFElectronsTagInfos'
+                   ,'inclusiveSecondaryVertexFinderTagInfos'
+                   ,'inclusiveSecondaryVertexFinderFilteredTagInfos'
+                   ]
+_defaultBTagDiscriminators =['jetBProbabilityBJetTags'
+                            ,'jetProbabilityBJetTags'
+                            ,'trackCountingHighPurBJetTags'
+                            ,'trackCountingHighEffBJetTags'
+                            #,'negativeOnlyJetBProbabilityJetTags'
+                            #,'negativeOnlyJetProbabilityJetTags'
+                            #,'negativeTrackCountingHighEffJetTags'
+                            #,'negativeTrackCountingHighPurJetTags'
+                            #,'positiveOnlyJetBProbabilityJetTags'
+                            #,'positiveOnlyJetProbabilityJetTags'
+                            ,'simpleSecondaryVertexHighEffBJetTags'
+                            ,'simpleSecondaryVertexHighPurBJetTags'
+                            #,'simpleSecondaryVertexNegativeHighEffBJetTags'
+                            #,'simpleSecondaryVertexNegativeHighPurBJetTags'
+                            ,'combinedSecondaryVertexBJetTags'
+                            #,'combinedSecondaryVertexPositiveBJetTags'
+                            #,'combinedSecondaryVertexV1BJetTags'
+                            #,'combinedSecondaryVertexV1PositiveBJetTags'
+                            #,'combinedSecondaryVertexMVABJetTags'
+                            #,'combinedSecondaryVertexNegativeBJetTags'
+                            #,'combinedSecondaryVertexV1NegativeBJetTags'
+                            #,'softPFMuonBJetTags'
+                            #,'softPFMuonByPtBJetTags'
+                            #,'softPFMuonByIP3dBJetTags'
+                            #,'softPFMuonByIP2dBJetTags'
+                            #,'positiveSoftPFMuonBJetTags'
+                            #,'positiveSoftPFMuonByPtBJetTags'
+                            #,'positiveSoftPFMuonByIP3dBJetTags'
+                            #,'positiveSoftPFMuonByIP2dBJetTags'
+                            #,'negativeSoftPFMuonBJetTags'
+                            #,'negativeSoftPFMuonByPtBJetTags'
+                            #,'negativeSoftPFMuonByIP3dBJetTags'
+                            #,'negativeSoftPFMuonByIP2dBJetTags'
+                            #,'softPFElectronBJetTags'
+                            #,'softPFElectronByPtBJetTags'
+                            #,'softPFElectronByIP3dBJetTags'
+                            #,'softPFElectronByIP2dBJetTags'
+                            #,'positiveSoftPFElectronBJetTags'
+                            #,'positiveSoftPFElectronByPtBJetTags'
+                            #,'positiveSoftPFElectronByIP3dBJetTags'
+                            #,'positiveSoftPFElectronByIP2dBJetTags'
+                            #,'negativeSoftPFElectronBJetTags'
+                            #,'negativeSoftPFElectronByPtBJetTags'
+                            #,'negativeSoftPFElectronByIP3dBJetTags'
+                            #,'negativeSoftPFElectronByIP2dBJetTags'
+                            #,'simpleInclusiveSecondaryVertexHighEffBJetTags'
+                            #,'simpleInclusiveSecondaryVertexHighPurBJetTags'
+                            #,'doubleSecondaryVertexHighEffBJetTags'
+                            #,'combinedInclusiveSecondaryVertexBJetTags'
+                            #,'combinedInclusiveSecondaryVertexPositiveBJetTags'
+                            #,'combinedMVABJetTags'
+                            #,'positiveCombinedMVABJetTags'
+                            #,'negativeCombinedMVABJetTags'
+                            #,'combinedSecondaryVertexSoftPFLeptonV1BJetTags'
+                            #,'positiveCombinedSecondaryVertexSoftPFLeptonV1BJetTags'
+                            #,'negativeCombinedSecondaryVertexSoftPFLeptonV1BJetTags'
+                            ]
+_allowedBTagDiscriminators =['jetBProbabilityBJetTags'
+                            ,'jetProbabilityBJetTags'
+                            ,'trackCountingHighPurBJetTags'
+                            ,'trackCountingHighEffBJetTags'
+                            ,'negativeOnlyJetBProbabilityJetTags'
+                            ,'negativeOnlyJetProbabilityJetTags'
+                            ,'negativeTrackCountingHighEffJetTags'
+                            ,'negativeTrackCountingHighPurJetTags'
+                            ,'positiveOnlyJetBProbabilityJetTags'
+                            ,'positiveOnlyJetProbabilityJetTags'
+                            ,'simpleSecondaryVertexHighEffBJetTags'
+                            ,'simpleSecondaryVertexHighPurBJetTags'
+                            ,'simpleSecondaryVertexNegativeHighEffBJetTags'
+                            ,'simpleSecondaryVertexNegativeHighPurBJetTags'
+                            ,'combinedSecondaryVertexBJetTags'
+                            ,'combinedSecondaryVertexPositiveBJetTags'
+                            ,'combinedSecondaryVertexV1BJetTags'
+                            ,'combinedSecondaryVertexV1PositiveBJetTags'
+                            ,'combinedSecondaryVertexMVABJetTags'
+                            ,'combinedSecondaryVertexNegativeBJetTags'
+                            ,'combinedSecondaryVertexV1NegativeBJetTags'
+                            ,'softPFMuonBJetTags'
+                            ,'softPFMuonByPtBJetTags'
+                            ,'softPFMuonByIP3dBJetTags'
+                            ,'softPFMuonByIP2dBJetTags'
+                            ,'positiveSoftPFMuonBJetTags'
+                            ,'positiveSoftPFMuonByPtBJetTags'
+                            ,'positiveSoftPFMuonByIP3dBJetTags'
+                            ,'positiveSoftPFMuonByIP2dBJetTags'
+                            ,'negativeSoftPFMuonBJetTags'
+                            ,'negativeSoftPFMuonByPtBJetTags'
+                            ,'negativeSoftPFMuonByIP3dBJetTags'
+                            ,'negativeSoftPFMuonByIP2dBJetTags'
+                            ,'softPFElectronBJetTags'
+                            ,'softPFElectronByPtBJetTags'
+                            ,'softPFElectronByIP3dBJetTags'
+                            ,'softPFElectronByIP2dBJetTags'
+                            ,'positiveSoftPFElectronBJetTags'
+                            ,'positiveSoftPFElectronByPtBJetTags'
+                            ,'positiveSoftPFElectronByIP3dBJetTags'
+                            ,'positiveSoftPFElectronByIP2dBJetTags'
+                            ,'negativeSoftPFElectronBJetTags'
+                            ,'negativeSoftPFElectronByPtBJetTags'
+                            ,'negativeSoftPFElectronByIP3dBJetTags'
+                            ,'negativeSoftPFElectronByIP2dBJetTags'
+                            ,'simpleInclusiveSecondaryVertexHighEffBJetTags'
+                            ,'simpleInclusiveSecondaryVertexHighPurBJetTags'
+                            ,'doubleSecondaryVertexHighEffBJetTags'
+                            ,'combinedInclusiveSecondaryVertexBJetTags'
+                            ,'combinedInclusiveSecondaryVertexPositiveBJetTags'
+                            ,'combinedMVABJetTags'
+                            ,'positiveCombinedMVABJetTags'
+                            ,'negativeCombinedMVABJetTags'
+                            ,'combinedSecondaryVertexSoftPFLeptonV1BJetTags'
+                            ,'positiveCombinedSecondaryVertexSoftPFLeptonV1BJetTags'
+                            ,'negativeCombinedSecondaryVertexSoftPFLeptonV1BJetTags'
+                            ]
+
+
 class RunBTagging(ConfigToolBase):
 
     """ Define sequence to run b tagging on AOD input for a given jet
@@ -24,8 +158,8 @@ class RunBTagging(ConfigToolBase):
         self.addParameter(self._defaultParameters,'jetCollection',self._defaultValue, 'input jet collection',Type=cms.InputTag)
         self.addParameter(self._defaultParameters,'label',self._defaultValue, 'postfix label to identify new sequence/modules', Type=str)
         self.addParameter(self._defaultParameters,'postfix',"", "postfix of default sequence (do not confuse with 'label')")
-        self.addParameter(self._defaultParameters,'btagInfo',['impactParameterTagInfos','secondaryVertexTagInfos','softMuonTagInfos','secondaryVertexNegativeTagInfos','secondaryVertexNegativeTagInfos','inclusiveSecondaryVertexFinderTagInfos','softElectronTagInfos'],"input btag info",allowedValues=['impactParameterTagInfos','secondaryVertexTagInfos','softMuonTagInfos','secondaryVertexNegativeTagInfos','inclusiveSecondaryVertexFinderTagInfos','softElectronTagInfos'],Type=list)
-        self.addParameter(self._defaultParameters,'btagdiscriminators',['jetBProbabilityBJetTags', 'jetProbabilityBJetTags','trackCountingHighPurBJetTags','trackCountingHighEffBJetTags','simpleSecondaryVertexHighEffBJetTags','simpleSecondaryVertexHighPurBJetTags','combinedSecondaryVertexBJetTags','combinedSecondaryVertexMVABJetTags','softMuonBJetTags','softMuonByPtBJetTags','softMuonByIP3dBJetTags','simpleSecondaryVertexNegativeHighEffBJetTags','simpleSecondaryVertexNegativeHighPurBJetTags','negativeTrackCountingHighEffJetTags','negativeTrackCountingHighPurJetTags','combinedInclusiveSecondaryVertexBJetTags','combinedMVABJetTags'],"input btag discriminators", allowedValues=['jetBProbabilityBJetTags', 'jetProbabilityBJetTags', 'trackCountingHighPurBJetTags', 'trackCountingHighEffBJetTags', 'simpleSecondaryVertexHighEffBJetTags','simpleSecondaryVertexHighPurBJetTags','combinedSecondaryVertexBJetTags','combinedSecondaryVertexMVABJetTags','softMuonBJetTags','softMuonByPtBJetTags','softMuonByIP3dBJetTags','simpleSecondaryVertexNegativeHighEffBJetTags','simpleSecondaryVertexNegativeHighPurBJetTags','negativeTrackCountingHighEffJetTags','negativeTrackCountingHighPurJetTags','combinedInclusiveSecondaryVertexBJetTags','combinedMVABJetTags'],Type=list)
+        self.addParameter(self._defaultParameters,'btagInfo',_defaultBTagInfos,"input btag info",allowedValues=_allowedBTagInfos,Type=list)
+        self.addParameter(self._defaultParameters,'btagdiscriminators',_defaultBTagDiscriminators,"input btag discriminators",allowedValues=_allowedBTagDiscriminators,Type=list)
 
         self._parameters=copy.deepcopy(self._defaultParameters)
         self._comment = ""
@@ -91,13 +225,10 @@ class RunBTagging(ConfigToolBase):
             raise ValueError, "label for re-running b tagging is not allowed to be empty"
 
         ## import track associator & b tag configuration
-        process.load("RecoJets.JetAssociationProducers.ak5JTA_cff")
+        ###process.load("RecoJets.JetAssociationProducers.ak5JTA_cff")
         from RecoJets.JetAssociationProducers.ak5JTA_cff import ak5JetTracksAssociatorAtVertex
         process.load("RecoBTag.Configuration.RecoBTag_cff")
         import RecoBTag.Configuration.RecoBTag_cff as btag
-
-        # add negative tag infos
-        import PhysicsTools.PatAlgos.recoLayer0.bTagging_cff as nbtag
 
         ## define jetTracksAssociator; for switchJetCollection
         ## the label is 'AOD' as empty labels will lead to crashes
@@ -109,21 +240,25 @@ class RunBTagging(ConfigToolBase):
         if (not label == 'AOD'):
             jtaLabel  += label
         ## define tag info labels (compare with jetProducer_cfi.py)
-        ipTILabel = 'impactParameterTagInfos'     + label + postfix
-        svTILabel = 'secondaryVertexTagInfos'     + label + postfix
-        ivfTILabel = 'inclusiveSecondaryVertexFinderTagInfos'     + label + postfix
-        nvTILabel = 'secondaryVertexNegativeTagInfos'     + label + postfix
-        seTILabel = 'softElectronTagInfos'        + label + postfix
-        smTILabel = 'softMuonTagInfos'            + label + postfix
+        ipTILabel      = 'impactParameterTagInfos'                        + label + postfix
+        svTILabel      = 'secondaryVertexTagInfos'                        + label + postfix
+        ivfTILabel     = 'inclusiveSecondaryVertexFinderTagInfos'         + label + postfix
+        ivfFiltTILabel = 'inclusiveSecondaryVertexFinderFilteredTagInfos' + label + postfix
+        nvTILabel      = 'secondaryVertexNegativeTagInfos'                + label + postfix
+        smTILabel      = 'softMuonTagInfos'                               + label + postfix
+        spfmTILabel    = 'softPFMuonsTagInfos'                            + label + postfix
+        spfeTILabel    = 'softPFElectronsTagInfos'                        + label + postfix
 
         ## make VInputTag from strings
         def vit(*args) : return cms.VInputTag( *[ cms.InputTag(x) for x in args ] )
 
         ## produce btags
+        btagInfoRun = []
         print
         print "The btaginfo below will be written to the jet collection in the PATtuple (default is all, see PatAlgos/PhysicsTools/python/tools/jetTools.py)"
         for tagInfo in btagInfo:
-                print tagInfo
+            print tagInfo
+            if hasattr( btag, tagInfo ):
                 if tagInfo=='impactParameterTagInfos':
                     if not hasattr( process, ipTILabel ):
                         tagInfoMod=getattr(btag,tagInfo).clone(jetTracks = cms.InputTag(jtaLabel))
@@ -142,12 +277,18 @@ class RunBTagging(ConfigToolBase):
                         setattr( process, smTILabel, tagInfoMod )
                     else:
                         getattr( process, smTILabel ).jets = jetCollection
-                if tagInfo=='softElectronTagInfos':
-                    if not hasattr( process, seTILabel ):
+                if tagInfo=='softPFMuonsTagInfos':
+                    if not hasattr( process, spfmTILabel ):
                         tagInfoMod=getattr(btag,tagInfo).clone(jets = jetCollection)
-                        setattr( process, seTILabel, tagInfoMod )
+                        setattr( process, spfmTILabel, tagInfoMod )
                     else:
-                        getattr( process, seTILabel ).jets = jetCollection
+                        getattr( process, spfmTILabel ).jets = jetCollection
+                if tagInfo=='softPFElectronsTagInfos':
+                    if not hasattr( process, spfeTILabel ):
+                        tagInfoMod=getattr(btag,tagInfo).clone(jets = jetCollection)
+                        setattr( process, spfeTILabel, tagInfoMod )
+                    else:
+                        getattr( process, spfeTILabel ).jets = jetCollection
                 if tagInfo=='secondaryVertexNegativeTagInfos':
                     if not hasattr( process, nvTILabel ):
                         tagInfoMod=getattr(btag,tagInfo).clone(trackIPTagInfos = cms.InputTag(ipTILabel))
@@ -160,67 +301,150 @@ class RunBTagging(ConfigToolBase):
                         setattr( process, ivfTILabel, tagInfoMod )
                     else:
                         getattr( process, ivfTILabel ).trackIPTagInfos = cms.InputTag(ipTILabel)
+                if tagInfo=='inclusiveSecondaryVertexFinderFilteredTagInfos':
+                    if not hasattr( process, ivfFiltTILabel ):
+                        tagInfoMod=getattr(btag,tagInfo).clone(trackIPTagInfos = cms.InputTag(ipTILabel))
+                        setattr( process, ivfFiltTILabel, tagInfoMod )
+                    else:
+                        getattr( process, ivfFiltTILabel ).trackIPTagInfos = cms.InputTag(ipTILabel)
+                btagInfoRun.append( tagInfo )
+            else:
+                print '  --> ignored, since not available via RecoBTag/Configuration/python/RecoBTag_cff.py!'
 
+        btagdiscriminatorsRun = []
         print
         print "The bdiscriminators below will be written to the jet collection in the PATtuple (default is all, see PatAlgos/PhysicsTools/python/tools/jetTools.py)"
         for tag in btagdiscriminators:
-                print tag
-                if tag == 'jetBProbabilityBJetTags' or tag == 'jetProbabilityBJetTags' or tag == 'trackCountingHighPurBJetTags' or tag == 'trackCountingHighEffBJetTags' or tag == 'negativeTrackCountingHighEffJetTags' or  tag =='negativeTrackCountingHighPurJetTags' :
-                    if not hasattr(process, tag+label+postfix):
-                        tagMod=getattr(btag,tag).clone(tagInfos = vit(ipTILabel))
-                        setattr(process, tag+label+postfix, tagMod)
+            print tag
+            if hasattr( btag, tag ):
+                if tag == 'jetBProbabilityBJetTags' or tag == 'jetProbabilityBJetTags' or tag == 'trackCountingHighPurBJetTags' or tag == 'trackCountingHighEffBJetTags' or tag == 'negativeOnlyJetBProbabilityJetTags' or tag == 'negativeOnlyJetProbabilityJetTags' or tag == 'negativeTrackCountingHighEffJetTags' or  tag =='negativeTrackCountingHighPurJetTags' or tag == 'positiveOnlyJetBProbabilityJetTags' or tag == 'positiveOnlyJetProbabilityJetTags':
+                    if hasattr( process, ipTILabel ):
+                        if not hasattr(process, tag+label+postfix):
+                            tagMod=getattr(btag,tag).clone(tagInfos = vit(ipTILabel))
+                            setattr(process, tag+label+postfix, tagMod)
+                        else:
+                            getattr(process, tag+label+postfix).tagInfos = vit(ipTILabel)
+                        btagdiscriminatorsRun.append( tag )
                     else:
-                        getattr(process, tag+label+postfix).tagInfos = vit(ipTILabel)
+                        print '  --> ignored, since input %s not available!'%( vit(ipTILabel) )
 
                 if tag == 'simpleSecondaryVertexHighEffBJetTags' or tag == 'simpleSecondaryVertexHighPurBJetTags':
-                    if not hasattr(process, tag+label+postfix):
-#                       tagMod=getattr(btag,tag).clone(tagInfos = vit(ipTILabel,svTILabel))
-                        tagMod=getattr(btag,tag).clone(tagInfos = vit(svTILabel))
-                        setattr(process, tag+label+postfix, tagMod)
+                    if hasattr( process, svTILabel ):
+                        if not hasattr(process, tag+label+postfix):
+                            tagMod=getattr(btag,tag).clone(tagInfos = vit(svTILabel))
+                            setattr(process, tag+label+postfix, tagMod)
+                        else:
+                            getattr(process, tag+label+postfix).tagInfos = vit(svTILabel)
+                        btagdiscriminatorsRun.append( tag )
                     else:
-                        #getattr(process, tag+label+postfix).tagInfos = vit(ipTILabel,svTILabel)
-                        getattr(process, tag+label+postfix).tagInfos = vit(svTILabel)
+                        print '  --> ignored, since input %s not available!'%( vit(svTILabel) )
 
-                if tag == 'combinedSecondaryVertexBJetTags' or tag == 'combinedSecondaryVertexMVABJetTags':
-                    if not hasattr(process, tag+label+postfix):
-                        tagMod=getattr(btag,tag).clone(tagInfos = vit(ipTILabel,svTILabel))
-                        setattr(process, tag+label+postfix, tagMod)
+                if tag == 'combinedSecondaryVertexBJetTags' or tag == 'combinedSecondaryVertexPositiveBJetTags' or tag == 'combinedSecondaryVertexV1BJetTags' or tag == 'combinedSecondaryVertexV1PositiveBJetTags' or tag == 'combinedSecondaryVertexMVABJetTags':
+                    if hasattr( process, ipTILabel ) and hasattr( process, svTILabel ):
+                        if not hasattr(process, tag+label+postfix):
+                            tagMod=getattr(btag,tag).clone(tagInfos = vit(ipTILabel,svTILabel))
+                            setattr(process, tag+label+postfix, tagMod)
+                        else:
+                            getattr(process, tag+label+postfix).tagInfos = vit(ipTILabel,svTILabel)
+                        btagdiscriminatorsRun.append( tag )
                     else:
-                        getattr(process, tag+label+postfix).tagInfos = vit(ipTILabel,svTILabel)
+                        print '  --> ignored, since input %s not available!'%( vit(ipTILabel,svTILabel) )
 
-                if tag == 'softMuonBJetTags' or tag == 'softMuonByPtBJetTags' or tag == 'softMuonByIP3dBJetTags' :
-                    if not hasattr(process, tag+label+postfix):
-                        tagMod=getattr(btag,tag).clone(tagInfos = vit(smTILabel))
-                        setattr(process, tag+label+postfix, tagMod)
+                if tag == 'combinedSecondaryVertexNegativeBJetTags' or tag == 'combinedSecondaryVertexV1NegativeBJetTags':
+                    if hasattr( process, ipTILabel ) and hasattr( process, nvTILabel ):
+                        if not hasattr(process, tag+label+postfix):
+                            tagMod=getattr(btag,tag).clone(tagInfos = vit(ipTILabel,nvTILabel))
+                            setattr(process, tag+label+postfix, tagMod)
+                        else:
+                            getattr(process, tag+label+postfix).tagInfos = vit(ipTILabel,nvTILabel)
+                        btagdiscriminatorsRun.append( tag )
                     else:
-                        getattr(process, tag+label+postfix).tagInfos = vit(smTILabel)
+                        print '  --> ignored, since input %s not available!'%( vit(ipTILabel,nvTILabel) )
+
+                if tag == 'softPFMuonBJetTags' or tag == 'softPFMuonByPtBJetTags' or tag == 'softPFMuonByIP3dBJetTags' or tag == 'softPFMuonByIP2dBJetTags' or tag == 'positiveSoftPFMuonBJetTags' or tag == 'positiveSoftPFMuonByPtBJetTags' or tag == 'positiveSoftPFMuonByIP3dBJetTags' or tag == 'positiveSoftPFMuonByIP2dBJetTags' or tag == 'negativeSoftPFMuonBJetTags' or tag == 'negativeSoftPFMuonByPtBJetTags' or tag == 'negativeSoftPFMuonByIP3dBJetTags' or tag == 'negativeSoftPFMuonByIP2dBJetTags':
+                    if hasattr( process, spfmTILabel ):
+                        if not hasattr(process, tag+label+postfix):
+                            tagMod=getattr(btag,tag).clone(tagInfos = vit(spfmTILabel))
+                            setattr(process, tag+label+postfix, tagMod)
+                        else:
+                            getattr(process, tag+label+postfix).tagInfos = vit(spfmTILabel)
+                        btagdiscriminatorsRun.append( tag )
+                    else:
+                        print '  --> ignored, since input %s not available!'%( vit(spfmTILabel) )
+
+                if tag == 'softPFElectronBJetTags' or tag == 'softPFElectronByPtBJetTags' or tag == 'softPFElectronByIP3dBJetTags' or tag == 'softPFElectronByIP2dBJetTags' or tag == 'positiveSoftPFElectronBJetTags' or tag == 'positiveSoftPFElectronByPtBJetTags' or tag == 'positiveSoftPFElectronByIP3dBJetTags' or tag == 'positiveSoftPFElectronByIP2dBJetTags' or tag == 'negativeSoftPFElectronBJetTags' or tag == 'negativeSoftPFElectronByPtBJetTags' or tag == 'negativeSoftPFElectronByIP3dBJetTags' or tag == 'negativeSoftPFElectronByIP2dBJetTags':
+                    if hasattr( process, spfeTILabel ):
+                        if not hasattr(process, tag+label+postfix):
+                            tagMod=getattr(btag,tag).clone(tagInfos = vit(spfeTILabel))
+                            setattr(process, tag+label+postfix, tagMod)
+                        else:
+                            getattr(process, tag+label+postfix).tagInfos = vit(spfeTILabel)
+                        btagdiscriminatorsRun.append( tag )
+                    else:
+                        print '  --> ignored, since input %s not available!'%( vit(spfeTILabel) )
 
                 if tag == 'simpleSecondaryVertexNegativeHighEffBJetTags' or tag == 'simpleSecondaryVertexNegativeHighPurBJetTags':
-                    if not hasattr(process, tag+label+postfix):
-                        tagMod=getattr(btag,tag).clone(tagInfos = vit(nvTILabel))
-                        setattr(process, tag+label+postfix, tagMod)
+                    if hasattr( process, nvTILabel ):
+                        if not hasattr(process, tag+label+postfix):
+                            tagMod=getattr(btag,tag).clone(tagInfos = vit(nvTILabel))
+                            setattr(process, tag+label+postfix, tagMod)
+                        else:
+                            getattr(process, tag+label+postfix).tagInfos = vit(nvTILabel)
+                        btagdiscriminatorsRun.append( tag )
                     else:
-                        getattr(process, tag+label+postfix).tagInfos = vit(nvTILabel)
+                        print '  --> ignored, since input %s not available!'%( vit(nvTILabel) )
 
-                if tag == 'combinedInclusiveSecondaryVertexBJetTags' :
-                    if not hasattr(process, tag+label+postfix):
-                        tagMod=getattr(btag,tag).clone(tagInfos = vit(ipTILabel,ivfTILabel))
-                        setattr(process, tag+label+postfix, tagMod)
+                if tag == 'simpleInclusiveSecondaryVertexHighEffBJetTags' or tag == 'simpleInclusiveSecondaryVertexHighPurBJetTags' or tag == 'doubleSecondaryVertexHighEffBJetTags':
+                    if hasattr( process, ivfFiltTILabel ):
+                        if not hasattr(process, tag+label+postfix):
+                            tagMod=getattr(btag,tag).clone(tagInfos = vit(ivfFiltTILabel))
+                            setattr(process, tag+label+postfix, tagMod)
+                        else:
+                            getattr(process, tag+label+postfix).tagInfos = vit(ivfFiltTILabel)
+                        btagdiscriminatorsRun.append( tag )
                     else:
-                        getattr(process, tag+label+postfix).tagInfos = vit(ipTILabel,ivfTILabel)
+                        print '  --> ignored, since input %s not available!'%( vit(ivfFiltTILabel) )
 
-                if tag == 'combinedMVABJetTags' :
-                    if not hasattr(process, tag+label+postfix):
-                        tagMod=getattr(btag,tag).clone(tagInfos = vit(ipTILabel, ivfTILabel,smTILabel,seTILabel))
-                        setattr(process, tag+label+postfix, tagMod)
+                if tag == 'combinedInclusiveSecondaryVertexBJetTags' or tag == 'combinedInclusiveSecondaryVertexPositiveBJetTags':
+                    if hasattr( process, ipTILabel ) and hasattr( process, ivfTILabel ):
+                        if not hasattr(process, tag+label+postfix):
+                            tagMod=getattr(btag,tag).clone(tagInfos = vit(ipTILabel,ivfTILabel))
+                            setattr(process, tag+label+postfix, tagMod)
+                        else:
+                            getattr(process, tag+label+postfix).tagInfos = vit(ipTILabel,ivfTILabel)
+                        btagdiscriminatorsRun.append( tag )
                     else:
-                        getattr(process, tag+label+postfix).tagInfos = vit(ipTILabel, ivfTILabel,smTILabel,seTILabel)
+                        print '  --> ignored, since input %s not available!'%( vit(ipTILabel,ivfTILabel) )
+
+                if tag == 'combinedMVABJetTags' or tag == 'positiveCombinedMVABJetTags' or tag == 'negativeCombinedMVABJetTags':
+                    if hasattr( process, ipTILabel ) and hasattr( process, ivfTILabel ) and hasattr( process, spfmTILabel ) and hasattr( process, spfeTILabel ):
+                        if not hasattr(process, tag+label+postfix):
+                            tagMod=getattr(btag,tag).clone(tagInfos = vit(ipTILabel, ivfTILabel,spfmTILabel,spfeTILabel))
+                            setattr(process, tag+label+postfix, tagMod)
+                        else:
+                            getattr(process, tag+label+postfix).tagInfos = vit(ipTILabel, ivfTILabel,spfmTILabel,spfeTILabel)
+                        btagdiscriminatorsRun.append( tag )
+                    else:
+                        print '  --> ignored, since input %s not available!'%( vit(ipTILabel, ivfTILabel,spfmTILabel,spfeTILabel) )
+
+                if tag == 'combinedSecondaryVertexSoftPFLeptonV1BJetTags' or tag == 'positiveCombinedSecondaryVertexSoftPFLeptonV1BJetTags' or tag == 'negativeCombinedSecondaryVertexSoftPFLeptonV1BJetTags':
+                    if hasattr( process, ipTILabel ) and hasattr( process, svTILabel ) and hasattr( process, spfmTILabel ) and hasattr( process, spfeTILabel ):
+                        if not hasattr(process, tag+label+postfix):
+                            tagMod=getattr(btag,tag).clone(tagInfos = vit(ipTILabel,svTILabel,spfmTILabel,spfeTILabel))
+                            setattr(process, tag+label+postfix, tagMod)
+                        else:
+                            getattr(process, tag+label+postfix).tagInfos = vit(ipTILabel,svTILabel,spfmTILabel,spfeTILabel)
+                        btagdiscriminatorsRun.append( tag )
+                    else:
+                        print '  --> ignored, since input %s not available!'%( vit(ipTILabel,svTILabel,spfmTILabel,spfeTILabel) )
+            else:
+                print '  --> ignored, since not available via RecoBTag/Configuration/python/RecoBTag_cff.py!'
 
 
         ## define vector of (output) labels
         labels = { 'jta'      : jtaLabel,
-                 'tagInfos' : [(y + label + postfix) for y in btagInfo],
-                 'jetTags'  : [ (x + label+postfix) for x in btagdiscriminators]
+                 'tagInfos' : [(y + label + postfix) for y in btagInfoRun],
+                 'jetTags'  : [ (x + label+postfix) for x in btagdiscriminatorsRun]
                    }
 
         ## add a combined b-tag sequence to the process
@@ -244,14 +468,20 @@ class RunBTagging(ConfigToolBase):
             seq = None
 
         ## return the combined sequence and the labels defined above
-        if seTILabel in getattr( process, 'btagging'+label+postfix ).moduleNames():
-            if not hasattr( process, 'softElectronCands' ):
-                setattr( process, 'softElectronCands', btag.softElectronCands )
-            getattr( process, 'btagging'+label+postfix ).replace( getattr( process, seTILabel ), ( process.softElectronCands * getattr( process, seTILabel ) ) )
         if ivfTILabel in getattr( process, 'btagging'+label+postfix ).moduleNames():
             if not hasattr( process, 'inclusiveVertexing' ):
                 process.load( 'RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff' )
-            getattr( process, 'btagging'+label+postfix ).replace( getattr( process, ivfTILabel ), ( process.inclusiveVertexing * getattr( process, ivfTILabel ) ) )
+            if hasattr( process, 'inclusiveVertexing' ):
+                getattr( process, 'btagging'+label+postfix ).replace( getattr( process, ivfTILabel ), ( process.inclusiveVertexing * getattr( process, ivfTILabel ) ) )
+        if ivfFiltTILabel in getattr( process, 'btagging'+label+postfix ).moduleNames():
+            if not hasattr( process, 'inclusiveVertexing' ):
+                process.load( 'RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff' )
+            if not hasattr( process, 'inclusiveMergedVerticesFiltered' ):
+                process.load( 'RecoBTag.SecondaryVertex.secondaryVertex_cff' )
+            if not hasattr( process, 'bToCharmDecayVertexMerged' ):
+                process.load( 'RecoBTag.SecondaryVertex.bToCharmDecayVertexMerger_cfi' )
+            if hasattr( process, 'inclusiveVertexing' ) and hasattr( process, 'inclusiveMergedVerticesFiltered' ) and hasattr( process, 'bToCharmDecayVertexMerged' ):
+                getattr( process, 'btagging'+label+postfix ).replace( getattr( process, ivfFiltTILabel ), ( process.inclusiveVertexing * process.inclusiveMergedVerticesFiltered * process.bToCharmDecayVertexMerged * getattr( process, ivfFiltTILabel ) ) )
 
         if hasattr(process, "addAction"):
             process.enableRecording()
@@ -277,8 +507,8 @@ class AddJetCollection(ConfigToolBase):
         self.addParameter(self._defaultParameters,'jetCollection',self._defaultValue,'Input jet collection', cms.InputTag)
         self.addParameter(self._defaultParameters,'algoLabel',self._defaultValue, "label to indicate the jet algorithm (e.g.'AK5')",str)
         self.addParameter(self._defaultParameters,'typeLabel',self._defaultValue, "label to indicate the type of constituents (e.g. 'Calo', 'Pflow', 'Jpt', ...)",str)
-        self.addParameter(self._defaultParameters,'btagInfo',['impactParameterTagInfos','secondaryVertexTagInfos','softMuonTagInfos','secondaryVertexNegativeTagInfos','secondaryVertexNegativeTagInfos','inclusiveSecondaryVertexFinderTagInfos','softElectronTagInfos'],"input btag info",allowedValues=['impactParameterTagInfos','secondaryVertexTagInfos','softMuonTagInfos','secondaryVertexNegativeTagInfos','inclusiveSecondaryVertexFinderTagInfos','softElectronTagInfos'],Type=list)
-        self.addParameter(self._defaultParameters,'btagdiscriminators',['jetBProbabilityBJetTags', 'jetProbabilityBJetTags','trackCountingHighPurBJetTags','trackCountingHighEffBJetTags','simpleSecondaryVertexHighEffBJetTags','simpleSecondaryVertexHighPurBJetTags','combinedSecondaryVertexBJetTags','combinedSecondaryVertexMVABJetTags','softMuonBJetTags','softMuonByPtBJetTags','softMuonByIP3dBJetTags','simpleSecondaryVertexNegativeHighEffBJetTags','simpleSecondaryVertexNegativeHighPurBJetTags','negativeTrackCountingHighEffJetTags','negativeTrackCountingHighPurJetTags','combinedInclusiveSecondaryVertexBJetTags','combinedMVABJetTags'],"input btag discriminators", allowedValues=['jetBProbabilityBJetTags', 'jetProbabilityBJetTags', 'trackCountingHighPurBJetTags', 'trackCountingHighEffBJetTags', 'simpleSecondaryVertexHighEffBJetTags','simpleSecondaryVertexHighPurBJetTags','combinedSecondaryVertexBJetTags','combinedSecondaryVertexMVABJetTags','softMuonBJetTags','softMuonByPtBJetTags','softMuonByIP3dBJetTags','simpleSecondaryVertexNegativeHighEffBJetTags','simpleSecondaryVertexNegativeHighPurBJetTags','negativeTrackCountingHighEffJetTags','negativeTrackCountingHighPurJetTags','combinedInclusiveSecondaryVertexBJetTags','combinedMVABJetTags'],Type=list)
+        self.addParameter(self._defaultParameters,'btagInfo',_defaultBTagInfos,"input btag info",allowedValues=_allowedBTagInfos,Type=list)
+        self.addParameter(self._defaultParameters,'btagdiscriminators',_defaultBTagDiscriminators,"input btag discriminators",allowedValues=_allowedBTagDiscriminators,Type=list)
         self.addParameter(self._defaultParameters,'doJTA',True, "run b tagging sequence for new jet collection and add it to the new pat jet collection")
         self.addParameter(self._defaultParameters,'doBTagging',True, 'run JetTracksAssociation and JetCharge and add it to the new pat jet collection (will autom. be true if doBTagging is set to true)')
         self.addParameter(self._defaultParameters,'jetCorrLabel',None, "payload and list of new jet correction labels, such as (\'AK5Calo\',[\'L2Relative\', \'L3Absolute\'])", tuple,acceptNoneValue=True )
@@ -290,7 +520,7 @@ class AddJetCollection(ConfigToolBase):
         self.addParameter(self._defaultParameters,'jetIdLabel',"ak5", " specify the label prefix of the xxxJetID object; in general it is the jet collection tag like ak5, kt4 sc5, aso. For more information have a look to SWGuidePATTools#add_JetCollection")
         self.addParameter(self._defaultParameters,'standardAlgo',"AK5", "standard algorithm label of the collection from which the clones for the new jet collection will be taken from (note that this jet collection has to be available in the event before hand)")
         self.addParameter(self._defaultParameters,'standardType',"Calo", "standard constituent type label of the collection from which the clones for the new jet collection will be taken from (note that this jet collection has to be available in the event before hand)")
-        self.addParameter(self._defaultParameters, 'outputModules', ['out'], "output module labels, empty list of label indicates no output, default: ['out']")
+        self.addParameter(self._defaultParameters,'outputModules', ['out'], "output module labels, empty list of label indicates no output, default: ['out']")
 
         self._parameters=copy.deepcopy(self._defaultParameters)
         self._comment = ""
@@ -459,7 +689,7 @@ class AddJetCollection(ConfigToolBase):
 
         if (doJTA or doBTagging):
             ## add clone of jet track association
-            process.load("RecoJets.JetAssociationProducers.ak5JTA_cff")
+            ###process.load("RecoJets.JetAssociationProducers.ak5JTA_cff")
             from RecoJets.JetAssociationProducers.ak5JTA_cff import ak5JetTracksAssociatorAtVertex
             ## add jet track association module to processes
             jtaLabel = 'jetTracksAssociatorAtVertex'+algoLabel+typeLabel
@@ -669,8 +899,8 @@ class SwitchJetCollection(ConfigToolBase):
     def __init__(self):
         ConfigToolBase.__init__(self)
         self.addParameter(self._defaultParameters,'jetCollection',self._defaultValue,'Input jet collection', cms.InputTag)
-        self.addParameter(self._defaultParameters,'btagInfo',['impactParameterTagInfos','secondaryVertexTagInfos','softMuonTagInfos','secondaryVertexNegativeTagInfos','secondaryVertexNegativeTagInfos','inclusiveSecondaryVertexFinderTagInfos','softElectronTagInfos'],"input btag info",allowedValues=['impactParameterTagInfos','secondaryVertexTagInfos','softMuonTagInfos','secondaryVertexNegativeTagInfos','inclusiveSecondaryVertexFinderTagInfos','softElectronTagInfos'],Type=list)
-        self.addParameter(self._defaultParameters,'btagdiscriminators',['jetBProbabilityBJetTags', 'jetProbabilityBJetTags','trackCountingHighPurBJetTags','trackCountingHighEffBJetTags','simpleSecondaryVertexHighEffBJetTags','simpleSecondaryVertexHighPurBJetTags','combinedSecondaryVertexBJetTags','combinedSecondaryVertexMVABJetTags','softMuonBJetTags','softMuonByPtBJetTags','softMuonByIP3dBJetTags','simpleSecondaryVertexNegativeHighEffBJetTags','simpleSecondaryVertexNegativeHighPurBJetTags','negativeTrackCountingHighEffJetTags','negativeTrackCountingHighPurJetTags','combinedInclusiveSecondaryVertexBJetTags','combinedMVABJetTags'],"input btag discriminators", allowedValues=['jetBProbabilityBJetTags', 'jetProbabilityBJetTags', 'trackCountingHighPurBJetTags', 'trackCountingHighEffBJetTags', 'simpleSecondaryVertexHighEffBJetTags','simpleSecondaryVertexHighPurBJetTags','combinedSecondaryVertexBJetTags','combinedSecondaryVertexMVABJetTags','softMuonBJetTags','softMuonByPtBJetTags','softMuonByIP3dBJetTags','simpleSecondaryVertexNegativeHighEffBJetTags','simpleSecondaryVertexNegativeHighPurBJetTags','negativeTrackCountingHighEffJetTags','negativeTrackCountingHighPurJetTags','combinedInclusiveSecondaryVertexBJetTags','combinedMVABJetTags'],Type=list)
+        self.addParameter(self._defaultParameters,'btagInfo',_defaultBTagInfos,"input btag info",allowedValues=_allowedBTagInfos,Type=list)
+        self.addParameter(self._defaultParameters,'btagdiscriminators',_defaultBTagDiscriminators,"input btag discriminators",allowedValues=_allowedBTagDiscriminators,Type=list)
 	self.addParameter(self._defaultParameters,'doJTA',True, "run b tagging sequence for new jet collection and add it to the new pat jet collection")
         self.addParameter(self._defaultParameters,'doBTagging',True, 'run JetTracksAssociation and JetCharge and add it to the new pat jet collection (will autom. be true if doBTagging is set to true)')
         self.addParameter(self._defaultParameters,'jetCorrLabel',None, "payload and list of new jet correction labels, such as (\'AK5Calo\',[\'L2Relative\', \'L3Absolute\'])", tuple,acceptNoneValue=True )
@@ -787,7 +1017,7 @@ class SwitchJetCollection(ConfigToolBase):
 
         if (doJTA or doBTagging):
             ## replace jet track association
-            process.load("RecoJets.JetAssociationProducers.ak5JTA_cff")
+            ###process.load("RecoJets.JetAssociationProducers.ak5JTA_cff")
             from RecoJets.JetAssociationProducers.ak5JTA_cff import ak5JetTracksAssociatorAtVertex
             if not hasattr(process, "jetTracksAssociatorAtVertex"+postfix):
                 setattr(process, "jetTracksAssociatorAtVertex"+postfix, ak5JetTracksAssociatorAtVertex.clone(jets = jetCollection))

--- a/PhysicsTools/PatAlgos/test/patTuple_addBTagging_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addBTagging_cfg.py
@@ -1,0 +1,57 @@
+## import skeleton process
+from PhysicsTools.PatAlgos.patTemplate_cfg import *
+
+##from PhysicsTools.PatAlgos.tools.coreTools import *
+##removeMCMatching(process, ['All'])
+
+## uncomment the following line to add tcMET to the event content
+from PhysicsTools.PatAlgos.tools.metTools import *
+addTcMET(process, 'TC')
+addPfMET(process, 'PF')
+
+## uncomment the following line to add different b-taggers collections
+## to the event content
+from PhysicsTools.PatAlgos.tools.jetTools import *
+
+process.patJets.addTagInfos = True
+
+# uncomment the following lines to add ak5PFJets with new b-tags to your PAT output
+addJetCollection(process,cms.InputTag('ak5PFJets'),
+                 'AK5', 'PF',
+                 doJTA        = True,
+                 doBTagging   = True,
+                 btagInfo           = cms.vstring('impactParameterTagInfos','secondaryVertexTagInfos','secondaryVertexNegativeTagInfos','inclusiveSecondaryVertexFinderTagInfos'),
+                 btagdiscriminators = cms.vstring('jetBProbabilityBJetTags','jetProbabilityBJetTags','trackCountingHighPurBJetTags','trackCountingHighEffBJetTags','simpleSecondaryVertexHighEffBJetTags','simpleSecondaryVertexHighPurBJetTags','combinedSecondaryVertexBJetTags','combinedInclusiveSecondaryVertexBJetTags'),
+                 jetCorrLabel = ('AK5PF', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute'])),
+                 doType1MET   = True,
+                 doL1Cleaning = True,
+                 doL1Counters = False,
+                 genJetCollection=cms.InputTag("ak5GenJets"),
+                 doJetID      = True,
+                 jetIdLabel   = "ak5"
+                 )
+process.patJetsAK5PF.addTagInfos = True
+
+## let it run
+process.p = cms.Path(
+    process.patDefaultSequence
+)
+
+## ------------------------------------------------------
+#  In addition you usually want to change the following
+#  parameters:
+## ------------------------------------------------------
+#
+#   process.GlobalTag.globaltag =  ...    ##  (according to https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideFrontierConditions)
+#                                         ##
+## switch to RECO input
+from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarAODSIM
+process.source.fileNames = filesRelValProdTTbarAODSIM
+#                                         ##
+process.maxEvents.input = 10
+#                                         ##
+#   process.out.outputCommands = [ ... ]  ##  (e.g. taken from PhysicsTools/PatAlgos/python/patEventContent_cff.py)
+#                                         ##
+process.out.fileName = 'patTuple_addBTagging.root'
+#                                         ##
+#   process.options.wantSummary = False   ##  (to suppress the long output at the end of the job)

--- a/PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
@@ -62,7 +62,7 @@ addJetCollection(process,cms.InputTag('kt6PFJets'),
                  'KT6', 'PF',
                  doJTA        = True,
                  doBTagging   = False,
-                 jetCorrLabel = ('KT6PF', cms.vstring()), # currently not available
+                 #jetCorrLabel = ('KT6PF', cms.vstring()), # currently not available
                  doType1MET   = False,
                  doL1Cleaning = True,
                  doL1Counters = False,

--- a/PhysicsTools/PatAlgos/test/patTuple_factorisedTaginfo_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_factorisedTaginfo_cfg.py
@@ -95,7 +95,7 @@ process.p = cms.Path(
 from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarAODSIM
 process.source.fileNames = filesRelValProdTTbarAODSIM
 #                                         ##
-process.maxEvents.input = 100
+process.maxEvents.input = 10
 #                                         ##
 #   process.out.outputCommands = [ ... ]  ##  (e.g. taken from PhysicsTools/PatAlgos/python/patEventContent_cff.py)
 #                                         ##

--- a/PhysicsTools/PatAlgos/test/runtests.sh
+++ b/PhysicsTools/PatAlgos/test/runtests.sh
@@ -12,6 +12,8 @@ cmsRun ${LOCAL_TEST_DIR}/patTuple_pfIso_cfg.py || die 'Failure using patTuple_pf
 
 cmsRun ${LOCAL_TEST_DIR}/patTuple_addDecayInFlight_cfg.py || die 'Failure using patTuple_addDecayInFlight_cfg.py' $?
 
+cmsRun ${LOCAL_TEST_DIR}/patTuple_addBTagging_cfg.py || die 'Failure using patTuple_addBTagging_cfg.py' $?
+
 cmsRun ${LOCAL_TEST_DIR}/patTuple_addJets_cfg.py || die 'Failure using patTuple_addJets_cfg.py' $?
 
 cmsRun ${LOCAL_TEST_DIR}/patTuple_addTracks_cfg.py || die 'Failure using patTuple_addTracks_cfg.py' $?
@@ -29,6 +31,7 @@ cmsRun ${LOCAL_TEST_DIR}/patTuple_topSelection_cfg.py || die 'Failure using patT
 cmsRun ${LOCAL_TEST_DIR}/patTuple_userData_cfg.py || die 'Failure using patTuple_userData_cfg.py' $?
 
 # Not needed in IBs
+# cmsRun ${LOCAL_TEST_DIR}/patTuple_factorisedTaginfo_cfg.py || die 'Failure using patTuple_factorisedTaginfo_cfg.py' $?
 # cmsRun ${LOCAL_TEST_DIR}/patTuple_onlyElectrons_cfg.py || die 'Failure using patTuple_onlyElectrons_cfg.py' $?
 # cmsRun ${LOCAL_TEST_DIR}/patTuple_onlyJets_cfg.py || die 'Failure using patTuple_onlyJets_cfg.py' $?
 # cmsRun ${LOCAL_TEST_DIR}/patTuple_onlyMET_cfg.py || die 'Failure using patTuple_onlyMET_cfg.py' $?

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -255,6 +255,7 @@ reco::Muon MuonIdProducer::makeMuon(edm::Event& iEvent, const edm::EventSetup& i
    reco::Muon aMuon( makeMuon( *(track.get()) ) );
 
    aMuon.setMuonTrack(type,track);
+   aMuon.setBestTrack(type);
    return aMuon;
 }
 


### PR DESCRIPTION
1- I introduced in DataFormats/MuonReco/interface/MuonCocktails.h a couple of function to check the validity of the inputs to the tuneP algo.

2- I added muonBestTrack(const reco::Muon& muon, reco::TunePType tunePType); in MuonCocktails.h/cc. The implementation simulate what is actually done in MuonIdProducer. T

3- I moved the tuneP enumerator in MuonFwd.h (this will make a lot CMSSW package to recompile... though it is a trivial change

4- I removed improvedMuonBestTrack(const reco::Muon&, TunePType); from MuonSelector.h and in the same file I also removed the default for isHighPtMuon(const reco::Muon&, const reco::Vertex&, reco::TunePType);

5- I modified pat::Muon.h/c to add:
    a) a new muonBestTrack(); method 
    b) reco::TrackRef improvedMuonBestTrack();
    c) MuonTrackType improvedMuonBestTrackType() and void setImprovedBestTrack(MuonTrackType muonType)
        cbis) improvedMuonBestTrackType_ has been added as datamember
    d) void embedImprovedMuonBestTrack(); and whatever is needed to make the embedding
    e) isLooseMuon(), isSoftMuon(), isHighPtMuon() to call the implementation in MuonSelctor.h
    f) the class version of Muon.h for pat is now 14 instead of 12

6- In PATMuonProducer.h and PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cfi.py I intruduced the possibility to embed the improved Muon best track. Default is set to true

7- In PATMuonProducer.cc I changed it to use the muonBestTrack properly. It was already protected, because I put a protection in the past. Now, however, it has an implementation that support STA-only muons too. The default here is the _default_ muonBestTrack (as it was till now). Note that in this part of the code the best track is used to calculate IP values.

8- In RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc I put back the fix that exited the 53X releases.
https://hypernews.cern.ch/HyperNews/CMS/get/pkgAnnounce/135377.html
