### PR TITLE
AlCa cleanups -- Interpolation log errors only once per channel.

### DIFF
--- a/CalibCalorimetry/EcalLaserCorrection/BuildFile.xml
+++ b/CalibCalorimetry/EcalLaserCorrection/BuildFile.xml
@@ -7,6 +7,7 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="Geometry/EcalMapping"/>
 <use   name="boost"/>
+<use   name="tbb"/>
 <export>
-  <lib   name="1"/>
+  <lib name="1"/>
 </export>

--- a/CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbService.h
+++ b/CalibCalorimetry/EcalLaserCorrection/interface/EcalLaserDbService.h
@@ -6,7 +6,9 @@
 #define EcalLaserDbService_h
 
 #include <memory>
-#include <map>
+#include <tbb/concurrent_unordered_set.h>
+#include <tbb/concurrent_hash_map.h>
+
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
@@ -44,6 +46,9 @@ class EcalLaserDbService {
   const EcalLaserAPDPNRatiosRef* mAPDPNRatiosRef_;
   const EcalLaserAPDPNRatios* mAPDPNRatios_;  
   const EcalLinearCorrections* mLinearCorrections_;  
+
+  typedef tbb::concurrent_unordered_set<uint32_t> ErrorMapT;
+  mutable ErrorMapT channelsWithInvalidCorrection_;
 
 };
 


### PR DESCRIPTION
With certain GT, the error stream was flooded by errors due to laser corrections interpolation. With this fix, errors are logged at most once per channel. Replaces #259
