### PR TITLE
Add cfi file for DQMStore for use with HLT ConfDB parsing

### DIFF
--- a/DQMServices/Core/python/DQMStore_cfi.py
+++ b/DQMServices/Core/python/DQMStore_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+DQMStore = cms.Service("DQMStore",
+    referenceFileName = cms.untracked.string(''),
+    verbose = cms.untracked.int32(0),
+    verboseQT = cms.untracked.int32(0),
+    collateHistograms = cms.untracked.bool(False)
+)


### PR DESCRIPTION
For ConfDB parsing, we need an cfi file (not cff nor cfg) which contains the module signature!
