### PR TITLE
Make InitRootHandlers safe for the threaded framework

### DIFF
--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -35,8 +35,10 @@ namespace {
     kSysError,
     kFatal
   };
+  
+  static thread_local bool s_ignoreWarnings = false;
 
-  void RootErrorHandlerImpl(int level, char const* location, char const* message, bool ignoreWarnings) {
+  void RootErrorHandlerImpl(int level, char const* location, char const* message) {
 
   bool die = false;
 
@@ -51,7 +53,7 @@ namespace {
     } else if (level >= kError) {
       el_severity = SeverityLevel::kError;
     } else if (level >= kWarning) {
-      el_severity = ignoreWarnings ? SeverityLevel::kInfo : SeverityLevel::kWarning;
+      el_severity = s_ignoreWarnings ? SeverityLevel::kInfo : SeverityLevel::kWarning;
     }
 
   // Adapt C-strings to std::strings
@@ -157,11 +159,7 @@ namespace {
   }
 
   void RootErrorHandler(int level, bool, char const* location, char const* message) {
-    RootErrorHandlerImpl(level, location, message, false);
-  }
-
-  void RootErrorHandlerWithoutWarnings(int level, bool, char const* location, char const* message) {
-    RootErrorHandlerImpl(level, location, message, true);
+    RootErrorHandlerImpl(level, location, message);
   }
 
   extern "C" {
@@ -279,18 +277,13 @@ namespace edm {
     }
 
     void
-    InitRootHandlers::disableErrorHandler_() {
-        SetErrorHandler(DefaultErrorHandler);
+    InitRootHandlers::enableWarnings_() {
+      s_ignoreWarnings =false;
     }
 
     void
-    InitRootHandlers::enableErrorHandler_() {
-        SetErrorHandler(RootErrorHandler);
-    }
-
-    void
-    InitRootHandlers::enableErrorHandlerWithoutWarnings_() {
-        SetErrorHandler(RootErrorHandlerWithoutWarnings);
+    InitRootHandlers::ignoreWarnings_() {
+      s_ignoreWarnings = true;
     }
 
   }  // end of namespace service

--- a/FWCore/Services/src/InitRootHandlers.h
+++ b/FWCore/Services/src/InitRootHandlers.h
@@ -17,9 +17,8 @@ namespace edm {
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
     private:
-      virtual void disableErrorHandler_();
-      virtual void enableErrorHandler_();
-      virtual void enableErrorHandlerWithoutWarnings_();
+      virtual void enableWarnings_() override;
+      virtual void ignoreWarnings_() override;
       bool unloadSigHandler_;
       bool resetErrHandler_;
       bool autoLibraryLoader_;

--- a/FWCore/Utilities/interface/RootHandlers.h
+++ b/FWCore/Utilities/interface/RootHandlers.h
@@ -3,16 +3,30 @@
 
 namespace edm {
   class RootHandlers {
+  private:
+    struct WarningSentry {
+      WarningSentry(RootHandlers* iHandler): m_handler(iHandler){
+        m_handler->ignoreWarnings_();
+      };
+      ~WarningSentry() {
+        m_handler->enableWarnings_();
+      }
+      RootHandlers* m_handler;
+    };
+    friend struct edm::RootHandlers::WarningSentry;
+
   public:
     RootHandlers () {}
     virtual ~RootHandlers () {}
-    void disableErrorHandler() {disableErrorHandler_();}
-    void enableErrorHandler() {enableErrorHandler_();}
-    void enableErrorHandlerWithoutWarnings() {enableErrorHandlerWithoutWarnings_();}
+
+    template<typename F>
+    void ignoreWarningsWhileDoing(F iFunc) {
+      WarningSentry sentry(this);
+      iFunc();
+    }
   private: 
-    virtual void disableErrorHandler_() = 0;
-    virtual void enableErrorHandler_() = 0;
-    virtual void enableErrorHandlerWithoutWarnings_() = 0;
+    virtual void enableWarnings_() = 0;
+    virtual void ignoreWarnings_() = 0;
   };
 }  // end of namespace edm
 

--- a/IOPool/Output/src/RootOutputTree.cc
+++ b/IOPool/Output/src/RootOutputTree.cc
@@ -195,9 +195,7 @@ namespace edm {
       }
       tree_->SetEntries(tree_->GetEntries() + in->GetEntries());
       Service<RootHandlers> rootHandler;
-      rootHandler->enableErrorHandlerWithoutWarnings();
-      cloner.Exec();
-      rootHandler->enableErrorHandler();
+      rootHandler->ignoreWarningsWhileDoing([&cloner] { cloner.Exec(); });
       if(mustRemoveSomeAuxs) {
         for(std::map<Int_t, TBranch *>::const_iterator it = auxIndexes.begin(), itEnd = auxIndexes.end();
              it != itEnd; ++it) {


### PR DESCRIPTION
InitRootHandlers was originally calling ROOT's 'SetErrorHandler' function during event processing. That operation is not thread safe. This was done solely to allow ROOT warning messages to be temporarily ignored. We now always keep the same error handler but now signal the request to ignore warnings via a thread local bool. To better encapsulate this behavior, RootHandlers was changed to use a function which takes a functor as an argument and then wraps the temporary disabling of warnings via a sentry. Only RootOutputTree actually makes use of this facility.
