### PR TITLE
Add 1 to the raw HCAL HTR fiber number for HTR histogram firmware unpacking.

### DIFF
--- a/EventFilter/HcalRawToDigi/src/HcalHTRData.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalHTRData.cc
@@ -419,8 +419,8 @@ void HcalHTRData::getHistogramFibers(int& a, int& b) const {
     a=((m_rawConst[2]&0x0F00)>>8);
     b=((m_rawConst[2]&0xF000)>>12);
   } else {
-    a=((m_rawConst[5]&0x0F00)>>8);
-    b=((m_rawConst[5]&0xF000)>>12);
+    a=((m_rawConst[5]&0x0F00)>>8)+1;
+    b=((m_rawConst[5]&0xF000)>>12)+1;
   }
 }
 


### PR DESCRIPTION
When unpacking data written with standard HCAL HTR firmware, the HTR fiber number from the raw data has 1 added to it so that the fiber numbers go from 1-8 "offline."  This patch does the same for raw data written with the HTR histogramming-mode firmware (for recent histogram firmware versions).  Previously this was not the case, leading to confusion and some complications when reading data written by the histogram firmware.
