### PR TITLE
Multithreaded TFileService

### DIFF
--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -159,7 +159,7 @@ private:
       if (!dqmMode){
 	edm::Service<TFileService> fs;
 	if (newDir.length()==0){
-	  tfd.reset(new TFileDirectory(static_cast<TFileDirectory&>(*fs)));
+	  tfd.reset(new TFileDirectory(fs->tFileDirectory()));
 	}
 	else {
 	  tfd.reset(new TFileDirectory(fs->mkdir(newDir)));

--- a/CommonTools/UtilAlgos/interface/HistoAnalyzer.h
+++ b/CommonTools/UtilAlgos/interface/HistoAnalyzer.h
@@ -57,7 +57,7 @@ HistoAnalyzer<C>::HistoAnalyzer( const edm::ParameterSet& par ) :
    for (; it!=end; ++it)
    {
       ExpressionHisto<typename C::value_type>* hist = new ExpressionHisto<typename C::value_type>(*it);
-      hist->initialize(*fs);
+      hist->initialize(fs->tFileDirectory());
       vhistograms.push_back(hist);
    }   
 

--- a/CommonTools/UtilAlgos/interface/TFileService.h
+++ b/CommonTools/UtilAlgos/interface/TFileService.h
@@ -4,16 +4,30 @@
  *
  * \author Luca Lista, INFN
  *
+ * Modified to run properly in the multithreaded Framework.
+ * Any modules that use this service in multithreaded mode
+ * must be type "One" modules that declared a shared resource
+ * of type TFileService::kSharedResource.
+ *
  */
+
 #include "CommonTools/Utils/interface/TFileDirectory.h"
+
+#include <string>
+
+class TDirectory;
+class TFile;
 
 namespace edm {
   class ActivityRegistry;
-  class ParameterSet;
+  class GlobalContext;
+  class ModuleCallingContext;
   class ModuleDescription;
+  class ParameterSet;
+  class StreamContext;
 }
 
-class TFileService : public TFileDirectory {
+class TFileService {
 public:
   /// constructor
   TFileService(const edm::ParameterSet &, edm::ActivityRegistry &);
@@ -25,19 +39,61 @@ public:
   /// Hook for writing info into JR
   void afterBeginJob();
 
+  TFileDirectory & tFileDirectory() { return tFileDirectory_; }
+
+  // The next 6 functions do nothing more than forward function calls
+  // to the TFileDirectory data member.
+
+  // cd()s to requested directory and returns true (if it is not
+  // able to cd, it throws exception).
+  bool cd() const { return tFileDirectory_.cd(); }
+
+  // returns a TDirectory pointer
+  TDirectory *getBareDirectory (const std::string &subdir = "") const {
+    return tFileDirectory_.getBareDirectory(subdir);
+  }
+
+  // reutrns a "T" pointer matched to objname
+  template< typename T > T* getObject (const std::string &objname,
+                                       const std::string &subdir = "") {
+    return tFileDirectory_.getObject<T>(objname, subdir);
+  }
+
+  /// make new ROOT object
+  template<typename T, typename ... Args>
+  T* make(const Args& ... args) const {
+    return tFileDirectory_.make<T>(args ...);
+  }
+
+  /// create a new subdirectory
+  TFileDirectory mkdir( const std::string & dir, const std::string & descr = "" ) {
+    return tFileDirectory_.mkdir(dir, descr);
+  }
+
+  /// return the full path of the stored histograms
+  std::string fullPath() const { return tFileDirectory_.fullPath(); }
+
+  static const std::string kSharedResource;
+
 private:
+  static thread_local TFileDirectory tFileDirectory_;
   /// pointer to opened TFile
   TFile * file_;
   std::string fileName_;
   bool fileNameRecorded_;
   bool closeFileFast_;
+
   // set current directory according to module name and prepair to create directory
   void setDirectoryName( const edm::ModuleDescription & desc );
+  void preModuleEvent(edm::StreamContext const&, edm::ModuleCallingContext const&);
+  void postModuleEvent(edm::StreamContext const&, edm::ModuleCallingContext const&);
+  void preModuleGlobal(edm::GlobalContext const&, edm::ModuleCallingContext const&);
+  void postModuleGlobal(edm::GlobalContext const&, edm::ModuleCallingContext const&);
 };
 
 namespace edm {
-   namespace service {
-    // This function is needed so that there will be only on instance
+  namespace service {
+    // This function is needed so that there will be only one instance
     // of this service per process when "subprocesses" are being used.
     inline
     bool isProcessWideService(TFileService const*) {
@@ -45,6 +101,4 @@ namespace edm {
     }
   }
 }
-
 #endif
-

--- a/CommonTools/UtilAlgos/src/TFileService.cc
+++ b/CommonTools/UtilAlgos/src/TFileService.cc
@@ -2,32 +2,49 @@
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/MessageLogger/interface/JobReport.h"
 #include "TFile.h"
 #include "TROOT.h"
 
-using namespace edm;
-using namespace std;
+#include <map>
+#include <unistd.h>
 
-TFileService::TFileService(const ParameterSet & cfg, ActivityRegistry & r) :
-  TFileDirectory("", "", TFile::Open(cfg.getParameter<string>("fileName").c_str() , "RECREATE"), ""),
-  file_(TFileDirectory::file_),
-  fileName_(cfg.getParameter<string>("fileName")),
+const std::string TFileService::kSharedResource = "TFileService";
+thread_local TFileDirectory TFileService::tFileDirectory_;
+
+TFileService::TFileService(const edm::ParameterSet & cfg, edm::ActivityRegistry & r) :
+  file_(nullptr),
+  fileName_(cfg.getParameter<std::string>("fileName")),
   fileNameRecorded_(false),
   closeFileFast_(cfg.getUntrackedParameter<bool>("closeFileFast", false)) 
 {
+  tFileDirectory_ = TFileDirectory("",
+                                  "",
+                                  TFile::Open(fileName_.c_str(), "RECREATE"),
+                                  "");
+  file_ = tFileDirectory_.file_;
+
   // activities to monitor in order to set the proper directory
   r.watchPreModuleConstruction(this, & TFileService::setDirectoryName);
-  r.watchPreModule(this, & TFileService::setDirectoryName);
   r.watchPreModuleBeginJob(this, & TFileService::setDirectoryName);
   r.watchPreModuleEndJob(this, & TFileService::setDirectoryName);
-  r.watchPreModuleBeginRun(this, & TFileService::setDirectoryName);
-  r.watchPreModuleEndRun(this, & TFileService::setDirectoryName);
-  r.watchPreModuleBeginLumi(this, & TFileService::setDirectoryName);
-  r.watchPreModuleEndLumi(this, & TFileService::setDirectoryName);
+  r.watchPreModuleEvent(this, & TFileService::preModuleEvent);
+  r.watchPostModuleEvent(this, & TFileService::postModuleEvent);
+
+  r.watchPreModuleGlobalBeginRun(this, &TFileService::preModuleGlobal);
+  r.watchPostModuleGlobalBeginRun(this, &TFileService::postModuleGlobal);
+  r.watchPreModuleGlobalEndRun(this, &TFileService::preModuleGlobal);
+  r.watchPostModuleGlobalEndRun(this, &TFileService::postModuleGlobal);
+
+  r.watchPreModuleGlobalBeginLumi(this, &TFileService::preModuleGlobal);
+  r.watchPostModuleGlobalBeginLumi(this, &TFileService::postModuleGlobal);
+  r.watchPreModuleGlobalEndLumi(this, &TFileService::preModuleGlobal);
+  r.watchPostModuleGlobalEndLumi(this, &TFileService::postModuleGlobal);
+
   // delay writing into JobReport after BeginJob
-  r.watchPostBeginJob(this,&TFileService::afterBeginJob);
+  r.watchPostBeginJob(this, &TFileService::afterBeginJob);
 }
 
 TFileService::~TFileService() {
@@ -37,24 +54,49 @@ TFileService::~TFileService() {
   delete file_;
 }
 
-void TFileService::setDirectoryName(const ModuleDescription & desc) {
-  dir_ = desc.moduleLabel();
-  descr_ = (dir_ + " (" + desc.moduleName() + ") folder").c_str();
+void TFileService::setDirectoryName(const edm::ModuleDescription & desc) {
+  tFileDirectory_.file_ = file_;
+  tFileDirectory_.dir_ = desc.moduleLabel();
+  tFileDirectory_.descr_ = (tFileDirectory_.dir_ + " (" + desc.moduleName() + ") folder").c_str();
+}
+
+void TFileService::preModuleEvent(edm::StreamContext const&, edm::ModuleCallingContext const& mcc) {
+  setDirectoryName(*mcc.moduleDescription());
+}
+
+void TFileService::postModuleEvent(edm::StreamContext const&, edm::ModuleCallingContext const& mcc) {
+  edm::ModuleCallingContext const* previous_mcc = mcc.previousModuleOnThread();
+  if(previous_mcc) {
+    setDirectoryName(*previous_mcc->moduleDescription());
+  }
+}
+
+void
+TFileService::preModuleGlobal(edm::GlobalContext const&, edm::ModuleCallingContext const& mcc) {
+  setDirectoryName(*mcc.moduleDescription());
+}
+
+void
+TFileService::postModuleGlobal(edm::GlobalContext const&, edm::ModuleCallingContext const& mcc) {
+  edm::ModuleCallingContext const* previous_mcc = mcc.previousModuleOnThread();
+  if(previous_mcc) {
+    setDirectoryName(*previous_mcc->moduleDescription());
+  }
 }
 
 void TFileService::afterBeginJob() {
 
   if(!fileName_.empty())  {
     if(!fileNameRecorded_) {
-      string fullName;
+      std::string fullName;
       fullName.reserve(1024);
       fullName = getcwd(&fullName[0],1024);
       fullName += "/" + fileName_;
 
-      map<string,string> fileData;
-      fileData.insert(make_pair("Source","TFileService"));
+      std::map<std::string, std::string> fileData;
+      fileData.insert(std::make_pair("Source","TFileService"));
 
-      Service<JobReport> reportSvc;
+      edm::Service<edm::JobReport> reportSvc;
       reportSvc->reportAnalysisFile(fullName,fileData);
       fileNameRecorded_ = true;
     }

--- a/CommonTools/Utils/interface/TFileDirectory.h
+++ b/CommonTools/Utils/interface/TFileDirectory.h
@@ -23,6 +23,10 @@ class TDirectory;
 
 class TFileDirectory {
    public:
+
+      TFileDirectory() : file_(nullptr), dir_(), descr_(), path_() {
+      }
+
       /// descructor
       virtual ~TFileDirectory() { }
 
@@ -51,159 +55,16 @@ class TFileDirectory {
       }
 
       /// make new ROOT object
-      template<typename T>
-      T * make() const {
+      template<typename T, typename ... Args>
+      T* make(const Args& ... args) const {
          TDirectory *d = _cd();
-         T* t = new T();
-         ROOT::DirAutoAdd_t func = T::Class()->GetDirectoryAutoAdd();
-         if (func) { TH1AddDirectorySentry sentry; func(t,d); } 
-         else { d->Append(t); }
-         return t;
-      }
-      /// make new ROOT object
-      template<typename T, typename Arg1>
-      T * make( const Arg1 & a1 ) const {
-         TDirectory *d = _cd();
-         T * t = new T( a1 );
-         ROOT::DirAutoAdd_t func = T::Class()->GetDirectoryAutoAdd();
-         if (func) { TH1AddDirectorySentry sentry; func(t,d); }
-         else { d->Append(t); }
-         return t; 
-      }
-      /// make new ROOT object
-      template<typename T, typename Arg1, typename Arg2>
-      T * make( const Arg1 & a1, const Arg2 & a2 ) const {
-         TDirectory *d = _cd();
-         T * t =  new T( a1, a2 );
+         T* t = new T(args ...);
          ROOT::DirAutoAdd_t func = T::Class()->GetDirectoryAutoAdd();
          if (func) { TH1AddDirectorySentry sentry; func(t,d); }
          else { d->Append(t); }
          return t;
       }
-      /// make new ROOT object
-      template<typename T, typename Arg1, typename Arg2, typename Arg3>
-      T * make( const Arg1 & a1, const Arg2 & a2, const Arg3 & a3 ) const {
-         TDirectory *d = _cd();
-         T * t =  new T( a1, a2, a3 );
-         ROOT::DirAutoAdd_t func = T::Class()->GetDirectoryAutoAdd();
-         if (func) { TH1AddDirectorySentry sentry; func(t,d); }
-         else { d->Append(t); }
-         return t;
-      }
-      /// make new ROOT object
-      template<typename T, typename Arg1, typename Arg2, typename Arg3, typename Arg4>
-      T * make( const Arg1 & a1, const Arg2 & a2, const Arg3 & a3, const Arg4 & a4 ) const {
-         TDirectory *d = _cd();
-         T * t =  new T( a1, a2, a3, a4 );
-         ROOT::DirAutoAdd_t func = T::Class()->GetDirectoryAutoAdd();
-         if (func) { TH1AddDirectorySentry sentry; func(t,d); }
-         else { d->Append(t); }
-         return t;
-      }
-      /// make new ROOT object
-      template<typename T, typename Arg1, typename Arg2, typename Arg3, typename Arg4, 
-               typename Arg5>
-      T * make( const Arg1 & a1, const Arg2 & a2, const Arg3 & a3, const Arg4 & a4, 
-                const Arg5 & a5 ) const {
-         TDirectory *d = _cd();
-         T * t =  new T( a1, a2, a3, a4, a5 );
-         ROOT::DirAutoAdd_t func = T::Class()->GetDirectoryAutoAdd();
-         if (func) { TH1AddDirectorySentry sentry; func(t,d); }
-         else { d->Append(t); }
-         return t;
-      }
-      /// make new ROOT object
-      template<typename T, typename Arg1, typename Arg2, typename Arg3, typename Arg4, 
-               typename Arg5, typename Arg6>
-      T * make( const Arg1 & a1, const Arg2 & a2, const Arg3 & a3, const Arg4 & a4, 
-                const Arg5 & a5, const Arg6 & a6 ) const {
-         TDirectory *d = _cd();
-         T * t =  new T( a1, a2, a3, a4, a5, a6 );
-         ROOT::DirAutoAdd_t func = T::Class()->GetDirectoryAutoAdd();
-         if (func) { TH1AddDirectorySentry sentry; func(t,d); }
-         else { d->Append(t); }
-         return t;
-      }
-      /// make new ROOT object
-      template<typename T, typename Arg1, typename Arg2, typename Arg3, typename Arg4, 
-               typename Arg5, typename Arg6, typename Arg7>
-      T * make( const Arg1 & a1, const Arg2 & a2, const Arg3 & a3, const Arg4 & a4, 
-                const Arg5 & a5, const Arg6 & a6, const Arg7 & a7 ) const {
-         TDirectory *d = _cd();
-         T * t =  new T( a1, a2, a3, a4, a5, a6, a7 );
-         ROOT::DirAutoAdd_t func = T::Class()->GetDirectoryAutoAdd();
-         if (func) { TH1AddDirectorySentry sentry; func(t,d); }
-         else { d->Append(t); }
-         return t;
-      }
-      /// make new ROOT object
-      template<typename T, typename Arg1, typename Arg2, typename Arg3, typename Arg4, 
-               typename Arg5, typename Arg6, typename Arg7, typename Arg8>
-      T * make( const Arg1 & a1, const Arg2 & a2, const Arg3 & a3, const Arg4 & a4, 
-                const Arg5 & a5, const Arg6 & a6, const Arg7 & a7, const Arg8 & a8 ) const {
-         TDirectory *d = _cd();
-         T * t =  new T( a1, a2, a3, a4, a5, a6, a7, a8 );
-         ROOT::DirAutoAdd_t func = T::Class()->GetDirectoryAutoAdd();
-         if (func) { TH1AddDirectorySentry sentry; func(t,d); }
-         else { d->Append(t); }
-         return t;
-      }
-      /// make new ROOT object
-      template<typename T, typename Arg1, typename Arg2, typename Arg3, typename Arg4, 
-               typename Arg5, typename Arg6, typename Arg7, typename Arg8, 
-               typename Arg9>
-      T * make( const Arg1 & a1, const Arg2 & a2, const Arg3 & a3, const Arg4 & a4, 
-                const Arg5 & a5, const Arg6 & a6, const Arg7 & a7, const Arg8 & a8,
-                const Arg9 & a9 ) const {
-         TDirectory *d = _cd();
-         T * t =  new T( a1, a2, a3, a4, a5, a6, a7, a8, a9 );
-         ROOT::DirAutoAdd_t func = T::Class()->GetDirectoryAutoAdd();
-         if (func) { TH1AddDirectorySentry sentry; func(t,d); }
-         else { d->Append(t); }
-         return t;
-      }
-      /// make new ROOT object
-      template<typename T, typename Arg1, typename Arg2, typename Arg3, typename Arg4, 
-               typename Arg5, typename Arg6, typename Arg7, typename Arg8, 
-               typename Arg9, typename Arg10>
-      T * make( const Arg1 & a1, const Arg2 & a2, const Arg3 & a3, const Arg4 & a4, 
-                const Arg5 & a5, const Arg6 & a6, const Arg7 & a7, const Arg8 & a8,
-                const Arg9 & a9, const Arg10 & a10 ) const {
-         TDirectory *d = _cd(); 
-         T * t =  new T( a1, a2, a3, a4, a5, a6, a7, a8, a9, a10 );
-         ROOT::DirAutoAdd_t func = T::Class()->GetDirectoryAutoAdd();
-         if (func) { TH1AddDirectorySentry sentry; func(t,d); }
-         else { d->Append(t); }
-         return t;
-      }
-      /// make new ROOT object
-      template<typename T, typename Arg1, typename Arg2, typename Arg3, typename Arg4, 
-               typename Arg5, typename Arg6, typename Arg7, typename Arg8, 
-               typename Arg9, typename Arg10, typename Arg11>
-      T * make( const Arg1 & a1, const Arg2 & a2, const Arg3 & a3, const Arg4 & a4, 
-                const Arg5 & a5, const Arg6 & a6, const Arg7 & a7, const Arg8 & a8,
-                const Arg9 & a9, const Arg10 & a10, const Arg11 & a11 ) const {
-         TDirectory *d = _cd();
-         T * t =  new T( a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11 );
-         ROOT::DirAutoAdd_t func = T::Class()->GetDirectoryAutoAdd();
-         if (func) { TH1AddDirectorySentry sentry; func(t,d); }
-         else { d->Append(t); }
-         return t;
-      }
-      /// make new ROOT object
-      template<typename T, typename Arg1, typename Arg2, typename Arg3, typename Arg4, 
-               typename Arg5, typename Arg6, typename Arg7, typename Arg8, 
-               typename Arg9, typename Arg10, typename Arg11, typename Arg12>
-      T * make( const Arg1 & a1, const Arg2 & a2, const Arg3 & a3, const Arg4 & a4, 
-                const Arg5 & a5, const Arg6 & a6, const Arg7 & a7, const Arg8 & a8,
-                const Arg9 & a9, const Arg10 & a10, const Arg11 & a11, const Arg12 & a12 ) const {
-         TDirectory *d = _cd();
-         T * t =  new T( a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12 );
-         ROOT::DirAutoAdd_t func = T::Class()->GetDirectoryAutoAdd();
-         if (func) { TH1AddDirectorySentry sentry; func(t,d); }
-         else { d->Append(t); }
-         return t;
-      }
+
       /// create a new subdirectory
       TFileDirectory mkdir( const std::string & dir, const std::string & descr = "" );
       /// return the full path of the stored histograms

--- a/DPGAnalysis/SiStripTools/src/DigiInvestigatorHistogramMaker.cc
+++ b/DPGAnalysis/SiStripTools/src/DigiInvestigatorHistogramMaker.cc
@@ -119,8 +119,7 @@ void DigiInvestigatorHistogramMaker::beginRun(const unsigned int nrun) {
   //  currdir = &(*tfserv);
   //  _rhm.beginRun(nrun,*currdir);
 
-  _rhm.beginRun(nrun,*tfserv);
-
+  _rhm.beginRun(nrun, tfserv->tFileDirectory());
 
   for(std::map<unsigned int,std::string>::const_iterator lab=_labels.begin();lab!=_labels.end();++lab) {
 

--- a/DPGAnalysis/SiStripTools/src/RunHistogramManager.cc
+++ b/DPGAnalysis/SiStripTools/src/RunHistogramManager.cc
@@ -90,7 +90,7 @@ TProfile2D** RunHistogramManager::makeTProfile2D(const char* name, const char* t
 void  RunHistogramManager::beginRun(const edm::Run&  iRun) {
 
   edm::Service<TFileService> tfserv;
-  beginRun(iRun,*tfserv);
+  beginRun(iRun, tfserv->tFileDirectory());
 
 }
 
@@ -110,7 +110,7 @@ void  RunHistogramManager::beginRun(const edm::Run& iRun, TFileDirectory& subdir
 void  RunHistogramManager::beginRun(const unsigned int irun) {
 
   edm::Service<TFileService> tfserv;
-  beginRun(irun,*tfserv);
+  beginRun(irun, tfserv->tFileDirectory());
 
 }
 

--- a/FWCore/Framework/interface/CurrentModuleOnThread.h
+++ b/FWCore/Framework/interface/CurrentModuleOnThread.h
@@ -1,0 +1,29 @@
+#ifndef FWCore_Framework_CurrentModuleOnThread_h
+#define FWCore_Framework_CurrentModuleOnThread_h
+
+/** \class edm::CurrentModuleOnThread
+
+\author W. David Dagenhart, created 30 August, 2013
+
+*/
+
+namespace edm {
+
+  class ModuleCallingContext;
+  class ModuleContextSentry;
+
+  class CurrentModuleOnThread {
+  public:
+    static ModuleCallingContext const* getCurrentModuleOnThread() {
+      return currentModuleOnThread_;
+    }
+  private:
+    friend class ModuleContextSentry;
+    static void setCurrentModuleOnThread(ModuleCallingContext const* v) {
+      currentModuleOnThread_ = v;
+    }
+
+    static thread_local ModuleCallingContext const* currentModuleOnThread_;
+  };
+}
+#endif

--- a/FWCore/Framework/interface/EDLooperBase.h
+++ b/FWCore/Framework/interface/EDLooperBase.h
@@ -53,7 +53,9 @@
 // Created:     Mon Aug  9 12:42:17 EDT 2010
 //
 
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 
 #include <set>
 #include <memory>
@@ -147,6 +149,9 @@ namespace edm {
 
       std::auto_ptr<ScheduleInfo> scheduleInfo_;
       ModuleChanger const* moduleChanger_;
+
+      ModuleDescription moduleDescription_;
+      ModuleCallingContext moduleCallingContext_;
   };
 }
 

--- a/FWCore/Framework/interface/ModuleContextSentry.h
+++ b/FWCore/Framework/interface/ModuleContextSentry.h
@@ -1,0 +1,27 @@
+#ifndef FWCore_Framework_ModuleContextSentry_h
+#define FWCore_Framework_ModuleContextSentry_h
+
+#include "FWCore/Framework/interface/CurrentModuleOnThread.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+
+namespace edm {
+
+  class ModuleContextSentry {
+  public:
+    ModuleContextSentry(ModuleCallingContext* moduleCallingContext,
+                        ParentContext const& parentContext) :
+      moduleCallingContext_(moduleCallingContext) {
+      moduleCallingContext_->setContext(ModuleCallingContext::State::kRunning, parentContext,
+                                        CurrentModuleOnThread::getCurrentModuleOnThread());
+      CurrentModuleOnThread::setCurrentModuleOnThread(moduleCallingContext_);
+    }
+    ~ModuleContextSentry() {
+      CurrentModuleOnThread::setCurrentModuleOnThread(moduleCallingContext_->previousModuleOnThread());
+      moduleCallingContext_->setContext(ModuleCallingContext::State::kInvalid, ParentContext(), nullptr);
+    }
+  private:
+    ModuleCallingContext* moduleCallingContext_;
+  };
+}
+#endif

--- a/FWCore/Framework/interface/OccurrenceTraits.h
+++ b/FWCore/Framework/interface/OccurrenceTraits.h
@@ -54,7 +54,7 @@ namespace edm {
     static void postScheduleSignal(ActivityRegistry *a, EventPrincipal* ep, EventSetup const* es, StreamContext const* streamContext) {
       edm::ModuleDescription modDesc("postScheduledSignal", "");
       ParentContext parentContext(streamContext);
-      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext, nullptr);
       Event ev(*ep, ModuleDescription(), &moduleCallingContext);
       a->postProcessEventSignal_(ev, *es);
       a->postEventSignal_(*streamContext, ev, *es);
@@ -103,7 +103,7 @@ namespace edm {
       // Next 4 lines not needed when we go to threaded interface
       edm::ModuleDescription modDesc("postScheduledSignal", "");
       ParentContext parentContext(globalContext);
-      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext, nullptr);
       Run run(*ep, ModuleDescription(), &moduleCallingContext);
       a->postBeginRunSignal_(run, *es);
       a->postGlobalBeginRunSignal_(*globalContext);
@@ -182,7 +182,7 @@ namespace edm {
     static void postScheduleSignal(ActivityRegistry *a, RunPrincipal* ep, EventSetup const* es, StreamContext const* streamContext) {
       edm::ModuleDescription modDesc("postScheduledSignal", "");
       ParentContext parentContext(streamContext);
-      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext, nullptr);
       Run run(*ep, ModuleDescription(), &moduleCallingContext);
       a->postStreamEndRunSignal_(*streamContext, run, *es);
     }
@@ -223,7 +223,7 @@ namespace edm {
     static void postScheduleSignal(ActivityRegistry *a, RunPrincipal* ep, EventSetup const* es, GlobalContext const* globalContext) {
       edm::ModuleDescription modDesc("postScheduledSignal", "");
       ParentContext parentContext(globalContext);
-      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext, nullptr);
       Run run(*ep, ModuleDescription(), &moduleCallingContext);
       a->postEndRunSignal_(run, *es);
       a->postGlobalEndRunSignal_(*globalContext, run, *es);
@@ -270,7 +270,7 @@ namespace edm {
       // Next 4 lines not needed when we go to threaded interface
       edm::ModuleDescription modDesc("postScheduledSignal", "");
       ParentContext parentContext(globalContext);
-      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext, nullptr);
       LuminosityBlock lumi(*ep, ModuleDescription(), &moduleCallingContext);
       a->postBeginLumiSignal_(lumi, *es);
       a->postGlobalBeginLumiSignal_(*globalContext);
@@ -351,7 +351,7 @@ namespace edm {
     static void postScheduleSignal(ActivityRegistry *a, LuminosityBlockPrincipal* ep, EventSetup const* es, StreamContext const* streamContext) {
       edm::ModuleDescription modDesc("postScheduledSignal", "");
       ParentContext parentContext(streamContext);
-      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext, nullptr);
       LuminosityBlock lumi(*ep, ModuleDescription(), &moduleCallingContext);
       a->postStreamEndLumiSignal_(*streamContext, lumi, *es);
     }
@@ -392,7 +392,7 @@ namespace edm {
     static void postScheduleSignal(ActivityRegistry *a, LuminosityBlockPrincipal* ep, EventSetup const* es, GlobalContext const* globalContext) {
       edm::ModuleDescription modDesc("postScheduledSignal", "");
       ParentContext parentContext(globalContext);
-      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext);
+      ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext, nullptr);
       LuminosityBlock lumi(*ep, ModuleDescription(), &moduleCallingContext);
       a->postEndLumiSignal_(lumi, *es);
       a->postGlobalEndLumiSignal_(*globalContext, lumi, *es); 

--- a/FWCore/Framework/src/CurrentModuleOnThread.cc
+++ b/FWCore/Framework/src/CurrentModuleOnThread.cc
@@ -1,0 +1,3 @@
+#include "FWCore/Framework/interface/CurrentModuleOnThread.h"
+
+thread_local edm::ModuleCallingContext const* edm::CurrentModuleOnThread::currentModuleOnThread_ = nullptr;

--- a/FWCore/Framework/src/OutputModuleCommunicatorT.cc
+++ b/FWCore/Framework/src/OutputModuleCommunicatorT.cc
@@ -5,6 +5,7 @@
 #include "DataFormats/Provenance/interface/LuminosityBlockID.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
+#include "FWCore/Framework/interface/ModuleContextSentry.h"
 #include "FWCore/ServiceRegistry/interface/GlobalContext.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
@@ -48,7 +49,8 @@ namespace edm {
                                 rp.endTime(),
                                 processContext);
     ParentContext parentContext(&globalContext);
-    ModuleCallingContext mcc(&description(), ModuleCallingContext::State::kRunning, parentContext);
+    ModuleCallingContext mcc(&description());
+    ModuleContextSentry moduleContextSentry(&mcc, parentContext);
     module().doWriteRun(rp, &mcc);
   }
 
@@ -62,7 +64,8 @@ namespace edm {
                                 lbp.beginTime(),
                                 processContext);
     ParentContext parentContext(&globalContext);
-    ModuleCallingContext mcc(&description(), ModuleCallingContext::State::kRunning, parentContext);
+    ModuleCallingContext mcc(&description());
+    ModuleContextSentry moduleContextSentry(&mcc, parentContext);
     module().doWriteLuminosityBlock(lbp, &mcc);
   }
 

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -103,10 +103,11 @@ private:
   }
   
   void Worker::resetModuleDescription(ModuleDescription const* iDesc) {
-    ModuleCallingContext temp(iDesc,moduleCallingContext_.state(),moduleCallingContext_.parent());
+    ModuleCallingContext temp(iDesc,moduleCallingContext_.state(),moduleCallingContext_.parent(),
+                              moduleCallingContext_.previousModuleOnThread());
     moduleCallingContext_ = temp;
   }
-  
+
   void Worker::beginJob() {
     try {
       try {

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -25,6 +25,7 @@ the worker is reset().
 #include "FWCore/MessageLogger/interface/ExceptionMessages.h"
 #include "FWCore/Framework/src/WorkerParams.h"
 #include "FWCore/Framework/interface/ExceptionActions.h"
+#include "FWCore/Framework/interface/ModuleContextSentry.h"
 #include "FWCore/Framework/interface/OccurrenceTraits.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
@@ -56,6 +57,7 @@ namespace edm {
   namespace workerhelper {
     template< typename O> class CallImpl;
   }
+
   class Worker {
   public:
     enum State { Ready, Pass, Fail, Exception };
@@ -149,7 +151,9 @@ namespace edm {
     virtual void implEndStream(StreamID) = 0;
     
     void resetModuleDescription(ModuleDescription const*);
+
   private:
+
     virtual void implRespondToOpenInputFile(FileBlock const& fb) = 0;
     virtual void implRespondToCloseInputFile(FileBlock const& fb) = 0;
 
@@ -196,20 +200,6 @@ namespace edm {
       ActivityRegistry* a_;
       ModuleDescription const* md_;
       typename T::Context const* context_;
-      ModuleCallingContext* moduleCallingContext_;
-    };
-
-    class ModuleContextSentry {
-    public:
-      ModuleContextSentry(ModuleCallingContext* moduleCallingContext,
-                          ParentContext const& parentContext) :
-        moduleCallingContext_(moduleCallingContext) {
-        moduleCallingContext_->setContext(ModuleCallingContext::State::kRunning, parentContext);
-      }
-      ~ModuleContextSentry() {
-        moduleCallingContext_->setContext(ModuleCallingContext::State::kInvalid, ParentContext());
-      }
-    private:
       ModuleCallingContext* moduleCallingContext_;
     };
 

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -350,6 +350,7 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+    previousModuleOnThread: same as parent module
 ++++++++++ finished module for event: intProducerA
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -365,6 +366,7 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+    previousModuleOnThread: same as parent module
 ++++++++ finished module for event: a2
 ++++++++ module for event: a3
 ++++++++ finished module for event: a3
@@ -460,6 +462,7 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+    previousModuleOnThread: same as parent module
 ++++++++++ finished module for event: intProducerA
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -475,6 +478,7 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+    previousModuleOnThread: same as parent module
 ++++++++ finished module for event: a2
 ++++++++ module for event: a3
 ++++++++ finished module for event: a3
@@ -570,6 +574,7 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+    previousModuleOnThread: same as parent module
 ++++++++++ finished module for event: intProducerA
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -585,6 +590,7 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+    previousModuleOnThread: same as parent module
 ++++++++ finished module for event: a2
 ++++++++ module for event: a3
 ++++++++ finished module for event: a3

--- a/FWCore/ServiceRegistry/interface/ModuleCallingContext.h
+++ b/FWCore/ServiceRegistry/interface/ModuleCallingContext.h
@@ -39,9 +39,15 @@ namespace edm {
     };
 
     ModuleCallingContext(ModuleDescription const* moduleDescription);
-    ModuleCallingContext(ModuleDescription const* moduleDescription, State state, ParentContext const& parent);
 
-    void setContext(State state, ParentContext const& parent);
+    ModuleCallingContext(ModuleDescription const* moduleDescription,
+                         State state,
+                         ParentContext const& parent,
+                         ModuleCallingContext const* previousOnThread);
+
+    void setContext(State state,
+                    ParentContext const& parent,
+                    ModuleCallingContext const* previousOnThread);
 
     ModuleDescription const* moduleDescription() const { return moduleDescription_; }
     State state() const { return state_; }
@@ -64,8 +70,10 @@ namespace edm {
     // pointer to itself.
     ModuleCallingContext const* getTopModuleCallingContext() const;
 
-  private:
+    ModuleCallingContext const* previousModuleOnThread() const { return previousModuleOnThread_; }
 
+  private:
+    ModuleCallingContext const* previousModuleOnThread_;
     ModuleDescription const* moduleDescription_;
     ParentContext parent_;
     State state_;

--- a/FWCore/ServiceRegistry/src/ModuleCallingContext.cc
+++ b/FWCore/ServiceRegistry/src/ModuleCallingContext.cc
@@ -10,20 +10,27 @@
 namespace edm {
 
   ModuleCallingContext::ModuleCallingContext(ModuleDescription const* moduleDescription) :
+    previousModuleOnThread_(nullptr),
     moduleDescription_(moduleDescription),
     parent_(),
     state_(State::kInvalid) {
   }
 
-  ModuleCallingContext::ModuleCallingContext(ModuleDescription const* moduleDescription, State state, ParentContext const& parent) :
+  ModuleCallingContext::ModuleCallingContext(ModuleDescription const* moduleDescription,
+                                             State state,
+                                             ParentContext const& parent,
+                                             ModuleCallingContext const* previousOnThread) :
+    previousModuleOnThread_(previousOnThread),
     moduleDescription_(moduleDescription),
     parent_(parent),
     state_(state) {
   }
 
-  void ModuleCallingContext::setContext(State state, ParentContext const& parent) {
+  void ModuleCallingContext::setContext(State state, ParentContext const& parent,
+                                        ModuleCallingContext const* previousOnThread) {
     state_ = state;
     parent_ = parent;
+    previousModuleOnThread_ = previousOnThread;
   }
 
   StreamContext const*
@@ -84,6 +91,13 @@ namespace edm {
       os << "    moduleDescription: " << *mcc.moduleDescription() << "\n";
     }
     os << "    " << mcc.parent();
+    if(mcc.previousModuleOnThread()) {
+      if(mcc.type() == ParentContext::Type::kModule && mcc.moduleCallingContext() == mcc.previousModuleOnThread()) {
+        os << "    previousModuleOnThread: same as parent module\n";
+      } else {
+        os << "    previousModuleOnThread: " << *mcc.previousModuleOnThread();
+      }
+    }
     return os;
   }
 }

--- a/PhysicsTools/UtilAlgos/interface/EDAnalyzerWrapper.h
+++ b/PhysicsTools/UtilAlgos/interface/EDAnalyzerWrapper.h
@@ -70,7 +70,7 @@ namespace edm {
     // defined TFileService
     edm::Service<TFileService> fileService;
     // create analysis class of type BasicAnalyzer
-    analyzer_ = boost::shared_ptr<T>( new T( cfg, *fileService) );
+    analyzer_ = boost::shared_ptr<T>( new T( cfg, fileService->tFileDirectory()) );
   }
 
 }

--- a/RecoParticleFlow/Benchmark/interface/PFJetBenchmark.h
+++ b/RecoParticleFlow/Benchmark/interface/PFJetBenchmark.h
@@ -20,7 +20,7 @@
 #include "DQMServices/Core/interface/MonitorElement.h"
 
 //#include "FWCore/ServiceRegistry/interface/Service.h" 
-#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
 #include "TH1F.h"
 #include "TH2F.h"
 #include <string>

--- a/RecoParticleFlow/Benchmark/interface/PFMETBenchmark.h
+++ b/RecoParticleFlow/Benchmark/interface/PFMETBenchmark.h
@@ -23,7 +23,7 @@
 #include "DQMServices/Core/interface/MonitorElement.h"
 
 //#include "FWCore/ServiceRegistry/interface/Service.h" 
-#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
 #include "TH1F.h"
 #include "TH2F.h"
 #include <string>

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
@@ -10,6 +10,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
+#include "FWCore/Framework/interface/ModuleContextSentry.h"
 #include "FWCore/ServiceRegistry/interface/InternalContext.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
@@ -335,7 +336,8 @@ namespace edm
 
     InternalContext internalContext(ep.id(), mcc);
     ParentContext parentContext(&internalContext);
-    ModuleCallingContext moduleCallingContext(&moduleDescription(), ModuleCallingContext::State::kRunning, parentContext);
+    ModuleCallingContext moduleCallingContext(&moduleDescription());
+    ModuleContextSentry moduleContextSentry(&moduleCallingContext, parentContext);
 
     LogDebug("DataMixingModule") <<"\n===============> adding pileups from event  "<<ep.id()<<" for bunchcrossing "<<bcr;
 

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -13,6 +13,7 @@
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ModuleContextSentry.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
 #include "FWCore/ServiceRegistry/interface/InternalContext.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
@@ -274,7 +275,8 @@ dropUnwantedBranches(wantedBranches_);
 
     InternalContext internalContext(eventPrincipal.id(), mcc);
     ParentContext parentContext(&internalContext);
-    ModuleCallingContext moduleCallingContext(&moduleDescription(), ModuleCallingContext::State::kRunning, parentContext);
+    ModuleCallingContext moduleCallingContext(&moduleDescription());
+    ModuleContextSentry moduleContextSentry(&moduleCallingContext, parentContext);
 
     PileUpEventPrincipal pep(eventPrincipal, &moduleCallingContext, bunchCrossing, bunchSpace_, eventId, vertexOffset);
     accumulateEvent(pep, setup);

--- a/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
+++ b/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
@@ -27,6 +27,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ModuleContextSentry.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
@@ -127,7 +128,8 @@ void  SecSourceAnalyzer::getBranches(EventPrincipal const &ep,
   { 
     InternalContext internalContext(ep.id(), mcc);
     ParentContext parentContext(&internalContext);
-    ModuleCallingContext moduleCallingContext(&moduleDescription(), ModuleCallingContext::State::kRunning, parentContext);
+    ModuleCallingContext moduleCallingContext(&moduleDescription());
+    ModuleContextSentry moduleContextSentry(&moduleCallingContext, parentContext);
 
     std::cout <<"-> Get the event:  id " << ep.id() << std::endl;
     std::cout << "-> dataStep2_ = " << dataStep2_ << std::endl;

--- a/Validation/RecoVertex/src/BSvsPVHistogramMaker.cc
+++ b/Validation/RecoVertex/src/BSvsPVHistogramMaker.cc
@@ -39,7 +39,7 @@ BSvsPVHistogramMaker::~BSvsPVHistogramMaker() {
 void BSvsPVHistogramMaker::book(const std::string dirname) {
 
   edm::Service<TFileService> tfserv;
-  TFileDirectory* currdir = &(*tfserv);
+  TFileDirectory* currdir = &(tfserv->tFileDirectory());
 
   if(dirname!="") {
     currdir = new TFileDirectory(tfserv->mkdir(dirname));
@@ -150,7 +150,7 @@ void BSvsPVHistogramMaker::beginRun(const unsigned int nrun) {
   TFileDirectory* currdir = _currdir;
   if(currdir==0) {
     edm::Service<TFileService> tfserv;
-    currdir = &(*tfserv);
+    currdir = &(tfserv->tFileDirectory());
   }
 
   _rhm.beginRun(nrun,*currdir);

--- a/Validation/RecoVertex/src/BeamSpotHistogramMaker.cc
+++ b/Validation/RecoVertex/src/BeamSpotHistogramMaker.cc
@@ -29,7 +29,7 @@ BeamSpotHistogramMaker::~BeamSpotHistogramMaker() {
 void BeamSpotHistogramMaker::book(const std::string dirname) {
 
   edm::Service<TFileService> tfserv;
-  TFileDirectory* currdir = &(*tfserv);
+  TFileDirectory* currdir = &(tfserv->tFileDirectory());
 
   if(dirname!="") {
     currdir = new TFileDirectory(tfserv->mkdir(dirname));
@@ -85,7 +85,7 @@ void BeamSpotHistogramMaker::beginRun(const unsigned int nrun) {
   TFileDirectory* currdir = _currdir;
   if(currdir==0) {
     edm::Service<TFileService> tfserv;
-    currdir = &(*tfserv);
+    currdir = &(tfserv->tFileDirectory());
   }
 
   _rhm.beginRun(nrun,*currdir);

--- a/Validation/RecoVertex/src/VertexHistogramMaker.cc
+++ b/Validation/RecoVertex/src/VertexHistogramMaker.cc
@@ -45,7 +45,7 @@ VertexHistogramMaker::~VertexHistogramMaker() {
 void VertexHistogramMaker::book(const std::string dirname) {
 
   edm::Service<TFileService> tfserv;
-  TFileDirectory* currdir = &(*tfserv);
+  TFileDirectory* currdir = &(tfserv->tFileDirectory());
 
   if(dirname!="") {
     currdir = new TFileDirectory(tfserv->mkdir(dirname));
@@ -200,7 +200,7 @@ void VertexHistogramMaker::beginRun(const edm::Run& iRun) {
   TFileDirectory* currdir = m_currdir;
   if(currdir==0) {
     edm::Service<TFileService> tfserv;
-    currdir = &(*tfserv);
+    currdir = &(tfserv->tFileDirectory());
   }
 
   m_rhm.beginRun(iRun,*currdir);
@@ -351,13 +351,6 @@ void VertexHistogramMaker::fill(const unsigned int orbit, const int bx, const fl
 }
 
 void VertexHistogramMaker::fill(const edm::Event& iEvent, const reco::VertexCollection& vertices, const double weight) {
-
-  TFileDirectory* currdir = m_currdir;
-  if(currdir==0) {
-    edm::Service<TFileService> tfserv;
-    currdir = &(*tfserv);
-  }
-
 
   // get luminosity
 


### PR DESCRIPTION
Modify TFileService so it will run in the multithreaded
Framework. Note that only "One" type modules that declare
TFileService as a shared resource will be able to use it
in multithreaded mode. TFileDirectory is now a thread local
member instead of being a base class of TFileService. This
change required some code that uses to the service to be
modified. Add Framework code that keeps track of the modules
active on the current thread and make this available to
the service through the context passed to the service.
Remove a couple unneeded includes in RecoParticleFlow
that were causing problems.
