### PR TITLE
Added preallocate signal for Services

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -45,6 +45,7 @@
 #include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/ServiceRegistry/interface/SystemBounds.h"
 
 #include "FWCore/Utilities/interface/DebugMacros.h"
 #include "FWCore/Utilities/interface/EDMException.h"
@@ -563,6 +564,10 @@ namespace edm {
     //make the services available
     ServiceRegistry::Operate operate(serviceToken_);
 
+    service::SystemBounds bounds(preallocations_.numberOfStreams(),
+                                 preallocations_.numberOfLuminosityBlocks(),
+                                 preallocations_.numberOfRuns());
+    actReg_->preallocateSignal_(bounds);
     //NOTE:  This implementation assumes 'Job' means one call
     // the EventProcessor::run
     // If it really means once per 'application' then this code will

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -57,12 +57,23 @@ namespace edm {
    class StreamContext;
    class PathContext;
    class ModuleCallingContext;
+   namespace service {
+     class SystemBounds;
+   }
 
    class ActivityRegistry : private boost::noncopyable {
    public:
       ActivityRegistry() {}
 
       // ---------- signals ------------------------------------
+      typedef signalslot::Signal<void(service::SystemBounds const&)> Preallocate;
+      ///signal is emitted before beginJob
+      Preallocate preallocateSignal_;
+      void watchPreallocate(Preallocate::slot_type const& iSlot) {
+        preallocateSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_1(watchPreallocate)
+     
       typedef signalslot::Signal<void()> PostBeginJob;
       ///signal is emitted after all modules have gotten their beginJob called
       PostBeginJob postBeginJobSignal_;

--- a/FWCore/ServiceRegistry/interface/SystemBounds.h
+++ b/FWCore/ServiceRegistry/interface/SystemBounds.h
@@ -1,0 +1,57 @@
+#ifndef FWCore_ServiceRegistry_SystemBounds_h
+#define FWCore_ServiceRegistry_SystemBounds_h
+// -*- C++ -*-
+//
+// Package:     FWCore/ServiceRegistry
+// Class  :     SystemBounds
+// 
+/**\class SystemBounds SystemBounds.h "SystemBounds.h"
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Sun, 08 Sep 2013 16:16:25 GMT
+//
+
+// system include files
+
+// user include files
+
+// forward declarations
+
+namespace edm {
+  namespace service {
+    class SystemBounds
+    {
+      
+    public:
+      SystemBounds(unsigned int iNStreams,
+                   unsigned int iNLumis,
+                   unsigned int iNRuns) :
+      m_nStreams(iNStreams),
+      m_nLumis(iNLumis),
+      m_nRuns(iNRuns) {}
+      
+      // ---------- const member functions ---------------------
+      unsigned int maxNumberOfStreams() const {return m_nStreams; }
+      unsigned int maxNumberOfConcurrentRuns() const {return m_nRuns;}
+      unsigned int maxNumberOfConcurrentLuminosityBlocks() const {return m_nLumis;}
+      
+    private:
+      
+      // ---------- member data --------------------------------
+      unsigned int m_nStreams;
+      unsigned int m_nLumis;
+      unsigned int m_nRuns;
+    };
+
+  }
+}
+
+
+#endif

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -86,7 +86,7 @@ namespace edm {
 
   void
   ActivityRegistry::connectGlobals(ActivityRegistry& iOther) {
-
+     preallocateSignal_.connect(std::cref(iOther.preallocateSignal_));
      postBeginJobSignal_.connect(std::cref(iOther.postBeginJobSignal_));
      postEndJobSignal_.connect(std::cref(iOther.postEndJobSignal_));
 
@@ -249,6 +249,7 @@ namespace edm {
 
   void
   ActivityRegistry::copySlotsFrom(ActivityRegistry& iOther) {
+    copySlotsToFrom(preallocateSignal_,iOther.preallocateSignal_);
     copySlotsToFrom(postBeginJobSignal_, iOther.postBeginJobSignal_);
     copySlotsToFromReverse(postEndJobSignal_, iOther.postEndJobSignal_);
 


### PR DESCRIPTION
Services can now listen for the preallocate Service in order to determine the maximum number of concurrent Streams, Lumis and Runs the system will use for the job.
