### PR TITLE
Remove obsolete comment

### DIFF
--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -109,7 +109,6 @@ namespace edm {
     ItemType nextItemType();
 
     /// Read next event
-    /// Indicate inability to get a new event by returning a null ptr.
     void readEvent(EventPrincipal& ep, StreamContext *);
 
     /// Read a specific event


### PR DESCRIPTION
When doing a previous change, an obsolete comment that should have been removed was not removed.
This trivial pull request removes the obsolete and now incorrect comment.
