### PR TITLE
Fix chimney hole

### DIFF
--- a/Geometry/CMSCommonData/data/mgnt.xml
+++ b/Geometry/CMSCommonData/data/mgnt.xml
@@ -4,7 +4,7 @@
 		<Constant name="MGNT_rmin" value="2.97*m"/>
 		<Constant name="MGNT_rmax1" value="3.77*m"/>
 		<Constant name="MGNT_rmax2" value="3.80*m"/>
-		<Constant name="ChimHole_height" value="([MGNT_rmax2]-[MGNT_rmin])/2."/>
+		<Constant name="ChimHole_height" value="([MGNT_rmax2]-[MGNT_rmin])/2.0*1.2"/>
 		<Constant name="ChimHole_posR" value="([MGNT_rmin]+[MGNT_rmax2])/2."/>
 		<Constant name="ChimHole_posZ_P" value="1.471*m"/>
 		<Constant name="ChimHole_posZ_N" value="-1.560*m"/>

--- a/Geometry/CMSCommonData/data/rotations.xml
+++ b/Geometry/CMSCommonData/data/rotations.xml
@@ -2447,7 +2447,7 @@
 		<Rotation name="MM412" thetaX="90*deg" phiX="60*deg" thetaY="180*deg" phiY="0*deg" thetaZ="90*deg" phiZ="150*deg"/>
 		<!--- Rotations for Chimney Holes in magnet -->
 		<Rotation name="RMCHIMHOLEP" thetaX="90*deg" phiX="00*deg" thetaY="180*deg" phiY="90*deg" thetaZ="90*deg" phiZ="90*deg"/>
-		<Rotation name="RMCHIMHOLEN" thetaX="90*deg" phiX="30*deg" thetaY="180*deg" phiY="90*deg" thetaZ="90*deg" phiZ="120*deg"/>
+                <Rotation name="RMCHIMHOLEN" thetaX="90*deg" phiX="330*deg" thetaY="180*deg" phiY="90*deg" thetaZ="90*deg" phiZ="60*deg" />
 		<Rotation name="RN090" thetaX="90*deg" phiX="270*deg" thetaY="90*deg" phiY="0*deg" thetaZ="0*deg" phiZ="0*deg"/>
 		<!--%%%%%%%%%%%  CASTOR rotations -->
 		<Rotation name="CARM" thetaX="135.0*deg" phiX="22.5*deg" thetaY="90.0*deg" phiY="112.5*deg" thetaZ="45.0*deg" phiZ="22.5*deg"/>


### PR DESCRIPTION
ChimHole_height was a bit too short for the solid subtractions to work properly. I made it long enough for the subtractions to succeed.

I think that the chimney hole was rotated to a wrong angle. I changed the angle such that the orientation of the hole makes more sense on the magnet.
