### PR TITLE
Reco Updates -- Fix ParticleFlow ECAL Cluster timing.

### DIFF
--- a/RecoEcal/EgammaCoreTools/interface/PositionCalc.h
+++ b/RecoEcal/EgammaCoreTools/interface/PositionCalc.h
@@ -99,8 +99,8 @@ PositionCalc::Calculate_Location( const PositionCalc::HitsAndFractions& iDetIds 
 	typename HitTypeCollection::const_iterator iHit ( iRecHits->find( dId ) ) ;
 	if( iHit != endRecHits ) {	       		   
 	  const double energy ( iHit->energy() *frac ) ;	   
-	  if( 0 < energy ) { // only save positive energies
-	    detIds.push_back( std::make_pair(dId,energy) );
+	  detIds.push_back( std::make_pair(dId,energy) );
+	  if( 0 < energy ) { // only save positive energies	    
 	    if( eMax < energy ) {
 	      eMax  = energy ;
 	      maxId = dId    ;	      

--- a/RecoEcal/EgammaCoreTools/interface/PositionCalc.h
+++ b/RecoEcal/EgammaCoreTools/interface/PositionCalc.h
@@ -100,7 +100,7 @@ PositionCalc::Calculate_Location( const PositionCalc::HitsAndFractions& iDetIds 
 	if( iHit != endRecHits ) {	       		   
 	  const double energy ( iHit->energy() *frac ) ;	   
 	  detIds.push_back( std::make_pair(dId,energy) );
-	  if( 0 < energy ) { // only save positive energies	    
+	  if( 0.0 < energy ) { // only save positive energies	    
 	    if( eMax < energy ) {
 	      eMax  = energy ;
 	      maxId = dId    ;	      
@@ -111,7 +111,7 @@ PositionCalc::Calculate_Location( const PositionCalc::HitsAndFractions& iDetIds 
       }
     }
     
-    if( 0 >= eTot ) {
+    if( 0.0 >= eTot ) {
       LogDebug("ZeroClusterEnergy") << "cluster with 0 energy: " 
 				    << eTot << " size: " << detIds.size() 
 				    << " , returning (0,0,0)";
@@ -165,7 +165,7 @@ PositionCalc::Calculate_Location( const PositionCalc::HitsAndFractions& iDetIds 
 	
 	double weight = 0;
 	if ( param_LogWeighted_ ) {
-	  if ( e_j > 0 ) {
+	  if ( e_j > 0.0 ) {
 	    weight = std::max( 0., param_W0_ + log(e_j/eTot) );
 	  } else {
 	    weight = 0;

--- a/RecoEcal/EgammaCoreTools/interface/PositionCalc.h
+++ b/RecoEcal/EgammaCoreTools/interface/PositionCalc.h
@@ -29,6 +29,8 @@
 class PositionCalc
 {
  public:
+  typedef std::vector< std::pair<DetId,float> > HitsAndFractions;
+  typedef std::vector< std::pair<DetId,double> > HitsAndEnergies;
   // You must call Initialize before you can calculate positions or 
   // covariances.
 
@@ -42,7 +44,7 @@ class PositionCalc
   // a subset of the map used to Initialize.
 
   template<typename HitType>
-  math::XYZPoint Calculate_Location( const std::vector< std::pair< DetId, float > >&      iDetIds  ,
+  math::XYZPoint Calculate_Location( const HitsAndFractions&      iDetIds  ,
 				     const edm::SortedCollection<HitType>*    iRecHits ,
 				     const CaloSubdetectorGeometry* iSubGeom ,
 				     const CaloSubdetectorGeometry* iESGeom = 0 ) ;
@@ -63,148 +65,131 @@ class PositionCalc
 
 template<typename HitType>
 math::XYZPoint 
-PositionCalc::Calculate_Location( const std::vector< std::pair<DetId, float> >&      iDetIds  ,
-				  const edm::SortedCollection<HitType>*    iRecHits ,
+PositionCalc::Calculate_Location( const PositionCalc::HitsAndFractions& iDetIds  ,
+				  const edm::SortedCollection<HitType>* iRecHits ,
 				  const CaloSubdetectorGeometry* iSubGeom ,
-				  const CaloSubdetectorGeometry* iESGeom   )
-{
+				  const CaloSubdetectorGeometry* iESGeom   ) {
   typedef edm::SortedCollection<HitType> HitTypeCollection;
   math::XYZPoint returnValue ( 0, 0, 0 ) ;
   
   // Throw an error if the cluster was not initialized properly
   
-  if( 0 == iRecHits || 
-      0 == iSubGeom    )
-    {
-      throw(std::runtime_error("\n\nPositionCalc::Calculate_Location called uninitialized or wrong initialization.\n\n"));
-    }
+  if( 0 == iRecHits || 0 == iSubGeom ) {
+    throw cms::Exception("PositionCalc")
+      << "Calculate_Location() called uninitialized or wrong initialization.";
+  }
   
   if( 0 != iDetIds.size()   &&
-      0 != iRecHits->size()     )
-   {
-     typedef std::vector< std::pair<DetId,float> > DetIdVec ; 
-     DetIdVec detIds ;
-     detIds.reserve( iDetIds.size() ) ;
-     
-     double eTot  ( 0 ) ;
-     double eMax  ( 0 ) ;
-     DetId  maxId ;
-     
-     // Check that DetIds are nonzero
-     typename HitTypeCollection::const_iterator endRecHits ( iRecHits->end() ) ;
-     for( std::vector< std::pair<DetId, float> >::const_iterator n ( iDetIds.begin() ) ; n != iDetIds.end() ; ++n ) 
-       {
-	 const DetId dId ( (*n).first ) ;
-         const float frac( (*n).second) ; 
-	 if( !dId.null() )
-	   {
-	     typename HitTypeCollection::const_iterator iHit ( iRecHits->find( dId ) ) ;
-	     if( iHit != endRecHits )
-	       {	       
-		 detIds.push_back( std::pair<DetId,float>(dId,frac) );  
-		 const double energy ( iHit->energy() *frac ) ;
-		 		 
-		 if( 0 < energy ) // only save positive energies
-		   {
-		     if( eMax < energy )
-		       {
-			 eMax  = energy ;
-			 maxId = dId    ;
-		       }
-		     eTot += energy ;
-		   }
-	       }
-	   }
-       }
-     
-     if( 0 >= eTot )
-       {
-	 LogDebug("ZeroClusterEnergy") << "cluster with 0 energy: " 
-				       << eTot << " size: " << detIds.size() 
-				       << " , returning (0,0,0)";
-       }
-     else
-       {
-	 // first time or when es geom changes set flags
-	 if( 0        != iESGeom &&
-	     m_esGeom != iESGeom    )
-	   {
-	     m_esGeom = iESGeom ;
-	     for( uint32_t ic ( 0 ) ;
-		  ( ic != m_esGeom->getValidDetIds().size() ) &&
-		    ( (!m_esPlus) || (!m_esMinus) ) ; ++ic )
-	       {
-		 const double z ( m_esGeom->getGeometry( m_esGeom->getValidDetIds()[ic] )->getPosition().z() ) ;
-		 m_esPlus  = m_esPlus  || ( 0 < z ) ;
-		 m_esMinus = m_esMinus || ( 0 > z ) ;
-	       }
-	   }
-	 
-	 //Select the correct value of the T0 parameter depending on subdetector
-	 
-	 const CaloCellGeometry* center_cell ( iSubGeom->getGeometry( maxId ) ) ;
-	 const double ctreta (center_cell->getPosition().eta());
-	 
-	 // for barrel, use barrel T0; 
-	 // for endcap: if preshower present && in preshower fiducial, 
-         //             use preshower T0
-	 // else use endcap only T0
-	 
-	 const double preshowerStartEta =  1.653;
-	 const int subdet = maxId.subdetId();
-	 const double T0 ( subdet == EcalBarrel ? param_T0_barl_ :
-			   ( ( ( preshowerStartEta < fabs( ctreta ) ) &&
-			       ( ( ( 0 < ctreta ) && 
-				   m_esPlus          ) ||
-				 ( ( 0 > ctreta ) &&
-				   m_esMinus         )   )    ) ?
-			     param_T0_endcPresh_ : param_T0_endc_ ) ) ;
-	 
-	 // Calculate shower depth
-	 const float maxDepth ( param_X0_ * ( T0 + log( eTot ) ) ) ;
-	 const float maxToFront ( center_cell->getPosition().mag() ) ; // to front face
-	 
-	 // Loop over hits and get weights
-	 double total_weight = 0;
-	 
-	 double xw ( 0 ) ;
-	 double yw ( 0 ) ;
-	 double zw ( 0 ) ;
-	 
-	 for( DetIdVec::const_iterator j ( detIds.begin() ) ; j != detIds.end() ; ++j ) 
-	   {
-	     const DetId dId ( (*j).first )  ;
-	     const float frac( (*j).second ) ;
-	     typename HitTypeCollection::const_iterator iR ( iRecHits->find( dId ) ) ;
-	     const double e_j ( iR->energy() *frac) ;
-	     
-	     double weight = 0;
-	     if ( param_LogWeighted_ ) {
-	       if ( e_j > 0 ) {
-		 weight = std::max( 0., param_W0_ + log(e_j/eTot) );
-	       } else {
-		 weight = 0;
-	       }
-	     } else {
-	       weight = e_j/eTot;
-	     }
-	     
-	     const CaloCellGeometry* cell ( iSubGeom->getGeometry( dId ) ) ;
-	     const float depth ( maxDepth + maxToFront - cell->getPosition().mag() ) ;
-	     
-	     const GlobalPoint pos (dynamic_cast<const TruncatedPyramid*>( cell )->getPosition( depth ) );
-	     
-	     xw += weight*pos.x() ;
-	     yw += weight*pos.y() ;
-	     zw += weight*pos.z() ;
-	     
-	     total_weight += weight ;
-	   }
-	 returnValue = math::XYZPoint( xw/total_weight, 
-				       yw/total_weight, 
-				       zw/total_weight ) ;
-       }
-   }
+      0 != iRecHits->size()     ) {
+    
+    HitsAndEnergies detIds; 
+    detIds.reserve( iDetIds.size() ) ;
+    
+    double eTot  ( 0 ) ;
+    double eMax  ( 0 ) ;
+    DetId  maxId ;
+    
+    // Check that DetIds are nonzero
+    typename HitTypeCollection::const_iterator endRecHits ( iRecHits->end() ) ;
+    HitsAndFractions::const_iterator n, endDiDs( iDetIds.end() );
+    for( n = iDetIds.begin(); n != endDiDs ; ++n ) {
+      const DetId dId ( (*n).first ) ;
+      const float frac( (*n).second) ; 
+      if( !dId.null() ) {
+	typename HitTypeCollection::const_iterator iHit ( iRecHits->find( dId ) ) ;
+	if( iHit != endRecHits ) {	       		   
+	  const double energy ( iHit->energy() *frac ) ;	   
+	  if( 0 < energy ) { // only save positive energies
+	    detIds.push_back( std::make_pair(dId,energy) );
+	    if( eMax < energy ) {
+	      eMax  = energy ;
+	      maxId = dId    ;	      
+	    }
+	    eTot += energy ;
+	  }
+	}
+      }
+    }
+    
+    if( 0 >= eTot ) {
+      LogDebug("ZeroClusterEnergy") << "cluster with 0 energy: " 
+				    << eTot << " size: " << detIds.size() 
+				    << " , returning (0,0,0)";
+    } else {
+      // first time or when es geom changes set flags
+      if( 0 != iESGeom && m_esGeom != iESGeom ) {
+	m_esGeom = iESGeom ;
+	for( uint32_t ic ( 0 ) ;
+	     ( ic != m_esGeom->getValidDetIds().size() ) &&
+	       ( (!m_esPlus) || (!m_esMinus) ) ; ++ic ) {
+	  const double z ( m_esGeom->getGeometry( m_esGeom->getValidDetIds()[ic] )->getPosition().z() ) ;
+	  m_esPlus  = m_esPlus  || ( 0 < z ) ;
+	  m_esMinus = m_esMinus || ( 0 > z ) ;
+	}
+      }
+      
+      //Select the correct value of the T0 parameter depending on subdetector       
+      const CaloCellGeometry* center_cell ( iSubGeom->getGeometry( maxId ) ) ;
+      const double ctreta (center_cell->getPosition().eta());
+      
+      // for barrel, use barrel T0; 
+      // for endcap: if preshower present && in preshower fiducial, 
+      //             use preshower T0
+      // else use endcap only T0       
+      const double preshowerStartEta =  1.653;
+      const int subdet = maxId.subdetId();
+      const double T0 ( subdet == EcalBarrel ? param_T0_barl_ :
+			( ( ( preshowerStartEta < fabs( ctreta ) ) &&
+			    ( ( ( 0 < ctreta ) && 
+				m_esPlus          ) ||
+			      ( ( 0 > ctreta ) &&
+				m_esMinus         )   )    ) ?
+			  param_T0_endcPresh_ : param_T0_endc_ ) ) ;
+      
+      // Calculate shower depth
+      const float maxDepth ( param_X0_ * ( T0 + log( eTot ) ) ) ;
+      const float maxToFront ( center_cell->getPosition().mag() ) ; // to front face
+      
+      // Loop over hits and get weights
+      double total_weight = 0;
+      
+      double xw ( 0 ) ;
+      double yw ( 0 ) ;
+      double zw ( 0 ) ;
+      
+      
+      HitsAndEnergies::const_iterator j, hAndE_end = detIds.end();
+      for( j = detIds.begin() ; j != hAndE_end ; ++j ) {
+	const DetId dId ( (*j).first )  ;
+	const double e_j( (*j).second ) ;	     
+	
+	double weight = 0;
+	if ( param_LogWeighted_ ) {
+	  if ( e_j > 0 ) {
+	    weight = std::max( 0., param_W0_ + log(e_j/eTot) );
+	  } else {
+	    weight = 0;
+	  }
+	} else {
+	  weight = e_j/eTot;
+	}
+	
+	const CaloCellGeometry* cell ( iSubGeom->getGeometry( dId ) ) ;
+	const float depth ( maxDepth + maxToFront - cell->getPosition().mag() ) ;
+	
+	const GlobalPoint pos (reinterpret_cast<const TruncatedPyramid*>( cell )->getPosition( depth ) );
+	
+	xw += weight*pos.x() ;
+	yw += weight*pos.y() ;
+	zw += weight*pos.z() ;
+	
+	total_weight += weight ;
+      }
+      returnValue = math::XYZPoint( xw/total_weight, 
+				    yw/total_weight, 
+				    zw/total_weight ) ;
+    }
+  }
   return returnValue ;
 }
 

--- a/RecoEcal/EgammaCoreTools/interface/PositionCalc.h
+++ b/RecoEcal/EgammaCoreTools/interface/PositionCalc.h
@@ -152,6 +152,7 @@ PositionCalc::Calculate_Location( const PositionCalc::HitsAndFractions& iDetIds 
       
       // Loop over hits and get weights
       double total_weight = 0;
+      const double eTot_inv = 1.0/eTot;
       
       double xw ( 0 ) ;
       double yw ( 0 ) ;
@@ -166,18 +167,18 @@ PositionCalc::Calculate_Location( const PositionCalc::HitsAndFractions& iDetIds 
 	double weight = 0;
 	if ( param_LogWeighted_ ) {
 	  if ( e_j > 0.0 ) {
-	    weight = std::max( 0., param_W0_ + log(e_j/eTot) );
+	    weight = std::max( 0., param_W0_ + log(e_j*eTot_inv) );
 	  } else {
 	    weight = 0;
 	  }
 	} else {
-	  weight = e_j/eTot;
+	  weight = e_j*eTot_inv;
 	}
 	
 	const CaloCellGeometry* cell ( iSubGeom->getGeometry( dId ) ) ;
 	const float depth ( maxDepth + maxToFront - cell->getPosition().mag() ) ;
 	
-	const GlobalPoint pos (reinterpret_cast<const TruncatedPyramid*>( cell )->getPosition( depth ) );
+	const GlobalPoint pos (static_cast<const TruncatedPyramid*>( cell )->getPosition( depth ) );
 	
 	xw += weight*pos.x() ;
 	yw += weight*pos.y() ;

--- a/RecoEcal/EgammaCoreTools/interface/PositionCalc.h
+++ b/RecoEcal/EgammaCoreTools/interface/PositionCalc.h
@@ -153,6 +153,7 @@ PositionCalc::Calculate_Location( const PositionCalc::HitsAndFractions& iDetIds 
       // Loop over hits and get weights
       double total_weight = 0;
       const double eTot_inv = 1.0/eTot;
+      const double logETot_inv = log(eTot_inv)
       
       double xw ( 0 ) ;
       double yw ( 0 ) ;
@@ -167,7 +168,7 @@ PositionCalc::Calculate_Location( const PositionCalc::HitsAndFractions& iDetIds 
 	double weight = 0;
 	if ( param_LogWeighted_ ) {
 	  if ( e_j > 0.0 ) {
-	    weight = std::max( 0., param_W0_ + log(e_j*eTot_inv) );
+	    weight = std::max( 0., param_W0_ + log(e_j) + logETot_inv );
 	  } else {
 	    weight = 0;
 	  }

--- a/RecoEcal/EgammaCoreTools/interface/PositionCalc.h
+++ b/RecoEcal/EgammaCoreTools/interface/PositionCalc.h
@@ -153,7 +153,7 @@ PositionCalc::Calculate_Location( const PositionCalc::HitsAndFractions& iDetIds 
       // Loop over hits and get weights
       double total_weight = 0;
       const double eTot_inv = 1.0/eTot;
-      const double logETot_inv = log(eTot_inv)
+      const double logETot_inv = ( param_LogWeighted_ ? log(eTot_inv) : 0 );
       
       double xw ( 0 ) ;
       double yw ( 0 ) ;

--- a/RecoParticleFlow/Configuration/test/RecoToDisplay_batch_cfg.py
+++ b/RecoParticleFlow/Configuration/test/RecoToDisplay_batch_cfg.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 import sys
 
 infile_name = sys.argv[2]
-outfile_name = '/afs/cern.ch/user/l/lgray/work/public/CMSSW_7_0_0_pre0_ged/src/RecoParticleFlow/Configuration/test/%s/superClusterDump_%i.root'%(sys.argv[5],int(sys.argv[3]))
+outfile_name = '/afs/cern.ch/user/l/lgray/work/public/CMSSW_7_0_0_pre3_singlegconv/src/RecoParticleFlow/Configuration/test/%s/superClusterDump_%i.root'%(sys.argv[5],int(sys.argv[3]))
 nevents = int(sys.argv[4])
 
 
@@ -24,7 +24,7 @@ process.maxEvents = cms.untracked.PSet(
 process.source = cms.Source(
     "PoolSource",
     fileNames = cms.untracked.vstring(
-    infile_name
+    'root://cms-xrd-global.cern.ch/%s'%infile_name
     ),
     eventsToProcess = cms.untracked.VEventRange(),
     #eventsToProcess = cms.untracked.VEventRange('1:1217421-1:1217421'),

--- a/RecoParticleFlow/Configuration/test/RecoToDisplay_cfg.py
+++ b/RecoParticleFlow/Configuration/test/RecoToDisplay_cfg.py
@@ -12,7 +12,7 @@ process.GlobalTag.globaltag = autoCond['startup']
 
 #process.Timing =cms.Service("Timing")
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(10000)
+    input = cms.untracked.int32(200)
 )
 
 process.source = cms.Source(
@@ -20,8 +20,8 @@ process.source = cms.Source(
     fileNames = cms.untracked.vstring(    
     #'root://eoscms//eos/cms/store/relval/CMSSW_5_2_0_pre5/RelValQCD_FlatPt_15_3000/GEN-SIM-RECO/START52_V1-v1/0105/2AAA5F86-8D57-E111-B6E8-003048678B84.root',
     #'root://eoscms//eos/cms/store/relval/CMSSW_5_2_0_pre5/RelValQCD_FlatPt_15_3000/GEN-SIM-RECO/START52_V1-v1/0105/38D32839-8A57-E111-849D-0026189438E4.root'
-    'root://cms-xrd-global.cern.ch//store/relval/CMSSW_6_1_0/SingleGammaPt300ExtRelVal610/GEN-SIM-RECO/START61_V8_NoPuCustomEvC-v1/00000/00110DD9-9390-E211-88AB-5404A63886E6.root'
-    #'root://cms-xrd-global.cern.ch//store/relval/CMSSW_7_0_0_pre2/RelValTTbar/GEN-SIM-RECO/PU_PRE_ST62_V8-v1/00000/EEC27D47-2F0C-E311-B9F2-003048FFD75C.root'
+    #'root://cms-xrd-global.cern.ch//store/relval/CMSSW_6_1_0/SingleGammaPt300ExtRelVal610/GEN-SIM-RECO/START61_V8_NoPuCustomEvC-v1/00000/00110DD9-9390-E211-88AB-5404A63886E6.root'
+    'root://cms-xrd-global.cern.ch//store/relval/CMSSW_7_0_0_pre2/RelValTTbar/GEN-SIM-RECO/PU_PRE_ST62_V8-v1/00000/EEC27D47-2F0C-E311-B9F2-003048FFD75C.root'
     ),
     eventsToProcess = cms.untracked.VEventRange(),
     #eventsToProcess = cms.untracked.VEventRange('1:1217421-1:1217421'),

--- a/RecoParticleFlow/Configuration/test/RecoToDisplay_cfg.py
+++ b/RecoParticleFlow/Configuration/test/RecoToDisplay_cfg.py
@@ -12,7 +12,7 @@ process.GlobalTag.globaltag = autoCond['startup']
 
 #process.Timing =cms.Service("Timing")
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(100)
+    input = cms.untracked.int32(10000)
 )
 
 process.source = cms.Source(
@@ -20,8 +20,8 @@ process.source = cms.Source(
     fileNames = cms.untracked.vstring(    
     #'root://eoscms//eos/cms/store/relval/CMSSW_5_2_0_pre5/RelValQCD_FlatPt_15_3000/GEN-SIM-RECO/START52_V1-v1/0105/2AAA5F86-8D57-E111-B6E8-003048678B84.root',
     #'root://eoscms//eos/cms/store/relval/CMSSW_5_2_0_pre5/RelValQCD_FlatPt_15_3000/GEN-SIM-RECO/START52_V1-v1/0105/38D32839-8A57-E111-849D-0026189438E4.root'
-    #'root://cms-xrd-global.cern.ch//store/relval/CMSSW_6_1_0/SingleGammaPt300ExtRelVal610/GEN-SIM-RECO/START61_V8_NoPuCustomEvC-v1/00000/20A36721-9490-E211-AE58-003048F1CAA8.root'
-    'root://cms-xrd-global.cern.ch//store/relval/CMSSW_7_0_0_pre2/RelValTTbar/GEN-SIM-RECO/PU_PRE_ST62_V8-v1/00000/EEC27D47-2F0C-E311-B9F2-003048FFD75C.root'
+    'root://cms-xrd-global.cern.ch//store/relval/CMSSW_6_1_0/SingleGammaPt300ExtRelVal610/GEN-SIM-RECO/START61_V8_NoPuCustomEvC-v1/00000/00110DD9-9390-E211-88AB-5404A63886E6.root'
+    #'root://cms-xrd-global.cern.ch//store/relval/CMSSW_7_0_0_pre2/RelValTTbar/GEN-SIM-RECO/PU_PRE_ST62_V8-v1/00000/EEC27D47-2F0C-E311-B9F2-003048FFD75C.root'
     ),
     eventsToProcess = cms.untracked.VEventRange(),
     #eventsToProcess = cms.untracked.VEventRange('1:1217421-1:1217421'),

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterAlgo.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterAlgo.h
@@ -33,13 +33,34 @@ class TH2F;
   \author Colin Bernet, Patrick Janot
   \date July 2006
 */
+
+namespace edm {
+  template<> 
+  struct StrictWeakOrdering<reco::PFRecHit> {   
+    typedef unsigned key_type;
+    bool operator()(unsigned a, reco::PFRecHit const& b) const { 
+      return a < b.detId(); 
+    }
+    bool operator()(reco::PFRecHit const& a, unsigned b) const { 
+      return a.detId() < b; 
+    }
+    bool operator()(reco::PFRecHit const& a, reco::PFRecHit const& b) const { 
+      return ( a.detId() < b.detId()  ); 
+    }
+  };
+}
+
 class PFClusterAlgo {
 
  public:
 
+  typedef edm::StrictWeakOrdering<reco::PFRecHit> PFStrictWeakOrdering;
+  typedef edm::SortedCollection<reco::PFRecHit> SortedPFRecHitCollection;
+
   enum PositionCalcType { EGPositionCalc,
 			  EGPositionFormula,			  
-			  PFPositionCalc };
+			  PFPositionCalc,
+			  kNotDefined };
 
   /// constructor
   PFClusterAlgo();
@@ -272,6 +293,8 @@ class PFClusterAlgo {
   
 
   PFRecHitHandle           rechitsHandle_;   
+  // for E\gamma Position calc
+  std::auto_ptr<SortedPFRecHitCollection> sortedRecHits_; 
 
   /// ids of rechits used in seed search
   std::set<unsigned>       idUsedRecHits_;

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterAlgo.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterAlgo.cc
@@ -1474,6 +1474,8 @@ PFClusterAlgo::calculateClusterPosition(reco::PFCluster& cluster,
 
     const reco::PFRecHit& rh = *(cluster.rechits_[ic].recHitRef());
 
+    hits_and_fracts.push_back(std::make_pair(DetId(rh.detId()),
+				     cluster.rechits_[ic].fraction()));
     if(rhi != seedIndex) { // not the seed
       if( posCalcNCrystal == 5 ) { // pos calculated from the 5 neighbours only
 	if(!rh.isNeighbour4(seedIndex) ) {
@@ -1486,13 +1488,9 @@ PFClusterAlgo::calculateClusterPosition(reco::PFCluster& cluster,
 	}
       }
     }
-    hits_and_fracts.push_back(std::make_pair(DetId(rh.detId()),
-					    cluster.rechits_[ic].fraction()));
+    
     double fraction = hits_and_fracts.back().second;
     double recHitEnergy = rh.energy() * fraction;
-  
-    
-
     double norm = fraction < 1E-9 ? 0. : max(0., log(recHitEnergy/p1));
         
     const math::XYZPoint& rechitposxyz = rh.position();


### PR DESCRIPTION
@bendavid @slava77

Down to 0.05 sec/event from 0.12 sec/event in https://github.com/cms-sw/cmssw/pull/706.
The timing was 0.03 sec/event originally. 
Further improvements would require factorization of PositionCalc code to take advantage of the PFCluster's refs to its rechits. Most of the extra time is spent building the necessary structures for pos calc and then in poscalc it is spent searching for the rechits in the sorted collection.

Since the PFClusters have the refs to the rechits that compose them, searching for the associated rechit again isn't really necessary. 

@argiro : Perhaps we could factor apart the rechit energy determination and position weighting parts of PositionCalc into two steps? If the sorted rechit collection wasn't required for the latter it would speed things up significantly in PFClusterAlgo.
