### PR TITLE
use "consumes" for RecoMET

### DIFF
--- a/RecoMET/METAlgorithms/interface/TCMETAlgo.h
+++ b/RecoMET/METAlgorithms/interface/TCMETAlgo.h
@@ -43,6 +43,8 @@
 #include "DataFormats/METReco/interface/CaloMETCollection.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/MuonReco/interface/MuonMETCorrectionData.h"
+#include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
+
 #include "TH2D.h"
 #include "TVector3.h"
 
@@ -57,7 +59,20 @@ class TCMETAlgo
   TH2D* getResponseFunction_mode ( );
   TH2D* getResponseFunction_shower ( );
   TH2D* getResponseFunction_noshower ( );
-  void configure(const edm::ParameterSet &iConfig, int myResponseFunctionType);
+  void configure(const edm::ParameterSet &iConfig, int myResponseFunctionType,
+		 edm::EDGetTokenT<reco::MuonCollection>* muonToken,
+		 edm::EDGetTokenT<reco::GsfElectronCollection>* electronToken,
+		 edm::EDGetTokenT<edm::View<reco::MET> >* metToken,
+		 edm::EDGetTokenT<reco::TrackCollection>* trackToken,
+		 edm::EDGetTokenT<reco::BeamSpot>* beamSpotToken,
+		 edm::EDGetTokenT<reco::VertexCollection>* vertexToken_,
+		 edm::EDGetTokenT<reco::PFClusterCollection>* clustersECALToken,
+		 edm::EDGetTokenT<reco::PFClusterCollection>* clustersHCALToken,
+		 edm::EDGetTokenT<reco::PFClusterCollection>* clustersHFEMToken,
+		 edm::EDGetTokenT<reco::PFClusterCollection>* clustersHFHADToken,
+		 edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData> >* muonDepValueMapToken,
+		 edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData> >* tcmetDepValueMapToken
+		 );
  private:
   double met_x;
   double met_y;
@@ -87,6 +102,19 @@ class TCMETAlgo
   edm::InputTag inputTagPFClustersHCAL_;
   edm::InputTag inputTagPFClustersHFEM_;
   edm::InputTag inputTagPFClustersHFHAD_;   
+
+  edm::EDGetTokenT<reco::MuonCollection>* muonToken_;
+  edm::EDGetTokenT<reco::GsfElectronCollection>* electronToken_;
+  edm::EDGetTokenT<edm::View<reco::MET> >* metToken_;
+  edm::EDGetTokenT<reco::TrackCollection>* trackToken_;
+  edm::EDGetTokenT<reco::BeamSpot>* beamSpotToken_;
+  edm::EDGetTokenT<reco::VertexCollection>* vertexToken_;
+  edm::EDGetTokenT<reco::PFClusterCollection>* clustersECALToken_;
+  edm::EDGetTokenT<reco::PFClusterCollection>* clustersHCALToken_;
+  edm::EDGetTokenT<reco::PFClusterCollection>* clustersHFEMToken_;
+  edm::EDGetTokenT<reco::PFClusterCollection>* clustersHFHADToken_;
+  edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData> >* muonDepValueMapToken_;
+  edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData> >* tcmetDepValueMapToken_;
 
   bool    usePFClusters_;
   int     nLayers_;

--- a/RecoMET/METProducers/interface/METProducer.h
+++ b/RecoMET/METProducers/interface/METProducer.h
@@ -21,8 +21,13 @@
 
 #include <string.h>
 #include "FWCore/Framework/interface/EDProducer.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
 #include "RecoMET/METAlgorithms/interface/TCMETAlgo.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 
 namespace edm {
   class ParameterSet;
@@ -60,6 +65,8 @@ namespace cms
       std::string METtype;
       std::string alias;
 
+      edm::EDGetTokenT<edm::View<reco::Candidate> > inputToken_;
+
       //Calculate MET Significance (not necessary at HLT)
       bool calculateSignificance_;
       metsig::SignAlgoResolutions *resolutions_;
@@ -80,7 +87,26 @@ namespace cms
       //Use Pt instaed of Et
       bool usePt;
 
+      // for pfMET
+      edm::EDGetTokenT<edm::View<reco::PFJet> > jetToken_;
+
+
       TCMETAlgo tcMetAlgo_;
+
+      // for tcMET
+      edm::EDGetTokenT<reco::MuonCollection> muonToken_;
+      edm::EDGetTokenT<reco::GsfElectronCollection> electronToken_;
+      edm::EDGetTokenT<edm::View<reco::MET> > metToken_;
+      edm::EDGetTokenT<reco::TrackCollection> trackToken_;
+      edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+      edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
+      edm::EDGetTokenT<reco::PFClusterCollection> clustersECALToken_;
+      edm::EDGetTokenT<reco::PFClusterCollection> clustersHCALToken_;
+      edm::EDGetTokenT<reco::PFClusterCollection> clustersHFEMToken_;
+      edm::EDGetTokenT<reco::PFClusterCollection> clustersHFHADToken_;
+      edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData> > muonDepValueMapToken_;
+      edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData> > tcmetDepValueMapToken_;
+
     };
 }
 

--- a/RecoMET/METProducers/interface/MuonMET.h
+++ b/RecoMET/METProducers/interface/MuonMET.h
@@ -22,9 +22,14 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Handle.h"
 
+#include "DataFormats/METReco/interface/MET.h"
+#include "DataFormats/METReco/interface/CaloMET.h"
+
 #include "RecoMET/METAlgorithms/interface/MuonMETAlgo.h"
 #include "TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h"
 #include "TrackingTools/TrackAssociator/interface/TrackAssociatorParameters.h"
+
+#include "DataFormats/MuonReco/interface/MuonMETCorrectionData.h"
 
 
 namespace cms 
@@ -45,6 +50,11 @@ namespace cms
     edm::InputTag uncorMETInputTag_;
     edm::InputTag muonsInputTag_;
     edm::InputTag muonDepValueMap_;
+
+    edm::EDGetTokenT<edm::View<reco::Muon> > inputMuonToken_;
+    edm::EDGetTokenT<edm::ValueMap<reco::MuonMETCorrectionData> > inputValueMapMuonMetCorrToken_;
+    edm::EDGetTokenT<edm::View<reco::CaloMET> > inputCaloMETToken_;
+    edm::EDGetTokenT<edm::View<reco::MET> > inputMETToken_;
     
   };
 }

--- a/RecoMET/METProducers/interface/ParticleFlowForChargedMETProducer.h
+++ b/RecoMET/METProducers/interface/ParticleFlowForChargedMETProducer.h
@@ -12,6 +12,9 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include <DataFormats/VertexReco/interface/VertexFwd.h>
+#include <DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h>
+
 namespace reco
 {
   class ParticleFlowForChargedMETProducer : public edm::EDProducer {
@@ -26,6 +29,9 @@ namespace reco
     
     edm::InputTag pfCollectionLabel;
     edm::InputTag pvCollectionLabel;
+
+    edm::EDGetTokenT<VertexCollection> pvCollectionToken;
+    edm::EDGetTokenT<PFCandidateCollection> pfCandidatesToken;
 
     double dzCut;
     double neutralEtThreshold;

--- a/RecoMET/METProducers/src/ParticleFlowForChargedMETProducer.cc
+++ b/RecoMET/METProducers/src/ParticleFlowForChargedMETProducer.cc
@@ -1,9 +1,7 @@
 #include "RecoMET/METProducers/interface/ParticleFlowForChargedMETProducer.h"
 
 #include <DataFormats/VertexReco/interface/Vertex.h>
-#include <DataFormats/VertexReco/interface/VertexFwd.h>
 #include <DataFormats/ParticleFlowCandidate/interface/PFCandidate.h>
-#include <DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h>
 
 using namespace edm;
 using namespace std;
@@ -13,6 +11,10 @@ ParticleFlowForChargedMETProducer::ParticleFlowForChargedMETProducer(const edm::
 {
   pfCollectionLabel    = iConfig.getParameter<edm::InputTag>("PFCollectionLabel");
   pvCollectionLabel    = iConfig.getParameter<edm::InputTag>("PVCollectionLabel");
+
+  pfCandidatesToken = consumes<PFCandidateCollection>(pfCollectionLabel);
+  pvCollectionToken = consumes<VertexCollection>(pvCollectionLabel);
+
   dzCut    = iConfig.getParameter<double>("dzCut");
   neutralEtThreshold    = iConfig.getParameter<double>("neutralEtThreshold");
 
@@ -24,12 +26,12 @@ void ParticleFlowForChargedMETProducer::produce(Event& iEvent, const EventSetup&
 
   //Get the PV collection
   Handle<VertexCollection> pvCollection;
-  iEvent.getByLabel(pvCollectionLabel, pvCollection);
+  iEvent.getByToken(pvCollectionToken, pvCollection);
   VertexCollection::const_iterator vertex = pvCollection->begin();
 
   //Get pfCandidates
   Handle<PFCandidateCollection> pfCandidates;
-  iEvent.getByLabel(pfCollectionLabel, pfCandidates);
+  iEvent.getByToken(pfCandidatesToken, pfCandidates);
 
   // the output collection
   auto_ptr<PFCandidateCollection> chargedPFCandidates( new PFCandidateCollection ) ;


### PR DESCRIPTION
I added "consumes" and replaced getByLabel() with getByToken() for the producers under RecoMET/METProducers as instructed at
- https://indico.cern.ch/conferenceDisplay.py?confId=254366
- https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideEDMGetDataFromEvent

Since "consumes" is a protected method of a base class of the producers, it cannot be called from classes in RecoMET/METAlgorithms which are used by METProducer. But to implement quickly, I called many "consumes" in METProducer and passed tokens to classes in RecoMET/METAlgorithms. The code is ugly now. I will clean up the code when I can.
