### PR TITLE
Reco Updates -- Add calibrated energy to CaloCluster

### DIFF
--- a/DataFormats/CaloRecHit/interface/CaloCluster.h
+++ b/DataFormats/CaloRecHit/interface/CaloCluster.h
@@ -41,18 +41,18 @@ namespace reco {
  
    /// default constructor. Sets energy and position to zero
     CaloCluster() : 
-      energy_(0), 
+      energy_(0), calibratedEnergy_(-1.0), 
       algoID_( undefined ), flags_(0) {}
 
     /// constructor with algoId, to be used in all child classes
     CaloCluster(AlgoID algoID) : 
-      energy_(0), 
+      energy_(0), calibratedEnergy_(-1.0), 
       algoID_( algoID ), flags_(0) {}
 
     CaloCluster( double energy,
                  const math::XYZPoint& position,
                  const CaloID& caloID) :
-      energy_ (energy), position_ (position), caloID_(caloID),algoID_( undefined ), flags_(0) {}
+      energy_ (energy), calibratedEnergy_(-1.0), position_ (position), caloID_(caloID),algoID_( undefined ), flags_(0) {}
 
 
     /// resets the CaloCluster (position, energy, hitsAndFractions)
@@ -61,7 +61,7 @@ namespace reco {
      /// constructor from values 
      CaloCluster( double energy,  
  		 const math::XYZPoint& position ) : 
-       energy_ (energy), position_ (position),algoID_( undefined ), flags_(0) {} 
+       energy_ (energy), calibratedEnergy_(-1.0), position_ (position),algoID_( undefined ), flags_(0) {} 
 
 
     CaloCluster( double energy,
@@ -69,7 +69,7 @@ namespace reco {
 		 const CaloID& caloID,
                  const AlgoID& algoID,
                  uint32_t flags = 0) :
-      energy_ (energy), position_ (position), 
+      energy_ (energy), calibratedEnergy_(-1.0), position_ (position), 
       caloID_(caloID), algoID_(algoID) {
       flags_=flags&flagsMask_;
     }
@@ -81,7 +81,7 @@ namespace reco {
                  const AlgoId algoId,
 		 const DetId seedId = DetId(0),
                  uint32_t flags = 0) :
-      energy_ (energy), position_ (position), caloID_(caloID), 
+      energy_ (energy), calibratedEnergy_(-1.0), position_ (position), caloID_(caloID), 
       hitsAndFractions_(usedHitsAndFractions), algoID_(algoId),seedId_(seedId){
       flags_=flags&flagsMask_;
     }
@@ -94,7 +94,7 @@ namespace reco {
                  const std::vector<DetId > &usedHits,
                  const AlgoId algoId,
                  uint32_t flags = 0) :
-      energy_ (energy), position_ (position),  algoID_(algoId)
+      energy_(energy), calibratedEnergy_(-1.0), position_ (position),  algoID_(algoId)
        {
           hitsAndFractions_.reserve(usedHits.size());
           for(size_t i = 0; i < usedHits.size(); i++) hitsAndFractions_.push_back(std::pair< DetId, float > ( usedHits[i],1.));
@@ -107,6 +107,7 @@ namespace reco {
 
 
     void setEnergy(double energy){energy_ = energy;}
+    void setCalibratedEnergy(double cenergy){calibratedEnergy_ = cenergy;}
     
     void setPosition(const math::XYZPoint& p){position_ = p;}
 
@@ -118,6 +119,7 @@ namespace reco {
 
     /// cluster energy
     double energy() const { return energy_; }
+    double calibratedEnergy() const { return calibratedEnergy_; }
 
     /// cluster centroid position
     const math::XYZPoint & position() const { return position_; }
@@ -202,6 +204,7 @@ namespace reco {
 
     /// cluster energy
     double              energy_;
+    double              calibratedEnergy_;
 
     /// cluster centroid position
     math::XYZPoint      position_;

--- a/DataFormats/CaloRecHit/interface/CaloCluster.h
+++ b/DataFormats/CaloRecHit/interface/CaloCluster.h
@@ -41,18 +41,18 @@ namespace reco {
  
    /// default constructor. Sets energy and position to zero
     CaloCluster() : 
-      energy_(0), calibratedEnergy_(-1.0), 
+      energy_(0), correctedEnergy_(-1.0), 
       algoID_( undefined ), flags_(0) {}
 
     /// constructor with algoId, to be used in all child classes
     CaloCluster(AlgoID algoID) : 
-      energy_(0), calibratedEnergy_(-1.0), 
+      energy_(0), correctedEnergy_(-1.0), 
       algoID_( algoID ), flags_(0) {}
 
     CaloCluster( double energy,
                  const math::XYZPoint& position,
                  const CaloID& caloID) :
-      energy_ (energy), calibratedEnergy_(-1.0), position_ (position), caloID_(caloID),algoID_( undefined ), flags_(0) {}
+      energy_ (energy), correctedEnergy_(-1.0), position_ (position), caloID_(caloID),algoID_( undefined ), flags_(0) {}
 
 
     /// resets the CaloCluster (position, energy, hitsAndFractions)
@@ -61,7 +61,7 @@ namespace reco {
      /// constructor from values 
      CaloCluster( double energy,  
  		 const math::XYZPoint& position ) : 
-       energy_ (energy), calibratedEnergy_(-1.0), position_ (position),algoID_( undefined ), flags_(0) {} 
+       energy_ (energy), correctedEnergy_(-1.0), position_ (position),algoID_( undefined ), flags_(0) {} 
 
 
     CaloCluster( double energy,
@@ -69,7 +69,7 @@ namespace reco {
 		 const CaloID& caloID,
                  const AlgoID& algoID,
                  uint32_t flags = 0) :
-      energy_ (energy), calibratedEnergy_(-1.0), position_ (position), 
+      energy_ (energy), correctedEnergy_(-1.0), position_ (position), 
       caloID_(caloID), algoID_(algoID) {
       flags_=flags&flagsMask_;
     }
@@ -81,7 +81,7 @@ namespace reco {
                  const AlgoId algoId,
 		 const DetId seedId = DetId(0),
                  uint32_t flags = 0) :
-      energy_ (energy), calibratedEnergy_(-1.0), position_ (position), caloID_(caloID), 
+      energy_ (energy), correctedEnergy_(-1.0), position_ (position), caloID_(caloID), 
       hitsAndFractions_(usedHitsAndFractions), algoID_(algoId),seedId_(seedId){
       flags_=flags&flagsMask_;
     }
@@ -94,7 +94,7 @@ namespace reco {
                  const std::vector<DetId > &usedHits,
                  const AlgoId algoId,
                  uint32_t flags = 0) :
-      energy_(energy), calibratedEnergy_(-1.0), position_ (position),  algoID_(algoId)
+      energy_(energy), correctedEnergy_(-1.0), position_ (position),  algoID_(algoId)
        {
           hitsAndFractions_.reserve(usedHits.size());
           for(size_t i = 0; i < usedHits.size(); i++) hitsAndFractions_.push_back(std::pair< DetId, float > ( usedHits[i],1.));
@@ -107,7 +107,7 @@ namespace reco {
 
 
     void setEnergy(double energy){energy_ = energy;}
-    void setCalibratedEnergy(double cenergy){calibratedEnergy_ = cenergy;}
+    void setCorrectedEnergy(double cenergy){correctedEnergy_ = cenergy;}
     
     void setPosition(const math::XYZPoint& p){position_ = p;}
 
@@ -119,7 +119,7 @@ namespace reco {
 
     /// cluster energy
     double energy() const { return energy_; }
-    double calibratedEnergy() const { return calibratedEnergy_; }
+    double correctedEnergy() const { return correctedEnergy_; }
 
     /// cluster centroid position
     const math::XYZPoint & position() const { return position_; }
@@ -204,7 +204,7 @@ namespace reco {
 
     /// cluster energy
     double              energy_;
-    double              calibratedEnergy_;
+    double              correctedEnergy_;
 
     /// cluster centroid position
     math::XYZPoint      position_;

--- a/DataFormats/CaloRecHit/src/CaloCluster.cc
+++ b/DataFormats/CaloRecHit/src/CaloCluster.cc
@@ -36,8 +36,11 @@ std::ostream& reco::operator<<(std::ostream& out,
 
   out<<"CaloCluster , algoID="<<cluster.algoID()
      <<", "<<cluster.caloID()    
-     <<", E="<<cluster.energy()
-     <<", eta,phi="<<pos.eta()<<","<<pos.phi()
+     <<", E="<<cluster.energy();
+  if( cluster.calibratedEnergy() != -1.0 ) {
+    out << ", E_calib="<<cluster.calibratedEnergy();
+  }
+  out<<", eta,phi="<<pos.eta()<<","<<pos.phi()
      <<", nhits="<<cluster.hitsAndFractions().size()<<endl;
   for(unsigned i=0; i<cluster.hitsAndFractions().size(); i++ ) {
     out<<""<<cluster.printHitAndFraction(i)<<", ";

--- a/DataFormats/CaloRecHit/src/CaloCluster.cc
+++ b/DataFormats/CaloRecHit/src/CaloCluster.cc
@@ -37,8 +37,8 @@ std::ostream& reco::operator<<(std::ostream& out,
   out<<"CaloCluster , algoID="<<cluster.algoID()
      <<", "<<cluster.caloID()    
      <<", E="<<cluster.energy();
-  if( cluster.calibratedEnergy() != -1.0 ) {
-    out << ", E_calib="<<cluster.calibratedEnergy();
+  if( cluster.correctedEnergy() != -1.0 ) {
+    out << ", E_corr="<<cluster.correctedEnergy();
   }
   out<<", eta,phi="<<pos.eta()<<","<<pos.phi()
      <<", nhits="<<cluster.hitsAndFractions().size()<<endl;

--- a/DataFormats/CaloRecHit/src/classes_def.xml
+++ b/DataFormats/CaloRecHit/src/classes_def.xml
@@ -2,8 +2,9 @@
   <class name="CaloRecHit" ClassVersion="10">
    <version ClassVersion="10" checksum="582597904"/>
   </class>
-  <class name="reco::CaloCluster" ClassVersion="10">
+  <class name="reco::CaloCluster" ClassVersion="11">
    <version ClassVersion="10" checksum="3936140"/>
+   <version ClassVersion="11" checksum="2867259993"/>
   </class>
 
   <class name="edm::RefToBase<CaloRecHit>"/>

--- a/DataFormats/CaloRecHit/src/classes_def.xml
+++ b/DataFormats/CaloRecHit/src/classes_def.xml
@@ -4,7 +4,7 @@
   </class>
   <class name="reco::CaloCluster" ClassVersion="11">
    <version ClassVersion="10" checksum="3936140"/>
-   <version ClassVersion="11" checksum="2867259993"/>
+   <version ClassVersion="11" checksum="2938838489"/>
   </class>
 
   <class name="edm::RefToBase<CaloRecHit>"/>

--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -42,7 +42,8 @@
   <class name="std::pair<edm::Ptr<reco::CaloCluster>::key_type,edm::Ptr<reco::CaloCluster> >"/>
   <class name="reco::SuperCluster::EEtoPSAssociation"/>
   <class name="edm::Wrapper<reco::SuperCluster::EEtoPSAssociation>"/>
-  <class name="reco::SuperCluster" ClassVersion="11">
+  <class name="reco::SuperCluster" ClassVersion="12">
+   <version ClassVersion="12" checksum="83023066"/>
    <version ClassVersion="11" checksum="83023066"/>
    <version ClassVersion="10" checksum="3131732439"/>
     <field name="rawEnergy_" iotype="Double32_t"/>

--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -122,7 +122,8 @@
   <class name="edm::reftobase::Holder<reco::ElectronSeed,edm::Ref<std::vector<reco::ElectronSeed>,reco::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ElectronSeed>,reco::ElectronSeed> > >"/>
 
 
-  <class name="reco::PreshowerCluster" ClassVersion="10">
+  <class name="reco::PreshowerCluster" ClassVersion="11">
+   <version ClassVersion="11" checksum="469230288"/>
    <version ClassVersion="10" checksum="469230288"/>
   </class>
   <class name="std::vector<reco::PreshowerCluster>"/>

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -1,7 +1,8 @@
 <lcgdict>
 <selection>
 
-  <class name="reco::PFCluster" ClassVersion="10">
+  <class name="reco::PFCluster" ClassVersion="11">
+   <version ClassVersion="11" checksum="1793013291"/>
    <version ClassVersion="10" checksum="1793013291"/>
     <field name="posrep_" transient="true"/>
     <field name="color_" transient="true"/>


### PR DESCRIPTION
This is to reduce the number of additional intermediate collections needed for the particle flow ECAL clusters and super clusters.
It doesn't interfere with any of the current cluster producers.
Based on CMSSW_7_0_0_pre3.
