### PR TITLE
Thread safety -- Fix CastorObjects

### DIFF
--- a/CondFormats/CastorObjects/interface/CastorElectronicsMap.h
+++ b/CondFormats/CastorObjects/interface/CastorElectronicsMap.h
@@ -14,6 +14,9 @@ Modified for CASTOR by L. Mundim
 #include <vector>
 #include <algorithm>
 #include <boost/cstdint.hpp>
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+#include <atomic>
+#endif
 
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
@@ -26,6 +29,16 @@ class CastorElectronicsMap {
  public:
   CastorElectronicsMap();
   ~CastorElectronicsMap();
+
+  // swap function
+  void swap(CastorElectronicsMap& other);
+  // copy-ctor
+  CastorElectronicsMap(const CastorElectronicsMap& src);  // copy assignment operator
+  CastorElectronicsMap& operator=(const CastorElectronicsMap& rhs);
+  // move constructor
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+  CastorElectronicsMap(CastorElectronicsMap&& other);
+#endif
 
   /// lookup the logical detid associated with the given electronics id
   //return Null item if no such mapping
@@ -86,10 +99,13 @@ class CastorElectronicsMap {
   
   std::vector<PrecisionItem> mPItems;
   std::vector<TriggerItem> mTItems;
-  mutable std::vector<const PrecisionItem*> mPItemsById;
-  mutable bool sortedByPId;
-  mutable std::vector<const TriggerItem*> mTItemsByTrigId;
-  mutable bool sortedByTId;
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+  mutable std::atomic<std::vector<const PrecisionItem*>*> mPItemsById;
+  mutable std::atomic<std::vector<const TriggerItem*>*> mTItemsByTrigId;
+#else
+  mutable std::vector<const PrecisionItem*>* mPItemsById;
+  mutable std::vector<const TriggerItem*>* mTItemsByTrigId;
+#endif
 };
 
 #endif

--- a/CondFormats/CastorObjects/src/CastorElectronicsMap.cc
+++ b/CondFormats/CastorObjects/src/CastorElectronicsMap.cc
@@ -16,7 +16,8 @@ Adapted for CASTOR by L. Mundim
 
 CastorElectronicsMap::CastorElectronicsMap() : 
   mPItems(CastorElectronicsId::maxLinearIndex+1),
-  mTItems(CastorElectronicsId::maxLinearIndex+1)
+  mTItems(CastorElectronicsId::maxLinearIndex+1),
+  mPItemsById(nullptr), mTItemsByTrigId(nullptr)
 {}
 
 namespace castor_impl {

--- a/CondFormats/CastorObjects/src/classes_def.xml
+++ b/CondFormats/CastorObjects/src/classes_def.xml
@@ -25,9 +25,7 @@
 
  <class name="CastorElectronicsMap">
   <field name="mPItemsById" transient="true"/>
-  <field name="sortedByPId" transient="true"/>
   <field name="mTItemsByTrigId" transient="true"/>
-  <field name="sortedByTId" transient="true"/>
  </class>
  <class name="CastorElectronicsMap::PrecisionItem"/>
  <class name="CastorElectronicsMap::TriggerItem"/>


### PR DESCRIPTION
This PR is replacing  #847 and includes Valentin's latest update (added initialisations).

The new version builds correctly and I successfully ran workflows 4.22, 8.0, and 1306.0 (the others are still running) in CMSSW_7_0_X_2013-09-19-1400 on slc6.

David, could you please schedule a Jenkins for this ?
