### PR TITLE
Add more missing std qualifiers and includes of iostream header

### DIFF
--- a/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerGeometryCompare.cc
@@ -107,7 +107,7 @@ TrackerGeometryCompare::TrackerGeometryCompare(const edm::ParameterSet& cfg) :
 		
 	// if want to use, make id cut list
 	if (_detIdFlag){
-        ifstream fin;
+        std::ifstream fin;
         fin.open( _detIdFlagFile.c_str() );
         
         while (!fin.eof() && fin.good() ){

--- a/CalibCalorimetry/EcalCorrectionModules/test/stubs/EcalContainmentCorrectionAnalyzer.cc
+++ b/CalibCalorimetry/EcalCorrectionModules/test/stubs/EcalContainmentCorrectionAnalyzer.cc
@@ -6,6 +6,8 @@
  *
 */
 
+#include <iostream>
+
 #include <FWCore/Framework/interface/EDAnalyzer.h>
 #include <FWCore/Framework/interface/Event.h>
 #include <FWCore/Framework/interface/MakerMacros.h>

--- a/CalibTracker/SiPixelGainCalibration/plugins/SiPixelGainCalibrationAnalysis.h
+++ b/CalibTracker/SiPixelGainCalibration/plugins/SiPixelGainCalibrationAnalysis.h
@@ -116,7 +116,7 @@ private:
   double scalarVcalHigh_VcalLow_;
   
   //Summary
-  ofstream summary_;
+  std::ofstream summary_;
   uint32_t currentDetID_;
   int* statusNumbers_;
   

--- a/CondCore/RPCPlugins/plugins/RPCObTempPyWrapper.cc
+++ b/CondCore/RPCPlugins/plugins/RPCObTempPyWrapper.cc
@@ -241,7 +241,7 @@ namespace cond {
 						std::string const &, std::vector<int> const&, std::vector<float> const& ) const {
 
     std::map<std::string,std::pair<float,float> > geoMap;
-    std::ifstream mapFile("/afs/cern.ch/user/s/stupputi/public/barDetPositions.txt",ifstream::in);
+    std::ifstream mapFile("/afs/cern.ch/user/s/stupputi/public/barDetPositions.txt",std::ifstream::in);
     std::string chamb;
     float xPos,yPos;
     while(mapFile >> chamb >> xPos >> yPos)

--- a/CondTools/Ecal/interface/EcalChannelStatusHandler.h
+++ b/CondTools/Ecal/interface/EcalChannelStatusHandler.h
@@ -130,12 +130,12 @@ namespace popcon {
 
       EcalElectronicsMapping ecalElectronicsMap_;
 
-      ofstream *ResFileEB;
-      ofstream *ResFileEE;
-      ofstream *ResFileNewEB;
-      ofstream *ResFileNewEE;
-      ofstream *daqFile;
-      ofstream *daqFile2;
+      std::ofstream *ResFileEB;
+      std::ofstream *ResFileEE;
+      std::ofstream *ResFileNewEB;
+      std::ofstream *ResFileNewEE;
+      std::ofstream *daqFile;
+      std::ofstream *daqFile2;
 
       std::map<DetId, float> maskedOnlinePedEB, maskedOnlinePedEE;
       std::map<DetId, float> maskedPedEB, maskedPedEE;

--- a/CondTools/Ecal/src/EcalChannelStatusHandler.cc
+++ b/CondTools/Ecal/src/EcalChannelStatusHandler.cc
@@ -1649,17 +1649,17 @@ void popcon::EcalChannelStatusHandler::getNewObjects() {
   // preparing the output files
   char outfile[800];
   sprintf(outfile,"BadChannelsEB_run%d.txt",min_run);
-  ResFileEB    = new ofstream(outfile,std::ios::out);
+  ResFileEB    = new std::ofstream(outfile,std::ios::out);
   sprintf(outfile,"BadChannelsEE_run%d.txt",min_run);
-  ResFileEE    = new ofstream(outfile,std::ios::out);
+  ResFileEE    = new std::ofstream(outfile,std::ios::out);
   sprintf(outfile,"BadNewChannelsEB_run%d.txt",min_run);
-  ResFileNewEB = new ofstream(outfile,std::ios::out);
+  ResFileNewEB = new std::ofstream(outfile,std::ios::out);
   sprintf(outfile,"BadNewChannelsEE_run%d.txt",min_run);
-  ResFileNewEE = new ofstream(outfile,std::ios::out);
+  ResFileNewEE = new std::ofstream(outfile,std::ios::out);
   sprintf(outfile,"DaqConfig_run%d.txt",min_run);
-  daqFile = new ofstream(outfile,std::ios::out);
+  daqFile = new std::ofstream(outfile,std::ios::out);
   sprintf(outfile,"DaqConfig_channels_run%d.txt",min_run);
-  daqFile2 = new ofstream(outfile,std::ios::out);
+  daqFile2 = new std::ofstream(outfile,std::ios::out);
 
   *daqFile  << "fed" << "\t\t" << "tower" << std::endl; 
 

--- a/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.h
+++ b/DQM/BeamMonitor/plugins/Vx3DHLTAnalyzer.h
@@ -146,8 +146,8 @@ class Vx3DHLTAnalyzer : public edm::EDAnalyzer {
       // ######################
       // # Internal variables #
       // ######################
-      ofstream outputFile;
-      ofstream outputDebugFile;
+      std::ofstream outputFile;
+      std::ofstream outputDebugFile;
       edm::TimeValue_t beginTimeOfFit;
       edm::TimeValue_t endTimeOfFit;
       unsigned int nBinsHistoricalPlot;

--- a/DataFormats/FWLite/src/MultiChainEvent.cc
+++ b/DataFormats/FWLite/src/MultiChainEvent.cc
@@ -11,6 +11,7 @@
 //
 
 // system include files
+#include <iostream>
 
 // user include files
 #include "DataFormats/FWLite/interface/MultiChainEvent.h"

--- a/IOPool/Streamer/src/ClassFiller.cc
+++ b/IOPool/Streamer/src/ClassFiller.cc
@@ -14,6 +14,7 @@
 #include <string>
 #include <set>
 #include <algorithm>
+#include <iostream>
 
 namespace edm {
   void loadCap(std::string const& name) {

--- a/MagneticField/ParametrizedEngine/test/MagneticFieldPlotter.cc
+++ b/MagneticField/ParametrizedEngine/test/MagneticFieldPlotter.cc
@@ -19,6 +19,7 @@
 
 
 // system include files
+#include <iostream>
 #include <memory>
 
 // user include files

--- a/PhysicsTools/FWLite/bin/FWLiteLumiAccess.cc
+++ b/PhysicsTools/FWLite/bin/FWLiteLumiAccess.cc
@@ -1,5 +1,6 @@
-#include <TFile.h>
-#include <TSystem.h>
+#include <iostream>
+#include "TFile.h"
+#include "TSystem.h"
 
 #include "DataFormats/FWLite/interface/Event.h"
 #include "DataFormats/FWLite/interface/Handle.h"


### PR DESCRIPTION
After moving from working with CMSSW_7_0_0_pre3 to working with CMSSW_7_0_0_pre4, I discovered several more packages that would not compile against ROOT6 because of missing std qualifiers or missing includes of iostream.  This purely technical request fixes those packages.  In one place, I also changed two includes of ROOT headers to use quotes instead of angle brackets, as they are not system headers.

Please bypass signatures, as this is purely technical. 
