### PR TITLE
Ecal fixes -- Get 101.0 and 102.0 back to work.

### DIFF
--- a/RecoEcal/EgammaClusterProducers/src/ReducedESRecHitCollectionProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/ReducedESRecHitCollectionProducer.cc
@@ -107,6 +107,15 @@ void ReducedESRecHitCollectionProducer::produce(edm::Event & e, const edm::Event
   for( unsigned int t = 0; t < interestingDetIdCollections_.size(); ++t )
     {
       e.getByToken(interestingDetIdCollections_[t],detId);    
+      if(!detId.isValid())
+      {
+          Labels labels;
+          labelsForToken(interestingDetIdCollections_[t], labels);
+          edm::LogError("MissingInput")<<"no reason to skip detid from : (" << labels.module << ", "
+                                                                            << labels.productInstance << ", "
+                                                                            << labels.process << ")" << std::endl;
+          continue;
+      }
       collectedIds_.insert(detId->begin(),detId->end());
     }
 

--- a/RecoEcal/EgammaClusterProducers/src/ReducedRecHitCollectionProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/ReducedRecHitCollectionProducer.cc
@@ -73,6 +73,15 @@ ReducedRecHitCollectionProducer::produce (edm::Event& iEvent,
      {
        Handle< DetIdCollection > detId;
        iEvent.getByToken(interestingDetIdCollections_[t],detId);
+       if(!detId.isValid())
+       {
+           Labels labels;
+           labelsForToken(interestingDetIdCollections_[t], labels);
+           edm::LogError("MissingInput")<<"no reason to skip detid from : (" << labels.module << ", "
+                                                                             << labels.productInstance << ", "
+                                                                             << labels.process << ")" << std::endl;
+           continue;
+       }
      
        
        for (unsigned int ii=0;ii<(*detId).size();ii++)


### PR DESCRIPTION
This reintroduces the LogError which was found in the old code and brings workflows 101.0 and 102.0 back into business. I'll merge this to get back to the original state, notice however that there are a bunch of errors in those two workflows which probably should be better understood.

```
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:00 CEST Run: 1 Event: 1
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:00 CEST Run: 1 Event: 1
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:00 CEST Run: 1 Event: 1
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:00 CEST Run: 1 Event: 1
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:00 CEST Run: 1 Event: 1
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:00 CEST Run: 1 Event: 1
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:00 CEST Run: 1 Event: 1
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:00 CEST Run: 1 Event: 1
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:00 CEST Run: 1 Event: 1
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:00 CEST Run: 1 Event: 1
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:00 CEST Run: 1 Event: 1
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:00 CEST Run: 1 Event: 1
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
Begin processing the 2nd record. Run 1, Event 2, LumiSection 1 at 19-Sep-2013 11:38:00.544 CEST
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:06 CEST Run: 1 Event: 2
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:06 CEST Run: 1 Event: 2
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:06 CEST Run: 1 Event: 2
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:06 CEST Run: 1 Event: 2
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:06 CEST Run: 1 Event: 2
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:06 CEST Run: 1 Event: 2
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:06 CEST Run: 1 Event: 2
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:06 CEST Run: 1 Event: 2
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:06 CEST Run: 1 Event: 2
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:06 CEST Run: 1 Event: 2
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:06 CEST Run: 1 Event: 2
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:06 CEST Run: 1 Event: 2
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
Begin processing the 3rd record. Run 1, Event 3, LumiSection 1 at 19-Sep-2013 11:38:06.198 CEST
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:09 CEST Run: 1 Event: 3
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:09 CEST Run: 1 Event: 3
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:09 CEST Run: 1 Event: 3
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:09 CEST Run: 1 Event: 3
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:09 CEST Run: 1 Event: 3
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:09 CEST Run: 1 Event: 3
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:09 CEST Run: 1 Event: 3
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:09 CEST Run: 1 Event: 3
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:09 CEST Run: 1 Event: 3
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:09 CEST Run: 1 Event: 3
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:09 CEST Run: 1 Event: 3
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:09 CEST Run: 1 Event: 3
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
Begin processing the 4th record. Run 1, Event 4, LumiSection 1 at 19-Sep-2013 11:38:09.937 CEST
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:16 CEST Run: 1 Event: 4
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:16 CEST Run: 1 Event: 4
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:16 CEST Run: 1 Event: 4
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:16 CEST Run: 1 Event: 4
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:16 CEST Run: 1 Event: 4
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:16 CEST Run: 1 Event: 4
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:16 CEST Run: 1 Event: 4
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:16 CEST Run: 1 Event: 4
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:16 CEST Run: 1 Event: 4
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:16 CEST Run: 1 Event: 4
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:16 CEST Run: 1 Event: 4
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:16 CEST Run: 1 Event: 4
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
Begin processing the 5th record. Run 1, Event 5, LumiSection 1 at 19-Sep-2013 11:38:16.323 CEST
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:17 CEST Run: 1 Event: 5
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:17 CEST Run: 1 Event: 5
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:17 CEST Run: 1 Event: 5
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:17 CEST Run: 1 Event: 5
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:17 CEST Run: 1 Event: 5
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:17 CEST Run: 1 Event: 5
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:17 CEST Run: 1 Event: 5
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:17 CEST Run: 1 Event: 5
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:17 CEST Run: 1 Event: 5
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:17 CEST Run: 1 Event: 5
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:17 CEST Run: 1 Event: 5
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:17 CEST Run: 1 Event: 5
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
Begin processing the 6th record. Run 1, Event 6, LumiSection 1 at 19-Sep-2013 11:38:17.284 CEST
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:21 CEST Run: 1 Event: 6
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:21 CEST Run: 1 Event: 6
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:21 CEST Run: 1 Event: 6
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:21 CEST Run: 1 Event: 6
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:21 CEST Run: 1 Event: 6
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:21 CEST Run: 1 Event: 6
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:21 CEST Run: 1 Event: 6
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:21 CEST Run: 1 Event: 6
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:21 CEST Run: 1 Event: 6
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:21 CEST Run: 1 Event: 6
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:21 CEST Run: 1 Event: 6
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:21 CEST Run: 1 Event: 6
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
Begin processing the 7th record. Run 1, Event 7, LumiSection 1 at 19-Sep-2013 11:38:21.861 CEST
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:25 CEST Run: 1 Event: 7
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:25 CEST Run: 1 Event: 7
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:25 CEST Run: 1 Event: 7
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:25 CEST Run: 1 Event: 7
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:25 CEST Run: 1 Event: 7
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:25 CEST Run: 1 Event: 7
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:25 CEST Run: 1 Event: 7
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:25 CEST Run: 1 Event: 7
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:25 CEST Run: 1 Event: 7
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:25 CEST Run: 1 Event: 7
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:25 CEST Run: 1 Event: 7
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:25 CEST Run: 1 Event: 7
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
Begin processing the 8th record. Run 1, Event 8, LumiSection 1 at 19-Sep-2013 11:38:25.736 CEST
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:30 CEST Run: 1 Event: 8
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:30 CEST Run: 1 Event: 8
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:30 CEST Run: 1 Event: 8
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:30 CEST Run: 1 Event: 8
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:30 CEST Run: 1 Event: 8
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:30 CEST Run: 1 Event: 8
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:30 CEST Run: 1 Event: 8
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:30 CEST Run: 1 Event: 8
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:30 CEST Run: 1 Event: 8
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:30 CEST Run: 1 Event: 8
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:30 CEST Run: 1 Event: 8
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:30 CEST Run: 1 Event: 8
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
Begin processing the 9th record. Run 1, Event 9, LumiSection 1 at 19-Sep-2013 11:38:30.502 CEST
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:35 CEST Run: 1 Event: 9
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:35 CEST Run: 1 Event: 9
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:35 CEST Run: 1 Event: 9
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:35 CEST Run: 1 Event: 9
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:35 CEST Run: 1 Event: 9
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:35 CEST Run: 1 Event: 9
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:35 CEST Run: 1 Event: 9
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:35 CEST Run: 1 Event: 9
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:35 CEST Run: 1 Event: 9
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:35 CEST Run: 1 Event: 9
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:35 CEST Run: 1 Event: 9
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:35 CEST Run: 1 Event: 9
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
Begin processing the 10th record. Run 1, Event 10, LumiSection 1 at 19-Sep-2013 11:38:35.618 CEST
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:40 CEST Run: 1 Event: 10
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:40 CEST Run: 1 Event: 10
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:40 CEST Run: 1 Event: 10
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:40 CEST Run: 1 Event: 10
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEB, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:40 CEST Run: 1 Event: 10
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEB  19-Sep-2013 11:38:40 CEST Run: 1 Event: 10
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:40 CEST Run: 1 Event: 10
no reason to skip detid from :InputTag:  label = interestingEleIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:40 CEST Run: 1 Event: 10
no reason to skip detid from :InputTag:  label = interestingGamIsoDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:40 CEST Run: 1 Event: 10
no reason to skip detid from :InputTag:  label = pfElectronInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:40 CEST Run: 1 Event: 10
no reason to skip detid from :InputTag:  label = pfPhotonInterestingEcalDetIdEE, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:40 CEST Run: 1 Event: 10
no reason to skip detid from :InputTag:  label = muonEcalDetIds, instance = 
%MSG
%MSG-e MissingInput:  ReducedRecHitCollectionProducer:reducedEcalRecHitsEE  19-Sep-2013 11:38:40 CEST Run: 1 Event: 10
no reason to skip detid from :InputTag:  label = interestingTrackEcalDetIds, instance = 
%MSG
```

@argiro @Martin-Grunewald @slava77 @thspeer
