### PR TITLE
Signal handlers use atomics

### DIFF
--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -259,7 +259,6 @@ namespace edm {
     std::auto_ptr<SubProcess>                     subProcess_;
     std::unique_ptr<HistoryAppender>            historyAppender_;
 
-    int                                           my_sig_num_;
     std::unique_ptr<FileBlock>                    fb_;
     boost::shared_ptr<EDLooperBase>               looper_;
 

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -214,7 +214,6 @@ namespace edm {
     schedule_(),
     subProcess_(),
     historyAppender_(new HistoryAppender),
-    my_sig_num_(getSigNum()),
     fb_(),
     looper_(),
     principalCache_(),
@@ -255,7 +254,6 @@ namespace edm {
     schedule_(),
     subProcess_(),
     historyAppender_(new HistoryAppender),
-    my_sig_num_(getSigNum()),
     fb_(),
     looper_(),
     principalCache_(),
@@ -299,7 +297,6 @@ namespace edm {
     schedule_(),
     subProcess_(),
     historyAppender_(new HistoryAppender),
-    my_sig_num_(getSigNum()),
     fb_(),
     looper_(),
     principalCache_(),
@@ -339,7 +336,6 @@ namespace edm {
     schedule_(),
     subProcess_(),
     historyAppender_(new HistoryAppender),
-    my_sig_num_(getSigNum()),
     fb_(),
     looper_(),
     principalCache_(),
@@ -1244,12 +1240,9 @@ namespace edm {
     bool returnValue = false;
     
     // Look for a shutdown signal
-    {
-      boost::mutex::scoped_lock sl(usr2_lock);
-      if(shutdown_flag) {
-        returnValue = true;
-        returnCode = epSignal;
-      }
+    if(shutdown_flag) {
+      returnValue = true;
+      returnCode = epSignal;
     }
     return returnValue;
   }

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1240,7 +1240,7 @@ namespace edm {
     bool returnValue = false;
     
     // Look for a shutdown signal
-    if(shutdown_flag) {
+    if(shutdown_flag.load(std::memory_order_relaxed)) {
       returnValue = true;
       returnCode = epSignal;
     }

--- a/FWCore/Utilities/interface/UnixSignalHandlers.h
+++ b/FWCore/Utilities/interface/UnixSignalHandlers.h
@@ -9,19 +9,18 @@ and manipulate Unix-style signal handling.
 ----------------------------------------------------------------------*/
 
 #include <signal.h>
+#include <atomic>
 #include "boost/thread/thread.hpp"
 
 namespace edm {
 
-    extern boost::mutex usr2_lock;
-    extern volatile bool shutdown_flag;
+    extern volatile std::atomic<bool> shutdown_flag;
 
     extern "C" {
       void ep_sigusr2(int,siginfo_t*,void*);
       typedef void(*CFUNC)(int,siginfo_t*,void*);
     }
 
-    int getSigNum();
     void disableAllSigs(sigset_t* oldset);
     void disableRTSigs();
     void enableSignal(sigset_t* newset, int signum);

--- a/FWCore/Utilities/src/UnixSignalHandlers.cc
+++ b/FWCore/Utilities/src/UnixSignalHandlers.cc
@@ -17,42 +17,19 @@
 
 namespace edm {
 
-    boost::mutex usr2_lock;
-
 //--------------------------------------------------------------
 
-    volatile bool shutdown_flag = false;
+    volatile std::atomic<bool> shutdown_flag{false};
 
     extern "C" {
       void ep_sigusr2(int,siginfo_t*,void*)
       {
 	FDEBUG(1) << "in sigusr2 handler\n";
-	shutdown_flag = true;
+	shutdown_flag.store(true);
       }
     }
-
-//--------------------------------------------------------------
-
-    boost::mutex signum_lock;
-    volatile int signum_value = 
-#if defined(__linux__)
-      SIGRTMIN;
-#else
-    0;
-#endif
-
-//--------------------------------------------------------------
-
-    int getSigNum()
-    {
-      boost::mutex::scoped_lock sl(signum_lock);
-      int rc = signum_value;
-      ++signum_value;
-      return rc;
-    }
-
 #define MUST_BE_ZERO(fun) if((fun) != 0)					\
-      { perror("UnixSignalHandlers::setupSignal: sig function failed"); abort(); }
+{ perror("UnixSignalHandlers::setupSignal: sig function failed"); abort(); }
 
 //--------------------------------------------------------------
 


### PR DESCRIPTION
Changed the unix signal handler used to allow an external user to tell cmsRun to stop processing. The signal handler used to use a mutex but now uses an std::atomic. 
Removed some obsolete code which was related to the signal handler.
