### PR TITLE
Performance improvement in KDTreeLinkerAlgo<T> 

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h
@@ -145,6 +145,10 @@ KDTreeLinkerAlgo<DATA>::recSearch(int	current,
   assert (!(((nodePool_.left[current] < 0) && (nodePool_.right[current] >= 0)) ||
             ((nodePool_.left[current] >= 0) && (nodePool_.right[current] < 0))));
   */
+  // Iterate until leaf is found, or there are no children in the
+  // search window. If search has to proceed on both children, proceed
+  // the search to left child via recursion. Swap search window
+  // dimension on alternate levels.
   while(true) {
     int right = nodePool_.right[current];
     if(nodePool_.isLeaf(right)) {
@@ -169,6 +173,7 @@ KDTreeLinkerAlgo<DATA>::recSearch(int	current,
       bool goLeft = (dimCurrMin <= median);
       bool goRight = (dimCurrMax > median);
 
+      // Swap dimension for the next search level
       std::swap(dimCurrMin, dimOtherMin);
       std::swap(dimCurrMax, dimOtherMax);
       if(goLeft & goRight) {

--- a/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h
@@ -28,51 +28,41 @@ class KDTreeLinkerAlgo
 	      std::vector<KDTreeNodeInfo<DATA> >	&resRecHitList);
 
   // This reurns true if the tree is empty
-  bool empty() {return nodePoolPos_ == -1;}
+  bool empty() {return nodePool_.empty();}
 
   // This returns the number of nodes + leaves in the tree
   // (nElements should be (size() +1)/2)
-  int size() { return nodePoolPos_ + 1;}
+  int size() { return nodePool_.size();}
 
   // This method clears all allocated structures.
   void clear();
   
  private:
-  // The KDTree root
-  KDTreeNode<DATA>*	root_;
-  
   // The node pool allow us to do just 1 call to new for each tree building.
-  KDTreeNode<DATA>*	nodePool_;
-  int		nodePoolSize_;
-  int		nodePoolPos_;
-
-
+  KDTreeNodes<DATA> nodePool_;
   
   std::vector<KDTreeNodeInfo<DATA> >	*closestNeighbour;
   std::vector<KDTreeNodeInfo<DATA> >	*initialEltList;
   
  private:
  
-  // Get next node from the node pool.
-  KDTreeNode<DATA>* getNextNode();
-
   //Fast median search with Wirth algorithm in eltList between low and high indexes.
   int medianSearch(int					low,
 		   int					high,
 		   int					treeDepth);
 
   // Recursif kdtree builder. Is called by build()
-  KDTreeNode<DATA> *recBuild(int				low,
-		       int				hight,
-		       int				depth,
-		       const KDTreeBox			&region);
+  int recBuild(int				low,
+               int				hight,
+               int				depth);
 
   // Recursif kdtree search. Is called by search()
-  void recSearch(const KDTreeNode<DATA>			*current,
-		 const KDTreeBox			&trackBox);    
+  void recSearch(int			current,
+                 float dimCurrMin, float dimCurrMax,
+                 float dimOtherMin, float dimOtherMax);
 
   // Add all elements of an subtree to the closest elements. Used during the recSearch().
-  void addSubtree(const KDTreeNode<DATA>			*current);
+  void addSubtree(int			current);
 
   // This method frees the KDTree.     
   void clearTree();
@@ -90,11 +80,11 @@ KDTreeLinkerAlgo<DATA>::build(std::vector<KDTreeNodeInfo<DATA> >	&eltList,
     initialEltList = &eltList;
     
     size_t size = initialEltList->size();
-    nodePoolSize_ = size * 2 - 1;
-    nodePool_ = new KDTreeNode<DATA>[nodePoolSize_];
+    nodePool_.build(size);
     
     // Here we build the KDTree
-    root_ = recBuild(0, size, 0, region);
+    int root = recBuild(0, size, 0);
+    assert(root == 0);
     
     initialEltList = 0;
   }
@@ -127,11 +117,11 @@ KDTreeLinkerAlgo<DATA>::medianSearch(int	low,
       // The even depth is associated to dim1 dimension
       // The odd one to dim2 dimension
       if (treeDepth & 1) {
-	while ((*initialEltList)[i].dim2 < elt.dim2) i++;
-	while ((*initialEltList)[j].dim2 > elt.dim2) j--;
+	while ((*initialEltList)[i].dim[1] < elt.dim[1]) i++;
+	while ((*initialEltList)[j].dim[1] > elt.dim[1]) j--;
       } else {
-	while ((*initialEltList)[i].dim1 < elt.dim1) i++;
-	while ((*initialEltList)[j].dim1 > elt.dim1) j--;
+	while ((*initialEltList)[i].dim[0] < elt.dim[0]) i++;
+	while ((*initialEltList)[j].dim[0] > elt.dim[0]) j--;
       }
 
       if (i <= j){
@@ -154,9 +144,9 @@ void
 KDTreeLinkerAlgo<DATA>::search(const KDTreeBox		&trackBox,
 			 std::vector<KDTreeNodeInfo<DATA> > &recHits)
 {
-  if (root_) {
+  if (!empty()) {
     closestNeighbour = &recHits;
-    recSearch(root_, trackBox);
+    recSearch(0, trackBox.dim1min, trackBox.dim1max, trackBox.dim2min, trackBox.dim2max);
     closestNeighbour = 0;
   }
 }
@@ -164,73 +154,59 @@ KDTreeLinkerAlgo<DATA>::search(const KDTreeBox		&trackBox,
 
 template < typename DATA >
 void 
-KDTreeLinkerAlgo<DATA>::recSearch(const KDTreeNode<DATA>	*current,
-				  const KDTreeBox		&trackBox)
+KDTreeLinkerAlgo<DATA>::recSearch(int	current,
+                                  float dimCurrMin, float dimCurrMax,
+                                  float dimOtherMin, float dimOtherMax)
 {
   /*
   // By construction, current can't be null
-  assert(current != 0);
+  assert(current >= 0);
 
   // By Construction, a node can't have just 1 son.
-  assert (!(((current->left == 0) && (current->right != 0)) ||
-	    ((current->left != 0) && (current->right == 0))));
+  assert (!(((nodePool_.left[current] < 0) && (nodePool_.right[current] >= 0)) ||
+            ((nodePool_.left[current] >= 0) && (nodePool_.right[current] < 0))));
   */
     
-  if ((current->left == 0) && (current->right == 0)) {//leaf case
-  
+  if (nodePool_.isLeaf(current)) {
+    const KDTreeNodeInfo<DATA>& info = nodePool_.info[current];
+
+    int dimIndex = nodePool_.nodes[current].right; // 0 or 1
+    float dimCurr = info.dim[dimIndex];
+    float dimOther = info.dim[1-dimIndex];
+
     // If point inside the rectangle/area
-    if ((current->info.dim1 >= trackBox.dim1min) && (current->info.dim1 <= trackBox.dim1max) &&
-	(current->info.dim2 >= trackBox.dim2min) && (current->info.dim2 <= trackBox.dim2max))
-      closestNeighbour->push_back(current->info);
+    if(dimCurr >= dimCurrMin && dimCurr <= dimCurrMax &&
+       dimOther >= dimOtherMin && dimOther <= dimOtherMax)
+      closestNeighbour->push_back(info);
 
   } else {
+    const typename KDTreeNodes<DATA>::Node& node = nodePool_.nodes[current];
+    float median = node.median;
 
-    //if region( v->left ) is fully contained in the rectangle
-    if ((current->left->region.dim1min >= trackBox.dim1min) && 
-	(current->left->region.dim1max <= trackBox.dim1max) &&
-	(current->left->region.dim2min >= trackBox.dim2min) && 
-	(current->left->region.dim2max <= trackBox.dim2max))
-      addSubtree(current->left);
-    
-    else { //if region( v->left ) intersects the rectangle
-      
-      if (!((current->left->region.dim1min >= trackBox.dim1max) || 
-	    (current->left->region.dim1max <= trackBox.dim1min) ||
-	    (current->left->region.dim2min >= trackBox.dim2max) || 
-	    (current->left->region.dim2max <= trackBox.dim2min)))
-	recSearch(current->left, trackBox);
+    if(dimCurrMin <= median) {
+      int left = current+1;
+      recSearch(left, dimOtherMin, dimOtherMax, dimCurrMin, dimCurrMax);
     }
-    
-    //if region( v->right ) is fully contained in the rectangle
-    if ((current->right->region.dim1min >= trackBox.dim1min) && 
-	(current->right->region.dim1max <= trackBox.dim1max) &&
-	(current->right->region.dim2min >= trackBox.dim2min) && 
-	(current->right->region.dim2max <= trackBox.dim2max))
-      addSubtree(current->right);
-
-    else { //if region( v->right ) intersects the rectangle
-     
-      if (!((current->right->region.dim1min >= trackBox.dim1max) || 
-	    (current->right->region.dim1max <= trackBox.dim1min) ||
-	    (current->right->region.dim2min >= trackBox.dim2max) || 
-	    (current->right->region.dim2max <= trackBox.dim2min)))
-	recSearch(current->right, trackBox);
-    } 
+    if(dimCurrMax > median) {
+      int right = node.right;
+      recSearch(right, dimOtherMin, dimOtherMax, dimCurrMin, dimCurrMax);
+    }
   }
 }
 
 template < typename DATA >
 void
-KDTreeLinkerAlgo<DATA>::addSubtree(const KDTreeNode<DATA>	*current)
+KDTreeLinkerAlgo<DATA>::addSubtree(int current)
 {
   // By construction, current can't be null
-  // assert(current != 0);
+  // assert(current >= 0);
 
-  if ((current->left == 0) && (current->right == 0)) // leaf
-    closestNeighbour->push_back(current->info);
+  if (nodePool_.isLeaf(current)) {// leaf
+    closestNeighbour->push_back(nodePool_.info[current]);
+  }
   else { // node
-    addSubtree(current->left);
-    addSubtree(current->right);
+    addSubtree(current+1);
+    addSubtree(nodePool_.right[current]);
   }
 }
 
@@ -239,10 +215,6 @@ KDTreeLinkerAlgo<DATA>::addSubtree(const KDTreeNode<DATA>	*current)
 
 template <typename DATA>
 KDTreeLinkerAlgo<DATA>::KDTreeLinkerAlgo()
-  : root_ (0),
-    nodePool_(0),
-    nodePoolSize_(-1),
-    nodePoolPos_(-1)
 {
 }
 
@@ -257,52 +229,34 @@ template <typename DATA>
 void 
 KDTreeLinkerAlgo<DATA>::clearTree()
 {
-  delete[] nodePool_;
-  nodePool_ = 0;
-  root_ = 0;
-  nodePoolSize_ = -1;
-  nodePoolPos_ = -1;
+  nodePool_.clear();
 }
 
 template <typename DATA>
 void 
 KDTreeLinkerAlgo<DATA>::clear()
 {
-  if (root_)
-    clearTree();
+  clearTree();
 }
 
 
 template <typename DATA>
-KDTreeNode<DATA>* 
-KDTreeLinkerAlgo<DATA>::getNextNode()
-{
-  ++nodePoolPos_;
-
-  // The tree size is exactly 2 * nbrElts - 1 and this is the total allocated memory.
-  // If we have used more than that....there is a big problem.
-  // assert(nodePoolPos_ < nodePoolSize_);
-
-  return &(nodePool_[nodePoolPos_]);
-}
-
-
-template <typename DATA>
-KDTreeNode<DATA>*
+int
 KDTreeLinkerAlgo<DATA>::recBuild(int					low, 
-			   int					high, 
-			   int					depth,
-			   const KDTreeBox&			region)
+                                 int					high, 
+                                 int					depth)
 {
   int portionSize = high - low;
+  int dimIndex = depth&1;
 
   // By construction, portionSize > 0 can't happend.
   // assert(portionSize > 0);
 
   if (portionSize == 1) { // Leaf case
    
-    KDTreeNode<DATA> *leaf = getNextNode();
-    leaf->setAttributs(region, (*initialEltList)[low]);
+    int leaf = nodePool_.getNextNode();
+    nodePool_.info[leaf] = (*initialEltList)[low];
+    nodePool_.nodes[leaf].right = dimIndex;
     return leaf;
 
   } else { // Node case
@@ -310,37 +264,22 @@ KDTreeLinkerAlgo<DATA>::recBuild(int					low,
     // The even depth is associated to dim1 dimension
     // The odd one to dim2 dimension
     int medianId = medianSearch(low, high, depth);
+    float medianVal = (*initialEltList)[medianId].dim[dimIndex];
 
     // We create the node
-    KDTreeNode<DATA> *node = getNextNode();
-    node->setAttributs(region);
-
-
-    // Here we split into 2 halfplanes the current plane
-    KDTreeBox leftRegion = region;
-    KDTreeBox rightRegion = region;
-    if (depth & 1) {
-
-      auto medianVal = (*initialEltList)[medianId].dim2;
-      leftRegion.dim2max = medianVal;
-      rightRegion.dim2min = medianVal;
-
-    } else {
-
-      auto medianVal = (*initialEltList)[medianId].dim1;
-      leftRegion.dim1max = medianVal;
-      rightRegion.dim1min = medianVal;
-
-    }
+    int nodeInd = nodePool_.getNextNode();
+    typename KDTreeNodes<DATA>::Node& node = nodePool_.nodes[nodeInd];
+    node.median = medianVal;
 
     ++depth;
     ++medianId;
 
     // We recursively build the son nodes
-    node->left = recBuild(low, medianId, depth, leftRegion);
-    node->right = recBuild(medianId, high, depth, rightRegion);
+    int left = recBuild(low, medianId, depth);
+    assert(nodeInd+1 == left);
+    node.right = recBuild(medianId, high, depth);
 
-    return node;
+    return nodeInd;
   }
 }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h
@@ -175,8 +175,12 @@ KDTreeLinkerAlgo<DATA>::recSearch(int	current,
     float dimOther = info.dim[1-dimIndex];
 
     // If point inside the rectangle/area
-    if(dimCurr >= dimCurrMin && dimCurr <= dimCurrMax &&
-       dimOther >= dimOtherMin && dimOther <= dimOtherMax)
+    // Use intentionally bit-wise & instead of logical && for better
+    // performance. It is faster to always do all comparisons than to
+    // allow use of branches to not do some if any of the first ones
+    // is false.
+    if((dimCurr >= dimCurrMin) & (dimCurr <= dimCurrMax) &
+       (dimOther >= dimOtherMin) & (dimOther <= dimOtherMax))
       closestNeighbour->push_back(info);
 
   } else {

--- a/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h
@@ -5,7 +5,6 @@
 
 #include <cassert>
 #include <vector>
-#include<algorithm>
 
 // Class that implements the KDTree partition of 2D space and 
 // a closest point search algorithme.
@@ -101,17 +100,36 @@ KDTreeLinkerAlgo<DATA>::medianSearch(int	low,
   int nbrElts = high - low;
   int median = (nbrElts & 1)	? nbrElts / 2 
 				: nbrElts / 2 - 1;
-
   median += low;
 
-  // The even depth is associated to dim1 dimension
-  // The odd one to dim2 dimension
-  int dimIndex = treeDepth&1;
+  int l = low;
+  int m = high - 1;
+  
+  while (l < m) {
+    KDTreeNodeInfo<DATA> elt = (*initialEltList)[median];
+    int i = l;
+    int j = m;
 
-  auto beg = initialEltList->begin();
-  std::nth_element(beg+low, beg+median, beg+high, [=](const KDTreeNodeInfo<DATA>& a, const KDTreeNodeInfo<DATA>& b) {
-      return a.dim[dimIndex] < b.dim[dimIndex];
-    });
+    do {
+      // The even depth is associated to dim1 dimension
+      // The odd one to dim2 dimension
+      if (treeDepth & 1) {
+	while ((*initialEltList)[i].dim[1] < elt.dim[1]) i++;
+	while ((*initialEltList)[j].dim[1] > elt.dim[1]) j--;
+      } else {
+	while ((*initialEltList)[i].dim[0] < elt.dim[0]) i++;
+	while ((*initialEltList)[j].dim[0] > elt.dim[0]) j--;
+      }
+
+      if (i <= j){
+	std::swap((*initialEltList)[i], (*initialEltList)[j]);
+	i++; 
+	j--;
+      }
+    } while (i <= j);
+    if (j < median) l = i;
+    if (i > median) m = j;
+  }
 
   return median;
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h
@@ -5,6 +5,7 @@
 
 #include <cassert>
 #include <vector>
+#include<algorithm>
 
 // Class that implements the KDTree partition of 2D space and 
 // a closest point search algorithme.
@@ -103,36 +104,17 @@ KDTreeLinkerAlgo<DATA>::medianSearch(int	low,
   int nbrElts = high - low;
   int median = (nbrElts & 1)	? nbrElts / 2 
 				: nbrElts / 2 - 1;
+
   median += low;
 
-  int l = low;
-  int m = high - 1;
-  
-  while (l < m) {
-    KDTreeNodeInfo<DATA> elt = (*initialEltList)[median];
-    int i = l;
-    int j = m;
+  // The even depth is associated to dim1 dimension
+  // The odd one to dim2 dimension
+  int dimIndex = treeDepth&1;
 
-    do {
-      // The even depth is associated to dim1 dimension
-      // The odd one to dim2 dimension
-      if (treeDepth & 1) {
-	while ((*initialEltList)[i].dim[1] < elt.dim[1]) i++;
-	while ((*initialEltList)[j].dim[1] > elt.dim[1]) j--;
-      } else {
-	while ((*initialEltList)[i].dim[0] < elt.dim[0]) i++;
-	while ((*initialEltList)[j].dim[0] > elt.dim[0]) j--;
-      }
-
-      if (i <= j){
-	std::swap((*initialEltList)[i], (*initialEltList)[j]);
-	i++; 
-	j--;
-      }
-    } while (i <= j);
-    if (j < median) l = i;
-    if (i > median) m = j;
-  }
+  auto beg = initialEltList->begin();
+  std::nth_element(beg+low, beg+median, beg+high, [=](const KDTreeNodeInfo<DATA>& a, const KDTreeNodeInfo<DATA>& b) {
+      return a.dim[dimIndex] < b.dim[dimIndex];
+    });
 
   return median;
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h
@@ -189,7 +189,7 @@ KDTreeLinkerAlgo<DATA>::recSearch(int	current,
       float median = nodePool_.median[current];
 
       bool goLeft = (dimCurrMin <= median);
-      bool goRight = (dimCurrMax > median);
+      bool goRight = (dimCurrMax >= median);
 
       // Swap dimension for the next search level
       std::swap(dimCurrMin, dimOtherMin);

--- a/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h
@@ -148,31 +148,47 @@ KDTreeLinkerAlgo<DATA>::recSearch(int	current,
   assert (!(((nodePool_.left[current] < 0) && (nodePool_.right[current] >= 0)) ||
             ((nodePool_.left[current] >= 0) && (nodePool_.right[current] < 0))));
   */
-  int right = nodePool_.right[current];
+  while(true) {
+    int right = nodePool_.right[current];
+    if(nodePool_.isLeaf(right)) {
+      float dimCurr = nodePool_.median[current];
 
-  if (nodePool_.isLeaf(right)) {
-    float dimCurr = nodePool_.median[current];
-
-    // If point inside the rectangle/area
-    // Use intentionally bit-wise & instead of logical && for better
-    // performance. It is faster to always do all comparisons than to
-    // allow use of branches to not do some if any of the first ones
-    // is false.
-    if((dimCurr >= dimCurrMin) & (dimCurr <= dimCurrMax)) {
-      float dimOther = nodePool_.dimOther[current];
-      if((dimOther >= dimOtherMin) & (dimOther <= dimOtherMax)) {
-        closestNeighbour->push_back(nodePool_.data[current]);
+      // If point inside the rectangle/area
+      // Use intentionally bit-wise & instead of logical && for better
+      // performance. It is faster to always do all comparisons than to
+      // allow use of branches to not do some if any of the first ones
+      // is false.
+      if((dimCurr >= dimCurrMin) & (dimCurr <= dimCurrMax)) {
+        float dimOther = nodePool_.dimOther[current];
+        if((dimOther >= dimOtherMin) & (dimOther <= dimOtherMax)) {
+          closestNeighbour->push_back(nodePool_.data[current]);
+        }
       }
+      break;
     }
-  } else {
-    float median = nodePool_.median[current];
+    else {
+      float median = nodePool_.median[current];
 
-    if(dimCurrMin <= median) {
-      int left = current+1;
-      recSearch(left, dimOtherMin, dimOtherMax, dimCurrMin, dimCurrMax);
-    }
-    if(dimCurrMax > median) {
-      recSearch(right, dimOtherMin, dimOtherMax, dimCurrMin, dimCurrMax);
+      bool goLeft = (dimCurrMin <= median);
+      bool goRight = (dimCurrMax > median);
+
+      std::swap(dimCurrMin, dimOtherMin);
+      std::swap(dimCurrMax, dimOtherMax);
+      if(goLeft & goRight) {
+        int left = current+1;
+        recSearch(left, dimCurrMin, dimCurrMax, dimOtherMin, dimOtherMax);
+        // continue with right
+        current = right;
+      }
+      else if(goLeft) {
+        ++current;
+      }
+      else if(goRight) {
+        current = right;
+      }
+      else {
+        break;
+      }
     }
   }
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h
@@ -62,9 +62,6 @@ class KDTreeLinkerAlgo
                  float dimCurrMin, float dimCurrMax,
                  float dimOtherMin, float dimOtherMax);
 
-  // Add all elements of an subtree to the closest elements. Used during the recSearch().
-  void addSubtree(int			current);
-
   // This method frees the KDTree.     
   void clearTree();
 };
@@ -192,25 +189,6 @@ KDTreeLinkerAlgo<DATA>::recSearch(int	current,
     }
   }
 }
-
-template < typename DATA >
-void
-KDTreeLinkerAlgo<DATA>::addSubtree(int current)
-{
-  // By construction, current can't be null
-  // assert(current >= 0);
-
-  if (nodePool_.isLeaf(current)) {// leaf
-    closestNeighbour->push_back(nodePool_.info[current]);
-  }
-  else { // node
-    addSubtree(current+1);
-    addSubtree(nodePool_.right[current]);
-  }
-}
-
-
-
 
 template <typename DATA>
 KDTreeLinkerAlgo<DATA>::KDTreeLinkerAlgo()

--- a/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h
@@ -94,9 +94,6 @@ KDTreeLinkerAlgo<DATA>::medianSearch(int	low,
 				     int	high,
 				     int	treeDepth)
 {
-  //We should have at least 1 element to calculate the median...
-  //assert(low < high);
-
   int nbrElts = high - low;
   int median = (nbrElts & 1)	? nbrElts / 2 
 				: nbrElts / 2 - 1;
@@ -155,14 +152,6 @@ KDTreeLinkerAlgo<DATA>::recSearch(int	current,
                                   float dimCurrMin, float dimCurrMax,
                                   float dimOtherMin, float dimOtherMax)
 {
-  /*
-  // By construction, current can't be null
-  assert(current >= 0);
-
-  // By Construction, a node can't have just 1 son.
-  assert (!(((nodePool_.left[current] < 0) && (nodePool_.right[current] >= 0)) ||
-            ((nodePool_.left[current] >= 0) && (nodePool_.right[current] < 0))));
-  */
   // Iterate until leaf is found, or there are no children in the
   // search window. If search has to proceed on both children, proceed
   // the search to left child via recursion. Swap search window
@@ -248,9 +237,6 @@ KDTreeLinkerAlgo<DATA>::recBuild(int					low,
 {
   int portionSize = high - low;
   int dimIndex = depth&1;
-
-  // By construction, portionSize > 0 can't happend.
-  // assert(portionSize > 0);
 
   if (portionSize == 1) { // Leaf case
     int leaf = nodePool_.getNextNode();

--- a/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerTools.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerTools.h
@@ -49,37 +49,6 @@ struct KDTreeNodeInfo
   {}
 };
 
-// KDTree node.
-template <typename DATA>
-struct KDTreeNode
-{
-  // Data
-  KDTreeNodeInfo<DATA> info;
-  
-  // Right/left sons.
-  KDTreeNode *left, *right;
-  
-  // Region bounding box.
-  KDTreeBox region;
-  
-  public:
-  KDTreeNode()
-    : left(0), right(0)
-  {}
-  
-  void setAttributs(const KDTreeBox&		regionBox,
-		    const KDTreeNodeInfo<DATA>&	infoToStore) 
-  {
-    info = infoToStore;
-    region = regionBox;
-  }
-  
-  void setAttributs(const KDTreeBox&   regionBox) 
-  {
-    region = regionBox;
-  }
-};
-
 template <typename DATA>
 struct KDTreeNodes {
   std::vector<float> median; // or dimCurrent;

--- a/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerTools.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerTools.h
@@ -1,7 +1,6 @@
 #ifndef KDTreeLinkerToolsTemplated_h
 #define KDTreeLinkerToolsTemplated_h
 
-#include <assert.h>
 #include <algorithm>
 
 // Box structure used to define 2D field.
@@ -75,9 +74,6 @@ struct KDTreeNodes {
 
   int getNextNode() {
     ++poolPos;
-    // The tree size is exactly 2 * nbrElts - 1 and this is the total allocated memory.
-    // If we have used more than that....there is a big problem.
-    //assert(poolPos < poolSize);
     return poolPos;
   }
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerTools.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerTools.h
@@ -82,13 +82,10 @@ struct KDTreeNode
 
 template <typename DATA>
 struct KDTreeNodes {
-  struct Node {
-    Node(): median(0.0f), right(0) {}
-    float median;
-    int right;
-  };
-  std::vector<Node> nodes;
-  std::vector<KDTreeNodeInfo<DATA>> info;
+  std::vector<float> median; // or dimCurrent;
+  std::vector<int> right;
+  std::vector<float> dimOther;
+  std::vector<DATA> data;
 
   int poolSize;
   int poolPos;
@@ -99,8 +96,10 @@ struct KDTreeNodes {
   int size() const { return poolPos + 1; }
 
   void clear() {
-    nodes.clear();
-    info.clear();
+    median.clear();
+    right.clear();
+    dimOther.clear();
+    data.clear();
     poolSize = -1;
     poolPos = -1;
   }
@@ -115,16 +114,22 @@ struct KDTreeNodes {
 
   void build(int sizeData) {
     poolSize = sizeData*2-1;
-    nodes.resize(poolSize);
-    info.resize(poolSize);
+    median.resize(poolSize);
+    right.resize(poolSize);
+    dimOther.resize(poolSize);
+    data.resize(poolSize);
   };
 
-  bool isLeaf(int index) const {
+  constexpr bool isLeaf(int right) const {
     // Valid values of right are always >= 2
     // index 0 is the root, and 1 is the first left node
     // Exploit index values 0 and 1 to mark which of dim1/dim2 is the
     // current one in recSearch() at the depth of the leaf.
-    return nodes[index].right < 2;
+    return right < 2;
+  }
+
+  bool isLeafIndex(int index) const {
+    return isLeaf(right[index]);
   }
 };
 


### PR DESCRIPTION
The improvements come mainly from
- Reorganized data structure of KDTreeLinkerAlgo<T> (more compact in Structure-of-Arrays style)
  - The interface of KDTreeLinkerAlgo::search() had to be modified slightly, and now only the data items are returned (returning of coordinates was dropped)
- Decreased amount of branching and recursive function calls in KDTreeLinkerAlgo::recSearch()
- Use of std::nth_element() instead of hand-written Wirth algorithm in the kdtree building

The physics results of seeding should stay the same (tested in 612_SLHC6). Timing improvement in a standalone test of KDTreeLinkerAlgo::recSearch() was roughly 40 %. In CMSSW at very high pileup (140) the timing of seeding (SeedGeneratorFromRegionHitsEDProducer::produce()) improved by roughly 3 %.
