### PR TITLE
add missing std:: namespace qualifiers

### DIFF
--- a/IOPool/Streamer/src/StreamDQMInputFile.cc
+++ b/IOPool/Streamer/src/StreamDQMInputFile.cc
@@ -12,7 +12,7 @@ StreamDQMInputFile::~StreamDQMInputFile()
 
 StreamDQMInputFile::StreamDQMInputFile(const std::string& name):
   currentEvMsg_(),
-  ist_(new ifstream(name.c_str())),
+  ist_(new std::ifstream(name.c_str())),
   eventBuf_(1000*1000*7)
 {
 

--- a/IOPool/Streamer/src/Utilities.cc
+++ b/IOPool/Streamer/src/Utilities.cc
@@ -162,7 +162,7 @@ namespace edm
     return rc;
   }
 
-  std::auto_ptr<SendJobHeader> readHeaderFromStream(ifstream& ist)
+  std::auto_ptr<SendJobHeader> readHeaderFromStream(std::ifstream& ist)
   {
     JobHeaderDecoder decoder;
     std::vector<char> regdata(1000*1000);
@@ -208,7 +208,7 @@ namespace edm
   {
     edm::ProductRegistry pr;
     edm::BranchIDListHelper bidlh;
-    ifstream ist(filename.c_str(), std::ios_base::binary | std::ios_base::in);
+    std::ifstream ist(filename.c_str(), std::ios_base::binary | std::ios_base::in);
 
     if(!ist)
       {

--- a/IOPool/Streamer/test/EventBuffer_t.cpp
+++ b/IOPool/Streamer/test/EventBuffer_t.cpp
@@ -50,7 +50,7 @@ void Producer::operator()()
       EventBuffer::ProducerBuffer ib(*b_);
       int* v = (int*)ib.buffer();
       *v = i;
-      //cout << "P" << i << std::endl;
+      //std::cout << "P" << i << std::endl;
       ib.commit(sizeof(int));
   }
 

--- a/IOPool/Streamer/test/PackBitsTest.cpp
+++ b/IOPool/Streamer/test/PackBitsTest.cpp
@@ -11,12 +11,12 @@ void printCharBits(unsigned char c){
 }
 
 void packIntoString(std::vector<unsigned char> const& source,
-                    vector<unsigned char>& package)
+                    std::vector<unsigned char>& package)
 {   
 unsigned int packInOneByte = 4;
 
 unsigned int sizeOfPackage = 1+((source.size()-1)/packInOneByte); //Two bits per HLT
-cout << "sizeOfPackage: "<<sizeOfPackage<< std::endl;
+std::cout << "sizeOfPackage: "<<sizeOfPackage<< std::endl;
 
 package.resize(sizeOfPackage);
 memset(&package[0], 0x00, sizeOfPackage);
@@ -29,15 +29,19 @@ memset(&package[0], 0x00, sizeOfPackage);
       std::cout <<"indxWithinByte: "<<indxWithinByte<< std::endl;
 
       std::cout <<"source["<<i<<"] B4: ";
-      printCharBits(source.at(i));cout<< std::endl;
+      printCharBits(source.at(i));
+      std::cout<< std::endl;
       std::cout<<"Shiffted by "<<indxWithinByte*2<<" source["<<i<<"] ";
-             printCharBits(source[i] << (indxWithinByte*2));cout<< std::endl;
+      printCharBits(source[i] << (indxWithinByte*2));
+      std::cout<< std::endl;
 
       std::cout << "package["<<whichByte<<"] B4: ";
-      printCharBits(package[whichByte]);cout<< std::endl;
+      printCharBits(package[whichByte]);
+      std::cout<< std::endl;
       package[whichByte] = package[whichByte] | (source[i] << (indxWithinByte*2));
       std::cout << "package["<<whichByte<<"] After: ";
-      printCharBits(package[whichByte]);cout<< std::endl;
+      printCharBits(package[whichByte]);
+      std::cout<< std::endl;
       std::cout<<"\n\n\n************"<< std::endl;
   }
   std::cout<<"Packaged Bits"<< std::endl;
@@ -50,7 +54,7 @@ int main()
 
 {
 //printCharBits(0xFF);
-vector<unsigned char> source;
+std::vector<unsigned char> source;
 
 //Mind that Only 2 LSBs are Important
 source.push_back(0);
@@ -59,9 +63,9 @@ source.push_back(2);
 source.push_back(3);
 //source.push_back(5);
 
-vector<unsigned char> hltbits;
+std::vector<unsigned char> hltbits;
 packIntoString(source, hltbits);
-cout<<"\nSource Was: \n";
+std::cout<<"\nSource Was: \n";
 string space="    ";
 for (unsigned int i=source.size()-1;i!=-1;--i) {
      space=+"    ";

--- a/IOPool/Streamer/test/ParamSetWalker_t.cpp
+++ b/IOPool/Streamer/test/ParamSetWalker_t.cpp
@@ -22,8 +22,8 @@ class ParamSetWalker {
       boost::shared_ptr<ParameterSet> procPset = pdesc.getProcessPSet();
       std::cout<< "Process PSet:" << procPset->toString() << std::endl;           
       
-      //cout << "Module Label: " << procPset->getParameter<string>("@module_label")
-      //     << std::endl;
+      //std::cout << "Module Label: " << procPset->getParameter<std::string>("@module_label")
+      //          << std::endl;
       
      edm::ParameterSet const& allTrigPaths = procPset->getParameterSet("@trigger_paths");
      std::cout << "Found  Trig Path :" << allTrigPaths.toString() << std::endl; 
@@ -44,7 +44,7 @@ class ParamSetWalker {
         {
           std::cout << "Found an end Path :" << (*it) << std::endl;
           //Lets try to get this PSet from the Process PSet
-          vector<std::string> anEndPath = procPset->getParameter<vector<std::string> >((*it));
+          std::vector<std::string> anEndPath = procPset->getParameter<std::vector<std::string> >((*it));
           for(std::vector<std::string>::iterator it = anEndPath.begin(), itEnd = anEndPath.end();
           it != itEnd; ++it) {  
               std::cout << "Found a end Path PSet :" << (*it) << std::endl;
@@ -54,11 +54,11 @@ class ParamSetWalker {
                     throw cms::Exception("ParamSetWalker","ParamSetWalker") 
                           << "Empty End Path Found in the Config File" << std::endl;
               std::cout << "This Module PSet is: " << aModInEndPathPset.toString() << std::endl;
-              std::string mod_type = aModInEndPathPset.getParameter<string> ("@module_type");
+              std::string mod_type = aModInEndPathPset.getParameter<std::string> ("@module_type");
               std::cout << "Type of This Module is: " << mod_type << std::endl;
               if (mod_type == "EventStreamFileWriter") {
                  std::cout << "FOUND WHAT WAS LOOKING FOR:::" << std::endl;
-                 std::string fileName = aModInEndPathPset.getParameter<string> ("fileName");
+                 std::string fileName = aModInEndPathPset.getParameter<std::string> ("fileName");
                  std::cout << "Streamer File Name:" << fileName << std::endl; 
 
                  edm::ParameterSet selectEventsPSet const& = aModInEndPathPset.getUntrackedParameterSet("SelectEvents");
@@ -79,7 +79,7 @@ class ParamSetWalker {
   
   
 int main() {
-  string test_config =   "process PROD  = { 
+  std::string test_config =   "process PROD  = { 
     untracked PSet maxEvents = { untracked int32 input = 10 }
     untracked PSet options = { 
           untracked bool wantSummary=false 
@@ -95,7 +95,7 @@ int main() {
           bool use_compression = true
           int32 compression_level = 1
 
-          string fileName = \"teststreamfile.dat\"
+          std::string fileName = \"teststreamfile.dat\"
           # untracked int32 numPerFile = 5
           untracked PSet SelectEvents = { vstring SelectEvents={\"p2\"}}
         }

--- a/IOPool/Streamer/test/StreamThingAnalyzer.cc
+++ b/IOPool/Streamer/test/StreamThingAnalyzer.cc
@@ -52,7 +52,7 @@ namespace edmtest_thing
     ProdList::iterator i(prod.begin()),end(prod.end());
     for(; i != end; ++i)
       total_ = accumulate((*i)->data_.begin(),(*i)->data_.end(),total_);
-    //cout << tot << std::endl;
+    //std::cout << tot << std::endl;
 
 #if 0
     for(i = prod.begin();i != end; ++i) {


### PR DESCRIPTION
When compiling the framework against ROOT 6, I noticed some compilation errors in IOPool/Streamer because "ifstream" was used, instead of "std::ifstream". I have no idea why this compiled before, because I can't find any relevant using directives or declarations.  So, this pull request adds any missing "std::" namespace qualifiers to instances of ifstream, vector, string, cout, endl, etc. that I could find in IOPool/Streamer.
In a couple of places, I also took multiple statements on the same line and put them on separate lines. 
