### PR TITLE
More XDAQ removal cleanups.

### DIFF
--- a/EventFilter/FEDInterface/BuildFile.xml
+++ b/EventFilter/FEDInterface/BuildFile.xml
@@ -1,4 +1,3 @@
-<use   name="xdaqheader"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/EventFilter/FEDInterface/interface/FEDHeader.h
+++ b/EventFilter/FEDInterface/interface/FEDHeader.h
@@ -7,7 +7,7 @@
  *  \author N. Amapane - CERN
  */
 
-#include "interface/shared/fed_header.h"
+#include "EventFilter/FEDInterface/interface/fed_header.h"
 
 class FEDHeader {
 public:

--- a/EventFilter/FEDInterface/interface/FEDTrailer.h
+++ b/EventFilter/FEDInterface/interface/FEDTrailer.h
@@ -8,7 +8,8 @@
  *  \author N. Amapane - CERN
  */
 
-#include "interface/shared/fed_trailer.h"
+#include "EventFilter/FEDInterface/interface/fed_header.h"
+#include "EventFilter/FEDInterface/interface/fed_trailer.h"
 
 
 class FEDTrailer {

--- a/EventFilter/FEDInterface/interface/GlobalEventNumber.h
+++ b/EventFilter/FEDInterface/interface/GlobalEventNumber.h
@@ -3,7 +3,7 @@
 
 
 #include <stddef.h>
-#include "interface/shared/fed_header.h" // from xdaq
+#include "EventFilter/FEDInterface/interface/fed_header.h"
 
 #include "EventFilter/FEDInterface/interface/FEDConstants.h"
 

--- a/EventFilter/Utilities/plugins/BuildFile.xml
+++ b/EventFilter/Utilities/plugins/BuildFile.xml
@@ -7,7 +7,6 @@
   <use   name="IOPool/Streamer"/>
   <use   name="EventFilter/Utilities"/>
   <use   name="DataFormats/FEDRawData"/>
-  <use   name="xdaq"/>
   <use   name="root"/>
   <use   name="boost"/>
   <flags   EDM_PLUGIN="1"/>

--- a/EventFilter/Utilities/plugins/ErrorStreamSource.cc
+++ b/EventFilter/Utilities/plugins/ErrorStreamSource.cc
@@ -27,8 +27,8 @@
 #include <vector>
 #include <fstream>
 #include <cstring>
-#include "interface/shared/fed_header.h"
-#include "interface/shared/fed_trailer.h"
+#include "EventFilter/FEDInterface/interface/fed_header.h"
+#include "EventFilter/FEDInterface/interface/fed_trailer.h"
 
 
 namespace errorstreamsource{

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -26,10 +26,10 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "interface/shared/fed_header.h"
-#include "interface/shared/fed_trailer.h"
+#include "EventFilter/FEDInterface/interface/fed_header.h"
+#include "EventFilter/FEDInterface/interface/fed_trailer.h"
 
-#include "../interface/FileIO.h"
+#include "EventFilter/Utilities/interface/FileIO.h"
 #include "FastMonitoringService.h"
 
 FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset,

--- a/EventFilter/Utilities/plugins/RawEventSourceFromBU.cc
+++ b/EventFilter/Utilities/plugins/RawEventSourceFromBU.cc
@@ -31,8 +31,8 @@
 #include <fstream>
 #include <cstring>
 
-#include "interface/shared/fed_header.h"
-#include "interface/shared/fed_trailer.h"
+#include "EventFilter/FEDInterface/interface/fed_header.h"
+#include "EventFilter/FEDInterface/interface/fed_trailer.h"
 
 
 namespace errorstreamsource{


### PR DESCRIPTION
- Replace now missing headers with their CMSSW counterparts.
- Drop xdaq and related from BuildFiles.
