### PR TITLE
Adding b-tagging only to the EITopPAG

### DIFF
--- a/CommonTools/ParticleFlow/python/EITopPAG_EventContent_cff.py
+++ b/CommonTools/ParticleFlow/python/EITopPAG_EventContent_cff.py
@@ -9,6 +9,11 @@ EITopPAGEventContent = cms.PSet(
     'keep *_pfIsolatedMuonsEI_*_*',
     # jets
     'keep recoPFJets_pfJetsEI_*_*',
+    # btags
+    'keep *_pfJetTrackAssociatorEI_*_*',
+    'keep *_impactParameterTagInfosEI_*_*',
+    'keep *_secondaryVertexTagInfosEI_*_*',
+    'keep *_combinedSecondaryVertexBJetTagsEI_*_*',
     # taus 
     'keep recoPFTaus_pfTausEI_*_*',
     'keep recoPFTauDiscriminator_pfTausDiscrimination*_*_*',

--- a/CommonTools/ParticleFlow/python/EITopPAG_cff.py
+++ b/CommonTools/ParticleFlow/python/EITopPAG_cff.py
@@ -16,6 +16,13 @@ from CommonTools.ParticleFlow.TopProjectors.pfNoJet_cfi import *
 from CommonTools.ParticleFlow.TopProjectors.pfNoTau_cfi import *
 
 
+# b-tagging
+from RecoJets.JetAssociationProducers.ak5JTA_cff import ak5JetTracksAssociatorAtVertex
+from RecoBTag.ImpactParameter.impactParameter_cfi import impactParameterTagInfos
+from RecoBTag.SecondaryVertex.secondaryVertexTagInfos_cfi import secondaryVertexTagInfos
+from RecoBTag.SecondaryVertex.combinedSecondaryVertexBJetTags_cfi import combinedSecondaryVertexBJetTags
+
+
 #### PU Again... need to do this twice because the "linking" stage of PF reco ####
 #### condenses information into the new "particleFlow" collection.            ####
 
@@ -122,6 +129,23 @@ pfTauEISequence = cms.Sequence(
     pfTausPtrsEI
     )
 
+#### B-tagging ####
+pfJetTrackAssociatorEI = ak5JetTracksAssociatorAtVertex.clone (
+    src = cms.InputTag("pfJetsEI")
+    )
+impactParameterTagInfosEI = impactParameterTagInfos.clone(
+    jetTracks = cms.InputTag( 'pfJetTrackAssociatorEI' )
+    )
+secondaryVertexTagInfosEI = secondaryVertexTagInfos.clone(
+    trackIPTagInfos = cms.InputTag( 'impactParameterTagInfosEI' )
+    )
+combinedSecondaryVertexBJetTagsEI = combinedSecondaryVertexBJetTags.clone(
+    tagInfos = cms.VInputTag(cms.InputTag("impactParameterTagInfosEI"),
+                             cms.InputTag("secondaryVertexTagInfosEI"))    
+    )
+
+
+
 #### MET ####
 pfMetEI = pfMET.clone(jets=cms.InputTag("pfJetsEI"))
 
@@ -145,6 +169,10 @@ EIsequence = cms.Sequence(
     pfNoJetEI + 
     pfTauEISequence +
     pfNoTauEI +
-    pfMetEI
+    pfMetEI+
+    pfJetTrackAssociatorEI+
+    impactParameterTagInfosEI+
+    secondaryVertexTagInfosEI+
+    combinedSecondaryVertexBJetTagsEI    
     )
 


### PR DESCRIPTION
As per Slava's request here : 

https://github.com/cms-sw/cmssw/pull/548#issuecomment-22763706

I added ONLY the b-tagging sequence to the EITopPAG without touching the lepton parts (yet) since there are conflicts with other Electron developments. 
