### PR TITLE
Add std:: qualifiers or directives

### DIFF
--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaGui.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaGui.h
@@ -877,7 +877,7 @@ class TEcnaGui : public TGMainFrame {
 
   //==================================================== Miscellaneous parameters
 
-  //ofstream fFcout_f;
+  //std::ofstream fFcout_f;
 
   TString  fKeyAnaType;           // Type of analysis
 

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaHistos.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaHistos.h
@@ -380,7 +380,7 @@ class TEcnaHistos : public TObject {
   TVectorD        fReadHistoDummy;
   TMatrixD        fReadMatrixDummy;
 
-  ifstream fFcin_f;
+  std::ifstream fFcin_f;
 
   TString fFapAnaType;             // Type of analysis
   Int_t   fFapNbOfSamples;         // Nb of required samples

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaParPaths.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaParPaths.h
@@ -36,11 +36,11 @@ class TEcnaParPaths : public TObject {
 
   Int_t   fCnaCommand,  fCnaError;
 
-  ifstream fFcin_rr;          // stream for results root files 
-  ifstream fFcin_ra;          // stream for results ascii files 
-  ifstream fFcin_lor;         // stream for list of runs files
-  //  ifstream fFcin_anapar;      // stream for EcnaAnalyzer parameters files
-  ifstream fFcin_cmssw;       // stream for cmssw version and subsystem 
+  std::ifstream fFcin_rr;          // stream for results root files 
+  std::ifstream fFcin_ra;          // stream for results ascii files 
+  std::ifstream fFcin_lor;         // stream for list of runs files
+  //  std::ifstream fFcin_anapar;      // stream for EcnaAnalyzer parameters files
+  std::ifstream fFcin_cmssw;       // stream for cmssw version and subsystem 
 
   TString fCfgResultsRootFilePath;     // absolute path for the results .root files (/afs/etc...)
   TString fFileForResultsRootFilePath; // name of the file containing the results .root  file path

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaRun.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaRun.h
@@ -504,7 +504,7 @@ class TEcnaRun: public TObject {
   Int_t**     fT2dCrysNumbersTable;
   Int_t*      fT1dCrysNumbersTable;
 
-  ofstream    fFcout_f;
+  std::ofstream    fFcout_f;
 
   Int_t       fFlagPrint;
   Int_t       fCodePrintComments, fCodePrintWarnings, fCodePrintAllComments, fCodePrintNoComment;

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaWrite.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaWrite.h
@@ -57,7 +57,7 @@ class TEcnaWrite : public TObject {
   TEcnaParPaths  *fCnaParPaths;
   TEcnaParCout   *fCnaParCout;
 
-  ofstream fFcout_f;
+  std::ofstream fFcout_f;
 
   //...................................... Codes for file names
   Int_t fCodeHeaderAscii;

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaGui.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaGui.cc
@@ -4,6 +4,7 @@
 
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaGui.h"
 #include <cstdlib>
+using namespace std;
 
 //--------------------------------------
 //  TEcnaGui.cc

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaHeader.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaHeader.cc
@@ -3,6 +3,7 @@
 //----------Modified:24/03/2011
 
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaHeader.h"
+using namespace std;
 
 //--------------------------------------
 //  TEcnaHeader.cc

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaHistos.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaHistos.cc
@@ -3,6 +3,7 @@
 //---------Modified: 04/07/2011
 
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaHistos.h"
+using namespace std;
 
 //--------------------------------------
 //  TEcnaHistos.cc

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaNArrayD.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaNArrayD.cc
@@ -4,6 +4,7 @@
 
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaNArrayD.h"
 #include "Riostream.h"
+using namespace std;
 
 //--------------------------------------
 //  TEcnaNArrayD.cc

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaNumbering.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaNumbering.cc
@@ -3,6 +3,7 @@
 //----------Modified:30/06/2011
 
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaNumbering.h"
+using namespace std;
 
 //--------------------------------------
 //  TEcnaNumbering.cc

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaObject.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaObject.cc
@@ -2,6 +2,7 @@
 //----------Copyright: Those valid for CEA sofware
 //----------Modified: 24/03/2011
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaObject.h"
+using namespace std;
 
 //--------------------------------------
 //  TEcnaObject.cc

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaParCout.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaParCout.cc
@@ -3,6 +3,7 @@
 //----------Modified: 24/03/2010
 
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaParCout.h"
+using namespace std;
 
 //--------------------------------------
 //  TEcnaParCout.cc

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaParEcal.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaParEcal.cc
@@ -4,6 +4,7 @@
 
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaParEcal.h"
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaNumbering.h"
+using namespace std;
 
 //--------------------------------------
 //  TEcnaParEcal.cc

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaParHistos.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaParHistos.cc
@@ -4,6 +4,7 @@
 
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaParHistos.h"
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaNumbering.h"
+using namespace std;
 
 //--------------------------------------
 //  TEcnaParHistos.cc

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaParPaths.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaParPaths.cc
@@ -4,6 +4,7 @@
 
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaParPaths.h"
 #include <cstdlib>
+using namespace std;
 
 //--------------------------------------
 //  TEcnaParPaths.cc

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRead.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRead.cc
@@ -3,6 +3,7 @@
 //----------Modified: 04/07/2011
 
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaRead.h"
+using namespace std;
 
 //--------------------------------------
 //  TEcnaRead.cc

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaResultType.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaResultType.cc
@@ -4,6 +4,7 @@
 
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaResultType.h"
 #include "Riostream.h"
+using namespace std;
 
 //--------------------------------------
 //  TEcnaResultType.cc

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRootFile.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRootFile.cc
@@ -4,6 +4,7 @@
 
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaRootFile.h"
 #include "Riostream.h"
+using namespace std;
 
 //--------------------------------------
 //  TEcnaRootFile.cc

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRun.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRun.cc
@@ -3,6 +3,7 @@
 //----------Modified: 24/03/2011
 
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaRun.h"
+using namespace std;
 
 //--------------------------------------
 //  TEcnaRun.cc

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaWrite.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaWrite.cc
@@ -3,6 +3,7 @@
 //----------Modified: 30/06/2011
 
 #include "CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaWrite.h"
+using namespace std;
 
 //--------------------------------------
 //  TEcnaWrite.cc


### PR DESCRIPTION
When adding missing std:: qualifiers, I missed this one package, CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos.

Without this change, this package and one other package will not compile against ROOT6.

The signature can be bypassed.

Tested with checkdeps -a and runTheMatrix.py -s.
