### PR TITLE
consumes API usage for Muon POG related packages

### DIFF
--- a/Validation/MuonIdentification/interface/MuonIdVal.h
+++ b/Validation/MuonIdentification/interface/MuonIdVal.h
@@ -75,6 +75,14 @@ class MuonIdVal : public edm::EDAnalyzer {
       edm::InputTag inputMuonTimeExtraValueMap_;
       edm::InputTag inputMuonCosmicCompatibilityValueMap_;
       edm::InputTag inputMuonShowerInformationValueMap_;
+      edm::EDGetTokenT<reco::MuonCollection> inputMuonCollectionToken_;
+      edm::EDGetTokenT<DTRecSegment4DCollection> inputDTRecSegment4DCollectionToken_;
+      edm::EDGetTokenT<CSCSegmentCollection> inputCSCSegmentCollectionToken_;
+      edm::EDGetTokenT<reco::MuonTimeExtraMap> inputMuonTimeExtraValueMapCombToken_;
+      edm::EDGetTokenT<reco::MuonTimeExtraMap> inputMuonTimeExtraValueMapDTToken_;
+      edm::EDGetTokenT<reco::MuonTimeExtraMap> inputMuonTimeExtraValueMapCSCToken_;
+      edm::EDGetTokenT<edm::ValueMap<reco::MuonCosmicCompatibility> > inputMuonCosmicCompatibilityValueMapToken_;
+      edm::EDGetTokenT<edm::ValueMap<reco::MuonShower> > inputMuonShowerInformationValueMapToken_;
       bool useTrackerMuons_;
       bool useGlobalMuons_;
       bool useTrackerMuonsNotGlobalMuons_;

--- a/Validation/MuonIdentification/src/MuonIdVal.cc
+++ b/Validation/MuonIdentification/src/MuonIdVal.cc
@@ -20,6 +20,19 @@ MuonIdVal::MuonIdVal(const edm::ParameterSet& iConfig)
    makeShowerInformationPlots_ = iConfig.getUntrackedParameter<bool>("makeShowerInformationPlots");
    baseFolder_ = iConfig.getUntrackedParameter<std::string>("baseFolder");
 
+   inputMuonCollectionToken_ = consumes<reco::MuonCollection>(inputMuonCollection_);
+   inputDTRecSegment4DCollectionToken_ = consumes<DTRecSegment4DCollection>(inputDTRecSegment4DCollection_);
+   inputCSCSegmentCollectionToken_ = consumes<CSCSegmentCollection>(inputCSCSegmentCollection_);
+   inputMuonTimeExtraValueMapCombToken_ = consumes<reco::MuonTimeExtraMap>(edm::InputTag(inputMuonTimeExtraValueMap_.label(), "combined"));
+   inputMuonTimeExtraValueMapDTToken_= consumes<reco::MuonTimeExtraMap>(edm::InputTag(inputMuonTimeExtraValueMap_.label(), "csc"));
+   inputMuonTimeExtraValueMapCSCToken_ = consumes<reco::MuonTimeExtraMap>(edm::InputTag(inputMuonTimeExtraValueMap_.label(), "dt"));
+   inputMuonCosmicCompatibilityValueMapToken_ = consumes<edm::ValueMap<reco::MuonCosmicCompatibility> >(inputMuonCosmicCompatibilityValueMap_);
+   inputMuonShowerInformationValueMapToken_ = consumes<edm::ValueMap<reco::MuonShower> >(inputMuonShowerInformationValueMap_);
+
+   //   iEvent.getByLabel(inputMuonTimeExtraValueMap_.label(), "combined", combinedMuonTimeExtraValueMapH_);
+   //   iEvent.getByLabel(inputMuonTimeExtraValueMap_.label(), "csc", cscMuonTimeExtraValueMapH_);
+   //   iEvent.getByLabel(inputMuonTimeExtraValueMap_.label(), "dt", dtMuonTimeExtraValueMapH_);
+
    dbe_ = 0;
    dbe_ = edm::Service<DQMStore>().operator->();
 }
@@ -287,14 +300,14 @@ MuonIdVal::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
    using namespace edm;
    using namespace reco;
 
-   iEvent.getByLabel(inputMuonCollection_, muonCollectionH_);
-   iEvent.getByLabel(inputDTRecSegment4DCollection_, dtSegmentCollectionH_);
-   iEvent.getByLabel(inputCSCSegmentCollection_, cscSegmentCollectionH_);
-   iEvent.getByLabel(inputMuonTimeExtraValueMap_.label(), "combined", combinedMuonTimeExtraValueMapH_);
-   iEvent.getByLabel(inputMuonTimeExtraValueMap_.label(), "csc", cscMuonTimeExtraValueMapH_);
-   iEvent.getByLabel(inputMuonTimeExtraValueMap_.label(), "dt", dtMuonTimeExtraValueMapH_);
-   iEvent.getByLabel(inputMuonCosmicCompatibilityValueMap_, muonCosmicCompatibilityValueMapH_);
-   iEvent.getByLabel(inputMuonShowerInformationValueMap_, muonShowerInformationValueMapH_);
+   iEvent.getByToken(inputMuonCollectionToken_, muonCollectionH_);
+   iEvent.getByToken(inputDTRecSegment4DCollectionToken_, dtSegmentCollectionH_);
+   iEvent.getByToken(inputCSCSegmentCollectionToken_, cscSegmentCollectionH_);
+   iEvent.getByToken(inputMuonTimeExtraValueMapCombToken_, combinedMuonTimeExtraValueMapH_);
+   iEvent.getByToken(inputMuonTimeExtraValueMapCSCToken_, cscMuonTimeExtraValueMapH_);
+   iEvent.getByToken(inputMuonTimeExtraValueMapDTToken_, dtMuonTimeExtraValueMapH_);
+   iEvent.getByToken(inputMuonShowerInformationValueMapToken_, muonShowerInformationValueMapH_);
+   iEvent.getByToken(inputMuonCosmicCompatibilityValueMapToken_, muonCosmicCompatibilityValueMapH_);
   
    iSetup.get<GlobalTrackingGeometryRecord>().get(geometry_);
 

--- a/Validation/MuonIsolation/interface/MuIsoValidation.h
+++ b/Validation/MuonIsolation/interface/MuIsoValidation.h
@@ -86,6 +86,7 @@ private:
   
   //Collection labels
   edm::InputTag Muon_Tag;
+  edm::EDGetTokenT<edm::View<reco::Muon> > Muon_Token;
   edm::InputTag tkIsoDeposit_Tag;
   edm::InputTag hcalIsoDeposit_Tag;
   edm::InputTag ecalIsoDeposit_Tag;

--- a/Validation/MuonIsolation/src/MuIsoValidation.cc
+++ b/Validation/MuonIsolation/src/MuIsoValidation.cc
@@ -72,6 +72,7 @@ MuIsoValidation::MuIsoValidation(const edm::ParameterSet& iConfig)
   
   //--------Initialize tags-------
   Muon_Tag = iConfig.getUntrackedParameter<edm::InputTag>("Global_Muon_Label");
+  Muon_Token = consumes<edm::View<reco::Muon> >(Muon_Tag);
   
   //-------Initialize counters----------------
   nEvents = 0;
@@ -298,7 +299,7 @@ void MuIsoValidation::analyze(const edm::Event& iEvent, const edm::EventSetup& i
   
   // Get Muon Collection 
   edm::Handle<edm::View<reco::Muon> > muonsHandle; // 
-  iEvent.getByLabel(Muon_Tag, muonsHandle);
+  iEvent.getByToken(Muon_Token, muonsHandle);
   
   //Fill event entry in histogram of number of muons
   edm::LogInfo("Tutorial") << "Number of Muons: " << muonsHandle->size();

--- a/Validation/RecoMuon/plugins/MuonTrackValidator.cc
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.cc
@@ -14,7 +14,6 @@
 #include "SimTracker/TrackAssociation/interface/TrackAssociatorByHits.h"
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 #include "SimTracker/Records/interface/TrackAssociatorRecord.h"
-#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
 #include "SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h"
@@ -238,15 +237,15 @@ void MuonTrackValidator::analyze(const edm::Event& event, const edm::EventSetup&
   setup.get<TrackAssociatorRecord>().get(parametersDefiner,parametersDefinerTP);    
   
   edm::Handle<TrackingParticleCollection>  TPCollectionHeff ;
-  event.getByLabel(label_tp_effic,TPCollectionHeff);
+  event.getByToken(tp_effic_Token,TPCollectionHeff);
   const TrackingParticleCollection tPCeff = *(TPCollectionHeff.product());
   
   edm::Handle<TrackingParticleCollection>  TPCollectionHfake ;
-  event.getByLabel(label_tp_fake,TPCollectionHfake);
+  event.getByToken(tp_fake_Token,TPCollectionHfake);
   const TrackingParticleCollection tPCfake = *(TPCollectionHfake.product());
   
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-  event.getByLabel(bsSrc,recoBeamSpotHandle);
+  event.getByToken(bsSrc_Token,recoBeamSpotHandle);
   reco::BeamSpot bs = *recoBeamSpotHandle;      
   
   int w=0;
@@ -255,14 +254,13 @@ void MuonTrackValidator::analyze(const edm::Event& event, const edm::EventSetup&
       //
       //get collections from the event
       //
-      edm::Handle<View<Track> >  trackCollection;
+      edm::Handle<edm::View<Track> >  trackCollection;
 
       reco::RecoToSimCollection recSimColl;
       reco::SimToRecoCollection simRecColl;
       unsigned int trackCollectionSize = 0;
 
-      //      if(!event.getByLabel(label[www], trackCollection)&&ignoremissingtkcollection_) continue;
-      if(!event.getByLabel(label[www], trackCollection)&&ignoremissingtkcollection_) {
+      if(!event.getByToken(track_Collection_Token[www], trackCollection)&&ignoremissingtkcollection_) {
 
 	recSimColl.post_insert();
 	simRecColl.post_insert();
@@ -299,11 +297,11 @@ void MuonTrackValidator::analyze(const edm::Event& event, const edm::EventSetup&
 						 << associatormap.instance()<<"\n";
 	
 	  Handle<reco::SimToRecoCollection > simtorecoCollectionH;
-	  event.getByLabel(associatormap,simtorecoCollectionH);
+	  event.getByToken(simToRecoCollection_Token,simtorecoCollectionH);
 	  simRecColl= *(simtorecoCollectionH.product()); 
 	
 	  Handle<reco::RecoToSimCollection > recotosimCollectionH;
-	  event.getByLabel(associatormap,recotosimCollectionH);
+	  event.getByToken(recoToSimCollection_Token,recotosimCollectionH);
 	  recSimColl= *(recotosimCollectionH.product()); 
 	}
 
@@ -528,7 +526,7 @@ void MuonTrackValidator::analyze(const edm::Event& event, const edm::EventSetup&
 					 << ": " << trackCollectionSize << "\n";
       int at=0;
       int rT=0;
-      for(View<Track>::size_type i=0; i<trackCollectionSize; ++i){
+      for(edm::View<Track>::size_type i=0; i<trackCollectionSize; ++i){
         bool Track_is_matched = false; 
 	RefToBase<Track> track(trackCollection, i);
 	rT++;

--- a/Validation/RecoMuon/plugins/MuonTrackValidator.h
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.h
@@ -48,12 +48,12 @@ class MuonTrackValidator : public edm::EDAnalyzer, protected MuonTrackValidatorB
     // dump cfg parameters
     edm::LogVerbatim("MuonTrackValidator") << "constructing  MuonTrackValidator: " << pset.dump();
     
-    // Declare concumes (also for the base class)
+    // Declare consumes (also for the base class)
     bsSrc_Token = consumes<reco::BeamSpot>(bsSrc);
     tp_effic_Token = consumes<TrackingParticleCollection>(label_tp_effic);
     tp_fake_Token = consumes<TrackingParticleCollection>(label_tp_fake);
     for (unsigned int www=0;www<label.size();www++){
-      track_Collection_Token[www] = consumes<edm::View<reco::Track> >(label[www]);
+      track_Collection_Token.push_back(consumes<edm::View<reco::Track> >(label[www]));
     }
     simToRecoCollection_Token = consumes<reco::SimToRecoCollection>(associatormap);
     recoToSimCollection_Token = consumes<reco::RecoToSimCollection>(associatormap);

--- a/Validation/RecoMuon/plugins/MuonTrackValidator.h
+++ b/Validation/RecoMuon/plugins/MuonTrackValidator.h
@@ -11,6 +11,7 @@
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
+#include "DataFormats/RecoCandidate/interface/TrackAssociation.h"
 
 class MuonTrackValidator : public edm::EDAnalyzer, protected MuonTrackValidatorBase {
  public:
@@ -47,6 +48,16 @@ class MuonTrackValidator : public edm::EDAnalyzer, protected MuonTrackValidatorB
     // dump cfg parameters
     edm::LogVerbatim("MuonTrackValidator") << "constructing  MuonTrackValidator: " << pset.dump();
     
+    // Declare concumes (also for the base class)
+    bsSrc_Token = consumes<reco::BeamSpot>(bsSrc);
+    tp_effic_Token = consumes<TrackingParticleCollection>(label_tp_effic);
+    tp_fake_Token = consumes<TrackingParticleCollection>(label_tp_fake);
+    for (unsigned int www=0;www<label.size();www++){
+      track_Collection_Token[www] = consumes<edm::View<reco::Track> >(label[www]);
+    }
+    simToRecoCollection_Token = consumes<reco::SimToRecoCollection>(associatormap);
+    recoToSimCollection_Token = consumes<reco::RecoToSimCollection>(associatormap);
+
     MABH = false;
     if (!UseAssociators) {
       // flag MuonAssociatorByHits
@@ -135,6 +146,8 @@ private:
  private:
   std::string dirName_;
   edm::InputTag associatormap;
+  edm::EDGetTokenT<reco::SimToRecoCollection> simToRecoCollection_Token;
+  edm::EDGetTokenT<reco::RecoToSimCollection> recoToSimCollection_Token;
   bool UseAssociators;
   double minPhi, maxPhi;
   int nintPhi;

--- a/Validation/RecoMuon/plugins/MuonTrackValidatorBase.h
+++ b/Validation/RecoMuon/plugins/MuonTrackValidatorBase.h
@@ -11,9 +11,14 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "MagneticField/Engine/interface/MagneticField.h" 
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h" 
+
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 
 #include "SimTracker/TrackAssociation/interface/TrackAssociatorByChi2.h"
 
@@ -34,6 +39,16 @@
 class MuonTrackValidatorBase {
  public:
   /// Constructor
+  MuonTrackValidatorBase(const edm::ParameterSet& pset, edm::ConsumesCollector iC) : MuonTrackValidatorBase(pset)
+    {
+      bsSrc_Token = iC.consumes<reco::BeamSpot>(bsSrc);
+      tp_effic_Token = iC.consumes<TrackingParticleCollection>(label_tp_effic);
+      tp_fake_Token = iC.consumes<TrackingParticleCollection>(label_tp_fake);
+      for (unsigned int www=0;www<label.size();www++){
+	track_Collection_Token[www] = iC.consumes<edm::View<reco::Track> >(label[www]);
+      }
+    }
+
   MuonTrackValidatorBase(const edm::ParameterSet& pset):
     label(pset.getParameter< std::vector<edm::InputTag> >("label")),
     usetracker(pset.getParameter<bool>("usetracker")),
@@ -341,6 +356,10 @@ class MuonTrackValidatorBase {
   std::vector<std::string> associators;
   std::string out;
   std::string parametersDefiner;
+  std::vector<edm::EDGetTokenT<edm::View<reco::Track> > > track_Collection_Token;
+  edm::EDGetTokenT<reco::BeamSpot> bsSrc_Token;
+  edm::EDGetTokenT<TrackingParticleCollection> tp_effic_Token;
+  edm::EDGetTokenT<TrackingParticleCollection> tp_fake_Token;
        
   double  min, max;
   int nint;

--- a/Validation/RecoMuon/src/GlobalMuonMatchAnalyzer.cc
+++ b/Validation/RecoMuon/src/GlobalMuonMatchAnalyzer.cc
@@ -25,9 +25,6 @@
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
-#include "DataFormats/Common/interface/View.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/MuonReco/interface/MuonTrackLinks.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 
@@ -52,6 +49,11 @@ GlobalMuonMatchAnalyzer::GlobalMuonMatchAnalyzer(const edm::ParameterSet& iConfi
 
   out = iConfig.getUntrackedParameter<std::string>("out");
   dbe_ = edm::Service<DQMStore>().operator->();
+
+  tpToken_ = consumes<edm::View<reco::Track> >(tpName_);
+  tkToken_ = consumes<edm::View<reco::Track> >(tkName_);
+  staToken_ = consumes<edm::View<reco::Track> >(staName_);
+  glbToken_ = consumes<edm::View<reco::Track> >(glbName_);
 }
 
 
@@ -76,23 +78,23 @@ GlobalMuonMatchAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
    using namespace reco;
 
    Handle<TrackingParticleCollection> tpHandle;
-   iEvent.getByLabel(tpName_,tpHandle);
+   iEvent.getByToken(tpToken_,tpHandle);
    const TrackingParticleCollection tpColl = *(tpHandle.product());
 
    Handle<reco::MuonTrackLinksCollection> muHandle;
-   iEvent.getByLabel(glbName_,muHandle);
+   iEvent.getByToken(glbToken_,muHandle);
    const reco::MuonTrackLinksCollection muColl = *(muHandle.product());
 
    Handle<View<Track> > staHandle;
-   iEvent.getByLabel(staName_,staHandle);
+   iEvent.getByToken(staToken_,staHandle);
    //   const reco::TrackCollection staColl = *(staHandle.product());
 
    Handle<View<Track> > glbHandle;
-   iEvent.getByLabel(glbName_,glbHandle);
+   iEvent.getByToken(glbToken_,glbHandle);
    //   const reco::TrackCollection glbColl = *(glbHandle.product());
 
    Handle<View<Track> > tkHandle;
-   iEvent.getByLabel(tkName_,tkHandle);
+   iEvent.getByToken(tkToken_,tkHandle);
    //   const reco::TrackCollection mtkColl = *(tkHandle.product());
 
    reco::RecoToSimCollection tkrecoToSimCollection;

--- a/Validation/RecoMuon/src/GlobalMuonMatchAnalyzer.h
+++ b/Validation/RecoMuon/src/GlobalMuonMatchAnalyzer.h
@@ -23,6 +23,10 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
 namespace reco {class Track;}
@@ -62,6 +66,7 @@ class GlobalMuonMatchAnalyzer : public edm::EDAnalyzer {
   const TrackAssociatorBase *tkAssociator_, *muAssociator_;
   std::string tkAssociatorName_, muAssociatorName_;
   edm::InputTag tkName_, tpName_, glbName_, staName_;
+  edm::EDGetTokenT<edm::View<reco::Track> >  tkToken_, tpToken_, glbToken_, staToken_;
 
 
 };

--- a/Validation/RecoMuon/src/MuonSeedTrack.cc
+++ b/Validation/RecoMuon/src/MuonSeedTrack.cc
@@ -14,7 +14,6 @@
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
-#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
 #include "Geometry/CommonDetUnit/interface/GeomDet.h"
 
@@ -46,6 +45,7 @@ MuonSeedTrack::MuonSeedTrack(const edm::ParameterSet& pset)
   ParameterSet updatorPar = pset.getParameter<ParameterSet>("MuonUpdatorAtVertexParameters");
   //theSeedPropagatorName = updatorPar.getParameter<string>("Propagator");
   theSeedsLabel = pset.getParameter<InputTag>("MuonSeed");
+  theSeedsToken = consumes<TrajectorySeedCollection>(theSeedsLabel);
   theUpdatorAtVtx = new MuonUpdatorAtVertex(updatorPar,theService);
 
   theAllowNoVtxFlag = pset.getUntrackedParameter<bool>("AllowNoVertex",false);
@@ -87,7 +87,7 @@ MuonSeedTrack::produce(edm::Event& event, const edm::EventSetup& eventSetup)
 
 
   Handle<TrajectorySeedCollection> seeds;
-  event.getByLabel(theSeedsLabel, seeds);
+  event.getByToken(theSeedsToken, seeds);
 
   for ( TrajectorySeedCollection::const_iterator iSeed = seeds->begin();
         iSeed != seeds->end(); iSeed++ ) {

--- a/Validation/RecoMuon/src/MuonSeedTrack.h
+++ b/Validation/RecoMuon/src/MuonSeedTrack.h
@@ -26,6 +26,8 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
 namespace reco {class Track;}
@@ -87,6 +89,7 @@ class MuonSeedTrack : public edm::EDProducer {
 
   /// the TrajectorySeed label  
   edm::InputTag theSeedsLabel;
+  edm::EDGetTokenT<TrajectorySeedCollection>  theSeedsToken;
   
   ///
   bool theAllowNoVtxFlag;      

--- a/Validation/RecoMuon/src/MuonTrackAnalyzer.h
+++ b/Validation/RecoMuon/src/MuonTrackAnalyzer.h
@@ -16,8 +16,15 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
-#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
+
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
 namespace edm {class ParameterSet; class Event; class EventSetup;}
 namespace reco {class TransientTrack;}
@@ -86,11 +93,20 @@ class MuonTrackAnalyzer: public edm::EDAnalyzer {
 
   EtaRange theEtaRange;
   
-  edm::InputTag theTracksLabel;
+  edm::InputTag theSimTracksLabel;
   edm::InputTag theSeedsLabel;
+  edm::InputTag theTracksLabel;
   edm::InputTag theCSCSimHitLabel;
   edm::InputTag theDTSimHitLabel; 
   edm::InputTag theRPCSimHitLabel;
+
+  edm::EDGetTokenT<edm::SimTrackContainer> theSimTracksToken;
+  edm::EDGetTokenT<TrajectorySeedCollection> theSeedsToken;
+  edm::EDGetTokenT<reco::TrackCollection> theTracksToken;
+  edm::EDGetTokenT<std::vector<PSimHit> > theCSCSimHitToken;
+  edm::EDGetTokenT<std::vector<PSimHit> > theDTSimHitToken;
+  edm::EDGetTokenT<std::vector<PSimHit> > theRPCSimHitToken;
+
 
   bool doTracksAnalysis;
   bool doSeedsAnalysis;

--- a/Validation/RecoMuon/src/MuonTrackResidualAnalyzer.h
+++ b/Validation/RecoMuon/src/MuonTrackResidualAnalyzer.h
@@ -22,6 +22,9 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
 #include "DataFormats/DetId/interface/DetId.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 
@@ -82,14 +85,19 @@ private:
   std::string out;
   
   edm::InputTag theDataType;
+  edm::EDGetTokenT<edm::SimTrackContainer> theDataTypeToken;
   EtaRange theEtaRange;
   
   edm::InputTag theMuonTrackLabel;
-  edm::InputTag theSeedCollectionLabel;
   edm::InputTag cscSimHitLabel;
   edm::InputTag dtSimHitLabel;
   edm::InputTag rpcSimHitLabel;
-  
+
+  edm::EDGetTokenT<reco::TrackCollection> theMuonTrackToken;
+  edm::EDGetTokenT<std::vector<PSimHit> > theCSCSimHitToken;
+  edm::EDGetTokenT<std::vector<PSimHit> > theDTSimHitToken;
+  edm::EDGetTokenT<std::vector<PSimHit> > theRPCSimHitToken;
+
   MuonServiceProxy *theService;
   KFUpdator *theUpdator;
   MeasurementEstimator *theEstimator;

--- a/Validation/RecoMuon/src/RecoMuonValidator.h
+++ b/Validation/RecoMuon/src/RecoMuonValidator.h
@@ -10,7 +10,14 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "CommonTools/RecoAlgos/interface/TrackingParticleSelector.h"
+
 #include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 
 #include "SimMuon/MCTruth/interface/MuonAssociatorByHits.h"
 
@@ -40,12 +47,17 @@ class RecoMuonValidator : public edm::EDAnalyzer
   edm::InputTag simLabel_;
   edm::InputTag muonLabel_;
   std::string muonSelection_;
+  edm::EDGetTokenT<TrackingParticleCollection> simToken_;
+  edm::EDGetTokenT<edm::View<reco::Muon> > muonToken_;
 
   edm::InputTag muAssocLabel_;
   const MuonAssociatorByHits * assoByHits;
+  //  edm::EDGetTokenT<> muAssocToken_;
   
   edm::InputTag beamspotLabel_;
   edm::InputTag primvertexLabel_;
+  edm::EDGetTokenT<reco::BeamSpot> beamspotToken_;
+  edm::EDGetTokenT<reco::VertexCollection> primvertexToken_;
 
   std::string outputFileName_;
   std::string subDir_;


### PR DESCRIPTION
Add consumes/getByToken in the modules belonging to the following validation packages linked to muon POG:
Validation/MuonIdentification
Validation/MuonIsolation
Validation/RecoMuon
