### PR TITLE
add missing namespaces or includes

### DIFF
--- a/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
+++ b/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
@@ -42,16 +42,16 @@ HIPAlignmentAlgorithm::HIPAlignmentAlgorithm(const edm::ParameterSet& cfg):
   
   verbose = cfg.getParameter<bool>("verbosity");
   
-  outpath = cfg.getParameter<string>("outpath");
-  outfile = cfg.getParameter<string>("outfile");
-  outfile2 = cfg.getParameter<string>("outfile2");
-  struefile = cfg.getParameter<string>("trueFile");
-  smisalignedfile = cfg.getParameter<string>("misalignedFile");
-  salignedfile = cfg.getParameter<string>("alignedFile");
-  siterationfile = cfg.getParameter<string>("iterationFile");
-  suvarfile = cfg.getParameter<string>("uvarFile");
-  sparameterfile = cfg.getParameter<string>("parameterFile");
-  ssurveyfile = cfg.getParameter<string>("surveyFile");
+  outpath = cfg.getParameter<std::string>("outpath");
+  outfile = cfg.getParameter<std::string>("outfile");
+  outfile2 = cfg.getParameter<std::string>("outfile2");
+  struefile = cfg.getParameter<std::string>("trueFile");
+  smisalignedfile = cfg.getParameter<std::string>("misalignedFile");
+  salignedfile = cfg.getParameter<std::string>("alignedFile");
+  siterationfile = cfg.getParameter<std::string>("iterationFile");
+  suvarfile = cfg.getParameter<std::string>("uvarFile");
+  sparameterfile = cfg.getParameter<std::string>("parameterFile");
+  ssurveyfile = cfg.getParameter<std::string>("surveyFile");
 	
   outfile        =outpath+outfile;//Eventwise tree
   outfile2       =outpath+outfile2;//Alignablewise tree
@@ -74,7 +74,7 @@ HIPAlignmentAlgorithm::HIPAlignmentAlgorithm(const edm::ParameterSet& cfg):
   // for collector mode (parallel processing)
   isCollector=cfg.getParameter<bool>("collectorActive");
   theCollectorNJobs=cfg.getParameter<int>("collectorNJobs");
-  theCollectorPath=cfg.getParameter<string>("collectorPath");
+  theCollectorPath=cfg.getParameter<std::string>("collectorPath");
   theFillTrackMonitoring=cfg.getUntrackedParameter<bool>("fillTrackMonitoring");
 	
   if (isCollector) edm::LogWarning("Alignment") << "[HIPAlignmentAlgorithm] Collector mode";
@@ -169,7 +169,7 @@ void HIPAlignmentAlgorithm::startNewLoop( void )
 {
 	
   // iterate over all alignables and attach user variables
-  for( vector<Alignable*>::const_iterator it=theAlignables.begin(); 
+  for( std::vector<Alignable*>::const_iterator it=theAlignables.begin(); 
        it!=theAlignables.end(); it++ )
     {
       AlignmentParameters* ap = (*it)->alignmentParameters();
@@ -371,7 +371,7 @@ void HIPAlignmentAlgorithm::terminate(const edm::EventSetup& iSetup)
   // now calculate alignment corrections ...
   int ialigned=0;
   // iterate over alignment parameters
-  for(vector<Alignable*>::const_iterator
+  for(std::vector<Alignable*>::const_iterator
 	it=theAlignables.begin(); it!=theAlignables.end(); it++) {
     Alignable* ali=(*it);
     // Alignment parameters
@@ -507,7 +507,7 @@ bool HIPAlignmentAlgorithm::processHit1D(const AlignableDetOrUnitPtr& alidet,
   // std::cout << "Preparing ThisJtVJ" << std::flush;
   // thisjtvj = covmat.similarity(derivs);
   thisjtvj.assign(jtvjtmp);
-  // cout<<" ThisJtVE"<<std::endl;
+  // std::cout<<" ThisJtVE"<<std::endl;
   thisjtve=derivs * covmat * (pos-coor);
   
   AlgebraicVector hitresidual(hitDim);
@@ -631,7 +631,7 @@ bool HIPAlignmentAlgorithm::processHit2D(const AlignableDetOrUnitPtr& alidet,
   // std::cout << "Preparing ThisJtVJ" << std::flush;
   // thisjtvj = covmat.similarity(derivs);
   thisjtvj.assign(jtvjtmp);
-  // cout<<" ThisJtVE"<<std::endl;
+  // std::cout<<" ThisJtVE"<<std::endl;
   thisjtve=derivs * covmat * (pos-coor);
   
   AlgebraicVector hitresidual(hitDim);
@@ -754,12 +754,12 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo &e
     }
     // AM: Can be simplified
 		
-    vector<const TransientTrackingRecHit*> hitvec;
-    vector<TrajectoryStateOnSurface> tsosvec;
+    std::vector<const TransientTrackingRecHit*> hitvec;
+    std::vector<TrajectoryStateOnSurface> tsosvec;
 		
     // loop over measurements	
-    vector<TrajectoryMeasurement> measurements = traj->measurements();
-    for (vector<TrajectoryMeasurement>::iterator im=measurements.begin();
+    std::vector<TrajectoryMeasurement> measurements = traj->measurements();
+    for (std::vector<TrajectoryMeasurement>::iterator im=measurements.begin();
 	 im!=measurements.end();
 	 ++im) {
    
@@ -800,7 +800,7 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo &e
 	      } else { 	 
 		edm::LogError("HIPAlignmentAlgorithm") 
 		  << "ERROR in <HIPAlignmentAlgorithm::run>: Dynamic cast of Strip RecHit failed! "
-		  << "TypeId of the RecHit: " << className(*hit) <<endl; 	 
+		  << "TypeId of the RecHit: " << className(*hit) <<std::endl; 	 
 	      } 	 
 	      
 	    }//end if type = SiStripRecHit1D 	 
@@ -814,8 +814,8 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo &e
 	      } else { 	 
 		edm::LogError("HIPAlignmentAlgorithm") 
 		  << "ERROR in <HIPAlignmentAlgorithm::run>: Dynamic cast of Strip RecHit failed! "
-		  // << "TypeId of the TTRH: " << className(*ttrhit) << endl; 	 
-		  << "TypeId of the TTRH: " << className(*hit) << endl; 	 
+		  // << "TypeId of the TTRH: " << className(*ttrhit) << std::endl; 	 
+		  << "TypeId of the TTRH: " << className(*hit) << std::endl; 	 
 	      } 
 	    } //end if type == SiStripRecHit2D 	 
 	  } //end if hit from strips 	 
@@ -829,14 +829,14 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo &e
 	    else { 	 
 	      edm::LogError("HIPAlignmentAlgorithm")
 		<< "ERROR in <HIPAlignmentAlgorithm::run>: Dynamic cast of Pixel RecHit failed! "
-		// << "TypeId of the TTRH: " << className(*ttrhit) << endl; 	 
-		<< "TypeId of the TTRH: " << className(*hit) << endl; 	 
+		// << "TypeId of the TTRH: " << className(*ttrhit) << std::endl; 	 
+		<< "TypeId of the TTRH: " << className(*hit) << std::endl; 	 
 	    }
 	  } //end 'else' it is a pixel hit 	 
 	    // bool hitTaken=myflag.isTaken(); 	 
 	  if (!myflag.isTaken()) { 	 
 	    skiphit=true;
-	    //cout<<"Hit from subdet "<<rechit->geographicalId().subdetId()<<" prescaled out."<<endl;
+	    //std::cout<<"Hit from subdet "<<rechit->geographicalId().subdetId()<<" prescaled out."<<std::endl;
 	    continue;
 	  }
 	}//end if Prescaled Hits 	 
@@ -844,7 +844,7 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo &e
 	if (skiphit) { 	 
 	  throw cms::Exception("LogicError")
 	    << "ERROR  in <HIPAlignmentAlgorithm::run>: this hit should have been skipped!"
-	    << endl;	 
+	    << std::endl;	 
 	}
 	
 	TrajectoryStateOnSurface tsos = tsoscomb.combine(meas.forwardPredictedState(),
@@ -860,13 +860,13 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo &e
     }
     
     // transform RecHit vector to AlignableDet vector
-    vector <AlignableDetOrUnitPtr> alidetvec = theAlignableDetAccessor->alignablesFromHits(hitvec);
+    std::vector <AlignableDetOrUnitPtr> alidetvec = theAlignableDetAccessor->alignablesFromHits(hitvec);
 		
     // get concatenated alignment parameters for list of alignables
     CompositeAlignmentParameters aap = theAlignmentParameterStore->selectParameters(alidetvec);
 		
-    vector<TrajectoryStateOnSurface>::const_iterator itsos=tsosvec.begin();
-    vector<const TransientTrackingRecHit*>::const_iterator ihit=hitvec.begin();
+    std::vector<TrajectoryStateOnSurface>::const_iterator itsos=tsosvec.begin();
+    std::vector<const TransientTrackingRecHit*>::const_iterator ihit=hitvec.begin();
     
     // loop over vectors(hit,tsos)
     while (itsos != tsosvec.end()) {
@@ -906,11 +906,11 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo &e
 
 // ----------------------------------------------------------------------------
 
-int HIPAlignmentAlgorithm::readIterationFile(string filename)
+int HIPAlignmentAlgorithm::readIterationFile(std::string filename)
 {
   int result;
   
-  ifstream inIterFile(filename.c_str(), ios::in);
+  std::ifstream inIterFile(filename.c_str(), std::ios::in);
   if (!inIterFile) {
     edm::LogError("Alignment") << "[HIPAlignmentAlgorithm::readIterationFile] ERROR! "
 			       << "Unable to open Iteration file";
@@ -928,9 +928,9 @@ int HIPAlignmentAlgorithm::readIterationFile(string filename)
 
 // ----------------------------------------------------------------------------
 
-void HIPAlignmentAlgorithm::writeIterationFile(string filename,int iter)
+void HIPAlignmentAlgorithm::writeIterationFile(std::string filename,int iter)
 {
-  ofstream outIterFile((filename.c_str()), ios::out);
+  std::ofstream outIterFile((filename.c_str()), std::ios::out);
   if (!outIterFile) {
     edm::LogError("Alignment") << "[HIPAlignmentAlgorithm::writeIterationFile] ERROR: Unable to write Iteration file";
   }
@@ -1095,6 +1095,7 @@ void HIPAlignmentAlgorithm::bookRoot(void)
 
 void HIPAlignmentAlgorithm::fillRoot(const edm::EventSetup& iSetup)
 {
+  using std::setw;
   theFile2->cd();
 	
   int naligned=0;
@@ -1104,7 +1105,7 @@ void HIPAlignmentAlgorithm::fillRoot(const edm::EventSetup& iSetup)
   iSetup.get<IdealGeometryRecord>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
 	
-  for (vector<Alignable*>::const_iterator it=theAlignables.begin();
+  for (std::vector<Alignable*>::const_iterator it=theAlignables.begin();
        it!=theAlignables.end();
        ++it) {
     Alignable* ali = (*it);
@@ -1301,13 +1302,13 @@ void HIPAlignmentAlgorithm::collector(void)
 		
     edm::LogWarning("Alignment") << "reading uservar for job " << ijob;
     
-    stringstream ss;
-    string str;
+    std::stringstream ss;
+    std::string str;
     ss << ijob;
     ss >> str;
-    string uvfile = theCollectorPath+"/job"+str+"/IOUserVariables.root";
+    std::string uvfile = theCollectorPath+"/job"+str+"/IOUserVariables.root";
 		
-    vector<AlignmentUserVariables*> uvarvec = 
+    std::vector<AlignmentUserVariables*> uvarvec = 
       HIPIO.readHIPUserVariables(theAlignables, uvfile.c_str(),
 				 theIteration, ioerr);
     
@@ -1318,9 +1319,9 @@ void HIPAlignmentAlgorithm::collector(void)
     }
 		
     // add
-    vector<AlignmentUserVariables*> uvarvecadd;
-    vector<AlignmentUserVariables*>::const_iterator iuvarnew=uvarvec.begin(); 
-    for (vector<Alignable*>::const_iterator it=theAlignables.begin(); 
+    std::vector<AlignmentUserVariables*> uvarvecadd;
+    std::vector<AlignmentUserVariables*>::const_iterator iuvarnew=uvarvec.begin(); 
+    for (std::vector<Alignable*>::const_iterator it=theAlignables.begin(); 
 	 it!=theAlignables.end();
 	 ++it) {
       Alignable* ali = *it;

--- a/CommonTools/TrackerMap/interface/TrackerMap.h
+++ b/CommonTools/TrackerMap/interface/TrackerMap.h
@@ -94,9 +94,9 @@ class TrackerMap {
   void save_as_HVtrackermap(bool print_total=true,float minval=0., float maxval=0.,std::string s="psu_svgmap.svg",int width=1500, int height=800);
   void drawApvPair( int crate, int numfed_incrate, bool total, TmApvPair* apvPair,std::ofstream * file,bool useApvPairValue);
   void drawCcu( int crate, int numfed_incrate, bool total, TmCcu* ccu,std::ofstream * file,bool useCcuValue);
-  void drawPsu(int rack,int numcrate_inrack, bool print_total, TmPsu* psu,ofstream * svgfile,bool usePsuValue);
-  void drawHV2(int rack,int numcrate_inrack, bool print_total, TmPsu* psu,ofstream * svgfile,bool usePsuValue);
-  void drawHV3(int rack,int numcrate_inrack, bool print_total, TmPsu* psu,ofstream * svgfile,bool usePsuValue);
+  void drawPsu(int rack,int numcrate_inrack, bool print_total, TmPsu* psu,std::ofstream * svgfile,bool usePsuValue);
+  void drawHV2(int rack,int numcrate_inrack, bool print_total, TmPsu* psu,std::ofstream * svgfile,bool usePsuValue);
+  void drawHV3(int rack,int numcrate_inrack, bool print_total, TmPsu* psu,std::ofstream * svgfile,bool usePsuValue);
   void fill_current_val(int idmod, float current_val );
   void fill(int layer , int ring, int nmod, float x );
   void fill(int idmod, float qty );

--- a/CommonTools/TrackerMap/src/TrackerMap.cc
+++ b/CommonTools/TrackerMap/src/TrackerMap.cc
@@ -148,7 +148,7 @@ TrackerMap::TrackerMap(const edm::ParameterSet & tkmapPset,const SiStripFedCabli
    SiStripFecCabling* fecCabling_;
    fecCabling_ = new SiStripFecCabling( *tkFed );
    std::string Ccufilename=tkmapPset.getUntrackedParameter<std::string>("trackerdatPath","")+"cculist.txt";
-   ifstream Ccufile(edm::FileInPath(Ccufilename).fullPath().c_str(),std::ios::in);
+   std::ifstream Ccufile(edm::FileInPath(Ccufilename).fullPath().c_str(),std::ios::in);
    std::string dummys;
    while(!Ccufile.eof()) {
      Ccufile >> crate >> slot >> ring >> addr >> pos;
@@ -242,21 +242,21 @@ TrackerMap::TrackerMap(const edm::ParameterSet & tkmapPset,const SiStripFedCabli
                          20,0,21,0,22,0,
                          23,0,24,25,0,26,
                          27,0,28,0,29};
- //  ifstream *LVfile;
- //  ifstream *HVfile;
+ //  std::ifstream *LVfile;
+ //  std::ifstream *HVfile;
    
   
  
   std::string LVfilename=tkmapPset.getUntrackedParameter<std::string>("trackerdatPath","CommonTools/TrackerMap/data/")+"psdcumap.dat";
   //std::string HVfilename=tkmapPset.getUntrackedParameter<std::string>("trackerdatPath","")+"hvmap.dat";
   
-  ifstream LVfile(edm::FileInPath(LVfilename).fullPath().c_str(),std::ios::in);
+  std::ifstream LVfile(edm::FileInPath(LVfilename).fullPath().c_str(),std::ios::in);
   
   std::cout<<LVfilename<<std::endl;
   
  /* 
    if(enableHVProcessing){
-	    ifstream HVfile(edm::FileInPath(HVfilename).fullPath().c_str(),std::ios::in);
+	    std::ifstream HVfile(edm::FileInPath(HVfilename).fullPath().c_str(),std::ios::in);
 	    while(!HVfile.eof()) {
 	    HVfile >> modId2 >> channelstr1;
 	    std::string channelstr2 = channelstr1.substr(9,1);
@@ -794,7 +794,7 @@ void TrackerMap::save(bool print_total,float minval, float maxval,std::string s,
   if (temporary_file){ // create root trackermap image
     int red,green,blue,npoints,colindex,ncolor;
     double x[4],y[4];
-    ifstream tempfile(tempfilename.c_str(),std::ios::in);
+    std::ifstream tempfile(tempfilename.c_str(),std::ios::in);
     TCanvas *MyC = new TCanvas("MyC", "TrackerMap",width,height);
     gPad->SetFillColor(38);
     
@@ -1440,7 +1440,7 @@ void TrackerMap::save_as_fectrackermap(bool print_total,float minval, float maxv
   std::string tempfilename = outputfilename + ".coor";
     int red,green,blue,npoints,colindex,ncolor;
     double x[4],y[4];
-    ifstream tempfile(tempfilename.c_str(),std::ios::in);
+    std::ifstream tempfile(tempfilename.c_str(),std::ios::in);
     TCanvas *MyC = new TCanvas("MyC", "TrackerMap",width,height);
     gPad->SetFillColor(38);
 
@@ -1721,7 +1721,7 @@ void TrackerMap::save_as_HVtrackermap(bool print_total,float minval, float maxva
   std::string tempfilename = outputfilename + ".coor";
     int red,green,blue,npoints,colindex,ncolor;
     double x[4],y[4];
-    ifstream tempfile(tempfilename.c_str(),std::ios::in);
+    std::ifstream tempfile(tempfilename.c_str(),std::ios::in);
     TCanvas *MyC = new TCanvas("MyC", "TrackerMap",width,height);
     gPad->SetFillColor(38);
     
@@ -2003,7 +2003,7 @@ void TrackerMap::save_as_psutrackermap(bool print_total,float minval, float maxv
   std::string tempfilename = outputfilename + ".coor";
     int red,green,blue,npoints,colindex,ncolor;
     double x[4],y[4];
-    ifstream tempfile(tempfilename.c_str(),std::ios::in);
+    std::ifstream tempfile(tempfilename.c_str(),std::ios::in);
     TCanvas *MyC = new TCanvas("MyC", "TrackerMap",width,height);
     gPad->SetFillColor(38);
     
@@ -2274,7 +2274,7 @@ void TrackerMap::save_as_fedtrackermap(bool print_total,float minval, float maxv
   std::string tempfilename = outputfilename + ".coor";
     int red,green,blue,npoints,colindex,ncolor;
     double x[4],y[4];
-    ifstream tempfile(tempfilename.c_str(),std::ios::in);
+    std::ifstream tempfile(tempfilename.c_str(),std::ios::in);
     TCanvas *MyC = new TCanvas("MyC", "TrackerMap",width,height);
     gPad->SetFillColor(38);
 
@@ -2375,7 +2375,7 @@ void TrackerMap::save_as_fedtrackermap(bool print_total,float minval, float maxv
 }
 
 void TrackerMap::load(std::string inputfilename){
-  inputfile = new ifstream(inputfilename.c_str(),std::ios::in);
+  inputfile = new std::ifstream(inputfilename.c_str(),std::ios::in);
   std::string line,value;
   int ipos,ipos1,ipos2,id=0,val=0;
   int nline=0;
@@ -2415,7 +2415,7 @@ void TrackerMap::print(bool print_total, float minval, float maxval, std::string
   minvalue=minval; maxvalue=maxval;
   outs << outputfilename << ".xml";
   svgfile = new std::ofstream(outs.str().c_str(),std::ios::out);
-  jsfile = new ifstream(edm::FileInPath(jsfilename).fullPath().c_str(),std::ios::in);
+  jsfile = new std::ifstream(edm::FileInPath(jsfilename).fullPath().c_str(),std::ios::in);
 
   //copy javascript interface from trackermap.txt file
   std::string line;
@@ -2785,14 +2785,14 @@ void TrackerMap::setText(int layer, int ring, int nmod, std::string s){
 } 
 
 void TrackerMap::build(){
-  //  ifstream* infile;
+  //  std::ifstream* infile;
 
   int nmods, pix_sil, fow_bar, ring, nmod, layer;
   unsigned int idex;
   float posx, posy, posz, length, width, thickness, widthAtHalfLength;
   int iModule=0,old_layer=0, ntotMod =0;
   std::string name,dummys;
-  ifstream infile(edm::FileInPath(infilename).fullPath().c_str(),std::ios::in);
+  std::ifstream infile(edm::FileInPath(infilename).fullPath().c_str(),std::ios::in);
   while(!infile.eof()) {
     infile >> nmods >> pix_sil >> fow_bar >> layer >> ring >> nmod >> posx >> posy
 	   >> posz>> length >> width >> thickness
@@ -3491,14 +3491,14 @@ std::ifstream * TrackerMap::findfile(std::string filename) {
   std::string ifname;
   if(jsPath!=""){
   ifname=jsPath+filename;
-  ifilename = new ifstream(edm::FileInPath(ifname).fullPath().c_str(),std::ios::in);
+  ifilename = new std::ifstream(edm::FileInPath(ifname).fullPath().c_str(),std::ios::in);
   if(!ifilename){
   ifname="CommonTools/TrackerMap/data/"+filename;
-  ifilename = new ifstream(edm::FileInPath(ifname).fullPath().c_str(),std::ios::in);
+  ifilename = new std::ifstream(edm::FileInPath(ifname).fullPath().c_str(),std::ios::in);
   }
   }else {
   ifname="CommonTools/TrackerMap/data/"+filename;
-  ifilename = new ifstream(edm::FileInPath(ifname).fullPath().c_str(),std::ios::in);
+  ifilename = new std::ifstream(edm::FileInPath(ifname).fullPath().c_str(),std::ios::in);
  }
   if(!ifilename)std::cout << "File " << filename << " missing" << std::endl;
   return ifilename;

--- a/DQM/HcalMonitorClient/interface/HcalClientUtils.h
+++ b/DQM/HcalMonitorClient/interface/HcalClientUtils.h
@@ -78,8 +78,8 @@ TH1F* getHisto(const MonitorElement* me, bool verb=false, bool clone=false);
 std::string getIMG(int runNo,TH1F* hist, int size, std::string htmlDir, const char* xlab, const char* ylab);
 std::string getIMG2(int runNo,TH2F* hist, int size, std::string htmlDir, const char* xlab, const char* ylab, bool color=false);
   
-void histoHTML(int runNo,TH1F* hist, const char* xlab, const char* ylab, int width, ofstream& htmlFile, std::string htmlDir);
-void histoHTML2(int runNo,TH2F* hist, const char* xlab, const char* ylab, int width, ofstream& htmlFile, std::string htmlDir, bool color=false);
+void histoHTML(int runNo,TH1F* hist, const char* xlab, const char* ylab, int width, std::ofstream& htmlFile, std::string htmlDir);
+void histoHTML2(int runNo,TH2F* hist, const char* xlab, const char* ylab, int width, std::ofstream& htmlFile, std::string htmlDir, bool color=false);
 
 void htmlErrors(int runNo,std::string htmlDir, std::string client, std::string process, DQMStore* dbe, std::map<std::string, std::vector<QReport*> > mapE, std::map<std::string, std::vector<QReport*> > mapW, std::map<std::string, std::vector<QReport*> > mapO);
 
@@ -104,7 +104,7 @@ TProfile* getHistoTProfile(const MonitorElement* me, bool verb=false, bool clone
 //getIMG, histoHTML are now deprecated by tools in HcalHistoUtils.h
 // Eventually, the getHisto algorithms will become deprecated as well
 std::string getIMGTProfile(int runNo,TProfile* hist, int size, std::string htmlDir, const char* xlab, const char* ylab,std::string opts="NONE");
-void histoHTMLTProfile(int runNo,TProfile* hist, const char* xlab, const char* ylab, int width, ofstream& htmlFile, std::string htmlDir, std::string opts="NONE");
+void histoHTMLTProfile(int runNo,TProfile* hist, const char* xlab, const char* ylab, int width, std::ofstream& htmlFile, std::string htmlDir, std::string opts="NONE");
 
 
 

--- a/DQM/HcalMonitorClient/interface/HcalHistoUtils.h
+++ b/DQM/HcalMonitorClient/interface/HcalHistoUtils.h
@@ -43,7 +43,7 @@
  *
  * void htmlAnyHisto(int runNo, myHist *hist, 
 		     const char* xlab, const char* ylab, 
-		     int width, ofstream& htmlFile, 
+		     int width, std::ofstream& htmlFile, 
 		     std::string htmlDir, bool setLogy, bool setLogx)
  
  *
@@ -485,7 +485,7 @@ std::string getAnyIMG(int runNo,myHist* hist, int size, std::string htmlDir,
 template <class myHist>
 void htmlAnyHisto(int runNo, myHist *hist, 
 		  const char* xlab, const char* ylab, 
-		  int width, ofstream& htmlFile, 
+		  int width, std::ofstream& htmlFile, 
 		  std::string htmlDir,
 		  int debug=0)
 {

--- a/DQM/HcalMonitorClient/interface/HcalLEDClient.h
+++ b/DQM/HcalMonitorClient/interface/HcalLEDClient.h
@@ -61,7 +61,7 @@ public:
 private:
   
   string m_outputFileName;
-  ofstream m_outTextFile;
+  std::ofstream m_outTextFile;
 
   const HcalElectronicsMap* readoutMap_;
   edm::ESHandle<HcalDbService> conditions_;

--- a/DQM/HcalMonitorClient/src/HcalBaseDQClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalBaseDQClient.cc
@@ -99,7 +99,7 @@ void HcalBaseDQClient::htmlOutput(std::string htmlDir)
       pcol_error[i]=901+i;
     } // for (int i=0;i<105;++i)
 
-  ofstream htmlFile;
+  std::ofstream htmlFile;
   std::string outfile=htmlDir+name_+".html";
   htmlFile.open(outfile.c_str());
 

--- a/DQM/HcalMonitorClient/src/HcalClientUtils.cc
+++ b/DQM/HcalMonitorClient/src/HcalClientUtils.cc
@@ -294,7 +294,7 @@ TH1F* getHisto(const MonitorElement* me, bool verb,bool clone){
 }
 
 
-void histoHTML(int runNo, TH1F* hist, const char* xlab, const char* ylab, int width, ofstream& htmlFile, std::string htmlDir){
+void histoHTML(int runNo, TH1F* hist, const char* xlab, const char* ylab, int width, std::ofstream& htmlFile, std::string htmlDir){
   
   if(hist!=NULL){    
     std::string imgNameTMB = "";   
@@ -311,7 +311,7 @@ void histoHTML(int runNo, TH1F* hist, const char* xlab, const char* ylab, int wi
   return;
 }
 
-void histoHTML2(int runNo, TH2F* hist, const char* xlab, const char* ylab, int width, ofstream& htmlFile, std::string htmlDir, bool color){
+void histoHTML2(int runNo, TH2F* hist, const char* xlab, const char* ylab, int width, std::ofstream& htmlFile, std::string htmlDir, bool color){
   if(hist!=NULL){
     std::string imgNameTMB = "";
     imgNameTMB = getIMG2(runNo,hist,1,htmlDir,xlab,ylab,color);  
@@ -450,7 +450,7 @@ void htmlErrors(int runNo, std::string htmlDir, std::string client, std::string 
 
   std::map<std::string, std::vector<QReport*> >::iterator mapIter;
 
-  ofstream errorFile;
+  std::ofstream errorFile;
   errorFile.open((htmlDir + client+ "Errors.html").c_str());
   errorFile << "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\">  " << std::endl;
   errorFile << "<html>  " << std::endl;
@@ -661,7 +661,7 @@ std::string getIMGTProfile(int runNo,TProfile* hist, int size, std::string htmlD
   return outName;
 }
 
-void histoHTMLTProfile(int runNo, TProfile* hist, const char* xlab, const char* ylab, int width, ofstream& htmlFile, std::string htmlDir, std::string opts){
+void histoHTMLTProfile(int runNo, TProfile* hist, const char* xlab, const char* ylab, int width, std::ofstream& htmlFile, std::string htmlDir, std::string opts){
   
   if(hist!=NULL){    
     std::string imgNameTMB = "";   

--- a/DQM/HcalMonitorClient/src/HcalDetDiagLEDClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalDetDiagLEDClient.cc
@@ -113,7 +113,7 @@ bool HcalDetDiagLEDClient::validHtmlOutput(){
   if(n<100) return false;
   return true;
 }
-static void printTableHeader(ofstream& file,std::string header){
+static void printTableHeader(std::ofstream& file,std::string header){
      file << "</html><html xmlns=\"http://www.w3.org/1999/xhtml\">"<< std::endl;
      file << "<head>"<< std::endl;
      file << "<meta http-equiv=\"Content-Type\" content=\"text/html\"/>"<< std::endl;
@@ -129,7 +129,7 @@ static void printTableHeader(ofstream& file,std::string header){
      file << "<body>"<< std::endl;
      file << "<table>"<< std::endl;
 }
-static void printTableLine(ofstream& file,int ind,HcalDetId& detid,HcalFrontEndId& lmap_entry,HcalElectronicsId &emap_entry, std::string comment=""){
+static void printTableLine(std::ofstream& file,int ind,HcalDetId& detid,HcalFrontEndId& lmap_entry,HcalElectronicsId &emap_entry, std::string comment=""){
    if(ind==0){
      file << "<tr>";
      file << "<td class=\"s4\" align=\"center\">#</td>"    << std::endl;
@@ -178,7 +178,7 @@ static void printTableLine(ofstream& file,int ind,HcalDetId& detid,HcalFrontEndI
    file << raw_class<< emap_entry.htrTopBottom()<<"</td>"<< std::endl;
    if(comment[0]!=0) file << raw_class<< comment<<"</td>"<< std::endl;
 }
-static void printTableTail(ofstream& file){
+static void printTableTail(std::ofstream& file){
      file << "</table>"<< std::endl;
      file << "</body>"<< std::endl;
      file << "</html>"<< std::endl;
@@ -315,19 +315,19 @@ std::string subdet[4]={"HB","HE","HO","HF"};
      }
   }
   // missing channels list
-  ofstream Missing;
+  std::ofstream Missing;
   Missing.open((htmlDir + "Missing.html").c_str());
   printTableHeader(Missing,"Missing Channels list");
   // Bad timing channels list
-  ofstream BadTiming;
+  std::ofstream BadTiming;
   BadTiming.open((htmlDir + "BadTiming.html").c_str());
   printTableHeader(BadTiming,"Bad Timing Channels list");
   // unstable channels list
-  ofstream Unstable;
+  std::ofstream Unstable;
   Unstable.open((htmlDir + "Unstable.html").c_str());
   printTableHeader(Unstable,"Low LED signal Channels list");
   // unstable LED signal list
-  ofstream BadLED;
+  std::ofstream BadLED;
   BadLED.open((htmlDir + "UnstableLED.html").c_str());
   printTableHeader(BadLED,"Unstable LED signal channels list");
 
@@ -555,7 +555,7 @@ std::string subdet[4]={"HB","HE","HO","HF"};
   can->SetGridx(); 
   can->cd();
 
-  ofstream htmlFile;
+  std::ofstream htmlFile;
   std::string outfile=htmlDir+name_+".html";
   htmlFile.open(outfile.c_str());
   // html page header

--- a/DQM/HcalMonitorClient/src/HcalDetDiagLaserClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalDetDiagLaserClient.cc
@@ -292,7 +292,7 @@ void HcalDetDiagLaserClient::updateChannelStatus(std::map<HcalDetId, unsigned in
   // see dead or hot cell code for an example
 
 } //void HcalDetDiagLaserClient::updateChannelStatus
-static void printTableHeader(ofstream& file,std::string  header){
+static void printTableHeader(std::ofstream& file,std::string  header){
      file << "</html><html xmlns=\"http://www.w3.org/1999/xhtml\">"<< endl;
      file << "<head>"<< endl;
      file << "<meta http-equiv=\"Content-Type\" content=\"text/html\"/>"<< endl;
@@ -308,7 +308,7 @@ static void printTableHeader(ofstream& file,std::string  header){
      file << "<body>"<< endl;
      file << "<table>"<< endl;
 }
-static void printTableLine(ofstream& file,int ind,HcalDetId& detid,HcalFrontEndId& lmap_entry,HcalElectronicsId &emap_entry,std::string comment=""){
+static void printTableLine(std::ofstream& file,int ind,HcalDetId& detid,HcalFrontEndId& lmap_entry,HcalElectronicsId &emap_entry,std::string comment=""){
    if(ind==0){
      file << "<tr>";
      file << "<td class=\"s4\" align=\"center\">#</td>"    << endl;
@@ -357,7 +357,7 @@ static void printTableLine(ofstream& file,int ind,HcalDetId& detid,HcalFrontEndI
    file << raw_class<< emap_entry.htrTopBottom()<<"</td>"<< endl;
    if(comment[0]!=0) file << raw_class<< comment<<"</td>"<< endl;
 }
-static void printTableTail(ofstream& file){
+static void printTableTail(std::ofstream& file){
      file << "</table>"<< endl;
      file << "</body>"<< endl;
      file << "</html>"<< endl;
@@ -538,10 +538,10 @@ void HcalDetDiagLaserClient::htmlOutput(string htmlDir){
   }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  ofstream badTiming; 
+  std::ofstream badTiming; 
   badTiming.open((htmlDir+"bad_timing_table.html").c_str());
   printTableHeader(badTiming,"Bad Timing Channels list");
-  ofstream badEnergy; 
+  std::ofstream badEnergy; 
   badEnergy.open((htmlDir+"bad_energy_table.html").c_str());
   printTableHeader(badEnergy,"Bad Energy Channels list");
 
@@ -767,7 +767,7 @@ void HcalDetDiagLaserClient::htmlOutput(string htmlDir){
   badEnergy.close();
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-  ofstream htmlFile;
+  std::ofstream htmlFile;
   string outfile=htmlDir+name_+".html";
   htmlFile.open(outfile.c_str());
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -780,7 +780,7 @@ void HcalDetDiagLaserClient::htmlOutput(string htmlDir){
   can->cd();
   
   if(Raddam[0]->GetEntries()>0){
-     ofstream RADDAM;
+     std::ofstream RADDAM;
      RADDAM.open((htmlDir + "RADDAM_"+name_).c_str());
      RADDAM << "</html><html xmlns=\"http://www.w3.org/1999/xhtml\">"<< endl;
      RADDAM << "<head>"<< endl;

--- a/DQM/HcalMonitorClient/src/HcalDetDiagPedestalClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalDetDiagPedestalClient.cc
@@ -302,7 +302,7 @@ void HcalDetDiagPedestalClient::updateChannelStatus(std::map<HcalDetId, unsigned
 
 } //void HcalDetDiagPedestalClient::updateChannelStatus
 
-static void printTableHeader(ofstream& file,std::string  header){
+static void printTableHeader(std::ofstream& file,std::string  header){
   file << "</html><html xmlns=\"http://www.w3.org/1999/xhtml\">"<< std::endl;
      file << "<head>"<< std::endl;
      file << "<meta http-equiv=\"Content-Type\" content=\"text/html\"/>"<< std::endl;
@@ -319,7 +319,7 @@ static void printTableHeader(ofstream& file,std::string  header){
      file << "<table>"<< std::endl;
 }
 
-static void printTableLine(ofstream& file,int ind,HcalDetId& detid,HcalFrontEndId& lmap_entry,HcalElectronicsId &emap_entry,std::string comment=""){
+static void printTableLine(std::ofstream& file,int ind,HcalDetId& detid,HcalFrontEndId& lmap_entry,HcalElectronicsId &emap_entry,std::string comment=""){
    if(ind==0){
      file << "<tr>";
      file << "<td class=\"s4\" align=\"center\">#</td>"    << std::endl;
@@ -368,7 +368,7 @@ static void printTableLine(ofstream& file,int ind,HcalDetId& detid,HcalFrontEndI
    file << raw_class<< emap_entry.htrTopBottom()<<"</td>"<< std::endl;
    if(comment[0]!=0) file << raw_class<< comment<<"</td>"<< std::endl;
 }
-static void printTableTail(ofstream& file){
+static void printTableTail(std::ofstream& file){
      file << "</table>"<< std::endl;
      file << "</body>"<< std::endl;
      file << "</html>"<< std::endl;
@@ -590,13 +590,13 @@ int  newHFP[4]={0,0,0,0},newHFM[4]={0,0,0,0},newHO[4] ={0,0,0,0};
   } 
 
 
-  ofstream badMissing; 
+  std::ofstream badMissing; 
   badMissing.open((htmlDir+"bad_missing_table.html").c_str());
   printTableHeader(badMissing,"Missing Channels list");
-  ofstream badUnstable; 
+  std::ofstream badUnstable; 
   badUnstable.open((htmlDir+"bad_unstable_table.html").c_str());
   printTableHeader(badUnstable,"Unstable Channels list");
-  ofstream badPedRMS; 
+  std::ofstream badPedRMS; 
   badPedRMS.open((htmlDir+"bad_badpedrms_table.html").c_str());
   printTableHeader(badPedRMS,"Missing Channels list");
 
@@ -918,7 +918,7 @@ int  newHFP[4]={0,0,0,0},newHFM[4]={0,0,0,0},newHO[4] ={0,0,0,0};
   TCanvas *can=new TCanvas("HcalDetDiagPedestalClient","HcalDetDiagPedestalClient",0,0,500,350);
   can->cd();
 
-  ofstream htmlFile;
+  std::ofstream htmlFile;
   std::string outfile=htmlDir+name_+".html";
   htmlFile.open(outfile.c_str());
   // html page header

--- a/DQM/HcalMonitorClient/src/HcalMonitorClient.cc
+++ b/DQM/HcalMonitorClient/src/HcalMonitorClient.cc
@@ -478,7 +478,7 @@ void HcalMonitorClient::writeHtml()
 
   ++htmlcounter_;
 
-  ofstream htmlFile;
+  std::ofstream htmlFile;
   htmlFile.open((htmlDir + "index.html").c_str());
 
   // html page header

--- a/DQM/SiStripCommissioningSources/src/CalibrationScanTask.cc
+++ b/DQM/SiStripCommissioningSources/src/CalibrationScanTask.cc
@@ -202,7 +202,7 @@ void CalibrationScanTask::checkAndSave(const uint16_t& isha, const uint16_t& vfs
     ss << "_000"; // Add FU instance number (fake)
     ss << ".root"; // Append ".root" extension
     if ( !filename_.empty() ) {
-      if(ifstream(ss.str().c_str(),ifstream::in).fail()) { //save only once. Skip if the file already exist
+      if(std::ifstream(ss.str().c_str(),std::ifstream::in).fail()) { //save only once. Skip if the file already exist
         dqm()->save( ss.str() ); 
         LogTrace("DQMsource")
           << "[SiStripCommissioningSource::" << __func__ << "]"

--- a/DQM/SiStripCommissioningSources/src/CalibrationTask.cc
+++ b/DQM/SiStripCommissioningSources/src/CalibrationTask.cc
@@ -179,7 +179,7 @@ void CalibrationTask::checkAndSave(const uint16_t& calchan) {
     ss << "_000"; // Add FU instance number (fake)
     ss << ".root"; // Append ".root" extension
     if ( !filename_.empty() ) {
-      if(ifstream(ss.str().c_str(),ifstream::in).fail()) { //save only once. Skip if the file already exist
+      if(std::ifstream(ss.str().c_str(),std::ifstream::in).fail()) { //save only once. Skip if the file already exist
         dqm()->save( ss.str() ); 
         LogTrace("DQMsource")
           << "[SiStripCommissioningSource::" << __func__ << "]"

--- a/FastSimulation/CaloRecHitsProducer/src/HcalRecHitsMaker.cc
+++ b/FastSimulation/CaloRecHitsProducer/src/HcalRecHitsMaker.cc
@@ -216,7 +216,7 @@ void HcalRecHitsMaker::init(const edm::EventSetup &es,bool doDigis,bool doMiscal
       gROOT->cd();
       edm::FileInPath myTPGFilePath("CalibCalorimetry/HcalTPGAlgos/data/RecHit-TPG-calib.dat");
       TPGFactor_.resize(87,1.2);
-      std::ifstream  myTPGFile(myTPGFilePath.fullPath().c_str(),ifstream::in);
+      std::ifstream  myTPGFile(myTPGFilePath.fullPath().c_str(),std::ifstream::in);
       if(myTPGFile)
   	    {
   	      float gain;

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTParametersTester.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTParametersTester.cc
@@ -32,6 +32,7 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
+#include <iostream>
 
 
 using std::cout;


### PR DESCRIPTION
This pull request is purely technical, and signatures should be bypassed.
When compiling CMSSW against ROOT 6, these packages or files did not compile because of either missing "std::" qualifiers or a missing iostream header.  This pull request adds them.

The file in FastSimulation looks like it was totally modified, but that is just because it was formerly in DOS format.  The only change was changing ifstream to std::ifstream in one place.

It would be very helpful to the ROOT6 effort if this request was merged in a timely manner.
