### PR TITLE
add configurations for several corrected METs

### DIFF
--- a/JetMETCorrections/Type1MET/python/correctedMet_cff.py
+++ b/JetMETCorrections/Type1MET/python/correctedMet_cff.py
@@ -1,0 +1,186 @@
+import FWCore.ParameterSet.Config as cms
+
+##____________________________________________________________________________||
+caloMetT1 = cms.EDProducer(
+    "CorrectedCaloMETProducer2",
+    src = cms.InputTag('corMetGlobalMuons'),
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrCaloMetType1', 'type1')
+        ),
+)   
+
+##____________________________________________________________________________||
+caloMetT1T2 = cms.EDProducer(
+    "CorrectedCaloMETProducer2",
+    src = cms.InputTag('corMetGlobalMuons'),
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrCaloMetType1', 'type1'),
+        cms.InputTag('corrCaloMetType2')
+    ),
+)   
+
+##____________________________________________________________________________||
+pfMetT0rt = cms.EDProducer(
+    "CorrectedPFMETProducer2",
+    src = cms.InputTag('pfMet'),
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrPfMetType0RecoTrack'),
+    ),
+)   
+
+##____________________________________________________________________________||
+pfMetT0rtT1 = cms.EDProducer(
+    "CorrectedPFMETProducer2",
+    src = cms.InputTag('pfMet'),
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrPfMetType0RecoTrack'),
+        cms.InputTag('corrPfMetType1', 'type1'),
+    ),
+)   
+
+##____________________________________________________________________________||
+pfMetT0rtT1T2 = cms.EDProducer(
+    "CorrectedPFMETProducer2",
+    src = cms.InputTag('pfMet'),
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrPfMetType0RecoTrackForType2'),
+        cms.InputTag('corrPfMetType1', 'type1'),
+        cms.InputTag('corrPfMetType2'),
+    ),
+)   
+
+##____________________________________________________________________________||
+pfMetT0rtT2 = cms.EDProducer(
+    "CorrectedPFMETProducer2",
+    src = cms.InputTag('pfMet'),
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrPfMetType0RecoTrackForType2'),
+        cms.InputTag('corrPfMetType2'),
+    ),
+)   
+
+##____________________________________________________________________________||
+pfMetT0pc = cms.EDProducer(
+    "CorrectedPFMETProducer2",
+    src = cms.InputTag('pfMet'),
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrPfMetType0PfCand'),
+    ),
+)   
+
+##____________________________________________________________________________||
+pfMetT0pcT1 = cms.EDProducer(
+    "CorrectedPFMETProducer2",
+    src = cms.InputTag('pfMet'),
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrPfMetType0PfCand'),
+        cms.InputTag('corrPfMetType1', 'type1')
+    ),
+)   
+
+##____________________________________________________________________________||
+pfMetT1 = cms.EDProducer(
+    "CorrectedPFMETProducer2",
+    src = cms.InputTag('pfMet'),
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrPfMetType1', 'type1')
+    ),
+)   
+
+##____________________________________________________________________________||
+pfMetT1T2 = cms.EDProducer(
+    "CorrectedPFMETProducer2",
+    src = cms.InputTag('pfMet'),
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrPfMetType1', 'type1'),
+        cms.InputTag('corrPfMetType2'),
+    ),
+)   
+
+##____________________________________________________________________________||
+pfMetT0rtTxy = cms.EDProducer(
+    "CorrectedPFMETProducer2",
+    src = cms.InputTag('pfMet'),
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrPfMetType0RecoTrack'),
+        cms.InputTag('corrPfMetShiftXY'),
+    ),
+)   
+
+##____________________________________________________________________________||
+pfMetT0rtT1Txy = cms.EDProducer(
+    "CorrectedPFMETProducer2",
+    src = cms.InputTag('pfMet'),
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrPfMetType0RecoTrack'),
+        cms.InputTag('corrPfMetType1', 'type1'),
+        cms.InputTag('corrPfMetShiftXY'),
+    ),
+)   
+
+##____________________________________________________________________________||
+pfMetT0rtT1T2Txy = cms.EDProducer(
+    "CorrectedPFMETProducer2",
+    src = cms.InputTag('pfMet'),
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrPfMetType0RecoTrackForType2'),
+        cms.InputTag('corrPfMetType1', 'type1'),
+        cms.InputTag('corrPfMetType2'),
+        cms.InputTag('corrPfMetShiftXY'),
+    ),
+)   
+
+##____________________________________________________________________________||
+pfMetT0rtT2Txy = cms.EDProducer(
+    "CorrectedPFMETProducer2",
+    src = cms.InputTag('pfMet'),
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrPfMetType0RecoTrackForType2'),
+        cms.InputTag('corrPfMetType2'),
+        cms.InputTag('corrPfMetShiftXY'),
+    ),
+)   
+
+##____________________________________________________________________________||
+pfMetT0pcTxy = cms.EDProducer(
+    "CorrectedPFMETProducer2",
+    src = cms.InputTag('pfMet'),
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrPfMetType0PfCand'),
+        cms.InputTag('corrPfMetShiftXY'),
+    ),
+)   
+
+##____________________________________________________________________________||
+pfMetT0pcT1Txy = cms.EDProducer(
+    "CorrectedPFMETProducer2",
+    src = cms.InputTag('pfMet'),
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrPfMetType0PfCand'),
+        cms.InputTag('corrPfMetType1', 'type1'),
+        cms.InputTag('corrPfMetShiftXY'),
+    ),
+)   
+
+##____________________________________________________________________________||
+pfMetT1Txy = cms.EDProducer(
+    "CorrectedPFMETProducer2",
+    src = cms.InputTag('pfMet'),
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrPfMetType1', 'type1'),
+        cms.InputTag('corrPfMetShiftXY'),
+    ),
+)   
+
+##____________________________________________________________________________||
+pfMetT1T2Txy = cms.EDProducer(
+    "CorrectedPFMETProducer2",
+    src = cms.InputTag('pfMet'),
+    srcCorrections = cms.VInputTag(
+        cms.InputTag('corrPfMetType1', 'type1'),
+        cms.InputTag('corrPfMetType2'),
+        cms.InputTag('corrPfMetShiftXY'),
+    ),
+)   
+
+##____________________________________________________________________________||

--- a/JetMETCorrections/Type1MET/python/correctionTermsCaloMet_cff.py
+++ b/JetMETCorrections/Type1MET/python/correctionTermsCaloMet_cff.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+
+##____________________________________________________________________________||
+from JetMETCorrections.Type1MET.caloMETCorrections_cff import *
+
+##____________________________________________________________________________||
+corrCaloMetType1 = caloJetMETcorr.clone()
+
+##____________________________________________________________________________||
+corrCaloMetType2 = cms.EDProducer(
+    "Type2CorrectionProducer",
+    srcUnclEnergySums = cms.VInputTag(
+        cms.InputTag('corrCaloMetType1', 'type2'),
+        cms.InputTag('muonCaloMETcorr') # NOTE: use 'muonCaloMETcorr' for 'corMetGlobalMuons', do **not** use it for 'met' !!
+        ),
+    type2CorrFormula = cms.string("A + B*TMath::Exp(-C*x)"),
+    type2CorrParameter = cms.PSet(
+        A = cms.double(2.0),
+        B = cms.double(1.3),
+        C = cms.double(0.1)
+        )
+    )
+
+##____________________________________________________________________________||
+correctionTermsCaloMet = cms.Sequence(
+    corrCaloMetType1 +
+    muonCaloMETcorr +
+    corrCaloMetType2
+    )
+
+##____________________________________________________________________________||

--- a/JetMETCorrections/Type1MET/python/correctionTermsPfMetShiftXY_cff.py
+++ b/JetMETCorrections/Type1MET/python/correctionTermsPfMetShiftXY_cff.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+##____________________________________________________________________________||
+from JetMETCorrections.Type1MET.pfMETsysShiftCorrections_cfi import *
+
+##____________________________________________________________________________||
+corrPfMetShiftXY = pfMEtSysShiftCorr.clone()
+
+##____________________________________________________________________________||
+correctionTermsPfMetShiftXY = cms.Sequence(
+    selectedVerticesForMEtCorr *
+    corrPfMetShiftXY
+    )
+
+##____________________________________________________________________________||

--- a/JetMETCorrections/Type1MET/python/correctionTermsPfMetType0PFCandidate_cff.py
+++ b/JetMETCorrections/Type1MET/python/correctionTermsPfMetType0PFCandidate_cff.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+##____________________________________________________________________________||
+from JetMETCorrections.Type1MET.pfMETCorrectionType0_cfi import *
+
+##____________________________________________________________________________||
+corrPfMetType0PfCand = pfMETcorrType0.clone()
+
+##____________________________________________________________________________||
+correctionTermsPfMetType0PFCandidate = cms.Sequence(
+    type0PFMEtCorrectionPFCandToVertexAssociation +
+    corrPfMetType0PfCand
+    )
+
+##____________________________________________________________________________||

--- a/JetMETCorrections/Type1MET/python/correctionTermsPfMetType0RecoTrack_cff.py
+++ b/JetMETCorrections/Type1MET/python/correctionTermsPfMetType0RecoTrack_cff.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+##____________________________________________________________________________||
+from JetMETCorrections.Type1MET.pfMETCorrections_cff import *
+
+##____________________________________________________________________________||
+corrPfMetType0RecoTrack = cms.EDProducer(
+    "ScaleCorrMETData",
+    src = cms.InputTag('pfchsMETcorr', 'type0'),
+    scaleFactor = cms.double(1 - 0.6)
+    )
+
+##____________________________________________________________________________||
+corrPfMetType0RecoTrackForType2 = cms.EDProducer(
+    "ScaleCorrMETData",
+    src = cms.InputTag('corrPfMetType0RecoTrack'),
+    scaleFactor = cms.double(1.4)
+    )
+
+##____________________________________________________________________________||
+correctionTermsPfMetType0RecoTrack = cms.Sequence(
+    pfchsMETcorr +
+    corrPfMetType0RecoTrack +
+    corrPfMetType0RecoTrackForType2
+    )
+
+##____________________________________________________________________________||

--- a/JetMETCorrections/Type1MET/python/correctionTermsPfMetType1Type2_cff.py
+++ b/JetMETCorrections/Type1MET/python/correctionTermsPfMetType1Type2_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+
+##____________________________________________________________________________||
+from JetMETCorrections.Type1MET.pfMETCorrections_cff import *
+
+##____________________________________________________________________________||
+corrPfMetType1 = pfJetMETcorr.clone()
+
+##____________________________________________________________________________||
+corrPfMetType2 = cms.EDProducer(
+    "Type2CorrectionProducer",
+    srcUnclEnergySums = cms.VInputTag(
+        cms.InputTag('corrPfMetType1', 'type2'),
+        cms.InputTag('corrPfMetType1', 'offset'),
+        cms.InputTag('pfCandMETcorr')
+    ),
+    type2CorrFormula = cms.string("A"),
+    type2CorrParameter = cms.PSet(
+        A = cms.double(1.4)
+        )
+    )
+
+##____________________________________________________________________________||
+correctionTermsPfMetType1Type2 = cms.Sequence(
+    ak5PFJetsPtrs +
+    particleFlowPtrs +
+    pfCandsNotInJetPtrs +
+    pfCandsNotInJet +
+    pfCandMETcorr +
+    corrPfMetType1 +
+    corrPfMetType2
+    )
+
+##____________________________________________________________________________||


### PR DESCRIPTION
The changes add python configuration files which include module configurations for MET with the following combinations of MET corrections.

caloMetT1        = caloMET + Type-I
caloMetT1        = caloMET + Type-I + Type-II
pfMetT0rt        = pfMET + Type-0(track)
pfMetT0rtT1      = pfMET + Type-I + Type-0(track)
pfMetT0rtT1T2    = pfMET + Type-I + Type-II + Type-0(track)
pfMetT0rtT2      = pfMET + Type-II + Type-0(track) 
pfMetT0pc        = pfMET + Type-0(pfcand)
pfMetT0pcT1      = pfMET + Type-I + Type-0(pfcand)
pfMetT1          = pfMET + Type-I
pfMetT1T2        = pfMET + Type-I + Type-II 
pfMetT0rtTxy     = pfMET + Type-0(track) + xy_shift
pfMetT0rtT1Txy   = pfMET + Type-I + Type-0(track)+ xy_shift
pfMetT0rtT1T2Txy = pfMET + Type-I + Type-II + Type-0(track) + xy_shift
pfMetT0rtT2Txy   = pfMET + Type-II + Type-0(track) + xy_shift
pfMetT0pcTxy     = pfMET + Type-0(pfcand) + xy_shift
pfMetT0pcT1Txy   = pfMET + Type-I + Type-0(pfcand) + xy_shift
pfMetT1Txy       = pfMET + Type-I + xy_shift
pfMetT1T2Txy     = pfMET + Type-I + Type-II + xy_shift
