### PR TITLE
Add missing std:: qualifiers and missing includes of iostream.

### DIFF
--- a/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
+++ b/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
@@ -1008,16 +1008,16 @@ HIPAlignmentAlgorithm::calcAPE(double* par, int iter, double function)
   // into 0.9999999999998 in the HIPAlignmentAlgorithm::initialize is
   // also used here.  If I'm wrong, you'll get an assertion.
   if (function == 0.) {
-    return max(par[1],par[0]+((par[1]-par[0])/par[2])*diter);
+    return std::max(par[1],par[0]+((par[1]-par[0])/par[2])*diter);
   }
   else if (function == 1.) {
-    return max(0.,par[0]*(exp(-pow(diter,par[1])/par[2])));
+    return std::max(0.,par[0]*(exp(-pow(diter,par[1])/par[2])));
   }
   else if (function == 2.) {
     int ipar2 = (int) par[2];
     int step = iter/ipar2;
     double dstep = (double) step;
-    return max(0.0, par[0] - par[1]*dstep);
+    return std::max(0.0, par[0] - par[1]*dstep);
   }
   else assert(false);  // should have been caught in the constructor
 }
@@ -1148,7 +1148,7 @@ void HIPAlignmentAlgorithm::fillRoot(const edm::EventSetup& iSetup)
 	  << " id: "    << setw(4) << m2_Id
 	  << " objId: " << setw(4) << m2_ObjId
 	  << '\n'
-	  << fixed << setprecision(5)
+	  << std::fixed << std::setprecision(5)
 	  << "x,y,z: "
 	  << setw(12) << m2_Xpos
 	  << setw(12) << m2_Ypos 

--- a/Alignment/LaserAlignment/src/LASBarrelAlgorithm.cc
+++ b/Alignment/LaserAlignment/src/LASBarrelAlgorithm.cc
@@ -624,7 +624,7 @@ void LASBarrelAlgorithm::Dump( void ) {
 
 
   // det parameters once again without leading column (for easy read-in), into a file
-  ofstream file( "/afs/cern.ch/user/o/olzem/public/parameters_det.txt" );
+  std::ofstream file( "/afs/cern.ch/user/o/olzem/public/parameters_det.txt" );
   for( int subdet = 0; subdet < 6; ++subdet ) {
     for( int par = subdetParMap[subdet]; par <= subdetParMap[subdet] + 4; par += 2 ) {
       minuit->GetParameter( par, value, error );
@@ -672,7 +672,7 @@ void LASBarrelAlgorithm::ReadMisalignmentFromFile( const char* filename,
 						   LASGlobalData<LASCoordinateSet>& measuredCoordinates,
 						   LASGlobalData<LASCoordinateSet>& nominalCoordinates  ) {
 
-  ifstream file( filename );
+  std::ifstream file( filename );
   if( file.bad() ) {
     std::cerr << " [LASBarrelAlgorithm::ReadMisalignmentFromFile] ** ERROR: cannot open file \"" << filename << "\"." << std::endl;
     return;
@@ -757,7 +757,7 @@ void LASBarrelAlgorithm::ReadMisalignmentFromFile( const char* filename,
 ///
 void LASBarrelAlgorithm::ReadStartParametersFromFile( const char* filename, float values[52] ) {
   
-  ifstream file( filename );
+  std::ifstream file( filename );
   if( file.bad() ) {
     std::cerr << " [LASBarrelAlgorithm::ReadStartParametersFromFile] ** ERROR: cannot open file \"" << filename << "\"." << std::endl;
     return;

--- a/Alignment/MuonAlignment/plugins/MuonGeometryArrange.cc
+++ b/Alignment/MuonAlignment/plugins/MuonGeometryArrange.cc
@@ -84,7 +84,7 @@ MuonGeometryArrange::MuonGeometryArrange(const edm::ParameterSet& cfg) :
 		
 	// if want to use, make id cut list
 	if (_detIdFlag){
-        ifstream fin;
+        std::ifstream fin;
         fin.open( _detIdFlagFile.c_str() );
         
         while (!fin.eof() && fin.good() ){

--- a/Alignment/TrackerAlignment/plugins/TkAlCaSkimTreeMerger.cc
+++ b/Alignment/TrackerAlignment/plugins/TkAlCaSkimTreeMerger.cc
@@ -41,7 +41,7 @@ class TkAlCaSkimTreeMerger : public edm::EDAnalyzer{
   std::string outfilename_;//name of the file where you want to save the output
  
   //Hit Population
-  typedef map<uint32_t,uint32_t>DetHitMap;
+  typedef std::map<uint32_t,uint32_t>DetHitMap;
   DetHitMap hitmap_;
   DetHitMap overlapmap_;
   int maxhits_;//above this number, the hit population is prescaled. Configurable for each subdet 
@@ -60,9 +60,9 @@ class TkAlCaSkimTreeMerger : public edm::EDAnalyzer{
 
 
 TkAlCaSkimTreeMerger::TkAlCaSkimTreeMerger(const edm::ParameterSet &iConfig) :
-    filelist_(iConfig.getParameter<string>("FileList")), 
-    treename_(iConfig.getParameter<string>("TreeName")),
-    outfilename_(iConfig.getParameter<string>("OutputFile")),
+    filelist_(iConfig.getParameter<std::string>("FileList")), 
+    treename_(iConfig.getParameter<std::string>("TreeName")),
+    outfilename_(iConfig.getParameter<std::string>("OutputFile")),
     // maxhits_(iConfig.getParameter<vint>("NhitsMaxLimit"))
     maxhits_(iConfig.getParameter<int32_t>("NhitsMaxLimit")),
     maxhitsSet_(iConfig.getParameter<edm::ParameterSet>("NhitsMaxSet"))
@@ -74,7 +74,7 @@ TkAlCaSkimTreeMerger::TkAlCaSkimTreeMerger(const edm::ParameterSet &iConfig) :
   maxTOBhits_=maxhitsSet_.getParameter<int32_t>("TOBmaxhits");
   maxTEChits_=maxhitsSet_.getParameter<int32_t>("TECmaxhits");
   //anything you want to do for initializing
-  cout<<"\n\n*** MAX N HITS = "<<maxhits_<<endl<<endl;
+  std::cout<<"\n\n*** MAX N HITS = "<<maxhits_<<std::endl<<std::endl;
   out_=0;
   firsttree_=0;
   ch_=0;
@@ -87,7 +87,7 @@ TkAlCaSkimTreeMerger::~TkAlCaSkimTreeMerger(){
   // delete firsttree_;
 
   delete ch_;
-  cout<<"finished."<<endl;
+  std::cout<<"finished."<<std::endl;
 }
 
 // ------------ method called before analyzing the first event  ------------
@@ -97,10 +97,10 @@ void TkAlCaSkimTreeMerger::beginJob(){
 
   //prepare the chain
   ch_=new TChain(treename_.c_str());
-  cout<<"The chain contains "<<ch_->GetNtrees()<<" trees"<<endl;
+  std::cout<<"The chain contains "<<ch_->GetNtrees()<<" trees"<<std::endl;
   
   //load the trees into the chain
-  ifstream flist(filelist_.c_str(),ios::in);
+  std::ifstream flist(filelist_.c_str(),std::ios::in);
   std::string filename;
   std::string firstfilename;
   bool first=true;
@@ -108,7 +108,7 @@ void TkAlCaSkimTreeMerger::beginJob(){
     filename="";
     flist>>filename;
     if(filename.empty())continue;
-    //cout<<"Adding "<<filename<<endl;
+    //std::cout<<"Adding "<<filename<<std::endl;
     ch_->Add(filename.c_str());
     if(first){
       firstfilename_=filename;
@@ -116,7 +116,7 @@ void TkAlCaSkimTreeMerger::beginJob(){
     }
    
   }
-  cout<<"Now the chain contains "<<ch_->GetNtrees()<<" trees ("<<ch_->GetEntries()<<" entries)"<<endl;
+  std::cout<<"Now the chain contains "<<ch_->GetNtrees()<<" trees ("<<ch_->GetEntries()<<" entries)"<<std::endl;
 
  
   unsigned int id_ch=0;
@@ -155,7 +155,7 @@ void TkAlCaSkimTreeMerger::beginJob(){
       hitmap_[id_ch]=hitmap_[id_ch]+nhits_ch;
     }
     else{//not present, let's add this key to the map with value=1
-      hitmap_.insert(pair<uint32_t, uint32_t>(id_ch, nhits_ch));
+      hitmap_.insert(std::pair<uint32_t, uint32_t>(id_ch, nhits_ch));
     }
     //do the same for overlaps
     overlapiter= overlapmap_.find(id_ch);
@@ -163,25 +163,25 @@ void TkAlCaSkimTreeMerger::beginJob(){
       overlapmap_[id_ch]=overlapmap_[id_ch]+noverlaps_ch;
     }
     else{
-      overlapmap_.insert(pair<uint32_t, uint32_t>(id_ch, noverlaps_ch));
+      overlapmap_.insert(std::pair<uint32_t, uint32_t>(id_ch, noverlaps_ch));
     }
     
   }//end loop on ent - entries in the chain
 
 
-  cout<<"Nhits in the chain: "<<totnhits<<endl;
-  cout<<"NOverlaps in the chain: "<<totnoverlaps<<endl;
+  std::cout<<"Nhits in the chain: "<<totnhits<<std::endl;
+  std::cout<<"NOverlaps in the chain: "<<totnoverlaps<<std::endl;
 
 
   myclock.Stop();
-  cout<<"Finished beginJob after "<<myclock.RealTime()<<" s (real time) / "<<myclock.CpuTime()<<" s (cpu time)"<<endl;
+  std::cout<<"Finished beginJob after "<<myclock.RealTime()<<" s (real time) / "<<myclock.CpuTime()<<" s (cpu time)"<<std::endl;
   myclock.Continue();
 }//end beginJob
 
 
 // ------------ method called to for each event  ------------
 void TkAlCaSkimTreeMerger::analyze(const edm::Event&, const edm::EventSetup&){
-    // cout<<firsttree_->GetEntries()<<endl;
+    // std::cout<<firsttree_->GetEntries()<<std::endl;
 }//end analyze
 
 // ------------ method called after having analyzed all the events  ------------
@@ -191,7 +191,7 @@ void TkAlCaSkimTreeMerger::endJob(){
   //address variables in the first tree and in the chain
   TFile *firstfile=new TFile(firstfilename_.c_str(),"READ");
   firsttree_=(TTree*)firstfile->Get(treename_.c_str());
-  cout<<"the first tree has "<<firsttree_->GetEntries() <<" entries"<<endl; 
+  std::cout<<"the first tree has "<<firsttree_->GetEntries() <<" entries"<<std::endl; 
   unsigned int id=0;
   uint32_t nhits=0,noverlaps=0;
   float posX(-99999.0),posY(-77777.0),posZ(-88888.0);
@@ -257,7 +257,7 @@ void TkAlCaSkimTreeMerger::endJob(){
     firsttree_->GetEntry(mod);
     nhits_out=hitmap_[id];
     noverlaps_out=overlapmap_[id];
-    // if(mod<25)cout<<"Nhits 1st tree: "<<nhits<<"\tTotal nhits chain: "<<nhits_out<<endl;
+    // if(mod<25)std::cout<<"Nhits 1st tree: "<<nhits<<"\tTotal nhits chain: "<<nhits_out<<std::endl;
     id_out=id;
     subdet_out=subdet;
     layer_out=layer;
@@ -304,10 +304,10 @@ void TkAlCaSkimTreeMerger::endJob(){
 
 
   myclock.Stop();
-  cout<<"Finished endJob after "<<myclock.RealTime()<<" s (real time) / "<<myclock.CpuTime()<<" s (cpu time)"<<endl;
-  cout<<"Ending the tree merging."<<endl;
+  std::cout<<"Finished endJob after "<<myclock.RealTime()<<" s (real time) / "<<myclock.CpuTime()<<" s (cpu time)"<<std::endl;
+  std::cout<<"Ending the tree merging."<<std::endl;
   out_->Write();
-  cout<<"Deleting..."<<flush;
+  std::cout<<"Deleting..."<<std::flush;
   delete firstfile;
   delete outfile;
  

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/interface/EcnaAnalyzer.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/interface/EcnaAnalyzer.h
@@ -148,11 +148,11 @@ class EcnaAnalyzer : public edm::EDAnalyzer {
   unsigned int verbosity_;
   Int_t  nChannels_;
   Int_t  iEvent_; // should be removed when we can access class EventID
-  string eventHeaderProducer_;
-  string digiProducer_;
-  string eventHeaderCollection_;
-  string EBdigiCollection_;
-  string EEdigiCollection_;
+  std::string eventHeaderProducer_;
+  std::string digiProducer_;
+  std::string eventHeaderCollection_;
+  std::string EBdigiCollection_;
+  std::string EEdigiCollection_;
 
   TString  sAnalysisName_;
   TString  sNbOfSamples_;
@@ -175,7 +175,7 @@ class EcnaAnalyzer : public edm::EDAnalyzer {
 
   TString  fCfgAnalyzerParametersFilePath;  // absolute path for the analyzer parameters files (/afs/etc...)
   TString  fCfgAnalyzerParametersFileName;  // name of the analyzer parameters file 
-  ifstream fFcin_f;
+  std::ifstream fFcin_f;
 
   TString fAnalysisName;
   Int_t   fChozenGainNumber;     // determined from fAnalysisName

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/src/EcnaAnalyzer.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/src/EcnaAnalyzer.cc
@@ -55,30 +55,30 @@ EcnaAnalyzer::EcnaAnalyzer(const edm::ParameterSet& pSet) :
   TEcnaParPaths* myPathEB = new TEcnaParPaths(fMyEcnaEBObjectManager);
   TEcnaParPaths* myPathEE = new TEcnaParPaths(fMyEcnaEEObjectManager);
 
-  std::cout << "*EcnaAnalyzer-constructor> Check path for resultsq Root files." << endl;
+  std::cout << "*EcnaAnalyzer-constructor> Check path for resultsq Root files." << std::endl;
 
   if( myPathEB->GetPathForResultsRootFiles() == kFALSE )
     {
-      std::cout << "*EcnaAnalyzer-constructor> *** ERROR *** Path for result files not found." << endl;
+      std::cout << "*EcnaAnalyzer-constructor> *** ERROR *** Path for result files not found." << std::endl;
       kill(getpid(),SIGUSR2);
     }
   else
     {
-      std::cout << "*EcnaAnalyzer-constructor> Path for result files found = " << myPathEB->ResultsRootFilePath() << endl;
+      std::cout << "*EcnaAnalyzer-constructor> Path for result files found = " << myPathEB->ResultsRootFilePath() << std::endl;
     }
 
   if( myPathEE->GetPathForResultsRootFiles() == kFALSE )
     {
-      std::cout << "*EcnaAnalyzer-constructor> *** ERROR *** Path for result files not found." << endl;
+      std::cout << "*EcnaAnalyzer-constructor> *** ERROR *** Path for result files not found." << std::endl;
       kill(getpid(),SIGUSR2);
     }
   else
     {
-      std::cout << "*EcnaAnalyzer-constructor> Path for result files found = " << myPathEE->ResultsRootFilePath() << endl;
+      std::cout << "*EcnaAnalyzer-constructor> Path for result files found = " << myPathEE->ResultsRootFilePath() << std::endl;
     }
 
 
-  std::cout << "*EcnaAnalyzer-constructor> Parameter initialization." << endl;
+  std::cout << "*EcnaAnalyzer-constructor> Parameter initialization." << std::endl;
 
   fgMaxCar = (Int_t)512;
   fTTBELL = '\007';
@@ -385,17 +385,17 @@ EcnaAnalyzer::EcnaAnalyzer(const edm::ParameterSet& pSet) :
   fFedId  = -1;
   fFedTcc = -1;
 
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fAnalysisName        = " << fAnalysisName << endl;
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fNbOfSamples         = " << fNbOfSamples << endl;
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fFirstReqEvent       = " << fFirstReqEvent << endl;
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fLastReqEvent        = " << fLastReqEvent << endl;
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fReqNbOfEvts         = " << fReqNbOfEvts << endl;
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fStexName            = " << fStexName << endl;
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fStexNumber          = " << fStexNumber << endl;
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fChozenRunTypeNumber = " << fChozenRunTypeNumber << endl;
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fChozenGainNumber    = " << fChozenGainNumber  << endl << endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fAnalysisName        = " << fAnalysisName << std::endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fNbOfSamples         = " << fNbOfSamples << std::endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fFirstReqEvent       = " << fFirstReqEvent << std::endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fLastReqEvent        = " << fLastReqEvent << std::endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fReqNbOfEvts         = " << fReqNbOfEvts << std::endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fStexName            = " << fStexName << std::endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fStexNumber          = " << fStexNumber << std::endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fChozenRunTypeNumber = " << fChozenRunTypeNumber << std::endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fChozenGainNumber    = " << fChozenGainNumber  << std::endl << std::endl;
 
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> Init done. " << endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> Init done. " << std::endl;
 }
 // end of constructor
 
@@ -413,7 +413,7 @@ EcnaAnalyzer::~EcnaAnalyzer()
   cout.setf(ios::left, ios::adjustfield);
   cout.setf(ios::right, ios::adjustfield);
 
-  std::cout << "EcnaAnalyzer::~EcnaAnalyzer()> destructor is going to be executed." << endl;
+  std::cout << "EcnaAnalyzer::~EcnaAnalyzer()> destructor is going to be executed." << std::endl;
 
   if( fOutcomeError == kTRUE )return;
 
@@ -422,10 +422,10 @@ EcnaAnalyzer::~EcnaAnalyzer()
   //....................................................... EB (SM)
   if( fMyCnaEBSM == 0 && fStexName == "SM" )
     {
-      std::cout << endl << "!EcnaAnalyzer-destructor> **** ERROR **** fMyCnaEBSM = " << fMyCnaEBSM
+      std::cout << std::endl << "!EcnaAnalyzer-destructor> **** ERROR **** fMyCnaEBSM = " << fMyCnaEBSM
 		<< ". !===> ECNA HAS NOT BEEN INITIALIZED. Last event run type = " << runtype(fRunTypeNumber)
-		<< ", last event fFedId(+601) = " << fFedId+601 << endl 
-		<< ", last event Mgpa gain = " << gainvalue(fMgpaGainNumber) << endl << endl;
+		<< ", last event fFedId(+601) = " << fFedId+601 << std::endl 
+		<< ", last event Mgpa gain = " << gainvalue(fMgpaGainNumber) << std::endl << std::endl;
     }
   else
     {
@@ -445,13 +445,13 @@ EcnaAnalyzer::~EcnaAnalyzer()
 	      if( fMyCnaEBSM[iSM]->WriteRootFile() == kFALSE )
 		{
 		  std::cout << "!EcnaAnalyzer-destructor> PROBLEM with write ROOT file for SM" << iSM+1
-			    << fTTBELL << endl;
+			    << fTTBELL << std::endl;
 		}
 	    }
 	  else
 	    {
 	      std::cout << "*EcnaAnalyzer-destructor> Calculations and writing on file already done for SM "
-			<< iSM+1 << endl;
+			<< iSM+1 << std::endl;
 	    }
 	}
       delete fMyCnaEBSM;
@@ -460,10 +460,10 @@ EcnaAnalyzer::~EcnaAnalyzer()
 
   if( fMyCnaEEDee == 0 && fStexName == "Dee" )
     {
-      std::cout << endl << "!EcnaAnalyzer-destructor> **** ERROR **** fMyCnaEEDee = " << fMyCnaEEDee
+      std::cout << std::endl << "!EcnaAnalyzer-destructor> **** ERROR **** fMyCnaEEDee = " << fMyCnaEEDee
 		<< ". !===> ECNA HAS NOT BEEN INITIALIZED. Last event run type = " << runtype(fRunTypeNumber)
-		<< ", last event fFedId(+601) = " << fFedId+601 << endl 
-		<< ", last event Mgpa gain = " << gainvalue(fMgpaGainNumber) << endl << endl;
+		<< ", last event fFedId(+601) = " << fFedId+601 << std::endl 
+		<< ", last event Mgpa gain = " << gainvalue(fMgpaGainNumber) << std::endl << std::endl;
     }
   else
     {
@@ -483,23 +483,23 @@ EcnaAnalyzer::~EcnaAnalyzer()
 	      if(fMyCnaEEDee[iDee]->WriteRootFile() == kFALSE )
 		{
 		  std::cout << "!EcnaAnalyzer-destructor> PROBLEM with write ROOT file for Dee" << iDee+1
-			    << fTTBELL << endl;
+			    << fTTBELL << std::endl;
 		}
 	    }
 	  else
 	    {
 	      std::cout << "*EcnaAnalyzer-destructor> Calculations and writing on file already done for Dee "
-			<< iDee+1 << endl;
+			<< iDee+1 << std::endl;
 	    }
 	}
       delete fMyCnaEEDee;
     }
-  std::cout <<endl;
+  std::cout <<std::endl;
 
   //-----------------------------------------------------------------------------------
 
   std::cout << "*EcnaAnalyzer-destructor> Status of events returned by GetSampleAdcValues(): "
-	    << endl;
+	    << std::endl;
 
   for(Int_t i0Stex=fStexIndexBegin; i0Stex<fStexIndexStop; i0Stex++ )
     {
@@ -507,53 +507,53 @@ EcnaAnalyzer::~EcnaAnalyzer()
 		<< " / ERROR(S): " << fBuildEventDistribBad[i0Stex];
       if( fBuildEventDistribBad[i0Stex] > 0 )
 	{std::cout << " <=== SHOULD BE EQUAL TO ZERO ! " << fTTBELL;}
-      std::cout << endl;
+      std::cout << std::endl;
     }
 
-  std::cout << endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  endl;
+  std::cout << std::endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  std::endl;
   
-  std::cout << "*EcnaAnalyzer-destructor> Run types seen in event headers before selection:" << endl;
+  std::cout << "*EcnaAnalyzer-destructor> Run types seen in event headers before selection:" << std::endl;
 
   for(Int_t i=0; i<fMaxRunTypeCounter; i++)
     {
-      std::cout << " => " << setw(10) << fRunTypeCounter[i]
-		<< " event header(s) with run type " << runtype(i) << endl; 
+      std::cout << " => " << std::setw(10) << fRunTypeCounter[i]
+		<< " event header(s) with run type " << runtype(i) << std::endl; 
     }
 
-  std::cout << endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  endl;
+  std::cout << std::endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  std::endl;
 
-  std::cout << "*EcnaAnalyzer-destructor> Mgpa gains seen in event headers before selection:" << endl;
+  std::cout << "*EcnaAnalyzer-destructor> Mgpa gains seen in event headers before selection:" << std::endl;
 
   for(Int_t i=0; i<fMaxMgpaGainCounter; i++)
     {
-      std::cout << " => " << setw(10) << fMgpaGainCounter[i]
-		<< " event header(s) with gain " << gainvalue(i) << endl; 
+      std::cout << " => " << std::setw(10) << fMgpaGainCounter[i]
+		<< " event header(s) with gain " << gainvalue(i) << std::endl; 
     }
 
-  std::cout << endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  endl;
+  std::cout << std::endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  std::endl;
 
-  std::cout << "*EcnaAnalyzer-destructor> Numbers of selected events for each FED:" << endl;
+  std::cout << "*EcnaAnalyzer-destructor> Numbers of selected events for each FED:" << std::endl;
 
   for(Int_t i=0; i<fMaxFedIdCounter; i++)
     {
 	  std::cout << " => FedId " << i+601 << ": "
-		    << setw(10) << fFedIdCounter[i] << " events" << endl;
+		    << std::setw(10) << fFedIdCounter[i] << " events" << std::endl;
     }
 
-  std::cout << endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  endl;
+  std::cout << std::endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  std::endl;
 
   if( fStexNumber == 0 )
     {
-      // std::cout << "*EcnaAnalyzer-destructor> fDateFirst = " << fDateFirst[0] << endl
-      //           << "                          fDateLast  = " << fDateLast[fMaxTreatedStexCounter-1] << endl << endl;
+      // std::cout << "*EcnaAnalyzer-destructor> fDateFirst = " << fDateFirst[0] << std::endl
+      //           << "                          fDateLast  = " << fDateLast[fMaxTreatedStexCounter-1] << std::endl << std::endl;
     }
   if( fStexNumber > 0 )
     {
-      std::cout << "*EcnaAnalyzer-destructor> fDateFirst = " << fDateFirst[fStexNumber-1] << endl
-		<< "                          fDateLast  = " << fDateLast[fStexNumber-1] << endl << endl;
+      std::cout << "*EcnaAnalyzer-destructor> fDateFirst = " << fDateFirst[fStexNumber-1] << std::endl
+		<< "                          fDateLast  = " << fDateLast[fStexNumber-1] << std::endl << std::endl;
     }
 
-  std::cout << endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  endl;
+  std::cout << std::endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  std::endl;
 
   Int_t n0 =0; CheckMsg(n0);
 
@@ -563,7 +563,7 @@ EcnaAnalyzer::~EcnaAnalyzer()
   delete fMyEBEcal;
   delete fMyEEEcal;
 
-  std::cout << "*EcnaAnalyzer-destructor> End of execution." << endl;
+  std::cout << "*EcnaAnalyzer-destructor> End of execution." << std::endl;
 }
 // end of destructor
 
@@ -759,15 +759,15 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 							       fFirstReqEvent, fLastReqEvent, fReqNbOfEvts,
 							       i0SM+1,         fRunTypeNumber);
 		      
-			  std::cout << "*EcnaAnalyzer::analyze(...)> ********* INIT ECNA EB ********* " << endl
-				    << "                                   fAnalysisName = " << fAnalysisName << endl
-				    << "                                      fRunNumber = " << fRunNumber << endl
-				    << "                                  fFirstReqEvent = " << fFirstReqEvent << endl
-				    << "                                   fLastReqEvent = " << fLastReqEvent << endl
-				    << "                                    fReqNbOfEvts = " << fReqNbOfEvts << endl
-				    << "                                              SM = " << i0SM+1 << endl
+			  std::cout << "*EcnaAnalyzer::analyze(...)> ********* INIT ECNA EB ********* " << std::endl
+				    << "                                   fAnalysisName = " << fAnalysisName << std::endl
+				    << "                                      fRunNumber = " << fRunNumber << std::endl
+				    << "                                  fFirstReqEvent = " << fFirstReqEvent << std::endl
+				    << "                                   fLastReqEvent = " << fLastReqEvent << std::endl
+				    << "                                    fReqNbOfEvts = " << fReqNbOfEvts << std::endl
+				    << "                                              SM = " << i0SM+1 << std::endl
 				    << "                                        run type = " << runtype(fRunTypeNumber)
-				    << endl;
+				    << std::endl;
 			  //============================================================================
 			}
 		      
@@ -794,10 +794,10 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 				  fTimeLast[i0SM]  = i_current_ev_time;
 				  fDateLast[i0SM]  = astime;
 				  std::cout << "*----> beginning of analysis for " << fStexName << i0SM+1
-					    << ". First analyzed event date : " << astime << endl;
-				  //      << " t_current_ev_time = " << t_current_ev_time  << endl
-				  //      << " i_current_ev_time = " << i_current_ev_time  << endl
-				  //      << " p_current_ev_time = " << p_current_ev_time  << endl
+					    << ". First analyzed event date : " << astime << std::endl;
+				  //      << " t_current_ev_time = " << t_current_ev_time  << std::endl
+				  //      << " i_current_ev_time = " << i_current_ev_time  << std::endl
+				  //      << " p_current_ev_time = " << p_current_ev_time  << std::endl
 				}
 
 			      if( i_current_ev_time < fTimeFirst[i0SM] )
@@ -849,7 +849,7 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 				  else
 				    {
 				      std::cout << "EcnaAnalyzer::analyze(...)> NbOfSamplesFromDigis out of bounds = "
-						<< NbOfSamplesFromDigis << endl;
+						<< NbOfSamplesFromDigis << std::endl;
 				    }
 				} // end of if( (fStexNumber > 0 && i0SM == fStexNumber-1) || (fStexNumber == 0) )
 			    } // end of if( fStexNbOfTreatedEvents[i0SM] >= 1 && fStexNbOfTreatedEvents[i0SM] <= fReqNbOfEvts )
@@ -934,15 +934,15 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 								 fFirstReqEvent, fLastReqEvent, fReqNbOfEvts,
 								 i0Dee+1,         fRunTypeNumber);
 			  
-			  std::cout << "*EcnaAnalyzer::analyze(...)> ********* INIT ECNA EE ********* " << endl
-				    << "                                   fAnalysisName = " << fAnalysisName << endl
-				    << "                                      fRunNumber = " << fRunNumber << endl
-				    << "                                  fFirstReqEvent = " << fFirstReqEvent << endl
-				    << "                                   fLastReqEvent = " << fLastReqEvent << endl
-				    << "                                    fReqNbOfEvts = " << fReqNbOfEvts << endl
-				    << "                                             Dee = " << i0Dee+1 << endl
+			  std::cout << "*EcnaAnalyzer::analyze(...)> ********* INIT ECNA EE ********* " << std::endl
+				    << "                                   fAnalysisName = " << fAnalysisName << std::endl
+				    << "                                      fRunNumber = " << fRunNumber << std::endl
+				    << "                                  fFirstReqEvent = " << fFirstReqEvent << std::endl
+				    << "                                   fLastReqEvent = " << fLastReqEvent << std::endl
+				    << "                                    fReqNbOfEvts = " << fReqNbOfEvts << std::endl
+				    << "                                             Dee = " << i0Dee+1 << std::endl
 				    << "                                        run type = " << runtype(fRunTypeNumber)
-				    << endl;
+				    << std::endl;
 			  //============================================================================
 			}
 
@@ -1028,13 +1028,13 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 				  fDateFirst[i0Dee] = astime;
 				  fTimeLast[i0Dee]  = i_current_ev_time;
 				  fDateLast[i0Dee]  = astime;
-				  std::cout << "----- beginning of analysis for " << fStexName << i0Dee+1 << "-------"  << endl
-				    //<< " t_current_ev_time = " << t_current_ev_time  << endl
-				    //<< " i_current_ev_time = " << i_current_ev_time  << endl
-				    //<< " p_current_ev_time = " << p_current_ev_time  << endl
-					    << " First event date  = " << astime << endl
-					    << " Nb of selected evts = " << fNbOfSelectedEvents << endl
-					    << "---------------------------------------------------------------"  << endl;
+				  std::cout << "----- beginning of analysis for " << fStexName << i0Dee+1 << "-------"  << std::endl
+				    //<< " t_current_ev_time = " << t_current_ev_time  << std::endl
+				    //<< " i_current_ev_time = " << i_current_ev_time  << std::endl
+				    //<< " p_current_ev_time = " << p_current_ev_time  << std::endl
+					    << " First event date  = " << astime << std::endl
+					    << " Nb of selected evts = " << fNbOfSelectedEvents << std::endl
+					    << "---------------------------------------------------------------"  << std::endl;
 				  fMemoDateFirstEvent[i0Dee]++;
 				}
 
@@ -1083,7 +1083,7 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 				  else
 				    {
 				      std::cout << "EcnaAnalyzer::analyze(...)> NbOfSamplesFromDigis out of bounds = "
-						<< NbOfSamplesFromDigis << endl;
+						<< NbOfSamplesFromDigis << std::endl;
 				    }
 				} // end of if( (fStexNumber > 0 && i0Dee == fStexNumber-1) || (fStexNumber == 0) )
 			    } // end of if( fFedNbOfTreatedEvents[fESFromFedTcc[fFedTcc-1]-1] >= 1 &&
@@ -1212,16 +1212,16 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 	  //if( i_current_ev_time > fTimeLast[i0Stex] )
 	  // {fTimeLast[i0Stex] = i_current_ev_time; fDateLast[i0Stex] = astime;}
 	  
-	  std::cout << "---------- End of analysis for " << fStexName << i0Stex+1 << " -----------" << endl;
+	  std::cout << "---------- End of analysis for " << fStexName << i0Stex+1 << " -----------" << std::endl;
 	  Int_t n3 = 3; CheckMsg(n3, i0Stex);
-	  // std::cout 	   << " t_current_ev_time = " << t_current_ev_time  << endl
-	  //<< " i_current_ev_time = " << i_current_ev_time  << endl
-	  //<< " p_current_ev_time = " << p_current_ev_time  << endl
-	  // std::cout 	    << " Last analyzed event date  = " << astime << endl;
-	  std::cout 	    << " Number of selected events = " << fNbOfSelectedEvents << endl;
-	  std::cout << endl << fNbOfTreatedStexs << " " << fStexName
-		    << "'s with " << fReqNbOfEvts << " events analyzed." << endl
-		    << "---------------------------------------------------------"  << endl;
+	  // std::cout 	   << " t_current_ev_time = " << t_current_ev_time  << std::endl
+	  //<< " i_current_ev_time = " << i_current_ev_time  << std::endl
+	  //<< " p_current_ev_time = " << p_current_ev_time  << std::endl
+	  // std::cout 	    << " Last analyzed event date  = " << astime << std::endl;
+	  std::cout 	    << " Number of selected events = " << fNbOfSelectedEvents << std::endl;
+	  std::cout << std::endl << fNbOfTreatedStexs << " " << fStexName
+		    << "'s with " << fReqNbOfEvts << " events analyzed." << std::endl
+		    << "---------------------------------------------------------"  << std::endl;
 	  
 	  //================================= WRITE RESULTS FILE
 	  if( fStexName == "SM" )
@@ -1240,12 +1240,12 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 		  if( fMyCnaEBSM[i0Stex]->WriteRootFile() == kFALSE )
 		    {
 		      std::cout << "!EcnaAnalyzer::analyze> PROBLEM with write ROOT file for SM" << i0Stex+1
-				<< fTTBELL << endl;
+				<< fTTBELL << std::endl;
 		    }
 		}
 	      // set pointer to zero in order to avoid recalculation and rewriting at the destructor level
 	      delete fMyCnaEBSM[i0Stex];  fMyCnaEBSM[i0Stex] = 0;
-	      std::cout << "!EcnaAnalyzer::analyze> Set memory free: delete done for SM " << i0Stex+1 << endl;
+	      std::cout << "!EcnaAnalyzer::analyze> Set memory free: delete done for SM " << i0Stex+1 << std::endl;
 	    }
 
 	  if( fStexName == "Dee" )
@@ -1264,16 +1264,16 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 		  if(fMyCnaEEDee[i0Stex]->WriteRootFile() == kFALSE )
 		    {
 		      std::cout << "!EcnaAnalyzer::analyze> PROBLEM with write ROOT file for Dee" << i0Stex+1
-				<< fTTBELL << endl;
+				<< fTTBELL << std::endl;
 		    }
 		}
 	      // set pointer to zero in order to avoid recalculation and rewriting at the destructor level
 	      delete fMyCnaEEDee[i0Stex]; fMyCnaEEDee[i0Stex] = 0;
-	      std::cout << "!EcnaAnalyzer::analyze> Set memory free: delete done for Dee " << i0Stex+1 << endl;
+	      std::cout << "!EcnaAnalyzer::analyze> Set memory free: delete done for Dee " << i0Stex+1 << std::endl;
 	    }
 
 	  fStexStatus[i0Stex] = 2;        // set fStexStatus[i0Stex] to 2 definitively
-	  std::cout << "*---------------------------------------------------------------------------- " << endl;
+	  std::cout << "*---------------------------------------------------------------------------- " << std::endl;
 
 	} // end of if( fStexStatus[i0Stex] == 1 )
     } // end of for(Int_t i0Stex=fStexIndexBegin; i0Stex<fStexIndexStop; i0Stex++)
@@ -1298,21 +1298,21 @@ Bool_t EcnaAnalyzer::AnalysisOutcome(const TString& s_opt)
 	    (fLastReqEvent >= fFirstReqEvent && fCurrentEventNumber <= fLastReqEvent) )
 	  )
 	{
-	  std::cout << endl
-		    << "**************************** ANALYSIS REPORT > OK **************************************" << endl
-		    << "*EcnaAnalyzer::AnalysisOutcome(...)> The maximum requested number of events and the maximum" << endl
+	  std::cout << std::endl
+		    << "**************************** ANALYSIS REPORT > OK **************************************" << std::endl
+		    << "*EcnaAnalyzer::AnalysisOutcome(...)> The maximum requested number of events and the maximum" << std::endl
 		    << "                                     number of treated " << fStexName
-		    << "'s have been reached." << endl
-		    << "                                     Analysis successfully ended from EcnaAnalyzer " << endl
-		    << "                                     by SIGNAL: kill(getpid(),SIGUSR2)." << endl
-		    << "                                     Number of selected events   = " << fNbOfSelectedEvents << endl
-		    << "                                     Last requested event number = " << fLastReqEvent << endl
-		    << "                                     Current event number        = " << fCurrentEventNumber << endl;
+		    << "'s have been reached." << std::endl
+		    << "                                     Analysis successfully ended from EcnaAnalyzer " << std::endl
+		    << "                                     by SIGNAL: kill(getpid(),SIGUSR2)." << std::endl
+		    << "                                     Number of selected events   = " << fNbOfSelectedEvents << std::endl
+		    << "                                     Last requested event number = " << fLastReqEvent << std::endl
+		    << "                                     Current event number        = " << fCurrentEventNumber << std::endl;
 
 	  Int_t n0 = 0; CheckMsg(n0);
 
-	  std::cout << "****************************************************************************************" << endl
-		    << endl;
+	  std::cout << "****************************************************************************************" << std::endl
+		    << std::endl;
 
 	  result = kTRUE;
 	  kill(getpid(),SIGUSR2);
@@ -1322,19 +1322,19 @@ Bool_t EcnaAnalyzer::AnalysisOutcome(const TString& s_opt)
 	  ! ( (fStexNumber > 0 && fNbOfTreatedStexs == 1) ||
 	      (fStexNumber == 0 && fNbOfTreatedStexs == MaxNbOfStex) ) )
 	{
-	  std::cout << endl
-		    << "**************************** ANALYSIS REPORT >>> *** WARNING *** WARNING *** WARNING ***" << endl
-		    << "*EcnaAnalyzer::AnalysisOutcome(...)> Last event reached before completion of analysis." << endl
-		    << "                                     Analysis ended from EcnaAnalyzer " << endl
-		    << "                                     by SIGNAL: kill(getpid(),SIGUSR2)." << endl
-		    << "                                     Number of selected events   = " << fNbOfSelectedEvents << endl
-		    << "                                     Last requested event number = " << fLastReqEvent << endl
-		    << "                                     Current event number        = " << fCurrentEventNumber << endl;
+	  std::cout << std::endl
+		    << "**************************** ANALYSIS REPORT >>> *** WARNING *** WARNING *** WARNING ***" << std::endl
+		    << "*EcnaAnalyzer::AnalysisOutcome(...)> Last event reached before completion of analysis." << std::endl
+		    << "                                     Analysis ended from EcnaAnalyzer " << std::endl
+		    << "                                     by SIGNAL: kill(getpid(),SIGUSR2)." << std::endl
+		    << "                                     Number of selected events   = " << fNbOfSelectedEvents << std::endl
+		    << "                                     Last requested event number = " << fLastReqEvent << std::endl
+		    << "                                     Current event number        = " << fCurrentEventNumber << std::endl;
 
 	  Int_t n0 = 0; CheckMsg(n0);
 
-	  std::cout << "****************************************************************************************" << endl
-		    << endl;
+	  std::cout << "****************************************************************************************" << std::endl
+		    << std::endl;
       
 	  result = kTRUE;
 	  kill(getpid(),SIGUSR2);
@@ -1344,31 +1344,31 @@ Bool_t EcnaAnalyzer::AnalysisOutcome(const TString& s_opt)
     {
       if( s_opt == "ERR_FNEG" )
 	{
-	  std::cout << endl
-		    << "**************************** ANALYSIS REPORT >>> **** ERROR **** ERROR **** ERROR ******" << endl
+	  std::cout << std::endl
+		    << "**************************** ANALYSIS REPORT >>> **** ERROR **** ERROR **** ERROR ******" << std::endl
 		    << "*EcnaAnalyzer::AnalysisOutcome(...)> First event number = " << fFirstReqEvent
-		    << ". Should be strictly potitive." << endl
-		    << "                             Analysis ended from EcnaAnalyzer " << endl
-		    << "                             by SIGNAL: kill(getpid(),SIGUSR2)." << endl;
+		    << ". Should be strictly potitive." << std::endl
+		    << "                             Analysis ended from EcnaAnalyzer " << std::endl
+		    << "                             by SIGNAL: kill(getpid(),SIGUSR2)." << std::endl;
 
-	  std::cout << "****************************************************************************************" << endl
-		    << endl;
+	  std::cout << "****************************************************************************************" << std::endl
+		    << std::endl;
 
 	  result = kTRUE;
 	  kill(getpid(),SIGUSR2);
 	}
       if( s_opt == "ERR_LREQ" )
 	{
-	  std::cout << endl
-		    << "**************************** ANALYSIS REPORT >>> **** ERROR **** ERROR **** ERROR ******" << endl
-		    << "*EcnaAnalyzer::analyze(...)> Requested number of events = " << fReqNbOfEvts << "." << endl
+	  std::cout << std::endl
+		    << "**************************** ANALYSIS REPORT >>> **** ERROR **** ERROR **** ERROR ******" << std::endl
+		    << "*EcnaAnalyzer::analyze(...)> Requested number of events = " << fReqNbOfEvts << "." << std::endl
 		    << "                             Too large compared to the event range: "
-		    << fFirstReqEvent << " - " << fLastReqEvent << endl
-		    << "                             Analysis ended from EcnaAnalyzer " << endl
-		    << "                             by SIGNAL: kill(getpid(),SIGUSR2)." << endl;
+		    << fFirstReqEvent << " - " << fLastReqEvent << std::endl
+		    << "                             Analysis ended from EcnaAnalyzer " << std::endl
+		    << "                             by SIGNAL: kill(getpid(),SIGUSR2)." << std::endl;
 
-	  std::cout << "****************************************************************************************" << endl
-		    << endl;
+	  std::cout << "****************************************************************************************" << std::endl
+		    << std::endl;
 
 	  result = kTRUE;
 	  kill(getpid(),SIGUSR2);
@@ -1385,28 +1385,28 @@ void EcnaAnalyzer::CheckMsg(const Int_t& MsgNum, const Int_t& i0Stex)
   //------ Cross-check messages
 
   if( MsgNum == 1 )
-    {std::cout << "---------------- CROSS-CHECK A ------------------ " << endl
-	       << "**************** CURRENT EVENT ****************** " << endl;}
+    {std::cout << "---------------- CROSS-CHECK A ------------------ " << std::endl
+	       << "**************** CURRENT EVENT ****************** " << std::endl;}
   if( MsgNum == 2 )
-    {std::cout << "---------------- CROSS-CHECK B ------------------ " << endl
-	       << "**** FIRST EVENT PASSING USER'S ANALYSIS CUT **** " << endl;}
+    {std::cout << "---------------- CROSS-CHECK B ------------------ " << std::endl
+	       << "**** FIRST EVENT PASSING USER'S ANALYSIS CUT **** " << std::endl;}
   if( MsgNum == 3 )
-    {std::cout << "---------------- CROSS-CHECK C ------------------ " << endl
-	       << "*** CURRENT VALUES BEFORE RESULT FILE WRITING *** " << endl;}
+    {std::cout << "---------------- CROSS-CHECK C ------------------ " << std::endl
+	       << "*** CURRENT VALUES BEFORE RESULT FILE WRITING *** " << std::endl;}
   if( MsgNum == 3 || MsgNum == 4 )
-    {std::cout << "          fRecNumber = " << fRecNumber << endl
-	       << "          fEvtNumber = " << fEvtNumber << endl;}
+    {std::cout << "          fRecNumber = " << fRecNumber << std::endl
+	       << "          fEvtNumber = " << fEvtNumber << std::endl;}
   
-  std::cout << " fCurrentEventNumber = " << fCurrentEventNumber << endl
-	    << " fNbOfSelectedEvents = " << fNbOfSelectedEvents << endl
-	    << "          fRunNumber = " << fRunNumber << endl
-	    << "     Chozen run type = " << runtype(fChozenRunTypeNumber) << endl
-	    << "            Run type = " << runtype(fRunTypeNumber) << endl
-	    << "             fFedTcc = " << fFedTcc << endl
-	    << "        fFedId(+601) = " << fFedId+601 << endl
-	    << "           fStexName = " << fStexName << endl
-	    << "         Chozen gain = " << gainvalue(fChozenGainNumber) << endl 
-	    << "           Mgpa Gain = " << gainvalue(fMgpaGainNumber) << endl << endl;
+  std::cout << " fCurrentEventNumber = " << fCurrentEventNumber << std::endl
+	    << " fNbOfSelectedEvents = " << fNbOfSelectedEvents << std::endl
+	    << "          fRunNumber = " << fRunNumber << std::endl
+	    << "     Chozen run type = " << runtype(fChozenRunTypeNumber) << std::endl
+	    << "            Run type = " << runtype(fRunTypeNumber) << std::endl
+	    << "             fFedTcc = " << fFedTcc << std::endl
+	    << "        fFedId(+601) = " << fFedId+601 << std::endl
+	    << "           fStexName = " << fStexName << std::endl
+	    << "         Chozen gain = " << gainvalue(fChozenGainNumber) << std::endl 
+	    << "           Mgpa Gain = " << gainvalue(fMgpaGainNumber) << std::endl << std::endl;
 	  
   if( fAnalysisName == "AdcPeg12"  || fAnalysisName == "AdcSPeg12" )
     {
@@ -1418,11 +1418,11 @@ void EcnaAnalyzer::CheckMsg(const Int_t& MsgNum, const Int_t& i0Stex)
 	      if( fStexStatus[j0Stex] == 1 ){nStexNbOfTreatedEvents = fStexNbOfTreatedEvents[j0Stex];}
 	      if( fStexStatus[j0Stex] == 2 ){nStexNbOfTreatedEvents = fStexNbOfTreatedEvents[j0Stex];}
 	      
-	      std::cout << fStexName << setw(3) << j0Stex+1 << ": "
-			<< setw(5) << nStexNbOfTreatedEvents << " events. "
+	      std::cout << fStexName << std::setw(3) << j0Stex+1 << ": "
+			<< std::setw(5) << nStexNbOfTreatedEvents << " events. "
 			<< fStexName << " status: " << fStexStatus[j0Stex];
 	      if( j0Stex == i0Stex ){std::cout << " (going to write file for this " << fStexName << ").";}
-	      std::cout << endl; 
+	      std::cout << std::endl; 
 	    }
 	}
 
@@ -1434,31 +1434,31 @@ void EcnaAnalyzer::CheckMsg(const Int_t& MsgNum, const Int_t& i0Stex)
 	      if( fFedStatus[i0FedES] == 1 ){nFedNbOfTreatedEvents = fFedNbOfTreatedEvents[i0FedES];}
 	      if( fFedStatus[i0FedES] == 2 ){nFedNbOfTreatedEvents = fFedNbOfTreatedEvents[i0FedES];}
 	      
-	      std::cout << "Fed (ES) " << setw(3) << i0FedES+1 << ": "
-			<< setw(5) << nFedNbOfTreatedEvents << " events."
+	      std::cout << "Fed (ES) " << std::setw(3) << i0FedES+1 << ": "
+			<< std::setw(5) << nFedNbOfTreatedEvents << " events."
 			<< " Fed status: " << fFedStatus[i0FedES]
-			<< ", order: " << setw(3) << fFedStatusOrder[i0FedES]
-			<< " (" << fDeeNumberString[i0FedES] << ")" << endl;
+			<< ", order: " << std::setw(3) << fFedStatusOrder[i0FedES]
+			<< " (" << fDeeNumberString[i0FedES] << ")" << std::endl;
 	    }
 	  
 	  for(Int_t j0Stex=fStexIndexBegin; j0Stex<fStexIndexStop; j0Stex++)
 	    {
-	      std::cout << fStexName << setw(3) << j0Stex+1 << ": "
-			<< setw(5) << fNbOfTreatedFedsInStex[j0Stex] << " analyzed Fed(s). "
+	      std::cout << fStexName << std::setw(3) << j0Stex+1 << ": "
+			<< std::setw(5) << fNbOfTreatedFedsInStex[j0Stex] << " analyzed Fed(s). "
 			<< fStexName << " status: " << fStexStatus[j0Stex];
 	      if( j0Stex == i0Stex ){std::cout << " (going to write file for this " << fStexName << ").";}
-	      std::cout << endl; 
+	      std::cout << std::endl; 
 	    }
 	}
 
       std::cout << "Number of " << fStexName << "'s with "
-		<< fReqNbOfEvts << " events analyzed: " << fNbOfTreatedStexs << endl;
+		<< fReqNbOfEvts << " events analyzed: " << fNbOfTreatedStexs << std::endl;
     }
   
   if( MsgNum == 1 || MsgNum == 2 )
-    {std::cout << "*---------------------------------------------------------------------------- " << endl;}
+    {std::cout << "*---------------------------------------------------------------------------- " << std::endl;}
   if( MsgNum == 3 )
-    {std::cout << "*............................................................................ " << endl;}
+    {std::cout << "*............................................................................ " << std::endl;}
 
 } // end of EcnaAnalyzer::CheckMsg(const Int_t& MsgNum, const Int_t& i0Stex)
 

--- a/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalStatusAnalyzer.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/plugins/EcalStatusAnalyzer.cc
@@ -290,7 +290,7 @@ void EcalStatusAnalyzer::endJob() {
 
   string statusfile=namefile.str();
   
-  ofstream statusFile(statusfile.c_str(), ofstream::out);
+  std::ofstream statusFile(statusfile.c_str(), std::ofstream::out);
   
   
   if(fedIDsLas.size()!=0 && fedIDsLas.size()==dccIDsLas.size()){

--- a/CalibCalorimetry/EcalLaserAnalyzer/src/MELaserPrim.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/src/MELaserPrim.cc
@@ -1002,7 +1002,7 @@ MELaserPrim::~MELaserPrim()
 }
 
 void 
-MELaserPrim::print( ostream& o )
+MELaserPrim::print( std::ostream& o )
 {
   o << "DCC/SM/side/type/color/run/ts " << _dcc << "/" << _sm << "/" << _side << "/" 
     << _type << "/" << _color << "/" << _run << "/" << _ts << std::endl;

--- a/CalibCalorimetry/EcalLaserAnalyzer/src/TPNCor.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/src/TPNCor.cc
@@ -39,7 +39,7 @@ TPNCor::TPNCor(string filename)
   char c;
   int gain;
   double aa, bb, cc;
-  ifstream fin;
+  std::ifstream fin;
   
   if( test ) {
     fclose( test );

--- a/CalibCalorimetry/EcalLaserAnalyzer/test/MusEcal/src/MERunManager.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/test/MusEcal/src/MERunManager.cc
@@ -52,7 +52,7 @@ MERunManager::updateRunList()
 {
   TString runlistfile = ME::runListName( _lmr, _type, _color );
 
-  ifstream fin;
+  std::ifstream fin;
   fin.open(runlistfile);
 
   MERun* aRun(0);

--- a/CalibCalorimetry/EcalLaserAnalyzer/test/MusEcal/src/MusEcal.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/test/MusEcal/src/MusEcal.cc
@@ -637,7 +637,7 @@ MusEcal::histConfig()
       char c;
       if( test )
 	{
-	  ifstream fin(filename);
+	  std::ifstream fin(filename);
 	  fclose( test );
 	  while( (c=fin.peek()) != EOF )
 	    {

--- a/CalibCalorimetry/EcalLaserAnalyzer/test/MusEcal/src/runGeom.cc
+++ b/CalibCalorimetry/EcalLaserAnalyzer/test/MusEcal/src/runGeom.cc
@@ -626,7 +626,7 @@ void writeGeom()
 int main(int argc, char **argv)
 {
 
-  //  ofstream o("eenum.txt");
+  //  std::ofstream o("eenum.txt");
 
   //
   // Test that the geometry corresponds to that of EEDetId

--- a/CalibMuon/CSCCalibration/plugins/CSCCrosstalkConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCCrosstalkConditions.cc
@@ -1,4 +1,5 @@
 #include <fstream>
+#include <iostream>
 
 #include "CalibMuon/CSCCalibration/interface/CSCCrosstalkConditions.h"
 

--- a/CalibMuon/CSCCalibration/plugins/CSCGainsConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCGainsConditions.cc
@@ -1,4 +1,5 @@
 #include <fstream>
+#include <iostream>
 
 #include "CalibMuon/CSCCalibration/interface/CSCGainsConditions.h"
 

--- a/CalibMuon/CSCCalibration/plugins/CSCNoiseMatrixConditions.cc
+++ b/CalibMuon/CSCCalibration/plugins/CSCNoiseMatrixConditions.cc
@@ -1,4 +1,5 @@
 #include <fstream>
+#include <iostream>
 
 #include "CalibMuon/CSCCalibration/interface/CSCNoiseMatrixConditions.h"
 

--- a/CalibTracker/SiPixelSCurveCalibration/src/SiPixelSCurveCalibrationAnalysis.cc
+++ b/CalibTracker/SiPixelSCurveCalibration/src/SiPixelSCurveCalibrationAnalysis.cc
@@ -23,7 +23,7 @@ void SiPixelSCurveCalibrationAnalysis::calibrationEnd(){
 }
 
 void SiPixelSCurveCalibrationAnalysis::makeThresholdSummary(void){
-  ofstream myfile;
+  std::ofstream myfile;
   myfile.open (thresholdfilename_.c_str());
   for(detIDHistogramMap::iterator  thisDetIdHistoGrams= histograms_.begin();  thisDetIdHistoGrams != histograms_.end(); ++thisDetIdHistoGrams){
    // loop over det id (det id = number (unsigned int) of pixel module 

--- a/CalibTracker/SiStripDCS/plugins/TkVoltageMapCreator.cc
+++ b/CalibTracker/SiStripDCS/plugins/TkVoltageMapCreator.cc
@@ -100,8 +100,8 @@ TkVoltageMapCreator::beginRun(const edm::Run& iRun, const edm::EventSetup&)
   TkHistoMap lvhisto("LV_Status","LV_Status",-1);
   TkHistoMap hvhisto("HV_Status","HV_Status",-1);
   
-  ifstream lvdata(_lvfile.c_str());
-  ifstream hvdata(_hvfile.c_str());
+  std::ifstream lvdata(_lvfile.c_str());
+  std::ifstream hvdata(_hvfile.c_str());
 
   // HV channel map filling
 

--- a/CalibTracker/SiStripDCS/src/SiStripDetVOffBuilder.cc
+++ b/CalibTracker/SiStripDCS/src/SiStripDetVOffBuilder.cc
@@ -740,7 +740,7 @@ void SiStripDetVOffBuilder::buildPSUdetIdMap(TimesAndValues & psuStruct, DetIdLi
   //Check here if there is a file already, otherwise initialize to OFF all channels in these PSU!
   if (FileExists("HVUnmappedChannelState.dat")) {
     std::cout<<"File HVUnmappedChannelState.dat exists!"<<std::endl;
-    ifstream ifs("HVUnmappedChannelState.dat");
+    std::ifstream ifs("HVUnmappedChannelState.dat");
     string line;
     while( getline( ifs, line ) ) {
       if( line != "" ) {
@@ -801,7 +801,7 @@ void SiStripDetVOffBuilder::buildPSUdetIdMap(TimesAndValues & psuStruct, DetIdLi
   //Check here if there is a file already, otherwise initialize to OFF all channels in these PSU!
   if (FileExists("HVCrosstalkingChannelState.dat")) {
     std::cout<<"File HVCrosstalkingChannelState.dat exists!"<<std::endl;
-    ifstream ifs("HVCrosstalkingChannelState.dat");
+    std::ifstream ifs("HVCrosstalkingChannelState.dat");
     string line;
     while( getline( ifs, line ) ) {
       if( line != "" ) {
@@ -1135,11 +1135,11 @@ void SiStripDetVOffBuilder::buildPSUdetIdMap(TimesAndValues & psuStruct, DetIdLi
     }
   }//End of the loop over all PSUChannels reported by the DB query.
   //At this point we need to (over)write the 2 files that will keep the HVUnmapped and HVCrosstalking channels status:
-  ofstream ofsUnmapped("HVUnmappedChannelState.dat");
+  std::ofstream ofsUnmapped("HVUnmappedChannelState.dat");
   for (std::map<std::string,bool>::iterator it=UnmappedState.begin(); it!=UnmappedState.end(); it++) {
     ofsUnmapped<<it->first<<"\t"<<it->second<<std::endl;
   }
-  ofstream ofsCrosstalking("HVCrosstalkingChannelState.dat");
+  std::ofstream ofsCrosstalking("HVCrosstalkingChannelState.dat");
   for (std::map<std::string,bool>::iterator it=CrosstalkingState.begin(); it!=CrosstalkingState.end(); it++) {
     ofsCrosstalking<<it->first<<"\t"<<it->second<<std::endl;
   }

--- a/CalibTracker/SiStripDCS/src/SiStripPsuDetIdMap.cc
+++ b/CalibTracker/SiStripDCS/src/SiStripPsuDetIdMap.cc
@@ -34,7 +34,7 @@ void SiStripPsuDetIdMap::BuildMap( const std::string & mapFile, std::vector<std:
   //This is not currently used, but I think we could slim this down to just a vector with 
   //the detIDs since the PSUChannel part of the excludedlist (if it ever is in a file) is never used!
   edm::FileInPath file(mapFile.c_str());
-  ifstream ifs( file.fullPath().c_str() );
+  std::ifstream ifs( file.fullPath().c_str() );
   string line;
   while( getline( ifs, line ) ) {
     if( line != "" ) {
@@ -61,7 +61,7 @@ void SiStripPsuDetIdMap::BuildMap( const std::string & mapFile, const bool debug
   //These maps are accessed, based on the LV/HV case, to extract the detIDs connected to a given PSUChannel... 
   //see the getDetIDs method...
   edm::FileInPath file(mapFile.c_str());
-  ifstream ifs( file.fullPath().c_str() );
+  std::ifstream ifs( file.fullPath().c_str() );
   string line;
   while( getline( ifs, line ) ) {
     if( line != "" ) {

--- a/CalibTracker/SiStripLorentzAngle/plugins/EnsembleCalibrationLA.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/EnsembleCalibrationLA.cc
@@ -46,7 +46,7 @@ void EnsembleCalibrationLA::
 write_ensembles_text(const Book& book) {
   std::pair<std::string, std::vector<LA_Filler_Fitter::EnsembleSummary> > ensemble;
   BOOST_FOREACH(ensemble, LA_Filler_Fitter::ensemble_summary(book)) {
-    fstream file((Prefix+ensemble.first+".dat").c_str(),std::ios::out);
+    std::fstream file((Prefix+ensemble.first+".dat").c_str(),std::ios::out);
     BOOST_FOREACH(LA_Filler_Fitter::EnsembleSummary summary, ensemble.second)
       file << summary << std::endl;
 
@@ -101,7 +101,7 @@ write_samples_plots(const Book& book) const {
 
 void EnsembleCalibrationLA::
 write_calibrations() const {
-  fstream file((Prefix+"calibrations.dat").c_str(),std::ios::out);
+  std::fstream file((Prefix+"calibrations.dat").c_str(),std::ios::out);
   std::pair<std::string,MethodCalibrations> cal;
   BOOST_FOREACH(cal,calibrations) {
     file << cal.first << std::endl

--- a/CalibTracker/SiStripLorentzAngle/plugins/MeasureLA.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/MeasureLA.cc
@@ -117,7 +117,7 @@ void MeasureLA::
 write_report_text(std::string name, const LA_Filler_Fitter::Method& _method, const std::map<T,LA_Filler_Fitter::Result>& _results) const {
   LA_Filler_Fitter::Method method = _method;
   std::map<T,LA_Filler_Fitter::Result>results = _results;
-  fstream file((name+".dat").c_str(),std::ios::out);
+  std::fstream file((name+".dat").c_str(),std::ios::out);
   std::pair<T,LA_Filler_Fitter::Result> result;
   BOOST_FOREACH(result, results) {
     calibrate( calibration_key(result.first,method), result.second); 
@@ -128,7 +128,7 @@ write_report_text(std::string name, const LA_Filler_Fitter::Method& _method, con
 
 void MeasureLA::
 write_report_text_ms(std::string name, LA_Filler_Fitter::Method method) const {
-  fstream file((name+".dat").c_str(),std::ios::out);
+  std::fstream file((name+".dat").c_str(),std::ios::out);
   const std::string key = ".*"+granularity(MODULESUMMARY)+LA_Filler_Fitter::method(method);
   for(Book::const_iterator it = book.begin(key); it!=book.end(); ++it) {
     const TF1*const f = it->second->GetFunction("gaus");

--- a/CalibTracker/SiStripLorentzAngle/plugins/SiStripCalibLorentzAngle.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/SiStripCalibLorentzAngle.cc
@@ -302,9 +302,9 @@ void SiStripCalibLorentzAngle::algoBeginJob(const edm::EventSetup& c){
   TF1 *fitfunc= new TF1("fitfunc","([4]/[3])*[1]*(TMath::Abs(x-[0]))+[2]",-1,1);
   TF1 *fitfunc2IT= new TF1("fitfunc2IT","([4]/[3])*[1]*(TMath::Abs(x-[0]))+[2]",-1,1);
  
-  ofstream NoEntries;
+  std::ofstream NoEntries;
   NoEntries.open(NoEntriesHisto_.c_str());
-  ofstream Rep;
+  std::ofstream Rep;
   Rep.open(LAreport_.c_str());
   
   gStyle->SetOptStat(1110);

--- a/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2.cc
+++ b/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2.cc
@@ -309,8 +309,8 @@ void PhiSymmetryCalibration_step2::endJob(){
   outResidHistos();
  
   // finally output global etsums
-  fstream ebf("etsummary_barl.dat",ios::out);
-  fstream eef("etsummary_endc.dat",ios::out);
+  std::fstream ebf("etsummary_barl.dat",ios::out);
+  std::fstream eef("etsummary_endc.dat",ios::out);
   
   for (int ieta=0; ieta<kBarlRings; ieta++) {
     for (int iphi=0; iphi<kBarlWedges; iphi++) {

--- a/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2_SM.cc
+++ b/Calibration/EcalCalibAlgos/src/PhiSymmetryCalibration_step2_SM.cc
@@ -272,7 +272,7 @@ void PhiSymmetryCalibration_step2_SM::endJob(){
 
 
   // output sc calibration
-  fstream scfile("sccalibration.dat",ios::out);
+  std::fstream scfile("sccalibration.dat",std::ios::out);
   for (int ieta =0; ieta< kBarlRings; ++ieta){
     for (int iphi_r =0; iphi_r< int(kBarlWedges/nscx);++iphi_r){
       for (int sign=0; sign<kSides; sign++) {

--- a/Calibration/EcalCalibAlgos/src/ZeeCalibration.cc
+++ b/Calibration/EcalCalibAlgos/src/ZeeCalibration.cc
@@ -2379,7 +2379,7 @@ void ZeeCalibration::printStatistics(){
   
   
   
-  ofstream fout("ZeeStatistics.txt");
+  std::ofstream fout("ZeeStatistics.txt");
   
   if(!fout) {
     std::cout << "Cannot open output file.\n";

--- a/Calibration/HcalCalibAlgos/src/Analyzer_minbias.cc
+++ b/Calibration/HcalCalibAlgos/src/Analyzer_minbias.cc
@@ -192,7 +192,7 @@ void Analyzer_minbias::beginJob()
 
    std::string ccc = "noise_0.dat";
 
-   myout_hcal = new ofstream(ccc.c_str());
+   myout_hcal = new std::ofstream(ccc.c_str());
    if(!myout_hcal) cout << " Output file not open!!! "<<endl;
 
 //

--- a/Calibration/HcalCalibAlgos/src/GammaJetAnalysis.cc
+++ b/Calibration/HcalCalibAlgos/src/GammaJetAnalysis.cc
@@ -125,16 +125,16 @@ void GammaJetAnalysis::beginJob()
 //   iSetup.get<CaloGeometryRecord>().get(pG);
 //   geo = pG.product();
 
-  myout_part = new ofstream((myName+"_part.dat").c_str()); 
+  myout_part = new std::ofstream((myName+"_part.dat").c_str()); 
   if(!myout_part) cout << " Output file not open!!! "<<endl;
-  myout_hcal = new ofstream((myName+"_hcal.dat").c_str()); 
+  myout_hcal = new std::ofstream((myName+"_hcal.dat").c_str()); 
   if(!myout_hcal) cout << " Output file not open!!! "<<endl;
-  myout_ecal = new ofstream((myName+"_ecal.dat").c_str()); 
+  myout_ecal = new std::ofstream((myName+"_ecal.dat").c_str()); 
   if(!myout_ecal) cout << " Output file not open!!! "<<endl;
   
-  myout_jet = new ofstream((myName+"_jet.dat").c_str()); 
+  myout_jet = new std::ofstream((myName+"_jet.dat").c_str()); 
   if(!myout_jet) cout << " Output file not open!!! "<<endl;
-  myout_photon = new ofstream((myName+"_photon.dat").c_str()); 
+  myout_photon = new std::ofstream((myName+"_photon.dat").c_str()); 
   if(!myout_photon) cout << " Output file not open!!! "<<endl;
    
    

--- a/Calibration/HcalCalibAlgos/src/HOCalibAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/src/HOCalibAnalyzer.cc
@@ -1765,7 +1765,7 @@ HOCalibAnalyzer::endJob() {
     int iiter = 0;
 
 
-    ofstream file_out(theoutputtxtFile.c_str());
+    std::ofstream file_out(theoutputtxtFile.c_str());
     //    TPostScript* ps=0;
     int ips=111;
     TPostScript ps(theoutputpsFile.c_str(),ips);

--- a/Calibration/HcalCalibAlgos/src/HcalCalibrator.cc
+++ b/Calibration/HcalCalibAlgos/src/HcalCalibrator.cc
@@ -28,6 +28,7 @@ to the actual calibration code in "endJob()".
 // system include files
 #include <memory>
 #include <fstream>
+#include <iostream>
 
 // user include files
 
@@ -149,25 +150,25 @@ HcalCalibrator::endJob() {
  
 
   if (mCalibType!="DI_JET" && mCalibType!="ISO_TRACK") {
-    cout << "\n\nUnknown calibration type " << mCalibType << endl;
-    cout << "Please select ISO_TRACK or DI_JET in the python file." << endl;
+    std::cout << "\n\nUnknown calibration type " << mCalibType << std::endl;
+    std::cout << "Please select ISO_TRACK or DI_JET in the python file." << std::endl;
     return;
   }
 
   if (mCalibMethod != "L3" && mCalibMethod != "MATRIX_INV_OF_ETA_AVE" && mCalibMethod != "L3_AND_MTRX_INV") {
-    cout << "\n\nUnknown calibration method " << mCalibMethod << endl;
-    cout << "Supported methods for IsoTrack calibration are: L3, MATRIX_INV_OF_ETA_AVE, L3_AND_MTRX_INV" << endl;
-    cout << "For DiJets the supported method is L3" << endl;
+    std::cout << "\n\nUnknown calibration method " << mCalibMethod << std::endl;
+    std::cout << "Supported methods for IsoTrack calibration are: L3, MATRIX_INV_OF_ETA_AVE, L3_AND_MTRX_INV" << std::endl;
+    std::cout << "For DiJets the supported method is L3" << std::endl;
     return;
   }
 
   if (mCalibType=="DI_JET" && mCalibMethod!="L3") {
-    cout << "\n\nDiJet calibration can use only the L3 method. Please change the python file." << endl;
+    std::cout << "\n\nDiJet calibration can use only the L3 method. Please change the python file." << std::endl;
     return;
   }
 
   if (mCalibAbsIEtaMin<1 || mCalibAbsIEtaMax>41 || mCalibAbsIEtaMin>mCalibAbsIEtaMax) {
-    cout << "\n\nInvalid ABS(iEta) calibration range. Check calibAbsIEtaMin and calibAbsIEtaMax in the python file." << endl;
+    std::cout << "\n\nInvalid ABS(iEta) calibration range. Check calibAbsIEtaMin and calibAbsIEtaMax in the python file." << std::endl;
     return;
   }
 
@@ -214,7 +215,7 @@ HcalCalibrator::endJob() {
   calibrator->SetCaloGeometry(mTheCaloGeometry,mTheHcalTopology);
 
  
-  ifstream inputFileList;  // contains list of input root files
+  std::ifstream inputFileList;  // contains list of input root files
 
   TString files = mInputFileList;
   inputFileList.open(files.Data());

--- a/Calibration/HcalCalibAlgos/src/HcalConstantsASCIIWriter.cc
+++ b/Calibration/HcalCalibAlgos/src/HcalConstantsASCIIWriter.cc
@@ -53,7 +53,7 @@ void HcalConstantsASCIIWriter::beginJob()
     edm::FileInPath f1(file_output);
     std::string fDataFile = f1.fullPath();
 
-  myout_hcal = new ofstream(fDataFile.c_str());
+  myout_hcal = new std::ofstream(fDataFile.c_str());
   if(!myout_hcal) std::cout << " Output file not open!!! "<<std::endl;
     
 }

--- a/Calibration/HcalCalibAlgos/src/HcalIsoTrkAnalyzer.cc
+++ b/Calibration/HcalCalibAlgos/src/HcalIsoTrkAnalyzer.cc
@@ -160,7 +160,7 @@ private:
   Float_t tagJetEmFrac; // dijet
   Float_t probeJetEmFrac; // dijet
   
-  ofstream input_to_L3;
+  std::ofstream input_to_L3;
   
 };
 

--- a/Calibration/HcalCalibAlgos/src/hcalCalib.cc
+++ b/Calibration/HcalCalibAlgos/src/hcalCalib.cc
@@ -613,7 +613,7 @@ void hcalCalib::GetCoefFromMtrxInvOfAve() {
 
 Bool_t hcalCalib::ReadPhiSymCor() {
 
-  ifstream phiSymFile(PHI_SYM_COR_FILENAME.Data());
+  std::ifstream phiSymFile(PHI_SYM_COR_FILENAME.Data());
 
   if (!phiSymFile) {
     cout << "\nERROR: Can not find file with phi symmetry constants \"" <<  PHI_SYM_COR_FILENAME.Data() << "\"" << endl;

--- a/Calibration/Tools/src/ZIterativeAlgorithmWithFit.cc
+++ b/Calibration/Tools/src/ZIterativeAlgorithmWithFit.cc
@@ -153,7 +153,7 @@ void ZIterativeAlgorithmWithFit::bookHistograms()
 }
 
 void ZIterativeAlgorithmWithFit::getStatWeights(const std::string &file) {
-  ifstream statfile;
+  std::ifstream statfile;
   statfile.open(file.c_str());
   if (!statfile) {
     std::cout << "ZIterativeAlgorithmWithFit::FATAL: stat weight  file " << file << " not found" << std::endl;

--- a/CaloOnlineTools/EcalTools/plugins/EcalBxOrbitNumberGrapher.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalBxOrbitNumberGrapher.cc
@@ -22,6 +22,8 @@ using namespace cms;
 using namespace edm;
 using namespace std;
 
+#include <iostream>
+
 //
 // constants, enums and typedefs
 //

--- a/CondTools/DQM/plugins/DQMReferenceHistogramRootFileEventSetupAnalyzer.cc
+++ b/CondTools/DQM/plugins/DQMReferenceHistogramRootFileEventSetupAnalyzer.cc
@@ -74,7 +74,7 @@ namespace edmtest {
 	
 	//here you can implement the stream for putting the TFile on disk...
 	std::string outfile("dqmreference.root") ;
-	ofstream output(outfile.c_str()) ;
+	std::ofstream output(outfile.c_str()) ;
 	output.write((const char *)&(*tb)[0], tb->size());
 	output.close() ;
 	

--- a/CondTools/DQM/plugins/DQMXMLFileEventSetupAnalyzer.cc
+++ b/CondTools/DQM/plugins/DQMXMLFileEventSetupAnalyzer.cc
@@ -71,7 +71,7 @@ namespace edmtest {
 	boost::scoped_ptr<std::vector<unsigned char> > tb1( (*rootgeo).getUncompressedBlob() );
 	//here you can implement the stream for putting the TFile on disk...
 	std::string outfile1("XML1_retrieved.xml") ;
-	ofstream output1(outfile1.c_str()) ;
+	std::ofstream output1(outfile1.c_str()) ;
 	output1.write((const char *)&(*tb1)[0], tb1->size());
 	output1.close() ;
 	
@@ -80,7 +80,7 @@ namespace edmtest {
 // 	boost::scoped_ptr<std::vector<unsigned char> > tb2( (*rootgeo).getUncompressedBlob() );
 // 	//here you can implement the stream for putting the TFile on disk...
 // 	std::string outfile2("XML2_retrieved.xml") ;
-// 	ofstream output2(outfile2.c_str()) ;
+// 	std::ofstream output2(outfile2.c_str()) ;
 // 	output2.write((const char *)&(*tb2)[0], tb2->size());
 // 	output2.close() ;
 	//	boost::scoped_ptr<std::vector<unsigned char> > tb( (*rootgeo).getUncompressedBlob() );

--- a/CondTools/SiPixel/test/SiPixelCPEGenericErrorParmReader.cc
+++ b/CondTools/SiPixel/test/SiPixelCPEGenericErrorParmReader.cc
@@ -3,6 +3,7 @@
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelCPEGenericDBErrorParametrization.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include <iostream>
 
 SiPixelCPEGenericErrorParmReader::SiPixelCPEGenericErrorParmReader(const edm::ParameterSet& iConfig)
 {

--- a/CondTools/SiPixel/test/SiPixelFakeCPEGenericErrorParmSourceReader.cc
+++ b/CondTools/SiPixel/test/SiPixelFakeCPEGenericErrorParmSourceReader.cc
@@ -4,6 +4,7 @@
 #include "CondTools/SiPixel/test/SiPixelFakeCPEGenericErrorParmSourceReader.h"
 #include "CondFormats/SiPixelObjects/interface/SiPixelCPEGenericErrorParm.h"
 #include "CondFormats/DataRecord/interface/SiPixelCPEGenericErrorParmRcd.h"
+#include <iostream>
 
 SiPixelFakeCPEGenericErrorParmSourceReader::SiPixelFakeCPEGenericErrorParmSourceReader(const edm::ParameterSet& iConfig)
 {

--- a/CondTools/SiPixel/test/SiPixelFakeTemplateDBSourceReader.cc
+++ b/CondTools/SiPixel/test/SiPixelFakeTemplateDBSourceReader.cc
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include <iostream>
 
 SiPixelFakeTemplateDBSourceReader::SiPixelFakeTemplateDBSourceReader(const edm::ParameterSet& iConfig)
 {

--- a/CondTools/SiPixel/test/SiPixelTemplateDBObjectReader.cc
+++ b/CondTools/SiPixel/test/SiPixelTemplateDBObjectReader.cc
@@ -1,6 +1,7 @@
 #include "CondTools/SiPixel/test/SiPixelTemplateDBObjectReader.h"
 #include <iomanip>
 #include <fstream>
+#include <iostream>
 #include <cmath>
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 

--- a/DPGAnalysis/SiStripTools/plugins/TrackerDpgAnalysis.cc
+++ b/DPGAnalysis/SiStripTools/plugins/TrackerDpgAnalysis.cc
@@ -1001,7 +1001,7 @@ TrackerDpgAnalysis::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup
    if(delayMap.size()) tmap.save(true, 0, 0, "delaymap.png");
 
    // cabling II (DCU map)
-   ifstream cablingFile(cablingFileName_.c_str());
+   std::ifstream cablingFile(cablingFileName_.c_str());
    if(cablingFile.is_open()) {
      char buffer[1024];
      cablingFile.getline(buffer,1024);

--- a/DPGAnalysis/Skims/src/BeamSplash.cc
+++ b/DPGAnalysis/Skims/src/BeamSplash.cc
@@ -6,6 +6,7 @@
 //
 // Original Author:  Luca Malgeri
 
+#include <iostream>
 #include <memory>
 #include <vector>
 #include <map>

--- a/DPGAnalysis/Skims/src/LogErrorEventFilter.cc
+++ b/DPGAnalysis/Skims/src/LogErrorEventFilter.cc
@@ -7,7 +7,6 @@
   \brief    Use StandAlone track to define the 4-momentum of a PAT Muon (normally the global one is used)
             
   \author   Giovanni Petrucciani
-  \version  $Id: LogErrorEventFilter.cc,v 1.4 2013/04/09 10:06:10 davidlt Exp $
 */
 
 
@@ -25,6 +24,7 @@
 #include <set>
 #include <string>
 #include <iomanip>
+#include <iostream>
 #include <iterator>
 #include <boost/foreach.hpp>
 #define foreach BOOST_FOREACH

--- a/DPGAnalysis/Skims/src/PickEvents.cc
+++ b/DPGAnalysis/Skims/src/PickEvents.cc
@@ -130,7 +130,7 @@ PickEvents::beginJob()
   nEventsSelected = 0;
 
   // open file listevent file
-  ifstream listfile;
+  std::ifstream listfile;
   listfile.open(listrunevents_.c_str());
   if (listfile.is_open())
     {

--- a/DQM/CastorMonitor/interface/CastorMonitorModule.h
+++ b/DQM/CastorMonitor/interface/CastorMonitorModule.h
@@ -249,7 +249,7 @@ public:
   std::vector<HcalGenericDetId> listEMap; //electronics Emap
 
 
-  ofstream m_logFile;
+  std::ofstream m_logFile;
 
   ////---- decide whether the Castor status should be checked
   bool checkCASTOR_;

--- a/DQM/HLTEvF/interface/HLTMon.h
+++ b/DQM/HLTEvF/interface/HLTMon.h
@@ -86,7 +86,7 @@ class HLTMon : public edm::EDAnalyzer {
       
       std::string dirname_;
       bool monitorDaemon_;
-      ofstream logFile_;
+      std::ofstream logFile_;
       int theHLTOutputType;
       std::string outputFile_;
 

--- a/DQM/HLTEvF/interface/HLTMonElectron.h
+++ b/DQM/HLTEvF/interface/HLTMonElectron.h
@@ -82,7 +82,7 @@ class HLTMonElectron : public edm::EDAnalyzer {
       
       std::string dirname_;
       bool monitorDaemon_;
-      ofstream logFile_;
+      std::ofstream logFile_;
       int theHLTOutputType;
       std::string outputFile_;
       

--- a/DQM/HLTEvF/interface/HLTMonElectronConsumer.h
+++ b/DQM/HLTEvF/interface/HLTMonElectronConsumer.h
@@ -81,7 +81,7 @@ class HLTMonElectronConsumer : public edm::EDAnalyzer {
       std::string pixeldirname_;
       std::string isodirname_;
       bool monitorDaemon_;
-      ofstream logFile_;
+      std::ofstream logFile_;
       std::string outputFile_;
       
 };

--- a/DQM/HLTEvF/interface/HLTMonPhotonClient.h
+++ b/DQM/HLTEvF/interface/HLTMonPhotonClient.h
@@ -57,7 +57,7 @@ class HLTMonPhotonClient : public edm::EDAnalyzer {
       std::string dirname_;
       std::string sourcedirname_;
       bool monitorDaemon_;
-      ofstream logFile_;
+      std::ofstream logFile_;
       std::string outputFile_;
       std::vector<edm::InputTag> theHLTCollectionLabels;
       

--- a/DQM/HLTEvF/interface/HLTMonPhotonSource.h
+++ b/DQM/HLTEvF/interface/HLTMonPhotonSource.h
@@ -69,7 +69,7 @@ class HLTMonPhotonSource : public edm::EDAnalyzer {
       
       std::string dirname_;
       bool monitorDaemon_;
-      ofstream logFile_;
+      std::ofstream logFile_;
       int theHLTOutputType;
       std::string outputFile_;
       

--- a/DQM/HcalMonitorModule/src/LumiblockFilter.cc
+++ b/DQM/HcalMonitorModule/src/LumiblockFilter.cc
@@ -18,6 +18,7 @@
 
 
 // system include files
+#include <iostream>
 #include <memory>
 
 // user include files

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagLEDMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagLEDMonitor.cc
@@ -813,7 +813,7 @@ char   Subdet[10],str[500];
 
       sprintf(str,"HcalDetDiagLED_%i_%i.xml",run_number,dataset_seq_number);
       std::string xmlName=str;
-      ofstream xmlFile;
+      std::ofstream xmlFile;
       xmlFile.open(xmlName.c_str());
 
       xmlFile<<"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n";
@@ -925,7 +925,7 @@ char   Subdet[10],str[500];
       //create CALIB XML file 
       sprintf(str,"HcalDetDiagLEDCalib_%i_%i.xml",run_number,dataset_seq_number);
       std::string xmlNameCalib=str;
-      ofstream xmlFileCalib;
+      std::ofstream xmlFileCalib;
       xmlFileCalib.open(xmlNameCalib.c_str());
 
       xmlFileCalib<<"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n";

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagLaserMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagLaserMonitor.cc
@@ -1537,7 +1537,7 @@ char   Subdet[10],str[500];
          sprintf(str,"HcalDetDiagLaser.xml");
       }
       std::string xmlName=str;
-      ofstream xmlFile;
+      std::ofstream xmlFile;
       xmlFile.open(xmlName.c_str());
 
       xmlFile<<"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n";
@@ -1650,7 +1650,7 @@ char   Subdet[10],str[500];
       //create CALIB XML file 
       sprintf(str,"HcalDetDiagLaserCalib_%i_%i.xml",run_number,dataset_seq_number);
       std::string xmlNameCalib=str;
-      ofstream xmlFileCalib;
+      std::ofstream xmlFileCalib;
       xmlFileCalib.open(xmlNameCalib.c_str());
 
       xmlFileCalib<<"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n";
@@ -1923,7 +1923,7 @@ char str[100];
              sprintf(str,"HcalDetDiagRaddam.xml");
           }
           std::string xmlName=str;
-          ofstream xmlFile;
+          std::ofstream xmlFile;
           xmlFile.open(xmlName.c_str());
           xmlFile<<"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"no\" ?>\n";
           xmlFile<<"<ROOT>\n";

--- a/DQM/HcalMonitorTasks/src/HcalDetDiagPedestalMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDetDiagPedestalMonitor.cc
@@ -1026,7 +1026,7 @@ char   Subdet[10],str[500];
       }
       printf("%s\n",str);
       std::string xmlName=str;
-      ofstream xmlFile;
+      std::ofstream xmlFile;
       xmlFile.open(xmlName.c_str());
 
       xmlFile<<"<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n";

--- a/DQM/L1TMonitor/interface/L1TCSCTF.h
+++ b/DQM/L1TMonitor/interface/L1TCSCTF.h
@@ -108,7 +108,7 @@ class L1TCSCTF : public edm::EDAnalyzer {
   std::string outputFile_; //file name for ROOT ouput
   bool verbose_;
   bool monitorDaemon_;
-  ofstream logFile_;
+  std::ofstream logFile_;
   edm::InputTag gmtProducer, lctProducer, trackProducer, statusProducer, mbProducer;
 
   CSCSectorReceiverLUT *srLUTs_[5];

--- a/DQM/L1TMonitor/interface/L1TCSCTPG.h
+++ b/DQM/L1TMonitor/interface/L1TCSCTPG.h
@@ -73,7 +73,7 @@ private:
   std::string outputFile_; //file name for ROOT ouput
   bool verbose_;
   bool monitorDaemon_;
-  ofstream logFile_;
+  std::ofstream logFile_;
   edm::InputTag csctpgSource_;
 };
 

--- a/DQM/L1TMonitor/interface/L1TCompare.h
+++ b/DQM/L1TMonitor/interface/L1TCompare.h
@@ -99,7 +99,7 @@ private:
   bool verbose_;
   bool verbose() const { return verbose_; };
   bool monitorDaemon_;
-  ofstream logFile_;
+  std::ofstream logFile_;
 
   edm::InputTag rctSource_;
   edm::InputTag gctSource_;

--- a/DQM/L1TMonitor/interface/L1TDTTPG.h
+++ b/DQM/L1TMonitor/interface/L1TDTTPG.h
@@ -96,7 +96,7 @@ class L1TDTTPG : public edm::EDAnalyzer {
   std::string outputFile_; //file name for ROOT ouput
   bool verbose_;
   bool monitorDaemon_;
-  ofstream logFile_;
+  std::ofstream logFile_;
   edm::InputTag dttpgSource_;
 };
 

--- a/DQM/L1TMonitor/interface/L1TFED.h
+++ b/DQM/L1TMonitor/interface/L1TFED.h
@@ -77,7 +77,7 @@ private:
   bool verbose_;
   bool monitorDaemon_;
   std::vector<int> l1feds_;
-  ofstream logFile_;
+  std::ofstream logFile_;
   edm::InputTag fedSource_;  
   edm::InputTag rawl_;
   std::string directory_;

--- a/DQM/L1TMonitor/interface/L1TGCT.h
+++ b/DQM/L1TMonitor/interface/L1TGCT.h
@@ -213,7 +213,7 @@ private:
   std::string outputFile_; //file name for ROOT ouput
   bool verbose_;
   bool monitorDaemon_;
-  ofstream logFile_;
+  std::ofstream logFile_;
 
   edm::InputTag gctCenJetsSource_;
   edm::InputTag gctForJetsSource_;

--- a/DQM/L1TMonitor/interface/L1TGMT.h
+++ b/DQM/L1TMonitor/interface/L1TGMT.h
@@ -110,7 +110,7 @@ private:
   std::string outputFile_; //file name for ROOT ouput
   bool verbose_;
   bool monitorDaemon_;
-  ofstream logFile_;
+  std::ofstream logFile_;
   edm::InputTag gmtSource_ ;
   
   int evnum_old_; // event number of previous event

--- a/DQM/L1TMonitor/interface/L1TRCT.h
+++ b/DQM/L1TMonitor/interface/L1TRCT.h
@@ -134,7 +134,7 @@ private:
   std::string outputFile_; //file name for ROOT ouput
   bool verbose_;
   bool monitorDaemon_;
-  ofstream logFile_;
+  std::ofstream logFile_;
 
   edm::InputTag rctSource_;
 

--- a/DQM/L1TMonitor/interface/L1TRPCTPG.h
+++ b/DQM/L1TMonitor/interface/L1TRPCTPG.h
@@ -94,7 +94,7 @@ private:
   std::string outputFile_; //file name for ROOT ouput
   bool verbose_;
   bool monitorDaemon_;
-  ofstream logFile_;
+  std::ofstream logFile_;
   edm::InputTag rpctpgSource_;
   edm::InputTag rpctfSource_ ;
 

--- a/DQM/L1TMonitor/interface/L1TdeRCT.h
+++ b/DQM/L1TMonitor/interface/L1TdeRCT.h
@@ -326,7 +326,7 @@ private:
   bool verbose_;
   bool singlechannelhistos_;
   bool monitorDaemon_;
-  ofstream logFile_;
+  std::ofstream logFile_;
 
   edm::InputTag rctSourceEmul_;
   edm::InputTag rctSourceData_;

--- a/DQM/SiPixelMonitorClient/interface/SiPixelDataQuality.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelDataQuality.h
@@ -90,7 +90,7 @@ class SiPixelDataQuality {
   bool DONE_;
   
   
-  ofstream myfile_;  
+  std::ofstream myfile_;  
   int nevents_;
   bool endOfModules_;
   edm::ESHandle<SiPixelFedCablingMap> theCablingMap;

--- a/DQM/SiPixelMonitorClient/interface/SiPixelInformationExtractor.h
+++ b/DQM/SiPixelMonitorClient/interface/SiPixelInformationExtractor.h
@@ -178,7 +178,7 @@ class SiPixelInformationExtractor {
   int errcount;
   bool gotDigis;
   
-  ofstream myfile_;  
+  std::ofstream myfile_;  
   int nevents_;
   std::map< uint32_t , std::vector< std::pair< std::pair<int,int> , float > > >  noisyDetIds_;
   bool endOfModules_;

--- a/DQM/SiPixelMonitorClient/src/SiPixelDataQuality.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelDataQuality.cc
@@ -763,7 +763,7 @@ void SiPixelDataQuality::fillGlobalQualityPlot(DQMStore * bei, bool init, edm::E
     //cout<<"currDir="<<currDir<<endl;
     string dname = currDir.substr(currDir.find_last_of("/")+1);
     // find a detId for Blades and Ladders (first of the contained Modules!):
-    ifstream infile(edm::FileInPath("DQM/SiPixelMonitorClient/test/detId.dat").fullPath().c_str(),ios::in);
+    std::ifstream infile(edm::FileInPath("DQM/SiPixelMonitorClient/test/detId.dat").fullPath().c_str(),ios::in);
     string I_name[1440];
     int I_detId[1440];
     int I_fedId[1440];

--- a/DQM/SiPixelMonitorClient/src/SiPixelEDAClient.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelEDAClient.cc
@@ -71,7 +71,7 @@ SiPixelEDAClient::SiPixelEDAClient(const edm::ParameterSet& ps) {
   
   if(!Tier0Flag_){
     string localPath = string("DQM/SiPixelMonitorClient/test/loader.html");
-    ifstream fin(edm::FileInPath(localPath).fullPath().c_str(), ios::in);
+    std::ifstream fin(edm::FileInPath(localPath).fullPath().c_str(), ios::in);
     char buf[BUF_SIZE];
   
     if (!fin) {

--- a/DQM/SiPixelMonitorClient/src/SiPixelHistoPlotter.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelHistoPlotter.cc
@@ -317,7 +317,7 @@ void SiPixelHistoPlotter::createDummyImage(const string & name) {
   string          line;
   ostringstream   local_str;
   // Read back the file line by line and temporarily store it in a stringstream
-  ifstream * imagefile = new ifstream("images/EmptyPlot.png",ios::in);
+  std::ifstream * imagefile = new std::ifstream("images/EmptyPlot.png",ios::in);
   if(imagefile->is_open()) {
     while (getline( *imagefile, line )) {
       local_str << line << endl ;

--- a/DQM/SiPixelMonitorClient/src/SiPixelTrackerMap.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelTrackerMap.cc
@@ -231,8 +231,8 @@ void SiPixelTrackerMap::print(bool print_total, string TKType, float minval, flo
 //cout<<"Entering SiPixelTrackerMap::print: "<<endl;
 
  minvalue=minval; maxvalue=maxval;
- svgfile = new ofstream("svgmap.xml",ios::out);
- jsfile = new ifstream("TrackerMapHeader.txt",ios::in);
+ svgfile = new std::ofstream("svgmap.xml",ios::out);
+ jsfile = new std::ifstream("TrackerMapHeader.txt",ios::in);
  
  //copy javascript interface from trackermap.txt file
  string line;
@@ -402,7 +402,7 @@ void SiPixelTrackerMap::print(bool print_total, string TKType, float minval, flo
           << "</svg:text>"
           << endl;
  delete jsfile ;					 
- jsfile = new ifstream("TrackerMapTrailer.txt",ios::in); 
+ jsfile = new std::ifstream("TrackerMapTrailer.txt",ios::in); 
  while (getline( *jsfile, line ))			 
        {						 
  	   *svgfile << line << endl;			 

--- a/DQM/SiPixelMonitorClient/src/SiPixelTrackerMapCreator.cc
+++ b/DQM/SiPixelMonitorClient/src/SiPixelTrackerMapCreator.cc
@@ -77,7 +77,7 @@ void SiPixelTrackerMapCreator::create(DQMStore * bei)
 
   trackerMap->print(true, TKType);  
 //cout<<"Going to create inner frame now! Still in TMC::create"<<endl;
-  ofstream innerFrame ;
+  std::ofstream innerFrame ;
 
   innerFrame.open( "rightEmbedded.html", ios::out );
   

--- a/DQM/SiStripCommissioningClients/src/SiStripCommissioningOfflineClient.cc
+++ b/DQM/SiStripCommissioningClients/src/SiStripCommissioningOfflineClient.cc
@@ -86,7 +86,7 @@ void SiStripCommissioningOfflineClient::beginRun( const edm::Run& run, const edm
   // Check if .root file can be opened
   std::vector<std::string>::const_iterator ifile = inputFiles_.begin();
   for ( ; ifile != inputFiles_.end(); ifile++ ) {
-    ifstream root_file;
+    std::ifstream root_file;
     root_file.open( ifile->c_str() );
     if( !root_file.is_open() ) {
       edm::LogError(mlDqmClient_)
@@ -124,7 +124,7 @@ void SiStripCommissioningOfflineClient::beginRun( const edm::Run& run, const edm
   
   // Check if .xml file can be opened
   if ( !xmlFile_.empty() ) {
-    ifstream xml_file;
+    std::ifstream xml_file;
     xml_file.open( xmlFile_.c_str() );
     if( !xml_file.is_open() ) {
       edm::LogError(mlDqmClient_)

--- a/DQM/SiStripCommon/src/TkHistoMap.cc
+++ b/DQM/SiStripCommon/src/TkHistoMap.cc
@@ -119,7 +119,7 @@ std::string TkHistoMap::folderDefinition(std::string& path, std::string& MapName
 
 #include "iostream"
 void TkHistoMap::fillFromAscii(std::string filename){
-  ifstream file;
+  std::ifstream file;
   file.open(filename.c_str());
   float value;
   uint32_t detid;

--- a/DQM/SiStripMonitorClient/bin/listbadmodule.cc
+++ b/DQM/SiStripMonitorClient/bin/listbadmodule.cc
@@ -44,7 +44,7 @@ void listbadmodule(std::string filename, std::string pclfilename) {
 
   std::set<unsigned int> pclbadmods;
 
-  ifstream pclfile(pclfilename);
+  std::ifstream pclfile(pclfilename);
 
   char line[400];
   unsigned int pcldetid;
@@ -53,10 +53,10 @@ void listbadmodule(std::string filename, std::string pclfilename) {
 
   while(pclfile.getline(line,400)) {
     if(strstr(line,sixapvs) || strstr(line,fourapvs)) {
-      stringstream linestream;
+      std::stringstream linestream;
       linestream << line;
       linestream >> pcldetid;
-      //      std::cout << pcldetid << endl;
+      //      std::cout << pcldetid << std::endl;
       pclbadmods.insert(pcldetid);
     }
   }
@@ -71,9 +71,9 @@ void listbadmodule(std::string filename, std::string pclfilename) {
 
   std::string nrun = filename.substr(filename.find("_R000")+5, 6);
   int fileNum = atoi(nrun.c_str()); 
-  cout << " ------   Run " << fileNum << endl;
+  std::cout << " ------   Run " << fileNum << std::endl;
   
-  ofstream outfile;
+  std::ofstream outfile;
   std::string namefile;
   namefile = "QualityTestOBSOLETE_run" + nrun + ".txt";
   outfile.open(namefile.c_str());
@@ -87,15 +87,15 @@ void listbadmodule(std::string filename, std::string pclfilename) {
   TDirectory* mec1 = gDirectory;
 
   //get the summary first                                                                                                                                    
-  vector <int> nbadmod;
+  std::vector <int> nbadmod;
   for (unsigned int i=0; i < subdet.size(); i++){
     int nbad = 0;
-    string badmodule_dir = subdet[i] + "/BadModuleList";
+    std::string badmodule_dir = subdet[i] + "/BadModuleList";
     if (gDirectory->cd(badmodule_dir.c_str())){
       TIter next(gDirectory->GetListOfKeys());
       TKey *key;
       while  ( (key = dynamic_cast<TKey*>(next())) ) {
-        string sflag = key->GetName();
+        std::string sflag = key->GetName();
         if (sflag.size() == 0) continue;
         nbad++;
       }
@@ -122,10 +122,10 @@ void listbadmodule(std::string filename, std::string pclfilename) {
 
   for (unsigned int i=0; i < subdet.size(); i++){
     std::string badmodule_dir = subdet[i] + "/BadModuleList";
-    outfile << " " << endl;
-    outfile << "SubDetector " << subdet[i] << endl;
-    outfile << " " << endl;
-    cout << badmodule_dir.c_str() << endl;
+    outfile << " " << std::endl;
+    outfile << "SubDetector " << subdet[i] << std::endl;
+    outfile << " " << std::endl;
+    std::cout << badmodule_dir.c_str() << std::endl;
     if (gDirectory->cd(badmodule_dir.c_str())){
     //
     // Loop to find bad module for each partition

--- a/DQM/SiStripMonitorClient/bin/ls_cert.cc
+++ b/DQM/SiStripMonitorClient/bin/ls_cert.cc
@@ -86,7 +86,7 @@ void    ls_cert( float threshold_pixel , float threshold , string filename )
   ls_cert_type( "Tracking" , threshold       , filename , cert_track , gLS_track , bLS_track , mLS_track );
   ls_cert_type( "Pixel"    , threshold_pixel , filename , cert_pixel , gLS_pixel , bLS_pixel , mLS_pixel );
 
-  ofstream outfile;
+  std::ofstream outfile;
   string namefile = "Certification_run_" + runnum_str( filename ) + ".txt";
   outfile.open(namefile.c_str());
   outfile << "Lumisection Certification (GOOD: >= " << threshold_pixel << " [Pixel]; >= " << threshold << " [SiStrip,Tracking] " 

--- a/DQM/SiStripMonitorClient/bin/lsbs_cert.cc
+++ b/DQM/SiStripMonitorClient/bin/lsbs_cert.cc
@@ -195,7 +195,7 @@ void    lsbs_cert( string filename )
       ls_good.push_back( i );
     }
 
-  ofstream outfile;
+  std::ofstream outfile;
   string namefile = "Certification_BS_run_" + runnum_str( filename ) + ".txt";
   outfile.open(namefile.c_str());
   outfile << "Lumibased BeamSpot Calibration Certification for run " << runnum_str( filename ) << ":" << endl << endl;

--- a/DQM/SiStripMonitorClient/bin/modulediff.cc
+++ b/DQM/SiStripMonitorClient/bin/modulediff.cc
@@ -83,7 +83,7 @@ void modulediff ( int run_2 , string repro_run2 )
   get_difference ( badmodlist_run2 , badmodlist_run1 , modules_malformed );  
 
   //save into file
-  ofstream outfile;
+  std::ofstream outfile;
   string namefile = "modulediff_emailbody.txt";
   outfile.open(namefile.c_str());
 
@@ -109,7 +109,7 @@ void modulediff ( int run_2 , string repro_run2 )
   
   if ( modules_recovered.size() > 0 )
     {
-      ofstream outfile_good;
+      std::ofstream outfile_good;
       outfile_good.open("modulediff_good.txt");
       for ( unsigned int i = 0; i < modules_recovered.size() ; i++ )
 	outfile_good << " " << modules_recovered[ i ] << endl;
@@ -118,7 +118,7 @@ void modulediff ( int run_2 , string repro_run2 )
 
   if ( modules_malformed.size() > 0 )
     {
-      ofstream outfile_bad;
+      std::ofstream outfile_bad;
       outfile_bad.open("modulediff_bad.txt");
       for ( unsigned int i = 0; i < modules_malformed.size() ; i++ )
 	outfile_bad << " " << modules_malformed[ i ] << endl;

--- a/DQM/SiStripMonitorClient/src/SiStripActionExecutor.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripActionExecutor.cc
@@ -144,7 +144,7 @@ void SiStripActionExecutor::fillStatusAtLumi(DQMStore* dqm_store) {
 // -- 
 //
 void SiStripActionExecutor::createDummyShiftReport(){
-  ofstream report_file;
+  std::ofstream report_file;
   report_file.open("sistrip_shift_report.txt", std::ios::out);
   report_file << " Nothing to report!!" << std::endl;
   report_file.close();
@@ -203,7 +203,7 @@ void SiStripActionExecutor::createShiftReport(DQMStore * dqm_store){
   shift_summary << std::endl;
   printShiftHistoParameters(dqm_store, layout_map, shift_summary);
   
-  ofstream report_file;
+  std::ofstream report_file;
   report_file.open("sistrip_shift_report.txt", std::ios::out);
   report_file << shift_summary.str() << std::endl;
   report_file.close();

--- a/DQM/SiStripMonitorClient/src/SiStripAnalyser.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripAnalyser.cc
@@ -59,7 +59,7 @@ SiStripAnalyser::SiStripAnalyser(edm::ParameterSet const& ps) {
   tkMapPSet_ = ps.getParameter<edm::ParameterSet>("TkmapParameters");
 
   std::string localPath = std::string("DQM/SiStripMonitorClient/test/loader.html");
-  ifstream fin(edm::FileInPath(localPath).fullPath().c_str(), std::ios::in);
+  std::ifstream fin(edm::FileInPath(localPath).fullPath().c_str(), std::ios::in);
   char buf[BUF_SIZE];
   
   if (!fin) {

--- a/DQM/SiStripMonitorClient/src/SiStripHistoPlotter.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripHistoPlotter.cc
@@ -215,7 +215,7 @@ void SiStripHistoPlotter::getDummyImage(std::string & image) {
   std::ostringstream   local_str;
   // Read back the file line by line and temporarily store it in a stringstream
   std::string localPath = std::string("DQM/TrackerCommon/test/images/EmptyPlot.png");
-  ifstream * imagefile = new ifstream((edm::FileInPath(localPath).fullPath()).c_str(),std::ios::in);
+  std::ifstream * imagefile = new std::ifstream((edm::FileInPath(localPath).fullPath()).c_str(),std::ios::in);
   if(imagefile->is_open()) {
     while (getline( *imagefile, line )) {
       local_str << line << std::endl ;

--- a/DQM/SiStripMonitorClient/src/SiStripInformationExtractor.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripInformationExtractor.cc
@@ -279,7 +279,7 @@ void SiStripInformationExtractor::getHistosFromPath(DQMStore * dqm_store, const 
 void SiStripInformationExtractor::plotHistosFromLayout(DQMStore * dqm_store){
   if (layoutMap.size() == 0) return;
 
-  ofstream image_file;
+  std::ofstream image_file;
   
   for (std::map<std::string, std::vector< std::string > >::iterator it = layoutMap.begin() ; it != layoutMap.end(); it++) {
     unsigned int ival = 0;

--- a/DQM/TrackingMonitor/src/GetLumi.cc
+++ b/DQM/TrackingMonitor/src/GetLumi.cc
@@ -4,6 +4,7 @@
  *  \author:  Mia Tosi,40 3-B32,+41227671609 
  */
 
+#include <iostream>
 #include "DQM/TrackingMonitor/interface/GetLumi.h"
 
 #include "FWCore/Framework/interface/LuminosityBlock.h"

--- a/DQMOffline/JetMET/interface/BeamHaloAnalyzer.h
+++ b/DQMOffline/JetMET/interface/BeamHaloAnalyzer.h
@@ -198,7 +198,7 @@ class BeamHaloAnalyzer: public edm::EDAnalyzer {
   std::string TextFileName;
   std::string FolderName;
 
-  ofstream* out;
+  std::ofstream* out;
   double DumpMET;
 
   //Muon-Segment Matching

--- a/DQMOffline/JetMET/src/BeamHaloAnalyzer.cc
+++ b/DQMOffline/JetMET/src/BeamHaloAnalyzer.cc
@@ -23,7 +23,7 @@ BeamHaloAnalyzer::BeamHaloAnalyzer( const edm::ParameterSet& iConfig)
   TextFileName   = iConfig.getParameter<std::string>("TextFile");
 
   if(TextFileName.size())
-    out = new ofstream(TextFileName.c_str() );
+    out = new std::ofstream(TextFileName.c_str() );
 
 
   if( iConfig.exists("StandardDQM") )  // If StandardDQM == true , coarse binning is used on selected (important) histograms   

--- a/DQMServices/Components/plugins/MEtoMEComparitor.cc
+++ b/DQMServices/Components/plugins/MEtoMEComparitor.cc
@@ -16,6 +16,7 @@
 //
 //
 
+#include <iostream>
 #include "MEtoMEComparitor.h"
 
 #include "classlib/utils/StringList.h"

--- a/DataFormats/Histograms/interface/MEtoEDMFormat.h
+++ b/DataFormats/Histograms/interface/MEtoEDMFormat.h
@@ -23,6 +23,7 @@
 #include <TString.h>
 #include <TList.h>
 
+#include <iostream>
 #include <string>
 #include <vector>
 #include <memory>

--- a/DataFormats/MuonDetId/test/RPCDetIdAnalyzer.cc
+++ b/DataFormats/MuonDetId/test/RPCDetIdAnalyzer.cc
@@ -18,6 +18,7 @@
 
 
 // system include files
+#include <iostream>
 #include <memory>
 
 // user include files

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -115,6 +115,7 @@
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
 #include <algorithm>
+#include <iostream>
 #include <ostream>
 
 

--- a/EventFilter/CSCRawToDigi/plugins/CSCDigiValidator.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCDigiValidator.cc
@@ -18,6 +18,7 @@
 
 
 // system include files
+#include <iostream>
 #include <memory>
 #include <map>
 #include <vector>

--- a/EventFilter/CSCRawToDigi/plugins/CSCViewDigi.cc
+++ b/EventFilter/CSCRawToDigi/plugins/CSCViewDigi.cc
@@ -19,6 +19,7 @@
 //
 
 #include "EventFilter/CSCRawToDigi/interface/CSCViewDigi.h"
+#include <iostream>
 //#include "CSCViewDigi.h"
 
 //

--- a/EventFilter/EcalRawToDigi/plugins/MatacqProducer.cc
+++ b/EventFilter/EcalRawToDigi/plugins/MatacqProducer.cc
@@ -13,6 +13,7 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/format.hpp>
 
+#include <iostream>
 #include <memory>
 
 #include <stdio.h>
@@ -775,7 +776,7 @@ MatacqProducer::~MatacqProducer(){
 }
 
 void MatacqProducer::loadOrbitOffset(){
-  ifstream f(orbitOffsetFile_.c_str());
+  std::ifstream f(orbitOffsetFile_.c_str());
   if(f.bad()){
     throw cms::Exception("Matacq")
       << "Failed to open orbit ID correction file '"

--- a/EventFilter/Playback/src/PlaybackRawDataProvider.cc
+++ b/EventFilter/Playback/src/PlaybackRawDataProvider.cc
@@ -12,6 +12,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include <cstring>
+#include <iostream>
 
 using namespace std;
 using namespace edm;

--- a/EventFilter/Utilities/plugins/BxNumberFilter.cc
+++ b/EventFilter/Utilities/plugins/BxNumberFilter.cc
@@ -4,6 +4,7 @@
 
 
 // system include files
+#include <iostream>
 #include <memory>
 
 // user include files
@@ -72,12 +73,12 @@ bool BxNumberFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
        result = true;
        
        if (debug) {
-	 cout << "Event # " << evf::evtn::get(data.data(),true) << endl;
-	 cout << "LS # " << evf::evtn::getlbn(data.data()) << endl;
-	 cout << "ORBIT # " << evf::evtn::getorbit(data.data()) << endl;
-	 cout << "GPS LOW # " << evf::evtn::getgpslow(data.data()) << endl;
-	 cout << "GPS HI # " << evf::evtn::getgpshigh(data.data()) << endl;
-	 cout << "BX FROM FDL 0-xing # " << evf::evtn::getfdlbx(data.data()) << endl;
+	 std::cout << "Event # " << evf::evtn::get(data.data(),true) << std::endl;
+	 std::cout << "LS # " << evf::evtn::getlbn(data.data()) << std::endl;
+	 std::cout << "ORBIT # " << evf::evtn::getorbit(data.data()) << std::endl;
+	 std::cout << "GPS LOW # " << evf::evtn::getgpslow(data.data()) << std::endl;
+	 std::cout << "GPS HI # " << evf::evtn::getgpshigh(data.data()) << std::endl;
+	 std::cout << "BX FROM FDL 0-xing # " << evf::evtn::getfdlbx(data.data()) << std::endl;
        }
        
      } 

--- a/FWCore/Integration/test/TestGetterOfProducts.cc
+++ b/FWCore/Integration/test/TestGetterOfProducts.cc
@@ -10,6 +10,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/BranchType.h"
 
+#include <iostream>
 #include <string>
 #include <vector>
 

--- a/FWCore/Integration/test/TestPSetAnalyzer.cc
+++ b/FWCore/Integration/test/TestPSetAnalyzer.cc
@@ -17,6 +17,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 // system include files
+#include <iostream>
 #include <memory>
 
 //

--- a/FWCore/Python/src/PythonService.cc
+++ b/FWCore/Python/src/PythonService.cc
@@ -12,6 +12,8 @@
 
 // system include files
 
+#include <iostream>
+
 // user include files
 #include "FWCore/Python/src/PythonService.h"
 

--- a/FastSimulation/MaterialEffects/src/NuclearInteractionSimulator.cc
+++ b/FastSimulation/MaterialEffects/src/NuclearInteractionSimulator.cc
@@ -623,7 +623,7 @@ NuclearInteractionSimulator::save() {
 bool
 NuclearInteractionSimulator::read(std::string inputFile) {
 
-  ifstream myInputFile;
+  std::ifstream myInputFile;
   struct stat results;
   //
   unsigned size1 = 

--- a/FastSimulation/PileUpProducer/plugins/PileUpProducer.cc
+++ b/FastSimulation/PileUpProducer/plugins/PileUpProducer.cc
@@ -415,7 +415,7 @@ PileUpProducer::save() {
 bool
 PileUpProducer::read(std::string inputFile) {
 
-  ifstream myInputFile;
+  std::ifstream myInputFile;
   struct stat results;
   unsigned size1 = theCurrentEntry.size()*sizeof(unsigned);
   unsigned size2 = theCurrentMinBiasEvt.size()*sizeof(unsigned);

--- a/Fireworks/Core/bin/cmsShow.cc
+++ b/Fireworks/Core/bin/cmsShow.cc
@@ -142,7 +142,7 @@ int main (int argc, char **argv)
    {
       TString infoFileName("data/version.txt");
       fireworks::setPath(infoFileName);
-      ifstream infoFile(infoFileName);
+      std::ifstream infoFile(infoFileName);
       infoText.ReadLine(infoFile);
       infoFile.close();
    }

--- a/Fireworks/Core/src/CmsShowMainBase.cc
+++ b/Fireworks/Core/src/CmsShowMainBase.cc
@@ -531,7 +531,7 @@ CmsShowMainBase::sendVersionInfo()
   // get OSX version
    TString osx_version;
    try {
-     ifstream infoFile("/System/Library/CoreServices/SystemVersion.plist");
+     std::ifstream infoFile("/System/Library/CoreServices/SystemVersion.plist");
      osx_version.ReadFile(infoFile);
      TPMERegexp re("ProductVersion\\</key\\>\\n\\t\\<string\\>(10.*)\\</string\\>");
      re.Match(osx_version);
@@ -552,7 +552,7 @@ CmsShowMainBase::sendVersionInfo()
    {
       TString versionFileName("data/version.txt");
       fireworks::setPath(versionFileName);
-      ifstream fs(versionFileName);
+      std::ifstream fs(versionFileName);
       TString infoText;
       infoText.ReadLine(fs);
       fs.close();

--- a/Fireworks/Core/src/CmsShowMainFrame.cc
+++ b/Fireworks/Core/src/CmsShowMainFrame.cc
@@ -743,7 +743,7 @@ CmsShowMainFrame::showFWorksInfo()
          TString infoFileName("/data/version.txt");
          fireworks::setPath(infoFileName);
          std::string line;
-         ifstream infoFile(infoFileName);
+         std::ifstream infoFile(infoFileName);
          while (std::getline(infoFile, line))
          {
             ++number_of_lines;

--- a/Fireworks/Core/src/FWConfigurationManager.cc
+++ b/Fireworks/Core/src/FWConfigurationManager.cc
@@ -106,7 +106,7 @@ FWConfigurationManager::writeToFile(const std::string& iName) const
 {
    try
    {
-      ofstream file(iName.c_str());
+      std::ofstream file(iName.c_str());
       if(not file) {
          std::string message("unable to open file %s ", iName.c_str());
          fflush(stdout);

--- a/Fireworks/Core/src/FWGenericHandle.cc
+++ b/Fireworks/Core/src/FWGenericHandle.cc
@@ -11,6 +11,7 @@
 //
 
 // system include files
+#include <iostream>
 
 // user include files
 #include "Fireworks/Core/src/FWGenericHandle.h"

--- a/Fireworks/Core/src/FWModelContextMenuHandler.cc
+++ b/Fireworks/Core/src/FWModelContextMenuHandler.cc
@@ -12,6 +12,7 @@
 
 // system include files
 #include <cassert>
+#include <iostream>
 #include "TGMenu.h"
 #include "KeySymbols.h"
 

--- a/Fireworks/Core/src/fwPaths.cc
+++ b/Fireworks/Core/src/fwPaths.cc
@@ -55,7 +55,7 @@ int* supportedDataFormatsVersion()
       {
          TString versionFileName = gSystem->Getenv("CMSSW_BASE");
          versionFileName += "/src/Fireworks/Core/data/version.txt";
-         ifstream fs(versionFileName);
+         std::ifstream fs(versionFileName);
          TString infoText;
          infoText.ReadLine(fs); infoText.ReadLine(fs);
          fs.close();

--- a/GeneratorInterface/Core/plugins/GenFilterEfficiencyAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenFilterEfficiencyAnalyzer.cc
@@ -1,4 +1,5 @@
 #include "GeneratorInterface/Core/interface/GenFilterEfficiencyAnalyzer.h"
+#include <iostream>
 
 GenFilterEfficiencyAnalyzer::GenFilterEfficiencyAnalyzer(const edm::ParameterSet& pset):
   nTota_(0),nPass_(0),

--- a/GeneratorInterface/ExternalDecays/test/EvtGenTestAnalyzer.cc
+++ b/GeneratorInterface/ExternalDecays/test/EvtGenTestAnalyzer.cc
@@ -89,8 +89,8 @@ void EvtGenTestAnalyzer::beginJob()
    hPhi2 = new TH1D( "hPhi2","#phi_{2}",  50, -3.14, 3.14) ;
    hCosThetaLambda = new TH1D( "hCosThetaLambda","cos#theta_{#Lambda}",  50, -1., 1.) ;
 
-   decayed = new ofstream("decayed.txt") ;
-   undecayed = new ofstream("undecayed.txt") ;
+   decayed = new std::ofstream("decayed.txt") ;
+   undecayed = new std::ofstream("undecayed.txt") ;
    return ;
 }
  

--- a/GeneratorInterface/ExternalDecays/test/EvtGenTestAnalyzer.h
+++ b/GeneratorInterface/ExternalDecays/test/EvtGenTestAnalyzer.h
@@ -66,8 +66,8 @@ class EvtGenTestAnalyzer : public edm::EDAnalyzer
      TH1D*       hPhi2 ;
      TH1D*       hCosThetaLambda ;
     
-     ofstream*   decayed; 
-     ofstream*   undecayed; 
+     std::ofstream*   decayed; 
+     std::ofstream*   undecayed; 
      int         nevent, nbs;
      
 };

--- a/GeneratorInterface/LHEInterface/plugins/LHECOMWeightProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHECOMWeightProducer.cc
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <memory>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"

--- a/Geometry/CaloEventSetup/test/dumpEEIndices2D.cpp
+++ b/Geometry/CaloEventSetup/test/dumpEEIndices2D.cpp
@@ -40,7 +40,7 @@ int main(int /*argc*/,char** /*argv*/)
   reference->GetYaxis()->SetTitle("Y [cm]");
   reference->Draw();
 
-  ifstream endcapDump;
+  std::ifstream endcapDump;
   endcapDump.open("ee.C");
   if (!endcapDump)
     {

--- a/Geometry/TrackerNumberingBuilder/test/TrackerTopologyAnalyzer.cc
+++ b/Geometry/TrackerNumberingBuilder/test/TrackerTopologyAnalyzer.cc
@@ -14,6 +14,7 @@
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 #include <climits>
+#include <iostream>
 
 class TrackerTopologyAnalyzer : public edm::EDAnalyzer {
 public:

--- a/HLTrigger/Tools/bin/hltTimingSummary.cpp
+++ b/HLTrigger/Tools/bin/hltTimingSummary.cpp
@@ -770,7 +770,7 @@ int main(int argc, char ** argv) {
   if (vmap.count("recalc")) {
 
     startHere = vmap["recalc"].as<std::string>() ; 
-    ifstream filterFile(startHere.c_str()) ;
+    std::ifstream filterFile(startHere.c_str()) ;
     if (filterFile.is_open()) { //--- Filter modules listed in a file ---//
       while ( !filterFile.eof() ) {
 	std::string skipped ;
@@ -798,7 +798,7 @@ int main(int argc, char ** argv) {
   if (vmap.count("excludeMod")) {
     excludeModName = vmap["excludeMod"].as<std::string>() ; 
         
-    ifstream excludeModFile(excludeModName.c_str()) ;
+    std::ifstream excludeModFile(excludeModName.c_str()) ;
     if (excludeModFile.is_open()) { //--- Excluded modules listed in a file ---//
       while ( !excludeModFile.eof() ) {
 	std::string skipped ;
@@ -827,7 +827,7 @@ int main(int argc, char ** argv) {
   if (vmap.count("excludePath")) {
     excludePathName = vmap["excludePath"].as<std::string>() ; 
     
-    ifstream excludePathFile(excludePathName.c_str()) ;
+    std::ifstream excludePathFile(excludePathName.c_str()) ;
     if (excludePathFile.is_open()) { //--- Excluded paths listed in a file ---//
       while ( !excludePathFile.eof() ) {
 	std::string skipped ;
@@ -856,7 +856,7 @@ int main(int argc, char ** argv) {
   if (vmap.count("modPrint")) {
     modPrintName = vmap["modPrint"].as<std::string>() ; 
  
-    ifstream modPrintFile(modPrintName.c_str()) ;
+    std::ifstream modPrintFile(modPrintName.c_str()) ;
     if (modPrintFile.is_open()) { //--- Excluded modules listed in a file ---//
       while ( !modPrintFile.eof() ) {
 	std::string modname ;
@@ -961,8 +961,8 @@ int main(int argc, char ** argv) {
     
   //--- Prepare the output ---//
   TFile* outFile = new TFile(outname.c_str(), "recreate") ;
-  ofstream txtfile ; 
-  ofstream sumfile ; 
+  std::ofstream txtfile ; 
+  std::ofstream sumfile ; 
   if ( !writeSummary ) {
     std::cout << "Output to file: " << outname << std::endl ;
   } else {

--- a/HLTriggerOffline/Common/src/HltComparator.cc
+++ b/HLTriggerOffline/Common/src/HltComparator.cc
@@ -11,6 +11,7 @@
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
 #include <TH1.h>
+#include <iostream>
 #include <vector>
 #include <string>
 

--- a/IOMC/EventVertexGenerators/src/BeamProfileVtxGenerator.cc
+++ b/IOMC/EventVertexGenerators/src/BeamProfileVtxGenerator.cc
@@ -38,7 +38,7 @@ BeamProfileVtxGenerator::BeamProfileVtxGenerator(const edm::ParameterSet & p) :
   
   if (ffile) {
     std::string file = p.getParameter<std::string>("File");
-    ifstream is(file.c_str(), std::ios::in);
+    std::ifstream is(file.c_str(), std::ios::in);
     if (is) {
       double elem,sum=0;
       while (!is.eof()) {

--- a/IOMC/ParticleGuns/src/BaseFlatGunProducer.cc
+++ b/IOMC/ParticleGuns/src/BaseFlatGunProducer.cc
@@ -71,7 +71,7 @@ BaseFlatGunProducer::BaseFlatGunProducer( const ParameterSet& pset ) :
   fPDGTableName = "PDG_mass_width_2004.mc"; // should it be 2004 table ?
 
   string TableFullName = fPDGTablePath + fPDGTableName ;
-  ifstream PDFile( TableFullName.c_str() ) ;
+  std::ifstream PDFile( TableFullName.c_str() ) ;
   if( !PDFile ) 
   {
       throw cms::Exception("FileNotFound", "BaseFlatGunProducer::BaseFlatGunProducer()")

--- a/IOMC/ParticleGuns/src/FileRandomKEThetaGunProducer.cc
+++ b/IOMC/ParticleGuns/src/FileRandomKEThetaGunProducer.cc
@@ -26,7 +26,7 @@ FileRandomKEThetaGunProducer::FileRandomKEThetaGunProducer(const edm::ParameterS
   edm::LogInfo("FlatThetaGun") << "Internal FileRandomKEThetaGun is initialzed"
 			       << " with data read from " << file << " and "
 			       << particleN << " particles created/event";
-  ifstream is(file.c_str(), std::ios::in);
+  std::ifstream is(file.c_str(), std::ios::in);
   if (is) {
     double energy, elem, sum=0;
     while (!is.eof()) {

--- a/JetMETCorrections/MCJet/bin/L2Correction.cc
+++ b/JetMETCorrections/MCJet/bin/L2Correction.cc
@@ -53,8 +53,8 @@ int main(int argc, char**argv)
   TF1 *Correction[MAX_NETA]; 
   TF1 *L2Correction[MAX_NETA];
   TF1 *L3Response;
-  ifstream L3ResponseFile;
-  ofstream L2File;
+  std::ifstream L3ResponseFile;
+  std::ofstream L2File;
   TGraph *g_L2Correction[MAX_NETA];
   TGraphErrors *g_EtaCorrection[MAX_NETA];
   double aux_CaloPt[NCaloPtValues] = {10,15,20,30,40,50,75,100,150,200,300,400,500,750,1000,1500,2000,3000};

--- a/JetMETCorrections/MCJet/bin/L3Correction.cc
+++ b/JetMETCorrections/MCJet/bin/L3Correction.cc
@@ -50,7 +50,7 @@ int main(int argc, char**argv)
  TGraphErrors *g_Resp;
  TVirtualFitter *fitter;
  TMatrixD *COV_Cor, *COV_Resp;
- ofstream L3CorrectionFile,L3ResponseFile;
+ std::ofstream L3CorrectionFile,L3ResponseFile;
  L3CorrectionFile.open(L3CorrectionTxtFilename.c_str());
  L3ResponseFile.open(L3ResponseTxtFilename.c_str());
  TKey *key;

--- a/JetMETCorrections/MCJet/bin/Utilities.h
+++ b/JetMETCorrections/MCJet/bin/Utilities.h
@@ -310,7 +310,7 @@ void CommandLine::print()
 //______________________________________________________________________________
 bool CommandLine::parse_file(const std::string& file_name)
 {
-  ifstream fin(file_name.c_str());
+  std::ifstream fin(file_name.c_str());
   if (!fin.is_open()) {
     std::cout<<"Can't open configuration file "<<file_name<<std::endl;
     return false;

--- a/L1Trigger/GlobalCaloTrigger/test/L1GctTest.cc
+++ b/L1Trigger/GlobalCaloTrigger/test/L1GctTest.cc
@@ -1,3 +1,4 @@
+#include <iostream>
 #include "L1Trigger/GlobalCaloTrigger/test/L1GctTest.h"
 
 #include "L1Trigger/GlobalCaloTrigger/test/gctTestFunctions.h"

--- a/L1TriggerConfig/CSCTFConfigProducers/src/CSCTFConfigTestAnalyzer.cc
+++ b/L1TriggerConfig/CSCTFConfigProducers/src/CSCTFConfigTestAnalyzer.cc
@@ -7,6 +7,7 @@
 
 
 // system include files
+#include <iostream>
 #include <memory>
 
 // user include files

--- a/L1TriggerConfig/CSCTFConfigProducers/src/L1MuCSCTFParametersTester.cc
+++ b/L1TriggerConfig/CSCTFConfigProducers/src/L1MuCSCTFParametersTester.cc
@@ -17,6 +17,7 @@
 
 // system include files
 #include <iomanip>
+#include <iostream>
 
 // user include files
 //   base class

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtBoardMapsTester.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtBoardMapsTester.cc
@@ -17,6 +17,7 @@
 
 // system include files
 #include <iomanip>
+#include <iostream>
 
 // user include files
 //   base class

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsAndMasksTester.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtPrescaleFactorsAndMasksTester.cc
@@ -17,6 +17,7 @@
 
 // system include files
 #include <iomanip>
+#include <iostream>
 
 // user include files
 //   base class

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtStableParametersTester.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtStableParametersTester.cc
@@ -17,6 +17,7 @@
 
 // system include files
 #include <iomanip>
+#include <iostream>
 
 // user include files
 //   base class

--- a/L1TriggerConfig/L1ScalesProducers/src/L1ScalesTester.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1ScalesTester.cc
@@ -11,6 +11,7 @@
 #include "CondFormats/DataRecord/interface/L1CaloEcalScaleRcd.h"
 #include "CondFormats/DataRecord/interface/L1CaloHcalScaleRcd.h"
 
+#include <iostream>
 
 using std::cout;
 using std::endl;

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTChannelMaskTester.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTChannelMaskTester.cc
@@ -15,6 +15,7 @@
 //         Created:  Mon Jul 16 23:48:35 CEST 2007
 //
 //
+#include <iostream>
 // user include files
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTParametersTester.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTParametersTester.cc
@@ -34,6 +34,7 @@
 
 #include <iostream>
 
+#include <iostream>
 
 using std::cout;
 using std::endl;

--- a/MagneticField/ParametrizedEngine/test/MagneticFieldPlotter.cc
+++ b/MagneticField/ParametrizedEngine/test/MagneticFieldPlotter.cc
@@ -86,12 +86,12 @@ MagneticFieldPlotter::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 	 GlobalVector myFieldVector = theMGField->inTesla(gp);
 	 float Br   = myFieldVector.x()*cos(gp.phi()) + myFieldVector.y()*sin(gp.phi());
 	 float Bphi = - myFieldVector.x()*sin(gp.phi()) + myFieldVector.y()*cos(gp.phi());
-	 cout << "Radius  = " << rCoordinate       ;
-	 cout << ", Z     = " << zCoordinate      ;
-	 cout << ", Phi    = " << phiCoordinate     <<endl;
-	 cout << "Bz     = " << myFieldVector.z() ;
-	 cout << ", Br     = " << Br                ;
-	 cout << ", Bphi   = " << Bphi              << endl;
+	 std::cout << "Radius  = " << rCoordinate       ;
+	 std::cout << ", Z     = " << zCoordinate      ;
+	 std::cout << ", Phi    = " << phiCoordinate     <<std::endl;
+	 std::cout << "Bz     = " << myFieldVector.z() ;
+	 std::cout << ", Br     = " << Br                ;
+	 std::cout << ", Bphi   = " << Bphi              << std::endl;
 	 gBz[iR]  ->Fill(phiCoordinate,zCoordinate,myFieldVector.z());
 	 gBr[iR]  ->Fill(phiCoordinate,zCoordinate,Br               );
 	 gBphi[iR]->Fill(phiCoordinate,zCoordinate,Bphi             );

--- a/MuonAnalysis/MomentumScaleCalibration/bin/TreeDump.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/bin/TreeDump.cc
@@ -72,7 +72,7 @@ int main(int argc, char* argv[])
     std::cout << "Error: the size of pairVector and genPairVector is different" << std::endl;
   }
 
-  ofstream outputFile;
+  std::ofstream outputFile;
   outputFile.open("TreeDump.txt");
 
   MuonPairVector::const_iterator it = pairVector.begin();

--- a/MuonAnalysis/MomentumScaleCalibration/bin/TreeFromDump.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/bin/TreeFromDump.cc
@@ -57,7 +57,7 @@ int main(int argc, char* argv[])
   // Create the RootTreeHandler to save the events in the root tree
   RootTreeHandler treeHandler;
 
-  ifstream inputFile;
+  std::ifstream inputFile;
   inputFile.open(fileName.c_str());
 
   std::string line;

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitUtils.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitUtils.cc
@@ -1126,7 +1126,7 @@ void MuScleFitUtils::minimizeLikelihood()
 {
   // Output file with fit parameters resulting from minimization
   // -----------------------------------------------------------
-  ofstream FitParametersFile;
+  std::ofstream FitParametersFile;
   FitParametersFile.open ("FitParameters.txt", std::ios::app);
   FitParametersFile << "Fitting with resolution, scale, bgr function # "
 		    << ResolFitType << " " << ScaleFitType << " " << BgrFitType

--- a/MuonAnalysis/MomentumScaleCalibration/src/BackgroundFunction.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/src/BackgroundFunction.cc
@@ -7,7 +7,7 @@ void BackgroundFunction::readParameters( TString fileName )
   // std::vector<double> parameterErrors;
 
   // Read the parameters file
-  ifstream parametersFile(fileName.Data());
+  std::ifstream parametersFile(fileName.Data());
   std::string line;
 
   std::string iteration("Iteration ");

--- a/MuonAnalysis/MomentumScaleCalibration/src/MomentumScaleCorrector.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/src/MomentumScaleCorrector.cc
@@ -7,7 +7,7 @@ void MomentumScaleCorrector::readParameters( TString fileName )
   // std::vector<double> parameterErrors;
 
   // Read the parameters file
-  ifstream parametersFile(fileName.Data());
+  std::ifstream parametersFile(fileName.Data());
 
   if( !parametersFile.is_open() ) {
     std::cout << "Error: file " << fileName << " not found. Aborting." << std::endl;

--- a/PhysicsTools/HepMCCandAlgos/plugins/ModelFilter.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/ModelFilter.cc
@@ -2,6 +2,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h"
 
+#include <iostream>
 #include <memory>
 #include <sstream>
 #include <stdlib.h>
@@ -43,12 +44,12 @@ bool ModelFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
          if(parameters.size() - 1 != parameterMins_.size())
          {
-            cout<<"Error: number of modeParameters does not match number of parameters in file"<<endl;
+            std::cout<<"Error: number of modeParameters does not match number of parameters in file"<<std::endl;
             return false;
          }
          else if(parameterMins_.size() != parameterMaxs_.size())
          {
-            cout<<"Error: umber of parameter mins != number parameter maxes"<<endl;
+            std::cout<<"Error: umber of parameter mins != number parameter maxes"<<std::endl;
          }
          else
          {
@@ -65,7 +66,7 @@ bool ModelFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 
       }
    }
-   cout<<"FAILED: "<<*comment<<endl; 
+   std::cout<<"FAILED: "<<*comment<<std::endl; 
    return false;
 
 }
@@ -89,7 +90,7 @@ vector<string> ModelFilter::split(string fstring, string splitter)
    string afterSplitter = fstring;
    if(fstring.find(splitter) == string::npos)
    {
-      cout<<"No "<<splitter<<" found"<<endl;
+      std::cout<<"No "<<splitter<<" found"<<std::endl;
       returnVector.push_back(fstring);      
       return returnVector;
    }

--- a/PhysicsTools/UtilAlgos/interface/Selections.h
+++ b/PhysicsTools/UtilAlgos/interface/Selections.h
@@ -4,6 +4,7 @@
 #include "PhysicsTools/UtilAlgos/interface/EventSelector.h"
 #include <cstdlib>
 #include <iomanip>
+#include <iostream>
 #include <sstream>
 
 class Filter {

--- a/PhysicsTools/Utilities/interface/RootMinuitCommands.h
+++ b/PhysicsTools/Utilities/interface/RootMinuitCommands.h
@@ -136,7 +136,7 @@ namespace fit {
       path += (cmssw_base + "/src");
     }
     FileInPath fileInPath(path, fileName);
-    ifstream * file = fileInPath();
+    std::ifstream * file = fileInPath();
     if(file==0 || !file->is_open())
       throw edm::Exception(edm::errors::Configuration)
 	<< "RootMinuitCommands: can't open file: " << fileName 

--- a/PhysicsTools/Utilities/src/Lumi3DReWeighting.cc
+++ b/PhysicsTools/Utilities/src/Lumi3DReWeighting.cc
@@ -24,6 +24,7 @@
 #include "TH1.h"
 #include "TH3.h"
 #include "TFile.h"
+#include <iostream>
 #include <string>
 #include <algorithm>
 #include <boost/shared_ptr.hpp>

--- a/PhysicsTools/Utilities/src/LumiReWeighting.cc
+++ b/PhysicsTools/Utilities/src/LumiReWeighting.cc
@@ -23,6 +23,7 @@
 #include "TStopwatch.h"
 #include "TH1.h"
 #include "TFile.h"
+#include <iostream>
 #include <string>
 #include <algorithm>
 #include <boost/shared_ptr.hpp>

--- a/PhysicsTools/Utilities/src/SideBandSubtraction.cc
+++ b/PhysicsTools/Utilities/src/SideBandSubtraction.cc
@@ -193,7 +193,7 @@ void SideBandSubtract::printResults(string prefix)
     cerr <<"ERROR: printResults, Data or ModelPDF is NULL!\n";
 
   string result_outname = prefix + "_fit_results.txt";
-  ofstream output(result_outname.c_str(),std::ios::out);
+  std::ofstream output(result_outname.c_str(),std::ios::out);
   if(!output)
     {
       cout <<"ERROR: Could not open file for writing!\n";

--- a/RecoBTag/PerformanceDB/plugins/BTagPerformaceRootProducerFromSQLITE.cc
+++ b/RecoBTag/PerformanceDB/plugins/BTagPerformaceRootProducerFromSQLITE.cc
@@ -18,6 +18,7 @@
 
 
 // system include files
+#include <iostream>
 #include <memory>
 
 // user include files

--- a/RecoBTag/PerformanceDB/test/DumpBtagTable.cc
+++ b/RecoBTag/PerformanceDB/test/DumpBtagTable.cc
@@ -18,6 +18,7 @@
 
 
 // system include files
+#include <iostream>
 #include <memory>
 #include <map>
 #include <vector>
@@ -112,22 +113,22 @@ DumpBtagTable::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   edm::ESHandle<BtagPerformance> perfH;
   if( measureName.size() != measureType.size() )
   {
-      cout << "measureName, measureType size mismatch!" << endl;
+      std::cout << "measureName, measureType size mismatch!" << std::endl;
       exit(-1);
   }
 
 
   for( size_t iMeasure = 0; iMeasure < measureName.size(); iMeasure++ )
   {
-      cout << "# Dump table: " << measureName[ iMeasure ] << " of type " << measureType[ iMeasure ] << endl;
+      std::cout << "# Dump table: " << measureName[ iMeasure ] << " of type " << measureType[ iMeasure ] << std::endl;
 
 //Setup our measurement
       iSetup.get<BTagPerformanceRecord>().get( measureName[ iMeasure ],perfH);
       const BtagPerformance & perf = *(perfH.product());
 
 //Working point
-      cout << "# Working point: " << perf.workingPoint().cut() << endl;
-      cout << "# [pt] [eta] [SF]" << endl;
+      std::cout << "# Working point: " << perf.workingPoint().cut() << std::endl;
+      std::cout << "# [pt] [eta] [SF]" << std::endl;
 
 //Setup the point we wish to test!
 
@@ -148,15 +149,15 @@ DumpBtagTable::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 	  measurePoint.insert(BinningVariables::JetEt, pt);
 	  measurePoint.insert(BinningVariables::JetAbsEta, eta);
 	
-	  //cout << " From performance DB: " << perf.isResultOk( measureMap[ measureType[ iMeasure] ], measurePoint)
+	  //std::cout << " From performance DB: " << perf.isResultOk( measureMap[ measureType[ iMeasure] ], measurePoint)
 	  //<< " result at Jet pT " << pt << " GeV, |eta| < 2.39 " << perf.getResult( measureMap[ measureType[ iMeasure] ], measurePoint)
-	  //<< endl;
-	  cout << pt << sep 
+	  //<< std::endl;
+	  std::cout << pt << sep 
 	       << pt+bin_pt << sep 
 	       << eta << sep 
 	       << eta+bin_eta << sep
 	       << perf.getResult( measureMap[ measureType[ iMeasure] ], measurePoint) 
-	       << endl;
+	       << std::endl;
 
 	  measurePoint.reset();
 
@@ -167,28 +168,28 @@ DumpBtagTable::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
       //measurePoint.insert(BinningVariables::JetEt,30);
       //measurePoint.insert(BinningVariables::JetAbsEta,2.39);
 
-      //cout << "Is it OK? " << perf.isResultOk( measureMap[ measureType[ iMeasure] ], measurePoint)
+      //std::cout << "Is it OK? " << perf.isResultOk( measureMap[ measureType[ iMeasure] ], measurePoint)
       //		<< " result at 30 GeV, |eta| < 2.39 " << perf.getResult( measureMap[ measureType[ iMeasure] ], measurePoint)
-      //	<< endl;
+      //	<< std::endl;
 
       /*
       BinningPointByMap measurePoint;
       measurePoint.insert(BinningVariables::JetEt,50);
       measurePoint.insert(BinningVariables::JetAbsEta,0.6);
 
-      cout << "Is it OK? " << perf.isResultOk( measureMap[ measureType[ iMeasure] ], measurePoint)
+      std::cout << "Is it OK? " << perf.isResultOk( measureMap[ measureType[ iMeasure] ], measurePoint)
 		<< " result at 50 GeV, 0,6 |eta| " << perf.getResult( measureMap[ measureType[ iMeasure] ], measurePoint)
-		<< endl;
+		<< std::endl;
 
-      cout << "Error checking!" << endl;
+      std::cout << "Error checking!" << std::endl;
       measurePoint.reset();
       measurePoint.insert(BinningVariables::JetEt,0);
       measurePoint.insert(BinningVariables::JetAbsEta,10);
 
-      cout << "Is it OK? " << perf.isResultOk( measureMap[ measureType[ iMeasure] ], measurePoint)
+      std::cout << "Is it OK? " << perf.isResultOk( measureMap[ measureType[ iMeasure] ], measurePoint)
 		<< " result at 0 GeV, 10 |eta| " << perf.getResult( measureMap[ measureType[ iMeasure] ], measurePoint)
-		<< endl;
-      cout << endl;
+		<< std::endl;
+      std::cout << std::endl;
       */
   }
 

--- a/RecoBTag/PerformanceDB/test/TestBtagPayloads.cc
+++ b/RecoBTag/PerformanceDB/test/TestBtagPayloads.cc
@@ -17,6 +17,7 @@
 //
 
 // system include files
+#include <iostream>
 #include <memory>
 #include <stdio.h>
 

--- a/RecoBTag/PerformanceDB/test/TestPerformanceFW_ES.cc
+++ b/RecoBTag/PerformanceDB/test/TestPerformanceFW_ES.cc
@@ -18,6 +18,7 @@
 
 
 // system include files
+#include <iostream>
 #include <memory>
 #include <map>
 #include <vector>

--- a/RecoBTag/PerformanceDB/test/TestPerformanceFW_ES_TFormula.cc
+++ b/RecoBTag/PerformanceDB/test/TestPerformanceFW_ES_TFormula.cc
@@ -18,6 +18,7 @@
 
 
 // system include files
+#include <iostream>
 #include <memory>
 
 // user include files

--- a/RecoLocalCalo/HcalRecAlgos/test/HcalRecHitReflagger.cc
+++ b/RecoLocalCalo/HcalRecAlgos/test/HcalRecHitReflagger.cc
@@ -15,6 +15,7 @@
 //
 
 // system include files
+#include <iostream>
 #include <memory>
 
 // user include files

--- a/RecoLocalCalo/HcalRecAlgos/test/HcalSevLvlAnalyzer.cc
+++ b/RecoLocalCalo/HcalRecAlgos/test/HcalSevLvlAnalyzer.cc
@@ -18,6 +18,7 @@
 
 
 // system include files
+#include <iostream>
 #include <memory>
 
 // user include files

--- a/RecoLocalMuon/RPCRecHit/test/RPCRecHitReader.cc
+++ b/RecoLocalMuon/RPCRecHit/test/RPCRecHitReader.cc
@@ -105,7 +105,7 @@ void RPCRecHitReader::beginRun(const edm::Run&, const edm::EventSetup& iSetup)
   _rollEff = roll;
 
   fOutputFile  = new TFile( fOutputFileName.c_str(), "RECREATE" );
-  fout = new fstream("RecHitOut.dat", std::ios::out);
+  fout = new std::fstream("RecHitOut.dat", std::ios::out);
 
   _mapLayer[0] = -413.675;
   _mapLayer[1] = -448.675;

--- a/RecoMET/METFilters/plugins/EEBadScFilter.cc
+++ b/RecoMET/METFilters/plugins/EEBadScFilter.cc
@@ -14,6 +14,7 @@
 
 
 // include files
+#include <iostream>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDFilter.h"

--- a/RecoParticleFlow/PFClusterTools/src/IO.cc
+++ b/RecoParticleFlow/PFClusterTools/src/IO.cc
@@ -32,7 +32,7 @@ IO::IO(const char* filepattern) :  fCurline(0) {
 bool IO::ParseFile(const char* filename) {
   cout<<"file : "<<filename<<"\t\t";
 
-  ifstream in(filename);
+  std::ifstream in(filename);
   if( !in.good() ) {
     cout<<"unreadable"<<endl;
     return false;

--- a/RecoParticleFlow/PFClusterTools/src/PFResolutionMap.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFResolutionMap.cc
@@ -88,7 +88,7 @@ bool PFResolutionMap::WriteMapFile(const char* mapfile) {
 
   // open the file
 
-  ofstream outf(mapfile);
+  std::ofstream outf(mapfile);
   if( !outf.good() ) {
     cout<<"PFResolutionMap::Write : cannot open file "<<mapfile<<endl;
     return false;
@@ -111,7 +111,7 @@ bool PFResolutionMap::ReadMapFile(const char* mapfile) {
   
   // open the file
 
-  ifstream inf(mapfile);
+  std::ifstream inf(mapfile);
   if( !inf.good() ) {
     // cout<<"PFResolutionMap::Read : cannot open file "<<mapfile<<endl;
     return false;

--- a/RecoParticleFlow/PFClusterTools/src/TreeUtility.cc
+++ b/RecoParticleFlow/PFClusterTools/src/TreeUtility.cc
@@ -50,7 +50,7 @@ void TreeUtility::dumpCaloDataToCSV(TChain& tree, std::string csvFilename, doubl
 	CalibratablePtr calib_ptr(new Calibratable());
 
 	tree.SetBranchAddress("Calibratable", &calib_ptr);
-	ofstream csvFile;
+	std::ofstream csvFile;
 	csvFile.open(csvFilename.c_str());
 
 	std::cout << "Looping over tree's "<< tree.GetEntries() << " entries...\n";

--- a/RecoParticleFlow/PFRootEvent/interface/PFJetAlgorithm.h
+++ b/RecoParticleFlow/PFRootEvent/interface/PFJetAlgorithm.h
@@ -43,7 +43,7 @@ class PFJetAlgorithm {
     const TLorentzVector& GetMomentum() const {return fMomentum;}
     const std::vector<int>&    GetIndexes() const {return fVecIndexes;}
 
-    friend ostream& operator<<(ostream& out, const PFJetAlgorithm::Jet& jet);
+    friend std::ostream& operator<<(std::ostream& out, const PFJetAlgorithm::Jet& jet);
   };
 
 

--- a/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
@@ -72,7 +72,7 @@ void CaloHitResponse::initHBHEScale() {
 
 void CaloHitResponse::setHBHEScale(std::string & fileIn) {
   
-  ifstream infile(fileIn.c_str());
+  std::ifstream infile(fileIn.c_str());
   LogDebug("CaloHitResponse") << "Reading from " << fileIn;
 #ifdef ChangeHcalEnergyScale
   if (!infile.is_open()) {

--- a/SimCalorimetry/EcalSimProducers/test/ESDigisReferenceDistrib.cc
+++ b/SimCalorimetry/EcalSimProducers/test/ESDigisReferenceDistrib.cc
@@ -26,7 +26,7 @@ ESDigisReferenceDistrib::ESDigisReferenceDistrib(const edm::ParameterSet& ps):
 ESDigisReferenceDistrib::~ESDigisReferenceDistrib(){ 
 
   // preparing the txt file with the histo infos
-   ofstream *outFile_ = new ofstream(outputTxtFile_.c_str(),std::ios::out);
+   std::ofstream *outFile_ = new std::ofstream(outputTxtFile_.c_str(),std::ios::out);
   *outFile_ << "# number of bin"                         << std::endl;
   *outFile_ << "# axis inf (common to the three axes"    << std::endl;
   *outFile_ << "# axis sup (common to the three axes"    << std::endl;

--- a/SimCalorimetry/EcalTestBeamAlgos/src/EcalTBReadout.cc
+++ b/SimCalorimetry/EcalTestBeamAlgos/src/EcalTBReadout.cc
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <iostream>
 
 #include "SimCalorimetry/EcalTestBeamAlgos/interface/EcalTBReadout.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"

--- a/SimG4Core/Application/test/SimHitCaloHitDumper.cc
+++ b/SimG4Core/Application/test/SimHitCaloHitDumper.cc
@@ -1,4 +1,5 @@
 // system include files
+#include <iostream>
 #include <memory>
 #include <vector>
 #include <string>

--- a/SimGeneral/MixingModule/plugins/TestMixedSource.h
+++ b/SimGeneral/MixingModule/plugins/TestMixedSource.h
@@ -54,7 +54,7 @@ class TestMixedSource : public edm::EDAnalyzer {
       virtual void endJob() ;
 
       // ----------member data ---------------------------
-      ofstream outputFile;
+      std::ofstream outputFile;
       std::string fileName_;
       int bunchcr_;
       int minbunch_;

--- a/SimMuon/Neutron/src/RootChamberWriter.cc
+++ b/SimMuon/Neutron/src/RootChamberWriter.cc
@@ -1,6 +1,9 @@
 #include "SimMuon/Neutron/src/RootChamberWriter.h"
 #include "SimMuon/Neutron/src/RootSimHit.h"
+
+#include <iostream>
 using namespace std;
+
 
 RootChamberWriter::RootChamberWriter(const std::string & treeName)
 {

--- a/SimMuon/RPCDigitizer/test/RPCEventDump.cc
+++ b/SimMuon/RPCDigitizer/test/RPCEventDump.cc
@@ -10,6 +10,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
+#include <iostream>
 
 RPCEventDump::RPCEventDump(const edm::ParameterSet& config) {
   std::cout <<"Initialize the Event Dump"<<std::endl;

--- a/SimMuon/RPCDigitizer/test/RPCFakeEvent.cc
+++ b/SimMuon/RPCDigitizer/test/RPCFakeEvent.cc
@@ -12,6 +12,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
+#include <iostream>
 
 RPCFakeEvent::RPCFakeEvent(const edm::ParameterSet& config) {
 

--- a/Validation/RecoMuon/test/multiPlotter.cpp
+++ b/Validation/RecoMuon/test/multiPlotter.cpp
@@ -118,7 +118,7 @@ int main(int argc, char *argv[] )
   if (vmap.count("infile")) {
     infileName = vmap["infile"].as<std::string>() ;
     /*
-    ifstream inFile(infileName.c_str()) ;
+    std::ifstream inFile(infileName.c_str()) ;
     if (inFile.is_open()) { //--- input files listed in a file ---//
       while ( !inFile.eof() ) {
 	std::string skipped ;
@@ -140,7 +140,7 @@ int main(int argc, char *argv[] )
     }
   }
   else {
-    cout << " *** No input file given: please define one " << endl;
+    std::cout << " *** No input file given: please define one " << std::endl;
     return 0;
   }
 
@@ -151,7 +151,7 @@ int main(int argc, char *argv[] )
   
   TList *sourcelist = new TList();  
   for (std::vector<std::string>::size_type i = 0; i < inFileVector.size(); i++) {
-    cout << inFileVector[i] << " " << endl;
+    std::cout << inFileVector[i] << " " << std::endl;
     sourcelist->Add(TFile::Open(TString(inFileVector[i])));
   }
 
@@ -328,10 +328,10 @@ void drawLoop( TDirectory *target, TList *sourcelist, TCanvas *c1 )
       }
     }
     else if ( obj->IsA()->InheritsFrom( "TTree" ) ) {
-      cout << "I don't draw trees" << endl;
+      std::cout << "I don't draw trees" << std::endl;
     } else if ( obj->IsA()->InheritsFrom( "TDirectory" ) ) {
       // it's a subdirectory
-      cout << "Found subdirectory " << obj->GetName() << endl;
+      std::cout << "Found subdirectory " << obj->GetName() << std::endl;
 
       // create a new subdir of same name and title in the target file
       target->cd();
@@ -348,8 +348,8 @@ void drawLoop( TDirectory *target, TList *sourcelist, TCanvas *c1 )
 
     } else {
       // object is of no type that we know or can handle
-      cout << "Unknown object type, name: " 
-           << obj->GetName() << " title: " << obj->GetTitle() << endl;
+      std::cout << "Unknown object type, name: " 
+           << obj->GetName() << " title: " << obj->GetTitle() << std::endl;
     }
  
     // now write the merged TCanvas (which is "in" obj) to the target file


### PR DESCRIPTION
This pull request adds missing std:: qualifiers and missing includes of iostream that are necessary to compile CMSSW against ROOT6.  It does nothing else.  These changes are _not_ ROOT6 specific, and can be merged into
the main 7_0_X line.  I tested with checkdeps -a and rootMatrix.py -s and everything passes.

Signatures should be bypassed.
Retesting is at your discretion.
I am also running the full rootMatrix.py, which is still in progress.
