### PR TITLE
Removed all code related to running EventProcessor asynchronously

### DIFF
--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -334,8 +334,7 @@ int main(int argc, char* argv[]) {
       alwaysAddContext = false;
       context = "Calling EventProcessor::runToCompletion (which does almost everything after beginJob and before endJob)";
       proc.on();
-      bool onlineStateTransitions = false;
-      proc->runToCompletion(onlineStateTransitions);
+      proc->runToCompletion();
       proc.off();
 
       context = "Calling endJob";

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -53,23 +53,6 @@ namespace edm {
     class EventSetupsController;
   }
 
-  namespace event_processor {
-    /*
-      Several of these state are likely to be transitory in
-      the offline because they are completly driven by the
-      data coming from the input source.
-    */
-    enum State { sInit = 0, sJobReady, sRunGiven, sRunning, sStopping,
-                 sShuttingDown, sDone, sJobEnded, sError, sErrorEnded, sEnd, sInvalid };
-
-    enum Msg { mSetRun = 0, mSkip, mRunAsync, mRunID, mRunCount, mBeginJob,
-               mStopAsync, mShutdownAsync, mEndJob, mCountComplete,
-               mInputExhausted, mStopSignal, mShutdownSignal, mFinished,
-               mAny, mDtor, mException, mInputRewind };
-
-    class StateSentry;
-  }
-
   class EventProcessor : public IEventProcessor {
   public:
 
@@ -112,45 +95,6 @@ namespace edm {
        throws if any module's endJob throws an exception.
        */
     void endJob();
-
-    /**Member functions to support asynchronous interface.
-       */
-
-    char const* currentStateName() const;
-    char const* stateName(event_processor::State s) const;
-    char const* msgName(event_processor::Msg m) const;
-    event_processor::State getState() const;
-    void runAsync();
-    StatusCode statusAsync() const;
-
-    // Concerning the async control functions:
-    // The event processor is left with the running thread.
-    // The async thread is stuck at this point and the process
-    // is likely not going to be able to continue.
-    // The reason for this timeout could be either an infinite loop
-    // or I/O blocking forever.
-    // The only thing to do is end the process.
-    // If you call endJob, you will likely get an exception from the
-    // state checks telling you that it is not valid to call this function.
-    // All these function force the event processor state into an
-    // error state.
-
-    // tell the event loop to stop and wait for its completion
-    StatusCode stopAsync(unsigned int timeout_secs = 60 * 2);
-
-    // tell the event loop to shutdown and wait for the completion
-    StatusCode shutdownAsync(unsigned int timeout_secs = 60 * 2);
-
-    // wait until async event loop thread completes
-    // or timeout occurs (See StatusCode for return values)
-    StatusCode waitTillDoneAsync(unsigned int timeout_seconds = 0);
-
-    // Both of these calls move the EP to the ready to run state but only
-    // the first actually sets the run number, the other one just stores
-    // the run number set externally in order to later compare to the one
-    // read from the input source for verification
-    void setRunNumber(RunNumber_t runNumber);
-    void declareRunNumber(RunNumber_t runNumber);
 
     // -------------
 
@@ -218,18 +162,7 @@ namespace edm {
     //                     requested by the argument
     //   epSuccess - all other cases
     //
-    // The online is an exceptional case.  Online uses the DaqSource
-    // and the StreamerOutputModule, which are specially written to
-    // handle multiple calls of "runToCompletion" in the same job.
-    // The call to setRunNumber resets the DaqSource between those calls.
-    // With most sources and output modules, this does not work.
-    // If and only if called by the online, the argument to runToCompletion
-    // is set to true and this affects the state initial and final state
-    // transitions that are managed directly in EventProcessor.cc. (I am
-    // not sure if there is a reason for this or it is just a historical
-    // peculiarity that could be cleaned up and removed).
-
-    virtual StatusCode runToCompletion(bool onlineStateTransitions);
+    virtual StatusCode runToCompletion();
 
     // The following functions are used by the code implementing our
     // boost statemachine
@@ -289,15 +222,7 @@ namespace edm {
     void terminateMachine(std::auto_ptr<statemachine::Machine>&);
     std::auto_ptr<statemachine::Machine> createStateMachine();
 
-    StatusCode doneAsync(event_processor::Msg m);
-
-    StatusCode waitForAsyncCompletion(unsigned int timeout_seconds);
-
-    void changeState(event_processor::Msg);
-    void errorState();
     void setupSignal();
-
-    static void asyncRun(EventProcessor*);
 
     bool hasSubProcess() const {
       return subProcess_.get() != 0;
@@ -334,23 +259,12 @@ namespace edm {
     std::auto_ptr<SubProcess>                     subProcess_;
     std::unique_ptr<HistoryAppender>            historyAppender_;
 
-    volatile event_processor::State               state_;
-    boost::shared_ptr<boost::thread>              event_loop_;
-
-    boost::mutex                                  state_lock_;
-    boost::mutex                                  stop_lock_;
-    boost::condition                              stopper_;
-    boost::condition                              starter_;
-    volatile int                                  stop_count_;
-    volatile Status                               last_rc_;
-    std::string                                   last_error_text_;
-    volatile bool                                 id_set_;
-    volatile pthread_t                            event_loop_id_;
     int                                           my_sig_num_;
     std::unique_ptr<FileBlock>                    fb_;
     boost::shared_ptr<EDLooperBase>               looper_;
 
     PrincipalCache                                principalCache_;
+    bool                                          beginJobCalled_;
     bool                                          shouldWeStop_;
     bool                                          stateMachineWasInErrorState_;
     std::string                                   fileMode_;
@@ -377,7 +291,6 @@ namespace edm {
     typedef std::set<std::pair<std::string, std::string> > ExcludedData;
     typedef std::map<std::string, ExcludedData> ExcludedDataMap;
     ExcludedDataMap                               eventSetupDataToExcludeFromPrefetching_;
-    friend class event_processor::StateSentry;
   }; // class EventProcessor
 
   //--------------------------------------------------------------------
@@ -385,7 +298,7 @@ namespace edm {
   inline
   EventProcessor::StatusCode
   EventProcessor::run() {
-    return runToCompletion(false);
+    return runToCompletion();
   }
 }
 #endif

--- a/FWCore/Framework/interface/IEventProcessor.h
+++ b/FWCore/Framework/interface/IEventProcessor.h
@@ -40,7 +40,7 @@ namespace edm {
 
     virtual ~IEventProcessor();
 
-    virtual StatusCode runToCompletion(bool onlineStateTransitions) = 0;
+    virtual StatusCode runToCompletion() = 0;
 
     virtual void readFile() = 0;
     virtual void closeInputFile(bool cleaningUpAfterException) = 0;

--- a/FWCore/Framework/test/MockEventProcessor.cc
+++ b/FWCore/Framework/test/MockEventProcessor.cc
@@ -36,7 +36,7 @@ namespace edm {
   }
 
   edm::MockEventProcessor::StatusCode
-  MockEventProcessor::runToCompletion(bool /*onlineStateTransitions*/) {
+  MockEventProcessor::runToCompletion() {
     statemachine::Machine myMachine(this,
                                     fileMode_,
                                     emptyRunLumiMode_);

--- a/FWCore/Framework/test/MockEventProcessor.h
+++ b/FWCore/Framework/test/MockEventProcessor.h
@@ -24,47 +24,47 @@ namespace edm {
                        statemachine::FileMode const& fileMode,
                        statemachine::EmptyRunLumiMode const& emptyRunLumiMode);
 
-    virtual StatusCode runToCompletion(bool onlineStateTransitions);
+    virtual StatusCode runToCompletion() override;
 
-    virtual void readFile();
-    virtual void closeInputFile(bool cleaningUpAfterException);
-    virtual void openOutputFiles();
-    virtual void closeOutputFiles();
+    virtual void readFile() override;
+    virtual void closeInputFile(bool cleaningUpAfterException) override;
+    virtual void openOutputFiles() override;
+    virtual void closeOutputFiles() override;
 
-    virtual void respondToOpenInputFile();
-    virtual void respondToCloseInputFile();
+    virtual void respondToOpenInputFile() override;
+    virtual void respondToCloseInputFile() override;
 
-    virtual void startingNewLoop();
-    virtual bool endOfLoop();
-    virtual void rewindInput();
-    virtual void prepareForNextLoop();
-    virtual bool shouldWeCloseOutput() const;
+    virtual void startingNewLoop() override;
+    virtual bool endOfLoop() override;
+    virtual void rewindInput() override;
+    virtual void prepareForNextLoop() override;
+    virtual bool shouldWeCloseOutput() const override;
 
-    virtual void doErrorStuff();
+    virtual void doErrorStuff() override;
 
-    virtual void beginRun(statemachine::Run const& run);
-    virtual void endRun(statemachine::Run const& run, bool cleaningUpAfterException);
+    virtual void beginRun(statemachine::Run const& run) override;
+    virtual void endRun(statemachine::Run const& run, bool cleaningUpAfterException) override;
 
-    virtual void beginLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi);
-    virtual void endLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi, bool cleaningUpAfterException);
+    virtual void beginLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi) override;
+    virtual void endLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi, bool cleaningUpAfterException) override;
 
-    virtual statemachine::Run readRun();
-    virtual statemachine::Run readAndMergeRun();
-    virtual int readLuminosityBlock();
-    virtual int readAndMergeLumi();
-    virtual void writeRun(statemachine::Run const& run);
-    virtual void deleteRunFromCache(statemachine::Run const& run);
-    virtual void writeLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi);
-    virtual void deleteLumiFromCache(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi);
+    virtual statemachine::Run readRun() override;
+    virtual statemachine::Run readAndMergeRun() override;
+    virtual int readLuminosityBlock() override;
+    virtual int readAndMergeLumi() override;
+    virtual void writeRun(statemachine::Run const& run) override;
+    virtual void deleteRunFromCache(statemachine::Run const& run) override;
+    virtual void writeLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi) override;
+    virtual void deleteLumiFromCache(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi) override;
 
-    virtual void readAndProcessEvent();
-    virtual bool shouldWeStop() const;
+    virtual void readAndProcessEvent() override;
+    virtual bool shouldWeStop() const override;
 
-    virtual void setExceptionMessageFiles(std::string& message);
-    virtual void setExceptionMessageRuns(std::string& message);
-    virtual void setExceptionMessageLumis(std::string& message);
+    virtual void setExceptionMessageFiles(std::string& message) override;
+    virtual void setExceptionMessageRuns(std::string& message) override;
+    virtual void setExceptionMessageLumis(std::string& message) override;
 
-    virtual bool alreadyHandlingException() const;
+    virtual bool alreadyHandlingException() const override;
 
   private:
     std::string mockData_;

--- a/FWCore/Framework/test/statemachine_t.cc
+++ b/FWCore/Framework/test/statemachine_t.cc
@@ -94,8 +94,7 @@ int main(int argc, char* argv[]) try {
                                                  fileMode,
                                                  emptyRunLumiMode);
 
-      bool onlineStateTransitions = false;
-      mockEventProcessor.runToCompletion(onlineStateTransitions);
+      mockEventProcessor.runToCompletion();
     }
   }
   return 0;


### PR DESCRIPTION
The asynchronous interface was previously only used online. This is no longer needed and would not play well with the up coming threaded framework.
