### PR TITLE
Consumes to CSCSharesInput

### DIFF
--- a/DataFormats/CSCRecHit/test/CSCSharesInputTest.cc
+++ b/DataFormats/CSCRecHit/test/CSCSharesInputTest.cc
@@ -5,17 +5,17 @@
 #include <sstream>
 #include <iostream>
 
-#include "DataFormats/MuonReco/interface/Muon.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
 #include "DataFormats/CSCRecHit/interface/CSCRecHit2D.h"
-#include "DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h"
-#include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "DataFormats/TrackReco/interface/Track.h"
 
-
-CSCSharesInputTest::CSCSharesInputTest(const edm::ParameterSet &myConfig):
-cscRecHitTag_(myConfig.getParameter<edm::InputTag>("CSCRecHitCollection")),
-muonTag_(myConfig.getParameter<edm::InputTag>("MuonCollection"))
+CSCSharesInputTest::CSCSharesInputTest(const edm::ParameterSet &myConfig)
 {
+
+  rh_token = consumes<CSCRecHit2DCollection>(myConfig.getParameter<edm::InputTag>("CSCRecHitCollection"));
+  mu_token = consumes<edm::View<reco::Muon> >(myConfig.getParameter<edm::InputTag>("MuonCollection"));
 
 	// Set up plots, ntuples
 	edm::Service<TFileService> rootFile;
@@ -40,11 +40,12 @@ void CSCSharesInputTest::analyze(const edm::Event &myEvent, const edm::EventSetu
   ++counts_["Events"]; // presuming default init of int elem to zero
 	
 	edm::Handle< edm::View<reco::Muon> > muonHandle;
-	myEvent.getByLabel(muonTag_, muonHandle);
+	myEvent.getByToken(mu_token, muonHandle);
+
 	edm::View<reco::Muon> muons = *muonHandle;
 	
 	edm::Handle<CSCRecHit2DCollection> recHits;
-	myEvent.getByLabel(cscRecHitTag_, recHits);
+	myEvent.getByToken(rh_token, recHits);
 	
 	// Muons:RecHits:TrackingRecHits:AllMatchedRecHits:SomeMatchedRecHits:AllWiresMatchedRecHits:SomeWiresMatchedRecHits:AllStripsMatchedRecHits:SomeStripsMatchedRecHits:NotMatchedRecHits
 	float perEventData[10] = {0,0,0,0,0,0,0,0,0,0};

--- a/DataFormats/CSCRecHit/test/CSCSharesInputTest.h
+++ b/DataFormats/CSCRecHit/test/CSCSharesInputTest.h
@@ -1,25 +1,25 @@
-//
-// Package:    SharesInputTest
-// Class:      SharesInputTest
-// 
-
-//
-// Original Author:  Phillip Killewald
-//         Created:  Thu Jan 29 17:33:51 CET 2009
-//
-
+/**
+ *  Test analyser: SharesInputTest
+ *
+ * Original Author:  Phillip Killewald
+ *         Created:  Thu Jan 29 17:33:51 CET 2009
+ */
 
 #include <map>
 #include <string>
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+#include "DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+
 #include "TNtuple.h"
 
 
@@ -36,8 +36,9 @@ class CSCSharesInputTest : public edm::EDAnalyzer {
 		
 		virtual void endJob();
 		
-		edm::InputTag cscRecHitTag_;
-		edm::InputTag muonTag_;
+
+		edm::EDGetTokenT<CSCRecHit2DCollection> rh_token;
+		edm::EDGetTokenT<edm::View<reco::Muon> > mu_token;
 		
 		std::map<std::string, uint64_t> counts_;
 		


### PR DESCRIPTION
Adds consumes interface to test of CSCSharesInput in DataFormats/CSCRecHit/test.
