### PR TITLE
Updated AdaptorConfig (aka TFileAdaptor) for the threaded framework

### DIFF
--- a/IOPool/TFileAdaptor/src/TFileAdaptor.h
+++ b/IOPool/TFileAdaptor/src/TFileAdaptor.h
@@ -20,14 +20,16 @@ public:
 
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
+  friend class TFileAdaptorUI;
+private:
   // Write current Storage statistics on a ostream
   void termination(void) const;
-
+  
+  //Called by TFileAdaptorUI
   void stats(std::ostream &o) const;
-
+  
   void statsXML(std::map<std::string, std::string> &data) const;
-
-private:
+  
   static void addType(TPluginManager* mgr, char const* type, int altType=0);
   bool native(char const* proto) const;
 


### PR DESCRIPTION
In principal no changes were actually needed since the service was already being used in a safe way. However, it was unnecessarily exposing member functions which could be misused. The functions were moved to private.
