### PR TITLE
Rappoccio : Backporting change of b tag sequences to use AK5PFCHS to 620

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,0 @@
-*.pyc
-*.log
-*__init__*
-25.0_TTbar+TTbar+DIGI+RECO+HARVEST+ALCATT
-5.1_TTbar+TTbarFS+HARVESTFS

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+*.log
+*__init__*
+25.0_TTbar+TTbar+DIGI+RECO+HARVEST+ALCATT
+5.1_TTbar+TTbarFS+HARVESTFS

--- a/CommonTools/ParticleFlow/python/EITopPAG_EventContent_cff.py
+++ b/CommonTools/ParticleFlow/python/EITopPAG_EventContent_cff.py
@@ -9,6 +9,11 @@ EITopPAGEventContent = cms.PSet(
     'keep *_pfIsolatedMuonsEI_*_*',
     # jets
     'keep recoPFJets_pfJetsEI_*_*',
+    # btags
+    'keep *_pfJetTrackAssociatorEI_*_*',
+    'keep *_impactParameterTagInfosEI_*_*',
+    'keep *_secondaryVertexTagInfosEI_*_*',
+    'keep *_combinedSecondaryVertexBJetTagsEI_*_*',
     # taus 
     'keep recoPFTaus_pfTausEI_*_*',
     'keep recoPFTauDiscriminator_pfTausDiscrimination*_*_*',

--- a/CommonTools/ParticleFlow/python/EITopPAG_cff.py
+++ b/CommonTools/ParticleFlow/python/EITopPAG_cff.py
@@ -16,6 +16,13 @@ from CommonTools.ParticleFlow.TopProjectors.pfNoJet_cfi import *
 from CommonTools.ParticleFlow.TopProjectors.pfNoTau_cfi import *
 
 
+# b-tagging
+from RecoJets.JetAssociationProducers.ak5JTA_cff import ak5JetTracksAssociatorAtVertex
+from RecoBTag.ImpactParameter.impactParameter_cfi import impactParameterTagInfos
+from RecoBTag.SecondaryVertex.secondaryVertexTagInfos_cfi import secondaryVertexTagInfos
+from RecoBTag.SecondaryVertex.combinedSecondaryVertexBJetTags_cfi import combinedSecondaryVertexBJetTags
+
+
 #### PU Again... need to do this twice because the "linking" stage of PF reco ####
 #### condenses information into the new "particleFlow" collection.            ####
 
@@ -122,6 +129,23 @@ pfTauEISequence = cms.Sequence(
     pfTausPtrsEI
     )
 
+#### B-tagging ####
+pfJetTrackAssociatorEI = ak5JetTracksAssociatorAtVertex.clone (
+    src = cms.InputTag("pfJetsEI")
+    )
+impactParameterTagInfosEI = impactParameterTagInfos.clone(
+    jetTracks = cms.InputTag( 'pfJetTrackAssociatorEI' )
+    )
+secondaryVertexTagInfosEI = secondaryVertexTagInfos.clone(
+    trackIPTagInfos = cms.InputTag( 'impactParameterTagInfosEI' )
+    )
+combinedSecondaryVertexBJetTagsEI = combinedSecondaryVertexBJetTags.clone(
+    tagInfos = cms.VInputTag(cms.InputTag("impactParameterTagInfosEI"),
+                             cms.InputTag("secondaryVertexTagInfosEI"))    
+    )
+
+
+
 #### MET ####
 pfMetEI = pfMET.clone(jets=cms.InputTag("pfJetsEI"))
 
@@ -145,6 +169,10 @@ EIsequence = cms.Sequence(
     pfNoJetEI + 
     pfTauEISequence +
     pfNoTauEI +
-    pfMetEI
+    pfMetEI+
+    pfJetTrackAssociatorEI+
+    impactParameterTagInfosEI+
+    secondaryVertexTagInfosEI+
+    combinedSecondaryVertexBJetTagsEI    
     )
 

--- a/FastSimulation/Configuration/python/FamosSequences_cff.py
+++ b/FastSimulation/Configuration/python/FamosSequences_cff.py
@@ -419,18 +419,11 @@ if(CaloMode==3):
         muonshighlevelreco+
         particleFlowLinks+
         caloJetMetGen+
-<<<<<<< HEAD
-        caloJetMet+
-        PFJetMet+
-        ic5JetTracksAssociatorAtVertex+
-        ak5JetTracksAssociatorAtVertex+
-=======
         caloJets+
         PFJetMet+
         jetTrackAssoc+
         recoJPTJets+
         metreco+
->>>>>>> 053d365... Fixing Fastsim sequence with btagging, and putting in the soft lepton b-tagging to AK5PFCHS jets per request of BTV
         reducedRecHits+
         famosBTaggingSequence+
         famosPFTauTaggingSequence

--- a/FastSimulation/Configuration/python/FamosSequences_cff.py
+++ b/FastSimulation/Configuration/python/FamosSequences_cff.py
@@ -65,13 +65,23 @@ from RecoJets.Configuration.RecoJetsGlobal_cff import *
 from RecoMET.Configuration.RecoMET_cff import *
 metreco.remove(BeamHaloId)
 
-caloJetMet = cms.Sequence(
+caloJets = cms.Sequence(
     recoJets+
     recoJetIds+
-    recoTrackJets+
-    recoJetAssociations+recoJPTJets+
-    metreco
+    recoTrackJets
 )
+
+jetTrackAssoc = cms.Sequence (
+    recoJetAssociations
+    )
+
+jetPlusTracks = cms.Sequence(
+    recoJPTJets
+    )
+
+metReco = cms.Sequence(
+    metreco
+    )
 
 
 
@@ -250,7 +260,6 @@ from RecoEgamma.EgammaIsolationAlgos.interestingEgammaIsoDetIdsSequence_cff impo
 
 # B tagging
 from RecoJets.JetAssociationProducers.ak5JTA_cff import *
-ak5JetTracksAssociatorAtVertex.tracks = 'generalTracks'
 from RecoVertex.Configuration.RecoVertex_cff import *
 from RecoVertex.BeamSpotProducer.BeamSpot_cff import *
 from RecoBTag.Configuration.RecoBTag_cff import *
@@ -410,10 +419,18 @@ if(CaloMode==3):
         muonshighlevelreco+
         particleFlowLinks+
         caloJetMetGen+
+<<<<<<< HEAD
         caloJetMet+
         PFJetMet+
         ic5JetTracksAssociatorAtVertex+
         ak5JetTracksAssociatorAtVertex+
+=======
+        caloJets+
+        PFJetMet+
+        jetTrackAssoc+
+        recoJPTJets+
+        metreco+
+>>>>>>> 053d365... Fixing Fastsim sequence with btagging, and putting in the soft lepton b-tagging to AK5PFCHS jets per request of BTV
         reducedRecHits+
         famosBTaggingSequence+
         famosPFTauTaggingSequence
@@ -436,10 +453,11 @@ else:
         muonshighlevelreco+
         particleFlowLinks+
         caloJetMetGen+
-        caloJetMet+
+        caloJets+
         PFJetMet+
-        ic5JetTracksAssociatorAtVertex+
-        ak5JetTracksAssociatorAtVertex+
+        jetTrackAssoc+
+        recoJPTJets+
+        metreco+
         reducedRecHits+
         famosBTaggingSequence+
         famosPFTauTaggingSequence
@@ -473,10 +491,11 @@ reconstructionHighLevel = cms.Sequence(
     muonshighlevelreco+
     particleFlowLinks+
     caloJetMetGen+
-    caloJetMet+
+    caloJets+
     PFJetMet+
-    ic5JetTracksAssociatorAtVertex+
-    ak5JetTracksAssociatorAtVertex+
+    jetTrackAssoc+
+    recoJPTJets+
+    metreco+
     reducedRecHits+
     famosBTaggingSequence+
     famosPFTauTaggingSequence
@@ -568,7 +587,8 @@ famosWithTracksAndJets = cms.Sequence(
     famosWithTracksAndCaloTowers+
     vertexreco+
     caloJetMetGen+
-    caloJetMet
+    caloJets+
+    metreco
 )
 
 ### Standard Jets _cannot_ be done without many other things...
@@ -584,7 +604,8 @@ famosWithJets = cms.Sequence(
     famosParticleFlowSequence+
     gsfElectronSequence+	
     caloJetMetGen+
-    caloJetMet
+    caloJets+
+    metreco
 )
 
 famosWithCaloTowersAndParticleFlow = cms.Sequence(
@@ -628,8 +649,10 @@ famosWithElectronsAndPhotons = cms.Sequence(
 famosWithBTagging = cms.Sequence(
     famosWithTracksAndCaloTowers+
     vertexreco+
-    ak5CaloJets+
-    ak5JetTracksAssociatorAtVertex+
+    ak5PFJetsCHS+
+    PFJetMet+
+    jetTrackAssoc+
+    metreco+
     ecalClustersNoPFBox+
     famosMuonSequence+
     reducedRecHits+ 
@@ -673,10 +696,12 @@ reconstructionWithFamosNoTk = cms.Sequence(
     egammaHighLevelRecoPostPF+
     muonshighlevelreco+
     caloJetMetGen+
-    caloJetMet+
+    caloJets+
+    metreco+
     PFJetMet+
-    ic5JetTracksAssociatorAtVertex+
-    ak5JetTracksAssociatorAtVertex+
+    jetTrackAssoc+
+    recoJPTJets+
+    metreco+
     reducedRecHits+
     famosBTaggingSequence+
     famosPFTauTaggingSequence

--- a/RecoBTag/ImpactParameter/python/impactParameter_cfi.py
+++ b/RecoBTag/ImpactParameter/python/impactParameter_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 impactParameterTagInfos = cms.EDProducer("TrackIPProducer",
-    jetTracks = cms.InputTag("ak5JetTracksAssociatorAtVertex"),
+    jetTracks = cms.InputTag("ak5JetTracksAssociatorAtVertexPF"),
     primaryVertex = cms.InputTag("offlinePrimaryVertices"),
     computeProbabilities = cms.bool(True),
     computeGhostTrack = cms.bool(True),

--- a/RecoBTag/SoftLepton/python/muonSelection.py
+++ b/RecoBTag/SoftLepton/python/muonSelection.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+All                              = cms.uint32(0)           # dummy options - always true
+AllGlobalMuons                   = cms.uint32(1)           # checks isGlobalMuon flag
+AllStandAloneMuons               = cms.uint32(2)           # checks isStandAloneMuon flag
+AllTrackerMuons                  = cms.uint32(3)           # checks isTrackerMuon flag
+TrackerMuonArbitrated            = cms.uint32(4)           # resolve ambiguity of sharing segments
+AllArbitrated                    = cms.uint32(5)           # all muons with the tracker muon arbitrated
+GlobalMuonPromptTight            = cms.uint32(6)           # global muons with tighter fit requirements
+TMLastStationLoose               = cms.uint32(7)           # penetration depth loose selector
+TMLastStationTight               = cms.uint32(8)           # penetration depth tight selector
+TM2DCompatibilityLoose           = cms.uint32(9)           # likelihood based loose selector
+TM2DCompatibilityTight           = cms.uint32(10)          # likelihood based tight selector
+TMOneStationLoose                = cms.uint32(11)          # require one well matched segment
+TMOneStationTight                = cms.uint32(12)          # require one well matched segment
+TMLastStationOptimizedLowPtLoose = cms.uint32(13)          # combination of TMLastStation and TMOneStation
+TMLastStationOptimizedLowPtTight = cms.uint32(14)          # combination of TMLastStation and TMOneStation

--- a/RecoBTag/SoftLepton/python/softLepton_cff.py
+++ b/RecoBTag/SoftLepton/python/softLepton_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
 from RecoBTau.JetTagComputer.jetTagRecord_cfi import *
+from RecoBTag.SoftLepton.softMuonTagInfos_cfi import *
 from RecoBTag.SoftLepton.softPFElectronTagInfos_cfi import *
 from RecoBTag.SoftLepton.softPFMuonTagInfos_cfi import *
 from RecoBTag.SoftLepton.SoftLeptonByMLP_cfi import *

--- a/RecoBTag/SoftLepton/python/softMuonTagInfos_cfi.py
+++ b/RecoBTag/SoftLepton/python/softMuonTagInfos_cfi.py
@@ -4,7 +4,7 @@ import RecoBTag.SoftLepton.muonSelection
 # SoftLeptonTagInfo producer for tagging caloJets with global muons 
 softMuonTagInfos = cms.EDProducer("SoftLepton",
     primaryVertex = cms.InputTag("offlinePrimaryVertices"),
-    jets = cms.InputTag("ak5CaloJets"),
+    jets = cms.InputTag("ak5PFJetsCHS"),
     leptons = cms.InputTag("muons"),
     leptonCands = cms.InputTag(""),         # optional
     leptonId = cms.InputTag(""),            # optional

--- a/RecoBTag/SoftLepton/python/softMuonTagInfos_cfi.py
+++ b/RecoBTag/SoftLepton/python/softMuonTagInfos_cfi.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+import RecoBTag.SoftLepton.muonSelection
+
+# SoftLeptonTagInfo producer for tagging caloJets with global muons 
+softMuonTagInfos = cms.EDProducer("SoftLepton",
+    primaryVertex = cms.InputTag("offlinePrimaryVertices"),
+    jets = cms.InputTag("ak5CaloJets"),
+    leptons = cms.InputTag("muons"),
+    leptonCands = cms.InputTag(""),         # optional
+    leptonId = cms.InputTag(""),            # optional
+    
+    refineJetAxis = cms.uint32(0),          # use calorimetric jet direction by default
+
+    leptonDeltaRCut = cms.double(0.4),      # lepton distance from jet axis
+    leptonChi2Cut = cms.double(9999.0),     # no cut on lepton's track's chi2/ndof
+    
+    muonSelection = RecoBTag.SoftLepton.muonSelection.AllGlobalMuons
+)

--- a/RecoBTag/SoftLepton/python/softPFElectronTagInfos_cfi.py
+++ b/RecoBTag/SoftLepton/python/softPFElectronTagInfos_cfi.py
@@ -2,5 +2,5 @@ import FWCore.ParameterSet.Config as cms
 
 softPFElectronsTagInfos = cms.EDProducer("SoftPFElectronTagInfoProducer",
     primaryVertex = cms.InputTag("offlinePrimaryVertices"),
-    jets = cms.InputTag("ak5PFJets")
+    jets = cms.InputTag("ak5PFJetsCHS")
 )

--- a/RecoBTag/SoftLepton/python/softPFMuonTagInfos_cfi.py
+++ b/RecoBTag/SoftLepton/python/softPFMuonTagInfos_cfi.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 softPFMuonsTagInfos = cms.EDProducer("SoftPFMuonTagInfoProducer",
     primaryVertex = cms.InputTag("offlinePrimaryVertices"),
-    jets = cms.InputTag("ak5PFJets"),
+    jets = cms.InputTag("ak5PFJetsCHS"),
     MuonId =cms.int32(0)
 )

--- a/RecoJets/Configuration/python/RecoJetsGlobal_cff.py
+++ b/RecoJets/Configuration/python/RecoJetsGlobal_cff.py
@@ -8,4 +8,4 @@ from RecoJets.Configuration.RecoPFJets_cff import *
 from RecoJets.Configuration.RecoJPTJets_cff import *
 
 jetGlobalReco = cms.Sequence(recoJets*recoJetIds*recoTrackJets)
-jetHighLevelReco = cms.Sequence(recoJetAssociations*recoPFJets*recoJetAssociationsExplicit*recoJPTJets)
+jetHighLevelReco = cms.Sequence(recoPFJets*recoJetAssociations*recoJetAssociationsExplicit*recoJPTJets)

--- a/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
@@ -80,8 +80,14 @@ RecoJetsRECO = cms.PSet(
                                            'keep *_kt4JetTracksAssociatorAtVertex_*_*', 
                                            'keep *_kt4JetTracksAssociatorAtCaloFace_*_*', 
                                            'keep *_kt4JetExtender_*_*',
+<<<<<<< HEAD
                                            'keep *_ak5JetTracksAssociatorAtVertex_*_*', 
                                            'keep *_ak5JetTracksAssociatorAtCaloFace_*_*', 
+=======
+                                           'keep *_ak5JetTracksAssociatorAtVertex_*_*',
+                                           'keep *_ak5JetTracksAssociatorAtVertexPF_*_*',
+                                           'keep *_ak5JetTracksAssociatorAtCaloFace_*_*',
+>>>>>>> 0ca6e99... Forgot to add JTA at calo face to event content
                                            'keep *_ak5JetTracksAssociatorExplicit_*_*',
                                            'keep *_ak5JetExtender_*_*',
                                            'keep *_ak7JetTracksAssociatorAtVertex_*_*', 

--- a/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
@@ -17,7 +17,8 @@ RecoJetsFEVT = cms.PSet(
                                            'keep *_kt4JetTracksAssociatorAtVertex_*_*', 
                                            'keep *_kt4JetTracksAssociatorAtCaloFace_*_*', 
                                            'keep *_kt4JetExtender_*_*',
-                                           'keep *_ak5JetTracksAssociatorAtVertex*_*_*', 
+                                           'keep *_ak5JetTracksAssociatorAtVertex*_*_*',
+                                           'keep *_ak5JetTracksAssociatorAtVertexPF*_*_*', 
                                            'keep *_ak5JetTracksAssociatorAtCaloFace*_*_*', 
                                            'keep *_ak5JetExtender_*_*',
                                            'keep *_ak5JetTracksAssociatorExplicit_*_*',
@@ -80,19 +81,9 @@ RecoJetsRECO = cms.PSet(
                                            'keep *_kt4JetTracksAssociatorAtVertex_*_*', 
                                            'keep *_kt4JetTracksAssociatorAtCaloFace_*_*', 
                                            'keep *_kt4JetExtender_*_*',
-<<<<<<< HEAD
-<<<<<<< HEAD
-                                           'keep *_ak5JetTracksAssociatorAtVertex_*_*', 
-                                           'keep *_ak5JetTracksAssociatorAtCaloFace_*_*', 
-=======
                                            'keep *_ak5JetTracksAssociatorAtVertex_*_*',
                                            'keep *_ak5JetTracksAssociatorAtVertexPF_*_*',
                                            'keep *_ak5JetTracksAssociatorAtCaloFace_*_*',
->>>>>>> 0ca6e99... Forgot to add JTA at calo face to event content
-=======
-                                           'keep *_ak5JetTracksAssociatorAtVertex_*_*',
-                                           'keep *_ak5JetTracksAssociatorAtVertexPF_*_*', 
->>>>>>> 9f8f426... Adding a JTA for PFJets
                                            'keep *_ak5JetTracksAssociatorExplicit_*_*',
                                            'keep *_ak5JetExtender_*_*',
                                            'keep *_ak7JetTracksAssociatorAtVertex*_*_*', 

--- a/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
@@ -17,12 +17,12 @@ RecoJetsFEVT = cms.PSet(
                                            'keep *_kt4JetTracksAssociatorAtVertex_*_*', 
                                            'keep *_kt4JetTracksAssociatorAtCaloFace_*_*', 
                                            'keep *_kt4JetExtender_*_*',
-                                           'keep *_ak5JetTracksAssociatorAtVertex_*_*', 
-                                           'keep *_ak5JetTracksAssociatorAtCaloFace_*_*', 
+                                           'keep *_ak5JetTracksAssociatorAtVertex*_*_*', 
+                                           'keep *_ak5JetTracksAssociatorAtCaloFace*_*_*', 
                                            'keep *_ak5JetExtender_*_*',
                                            'keep *_ak5JetTracksAssociatorExplicit_*_*',
-                                           'keep *_ak7JetTracksAssociatorAtVertex_*_*', 
-                                           'keep *_ak7JetTracksAssociatorAtCaloFace_*_*', 
+                                           'keep *_ak7JetTracksAssociatorAtVertex*_*_*', 
+                                           'keep *_ak7JetTracksAssociatorAtCaloFace*_*_*', 
                                            'keep *_ak7JetExtender_*_*',
                                            'keep *_ak5JetID_*_*','keep *_ak7JetID_*_*',
                                            'keep *_sc5JetID_*_*','keep *_sc7JetID_*_*',
@@ -81,6 +81,7 @@ RecoJetsRECO = cms.PSet(
                                            'keep *_kt4JetTracksAssociatorAtCaloFace_*_*', 
                                            'keep *_kt4JetExtender_*_*',
 <<<<<<< HEAD
+<<<<<<< HEAD
                                            'keep *_ak5JetTracksAssociatorAtVertex_*_*', 
                                            'keep *_ak5JetTracksAssociatorAtCaloFace_*_*', 
 =======
@@ -88,10 +89,14 @@ RecoJetsRECO = cms.PSet(
                                            'keep *_ak5JetTracksAssociatorAtVertexPF_*_*',
                                            'keep *_ak5JetTracksAssociatorAtCaloFace_*_*',
 >>>>>>> 0ca6e99... Forgot to add JTA at calo face to event content
+=======
+                                           'keep *_ak5JetTracksAssociatorAtVertex_*_*',
+                                           'keep *_ak5JetTracksAssociatorAtVertexPF_*_*', 
+>>>>>>> 9f8f426... Adding a JTA for PFJets
                                            'keep *_ak5JetTracksAssociatorExplicit_*_*',
                                            'keep *_ak5JetExtender_*_*',
-                                           'keep *_ak7JetTracksAssociatorAtVertex_*_*', 
-                                           'keep *_ak7JetTracksAssociatorAtCaloFace_*_*', 
+                                           'keep *_ak7JetTracksAssociatorAtVertex*_*_*', 
+                                           'keep *_ak7JetTracksAssociatorAtCaloFace*_*_*', 
                                            'keep *_ak7JetExtender_*_*',        
                                            'keep *_ak5JetID_*_*','keep *_ak7JetID_*_*',
                                            'keep *_ic5JetID_*_*',
@@ -144,7 +149,8 @@ RecoJetsAOD = cms.PSet(
                                            #        'keep *_towerMaker_*_*',
                                            'keep *_CastorTowerReco_*_*',                                           
                                            #        'keep *_ic5JetTracksAssociatorAtVertex_*_*',
-                                           'keep *_ak5JetTracksAssociatorAtVertex_*_*', 
+                                           'keep *_ak5JetTracksAssociatorAtVertex_*_*',
+                                           'keep *_ak5JetTracksAssociatorAtVertexPF_*_*', 
                                            'keep *_ak5JetTracksAssociatorExplicit_*_*',
                                            #'keep *_ak7JetTracksAssociatorAtVertex_*_*', 
                                            #        'keep *_iterativeCone5JetExtender_*_*', 

--- a/RecoJets/JetAssociationProducers/python/ak5JTA_cff.py
+++ b/RecoJets/JetAssociationProducers/python/ak5JTA_cff.py
@@ -7,19 +7,12 @@ from RecoJets.JetAssociationProducers.j2tParametersCALO_cfi import *
 from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import *
 ak5JetTracksAssociatorAtVertex = cms.EDProducer("JetTracksAssociatorAtVertex",
     j2tParametersVX,
-<<<<<<< HEAD
     jets = cms.InputTag("ak5CaloJets")
-<<<<<<< HEAD
-=======
-=======
-    jets = cms.InputTag("ak5PFJetsCHS")
->>>>>>> 56cbdee... Switching calo jets to AK5PFchs jets for JTA at the request of the BTV pog
 )
 
 ak5JetTracksAssociatorAtVertexPF = cms.EDProducer("JetTracksAssociatorAtVertex",
     j2tParametersVX,
     jets = cms.InputTag("ak5PFJetsCHS")
->>>>>>> 9f8f426... Adding a JTA for PFJets
 )
 
 
@@ -30,11 +23,11 @@ ak5JetTracksAssociatorExplicit = cms.EDProducer("JetTracksAssociatorExplicit",
 
 ak5JetTracksAssociatorAtCaloFace = cms.EDProducer("JetTracksAssociatorAtCaloFace",
     j2tParametersCALO,
-    jets = cms.InputTag("ak5PFJetsCHS")
+    jets = cms.InputTag("ak5CaloJets")
 )
 
 ak5JetExtender = cms.EDProducer("JetExtender",
-    jets = cms.InputTag("ak5PFJetsCHS"),
+    jets = cms.InputTag("ak5CaloJets"),
     jet2TracksAtCALO = cms.InputTag("ak5JetTracksAssociatorAtCaloFace"),
     jet2TracksAtVX = cms.InputTag("ak5JetTracksAssociatorAtVertex"),
     coneSize = cms.double(0.5)

--- a/RecoJets/JetAssociationProducers/python/ak5JTA_cff.py
+++ b/RecoJets/JetAssociationProducers/python/ak5JTA_cff.py
@@ -8,7 +8,16 @@ from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import *
 ak5JetTracksAssociatorAtVertex = cms.EDProducer("JetTracksAssociatorAtVertex",
     j2tParametersVX,
     jets = cms.InputTag("ak5CaloJets")
+<<<<<<< HEAD
+=======
 )
+
+ak5JetTracksAssociatorAtVertexPF = cms.EDProducer("JetTracksAssociatorAtVertex",
+    j2tParametersVX,
+    jets = cms.InputTag("ak5PFJetsCHS")
+>>>>>>> 9f8f426... Adding a JTA for PFJets
+)
+
 
 ak5JetTracksAssociatorExplicit = cms.EDProducer("JetTracksAssociatorExplicit",
     j2tParametersVX,
@@ -27,6 +36,8 @@ ak5JetExtender = cms.EDProducer("JetExtender",
     coneSize = cms.double(0.5)
 )
 
-ak5JTA = cms.Sequence(ak5JetTracksAssociatorAtVertex*ak5JetTracksAssociatorAtCaloFace*ak5JetExtender)
+ak5JTA = cms.Sequence(ak5JetTracksAssociatorAtVertexPF*
+                      ak5JetTracksAssociatorAtVertex*
+                      ak5JetTracksAssociatorAtCaloFace*ak5JetExtender)
 
 ak5JTAExplicit = cms.Sequence(ak5JetTracksAssociatorExplicit)

--- a/RecoJets/JetAssociationProducers/python/ak5JTA_cff.py
+++ b/RecoJets/JetAssociationProducers/python/ak5JTA_cff.py
@@ -7,9 +7,13 @@ from RecoJets.JetAssociationProducers.j2tParametersCALO_cfi import *
 from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import *
 ak5JetTracksAssociatorAtVertex = cms.EDProducer("JetTracksAssociatorAtVertex",
     j2tParametersVX,
+<<<<<<< HEAD
     jets = cms.InputTag("ak5CaloJets")
 <<<<<<< HEAD
 =======
+=======
+    jets = cms.InputTag("ak5PFJetsCHS")
+>>>>>>> 56cbdee... Switching calo jets to AK5PFchs jets for JTA at the request of the BTV pog
 )
 
 ak5JetTracksAssociatorAtVertexPF = cms.EDProducer("JetTracksAssociatorAtVertex",
@@ -21,16 +25,16 @@ ak5JetTracksAssociatorAtVertexPF = cms.EDProducer("JetTracksAssociatorAtVertex",
 
 ak5JetTracksAssociatorExplicit = cms.EDProducer("JetTracksAssociatorExplicit",
     j2tParametersVX,
-    jets = cms.InputTag("ak5PFJets")
+    jets = cms.InputTag("ak5PFJetsCHS")
 )
 
 ak5JetTracksAssociatorAtCaloFace = cms.EDProducer("JetTracksAssociatorAtCaloFace",
     j2tParametersCALO,
-    jets = cms.InputTag("ak5CaloJets")
+    jets = cms.InputTag("ak5PFJetsCHS")
 )
 
 ak5JetExtender = cms.EDProducer("JetExtender",
-    jets = cms.InputTag("ak5CaloJets"),
+    jets = cms.InputTag("ak5PFJetsCHS"),
     jet2TracksAtCALO = cms.InputTag("ak5JetTracksAssociatorAtCaloFace"),
     jet2TracksAtVX = cms.InputTag("ak5JetTracksAssociatorAtVertex"),
     coneSize = cms.double(0.5)

--- a/RecoJets/JetAssociationProducers/python/ak7JTA_cff.py
+++ b/RecoJets/JetAssociationProducers/python/ak7JTA_cff.py
@@ -5,6 +5,11 @@ from TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAlong_cfi i
 
 from RecoJets.JetAssociationProducers.j2tParametersCALO_cfi import *
 from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import *
+ak7JetTracksAssociatorAtVertexPF = cms.EDProducer("JetTracksAssociatorAtVertex",
+    j2tParametersVX,
+    jets = cms.InputTag("ak7PFJetsCHS")
+)
+
 ak7JetTracksAssociatorAtVertex = cms.EDProducer("JetTracksAssociatorAtVertex",
     j2tParametersVX,
     jets = cms.InputTag("ak7CaloJets")
@@ -22,5 +27,5 @@ ak7JetExtender = cms.EDProducer("JetExtender",
     coneSize = cms.double(0.7)
 )
 
-ak7JTA = cms.Sequence(ak7JetTracksAssociatorAtVertex*ak7JetTracksAssociatorAtCaloFace*ak7JetExtender)
+ak7JTA = cms.Sequence(ak7JetTracksAssociatorAtVertexPF*ak7JetTracksAssociatorAtVertex*ak7JetTracksAssociatorAtCaloFace*ak7JetExtender)
 


### PR DESCRIPTION
This is a backport of this pull request to 620 at the request of the b-tagging group : 

https://github.com/cms-sw/cmssw/pull/884

(I hope this time I didn't screw anything up). 

Cheers,
Sal
