### PR TITLE
Make ParentageRegistry thread-safe

### DIFF
--- a/DataFormats/Provenance/BuildFile.xml
+++ b/DataFormats/Provenance/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="boost"/>
 <use   name="rootcore"/>
+<use   name="tbb"/>
 <use   name="FWCore/MessageLogger"/>
 <export>
   <lib   name="1"/>

--- a/DataFormats/Provenance/interface/Hash.h
+++ b/DataFormats/Provenance/interface/Hash.h
@@ -35,6 +35,7 @@ namespace edm {
     void toString_(std::string& result, value_type const& hash);
     void toDigest_(cms::Digest& digest, value_type const& hash);
     std::ostream& print_(std::ostream& os, value_type const& hash);
+    size_t smallHash_(value_type const& hash);
   }
 
   template <int I>
@@ -70,6 +71,9 @@ namespace edm {
     value_type compactForm() const;
     
     bool isCompactForm() const;
+
+    ///returns a short hash which can be used with hashing containers
+    size_t smallHash() const;
     
     //Used by ROOT storage
     // CMS_CLASS_VERSION(10) // This macro is not defined here, so expand it.
@@ -210,6 +214,13 @@ namespace edm {
     return hash_detail::compactForm_(hash_);
   }
 
+  template<int I>
+  inline
+  size_t
+  Hash<I>::smallHash() const {
+    return hash_detail::smallHash_(hash_);
+  }
+  
   // Note: this template is not declared 'inline' because of the
   // switch statement.
 

--- a/DataFormats/Provenance/interface/ParentageRegistry.h
+++ b/DataFormats/Provenance/interface/ParentageRegistry.h
@@ -1,7 +1,8 @@
 #ifndef DataFormats_Provenance_ParentageRegistry_h
 #define DataFormats_Provenance_ParentageRegistry_h
 
-#include "FWCore/Utilities/interface/ThreadSafeRegistry.h"
+#include "tbb/concurrent_unordered_map.h"
+
 #include "DataFormats/Provenance/interface/Parentage.h"
 #include "DataFormats/Provenance/interface/ParentageID.h"
 
@@ -10,8 +11,46 @@
 // are persisted, but not the container.
 namespace edm
 {
-  typedef edm::detail::ThreadSafeRegistry<edm::ParentageID, edm::Parentage> ParentageRegistry;
-  typedef ParentageRegistry::collection_type ParentageMap;
+  class ParentageRegistry {
+  public:
+    typedef edm::ParentageID   key_type;
+    typedef edm::Parentage     value_type;
+    
+    static ParentageRegistry* instance();
+    
+    /// Retrieve the value_type object with the given key.
+    /// If we return 'true', then 'result' carries the
+    /// value_type object.
+    /// If we return 'false, no matching key was found, and
+    /// the value of 'result' is undefined.
+    bool getMapped(key_type const& k, value_type& result) const;
+    
+    /** Retrieve a pointer to the value_type object with the given key.
+     If there is no object associated with the given key 0 is returned.
+     */
+    value_type const* getMapped(key_type const& k) const;
+    
+    /// Insert the given value_type object into the
+    /// registry. If there was already a value_type object
+    /// with the same key, we don't change it. This should be OK,
+    /// since it should have the same contents if the key is the
+    /// same.  Return 'true' if we really added the new
+    /// value_type object, and 'false' if the
+    /// value_type object was already present.
+    bool insertMapped(value_type const& v);
+    
+    ///Not thread safe
+    void clear();
+
+    struct key_hash {
+      std::size_t operator()(key_type const& iKey) const{
+        return iKey.smallHash();
+      }
+    };
+  private:
+    tbb::concurrent_unordered_map<key_type,value_type,key_hash> m_map;
+  };
+
 }
 
 #endif

--- a/DataFormats/Provenance/src/Hash.cc
+++ b/DataFormats/Provenance/src/Hash.cc
@@ -3,6 +3,8 @@
 #include "FWCore/Utilities/interface/Digest.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
+#include <functional>
+
 namespace edm {
   namespace detail {
     // This string is the 16-byte, non-printable version.
@@ -49,6 +51,16 @@ namespace edm {
             << "\nPlease report this to the core framework developers";
         }
       }
+    }
+    
+    size_t
+    smallHash_(value_type const& hash) {
+      //NOTE: In future we could try to xor the first 8bytes into the second 8bytes of the string to make the hash
+      std::hash<std::string> h;
+      if (hash.size()==16) {
+        return h(hash);
+      }
+      return h(compactForm_(hash));
     }
 
     bool

--- a/DataFormats/Provenance/src/ParentageRegistry.cc
+++ b/DataFormats/Provenance/src/ParentageRegistry.cc
@@ -1,4 +1,38 @@
 #include "DataFormats/Provenance/interface/ParentageRegistry.h"
-#include "FWCore/Utilities/interface/ThreadSafeRegistry.icc"
 
-DEFINE_THREAD_SAFE_REGISTRY_INSTANCE(ParentageRegistry)
+namespace edm {
+  ParentageRegistry*
+  ParentageRegistry::instance() {
+    static ParentageRegistry s_reg;
+    return &s_reg;
+  }
+  
+  bool
+  ParentageRegistry::getMapped(key_type const& k, value_type& result) const
+  {
+    auto it = m_map.find(k);
+    bool found = it != m_map.end();
+    if(found) {
+      result = it->second;
+    }
+    return found;
+  }
+  
+  ParentageRegistry::value_type const*
+  ParentageRegistry::getMapped(key_type const& k) const
+  {
+    auto it = m_map.find(k);
+    bool found = it != m_map.end();
+    return found? &(it->second) : static_cast<value_type const*>(nullptr);
+  }
+
+  bool
+  ParentageRegistry::insertMapped(value_type const& v) {
+    return m_map.insert(std::make_pair(v.id(),v)).second;
+  }
+  
+  void
+  ParentageRegistry::clear() {
+    m_map.clear();
+  }
+}

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -552,7 +552,7 @@ namespace edm {
     psetRegistry->dataForUpdate().clear();
     psetRegistry->extraForUpdate().setID(ParameterSetID());
 
-    ParentageRegistry::instance()->dataForUpdate().clear();
+    ParentageRegistry::instance()->clear();
   }
 
   void


### PR DESCRIPTION
Changed the edm::ParentageRegistry to be its own class which uses tbb::concurrent_unordered_map. This allows for safe concurrent reads and updates. The hash used by the container is generated by the std::hash function which is applied to the 16byte string internal the the edm::Hash<> class.
