### PR TITLE
return pointer to streamCache type

### DIFF
--- a/FWCore/Framework/interface/global/implementors.h
+++ b/FWCore/Framework/interface/global/implementors.h
@@ -47,7 +47,7 @@ namespace edm {
           }
         }
       protected:
-        T * streamCache(edm::StreamID iID) const { return caches_[iID.value()]; }
+        C * streamCache(edm::StreamID iID) const { return caches_[iID.value()]; }
       private:
         virtual void preallocStreams(unsigned int iNStreams) override final {
           caches_.resize(iNStreams,static_cast<C*>(nullptr));


### PR DESCRIPTION
Small typo found when implementing test classes for edm:global namespace. Returned pointer to Class type T instead of Cache type C. Compared to RunCacheHolder and LuminosityBlockCacheHolder to determine what return type should be.
