### PR TITLE
Use correct stream for Delayed Reading

### DIFF
--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
@@ -76,7 +76,8 @@ namespace sistrip {
                                             *productRegistry_,
                                             boost::shared_ptr<edm::BranchIDListHelper>(new edm::BranchIDListHelper),
                                             boost::shared_ptr<edm::ActivityRegistry>(new edm::ActivityRegistry),
-                                            -1, -1);
+                                            -1, -1,
+                                            edm::PreallocationConfiguration());
     return sourceFactory->makeVectorInputSource(sourceConfig, description);
   }
 

--- a/DataFormats/Common/interface/EDProductGetter.h
+++ b/DataFormats/Common/interface/EDProductGetter.h
@@ -36,6 +36,10 @@ namespace edm {
      // ---------- const member functions ---------------------
      virtual WrapperHolder getIt(ProductID const&) const = 0;
 
+     unsigned int transitionIndex() const {
+       return transitionIndex_();
+     }
+
      // ---------- member functions ---------------------------
 
      ///These can only be used internally by the framework
@@ -43,6 +47,8 @@ namespace edm {
      static void assignEDProductGetter(EDProductGetter const*&);
 
 private:
+    virtual unsigned int transitionIndex_() const = 0;
+
      // ---------- member data --------------------------------
 
    };

--- a/DataFormats/Common/test/DetSetVector_t.cpp
+++ b/DataFormats/Common/test/DetSetVector_t.cpp
@@ -167,7 +167,10 @@ namespace {
   struct DSVGetter : edm::EDProductGetter {
     DSVGetter() : edm::EDProductGetter(), prod_(0) {}
     virtual WrapperHolder
-    getIt(ProductID const&) const {return WrapperHolder(prod_, prod_->getInterface());}
+    getIt(ProductID const&) const override {return WrapperHolder(prod_, prod_->getInterface());}
+    virtual unsigned int
+    transitionIndex_() const override {return 0U;}
+
     edm::Wrapper<T> const* prod_;
   };
 }

--- a/DataFormats/Common/test/SimpleEDProductGetter.h
+++ b/DataFormats/Common/test/SimpleEDProductGetter.h
@@ -27,7 +27,7 @@ public:
     return database.size();
   }
 
-  virtual edm::WrapperHolder getIt(edm::ProductID const& id) const {
+  virtual edm::WrapperHolder getIt(edm::ProductID const& id) const override {
     map_t::const_iterator i = database.find(id);
     if (i == database.end()) {
       edm::Exception e(edm::errors::ProductNotFound, "InvalidID");
@@ -40,6 +40,10 @@ public:
   }
 
 private:
+  virtual unsigned int transitionIndex_() const override {
+    return 0U;
+  }
+
   map_t database;
 };
 #endif

--- a/DataFormats/Common/test/ptr_t.cppunit.cc
+++ b/DataFormats/Common/test/ptr_t.cppunit.cc
@@ -288,9 +288,13 @@ void testPtr::comparisonTest() {
 namespace {
    struct TestGetter : public edm::EDProductGetter {
       WrapperHolder hold_;
-      WrapperHolder getIt(ProductID const&) const {
+      virtual WrapperHolder getIt(ProductID const&) const override {
          return hold_;
       }
+      virtual unsigned int transitionIndex_() const override {
+        return 0U;
+      }
+
       TestGetter() : hold_() {}
    };
 }

--- a/DataFormats/Common/test/ptrvector_t.cppunit.cc
+++ b/DataFormats/Common/test/ptrvector_t.cppunit.cc
@@ -41,9 +41,13 @@ namespace testPtr {
 
   struct TestGetter : public edm::EDProductGetter {
     edm::WrapperHolder hold_;
-    edm::WrapperHolder getIt(edm::ProductID const&) const {
+    virtual edm::WrapperHolder getIt(edm::ProductID const&) const override {
       return hold_;
     }
+    virtual unsigned int transitionIndex_() const override {
+    return 0U;
+    }
+
     TestGetter() : hold_() {}
   };
 }

--- a/DataFormats/Common/test/ref_t.cppunit.cc
+++ b/DataFormats/Common/test/ref_t.cppunit.cc
@@ -159,8 +159,11 @@ void testRef::comparisonTest() {
 namespace {
    struct TestGetter : public edm::EDProductGetter {
       WrapperHolder hold_;
-      WrapperHolder getIt(ProductID const&) const {
+      virtual WrapperHolder getIt(ProductID const&) const override {
          return hold_;
+      }
+      virtual unsigned int transitionIndex_() const override {
+        return 0U;
       }
       TestGetter() : hold_() {}
    };

--- a/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
+++ b/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
@@ -175,9 +175,13 @@ void testRefToBaseProd::constructTest() {
 namespace {
    struct TestGetter : public edm::EDProductGetter {
       WrapperHolder hold_;
-      WrapperHolder getIt(ProductID const&) const {
+      virtual WrapperHolder getIt(ProductID const&) const override {
          return hold_;
       }
+      virtual unsigned int transitionIndex_() const override {
+         return 0U;
+      }
+
       TestGetter() : hold_() {}
    };
 }

--- a/DataFormats/FWLite/src/Event.cc
+++ b/DataFormats/FWLite/src/Event.cc
@@ -60,11 +60,19 @@ namespace fwlite {
             public:
                 ProductGetter(Event* iEvent) : event_(iEvent) {}
 
+                virtual
                 edm::WrapperHolder
                 getIt(edm::ProductID const& iID) const override {
                     return event_->getByProductID(iID);
                 }
+
             private:
+                virtual
+                unsigned int
+                transitionIndex_() const override {
+                    return 0U;
+                }
+
                 Event* event_;
         };
     }

--- a/DataFormats/FWLite/src/MultiChainEvent.cc
+++ b/DataFormats/FWLite/src/MultiChainEvent.cc
@@ -30,10 +30,14 @@ public:
 
       virtual edm::WrapperHolder
       getIt(edm::ProductID const& iID) const override {
-
-	return event_->getByProductID(iID);
+        return event_->getByProductID(iID);
       }
+
 private:
+      virtual unsigned int transitionIndex_() const override {
+        return 0U;
+      }
+
       MultiChainEvent const* event_;
 
     };

--- a/FWCore/FWLite/src/BareRootProductGetter.h
+++ b/FWCore/FWLite/src/BareRootProductGetter.h
@@ -40,11 +40,16 @@ class BareRootProductGetter : public edm::EDProductGetter {
       virtual ~BareRootProductGetter();
 
       // ---------- const member functions ---------------------
-      virtual edm::WrapperHolder getIt(edm::ProductID const&) const;
+      virtual edm::WrapperHolder getIt(edm::ProductID const&) const override;
+
+private:
 
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------
+      virtual unsigned int transitionIndex_() const override {
+        return 0u;
+      }
 
       struct Buffer {
         Buffer(edm::WrapperOwningHolder const& iProd, TBranch* iBranch, void* iAddress,

--- a/FWCore/Framework/interface/DelayedReader.h
+++ b/FWCore/Framework/interface/DelayedReader.h
@@ -3,12 +3,13 @@
 
 /*----------------------------------------------------------------------
 
-DelayedReader: The abstract interface through which the EventPrincipal
+DelayedReader: The abstract interface through which the Principal
 uses input sources to retrieve EDProducts from external storage.
 
 ----------------------------------------------------------------------*/
 
 #include "DataFormats/Common/interface/WrapperOwningHolder.h"
+#include "FWCore/Utilities/interface/StreamID.h"
 
 #include <memory>
 
@@ -25,7 +26,9 @@ namespace edm {
     void mergeReaders(DelayedReader* other) {mergeReaders_(other);}
     void reset() {reset_();}
   private:
-    virtual WrapperOwningHolder getProduct_(BranchKey const& k, WrapperInterfaceBase const* interface, EDProductGetter const* ep) const = 0;
+    virtual WrapperOwningHolder getProduct_(BranchKey const& k,
+                                            WrapperInterfaceBase const* interface,
+                                            EDProductGetter const* ep) const = 0;
     virtual void mergeReaders_(DelayedReader*) = 0;
     virtual void reset_() = 0;
   };

--- a/FWCore/Framework/interface/DelayedReader.h
+++ b/FWCore/Framework/interface/DelayedReader.h
@@ -9,7 +9,6 @@ uses input sources to retrieve EDProducts from external storage.
 ----------------------------------------------------------------------*/
 
 #include "DataFormats/Common/interface/WrapperOwningHolder.h"
-#include "FWCore/Utilities/interface/StreamID.h"
 
 #include <memory>
 

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -110,10 +110,7 @@ namespace edm {
     }
 
     StreamID streamID() const { return streamID_;}
-    void setStreamID(StreamID const& iID) {
-      streamID_ = iID;
-    }
-    
+
     LuminosityBlockNumber_t luminosityBlock() const {
       return id().luminosityBlock();
     }
@@ -170,6 +167,8 @@ namespace edm {
                                  bool fillOnDemand,
                                  ModuleCallingContext const* mcc) const override;
 
+    virtual unsigned int transitionIndex_() const override;
+    
   private:
 
     class UnscheduledSentry {

--- a/FWCore/Framework/interface/InputSourceDescription.h
+++ b/FWCore/Framework/interface/InputSourceDescription.h
@@ -8,32 +8,39 @@ input source that does not come in through the ParameterSet
 ----------------------------------------------------------------------*/
 #include "boost/shared_ptr.hpp"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
+#include "FWCore/Framework/src/PreallocationConfiguration.h"
 
 namespace edm {
   class ProductRegistry;
   class ActivityRegistry;
   class BranchIDListHelper;
+  class PreallocationConfiguration;
 
   struct InputSourceDescription {
     InputSourceDescription() :
       moduleDescription_(),
       productRegistry_(nullptr),
-      actReg_(), maxEvents_(-1),
-      maxLumis_(-1) {}
+      actReg_(),
+      maxEvents_(-1),
+      maxLumis_(-1),
+      allocations_(nullptr) {
+    }
+
     InputSourceDescription(ModuleDescription const& md,
-			   ProductRegistry& preg,
+                           ProductRegistry& preg,
                            boost::shared_ptr<BranchIDListHelper> branchIDListHelper,
-			   boost::shared_ptr<ActivityRegistry> areg,
-			   int maxEvents,
-			   int maxLumis) :
+                           boost::shared_ptr<ActivityRegistry> areg,
+                           int maxEvents,
+                           int maxLumis,
+                           PreallocationConfiguration const& allocations) :
       moduleDescription_(md),
       productRegistry_(&preg),
       branchIDListHelper_(branchIDListHelper),
       actReg_(areg),
       maxEvents_(maxEvents),
-      maxLumis_(maxLumis)
-	 
-    {}
+      maxLumis_(maxLumis),
+      allocations_(&allocations) {
+   }
 
     ModuleDescription moduleDescription_;
     ProductRegistry* productRegistry_;
@@ -41,6 +48,7 @@ namespace edm {
     boost::shared_ptr<ActivityRegistry> actReg_;
     int maxEvents_;
     int maxLumis_;
+    PreallocationConfiguration const* allocations_;
   };
 }
 

--- a/FWCore/Framework/interface/LuminosityBlockPrincipal.h
+++ b/FWCore/Framework/interface/LuminosityBlockPrincipal.h
@@ -112,6 +112,8 @@ namespace edm {
     virtual bool unscheduledFill(std::string const&,
                                  ModuleCallingContext const* mcc) const override {return false;}
 
+    virtual unsigned int transitionIndex_() const override;
+
     void resolveProductImmediate(ProductHolderBase const& phb) const;
 
     boost::shared_ptr<RunPrincipal> runPrincipal_;

--- a/FWCore/Framework/interface/RunPrincipal.h
+++ b/FWCore/Framework/interface/RunPrincipal.h
@@ -100,6 +100,8 @@ namespace edm {
     virtual bool unscheduledFill(std::string const&,
                                  ModuleCallingContext const* mcc) const override {return false;}
 
+    virtual unsigned int transitionIndex_() const override;
+
     void resolveProductImmediate(ProductHolderBase const& phb) const;
 
     // A vector of product holders.

--- a/FWCore/Framework/src/DelayedReader.cc
+++ b/FWCore/Framework/src/DelayedReader.cc
@@ -1,5 +1,6 @@
 #include "FWCore/Framework/interface/DelayedReader.h"
 
+#include <cassert>
 /*----------------------------------------------------------------------
   
 

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -203,6 +203,11 @@ namespace edm {
     return ProductID();
   }
 
+  unsigned int
+  EventPrincipal::transitionIndex_() const {
+    return streamID_.value();
+  }
+
   static void throwProductDeletedException(ProductID const& pid, edm::EventPrincipal::ConstProductPtr const phb) {
     ProductDeletedException exception;
     exception<<"get by product ID: The product with given id: "<<pid

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -96,7 +96,8 @@ namespace edm {
             ProductRegistry& preg,
             boost::shared_ptr<BranchIDListHelper> branchIDListHelper,
             boost::shared_ptr<ActivityRegistry> areg,
-            boost::shared_ptr<ProcessConfiguration const> processConfiguration) {
+            boost::shared_ptr<ProcessConfiguration const> processConfiguration,
+            PreallocationConfiguration const& allocations) {
     ParameterSet* main_input = params.getPSetForUpdate("@main_input");
     if(main_input == 0) {
       throw Exception(errors::Configuration)
@@ -143,7 +144,7 @@ namespace edm {
                          processConfiguration.get(),
                          ModuleDescription::getUniqueID());
 
-    InputSourceDescription isdesc(md, preg, branchIDListHelper, areg, common.maxEventsInput_, common.maxLumisInput_);
+    InputSourceDescription isdesc(md, preg, branchIDListHelper, areg, common.maxEventsInput_, common.maxLumisInput_, allocations);
     areg->preSourceConstructionSignal_(md);
     std::unique_ptr<InputSource> input;
     try {
@@ -491,7 +492,7 @@ namespace edm {
     preallocations_ = PreallocationConfiguration{nThreads,nStreams,nConcurrentLumis,nConcurrentRuns};
 
     // initialize the input source
-    input_ = makeInput(*parameterSet, *common, *items.preg_, items.branchIDListHelper_, items.actReg_, items.processConfiguration_);
+    input_ = makeInput(*parameterSet, *common, *items.preg_, items.branchIDListHelper_, items.actReg_, items.processConfiguration_, preallocations_);
 
     // intialize the Schedule
     schedule_ = items.initSchedule(*parameterSet,subProcessParameterSet.get(),preallocations_,&processContext_);
@@ -515,7 +516,7 @@ namespace edm {
                                                               *processConfiguration_,
                                                               historyAppender_.get(),
                                                               index));
-      principalCache_.insert(ep,index);
+      principalCache_.insert(ep);
     }
     // initialize the subprocess, if there is one
     if(subProcessParameterSet) {

--- a/FWCore/Framework/src/LuminosityBlockPrincipal.cc
+++ b/FWCore/Framework/src/LuminosityBlockPrincipal.cc
@@ -54,8 +54,8 @@ namespace edm {
 
   void
   LuminosityBlockPrincipal::readImmediate() const {
-    for(Principal::const_iterator i = begin(), iEnd = end(); i != iEnd; ++i) {
-      ProductHolderBase const& phb = **i;
+    for(auto const& prod : *this) {
+      ProductHolderBase const& phb = *prod;
       if(phb.singleProduct() && !phb.branchDescription().produced()) {
         if(!phb.productUnavailable()) {
           resolveProductImmediate(phb);
@@ -78,4 +78,10 @@ namespace edm {
       putOrMerge(edp, &phb);
     }
   }
+
+  unsigned int
+  LuminosityBlockPrincipal::transitionIndex_() const {
+    return 0U;
+  }
+
 }

--- a/FWCore/Framework/src/LuminosityBlockPrincipal.cc
+++ b/FWCore/Framework/src/LuminosityBlockPrincipal.cc
@@ -81,7 +81,7 @@ namespace edm {
 
   unsigned int
   LuminosityBlockPrincipal::transitionIndex_() const {
-    return 0U;
+    return index().value();
   }
 
 }

--- a/FWCore/Framework/src/PrincipalCache.cc
+++ b/FWCore/Framework/src/PrincipalCache.cc
@@ -207,6 +207,12 @@ namespace edm {
     lumiPrincipal_ = lbp; 
   }
 
+  void PrincipalCache::insert(boost::shared_ptr<EventPrincipal> ep) {
+    unsigned int iStreamIndex = ep->streamID().value();
+    assert(iStreamIndex < eventPrincipals_.size());
+    eventPrincipals_[iStreamIndex] = ep;
+  }
+
   void PrincipalCache::deleteRun(ProcessHistoryID const& phid, RunNumber_t run) {
     if (runPrincipal_.get() == 0) {
       throw edm::Exception(edm::errors::LogicError)

--- a/FWCore/Framework/src/PrincipalCache.h
+++ b/FWCore/Framework/src/PrincipalCache.h
@@ -68,7 +68,7 @@ namespace edm {
     void setNumberOfConcurrentPrincipals(PreallocationConfiguration const&);
     void insert(boost::shared_ptr<RunPrincipal> rp);
     void insert(boost::shared_ptr<LuminosityBlockPrincipal> lbp);
-    void insert(boost::shared_ptr<EventPrincipal> ep, unsigned int iStreamIndex) { assert(iStreamIndex < eventPrincipals_.size()); eventPrincipals_[iStreamIndex] = ep; }
+    void insert(boost::shared_ptr<EventPrincipal> ep);
 
     void deleteRun(ProcessHistoryID const& phid, RunNumber_t run);
     void deleteLumi(ProcessHistoryID const& phid, RunNumber_t run, LuminosityBlockNumber_t lumi);

--- a/FWCore/Framework/src/RunPrincipal.cc
+++ b/FWCore/Framework/src/RunPrincipal.cc
@@ -76,7 +76,7 @@ namespace edm {
 
   unsigned int
   RunPrincipal::transitionIndex_() const {
-    return 0U;
+    return index().value();
   }
 
 }

--- a/FWCore/Framework/src/RunPrincipal.cc
+++ b/FWCore/Framework/src/RunPrincipal.cc
@@ -73,4 +73,10 @@ namespace edm {
       putOrMerge(edp, &phb);
     }
   }
+
+  unsigned int
+  RunPrincipal::transitionIndex_() const {
+    return 0U;
+  }
+
 }

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -149,7 +149,7 @@ namespace edm {
                                                               *processConfiguration_,
                                                               historyAppender_.get(),
                                                               index));
-      principalCache_.insert(ep,index);
+      principalCache_.insert(ep);
     }
     if(subProcessParameterSet) {
       subProcess_.reset(new SubProcess(*subProcessParameterSet,
@@ -300,7 +300,6 @@ namespace edm {
     }
 
     EventPrincipal& ep = principalCache_.eventPrincipal(principal.streamID().value());
-    ep.setStreamID(principal.streamID());
     ep.fillEventPrincipal(aux,
                           processHistoryRegistry_,
                           esids,

--- a/IOPool/Input/src/PoolSource.h
+++ b/IOPool/Input/src/PoolSource.h
@@ -65,7 +65,7 @@ namespace edm {
     std::unique_ptr<RootInputFileSequence> secondaryFileSequence_;
     boost::shared_ptr<RunPrincipal> secondaryRunPrincipal_;
     boost::shared_ptr<LuminosityBlockPrincipal> secondaryLumiPrincipal_;
-    std::unique_ptr<EventPrincipal> secondaryEventPrincipal_;
+    std::vector<std::unique_ptr<EventPrincipal>> secondaryEventPrincipals_;
     std::array<std::vector<BranchID>, NumBranchTypes>  branchIDsToReplace_;
   }; // class PoolSource
   typedef PoolSource PoolRASource;

--- a/IOPool/Input/src/RootDelayedReader.cc
+++ b/IOPool/Input/src/RootDelayedReader.cc
@@ -3,12 +3,15 @@
 
 #include "RootDelayedReader.h"
 #include "InputFile.h"
+#include "DataFormats/Common/interface/EDProductGetter.h"
 #include "DataFormats/Common/interface/WrapperOwningHolder.h"
 #include "DataFormats/Common/interface/RefCoreStreamer.h"
 
 #include "TROOT.h"
 #include "TBranch.h"
 #include "TClass.h"
+
+#include <cassert>
 
 namespace edm {
 
@@ -35,22 +38,23 @@ namespace edm {
     }
     roottree::BranchInfo const& branchInfo = getBranchInfo(iter);
     TBranch* br = branchInfo.productBranch_;
-    if (br == 0) {
+    if (br == nullptr) {
       if (nextReader_) {
         return nextReader_->getProduct(k, interface, ep);
       } else {
         return WrapperOwningHolder();
       }
     }
+   
     setRefCoreStreamer(ep);
     TClass* cp = branchInfo.classCache_;
-    if(0 == cp) {
+    if(nullptr == cp) {
       branchInfo.classCache_ = gROOT->GetClass(branchInfo.branchDescription_.wrappedName().c_str());
       cp = branchInfo.classCache_;
     }
     void* p = cp->New();
     br->SetAddress(&p);
-    tree_.getEntry(br, entryNumber());
+    tree_.getEntry(br, tree_.entryNumberForIndex(ep->transitionIndex()));
     if(tree_.branchType() == InEvent) {
       InputFile::reportReadBranch(std::string(br->GetName()));
     }

--- a/IOPool/Input/src/RootDelayedReader.h
+++ b/IOPool/Input/src/RootDelayedReader.h
@@ -39,7 +39,9 @@ namespace edm {
     RootDelayedReader& operator=(RootDelayedReader const&) = delete; // Disallow copying and moving
 
   private:
-    virtual WrapperOwningHolder getProduct_(BranchKey const& k, WrapperInterfaceBase const* interface, EDProductGetter const* ep) const;
+    virtual WrapperOwningHolder getProduct_(BranchKey const& k, 
+                                            WrapperInterfaceBase const* interface,
+                                            EDProductGetter const* ep) const override;
     virtual void mergeReaders_(DelayedReader* other) {nextReader_ = other;}
     virtual void reset_() {nextReader_ = 0;}
     BranchMap const& branches() const {return tree_.branches();}

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -63,6 +63,7 @@ namespace edm {
              bool skipAnyEvents,
              int remainingEvents,
              int remainingLumis,
+             unsigned int nStreams,
              unsigned int treeCacheSize,
              int treeMaxVirtualSize,
              InputSource::ProcessingMode processingMode,

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -29,6 +29,7 @@ namespace edm {
                 ParameterSet const& pset,
                 PoolSource& input,
                 InputFileCatalog const& catalog,
+                unsigned int nStreams,
                 InputType::InputType inputType) :
     input_(input),
     inputType_(inputType),
@@ -44,6 +45,7 @@ namespace edm {
     flatDistribution_(),
     indexesIntoFiles_(fileCatalogItems().size()),
     orderedProcessHistoryIDs_(),
+    nStreams_(nStreams),
     eventSkipperByID_(inputType == InputType::Primary ? EventSkipperByID::create(pset).release() : 0),
     eventsRemainingInFile_(0),
     // The default value provided as the second argument to the getUntrackedParameter function call
@@ -240,10 +242,18 @@ namespace edm {
     }
     if(filePtr) {
       std::vector<boost::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile = fileIter_ - fileIterBegin_;
-      rootFile_ = RootFileSharedPtr(new RootFile(fileIter_->fileName(),
-          processConfiguration(), fileIter_->logicalFileName(), filePtr,
-          eventSkipperByID_, initialNumberOfEventsToSkip_ != 0,
-          remainingEvents(), remainingLuminosityBlocks(), treeCacheSize_, treeMaxVirtualSize_,
+      rootFile_ = RootFileSharedPtr(new RootFile(
+          fileIter_->fileName(),
+          processConfiguration(),
+          fileIter_->logicalFileName(),
+          filePtr,
+          eventSkipperByID_,
+          initialNumberOfEventsToSkip_ != 0,
+          remainingEvents(),
+          remainingLuminosityBlocks(),
+	  nStreams_,
+          treeCacheSize_,
+          treeMaxVirtualSize_,
           input_.processingMode(),
           setRun_,
           noEventSort_,

--- a/IOPool/Input/src/RootInputFileSequence.h
+++ b/IOPool/Input/src/RootInputFileSequence.h
@@ -37,7 +37,11 @@ namespace edm {
 
   class RootInputFileSequence {
   public:
-    explicit RootInputFileSequence(ParameterSet const& pset, PoolSource& input, InputFileCatalog const& catalog, InputType::InputType inputType);
+    explicit RootInputFileSequence(ParameterSet const& pset,
+                                   PoolSource& input,
+                                   InputFileCatalog const& catalog,
+                                   unsigned int nStreams,
+                                   InputType::InputType inputType);
     virtual ~RootInputFileSequence();
 
     RootInputFileSequence(RootInputFileSequence const&) = delete; // Disallow copying and moving
@@ -105,6 +109,7 @@ namespace edm {
     std::vector<boost::shared_ptr<IndexIntoFile> > indexesIntoFiles_;
     std::vector<ProcessHistoryID> orderedProcessHistoryIDs_;
 
+    unsigned int nStreams_; 
     boost::shared_ptr<EventSkipperByID> eventSkipperByID_;
     int eventsRemainingInFile_;
     int initialNumberOfEventsToSkip_;

--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -15,7 +15,7 @@ namespace edm {
   namespace {
     TBranch* getAuxiliaryBranch(TTree* tree, BranchType const& branchType) {
       TBranch* branch = tree->GetBranch(BranchTypeToAuxiliaryBranchName(branchType).c_str());
-      if (branch == 0) {
+      if (branch == nullptr) {
         branch = tree->GetBranch(BranchTypeToAuxBranchName(branchType).c_str());
       }
       return branch;
@@ -27,15 +27,16 @@ namespace edm {
   }
   RootTree::RootTree(boost::shared_ptr<InputFile> filePtr,
                      BranchType const& branchType,
+                     unsigned int nIndexes,
                      unsigned int maxVirtualSize,
                      unsigned int cacheSize,
                      unsigned int learningEntries,
                      bool enablePrefetching) :
     filePtr_(filePtr),
-    tree_(dynamic_cast<TTree*>(filePtr_.get() != 0 ? filePtr_->Get(BranchTypeToProductTreeName(branchType).c_str()) : 0)),
-    metaTree_(dynamic_cast<TTree*>(filePtr_.get() != 0 ? filePtr_->Get(BranchTypeToMetaDataTreeName(branchType).c_str()) : 0)),
+    tree_(dynamic_cast<TTree*>(filePtr_.get() != nullptr ? filePtr_->Get(BranchTypeToProductTreeName(branchType).c_str()) : nullptr)),
+    metaTree_(dynamic_cast<TTree*>(filePtr_.get() != nullptr ? filePtr_->Get(BranchTypeToMetaDataTreeName(branchType).c_str()) : nullptr)),
     branchType_(branchType),
-    auxBranch_(tree_ ? getAuxiliaryBranch(tree_, branchType_) : 0),
+    auxBranch_(tree_ ? getAuxiliaryBranch(tree_, branchType_) : nullptr),
     treeCache_(),
     rawTreeCache_(),
     triggerTreeCache_(),
@@ -44,6 +45,7 @@ namespace edm {
     triggerSet_(),
     entries_(tree_ ? tree_->GetEntries() : 0),
     entryNumber_(-1),
+    entryNumberForIndex_(new std::vector<EntryNumber>(nIndexes, -1LL)),
     branchNames_(),
     branches_(new BranchMap),
     trainNow_(false),
@@ -56,7 +58,7 @@ namespace edm {
     enableTriggerCache_(branchType_ == InEvent),
     rootDelayedReader_(new RootDelayedReader(*this, filePtr)),
     branchEntryInfoBranch_(metaTree_ ? getProductProvenanceBranch(metaTree_, branchType_) : (tree_ ? getProductProvenanceBranch(tree_, branchType_) : 0)),
-    infoTree_(dynamic_cast<TTree*>(filePtr_.get() != 0 ? filePtr->Get(BranchTypeToInfoTreeName(branchType).c_str()) : 0)) // backward compatibility
+    infoTree_(dynamic_cast<TTree*>(filePtr_.get() != nullptr ? filePtr->Get(BranchTypeToInfoTreeName(branchType).c_str()) : nullptr)) // backward compatibility
     {
       assert(tree_);
       // On merged files in older releases of ROOT, the autoFlush setting is always negative; we must guess.
@@ -84,13 +86,25 @@ namespace edm {
   RootTree::~RootTree() {
   }
 
+  RootTree::EntryNumber const&
+  RootTree::entryNumberForIndex(unsigned int index) const {
+    assert(index < entryNumberForIndex_->size());
+    return (*entryNumberForIndex_)[index];
+  }
+
+  void
+  RootTree::insertEntryForIndex(unsigned int index) {
+    assert(index < entryNumberForIndex_->size());
+    (*entryNumberForIndex_)[index] = entryNumber();
+  }
+
   bool
   RootTree::isValid() const {
-    if (metaTree_ == 0 || metaTree_->GetNbranches() == 0) {
-      return tree_ != 0 && auxBranch_ != 0;
+    if (metaTree_ == nullptr || metaTree_->GetNbranches() == 0) {
+      return tree_ != nullptr && auxBranch_ != nullptr;
     }
-    if (tree_ != 0 && auxBranch_ != 0 && metaTree_ != 0) { // backward compatibility
-      if (branchEntryInfoBranch_ != 0 || infoTree_ != 0) return true; // backward compatibility
+    if (tree_ != nullptr && auxBranch_ != nullptr && metaTree_ != nullptr) { // backward compatibility
+      if (branchEntryInfoBranch_ != nullptr || infoTree_ != nullptr) return true; // backward compatibility
       return (entries_ == metaTree_->GetEntries() && tree_->GetNbranches() <= metaTree_->GetNbranches() + 1);  // backward compatibility
     } // backward compatibility
     return false;
@@ -105,7 +119,7 @@ namespace edm {
   void
   RootTree::setPresence(BranchDescription& prod, std::string const& oldBranchName) {
       assert(isValid());
-      if(tree_->GetBranch(oldBranchName.c_str()) == 0){
+      if(tree_->GetBranch(oldBranchName.c_str()) == nullptr){
         prod.setDropped(true);
       }
   }
@@ -118,13 +132,13 @@ namespace edm {
       //use the translated branch name
       TBranch* branch = tree_->GetBranch(oldBranchName.c_str());
       roottree::BranchInfo info = roottree::BranchInfo(BranchDescription(prod));
-      info.productBranch_ = 0;
+      info.productBranch_ = nullptr;
       if (prod.present()) {
         info.productBranch_ = branch;
         //we want the new branch name for the JobReport
         branchNames_.push_back(prod.branchName());
       }
-      TTree* provTree = (metaTree_ != 0 ? metaTree_ : tree_);
+      TTree* provTree = (metaTree_ != nullptr ? metaTree_ : tree_);
       info.provenanceBranch_ = provTree->GetBranch(oldBranchName.c_str());
       branches_->insert(std::make_pair(key, info));
   }
@@ -133,14 +147,14 @@ namespace edm {
   RootTree::dropBranch(std::string const& oldBranchName) {
       //use the translated branch name
       TBranch* branch = tree_->GetBranch(oldBranchName.c_str());
-      if (branch != 0) {
+      if (branch != nullptr) {
         TObjArray* leaves = tree_->GetListOfLeaves();
         int entries = leaves->GetEntries();
         for (int i = 0; i < entries; ++i) {
           TLeaf* leaf = (TLeaf*)(*leaves)[i];
-          if (leaf == 0) continue;
+          if (leaf == nullptr) continue;
           TBranch* br = leaf->GetBranch();
-          if (br == 0) continue;
+          if (br == nullptr) continue;
           if (br->GetMother() == branch) {
             leaves->Remove(leaf);
           }
@@ -392,8 +406,8 @@ namespace edm {
   RootTree::close () {
     // The TFile is about to be closed, and destructed.
     // Just to play it safe, zero all pointers to quantities that are owned by the TFile.
-    auxBranch_  = branchEntryInfoBranch_ = 0;
-    tree_ = metaTree_ = infoTree_ = 0;
+    auxBranch_  = branchEntryInfoBranch_ = nullptr;
+    tree_ = metaTree_ = infoTree_ = nullptr;
     // We own the treeCache_.
     // We make sure the treeCache_ is detached from the file,
     // so that ROOT does not also delete it.
@@ -470,7 +484,7 @@ namespace edm {
       tree->LoadTree(0);
       tree->SetCacheSize(cacheSize);
       std::unique_ptr<TTreeCache> treeCache(dynamic_cast<TTreeCache*>(file.GetCacheRead()));
-      if (0 != treeCache.get()) {
+      if (nullptr != treeCache.get()) {
         treeCache->StartLearningPhase();
         treeCache->SetEntryRange(0, tree->GetEntries());
         treeCache->AddBranch(branchNames, kTRUE);

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -26,7 +26,7 @@ class TTree;
 class TTreeCache;
 
 namespace edm {
-  struct BranchKey;
+  class BranchKey;
   class DelayedReader;
   class InputFile;
   class RootTree;
@@ -60,6 +60,7 @@ namespace edm {
     typedef roottree::EntryNumber EntryNumber;
     RootTree(boost::shared_ptr<InputFile> filePtr,
              BranchType const& branchType,
+             unsigned int nIndexes,
              unsigned int maxVirtualSize,
              unsigned int cacheSize,
              unsigned int learningEntries,
@@ -80,12 +81,14 @@ namespace edm {
 
     bool next() {return ++entryNumber_ < entries_;}
     bool previous() {return --entryNumber_ >= 0;}
-    bool current() {return entryNumber_ < entries_ && entryNumber_ >= 0;}
+    bool current() const {return entryNumber_ < entries_ && entryNumber_ >= 0;}
     void rewind() {entryNumber_ = 0;}
     void close();
     EntryNumber const& entryNumber() const {return entryNumber_;}
+    EntryNumber const& entryNumberForIndex(unsigned int index) const;
     EntryNumber const& entries() const {return entries_;}
     void setEntryNumber(EntryNumber theEntryNumber);
+    void insertEntryForIndex(unsigned int index);
     std::vector<std::string> const& branchNames() const {return branchNames_;}
     DelayedReader* rootDelayedReader() const;
     template <typename T>
@@ -150,6 +153,7 @@ namespace edm {
     mutable std::unordered_set<TBranch*> triggerSet_;
     EntryNumber entries_;
     EntryNumber entryNumber_;
+    std::unique_ptr<std::vector<EntryNumber> > entryNumberForIndex_;
     std::vector<std::string> branchNames_;
     boost::shared_ptr<BranchMap> branches_;
     bool trainNow_;

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -65,8 +65,7 @@ namespace edm {
     eventPrincipal_.reset(new EventPrincipal(secInput_->productRegistry(),
                                              secInput_->branchIDListHelper(),
                                              *processConfiguration_,
-                                             nullptr,
-                                             StreamID::invalidStreamID()));
+                                             nullptr));
 
   }
 
@@ -152,11 +151,12 @@ namespace edm {
 
   boost::shared_ptr<VectorInputSource> SecondaryProducer::makeSecInput(ParameterSet const& ps) {
     ParameterSet const& sec_input = ps.getParameterSet("input");
+    PreallocationConfiguration dummy;
     InputSourceDescription desc(ModuleDescription(),
                                 *productRegistry_,
 				boost::shared_ptr<BranchIDListHelper>(new BranchIDListHelper),
 				boost::shared_ptr<ActivityRegistry>(new ActivityRegistry),
-				-1, -1);
+				-1, -1, dummy);
     boost::shared_ptr<VectorInputSource> input_(static_cast<VectorInputSource *>
       (VectorInputSourceFactory::get()->makeVectorInputSource(sec_input,
       desc).release()));

--- a/IOPool/Streamer/interface/StreamerInputSource.h
+++ b/IOPool/Streamer/interface/StreamerInputSource.h
@@ -62,12 +62,14 @@ namespace edm {
 
   private:
 
-    class ProductGetter : public EDProductGetter {
+    class EventPrincipalHolder : public EDProductGetter {
     public:
-      ProductGetter();
-      virtual ~ProductGetter();
+      EventPrincipalHolder();
+      virtual ~EventPrincipalHolder();
 
-      virtual WrapperHolder getIt(edm::ProductID const& id) const;
+      virtual WrapperHolder getIt(edm::ProductID const& id) const override;
+ 
+      virtual unsigned int transitionIndex_() const override;
 
       void setEventPrincipal(EventPrincipal* ep);
 
@@ -86,7 +88,7 @@ namespace edm {
     std::vector<unsigned char> dest_;
     TBufferFile xbuf_;
     std::unique_ptr<SendEvent> sendEvent_;
-    ProductGetter productGetter_;
+    EventPrincipalHolder eventPrincipalHolder_;
     bool adjustEventToNewProductRegistry_;
 
     //Do not like these to be static, but no choice as deserializeRegistry() that sets it is a static memeber 

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -51,7 +51,7 @@ namespace edm {
     dest_(init_size),
     xbuf_(TBuffer::kRead, init_size),
     sendEvent_(),
-    productGetter_(),
+    eventPrincipalHolder_(),
     adjustEventToNewProductRegistry_(false) {
   }
 
@@ -233,7 +233,7 @@ namespace edm {
     xbuf_.SetBuffer(&dest_[0],dest_size,kFALSE);
     RootDebug tracer(10,10);
 
-    setRefCoreStreamer(&productGetter_);
+    setRefCoreStreamer(&eventPrincipalHolder_);
     sendEvent_ = std::unique_ptr<SendEvent>((SendEvent*)xbuf_.ReadObjectAny(tc_));
     setRefCoreStreamer();
 
@@ -271,7 +271,7 @@ namespace edm {
     boost::shared_ptr<BranchListIndexes> indexes(new BranchListIndexes(sendEvent_->branchListIndexes()));
     branchIDListHelper()->fixBranchListIndexes(*indexes);
     eventPrincipal.fillEventPrincipal(sendEvent_->aux(), processHistoryRegistryForUpdate(), ids, indexes);
-    productGetter_.setEventPrincipal(&eventPrincipal);
+    eventPrincipalHolder_.setEventPrincipal(&eventPrincipal);
 
     // no process name list handling
 
@@ -367,17 +367,23 @@ namespace edm {
      << "Contact a Storage Manager Developer\n";
   }
 
-  StreamerInputSource::ProductGetter::ProductGetter() : eventPrincipal_(0) {}
+  StreamerInputSource::EventPrincipalHolder::EventPrincipalHolder() : eventPrincipal_(nullptr) {}
 
-  StreamerInputSource::ProductGetter::~ProductGetter() {}
+  StreamerInputSource::EventPrincipalHolder::~EventPrincipalHolder() {}
 
   WrapperHolder
-  StreamerInputSource::ProductGetter::getIt(ProductID const& id) const {
+  StreamerInputSource::EventPrincipalHolder::getIt(ProductID const& id) const {
     return eventPrincipal_ ? eventPrincipal_->getIt(id) : WrapperHolder();
   }
 
+  unsigned int
+  StreamerInputSource::EventPrincipalHolder::transitionIndex_() const {
+    assert(eventPrincipal_ != nullptr);
+    return eventPrincipal_->transitionIndex();
+  }
+
   void
-  StreamerInputSource::ProductGetter::setEventPrincipal(EventPrincipal* ep) {
+  StreamerInputSource::EventPrincipalHolder::setEventPrincipal(EventPrincipal* ep) {
     eventPrincipal_ = ep;
   }
 

--- a/Mixing/Base/src/PileUp.cc
+++ b/Mixing/Base/src/PileUp.cc
@@ -42,7 +42,8 @@ namespace edm {
                                                                    *productRegistry_,
                                                                    boost::shared_ptr<BranchIDListHelper>(new BranchIDListHelper),
                                                                    boost::shared_ptr<ActivityRegistry>(new ActivityRegistry),
-                                                                   -1, -1
+                                                                   -1, -1,
+                                                                   PreallocationConfiguration()
                                                                    )).release()),
     processConfiguration_(new ProcessConfiguration(std::string("@MIXING"), getReleaseVersion(), getPassID())),
     eventPrincipal_(),


### PR DESCRIPTION
This pull request ensures that a delayed read of a product by the ROOT/EDM input source (PoolSource) reads the correct entry in the Events tree in the multithreaded framework, where events are processed in parallel.  This requires a mapping between the stream ID of the event to the entry number in the events tree.  Without this pull request, a delayed read of a product would likely read it from the entry in the Events tree corresponding to the most recent event read, rather than the correct event. 
