### PR TITLE
Thread safe callbacks from Service system will not give access to Run, LuminosityBlock or Event

### DIFF
--- a/FWCore/Framework/interface/OccurrenceTraits.h
+++ b/FWCore/Framework/interface/OccurrenceTraits.h
@@ -57,7 +57,7 @@ namespace edm {
       ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext, nullptr);
       Event ev(*ep, ModuleDescription(), &moduleCallingContext);
       a->postProcessEventSignal_(ev, *es);
-      a->postEventSignal_(*streamContext, ev, *es);
+      a->postEventSignal_(*streamContext);
     }
     static void prePathSignal(ActivityRegistry *a, std::string const& s, PathContext const* pathContext) {
       a->preProcessPathSignal_(s);
@@ -183,8 +183,7 @@ namespace edm {
       edm::ModuleDescription modDesc("postScheduledSignal", "");
       ParentContext parentContext(streamContext);
       ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext, nullptr);
-      Run run(*ep, ModuleDescription(), &moduleCallingContext);
-      a->postStreamEndRunSignal_(*streamContext, run, *es);
+      a->postStreamEndRunSignal_(*streamContext);
     }
     static void prePathSignal(ActivityRegistry *a, std::string const& s, PathContext const* pathContext) {
     }
@@ -226,7 +225,7 @@ namespace edm {
       ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext, nullptr);
       Run run(*ep, ModuleDescription(), &moduleCallingContext);
       a->postEndRunSignal_(run, *es);
-      a->postGlobalEndRunSignal_(*globalContext, run, *es);
+      a->postGlobalEndRunSignal_(*globalContext);
     }
     static void prePathSignal(ActivityRegistry *a, std::string const& s, PathContext const* pathContext) {
       a->prePathEndRunSignal_(s);
@@ -353,7 +352,7 @@ namespace edm {
       ParentContext parentContext(streamContext);
       ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext, nullptr);
       LuminosityBlock lumi(*ep, ModuleDescription(), &moduleCallingContext);
-      a->postStreamEndLumiSignal_(*streamContext, lumi, *es);
+      a->postStreamEndLumiSignal_(*streamContext);
     }
     static void prePathSignal(ActivityRegistry *a, std::string const& s, PathContext const* pathContext) {
     }
@@ -395,7 +394,7 @@ namespace edm {
       ModuleCallingContext moduleCallingContext(&modDesc, ModuleCallingContext::State::kRunning, parentContext, nullptr);
       LuminosityBlock lumi(*ep, ModuleDescription(), &moduleCallingContext);
       a->postEndLumiSignal_(lumi, *es);
-      a->postGlobalEndLumiSignal_(*globalContext, lumi, *es); 
+      a->postGlobalEndLumiSignal_(*globalContext); 
     }
     static void prePathSignal(ActivityRegistry *a, std::string const& s, PathContext const* pathContext) {
       a->prePathEndLumiSignal_(s); 

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -234,12 +234,12 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPreGlobalEndRun)
 
-        typedef signalslot::Signal<void(GlobalContext const&, Run const&, EventSetup const&)> PostGlobalEndRun;
+        typedef signalslot::Signal<void(GlobalContext const&)> PostGlobalEndRun;
       PostGlobalEndRun postGlobalEndRunSignal_;
       void watchPostGlobalEndRun(PostGlobalEndRun::slot_type const& iSlot) {
          postGlobalEndRunSignal_.connect_front(iSlot);
       }
-      AR_WATCH_USING_METHOD_3(watchPostGlobalEndRun)
+      AR_WATCH_USING_METHOD_1(watchPostGlobalEndRun)
       
       typedef signalslot::Signal<void(StreamContext const&)> PreStreamBeginRun;
       PreStreamBeginRun preStreamBeginRunSignal_;
@@ -262,12 +262,12 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPreStreamEndRun)
 
-      typedef signalslot::Signal<void(StreamContext const&, Run const&, EventSetup const&)> PostStreamEndRun;
+      typedef signalslot::Signal<void(StreamContext const&)> PostStreamEndRun;
       PostStreamEndRun postStreamEndRunSignal_;
       void watchPostStreamEndRun(PostStreamEndRun::slot_type const& iSlot) {
          postStreamEndRunSignal_.connect_front(iSlot);
       }
-      AR_WATCH_USING_METHOD_3(watchPostStreamEndRun)
+      AR_WATCH_USING_METHOD_1(watchPostStreamEndRun)
       
       typedef signalslot::Signal<void(GlobalContext const&)> PreGlobalBeginLumi;
       PreGlobalBeginLumi preGlobalBeginLumiSignal_;
@@ -290,12 +290,12 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPreGlobalEndLumi)
 
-      typedef signalslot::Signal<void(GlobalContext const&, LuminosityBlock const&, EventSetup const&)> PostGlobalEndLumi;
+      typedef signalslot::Signal<void(GlobalContext const&)> PostGlobalEndLumi;
       PostGlobalEndLumi postGlobalEndLumiSignal_;
       void watchPostGlobalEndLumi(PostGlobalEndLumi::slot_type const& iSlot) {
          postGlobalEndLumiSignal_.connect_front(iSlot);
       }
-      AR_WATCH_USING_METHOD_3(watchPostGlobalEndLumi)
+      AR_WATCH_USING_METHOD_1(watchPostGlobalEndLumi)
       
       typedef signalslot::Signal<void(StreamContext const&)> PreStreamBeginLumi;
       PreStreamBeginLumi preStreamBeginLumiSignal_;
@@ -318,12 +318,12 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPreStreamEndLumi)
 
-      typedef signalslot::Signal<void(StreamContext const&, LuminosityBlock const&, EventSetup const&)> PostStreamEndLumi;
+      typedef signalslot::Signal<void(StreamContext const&)> PostStreamEndLumi;
       PostStreamEndLumi postStreamEndLumiSignal_;
       void watchPostStreamEndLumi(PostStreamEndLumi::slot_type const& iSlot) {
          postStreamEndLumiSignal_.connect_front(iSlot);
       }
-      AR_WATCH_USING_METHOD_3(watchPostStreamEndLumi)
+      AR_WATCH_USING_METHOD_1(watchPostStreamEndLumi)
 
       typedef signalslot::Signal<void(StreamContext const&)> PreEvent;
       /// signal is emitted after the Event has been created by the InputSource but before any modules have seen the Event
@@ -333,13 +333,13 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_1(watchPreEvent)
 
-      typedef signalslot::Signal<void(StreamContext const&, Event const&, EventSetup const&)> PostEvent;
+      typedef signalslot::Signal<void(StreamContext const&)> PostEvent;
       /// signal is emitted after all modules have finished processing the Event
       PostEvent postEventSignal_;
       void watchPostEvent(PostEvent::slot_type const& iSlot) {
          postEventSignal_.connect_front(iSlot);
       }
-      AR_WATCH_USING_METHOD_3(watchPostEvent)
+      AR_WATCH_USING_METHOD_1(watchPostEvent)
 
       /// signal is emitted before starting to process a Path for an event
         typedef signalslot::Signal<void(StreamContext const&, PathContext const&)> PrePathEvent;

--- a/FWCore/Services/src/Tracer.cc
+++ b/FWCore/Services/src/Tracer.cc
@@ -14,8 +14,6 @@
 #include "FWCore/Services/src/Tracer.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/LuminosityBlockID.h"
@@ -313,7 +311,7 @@ Tracer::preGlobalEndRun(GlobalContext const& gc) {
 }
 
 void
-Tracer::postGlobalEndRun(GlobalContext const& gc, Run const&, EventSetup const&) {
+Tracer::postGlobalEndRun(GlobalContext const& gc) {
   std::cout << indention_ << indention_ << " GlobalEndRun finished\n"; 
   if(dumpNonModuleContext_) {
     std::cout << gc;
@@ -351,7 +349,7 @@ Tracer::preStreamEndRun(StreamContext const& sc) {
 }
 
 void
-Tracer::postStreamEndRun(StreamContext const& sc, Run const& run, EventSetup const& es) {
+Tracer::postStreamEndRun(StreamContext const& sc) {
   std::cout << indention_ << indention_ << " StreamEndRun finished\n"; 
   if(dumpNonModuleContext_) {
     std::cout << sc;
@@ -389,7 +387,7 @@ Tracer::preGlobalEndLumi(GlobalContext const& gc) {
 }
 
 void
-Tracer::postGlobalEndLumi(GlobalContext const& gc, LuminosityBlock const& lumi, EventSetup const& es) {
+Tracer::postGlobalEndLumi(GlobalContext const& gc) {
   std::cout << indention_ << indention_ << " GlobalEndLumi finished\n";
   if(dumpNonModuleContext_) {
     std::cout << gc;
@@ -427,7 +425,7 @@ Tracer::preStreamEndLumi(StreamContext const& sc) {
 }
 
 void
-Tracer::postStreamEndLumi(StreamContext const& sc, LuminosityBlock const&, EventSetup const&) {
+Tracer::postStreamEndLumi(StreamContext const& sc) {
   std::cout << indention_ << indention_ << " StreamEndLumi finished\n"; 
   if(dumpNonModuleContext_) {
     std::cout << sc;
@@ -445,7 +443,7 @@ Tracer::preEvent(StreamContext const& sc) {
 }
 
 void
-Tracer::postEvent(StreamContext const& sc, Event const&, EventSetup const&) {
+Tracer::postEvent(StreamContext const& sc) {
   std::cout << indention_ << indention_ << " event finished\n";
   if(dumpNonModuleContext_) {
     std::cout << sc;

--- a/FWCore/Services/src/Tracer.h
+++ b/FWCore/Services/src/Tracer.h
@@ -31,8 +31,6 @@
 
 namespace edm {
    class ConfigurationDescriptions;
-   class Event;
-   class EventSetup;
    class GlobalContext;
    class HLTPathStatus;
    class LuminosityBlock;
@@ -77,28 +75,28 @@ public:
          void postGlobalBeginRun(GlobalContext const&);
 
          void preGlobalEndRun(GlobalContext const&);
-         void postGlobalEndRun(GlobalContext const&, Run const&, EventSetup const&);
+         void postGlobalEndRun(GlobalContext const&);
 
          void preStreamBeginRun(StreamContext const&);
          void postStreamBeginRun(StreamContext const&);
 
          void preStreamEndRun(StreamContext const&);
-         void postStreamEndRun(StreamContext const&, Run const&, EventSetup const&);
+         void postStreamEndRun(StreamContext const&);
 
          void preGlobalBeginLumi(GlobalContext const&);
          void postGlobalBeginLumi(GlobalContext const&);
 
          void preGlobalEndLumi(GlobalContext const&);
-         void postGlobalEndLumi(GlobalContext const&, LuminosityBlock const&, EventSetup const&);
+         void postGlobalEndLumi(GlobalContext const&);
 
          void preStreamBeginLumi(StreamContext const&);
          void postStreamBeginLumi(StreamContext const&);
 
          void preStreamEndLumi(StreamContext const&);
-         void postStreamEndLumi(StreamContext const&, LuminosityBlock const&, EventSetup const&);
+         void postStreamEndLumi(StreamContext const&);
 
          void preEvent(StreamContext const&);
-         void postEvent(StreamContext const&, Event const&, EventSetup const&);
+         void postEvent(StreamContext const&);
 
          void prePathEvent(StreamContext const&, PathContext const&);
          void postPathEvent(StreamContext const&, PathContext const&, HLTPathStatus const&);


### PR DESCRIPTION
Given there is no way for a Service to register what it would read from a Run, LuminosityBlock or Event, it is not safe to give access to those objects to Services.
