### PR TITLE
From cmssw 5 3 11 patch6 tracking summary map patch4repro2011

### DIFF
--- a/DQM/SiStripMonitorClient/src/SiStripUtility.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripUtility.cc
@@ -225,7 +225,8 @@ bool SiStripUtility::goToDir(DQMStore * dqm_store, std::string name) {
        ic != subDirVec.end(); ic++) {
     std::string fname = (*ic);
     if ((fname.find("Reference") != std::string::npos) ||
-         (fname.find("AlCaReco") != std::string::npos)) continue;
+	(fname.find("AlCaReco")  != std::string::npos) || 
+	(fname.find("HLT")       != std::string::npos) ) continue;
     dqm_store->cd(fname);
     if (!goToDir(dqm_store, name))  dqm_store->goUp();
     else return true;


### PR DESCRIPTION
this patch was done months ago, but apparently not propagated in 53x :(

this patch is needed in order to have the TrackingSummaryMap filled [it is used in the certification]
w/o this patch the map is white

![before_patch](https://f.cloud.github.com/assets/4946419/1074288/06d7a76a-14b7-11e3-9f36-62b483683677.png)
![after_patch](https://f.cloud.github.com/assets/4946419/1074255/6e333236-14b6-11e3-8ef5-133c08a94285.png)
