### PR TITLE
Thread safety -- Make static variables thread_local in  DetectorDescription/Core to avoid issues when multithreaded.

### DIFF
--- a/DetectorDescription/Core/src/DDPartSelection.cc
+++ b/DetectorDescription/Core/src/DDPartSelection.cc
@@ -226,7 +226,7 @@ DDPartSelectionLevel::DDPartSelectionLevel(const DDLogicalPart & lp, int c, ddse
 
 void DDTokenize2(const std::string & sel, std::vector<DDPartSelRegExpLevel> & path)
 {
-  static SpecParParser parser;
+  thread_local static SpecParParser parser;
   DDI::Singleton<DDSelLevelCollector>::instance().path(&path);
   bool result = parse(sel.c_str(), parser).full;
   if (!result) {


### PR DESCRIPTION
Not sure this is really needed (@ianna, when is this actually called? beginRun?) however I think that having one copy per thread is simply the right thing to do, since this is static only to save on the initialisation cost, right?
