### PR TITLE
adding back DbClients now that tkonlinesw is back in

### DIFF
--- a/DQM/SiStripCommissioningDbClients/BuildFile.xml
+++ b/DQM/SiStripCommissioningDbClients/BuildFile.xml
@@ -1,0 +1,22 @@
+<use   name="CalibFormats/SiStripObjects"/>
+<use   name="CondFormats/SiStripObjects"/>
+<use   name="DataFormats/DetId"/>
+<use   name="DataFormats/GeometryVector"/>
+<use   name="DataFormats/SiStripCommon"/>
+<use   name="CondFormats/DataRecord"/>
+<use   name="DQM/SiStripCommissioningClients"/>
+<use   name="DQMServices/Core"/>
+<use   name="FWCore/MessageLogger"/>
+<use   name="FWCore/PluginManager"/>
+<use   name="FWCore/ServiceRegistry"/>
+<use   name="Geometry/CommonDetUnit"/>
+<use   name="Geometry/CommonTopologies"/>
+<use   name="Geometry/Records"/>
+<use   name="Geometry/TrackerGeometryBuilder"/>
+<use   name="OnlineDB/SiStripConfigDb"/>
+<use   name="OnlineDB/SiStripESSources"/>
+<use   name="boost"/>
+<use   name="rootcore"/>
+<export>
+  <lib   name="1"/>
+</export>

--- a/DQM/SiStripCommissioningDbClients/data/.OfflineDbClient.cfg
+++ b/DQM/SiStripCommissioningDbClients/data/.OfflineDbClient.cfg
@@ -1,0 +1,26 @@
+process SiStripCommissioningOfflineDbClient = {
+    
+    include "DQM/SiStripCommon/data/MessageLogger.cfi"
+    include "DQM/SiStripCommon/data/DaqMonitorROOTBackEnd.cfi"
+    
+    include "OnlineDB/SiStripConfigDb/data/SiStripConfigDb.cfi"
+    replace SiStripConfigDb.UsingDb   = true
+    replace SiStripConfigDb.ConfDb    = "CONF_DB"
+    replace SiStripConfigDb.Partition = "DB_PARTITION"
+    replace SiStripConfigDb.RunNumber = RUN_NUMBER
+    
+    include "IORawData/SiStripInputSources/data/EmptySource.cff"
+    replace maxEvents.input = 2
+    
+    module db_client = SiStripCommissioningOfflineDbClient
+    { 
+	untracked string     FilePath         = "FILE_PATH"
+	untracked uint32     RunNumber        = RUN_NUMBER
+	untracked bool       CollateHistos    = true 
+	untracked FileInPath SummaryXmlFile   = "DQM/SiStripCommissioningClients/data/summary.xml"
+	untracked bool       UploadToConfigDb = DB_UPDATE
+    }
+    
+    path p = { db_client }
+    
+}

--- a/DQM/SiStripCommissioningDbClients/data/run_client.sh
+++ b/DQM/SiStripCommissioningDbClients/data/run_client.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# usage ./run_client.sh <run_number> <db_upload> 
+
+eval `scramv1 runtime -sh`
+cp $CMSSW_BASE/src/DQM/SiStripCommissioningDbClients/data/.OfflineDbClient.cfg client_$1.cfg
+replace FILE_PATH ${SCRATCH}/source -- client_$1.cfg
+replace RUN_NUMBER $1 -- client_$1.cfg
+replace DB_UPDATE $2 -- client_$1.cfg 
+replace CONF_DB ${CONFDB} -- client_$1.cfg 
+replace DB_PARTITION ${ENV_CMS_TK_PARTITION} -- client_$1.cfg 
+cmsRun client_$1.cfg
+mkdir ${SCRATCH}/client/$1
+mv ${SCRATCH}/*$1*.root ${SCRATCH}/client/$1
+mv client_$1.cfg ${SCRATCH}/client/$1
+mv event.log ${SCRATCH}/client/$1/event_$1.log
+mv error.log ${SCRATCH}/client/$1/error_$1.log
+mv debug.log ${SCRATCH}/client/$1/debug_$1.log

--- a/DQM/SiStripCommissioningDbClients/doc/html/index.html
+++ b/DQM/SiStripCommissioningDbClients/doc/html/index.html
@@ -1,0 +1,11 @@
+<! Template File - Modify as required.>
+<! Use as an index to other html documents>
+<! References to local pages should be relative to this directory>
+<! This makes it easy for both users of the web project space and>
+<! any others who might simply look at html files directly in the source code.>
+<! e.g. href=page1.html or  href=mysubdir/page2.html > 
+<html>
+<body>
+This Text Inserted from File doc/html/index.html
+</body>
+</html>

--- a/DQM/SiStripCommissioningDbClients/doc/html/overview.html
+++ b/DQM/SiStripCommissioningDbClients/doc/html/overview.html
@@ -1,0 +1,12 @@
+<! Template File - Modify as required.>
+<! Use as a brief project description that appears on your main page>
+<! Links are not encouraged from this section - use index.html for this>
+This Text Inserted from File doc/html/overview.html
+<table border=0 width=100%>
+<tr>
+<td align=center><b>Status :</b></td>
+<td align=center>
+Unknown
+</td>
+</tr>
+</table>

--- a/DQM/SiStripCommissioningDbClients/interface/ApvTimingHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/ApvTimingHistosUsingDb.h
@@ -1,0 +1,36 @@
+
+#ifndef DQM_SiStripCommissioningClients_ApvTimingHistosUsingDb_H
+#define DQM_SiStripCommissioningClients_ApvTimingHistosUsingDb_H
+
+#include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
+#include "DQM/SiStripCommissioningClients/interface/ApvTimingHistograms.h"
+
+class ApvTimingHistosUsingDb : public CommissioningHistosUsingDb, public ApvTimingHistograms  {
+  
+ public:
+
+  ApvTimingHistosUsingDb( const edm::ParameterSet & pset,
+                          DQMStore*,
+                          SiStripConfigDb* const );
+
+  virtual ~ApvTimingHistosUsingDb();
+  
+  virtual void uploadConfigurations();
+
+ private:
+
+  bool update( SiStripConfigDb::DeviceDescriptionsRange );
+  
+  void update( SiStripConfigDb::FedDescriptionsRange );
+  
+  void create( SiStripConfigDb::AnalysisDescriptionsV&, Analysis ); 
+  
+  // switch for uploading the pll thresholds
+  bool skipFecUpdate_;
+  // switch for uploading the frame finding thresholds
+  bool skipFedUpdate_;
+  
+};
+
+
+#endif // DQM_SiStripCommissioningClients_ApvTimingHistosUsingDb_H

--- a/DQM/SiStripCommissioningDbClients/interface/CalibrationHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/CalibrationHistosUsingDb.h
@@ -1,0 +1,38 @@
+
+#ifndef DQM_SiStripCommissioningClients_CalibrationHistosUsingDb_H
+#define DQM_SiStripCommissioningClients_CalibrationHistosUsingDb_H
+
+#include "DQM/SiStripCommissioningClients/interface/CalibrationHistograms.h"
+#include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
+#include "OnlineDB/SiStripConfigDb/interface/SiStripConfigDb.h"
+#include <boost/cstdint.hpp>
+#include <string>
+#include <map>
+
+class TH1F;
+
+class CalibrationHistosUsingDb : public CommissioningHistosUsingDb, public CalibrationHistograms {
+  
+ public:
+  
+  CalibrationHistosUsingDb( const edm::ParameterSet & pset,
+                            DQMStore*,
+                            SiStripConfigDb* const,
+                            const sistrip::RunType& task = sistrip::CALIBRATION );
+
+  virtual ~CalibrationHistosUsingDb();
+
+  virtual void uploadConfigurations();
+  
+ private:
+  
+  void update( SiStripConfigDb::DeviceDescriptionsRange& );
+  
+  void create( SiStripConfigDb::AnalysisDescriptionsV&, Analysis );
+
+  TH1F *ishaHistogram_, *vfsHistogram_; 
+
+};
+
+#endif // DQM_SiStripCommissioningClients_CalibrationHistosUsingDb_H
+

--- a/DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h
@@ -1,0 +1,103 @@
+
+#ifndef DQM_SiStripCommissioningClients_CommissioningHistosUsingDb_H
+#define DQM_SiStripCommissioningClients_CommissioningHistosUsingDb_H
+
+#include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
+#include "DQM/SiStripCommissioningClients/interface/CommissioningHistograms.h"
+#include "OnlineDB/SiStripConfigDb/interface/SiStripConfigDb.h"
+#include "boost/range/iterator_range.hpp"
+#include <boost/cstdint.hpp>
+#include <string>
+#include <map>
+
+class SiStripConfigDb;
+class SiStripFedCabling;
+
+class CommissioningHistosUsingDb : public virtual CommissioningHistograms {
+  
+ // ---------- public interface ----------
+
+ public:
+
+  CommissioningHistosUsingDb( SiStripConfigDb* const,
+                              sistrip::RunType = sistrip::UNDEFINED_RUN_TYPE );
+
+  virtual ~CommissioningHistosUsingDb();
+
+  void uploadToConfigDb();
+  
+  bool doUploadAnal() const;
+  
+  bool doUploadConf() const;
+
+  void doUploadAnal( bool );
+  
+  void doUploadConf( bool );
+  
+ // ---------- protected methods ----------
+
+ protected:
+  
+  void buildDetInfo();
+  
+  virtual void addDcuDetIds();
+  
+  virtual void uploadConfigurations() {;}
+  
+  void uploadAnalyses();
+  
+  virtual void createAnalyses( SiStripConfigDb::AnalysisDescriptionsV& );
+  
+  virtual void create( SiStripConfigDb::AnalysisDescriptionsV&, Analysis ) {;}
+  
+  SiStripConfigDb* const db() const; 
+
+  SiStripFedCabling* const cabling() const;
+  
+  class DetInfo { 
+  public:
+    uint32_t dcuId_;
+    uint32_t detId_;
+    uint16_t pairs_;
+    DetInfo() : 
+      dcuId_(sistrip::invalid32_), 
+      detId_(sistrip::invalid32_), 
+      pairs_(sistrip::invalid_) {;}
+  };
+  
+  std::pair<std::string,DetInfo> detInfo( const SiStripFecKey& );
+  
+  bool deviceIsPresent( const SiStripFecKey& );
+  
+ // ---------- private member data ----------
+  
+ private: 
+  
+  CommissioningHistosUsingDb(); 
+
+  sistrip::RunType runType_;
+  
+  SiStripConfigDb* db_;
+  
+  SiStripFedCabling* cabling_;
+
+  typedef std::map<uint32_t,DetInfo> DetInfos;
+  
+  std::map<std::string,DetInfos> detInfo_;
+  
+  bool uploadAnal_;
+  
+  bool uploadConf_;
+  
+};
+
+inline void CommissioningHistosUsingDb::doUploadConf( bool upload ) { uploadConf_ = upload; }
+inline void CommissioningHistosUsingDb::doUploadAnal( bool upload ) { uploadAnal_ = upload; }
+
+inline bool CommissioningHistosUsingDb::doUploadAnal() const { return uploadAnal_; }
+inline bool CommissioningHistosUsingDb::doUploadConf() const { return uploadConf_; }
+
+inline SiStripConfigDb* const CommissioningHistosUsingDb::db() const { return db_; } 
+inline SiStripFedCabling* const CommissioningHistosUsingDb::cabling() const { return cabling_; }
+
+#endif // DQM_SiStripCommissioningClients_CommissioningHistosUsingDb_H

--- a/DQM/SiStripCommissioningDbClients/interface/FastFedCablingHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/FastFedCablingHistosUsingDb.h
@@ -1,0 +1,39 @@
+
+#ifndef DQM_SiStripCommissioningClients_FastFedCablingHistosUsingDb_H
+#define DQM_SiStripCommissioningClients_FastFedCablingHistosUsingDb_H
+
+#include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
+#include "DQM/SiStripCommissioningClients/interface/FastFedCablingHistograms.h"
+
+class FastFedCablingHistosUsingDb : public CommissioningHistosUsingDb, public FastFedCablingHistograms  {
+  
+ public:
+  
+  FastFedCablingHistosUsingDb( const edm::ParameterSet & pset,
+                               DQMStore*,
+                               SiStripConfigDb* const );
+
+  virtual ~FastFedCablingHistosUsingDb();
+ 
+  virtual void addDcuDetIds(); // override
+  
+  virtual void uploadConfigurations();
+  
+ private:
+  
+  void update( SiStripConfigDb::FedConnectionsV&,
+               SiStripConfigDb::FedDescriptionsRange,
+               SiStripConfigDb::DeviceDescriptionsRange, 
+               SiStripConfigDb::DcuDetIdsRange );
+  
+  void update( SiStripConfigDb::FedDescriptionsRange );
+  
+  void create( SiStripConfigDb::AnalysisDescriptionsV&, Analysis ); 
+  
+  void connections( SiStripConfigDb::DeviceDescriptionsRange, 
+                    SiStripConfigDb::DcuDetIdsRange );
+  
+};
+
+#endif // DQM_SiStripCommissioningClients_FastFedCablingHistosUsingDb_H
+

--- a/DQM/SiStripCommissioningDbClients/interface/FineDelayHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/FineDelayHistosUsingDb.h
@@ -1,0 +1,46 @@
+
+#ifndef DQM_SiStripCommissioningClients_FineDelayHistosUsingDb_H
+#define DQM_SiStripCommissioningClients_FineDelayHistosUsingDb_H
+
+#include "DQM/SiStripCommissioningClients/interface/SamplingHistograms.h"
+#include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
+#include "OnlineDB/SiStripConfigDb/interface/SiStripConfigDb.h"
+#include <boost/cstdint.hpp>
+#include <string>
+#include <map>
+
+class TrackerGeometry;
+
+class FineDelayHistosUsingDb : public CommissioningHistosUsingDb, public SamplingHistograms {
+  
+ public:
+  
+  FineDelayHistosUsingDb( const edm::ParameterSet & pset,
+                          DQMStore*,
+                          SiStripConfigDb* const );
+
+  virtual ~FineDelayHistosUsingDb();
+
+  virtual void configure( const edm::ParameterSet&, 
+                          const edm::EventSetup& );
+
+  virtual void uploadConfigurations();
+
+ private:
+  
+  bool update( SiStripConfigDb::DeviceDescriptionsRange );
+
+  void update( SiStripConfigDb::FedDescriptionsRange );
+
+  void create( SiStripConfigDb::AnalysisDescriptionsV&, Analysis ); 
+
+  void computeDelays();
+
+  std::map<unsigned int,float > delays_;
+
+  const TrackerGeometry* tracker_;
+  
+  bool cosmic_;
+};
+
+#endif // DQM_SiStripCommissioningClients_FineDelayHistosUsingDb_H

--- a/DQM/SiStripCommissioningDbClients/interface/LatencyHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/LatencyHistosUsingDb.h
@@ -1,0 +1,38 @@
+
+#ifndef DQM_SiStripCommissioningClients_LatencyHistosUsingDb_H
+#define DQM_SiStripCommissioningClients_LatencyHistosUsingDb_H
+
+#include "DQM/SiStripCommissioningClients/interface/SamplingHistograms.h"
+#include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
+#include "OnlineDB/SiStripConfigDb/interface/SiStripConfigDb.h"
+#include <boost/cstdint.hpp>
+#include <string>
+#include <map>
+
+class LatencyHistosUsingDb : public CommissioningHistosUsingDb, public SamplingHistograms {
+  
+ public:
+  
+  LatencyHistosUsingDb( const edm::ParameterSet & pset,
+                        DQMStore*,
+                        SiStripConfigDb* const );
+  
+  virtual ~LatencyHistosUsingDb();
+  
+  virtual void uploadConfigurations();
+
+  virtual void configure( const edm::ParameterSet&, const edm::EventSetup& );
+  
+ private:
+  
+  bool update( SiStripConfigDb::DeviceDescriptionsRange, 
+               SiStripConfigDb::FedDescriptionsRange );
+  
+  void create( SiStripConfigDb::AnalysisDescriptionsV&, Analysis );
+  
+  bool perPartition_;
+
+};
+
+#endif // DQM_SiStripCommissioningClients_LatencyHistosUsingDb_H
+

--- a/DQM/SiStripCommissioningDbClients/interface/NoiseHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/NoiseHistosUsingDb.h
@@ -1,0 +1,29 @@
+
+#ifndef DQM_SiStripCommissioningClients_NoiseHistosUsingDb_H
+#define DQM_SiStripCommissioningClients_NoiseHistosUsingDb_H
+#include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
+
+#include "DQM/SiStripCommissioningClients/interface/NoiseHistograms.h"
+
+class NoiseHistosUsingDb : public CommissioningHistosUsingDb, public NoiseHistograms {
+  
+ public:
+
+  NoiseHistosUsingDb( const edm::ParameterSet & pset,
+                      DQMStore*,
+                      SiStripConfigDb* const );
+  
+  virtual ~NoiseHistosUsingDb();
+ 
+  virtual void uploadConfigurations();
+  
+ private:
+
+  void update( SiStripConfigDb::FedDescriptionsRange );
+
+  void create( SiStripConfigDb::AnalysisDescriptionsV&, Analysis );
+
+};
+
+#endif // DQM_SiStripCommissioningClients_NoiseHistosUsingDb_H
+

--- a/DQM/SiStripCommissioningDbClients/interface/OptoScanHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/OptoScanHistosUsingDb.h
@@ -1,0 +1,32 @@
+
+#ifndef DQM_SiStripCommissioningClients_OptoScanHistosUsingDb_H
+#define DQM_SiStripCommissioningClients_OptoScanHistosUsingDb_H
+
+#include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
+#include "DQM/SiStripCommissioningClients/interface/OptoScanHistograms.h"
+
+class OptoScanHistosUsingDb : public CommissioningHistosUsingDb, public OptoScanHistograms {
+  
+ public:
+  
+  OptoScanHistosUsingDb( const edm::ParameterSet & pset,
+                         DQMStore*,
+                         SiStripConfigDb* const );
+
+  virtual ~OptoScanHistosUsingDb();
+
+  virtual void uploadConfigurations();
+  
+ private:
+  
+  void update( SiStripConfigDb::DeviceDescriptionsRange );
+  
+  void create( SiStripConfigDb::AnalysisDescriptionsV&, Analysis ); 
+
+  // parameters
+  bool skipGainUpdate_;
+
+};
+
+#endif // DQM_SiStripCommissioningClients_OptoScanHistosUsingDb_H
+

--- a/DQM/SiStripCommissioningDbClients/interface/PedestalsHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/PedestalsHistosUsingDb.h
@@ -1,0 +1,35 @@
+
+#ifndef DQM_SiStripCommissioningClients_PedestalsHistosUsingDb_H
+#define DQM_SiStripCommissioningClients_PedestalsHistosUsingDb_H
+#include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
+
+#include "DQM/SiStripCommissioningClients/interface/PedestalsHistograms.h"
+
+class PedestalsHistosUsingDb : public CommissioningHistosUsingDb, public PedestalsHistograms {
+  
+ public:
+  
+  PedestalsHistosUsingDb( const edm::ParameterSet & pset,
+                          DQMStore*,
+                          SiStripConfigDb* const );
+  
+  virtual ~PedestalsHistosUsingDb();
+  
+  virtual void uploadConfigurations();
+  
+ private:
+
+  void update( SiStripConfigDb::FedDescriptionsRange );
+
+  void create( SiStripConfigDb::AnalysisDescriptionsV&, Analysis );
+
+  // parameters
+  float highThreshold_;
+  float lowThreshold_;
+  bool disableBadStrips_;
+  bool keepStripsDisabled_;
+
+};
+
+#endif // DQM_SiStripCommissioningClients_PedestalsHistosUsingDb_H
+

--- a/DQM/SiStripCommissioningDbClients/interface/PedsFullNoiseHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/PedsFullNoiseHistosUsingDb.h
@@ -1,0 +1,36 @@
+
+#ifndef DQM_SiStripCommissioningClients_PedsFullNoiseHistosUsingDb_H
+#define DQM_SiStripCommissioningClients_PedsFullNoiseHistosUsingDb_H
+#include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
+
+#include "DQM/SiStripCommissioningClients/interface/PedsFullNoiseHistograms.h"
+
+class PedsFullNoiseHistosUsingDb : public CommissioningHistosUsingDb, public PedsFullNoiseHistograms {
+
+  public:
+
+    PedsFullNoiseHistosUsingDb( const edm::ParameterSet & pset,
+                                DQMStore*,
+                                SiStripConfigDb* const );
+
+    virtual ~PedsFullNoiseHistosUsingDb();
+
+    virtual void uploadConfigurations();
+
+   private:
+
+    void update( SiStripConfigDb::FedDescriptionsRange );
+
+    void create( SiStripConfigDb::AnalysisDescriptionsV&, Analysis );
+
+    // parameters
+    float highThreshold_;
+    float lowThreshold_;
+    bool disableBadStrips_;
+    bool keepStripsDisabled_;
+    bool addBadStrips_;
+
+};
+
+#endif // DQM_SiStripCommissioningClients_PedsFullNoiseHistosUsingDb_H
+

--- a/DQM/SiStripCommissioningDbClients/interface/PedsOnlyHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/PedsOnlyHistosUsingDb.h
@@ -1,0 +1,29 @@
+
+#ifndef DQM_SiStripCommissioningClients_PedsOnlyHistosUsingDb_H
+#define DQM_SiStripCommissioningClients_PedsOnlyHistosUsingDb_H
+#include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
+
+#include "DQM/SiStripCommissioningClients/interface/PedsOnlyHistograms.h"
+
+class PedsOnlyHistosUsingDb : public CommissioningHistosUsingDb, public PedsOnlyHistograms {
+  
+ public:
+
+  PedsOnlyHistosUsingDb( const edm::ParameterSet & pset,
+                         DQMStore*,
+                         SiStripConfigDb* const );
+  
+  virtual ~PedsOnlyHistosUsingDb();
+ 
+  virtual void uploadConfigurations();
+  
+ private:
+
+  void update( SiStripConfigDb::FedDescriptionsRange );
+
+  void create( SiStripConfigDb::AnalysisDescriptionsV&, Analysis );
+
+};
+
+#endif // DQM_SiStripCommissioningClients_PedsOnlyHistosUsingDb_H
+

--- a/DQM/SiStripCommissioningDbClients/interface/SamplingHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/SamplingHistosUsingDb.h
@@ -1,0 +1,33 @@
+
+#ifndef DQM_SiStripCommissioningClients_SamplingHistosUsingDb_H
+#define DQM_SiStripCommissioningClients_SamplingHistosUsingDb_H
+
+#include "DQM/SiStripCommissioningClients/interface/SamplingHistograms.h"
+#include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
+#include "OnlineDB/SiStripConfigDb/interface/SiStripConfigDb.h"
+#include <boost/cstdint.hpp>
+#include <string>
+#include <map>
+
+class SamplingHistosUsingDb : public CommissioningHistosUsingDb, public SamplingHistograms {
+  
+ public:
+  
+  SamplingHistosUsingDb( const edm::ParameterSet & pset,
+                         DaqMonitorBEInterface*,
+                         SiStripConfigDb* const );
+
+  virtual ~SamplingHistosUsingDb();
+
+  virtual void uploadConfigurations();
+  
+ private:
+  
+  void update( SiStripConfigDb::DeviceDescriptions& );
+  
+  void create( SiStripConfigDb::AnalysisDescriptionsV&, Analysis );
+  
+};
+
+#endif // DQM_SiStripCommissioningClients_SamplingHistosUsingDb_H
+

--- a/DQM/SiStripCommissioningDbClients/interface/VpspScanHistosUsingDb.h
+++ b/DQM/SiStripCommissioningDbClients/interface/VpspScanHistosUsingDb.h
@@ -1,0 +1,29 @@
+
+#ifndef DQM_SiStripCommissioningClients_VpspScanHistosUsingDb_H
+#define DQM_SiStripCommissioningClients_VpspScanHistosUsingDb_H
+
+#include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
+#include "DQM/SiStripCommissioningClients/interface/VpspScanHistograms.h"
+
+class VpspScanHistosUsingDb : public CommissioningHistosUsingDb, public VpspScanHistograms {
+  
+ public:
+  
+  VpspScanHistosUsingDb( const edm::ParameterSet & pset,
+                         DQMStore*,
+                         SiStripConfigDb* const );
+
+  virtual ~VpspScanHistosUsingDb();
+
+  virtual void uploadConfigurations();
+  
+ private:
+
+  void update( SiStripConfigDb::DeviceDescriptionsRange );
+  
+  void create( SiStripConfigDb::AnalysisDescriptionsV&, Analysis );
+  
+};
+
+#endif // DQM_SiStripCommissioningClients_VpspScanHistosUsingDb_H
+

--- a/DQM/SiStripCommissioningDbClients/plugins/BuildFile.xml
+++ b/DQM/SiStripCommissioningDbClients/plugins/BuildFile.xml
@@ -1,0 +1,10 @@
+<library   file="*.cc" name="DQMSiStripCommissioningDbClientsPlugins">
+  <use   name="DataFormats/SiStripCommon"/>
+  <use   name="DQM/SiStripCommissioningClients"/>
+  <use   name="DQM/SiStripCommissioningDbClients"/>
+  <use   name="DQMServices/Core"/>
+  <use   name="FWCore/MessageLogger"/>
+  <use   name="OnlineDB/SiStripConfigDb"/>
+  <use   name="boost"/>
+  <flags   EDM_PLUGIN="1"/>
+</library>

--- a/DQM/SiStripCommissioningDbClients/plugins/SiStripCommissioningOfflineDbClient.cc
+++ b/DQM/SiStripCommissioningDbClients/plugins/SiStripCommissioningOfflineDbClient.cc
@@ -1,0 +1,167 @@
+
+#include "DQM/SiStripCommissioningDbClients/plugins/SiStripCommissioningOfflineDbClient.h"
+#include "DataFormats/SiStripCommon/interface/SiStripEnumsAndStrings.h"
+#include "DataFormats/SiStripCommon/interface/SiStripHistoTitle.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFecKey.h"
+#include "DQM/SiStripCommissioningDbClients/interface/FastFedCablingHistosUsingDb.h"
+#include "DQM/SiStripCommissioningDbClients/interface/ApvTimingHistosUsingDb.h"
+#include "DQM/SiStripCommissioningDbClients/interface/OptoScanHistosUsingDb.h"
+#include "DQM/SiStripCommissioningDbClients/interface/VpspScanHistosUsingDb.h"
+#include "DQM/SiStripCommissioningDbClients/interface/PedestalsHistosUsingDb.h"
+#include "DQM/SiStripCommissioningDbClients/interface/PedsOnlyHistosUsingDb.h"
+#include "DQM/SiStripCommissioningDbClients/interface/NoiseHistosUsingDb.h"
+#include "DQM/SiStripCommissioningDbClients/interface/PedsFullNoiseHistosUsingDb.h"
+#include "DQM/SiStripCommissioningDbClients/interface/LatencyHistosUsingDb.h"
+#include "DQM/SiStripCommissioningDbClients/interface/FineDelayHistosUsingDb.h"
+#include "DQM/SiStripCommissioningDbClients/interface/CalibrationHistosUsingDb.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "OnlineDB/SiStripConfigDb/interface/SiStripConfigDb.h"
+
+using namespace sistrip;
+
+// -----------------------------------------------------------------------------
+// 
+SiStripCommissioningOfflineDbClient::SiStripCommissioningOfflineDbClient( const edm::ParameterSet& pset ) 
+  : SiStripCommissioningOfflineClient(pset),
+    uploadAnal_( pset.getUntrackedParameter<bool>("UploadAnalyses",false) ),
+    uploadConf_( pset.getUntrackedParameter<bool>("UploadHwConfig",false) )
+{
+  LogTrace(mlDqmClient_)
+    << "[SiStripCommissioningOfflineDbClient::" << __func__ << "]"
+    << " Constructing object...";
+  if ( !uploadConf_ ) {
+    edm::LogWarning(mlDqmClient_) 
+      << "[SiStripCommissioningOfflineDbClient::" << __func__ << "]"
+      << " ===> TEST only! No hardware configurations"
+      << " will be uploaded to the DB...";
+  }
+  if ( !uploadAnal_ ) {
+    edm::LogWarning(mlDqmClient_) 
+      << "[SiStripCommissioningOfflineDbClient::" << __func__ << "]"
+      << " ===> TEST only! No analysis descriptions"
+      << " will be uploaded to the DB...";
+  }
+  
+}
+
+// -----------------------------------------------------------------------------
+// 
+SiStripCommissioningOfflineDbClient::~SiStripCommissioningOfflineDbClient() {
+  LogTrace(mlDqmClient_)
+    << "[SiStripCommissioningOfflineDbClient::" << __func__ << "]"
+    << " Destructing object...";
+}
+
+// -----------------------------------------------------------------------------
+// 
+void SiStripCommissioningOfflineDbClient::createHistos( const edm::ParameterSet& pset, const edm::EventSetup& setup) {
+
+  // Check pointer
+  if ( histos_ ) {
+    edm::LogError(mlDqmClient_)
+      << "[SiStripCommissioningOfflineDbClient::" << __func__ << "]"
+      << " CommissioningHistogram object already exists!"
+      << " Aborting...";
+    return;
+  } 
+
+  // Check pointer to BEI
+  // is this needed here? bei_ = edm::Service<DQMStore>().operator->();
+  if ( !bei_ ) {
+    edm::LogError(mlDqmClient_)
+      << "[SiStripCommissioningOfflineDbClient::" << __func__ << "]"
+      << " NULL pointer to DQMStore!";
+    return;
+  }
+
+  // Create DB connection
+  SiStripConfigDb* db = edm::Service<SiStripConfigDb>().operator->(); //@@ NOT GUARANTEED TO BE THREAD SAFE! 
+  LogTrace(mlCabling_) 
+    << "[SiStripCommissioningOfflineDbClient::" << __func__ << "]"
+    << " Nota bene: using the SiStripConfigDb API"
+    << " as a \"service\" does not presently guarantee"
+    << " thread-safe behaviour!...";
+  
+  // Check DB connection
+  if ( !db ) {
+    edm::LogError(mlCabling_) 
+      << "[SiStripCommissioningOfflineDbClient::" << __func__ << "]"
+      << " NULL pointer to SiStripConfigDb!"
+      << " Aborting...";
+    return;
+  } 
+  
+  // Create corresponding "commissioning histograms" object 
+  if      ( runType_ == sistrip::FAST_CABLING ) { histos_ = new FastFedCablingHistosUsingDb( pset, bei_, db ); }
+  else if ( runType_ == sistrip::APV_TIMING )   { histos_ = new ApvTimingHistosUsingDb( pset, bei_, db ); }
+  else if ( runType_ == sistrip::OPTO_SCAN )    { histos_ = new OptoScanHistosUsingDb( pset, bei_, db ); }
+  else if ( runType_ == sistrip::VPSP_SCAN )    { histos_ = new VpspScanHistosUsingDb( pset, bei_, db ); }
+  else if ( runType_ == sistrip::PEDESTALS )    { histos_ = new PedestalsHistosUsingDb( pset, bei_, db ); }
+  else if ( runType_ == sistrip::PEDS_ONLY )    { histos_ = new PedsOnlyHistosUsingDb( pset, bei_, db ); }
+  else if ( runType_ == sistrip::PEDS_FULL_NOISE ) { histos_ = new PedsFullNoiseHistosUsingDb( pset, bei_, db ); }
+  else if ( runType_ == sistrip::NOISE )        { histos_ = new NoiseHistosUsingDb( pset, bei_, db ); }
+  else if ( runType_ == sistrip::APV_LATENCY )  { histos_ = new LatencyHistosUsingDb( pset, bei_, db ); }
+  else if ( runType_ == sistrip::FINE_DELAY )   { histos_ = new FineDelayHistosUsingDb( pset, bei_, db ); }
+  else if ( runType_ == sistrip::CALIBRATION ||
+            runType_ == sistrip::CALIBRATION_DECO ||
+            runType_ == sistrip::CALIBRATION_SCAN ||
+            runType_ == sistrip::CALIBRATION_SCAN_DECO)
+                                                { histos_ = new CalibrationHistosUsingDb( pset, bei_, db, runType_ ); }
+  else if ( runType_ == sistrip::UNDEFINED_RUN_TYPE ) { 
+    histos_ = 0; 
+    edm::LogError(mlDqmClient_)
+      << "[SiStripCommissioningOfflineDbClient::" << __func__ << "]"
+      << " Undefined run type!";
+    return;
+  } else if ( runType_ == sistrip::UNKNOWN_RUN_TYPE ) {
+    histos_ = 0;
+    edm::LogError(mlDqmClient_)
+      << "[SiStripCommissioningOfflineDbClient::" << __func__ << "]"
+      << " Unknown run type!";
+    return;
+  }
+  histos_->configure(pset,setup);
+
+  CommissioningHistosUsingDb* tmp = dynamic_cast<CommissioningHistosUsingDb*>(histos_);
+  if ( tmp ) { 
+    tmp->doUploadConf( uploadConf_ ); 
+    tmp->doUploadAnal( uploadAnal_ ); 
+    std::stringstream ss;
+    ss << "[SiStripCommissioningOfflineDbClient::" << __func__ << "]" 
+       << std::endl
+       << " Uploading hardware configurations?    : " 
+       << ( tmp->doUploadConf() ? "true" : "false" )
+       << std::endl
+       << " Uploading calibrations from analysis? : " 
+       << ( tmp->doUploadAnal() ? "true" : "false" )
+       << std::endl;
+    edm::LogVerbatim(mlDqmClient_) << ss.str();
+  } else {
+    edm::LogError(mlDqmClient_) 
+      << "[SiStripCommissioningOfflineDbClient::" << __func__ << "]"
+      << " NULL pointer to CommissioningHistosUsingDb!";
+  }
+
+}
+
+// -----------------------------------------------------------------------------
+// 
+void SiStripCommissioningOfflineDbClient::uploadToConfigDb() {
+  edm::LogVerbatim(mlDqmClient_)
+    << "[SiStripCommissioningOfflineDbClient::" << __func__ << "]"
+    << " Uploading parameters to database...";
+  CommissioningHistosUsingDb* tmp = dynamic_cast<CommissioningHistosUsingDb*>(histos_);
+  if ( tmp ) { 
+    tmp->uploadToConfigDb(); 
+    edm::LogVerbatim(mlDqmClient_)
+      << "[SiStripCommissioningOfflineDbClient::" << __func__ << "]"
+      << " Uploaded parameters to database!";
+  } else {
+    edm::LogError(mlDqmClient_)
+      << "[SiStripCommissioningOfflineDbClient::" << __func__ << "]"
+      << " NULL pointer to CommissioningHistosUsingDb object!"
+      << " Upload aborted!...";
+  }
+}

--- a/DQM/SiStripCommissioningDbClients/plugins/SiStripCommissioningOfflineDbClient.h
+++ b/DQM/SiStripCommissioningDbClients/plugins/SiStripCommissioningOfflineDbClient.h
@@ -1,0 +1,43 @@
+
+#ifndef DQM_SiStripCommissioningDbClients_SiStripCommissioningOfflineDbClient_H
+#define DQM_SiStripCommissioningDbClients_SiStripCommissioningOfflineDbClient_H
+
+#include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
+#include "DQM/SiStripCommissioningClients/interface/SiStripCommissioningOfflineClient.h"
+#include "DQM/SiStripCommissioningClients/interface/SiStripTFile.h"
+
+/**
+   @class SiStripCommissioningOfflineDbClient 
+   @author R.Bainbridge, M.Wingham
+   
+   @brief Class which reads a root file containing "commissioning
+   histograms", analyzes the histograms to extract "monitorables",
+   creates summary histograms, and uploads to DB.
+*/
+class SiStripCommissioningOfflineDbClient : public SiStripCommissioningOfflineClient {
+
+ public:
+  
+  SiStripCommissioningOfflineDbClient( const edm::ParameterSet& );
+
+  virtual ~SiStripCommissioningOfflineDbClient();
+  
+ protected:
+  
+  void createHistos( const edm::ParameterSet&, const edm::EventSetup& );
+  
+  void uploadToConfigDb();
+  
+ private:
+  
+  bool uploadToDb_;
+  
+  bool uploadAnal_;
+  
+  bool uploadConf_;
+  
+
+};
+
+#endif // DQM_SiStripCommissioningDbClients_SiStripCommissioningOfflineDbClient_H
+

--- a/DQM/SiStripCommissioningDbClients/plugins/module.cc
+++ b/DQM/SiStripCommissioningDbClients/plugins/module.cc
@@ -1,0 +1,6 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+
+#include "DQM/SiStripCommissioningDbClients/plugins/SiStripCommissioningOfflineDbClient.h"
+DEFINE_FWK_MODULE(SiStripCommissioningOfflineDbClient);
+

--- a/DQM/SiStripCommissioningDbClients/python/OfflineDbClientMP_cfg.py
+++ b/DQM/SiStripCommissioningDbClients/python/OfflineDbClientMP_cfg.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("SiStripCommissioningOfflineDbClientMP")
+
+process.load("DQM.SiStripCommon.MessageLogger_cfi")
+
+process.load("DQM.SiStripCommon.DaqMonitorROOTBackEnd_cfi")
+
+process.SiStripConfigDb = cms.Service("SiStripConfigDb",
+    ConfDb  = cms.untracked.string(''),
+    UsingDb = cms.untracked.bool(True),
+    Partitions = cms.untracked.PSet(
+        SecondaryPartition = cms.untracked.PSet(
+            RunNumber     = cms.untracked.uint32(0),
+            PartitionName = cms.untracked.string('')
+        ),
+        PrimaryPartition = cms.untracked.PSet(
+            RunNumber     = cms.untracked.uint32(0),
+            PartitionName = cms.untracked.string('')
+        )
+    )
+)
+
+process.load("IORawData.SiStripInputSources.EmptySource_cff")
+process.maxEvents.input = 2
+
+process.db_client = cms.EDAnalyzer(
+    "SiStripCommissioningOfflineDbClient",
+    FilePath         = cms.untracked.string('/tmp'),
+    RunNumber        = cms.untracked.uint32(0),
+    UseClientFile    = cms.untracked.bool(False),
+    SummaryXmlFile   = cms.untracked.FileInPath('DQM/SiStripCommissioningClients/data/summary.xml'),
+    UploadHwConfig   = cms.untracked.bool(False),
+    UploadAnalyses   = cms.untracked.bool(False),
+    DisableDevices   = cms.untracked.bool(False),
+    DisableBadStrips = cms.untracked.bool(False),
+    AddBadStrips 		= cms.untracked.bool(False),
+    SaveClientFile = cms.untracked.bool(True)
+    )
+
+process.p = cms.Path(process.db_client)
+

--- a/DQM/SiStripCommissioningDbClients/python/OfflineDbClient_cff.py
+++ b/DQM/SiStripCommissioningDbClients/python/OfflineDbClient_cff.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+db_client = cms.EDAnalyzer("SiStripCommissioningOfflineDbClient",
+  # general parameters
+  FilePath         = cms.untracked.string('/tmp'),
+  RunNumber        = cms.untracked.uint32(0),
+  UseClientFile    = cms.untracked.bool(False),
+  UploadHwConfig   = cms.untracked.bool(False),
+  UploadAnalyses   = cms.untracked.bool(False),
+  DisableDevices   = cms.untracked.bool(False),
+  SaveClientFile   = cms.untracked.bool(True),
+  SummaryXmlFile   = cms.untracked.FileInPath('DQM/SiStripCommissioningClients/data/summary.xml'),
+  # individual parameters
+  ApvTimingParameters      = cms.PSet(
+    SkipFecUpdate = cms.bool(False),  # skip upload of APV PLL settings
+    SkipFedUpdate = cms.bool(False),  # skip upload of FED frame finding threshold
+    TargetDelay = cms.int32(-1)       # -1: latest tick (old default), otherwise target delay for all ticks' rising edge
+  ),
+  CalibrationParameters    = cms.PSet(),
+  DaqScopeModeParameters   = cms.PSet(),
+  FastFedCablingParameters = cms.PSet(),
+  FedCablingParameters     = cms.PSet(),
+  FedTimingParameters      = cms.PSet(),
+  FineDelayParameters      = cms.PSet(
+    cosmic =  cms.bool(True)
+  ),
+  LatencyParamameters      = cms.PSet(
+    OptimizePerPartition = cms.bool(False)
+  ),
+  NoiseParameters          = cms.PSet(),
+  OptoScanParameters       = cms.PSet(
+    TargetGain = cms.double(0.863),   # target gain (0.863 ~ 690ADC for tickmark)
+    SkipGainUpdate = cms.bool(False)  # wether to keep the gain the same as already on the db
+  ),
+  PedestalsParameters      = cms.PSet(
+    DeadStripMax        = cms.double(10),    # number times the noise spread below mean noise
+    NoisyStripMin       = cms.double(10),    # number times the noise spread above mean noise
+    HighThreshold       = cms.double(5),    # analysis-wide high threshold for the fed zero suppression
+    LowThreshold        = cms.double(2),    # analysis-wide low threshold for the fed zero suppression
+    DisableBadStrips    = cms.bool(False),  # for experts! disables bad strips on the fed level 
+    AddBadStrips				= cms.bool(False), #for experts! keep and add disabled bad strips. 
+    KeepsStripsDisabled = cms.bool(False)   # for experts! keep strips disabled as in the db's current state
+  ),
+  PedsOnlyParameters       = cms.PSet(),
+  PedsFullNoiseParameters  = cms.PSet(
+    DeadStripMax        = cms.double(10),    # number times the noise spread below mean noise
+    NoisyStripMin       = cms.double(10),    # number times the noise spread above mean noise
+    HighThreshold       = cms.double(5),    # analysis-wide high threshold for the fed zero suppression
+    LowThreshold        = cms.double(2),    # analysis-wide low threshold for the fed zero suppression
+    KsProbCut						= cms.double(10),
+    DisableBadStrips    = cms.bool(False),  # for experts! disables bad strips on the fed level 
+    AddBadStrips				= cms.bool(False), 	#for experts! keep and add disabled bad strips.
+    KeepsStripsDisabled = cms.bool(False)   # for experts! keeps strip disabling as in the db's current state
+  ),
+  SamplingParameters       = cms.PSet(),
+  VpspScanParameters       = cms.PSet(),
+)

--- a/DQM/SiStripCommissioningDbClients/python/OfflineDbClient_cfg.py
+++ b/DQM/SiStripCommissioningDbClients/python/OfflineDbClient_cfg.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+# process declaration
+process = cms.Process("SiStripCommissioningOfflineDbClient")
+
+
+#############################################
+# General setup
+#############################################
+
+# message logger
+process.load('DQM.SiStripCommissioningSources.OfflineMessageLogger_cff')
+
+# DQM service
+process.load('DQM.SiStripCommissioningSources.OfflineDQM_cff')
+
+# config db settings
+process.load("OnlineDB.SiStripConfigDb.SiStripConfigDb_cfi")
+process.SiStripConfigDb.UsingDb = True                                            # true means use database (not xml files)
+process.SiStripConfigDb.ConfDb  = 'overwritten/by@confdb'                         # database connection account ( or use CONFDB env. var.)
+process.SiStripConfigDb.Partitions.PrimaryPartition.PartitionName = 'DBPART'      # database partition (or use ENV_CMS_TK_PARTITION env. var.)
+process.SiStripConfigDb.Partitions.PrimaryPartition.RunNumber     = RUNNUMBER     # specify run number ("0" means use major/minor versions, which are by default set to "current state")
+#process.SiStripConfigDb.TNS_ADMIN = '/etc'                                        # location of tnsnames.ora, needed at P5, not in TAC
+    
+# input source
+process.load("IORawData.SiStripInputSources.EmptySource_cff")
+process.maxEvents.input = 2
+
+
+#############################################
+# extra setup for latency & fine delay
+#############################################
+
+# geometry
+process.load('DQM.SiStripCommissioningSources.P5Geometry_cff')
+# magnetic field (0T by default)
+process.load('MagneticField.Engine.uniformMagneticField_cfi')
+# fake global position
+process.load('Alignment.CommonAlignmentProducer.GlobalPosition_Fake_cff')
+
+
+##############################################
+# modules & path for analysis
+##############################################
+
+process.load("DQM.SiStripCommissioningDbClients.OfflineDbClient_cff")
+process.db_client.FilePath         = cms.untracked.string('DATALOCATION')
+process.db_client.RunNumber        = cms.untracked.uint32(RUNNUMBER)
+process.db_client.UseClientFile    = cms.untracked.bool(CLIENTFLAG)
+process.db_client.UploadHwConfig   = cms.untracked.bool(DBUPDATE)
+process.db_client.UploadAnalyses   = cms.untracked.bool(ANALUPDATE)
+process.db_client.DisableDevices   = cms.untracked.bool(DISABLEDEVICES)
+process.db_client.DisableBadStrips = cms.untracked.bool(DISABLEBADSTRIPS)
+process.db_client.AddBadStrips		 = cms.untracked.bool(ADDBADSTRIPS)
+process.db_client.SaveClientFile   = cms.untracked.bool(SAVECLIENTFILE)
+
+process.p = cms.Path(process.db_client)

--- a/DQM/SiStripCommissioningDbClients/src/ApvTimingHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/ApvTimingHistosUsingDb.cc
@@ -1,0 +1,460 @@
+
+#include "DQM/SiStripCommissioningDbClients/interface/ApvTimingHistosUsingDb.h"
+#include "CondFormats/SiStripObjects/interface/ApvTimingAnalysis.h"
+#include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFecKey.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFedKey.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <iostream>
+
+using namespace sistrip;
+
+// -----------------------------------------------------------------------------
+/** */
+ApvTimingHistosUsingDb::ApvTimingHistosUsingDb( const edm::ParameterSet & pset,
+                                                DQMStore* bei,
+                                                SiStripConfigDb* const db ) 
+  : CommissioningHistograms( pset.getParameter<edm::ParameterSet>("ApvTimingParameters"),
+                             bei,
+                             sistrip::APV_TIMING ),
+    CommissioningHistosUsingDb( db,
+                                sistrip::APV_TIMING ),
+    ApvTimingHistograms( pset.getParameter<edm::ParameterSet>("ApvTimingParameters"),
+                         bei )
+{
+  LogTrace(mlDqmClient_) 
+    << "[ApvTimingHistosUsingDb::" << __func__ << "]"
+    << " Constructing object...";
+  skipFecUpdate_ = this->pset().getParameter<bool>("SkipFecUpdate");
+  skipFedUpdate_ = this->pset().getParameter<bool>("SkipFedUpdate");
+  if (skipFecUpdate_)
+    LogTrace(mlDqmClient_)
+      << "[ApvTimingHistosUsingDb::" << __func__ << "]"
+      << " Skipping update of FEC parameters.";
+  if (skipFedUpdate_)
+    LogTrace(mlDqmClient_)
+      << "[ApvTimingHistosUsingDb::" << __func__ << "]"
+      << " Skipping update of FED parameters.";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+ApvTimingHistosUsingDb::~ApvTimingHistosUsingDb() {
+  LogTrace(mlDqmClient_) 
+    << "[ApvTimingHistosUsingDb::" << __func__ << "]"
+    << " Destructing object...";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void ApvTimingHistosUsingDb::uploadConfigurations() {
+  LogTrace(mlDqmClient_) 
+    << "[ApvTimingHistosUsingDb::" << __func__ << "]";
+  
+  if ( !db() ) {
+    edm::LogError(mlDqmClient_) 
+      << "[ApvTimingHistosUsingDb::" << __func__ << "]"
+      << " NULL pointer to SiStripConfigDb interface!"
+      << " Aborting upload...";
+    return;
+  }
+  
+  if ( !skipFecUpdate_ ) {
+
+    // Retrieve and update PLL device descriptions
+    SiStripConfigDb::DeviceDescriptionsRange devices = db()->getDeviceDescriptions( PLL ); 
+    bool upload = update( devices );
+    
+    // Check if new PLL settings are valid 
+    if ( !upload ) {
+      edm::LogError(mlDqmClient_) 
+	<< "[ApvTimingHistosUsingDb::" << __func__ << "]"
+	<< " Found invalid PLL settings (coarse > 15)"
+	<< " Aborting update to database...";
+      return;
+    }
+    
+    // Upload PLL device descriptions
+    if ( doUploadConf() ) { 
+      edm::LogVerbatim(mlDqmClient_) 
+	<< "[ApvTimingHistosUsingDb::" << __func__ << "]"
+	<< " Uploading PLL settings to DB...";
+      db()->uploadDeviceDescriptions(); 
+      edm::LogVerbatim(mlDqmClient_) 
+	<< "[ApvTimingHistosUsingDb::" << __func__ << "]"
+	<< " Upload of PLL settings to DB finished!";
+    } else {
+      edm::LogWarning(mlDqmClient_) 
+	<< "[ApvTimingHistosUsingDb::" << __func__ << "]"
+	<< " TEST only! No PLL settings will be uploaded to DB...";
+    }
+    
+  } else {
+    LogTrace(mlDqmClient_) 
+      << "[ApvTimingHistosUsingDb::" << __func__ << "]"
+      << " No upload of PLL settings to DB, as defined by .cfg file!";
+  }
+  
+  if ( !skipFedUpdate_ ) {
+    
+    // Update FED descriptions with new ticker thresholds
+    SiStripConfigDb::FedDescriptionsRange feds = db()->getFedDescriptions(); 
+    update( feds );
+    
+    // Update FED descriptions with new ticker thresholds
+    if ( doUploadConf() ) { 
+      edm::LogVerbatim(mlDqmClient_) 
+	<< "[ApvTimingHistosUsingDb::" << __func__ << "]"
+	<< " Uploading FED ticker thresholds to DB...";
+      db()->uploadFedDescriptions(); 
+      edm::LogVerbatim(mlDqmClient_) 
+	<< "[ApvTimingHistosUsingDb::" << __func__ << "]"
+	<< " Upload of FED ticker thresholds to DB finished!";
+    } else {
+      edm::LogWarning(mlDqmClient_) 
+	<< "[ApvTimingHistosUsingDb::" << __func__ << "]"
+	<< " TEST only! No FED ticker thresholds will be uploaded to DB...";
+    }
+    
+  } else {
+    LogTrace(mlDqmClient_) 
+      << "[ApvTimingHistosUsingDb::" << __func__ << "]"
+      << " No Upload of FED ticker thresholds to DB, as defined by .cfg file!";
+  }
+
+}
+
+// -----------------------------------------------------------------------------
+/** */
+bool ApvTimingHistosUsingDb::update( SiStripConfigDb::DeviceDescriptionsRange devices ) {
+  
+  // Iterate through devices and update device descriptions
+  uint16_t updated = 0;
+  std::vector<SiStripFecKey> invalid;
+  SiStripConfigDb::DeviceDescriptionsV::const_iterator idevice;
+
+  for ( idevice = devices.begin(); idevice != devices.end(); idevice++ ) {
+
+    // Check device type
+    if ( (*idevice)->getDeviceType() != PLL ) { continue; }
+    
+    // Cast to retrieve appropriate description object
+    pllDescription* desc = dynamic_cast<pllDescription*>( *idevice ); 
+    if ( !desc ) { continue; }
+    
+    // Retrieve device addresses from device description
+    const SiStripConfigDb::DeviceAddress& addr = db()->deviceAddress(*desc);
+    SiStripFecKey fec_path;
+    
+    // PLL delay settings
+    uint32_t coarse = sistrip::invalid_; 
+    uint32_t fine = sistrip::invalid_; 
+
+    // Iterate through LLD channels
+    for ( uint16_t ichan = 0; ichan < sistrip::CHANS_PER_LLD; ichan++ ) {
+      
+      // Construct key from device description
+      SiStripFecKey fec_key( addr.fecCrate_,
+			     addr.fecSlot_, 
+			     addr.fecRing_,
+			     addr.ccuAddr_, 
+			     addr.ccuChan_,
+			     ichan+1 );
+      fec_path = fec_key;
+      
+      // Locate appropriate analysis object
+      Analyses::const_iterator iter = data().find( fec_key.key() );
+      if ( iter != data().end() ) { 
+	
+	ApvTimingAnalysis* anal = dynamic_cast<ApvTimingAnalysis*>( iter->second );
+	if ( !anal ) { 
+	  edm::LogError(mlDqmClient_)
+	    << "[ApvTimingHistosUsingDb::" << __func__ << "]"
+	    << " NULL pointer to analysis object!";
+	  continue; 
+	}
+	
+	// Calculate coarse and fine delays
+        int32_t delay = static_cast<int32_t>( rint( anal->delay() )*24./25 );
+        // first set course delay
+	coarse = static_cast<uint16_t>( desc->getDelayCoarse() + (delay/24) ) 
+             + ( static_cast<uint16_t>( desc->getDelayFine() ) + (delay%24) ) / 24;
+        delay = delay % 24; // only bother with fine delay now
+        if ( ( static_cast<uint16_t>( desc->getDelayFine() ) + delay ) % 24 < 0 ) {
+          coarse -= 1;
+	  delay += 24;
+	}
+	fine = ( static_cast<uint16_t>( desc->getDelayFine() ) + delay ) % 24;
+	
+	// Record PPLs maximum coarse setting
+	if ( coarse > 15 ) { invalid.push_back(fec_key); }
+	
+      } else {
+	if ( deviceIsPresent(fec_key) ) { 
+	  edm::LogWarning(mlDqmClient_) 
+	    << "[ApvTimingHistosUsingDb::" << __func__ << "]"
+	    << " Unable to find FEC key with params crate/FEC/ring/CCU/module/LLD: " 
+	    << fec_key.fecCrate() << "/"
+	    << fec_key.fecSlot() << "/"
+	    << fec_key.fecRing() << "/"
+	    << fec_key.ccuAddr() << "/" 
+	    << fec_key.ccuChan() << "/"
+	    << fec_key.channel();
+	}
+      }
+      
+      // Exit LLD channel loop if coarse and fine delays are known
+      if ( coarse != sistrip::invalid_ && 
+	   fine != sistrip::invalid_ ) { break; }
+      
+    } // lld channel loop
+    
+    // Update PLL settings
+    if ( coarse != sistrip::invalid_ && 
+	 fine != sistrip::invalid_ ) { 
+      
+      std::stringstream ss;
+      if ( edm::isDebugEnabled() ) {
+	ss << "[ApvTimingHistosUsingDb::" << __func__ << "]"
+	   << " Updating coarse/fine PLL settings"
+	   << " for crate/FEC/ring/CCU/module "
+	   << fec_path.fecCrate() << "/"
+	   << fec_path.fecSlot() << "/"
+	   << fec_path.fecRing() << "/"
+	   << fec_path.ccuAddr() << "/"
+	   << fec_path.ccuChan() 
+	   << " from "
+	   << static_cast<uint16_t>( desc->getDelayCoarse() ) << "/" 
+	   << static_cast<uint16_t>( desc->getDelayFine() );
+      }
+      desc->setDelayCoarse(coarse);
+      desc->setDelayFine(fine);
+      updated++;
+      if ( edm::isDebugEnabled() ) {
+	ss << " to "
+	   << static_cast<uint16_t>( desc->getDelayCoarse() ) << "/" 
+	   << static_cast<uint16_t>( desc->getDelayFine() );
+	LogTrace(mlDqmClient_) << ss.str();
+      }
+      
+    } else {
+      edm::LogWarning(mlDqmClient_) 
+	<< "[ApvTimingHistosUsingDb::" << __func__ << "]"
+	<< " Invalid PLL delay settings course/fine = "
+        << coarse << "/" << fine
+        << " for crate/FEC/ring/CCU/module " 
+	<< fec_path.fecCrate() << "/"
+	<< fec_path.fecSlot() << "/"
+	<< fec_path.fecRing() << "/"
+	<< fec_path.ccuAddr() << "/"
+	<< fec_path.ccuChan();
+    }
+    
+  }
+
+  // Check if invalid settings were found
+  if ( !invalid.empty() ) {
+    std::stringstream ss;
+    ss << "[ApvTimingHistosUsingDb::" << __func__ << "]"
+       << " Found PLL coarse setting of >15" 
+       << " (not allowed!) for "
+       << invalid.size()
+       << " channels";
+    ss << " (Example is crate/FEC/ring/CCU/module/LLD: "
+       << invalid.front().fecCrate() << "/"
+       << invalid.front().fecSlot() << "/"
+       << invalid.front().fecRing() << "/"
+       << invalid.front().ccuAddr() << "/"
+       << invalid.front().ccuChan() << "/"
+       << invalid.front().channel();
+    edm::LogWarning(mlDqmClient_) << ss.str();
+    return false;
+  }
+  
+  edm::LogVerbatim(mlDqmClient_) 
+    << "[ApvTimingHistosUsingDb::" << __func__ << "]"
+    << " Updated PLL settings for " 
+    << updated << " modules";
+  return true;
+    
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void ApvTimingHistosUsingDb::update( SiStripConfigDb::FedDescriptionsRange feds ) {
+  
+  // Retrieve FED ids from cabling
+  std::vector<uint16_t> ids = cabling()->feds();
+  
+  // Iterate through feds and update fed descriptions
+  uint16_t updated = 0;
+  SiStripConfigDb::FedDescriptionsV::const_iterator ifed;
+  for ( ifed = feds.begin(); ifed != feds.end(); ifed++ ) {
+    
+    // If FED id not found in list (from cabling), then continue
+    if ( find( ids.begin(), ids.end(), (*ifed)->getFedId() ) == ids.end() ) { continue; } 
+    
+    for ( uint16_t ichan = 0; ichan < sistrip::FEDCH_PER_FED; ichan++ ) {
+
+      // Build FED and FEC keys
+      const FedChannelConnection& conn = cabling()->connection( (*ifed)->getFedId(), ichan );
+      if ( conn.fecCrate() == sistrip::invalid_ ||
+	   conn.fecSlot() == sistrip::invalid_ ||
+	   conn.fecRing() == sistrip::invalid_ ||
+	   conn.ccuAddr() == sistrip::invalid_ ||
+	   conn.ccuChan() == sistrip::invalid_ ||
+	   conn.lldChannel() == sistrip::invalid_ ) { continue; }
+      SiStripFedKey fed_key( conn.fedId(), 
+			     SiStripFedKey::feUnit( conn.fedCh() ),
+			     SiStripFedKey::feChan( conn.fedCh() ) );
+      SiStripFecKey fec_key( conn.fecCrate(), 
+			     conn.fecSlot(), 
+			     conn.fecRing(), 
+			     conn.ccuAddr(), 
+			     conn.ccuChan(), 
+			     conn.lldChannel() );
+      
+      // Locate appropriate analysis object 
+      Analyses::const_iterator iter = data().find( fec_key.key() );
+      if ( iter != data().end() ) { 
+	
+	ApvTimingAnalysis* anal = dynamic_cast<ApvTimingAnalysis*>( iter->second );
+	if ( !anal ) { 
+	  edm::LogError(mlDqmClient_)
+	    << "[ApvTimingHistosUsingDb::" << __func__ << "]"
+	    << " NULL pointer to analysis object!";
+	  continue; 
+	}
+	
+	// Update frame finding threshold
+	Fed9U::Fed9UAddress addr( ichan );
+	uint16_t old_threshold = static_cast<uint16_t>( (*ifed)->getFrameThreshold( addr ) );
+	if ( anal->isValid() ) {
+	  (*ifed)->setFrameThreshold( addr, anal->frameFindingThreshold() );
+	  updated++;
+	}
+	uint16_t new_threshold = static_cast<uint16_t>( (*ifed)->getFrameThreshold( addr ) );
+	
+	// Debug
+	std::stringstream ss;
+	ss << "[ApvTimingHistosUsingDb::" << __func__ << "]";
+	if ( anal->isValid() ) {
+	  ss << " Updating the frame-finding threshold"
+	     << " from " << old_threshold
+	     << " to " << new_threshold
+	     << " using tick mark base/peak/height "
+	     << anal->base() << "/"
+	     << anal->peak() << "/"
+	     << anal->height();
+	} else {
+	  ss << " Cannot update the frame-finding threshold"
+	     << " from " << old_threshold
+	     << " to a new value using invalid analysis ";
+	}
+	ss << " for crate/FEC/ring/CCU/module/LLD "
+	   << fec_key.fecCrate() << "/"
+	   << fec_key.fecSlot() << "/"
+	   << fec_key.fecRing() << "/"
+	   << fec_key.ccuAddr() << "/"
+	   << fec_key.ccuChan() 
+	   << fec_key.channel() 
+	   << " and FED id/ch "
+	   << fed_key.fedId() << "/"
+	   << fed_key.fedChannel();
+	anal->print(ss);
+	//LogTrace(mlDqmClient_) << ss.str();
+	
+      } else {
+	if ( deviceIsPresent(fec_key) ) { 
+	  std::stringstream ss;
+	  ss << "[ApvTimingHistosUsingDb::" << __func__ << "]"
+	     << " Unable to find analysis object and update ticker thresholds"
+	     << " for key/crate/FEC/ring/CCU/module/LLD " 
+	     << std::hex << std::setw(8) << std::setfill('0') << fec_key.key() << std::dec
+	     << fec_key.fecCrate() << "/"
+	     << fec_key.fecSlot() << "/"
+	     << fec_key.fecRing() << "/"
+	     << fec_key.ccuAddr() << "/"
+	     << fec_key.ccuChan() << "/"
+	     << fec_key.channel()
+	     << " and FED key/id/ch "
+	     << std::hex << std::setw(8) << std::setfill('0') << fed_key.key() << std::dec
+	     << fed_key.fedId() << "/"
+	     << fed_key.fedChannel();
+	  edm::LogWarning(mlDqmClient_) << ss.str();
+	}
+      }
+    }
+  }
+
+  edm::LogVerbatim(mlDqmClient_) 
+    << "[ApvTimingHistosUsingDb::" << __func__ << "]"
+    << " Updated ticker thresholds for " << updated 
+    << " channels on " << ids.size() << " FEDs!";
+  
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void ApvTimingHistosUsingDb::create( SiStripConfigDb::AnalysisDescriptionsV& desc,
+				     Analysis analysis ) {
+
+  ApvTimingAnalysis* anal = dynamic_cast<ApvTimingAnalysis*>( analysis->second );
+  if ( !anal ) { return; }
+  
+  SiStripFecKey fec_key( anal->fecKey() );
+  SiStripFedKey fed_key( anal->fedKey() );
+  
+  for ( uint16_t iapv = 0; iapv < 2; ++iapv ) {
+    
+//     std::stringstream ss;
+//     if ( anal->isValid() ) { ss << " TEST VALID "; } 
+//     else { ss << " TEST INVALID "; }
+//     ss << std::hex << anal->fecKey() << std::dec << " "
+//        << anal->base() << " "
+//        << anal->peak() << " "
+//        << anal->height() << " "
+//        << ( anal->base() + anal->height() * ApvTimingAnalysis::frameFindingThreshold_ ) << " "
+//        << anal->frameFindingThreshold();
+//     edm::LogError("TEST") << ss.str();
+    
+    // Create description
+    TimingAnalysisDescription* tmp;
+    tmp = new TimingAnalysisDescription( anal->time(),
+					 anal->refTime(),
+					 anal->delay(),
+					 anal->height(),
+					 anal->base(),
+					 anal->peak(),
+					 anal->frameFindingThreshold(),
+					 anal->optimumSamplingPoint(),
+					 ApvTimingAnalysis::tickMarkHeightThreshold_,
+					 true, //@@ APV timing analysis (not FED timing)
+					 fec_key.fecCrate(),
+					 fec_key.fecSlot(),
+					 fec_key.fecRing(),
+					 fec_key.ccuAddr(),
+					 fec_key.ccuChan(),
+					 SiStripFecKey::i2cAddr( fec_key.lldChan(), !iapv ), 
+					 db()->dbParams().partitions().begin()->second.partitionName(),
+					 db()->dbParams().partitions().begin()->second.runNumber(),
+					 anal->isValid(),
+					 "",
+					 fed_key.fedId(),
+					 fed_key.feUnit(),
+					 fed_key.feChan(),
+					 fed_key.fedApv() );
+    
+    // Add comments
+    typedef std::vector<std::string> Strings;
+    Strings errors = anal->getErrorCodes();
+    Strings::const_iterator istr = errors.begin();
+    Strings::const_iterator jstr = errors.end();
+    for ( ; istr != jstr; ++istr ) { tmp->addComments( *istr ); }
+    
+    // Store description
+    desc.push_back( tmp );
+    
+  }
+
+}

--- a/DQM/SiStripCommissioningDbClients/src/CalibrationHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/CalibrationHistosUsingDb.cc
@@ -1,0 +1,243 @@
+
+#include "DQM/SiStripCommissioningDbClients/interface/CalibrationHistosUsingDb.h"
+#include "CondFormats/SiStripObjects/interface/CalibrationAnalysis.h"
+#include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFecKey.h"
+#include "DQM/SiStripCommon/interface/ExtractTObject.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <iostream>
+
+using namespace sistrip;
+
+// -----------------------------------------------------------------------------
+/** */
+std::string getBasePath (const std::string &path)
+{
+  return path.substr(0,path.find(std::string(sistrip::root_) + "/")+sizeof(sistrip::root_) );
+}
+
+// -----------------------------------------------------------------------------
+/** */
+CalibrationHistosUsingDb::CalibrationHistosUsingDb( const edm::ParameterSet & pset,
+                                                    DQMStore* bei,
+                                                    SiStripConfigDb* const db,
+                                                    const sistrip::RunType& task ) 
+  : CommissioningHistograms( pset.getParameter<edm::ParameterSet>("CalibrationParameters"),
+                             bei,
+                             task ),
+    CommissioningHistosUsingDb( db,
+                                task ),
+    CalibrationHistograms( pset.getParameter<edm::ParameterSet>("CalibrationParameters"),
+                           bei,
+                           task )
+{
+  LogTrace(mlDqmClient_) 
+    << "[CalibrationHistosUsingDb::" << __func__ << "]"
+    << " Constructing object...";
+  // Load and dump the current ISHA/VFS values. This is used by the standalone analysis script
+  const SiStripConfigDb::DeviceDescriptionsRange & apvDescriptions = db->getDeviceDescriptions(APV25);
+  for(SiStripConfigDb::DeviceDescriptionsV::const_iterator apv = apvDescriptions.begin();apv!=apvDescriptions.end();++apv) {
+    apvDescription* desc = dynamic_cast<apvDescription*>( *apv );
+    if ( !desc ) { continue; }
+    // Retrieve device addresses from device description
+    const SiStripConfigDb::DeviceAddress& addr = db->deviceAddress(*desc);
+    std::stringstream bin;
+    bin        << std::setw(1) << std::setfill('0') << addr.fecCrate_;
+    bin << "." << std::setw(2) << std::setfill('0') << addr.fecSlot_;
+    bin << "." << std::setw(1) << std::setfill('0') << addr.fecRing_;
+    bin << "." << std::setw(3) << std::setfill('0') << addr.ccuAddr_;
+    bin << "." << std::setw(2) << std::setfill('0') << addr.ccuChan_;
+    bin << "." << desc->getAddress();
+    LogTrace(mlDqmClient_) << "Present values for ISHA/VFS of APV " 
+			   << bin.str() << " : " 
+			   << static_cast<uint16_t>(desc->getIsha()) << " " << static_cast<uint16_t>(desc->getVfs());
+  }
+  // Load the histograms with the results
+  std::string pwd = bei->pwd();
+  std::string ishaPath = getBasePath(pwd);
+  ishaPath += "/ControlView/isha";
+  LogTrace(mlDqmClient_) << "Looking for " << ishaPath;
+  ishaHistogram_ = ExtractTObject<TH1F>().extract( bei->get(ishaPath) );
+  std::string vfsPath = getBasePath(pwd);
+  vfsPath += "/ControlView/vfs";
+  LogTrace(mlDqmClient_) << "Looking for " << vfsPath;
+  vfsHistogram_ = ExtractTObject<TH1F>().extract( bei->get(vfsPath) );
+  
+}
+
+// -----------------------------------------------------------------------------
+/** */
+CalibrationHistosUsingDb::~CalibrationHistosUsingDb() {
+  LogTrace(mlDqmClient_) 
+    << "[CalibrationHistosUsingDb::" << __func__ << "]"
+    << " Destructing object...";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void CalibrationHistosUsingDb::uploadConfigurations() {
+  
+  LogTrace(mlDqmClient_)
+    << "[CalibrationHistosUsingDb::" << __func__ << "]" << ishaHistogram_ << " " << vfsHistogram_;
+
+  if(!ishaHistogram_ && !vfsHistogram_) return;
+
+  if ( !db() ) {
+    edm::LogWarning(mlDqmClient_) 
+      << "[CalibrationHistosUsingDb::" << __func__ << "]"
+      << " NULL pointer to SiStripConfigDb interface!"
+      << " Aborting upload...";
+    return;
+  }
+  
+  // Update all APV device descriptions with new ISHA and VFS settings
+  SiStripConfigDb::DeviceDescriptionsRange devices = db()->getDeviceDescriptions();
+  update( devices );
+  if ( doUploadConf() ) {
+    edm::LogVerbatim(mlDqmClient_)
+      << "[CalibrationHistosUsingDb::" << __func__ << "]"
+      << " Uploading ISHA/VFS settings to DB...";
+    db()->uploadDeviceDescriptions();
+    edm::LogVerbatim(mlDqmClient_)
+      << "[CalibrationHistosUsingDb::" << __func__ << "]"
+      << " Uploaded ISHA/VFS settings to DB!";
+  } else {
+    edm::LogWarning(mlDqmClient_)
+      << "[CalibrationHistosUsingDb::" << __func__ << "]"
+      << " TEST only! No ISHA/VFS settings will be uploaded to DB...";
+  }
+
+  LogTrace(mlDqmClient_)
+    << "[CalibrationHistosUsingDb::" << __func__ << "]"
+    << " Upload of ISHA/VFS settings to DB finished!";
+
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void CalibrationHistosUsingDb::update( SiStripConfigDb::DeviceDescriptionsRange& devices ) {
+  
+  if(!ishaHistogram_ && !vfsHistogram_) return;
+  
+  // Iterate through devices and update device descriptions
+  SiStripConfigDb::DeviceDescriptionsV::const_iterator idevice;
+  for ( idevice = devices.begin(); idevice != devices.end(); idevice++ ) {
+
+    // Check device type
+    if ( (*idevice)->getDeviceType() != APV25 ) { continue; }
+
+    // Cast to retrieve appropriate description object
+    apvDescription* desc = dynamic_cast<apvDescription*>( *idevice );
+    if ( !desc ) { continue; }
+
+    // Retrieve the device address from device description
+    const SiStripConfigDb::DeviceAddress& addr = db()->deviceAddress(*desc);
+
+    // Construct the string for that address
+    std::stringstream bin;
+    bin        << std::setw(1) << std::setfill('0') << addr.fecCrate_;
+    bin << "." << std::setw(2) << std::setfill('0') << addr.fecSlot_;
+    bin << "." << std::setw(1) << std::setfill('0') << addr.fecRing_;
+    bin << "." << std::setw(3) << std::setfill('0') << addr.ccuAddr_;
+    bin << "." << std::setw(2) << std::setfill('0') << addr.ccuChan_;
+    bin << "." << desc->getAddress();
+
+    // Iterate over the histo bins and find the right one
+    for(int i = 1;i <= ishaHistogram_->GetNbinsX(); ++i) {
+      std::string label = ishaHistogram_->GetXaxis()->GetBinLabel(i);
+      if(label == bin.str()) {
+        desc->setIsha( (int)round(ishaHistogram_->GetBinContent(i)) );
+	LogDebug(mlDqmClient_) << "Setting ISHA to " << ((int)round(ishaHistogram_->GetBinContent(i))) << " for " << label;
+      }
+    }
+    for(int i = 1;i <= vfsHistogram_->GetNbinsX(); ++i) {
+      std::string label = vfsHistogram_->GetXaxis()->GetBinLabel(i);
+      if(label == bin.str()) {
+        desc->setVfs( (int)round(vfsHistogram_->GetBinContent(i)) );
+	LogDebug(mlDqmClient_) << "Setting VFS to " << ((int)round(vfsHistogram_->GetBinContent(i))) << " for " << label;
+      }
+    }
+    
+  }
+
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void CalibrationHistosUsingDb::create( SiStripConfigDb::AnalysisDescriptionsV& desc,
+				       Analysis analysis) {
+
+  CalibrationAnalysis* anal = dynamic_cast<CalibrationAnalysis*>( analysis->second );
+  if ( !anal ) { return; }
+
+  SiStripFecKey fec_key( anal->fecKey() );
+  SiStripFedKey fed_key( anal->fedKey() );
+
+  std::ofstream ofile("calibrationResults.txt",ios_base::app);
+  for ( uint16_t iapv = 0; iapv < 2; ++iapv ) {
+
+    // Create description
+    CalibrationAnalysisDescription *tmp;
+    tmp = new CalibrationAnalysisDescription(anal->amplitudeMean()[iapv],
+                                             anal->tailMean()[iapv],
+  					     anal->riseTimeMean()[iapv],
+  					     anal->timeConstantMean()[iapv],
+  					     anal->smearingMean()[iapv],
+  					     anal->chi2Mean()[iapv],
+  					     anal->deconvMode(),
+  					     fec_key.fecCrate(),
+  					     fec_key.fecSlot(),
+  					     fec_key.fecRing(),
+  					     fec_key.ccuAddr(),
+  					     fec_key.ccuChan(),
+  					     SiStripFecKey::i2cAddr( fec_key.lldChan(), !iapv ),
+  					     db()->dbParams().partitions().begin()->second.partitionName(),
+  					     db()->dbParams().partitions().begin()->second.runNumber(),
+  					     anal->isValid(),
+  					     "",
+  					     fed_key.fedId(),
+  					     fed_key.feUnit(),
+  					     fed_key.feChan(),
+  					     fed_key.fedApv(),
+					     calchan_,
+					     isha_,
+					     vfs_ );
+  
+    // debug simplified printout in text file
+    ofile << " " <<  anal->amplitudeMean()[iapv]
+          << " " <<  anal->tailMean()[iapv]
+          << " " <<  anal->riseTimeMean()[iapv]
+          << " " <<  anal->timeConstantMean()[iapv]
+          << " " <<  anal->smearingMean()[iapv]
+          << " " <<  anal->chi2Mean()[iapv]
+          << " " <<  anal->deconvMode()
+          << " " <<  fec_key.fecCrate()
+          << " " <<  fec_key.fecSlot()
+          << " " <<  fec_key.fecRing()
+          << " " <<  fec_key.ccuAddr()
+          << " " <<  fec_key.ccuChan()
+          << " " <<  SiStripFecKey::i2cAddr( fec_key.lldChan(), !iapv )
+          << " " <<  db()->dbParams().partitions().begin()->second.partitionName()
+          << " " <<  db()->dbParams().partitions().begin()->second.runNumber()
+          << " " <<  fed_key.fedId()
+          << " " <<  fed_key.feUnit()
+          << " " <<  fed_key.feChan()
+          << " " <<  fed_key.fedApv()
+          << " " <<  calchan_
+          << " " <<  isha_
+          << " " <<  vfs_ << std::endl;
+
+    // Add comments
+    typedef std::vector<std::string> Strings;
+    Strings errors = anal->getErrorCodes();
+    Strings::const_iterator istr = errors.begin();
+    Strings::const_iterator jstr = errors.end();
+    for ( ; istr != jstr; ++istr ) { tmp->addComments( *istr ); }
+  
+    // Store description
+    desc.push_back( tmp );
+  }
+  ofile.close();
+
+}
+

--- a/DQM/SiStripCommissioningDbClients/src/CommissioningHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/CommissioningHistosUsingDb.cc
@@ -1,0 +1,441 @@
+
+#include "DQM/SiStripCommissioningDbClients/interface/CommissioningHistosUsingDb.h"
+#include "CalibFormats/SiStripObjects/interface/NumberOfDevices.h"
+#include "CalibFormats/SiStripObjects/interface/SiStripFecCabling.h"
+#include "CondFormats/SiStripObjects/interface/CommissioningAnalysis.h"
+#include "CondFormats/SiStripObjects/interface/FedChannelConnection.h"
+#include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
+#include "DataFormats/SiStripCommon/interface/SiStripEnumsAndStrings.h"
+#include "OnlineDB/SiStripConfigDb/interface/SiStripConfigDb.h"
+#include "OnlineDB/SiStripESSources/interface/SiStripFedCablingBuilderFromDb.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <iostream>
+
+using namespace sistrip;
+
+// -----------------------------------------------------------------------------
+/** */
+CommissioningHistosUsingDb::CommissioningHistosUsingDb( SiStripConfigDb* const db,
+                                                        sistrip::RunType type )
+  : CommissioningHistograms(),
+    runType_(type),
+    db_(db),
+    cabling_(0),
+    detInfo_(),
+    uploadAnal_(true),
+    uploadConf_(false)
+{
+  LogTrace(mlDqmClient_) 
+    << "[" << __PRETTY_FUNCTION__ << "]"
+    << " Constructing object...";
+  
+  // Build FEC cabling object from connections found in DB
+  SiStripFecCabling fec_cabling;
+  if ( runType_ == sistrip::FAST_CABLING ) {
+    SiStripFedCablingBuilderFromDb::buildFecCablingFromDevices( db_, fec_cabling );
+  } else {
+    SiStripFedCablingBuilderFromDb::buildFecCabling( db_, fec_cabling );
+  }
+  
+  // Build FED cabling from FEC cabling
+  cabling_ = new SiStripFedCabling();
+  SiStripFedCablingBuilderFromDb::getFedCabling( fec_cabling, *cabling_ );
+  std::stringstream ss;
+  ss << "[CommissioningHistosUsingDb::" << __func__ << "]"
+     << " Terse print out of FED cabling:" << std::endl;
+  cabling_->terse(ss);
+  LogTrace(mlDqmClient_) << ss.str();
+  
+  std::stringstream sss;
+  sss << "[CommissioningHistosUsingDb::" << __func__ << "]"
+      << " Summary of FED cabling:" << std::endl;
+  cabling_->summary(sss);
+  edm::LogVerbatim(mlDqmClient_) << sss.str();
+  
+}
+
+// -----------------------------------------------------------------------------
+/** */
+CommissioningHistosUsingDb::CommissioningHistosUsingDb()
+  : CommissioningHistograms(),
+    runType_(sistrip::UNDEFINED_RUN_TYPE),
+    db_(0),
+    cabling_(0),
+    detInfo_(),
+    uploadAnal_(false),
+    uploadConf_(false)
+{
+  LogTrace(mlDqmClient_) 
+    << "[" << __PRETTY_FUNCTION__ << "]"
+    << " Constructing object..." << endl;
+}
+
+// -----------------------------------------------------------------------------
+/** */
+CommissioningHistosUsingDb::~CommissioningHistosUsingDb() {
+  if ( db_ ) { delete db_; }
+  LogTrace(mlDqmClient_) 
+    << "[" << __PRETTY_FUNCTION__ << "]"
+    << " Destructing object...";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void CommissioningHistosUsingDb::uploadToConfigDb() {
+  buildDetInfo();
+  addDcuDetIds(); 
+  uploadConfigurations();
+  uploadAnalyses(); 
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void CommissioningHistosUsingDb::uploadAnalyses() {
+
+  if ( !db_ ) {
+    edm::LogError(mlDqmClient_) 
+      << "[CommissioningHistosUsingDb::" << __func__ << "]"
+      << " NULL pointer to SiStripConfigDb interface!"
+      << " Aborting upload...";
+    return;
+  }
+  
+  db_->clearAnalysisDescriptions();
+  SiStripDbParams::SiStripPartitions::const_iterator ip = db_->dbParams().partitions().begin();
+  SiStripDbParams::SiStripPartitions::const_iterator jp = db_->dbParams().partitions().end();
+  for ( ; ip != jp; ++ip ) {
+
+    edm::LogVerbatim(mlDqmClient_) 
+      << "[CommissioningHistosUsingDb::" << __func__ << "]"
+      << " Starting from partition " << ip->first
+      << " with versions:\n" << std::dec
+      << "   Conn: " << ip->second.cabVersion().first << "." << ip->second.cabVersion().second << "\n"
+      << "   FED:  " << ip->second.fedVersion().first  << "." << ip->second.fedVersion().second << "\n"
+      << "   FEC:  " << ip->second.fecVersion().first  << "." << ip->second.fecVersion().second << "\n"
+      << "   Mask: " << ip->second.maskVersion().first << "." << ip->second.maskVersion().second;
+
+    // Upload commissioning analysis results 
+    SiStripConfigDb::AnalysisDescriptionsV anals;
+    createAnalyses( anals );
+    
+    edm::LogVerbatim(mlDqmClient_) 
+      << "[CommissioningHistosUsingDb::" << __func__ << "]"
+      << " Created analysis descriptions for " 
+      << anals.size() << " devices";
+    
+    // Update analysis descriptions with new commissioning results
+    if ( uploadAnal_ ) {
+      if ( uploadConf_ ) { 
+				edm::LogVerbatim(mlDqmClient_)
+	  		<< "[CommissioningHistosUsingDb::" << __func__ << "]"
+	  		<< " Uploading major version of analysis descriptions to DB"
+	  		<< " (will be used for physics)...";
+      } 
+      else {
+				edm::LogVerbatim(mlDqmClient_)
+	 			<< "[CommissioningHistosUsingDb::" << __func__ << "]"
+	  		<< " Uploading minor version of analysis descriptions to DB"
+	  		<< " (will not be used for physics)...";
+      }
+      db_->clearAnalysisDescriptions( ip->second.partitionName() );
+      db_->addAnalysisDescriptions( ip->second.partitionName(), anals ); 
+      db_->uploadAnalysisDescriptions( uploadConf_, ip->second.partitionName() ); 
+      edm::LogVerbatim(mlDqmClient_) 
+			<< "[CommissioningHistosUsingDb::" << __func__ << "]"
+      << " Upload of analysis descriptions to DB finished!";
+    } 
+    else {
+      edm::LogWarning(mlDqmClient_) 
+        << "[CommissioningHistosUsingDb::" << __func__ << "]"
+        << " TEST! No analysis descriptions will be uploaded to DB...";
+    }
+
+    if ( uploadConf_ ) {
+      SiStripDbParams::SiStripPartitions::const_iterator ip = db_->dbParams().partitions().begin();
+      SiStripDbParams::SiStripPartitions::const_iterator jp = db_->dbParams().partitions().end();
+      for ( ; ip != jp; ++ip ) {
+        DeviceFactory* df = db_->deviceFactory();
+        tkStateVector states = df->getCurrentStates();
+        tkStateVector::const_iterator istate = states.begin();
+        tkStateVector::const_iterator jstate = states.end();
+        while ( istate != jstate ) {
+          if ( *istate && ip->first == (*istate)->getPartitionName() ) { break; }
+          istate++;
+        }
+        // Set versions if state was found
+        if ( istate != states.end() ) {
+          edm::LogVerbatim(mlDqmClient_) 
+            << "[CommissioningHistosUsingDb::" << __func__ << "]"
+            << " Created new version for partition " << ip->first
+            << ". Current state:\n" << std::dec
+            << "   Conn: " << (*istate)->getConnectionVersionMajorId() << "." << (*istate)->getConnectionVersionMinorId() << "\n"
+            << "   FED:  " << (*istate)->getFedVersionMajorId()  << "." << (*istate)->getFedVersionMinorId() << "\n"
+            << "   FEC:  " << (*istate)->getFecVersionMajorId()  << "." << (*istate)->getFecVersionMinorId() << "\n"
+            << "   Mask: " << (*istate)->getMaskVersionMajorId() << "." << (*istate)->getMaskVersionMinorId();
+        }
+      }
+    }
+
+  }
+  
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void CommissioningHistosUsingDb::addDcuDetIds() {
+  
+  if ( !cabling_ ) {
+    edm::LogWarning(mlDqmClient_) 
+      << "[CommissioningHistosUsingDb::" << __func__ << "]"
+      << " NULL pointer to SiStripFedCabling object!";
+    return;
+  }
+  
+  Analyses::iterator ianal = data().begin();
+  Analyses::iterator janal = data().end();
+  for ( ; ianal != janal; ++ianal ) { 
+
+    CommissioningAnalysis* anal = ianal->second;
+  
+    if ( !anal ) {
+      edm::LogWarning(mlDqmClient_) 
+	<< "[CommissioningHistosUsingDb::" << __func__ << "]"
+	<< " NULL pointer to CommissioningAnalysis object!";
+      return;
+    }
+    
+    SiStripFedKey fed_key = anal->fedKey();
+    SiStripFecKey fec_key = anal->fecKey();
+    
+    FedChannelConnection conn = cabling_->connection( fed_key.fedId(),
+						      fed_key.fedChannel() );
+  
+    SiStripFedKey fed( conn.fedId(),
+		       SiStripFedKey::feUnit( conn.fedCh() ),
+		       SiStripFedKey::feChan( conn.fedCh() ) );
+  
+    SiStripFecKey fec( conn.fecCrate(),
+		       conn.fecSlot(),
+		       conn.fecRing(),
+		       conn.ccuAddr(),
+		       conn.ccuChan(),
+		       conn.lldChannel() );
+  
+    if ( fed_key.path() != fed.path() ) {
+
+      std::stringstream ss;
+      ss << "[CommissioningHistosUsingDb::" << __func__ << "]"
+	 << " Cannot set DCU and DetId values in commissioning analysis object!" << std::endl
+	 << " Incompatible FED key retrieved from cabling!" << std::endl
+	 << " FED key from analysis object  : " << fed_key.path() << std::endl
+	 << " FED key from cabling object   : " << fed.path() << std::endl
+	 << " FED id/ch from analysis object: " << fed_key.fedId() << "/" << fed_key.fedChannel() << std::endl
+	 << " FED id/ch from cabling object : " << conn.fedId() << "/" << conn.fedCh();
+      edm::LogWarning(mlDqmClient_) << ss.str();
+
+    } else if ( fec_key.path() != fec.path() ) {
+
+      std::stringstream ss;
+      ss << "[CommissioningHistosUsingDb::" << __func__ << "]"
+	 << " Cannot set DCU and DetId values in commissioning analysis object!" << std::endl
+	 << " Incompatible FEC key retrieved from cabling!" << std::endl
+	 << " FEC key from analysis object : " << fec_key.path() << std::endl
+	 << " FEC key from cabling object  : " << fec.path();
+      edm::LogWarning(mlDqmClient_) << ss.str();
+
+    } else {
+
+      anal->dcuId( conn.dcuId() );
+      anal->detId( conn.detId() );
+
+    }
+
+  }
+
+}
+
+// -----------------------------------------------------------------------------
+//
+void CommissioningHistosUsingDb::createAnalyses( SiStripConfigDb::AnalysisDescriptionsV& desc ) {
+  
+  LogTrace(mlDqmClient_) 
+    << "[CommissioningHistosUsingDb::" << __func__ << "]"
+    << " Creating AnalysisDescriptions...";
+
+  desc.clear();
+  
+//   uint16_t size = 0;
+//   std::stringstream ss;
+//   ss << "[CommissioningHistosUsingDb::" << __func__ << "]"
+//      << " Analysis descriptions:" << std::endl;
+
+  Analyses::iterator ianal = data().begin();
+  Analyses::iterator janal = data().end();
+  for ( ; ianal != janal; ++ianal ) { 
+
+    // create analysis description
+    create( desc, ianal ); 
+    
+//     // debug
+//     if ( ianal->second ) {
+//       if ( desc.size()/2 > size ) { // print every 2nd description
+// 	size = desc.size()/2;
+// 	ianal->second->print(ss); 
+// 	ss << (*(desc.end()-2))->toString();
+// 	ss << (*(desc.end()-1))->toString();
+// 	ss << std::endl;
+//       }
+//     }
+
+  }
+
+//   LogTrace(mlDqmClient_) << ss.str(); 
+  
+}
+
+// -----------------------------------------------------------------------------
+//
+void CommissioningHistosUsingDb::buildDetInfo() {
+  
+  detInfo_.clear();
+  
+  if ( !db() ) {
+    edm::LogError(mlDqmClient_) 
+      << "[CommissioningHistosUsingDb::" << __func__ << "]"
+      << " NULL pointer to SiStripConfigDb interface!";
+    return;
+  }
+
+  SiStripDbParams::SiStripPartitions::const_iterator ii = db_->dbParams().partitions().begin();
+  SiStripDbParams::SiStripPartitions::const_iterator jj = db_->dbParams().partitions().end();
+  for ( ; ii != jj; ++ii ) {
+    
+    // Retrieve DCUs and DetIds for given partition
+    std::string pp = ii->second.partitionName();
+    SiStripConfigDb::DeviceDescriptionsRange dcus = db()->getDeviceDescriptions( DCU, pp ); 
+    SiStripConfigDb::DcuDetIdsRange dets = db()->getDcuDetIds( pp ); 
+    
+    // Iterate through DCUs
+    SiStripConfigDb::DeviceDescriptionsV::const_iterator idcu = dcus.begin();
+    SiStripConfigDb::DeviceDescriptionsV::const_iterator jdcu = dcus.end();
+    for ( ; idcu != jdcu; ++idcu ) {
+      
+      // Extract DCU-FEH description 
+      dcuDescription* dcu = dynamic_cast<dcuDescription*>( *idcu );
+      if ( !dcu ) { continue; }
+      if ( dcu->getDcuType() != "FEH" ) { continue; }
+
+      // S.L. 29/1/2010
+      // HARDCODED!!! We have a broken module, known from Pisa integration tests
+      // We could really use a better solutin for this than hardcode it!!!
+      if ( dcu->getDcuHardId() == 16448250 ) continue; // fake dcu (0xfafafa)
+
+      // Find TkDcuInfo object corresponding to given DCU description
+      SiStripConfigDb::DcuDetIdsV::const_iterator idet = dets.end();
+      idet = SiStripConfigDb::findDcuDetId( dets.begin(), dets.end(), dcu->getDcuHardId() );
+      if ( idet == dets.begin() ) { continue; }
+      
+      // Extract TkDcuInfo object
+      TkDcuInfo* det = idet->second;
+      if ( !det ) { continue; }
+      
+      // Build FEC key
+      const SiStripConfigDb::DeviceAddress& addr = db()->deviceAddress( *dcu );
+      SiStripFecKey fec_key( addr.fecCrate_,
+			     addr.fecSlot_,
+			     addr.fecRing_,
+			     addr.ccuAddr_,
+			     addr.ccuChan_ );
+      
+      // Build DetInfo object
+      DetInfo info;
+      info.dcuId_ = det->getDcuHardId();
+      info.detId_ = det->getDetId();
+      info.pairs_ = det->getApvNumber()/2; 
+
+      // Add it to map
+      if ( fec_key.isValid() ) { detInfo_[pp][fec_key.key()] = info; }
+      
+    } 
+  }
+  
+  // Debug
+  if ( edm::isDebugEnabled() ) {
+    std::stringstream ss;
+    ss << "[CommissioningHistosUsingDb::" << __func__ << "]"
+       << " List of modules for "
+       << detInfo_.size()
+       << " partitions, with their DCUids, DetIds, and nApvPairs: " << std::endl;
+    std::map<std::string,DetInfos>::const_iterator ii = detInfo_.begin();
+    std::map<std::string,DetInfos>::const_iterator jj = detInfo_.end();
+    for ( ; ii != jj; ++ii ) {
+      ss << " Partition \"" << ii->first 
+	 << "\" has " << ii->second.size()
+	 << " modules:"
+	 << std::endl;
+      DetInfos::const_iterator iii = ii->second.begin();
+      DetInfos::const_iterator jjj = ii->second.end();
+      for ( ; iii != jjj; ++iii ) {
+	SiStripFecKey key = iii->first;
+	ss << "  module= "
+	   << key.fecCrate() << "/"    
+	   << key.fecSlot() << "/"
+	   << key.fecRing() << "/"
+	   << key.ccuAddr() << "/"
+	   << key.ccuChan() << ", "
+	   << std::hex
+	   << " DCUid= " 
+	   << std::setw(8) << std::setfill('0') << iii->second.dcuId_
+	   << " DetId= " 
+	   << std::setw(8) << std::setfill('0') << iii->second.detId_
+	   << std::dec
+	   << " nPairs= "
+	   << iii->second.pairs_
+	   << std::endl;
+      }
+    }
+    //LogTrace(mlDqmClient_) << ss.str();
+  }
+  
+}
+
+// -----------------------------------------------------------------------------
+//
+std::pair<std::string,CommissioningHistosUsingDb::DetInfo> CommissioningHistosUsingDb::detInfo( const SiStripFecKey& key ) {
+  SiStripFecKey tmp( key, sistrip::CCU_CHAN );
+  if ( tmp.isInvalid() ) { return std::make_pair("",DetInfo()); }
+  std::map<std::string,DetInfos>::const_iterator ii = detInfo_.begin();
+  std::map<std::string,DetInfos>::const_iterator jj = detInfo_.end();
+  for ( ; ii != jj; ++ii ) {
+    DetInfos::const_iterator iii = ii->second.find( tmp.key() );
+    if ( iii != ii->second.end() ) { return std::make_pair(ii->first,iii->second); }
+  }
+  return std::make_pair("",DetInfo());
+}
+
+// -----------------------------------------------------------------------------
+//
+bool CommissioningHistosUsingDb::deviceIsPresent( const SiStripFecKey& key ) {
+  SiStripFecKey tmp( key, sistrip::CCU_CHAN );
+  std::pair<std::string,DetInfo> info = detInfo(key);
+  if ( info.second.dcuId_ != sistrip::invalid32_ ) {
+    if ( key.channel() == 2 && info.second.pairs_ == 2 ) { return false; }
+    else { return true; }
+  } else {
+    std::stringstream ss;
+    ss << "[CommissioningHistosUsingDb::" << __func__ << "]"
+       << " Cannot find module (crate/FEC/ring/CCU/module): "
+       << tmp.fecCrate() << "/"
+       << tmp.fecSlot() << "/"
+       << tmp.fecRing() << "/"
+       << tmp.ccuAddr() << "/"
+       << tmp.ccuChan()
+       << "!";
+    edm::LogWarning(mlDqmClient_) << ss.str();
+    return true;
+  }
+}
+
+
+
+  

--- a/DQM/SiStripCommissioningDbClients/src/FastFedCablingHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/FastFedCablingHistosUsingDb.cc
@@ -1,0 +1,711 @@
+
+#include "DQM/SiStripCommissioningDbClients/interface/FastFedCablingHistosUsingDb.h"
+#include "CondFormats/SiStripObjects/interface/FastFedCablingAnalysis.h"
+#include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFecKey.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <iostream>
+
+using namespace sistrip;
+
+// -----------------------------------------------------------------------------
+/** */
+FastFedCablingHistosUsingDb::FastFedCablingHistosUsingDb( const edm::ParameterSet & pset,
+                                                          DQMStore* bei,
+                                                          SiStripConfigDb* const db ) 
+  : CommissioningHistograms( pset.getParameter<edm::ParameterSet>("FastFedCablingParameters"),
+                             bei,
+                             sistrip::FAST_CABLING ),
+    CommissioningHistosUsingDb( db,
+                                sistrip::FAST_CABLING ),
+    FastFedCablingHistograms( pset.getParameter<edm::ParameterSet>("FastFedCablingParameters"),
+                              bei )
+{
+  LogTrace(mlDqmClient_) 
+    << "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+    << " Constructing object...";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+FastFedCablingHistosUsingDb::~FastFedCablingHistosUsingDb() {
+  LogTrace(mlDqmClient_)
+    << "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+    << " Destructing object...";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void FastFedCablingHistosUsingDb::uploadConfigurations() {
+  LogTrace(mlDqmClient_) 
+    << "[FastFedCablingHistosUsingDb::" << __func__ << "]";
+  
+  if ( !db() ) {
+    edm::LogError(mlDqmClient_) 
+      << "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+      << " NULL pointer to SiStripConfigDb interface!"
+      << " Aborting upload...";
+    return;
+  }
+
+  SiStripDbParams::SiStripPartitions::const_iterator ip = db()->dbParams().partitions().begin();
+  SiStripDbParams::SiStripPartitions::const_iterator jp = db()->dbParams().partitions().end();
+  for ( ; ip != jp; ++ip ) {
+    
+    // Retrieve descriptions
+    db()->clearFedConnections(); 
+    SiStripConfigDb::FedDescriptionsRange feds = db()->getFedDescriptions( ip->second.partitionName() ); 
+    SiStripConfigDb::DeviceDescriptionsRange dcus = db()->getDeviceDescriptions( DCU, ip->second.partitionName() ); 
+    SiStripConfigDb::DcuDetIdsRange detids = db()->getDcuDetIds( ip->second.partitionName() ); 
+    
+    // Update FED connection descriptions
+    SiStripConfigDb::FedConnectionsV conns;
+    update( conns, feds, dcus, detids );
+    
+    if ( doUploadConf() ) { 
+      edm::LogVerbatim(mlDqmClient_) 
+	<< "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+	<< " Uploading FED connections for partition \"" 
+	<< ip->second.partitionName() << "\" to DB...";
+      db()->clearFedConnections( ip->second.partitionName() ); 
+      db()->addFedConnections( ip->second.partitionName(), conns ); 
+      db()->uploadFedConnections( ip->second.partitionName() ); 
+      edm::LogVerbatim(mlDqmClient_) 
+	<< "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+	<< " Completed database upload of " << conns.size() 
+	<< " ConnectionDescriptions!";
+    } else {
+      edm::LogWarning(mlDqmClient_) 
+	<< "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+	<< " TEST only! No FED connections will be uploaded to DB...";
+    }
+    
+    // Update FED descriptions with enabled/disabled channels
+    update( feds );
+    if ( doUploadConf() ) { 
+      edm::LogVerbatim(mlDqmClient_) 
+	<< "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+	<< " Uploading FED descriptions to DB...";
+      db()->uploadFedDescriptions( ip->second.partitionName() ); 
+      edm::LogVerbatim(mlDqmClient_) 
+	<< "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+	<< " Completed database upload of " << feds.size()
+	<< " Fed9UDescriptions (with connected channels enabled)!";
+    } else {
+      edm::LogWarning(mlDqmClient_) 
+	<< "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+	<< " TEST only! No FED descriptions will be uploaded to DB...";
+    }
+    
+    // Some debug on good / dirty / missing connections
+    connections( dcus, detids );
+    
+  }
+  
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void FastFedCablingHistosUsingDb::update( SiStripConfigDb::FedConnectionsV& conns,
+					  SiStripConfigDb::FedDescriptionsRange feds,
+					  SiStripConfigDb::DeviceDescriptionsRange dcus, 
+					  SiStripConfigDb::DcuDetIdsRange detids ) {
+  
+  // Update FED-FEC mapping in base class, based on analysis results
+  Analyses::iterator ianal = data().begin();
+  Analyses::iterator janal = data().end();
+  for ( ; ianal != janal; ++ianal ) {
+    
+    FastFedCablingAnalysis* anal = dynamic_cast<FastFedCablingAnalysis*>( ianal->second );
+    if ( !anal ) { 
+      edm::LogError(mlDqmClient_)
+	<< "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+	<< " NULL pointer to analysis object!";
+      continue; 
+    }
+    
+    if ( !anal->isValid() || anal->dcuId() == sistrip::invalid32_ ) { continue; }
+    
+    SiStripFecKey fec_key( anal->fecKey() );
+    SiStripFedKey fed_key( anal->fedKey() );
+
+    ConnectionDescription* conn = new ConnectionDescription();
+    conn->setFedId( fed_key.fedId() );
+    conn->setFedChannel( fed_key.fedChannel() );
+    conn->setFecHardwareId( "" ); //@@
+    conn->setFecCrateId( fec_key.fecCrate() );
+    conn->setFecSlot( fec_key.fecSlot() );
+    conn->setRingSlot( fec_key.fecRing() );
+    conn->setCcuAddress( fec_key.ccuAddr() );
+    conn->setI2cChannel( fec_key.ccuChan() );
+    conn->setApvAddress( SiStripFecKey::i2cAddr(anal->lldCh(),true) );
+    conn->setDcuHardId( anal->dcuHardId() );
+    
+    // Retrieve FED crate and slot numbers
+    bool found = false;
+    SiStripConfigDb::FedDescriptionsV::const_iterator ifed = feds.begin();
+    while ( ifed != feds.end() && !found ) {
+      if ( *ifed ) {
+	uint16_t fed_id = static_cast<uint16_t>( (*ifed)->getFedId() );
+	if ( fed_key.fedId() == fed_id ) {
+	  conn->setFedCrateId( static_cast<uint16_t>( (*ifed)->getCrateNumber() ) );
+	  conn->setFedSlot( static_cast<uint16_t>( (*ifed)->getSlotNumber() ) );
+	  found = true;
+	}
+      } else {
+	edm::LogError(mlDqmClient_)
+	  << "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+	  << " NULL pointer to Fed9UDescription object!";
+	continue; 
+      }
+      ++ifed;
+    }
+    if ( !found ) {
+      edm::LogError(mlDqmClient_)
+	<< "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+	<< " Could not find FED id " << fed_key.fedId()
+	<< " in vector of FED descriptions!"
+	<< " Unable to set FED crate and slot for this FED!";
+    }
+    
+    conns.push_back(conn);
+
+  }  
+
+  if (0) {
+    SiStripConfigDb::FedConnectionsV::iterator ifed = conns.begin();
+    for ( ; ifed != conns.end(); ifed++ ) { (*ifed)->display(); }
+  }
+
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void FastFedCablingHistosUsingDb::update( SiStripConfigDb::FedDescriptionsRange feds ) {
+
+  // Iterate through feds and disable all channels 
+  SiStripConfigDb::FedDescriptionsV::const_iterator ifed = feds.begin();
+  SiStripConfigDb::FedDescriptionsV::const_iterator jfed = feds.end();
+  try {
+    for ( ; ifed != jfed; ++ifed ) {
+      for ( uint16_t ichan = 0; ichan < sistrip::FEDCH_PER_FED; ichan++ ) {
+	Fed9U::Fed9UAddress addr( ichan );
+	Fed9U::Fed9UAddress addr0( ichan, static_cast<Fed9U::u8>(0) );
+	Fed9U::Fed9UAddress addr1( ichan, static_cast<Fed9U::u8>(1) );
+	(*ifed)->setFedFeUnitDisable( addr, true );
+	(*ifed)->setApvDisable( addr0, true );
+	(*ifed)->setApvDisable( addr1, true );
+      }
+    }
+  } catch( ICUtils::ICException& e ) {
+    edm::LogWarning(mlDqmClient_) << e.what();
+  }
+  
+  // Counters for number of connected / enabled channels
+  uint16_t connected = 0;
+  std::map< uint16_t, std::vector<uint16_t> > enabled;
+
+  // Iterate through feds and enable connected channels
+  for ( ifed = feds.begin(); ifed != feds.end(); ifed++ ) {
+    for ( uint16_t ichan = 0; ichan < sistrip::FEDCH_PER_FED; ichan++ ) {
+      
+      // Retrieve FEC key from FED-FEC map
+      SiStripFedKey fed( static_cast<uint16_t>( (*ifed)->getFedId() ),
+			 SiStripFedKey::feUnit(ichan),
+			 SiStripFedKey::feChan(ichan) );
+      uint32_t fed_key = fed.key();
+      
+      // Retrieve analysis for given FED id and channel
+      Analyses::const_iterator iter = data().find( fed_key );
+      if ( iter == data().end() ) { continue; }
+      
+      if ( !iter->second->isValid() ) { continue; }
+      
+      FastFedCablingAnalysis* anal = dynamic_cast<FastFedCablingAnalysis*>( iter->second );
+      if ( !anal ) { 
+	edm::LogError(mlDqmClient_)
+	  << "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+	  << " NULL pointer to OptoScanAnalysis object!";
+	continue; 
+      }
+      
+      // Retrieve FED id and channel 
+      SiStripFedKey key( anal->fedKey() );
+      uint16_t fed_id = key.fedId();
+      uint16_t fed_ch = key.fedChannel();
+      
+      // Enable front-end unit and channel
+      Fed9U::Fed9UAddress addr( fed_ch );
+      Fed9U::Fed9UAddress addr0( fed_ch, static_cast<Fed9U::u8>(0) );
+      Fed9U::Fed9UAddress addr1( fed_ch, static_cast<Fed9U::u8>(1) );
+      (*ifed)->setFedFeUnitDisable( addr, false );
+      (*ifed)->setApvDisable( addr0, false );
+      (*ifed)->setApvDisable( addr1, false );
+      connected++;
+      enabled[fed_id].push_back(fed_ch);
+      
+    }
+  }
+      
+  // Some debug 
+  std::stringstream sss;
+  if ( !feds.empty() ) {
+    sss << "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+	<< " Enabled a total of " << connected 
+	<< " FED channels and disabled " << feds.size() * 96 - connected 
+	<< " FED channels (" << 100 * connected / ( feds.size() * 96 )
+	<< "% of total)";
+    edm::LogVerbatim(mlDqmClient_) << sss.str();
+  } else {
+    sss << "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+	<< " Found no FEDs! (and therefore no connected channels)";
+    edm::LogWarning(mlDqmClient_) << sss.str();
+  }
+  
+  // Some debug 
+  std::stringstream ss;
+  ss << "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+     << " Dump of enabled FED channels:" 
+     << std::endl;
+  std::map< uint16_t, std::vector<uint16_t> >::const_iterator fed = enabled.begin();
+  for ( ; fed != enabled.end(); fed++ ) {
+    ss << " Enabled " << fed->second.size()
+       << " channels for FED id " 
+       << std::setw(3) << fed->first << ": ";
+    if ( !fed->second.empty() ) { 
+      uint16_t first = fed->second.front();
+      uint16_t last = fed->second.front();
+      std::vector<uint16_t>::const_iterator chan = fed->second.begin();
+      for ( ; chan != fed->second.end(); chan++ ) { 
+	if ( chan != fed->second.begin() ) {
+	  if ( *chan != last+1 ) { 
+	    ss << std::setw(2) << first << "->" << std::setw(2) << last << ", ";
+	    if ( chan != fed->second.end() ) { first = *(chan+1); }
+	  } 
+	}
+	last = *chan;
+      }
+      if ( first != last ) { ss << std::setw(2) << first << "->" << std::setw(2) << last; }
+      ss << std::endl;
+    }
+  }
+  LogTrace(mlDqmClient_) << ss.str();
+  
+}
+
+// -----------------------------------------------------------------------------
+// 
+void FastFedCablingHistosUsingDb::addDcuDetIds() {
+
+  if ( !cabling() ) {
+    edm::LogError(mlDqmClient_) 
+      << "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+      << " NULL pointer to SiStripFedCabling object!";
+    return;
+  }
+
+  // retrieve descriptions for dcu id and det id 
+  SiStripConfigDb::DeviceDescriptionsRange dcus = db()->getDeviceDescriptions( DCU ); 
+  SiStripConfigDb::DcuDetIdsRange detids = db()->getDcuDetIds(); 
+  
+  if ( dcus.empty() ) { 
+    edm::LogError(mlCabling_)
+      << "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+      << " No DCU descriptions found!";
+    return;
+  }
+  
+  if ( detids.empty() ) { 
+    edm::LogWarning(mlCabling_)
+      << "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+      << " DCU-DetId map is empty!";
+  }
+  
+  Analyses::iterator ianal = data().begin();
+  Analyses::iterator janal = data().end();
+  for ( ; ianal != janal; ++ianal ) { 
+
+    // check if analysis is valid (ie, dcu id and lld channel have been identified)
+    if ( !ianal->second->isValid() ) { continue; }
+    
+    // retrieve analysis object
+    FastFedCablingAnalysis* anal = dynamic_cast<FastFedCablingAnalysis*>( ianal->second );
+    
+    if ( !anal ) {
+      edm::LogError(mlDqmClient_) 
+	<< "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+	<< " NULL pointer to FastFedCablingAnalysis object!";
+      return;
+    }
+
+    // find dcu that matches analysis result 
+    bool found = false;
+    SiStripConfigDb::DeviceDescriptionsV::const_iterator idcu = dcus.begin();
+    SiStripConfigDb::DeviceDescriptionsV::const_iterator jdcu = dcus.end();
+    while ( !found && idcu != jdcu ) {
+      dcuDescription* dcu = dynamic_cast<dcuDescription*>( *idcu );
+      if ( dcu ) { 
+	if ( dcu->getDcuType() == "FEH" ) { 
+	  if ( dcu->getDcuHardId() == anal->dcuHardId() ) {
+	    found = true; 
+	    anal->dcuId( dcu->getDcuHardId() ); 
+	    const SiStripConfigDb::DeviceAddress& addr = db()->deviceAddress(*dcu);
+	    uint32_t fec_key = SiStripFecKey( addr.fecCrate_,
+					      addr.fecSlot_,
+					      addr.fecRing_,
+					      addr.ccuAddr_,
+					      addr.ccuChan_,
+					      anal->lldCh() ).key();
+	    anal->fecKey( fec_key );
+	    SiStripConfigDb::DcuDetIdsV::const_iterator idet = detids.end();
+	    idet = SiStripConfigDb::findDcuDetId( detids.begin(), detids.end(), dcu->getDcuHardId() );
+	    if ( idet != detids.end() ) { anal->detId( idet->second->getDetId() ); }
+	  }
+	}
+      }
+      idcu++;
+    }
+
+  }
+
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void FastFedCablingHistosUsingDb::create( SiStripConfigDb::AnalysisDescriptionsV& desc,
+					  Analysis analysis ) {
+
+  FastFedCablingAnalysis* anal = dynamic_cast<FastFedCablingAnalysis*>( analysis->second );
+  if ( !anal ) { return; }
+  
+  if ( !anal->isValid() || anal->dcuId() == sistrip::invalid32_ ) { return; } //@@ only store valid descriptions!
+  
+  SiStripFecKey fec_key( anal->fecKey() );
+  SiStripFedKey fed_key( anal->fedKey() );
+    
+  for ( uint16_t iapv = 0; iapv < 2; ++iapv ) {
+    
+    // Create description
+    FastFedCablingAnalysisDescription* tmp;
+    tmp = new FastFedCablingAnalysisDescription( anal->highLevel(),
+						 anal->highRms(),
+						 anal->lowLevel(),
+						 anal->lowRms(),
+						 anal->max(),
+						 anal->min(),
+						 anal->dcuId(),
+						 anal->lldCh(),
+						 anal->isDirty(),
+						 FastFedCablingAnalysis::threshold_,
+						 FastFedCablingAnalysis::dirtyThreshold_,
+						 fec_key.fecCrate(),
+						 fec_key.fecSlot(),
+						 fec_key.fecRing(),
+						 fec_key.ccuAddr(),
+						 fec_key.ccuChan(),
+						 SiStripFecKey::i2cAddr( fec_key.lldChan(), !iapv ), 
+						 db()->dbParams().partitions().begin()->second.partitionName(),
+						 db()->dbParams().partitions().begin()->second.runNumber(),
+						 anal->isValid(),
+						 "",
+						 fed_key.fedId(),
+						 fed_key.feUnit(),
+						 fed_key.feChan(),
+						 fed_key.fedApv() );
+      
+    // Add comments
+    typedef std::vector<std::string> Strings;
+    Strings errors = anal->getErrorCodes();
+    Strings::const_iterator istr = errors.begin();
+    Strings::const_iterator jstr = errors.end();
+    for ( ; istr != jstr; ++istr ) { tmp->addComments( *istr ); }
+
+    // Store description
+    desc.push_back( tmp );
+      
+  }
+
+}
+
+// -----------------------------------------------------------------------------
+// prints debug info on good, dirty, missing connections, and missing devices
+void FastFedCablingHistosUsingDb::connections( SiStripConfigDb::DeviceDescriptionsRange dcus, 
+					       SiStripConfigDb::DcuDetIdsRange detids ) {
+  
+  // strings
+  std::vector<std::string> valid;
+  std::vector<std::string> dirty;
+  std::vector<std::string> trimdac;
+  std::vector<std::string> missing;
+  std::vector<std::string> devices;
+  uint32_t missing_pairs = 0;
+
+  // iterate through analyses
+  std::vector<uint32_t> found_dcus;
+  Analyses::iterator ianal = data().begin();
+  Analyses::iterator janal = data().end();
+  for ( ; ianal != janal; ++ianal ) {
+
+    // extract fast fed cabling object
+    FastFedCablingAnalysis* anal = dynamic_cast<FastFedCablingAnalysis*>( ianal->second );
+    if ( !anal ) { continue; }
+    
+    // construct strings for various categories of connections
+    std::stringstream ss;
+    SiStripFedKey( anal->fedKey() ).terse(ss); ss << " ";
+    SiStripFecKey( anal->fecKey() ).terse(ss); ss << " "; 
+    ss << "DcuId= " << std::hex << std::setw(8) << std::setfill('0') << anal->dcuId() << std::dec << " ";
+    ss << "DetId= " << std::hex << std::setw(8) << std::setfill('0') << anal->detId() << std::dec;
+    if ( anal->isValid() &&
+	 !(anal->isDirty()) &&
+	 !(anal->badTrimDac()) ) { valid.push_back( ss.str() ); }
+    if ( anal->isDirty() ) { dirty.push_back( ss.str() ); }
+    if ( anal->badTrimDac() ) { trimdac.push_back( ss.str() ); }
+    
+    // record "found" dcus
+    found_dcus.push_back( anal->dcuHardId() );
+
+  }
+  
+  // iterate through dcu devices
+  SiStripConfigDb::DeviceDescriptionsV::const_iterator idcu = dcus.begin();
+  SiStripConfigDb::DeviceDescriptionsV::const_iterator jdcu = dcus.end();
+  for ( ; idcu != jdcu; ++idcu ) {
+    
+    // extract dcu description
+    dcuDescription* dcu = dynamic_cast<dcuDescription*>( *idcu );
+    if ( !dcu ) { continue; }
+    if ( dcu->getDcuType() != "FEH" ) { continue; }
+    SiStripConfigDb::DeviceAddress dcu_addr = db()->deviceAddress( *dcu );
+    
+    // continue if dcu has been "found"
+    std::vector<uint32_t>::const_iterator iter = find( found_dcus.begin(), found_dcus.end(), dcu->getDcuHardId() );
+    if ( iter != found_dcus.end() ) { continue; }
+    
+    // find detid for "missing" dcu
+    SiStripConfigDb::DcuDetIdsV::const_iterator idet = detids.end();
+    idet = SiStripConfigDb::findDcuDetId( detids.begin(), detids.end(), dcu->getDcuHardId() );
+    if ( idet == detids.end() ) { continue; }
+    if ( idet->second ) { continue; }
+    
+    // retrieve number of apv pairs
+    uint16_t npairs = idet->second->getApvNumber()/2; 
+  
+    // retrieve apvs for given dcu
+    vector<bool> addrs; 
+    addrs.resize(6,false);
+    SiStripConfigDb::DeviceDescriptionsRange apvs = db()->getDeviceDescriptions( APV25 );
+    SiStripConfigDb::DeviceDescriptionsV::const_iterator iapv = apvs.begin();
+    SiStripConfigDb::DeviceDescriptionsV::const_iterator japv = apvs.end();
+    for ( ; iapv != japv; ++iapv ) {
+      apvDescription* apv = dynamic_cast<apvDescription*>( *iapv );
+      if ( !apv ) { continue; }
+      SiStripConfigDb::DeviceAddress apv_addr = db()->deviceAddress( *apv );
+      if ( apv_addr.fecCrate_ == dcu_addr.fecCrate_ &&
+	   apv_addr.fecSlot_  == dcu_addr.fecSlot_ &&
+	   apv_addr.fecRing_  == dcu_addr.fecRing_ &&
+	   apv_addr.ccuAddr_  == dcu_addr.ccuAddr_ &&
+	   apv_addr.ccuChan_  == dcu_addr.ccuChan_ ) {
+	uint16_t pos = apv_addr.i2cAddr_ - 32;
+	if ( pos < 6 ) { addrs[pos] = true; }
+      }
+    }
+    
+    // construct strings for missing fibres
+    uint16_t pairs = 0;
+    if ( addrs[0] || addrs[1] ) {
+      pairs++;
+      std::stringstream ss;
+      SiStripFecKey( dcu_addr.fecCrate_,
+		     dcu_addr.fecSlot_,
+		     dcu_addr.fecRing_,
+		     dcu_addr.ccuAddr_,
+		     dcu_addr.ccuChan_,
+		     1 ).terse(ss); 
+      ss << " DcuId=" << std::hex << std::setw(8) << std::setfill('0') << dcu->getDcuHardId() << std::dec;
+      ss << " DetId=" << std::hex << std::setw(8) << std::setfill('0') << idet->first << std::dec;
+      missing.push_back( ss.str() ); 
+    } 
+    if ( addrs[2] || addrs[3] ) {
+      pairs++;
+      std::stringstream ss;
+      SiStripFecKey( dcu_addr.fecCrate_,
+		     dcu_addr.fecSlot_,
+		     dcu_addr.fecRing_,
+		     dcu_addr.ccuAddr_,
+		     dcu_addr.ccuChan_,
+		     2 ).terse(ss); 
+      ss << " DcuId=" << std::hex << std::setw(8) << std::setfill('0') << dcu->getDcuHardId() << std::dec;
+      ss << " DetId=" << std::hex << std::setw(8) << std::setfill('0') << idet->first << std::dec;
+      missing.push_back( ss.str() ); 
+    } 
+    if ( addrs[4] || addrs[5] ) {
+      pairs++;
+      std::stringstream ss;
+      SiStripFecKey( dcu_addr.fecCrate_,
+		     dcu_addr.fecSlot_,
+		     dcu_addr.fecRing_,
+		     dcu_addr.ccuAddr_,
+		     dcu_addr.ccuChan_,
+		     3 ).terse(ss); 
+      ss << " DcuId=" << std::hex << std::setw(8) << std::setfill('0') << dcu->getDcuHardId() << std::dec;
+      ss << " DetId=" << std::hex << std::setw(8) << std::setfill('0') << idet->first << std::dec;
+      missing.push_back( ss.str() ); 
+    }
+    
+    if ( pairs != npairs ) {
+      
+      missing_pairs = npairs - pairs;
+      
+      if ( !addrs[0] ) { 
+	std::stringstream ss;
+	SiStripFecKey( dcu_addr.fecCrate_,
+		       dcu_addr.fecSlot_,
+		       dcu_addr.fecRing_,
+		       dcu_addr.ccuAddr_,
+		       dcu_addr.ccuChan_,
+		       1, 32 ).terse(ss); 
+	ss << " DcuId=" << std::hex << std::setw(8) << std::setfill('0') << dcu->getDcuHardId() << std::dec;
+	ss << " DetId=" << std::hex << std::setw(8) << std::setfill('0') << idet->first << std::dec;
+	devices.push_back( ss.str() ); 
+      }
+      
+      if ( !addrs[1] ) { 
+	std::stringstream ss;
+	SiStripFecKey( dcu_addr.fecCrate_,
+		       dcu_addr.fecSlot_,
+		       dcu_addr.fecRing_,
+		       dcu_addr.ccuAddr_,
+		       dcu_addr.ccuChan_,
+		       1, 33 ).terse(ss); 
+	ss << " DcuId=" << std::hex << std::setw(8) << std::setfill('0') << dcu->getDcuHardId() << std::dec;
+	ss << " DetId=" << std::hex << std::setw(8) << std::setfill('0') << idet->first << std::dec;
+	devices.push_back( ss.str() ); 
+      }
+      
+      if ( !addrs[2] && npairs == 3 ) {
+	std::stringstream ss;
+	SiStripFecKey( dcu_addr.fecCrate_,
+		       dcu_addr.fecSlot_,
+		       dcu_addr.fecRing_,
+		       dcu_addr.ccuAddr_,
+		       dcu_addr.ccuChan_,
+		       2, 34 ).terse(ss); 
+	ss << " DcuId=" << std::hex << std::setw(8) << std::setfill('0') << dcu->getDcuHardId() << std::dec;
+	ss << " DetId=" << std::hex << std::setw(8) << std::setfill('0') << idet->first << std::dec;
+	devices.push_back( ss.str() ); 
+      }
+      
+      if ( !addrs[3] && npairs == 3 ) {
+	std::stringstream ss;
+	SiStripFecKey( dcu_addr.fecCrate_,
+		       dcu_addr.fecSlot_,
+		       dcu_addr.fecRing_,
+		       dcu_addr.ccuAddr_,
+		       dcu_addr.ccuChan_,
+		       2, 35 ).terse(ss); 
+	ss << " DcuId=" << std::hex << std::setw(8) << std::setfill('0') << dcu->getDcuHardId() << std::dec;
+	ss << " DetId=" << std::hex << std::setw(8) << std::setfill('0') << idet->first << std::dec;
+	devices.push_back( ss.str() ); 
+      }
+      
+      if ( !addrs[4] ) { 
+	std::stringstream ss;
+	SiStripFecKey( dcu_addr.fecCrate_,
+		       dcu_addr.fecSlot_,
+		       dcu_addr.fecRing_,
+		       dcu_addr.ccuAddr_,
+		       dcu_addr.ccuChan_,
+		       3, 36 ).terse(ss); 
+	ss << " DcuId=" << std::hex << std::setw(8) << std::setfill('0') << dcu->getDcuHardId() << std::dec;
+	ss << " DetId=" << std::hex << std::setw(8) << std::setfill('0') << idet->first << std::dec;
+	devices.push_back( ss.str() ); 
+      }
+      
+      if ( !addrs[5] ) { 
+	std::stringstream ss;
+	SiStripFecKey( dcu_addr.fecCrate_,
+		       dcu_addr.fecSlot_,
+		       dcu_addr.fecRing_,
+		       dcu_addr.ccuAddr_,
+		       dcu_addr.ccuChan_,
+		       3, 37 ).terse(ss); 
+	ss << " DcuId=" << std::hex << std::setw(8) << std::setfill('0') << dcu->getDcuHardId() << std::dec;
+	ss << " DetId=" << std::hex << std::setw(8) << std::setfill('0') << idet->first << std::dec;
+	devices.push_back( ss.str() ); 
+      }
+      
+    }
+
+  }
+
+  // summary
+  { 
+    std::stringstream ss;
+    ss << "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+       << " Summary of connections: " << std::endl
+       << " \"Good\" connections     : " << valid.size() << std::endl
+       << " \"Dirty\" connections    : " << dirty.size() << std::endl
+       << " \"Bad\" TrimDAQ settings : " << trimdac.size() << std::endl
+       << " (\"Missing\" connections : " << missing.size() << ")" << std::endl
+       << " (\"Missing\" APV pairs   : " << missing_pairs << ")" << std::endl
+       << " (\"Missing\" APVs        : " << devices.size() << ")" << std::endl;
+    edm::LogVerbatim(mlCabling_) << ss.str();
+  }
+
+  // good connections
+  if ( !valid.empty() ) { 
+    std::stringstream ss;
+    ss << "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+       << " List of \"good\" connections: " << std::endl;
+    std::vector<std::string>::const_iterator istr = valid.begin();
+    std::vector<std::string>::const_iterator jstr = valid.end();
+    for ( ; istr != jstr; ++istr ) { ss << *istr << std::endl; }
+    LogTrace(mlCabling_) << ss.str();
+  }
+
+  // dirty connections
+  if ( !dirty.empty() ) { 
+    std::stringstream ss;
+    ss << "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+       << " List of \"dirty\" connections: " << std::endl;
+    std::vector<std::string>::const_iterator istr = dirty.begin();
+    std::vector<std::string>::const_iterator jstr = dirty.end();
+    for ( ; istr != jstr; ++istr ) { ss << *istr << std::endl; }
+    edm::LogWarning(mlCabling_) << ss.str();
+  }
+
+  // TrimDAC connections
+  if ( !trimdac.empty() ) { 
+    std::stringstream ss;
+    ss << "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+       << " List of \"bad\" TrimDAC settings: " << std::endl;
+    std::vector<std::string>::const_iterator istr = trimdac.begin();
+    std::vector<std::string>::const_iterator jstr = trimdac.end();
+    for ( ; istr != jstr; ++istr ) { ss << *istr << std::endl; }
+    edm::LogWarning(mlCabling_) << ss.str();
+  }
+
+  // missing connections
+  if ( !missing.empty() ) { 
+    std::stringstream ss;
+    ss << "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+       << " List of \"missing\" connections: " << std::endl;
+    std::vector<std::string>::const_iterator istr = missing.begin();
+    std::vector<std::string>::const_iterator jstr = missing.end();
+    for ( ; istr != jstr; ++istr ) { ss << *istr << std::endl; }
+    edm::LogError(mlCabling_) << ss.str();
+  }
+
+  // missing devices
+  if ( !devices.empty() ) { 
+    std::stringstream ss;
+    ss << "[FastFedCablingHistosUsingDb::" << __func__ << "]"
+       << " List of \"missing\" APVs: " << std::endl;
+    std::vector<std::string>::const_iterator istr = devices.begin();
+    std::vector<std::string>::const_iterator jstr = devices.end();
+    for ( ; istr != jstr; ++istr ) { ss << *istr << std::endl; }
+    edm::LogError(mlCabling_) << ss.str();
+  }
+
+}

--- a/DQM/SiStripCommissioningDbClients/src/FineDelayHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/FineDelayHistosUsingDb.cc
@@ -1,0 +1,378 @@
+
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "DQM/SiStripCommissioningDbClients/interface/FineDelayHistosUsingDb.h"
+#include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFecKey.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFedKey.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include <Geometry/CommonTopologies/interface/Topology.h>
+#include <CondFormats/DataRecord/interface/SiStripFedCablingRcd.h>
+#include <CondFormats/SiStripObjects/interface/SiStripFedCabling.h>
+#include <CondFormats/SiStripObjects/interface/FedChannelConnection.h>
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <iostream>
+
+using namespace sistrip;
+
+// -----------------------------------------------------------------------------
+/** */
+FineDelayHistosUsingDb::FineDelayHistosUsingDb( const edm::ParameterSet & pset,
+                                                DQMStore* bei,
+                                                SiStripConfigDb* const db ) 
+  : CommissioningHistograms( pset.getParameter<edm::ParameterSet>("FineDelayParameters"),
+                             bei,
+                             sistrip::FINE_DELAY ),
+    CommissioningHistosUsingDb( db,
+                             sistrip::FINE_DELAY ),
+    SamplingHistograms( pset.getParameter<edm::ParameterSet>("FineDelayParameters"),
+                        bei,
+                        sistrip::FINE_DELAY ),
+    tracker_(0)
+{
+  LogTrace(mlDqmClient_) 
+    << "[FineDelayHistosUsingDb::" << __func__ << "]"
+    << " Constructing object...";
+  delays_.clear();
+}
+
+// -----------------------------------------------------------------------------
+/** */
+FineDelayHistosUsingDb::~FineDelayHistosUsingDb() {
+  LogTrace(mlDqmClient_) 
+    << "[FineDelayHistosUsingDb::" << __func__ << "]"
+    << " Destructing object...";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void FineDelayHistosUsingDb::configure( const edm::ParameterSet& pset, 
+					const edm::EventSetup& setup ) {
+  // get geometry
+  edm::ESHandle<TrackerGeometry> estracker;
+  setup.get<TrackerDigiGeometryRecord>().get(estracker);
+  tracker_=&(* estracker);
+  SamplingHistograms::configure(pset,setup);
+  cosmic_ = this->pset().getParameter<bool>("cosmic");
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void FineDelayHistosUsingDb::uploadConfigurations() {
+  
+  if ( !db() ) {
+    edm::LogWarning(mlDqmClient_) 
+      << "[FineDelayHistosUsingDb::" << __func__ << "]"
+      << " NULL pointer to SiStripConfigDb interface!"
+      << " Aborting upload...";
+    return;
+  }
+  
+  // Retrieve and update PLL device descriptions
+  db()->clearDeviceDescriptions(); 
+  SiStripConfigDb::DeviceDescriptionsRange devices = db()->getDeviceDescriptions( PLL ); 
+  bool upload = update( devices );
+    
+  // Check if new PLL settings are valid 
+  if ( !upload ) {
+    edm::LogWarning(mlDqmClient_) 
+      << "[FineDelayHistosUsingDb::" << __func__ << "]"
+      << " Found invalid PLL settings (coarse > 15)"
+      << " Aborting update to database...";
+    return;
+  }
+    
+  // Upload PLL device descriptions
+  if ( doUploadConf() ) { 
+    LogTrace(mlDqmClient_) 
+      << "[FineDelayHistosUsingDb::" << __func__ << "]"
+      << " Uploading PLL settings to DB...";
+    db()->uploadDeviceDescriptions(); 
+    LogTrace(mlDqmClient_) 
+      << "[FineDelayHistosUsingDb::" << __func__ << "]"
+      << " Upload of PLL settings to DB finished!";
+  } else {
+    edm::LogWarning(mlDqmClient_) 
+      << "[FineDelayHistosUsingDb::" << __func__ << "]"
+      << " TEST only! No PLL settings will be uploaded to DB...";
+  }
+
+  // Update FED descriptions with new ticker thresholds
+  db()->clearFedDescriptions(); 
+  SiStripConfigDb::FedDescriptionsRange feds = db()->getFedDescriptions(); 
+  update( feds );
+    
+  // Update FED descriptions with new ticker thresholds
+  if ( doUploadConf() ) { 
+    LogTrace(mlDqmClient_) 
+      << "[FineDelayHistosUsingDb::" << __func__ << "]"
+      << " Uploading FED ticker thresholds to DB...";
+    db()->uploadFedDescriptions(); 
+    LogTrace(mlDqmClient_) 
+      << "[FineDelayHistosUsingDb::" << __func__ << "]"
+      << " Upload of FED ticker thresholds to DB finished!";
+  } else {
+    edm::LogWarning(mlDqmClient_) 
+      << "[FineDelayHistosUsingDb::" << __func__ << "]"
+      << " TEST only! No FED ticker thresholds will be uploaded to DB...";
+  }
+
+}
+
+void FineDelayHistosUsingDb::computeDelays() {
+  // do nothing if delays_ map is already filled
+  if(delays_.size()>0) return;
+
+  // the point from which track should originate
+  float x = 0.; float y = 0.; float z = 0.;
+  if(cosmic_) { y = 385.; z=20.; } // mean entry point of cosmics
+  GlobalPoint referenceP_ = GlobalPoint(x,y,z);
+  const double c = 30; // cm/ns
+  
+  // the reference parameters (best delay in ns, initial Latency)
+  float bestDelay_ = 0.;
+  if(data().size()) {
+    Analyses::const_iterator iter = data().begin();
+    bestDelay_ = dynamic_cast<SamplingAnalysis*>(iter->second)->maximum();
+  }
+
+  // Retrieve FED ids from cabling
+  std::vector<uint16_t> ids = cabling()->feds() ;
+  
+  // loop over the FED ids
+  for (std::vector<uint16_t>::const_iterator ifed = ids.begin(); ifed != ids.end(); ++ifed) {
+    const std::vector<FedChannelConnection>& conns = cabling()->connections(*ifed);
+    // loop over the connections for that FED 
+    for ( std::vector<FedChannelConnection>::const_iterator iconn = conns.begin(); iconn != conns.end(); iconn++ ) {
+      // check that this is a tracker module
+      if(DetId(iconn->detId()).det()!=DetId::Tracker) continue;
+      // retrieve the position of that module in the tracker using the geometry
+      // and use it to compute the distance to the reference point set in the configuration
+      if(tracker_) {
+        float dist = tracker_->idToDetUnit(DetId(iconn->detId()))->toLocal(referenceP_).mag(); 
+        float tof  = dist/c ;
+        // compute the PLL delay shift for the module as delay + tof 
+        float delay = bestDelay_+tof;
+        // store that in the map
+        delays_[SiStripFecKey( iconn->fecCrate(),
+                               iconn->fecSlot(),
+                               iconn->fecRing(),
+                               iconn->ccuAddr(),
+                               iconn->ccuChan(), 0 ).key()] = delay;
+        edm::LogVerbatim(mlDqmClient_)
+            << "[FineDelayHistosUsingDb::" << __func__ << "] Computed Delay to be added to PLL: "
+            << bestDelay_ << " " << tof << " " << delay << std::endl;
+      } else {
+        edm::LogError(mlDqmClient_)
+	  << "[FineDelayHistosUsingDb::" << __func__ << "]"
+	  << " Tracker geometry not initialized. Impossible to compute the delays.";
+      }
+    }
+  }
+}
+
+// -----------------------------------------------------------------------------
+/** */
+bool FineDelayHistosUsingDb::update( SiStripConfigDb::DeviceDescriptionsRange devices ) {
+
+  // do the core computation of delays per FED connection
+  computeDelays();
+
+  // Iterate through devices and update device descriptions
+  uint16_t updated = 0;
+  std::vector<SiStripFecKey> invalid;
+  SiStripConfigDb::DeviceDescriptionsV::const_iterator idevice;
+  for ( idevice = devices.begin(); idevice != devices.end(); idevice++ ) {
+    
+    // Check device type
+    if ( (*idevice)->getDeviceType() != PLL ) { continue; }
+    
+    // Cast to retrieve appropriate description object
+    pllDescription* desc = dynamic_cast<pllDescription*>( *idevice ); 
+    if ( !desc ) { continue; }
+    
+    // Retrieve device addresses from device description
+    const SiStripConfigDb::DeviceAddress& addr = db()->deviceAddress(*desc);
+
+    // Construct key from device description
+    uint32_t fec_key = SiStripFecKey( addr.fecCrate_,
+                                      addr.fecSlot_, 
+                                      addr.fecRing_,
+                                      addr.ccuAddr_, 
+                                      addr.ccuChan_,
+                                      0 ).key();
+    SiStripFecKey fec_path = SiStripFecKey( fec_key );
+    
+    // extract the delay from the map
+    float delay = desc->getDelayCoarse()*25+desc->getDelayFine()*25./24. + delays_[fec_key];
+    int delayCoarse = int(delay/25);
+    int delayFine   = int(round((delay-25*delayCoarse)*24./25.));
+    if(delayFine==24) { delayFine=0; ++delayCoarse; }
+    //  maximum coarse setting
+    if ( delayCoarse > 15 ) { invalid.push_back(fec_key); delayCoarse = sistrip::invalid_; }
+		    
+    // Update PLL settings
+    if ( delayCoarse != sistrip::invalid_ && 
+	 delayFine != sistrip::invalid_ ) { 
+      
+      std::stringstream ss;
+      ss << "[FineDelayHistosUsingDb::" << __func__ << "]"
+	 << " Updating coarse/fine PLL settings"
+	 << " for Crate/FEC/slot/ring/CCU "
+	 << fec_path.fecCrate() << "/"
+	 << fec_path.fecSlot() << "/"
+	 << fec_path.fecRing() << "/"
+	 << fec_path.ccuAddr() << "/"
+	 << fec_path.ccuChan() 
+	 << " from "
+	 << static_cast<uint16_t>( desc->getDelayCoarse() ) << "/" 
+	 << static_cast<uint16_t>( desc->getDelayFine() );
+      desc->setDelayCoarse(delayCoarse);
+      desc->setDelayFine(delayFine);
+      updated++;
+      ss << " to "
+	 << static_cast<uint16_t>( desc->getDelayCoarse() ) << "/" 
+	 << static_cast<uint16_t>( desc->getDelayFine() );
+      LogTrace(mlDqmClient_) << ss.str();
+
+    } else {
+      LogTrace(mlDqmClient_) 
+	<< "[FineDelayHistosUsingDb::" << __func__ << "]"
+	<< " Unexpected PLL delay settings for Crate/FEC/slot/ring/CCU " 
+	<< fec_path.fecCrate() << "/"
+	<< fec_path.fecSlot() << "/"
+	<< fec_path.fecRing() << "/"
+	<< fec_path.ccuAddr() << "/"
+	<< fec_path.ccuChan();
+    }
+
+  }
+
+  // Check if invalid settings were found
+  if ( !invalid.empty() ) {
+    std::stringstream ss;
+    ss << "[FineDelayHistosUsingDb::" << __func__ << "]"
+       << " Found PLL coarse setting of 15" 
+       << " (not allowed!) for following channels"
+       << " (Crate/FEC/slot/ring/CCU/LLD): ";
+    std::vector<SiStripFecKey>::iterator ikey = invalid.begin();
+    std::vector<SiStripFecKey>::iterator jkey = invalid.end();
+    for ( ; ikey != jkey; ++ikey ) {
+      ss << ikey->fecCrate() << "/"
+	 << ikey->fecSlot() << "/"
+	 << ikey->fecRing() << "/"
+	 << ikey->ccuAddr() << "/"
+	 << ikey->ccuChan() << ", ";
+    }
+    edm::LogWarning(mlDqmClient_) << ss.str();
+    return false;
+  }
+  
+  edm::LogVerbatim(mlDqmClient_) 
+    << "[FineDelayHistosUsingDb::" << __func__ << "]"
+    << " Updated PLL settings for " 
+    << updated << " modules";
+  return true;
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void FineDelayHistosUsingDb::update( SiStripConfigDb::FedDescriptionsRange feds ) {
+
+  // do the core computation of delays per FED connection
+  computeDelays();
+
+  // Retrieve FED ids from cabling
+  std::vector<uint16_t> ids = cabling()->feds() ;
+  
+  // loop over the FED ids
+  for ( SiStripConfigDb::FedDescriptionsV::const_iterator ifed = feds.begin(); ifed != feds.end(); ifed++ ) {
+    // If FED id not found in list (from cabling), then continue
+    if ( find( ids.begin(), ids.end(), (*ifed)->getFedId() ) == ids.end() ) { continue; }
+    const std::vector<FedChannelConnection>& conns = cabling()->connections((*ifed)->getFedId());
+    // loop over the connections for that FED 
+    for ( std::vector<FedChannelConnection>::const_iterator iconn = conns.begin(); iconn != conns.end(); iconn++ ) {
+      // check that this is a tracker module
+      if(DetId(iconn->detId()).det()!=DetId::Tracker) continue;
+      // build the Fed9UAddress for that channel. Used to update the description.
+      Fed9U::Fed9UAddress fedChannel = Fed9U::Fed9UAddress(iconn->fedCh()); 
+      // retreive the current value for the delays
+      int fedDelayCoarse = (*ifed)->getCoarseDelay(fedChannel);
+      int fedDelayFine = (*ifed)->getFineDelay(fedChannel);
+      int fedDelay = int(fedDelayCoarse*25. - fedDelayFine*24./25.);
+      // extract the delay from the map
+      int delay = int(round( delays_[SiStripFecKey( iconn->fecCrate(),
+                                                    iconn->fecSlot(),
+                                                    iconn->fecRing(),
+                                                    iconn->ccuAddr(),
+                                                    iconn->ccuChan(), 0 ).key()]));
+      // compute the FED delay
+      // this is done by substracting the best (PLL) delay to the present value (from the db)
+      fedDelay -= delay;
+      fedDelayCoarse = (fedDelay/25)+1;
+      fedDelayFine = fedDelayCoarse*25-fedDelay;
+      if(fedDelayFine==25) { fedDelayFine = 0; --fedDelayCoarse; }
+      // update the FED delay
+      std::stringstream ss;
+      ss << "[FineDelayHistosUsingDb::" << __func__ << "]"
+         << " Updating the FED delay"
+         << " for loop FED id/ch "
+         << (*ifed)->getFedId() << "/" << iconn->fedCh()
+         << " from "
+         << (*ifed)->getCoarseDelay( fedChannel) << "/" << (*ifed)->getFineDelay( fedChannel)
+         << " to ";
+      (*ifed)->setDelay(fedChannel, fedDelayCoarse, fedDelayFine);
+      ss << (*ifed)->getCoarseDelay(fedChannel) << "/" << (*ifed)->getFineDelay( fedChannel) << std::endl;
+      LogTrace(mlDqmClient_) << ss.str();
+    }
+  }
+
+  edm::LogVerbatim(mlDqmClient_)
+    << "[FineDelayHistosUsingDb::" << __func__ << "]"
+    << " Updated FED delay for " << ids.size() << " FEDs!";
+
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void FineDelayHistosUsingDb::create( SiStripConfigDb::AnalysisDescriptionsV& desc,
+				     Analysis analysis ) {
+
+  SamplingAnalysis* anal = dynamic_cast<SamplingAnalysis*>( analysis->second );
+  if ( !anal ) { return; }
+  
+  SiStripFecKey fec_key( anal->fecKey() ); //@@ analysis->first
+  SiStripFedKey fed_key( anal->fedKey() );
+
+  FineDelayAnalysisDescription* tmp;
+  tmp = new FineDelayAnalysisDescription( anal->maximum(),
+					  anal->error(),
+					  0,
+					  0,
+					  0,
+					  0,
+					  0,
+					  0, 
+					  db()->dbParams().partitions().begin()->second.partitionName(),
+					  db()->dbParams().partitions().begin()->second.runNumber(),
+					  anal->isValid(),
+					  "",
+					  fed_key.fedId(),
+					  fed_key.feUnit(),
+					  fed_key.feChan(),
+					  fed_key.fedApv() );
+    
+  // Add comments
+  typedef std::vector<std::string> Strings;
+  Strings errors = anal->getErrorCodes();
+  Strings::const_iterator istr = errors.begin();
+  Strings::const_iterator jstr = errors.end();
+  for ( ; istr != jstr; ++istr ) { tmp->addComments( *istr ); }
+    
+  // Store description
+  desc.push_back( tmp );
+
+}

--- a/DQM/SiStripCommissioningDbClients/src/LatencyHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/LatencyHistosUsingDb.cc
@@ -1,0 +1,382 @@
+
+#include "DQM/SiStripCommissioningDbClients/interface/LatencyHistosUsingDb.h"
+#include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFecKey.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include <iostream>
+
+#define MAXFEDCOARSE 15
+
+using namespace sistrip;
+
+// -----------------------------------------------------------------------------
+/** */
+LatencyHistosUsingDb::LatencyHistosUsingDb( const edm::ParameterSet & pset,
+                                            DQMStore* bei,
+                                            SiStripConfigDb* const db )
+  : CommissioningHistograms( pset.getParameter<edm::ParameterSet>("LatencyParameters"),
+                             bei,
+                             sistrip::APV_LATENCY ),
+    CommissioningHistosUsingDb( db,
+                                sistrip::APV_LATENCY ),
+    SamplingHistograms( pset.getParameter<edm::ParameterSet>("LatencyParameters"),
+                        bei,
+                        sistrip::APV_LATENCY )
+{
+  LogTrace(mlDqmClient_) 
+    << "[LatencyHistosUsingDb::" << __func__ << "]"
+    << " Constructing object...";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+LatencyHistosUsingDb::~LatencyHistosUsingDb() {
+  LogTrace(mlDqmClient_) 
+    << "[LatencyHistosUsingDb::" << __func__ << "]"
+    << " Destructing object...";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void LatencyHistosUsingDb::uploadConfigurations() {
+  
+  if ( !db() ) {
+    edm::LogWarning(mlDqmClient_) 
+      << "[LatencyHistosUsingDb::" << __func__ << "]"
+      << " NULL pointer to SiStripConfigDb interface!"
+      << " Aborting upload...";
+    return;
+  }
+
+  SiStripConfigDb::DeviceDescriptionsRange devices = db()->getDeviceDescriptions(); 
+  SiStripConfigDb::FedDescriptionsRange feds = db()->getFedDescriptions();
+  bool upload = update( devices, feds );
+  // Check if new PLL settings are valid
+  if ( !upload ) {
+    edm::LogWarning(mlDqmClient_)
+      << "[LatencyHistosUsingDb::" << __func__ << "]"
+      << " Found invalid PLL settings (coarse > 15)"
+      << " Aborting update to database...";
+    return;
+  }
+  
+  if ( doUploadConf() ) { 
+    // Update APV descriptions with new Latency settings
+    LogTrace(mlDqmClient_) 
+      << "[LatencyHistosUsingDb::" << __func__ << "]"
+      << " Uploading APV settings to DB...";
+    db()->uploadDeviceDescriptions(); 
+    LogTrace(mlDqmClient_) 
+      << "[LatencyHistosUsingDb::" << __func__ << "]"
+      << " Upload of APV settings to DB finished!";
+    // Update FED descriptions 
+    LogTrace(mlDqmClient_)
+      << "[LatencyHistosUsingDb::" << __func__ << "]"
+      << " Uploading FED delays to DB...";
+    db()->uploadFedDescriptions();
+    LogTrace(mlDqmClient_)
+      << "[LatencyHistosUsingDb::" << __func__ << "]"
+      << " Upload of FED delays to DB finished!";
+  } else {
+    edm::LogWarning(mlDqmClient_) 
+      << "[LatencyHistosUsingDb::" << __func__ << "]"
+      << " TEST only! No APV settings will be uploaded to DB...";
+  }
+
+}
+
+// -----------------------------------------------------------------------------
+/** */
+bool LatencyHistosUsingDb::update( SiStripConfigDb::DeviceDescriptionsRange devices, 
+				   SiStripConfigDb::FedDescriptionsRange feds ) {
+  
+  // Obtain the latency from the analysis object
+  if(!data().size() || !data().begin()->second->isValid() ) {
+    edm::LogVerbatim(mlDqmClient_) 
+      << "[LatencyHistosUsingDb::" << __func__ << "]"
+      << " Updated NO Latency settings. No analysis result available !" ;
+    return false;
+  }
+
+  // Compute the minimum coarse delay
+  uint16_t minCoarseDelay = 256;
+  SiStripConfigDb::DeviceDescriptionsV::const_iterator idevice;
+  for ( idevice = devices.begin(); idevice != devices.end(); idevice++ ) {
+    // Check device type
+    if ( (*idevice)->getDeviceType() == PLL ) {
+      // Cast to retrieve appropriate description object
+      pllDescription* desc = dynamic_cast<pllDescription*>( *idevice );
+      if ( desc ) { 
+/*
+        // add 1 to aim at 1 and not 0 (just to avoid a special 0 value for security)
+        int delayCoarse = desc->getDelayCoarse() - 1;
+        delayCoarse = delayCoarse < 0 ? 0 : delayCoarse;
+        minCoarseDelay = minCoarseDelay < delayCoarse ? minCoarseDelay : delayCoarse;
+*/
+        int delayCoarse = desc->getDelayCoarse();
+        minCoarseDelay = minCoarseDelay < delayCoarse ? minCoarseDelay : delayCoarse;
+      }
+    }
+  }
+
+  // Compute latency and PLL shift from the sampling measurement
+  SamplingAnalysis* anal = NULL;
+  for( CommissioningHistograms::Analysis it = data().begin(); it!=data().end();++it) {
+    if(dynamic_cast<SamplingAnalysis*>( it->second ) && 
+       dynamic_cast<SamplingAnalysis*>( it->second )->granularity()==sistrip::TRACKER)
+      anal = dynamic_cast<SamplingAnalysis*>( it->second );
+  }
+  if(!anal) return false;
+  uint16_t globalLatency = uint16_t(ceil(anal->maximum()/(-25.)));
+  float globalShift = anal->maximum()-(globalLatency*(-25));
+
+  // Compute latency and PLL shift per partition... this is an option
+  uint16_t latency = globalLatency;
+  float shift[5] = {0.};
+  for( CommissioningHistograms::Analysis it = data().begin(); it!=data().end();++it) {
+    if(dynamic_cast<SamplingAnalysis*>( it->second ) &&
+       dynamic_cast<SamplingAnalysis*>( it->second )->granularity()==sistrip::PARTITION       )
+      anal = dynamic_cast<SamplingAnalysis*>( it->second );
+      latency = uint16_t(ceil(anal->maximum()/(-25.)))>latency ? uint16_t(ceil(anal->maximum()/(-25.))) : latency;
+  }
+  for( CommissioningHistograms::Analysis it = data().begin(); it!=data().end();++it) {
+    if(dynamic_cast<SamplingAnalysis*>( it->second ) &&
+       dynamic_cast<SamplingAnalysis*>( it->second )->granularity()==sistrip::PARTITION       )
+      anal = dynamic_cast<SamplingAnalysis*>( it->second );
+      shift[SiStripFecKey(anal->fecKey()).fecCrate()] = anal->maximum()-(latency*(-25));
+  }
+  if(!perPartition_) {
+    latency = globalLatency;
+    for(int i=0;i<5;i++) shift[i] = globalShift;
+  }
+
+  // Take into account the minimum coarse delay to bring the coarse delay down
+  // the same quantity is subtracted to the coarse delay of each APV 
+  latency -= minCoarseDelay;
+  
+  // Iterate through devices and update device descriptions
+  uint16_t updatedAPV = 0;
+  uint16_t updatedPLL = 0;
+  std::vector<SiStripFecKey> invalid;
+  for ( idevice = devices.begin(); idevice != devices.end(); idevice++ ) {
+    // Check device type
+    if ( (*idevice)->getDeviceType() != APV25 ) { continue; }
+    // Cast to retrieve appropriate description object
+    apvDescription* desc = dynamic_cast<apvDescription*>( *idevice );
+    if ( !desc ) { continue; }
+    // Retrieve device addresses from device description
+    const SiStripConfigDb::DeviceAddress& addr = db()->deviceAddress(*desc);
+    // Do it!
+    std::stringstream ss;
+    ss << "[LatencyHistosUsingDb::" << __func__ << "]"
+       << " Updating latency APV settings for crate/FEC/slot/ring/CCU/i2cAddr "
+       << addr.fecCrate_ << "/"
+       << addr.fecSlot_ << "/"
+       << addr.fecRing_ << "/"
+       << addr.ccuAddr_ << "/"
+       << addr.ccuChan_ << "/"
+       << addr.i2cAddr_
+       << " from "
+       << static_cast<uint16_t>(desc->getLatency());
+    desc->setLatency(latency);
+    ss << " to "
+       << static_cast<uint16_t>(desc->getLatency());
+    LogTrace(mlDqmClient_) << ss.str();
+    updatedAPV++;
+  }
+
+  // Change also the PLL delay
+  for ( idevice = devices.begin(); idevice != devices.end(); idevice++ ) {
+    // Check device type
+    if ( (*idevice)->getDeviceType() != PLL ) { continue; }
+    // Cast to retrieve appropriate description object
+    pllDescription* desc = dynamic_cast<pllDescription*>( *idevice );
+    if ( !desc ) { continue; }
+    if ( desc->getDelayCoarse() >= 15 ) { continue; }
+    // Retrieve device addresses from device description
+    const SiStripConfigDb::DeviceAddress& addr = db()->deviceAddress(*desc);
+    // Construct key from device description
+    uint32_t fec_key = SiStripFecKey( addr.fecCrate_,
+                                      addr.fecSlot_,
+                                      addr.fecRing_,
+                                      addr.ccuAddr_,
+                                      addr.ccuChan_,
+                                      0 ).key();
+    SiStripFecKey fec_path = SiStripFecKey( fec_key );    
+    // Do it!
+    float delay = desc->getDelayCoarse()*25+desc->getDelayFine()*25./24. + shift[addr.fecCrate_];
+    int delayCoarse = int(delay/25);
+    int delayFine   = int(round((delay-25*delayCoarse)*24./25.));
+    if(delayFine==24) { delayFine=0; ++delayCoarse; }
+    delayCoarse -= minCoarseDelay;
+    //  maximum coarse setting
+    if ( delayCoarse > 15 ) { invalid.push_back(fec_key); delayCoarse = sistrip::invalid_; }
+    // Update PLL settings
+    if ( delayCoarse != sistrip::invalid_ &&
+         delayFine != sistrip::invalid_ ) {
+      std::stringstream ss;
+      ss << "[LatencyHistosUsingDb::" << __func__ << "]"
+	 << " Updating coarse/fine PLL settings"
+	 << " for Crate/FEC/slot/ring/CCU "
+	 << fec_path.fecCrate() << "/"
+	 << fec_path.fecSlot() << "/"
+	 << fec_path.fecRing() << "/"
+	 << fec_path.ccuAddr() << "/"
+	 << fec_path.ccuChan()
+	 << " from "
+	 << static_cast<uint16_t>( desc->getDelayCoarse() ) << "/"
+	 << static_cast<uint16_t>( desc->getDelayFine() );
+      desc->setDelayCoarse(delayCoarse);
+      desc->setDelayFine(delayFine);
+      updatedPLL++;
+      ss << " to "
+	 << static_cast<uint16_t>( desc->getDelayCoarse() ) << "/"
+	 << static_cast<uint16_t>( desc->getDelayFine() );
+      LogTrace(mlDqmClient_) << ss.str();
+    }
+  }
+  
+  // Retrieve FED ids from cabling
+  std::vector<uint16_t> ids = cabling()->feds() ;
+
+  // loop over the FED ids to determine min and max values of coarse delay
+  uint16_t minDelay = 256;
+  uint16_t maxDelay = 0;
+  uint16_t fedDelayCoarse = 0;
+  for ( SiStripConfigDb::FedDescriptionsV::const_iterator ifed = feds.begin(); ifed != feds.end(); ifed++ ) {
+    // If FED id not found in list (from cabling), then continue
+    if ( find( ids.begin(), ids.end(), (*ifed)->getFedId() ) == ids.end() ) { continue; }
+    const std::vector<FedChannelConnection>& conns = cabling()->connections((*ifed)->getFedId());
+    // loop over the connections for that FED
+    for ( std::vector<FedChannelConnection>::const_iterator iconn = conns.begin(); iconn != conns.end(); iconn++ ) {
+      // check that this is a tracker module
+      if(DetId(iconn->detId()).det()!=DetId::Tracker) continue;
+      // build the Fed9UAddress for that channel. Used to update the description.
+      Fed9U::Fed9UAddress fedChannel = Fed9U::Fed9UAddress(iconn->fedCh());
+      // retreive the current value for the delays
+      fedDelayCoarse = (*ifed)->getCoarseDelay(fedChannel);
+      // update min and max
+      minDelay = minDelay<fedDelayCoarse ? minDelay : fedDelayCoarse;
+      maxDelay = maxDelay>fedDelayCoarse ? maxDelay : fedDelayCoarse;
+    }
+  }
+
+  // compute the FED coarse global offset
+  int offset = (10-minDelay)*25;  // try to ensure 10BX room for later fine delay scan
+  if(maxDelay+(offset/25)>MAXFEDCOARSE) offset = (MAXFEDCOARSE-maxDelay)*25; // otherwise, take the largest possible
+
+  // loop over the FED ids
+  for ( SiStripConfigDb::FedDescriptionsV::const_iterator ifed = feds.begin(); ifed != feds.end(); ifed++ ) {
+    // If FED id not found in list (from cabling), then continue
+    if ( find( ids.begin(), ids.end(), (*ifed)->getFedId() ) == ids.end() ) { continue; }
+    const std::vector<FedChannelConnection>& conns = cabling()->connections((*ifed)->getFedId());
+    // loop over the connections for that FED
+    for ( std::vector<FedChannelConnection>::const_iterator iconn = conns.begin(); iconn != conns.end(); iconn++ ) {
+      // check that this is a tracker module
+      if(DetId(iconn->detId()).det()!=DetId::Tracker) continue;
+      // build the Fed9UAddress for that channel. Used to update the description.
+      Fed9U::Fed9UAddress fedChannel = Fed9U::Fed9UAddress(iconn->fedCh());
+      // retreive the current value for the delays
+      int fedDelayCoarse = (*ifed)->getCoarseDelay(fedChannel);
+      int fedDelayFine = (*ifed)->getFineDelay(fedChannel);
+      // compute the FED delay
+      // this is done by substracting the best (PLL) delay to the present value (from the db)
+      int fedDelay = int(fedDelayCoarse*25. - fedDelayFine*24./25. - round(shift[iconn->fecCrate()]) + offset);
+      fedDelayCoarse = (fedDelay/25)+1;
+      fedDelayFine = fedDelayCoarse*25-fedDelay;
+      if(fedDelayFine==25) { fedDelayFine = 0; --fedDelayCoarse; }
+      // update the FED delay
+      std::stringstream ss;
+      ss << "[LatencyHistosUsingDb::" << __func__ << "]"
+         << " Updating the FED delay"
+         << " for loop FED id/ch "
+         << (*ifed)->getFedId() << "/" << iconn->fedCh()
+         << " from "
+         << (*ifed)->getCoarseDelay( fedChannel) << "/" << (*ifed)->getFineDelay( fedChannel)
+         << " to ";
+      (*ifed)->setDelay(fedChannel, fedDelayCoarse, fedDelayFine);
+      ss << (*ifed)->getCoarseDelay(fedChannel) << "/" << (*ifed)->getFineDelay( fedChannel);
+      LogTrace(mlDqmClient_) << ss.str();
+    }
+  }
+
+  // Summary output
+  edm::LogVerbatim(mlDqmClient_)
+    << "[LatencyHistosUsingDb::" << __func__ << "]"
+    << " Updated FED delays for " << ids.size() << " FEDs!";
+  
+  // Check if invalid settings were found
+  if ( !invalid.empty() ) {
+    std::stringstream ss;
+    ss << "[LatencyHistosUsingDb::" << __func__ << "]"
+       << " Found PLL coarse setting of 15"
+       << " (not allowed!) for following channels"
+       << " (Crate/FEC/slot/ring/CCU/LLD): ";
+    std::vector<SiStripFecKey>::iterator ikey = invalid.begin();
+    std::vector<SiStripFecKey>::iterator jkey = invalid.end();
+    for ( ; ikey != jkey; ++ikey ) {
+      ss << ikey->fecCrate() << "/"
+         << ikey->fecSlot() << "/"
+         << ikey->fecRing() << "/"
+         << ikey->ccuAddr() << "/"
+         << ikey->ccuChan() << ", ";
+    }
+    edm::LogWarning(mlDqmClient_) << ss.str();
+    return false;
+  }
+
+  // Summary output
+  edm::LogVerbatim(mlDqmClient_) 
+    << "[LatencyHistosUsingDb::" << __func__ << "] "
+    << "Updated settings for " << updatedAPV << " APV devices and " << updatedPLL << " PLL devices.";
+  return true;
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void LatencyHistosUsingDb::create( SiStripConfigDb::AnalysisDescriptionsV& desc,
+				   Analysis analysis ) {
+
+  SamplingAnalysis* anal = dynamic_cast<SamplingAnalysis*>( analysis->second );
+  if ( !anal ) { return; }
+  
+  SiStripFecKey fec_key( anal->fecKey() ); //@@ analysis->first
+  SiStripFedKey fed_key( anal->fedKey() );
+  
+  uint16_t latency = static_cast<uint16_t>( ( anal->maximum() / (-25.) ) + 0.5 );
+
+  ApvLatencyAnalysisDescription* tmp;
+  tmp = new ApvLatencyAnalysisDescription( latency, 
+					   0,
+					   0,
+					   0,
+					   0,
+					   0,
+					   0, 
+					   db()->dbParams().partitions().begin()->second.partitionName(),
+					   db()->dbParams().partitions().begin()->second.runNumber(),
+					   anal->isValid(),
+					   "",
+					   fed_key.fedId(),
+					   fed_key.feUnit(),
+					   fed_key.feChan(),
+					   fed_key.fedApv() );
+    
+  // Add comments
+  typedef std::vector<std::string> Strings;
+  Strings errors = anal->getErrorCodes();
+  Strings::const_iterator istr = errors.begin();
+  Strings::const_iterator jstr = errors.end();
+  for ( ; istr != jstr; ++istr ) { tmp->addComments( *istr ); }
+    
+  // Store description
+  desc.push_back( tmp );
+    
+}
+
+void LatencyHistosUsingDb::configure( const edm::ParameterSet& pset, const edm::EventSetup& es)
+{
+  perPartition_ = this->pset().getParameter<bool>("OptimizePerPartition");
+}
+

--- a/DQM/SiStripCommissioningDbClients/src/NoiseHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/NoiseHistosUsingDb.cc
@@ -1,0 +1,217 @@
+
+#include "DQM/SiStripCommissioningDbClients/interface/NoiseHistosUsingDb.h"
+#include "CondFormats/SiStripObjects/interface/NoiseAnalysis.h"
+#include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFecKey.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFedKey.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <iostream>
+
+using namespace sistrip;
+
+// -----------------------------------------------------------------------------
+/** */
+NoiseHistosUsingDb::NoiseHistosUsingDb( const edm::ParameterSet & pset,
+                                        DQMStore* bei,
+                                        SiStripConfigDb* const db ) 
+  : CommissioningHistograms( pset.getParameter<edm::ParameterSet>("NoiseParameters"),
+                             bei,
+                             sistrip::NOISE ),
+    CommissioningHistosUsingDb( db,
+                                sistrip::NOISE ),
+    NoiseHistograms( pset.getParameter<edm::ParameterSet>("NoiseParameters"),
+                     bei )
+{
+  LogTrace(mlDqmClient_) 
+    << "[NoiseHistosUsingDb::" << __func__ << "]"
+    << " Constructing object...";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+NoiseHistosUsingDb::~NoiseHistosUsingDb() {
+  LogTrace(mlDqmClient_) 
+    << "[NoiseHistosUsingDb::" << __func__ << "]"
+    << " Destructing object...";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void NoiseHistosUsingDb::uploadConfigurations() {
+  LogTrace(mlDqmClient_) 
+    << "[NoiseHistosUsingDb::" << __func__ << "]";
+
+  if ( !db() ) {
+    edm::LogError(mlDqmClient_) 
+      << "[NoiseHistosUsingDb::" << __func__ << "]"
+      << " NULL pointer to SiStripConfigDb interface!"
+      << " Aborting upload...";
+    return;
+  }
+  
+  // Update FED descriptions with new peds/noise values
+  SiStripConfigDb::FedDescriptionsRange feds = db()->getFedDescriptions(); 
+  update( feds );
+  if ( doUploadConf() ) { 
+    edm::LogVerbatim(mlDqmClient_) 
+      << "[NoiseHistosUsingDb::" << __func__ << "]"
+      << " Uploading pedestals/noise to DB...";
+    db()->uploadFedDescriptions();
+    edm::LogVerbatim(mlDqmClient_) 
+      << "[NoiseHistosUsingDb::" << __func__ << "]"
+      << " Completed database upload of " << feds.size() 
+      << " FED descriptions!";
+  } else {
+    edm::LogWarning(mlDqmClient_) 
+      << "[NoiseHistosUsingDb::" << __func__ << "]"
+      << " TEST only! No pedestals/noise values will be uploaded to DB...";
+  }
+  
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void NoiseHistosUsingDb::update( SiStripConfigDb::FedDescriptionsRange feds ) {
+ 
+  // Iterate through feds and update fed descriptions
+  uint16_t updated = 0;
+  SiStripConfigDb::FedDescriptionsV::const_iterator ifed;
+  for ( ifed = feds.begin(); ifed != feds.end(); ifed++ ) {
+    
+    for ( uint16_t ichan = 0; ichan < sistrip::FEDCH_PER_FED; ichan++ ) {
+
+      // Build FED and FEC keys
+      const FedChannelConnection& conn = cabling()->connection( (*ifed)->getFedId(), ichan );
+      if ( conn.fecCrate() == sistrip::invalid_ ||
+	   conn.fecSlot() == sistrip::invalid_ ||
+	   conn.fecRing() == sistrip::invalid_ ||
+	   conn.ccuAddr() == sistrip::invalid_ ||
+	   conn.ccuChan() == sistrip::invalid_ ||
+	   conn.lldChannel() == sistrip::invalid_ ) { continue; }
+      SiStripFedKey fed_key( conn.fedId(), 
+			     SiStripFedKey::feUnit( conn.fedCh() ),
+			     SiStripFedKey::feChan( conn.fedCh() ) );
+      SiStripFecKey fec_key( conn.fecCrate(), 
+			     conn.fecSlot(), 
+			     conn.fecRing(), 
+			     conn.ccuAddr(), 
+			     conn.ccuChan(), 
+			     conn.lldChannel() );
+
+      // Locate appropriate analysis object 
+      Analyses::const_iterator iter = data().find( fec_key.key() );
+      if ( iter != data().end() ) {
+
+	// Check if analysis is valid
+	if ( !iter->second->isValid() ) { continue; }
+	
+	NoiseAnalysis* anal = dynamic_cast<NoiseAnalysis*>( iter->second );
+	if ( !anal ) { 
+	  edm::LogError(mlDqmClient_)
+	    << "[NoiseHistosUsingDb::" << __func__ << "]"
+	    << " NULL pointer to analysis object!";
+	  continue; 
+	}
+	
+	// Iterate through APVs and strips
+	for ( uint16_t iapv = 0; iapv < sistrip::APVS_PER_FEDCH; iapv++ ) {
+	  for ( uint16_t istr = 0; istr < anal->peds()[iapv].size(); istr++ ) { 
+	    
+	    constexpr float high_threshold = 5.;
+	    constexpr float low_threshold  = 2.;
+	    constexpr bool  disable_strip  = false;
+	    Fed9U::Fed9UStripDescription data( static_cast<uint32_t>( anal->peds()[iapv][istr] ), 
+					       high_threshold, 
+					       low_threshold, 
+					       anal->noise()[iapv][istr],
+					       disable_strip );
+	    Fed9U::Fed9UAddress addr( ichan, iapv, istr );
+	    (*ifed)->getFedStrips().setStrip( addr, data );
+	    
+	  }
+	}
+	updated++;
+      
+      } else {
+	edm::LogWarning(mlDqmClient_) 
+	  << "[NoiseHistosUsingDb::" << __func__ << "]"
+	  << " Unable to find pedestals/noise for FedKey/Id/Ch: " 
+	  << hex << setw(8) << setfill('0') << fed_key.key() << dec << "/"
+	  << (*ifed)->getFedId() << "/"
+	  << ichan
+	  << " and device with FEC/slot/ring/CCU/LLD " 
+	  << fec_key.fecCrate() << "/"
+	  << fec_key.fecSlot() << "/"
+	  << fec_key.fecRing() << "/"
+	  << fec_key.ccuAddr() << "/"
+	  << fec_key.ccuChan() << "/"
+	  << fec_key.channel();
+      }
+    }
+  }
+
+  edm::LogVerbatim(mlDqmClient_) 
+    << "[NoiseHistosUsingDb::" << __func__ << "]"
+    << " Updated FED pedestals/noise for " 
+    << updated << " channels";
+
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void NoiseHistosUsingDb::create( SiStripConfigDb::AnalysisDescriptionsV& desc,
+				 Analysis analysis ) {
+
+  NoiseAnalysis* anal = dynamic_cast<NoiseAnalysis*>( analysis->second );
+  if ( !anal ) { return; }
+  
+  SiStripFecKey fec_key( anal->fecKey() );
+  SiStripFedKey fed_key( anal->fedKey() );
+  
+  for ( uint16_t iapv = 0; iapv < 2; ++iapv ) {
+    
+    // Create description
+    PedestalsAnalysisDescription* tmp;
+    tmp = new PedestalsAnalysisDescription( anal->dead()[iapv],
+					    anal->noisy()[iapv],
+					    anal->pedsMean()[iapv],
+					    anal->pedsSpread()[iapv],
+					    anal->noiseMean()[iapv],
+					    anal->noiseSpread()[iapv],
+					    anal->rawMean()[iapv],
+					    anal->rawSpread()[iapv],
+					    anal->pedsMax()[iapv], 
+					    anal->pedsMin()[iapv], 
+					    anal->noiseMax()[iapv],
+					    anal->noiseMin()[iapv],
+					    anal->rawMax()[iapv],
+					    anal->rawMin()[iapv],
+					    fec_key.fecCrate(),
+					    fec_key.fecSlot(),
+					    fec_key.fecRing(),
+					    fec_key.ccuAddr(),
+					    fec_key.ccuChan(),
+					    SiStripFecKey::i2cAddr( fec_key.lldChan(), !iapv ), 
+					    db()->dbParams().partitions().begin()->second.partitionName(),
+					    db()->dbParams().partitions().begin()->second.runNumber(),
+					    anal->isValid(),
+					    "",
+					    fed_key.fedId(),
+					    fed_key.feUnit(),
+					    fed_key.feChan(),
+					    fed_key.fedApv() );
+    
+    // Add comments
+    typedef std::vector<std::string> Strings;
+    Strings errors = anal->getErrorCodes();
+    Strings::const_iterator istr = errors.begin();
+    Strings::const_iterator jstr = errors.end();
+    for ( ; istr != jstr; ++istr ) { tmp->addComments( *istr ); }
+
+    // Store description
+    desc.push_back( tmp );
+      
+  }
+
+}
+

--- a/DQM/SiStripCommissioningDbClients/src/OptoScanHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/OptoScanHistosUsingDb.cc
@@ -1,0 +1,237 @@
+
+#include "DQM/SiStripCommissioningDbClients/interface/OptoScanHistosUsingDb.h"
+#include "CondFormats/SiStripObjects/interface/OptoScanAnalysis.h"
+#include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFecKey.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <iostream>
+
+using namespace sistrip;
+
+// -----------------------------------------------------------------------------
+/** */
+OptoScanHistosUsingDb::OptoScanHistosUsingDb( const edm::ParameterSet & pset,
+                                              DQMStore* bei,
+                                              SiStripConfigDb* const db ) 
+  : CommissioningHistograms( pset.getParameter<edm::ParameterSet>("OptoScanParameters"),
+                             bei,
+                             sistrip::OPTO_SCAN ),
+    CommissioningHistosUsingDb( db,
+                                sistrip::OPTO_SCAN ),
+    OptoScanHistograms( pset.getParameter<edm::ParameterSet>("OptoScanParameters"),
+                        bei )
+{
+  LogTrace(mlDqmClient_) 
+    << "[OptoScanHistosUsingDb::" << __func__ << "]"
+    << " Constructing object...";
+  skipGainUpdate_ = this->pset().getParameter<bool>("SkipGainUpdate");
+  if (skipGainUpdate_)
+    LogTrace(mlDqmClient_)
+      << "[OptoScanHistosUsingDb::" << __func__ << "]"
+      << " Skipping db update of gain parameters.";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+OptoScanHistosUsingDb::~OptoScanHistosUsingDb() {
+  LogTrace(mlDqmClient_) 
+    << "[OptoScanHistosUsingDb::" << __func__ << "]"
+    << " Destructing object...";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void OptoScanHistosUsingDb::uploadConfigurations() {
+  LogTrace(mlDqmClient_) 
+    << "[OptoScanHistosUsingDb::" << __func__ << "]";
+
+  if ( !db() ) {
+    edm::LogError(mlDqmClient_) 
+      << "[OptoScanHistosUsingDb::" << __func__ << "]"
+      << " NULL pointer to SiStripConfigDb interface!"
+      << " Aborting upload...";
+    return;
+  }
+  
+  // Update LLD descriptions with new bias/gain settings
+  SiStripConfigDb::DeviceDescriptionsRange devices = db()->getDeviceDescriptions( LASERDRIVER ); 
+  update( devices );
+  if ( doUploadConf() ) { 
+    edm::LogVerbatim(mlDqmClient_) 
+      << "[OptoScanHistosUsingDb::" << __func__ << "]"
+      << " Uploading LLD settings to DB...";
+    db()->uploadDeviceDescriptions(); 
+    edm::LogVerbatim(mlDqmClient_) 
+      << "[OptoScanHistosUsingDb::" << __func__ << "]"
+      << " Upload of LLD settings to DB finished!";
+  } else {
+    edm::LogWarning(mlDqmClient_) 
+      << "[OptoScanHistosUsingDb::" << __func__ << "]"
+      << " TEST only! No LLD settings will be uploaded to DB...";
+  }
+  
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void OptoScanHistosUsingDb::update( SiStripConfigDb::DeviceDescriptionsRange devices ) {
+  
+  // Iterate through devices and update device descriptions
+  uint16_t updated = 0;
+  SiStripConfigDb::DeviceDescriptionsV::const_iterator idevice;
+  for ( idevice = devices.begin(); idevice != devices.end(); idevice++ ) {
+    
+    if ( (*idevice)->getDeviceType() != LASERDRIVER ) { continue; }
+
+    // Cast to retrieve appropriate description object
+    laserdriverDescription* desc = dynamic_cast<laserdriverDescription*>( *idevice );
+    if ( !desc ) { continue; }
+    
+    // Retrieve device addresses from device description
+    const SiStripConfigDb::DeviceAddress& addr = db()->deviceAddress(*desc);
+    
+    // Iterate through LLD channels
+    for ( uint16_t ichan = 0; ichan < sistrip::CHANS_PER_LLD; ichan++ ) {
+      
+      // Construct key from device description
+      SiStripFecKey fec_key( addr.fecCrate_, 
+			     addr.fecSlot_, 
+			     addr.fecRing_, 
+			     addr.ccuAddr_, 
+			     addr.ccuChan_,
+			     ichan+1 );
+      
+      // Iterate through all channels and extract LLD settings 
+      Analyses::const_iterator iter = data().find( fec_key.key() );
+      if ( iter != data().end() ) {
+
+	OptoScanAnalysis* anal = dynamic_cast<OptoScanAnalysis*>( iter->second );
+	if ( !anal ) { 
+	  edm::LogError(mlDqmClient_)
+	    << "[OptoScanHistosUsingDb::" << __func__ << "]"
+	    << " NULL pointer to analysis object!";	
+	  continue; 
+	}
+	
+	uint16_t gain = anal->gain();
+	std::stringstream ss;
+	ss << "[OptoScanHistosUsingDb::" << __func__ << "]"
+	   << " Updating LLD gain/bias settings for crate/crate/FEC/ring/CCU/module/LLD "
+	   << fec_key.fecCrate() << "/"
+	   << fec_key.fecSlot() << "/"
+	   << fec_key.fecRing() << "/"
+	   << fec_key.ccuAddr() << "/"
+	   << fec_key.ccuChan() << "/"
+	   << fec_key.channel() 
+	   << " from "
+	   << static_cast<uint16_t>( desc->getGain(ichan) ) << "/" 
+	   << static_cast<uint16_t>( desc->getBias(ichan) );
+        if (!skipGainUpdate_) desc->setGain( ichan, gain );
+        desc->setBias( ichan, anal->bias()[gain] );
+	updated++;
+	ss << " to "
+	   << static_cast<uint16_t>(desc->getGain(ichan)) << "/" 
+	   << static_cast<uint16_t>(desc->getBias(ichan));
+	LogTrace(mlDqmClient_) << ss.str();
+	
+      } else {
+	if ( deviceIsPresent(fec_key) ) { 
+	  edm::LogWarning(mlDqmClient_) 
+	    << "[OptoScanHistosUsingDb::" << __func__ << "]"
+	    << " Unable to find FEC key with params crate/FEC/ring/CCU/module/LLD " 
+	    << fec_key.fecCrate() << "/"
+	    << fec_key.fecSlot() << "/"
+	    << fec_key.fecRing() << "/"
+	    << fec_key.ccuAddr() << "/"
+	    << fec_key.ccuChan() << "/"
+	    << fec_key.channel();
+	}
+      }
+    }
+  }
+
+  edm::LogVerbatim(mlDqmClient_) 
+    << "[OptoScanHistosUsingDb::" << __func__ << "]"
+    << " Updated LLD bias/gain settings for " 
+    << updated << " modules";
+  
+
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void OptoScanHistosUsingDb::create( SiStripConfigDb::AnalysisDescriptionsV& desc,
+				    Analysis analysis ) {
+
+  OptoScanAnalysis* anal = dynamic_cast<OptoScanAnalysis*>( analysis->second );
+  if ( !anal ) { return; }
+  
+  SiStripFecKey fec_key( anal->fecKey() ); 
+  SiStripFedKey fed_key( anal->fedKey() );
+
+  for ( uint16_t iapv = 0; iapv < 2; ++iapv ) {
+
+    // Create description
+    OptoScanAnalysisDescription* tmp;
+    tmp = new OptoScanAnalysisDescription( anal->baseSlope()[0],
+                                           anal->baseSlope()[1],
+                                           anal->baseSlope()[2],
+                                           anal->baseSlope()[3],
+                                           anal->gain(),
+					   anal->bias()[0],
+					   anal->bias()[1],
+					   anal->bias()[2],
+					   anal->bias()[3],
+					   anal->measGain()[0],
+					   anal->measGain()[1],
+					   anal->measGain()[2],
+					   anal->measGain()[3],
+					   anal->zeroLight()[0],
+					   anal->zeroLight()[1],
+					   anal->zeroLight()[2],
+					   anal->zeroLight()[3],
+					   anal->linkNoise()[0],
+					   anal->linkNoise()[1],
+					   anal->linkNoise()[2],
+					   anal->linkNoise()[3],
+					   anal->liftOff()[0],
+					   anal->liftOff()[1],
+					   anal->liftOff()[2],
+					   anal->liftOff()[3],
+					   anal->threshold()[0],
+					   anal->threshold()[1],
+					   anal->threshold()[2],
+					   anal->threshold()[3],
+					   anal->tickHeight()[0],
+					   anal->tickHeight()[1],
+					   anal->tickHeight()[2],
+					   anal->tickHeight()[3],
+					   fec_key.fecCrate(),
+					   fec_key.fecSlot(),
+					   fec_key.fecRing(),
+					   fec_key.ccuAddr(),
+					   fec_key.ccuChan(),
+					   SiStripFecKey::i2cAddr( fec_key.lldChan(), !iapv ), 
+					   db()->dbParams().partitions().begin()->second.partitionName(),
+					   db()->dbParams().partitions().begin()->second.runNumber(),
+					   anal->isValid(),
+					   "",
+					   fed_key.fedId(),
+					   fed_key.feUnit(),
+					   fed_key.feChan(),
+					   fed_key.fedApv() );
+    
+    // Add comments
+    typedef std::vector<std::string> Strings;
+    Strings errors = anal->getErrorCodes();
+    Strings::const_iterator istr = errors.begin();
+    Strings::const_iterator jstr = errors.end();
+    for ( ; istr != jstr; ++istr ) { tmp->addComments( *istr ); }
+    
+    // Store description
+    desc.push_back( tmp );
+    
+  }
+
+}
+

--- a/DQM/SiStripCommissioningDbClients/src/PedestalsHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/PedestalsHistosUsingDb.cc
@@ -1,0 +1,280 @@
+
+#include "DQM/SiStripCommissioningDbClients/interface/PedestalsHistosUsingDb.h"
+#include "CondFormats/SiStripObjects/interface/PedestalsAnalysis.h"
+#include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFecKey.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFedKey.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <iostream>
+
+using namespace sistrip;
+
+// -----------------------------------------------------------------------------
+/** */
+PedestalsHistosUsingDb::PedestalsHistosUsingDb( const edm::ParameterSet & pset,
+                                                DQMStore* bei,
+                                                SiStripConfigDb* const db ) 
+  : CommissioningHistograms( pset.getParameter<edm::ParameterSet>("PedestalsParameters"),
+                             bei,
+                             sistrip::PEDESTALS ),
+    CommissioningHistosUsingDb( db,
+                                sistrip::PEDESTALS ),
+    PedestalsHistograms( pset.getParameter<edm::ParameterSet>("PedestalsParameters"),
+                         bei )
+{
+  LogTrace(mlDqmClient_) 
+    << "[PedestalsHistosUsingDb::" << __func__ << "]"
+    << " Constructing object...";
+  highThreshold_ = this->pset().getParameter<double>("HighThreshold");
+  lowThreshold_ = this->pset().getParameter<double>("LowThreshold");
+  LogTrace(mlDqmClient_)
+    << "[PedestalsHistosUsingDb::" << __func__ << "]"
+    << " Set FED zero suppression high/low threshold to "
+    << highThreshold_ << "/" << lowThreshold_;
+  disableBadStrips_ = this->pset().getParameter<bool>("DisableBadStrips");
+  keepStripsDisabled_ = this->pset().getParameter<bool>("KeepStripsDisabled");
+  LogTrace(mlDqmClient_)
+    << "[PedestalsHistosUsingDb::" << __func__ << "]"
+    << " Disabling strips: " << disableBadStrips_
+    << " ; keeping previously disabled strips: " << keepStripsDisabled_;
+}
+
+// -----------------------------------------------------------------------------
+/** */
+PedestalsHistosUsingDb::~PedestalsHistosUsingDb() {
+  LogTrace(mlDqmClient_) 
+    << "[PedestalsHistosUsingDb::" << __func__ << "]"
+    << " Destructing object...";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void PedestalsHistosUsingDb::uploadConfigurations() {
+  LogTrace(mlDqmClient_) 
+    << "[PedestalsHistosUsingDb::" << __func__ << "]";
+
+  if ( !db() ) {
+    edm::LogError(mlDqmClient_) 
+      << "[PedestalsHistosUsingDb::" << __func__ << "]"
+      << " NULL pointer to SiStripConfigDb interface!"
+      << " Aborting upload...";
+    return;
+  }
+  
+  // Update FED descriptions with new peds/noise values
+  SiStripConfigDb::FedDescriptionsRange feds = db()->getFedDescriptions(); 
+  update( feds );
+  if ( doUploadConf() ) { 
+    edm::LogVerbatim(mlDqmClient_) 
+      << "[PedestalsHistosUsingDb::" << __func__ << "]"
+      << " Uploading pedestals/noise to DB...";
+    db()->uploadFedDescriptions();
+    edm::LogVerbatim(mlDqmClient_) 
+      << "[PedestalsHistosUsingDb::" << __func__ << "]"
+      << " Completed database upload of " << feds.size() 
+      << " FED descriptions!";
+  } else {
+    edm::LogWarning(mlDqmClient_) 
+      << "[PedestalsHistosUsingDb::" << __func__ << "]"
+      << " TEST! No pedestals/noise values will be uploaded to DB...";
+  }
+  
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void PedestalsHistosUsingDb::update( SiStripConfigDb::FedDescriptionsRange feds ) {
+ 
+  // Iterate through feds and update fed descriptions
+  uint16_t updated = 0;
+  SiStripConfigDb::FedDescriptionsV::const_iterator ifed;
+  for ( ifed = feds.begin(); ifed != feds.end(); ifed++ ) {
+    
+    for ( uint16_t ichan = 0; ichan < sistrip::FEDCH_PER_FED; ichan++ ) {
+
+      // Build FED and FEC keys
+      const FedChannelConnection& conn = cabling()->connection( (*ifed)->getFedId(), ichan );
+      if ( conn.fecCrate() == sistrip::invalid_ ||
+           conn.fecSlot() == sistrip::invalid_ ||
+           conn.fecRing() == sistrip::invalid_ ||
+           conn.ccuAddr() == sistrip::invalid_ ||
+           conn.ccuChan() == sistrip::invalid_ ||
+           conn.lldChannel() == sistrip::invalid_ ) { continue; }
+      SiStripFedKey fed_key( conn.fedId(), 
+                             SiStripFedKey::feUnit( conn.fedCh() ),
+                             SiStripFedKey::feChan( conn.fedCh() ) );
+      SiStripFecKey fec_key( conn.fecCrate(), 
+                             conn.fecSlot(), 
+                             conn.fecRing(), 
+                             conn.ccuAddr(), 
+                             conn.ccuChan(), 
+                             conn.lldChannel() );
+
+      // Locate appropriate analysis object 
+      Analyses::const_iterator iter = data().find( fec_key.key() );
+      if ( iter != data().end() ) {
+
+         PedestalsAnalysis* anal = dynamic_cast<PedestalsAnalysis*>( iter->second );
+         if ( !anal ) { 
+           edm::LogError(mlDqmClient_)
+             << "[PedestalsHistosUsingDb::" << __func__ << "]"
+             << " NULL pointer to analysis object!";
+           continue; 
+         }
+
+        // Determine the pedestal shift to apply
+        uint32_t pedshift = 127;
+        for ( uint16_t iapv = 0; iapv < sistrip::APVS_PER_FEDCH; iapv++ ) {
+          uint32_t pedmin = (uint32_t) anal->pedsMin()[iapv];
+          pedshift = pedmin < pedshift ? pedmin : pedshift;
+        }
+
+        // Iterate through APVs and strips
+        for ( uint16_t iapv = 0; iapv < sistrip::APVS_PER_FEDCH; iapv++ ) {
+          for ( uint16_t istr = 0; istr < anal->peds()[iapv].size(); istr++ ) { 
+
+            // get the information on the strip as it was on the db
+            Fed9U::Fed9UAddress addr( ichan, iapv, istr );
+            Fed9U::Fed9UStripDescription temp = (*ifed)->getFedStrips().getStrip( addr );
+
+            // determine whether we need to disable the strip
+            bool disableStrip = false;
+            if ( keepStripsDisabled_ ) {
+              disableStrip = temp.getDisable();
+            } else if (disableBadStrips_) {
+              PedestalsAnalysis::VInt dead = anal->dead()[iapv];
+              if ( find( dead.begin(), dead.end(), istr ) != dead.end() ) disableStrip = true;
+              PedestalsAnalysis::VInt noisy = anal->noisy()[iapv];
+              if ( find( noisy.begin(), noisy.end(), istr ) != noisy.end() ) disableStrip = true;
+            }
+
+            Fed9U::Fed9UStripDescription data( static_cast<uint32_t>( anal->peds()[iapv][istr]-pedshift ),
+                                               highThreshold_,
+                                               lowThreshold_,
+                                               anal->noise()[iapv][istr],
+                                               disableStrip );
+
+            std::stringstream ss;
+            if ( data.getDisable() && edm::isDebugEnabled() ) {
+              ss << "[PedestalsHistosUsingDb::" << __func__ << "]"
+                 << " Disabling strip in Fed9UStripDescription object..." << std::endl
+                 << " for FED id/channel and APV/strip : "
+                 << fed_key.fedId() << "/"
+                 << fed_key.fedChannel() << " "
+                 << iapv << "/"
+                 << istr << std::endl 
+                 << " and crate/FEC/ring/CCU/module    : "
+                 << fec_key.fecCrate() << "/"
+                 << fec_key.fecSlot() << "/"
+                 << fec_key.fecRing() << "/"
+                 << fec_key.ccuAddr() << "/"
+                 << fec_key.ccuChan() << std::endl 
+                 << " from ped/noise/high/low/disable  : "
+                 << static_cast<uint16_t>( temp.getPedestal() ) << "/" 
+                 << static_cast<uint16_t>( temp.getHighThreshold() ) << "/" 
+                 << static_cast<uint16_t>( temp.getLowThreshold() ) << "/" 
+                 << static_cast<uint16_t>( temp.getNoise() ) << "/" 
+                 << static_cast<uint16_t>( temp.getDisable() ) << std::endl;
+            }
+            (*ifed)->getFedStrips().setStrip( addr, data );
+            if ( data.getDisable() && edm::isDebugEnabled() ) {
+              ss << " to ped/noise/high/low/disable    : "
+                 << static_cast<uint16_t>( data.getPedestal() ) << "/" 
+                 << static_cast<uint16_t>( data.getHighThreshold() ) << "/" 
+                 << static_cast<uint16_t>( data.getLowThreshold() ) << "/" 
+                 << static_cast<uint16_t>( data.getNoise() ) << "/" 
+                 << static_cast<uint16_t>( data.getDisable() ) << std::endl;
+              LogTrace(mlDqmClient_) << ss.str();
+            }
+    
+          } // end loop on strips
+        } // end loop on apvs
+        updated++;
+      
+      } else {
+        if ( deviceIsPresent(fec_key) ) {
+          edm::LogWarning(mlDqmClient_) 
+            << "[PedestalsHistosUsingDb::" << __func__ << "]"
+            << " Unable to find pedestals/noise for FedKey/Id/Ch: " 
+            << hex << setw(8) << setfill('0') << fed_key.key() << dec << "/"
+            << (*ifed)->getFedId() << "/"
+            << ichan
+            << " and device with FEC/slot/ring/CCU/LLD " 
+            << fec_key.fecCrate() << "/"
+            << fec_key.fecSlot() << "/"
+            << fec_key.fecRing() << "/"
+            << fec_key.ccuAddr() << "/"
+            << fec_key.ccuChan() << "/"
+            << fec_key.channel();
+        }
+      }
+    }
+  }
+  
+  edm::LogVerbatim(mlDqmClient_) 
+    << "[PedestalsHistosUsingDb::" << __func__ << "]"
+    << " Updated FED pedestals/noise for " 
+    << updated << " channels";
+
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void PedestalsHistosUsingDb::create( SiStripConfigDb::AnalysisDescriptionsV& desc,
+                                     Analysis analysis ) {
+
+  PedestalsAnalysis* anal = dynamic_cast<PedestalsAnalysis*>( analysis->second );
+  if ( !anal ) { return; }
+  
+  SiStripFecKey fec_key( anal->fecKey() );
+  SiStripFedKey fed_key( anal->fedKey() );
+  
+  for ( uint16_t iapv = 0; iapv < 2; ++iapv ) {
+    
+    // Create description
+    PedestalsAnalysisDescription* tmp;
+    tmp = new PedestalsAnalysisDescription( 
+      anal->dead()[iapv],
+      anal->noisy()[iapv],
+      anal->pedsMean()[iapv],
+      anal->pedsSpread()[iapv],
+      anal->noiseMean()[iapv],
+      anal->noiseSpread()[iapv],
+      anal->rawMean()[iapv],
+      anal->rawSpread()[iapv],
+      anal->pedsMax()[iapv], 
+      anal->pedsMin()[iapv], 
+      anal->noiseMax()[iapv],
+      anal->noiseMin()[iapv],
+      anal->rawMax()[iapv],
+      anal->rawMin()[iapv],
+      fec_key.fecCrate(),
+      fec_key.fecSlot(),
+      fec_key.fecRing(),
+      fec_key.ccuAddr(),
+      fec_key.ccuChan(),
+      SiStripFecKey::i2cAddr( fec_key.lldChan(), !iapv ), 
+      db()->dbParams().partitions().begin()->second.partitionName(),
+      db()->dbParams().partitions().begin()->second.runNumber(),
+      anal->isValid(),
+      "",
+      fed_key.fedId(),
+      fed_key.feUnit(),
+      fed_key.feChan(),
+      fed_key.fedApv()
+    );
+    
+    // Add comments
+    typedef std::vector<std::string> Strings;
+    Strings errors = anal->getErrorCodes();
+    Strings::const_iterator istr = errors.begin();
+    Strings::const_iterator jstr = errors.end();
+    for ( ; istr != jstr; ++istr ) { tmp->addComments( *istr ); }
+
+    // Store description
+    desc.push_back( tmp );
+      
+  }
+
+}
+

--- a/DQM/SiStripCommissioningDbClients/src/PedsFullNoiseHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/PedsFullNoiseHistosUsingDb.cc
@@ -1,0 +1,334 @@
+
+#include "DQM/SiStripCommissioningDbClients/interface/PedsFullNoiseHistosUsingDb.h"
+#include "CondFormats/SiStripObjects/interface/PedsFullNoiseAnalysis.h"
+#include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFecKey.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFedKey.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <iostream>
+
+using namespace sistrip;
+
+// -----------------------------------------------------------------------------
+/** */
+PedsFullNoiseHistosUsingDb::PedsFullNoiseHistosUsingDb( const edm::ParameterSet & pset,
+                                                        DQMStore* bei,
+                                                        SiStripConfigDb* const db ) 
+  : CommissioningHistograms( pset.getParameter<edm::ParameterSet>("PedsFullNoiseParameters"),
+                             bei,
+                             sistrip::PEDS_FULL_NOISE ),
+    CommissioningHistosUsingDb( db,
+                                sistrip::PEDS_FULL_NOISE ),
+    PedsFullNoiseHistograms( pset.getParameter<edm::ParameterSet>("PedsFullNoiseParameters"),
+                             bei )
+{
+    LogTrace(mlDqmClient_) 
+    << "[PedsFullNoiseHistosUsingDb::" << __func__ << "]"
+    << " Constructing object...";
+  highThreshold_ = this->pset().getParameter<double>("HighThreshold");
+  lowThreshold_ = this->pset().getParameter<double>("LowThreshold");
+  LogTrace(mlDqmClient_)
+    << "[PedsFullNoiseHistosUsingDb::" << __func__ << "]"
+    << " Set FED zero suppression high/low threshold to "
+    << highThreshold_ << "/" << lowThreshold_;
+  disableBadStrips_ = this->pset().getParameter<bool>("DisableBadStrips");
+  keepStripsDisabled_ = this->pset().getParameter<bool>("KeepStripsDisabled");
+  addBadStrips_ = this->pset().getParameter<bool>("AddBadStrips");
+  LogTrace(mlDqmClient_)
+    << "[PedestalsHistosUsingDb::" << __func__ << "]"
+    << " Disabling strips: " << disableBadStrips_
+    << " ; keeping previously disabled strips: " << keepStripsDisabled_;
+}
+
+// -----------------------------------------------------------------------------
+/** */
+PedsFullNoiseHistosUsingDb::~PedsFullNoiseHistosUsingDb() {
+  LogTrace(mlDqmClient_) 
+    << "[PedsFullNoiseHistosUsingDb::" << __func__ << "]"
+    << " Destructing object...";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void PedsFullNoiseHistosUsingDb::uploadConfigurations() {
+  LogTrace(mlDqmClient_) 
+    << "[PedsFullNoiseHistosUsingDb::" << __func__ << "]";
+
+  if ( !db() ) {
+    edm::LogError(mlDqmClient_) 
+      << "[PedsFullNoiseHistosUsingDb::" << __func__ << "]"
+      << " NULL pointer to SiStripConfigDb interface!"
+      << " Aborting upload...";
+    return;
+  }
+  
+  // Update FED descriptions with new peds/noise values
+  SiStripConfigDb::FedDescriptionsRange feds = db()->getFedDescriptions(); 
+  update( feds );
+  if ( doUploadConf() ) { 
+    edm::LogVerbatim(mlDqmClient_) 
+      << "[PedsFullNoiseHistosUsingDb::" << __func__ << "]"
+      << " Uploading pedestals/noise to DB...";
+    db()->uploadFedDescriptions();
+    edm::LogVerbatim(mlDqmClient_) 
+      << "[PedsFullNoiseHistosUsingDb::" << __func__ << "]"
+      << " Completed database upload of " << feds.size() 
+      << " FED descriptions!";
+  } else {
+    edm::LogWarning(mlDqmClient_) 
+      << "[PedsFullNoiseHistosUsingDb::" << __func__ << "]"
+      << " TEST! No pedestals/noise values will be uploaded to DB...";
+  }
+  
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void PedsFullNoiseHistosUsingDb::update( SiStripConfigDb::FedDescriptionsRange feds ) {
+ 
+  // Iterate through feds and update fed descriptions
+  uint16_t updated = 0;
+  SiStripConfigDb::FedDescriptionsV::const_iterator ifed;
+  for ( ifed = feds.begin(); ifed != feds.end(); ifed++ ) {
+    
+    for ( uint16_t ichan = 0; ichan < sistrip::FEDCH_PER_FED; ichan++ ) {
+
+      // Build FED and FEC keys
+      const FedChannelConnection& conn = cabling()->connection( (*ifed)->getFedId(), ichan );
+      if ( conn.fecCrate()== sistrip::invalid_ ||
+           conn.fecSlot() == sistrip::invalid_ ||
+           conn.fecRing() == sistrip::invalid_ ||
+           conn.ccuAddr() == sistrip::invalid_ ||
+           conn.ccuChan() == sistrip::invalid_ ||
+           conn.lldChannel() == sistrip::invalid_ ) { continue; }
+           
+      SiStripFedKey fed_key( conn.fedId(), 
+                             SiStripFedKey::feUnit( conn.fedCh() ),
+                             SiStripFedKey::feChan( conn.fedCh() ) );
+      SiStripFecKey fec_key( conn.fecCrate(),
+                             conn.fecSlot(),
+                             conn.fecRing(),
+                             conn.ccuAddr(),
+                             conn.ccuChan(),
+                             conn.lldChannel() );
+
+      // Locate appropriate analysis object 
+      Analyses::const_iterator iter = data().find( fec_key.key() );
+      if ( iter != data().end() ) {
+      
+        PedsFullNoiseAnalysis* anal = dynamic_cast<PedsFullNoiseAnalysis*>( iter->second );
+        if ( !anal ) { 
+          edm::LogError(mlDqmClient_)
+            << "[PedsFullNoiseHistosUsingDb::" << __func__ << "]"
+            << " NULL pointer to analysis object!";
+          continue; 
+        }
+
+        // Determine the pedestal shift to apply
+        uint32_t pedshift = 127;
+        for ( uint16_t iapv = 0; iapv < sistrip::APVS_PER_FEDCH; iapv++ ) {
+          uint32_t pedmin = (uint32_t) anal->pedsMin()[iapv];
+          pedshift = pedmin < pedshift ? pedmin : pedshift;
+        }
+
+        // Iterate through APVs and strips
+        for ( uint16_t iapv = 0; iapv < sistrip::APVS_PER_FEDCH; iapv++ ) {
+          for ( uint16_t istr = 0; istr < anal->peds()[iapv].size(); istr++ ) { 
+
+            // get the information on the strip as it was on the db
+            Fed9U::Fed9UAddress addr( ichan, iapv, istr );
+            Fed9U::Fed9UStripDescription temp = (*ifed)->getFedStrips().getStrip( addr );
+						if(temp.getDisable()) {
+            	std::cout<<"Already Disabled: "<<conn.fecCrate()
+							<<" "<<conn.fecSlot()
+							<<" "<<conn.fecRing()
+							<<" "<<conn.ccuAddr()
+							<<" "<<conn.ccuChan()
+							<<" "<<conn.lldChannel()
+              <<" "<<iapv*128+istr<<std::endl;
+            }
+            // determine whether we need to disable the strip
+            bool disableStrip = false;
+            if ( addBadStrips_ ) {
+              disableStrip = temp.getDisable();
+              SiStripFedKey fed_key(anal->fedKey());              
+              if(!disableStrip){
+              	PedsFullNoiseAnalysis::VInt dead = anal->dead()[iapv];
+              	if ( find( dead.begin(), dead.end(), istr ) != dead.end() ) {
+                	disableStrip = true;
+                  std::cout<<"Disabling Dead: "<<conn.fecCrate()
+									<<" "<<conn.fecSlot()
+									<<" "<<conn.fecRing()
+									<<" "<<conn.ccuAddr()
+									<<" "<<conn.ccuChan()
+									<<" "<<conn.lldChannel()
+              		<<" "<<iapv*128+istr<<std::endl;
+                }
+              	PedsFullNoiseAnalysis::VInt noisy = anal->noisy()[iapv];
+              	if ( find( noisy.begin(), noisy.end(), istr ) != noisy.end() ) {
+                	disableStrip = true;
+                  std::cout<<"Disabling Noisy: "<<conn.fecCrate()
+									<<" "<<conn.fecSlot()
+									<<" "<<conn.fecRing()
+									<<" "<<conn.ccuAddr()
+									<<" "<<conn.ccuChan()
+									<<" "<<conn.lldChannel()
+              		<<" "<<iapv*128+istr<<std::endl;
+                }
+              }
+            } else if ( keepStripsDisabled_ ) {
+              disableStrip = temp.getDisable();
+            } else if (disableBadStrips_) {
+              PedsFullNoiseAnalysis::VInt dead = anal->dead()[iapv];
+              if ( find( dead.begin(), dead.end(), istr ) != dead.end() ) {
+              	disableStrip = true;              
+                std::cout<<"Disabling Dead: "<<conn.fecCrate()
+								<<" "<<conn.fecSlot()
+								<<" "<<conn.fecRing()
+								<<" "<<conn.ccuAddr()
+								<<" "<<conn.ccuChan()
+								<<" "<<conn.lldChannel()
+              	<<" "<<iapv*128+istr<<std::endl;
+              }
+              PedsFullNoiseAnalysis::VInt noisy = anal->noisy()[iapv];
+              if ( find( noisy.begin(), noisy.end(), istr ) != noisy.end() ) {
+              	disableStrip = true;                
+                std::cout<<"Disabling Noisy: "<<conn.fecCrate()
+								<<" "<<conn.fecSlot()
+								<<" "<<conn.fecRing()
+								<<" "<<conn.ccuAddr()
+								<<" "<<conn.ccuChan()
+								<<" "<<conn.lldChannel()
+              	<<" "<<iapv*128+istr<<std::endl;
+              }
+            }
+
+            Fed9U::Fed9UStripDescription data( static_cast<uint32_t>( anal->peds()[iapv][istr]-pedshift ),
+                                               highThreshold_,
+                                               lowThreshold_,
+                                               anal->noise()[iapv][istr],
+                                               disableStrip );
+
+            std::stringstream ss;
+            if ( data.getDisable() && edm::isDebugEnabled() ) {
+              ss << "[PedsFullNoiseHistosUsingDb::" << __func__ << "]"
+                 << " Disabling strip in Fed9UStripDescription object..." << std::endl
+                 << " for FED id/channel and APV/strip : "
+                 << fed_key.fedId() << "/"
+                 << fed_key.fedChannel() << " "
+                 << iapv << "/"
+                 << istr << std::endl 
+                 << " and crate/FEC/ring/CCU/module    : "
+                 << fec_key.fecCrate() << "/"
+                 << fec_key.fecSlot() << "/"
+                 << fec_key.fecRing() << "/"
+                 << fec_key.ccuAddr() << "/"
+                 << fec_key.ccuChan() << std::endl 
+                 << " from ped/noise/high/low/disable  : "
+                 << static_cast<uint16_t>( temp.getPedestal() ) << "/" 
+                 << static_cast<uint16_t>( temp.getHighThreshold() ) << "/" 
+                 << static_cast<uint16_t>( temp.getLowThreshold() ) << "/" 
+                 << static_cast<uint16_t>( temp.getNoise() ) << "/" 
+                 << static_cast<uint16_t>( temp.getDisable() ) << std::endl;
+            }
+            (*ifed)->getFedStrips().setStrip( addr, data );
+            if ( data.getDisable() && edm::isDebugEnabled() ) {
+              ss << " to ped/noise/high/low/disable    : "
+                 << static_cast<uint16_t>( data.getPedestal() ) << "/" 
+                 << static_cast<uint16_t>( data.getHighThreshold() ) << "/" 
+                 << static_cast<uint16_t>( data.getLowThreshold() ) << "/" 
+                 << static_cast<uint16_t>( data.getNoise() ) << "/" 
+                 << static_cast<uint16_t>( data.getDisable() ) << std::endl;
+              LogTrace(mlDqmClient_) << ss.str();
+            }
+
+          } // end loop on strips
+        } // end loop on apvs
+        updated++;
+
+      } else {
+        if ( deviceIsPresent(fec_key) ) {
+          edm::LogWarning(mlDqmClient_) 
+            << "[PedsFullNoiseHistosUsingDb::" << __func__ << "]"
+            << " Unable to find pedestals/noise for FedKey/Id/Ch: " 
+            << hex << setw(8) << setfill('0') << fed_key.key() << dec << "/"
+            << (*ifed)->getFedId() << "/"
+            << ichan
+            << " and device with FEC/slot/ring/CCU/LLD " 
+            << fec_key.fecCrate() << "/"
+            << fec_key.fecSlot() << "/"
+            << fec_key.fecRing() << "/"
+            << fec_key.ccuAddr() << "/"
+            << fec_key.ccuChan() << "/"
+            << fec_key.channel();
+        }
+      }
+    }
+  }
+  
+  edm::LogVerbatim(mlDqmClient_) 
+    << "[PedsFullNoiseHistosUsingDb::" << __func__ << "]"
+    << " Updated FED pedestals/noise for " 
+    << updated << " channels";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void PedsFullNoiseHistosUsingDb::create( SiStripConfigDb::AnalysisDescriptionsV& desc,
+                                         Analysis analysis ) {
+
+  PedsFullNoiseAnalysis* anal = dynamic_cast<PedsFullNoiseAnalysis*>( analysis->second );
+  if ( !anal ) { return; }
+  
+  SiStripFecKey fec_key( anal->fecKey() );
+  SiStripFedKey fed_key( anal->fedKey() );
+  
+  for ( uint16_t iapv = 0; iapv < 2; ++iapv ) {
+    
+    // Create description
+    PedestalsAnalysisDescription* tmp;
+    tmp = new PedestalsAnalysisDescription(
+      anal->dead()[iapv],
+      anal->noisy()[iapv],
+      anal->pedsMean()[iapv],
+      anal->pedsSpread()[iapv],
+      anal->noiseMean()[iapv],
+      anal->noiseSpread()[iapv],
+      anal->rawMean()[iapv],
+      anal->rawSpread()[iapv],
+      anal->pedsMax()[iapv], 
+      anal->pedsMin()[iapv], 
+      anal->noiseMax()[iapv],
+      anal->noiseMin()[iapv],
+      anal->rawMax()[iapv],
+      anal->rawMin()[iapv],
+      fec_key.fecCrate(),
+      fec_key.fecSlot(),
+      fec_key.fecRing(),
+      fec_key.ccuAddr(),
+      fec_key.ccuChan(),
+      SiStripFecKey::i2cAddr( fec_key.lldChan(), !iapv ), 
+      db()->dbParams().partitions().begin()->second.partitionName(),
+      db()->dbParams().partitions().begin()->second.runNumber(),
+      anal->isValid(),
+      "",
+      fed_key.fedId(),
+      fed_key.feUnit(),
+      fed_key.feChan(),
+      fed_key.fedApv()
+    );
+    
+    // Add comments
+    typedef std::vector<std::string> Strings;
+    Strings errors = anal->getErrorCodes();
+    Strings::const_iterator istr = errors.begin();
+    Strings::const_iterator jstr = errors.end();
+    for ( ; istr != jstr; ++istr ) { tmp->addComments( *istr ); }
+
+    // Store description
+    desc.push_back( tmp );
+      
+  }
+
+}
+

--- a/DQM/SiStripCommissioningDbClients/src/PedsOnlyHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/PedsOnlyHistosUsingDb.cc
@@ -1,0 +1,224 @@
+
+#include "DQM/SiStripCommissioningDbClients/interface/PedsOnlyHistosUsingDb.h"
+#include "CondFormats/SiStripObjects/interface/PedsOnlyAnalysis.h"
+#include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFecKey.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFedKey.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <iostream>
+
+using namespace sistrip;
+
+// -----------------------------------------------------------------------------
+/** */
+PedsOnlyHistosUsingDb::PedsOnlyHistosUsingDb( const edm::ParameterSet & pset,
+                                              DQMStore* bei,
+                                              SiStripConfigDb* const db ) 
+  : CommissioningHistograms( pset.getParameter<edm::ParameterSet>("PedsOnlyParameters"),
+                             bei,
+                             sistrip::PEDS_ONLY ),
+    CommissioningHistosUsingDb( db,
+                                sistrip::PEDS_ONLY ),
+    PedsOnlyHistograms( pset.getParameter<edm::ParameterSet>("PedsOnlyParameters"),
+                        bei )
+{
+  LogTrace(mlDqmClient_) 
+    << "[PedsOnlyHistosUsingDb::" << __func__ << "]"
+    << " Constructing object...";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+PedsOnlyHistosUsingDb::~PedsOnlyHistosUsingDb() {
+  LogTrace(mlDqmClient_) 
+    << "[PedsOnlyHistosUsingDb::" << __func__ << "]"
+    << " Destructing object...";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void PedsOnlyHistosUsingDb::uploadConfigurations() {
+  LogTrace(mlDqmClient_) 
+    << "[PedsOnlyHistosUsingDb::" << __func__ << "]";
+
+  if ( !db() ) {
+    edm::LogError(mlDqmClient_) 
+      << "[PedsOnlyHistosUsingDb::" << __func__ << "]"
+      << " NULL pointer to SiStripConfigDb interface!"
+      << " Aborting upload...";
+    return;
+  }
+  
+  // Update FED descriptions with new peds/noise values
+  SiStripConfigDb::FedDescriptionsRange feds = db()->getFedDescriptions(); 
+  update( feds );
+  if ( doUploadConf() ) { 
+    edm::LogVerbatim(mlDqmClient_) 
+      << "[PedsOnlyHistosUsingDb::" << __func__ << "]"
+      << " Uploading pedestals/noise to DB...";
+    db()->uploadFedDescriptions(); 
+    edm::LogVerbatim(mlDqmClient_) 
+      << "[PedsOnlyHistosUsingDb::" << __func__ << "]"
+      << " Completed database upload of " << feds.size() 
+      << " FED descriptions!";
+  } else {
+    edm::LogWarning(mlDqmClient_) 
+      << "[PedsOnlyHistosUsingDb::" << __func__ << "]"
+      << " TEST only! No pedestals/noise values will be uploaded to DB...";
+  }
+  
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void PedsOnlyHistosUsingDb::update( SiStripConfigDb::FedDescriptionsRange feds ) {
+ 
+  // Iterate through feds and update fed descriptions
+  uint16_t updated = 0;
+  SiStripConfigDb::FedDescriptionsV::const_iterator ifed;
+  for ( ifed = feds.begin(); ifed != feds.end(); ifed++ ) {
+    
+    for ( uint16_t ichan = 0; ichan < sistrip::FEDCH_PER_FED; ichan++ ) {
+
+      // Build FED and FEC keys
+      const FedChannelConnection& conn = cabling()->connection( (*ifed)->getFedId(), ichan );
+      if ( conn.fecCrate() == sistrip::invalid_ ||
+	   conn.fecSlot() == sistrip::invalid_ ||
+	   conn.fecRing() == sistrip::invalid_ ||
+	   conn.ccuAddr() == sistrip::invalid_ ||
+	   conn.ccuChan() == sistrip::invalid_ ||
+	   conn.lldChannel() == sistrip::invalid_ ) { continue; }
+      SiStripFedKey fed_key( conn.fedId(), 
+			     SiStripFedKey::feUnit( conn.fedCh() ),
+			     SiStripFedKey::feChan( conn.fedCh() ) );
+      SiStripFecKey fec_key( conn.fecCrate(), 
+			     conn.fecSlot(), 
+			     conn.fecRing(), 
+			     conn.ccuAddr(), 
+			     conn.ccuChan(), 
+			     conn.lldChannel() );
+
+      // Locate appropriate analysis object 
+      Analyses::const_iterator iter = data().find( fec_key.key() );
+      if ( iter != data().end() ) {
+
+	// Check if analysis is valid
+	if ( !iter->second->isValid() ) { continue; }
+	
+	PedsOnlyAnalysis* anal = dynamic_cast<PedsOnlyAnalysis*>( iter->second );
+	if ( !anal ) { 
+	  edm::LogError(mlDqmClient_)
+	    << "[PedsOnlyHistosUsingDb::" << __func__ << "]"
+	    << " NULL pointer to analysis object!";
+	  continue; 
+	}
+	
+        // Determine the pedestal shift to apply
+        uint32_t pedshift = 127;
+        for ( uint16_t iapv = 0; iapv < sistrip::APVS_PER_FEDCH; iapv++ ) {
+          uint32_t pedmin = (uint32_t) anal->pedsMin()[iapv];
+          pedshift = pedmin < pedshift ? pedmin : pedshift;
+        }
+
+	// Iterate through APVs and strips
+	for ( uint16_t iapv = 0; iapv < sistrip::APVS_PER_FEDCH; iapv++ ) {
+	  for ( uint16_t istr = 0; istr < anal->peds()[iapv].size(); istr++ ) { 
+	    
+	    constexpr float high_threshold = 5.;
+	    constexpr float low_threshold  = 2.;
+	    constexpr bool  disable_strip  = false;
+	    Fed9U::Fed9UStripDescription data( static_cast<uint32_t>( anal->peds()[iapv][istr]-pedshift ), 
+					       high_threshold, 
+					       low_threshold, 
+					       anal->raw()[iapv][istr], //@@ raw noise!
+					       disable_strip );
+	    Fed9U::Fed9UAddress addr( ichan, iapv, istr );
+	    (*ifed)->getFedStrips().setStrip( addr, data );
+	    
+	  }
+	}
+	updated++;
+      
+      } else {
+	edm::LogWarning(mlDqmClient_) 
+	  << "[PedsOnlyHistosUsingDb::" << __func__ << "]"
+	  << " Unable to find pedestals/noise for FedKey/Id/Ch: " 
+	  << hex << setw(8) << setfill('0') << fed_key.key() << dec << "/"
+	  << (*ifed)->getFedId() << "/"
+	  << ichan
+	  << " and device with FEC/slot/ring/CCU/LLD " 
+	  << fec_key.fecCrate() << "/"
+	  << fec_key.fecSlot() << "/"
+	  << fec_key.fecRing() << "/"
+	  << fec_key.ccuAddr() << "/"
+	  << fec_key.ccuChan() << "/"
+	  << fec_key.channel();
+      }
+    }
+  }
+
+  edm::LogVerbatim(mlDqmClient_) 
+    << "[PedsOnlyHistosUsingDb::" << __func__ << "]"
+    << " Updated FED pedestals/noise for " 
+    << updated << " channels";
+
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void PedsOnlyHistosUsingDb::create( SiStripConfigDb::AnalysisDescriptionsV& desc,
+				    Analysis analysis ) {
+
+  PedsOnlyAnalysis* anal = dynamic_cast<PedsOnlyAnalysis*>( analysis->second );
+  if ( !anal ) { return; }
+  
+  SiStripFecKey fec_key( anal->fecKey() );
+  SiStripFedKey fed_key( anal->fedKey() );
+  
+  for ( uint16_t iapv = 0; iapv < 2; ++iapv ) {
+    
+    // Create description
+    PedestalsAnalysisDescription* tmp;
+    tmp = new PedestalsAnalysisDescription( std::vector<uint16_t>(0,0), //@@
+					    std::vector<uint16_t>(0,0), //@@
+					    anal->pedsMean()[iapv],
+					    anal->pedsSpread()[iapv],
+					    1.*sistrip::invalid_, //@@
+					    1.*sistrip::invalid_, //@@
+					    anal->rawMean()[iapv],
+					    anal->rawSpread()[iapv],
+					    anal->pedsMax()[iapv], 
+					    anal->pedsMin()[iapv], 
+					    1.*sistrip::invalid_, //@@
+					    1.*sistrip::invalid_, //@@
+					    anal->rawMax()[iapv],
+					    anal->rawMin()[iapv],
+					    fec_key.fecCrate(),
+					    fec_key.fecSlot(),
+					    fec_key.fecRing(),
+					    fec_key.ccuAddr(),
+					    fec_key.ccuChan(),
+					    SiStripFecKey::i2cAddr( fec_key.lldChan(), !iapv ), 
+					    db()->dbParams().partitions().begin()->second.partitionName(),
+					    db()->dbParams().partitions().begin()->second.runNumber(),
+					    anal->isValid(),
+					    "",
+					    fed_key.fedId(),
+					    fed_key.feUnit(),
+					    fed_key.feChan(),
+					    fed_key.fedApv() );
+    
+    // Add comments
+    typedef std::vector<std::string> Strings;
+    Strings errors = anal->getErrorCodes();
+    Strings::const_iterator istr = errors.begin();
+    Strings::const_iterator jstr = errors.end();
+    for ( ; istr != jstr; ++istr ) { tmp->addComments( *istr ); }
+
+    // Store description
+    desc.push_back( tmp );
+      
+  }
+
+}
+

--- a/DQM/SiStripCommissioningDbClients/src/VpspScanHistosUsingDb.cc
+++ b/DQM/SiStripCommissioningDbClients/src/VpspScanHistosUsingDb.cc
@@ -1,0 +1,200 @@
+
+#include "DQM/SiStripCommissioningDbClients/interface/VpspScanHistosUsingDb.h"
+#include "CondFormats/SiStripObjects/interface/VpspScanAnalysis.h"
+#include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
+#include "DataFormats/SiStripCommon/interface/SiStripFecKey.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include <iostream>
+
+using namespace sistrip;
+
+// -----------------------------------------------------------------------------
+/** */
+VpspScanHistosUsingDb::VpspScanHistosUsingDb( const edm::ParameterSet & pset,
+                                              DQMStore* bei,
+                                              SiStripConfigDb* const db ) 
+  : CommissioningHistograms( pset.getParameter<edm::ParameterSet>("VpspScanParameters"),
+                             bei,
+                             sistrip::VPSP_SCAN ),
+    CommissioningHistosUsingDb( db,
+                                sistrip::VPSP_SCAN ),
+    VpspScanHistograms( pset.getParameter<edm::ParameterSet>("VpspScanParameters"),
+                        bei )
+{
+  LogTrace(mlDqmClient_) 
+    << "[VpspScanHistosUsingDb::" << __func__ << "]"
+    << " Constructing object...";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+VpspScanHistosUsingDb::~VpspScanHistosUsingDb() {
+  LogTrace(mlDqmClient_) 
+    << "[VpspScanHistosUsingDb::" << __func__ << "]"
+    << " Destructing object...";
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void VpspScanHistosUsingDb::uploadConfigurations() {
+  LogTrace(mlDqmClient_) 
+    << "[VpspScanHistosUsingDb::" << __func__ << "]";
+  
+  if ( !db() ) {
+    edm::LogError(mlDqmClient_) 
+      << "[VpspScanHistosUsingDb::" << __func__ << "]"
+      << " NULL pointer to SiStripConfigDb interface!"
+      << " Aborting upload...";
+    return;
+  }
+  
+  // Update all APV device descriptions with new VPSP settings
+  SiStripConfigDb::DeviceDescriptionsRange devices = db()->getDeviceDescriptions();
+  update( devices );
+  if ( doUploadConf() ) { 
+    edm::LogVerbatim(mlDqmClient_) 
+      << "[VpspScanHistosUsingDb::" << __func__ << "]"
+      << " Uploading VPSP settings to DB...";
+    db()->uploadDeviceDescriptions(); 
+    edm::LogVerbatim(mlDqmClient_) 
+      << "[VpspScanHistosUsingDb::" << __func__ << "]"
+      << " Uploaded VPSP settings to DB!";
+  } else {
+    edm::LogWarning(mlDqmClient_) 
+      << "[VpspScanHistosUsingDb::" << __func__ << "]"
+      << " TEST only! No VPSP settings will be uploaded to DB...";
+  }
+  LogTrace(mlDqmClient_) 
+    << "[VpspScanHistosUsingDb::" << __func__ << "]"
+    << " Upload of VPSP settings to DB finished!";
+  
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void VpspScanHistosUsingDb::update( SiStripConfigDb::DeviceDescriptionsRange devices ) {
+  
+  // Iterate through devices and update device descriptions
+  SiStripConfigDb::DeviceDescriptionsV::const_iterator idevice;
+  for ( idevice = devices.begin(); idevice != devices.end(); idevice++ ) {
+    
+    // Check device type
+    if ( (*idevice)->getDeviceType() != APV25 ) { continue; }
+    
+    // Cast to retrieve appropriate description object
+    apvDescription* desc = dynamic_cast<apvDescription*>( *idevice );
+    if ( !desc ) { continue; }
+    
+    // Retrieve device addresses from device description
+    const SiStripConfigDb::DeviceAddress& addr = db()->deviceAddress(*desc);
+    
+    // Retrieve LLD channel and APV numbers
+    uint16_t ichan = ( desc->getAddress() - 0x20 ) / 2;
+    uint16_t iapv  = ( desc->getAddress() - 0x20 ) % 2;
+    
+    // Construct key from device description
+    SiStripFecKey fec_key( addr.fecCrate_, 
+			   addr.fecSlot_, 
+			   addr.fecRing_, 
+			   addr.ccuAddr_, 
+			   addr.ccuChan_,
+			   ichan+1 );
+      
+    // Iterate through all channels and extract LLD settings 
+    Analyses::const_iterator iter = data().find( fec_key.key() );
+    if ( iter != data().end() ) {
+
+      VpspScanAnalysis* anal = dynamic_cast<VpspScanAnalysis*>( iter->second );
+      if ( !anal ) { 
+	edm::LogError(mlDqmClient_)
+	  << "[VpspScanHistosUsingDb::" << __func__ << "]"
+	  << " NULL pointer to analysis object!";
+	continue; 
+      }
+      
+      std::stringstream ss;
+      ss << "[VpspScanHistosUsingDb::" << __func__ << "]"
+	 << " Updating VPSP setting for crate/FEC/slot/ring/CCU/LLD/APV " 
+	 << fec_key.fecCrate() << "/"
+	 << fec_key.fecSlot() << "/"
+	 << fec_key.fecRing() << "/"
+	 << fec_key.ccuAddr() << "/"
+	 << fec_key.ccuChan() << "/"
+	 << fec_key.channel() 
+	 << iapv
+	 << " from "
+	 << static_cast<uint16_t>(desc->getVpsp());
+      if ( iapv == 0 ) { desc->setVpsp( anal->vpsp()[0] ); }
+      if ( iapv == 1 ) { desc->setVpsp( anal->vpsp()[1] ); }
+      ss << " to " << static_cast<uint16_t>(desc->getVpsp());
+      LogTrace(mlDqmClient_) << ss.str();
+      
+    } else {
+      if ( deviceIsPresent(fec_key) ) {
+	edm::LogWarning(mlDqmClient_) 
+	  << "[VpspScanHistosUsingDb::" << __func__ << "]"
+	  << " Unable to find FEC key with params FEC/slot/ring/CCU/LLDchan/APV: " 
+	  << fec_key.fecCrate() << "/"
+	  << fec_key.fecSlot() << "/"
+	  << fec_key.fecRing() << "/"
+	  << fec_key.ccuAddr() << "/"
+	  << fec_key.ccuChan() << "/"
+	  << fec_key.channel() << "/" 
+	  << iapv+1;
+      }
+    }
+  }
+  
+}
+
+// -----------------------------------------------------------------------------
+/** */
+void VpspScanHistosUsingDb::create( SiStripConfigDb::AnalysisDescriptionsV& desc,
+				    Analysis analysis ) {
+
+  VpspScanAnalysis* anal = dynamic_cast<VpspScanAnalysis*>( analysis->second );
+  if ( !anal ) { return; }
+  
+  SiStripFecKey fec_key( anal->fecKey() ); 
+  SiStripFedKey fed_key( anal->fedKey() );
+  
+  for ( uint16_t iapv = 0; iapv < 2; ++iapv ) {
+
+    // Create description
+    VpspScanAnalysisDescription* tmp;
+    tmp = new VpspScanAnalysisDescription( anal->vpsp()[iapv],
+					   anal->adcLevel()[iapv],
+					   anal->fraction()[iapv],
+					   anal->topEdge()[iapv],
+					   anal->bottomEdge()[iapv],
+					   anal->topLevel()[iapv],
+					   anal->bottomLevel()[iapv],
+					   fec_key.fecCrate(),
+					   fec_key.fecSlot(),
+					   fec_key.fecRing(),
+					   fec_key.ccuAddr(),
+					   fec_key.ccuChan(),
+					   SiStripFecKey::i2cAddr( fec_key.lldChan(), !iapv ), 
+					   db()->dbParams().partitions().begin()->second.partitionName(),
+					   db()->dbParams().partitions().begin()->second.runNumber(),
+					   anal->isValid(),
+					   "",
+					   fed_key.fedId(),
+					   fed_key.feUnit(),
+					   fed_key.feChan(),
+					   fed_key.fedApv() );
+    
+    // Add comments
+    typedef std::vector<std::string> Strings;
+    Strings errors = anal->getErrorCodes();
+    Strings::const_iterator istr = errors.begin();
+    Strings::const_iterator jstr = errors.end();
+    for ( ; istr != jstr; ++istr ) { tmp->addComments( *istr ); }
+
+    // Store description
+    desc.push_back( tmp );
+      
+  }
+
+}
+


### PR DESCRIPTION
The original dqm purge of xdaq dependencies included this pkg due to its dependence on tkonlinesw, which itself had to be cleaned up. Now that tkonlinesw is cleaned and in pre4, this pkg can also be re-included.
