### PR TITLE
Performance improvement in quadruplet seeding (62X_SLHC)

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/interface/QuadrupletSeedMerger.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/QuadrupletSeedMerger.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 #include <functional>
+#include <tuple>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -106,26 +107,6 @@ class QuadrupletSeedMerger {
 			  const TrackerTopology *tTopo) const; 
 
     // bool isValidQuadruplet( const SeedingHitSet&, const std::vector<SeedMergerPixelLayer>& ) const;
-
-bool isTripletsShareHitsOnLayers( const SeedingHitSet& firstTriplet, const SeedingHitSet& secondTriplet, 
-				  const SeedMergerPixelLayer &share1, const SeedMergerPixelLayer &share2,
-				  std::pair<TransientTrackingRecHit::ConstRecHitPointer,TransientTrackingRecHit::ConstRecHitPointer>& hits,
-				  const TrackerTopology *tTopo) const;
-
-//bool isTripletsShareHitsOnLayers( const SeedingHitSet&, const SeedingHitSet&, 
-//   const std::pair<SeedMergerPixelLayer, SeedMergerPixelLayer>&,
-//  std::pair<TransientTrackingRecHit::ConstRecHitPointer,TransientTrackingRecHit::ConstRecHitPointer>& ) const;
-//
-//  bool isMergeableHitsInTriplets( const SeedingHitSet&, const SeedingHitSet&, 
-//    const std::pair<SeedMergerPixelLayer, SeedMergerPixelLayer>&,
-//    std::pair<TransientTrackingRecHit::ConstRecHitPointer,TransientTrackingRecHit::ConstRecHitPointer>& ) const;
-
-bool isMergeableHitsInTriplets( const SeedingHitSet& firstTriplet, const SeedingHitSet& secondTriplet, 
-				const SeedMergerPixelLayer &nonShared1, const SeedMergerPixelLayer &nonShared2,
-				std::pair<TransientTrackingRecHit::ConstRecHitPointer,TransientTrackingRecHit::ConstRecHitPointer>& hits,
-				const TrackerTopology *tTopo) const;
-
-
 
   ctfseeding::SeedingLayerSets theLayerSets_;
   edm::ESHandle<TrackerGeometry> theTrackerGeometry_;

--- a/RecoPixelVertexing/PixelTriplets/interface/QuadrupletSeedMerger.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/QuadrupletSeedMerger.h
@@ -3,7 +3,7 @@
 #include <memory>
 #include <vector>
 #include <functional>
-#include <tuple>
+#include <array>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -96,15 +96,10 @@ class QuadrupletSeedMerger {
   void setTTRHBuilderLabel( std::string );
 
  private:
+  typedef std::array<TransientTrackingRecHit::ConstRecHitPointer, 4> QuadrupletHits;
+  void mySort(QuadrupletHits& unsortedHits);
 
-  std::vector<TransientTrackingRecHit::ConstRecHitPointer> mySort(TransientTrackingRecHit::ConstRecHitPointer &h1,
-								  TransientTrackingRecHit::ConstRecHitPointer &h2,
-								  TransientTrackingRecHit::ConstRecHitPointer &h3,
-								  TransientTrackingRecHit::ConstRecHitPointer &h4);
-    
-
-  bool isValidQuadruplet( std::vector<TransientTrackingRecHit::ConstRecHitPointer> &quadruplet, const std::vector<SeedMergerPixelLayer>& layers,
-			  const TrackerTopology *tTopo) const; 
+  bool isValidQuadruplet(const QuadrupletHits& quadruplet, const std::vector<SeedMergerPixelLayer>& layers, const TrackerTopology *tTopo) const;
 
     // bool isValidQuadruplet( const SeedingHitSet&, const std::vector<SeedMergerPixelLayer>& ) const;
 

--- a/RecoPixelVertexing/PixelTriplets/interface/QuadrupletSeedMerger.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/QuadrupletSeedMerger.h
@@ -85,7 +85,6 @@ class QuadrupletSeedMerger {
   //const std::vector<SeedingHitSet> mergeTriplets( const OrderedSeedingHits&, const edm::EventSetup& );
   const OrderedSeedingHits& mergeTriplets( const OrderedSeedingHits&, const edm::EventSetup& );
   const TrajectorySeedCollection mergeTriplets( const TrajectorySeedCollection&, const TrackingRegion&, const edm::EventSetup&, const edm::ParameterSet& );
-  bool isEqual( const TrackingRecHit*, const TrackingRecHit* ) const;
   std::pair<double,double> calculatePhiEta( SeedingHitSet const& ) const;
   void printHit( const TrackingRecHit* ) const;
   void printHit( const  TransientTrackingRecHit::ConstRecHitPointer& ) const;

--- a/RecoPixelVertexing/PixelTriplets/src/QuadrupletSeedMerger.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/QuadrupletSeedMerger.cc
@@ -273,7 +273,6 @@ const OrderedSeedingHits& QuadrupletSeedMerger::mergeTriplets( const OrderedSeed
   }
   nodes.clear();
 
-
   for( ctfseeding::SeedingLayerSets::const_iterator lsIt = theLayerSets_.begin(); lsIt < theLayerSets_.end(); ++lsIt ) {
 
     // fill a vector with the layers in this set
@@ -309,8 +308,6 @@ const OrderedSeedingHits& QuadrupletSeedMerger::mergeTriplets( const OrderedSeed
             sharedHits.first = firstTriplet[nonSharedToShared[t1NonShared][0]];
             sharedHits.second = firstTriplet[nonSharedToShared[t1NonShared][1]];
 
-	    //    if ( !phiEtaClose[t1*nInputTriplets+t2] ) continue;
-
             // are the shared hits on these two layers?
             if(areHitsOnLayers(currentLayers[s1], currentLayers[s2], sharedHits, tTopo)) {
               short t2NonShared = t2NonSharedHitList[t12];
@@ -320,10 +317,10 @@ const OrderedSeedingHits& QuadrupletSeedMerger::mergeTriplets( const OrderedSeed
 
 	      // are the remaining hits on different layers?
               if(areHitsOnLayers(currentLayers[nonSharedLayerNums[0]], currentLayers[nonSharedLayerNums[1]], nonSharedHits, tTopo)) {
-		std::vector<TransientTrackingRecHit::ConstRecHitPointer> unsortedHits=mySort(sharedHits.first,
-											     sharedHits.second,
-											     nonSharedHits.first,
-											     nonSharedHits.second);
+                QuadrupletHits unsortedHits{ {sharedHits.first, sharedHits.second,
+                      nonSharedHits.first, nonSharedHits.second} };
+
+                mySort(unsortedHits);
 
 		//start here with old addtoresult
 		if( isValidQuadruplet( unsortedHits, currentLayers, tTopo ) ) {
@@ -637,8 +634,7 @@ void QuadrupletSeedMerger::setAddRemainingTriplets( bool isAddTriplets ) {
 ///  1. after sorting, hits must be on layers according to the 
 ///     order given in PixelSeedMergerQuadruplets (from cfg)
 ///
-bool QuadrupletSeedMerger::isValidQuadruplet( std::vector<TransientTrackingRecHit::ConstRecHitPointer> &quadruplet, const std::vector<SeedMergerPixelLayer>& layers,
-					      const TrackerTopology *tTopo) const {
+bool QuadrupletSeedMerger::isValidQuadruplet(const QuadrupletHits &quadruplet, const std::vector<SeedMergerPixelLayer>& layers, const TrackerTopology *tTopo) const {
 
   const unsigned int quadrupletSize = quadruplet.size();
 
@@ -758,18 +754,7 @@ bool SeedMergerPixelLayer::isContainsDetector( const DetId& detId, const Tracker
 }
 
 
-std::vector<TransientTrackingRecHit::ConstRecHitPointer> QuadrupletSeedMerger::mySort(TransientTrackingRecHit::ConstRecHitPointer &h1,
-										      TransientTrackingRecHit::ConstRecHitPointer &h2,
-										      TransientTrackingRecHit::ConstRecHitPointer &h3,
-										      TransientTrackingRecHit::ConstRecHitPointer &h4) {
-  // create an intermediate vector with all hits
-  std::vector<TransientTrackingRecHit::ConstRecHitPointer> unsortedHits;
-  unsortedHits.reserve(4);
-  unsortedHits.push_back( h1);
-  unsortedHits.push_back( h2);
-  unsortedHits.push_back( h3);
-  unsortedHits.push_back( h4);
-  
+void QuadrupletSeedMerger::mySort(std::array<TransientTrackingRecHit::ConstRecHitPointer, 4>& unsortedHits) {
   float radiiSq[4];
   for ( unsigned int iR=0; iR<4; iR++){
     const GeomDet* geom1=theTrackerGeometry_->idToDet( unsortedHits[iR]->hit()->geographicalId() );
@@ -790,7 +775,6 @@ std::vector<TransientTrackingRecHit::ConstRecHitPointer> QuadrupletSeedMerger::m
       }
     }
   }
-  return unsortedHits;
 }
 
 

--- a/RecoPixelVertexing/PixelTriplets/src/QuadrupletSeedMerger.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/QuadrupletSeedMerger.cc
@@ -570,7 +570,7 @@ bool QuadrupletSeedMerger::isTripletsShareHitsOnLayers( const SeedingHitSet& fir
     { // first triplet
       if( ! firstTriplet[index]->isValid() ) return false; // catch invalid TTRH pointers (tbd: erase triplet)
       bool firsthit(false); // Don't look in second layer if found in first
-      DetId const& thisDetId = firstTriplet[index]->hit()->geographicalId();
+      DetId const& thisDetId = firstTriplet[index]->geographicalId();
       
       if( ! isSuccess1[0] ) { // first triplet on shared layer 1
 	if( shared1.isContainsDetector( thisDetId, tTopo ) ) {
@@ -593,7 +593,7 @@ bool QuadrupletSeedMerger::isTripletsShareHitsOnLayers( const SeedingHitSet& fir
       { // second triplet
 	if( ! secondTriplet[index]->isValid() ) { return false; } // catch invalid TTRH pointers (tbd: erase triplet)
 	bool firsthit(false); // Don't look in second layer if found in first
-	DetId const& thisDetId = secondTriplet[index]->hit()->geographicalId();
+	DetId const& thisDetId = secondTriplet[index]->geographicalId();
 	
 	if( ! isSuccess2[0] ) { // second triplet on shared layer 1
 	  if( shared1.isContainsDetector( thisDetId, tTopo ) ) {
@@ -644,13 +644,13 @@ bool QuadrupletSeedMerger::isMergeableHitsInTriplets( const SeedingHitSet& first
   for( unsigned int index1 = 0; index1 < 3; ++index1 ) {
     
     { // first triplet on non-shared layer 1
-      DetId const& aDetId = firstTriplet[index1]->hit()->geographicalId();
+      DetId const& aDetId = firstTriplet[index1]->geographicalId();
       if( nonShared1.isContainsDetector( aDetId, tTopo ) ) {
 	
 	// look for hit in other (second) triplet on other layer
 	for( unsigned int index2 = 0; index2 < 3; ++index2 ) {
 	  
-	  DetId const& anotherDetId = secondTriplet[index2]->hit()->geographicalId();
+	  DetId const& anotherDetId = secondTriplet[index2]->geographicalId();
 	  if( nonShared2.isContainsDetector( anotherDetId, tTopo ) ) {
 	    
 	    // ok!
@@ -666,13 +666,13 @@ bool QuadrupletSeedMerger::isMergeableHitsInTriplets( const SeedingHitSet& first
     // and vice versa..
 
     { // second triplet on non-shared layer 1
-      DetId const& aDetId = secondTriplet[index1]->hit()->geographicalId();
+      DetId const& aDetId = secondTriplet[index1]->geographicalId();
       if( nonShared1.isContainsDetector( aDetId, tTopo ) ) {
 	
 	// look for hit in other (second) triplet on other layer
 	for( unsigned int index2 = 0; index2 < 3; ++index2 ) {
 	  
-	  DetId const& anotherDetId = firstTriplet[index2]->hit()->geographicalId();
+	  DetId const& anotherDetId = firstTriplet[index2]->geographicalId();
 	  if( nonShared2.isContainsDetector( anotherDetId, tTopo ) ) {
 	    
 	    // ok!

--- a/RecoPixelVertexing/PixelTriplets/src/QuadrupletSeedMerger.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/QuadrupletSeedMerger.cc
@@ -1,8 +1,14 @@
-
 #include "RecoPixelVertexing/PixelTriplets/interface/QuadrupletSeedMerger.h"
+#include "RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerAlgo.h"
+#include "RecoPixelVertexing/PixelTriplets/plugins/KDTreeLinkerTools.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
+
+#include "DataFormats/GeometryVector/interface/Pi.h"
+
 #include <time.h>
+#include <cmath>
+#include <algorithm>
 
 /***
 
@@ -131,36 +137,49 @@ const OrderedSeedingHits& QuadrupletSeedMerger::mergeTriplets( const OrderedSeed
   std::pair<TransientTrackingRecHit::ConstRecHitPointer,TransientTrackingRecHit::ConstRecHitPointer> sharedHits;
   std::pair<TransientTrackingRecHit::ConstRecHitPointer,TransientTrackingRecHit::ConstRecHitPointer> nonSharedHits;
 
-  //std::vector<bool> phiEtaClose(nInputTriplets*nInputTriplets,true);
+  // k-d tree, indices are (th)eta, phi
+  // build the tree
+  std::vector<KDTreeNodeInfo<unsigned int> > nodes; // re-use for searching too
+  nodes.reserve(2*nInputTriplets);
+  KDTreeLinkerAlgo<unsigned int> kdtree;
+  double minEta=1e10, maxEta=-1e10;
+  for(unsigned int it=0; it < nInputTriplets; ++it) {
+    double phi = phiEtaCache[it].first;
+    double eta = phiEtaCache[it].second;
+    nodes.push_back(KDTreeNodeInfo<unsigned int>(it, eta, phi));
+    minEta = std::min(minEta, eta);
+    maxEta = std::max(maxEta, eta);
 
-  //  for (unsigned int t1=0; t1<nInputTriplets-1; t1++) {
-  //  for (unsigned int t2=t1+1; t2<nInputTriplets; t2++) {
-  //    if( fabs( phiEtaCache[t1].second - phiEtaCache[t2].second ) > 0.05 ) {
-  //	phiEtaClose[t1*nInputTriplets+t2]=false;
-  //	phiEtaClose[t2*nInputTriplets+t1]=false;
-  //	continue;
-  //   }
-  //   double temp = fabs( phiEtaCache[t1].first - phiEtaCache[t2].first );
-  //   if( (temp > 0.15) && (temp <6.133185) ) {
-  //phiEtaClose[t1*nInputTriplets+t2]=false;
-  //phiEtaClose[t2*nInputTriplets+t1]=false;
-  //  }
-  //}
-  //}
- 
+    // to wrap all points in phi
+    // if(phi < 0) phi += twoPi(); else phi -= twoPi();
+    double twoPi = std::copysign(Geom::twoPi(), phi);
+    nodes.push_back(KDTreeNodeInfo<unsigned int>(it, eta, phi-twoPi));
+  }
+  KDTreeBox kdEtaPhi(minEta-0.01, maxEta+0.01, -1*Geom::twoPi(), Geom::twoPi());
+  kdtree.build(nodes, kdEtaPhi);
+  nodes.clear();
+  
+  // loop over triplets, search for close-by triplets by using the k-d tree
   std::vector<unsigned int> t1List;
   std::vector<unsigned int> t2List;
-  for (unsigned int t1=0; t1<nInputTriplets-1; t1++) {
+  std::vector<unsigned int> t2Tmp; // temporary to sort t2's before insertion to t2List
+  for(unsigned int t1=0; t1<nInputTriplets; ++t1) {
+    double phi = phiEtaCache[t1].first;
+    double eta = phiEtaCache[t1].second;
+
+    KDTreeBox box(eta-0.05, eta+0.05, phi-0.15, phi+0.15);
+    nodes.clear();
+    kdtree.search(box, nodes);
+    if(nodes.empty())
+      continue;
+
     const SeedingHitSet& tr1 = tripletCache[t1];
     const TrackingRecHit *tr1h[3] = {tr1[0]->hit(), tr1[1]->hit(), tr1[2]->hit()};
 
-    for (unsigned int t2=t1+1; t2<nInputTriplets; t2++) {
-      if( fabs( phiEtaCache[t1].second - phiEtaCache[t2].second ) > 0.05 ) 
-  	continue;
-      double temp = fabs( phiEtaCache[t1].first - phiEtaCache[t2].first );
-      if( (temp > 0.15) && (temp <6.133185) ) {
-	continue;
-      }
+    for(size_t i=0; i<nodes.size(); ++i) {
+      unsigned int t2 = nodes[i].data;
+      if(t1 >= t2)
+        continue;
 
       // Ensure here that the triplet pairs share two hits.
       const SeedingHitSet& tr2 = tripletCache[t2];
@@ -192,10 +211,19 @@ const OrderedSeedingHits& QuadrupletSeedMerger::mergeTriplets( const OrderedSeed
           continue;
       }
 
+      t2Tmp.push_back(t2);
+    }
+
+    // Sort to increasing order in t2 in order to get exactly same result as before
+    std::sort(t2Tmp.begin(), t2Tmp.end());
+    for(unsigned int t2: t2Tmp) {
       t1List.push_back(t1);
       t2List.push_back(t2);
     }
+    t2Tmp.clear();
   }
+  nodes.clear();
+
 
   for( ctfseeding::SeedingLayerSets::const_iterator lsIt = theLayerSets_.begin(); lsIt < theLayerSets_.end(); ++lsIt ) {
 

--- a/RecoPixelVertexing/PixelTriplets/src/QuadrupletSeedMerger.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/QuadrupletSeedMerger.cc
@@ -42,6 +42,15 @@ namespace {
             (layer1.isContainsDetector(secondHitId, tTopo) &&
              layer2.isContainsDetector(firstHitId, tTopo)));
   }
+
+  bool areHitsEqual(const TransientTrackingRecHit& hit1, const TransientTrackingRecHit& hit2) {
+    constexpr double epsilon = 0.00001;
+    if(hit1.geographicalId() != hit2.geographicalId())
+      return false;
+
+    LocalPoint lp1 = hit1.localPosition(), lp2 = hit2.localPosition();
+    return std::abs(lp1.x() - lp2.x()) < epsilon && std::abs(lp1.y() - lp2.y()) < epsilon;
+  }
 }
 
 
@@ -204,7 +213,6 @@ const OrderedSeedingHits& QuadrupletSeedMerger::mergeTriplets( const OrderedSeed
       continue;
 
     const SeedingHitSet& tr1 = tripletCache[t1];
-    const TrackingRecHit *tr1h[3] = {tr1[0]->hit(), tr1[1]->hit(), tr1[2]->hit()};
 
     for(size_t i=0; i<nodes.size(); ++i) {
       unsigned int t2 = nodes[i].data;
@@ -213,7 +221,6 @@ const OrderedSeedingHits& QuadrupletSeedMerger::mergeTriplets( const OrderedSeed
 
       // Ensure here that the triplet pairs share two hits.
       const SeedingHitSet& tr2 = tripletCache[t2];
-      const TrackingRecHit *tr2h[3] = {tr2[0]->hit(), tr2[1]->hit(), tr2[2]->hit()};
 
       // If neither of first two hits in tr1 are found from tr2, this
       // pair can be skipped
@@ -226,7 +233,7 @@ const OrderedSeedingHits& QuadrupletSeedMerger::mergeTriplets( const OrderedSeed
       unsigned int t2Shared = 0;
       for(unsigned int i=0; i<2; ++i) {
         for(unsigned int j=0; j<3; ++j) {
-          if(isEqual(tr1h[i], tr2h[j])) {
+          if(areHitsEqual(*tr1[i], *tr2[j])) {
             t1Shared |= (1<<i);
             t2Shared |= (1<<j);
             ++equalHits;
@@ -240,7 +247,7 @@ const OrderedSeedingHits& QuadrupletSeedMerger::mergeTriplets( const OrderedSeed
       // hits is not 2, this pair can be skipped
       if(equalHits != 2) {
         for(unsigned int j=0; j<3; ++j) {
-          if(isEqual(tr1h[2], tr2h[j])) {
+          if(areHitsEqual(*tr1[2], *tr2[j])) {
             t1Shared |= (1<<2);
             t2Shared |= (1<<j);
             ++equalHits;
@@ -462,29 +469,6 @@ const TrajectorySeedCollection QuadrupletSeedMerger::mergeTriplets( const Trajec
 }
 
 
-
-///
-///
-///
-bool QuadrupletSeedMerger::isEqual( const TrackingRecHit* hit1, const TrackingRecHit* hit2 ) const {
-
-  const double epsilon = 0.00001;
-  
-  DetId det1 =  hit1->geographicalId(), det2 =  hit2->geographicalId();
-  if (det1 == det2) { 
-    LocalPoint lp1 = hit1->localPosition(), lp2 = hit2->localPosition();
-    if( ( fabs( lp1.x() - lp2.x() ) < epsilon ) &&
-	( fabs( lp1.y() - lp2.y() ) < epsilon ) ) {
-      return true;
-    }
-    
-  }
-  return false;
-  
-}
-
-
-
 ///
 ///
 ///
@@ -495,14 +479,8 @@ std::pair<double,double> QuadrupletSeedMerger::calculatePhiEta( SeedingHitSet co
 //     throw; // tbr.
 //   }
 
-  const TrackingRecHit* hit1 = nTuplet[0]->hit();
-  const GeomDet* geomDet1 = theTrackerGeometry_->idToDet( hit1->geographicalId() );
-
-  const TrackingRecHit* hit2 = nTuplet[1]->hit();
-  const GeomDet* geomDet2 = theTrackerGeometry_->idToDet( hit2->geographicalId() );
-
-  GlobalPoint p1=geomDet1->toGlobal( hit1->localPosition() );
-  GlobalPoint p2=geomDet2->toGlobal( hit2->localPosition() );
+  GlobalPoint p1 = nTuplet[0]->globalPosition();
+  GlobalPoint p2 = nTuplet[1]->globalPosition();
 
   const double x1 = p1.x();
   const double x2 = p2.x();
@@ -757,8 +735,7 @@ bool SeedMergerPixelLayer::isContainsDetector( const DetId& detId, const Tracker
 void QuadrupletSeedMerger::mySort(std::array<TransientTrackingRecHit::ConstRecHitPointer, 4>& unsortedHits) {
   float radiiSq[4];
   for ( unsigned int iR=0; iR<4; iR++){
-    const GeomDet* geom1=theTrackerGeometry_->idToDet( unsortedHits[iR]->hit()->geographicalId() );
-    GlobalPoint p1=geom1->toGlobal(  unsortedHits[iR]->hit()->localPosition() );
+    GlobalPoint p1 = unsortedHits[iR]->globalPosition();
     radiiSq[iR]=( p1.x()*p1.x()+p1.y()*p1.y()); // no need to take the sqrt
   }
   TransientTrackingRecHit::ConstRecHitPointer tempRHP;

--- a/RecoPixelVertexing/PixelTriplets/src/QuadrupletSeedMerger.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/QuadrupletSeedMerger.cc
@@ -6,9 +6,14 @@
 
 #include "DataFormats/GeometryVector/interface/Pi.h"
 
-#include <time.h>
-#include <cmath>
 #include <algorithm>
+
+namespace {
+  template <typename T>
+  constexpr T sqr(T x) {
+    return x*x;
+  }
+}
 
 /***
 
@@ -490,7 +495,7 @@ std::pair<double,double> QuadrupletSeedMerger::calculatePhiEta( SeedingHitSet co
   const double z2 = p2.z();
 
   const double phi = atan2( x2 - x1, y2 -y1 );
-  const double eta = acos( (z2 - z1) / sqrt( pow( x2 - x1, 2. ) + pow( y2 - y1, 2. ) + pow( z2 - z1, 2. ) ) ); // this is theta angle in reality
+  const double eta = acos( (z2 - z1) / sqrt( sqr( x2 - x1 ) + sqr( y2 - y1 ) + sqr( z2 - z1 ) ) ); // this is theta angle in reality
 
   std::pair<double,double> retVal;
   retVal=std::make_pair (phi,eta);


### PR DESCRIPTION
These changes improve the CPU performance of the quadruplet seed generation used with Phase1 pixel geometry. Only the implementation of the QuadrupletSeedMerger is altered, the results should stay the same (tested with MultiTrackValidator and TrackerSeedValidator using 50 ttbar events with PU 35 in 620_SLHC1).

Forward port of PR #126.
