### PR TITLE
Remove dependency on XDAQ from HcalOnlineDb (for CMSSW_6_2_0_noxdaq)

### DIFF
--- a/CaloOnlineTools/HcalOnlineDb/BuildFile.xml
+++ b/CaloOnlineTools/HcalOnlineDb/BuildFile.xml
@@ -8,7 +8,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="rootrflx"/>
 <use   name="xerces-c"/>
-<use   name="xdaq"/>
 <use   name="zlib"/>
 <use   name="DataFormats/HcalDetId"/>
 <use   name="CalibCalorimetry/CaloTPG"/>

--- a/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabase.hh
+++ b/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabase.hh
@@ -4,10 +4,15 @@
 #include <string>
 #include <map>
 #include <vector>
-#include "log4cplus/logger.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseException.hh"
 #include "xercesc/dom/DOMDocument.hpp"
 #include <stdint.h>
+
+#ifdef HAVE_XDAQ
+#include "log4cplus/logger.h"
+#else
+#include "CaloOnlineTools/HcalOnlineDb/interface/xdaq_compat.h"  // Includes typedef for log4cplus::Logger
+#endif
 
 namespace hcal {
 
@@ -198,9 +203,9 @@ namespace hcal {
 
     
   private:
-    log4cplus::Logger m_logger;
     std::vector<ConfigurationDatabaseImpl*> m_implementationOptions;
     ConfigurationDatabaseImpl* m_implementation;
+    log4cplus::Logger m_logger;
   };
 
 }

--- a/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseException.hh
+++ b/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseException.hh
@@ -11,11 +11,12 @@ namespace hcal {
       ConfigurationDatabaseException( const std::string& name, const std::string& message, const std::string& module, int line, const std::string& function ): 
 	Exception(name, message, module, line, function) 
       {} 
-      
+#ifdef HAVE_XDAQ
       ConfigurationDatabaseException( const std::string& name, const std::string& message, const std::string& module, int line, const std::string& function,
 			 xcept::Exception& e ): 
 	Exception(name, message, module, line, function, e) 
       {} 
+#endif
     }; 
     
   }

--- a/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseImpl.hh
+++ b/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseImpl.hh
@@ -4,10 +4,15 @@
 #include <string>
 #include <vector>
 #include <map>
-#include "log4cplus/logger.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseException.hh"
 #include "CaloOnlineTools/HcalOnlineDb/interface/PluginManager.hh"
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabase.hh"
+
+#ifdef HAVE_XDAQ
+#include "log4cplus/logger.h"
+#else
+#include "CaloOnlineTools/HcalOnlineDb/interface/xdaq_compat.h"  // Includes typedef for log4cplus::Logger
+#endif
 
 //OCCI include
 #include "OnlineDB/Oracle/interface/Oracle.h"

--- a/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseImplOracle.hh
+++ b/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseImplOracle.hh
@@ -5,8 +5,12 @@
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseImpl.hh"
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseStandardXMLParser.hh"
 
+#ifdef HAVE_XDAQ
 #include "xgi/Method.h"
 #include "xdata/xdata.h"
+#else
+#include <string>
+#endif
 
 //OCCI include
 #include "OnlineDB/Oracle/interface/Oracle.h"
@@ -62,16 +66,25 @@ class ConfigurationDatabaseImplOracle: public hcal::ConfigurationDatabaseImpl {
 
 		ConfigurationDatabaseStandardXMLParser m_parser;
 		
+#ifdef HAVE_XDAQ
 		xdata::String username_;
 		xdata::String password_;
 		xdata::String database_;
+#else
+		std::string username_;
+		std::string password_;
+		std::string database_;
+#endif
 
 		//Used by getZSThresholds
 		std::string lhwm_version;
 
 		//Utility methods
 		std::string clobToString(const oracle::occi::Clob&);
+
+#ifdef HAVE_XDAQ
 		std::string getParameter(cgicc::Cgicc &cgi,const std::string &name);
+#endif
 
   		void getLUTs_real(const std::string& tag, int crate, std::map<hcal::ConfigurationDatabase::LUTId, 
 				hcal::ConfigurationDatabase::LUT >& LUTs) throw (hcal::exception::ConfigurationDatabaseException);

--- a/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationItemNotFoundException.hh
+++ b/CaloOnlineTools/HcalOnlineDb/interface/ConfigurationItemNotFoundException.hh
@@ -12,10 +12,12 @@ namespace hcal {
 	ConfigurationDatabaseException(name, message, module, line, function) 
       {} 
       
+#ifdef HAVE_XDAQ
       ConfigurationItemNotFoundException( const std::string& name, const std::string& message, const std::string& module, int line, const std::string& function,
 			 xcept::Exception& e ): 
 	ConfigurationDatabaseException(name, message, module, line, function, e) 
       {} 
+#endif
     }; 
     
   }

--- a/CaloOnlineTools/HcalOnlineDb/interface/Exception.hh
+++ b/CaloOnlineTools/HcalOnlineDb/interface/Exception.hh
@@ -32,7 +32,6 @@ namespace hcal {
         Exception( const std::string& message ): message_(message) { }
 
         virtual const char* what () const throw() { return message_.c_str(); }
-        virtual ~Exception() { }
 
       private:
         std::string message_;

--- a/CaloOnlineTools/HcalOnlineDb/interface/Exception.hh
+++ b/CaloOnlineTools/HcalOnlineDb/interface/Exception.hh
@@ -1,22 +1,47 @@
 #ifndef hcal_Exception_hh_included
 #define hcal_Exception_hh_included 1
 
+#ifdef HAVE_XDAQ
 #include "xcept/Exception.h"
+#else
+#include <exception>
+#include <string>
+#endif
+
 
 namespace hcal {
   namespace exception {
-
+#ifdef HAVE_XDAQ
     class Exception: public xcept::Exception {
-    public: 
-      Exception( const std::string& name, const std::string& message, const std::string& module, int line, const std::string& function ): 
-	xcept::Exception(name, message, module, line, function) 
+      public: 
+        Exception( const std::string& name, const std::string& message, const std::string& module, int line, const std::string& function ): 
+          xcept::Exception(name, message, module, line, function) 
       {} 
-      
-      Exception( const std::string& name, const std::string& message, const std::string& module, int line, const std::string& function,
-		 xcept::Exception& e ): 
-	xcept::Exception(name, message, module, line, function, e) 
+
+        Exception( const std::string& name, const std::string& message, const std::string& module, int line, const std::string& function,
+            xcept::Exception& e ): 
+          xcept::Exception(name, message, module, line, function, e) 
       {} 
     };     
+#else
+    class Exception: public std::exception {
+      public:
+        Exception( const std::string& name, const std::string& message, const std::string& module, int line, const std::string& function ):
+          Exception( message )
+      {} 
+        Exception( const std::string& message ): message_(message) { }
+
+        virtual const char* what () const throw() { return message_.c_str(); }
+        virtual ~Exception() { }
+
+      private:
+        std::string message_;
+    };
+
+#define XCEPT_RAISE( EXCEPTION, MSG ) \
+    throw EXCEPTION( #EXCEPTION, MSG, __FILE__, __LINE__, __FUNCTION__)
+
+#endif
   }
 }
 

--- a/CaloOnlineTools/HcalOnlineDb/interface/HcalDbOmds.h
+++ b/CaloOnlineTools/HcalOnlineDb/interface/HcalDbOmds.h
@@ -9,8 +9,6 @@
 
 #include <iostream>
 
-#include "xgi/Utils.h"
-#include "toolbox/string.h"
 #include "OnlineDB/Oracle/interface/Oracle.h"
 
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"

--- a/CaloOnlineTools/HcalOnlineDb/interface/xdaq_compat.h
+++ b/CaloOnlineTools/HcalOnlineDb/interface/xdaq_compat.h
@@ -1,0 +1,20 @@
+#ifndef XDAQ_COMPAT
+#define XDAQ_COMPAT
+
+#ifndef HAVE_XDAQ
+#include <string>  // std::string
+#include <stdarg.h>  // va_list, va_start
+#include <ostream>  // std::ostream
+
+/* Replace log4cplus::Logger */
+namespace log4cplus{
+    typedef std::ostream* Logger;
+}
+
+namespace toolbox{
+    std::string toString(const char* format, ... );
+}
+
+#endif  // HAVE_XDAQ
+
+#endif  // XDAQ_COMPAT

--- a/CaloOnlineTools/HcalOnlineDb/plugins/BuildFile.xml
+++ b/CaloOnlineTools/HcalOnlineDb/plugins/BuildFile.xml
@@ -8,7 +8,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="rootrflx"/>
 <use   name="xerces-c"/>
-<use   name="xdaq"/>
 <use   name="zlib"/>
 <use   name="DataFormats/HcalDetId"/>
 <use   name="CalibCalorimetry/CaloTPG"/>

--- a/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseImpl.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseImpl.cc
@@ -1,8 +1,14 @@
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseImpl.hh"
 
+#ifndef HAVE_XDAQ
+#include "CaloOnlineTools/HcalOnlineDb/interface/xdaq_compat.h"  // Includes typedef for log4cplus::Logger
+#endif
+
+#include <iostream>  // std::cout
+
 namespace hcal {
 
-ConfigurationDatabaseImpl::ConfigurationDatabaseImpl() : m_logger(log4cplus::Logger::getInstance("hcal_ConfigurationDatabaseImpl")) {
+ConfigurationDatabaseImpl::ConfigurationDatabaseImpl() : m_logger(&std::cout) {
   }
 
   void ConfigurationDatabaseImpl::parseAccessor(const std::string& accessor, std::string& method, std::string& host, std::string& port, std::string& user, std::string& db, std::map<std::string,std::string>& params) {

--- a/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseImplOracle.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseImplOracle.cc
@@ -1,9 +1,13 @@
 // $Id: ConfigurationDatabaseImplOracle.cc,v 1.4 2013/05/23 15:17:36 gartung Exp $
 
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseImplOracle.hh"
+#include <iostream>  // std::cout
 
-#include "xgi/Utils.h"
-#include "toolbox/string.h"
+#ifdef HAVE_XDAQ
+#include <toolbox/string.h>
+#else
+#include "CaloOnlineTools/HcalOnlineDb/interface/xdaq_compat.h"  // Replaces toolbox::toString
+#endif
 
 using namespace std;
 using namespace oracle::occi;
@@ -31,13 +35,13 @@ void ConfigurationDatabaseImplOracle::connect(const std::string& accessor) throw
   std::map<std::string,std::string> params;
   std::string user, host, method, db, port,password;
   ConfigurationDatabaseImpl::parseAccessor(accessor,method,host,port,user,db,params);
-  
+
   if (method!="occi") XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,std::string("Invalid accessor for Oracle : ")+accessor);
-    
+
   if (params.find("PASSWORD")!=params.end()) password=params["PASSWORD"];
   if (params.find("LHWM_VERSION")!=params.end()) lhwm_version=params["LHWM_VERSION"];
 
-  try {    
+  try {
      env_ = oracle::occi::Environment::createEnvironment (oracle::occi::Environment::DEFAULT);
      conn_ = env_->createConnection (user, password, db);
    } catch (SQLException& e) {
@@ -83,8 +87,8 @@ inline static int cvtChar(int c) {
   return c&0xF;
 }
 
-void ConfigurationDatabaseImplOracle::getLUTChecksums(const std::string& tag, 
-		std::map<hcal::ConfigurationDatabase::LUTId, 
+void ConfigurationDatabaseImplOracle::getLUTChecksums(const std::string& tag,
+		std::map<hcal::ConfigurationDatabase::LUTId,
 		hcal::ConfigurationDatabase::MD5Fingerprint>& checksums) throw (hcal::exception::ConfigurationDatabaseException) {
 
 	if (env_ == NULL || conn_ == NULL) XCEPT_RAISE(hcal::exception::ConfigurationDatabaseException,"Database is not open");
@@ -106,13 +110,13 @@ void ConfigurationDatabaseImplOracle::getLUTChecksums(const std::string& tag,
                 std::string buffer = clobToString(clob);
 
                 m_parser.parseMultiple(buffer,items);
-		
+
                 for (std::list<ConfigurationDatabaseStandardXMLParser::Item>::iterator i=items.begin(); i!=items.end(); ++i) {
-	
-                        hcal::ConfigurationDatabase::FPGASelection ifpga = 
+
+                        hcal::ConfigurationDatabase::FPGASelection ifpga =
 				(hcal::ConfigurationDatabase::FPGASelection)atoi(i->parameters["topbottom"].c_str());
                         int islot = atoi(i->parameters["slot"].c_str());
-			hcal::ConfigurationDatabase::LUTType ilut_type = 
+			hcal::ConfigurationDatabase::LUTType ilut_type =
 				(hcal::ConfigurationDatabase::LUTType)atoi(i->parameters["luttype"].c_str());
 			int crate=atoi(i->parameters["crate"].c_str());
                         int islb=atoi(i->parameters["slb"].c_str());
@@ -155,8 +159,8 @@ void ConfigurationDatabaseImplOracle::getLUTs(const std::string& tag, int crate,
 }
 
 
-void ConfigurationDatabaseImplOracle::getLUTs_real(const std::string& tag, int crate,  
-			std::map<hcal::ConfigurationDatabase::LUTId, hcal::ConfigurationDatabase::LUT >& LUTs) 
+void ConfigurationDatabaseImplOracle::getLUTs_real(const std::string& tag, int crate,
+			std::map<hcal::ConfigurationDatabase::LUTId, hcal::ConfigurationDatabase::LUT >& LUTs)
 								throw (hcal::exception::ConfigurationDatabaseException)
 {
 
@@ -179,13 +183,13 @@ void ConfigurationDatabaseImplOracle::getLUTs_real(const std::string& tag, int c
 		m_parser.parseMultiple(buffer,items);
 
       		for (std::list<ConfigurationDatabaseStandardXMLParser::Item>::iterator i=items.begin(); i!=items.end(); ++i) {
-			hcal::ConfigurationDatabase::FPGASelection ifpga = 
+			hcal::ConfigurationDatabase::FPGASelection ifpga =
 					(hcal::ConfigurationDatabase::FPGASelection)atoi(i->parameters["TOPBOTTOM"].c_str());
 			int islot = atoi(i->parameters["SLOT"].c_str());
 
 			//If this is the desired slot
 			//if (islot == slot) {
-				hcal::ConfigurationDatabase::LUTType ilut_type = 
+				hcal::ConfigurationDatabase::LUTType ilut_type =
 						(hcal::ConfigurationDatabase::LUTType)atoi(i->parameters["LUT_TYPE"].c_str());
 				hcal::ConfigurationDatabase::LUTId lut_id;
         			if (ilut_type==hcal::ConfigurationDatabase::LinearizerLUT) {
@@ -206,11 +210,11 @@ void ConfigurationDatabaseImplOracle::getLUTs_real(const std::string& tag, int c
 				else if (i->encoding=="dec") strtol_base=10;
 
 				// convert the data
-				for (unsigned int j=0; j<i->items.size(); j++) 
+				for (unsigned int j=0; j<i->items.size(); j++)
 					lut.push_back(strtol(i->items[j].c_str(),0,strtol_base));
 
 				LUTs.insert(make_pair(lut_id, lut));
-			//}    
+			//}
     		}
 	}
 
@@ -238,8 +242,8 @@ void ConfigurationDatabaseImplOracle::getPatterns(const std::string& tag, int cr
   }
 }
 
-void ConfigurationDatabaseImplOracle::getPatterns_real(const std::string& tag, int crate,  
-			std::map<hcal::ConfigurationDatabase::PatternId, hcal::ConfigurationDatabase::HTRPattern >& patterns) 
+void ConfigurationDatabaseImplOracle::getPatterns_real(const std::string& tag, int crate,
+			std::map<hcal::ConfigurationDatabase::PatternId, hcal::ConfigurationDatabase::HTRPattern >& patterns)
 							throw (hcal::exception::ConfigurationDatabaseException) {
    try {
         //Lets run the SQl Query
@@ -450,15 +454,15 @@ void ConfigurationDatabaseImplOracle::getHLXMasks(const std::string& tag, int cr
     getHLXMasks_real(tag,crate,m_hlxMaskCache.masks);
     m_hlxMaskCache.crate=crate;
     m_hlxMaskCache.tag=tag;
-  } 
-  
+  }
+
   masks.clear();
   std::map<ConfigurationDatabase::FPGAId, ConfigurationDatabase::HLXMasks>::const_iterator i;
   for (i=m_hlxMaskCache.masks.begin(); i!=m_hlxMaskCache.masks.end(); i++) {
     if (i->first.slot==slot)
       masks.insert(*i);
   }
-} 
+}
 
 
 void ConfigurationDatabaseImplOracle::getHLXMasks_real(const std::string& tag, int crate,

--- a/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseImplXMLFile.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/ConfigurationDatabaseImplXMLFile.cc
@@ -1,7 +1,12 @@
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseImplXMLFile.hh"
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConfigurationItemNotFoundException.hh"
 #include <zlib.h>
-#include "toolbox/string.h"
+
+#ifdef HAVE_XDAQ
+#include <toolbox/string.h>
+#else
+#include "CaloOnlineTools/HcalOnlineDb/interface/xdaq_compat.h"  // Replaces toolbox::toString
+#endif
 
 DECLARE_PLUGGABLE(hcal::ConfigurationDatabaseImpl,ConfigurationDatabaseImplXMLFile)
 
@@ -144,6 +149,7 @@ unsigned int ConfigurationDatabaseImplXMLFile::getFirmwareChecksum(const std::st
 }
 
 void ConfigurationDatabaseImplXMLFile::getFirmwareMCS(const std::string& board, unsigned int version, std::vector<std::string>& mcsLines) throw (hcal::exception::ConfigurationDatabaseException) {
+
   std::string key=::toolbox::toString("%s:%x",board.c_str(),version);
 
   std::map<std::string, std::pair<int,int> >::iterator j=m_lookup.find(key);
@@ -230,6 +236,7 @@ void ConfigurationDatabaseImplXMLFile::getLUTs(const std::string& tag, int crate
 void ConfigurationDatabaseImplXMLFile::getZSThresholds(const std::string& tag, int crate, int slot, std::map<hcal::ConfigurationDatabase::ZSChannelId, int>& thresholds) throw (hcal::exception::ConfigurationDatabaseException) {
   thresholds.clear();
   for (int tb=0; tb<=1; tb++) {
+
     std::string key=toolbox::toString("%s:%d:%d:%d",
 				      tag.c_str(), crate, slot, tb);
     std::map<std::string, std::pair<int,int> >::iterator j=m_lookup.find(key);

--- a/CaloOnlineTools/HcalOnlineDb/src/HCALConfigDB.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HCALConfigDB.cc
@@ -7,8 +7,12 @@
 #include <iostream>
 #include <string.h>
 
-#include "xgi/Utils.h"
-#include "toolbox/string.h"
+#ifdef HAVE_XDAQ
+#include <toolbox/string.h>
+#else
+#include "CaloOnlineTools/HcalOnlineDb/interface/xdaq_compat.h"  // Replaces toolbox::toString
+#endif
+
 
 #include "OnlineDB/Oracle/interface/Oracle.h"
 

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalAssistant.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalAssistant.cc
@@ -19,10 +19,14 @@
 #include "CaloOnlineTools/HcalOnlineDb/interface/HcalAssistant.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConnectionManager.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseException.hh"
-#include "xgi/Utils.h"
-#include "toolbox/string.h"
 #include "OnlineDB/Oracle/interface/Oracle.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
+
+#ifdef HAVE_XDAQ
+#include <toolbox/string.h>
+#else
+#include "CaloOnlineTools/HcalOnlineDb/interface/xdaq_compat.h"  // Includes typedef for log4cplus::Logger
+#endif
 
 using namespace std;
 using namespace oracle::occi;

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalChannelQualityXml.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalChannelQualityXml.cc
@@ -19,9 +19,13 @@
 #include "CaloOnlineTools/HcalOnlineDb/interface/HcalChannelIterator.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConnectionManager.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseException.hh"
-#include "xgi/Utils.h"
-#include "toolbox/string.h"
 #include "OnlineDB/Oracle/interface/Oracle.h"
+
+#ifdef HAVE_XDAQ
+#include <toolbox/string.h>
+#else
+#include "CaloOnlineTools/HcalOnlineDb/interface/xdaq_compat.h"  // Replaces toolbox::toString
+#endif
 
 using namespace std;
 using namespace oracle::occi;

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalDbOmds.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalDbOmds.cc
@@ -18,6 +18,12 @@
 #include "CaloOnlineTools/HcalOnlineDb/interface/HcalDbOmds.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/RooGKCounter.h"
 
+#ifdef HAVE_XDAQ
+#include "toolbox/string.h"
+#else
+#include "CaloOnlineTools/HcalOnlineDb/interface/xdaq_compat.h"  // Replaces toolbox::toString
+#endif
+
 typedef oracle::occi::ResultSet ResultSet;
 typedef oracle::occi::SQLException SQLException;
 

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalL1TriggerObjectsXml.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalL1TriggerObjectsXml.cc
@@ -18,9 +18,8 @@
 #include "CaloOnlineTools/HcalOnlineDb/interface/HcalL1TriggerObjectsXml.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConnectionManager.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseException.hh"
-#include "xgi/Utils.h"
-#include "toolbox/string.h"
 #include "OnlineDB/Oracle/interface/Oracle.h"
+
 
 using namespace std;
 using namespace oracle::occi;

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
@@ -8,8 +8,12 @@
 
 #include <cstdlib>  // For srand() and rand()
 
-#include "xgi/Utils.h"
-#include "toolbox/string.h"
+#ifdef HAVE_XDAQ
+#include <toolbox/string.h>
+#else
+#include "CaloOnlineTools/HcalOnlineDb/interface/xdaq_compat.h"  // Replaces toolbox::toString
+#endif
+
 #include "OnlineDB/Oracle/interface/Oracle.h"
 
 #include "CaloOnlineTools/HcalOnlineDb/interface/HcalLutManager.h"

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalO2OManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalO2OManager.cc
@@ -29,10 +29,13 @@
 
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConnectionManager.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConfigurationDatabaseException.hh"
-#include "xgi/Utils.h"
-#include "toolbox/string.h"
 #include "OnlineDB/Oracle/interface/Oracle.h"
 
+#ifdef HAVE_XDAQ
+#include <toolbox/string.h>
+#else
+#include "CaloOnlineTools/HcalOnlineDb/interface/xdaq_compat.h"  // Replaces toolbox::toString
+#endif
 
 using namespace oracle::occi;
 

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalQIEManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalQIEManager.cc
@@ -6,10 +6,14 @@
 
 #include "CaloOnlineTools/HcalOnlineDb/interface/HcalQIEManager.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/RooGKCounter.h"
-#include "xgi/Utils.h"
-#include "toolbox/string.h"
 #include "OnlineDB/Oracle/interface/Oracle.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConfigurationItemNotFoundException.hh"
+
+#ifdef HAVE_XDAQ
+#include "toolbox/string.h"
+#else
+#include "CaloOnlineTools/HcalOnlineDb/interface/xdaq_compat.h"  // Replaces toolbox::toString
+#endif
 
 using namespace std;
 using namespace oracle::occi;

--- a/CaloOnlineTools/HcalOnlineDb/src/xdaq_compat.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/xdaq_compat.cc
@@ -1,0 +1,12 @@
+#ifndef HAVE_XDAQ
+#include "CaloOnlineTools/HcalOnlineDb/interface/xdaq_compat.h"
+
+std::string toolbox::toString(const char* format, ... ){
+    va_list varlist;
+    va_start(varlist, format);
+    char tmp[512];
+    vsnprintf(tmp, 512, format, varlist);
+    return tmp;
+}
+
+#endif

--- a/CaloOnlineTools/HcalOnlineDb/test/BuildFile.xml
+++ b/CaloOnlineTools/HcalOnlineDb/test/BuildFile.xml
@@ -1,7 +1,6 @@
 <bin   file="xmlTools.cc" name="xmlToolsRun">
   <use   name="DataFormats/Common"/>
   <use   name="rootrflx"/>
-  <use   name="xdaq"/>
   <use   name="DataFormats/HcalDetId"/>
   <use   name="CondTools/Hcal"/>
   <use   name="CalibCalorimetry/HcalTPGAlgos"/>
@@ -12,7 +11,6 @@
 <bin   file="channelQualityTools.cc" name="channelQualityRun">
   <use   name="DataFormats/Common"/>
   <use   name="rootrflx"/>
-  <use   name="xdaq"/>
   <use   name="DataFormats/HcalDetId"/>
   <use   name="CondTools/Hcal"/>
   <use   name="CalibCalorimetry/HcalTPGAlgos"/>

--- a/CaloOnlineTools/HcalOnlineDb/test/xmlTools.cc
+++ b/CaloOnlineTools/HcalOnlineDb/test/xmlTools.cc
@@ -34,14 +34,19 @@
 #include "CaloOnlineTools/HcalOnlineDb/interface/ZdcLut.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/HcalDbOmds.h"
 
-#include "xgi/Utils.h"
-#include "toolbox/string.h"
 #include "OnlineDB/Oracle/interface/Oracle.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/ConfigurationItemNotFoundException.hh"
 #include "CaloOnlineTools/HcalOnlineDb/interface/LMap.h"
 
 #include "CaloOnlineTools/HcalOnlineDb/interface/HcalO2OManager.h"
 
+#include <sys/time.h>  // gettimeofday
+
+#ifdef HAVE_XDAQ
+#include "toolbox/string.h"
+#else
+#include "CaloOnlineTools/HcalOnlineDb/interface/xdaq_compat.h"  // Replaces toolbox::toString
+#endif
 
 
 using namespace std;


### PR DESCRIPTION
A compatibility library has been added called xdaq_compat. It includes a
typedef for replacing log4cplus, and copies the toString function from
toolbox.

Most of the changes introduced in this patch are revertible at compile
time by passing the definition "HAVE_XDAQ" to the compiler.

A summary of the changes follows:
- log4cplus/logger has been replaced with an ostream
- toolbox::toString has been copied into xdaq_compat.h
- xgi/Utils.h was unused and so removed
