### PR TITLE
Thread safety -- Make DDAxesNames thread safe

### DIFF
--- a/DetectorDescription/Core/interface/DDAxes.h
+++ b/DetectorDescription/Core/interface/DDAxes.h
@@ -1,37 +1,16 @@
 #ifndef DDAxes_h
 #define DDAxes_h
 
-#include "DetectorDescription/Base/interface/Singleton.h"
-
 #include <string>
-#include <map>
 
 //! analagous to geant4/source/global/HEPGeometry/include/geomdefs.hh
 enum DDAxes {x, y, z, rho, radial3D, phi, undefined};
 
-class AxesNames
-{
-  
-public:
-  AxesNames();
-  ~AxesNames();
-  
-  const std::string name(const DDAxes& s) ;
-  
-  DDAxes index(const std::string & s);
-  
-private:
-  std::map<std::string, DDAxes> axesmap_;
-};
-  
-
-class DDAxesNames : public DDI::Singleton<AxesNames>
+class DDAxesNames
 {
 public:
-
-  static const std::string name(const DDAxes& s);
-
-  static DDAxes index(const std::string & s);
+  static char const*name(const DDAxes& s);
+  static DDAxes index(const std::string &s);
 };	   
 
 #endif // DDAxes_h

--- a/DetectorDescription/Core/src/DDAxes.cc
+++ b/DetectorDescription/Core/src/DDAxes.cc
@@ -2,45 +2,52 @@
 
 namespace DDI { } using namespace DDI;
 
-AxesNames::AxesNames() {
-  axesmap_["x"] = x;
-  axesmap_["y"] = y;
-  axesmap_["z"] = z;
-  axesmap_["rho"] = rho;
-  axesmap_["radial3D"] = radial3D;
-  axesmap_["phi"] = phi;
-  axesmap_["undefined"] = undefined;
-}
+namespace {
+  template <class T>
+  struct entry {                                                                                                                                                    
+     char const* label;
+     T           value;
+  };
 
-AxesNames::~AxesNames() { }
-
-const std::string
-AxesNames::name(const DDAxes& s) 
-{
-  std::map<std::string, DDAxes>::const_iterator it;
-
-  for(it = axesmap_.begin(); it != axesmap_.end(); ++it)
-  {
-    if(it->second == s)
-      break;
+  constexpr bool same(char const *x, char const *y) {
+    return !*x && !*y     ? true                                                                                                                                
+           : /* default */    (*x == *y && same(x+1, y+1));                                                                                                       
   }
-  return it->first;
+
+  template <class T>
+  constexpr T keyToValue(char const *label, entry<T> const *entries) {                                                                                  
+     return !entries->label ? entries->value                         
+            : same(entries->label, label) ? entries->value
+            : /*default*/                   keyToValue(label, entries+1);                                                                                 
+  }
+
+  template <class T>
+  constexpr char const*valueToKey(T value, entry<T> const *entries) {
+     return !entries->label ? entries->label
+            : entries->value == value ? entries->label
+            : /*default*/       valueToKey(value, entries+1);
+  }
+
+  entry<DDAxes> axesNames[] = {
+    {"x", x},
+    {"y", y},
+    {"z", z},
+    {"rho", rho},
+    {"radial3D", radial3D},
+    {"phi", phi},
+    {"undefined", undefined},
+    {0, undefined},
+  };
 }
 
-DDAxes
-AxesNames::index(const std::string & s)
-{
-  return axesmap_[s];
-}
-
-const std::string
+char const*
 DDAxesNames::name(const DDAxes& s) 
 {
-  return instance().name(s);
+  return valueToKey(s, axesNames);
 }
 
 DDAxes
-DDAxesNames::index(const std::string & s) 
+DDAxesNames::index(const std::string & s)
 {
-  return instance().index(s);
+  return keyToValue(s.c_str(), axesNames);
 }

--- a/DetectorDescription/Core/src/StoresInstantiation.cc
+++ b/DetectorDescription/Core/src/StoresInstantiation.cc
@@ -19,7 +19,6 @@
 #include <map>
 #include <vector>
 
-template class DDI::Singleton<AxesNames>;
 template class DDI::Singleton<ClhepEvaluator>;
 template class DDI::Singleton<DDRoot>;
 template class DDI::Singleton<DDCompactViewImpl>;

--- a/DetectorDescription/Core/test/BuildFile.xml
+++ b/DetectorDescription/Core/test/BuildFile.xml
@@ -5,6 +5,8 @@
 <bin   name="testCore" file="testRunner.cpp,DDIsValid.cppunit.cc">
 </bin>
 <bin   name="testShapes" file="testShapes.cpp">
+<bin   file="test_DDAxesNames.cpp">
+</bin>
 </bin>
 <bin   file="clhepToROOTMath.cpp">
 </bin>

--- a/DetectorDescription/Core/test/test_DDAxesNames.cpp
+++ b/DetectorDescription/Core/test/test_DDAxesNames.cpp
@@ -1,0 +1,26 @@
+#include "DetectorDescription/Core/interface/DDAxes.h"
+#include <string>
+#include <cassert>
+#include <iostream>
+
+int
+main(int argc, char **argv)
+{
+  assert(DDAxesNames::index("x") == x);
+  assert(DDAxesNames::index("y") == y);
+  assert(DDAxesNames::index("z") == z);
+  assert(DDAxesNames::index("rho") == rho);
+  assert(DDAxesNames::index("radial3D") == radial3D);
+  assert(DDAxesNames::index("phi") == phi);
+  assert(DDAxesNames::index("undefined") == undefined);
+  // If the name does not exists result is always 0.
+  //  assert(DDAxesNames::index("foo") == 0);
+
+  assert(DDAxesNames::name(x) == std::string("x"));
+  assert(DDAxesNames::name(y) == std::string("y"));
+  assert(DDAxesNames::name(z) == std::string("z"));
+  assert(DDAxesNames::name(rho) == std::string("rho"));
+  assert(DDAxesNames::name(radial3D) == std::string("radial3D"));
+  assert(DDAxesNames::name(phi) == std::string("phi"));
+  assert(DDAxesNames::name(undefined) == std::string("undefined"));
+}

--- a/DetectorDescription/Parser/src/DDLDivision.cc
+++ b/DetectorDescription/Parser/src/DDLDivision.cc
@@ -48,10 +48,7 @@ DDLDivision::processElement( const std::string& name, const std::string& nmspace
 
   DDName parent = getDDName(nmspace, "parent");
   ExprEvalInterface & ev = ExprEvalSingleton::instance();
-  size_t ax = 0;
-  while (DDAxesNames::name(DDAxes(ax)) != atts.find("axis")->second &&
-	 DDAxesNames::name(DDAxes(ax)) != "undefined")
-    ++ax;
+  size_t ax = DDAxesNames::index(atts.find("axis")->second);
 
   DDLogicalPart lp(parent);
   if ( !lp.isDefined().second || !lp.solid().isDefined().second ) {
@@ -127,7 +124,8 @@ DDLDivision::makeDivider( const DDDivision& div, DDCompactView* cpv )
     else {
       std::string s = "DDLDivision can not divide a ";
       s += DDSolidShapesName::name(div.parent().solid().shape());
-      s += " along axis " + DDAxesNames::name(div.axis());
+      s += " along axis ";
+      s += DDAxesNames::name(div.axis());
       s += ".";
       s += "\n    name= " + div.name().ns() + ":" + div.name().name() ;
       s += "\n    parent= " + div.parent().name().ns() + ":" + div.parent().name().name();
@@ -145,7 +143,8 @@ DDLDivision::makeDivider( const DDDivision& div, DDCompactView* cpv )
     else {
       std::string s = "DDLDivision can not divide a ";
       s += DDSolidShapesName::name(div.parent().solid().shape());
-      s += " along axis " + DDAxesNames::name(div.axis());
+      s += " along axis ";
+      s += DDAxesNames::name(div.axis());
       s += ".";
       s += "\n    name= " + div.name().ns() + ":" + div.name().name() ;
       s += "\n    parent= " + div.parent().name().ns() + ":" + div.parent().name().name();
@@ -182,7 +181,8 @@ DDLDivision::makeDivider( const DDDivision& div, DDCompactView* cpv )
     else {
       std::string s = "DDLDivision can not divide a ";
       s += DDSolidShapesName::name(div.parent().solid().shape());
-      s += " along axis " + DDAxesNames::name(div.axis());
+      s += " along axis ";
+      s += DDAxesNames::name(div.axis());
       s += ".";
       s += "\n    name= " + div.name().ns() + ":" + div.name().name() ;
       s += "\n    parent= " + div.parent().name().ns() + ":" + div.parent().name().name();


### PR DESCRIPTION
This is along the lines of what I already did in:

http://cmslxr.fnal.gov/lxr/source/CondFormats/L1TObjects/src/L1GtDefinitions.cc#256

and other places.

I've added a unit test which passes with both the new and the old code. I did not do a full rebuild. @nclopezo, can you please do it? @ianna
