### PR TITLE
Add direct dependency on xdaq.

### DIFF
--- a/DQM/SiPixelMonitorClient/BuildFile.xml
+++ b/DQM/SiPixelMonitorClient/BuildFile.xml
@@ -32,6 +32,8 @@
 <use   name="RecoLocalTracker/Records"/>
 <use   name="RecoTracker/TransientTrackingRecHit"/>
 <use   name="CalibTracker/Records"/>
+<use   name="xdaq"/>
+<use   name="xdaqheader"/>
 <use   name="rootcore"/>
 <use   name="boost"/>
 <flags   EDM_PLUGIN="1"/>

--- a/DQM/SiStripMonitorClient/BuildFile.xml
+++ b/DQM/SiStripMonitorClient/BuildFile.xml
@@ -14,4 +14,6 @@
 <use   name="DataFormats/SiStripDetId"/>
 <use   name="boost"/>
 <use   name="root"/>
+<use   name="xdaq"/>
+<use   name="xdaqheader"/>
 <flags EDM_PLUGIN="1"/>


### PR DESCRIPTION
This is done to avoid that dropping xdaq from EventFilter/Utilities breaks
builds.
