### PR TITLE
Consumes to CSCSegment

### DIFF
--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDProducer.cc
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDProducer.cc
@@ -15,24 +15,23 @@
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
 
 #include <DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h>
-#include <DataFormats/CSCDigi/interface/CSCStripDigiCollection.h>
-#include <DataFormats/CSCDigi/interface/CSCWireDigiCollection.h>
 
 CSCRecHitDProducer::CSCRecHitDProducer( const edm::ParameterSet& ps ) : 
   iRun( 0 ),   
   useCalib( ps.getParameter<bool>("CSCUseCalibrations") ),
   useStaticPedestals( ps.getParameter<bool>("CSCUseStaticPedestals") ),
   useTimingCorrections(ps.getParameter<bool>("CSCUseTimingCorrections") ),
-  useGasGainCorrections(ps.getParameter<bool>("CSCUseGasGainCorrections") ),
-  stripDigiTag_( ps.getParameter<edm::InputTag>("stripDigiTag") ),
-  wireDigiTag_(  ps.getParameter<edm::InputTag>("wireDigiTag") )
+  useGasGainCorrections(ps.getParameter<bool>("CSCUseGasGainCorrections") )
 
 {
+  s_token = consumes<CSCStripDigiCollection>( ps.getParameter<edm::InputTag>("stripDigiTag") );
+  w_token = consumes<CSCWireDigiCollection>( ps.getParameter<edm::InputTag>("wireDigiTag") );
+
   recHitBuilder_     = new CSCRecHitDBuilder( ps ); // pass on the parameter sets
   recoConditions_    = new CSCRecoConditions( ps ); // access to conditions data
 
   recHitBuilder_->setConditions( recoConditions_ ); // pass down to who needs access
-  
+
   // register what this produces
   produces<CSCRecHit2DCollection>();
 
@@ -64,8 +63,9 @@ void  CSCRecHitDProducer::produce( edm::Event& ev, const edm::EventSetup& setup 
   // Get the collections of strip & wire digis from event
   edm::Handle<CSCStripDigiCollection> stripDigis;
   edm::Handle<CSCWireDigiCollection> wireDigis;
-  ev.getByLabel( stripDigiTag_, stripDigis);
-  ev.getByLabel( wireDigiTag_,  wireDigis);
+
+  ev.getByToken( s_token, stripDigis);
+  ev.getByToken( w_token, wireDigis);
 
   // Create empty collection of rechits  
   std::auto_ptr<CSCRecHit2DCollection> oc( new CSCRecHit2DCollection );

--- a/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDProducer.h
+++ b/RecoLocalMuon/CSCRecHitD/src/CSCRecHitDProducer.h
@@ -14,11 +14,15 @@
  *
  */
 
+#include <FWCore/Framework/interface/ConsumesCollector.h>
 #include <FWCore/Framework/interface/Frameworkfwd.h>
 #include <FWCore/Framework/interface/EDProducer.h>
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
 #include <FWCore/Utilities/interface/InputTag.h>
+
+#include <DataFormats/CSCDigi/interface/CSCStripDigiCollection.h>
+#include <DataFormats/CSCDigi/interface/CSCWireDigiCollection.h>
 
 class CSCRecHitDBuilder; 
 class CSCRecoConditions;
@@ -40,11 +44,11 @@ public:
   bool useTimingCorrections;
   bool useGasGainCorrections;
 
-  edm::InputTag stripDigiTag_;
-  edm::InputTag wireDigiTag_;
-
   CSCRecHitDBuilder* recHitBuilder_;
   CSCRecoConditions* recoConditions_;
+
+  edm::EDGetTokenT<CSCStripDigiCollection> s_token;
+  edm::EDGetTokenT<CSCWireDigiCollection> w_token;
 };
 
 #endif

--- a/RecoLocalMuon/CSCSegment/src/CSCSegmentProducer.cc
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegmentProducer.cc
@@ -7,17 +7,17 @@
 
 #include <DataFormats/Common/interface/Handle.h>
 #include <FWCore/Framework/interface/ESHandle.h>
+#include <FWCore/Utilities/interface/InputTag.h>
 #include <FWCore/MessageLogger/interface/MessageLogger.h> 
 
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
 
-#include <DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h>
 #include <DataFormats/CSCRecHit/interface/CSCSegmentCollection.h>
 #include <DataFormats/CSCRecHit/interface/CSCSegment.h>
 
 CSCSegmentProducer::CSCSegmentProducer(const edm::ParameterSet& pas) : iev(0) {
 	
-    inputObjectsTag = pas.getParameter<edm::InputTag>("inputObjects");
+    m_token = consumes<CSCRecHit2DCollection>( pas.getParameter<edm::InputTag>("inputObjects") );
     segmentBuilder_ = new CSCSegmentBuilder(pas); // pass on the PS
 
   	// register what this produces
@@ -43,7 +43,7 @@ void CSCSegmentProducer::produce(edm::Event& ev, const edm::EventSetup& setup) {
 	
     // get the collection of CSCRecHit2D
     edm::Handle<CSCRecHit2DCollection> cscRecHits;
-    ev.getByLabel(inputObjectsTag, cscRecHits);  
+    ev.getByToken( m_token, cscRecHits);
 
     // create empty collection of Segments
     std::auto_ptr<CSCSegmentCollection> oc( new CSCSegmentCollection );

--- a/RecoLocalMuon/CSCSegment/src/CSCSegmentProducer.h
+++ b/RecoLocalMuon/CSCSegment/src/CSCSegmentProducer.h
@@ -7,11 +7,13 @@
  * \author M. Sani
  */
 
+#include <FWCore/Framework/interface/ConsumesCollector.h>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
+
+#include <DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h>
 
 class CSCSegmentBuilder; 
 
@@ -26,8 +28,8 @@ public:
 
 private:
     int iev; // events through
-    edm::InputTag inputObjectsTag; // input tag labelling rechits for input
     CSCSegmentBuilder* segmentBuilder_;
+    edm::EDGetTokenT<CSCRecHit2DCollection> m_token;
 };
 
 #endif

--- a/RecoLocalMuon/CSCSegment/test/run_on_raw_700.py
+++ b/RecoLocalMuon/CSCSegment/test/run_on_raw_700.py
@@ -1,0 +1,58 @@
+## Dump  100  events in CSC segment builder - Tim Cox - 09.09.2013
+## This version runs in 700pre3 on a real data RelVal RAW sample.
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+process.load("Configuration/StandardSequences/Geometry_cff")
+process.load("Configuration/StandardSequences/MagneticField_cff")
+process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
+process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.Reconstruction_cff")
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+
+# --- MATCH GT TO RELEASE AND DATA SAMPLE
+
+process.GlobalTag.globaltag = 'PRE_62_V8::All'
+
+# --- NUMBER OF EVENTS --- 
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+
+process.options   = cms.untracked.PSet( SkipEvent = cms.untracked.vstring('ProductNotFound') )
+process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+process.source    = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+    '/store/relval/CMSSW_7_0_0_pre3/SingleMu/RAW/PRE_P62_V8_RelVal_mu2011B-v1/00000/127160CD-7215-E311-91F3-003048D15E14.root'
+    )
+)
+
+# --- ACTIVATE LogTrace IN CSCRecHitD BUT NEED TO COMPILE IT WITH scram b -j8 USER_CXXFLAGS="-DEDM_ML_DEBUG"
+# LogTrace output goes to cout; all other output to "junk.log"
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.categories.append("CSCRecHit")
+process.MessageLogger.categories.append("CSCSegAlgoST")
+
+# module label is something like "muonCSCDigis"...
+process.MessageLogger.debugModules = cms.untracked.vstring("*")
+process.MessageLogger.destinations = cms.untracked.vstring("cout","junk")
+process.MessageLogger.cout = cms.untracked.PSet(
+    threshold = cms.untracked.string("DEBUG"),
+    default   = cms.untracked.PSet( limit = cms.untracked.int32(0)  ),
+    FwkReport = cms.untracked.PSet( limit = cms.untracked.int32(-1) ),
+    CSCRecHit = cms.untracked.PSet( limit = cms.untracked.int32(-1) ),
+    CSCSegAlgoST = cms.untracked.PSet( limit = cms.untracked.int32(-1) ) 
+)
+
+#process.p = cms.Path(process.muonCSCDigis * process.csc2DRecHits * process.cscSegments * process.cscValidation)
+
+# Path and EndPath def
+process.unpack = cms.Path(process.muonCSCDigis)
+process.reco = cms.Path(process.csc2DRecHits * process.cscSegments)
+process.endjob = cms.EndPath(process.endOfProcess)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.unpack, process.reco, process.endjob)
+


### PR DESCRIPTION
Add consumes interface to CSCSegment. Of course this also includes addition of consumes interface to CSCRecHitD. I have not added consumes interface to two programs in test, CSCSegmentReader and CSCSegment Visualise because these obvioulsy haven't been used in a while and would need more updating than just the consumes interface to run. Not only that I find the config files to run them were deleted from cvs almost 5 years ago. I added a new config to test which runs a 100 event dump of CSC rechits and segments based on a relval raw data sample in 700pre3.
