### PR TITLE
53 x cms driver fix for HIon L1REPACK (also in 70X)

### DIFF
--- a/Configuration/PyReleaseValidation/python/ConfigBuilder.py
+++ b/Configuration/PyReleaseValidation/python/ConfigBuilder.py
@@ -1673,7 +1673,7 @@ class ConfigBuilder(object):
 	    loadMe='from PhysicsTools.PatAlgos.tools.helpers import massSearchReplaceAnyInputTag'
 	    if not loadMe in self.additionalCommands:
 		    self.additionalCommands.append(loadMe)
-	    self.additionalCommands.append('massSearchReplaceAnyInputTag(process.%s,"%s","%s",False)'%(sequence,oldT,newT))
+	    self.additionalCommands.append('massSearchReplaceAnyInputTag(process.%s,"%s","%s",False,True)'%(sequence,oldT,newT))
 
     #change the process name used to address HLT results in any sequence
     def renameHLTprocessInSequence(self,sequence,proc=None,HLTprocess='HLT'):


### PR DESCRIPTION
53 x cms driver fix for HIon L1REPACK - see:
https://hypernews.cern.ch/HyperNews/CMS/get/swDevelopment/2852.html
