### PR TITLE
Fix wrong import in metFilters_cff

### DIFF
--- a/RecoMET/METFilters/python/metFilters_cff.py
+++ b/RecoMET/METFilters/python/metFilters_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 from CommonTools.RecoAlgos.HBHENoiseFilter_cfi import *
 
 ## The CSC beam halo tight filter ____________________________________________||
-from RecoMET.METFilters.CSCTightHaloFilter import *
+from RecoMET.METFilters.CSCTightHaloFilter_cfi import *
 
 ## The HCAL laser filter _____________________________________________________||
 from RecoMET.METFilters.hcalLaserEventFilter_cfi import *


### PR DESCRIPTION
This PR fix a wrong import in metFilters_cff.py.

It'll need to be also applied on CMSSW_7_0_X branch (it's fine on 5.3.x).
