### PR TITLE
Tests of cache types for EDProducer, EDAnalyzer and EDFilter

### DIFF
--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -67,6 +67,21 @@
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/ParameterSet"/>
 </library>
+<library   file="stubs/TestGlobalProducers.cc,stubs/TestGlobalAnalyzers.cc,stubs/TestGlobalFilters.cc" name="TestGlobalModules">
+  <flags   EDM_PLUGIN="1"/>
+  <use   name="FWCore/Framework"/>
+  <use   name="FWCore/ParameterSet"/>
+</library>
+<library   file="stubs/TestOneProducers.cc,stubs/TestOneAnalyzers.cc,stubs/TestOneFilters.cc" name="TestOneModules">
+  <flags   EDM_PLUGIN="1"/>
+  <use   name="FWCore/Framework"/>
+  <use   name="FWCore/ParameterSet"/>
+</library>
+<library   file="stubs/TestStreamProducers.cc,stubs/TestStreamFilters.cc,stubs/TestStreamAnalyzers.cc" name="TestStreamModules">
+  <flags   EDM_PLUGIN="1"/>
+  <use   name="FWCore/Framework"/>
+  <use   name="FWCore/ParameterSet"/>
+</library>
 <library   file="stubs/TestSchedulerModule1.cc" name="TestSchedulerModule1">
   <flags   EDM_PLUGIN="1"/>
   <use   name="FWCore/Framework"/>
@@ -198,6 +213,10 @@
 </bin>
 <bin   name="TestFWCoreFrameworkUnscheduled" file="TestDriver.cpp">
   <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_unscheduled.sh"/>
+  <use   name="FWCore/Utilities"/>
+</bin>
+<bin   name="TestFWCoreFrameworkGlobalStreamOne" file="TestDriver.cpp">
+  <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_global_stream_one.sh"/>
   <use   name="FWCore/Utilities"/>
 </bin>
 <bin   name="TestFWCoreFrameworkReplace" file="TestDriver.cpp">

--- a/FWCore/Framework/test/run_global_stream_one.sh
+++ b/FWCore/Framework/test/run_global_stream_one.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Pass in name and status
+function die { echo $1: status $2 ;  exit $2; }
+
+F1=${LOCAL_TEST_DIR}/test_global_modules_cfg.py
+F2=${LOCAL_TEST_DIR}/test_stream_modules_cfg.py
+F3=${LOCAL_TEST_DIR}/test_one_modules_cfg.py
+(cmsRun $F1 ) || die "Failure using $F1" $?
+(cmsRun $F2 ) || die "Failure using $F2" $?
+(cmsRun $F3 ) || die "Failure using $F3" $?
+

--- a/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalAnalyzers.cc
@@ -1,0 +1,290 @@
+
+/*----------------------------------------------------------------------
+
+Toy edm::global::EDAnalyzer modules of 
+edm::*Cache templates 
+for testing purposes only.
+
+----------------------------------------------------------------------*/
+#include <iostream>
+#include <atomic>
+#include <vector>
+#include <map>
+#include <functional>
+#include "FWCore/Framework/interface/global/EDAnalyzer.h"
+#include "FWCore/Framework/src/WorkerT.h"
+#include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+namespace edmtest {
+namespace global {
+
+struct Cache { 
+   Cache():value(0),run(0),lumi(0),strm(0),work(0) {}
+   //Using mutable since we want to update the value.
+   mutable std::atomic<unsigned int> value;
+   mutable std::atomic<unsigned int> run;
+   mutable std::atomic<unsigned int> lumi;
+   mutable std::atomic<unsigned int> strm;
+   mutable std::atomic<unsigned int> work;
+};
+
+struct UnsafeCache {
+   UnsafeCache():value(0),run(0),lumi(0),strm(0),work(0) {}
+   unsigned int value;
+   unsigned int run;
+   unsigned int lumi;
+   unsigned int strm;
+   unsigned int work;
+};
+
+
+  class StreamIntAnalyzer: public edm::global::EDAnalyzer<edm::StreamCache<Cache>> {
+  public:
+    explicit StreamIntAnalyzer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions"))
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {}
+    const unsigned int trans_;
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    
+    std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
+      ++m_count;
+      return std::unique_ptr<Cache>(new Cache());
+    }
+    
+    void streamBeginRun(edm::StreamID , edm::Run const&, edm::EventSetup const&) const  override{
+      ++m_count;
+    }
+
+    void streamBeginLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+
+    void analyze(edm::StreamID iID, const edm::Event&, const edm::EventSetup&) const override {
+      ++m_count;
+       
+    }
+
+    void streamEndLuminosityBlock(edm::StreamID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+
+    void streamEndRun(edm::StreamID, edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+
+    void endStream(edm::StreamID iID ) const override {
+      ++m_count;
+      ++((streamCache(iID))->value);
+      if ( (streamCache(iID))->value != cvalue_) {
+          throw cms::Exception("cache value")
+          << "StreamIntAnalyzer cache value "
+          << (streamCache(iID))->value << " but it was supposed to be " << cvalue_;
+      }
+    } 
+
+    ~StreamIntAnalyzer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "StreamIntAnalyzer transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+  
+  class RunIntAnalyzer: public edm::global::EDAnalyzer<edm::RunCache<Cache>> {
+  public:
+    explicit RunIntAnalyzer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions"))
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {}
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    
+    std::shared_ptr<Cache> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::shared_ptr<Cache>(new Cache());
+    }
+
+    void analyze(edm::StreamID iID, const edm::Event& iEvent, const edm::EventSetup&) const override {
+      ++m_count;
+      ++((runCache(iEvent.getRun().index()))->value);
+       
+    }
+
+    void globalEndRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+      ++m_count;
+      if ( (runCache(iRun.index()))->value != cvalue_ ) {
+          throw cms::Exception("cache value")
+          << "RunIntAnalyzer cache value "
+          << (runCache(iRun.index()))->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+    ~RunIntAnalyzer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "RunIntAnalyzer transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+
+  class LumiIntAnalyzer: public edm::global::EDAnalyzer<edm::LuminosityBlockCache<Cache>> {
+  public:
+    explicit LumiIntAnalyzer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {}
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+   
+    std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::shared_ptr<Cache>(new Cache());
+    }
+
+    void analyze(edm::StreamID, const edm::Event& iEvent, const edm::EventSetup&) const override {
+      ++m_count;
+      ++(luminosityBlockCache(iEvent.getLuminosityBlock().index())->value);
+       
+    }
+     
+    void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      ++m_count;
+      if( (luminosityBlockCache(iLB.index()))->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << "LumiIntAnalyzer cache value "
+          << (luminosityBlockCache(iLB.index()))->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+    ~LumiIntAnalyzer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "LumiIntAnalyzer transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+  
+  class RunSummaryIntAnalyzer: public edm::global::EDAnalyzer<edm::StreamCache<Cache>,edm::RunSummaryCache<Cache>> {
+  public:
+    explicit RunSummaryIntAnalyzer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {}
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+
+    std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
+      ++m_count;
+      return std::unique_ptr<Cache>(new Cache());
+    }
+
+    std::shared_ptr<Cache> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::shared_ptr<Cache>(new Cache());
+    }
+  
+    void analyze(edm::StreamID iID, const edm::Event&, const edm::EventSetup&) const override {
+      ++m_count;
+      ++((streamCache(iID))->value);
+       
+    }
+  
+    void streamEndRunSummary(edm::StreamID iID, edm::Run const&, edm::EventSetup const&, Cache* gCache) const override {
+      ++m_count;
+      gCache->value += (streamCache(iID))->value;
+      (streamCache(iID))->value = 0;
+    }
+    
+    void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, Cache* gCache) const override {
+      ++m_count;
+      if( gCache->value  != cvalue_) {
+        throw cms::Exception("cache value")
+          << "RunSummaryIntAnalyzer cache value "
+          << gCache->value << " but it was supposed to be " << cvalue_;
+      } 
+    }
+
+    ~RunSummaryIntAnalyzer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "RunSummaryIntAnalyzer transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class LumiSummaryIntAnalyzer: public edm::global::EDAnalyzer<edm::StreamCache<Cache>,edm::LuminosityBlockSummaryCache<Cache>> {
+  public:
+    explicit LumiSummaryIntAnalyzer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {}
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+
+    std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
+      ++m_count;
+      return std::unique_ptr<Cache>(new Cache());
+    }
+
+    std::shared_ptr<Cache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      return std::shared_ptr<Cache>(new Cache());
+    }
+    
+    void analyze(edm::StreamID iID, const edm::Event& iEvent, const edm::EventSetup&) const override {
+      ++m_count;
+      ++((streamCache(iID))->value);
+       
+    }
+
+    void streamEndLuminosityBlockSummary(edm::StreamID iID, edm::LuminosityBlock const& iLumiBlock, edm::EventSetup const&, Cache* gCache) const override {
+      ++m_count;
+      gCache->value += (streamCache(iID))->value;
+      (streamCache(iID))->value = 0;
+    }
+ 
+    void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, Cache* gCache) const override {
+      ++m_count;
+      if( gCache->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << "LumiSummaryIntAnalyzer cache value "
+          << gCache->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+    ~LumiSummaryIntAnalyzer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "LumiSummaryIntAnalyzer transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+}
+}
+
+DEFINE_FWK_MODULE(edmtest::global::StreamIntAnalyzer);
+DEFINE_FWK_MODULE(edmtest::global::RunIntAnalyzer);
+DEFINE_FWK_MODULE(edmtest::global::LumiIntAnalyzer);
+DEFINE_FWK_MODULE(edmtest::global::RunSummaryIntAnalyzer);
+DEFINE_FWK_MODULE(edmtest::global::LumiSummaryIntAnalyzer);
+

--- a/FWCore/Framework/test/stubs/TestGlobalFilters.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalFilters.cc
@@ -1,0 +1,538 @@
+
+/*----------------------------------------------------------------------
+
+Toy edm::global::EDFilter modules of 
+edm::*Cache templates and edm::*Producer classes
+for testing purposes only.
+
+----------------------------------------------------------------------*/
+#include <iostream>
+#include <atomic>
+#include <vector>
+#include <map>
+#include <functional>
+#include "FWCore/Framework/interface/global/EDFilter.h"
+#include "FWCore/Framework/src/WorkerT.h"
+#include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+
+
+namespace edmtest {
+namespace global {
+
+struct Cache { 
+   Cache():value(0),run(0),lumi(0),strm(0),work(0) {}
+   //Using mutable since we want to update the value.
+   mutable std::atomic<unsigned int> value;
+   mutable std::atomic<unsigned int> run;
+   mutable std::atomic<unsigned int> lumi;
+   mutable std::atomic<unsigned int> strm;
+   mutable std::atomic<unsigned int> work;
+};
+
+struct UnsafeCache {
+   UnsafeCache():value(0),run(0),lumi(0),strm(0),work(0) {}
+   unsigned int value;
+   unsigned int run;
+   unsigned int lumi;
+   unsigned int strm;
+   unsigned int work;
+};
+
+
+  class StreamIntFilter : public edm::global::EDFilter<edm::StreamCache<Cache>> {
+  public:
+    explicit StreamIntFilter(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {
+    produces<unsigned int>();
+    }
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+   
+    std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
+      ++m_count;
+      std::unique_ptr<Cache> sCache = std::unique_ptr<Cache>(new Cache());
+      ++(sCache->strm);
+      return sCache;
+    }
+    
+    void streamBeginRun(edm::StreamID iID, edm::Run const&, edm::EventSetup const&) const  override{
+      ++m_count;
+      Cache const* sCache = streamCache(iID);
+      if ( sCache->run != 0 || sCache->lumi !=0 || sCache->work !=0 || sCache->strm !=1 ) {
+        throw cms::Exception("out of sequence")
+          << "streamBeginRun out of sequence in Stream " << iID.value();
+      }      
+      ++(sCache->run);
+     }
+
+    void streamBeginLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      Cache const* sCache = streamCache(iID);
+      if ( sCache->lumi != 0 || sCache->work != 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamBeginLuminosityBlock out of sequence in Stream " << iID.value();
+      }      
+       ++(sCache->lumi);
+     }
+
+    bool filter(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+      Cache const* sCache = streamCache(iID);
+      ++(sCache->work);
+      if ( sCache->lumi == 0 && sCache->run == 0) {
+        throw cms::Exception("out of sequence")
+          << "produce out of sequence in Stream " << iID.value();
+      }       
+       
+      return true;
+    }
+ 
+    void streamEndLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      Cache const* sCache = streamCache(iID);
+      --(sCache->lumi);
+      sCache->work = 0;
+      if ( sCache->lumi != 0 || sCache->run == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndLuminosityBlock out of sequence in Stream " << iID.value();
+      }      
+     }
+
+    void streamEndRun(edm::StreamID iID, edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      Cache const* sCache = streamCache(iID);
+      --(sCache->run);
+      sCache->work = 0;
+      if ( sCache->run != 0 || sCache->lumi != 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndRun out of sequence in Stream " << iID.value();
+      }      
+    }
+
+    void endStream(edm::StreamID iID) const override {
+      ++m_count;
+      Cache const* sCache = streamCache(iID);
+      --(sCache->strm);
+      if ( sCache->strm != 0 || sCache->run != 0 || sCache->lumi != 0 ) {
+        throw cms::Exception("out of sequence")
+          << "endStream out of sequence in Stream " << iID.value();
+      }      
+   }
+
+    ~StreamIntFilter() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "StreamIntFilter transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+  
+  class RunIntFilter : public edm::global::EDFilter<edm::StreamCache<Cache>,edm::RunCache<Cache>> {
+  public:
+    explicit RunIntFilter(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {    
+    produces<unsigned int>();
+    }
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    
+    std::shared_ptr<Cache> globalBeginRun(edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      std::shared_ptr<Cache> rCache = std::shared_ptr<Cache>{new Cache()};
+      ++(rCache->run);
+      return rCache;
+    }
+ 
+    std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
+      return std::unique_ptr<Cache>(new Cache());
+    }
+
+    void streamBeginRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const  override {
+      Cache const * rCache = runCache(iRun.index());
+      if ( rCache->run == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamBeginRun before globalBeginRun in Stream " << iID.value();
+      }      
+    }
+ 
+    bool filter(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const override {
+      ++m_count;
+      Cache const * rCache = runCache(iEvent.getRun().index());
+      ++(rCache->value);
+       
+      return true;
+    }
+
+    void streamEndRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const override {
+      Cache const * rCache = runCache(iRun.index());
+      if ( rCache->run == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndRun after globalEndRun in Stream " << iID.value();
+      }      
+    }
+
+
+    void globalEndRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+      ++m_count;
+      Cache const * rCache = runCache(iRun.index());
+      if ( rCache->value != cvalue_ ) {
+          throw cms::Exception("cache value")
+          << "RunIntFilter cache value "
+          << rCache->value << " but it was supposed to be " << cvalue_;
+      }
+     --(rCache->run);
+    }
+
+    ~RunIntFilter() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "RunIntFilter transitions "     
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+
+  class LumiIntFilter : public edm::global::EDFilter<edm::StreamCache<Cache>,edm::LuminosityBlockCache<Cache>> {
+  public:
+    explicit LumiIntFilter(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {    
+    produces<unsigned int>();
+    }
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    
+    std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      std::shared_ptr<Cache> lCache = std::shared_ptr<Cache>{new Cache()};
+      ++(lCache->lumi);  
+      return lCache;
+    }
+
+   std::unique_ptr<Cache> beginStream(edm::StreamID iID) const override {
+      std::unique_ptr<Cache> sCache = std::unique_ptr<Cache>(new Cache());
+      return sCache;
+    }
+
+   void streamBeginLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      Cache const* lCache = luminosityBlockCache(iLB.index()); 
+      if ( lCache->lumi == 0) {
+        throw cms::Exception("out of sequence")
+          << "streamBeginLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+       }
+   }
+
+
+    bool filter(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const override {
+      ++m_count;
+      ++(luminosityBlockCache(iEvent.getLuminosityBlock().index())->value);
+       
+      return true;
+    }
+ 
+   void streamEndLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      Cache const* lCache = luminosityBlockCache(iLB.index()); 
+      if ( lCache->lumi == 0) {
+        throw cms::Exception("out of sequence")
+          << "streamEndLuminosityBlock seen before globalEndLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+       }
+    }
+ 
+    
+    void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      ++m_count;
+      Cache const* lCache = luminosityBlockCache(iLB.index());
+      --(lCache->lumi); 
+      if ( lCache->lumi != 0 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+      }
+      if( lCache->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << "LumiIntFilter cache value "
+          << lCache->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+    ~LumiIntFilter() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "LumiIntFilter transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+  
+  class RunSummaryIntFilter : public edm::global::EDFilter<edm::StreamCache<Cache>,edm::RunSummaryCache<UnsafeCache>> {
+  public:
+    explicit RunSummaryIntFilter(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {
+    produces<unsigned int>();
+      
+    }
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+
+    std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
+      ++m_count;
+      return std::unique_ptr<Cache>(new Cache());
+    }
+    
+    std::shared_ptr<UnsafeCache> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      std::shared_ptr<UnsafeCache> gCache = std::shared_ptr<UnsafeCache>{new UnsafeCache()};
+      ++(gCache->run);
+      return gCache;
+    }
+    
+    bool filter(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+      ++((streamCache(iID))->value);
+       
+      return true;
+    }
+    
+    void streamEndRunSummary(edm::StreamID iID, edm::Run const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      if ( gCache->run == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndRunSummary after globalEndRunSummary in Stream " << iID.value();
+      }      
+      Cache const* sCache = streamCache(iID);
+      gCache->value += sCache->value;
+      sCache->value = 0;
+    }
+    
+    void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      if( gCache->value  != cvalue_) {
+        throw cms::Exception("cache value")
+          << "RunSummaryIntFilter cache value "
+          << gCache->value << " but it was supposed to be " << cvalue_;
+      }
+      --(gCache->run);
+    }
+
+    ~RunSummaryIntFilter() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "RunSummaryIntFilter transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class LumiSummaryIntFilter : public edm::global::EDFilter<edm::StreamCache<Cache>,edm::LuminosityBlockSummaryCache<UnsafeCache>> {
+  public:
+    explicit LumiSummaryIntFilter(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {	
+    produces<unsigned int>();
+      
+    }
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+
+    std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
+      ++m_count;
+      return std::unique_ptr<Cache>(new Cache());
+    }
+  
+    std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      std::shared_ptr<UnsafeCache> gCache = std::shared_ptr<UnsafeCache>{new UnsafeCache()};
+      ++(gCache->lumi);
+      return gCache;
+    }
+
+    bool filter(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+      ++((streamCache(iID))->value);
+      return true;
+    }
+    
+    void streamEndLuminosityBlockSummary(edm::StreamID iID, edm::LuminosityBlock const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      if ( gCache->lumi == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndLuminosityBlockSummary after globalEndLuminosityBlockSummary in Stream " << iID.value();
+      }
+      Cache const* sCache = streamCache(iID);
+      gCache->value += sCache->value;
+      sCache->value = 0;
+    }
+    
+    void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      if( gCache->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << "LumiSummaryIntFilter cache value "
+          << gCache->value << " but it was supposed to be " << cvalue_;
+      }
+      --(gCache->lumi);
+    }
+
+    ~LumiSummaryIntFilter() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "LumiSummaryIntFilter transitions "     
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestBeginRunFilter : public edm::global::EDFilter<edm::BeginRunProducer> {
+  public:
+    explicit TestBeginRunFilter(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {
+    produces<unsigned int>();
+    }
+    const unsigned int trans_; 
+    mutable std::atomic<unsigned int> m_count{0};
+
+    void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+
+    bool filter(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      if (m_count == 0) {
+        throw cms::Exception("out of sequence")
+          << "filter before globalBeginRunProduce in Stream " << iID.value();
+      }
+      ++m_count;
+       
+      return true;
+    }
+
+    ~TestBeginRunFilter() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestBeginRunFilter transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestEndRunFilter : public edm::global::EDFilter<edm::EndRunProducer> {
+  public:
+    explicit TestEndRunFilter(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {
+    produces<unsigned int>();
+    }
+    const unsigned int trans_; 
+    mutable std::atomic<unsigned int> m_count{0};
+
+    bool filter(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+      return true;
+    }
+
+    void globalEndRunProduce(edm::Run&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+
+    ~TestEndRunFilter() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestEndRunFilter transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestBeginLumiBlockFilter : public edm::global::EDFilter<edm::BeginLuminosityBlockProducer> {
+  public:
+    explicit TestBeginLumiBlockFilter(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {
+    produces<unsigned int>();
+    }
+    const unsigned int trans_; 
+    mutable std::atomic<unsigned int> m_count{0};
+
+    void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const {
+      ++m_count;
+    }
+
+    bool filter(edm::StreamID iID, edm::Event&, const edm::EventSetup&) const override{
+      if (m_count == 0) {
+        throw cms::Exception("out of sequence")
+          << "filter before globalBeginLuminosityBlockProduce in Stream " << iID.value();
+      }
+       ++m_count;
+       
+      return true;
+    }
+
+    ~TestBeginLumiBlockFilter() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestBeginLumiBlockFilter transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestEndLumiBlockFilter : public edm::global::EDFilter<edm::EndLuminosityBlockProducer> {
+  public:
+    explicit TestEndLumiBlockFilter(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {
+    produces<unsigned int>();
+    }
+    const unsigned int trans_; 
+    mutable std::atomic<unsigned int> m_count{0};
+
+    bool filter(edm::StreamID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+      return true;
+    }
+
+    void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override {
+      ++m_count;
+    }
+
+    ~TestEndLumiBlockFilter() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestEndLumiBlockFilter transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+
+}
+}
+
+DEFINE_FWK_MODULE(edmtest::global::StreamIntFilter);
+DEFINE_FWK_MODULE(edmtest::global::RunIntFilter);
+DEFINE_FWK_MODULE(edmtest::global::LumiIntFilter);
+DEFINE_FWK_MODULE(edmtest::global::RunSummaryIntFilter);
+DEFINE_FWK_MODULE(edmtest::global::LumiSummaryIntFilter);
+DEFINE_FWK_MODULE(edmtest::global::TestBeginRunFilter);
+DEFINE_FWK_MODULE(edmtest::global::TestBeginLumiBlockFilter);
+DEFINE_FWK_MODULE(edmtest::global::TestEndRunFilter);
+DEFINE_FWK_MODULE(edmtest::global::TestEndLumiBlockFilter);
+

--- a/FWCore/Framework/test/stubs/TestGlobalProducers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalProducers.cc
@@ -1,0 +1,577 @@
+
+/*----------------------------------------------------------------------
+
+Toy edm::global::EDProducer modules of 
+edm::*Cache templates and edm::*Producer classes
+for testing purposes only.
+
+----------------------------------------------------------------------*/
+#include <iostream>
+#include <atomic>
+#include <vector>
+#include <map>
+#include <functional>
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/src/WorkerT.h"
+#include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+
+
+namespace edmtest {
+namespace global {
+
+struct Cache { 
+   Cache():value(0),run(0),lumi(0),strm(0),work(0) {}
+   //Using mutable since we want to update the value.
+   mutable std::atomic<unsigned int> value;
+   mutable std::atomic<unsigned int> run;
+   mutable std::atomic<unsigned int> lumi;
+   mutable std::atomic<unsigned int> strm;
+   mutable std::atomic<unsigned int> work;
+};
+
+struct UnsafeCache {
+   UnsafeCache():value(0),run(0),lumi(0),strm(0),work(0) {}
+   unsigned int value;
+   unsigned int run;
+   unsigned int lumi;
+   unsigned int strm;
+   unsigned int work;
+};
+
+
+
+  class StreamIntProducer : public edm::global::EDProducer<edm::StreamCache<Cache>> {
+  public:
+    explicit StreamIntProducer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {
+    produces<unsigned int>();
+    }
+
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+
+   std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
+      ++m_count;
+      std::unique_ptr<Cache> sCache = std::unique_ptr<Cache>(new Cache());
+      ++(sCache->strm);
+      return sCache;
+    }
+    
+    void streamBeginRun(edm::StreamID iID, edm::Run const&, edm::EventSetup const&) const  override {
+      ++m_count;
+      Cache const* sCache = streamCache(iID);
+      if ( sCache->run != 0 || sCache->lumi !=0 || sCache->work !=0 || sCache->strm !=1 ) {
+        throw cms::Exception("out of sequence")
+          << "streamBeginRun out of sequence in Stream " << iID.value();
+      }      
+      ++(sCache->run);
+    }
+
+    void streamBeginLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      Cache const* sCache = streamCache(iID);
+      if ( sCache->lumi != 0 || sCache->work != 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamBeginLuminosityBlock out of sequence in Stream " << iID.value();
+      }      
+       ++(sCache->lumi);
+    }
+
+    void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      ++m_count;
+      Cache const* sCache = streamCache(iID);
+      ++(sCache->work);
+      if ( sCache->lumi == 0 && sCache->run == 0) {
+        throw cms::Exception("out of sequence")
+          << "produce out of sequence in Stream " << iID.value();
+      }       
+       
+    }
+    
+ 
+    void streamEndLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
+      ++m_count;
+      Cache const* sCache = streamCache(iID);
+      --(sCache->lumi);
+      sCache->work = 0;
+      if ( sCache->lumi != 0 || sCache->run == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndLuminosityBlock out of sequence in Stream " << iID.value();
+      }      
+     }
+
+    void streamEndRun(edm::StreamID iID, edm::Run const&, edm::EventSetup const&) const override {
+      ++m_count;
+      Cache const* sCache = streamCache(iID);
+      --(sCache->run);
+      sCache->work = 0;
+      if ( sCache->run != 0 || sCache->lumi != 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndRun out of sequence in Stream " << iID.value();
+      }      
+     }
+
+    void endStream(edm::StreamID iID) const override {
+      ++m_count;
+      Cache const* sCache = streamCache(iID);
+      --(sCache->strm);
+      if ( sCache->strm != 0 || sCache->run != 0 || sCache->lumi != 0 ) {
+        throw cms::Exception("out of sequence")
+          << "endStream out of sequence in Stream " << iID.value();
+      }      
+    }
+
+    ~StreamIntProducer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "StreamIntProducer transitions " 
+          << m_count << " but it was supposed to be " << trans_;
+      }
+    }
+  };
+  
+  class RunIntProducer : public edm::global::EDProducer<edm::StreamCache<Cache>,edm::RunCache<Cache>> {
+  public:
+    explicit RunIntProducer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {
+    produces<unsigned int>();
+    }
+
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+
+    std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+      ++m_count;
+      std::shared_ptr<Cache> rCache = std::shared_ptr<Cache>{new Cache()};
+      ++(rCache->run);
+      return rCache;
+    }
+
+    std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
+      return std::unique_ptr<Cache>(new Cache());
+    }
+    
+    void streamBeginRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const  override {
+      Cache const * rCache = runCache(iRun.index());
+      if ( rCache->run == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamBeginRun before globalBeginRun in Stream " << iID.value();
+      }      
+    }
+
+
+    void produce(edm::StreamID iID, edm::Event& iEvent, edm::EventSetup const&) const override {
+      Cache const * rCache = runCache(iEvent.getRun().index());
+      ++(rCache->value);
+       
+    }
+
+    void streamEndRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const override {
+      Cache const * rCache = runCache(iRun.index());
+      if ( rCache->run == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndRun after globalEndRun in Stream " << iID.value();
+      }      
+    }
+
+    void globalEndRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+      ++m_count;
+      Cache const * rCache = runCache(iRun.index());
+      if ( rCache->value != cvalue_ ) {
+          throw cms::Exception("cache value")
+          << "RunIntProducer cache value "
+          << rCache->value << " but it was supposed to be " << cvalue_;
+      }
+     --(rCache->run);
+    }
+
+
+    ~RunIntProducer() {
+       if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "RunIntProducer transitions " 
+          << m_count << " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+
+  class LumiIntProducer : public edm::global::EDProducer<edm::StreamCache<Cache>,edm::LuminosityBlockCache<Cache>> {
+  public:
+    explicit LumiIntProducer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {
+    produces<unsigned int>();
+    }
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    
+    std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      ++m_count;
+      std::shared_ptr<Cache> lCache = std::shared_ptr<Cache>{new Cache()};
+      ++(lCache->lumi);  
+      return lCache;
+    }
+
+   std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
+      std::unique_ptr<Cache> sCache = std::unique_ptr<Cache>(new Cache());
+      return sCache;
+    }
+
+    void streamBeginLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      Cache const* lCache = luminosityBlockCache(iLB.index()); 
+      if ( lCache->lumi == 0) {
+        throw cms::Exception("out of sequence")
+          << "streamBeginLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+       }
+   }
+
+
+    void produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const override {
+      Cache const * lCache = luminosityBlockCache(iEvent.getLuminosityBlock().index());
+      ++(lCache->value);
+       
+    }
+
+    void streamEndLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      Cache const* lCache = luminosityBlockCache(iLB.index()); 
+      if ( lCache->lumi == 0) {
+        throw cms::Exception("out of sequence")
+          << "streamEndLuminosityBlock seen before globalEndLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+       }
+    }
+  
+    void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      ++m_count;
+      Cache const* lCache = luminosityBlockCache(iLB.index());
+      --(lCache->lumi); 
+      if ( lCache->lumi != 0 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+      }
+      if( lCache->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << "LumiIntProducer cache value "
+          << lCache->value << " but it was supposed to be " << cvalue_;
+      }
+     }
+
+
+    ~LumiIntProducer() {
+       if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "LumiIntProducer transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+       }
+    }
+  };
+  
+  class RunSummaryIntProducer : public edm::global::EDProducer<edm::StreamCache<Cache>,edm::RunSummaryCache<UnsafeCache>> {
+  public:
+    explicit RunSummaryIntProducer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {
+    produces<unsigned int>();
+      
+    }
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+   
+    std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
+       return std::unique_ptr<Cache>{new Cache()};
+    }
+
+    std::shared_ptr<UnsafeCache> globalBeginRunSummary(edm::Run const& iRun, edm::EventSetup const&) const override {
+      ++m_count;
+      std::shared_ptr<UnsafeCache> gCache = std::shared_ptr<UnsafeCache>{new UnsafeCache()};
+      ++(gCache->run);
+      return gCache;
+    }
+
+    void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      Cache const* sCache = streamCache(iID);
+      ++(sCache->value);
+       
+    }
+     
+    void streamEndRunSummary(edm::StreamID iID, edm::Run const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      if ( gCache->run == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndRunSummary after globalEndRunSummary in Stream " << iID.value();
+      }      
+      Cache const* sCache = streamCache(iID);
+      gCache->value += sCache->value;
+      sCache->value = 0;
+    }
+    
+    void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      if( gCache->value  != cvalue_) {
+        throw cms::Exception("cache value")
+          << "RunSummaryIntProducer cache value "
+          << gCache->value << " but it was supposed to be " << cvalue_;
+      }
+      --(gCache->run);
+    }
+
+
+    ~RunSummaryIntProducer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "RunSummaryIntProducer transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class LumiSummaryIntProducer : public edm::global::EDProducer<edm::StreamCache<Cache>,edm::LuminosityBlockSummaryCache<UnsafeCache>> {
+  public:
+    explicit LumiSummaryIntProducer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) 
+        ,cvalue_(p.getParameter<int>("cachevalue")) 
+    {	
+    produces<unsigned int>();
+      
+    }
+    const unsigned int trans_; 
+    const unsigned int cvalue_; 
+    mutable std::atomic<unsigned int> m_count{0};
+  
+    std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
+      return std::unique_ptr<Cache>{new Cache()};
+    }
+
+    std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      ++m_count;
+      std::shared_ptr<UnsafeCache> gCache = std::shared_ptr<UnsafeCache>{new UnsafeCache()};
+      ++(gCache->lumi);
+       return gCache;
+    }
+
+    void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      Cache const* sCache = streamCache(iID);
+      ++(sCache->value);
+       
+    }
+      
+    void streamEndLuminosityBlockSummary(edm::StreamID iID, edm::LuminosityBlock const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      if ( gCache->lumi == 0 ) {
+        throw cms::Exception("out of sequence")
+          << "streamEndLuminosityBlockSummary after globalEndLuminosityBlockSummary in Stream " << iID.value();
+      }
+      Cache const* sCache = streamCache(iID);
+      gCache->value += sCache->value;
+      sCache->value = 0;
+    }
+    
+    void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
+      ++m_count;
+      if( gCache->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << "LumiSummaryIntProducer cache value "
+          << gCache->value << " but it was supposed to be " << cvalue_;
+      }
+      --(gCache->lumi);
+    }
+
+    ~LumiSummaryIntProducer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "LumiSummaryIntProducer transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestBeginRunProducer : public edm::global::EDProducer<edm::RunCache<Cache>,edm::BeginRunProducer> {
+  public:
+    explicit TestBeginRunProducer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {	
+    produces<unsigned int>();
+    }
+
+    const unsigned int trans_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    mutable std::atomic<bool> brp{false}; 
+ 
+    std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+      brp = false;
+      return std::shared_ptr<Cache>{new Cache()};
+    }
+
+    void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      if (!brp) {
+        throw cms::Exception("out of sequence")
+          << "produce before globalBeginRunProduce";
+      }
+    }
+
+    void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const override {
+      ++m_count;
+      brp = true;
+    }
+
+    void globalEndRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+    }
+
+    ~TestBeginRunProducer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestBeginRunProducer transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+
+  };
+
+  class TestEndRunProducer : public edm::global::EDProducer<edm::RunCache<Cache>,edm::EndRunProducer> {
+  public:
+    explicit TestEndRunProducer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {	
+    produces<unsigned int>();
+    }
+    const unsigned int trans_;
+    mutable std::atomic<unsigned int> m_count{0};
+    mutable std::atomic<bool> p{false}; 
+
+    std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+      p = false;
+      return std::shared_ptr<Cache>{new Cache()};
+    }
+
+    void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      p = true;
+    }
+
+    void globalEndRunProduce(edm::Run&, edm::EventSetup const&) const override {
+      if ( !p ) {
+        throw cms::Exception("out of sequence")
+          << "endRunProduce before produce";
+      }
+      ++m_count;
+    }
+
+    void globalEndRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+    }
+
+    ~TestEndRunProducer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestEndRunProducer transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestBeginLumiBlockProducer : public edm::global::EDProducer<edm::LuminosityBlockCache<Cache>,edm::BeginLuminosityBlockProducer> {
+  public:
+    explicit TestBeginLumiBlockProducer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {	
+    produces<unsigned int>();
+    }
+    const unsigned int trans_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    mutable std::atomic<bool> gblp{false}; 
+
+    std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      gblp = false;
+      return std::shared_ptr<Cache>{new Cache()};
+    }
+
+    void produce(edm::StreamID iID, edm::Event&, const edm::EventSetup&) const override{
+      if ( !gblp ) {
+        throw cms::Exception("out of sequence")
+          << "produce before globalBeginLuminosityBlockProduce";
+      }
+    }
+
+    void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const {
+      ++m_count;
+      gblp = true;
+    }
+
+    void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+    }
+
+    ~TestBeginLumiBlockProducer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestBeginLumiBlockProducer transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestEndLumiBlockProducer : public edm::global::EDProducer<edm::LuminosityBlockCache<Cache>,edm::EndLuminosityBlockProducer> {
+  public:
+    explicit TestEndLumiBlockProducer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {	
+    produces<unsigned int>();
+    }
+    const unsigned int trans_; 
+    mutable std::atomic<bool> p{false}; 
+    mutable std::atomic<unsigned int> m_count{0};
+
+    std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+      p = false;
+      return std::shared_ptr<Cache>{new Cache()};
+    }
+
+
+    void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
+      p = true;    
+    }
+
+    void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override {
+      if ( !p ) {
+        throw cms::Exception("out of sequence")
+          << "endLumiBlockProduce before produce";
+      }
+      ++m_count;
+    }
+
+    void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+    }
+
+    ~TestEndLumiBlockProducer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestEndLumiBlockProducer transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+}
+}
+
+DEFINE_FWK_MODULE(edmtest::global::StreamIntProducer);
+DEFINE_FWK_MODULE(edmtest::global::RunIntProducer);
+DEFINE_FWK_MODULE(edmtest::global::LumiIntProducer);
+DEFINE_FWK_MODULE(edmtest::global::RunSummaryIntProducer);
+DEFINE_FWK_MODULE(edmtest::global::LumiSummaryIntProducer);
+DEFINE_FWK_MODULE(edmtest::global::TestBeginRunProducer);
+DEFINE_FWK_MODULE(edmtest::global::TestEndRunProducer);
+DEFINE_FWK_MODULE(edmtest::global::TestBeginLumiBlockProducer);
+DEFINE_FWK_MODULE(edmtest::global::TestEndLumiBlockProducer);
+

--- a/FWCore/Framework/test/stubs/TestGlobalProducers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalProducers.cc
@@ -27,6 +27,7 @@ for testing purposes only.
 namespace edmtest {
 namespace global {
 
+namespace {
 struct Cache { 
    Cache():value(0),run(0),lumi(0),strm(0),work(0) {}
    //Using mutable since we want to update the value.
@@ -45,32 +46,35 @@ struct UnsafeCache {
    unsigned int strm;
    unsigned int work;
 };
+} //end anonymous namespace
 
-
-
-  class StreamIntProducer : public edm::global::EDProducer<edm::StreamCache<Cache>> {
+  class StreamIntProducer : public edm::global::EDProducer<edm::StreamCache<UnsafeCache>> {
   public:
     explicit StreamIntProducer(edm::ParameterSet const& p) :
 	trans_(p.getParameter<int>("transitions")) 
-        ,cvalue_(p.getParameter<int>("cachevalue")) 
     {
     produces<unsigned int>();
     }
 
     const unsigned int trans_; 
-    const unsigned int cvalue_; 
     mutable std::atomic<unsigned int> m_count{0};
 
-   std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
+   std::unique_ptr<UnsafeCache> beginStream(edm::StreamID iID) const override {
       ++m_count;
-      std::unique_ptr<Cache> sCache = std::unique_ptr<Cache>(new Cache());
+      std::unique_ptr<UnsafeCache> sCache(new UnsafeCache);
       ++(sCache->strm);
+      sCache->value = iID.value();
       return sCache;
     }
     
     void streamBeginRun(edm::StreamID iID, edm::Run const&, edm::EventSetup const&) const  override {
       ++m_count;
-      Cache const* sCache = streamCache(iID);
+      auto sCache = streamCache(iID);
+      if ( sCache->value != iID.value() ) {
+          throw cms::Exception("cache value")
+          << "StreamIntAnalyzer cache value "
+          << (streamCache(iID))->value << " but it was supposed to be " << iID;
+      }
       if ( sCache->run != 0 || sCache->lumi !=0 || sCache->work !=0 || sCache->strm !=1 ) {
         throw cms::Exception("out of sequence")
           << "streamBeginRun out of sequence in Stream " << iID.value();
@@ -80,7 +84,7 @@ struct UnsafeCache {
 
     void streamBeginLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
       ++m_count;
-      Cache const* sCache = streamCache(iID);
+      auto sCache = streamCache(iID);
       if ( sCache->lumi != 0 || sCache->work != 0 ) {
         throw cms::Exception("out of sequence")
           << "streamBeginLuminosityBlock out of sequence in Stream " << iID.value();
@@ -90,7 +94,7 @@ struct UnsafeCache {
 
     void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
       ++m_count;
-      Cache const* sCache = streamCache(iID);
+      auto sCache = streamCache(iID);
       ++(sCache->work);
       if ( sCache->lumi == 0 && sCache->run == 0) {
         throw cms::Exception("out of sequence")
@@ -102,7 +106,7 @@ struct UnsafeCache {
  
     void streamEndLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const&, edm::EventSetup const&) const override {
       ++m_count;
-      Cache const* sCache = streamCache(iID);
+      auto sCache = streamCache(iID);
       --(sCache->lumi);
       sCache->work = 0;
       if ( sCache->lumi != 0 || sCache->run == 0 ) {
@@ -113,7 +117,7 @@ struct UnsafeCache {
 
     void streamEndRun(edm::StreamID iID, edm::Run const&, edm::EventSetup const&) const override {
       ++m_count;
-      Cache const* sCache = streamCache(iID);
+      auto sCache = streamCache(iID);
       --(sCache->run);
       sCache->work = 0;
       if ( sCache->run != 0 || sCache->lumi != 0 ) {
@@ -124,7 +128,7 @@ struct UnsafeCache {
 
     void endStream(edm::StreamID iID) const override {
       ++m_count;
-      Cache const* sCache = streamCache(iID);
+      auto sCache = streamCache(iID);
       --(sCache->strm);
       if ( sCache->strm != 0 || sCache->run != 0 || sCache->lumi != 0 ) {
         throw cms::Exception("out of sequence")
@@ -141,7 +145,7 @@ struct UnsafeCache {
     }
   };
   
-  class RunIntProducer : public edm::global::EDProducer<edm::StreamCache<Cache>,edm::RunCache<Cache>> {
+  class RunIntProducer : public edm::global::EDProducer<edm::StreamCache<UnsafeCache>,edm::RunCache<Cache>> {
   public:
     explicit RunIntProducer(edm::ParameterSet const& p) :
 	trans_(p.getParameter<int>("transitions")) 
@@ -156,17 +160,17 @@ struct UnsafeCache {
 
     std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
       ++m_count;
-      std::shared_ptr<Cache> rCache = std::shared_ptr<Cache>{new Cache()};
+      std::shared_ptr<Cache> rCache(new Cache);
       ++(rCache->run);
       return rCache;
     }
 
-    std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
-      return std::unique_ptr<Cache>(new Cache());
+    std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
+      return std::unique_ptr<UnsafeCache>{new UnsafeCache};
     }
     
     void streamBeginRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const  override {
-      Cache const * rCache = runCache(iRun.index());
+      auto rCache = runCache(iRun.index());
       if ( rCache->run == 0 ) {
         throw cms::Exception("out of sequence")
           << "streamBeginRun before globalBeginRun in Stream " << iID.value();
@@ -175,13 +179,13 @@ struct UnsafeCache {
 
 
     void produce(edm::StreamID iID, edm::Event& iEvent, edm::EventSetup const&) const override {
-      Cache const * rCache = runCache(iEvent.getRun().index());
+      auto rCache = runCache(iEvent.getRun().index());
       ++(rCache->value);
        
     }
 
     void streamEndRun(edm::StreamID iID, edm::Run const& iRun, edm::EventSetup const&) const override {
-      Cache const * rCache = runCache(iRun.index());
+      auto rCache = runCache(iRun.index());
       if ( rCache->run == 0 ) {
         throw cms::Exception("out of sequence")
           << "streamEndRun after globalEndRun in Stream " << iID.value();
@@ -190,7 +194,7 @@ struct UnsafeCache {
 
     void globalEndRun(edm::Run const& iRun, edm::EventSetup const&) const override {
       ++m_count;
-      Cache const * rCache = runCache(iRun.index());
+      auto rCache = runCache(iRun.index());
       if ( rCache->value != cvalue_ ) {
           throw cms::Exception("cache value")
           << "RunIntProducer cache value "
@@ -210,7 +214,7 @@ struct UnsafeCache {
   };
 
 
-  class LumiIntProducer : public edm::global::EDProducer<edm::StreamCache<Cache>,edm::LuminosityBlockCache<Cache>> {
+  class LumiIntProducer : public edm::global::EDProducer<edm::StreamCache<UnsafeCache>,edm::LuminosityBlockCache<Cache>> {
   public:
     explicit LumiIntProducer(edm::ParameterSet const& p) :
 	trans_(p.getParameter<int>("transitions")) 
@@ -224,18 +228,17 @@ struct UnsafeCache {
     
     std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
       ++m_count;
-      std::shared_ptr<Cache> lCache = std::shared_ptr<Cache>{new Cache()};
+      std::shared_ptr<Cache> lCache(new Cache);
       ++(lCache->lumi);  
       return lCache;
     }
 
-   std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
-      std::unique_ptr<Cache> sCache = std::unique_ptr<Cache>(new Cache());
-      return sCache;
+   std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
+      return std::unique_ptr<UnsafeCache>{new UnsafeCache};
     }
 
     void streamBeginLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
-      Cache const* lCache = luminosityBlockCache(iLB.index()); 
+      auto lCache = luminosityBlockCache(iLB.index()); 
       if ( lCache->lumi == 0) {
         throw cms::Exception("out of sequence")
           << "streamBeginLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
@@ -244,13 +247,13 @@ struct UnsafeCache {
 
 
     void produce(edm::StreamID, edm::Event& iEvent, edm::EventSetup const&) const override {
-      Cache const * lCache = luminosityBlockCache(iEvent.getLuminosityBlock().index());
+      auto lCache = luminosityBlockCache(iEvent.getLuminosityBlock().index());
       ++(lCache->value);
        
     }
 
     void streamEndLuminosityBlock(edm::StreamID iID, edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
-      Cache const* lCache = luminosityBlockCache(iLB.index()); 
+      auto lCache = luminosityBlockCache(iLB.index()); 
       if ( lCache->lumi == 0) {
         throw cms::Exception("out of sequence")
           << "streamEndLuminosityBlock seen before globalEndLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
@@ -259,7 +262,7 @@ struct UnsafeCache {
   
     void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
       ++m_count;
-      Cache const* lCache = luminosityBlockCache(iLB.index());
+      auto lCache = luminosityBlockCache(iLB.index());
       --(lCache->lumi); 
       if ( lCache->lumi != 0 ) {
         throw cms::Exception("end out of sequence")
@@ -282,7 +285,7 @@ struct UnsafeCache {
     }
   };
   
-  class RunSummaryIntProducer : public edm::global::EDProducer<edm::StreamCache<Cache>,edm::RunSummaryCache<UnsafeCache>> {
+  class RunSummaryIntProducer : public edm::global::EDProducer<edm::StreamCache<UnsafeCache>,edm::RunSummaryCache<UnsafeCache>> {
   public:
     explicit RunSummaryIntProducer(edm::ParameterSet const& p) :
 	trans_(p.getParameter<int>("transitions")) 
@@ -295,19 +298,19 @@ struct UnsafeCache {
     const unsigned int cvalue_; 
     mutable std::atomic<unsigned int> m_count{0};
    
-    std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
-       return std::unique_ptr<Cache>{new Cache()};
+    std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
+       return std::unique_ptr<UnsafeCache>(new UnsafeCache);
     }
 
     std::shared_ptr<UnsafeCache> globalBeginRunSummary(edm::Run const& iRun, edm::EventSetup const&) const override {
       ++m_count;
-      std::shared_ptr<UnsafeCache> gCache = std::shared_ptr<UnsafeCache>{new UnsafeCache()};
+      std::shared_ptr<UnsafeCache> gCache(new UnsafeCache);
       ++(gCache->run);
       return gCache;
     }
 
     void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
-      Cache const* sCache = streamCache(iID);
+      auto sCache = streamCache(iID);
       ++(sCache->value);
        
     }
@@ -318,7 +321,7 @@ struct UnsafeCache {
         throw cms::Exception("out of sequence")
           << "streamEndRunSummary after globalEndRunSummary in Stream " << iID.value();
       }      
-      Cache const* sCache = streamCache(iID);
+      auto sCache = streamCache(iID);
       gCache->value += sCache->value;
       sCache->value = 0;
     }
@@ -343,7 +346,7 @@ struct UnsafeCache {
     }
   };
 
-  class LumiSummaryIntProducer : public edm::global::EDProducer<edm::StreamCache<Cache>,edm::LuminosityBlockSummaryCache<UnsafeCache>> {
+  class LumiSummaryIntProducer : public edm::global::EDProducer<edm::StreamCache<UnsafeCache>,edm::LuminosityBlockSummaryCache<UnsafeCache>> {
   public:
     explicit LumiSummaryIntProducer(edm::ParameterSet const& p) :
 	trans_(p.getParameter<int>("transitions")) 
@@ -356,19 +359,19 @@ struct UnsafeCache {
     const unsigned int cvalue_; 
     mutable std::atomic<unsigned int> m_count{0};
   
-    std::unique_ptr<Cache> beginStream(edm::StreamID) const override {
-      return std::unique_ptr<Cache>{new Cache()};
+    std::unique_ptr<UnsafeCache> beginStream(edm::StreamID) const override {
+      return std::unique_ptr<UnsafeCache>(new UnsafeCache);
     }
 
     std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
       ++m_count;
-      std::shared_ptr<UnsafeCache> gCache = std::shared_ptr<UnsafeCache>{new UnsafeCache()};
+      std::shared_ptr<UnsafeCache> gCache(new UnsafeCache);
       ++(gCache->lumi);
        return gCache;
     }
 
     void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
-      Cache const* sCache = streamCache(iID);
+      auto sCache = streamCache(iID);
       ++(sCache->value);
        
     }
@@ -379,7 +382,7 @@ struct UnsafeCache {
         throw cms::Exception("out of sequence")
           << "streamEndLuminosityBlockSummary after globalEndLuminosityBlockSummary in Stream " << iID.value();
       }
-      Cache const* sCache = streamCache(iID);
+      auto sCache = streamCache(iID);
       gCache->value += sCache->value;
       sCache->value = 0;
     }
@@ -403,7 +406,7 @@ struct UnsafeCache {
     }
   };
 
-  class TestBeginRunProducer : public edm::global::EDProducer<edm::RunCache<Cache>,edm::BeginRunProducer> {
+  class TestBeginRunProducer : public edm::global::EDProducer<edm::RunCache<void>,edm::BeginRunProducer> {
   public:
     explicit TestBeginRunProducer(edm::ParameterSet const& p) :
 	trans_(p.getParameter<int>("transitions")) {	
@@ -414,16 +417,15 @@ struct UnsafeCache {
     mutable std::atomic<unsigned int> m_count{0};
     mutable std::atomic<bool> brp{false}; 
  
-    std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+    std::shared_ptr<void> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
       brp = false;
-      return std::shared_ptr<Cache>{new Cache()};
+      return std::shared_ptr<void>();
     }
 
     void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
       if (!brp) {
         throw cms::Exception("out of sequence")
-          << "produce before globalBeginRunProduce";
-      }
+          << "produce before globalBeginRunProduce in Stream " << iID.value();      }
     }
 
     void globalBeginRunProduce(edm::Run&, edm::EventSetup const&) const override {
@@ -444,7 +446,7 @@ struct UnsafeCache {
 
   };
 
-  class TestEndRunProducer : public edm::global::EDProducer<edm::RunCache<Cache>,edm::EndRunProducer> {
+  class TestEndRunProducer : public edm::global::EDProducer<edm::RunCache<void>,edm::EndRunProducer> {
   public:
     explicit TestEndRunProducer(edm::ParameterSet const& p) :
 	trans_(p.getParameter<int>("transitions")) {	
@@ -454,9 +456,9 @@ struct UnsafeCache {
     mutable std::atomic<unsigned int> m_count{0};
     mutable std::atomic<bool> p{false}; 
 
-    std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
+    std::shared_ptr<void> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&) const override {
       p = false;
-      return std::shared_ptr<Cache>{new Cache()};
+      return std::shared_ptr<void>();
     }
 
     void produce(edm::StreamID iID, edm::Event&, edm::EventSetup const&) const override {
@@ -483,7 +485,7 @@ struct UnsafeCache {
     }
   };
 
-  class TestBeginLumiBlockProducer : public edm::global::EDProducer<edm::LuminosityBlockCache<Cache>,edm::BeginLuminosityBlockProducer> {
+  class TestBeginLumiBlockProducer : public edm::global::EDProducer<edm::LuminosityBlockCache<void>,edm::BeginLuminosityBlockProducer> {
   public:
     explicit TestBeginLumiBlockProducer(edm::ParameterSet const& p) :
 	trans_(p.getParameter<int>("transitions")) {	
@@ -493,15 +495,15 @@ struct UnsafeCache {
     mutable std::atomic<unsigned int> m_count{0};
     mutable std::atomic<bool> gblp{false}; 
 
-    std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+    std::shared_ptr<void> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
       gblp = false;
-      return std::shared_ptr<Cache>{new Cache()};
+      return std::shared_ptr<void>();
     }
 
     void produce(edm::StreamID iID, edm::Event&, const edm::EventSetup&) const override{
       if ( !gblp ) {
         throw cms::Exception("out of sequence")
-          << "produce before globalBeginLuminosityBlockProduce";
+          << "produce before globalBeginLuminosityBlockProduce in Stream " << iID.value();
       }
     }
 
@@ -522,19 +524,19 @@ struct UnsafeCache {
     }
   };
 
-  class TestEndLumiBlockProducer : public edm::global::EDProducer<edm::LuminosityBlockCache<Cache>,edm::EndLuminosityBlockProducer> {
+  class TestEndLumiBlockProducer : public edm::global::EDProducer<edm::LuminosityBlockCache<void>,edm::EndLuminosityBlockProducer> {
   public:
     explicit TestEndLumiBlockProducer(edm::ParameterSet const& p) :
 	trans_(p.getParameter<int>("transitions")) {	
     produces<unsigned int>();
     }
     const unsigned int trans_; 
-    mutable std::atomic<bool> p{false}; 
     mutable std::atomic<unsigned int> m_count{0};
+    mutable std::atomic<bool> p{false}; 
 
-    std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
+    std::shared_ptr<void> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&) const override {
       p = false;
-      return std::shared_ptr<Cache>{new Cache()};
+      return std::shared_ptr<void>();
     }
 
 

--- a/FWCore/Framework/test/stubs/TestOneAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestOneAnalyzers.cc
@@ -1,0 +1,157 @@
+
+/*----------------------------------------------------------------------
+
+Toy edm::one::EDAnalyzer modules of 
+edm::one cache templates 
+for testing purposes only.
+
+----------------------------------------------------------------------*/
+#include <iostream>
+#include <atomic>
+#include <vector>
+#include <map>
+#include <functional>
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
+#include "FWCore/Framework/src/WorkerT.h"
+#include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+
+
+namespace edmtest {
+namespace one {
+
+
+  class SharedResourcesAnalyzer : public edm::one::EDAnalyzer<edm::one::SharedResources> {
+  public:
+    explicit SharedResourcesAnalyzer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {
+      usesResource();
+    }
+    const unsigned int trans_; 
+    unsigned int m_count = 0;
+
+    void analyze(edm::Event const&, edm::EventSetup const&) override {
+      ++m_count;
+       
+    }
+    
+   ~SharedResourcesAnalyzer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "SharedResourcesAnalyzer transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+  
+  class WatchRunsAnalyzer: public edm::one::EDAnalyzer<edm::one::WatchRuns> {
+  public:
+    explicit WatchRunsAnalyzer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {
+    }
+    bool br = false;
+    bool er = false;
+    const unsigned int trans_; 
+    unsigned int m_count = 0;
+
+    void analyze(edm::Event const&, edm::EventSetup const&) override {
+      ++m_count;
+      if ( !br  || er ) {
+          throw cms::Exception("out of sequence")
+          << " produce before beginRun or after endRun";
+      }       
+    }
+
+    void beginRun(edm::Run const&, edm::EventSetup const&) override {
+      ++m_count;
+      if ( br ) {
+        throw cms::Exception("out of sequence")
+          << " beginRun seen multiple times";    
+      }
+      br = true;
+      er = false;
+    }
+
+    void endRun(edm::Run const&, edm::EventSetup const&) override {
+      ++m_count;
+      if ( !br ) {
+        throw cms::Exception("out of sequence")
+          << " endRun before beginRun";    
+      }
+      br = false;
+      er = true;
+    }
+ 
+   ~WatchRunsAnalyzer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "WatchRunsAnalyzer transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+
+  class WatchLumiBlocksAnalyzer: public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks> {
+  public:
+    explicit WatchLumiBlocksAnalyzer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {
+    }
+    const unsigned int trans_; 
+    bool bl = false;
+    bool el = false;
+    unsigned int m_count = 0;
+
+   void analyze(edm::Event const&, edm::EventSetup const&) override {
+      ++m_count;
+      if ( !bl  || el ) {
+          throw cms::Exception("out of sequence")
+          << " produce before beginLumiBlock or after endLumiBlock";
+      }              
+    }
+
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
+      ++m_count;
+      if ( bl ) {
+        throw cms::Exception("out of sequence")
+          << " beginLumiBlock seen mutiple times";    
+      }
+      bl = true;
+      el = false;
+    }
+
+    void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
+      ++m_count;
+      if ( !bl ) {
+        throw cms::Exception("out of sequence")
+          << " endLumiBlock before beginLumiBlock";    
+      }
+      bl = false;
+      el = true;
+    }
+
+   ~WatchLumiBlocksAnalyzer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "WatchLumiBlocksAnalyzer transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+  
+
+
+}
+}
+
+DEFINE_FWK_MODULE(edmtest::one::SharedResourcesAnalyzer);
+DEFINE_FWK_MODULE(edmtest::one::WatchRunsAnalyzer);
+DEFINE_FWK_MODULE(edmtest::one::WatchLumiBlocksAnalyzer);
+

--- a/FWCore/Framework/test/stubs/TestOneFilters.cc
+++ b/FWCore/Framework/test/stubs/TestOneFilters.cc
@@ -48,7 +48,6 @@ namespace one {
           << "SharedResourcesFilter transitions "
           << m_count<< " but it was supposed to be " << trans_;
       }
-      //std::cout << "SharedResourcesFilter transitions " << m_count<< " but it was supposed to be " << trans_ <<"\n";
     }
   };
   

--- a/FWCore/Framework/test/stubs/TestOneFilters.cc
+++ b/FWCore/Framework/test/stubs/TestOneFilters.cc
@@ -1,0 +1,323 @@
+
+/*----------------------------------------------------------------------
+
+Toy edm::one::EDFilter modules of 
+edm::one cache classes and edm::*Producer classes
+for testing purposes only.
+
+----------------------------------------------------------------------*/
+#include <iostream>
+#include <atomic>
+#include <vector>
+#include <map>
+#include <functional>
+#include "FWCore/Framework/interface/one/EDFilter.h"
+#include "FWCore/Framework/src/WorkerT.h"
+#include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+
+
+namespace edmtest {
+namespace one {
+
+
+  class SharedResourcesFilter : public edm::one::EDFilter<edm::one::SharedResources> {
+  public:
+    explicit SharedResourcesFilter(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {
+      produces<int>();
+      usesResource();
+    }
+    const unsigned int trans_; 
+    mutable std::atomic<unsigned int> m_count{0};
+    bool filter(edm::Event &, edm::EventSetup const&) override {
+      ++m_count;
+      return true;
+    }
+    
+   ~SharedResourcesFilter() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "SharedResourcesFilter transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+      //std::cout << "SharedResourcesFilter transitions " << m_count<< " but it was supposed to be " << trans_ <<"\n";
+    }
+  };
+  
+  class WatchRunsFilter : public edm::one::EDFilter<edm::one::WatchRuns> {
+  public:
+    explicit WatchRunsFilter(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {
+    }
+    bool br = false;
+    bool er = false;
+    const unsigned int trans_; 
+    unsigned int m_count = 0;
+
+   bool filter(edm::Event &, edm::EventSetup const&) override {
+      ++m_count;
+      if ( !br  || er ) {
+          throw cms::Exception("out of sequence")
+          << " produce before beginRun or after endRun";
+      } 
+      return true;
+    }
+
+   void beginRun(edm::Run const&, edm::EventSetup const&) override {
+      ++m_count;
+      if ( br ) {
+        throw cms::Exception("out of sequence")
+          << " beginRun seen multiple times";    
+      }
+      br = true;
+      er = false;
+    }
+
+   void endRun(edm::Run const&, edm::EventSetup const&) override {  
+      ++m_count;
+      if ( !br ) {
+        throw cms::Exception("out of sequence")
+          << " endRun before beginRun";    
+      }
+      br = false;
+      er = true;
+    }
+
+   ~WatchRunsFilter() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "WatchRunsFilter transitions "     
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+
+  class WatchLumiBlocksFilter : public edm::one::EDFilter<edm::one::WatchLuminosityBlocks> {
+  public:
+    explicit WatchLumiBlocksFilter(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {
+    }
+    const unsigned int trans_; 
+    bool bl = false;
+    bool el = false;
+    unsigned int m_count = 0;
+
+    bool filter(edm::Event &, edm::EventSetup const&)  override {
+      ++m_count;
+      if ( !bl  || el ) {
+          throw cms::Exception("out of sequence")
+          << " produce before beginLumiBlock or after endLumiBlock";
+      }              
+      return true;
+    }
+
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override { 
+      ++m_count;
+      if ( bl ) {
+        throw cms::Exception("out of sequence")
+          << " beginLumiBlock seen mutiple times";    
+      }
+      bl = true;
+      el = false;
+     }
+
+    void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
+      ++m_count;
+      if ( !bl ) {
+        throw cms::Exception("out of sequence")
+          << " endLumiBlock before beginLumiBlock";    
+      }
+      bl = false;
+      el = true;
+    }
+
+   ~WatchLumiBlocksFilter() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "WatchLumiBlocksFilter transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+  
+  class BeginRunFilter : public edm::one::EDFilter<edm::one::WatchRuns,edm::BeginRunProducer> {
+  public:
+    explicit BeginRunFilter(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {
+      produces<int>();
+    }
+    const unsigned int trans_; 
+    unsigned int m_count = 0;
+    bool p = false;
+ 
+   void beginRun(edm::Run const&, edm::EventSetup const&) override { 
+      p = false;
+    }
+ 
+   bool filter(edm::Event &, edm::EventSetup const&) override {
+      ++m_count;
+      p=true; 
+      return true;
+    }
+
+   void beginRunProduce(edm::Run&, edm::EventSetup const&) override {
+      if ( p ) {
+        throw cms::Exception("out of sequence")
+          << "produce before beginRunProduce";
+      }
+      ++m_count;
+    }
+
+    void endRun(edm::Run const&, edm::EventSetup const&) override { 
+    }
+
+   ~BeginRunFilter() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "BeginRunFilter transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class BeginLumiBlockFilter : public edm::one::EDFilter<edm::one::WatchLuminosityBlocks,edm::BeginLuminosityBlockProducer> {
+  public:
+    explicit BeginLumiBlockFilter(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {	
+    }
+    const unsigned int trans_; 
+    unsigned int m_count = 0;
+    bool p = false;
+
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override  {
+      p = false;
+    }
+ 
+
+    bool filter(edm::Event &, edm::EventSetup const&) override {
+      ++m_count;
+      p = true; 
+      return true;
+    }
+
+    void beginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) override {
+      ++m_count;
+      if ( p ) {
+        throw cms::Exception("out of sequence")
+          << "produce before beginLuminosityBlockProduce";
+      }
+    }
+
+    void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
+    }
+
+
+   ~BeginLumiBlockFilter() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "BeginLumiBlockFilter transitions "     
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class EndRunFilter : public edm::one::EDFilter<edm::one::WatchRuns,edm::EndRunProducer> {
+  public:
+    explicit EndRunFilter(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {
+    }
+    const unsigned int trans_;
+    bool erp = false; 
+    unsigned int m_count = 0;
+
+    void beginRun(edm::Run const&, edm::EventSetup const&) override { 
+      erp = false;
+    }
+
+    bool filter(edm::Event &, edm::EventSetup const&) override {
+      ++m_count;
+      if ( erp ) {
+        throw cms::Exception("out of sequence")
+          << "endRunProduce before produce";
+      }       
+      return true;
+    }
+
+    void endRunProduce(edm::Run&, edm::EventSetup const&) override {
+      ++m_count;
+    }    
+
+    void endRun(edm::Run const&, edm::EventSetup const&) override { 
+    }
+
+
+   ~EndRunFilter() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "EndRunFilter transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class EndLumiBlockFilter : public edm::one::EDFilter<edm::one::WatchLuminosityBlocks,edm::EndLuminosityBlockProducer> {
+  public:
+    explicit EndLumiBlockFilter(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {	
+    }
+    const unsigned int trans_; 
+    bool elbp = false;
+    unsigned int m_count = 0;
+
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override  {
+      elbp = false;
+    }
+ 
+   bool filter(edm::Event &, edm::EventSetup const&) override {
+      ++m_count;
+      if ( elbp ) {
+        throw cms::Exception("out of sequence")
+          << "endLumiBlockProduce before produce";
+      }       
+      return true;
+    }
+
+    void endLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) override {
+      ++m_count;
+      elbp = true;
+    }
+
+    void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
+    }
+
+   ~EndLumiBlockFilter() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "EndLumiBlockFilter transitions "     
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+
+}
+}
+
+DEFINE_FWK_MODULE(edmtest::one::SharedResourcesFilter);
+DEFINE_FWK_MODULE(edmtest::one::WatchRunsFilter);
+DEFINE_FWK_MODULE(edmtest::one::WatchLumiBlocksFilter);
+DEFINE_FWK_MODULE(edmtest::one::BeginRunFilter);
+DEFINE_FWK_MODULE(edmtest::one::BeginLumiBlockFilter);
+DEFINE_FWK_MODULE(edmtest::one::EndRunFilter);
+DEFINE_FWK_MODULE(edmtest::one::EndLumiBlockFilter);
+
+

--- a/FWCore/Framework/test/stubs/TestOneProducers.cc
+++ b/FWCore/Framework/test/stubs/TestOneProducers.cc
@@ -1,0 +1,319 @@
+
+/*----------------------------------------------------------------------
+
+Toy edm::one::EDProducer modules of 
+edm::one cache classes and edm::*Producer classes
+for testing purposes only.
+
+----------------------------------------------------------------------*/
+#include <iostream>
+#include <atomic>
+#include <vector>
+#include <map>
+#include <functional>
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/src/WorkerT.h"
+#include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+
+
+namespace edmtest {
+namespace one {
+
+  class SharedResourcesProducer : public edm::one::EDProducer<edm::one::SharedResources> {
+  public:
+    explicit SharedResourcesProducer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {
+      produces<int>();
+      usesResource();
+    }
+    const unsigned int trans_; 
+    unsigned int m_count = 0;
+
+    void produce(edm::Event&, edm::EventSetup const&) override { 
+      ++m_count;
+    }
+       
+    ~SharedResourcesProducer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "SharedResourcesProducer transitions " 
+          << m_count << " but it was supposed to be " << trans_;
+      }
+    }
+
+  };
+
+  
+  class WatchRunsProducer : public edm::one::EDProducer<edm::one::WatchRuns> {
+  public:
+    explicit WatchRunsProducer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {
+      produces<int>();
+    }
+    bool br = false;
+    bool er = false;
+    const unsigned int trans_; 
+    unsigned int m_count = 0;
+
+    void produce(edm::Event &, edm::EventSetup const&) override  { 
+      ++m_count;
+      if ( !br  || er ) {
+          throw cms::Exception("out of sequence")
+          << " produce before beginRun or after endRun";
+      } 
+    }
+ 
+    void beginRun(edm::Run const&, edm::EventSetup const&) override { 
+      ++m_count;
+      if ( br ) {
+        throw cms::Exception("out of sequence")
+          << " beginRun seen multiple times";    
+      }
+      br = true;
+      er = false;
+    }
+ 
+    void endRun(edm::Run const&, edm::EventSetup const&) override { 
+      ++m_count;
+      if ( !br ) {
+        throw cms::Exception("out of sequence")
+          << " endRun before beginRun";    
+      }
+      br = false;
+      er = true;
+    }
+     
+   ~WatchRunsProducer() {
+       if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "WatchRunsProducer transitions " 
+          << m_count << " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+
+  class WatchLumiBlocksProducer : public edm::one::EDProducer<edm::one::WatchLuminosityBlocks> {
+  public:
+    explicit WatchLumiBlocksProducer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {
+      produces<int>();
+    }
+    const unsigned int trans_; 
+    bool bl = false;
+    bool el = false;
+    unsigned int m_count = 0;
+
+    void produce(edm::Event&, edm::EventSetup const&) override { 
+      ++m_count;
+      if ( !bl  || el ) {
+          throw cms::Exception("out of sequence")
+          << " produce before beginLumiBlock or after endLumiBlock";
+      }       
+    }
+
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override  {
+      ++m_count;
+      if ( bl ) {
+        throw cms::Exception("out of sequence")
+          << " beginLumiBlock seen mutiple times";    
+      }
+      bl = true;
+      el = false;
+     }
+
+    void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
+      ++m_count;
+      if ( !bl ) {
+        throw cms::Exception("out of sequence")
+          << " endLumiBlock before beginLumiBlock";    
+      }
+      bl = false;
+      el = true;
+    }
+
+    ~WatchLumiBlocksProducer() {
+       if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "WatchLumiBlockProducer transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+       }
+    }
+  };
+  
+  class TestBeginRunProducer : public edm::one::EDProducer<edm::one::WatchRuns,edm::BeginRunProducer> {
+  public:
+    explicit TestBeginRunProducer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {
+      produces<int>();
+    }
+    const unsigned int trans_; 
+    unsigned int m_count = 0;
+    bool p = false;
+
+    void beginRun(edm::Run const&, edm::EventSetup const&) override { 
+      p = false;
+    }
+ 
+    void produce(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+      p=true;
+    }
+
+    void beginRunProduce(edm::Run&, edm::EventSetup const&) override {
+      if ( p ) {
+        throw cms::Exception("out of sequence")
+          << "produce before beginRunProduce";
+      }
+      ++m_count;
+    }
+
+    void endRun(edm::Run const&, edm::EventSetup const&) override { 
+    }
+
+   ~TestBeginRunProducer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestBeginRunProducer transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestBeginLumiBlockProducer : public edm::one::EDProducer<edm::one::WatchLuminosityBlocks,edm::BeginLuminosityBlockProducer> {
+  public:
+    explicit TestBeginLumiBlockProducer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {	
+      produces<int>();
+    }
+    const unsigned int trans_; 
+    unsigned int m_count = 0;
+    bool p = false;
+
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override  {
+      p = false;
+    }
+ 
+    void produce(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+      p = true;
+    }
+
+    void beginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) override {   
+       ++m_count;
+      if ( p ) {
+        throw cms::Exception("out of sequence")
+          << "produce before beginLuminosityBlockProduce";
+      }
+    }
+
+    void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
+    }
+
+   ~TestBeginLumiBlockProducer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestBeginLumiBlockProducer transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestEndRunProducer : public edm::one::EDProducer<edm::one::WatchRuns,edm::EndRunProducer> {
+  public:
+    explicit TestEndRunProducer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {
+      produces<int>();
+    }
+    const unsigned int trans_;
+    bool erp = false; 
+
+    void beginRun(edm::Run const&, edm::EventSetup const&) override { 
+      erp = false;
+    }
+ 
+     unsigned int m_count = 0;
+
+    void produce(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+      if ( erp ) {
+        throw cms::Exception("out of sequence")
+          << "endRunProduce before produce";
+      }
+    }
+
+    void endRunProduce(edm::Run&, edm::EventSetup const&) override {
+      ++m_count;
+      erp = true;
+    }
+
+    void endRun(edm::Run const&, edm::EventSetup const&) override { 
+    }
+
+   ~TestEndRunProducer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestEndRunProducer transitions "
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestEndLumiBlockProducer : public edm::one::EDProducer<edm::one::WatchLuminosityBlocks,edm::EndLuminosityBlockProducer> {
+  public:
+    explicit TestEndLumiBlockProducer(edm::ParameterSet const& p) :
+	trans_(p.getParameter<int>("transitions")) {	
+      produces<int>();
+    }
+    const unsigned int trans_; 
+    bool elbp = false;
+    unsigned int m_count = 0;
+
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override  {
+      elbp = false;
+    }
+ 
+
+    void produce(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+      if ( elbp ) {
+        throw cms::Exception("out of sequence")
+          << "endLumiBlockProduce before produce";
+      }
+    }
+
+    void endLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) override {
+      ++m_count;
+      elbp = true;
+    }
+
+    void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
+    }
+     
+   ~TestEndLumiBlockProducer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << "TestEndLumiBlockProducer transitions " 
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+}
+}
+
+DEFINE_FWK_MODULE(edmtest::one::SharedResourcesProducer);
+DEFINE_FWK_MODULE(edmtest::one::WatchRunsProducer);
+DEFINE_FWK_MODULE(edmtest::one::WatchLumiBlocksProducer);
+DEFINE_FWK_MODULE(edmtest::one::TestBeginRunProducer);
+DEFINE_FWK_MODULE(edmtest::one::TestBeginLumiBlockProducer);
+DEFINE_FWK_MODULE(edmtest::one::TestEndRunProducer);
+DEFINE_FWK_MODULE(edmtest::one::TestEndLumiBlockProducer);

--- a/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
@@ -27,6 +27,7 @@ for testing purposes only.
 namespace edmtest {
 namespace stream {
 
+namespace {
 struct Cache { 
    Cache():value(0),run(0),lumi(0) {}
    //Using mutable since we want to update the value.
@@ -34,6 +35,8 @@ struct Cache {
    mutable std::atomic<unsigned int> run;
    mutable std::atomic<unsigned int> lumi;
 };
+} //end anonymous namespace
+
 
 
 
@@ -45,7 +48,7 @@ struct Cache {
    
     static std::unique_ptr<Cache> initializeGlobalCache(edm::ParameterSet const& p) {
       ++m_count;
-      return std::unique_ptr<Cache>(new Cache());
+      return std::unique_ptr<Cache>{ new Cache };
     }
 
     GlobalIntAnalyzer(edm::ParameterSet const& p, Cache const * iGlobal)  {
@@ -103,7 +106,7 @@ struct Cache {
       ++m_count;
       gbr = true;
       ger = false;
-      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      std::shared_ptr<Cache> pCache{ new Cache };
       ++(pCache->run);
       return pCache;
     }
@@ -119,7 +122,7 @@ struct Cache {
 
     static void globalEndRun(edm::Run const& iRun, edm::EventSetup const&, RunContext const* iContext) {
       ++m_count;
-      Cache const * pCache = iContext->run();
+      auto pCache = iContext->run();
       if ( pCache->run != 1 ) {
         throw cms::Exception("end out of sequence")
           << "globalEndRun seen before globalBeginRun in Run" << iRun.run();
@@ -178,7 +181,7 @@ struct Cache {
       ++m_count;
       gbl = true;
       gel = false;
-      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      std::shared_ptr<Cache> pCache{ new Cache };
       ++(pCache->lumi);
       return pCache;
    }
@@ -195,7 +198,7 @@ struct Cache {
 
     static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, LuminosityBlockContext const* iLBContext) {
       ++m_count;
-      Cache const * pCache = iLBContext->luminosityBlock();
+      auto pCache = iLBContext->luminosityBlock();
       if ( pCache->lumi != 1 ) {
         throw cms::Exception("end out of sequence")
           << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
@@ -260,7 +263,7 @@ struct Cache {
       ++m_count;
       gbr=true;
       ger=false;
-      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      std::shared_ptr<Cache> pCache{ new Cache };
       ++(pCache->run);
       return pCache;
    }
@@ -275,7 +278,7 @@ struct Cache {
         throw cms::Exception("begin out of sequence")
           << "globalBeginRunSummary seen before globalBeginRun";
       }
-      return std::shared_ptr<Cache>{new Cache()};
+      return std::shared_ptr<Cache>{ new Cache };
     }
 
    void endRunSummary(edm::Run const&, edm::EventSetup const&, Cache* gCache) const override {
@@ -307,7 +310,7 @@ struct Cache {
       ++m_count;
       gbr=false;
       ger=true;
-      Cache const * pCache = iContext->run();
+      auto pCache = iContext->run();
       if ( pCache->run != 1 ) {
         throw cms::Exception("end out of sequence")
           << "globalEndRun seen before globalBeginRun in Run" << iRun.run();
@@ -364,7 +367,7 @@ struct Cache {
       ++m_count;
       gbl = true;
       gel = false;
-      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      std::shared_ptr<Cache> pCache{ new Cache };
       ++(pCache->lumi);
       return pCache;
     }
@@ -380,7 +383,7 @@ struct Cache {
        throw cms::Exception("begin out of sequence")
          << "globalBeginLuminosityBlockSummary seen before globalBeginLuminosityBlock";
       }
-      return std::shared_ptr<Cache>{new Cache()};
+      return std::shared_ptr<Cache>{ new Cache };
    }
    
    
@@ -411,7 +414,7 @@ struct Cache {
 
    static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, LuminosityBlockContext const* iLBContext) {
       ++m_count;
-      Cache const * pCache = iLBContext->luminosityBlock();
+      auto pCache = iLBContext->luminosityBlock();
       if ( pCache->lumi != 1 ) {
         throw cms::Exception("end out of sequence")
           << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();

--- a/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
@@ -1,0 +1,481 @@
+
+/*----------------------------------------------------------------------
+
+Toy edm::stream::EDAnalyzer modules of 
+edm::*Cache templates 
+for testing purposes only.
+
+----------------------------------------------------------------------*/
+#include <iostream>
+#include <atomic>
+#include <vector>
+#include <map>
+#include <functional>
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
+#include "FWCore/Framework/src/WorkerT.h"
+#include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+
+
+namespace edmtest {
+namespace stream {
+
+struct Cache { 
+   Cache():value(0),run(0),lumi(0) {}
+   //Using mutable since we want to update the value.
+   mutable std::atomic<unsigned int> value;
+   mutable std::atomic<unsigned int> run;
+   mutable std::atomic<unsigned int> lumi;
+};
+
+
+
+  class GlobalIntAnalyzer : public edm::stream::EDAnalyzer<edm::GlobalCache<Cache>> {
+  public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+   
+    static std::unique_ptr<Cache> initializeGlobalCache(edm::ParameterSet const& p) {
+      ++m_count;
+      return std::unique_ptr<Cache>(new Cache());
+    }
+
+    GlobalIntAnalyzer(edm::ParameterSet const& p, Cache const * iGlobal)  {
+      trans_ = p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+    }
+
+    void analyze(edm::Event const&, edm::EventSetup const&) {
+      ++m_count;
+      ++((globalCache())->value);
+       
+    }
+    
+    static void globalEndJob(Cache * iGlobal) {
+      ++m_count;
+      if(iGlobal->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << iGlobal->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+    ~GlobalIntAnalyzer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << m_count << " but it was supposed to be " << trans_;
+      }
+    }
+
+    
+  };
+
+  class RunIntAnalyzer : public edm::stream::EDAnalyzer<edm::RunCache<Cache>> {
+  public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbr;
+    static bool ger;
+    bool br;
+    bool er;
+
+    RunIntAnalyzer(edm::ParameterSet const&p) {
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      m_count = 0;
+    }
+    
+    void analyze(edm::Event const&, edm::EventSetup const&) {
+      ++m_count;
+      ++(runCache()->value);
+       
+    }
+
+    static std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&, GlobalCache const*) {
+      ++m_count;
+      gbr = true;
+      ger = false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->run);
+      return pCache;
+    }
+
+    void beginRun(edm::Run const&, edm::EventSetup const&) override {
+      br = true;
+      er = true;
+      if ( !gbr ) {
+        throw cms::Exception("begin out of sequence")
+          << "beginRun seen before globalBeginRun";
+      }
+    }
+
+    static void globalEndRun(edm::Run const& iRun, edm::EventSetup const&, RunContext const* iContext) {
+      ++m_count;
+      Cache const * pCache = iContext->run();
+      if ( pCache->run != 1 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndRun seen before globalBeginRun in Run" << iRun.run();
+      } 
+      ger = true;
+      gbr = false;
+      if( iContext->run()->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << iContext->run()->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+    void endRun(edm::Run const&, edm::EventSetup const&) override {
+      er = true;
+      br = false;
+      if ( ger ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndRun seen before endRun";
+      }
+    }
+
+    ~RunIntAnalyzer() {
+       if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << m_count << " but it was supposed to be " << trans_;
+      }
+
+    }
+  };
+
+
+  class LumiIntAnalyzer : public edm::stream::EDAnalyzer<edm::LuminosityBlockCache<Cache>> {
+  public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbl;
+    static bool gel;
+    static bool bl;
+    static bool el;
+
+    LumiIntAnalyzer(edm::ParameterSet const&p){
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      m_count = 0;
+    }
+     
+    void analyze(edm::Event const&, edm::EventSetup const&) override {
+      ++m_count;
+      ++(luminosityBlockCache()->value);
+       
+    }
+
+   
+    static std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, RunContext const*) {
+      ++m_count;
+      gbl = true;
+      gel = false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->lumi);
+      return pCache;
+   }
+
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
+      bl = true;
+      el = false;
+      if ( !gbl ) {
+        throw cms::Exception("begin out of sequence")
+          << "beginLuminosityBlock seen before globalBeginLuminosityBlock";
+      }
+    }
+
+
+    static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, LuminosityBlockContext const* iLBContext) {
+      ++m_count;
+      Cache const * pCache = iLBContext->luminosityBlock();
+      if ( pCache->lumi != 1 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+      }       
+      gel = true;
+      gbl = false;
+      if(iLBContext->luminosityBlock()->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << iLBContext->luminosityBlock()->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+   static void endLuminosityBlock(edm::Run const&, edm::EventSetup const&, LuminosityBlockContext const*) {
+      el = true;
+      bl = false;
+      if ( gel ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlock seen before endLuminosityBlock";
+      }      
+   }
+
+    ~LumiIntAnalyzer() {
+       if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << m_count<< " but it was supposed to be " << trans_;
+       }
+    }
+  };
+  
+  class RunSummaryIntAnalyzer : public edm::stream::EDAnalyzer<edm::RunCache<Cache>,edm::RunSummaryCache<Cache>> {
+  public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbr;
+    static bool ger;
+    static bool gbrs;
+    static bool gers;
+    static bool brs;
+    static bool ers;
+    static bool br;
+    static bool er;
+
+    RunSummaryIntAnalyzer(edm::ParameterSet const&p){
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      m_count = 0;
+    }
+
+    void analyze(edm::Event const&, edm::EventSetup const&)  override {
+      ++m_count;
+      ++(runCache()->value);
+       
+    }
+    
+    void beginRun(edm::Run const&, edm::EventSetup const&) override {
+      br=true;
+      er=false;
+    }
+
+    static std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&, GlobalCache const*) {
+      ++m_count;
+      gbr=true;
+      ger=false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->run);
+      return pCache;
+   }
+    
+    static std::shared_ptr<Cache> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&, GlobalCache const*) {
+      ++m_count;
+      gbrs = true;
+      gers = false;
+      brs = true;
+      ers = false;
+      if ( !gbr ) {
+        throw cms::Exception("begin out of sequence")
+          << "globalBeginRunSummary seen before globalBeginRun";
+      }
+      return std::shared_ptr<Cache>{new Cache()};
+    }
+
+   void endRunSummary(edm::Run const&, edm::EventSetup const&, Cache* gCache) const override {
+      brs=false;
+      ers=true;
+      gCache->value += runCache()->value;
+      runCache()->value = 0;
+      if ( !er ) {
+        throw cms::Exception("end out of sequence")
+          << "endRunSummary seen before endRun";
+      }
+   }
+    
+    static void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, RunContext const*, Cache* gCache) {
+      ++m_count;
+      gbrs=false;
+      gers=true;
+      if ( !ers ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndRunSummary seen before endRunSummary";
+      }
+      if(gCache->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << gCache->value << " but it was supposed to be " << cvalue_;
+      }
+   }
+
+   static void globalEndRun(edm::Run const& iRun, edm::EventSetup const&, RunContext const* iContext) {
+      ++m_count;
+      gbr=false;
+      ger=true;
+      Cache const * pCache = iContext->run();
+      if ( pCache->run != 1 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndRun seen before globalBeginRun in Run" << iRun.run();
+      } 
+   }
+
+    void endRun(edm::Run const&, edm::EventSetup const&) override {
+      er = true;
+      br = false;
+    }   
+
+
+    ~RunSummaryIntAnalyzer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+ 
+    }
+  };
+
+  class LumiSummaryIntAnalyzer : public edm::stream::EDAnalyzer<edm::LuminosityBlockCache<Cache>,edm::LuminosityBlockSummaryCache<Cache>> {
+  public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbl;
+    static bool gel;
+    static bool gbls;
+    static bool gels;
+    static bool bls;
+    static bool els;
+    static bool bl;
+    static bool el;
+
+    LumiSummaryIntAnalyzer(edm::ParameterSet const&p){
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      m_count = 0;
+    }
+
+    void analyze(edm::Event const&, edm::EventSetup const&) override  {
+      ++m_count;
+      ++(luminosityBlockCache()->value);
+       
+    }
+
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
+      bl = true;
+      el = false;
+    }
+
+    static std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, RunContext const*) {
+      ++m_count;
+      gbl = true;
+      gel = false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->lumi);
+      return pCache;
+    }
+
+ 
+    static std::shared_ptr<Cache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, LuminosityBlockContext const*){
+      ++m_count;
+      gbls = true;
+      gels = false;
+      bls = true;
+      els = false;
+      if ( !gbl ) {
+       throw cms::Exception("begin out of sequence")
+         << "globalBeginLuminosityBlockSummary seen before globalBeginLuminosityBlock";
+      }
+      return std::shared_ptr<Cache>{new Cache()};
+   }
+   
+   
+    void endLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, Cache* gCache) const override {
+      bls=false;
+      els=true;
+      gCache->value += luminosityBlockCache()->value;
+      luminosityBlockCache()->value = 0;
+      if ( el ) {
+        throw cms::Exception("end out of sequence")
+          << "endLuminosityBlock seen before endLuminosityBlockSummary";
+      }
+   }
+    
+    static void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, LuminosityBlockContext const*, Cache* gCache){
+     ++m_count;
+     gbls=false;
+     gels=true;
+      if ( !els ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlockSummary seen before endLuminosityBlockSummary";
+      }
+     if ( gCache->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << gCache->value << " but it was supposed to be " << cvalue_;
+     }
+   }
+
+   static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, LuminosityBlockContext const* iLBContext) {
+      ++m_count;
+      Cache const * pCache = iLBContext->luminosityBlock();
+      if ( pCache->lumi != 1 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+      }       
+      gel = true;
+      gbl = false;
+      if ( !gels ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlockSummary seen before globalEndLuminosityBlock";  
+      }
+   }
+ 
+    static void endLuminosityBlock(edm::Run const&, edm::EventSetup const&, LuminosityBlockContext const*) {
+      el = true;
+      bl = false;
+    }
+
+
+    ~LumiSummaryIntAnalyzer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  }; 
+
+
+}
+}
+std::atomic<unsigned int> edmtest::stream::GlobalIntAnalyzer::m_count{0};
+std::atomic<unsigned int> edmtest::stream::RunIntAnalyzer::m_count{0};
+std::atomic<unsigned int> edmtest::stream::LumiIntAnalyzer::m_count{0};
+std::atomic<unsigned int> edmtest::stream::RunSummaryIntAnalyzer::m_count{0};
+std::atomic<unsigned int> edmtest::stream::LumiSummaryIntAnalyzer::m_count{0};
+unsigned int edmtest::stream::GlobalIntAnalyzer::cvalue_ = 0;
+unsigned int edmtest::stream::RunIntAnalyzer::cvalue_ = 0;
+unsigned int edmtest::stream::LumiIntAnalyzer::cvalue_ = 0;
+unsigned int edmtest::stream::RunSummaryIntAnalyzer::cvalue_ = 0;
+unsigned int edmtest::stream::LumiSummaryIntAnalyzer::cvalue_ = 0;
+bool edmtest::stream::RunIntAnalyzer::gbr=false;
+bool edmtest::stream::RunIntAnalyzer::ger=false;
+bool edmtest::stream::LumiIntAnalyzer::gbl=false;
+bool edmtest::stream::LumiIntAnalyzer::gel=false;
+bool edmtest::stream::LumiIntAnalyzer::bl=false;
+bool edmtest::stream::LumiIntAnalyzer::el=false;
+bool edmtest::stream::RunSummaryIntAnalyzer::gbr=false;
+bool edmtest::stream::RunSummaryIntAnalyzer::ger=false;
+bool edmtest::stream::RunSummaryIntAnalyzer::gbrs=false;
+bool edmtest::stream::RunSummaryIntAnalyzer::gers=false;
+bool edmtest::stream::RunSummaryIntAnalyzer::brs=false;
+bool edmtest::stream::RunSummaryIntAnalyzer::ers=false;
+bool edmtest::stream::RunSummaryIntAnalyzer::br=false;
+bool edmtest::stream::RunSummaryIntAnalyzer::er=false;
+bool edmtest::stream::LumiSummaryIntAnalyzer::gbl=false;
+bool edmtest::stream::LumiSummaryIntAnalyzer::gel=false;
+bool edmtest::stream::LumiSummaryIntAnalyzer::gbls=false;
+bool edmtest::stream::LumiSummaryIntAnalyzer::gels=false;
+bool edmtest::stream::LumiSummaryIntAnalyzer::bls=false;
+bool edmtest::stream::LumiSummaryIntAnalyzer::els=false;
+bool edmtest::stream::LumiSummaryIntAnalyzer::bl=false;
+bool edmtest::stream::LumiSummaryIntAnalyzer::el=false;
+DEFINE_FWK_MODULE(edmtest::stream::GlobalIntAnalyzer);
+DEFINE_FWK_MODULE(edmtest::stream::RunIntAnalyzer);
+DEFINE_FWK_MODULE(edmtest::stream::LumiIntAnalyzer);
+DEFINE_FWK_MODULE(edmtest::stream::RunSummaryIntAnalyzer);
+DEFINE_FWK_MODULE(edmtest::stream::LumiSummaryIntAnalyzer);
+

--- a/FWCore/Framework/test/stubs/TestStreamFilters.cc
+++ b/FWCore/Framework/test/stubs/TestStreamFilters.cc
@@ -1,0 +1,716 @@
+
+/*----------------------------------------------------------------------
+
+Toy edm::stream::EDFilter modules of 
+edm::*Cache templates and edm::*Producer classes
+for testing purposes only.
+
+----------------------------------------------------------------------*/
+#include <iostream>
+#include <atomic>
+#include <vector>
+#include <map>
+#include <functional>
+#include "FWCore/Framework/interface/stream/EDFilter.h"
+#include "FWCore/Framework/src/WorkerT.h"
+#include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+
+
+namespace edmtest {
+namespace stream {
+
+struct Cache { 
+   Cache():value(0),run(0),lumi(0) {}
+   //Using mutable since we want to update the value.
+   mutable std::atomic<unsigned int> value;
+   mutable std::atomic<unsigned int> run;
+   mutable std::atomic<unsigned int> lumi;
+};
+
+
+  class GlobalIntFilter : public edm::stream::EDFilter<edm::GlobalCache<Cache>> {
+  public:
+    static std::atomic<unsigned int> m_count; 
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    
+    static std::unique_ptr<Cache> initializeGlobalCache(edm::ParameterSet const&) {
+      ++m_count;
+      return std::unique_ptr<Cache>{new Cache()};
+    }
+
+    GlobalIntFilter(edm::ParameterSet const& p, const Cache* iGlobal) {
+      trans_ = p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      produces<unsigned int>();
+    }
+    
+    bool filter(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+      ++((globalCache())->value);
+       
+      return true;
+    }
+    
+    static void globalEndJob(Cache* iGlobal) {
+      ++m_count;
+      if(iGlobal->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << iGlobal->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+    ~GlobalIntFilter() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << m_count << " but it was supposed to be " << trans_;
+      }
+    }
+
+    
+  };
+
+  class RunIntFilter : public edm::stream::EDFilter<edm::RunCache<Cache>> {
+  public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbr;
+    static bool ger;
+    bool br;
+    bool er;
+
+    RunIntFilter(edm::ParameterSet const&p){
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      m_count = 0;
+      produces<unsigned int>();
+    }
+
+    bool filter(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+      ++(runCache()->value);
+       
+      return true;
+    }
+    
+    static std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&, GlobalCache const*) {
+      ++m_count;
+      gbr = true;
+      ger = false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->run);
+      return pCache;
+   }
+
+    static void globalEndRun(edm::Run const& iRun, edm::EventSetup const&, RunContext const* iContext) {
+       ++m_count;
+      Cache const * pCache = iContext->run();
+      if ( pCache->run != 1 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndRun seen before globalBeginRun in Run" << iRun.run();
+      } 
+      ger = true;
+      gbr = false;
+      if( iContext->run()->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << iContext->run()->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+    ~RunIntFilter() {
+       if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << m_count << " but it was supposed to be " << trans_;
+      }
+
+    }
+  };
+
+
+  class LumiIntFilter : public edm::stream::EDFilter<edm::LuminosityBlockCache<Cache>> {
+  public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbl;
+    static bool gel;
+    static bool bl;
+    static bool el;
+
+    LumiIntFilter(edm::ParameterSet const&p){
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      m_count = 0;
+      produces<unsigned int>();
+    }
+
+    bool filter(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+      ++(luminosityBlockCache()->value);
+       
+      return true;
+    }
+    
+    static std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, RunContext const*) {
+      ++m_count;
+      gbl = true;
+      gel = false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->lumi);
+      return pCache;
+   }
+
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
+      bl = true;
+      el = false;
+      if ( !gbl ) {
+        throw cms::Exception("begin out of sequence")
+          << "beginLuminosityBlock seen before globalBeginLuminosityBlock";
+      }
+    }
+
+ 
+    static void globalEndLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&, LuminosityBlockContext const* iLBContext) {
+      ++m_count;
+      if(iLBContext->luminosityBlock()->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << "LumiIntFilter cache value " 
+          << iLBContext->luminosityBlock()->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+   static void endLuminosityBlock(edm::Run const&, edm::EventSetup const&, LuminosityBlockContext const*) {
+      el = true;
+      bl = false;
+      if ( gel ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlock seen before endLuminosityBlock";
+      }      
+   }
+   
+
+    ~LumiIntFilter() {
+       if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << m_count<< " but it was supposed to be " << trans_;
+       }
+    }
+  };
+  
+  class RunSummaryIntFilter : public edm::stream::EDFilter<edm::RunCache<Cache>,edm::RunSummaryCache<Cache>> {
+  public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbr;
+    static bool ger;
+    static bool gbrs;
+    static bool gers;
+    static bool brs;
+    static bool ers;
+    static bool br;
+    static bool er;
+
+    RunSummaryIntFilter(edm::ParameterSet const&p){
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      m_count = 0;
+      produces<unsigned int>();
+    }
+
+    void beginRun(edm::Run const&, edm::EventSetup const&) override {
+      br=true;
+      er=false;
+    }
+
+    bool filter(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+      ++(runCache()->value);
+       
+      return true;
+    }
+    
+    static std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&, GlobalCache const*) {
+      ++m_count;
+      gbr=true;
+      ger=false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->run);
+      return pCache;
+   }
+
+    static std::shared_ptr<Cache> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&, GlobalCache const*) {
+      ++m_count;
+      gbrs = true;
+      gers = false;
+      brs = true;
+      ers = false;
+      if ( !gbr ) {
+        throw cms::Exception("begin out of sequence")
+          << "globalBeginRunSummary seen before globalBeginRun";
+      }
+      return std::shared_ptr<Cache>{new Cache()};
+   }
+    
+    void endRunSummary(edm::Run const&, edm::EventSetup const&, Cache* gCache) const override {
+      brs=false;
+      ers=true;
+      gCache->value += runCache()->value;
+      runCache()->value = 0;
+      if ( !er ) {
+        throw cms::Exception("end out of sequence")
+          << "endRunSummary seen before endRun";
+      }
+    }
+    
+    static void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, RunContext const*, Cache* gCache){
+      ++m_count;
+      gbrs=false;
+      gers=true;
+      if ( !ers ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndRunSummary seen before endRunSummary";
+      }
+      if(gCache->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << gCache->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+   static void globalEndRun(edm::Run const& iRun, edm::EventSetup const&, RunContext const* iContext) {
+      ++m_count;
+      gbr=false;
+      ger=true;
+      Cache const * pCache = iContext->run();
+      if ( pCache->run != 1 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndRun seen before globalBeginRun in Run" << iRun.run();
+      } 
+  }
+
+    void endRun(edm::Run const&, edm::EventSetup const&) override {
+      er = true;
+      br = false;
+    }   
+
+
+
+    ~RunSummaryIntFilter() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class LumiSummaryIntFilter : public edm::stream::EDFilter<edm::LuminosityBlockCache<Cache>,edm::LuminosityBlockSummaryCache<Cache>> {
+  public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbl;
+    static bool gel;
+    static bool gbls;
+    static bool gels;
+    static bool bls;
+    static bool els;
+    static bool bl;
+    static bool el;
+
+    LumiSummaryIntFilter(edm::ParameterSet const&p) {
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      m_count = 0;
+      produces<unsigned int>();
+    }
+
+    bool filter(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+      ++(luminosityBlockCache()->value);
+       
+      return true;
+    }
+
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
+      bl = true;
+      el = false;
+    }
+
+    static std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, RunContext const*) {
+      ++m_count;
+      gbl = true;
+      gel = false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->lumi);
+      return pCache;
+    }
+
+
+    static std::shared_ptr<Cache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, LuminosityBlockContext const*){
+      ++m_count;
+      gbls = true;
+      gels = false;
+      bls = true;
+      els = false;
+      if ( !gbl ) {
+       throw cms::Exception("begin out of sequence")
+         << "globalBeginLuminosityBlockSummary seen before globalBeginLuminosityBlock";
+      }
+      return std::shared_ptr<Cache>{new Cache};
+    }
+    
+    void endLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, Cache* gCache) const override {
+      bls=false;
+      els=true;
+      gCache->value += luminosityBlockCache()->value;
+      luminosityBlockCache()->value = 0;
+      if ( el ) {
+        throw cms::Exception("end out of sequence")
+          << "endLuminosityBlock seen before endLuminosityBlockSummary";
+      }
+    }
+    
+    static void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, LuminosityBlockContext const*, Cache* gCache){
+     ++m_count;
+     gbls=false;
+     gels=true;
+      if ( !els ) {
+        throw cms::Exception("end out of sequence")
+          << "LumiSummaryIntFilter " 
+          << "globalEndLuminosityBlockSummary seen before endLuminosityBlockSummary";
+      }
+      if( gCache->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << gCache->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+   static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, LuminosityBlockContext const* iLBContext) {
+      ++m_count;
+      Cache const * pCache = iLBContext->luminosityBlock();
+      if ( pCache->lumi != 1 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+      }       
+      gel = true;
+      gbl = false;
+      if ( !gels ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlockSummary seen before globalEndLuminosityBlock";  
+      }
+   }
+
+    static void endLuminosityBlock(edm::Run const&, edm::EventSetup const&, LuminosityBlockContext const*) {
+      el = true;
+      bl = false;
+    }
+
+
+    ~LumiSummaryIntFilter() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestBeginRunFilter : public edm::stream::EDFilter<edm::RunCache<Cache>,edm::BeginRunProducer> {
+    public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbr;
+    static bool ger;
+
+    TestBeginRunFilter(edm::ParameterSet const&p){
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      m_count = 0;
+      produces<unsigned int>();
+    }
+
+  static std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&, GlobalCache const*) {
+     ++m_count;
+      gbr=true;
+      ger=false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->run);
+      return pCache;
+   }
+
+    bool filter(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+       
+      return true;
+    }
+
+    static void globalBeginRunProduce(edm::Run& iRun, edm::EventSetup const&, RunContext const*) {
+      ++m_count;
+      if ( !gbr ) {
+        throw cms::Exception("begin out of sequence")
+          << "globalBeginRunProduce seen before globalBeginRun";
+      }
+    }
+
+    static void globalEndRun(edm::Run const& iRun, edm::EventSetup const&, RunContext const* iContext) {
+     ++m_count;
+      Cache const * pCache = iContext->run();
+      if ( pCache->run != 1 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndRun seen before globalBeginRun in Run" << iRun.run();
+      } 
+      gbr=false;
+      ger=true;
+    }
+
+    ~TestBeginRunFilter() {
+    if(m_count != trans_) {
+       throw cms::Exception("transitions")
+         << m_count<< " but it was supposed to be " << trans_;
+     }
+    }
+  };
+
+  class TestEndRunFilter : public edm::stream::EDFilter<edm::RunCache<Cache>,edm::EndRunProducer> {
+    public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbr;
+    static bool ger;
+
+  static std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&, GlobalCache const*) {
+     ++m_count;
+      gbr=true;
+      ger=false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->run);
+      return pCache;
+   }
+
+ 
+    TestEndRunFilter(edm::ParameterSet const&p){
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      m_count = 0;
+      produces<unsigned int>();
+    }
+
+    bool filter(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+       
+      return true;
+    }
+
+    static void globalEndRunProduce(edm::Run& iRun, edm::EventSetup const&, RunContext const*) {
+      ++m_count;
+      if ( ger ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndRun seen before globalEndRunProduce";
+      }
+    }
+
+    static void globalEndRun(edm::Run const& iRun, edm::EventSetup const&, RunContext const* iContext) {
+      ++m_count;
+      Cache const * pCache = iContext->run();
+      if ( pCache->run != 1 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndRun seen before globalBeginRun in Run" << iRun.run();
+      } 
+      gbr=false;
+      ger=true;
+    }
+
+
+    ~TestEndRunFilter() {
+    if(m_count != trans_) {
+       throw cms::Exception("transitions")
+         << m_count<< " but it was supposed to be " << trans_;
+     }
+    }
+  };
+
+  class TestBeginLumiBlockFilter : public edm::stream::EDFilter<edm::LuminosityBlockCache<Cache>,edm::BeginLuminosityBlockProducer> {
+    public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbl;
+    static bool gel;
+ 
+    TestBeginLumiBlockFilter(edm::ParameterSet const&p){
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      m_count = 0;
+      produces<unsigned int>();
+    }
+
+    bool filter(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+       
+      return true;
+    }
+
+    static void globalBeginLuminosityBlockProduce(edm::LuminosityBlock& , edm::EventSetup const&, LuminosityBlockContext const*) {
+      ++m_count;
+      if ( !gbl ) {
+        throw cms::Exception("begin out of sequence")
+          << "globalBeginLumiBlockProduce seen before globalBeginLumiBlock";
+      }
+    }
+
+    static std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, RunContext const*) {
+      ++m_count;
+      gbl = true;
+      gel = false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->lumi);
+      return pCache;
+   }
+
+    static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, LuminosityBlockContext const* iLBContext) {
+      ++m_count;
+      Cache const * pCache = iLBContext->luminosityBlock();
+      if ( pCache->lumi != 1 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+      }
+      gel = true;
+      gbl = false;
+    }
+
+
+    ~TestBeginLumiBlockFilter() {
+    if(m_count != trans_) {
+       throw cms::Exception("transitions")
+         << m_count<< " but it was supposed to be " << trans_;
+     }
+    }
+  };
+
+  class TestEndLumiBlockFilter : public edm::stream::EDFilter<edm::LuminosityBlockCache<Cache>,edm::EndLuminosityBlockProducer> {
+    public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbl;
+    static bool gel;
+ 
+    TestEndLumiBlockFilter(edm::ParameterSet const&p){
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      m_count = 0;
+      produces<unsigned int>();
+    }
+
+    bool filter(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+       
+      return true;
+    }
+
+    static std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, RunContext const*) {
+      ++m_count;
+      gbl = true;
+      gel = false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->lumi);
+      return pCache;
+   }
+
+  static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, LuminosityBlockContext const* iLBContext) {
+      ++m_count;
+      Cache const * pCache = iLBContext->luminosityBlock();
+      if ( pCache->lumi != 1 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+      }
+      gel = true;
+      gbl = false;
+   }
+
+
+    static void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&, LuminosityBlockContext const*) {
+      ++m_count;
+    }
+
+    ~TestEndLumiBlockFilter() {
+    if(m_count != trans_) {
+       throw cms::Exception("transitions")
+         << m_count<< " but it was supposed to be " << trans_;
+     }
+    }
+  };
+
+
+
+
+
+}
+}
+std::atomic<unsigned int> edmtest::stream::GlobalIntFilter::m_count{0};
+std::atomic<unsigned int> edmtest::stream::RunIntFilter::m_count{0};
+std::atomic<unsigned int> edmtest::stream::LumiIntFilter::m_count{0};
+std::atomic<unsigned int> edmtest::stream::RunSummaryIntFilter::m_count{0};
+std::atomic<unsigned int> edmtest::stream::LumiSummaryIntFilter::m_count{0};
+std::atomic<unsigned int> edmtest::stream::TestBeginRunFilter::m_count{0};
+std::atomic<unsigned int> edmtest::stream::TestEndRunFilter::m_count{0};
+std::atomic<unsigned int> edmtest::stream::TestBeginLumiBlockFilter::m_count{0};
+std::atomic<unsigned int> edmtest::stream::TestEndLumiBlockFilter::m_count{0};
+unsigned int edmtest::stream::GlobalIntFilter::cvalue_ = 0;
+unsigned int edmtest::stream::RunIntFilter::cvalue_ = 0;
+unsigned int edmtest::stream::LumiIntFilter::cvalue_ = 0;
+unsigned int edmtest::stream::RunSummaryIntFilter::cvalue_ = 0;
+unsigned int edmtest::stream::LumiSummaryIntFilter::cvalue_ = 0;
+unsigned int edmtest::stream::TestBeginRunFilter::cvalue_ = 0;
+unsigned int edmtest::stream::TestEndRunFilter::cvalue_ = 0;
+unsigned int edmtest::stream::TestBeginLumiBlockFilter::cvalue_ = 0;
+unsigned int edmtest::stream::TestEndLumiBlockFilter::cvalue_ = 0;
+bool edmtest::stream::RunIntFilter::gbr=false;
+bool edmtest::stream::RunIntFilter::ger=false;
+bool edmtest::stream::LumiIntFilter::gbl=false;
+bool edmtest::stream::LumiIntFilter::gel=false;
+bool edmtest::stream::LumiIntFilter::bl=false;
+bool edmtest::stream::LumiIntFilter::el=false;
+bool edmtest::stream::RunSummaryIntFilter::gbr=false;
+bool edmtest::stream::RunSummaryIntFilter::ger=false;
+bool edmtest::stream::RunSummaryIntFilter::gbrs=false;
+bool edmtest::stream::RunSummaryIntFilter::gers=false;
+bool edmtest::stream::RunSummaryIntFilter::brs=false;
+bool edmtest::stream::RunSummaryIntFilter::ers=false;
+bool edmtest::stream::RunSummaryIntFilter::br=false;
+bool edmtest::stream::RunSummaryIntFilter::er=false;
+bool edmtest::stream::LumiSummaryIntFilter::gbl=false;
+bool edmtest::stream::LumiSummaryIntFilter::gel=false;
+bool edmtest::stream::LumiSummaryIntFilter::gbls=false;
+bool edmtest::stream::LumiSummaryIntFilter::gels=false;
+bool edmtest::stream::LumiSummaryIntFilter::bls=false;
+bool edmtest::stream::LumiSummaryIntFilter::els=false;
+bool edmtest::stream::LumiSummaryIntFilter::bl=false;
+bool edmtest::stream::LumiSummaryIntFilter::el=false;
+bool edmtest::stream::TestBeginRunFilter::gbr=false;
+bool edmtest::stream::TestBeginRunFilter::ger=false;
+bool edmtest::stream::TestEndRunFilter::gbr=false;
+bool edmtest::stream::TestEndRunFilter::ger=false;
+bool edmtest::stream::TestBeginLumiBlockFilter::gbl=false;
+bool edmtest::stream::TestBeginLumiBlockFilter::gel=false;
+bool edmtest::stream::TestEndLumiBlockFilter::gbl=false;
+bool edmtest::stream::TestEndLumiBlockFilter::gel=false;
+DEFINE_FWK_MODULE(edmtest::stream::GlobalIntFilter);
+DEFINE_FWK_MODULE(edmtest::stream::RunIntFilter);
+DEFINE_FWK_MODULE(edmtest::stream::LumiIntFilter);
+DEFINE_FWK_MODULE(edmtest::stream::RunSummaryIntFilter);
+DEFINE_FWK_MODULE(edmtest::stream::LumiSummaryIntFilter);
+DEFINE_FWK_MODULE(edmtest::stream::TestBeginRunFilter);
+DEFINE_FWK_MODULE(edmtest::stream::TestEndRunFilter);
+DEFINE_FWK_MODULE(edmtest::stream::TestBeginLumiBlockFilter);
+DEFINE_FWK_MODULE(edmtest::stream::TestEndLumiBlockFilter);

--- a/FWCore/Framework/test/stubs/TestStreamFilters.cc
+++ b/FWCore/Framework/test/stubs/TestStreamFilters.cc
@@ -27,6 +27,7 @@ for testing purposes only.
 namespace edmtest {
 namespace stream {
 
+namespace {
 struct Cache { 
    Cache():value(0),run(0),lumi(0) {}
    //Using mutable since we want to update the value.
@@ -34,6 +35,9 @@ struct Cache {
    mutable std::atomic<unsigned int> run;
    mutable std::atomic<unsigned int> lumi;
 };
+
+} //end anonymous namespace
+
 
 
   class GlobalIntFilter : public edm::stream::EDFilter<edm::GlobalCache<Cache>> {
@@ -44,7 +48,7 @@ struct Cache {
     
     static std::unique_ptr<Cache> initializeGlobalCache(edm::ParameterSet const&) {
       ++m_count;
-      return std::unique_ptr<Cache>{new Cache()};
+      return std::unique_ptr<Cache>{ new Cache };
     }
 
     GlobalIntFilter(edm::ParameterSet const& p, const Cache* iGlobal) {
@@ -106,14 +110,14 @@ struct Cache {
       ++m_count;
       gbr = true;
       ger = false;
-      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      std::shared_ptr<Cache> pCache{ new Cache };
       ++(pCache->run);
       return pCache;
    }
 
     static void globalEndRun(edm::Run const& iRun, edm::EventSetup const&, RunContext const* iContext) {
        ++m_count;
-      Cache const * pCache = iContext->run();
+      auto pCache = iContext->run();
       if ( pCache->run != 1 ) {
         throw cms::Exception("end out of sequence")
           << "globalEndRun seen before globalBeginRun in Run" << iRun.run();
@@ -164,7 +168,7 @@ struct Cache {
       ++m_count;
       gbl = true;
       gel = false;
-      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      std::shared_ptr<Cache> pCache{ new Cache };
       ++(pCache->lumi);
       return pCache;
    }
@@ -243,7 +247,7 @@ struct Cache {
       ++m_count;
       gbr=true;
       ger=false;
-      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      std::shared_ptr<Cache> pCache {new Cache };
       ++(pCache->run);
       return pCache;
    }
@@ -258,7 +262,7 @@ struct Cache {
         throw cms::Exception("begin out of sequence")
           << "globalBeginRunSummary seen before globalBeginRun";
       }
-      return std::shared_ptr<Cache>{new Cache()};
+      return std::shared_ptr<Cache>{ new Cache };
    }
     
     void endRunSummary(edm::Run const&, edm::EventSetup const&, Cache* gCache) const override {
@@ -290,7 +294,7 @@ struct Cache {
       ++m_count;
       gbr=false;
       ger=true;
-      Cache const * pCache = iContext->run();
+      auto pCache = iContext->run();
       if ( pCache->run != 1 ) {
         throw cms::Exception("end out of sequence")
           << "globalEndRun seen before globalBeginRun in Run" << iRun.run();
@@ -349,7 +353,7 @@ struct Cache {
       ++m_count;
       gbl = true;
       gel = false;
-      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      std::shared_ptr<Cache> pCache{ new Cache };
       ++(pCache->lumi);
       return pCache;
     }
@@ -365,7 +369,7 @@ struct Cache {
        throw cms::Exception("begin out of sequence")
          << "globalBeginLuminosityBlockSummary seen before globalBeginLuminosityBlock";
       }
-      return std::shared_ptr<Cache>{new Cache};
+      return std::shared_ptr<Cache>{ new Cache };
     }
     
     void endLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, Cache* gCache) const override {
@@ -396,7 +400,7 @@ struct Cache {
 
    static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, LuminosityBlockContext const* iLBContext) {
       ++m_count;
-      Cache const * pCache = iLBContext->luminosityBlock();
+      auto pCache = iLBContext->luminosityBlock();
       if ( pCache->lumi != 1 ) {
         throw cms::Exception("end out of sequence")
           << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
@@ -442,14 +446,13 @@ struct Cache {
      ++m_count;
       gbr=true;
       ger=false;
-      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      std::shared_ptr<Cache> pCache{ new Cache };
       ++(pCache->run);
       return pCache;
    }
 
     bool filter(edm::Event&, edm::EventSetup const&) override {
       ++m_count;
-       
       return true;
     }
 
@@ -463,7 +466,7 @@ struct Cache {
 
     static void globalEndRun(edm::Run const& iRun, edm::EventSetup const&, RunContext const* iContext) {
      ++m_count;
-      Cache const * pCache = iContext->run();
+      auto pCache = iContext->run();
       if ( pCache->run != 1 ) {
         throw cms::Exception("end out of sequence")
           << "globalEndRun seen before globalBeginRun in Run" << iRun.run();
@@ -492,7 +495,7 @@ struct Cache {
      ++m_count;
       gbr=true;
       ger=false;
-      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      std::shared_ptr<Cache> pCache{ new Cache };
       ++(pCache->run);
       return pCache;
    }
@@ -521,7 +524,7 @@ struct Cache {
 
     static void globalEndRun(edm::Run const& iRun, edm::EventSetup const&, RunContext const* iContext) {
       ++m_count;
-      Cache const * pCache = iContext->run();
+      auto pCache = iContext->run();
       if ( pCache->run != 1 ) {
         throw cms::Exception("end out of sequence")
           << "globalEndRun seen before globalBeginRun in Run" << iRun.run();
@@ -572,14 +575,14 @@ struct Cache {
       ++m_count;
       gbl = true;
       gel = false;
-      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      std::shared_ptr<Cache> pCache{ new Cache };
       ++(pCache->lumi);
       return pCache;
    }
 
     static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, LuminosityBlockContext const* iLBContext) {
       ++m_count;
-      Cache const * pCache = iLBContext->luminosityBlock();
+      auto pCache = iLBContext->luminosityBlock();
       if ( pCache->lumi != 1 ) {
         throw cms::Exception("end out of sequence")
           << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
@@ -622,14 +625,14 @@ struct Cache {
       ++m_count;
       gbl = true;
       gel = false;
-      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      std::shared_ptr<Cache> pCache{ new Cache };
       ++(pCache->lumi);
       return pCache;
    }
 
   static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, LuminosityBlockContext const* iLBContext) {
       ++m_count;
-      Cache const * pCache = iLBContext->luminosityBlock();
+      auto pCache = iLBContext->luminosityBlock();
       if ( pCache->lumi != 1 ) {
         throw cms::Exception("end out of sequence")
           << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();

--- a/FWCore/Framework/test/stubs/TestStreamProducers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamProducers.cc
@@ -236,7 +236,7 @@ struct UnsafeCache {
     }
   };
   
-  class RunSummaryIntProducer : public edm::stream::EDProducer<edm::RunCache<Cache>,edm::RunSummaryCache<Cache>> {
+  class RunSummaryIntProducer : public edm::stream::EDProducer<edm::RunCache<Cache>,edm::RunSummaryCache<UnsafeCache>> {
   public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
@@ -277,7 +277,7 @@ struct UnsafeCache {
  
     }
 
-    static std::shared_ptr<Cache> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&, GlobalCache const*) {
+    static std::shared_ptr<UnsafeCache> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&, GlobalCache const*) {
       ++m_count;
       gbrs = true;
       gers = false;
@@ -287,13 +287,13 @@ struct UnsafeCache {
         throw cms::Exception("begin out of sequence")
           << "globalBeginRunSummary seen before globalBeginRun";
       }
-      return std::shared_ptr<Cache>{ new Cache };
+      return std::shared_ptr<UnsafeCache>{ new UnsafeCache };
     }
     
-    void endRunSummary(edm::Run const&, edm::EventSetup const&, Cache* gCache) const override {
+    void endRunSummary(edm::Run const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
       brs=false;
       ers=true;
-      gCache->value += runCache()->value.load();
+      gCache->value += runCache()->value;
       runCache()->value = 0;
       if ( !er ) {
         throw cms::Exception("end out of sequence")
@@ -301,7 +301,7 @@ struct UnsafeCache {
       }
     }
     
-    static void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, RunContext const*, Cache * gCache) {
+    static void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, RunContext const*, UnsafeCache * gCache) {
       ++m_count;
       gbrs=false;
       gers=true;
@@ -340,7 +340,7 @@ struct UnsafeCache {
     }
   };
 
-  class LumiSummaryIntProducer : public edm::stream::EDProducer<edm::LuminosityBlockCache<Cache>,edm::LuminosityBlockSummaryCache<Cache>> {
+  class LumiSummaryIntProducer : public edm::stream::EDProducer<edm::LuminosityBlockCache<Cache>,edm::LuminosityBlockSummaryCache<UnsafeCache>> {
   public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
@@ -381,7 +381,7 @@ struct UnsafeCache {
     }
 
 
-    static std::shared_ptr<Cache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, LuminosityBlockContext const*) {
+    static std::shared_ptr<UnsafeCache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, LuminosityBlockContext const*) {
       ++m_count;
       gbls = true;
       gels = false;
@@ -391,15 +391,15 @@ struct UnsafeCache {
        throw cms::Exception("begin out of sequence")
          << "globalBeginLuminosityBlockSummary seen before globalBeginLuminosityBlock";
       }
-      return std::shared_ptr<Cache>{ new Cache };
+      return std::shared_ptr<UnsafeCache>{ new UnsafeCache };
     }
     
 
 
-    void endLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, Cache* gCache) const override {
+    void endLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, UnsafeCache* gCache) const override {
       bls=false;
       els=true;
-      gCache->value += luminosityBlockCache()->value.load();
+      gCache->value += luminosityBlockCache()->value;
       luminosityBlockCache()->value = 0;
       if ( el ) {
         throw cms::Exception("end out of sequence")
@@ -407,7 +407,7 @@ struct UnsafeCache {
       }
     }
     
-   static void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, LuminosityBlockContext const*, Cache* gCache) {
+   static void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, LuminosityBlockContext const*, UnsafeCache* gCache) {
      ++m_count;
      gbls=false;
      gels=true;

--- a/FWCore/Framework/test/stubs/TestStreamProducers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamProducers.cc
@@ -449,7 +449,7 @@ struct UnsafeCache {
     }
   };
 
-  class TestBeginRunProducer : public edm::stream::EDProducer<edm::RunCache<Cache>,edm::BeginRunProducer> {
+  class TestBeginRunProducer : public edm::stream::EDProducer<edm::RunCache<bool>,edm::BeginRunProducer> {
     public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
@@ -464,11 +464,11 @@ struct UnsafeCache {
       produces<unsigned int>();
     }
 
-    static std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&, GlobalCache const*) {
+    static std::shared_ptr<bool> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&, GlobalCache const*) {
       gbr=true;
       ger=false;
       gbrp=false;
-      return std::shared_ptr<Cache>{new Cache};
+      return std::shared_ptr<bool>{};
    }
 
     void produce(edm::Event&, edm::EventSetup const&) override {
@@ -505,7 +505,7 @@ struct UnsafeCache {
     }
   };
 
-  class TestEndRunProducer : public edm::stream::EDProducer<edm::RunCache<Cache>,edm::EndRunProducer> {
+  class TestEndRunProducer : public edm::stream::EDProducer<edm::RunCache<bool>,edm::EndRunProducer> {
     public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
@@ -514,11 +514,11 @@ struct UnsafeCache {
     static bool ger;
     static bool p;
 
-    static std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&, GlobalCache const*) {
+    static std::shared_ptr<bool> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&, GlobalCache const*) {
       gbr=true;
       ger=false;
       p =false;
-      return std::shared_ptr<Cache>{ new Cache };
+      return std::shared_ptr<bool>{};
    }
 
 
@@ -562,7 +562,7 @@ struct UnsafeCache {
     }
   };
 
-  class TestBeginLumiBlockProducer : public edm::stream::EDProducer<edm::LuminosityBlockCache<Cache>,edm::BeginLuminosityBlockProducer> {
+  class TestBeginLumiBlockProducer : public edm::stream::EDProducer<edm::LuminosityBlockCache<bool>,edm::BeginLuminosityBlockProducer> {
     public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
@@ -593,11 +593,11 @@ struct UnsafeCache {
       gblp = true;
     }
 
-    static std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, RunContext const*) {
+    static std::shared_ptr<bool> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, RunContext const*) {
       gbl = true;
       gel = false;
       gblp = false;
-      return std::shared_ptr<Cache>{ new Cache };
+      return std::shared_ptr<bool>();
    }
 
     static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, LuminosityBlockContext const* iLBContext) {
@@ -618,7 +618,7 @@ struct UnsafeCache {
     }
   };
 
-  class TestEndLumiBlockProducer : public edm::stream::EDProducer<edm::LuminosityBlockCache<Cache>,edm::EndLuminosityBlockProducer> {
+  class TestEndLumiBlockProducer : public edm::stream::EDProducer<edm::LuminosityBlockCache<bool>,edm::EndLuminosityBlockProducer> {
     public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
@@ -645,11 +645,11 @@ struct UnsafeCache {
       }
     }
 
-    static std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, RunContext const*) {
+    static std::shared_ptr<bool> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, RunContext const*) {
       gbl = true;
       gel = false;
       p = false;
-      return std::shared_ptr<Cache>{ new Cache };
+      return std::shared_ptr<bool>{};
    }
 
     static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, LuminosityBlockContext const* iLBContext) {

--- a/FWCore/Framework/test/stubs/TestStreamProducers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamProducers.cc
@@ -1,0 +1,753 @@
+
+/*----------------------------------------------------------------------
+
+Toy edm::stream::EDProducer modules of 
+edm::*Cache templates and edm::*Producer classes 
+for testing purposes only.
+
+----------------------------------------------------------------------*/
+#include <iostream>
+#include <atomic>
+#include <vector>
+#include <map>
+#include <functional>
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/src/WorkerT.h"
+#include "FWCore/Framework/interface/HistoryAppender.h"
+#include "FWCore/ServiceRegistry/interface/ParentContext.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/Utilities/interface/GlobalIdentifier.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+
+
+namespace edmtest {
+namespace stream {
+
+struct Cache { 
+   Cache():value(0),run(0),lumi(0) {}
+   //Using mutable since we want to update the value.
+   mutable std::atomic<unsigned int> value;
+   mutable std::atomic<unsigned int> run;
+   mutable std::atomic<unsigned int> lumi;
+};
+
+
+  class GlobalIntProducer : public edm::stream::EDProducer<edm::GlobalCache<Cache>> {
+  public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+
+    static std::unique_ptr<Cache> initializeGlobalCache(edm::ParameterSet const&) {
+      ++m_count;
+      return std::unique_ptr<Cache>{new Cache()};
+    }
+
+    GlobalIntProducer(edm::ParameterSet const& p, const Cache* iGlobal)  {
+      trans_ = p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      produces<unsigned int>();
+    }
+
+    void produce(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+      ++((globalCache())->value);
+       
+    }
+    
+    static void globalEndJob(Cache* iGlobal) {
+      ++m_count;
+      if(iGlobal->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << iGlobal->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+    ~GlobalIntProducer() {
+      if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << m_count << " but it was supposed to be " << trans_;
+      }
+    }
+
+    
+  };
+
+  class RunIntProducer : public edm::stream::EDProducer<edm::RunCache<Cache>> {
+  public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbr;
+    static bool ger;
+    bool br;
+    bool er;
+
+    RunIntProducer(edm::ParameterSet const&p) {
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      produces<unsigned int>();
+    }
+
+    void produce(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+      ++(runCache()->value);
+       
+    }
+
+    static std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&, GlobalCache const*) {
+      ++m_count;
+      gbr = true;
+      ger = false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->run);
+      return pCache;
+    }
+
+    void beginRun(edm::Run const&, edm::EventSetup const&) override {
+      br = true;
+      er = true;
+      if ( !gbr ) {
+        throw cms::Exception("begin out of sequence")
+          << "beginRun seen before globalBeginRun";
+      }
+    }
+   
+    static void globalEndRun(edm::Run const& iRun, edm::EventSetup const&, RunContext const* iContext) {
+      ++m_count;
+      Cache const * pCache = iContext->run();
+      if ( pCache->run != 1 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndRun seen before globalBeginRun in Run" << iRun.run();
+      } 
+      ger = true;
+      gbr = false;
+      if( iContext->run()->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << iContext->run()->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+    void endRun(edm::Run const&, edm::EventSetup const&) override {
+      er = true;
+      br = false;
+      if ( ger ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndRun seen before endRun";
+      }
+    }
+
+    ~RunIntProducer() {
+       if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << m_count << " but it was supposed to be " << trans_;
+      }
+
+    }
+  };
+
+
+  class LumiIntProducer : public edm::stream::EDProducer<edm::LuminosityBlockCache<Cache>> {
+  public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbl;
+    static bool gel;
+    static bool bl;
+    static bool el;
+
+
+    LumiIntProducer(edm::ParameterSet const&p) {
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      produces<unsigned int>();
+    }
+
+    void produce(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+      ++(luminosityBlockCache()->value);
+       
+    }
+    
+     static std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, RunContext const*) {
+      ++m_count;
+      gbl = true;
+      gel = false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->lumi);
+      return pCache;
+    }
+
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
+      bl = true;
+      el = false;
+      if ( !gbl ) {
+        throw cms::Exception("begin out of sequence")
+          << "beginLuminosityBlock seen before globalBeginLuminosityBlock";
+      }
+    }
+
+   
+    static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, LuminosityBlockContext const* iLBContext) {
+      ++m_count;
+      Cache const * pCache = iLBContext->luminosityBlock();
+      if ( pCache->lumi != 1 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+      }       
+      gel = true;
+      gbl = false;
+      if(iLBContext->luminosityBlock()->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << iLBContext->luminosityBlock()->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+   static void endLuminosityBlock(edm::Run const&, edm::EventSetup const&, LuminosityBlockContext const*) {
+      el = true;
+      bl = false;
+      if ( gel ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlock seen before endLuminosityBlock";
+      }      
+   }
+
+
+    ~LumiIntProducer() {
+       if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << m_count<< " but it was supposed to be " << trans_;
+       }
+    }
+  };
+  
+  class RunSummaryIntProducer : public edm::stream::EDProducer<edm::RunCache<Cache>,edm::RunSummaryCache<Cache>> {
+  public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbr;
+    static bool ger;
+    static bool gbrs;
+    static bool gers;
+    static bool brs;
+    static bool ers;
+    static bool br;
+    static bool er;
+
+    RunSummaryIntProducer(edm::ParameterSet const&p){
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      produces<unsigned int>();
+    }
+
+    void beginRun(edm::Run const&, edm::EventSetup const&) override {
+      br=true;
+      er=false;
+    }
+
+    void produce(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+      ++(runCache()->value);
+       
+    }
+    
+    static std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&, GlobalCache const*) {
+      ++m_count;
+      gbr=true;
+      ger=false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->run);
+      return pCache;
+ 
+    }
+
+    static std::shared_ptr<Cache> globalBeginRunSummary(edm::Run const&, edm::EventSetup const&, GlobalCache const*) {
+      ++m_count;
+      gbrs = true;
+      gers = false;
+      brs = true;
+      ers = false;
+      if ( !gbr ) {
+        throw cms::Exception("begin out of sequence")
+          << "globalBeginRunSummary seen before globalBeginRun";
+      }
+      return std::shared_ptr<Cache>{new Cache()};
+    }
+    
+    void endRunSummary(edm::Run const&, edm::EventSetup const&, Cache* gCache) const override {
+      brs=false;
+      ers=true;
+      gCache->value += runCache()->value;
+      runCache()->value = 0;
+      if ( !er ) {
+        throw cms::Exception("end out of sequence")
+          << "endRunSummary seen before endRun";
+      }
+    }
+    
+    static void globalEndRunSummary(edm::Run const&, edm::EventSetup const&, RunContext const*, Cache * gCache) {
+      ++m_count;
+      gbrs=false;
+      gers=true;
+      if ( !ers ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndRunSummary seen before endRunSummary";
+      }
+      if(gCache->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << gCache->value << " but it was supposed to be " << cvalue_;
+      }
+    }
+
+    static void globalEndRun(edm::Run const& iRun, edm::EventSetup const&, RunContext const* iContext) {
+      ++m_count;
+      gbr=false;
+      ger=true;
+      Cache const * pCache = iContext->run();
+      if ( pCache->run != 1 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndRun seen before globalBeginRun in Run" << iRun.run();
+      } 
+    }
+
+    void endRun(edm::Run const&, edm::EventSetup const&) override {
+      er = true;
+      br = false;
+    }   
+
+    ~RunSummaryIntProducer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+ 
+    }
+  };
+
+  class LumiSummaryIntProducer : public edm::stream::EDProducer<edm::LuminosityBlockCache<Cache>,edm::LuminosityBlockSummaryCache<Cache>> {
+  public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbl;
+    static bool gel;
+    static bool gbls;
+    static bool gels;
+    static bool bls;
+    static bool els;
+    static bool bl;
+    static bool el;
+
+    LumiSummaryIntProducer(edm::ParameterSet const&p){
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      produces<unsigned int>();
+    }
+
+    void produce(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+      ++(luminosityBlockCache()->value);
+       
+    }
+
+    void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override {
+      bl = true;
+      el = false;
+    }
+ 
+    static std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, RunContext const*) {
+      ++m_count;
+      gbl = true;
+      gel = false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->lumi);
+      return pCache;
+    }
+
+
+    static std::shared_ptr<Cache> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, LuminosityBlockContext const*) {
+      ++m_count;
+      gbls = true;
+      gels = false;
+      bls = true;
+      els = false;
+      if ( !gbl ) {
+       throw cms::Exception("begin out of sequence")
+         << "globalBeginLuminosityBlockSummary seen before globalBeginLuminosityBlock";
+      }
+      return std::shared_ptr<Cache>{new Cache()};
+    }
+    
+
+
+    void endLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, Cache* gCache) const override {
+      bls=false;
+      els=true;
+      gCache->value += luminosityBlockCache()->value;
+      luminosityBlockCache()->value = 0;
+      if ( el ) {
+        throw cms::Exception("end out of sequence")
+          << "endLuminosityBlock seen before endLuminosityBlockSummary";
+      }
+    }
+    
+   static void globalEndLuminosityBlockSummary(edm::LuminosityBlock const&, edm::EventSetup const&, LuminosityBlockContext const*, Cache* gCache) {
+     ++m_count;
+     gbls=false;
+     gels=true;
+      if ( !els ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlockSummary seen before endLuminosityBlockSummary";
+      }
+     if ( gCache->value != cvalue_) {
+        throw cms::Exception("cache value")
+          << gCache->value << " but it was supposed to be " << cvalue_;
+     }
+   }
+
+   static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, LuminosityBlockContext const* iLBContext) {
+      ++m_count;
+      Cache const * pCache = iLBContext->luminosityBlock();
+      if ( pCache->lumi != 1 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+      }       
+      gel = true;
+      gbl = false;
+      if ( !gels ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlockSummary seen before globalEndLuminosityBlock";  
+      }
+   }
+ 
+    static void endLuminosityBlock(edm::Run const&, edm::EventSetup const&, LuminosityBlockContext const*) {
+      el = true;
+      bl = false;
+    }
+
+    ~LumiSummaryIntProducer() {
+     if(m_count != trans_) {
+        throw cms::Exception("transitions")
+          << m_count<< " but it was supposed to be " << trans_;
+      }
+    }
+  };
+
+  class TestBeginRunProducer : public edm::stream::EDProducer<edm::RunCache<Cache>,edm::BeginRunProducer> {
+    public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbr;
+    static bool ger;
+    static bool gbrp;
+ 
+    TestBeginRunProducer(edm::ParameterSet const&p) {
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      produces<unsigned int>();
+    }
+
+    static std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&, GlobalCache const*) {
+      ++m_count;
+      gbr=true;
+      ger=false;
+      gbrp=false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->run);
+      return pCache;
+   }
+
+    void produce(edm::Event&, edm::EventSetup const&) override {
+      if ( !gbrp ) {
+        throw cms::Exception("out of sequence")
+          << "produce before globalBeginRunProduce";
+      }
+      ++m_count;               
+    }
+
+    static void globalBeginRunProduce(edm::Run& iRun, edm::EventSetup const&, RunContext const*) {
+      gbrp = true;
+      ++m_count;
+      if ( !gbr ) {
+        throw cms::Exception("begin out of sequence")
+          << "globalBeginRunProduce seen before globalBeginRun";
+      }
+    }
+
+    static void globalEndRun(edm::Run const& iRun, edm::EventSetup const&, RunContext const* iContext) {
+      Cache const * pCache = iContext->run();
+      if ( pCache->run != 1 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndRun seen before globalBeginRun in Run" << iRun.run();
+      } 
+      ++m_count;
+      gbr=false;
+      ger=true;
+    }
+
+
+    ~TestBeginRunProducer() {
+    if(m_count != trans_) {
+       throw cms::Exception("transitions")
+         << m_count<< " but it was supposed to be " << trans_;
+     }
+    }
+  };
+
+  class TestEndRunProducer : public edm::stream::EDProducer<edm::RunCache<Cache>,edm::EndRunProducer> {
+    public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbr;
+    static bool ger;
+    static bool p;
+
+    static std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&, GlobalCache const*) {
+     ++m_count;
+      gbr=true;
+      ger=false;
+      p =false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->run);
+      return pCache;
+   }
+
+
+    TestEndRunProducer(edm::ParameterSet const&p){
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      produces<unsigned int>();
+    }
+
+    void produce(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+      p = true; 
+    }
+
+    static void globalEndRunProduce(edm::Run& iRun, edm::EventSetup const&, RunContext const*) {
+      ++m_count;
+      if ( !p ) {
+        throw cms::Exception("out of sequence")
+          << "globalEndRunProduce seen before produce";
+      }
+      if ( ger ) {
+        throw cms::Exception("out of sequence")
+          << "globalEndRun seen before globalEndRunProduce";
+      }
+    }
+
+    static void globalEndRun(edm::Run const& iRun, edm::EventSetup const&, RunContext const* iContext) {
+      ++m_count;
+      Cache const * pCache = iContext->run();
+      if ( pCache->run != 1 ) {
+        throw cms::Exception("out of sequence")
+          << "globalEndRun seen before globalBeginRun in Run" << iRun.run();
+      } 
+      gbr=false;
+      ger=true;
+    }
+
+
+    ~TestEndRunProducer() {
+    if(m_count != trans_) {
+       throw cms::Exception("transitions")
+         << m_count<< " but it was supposed to be " << trans_;
+     }
+    }
+  };
+
+  class TestBeginLumiBlockProducer : public edm::stream::EDProducer<edm::LuminosityBlockCache<Cache>,edm::BeginLuminosityBlockProducer> {
+    public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbl;
+    static bool gel;
+    static bool gblp;
+ 
+    TestBeginLumiBlockProducer(edm::ParameterSet const&p){
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      produces<unsigned int>();
+    }
+
+    void produce(edm::Event&, edm::EventSetup const&) override {
+      if ( !gblp ) {
+        throw cms::Exception("begin out of sequence")
+          << "produce seen before globalBeginLumiBlockProduce";
+      }
+      ++m_count;
+    }
+
+    static void globalBeginLuminosityBlockProduce(edm::LuminosityBlock& , edm::EventSetup const&, LuminosityBlockContext const*) {
+     ++m_count;
+      if ( !gbl ) {
+        throw cms::Exception("begin out of sequence")
+          << "globalBeginLumiBlockProduce seen before globalBeginLumiBlock";
+      }
+      gblp = true;
+    }
+
+    static std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, RunContext const*) {
+      ++m_count;
+      gbl = true;
+      gel = false;
+      gblp = false;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->lumi);
+      return pCache;
+   }
+
+    static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, LuminosityBlockContext const* iLBContext) {
+      ++m_count;
+      Cache const * pCache = iLBContext->luminosityBlock();
+      if ( pCache->lumi != 1 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+      }
+      gel = true;
+      gbl = false;
+    }
+
+
+    ~TestBeginLumiBlockProducer() {
+    if(m_count != trans_) {
+       throw cms::Exception("transitions")
+         << m_count<< " but it was supposed to be " << trans_;
+     }
+    }
+  };
+
+  class TestEndLumiBlockProducer : public edm::stream::EDProducer<edm::LuminosityBlockCache<Cache>,edm::EndLuminosityBlockProducer> {
+    public:
+    static std::atomic<unsigned int> m_count;
+    unsigned int trans_;
+    static unsigned int cvalue_;
+    static bool gbl;
+    static bool gel;
+    static bool p;
+ 
+    TestEndLumiBlockProducer(edm::ParameterSet const&p){
+      trans_= p.getParameter<int>("transitions");
+      cvalue_ = p.getParameter<int>("cachevalue");
+      produces<unsigned int>();
+    }
+
+    void produce(edm::Event&, edm::EventSetup const&) override {
+      ++m_count;
+      p = true;
+    }
+
+    static void globalEndLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&, LuminosityBlockContext const*) {
+      ++m_count;
+      if ( !p ) {
+        throw cms::Exception("out of sequence")
+          << "globalEndLumiBlockProduce seen before produce";
+      }
+    }
+
+    static std::shared_ptr<Cache> globalBeginLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, RunContext const*) {
+      ++m_count;
+      gbl = true;
+      gel = false;
+      p = true;
+      std::shared_ptr<Cache> pCache = std::shared_ptr<Cache>{new Cache()};
+      ++(pCache->lumi);
+      return pCache;
+   }
+
+    static void globalEndLuminosityBlock(edm::LuminosityBlock const& iLB, edm::EventSetup const&, LuminosityBlockContext const* iLBContext) {
+      ++m_count;
+      Cache const * pCache = iLBContext->luminosityBlock();
+      if ( pCache->lumi != 1 ) {
+        throw cms::Exception("end out of sequence")
+          << "globalEndLuminosityBlock seen before globalBeginLuminosityBlock in LuminosityBlock" << iLB.luminosityBlock();
+      }
+      gel = true;
+      gbl = false;
+   }
+
+
+    ~TestEndLumiBlockProducer() {
+    if(m_count != trans_) {
+       throw cms::Exception("transitions")
+         << m_count<< " but it was supposed to be " << trans_;
+     }
+    }
+  };
+
+
+   
+
+}
+}
+std::atomic<unsigned int> edmtest::stream::GlobalIntProducer::m_count{0};
+std::atomic<unsigned int> edmtest::stream::RunIntProducer::m_count{0};
+std::atomic<unsigned int> edmtest::stream::LumiIntProducer::m_count{0};
+std::atomic<unsigned int> edmtest::stream::RunSummaryIntProducer::m_count{0};
+std::atomic<unsigned int> edmtest::stream::LumiSummaryIntProducer::m_count{0};
+std::atomic<unsigned int> edmtest::stream::TestBeginRunProducer::m_count{0};
+std::atomic<unsigned int> edmtest::stream::TestEndRunProducer::m_count{0};
+std::atomic<unsigned int> edmtest::stream::TestBeginLumiBlockProducer::m_count{0};
+std::atomic<unsigned int> edmtest::stream::TestEndLumiBlockProducer::m_count{0};
+unsigned int edmtest::stream::GlobalIntProducer::cvalue_ = 0;
+unsigned int edmtest::stream::RunIntProducer::cvalue_ = 0;
+unsigned int edmtest::stream::LumiIntProducer::cvalue_ = 0;
+unsigned int edmtest::stream::RunSummaryIntProducer::cvalue_ = 0;
+unsigned int edmtest::stream::LumiSummaryIntProducer::cvalue_ = 0;
+unsigned int edmtest::stream::TestBeginRunProducer::cvalue_ = 0;
+unsigned int edmtest::stream::TestEndRunProducer::cvalue_ = 0;
+unsigned int edmtest::stream::TestBeginLumiBlockProducer::cvalue_ = 0;
+unsigned int edmtest::stream::TestEndLumiBlockProducer::cvalue_ = 0;
+bool edmtest::stream::RunIntProducer::gbr=false;
+bool edmtest::stream::RunIntProducer::ger=false;
+bool edmtest::stream::LumiIntProducer::gbl=false;
+bool edmtest::stream::LumiIntProducer::gel=false;
+bool edmtest::stream::LumiIntProducer::bl=false;
+bool edmtest::stream::LumiIntProducer::el=false;
+bool edmtest::stream::RunSummaryIntProducer::gbr=false;
+bool edmtest::stream::RunSummaryIntProducer::ger=false;
+bool edmtest::stream::RunSummaryIntProducer::gbrs=false;
+bool edmtest::stream::RunSummaryIntProducer::gers=false;
+bool edmtest::stream::RunSummaryIntProducer::brs=false;
+bool edmtest::stream::RunSummaryIntProducer::ers=false;
+bool edmtest::stream::RunSummaryIntProducer::br=false;
+bool edmtest::stream::RunSummaryIntProducer::er=false;
+bool edmtest::stream::LumiSummaryIntProducer::gbl=false;
+bool edmtest::stream::LumiSummaryIntProducer::gel=false;
+bool edmtest::stream::LumiSummaryIntProducer::gbls=false;
+bool edmtest::stream::LumiSummaryIntProducer::gels=false;
+bool edmtest::stream::LumiSummaryIntProducer::bls=false;
+bool edmtest::stream::LumiSummaryIntProducer::els=false;
+bool edmtest::stream::LumiSummaryIntProducer::bl=false;
+bool edmtest::stream::LumiSummaryIntProducer::el=false;
+bool edmtest::stream::TestBeginRunProducer::gbr=false;
+bool edmtest::stream::TestBeginRunProducer::gbrp=false;
+bool edmtest::stream::TestBeginRunProducer::ger=false;
+bool edmtest::stream::TestEndRunProducer::gbr=false;
+bool edmtest::stream::TestEndRunProducer::ger=false;
+bool edmtest::stream::TestEndRunProducer::p=false;
+bool edmtest::stream::TestBeginLumiBlockProducer::gbl=false;
+bool edmtest::stream::TestBeginLumiBlockProducer::gblp=false;
+bool edmtest::stream::TestBeginLumiBlockProducer::gel=false;
+bool edmtest::stream::TestEndLumiBlockProducer::gbl=false;
+bool edmtest::stream::TestEndLumiBlockProducer::gel=false;
+bool edmtest::stream::TestEndLumiBlockProducer::p=false;
+DEFINE_FWK_MODULE(edmtest::stream::GlobalIntProducer);
+DEFINE_FWK_MODULE(edmtest::stream::RunIntProducer);
+DEFINE_FWK_MODULE(edmtest::stream::LumiIntProducer);
+DEFINE_FWK_MODULE(edmtest::stream::RunSummaryIntProducer);
+DEFINE_FWK_MODULE(edmtest::stream::LumiSummaryIntProducer);
+DEFINE_FWK_MODULE(edmtest::stream::TestBeginRunProducer);
+DEFINE_FWK_MODULE(edmtest::stream::TestEndRunProducer);
+DEFINE_FWK_MODULE(edmtest::stream::TestBeginLumiBlockProducer);
+DEFINE_FWK_MODULE(edmtest::stream::TestEndLumiBlockProducer);
+

--- a/FWCore/Framework/test/test_global_modules_cfg.py
+++ b/FWCore/Framework/test/test_global_modules_cfg.py
@@ -2,8 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 nEvtLumi = 4
 nEvtRun = 2*nEvtLumi
-nStreams = 64
-nEvt = (nStreams/4)*nEvtRun*nEvtLumi
+nStreams = 16 
+nEvt = nStreams*nEvtRun*nEvtLumi
 
 process = cms.Process("TESTGLOBALMODULES")
 
@@ -119,19 +119,19 @@ process.LumiSumIntFil = cms.EDFilter("edmtest::global::LumiSummaryIntFilter",
 )
 
 process.TestBeginRunFil = cms.EDFilter("edmtest::global::TestBeginRunFilter",
-    transitions = cms.int32(nEvt+(nEvt/nEvtRun))
+    transitions = cms.int32((nEvt/nEvtRun))
 )
 
 process.TestEndRunFil = cms.EDFilter("edmtest::global::TestEndRunFilter",
-    transitions = cms.int32(nEvt+(nEvt/nEvtRun))
+    transitions = cms.int32((nEvt/nEvtRun))
 )
 
 process.TestBeginLumiBlockFil = cms.EDFilter("edmtest::global::TestBeginLumiBlockFilter",
-    transitions = cms.int32(nEvt+(nEvt/nEvtLumi))
+    transitions = cms.int32((nEvt/nEvtLumi))
 )
 
 process.TestEndLumiBlockFil = cms.EDFilter("edmtest::global::TestEndLumiBlockFilter",
-    transitions = cms.int32(nEvt+(nEvt/nEvtLumi))
+    transitions = cms.int32((nEvt/nEvtLumi))
 )
 
 

--- a/FWCore/Framework/test/test_global_modules_cfg.py
+++ b/FWCore/Framework/test/test_global_modules_cfg.py
@@ -1,0 +1,139 @@
+import FWCore.ParameterSet.Config as cms
+
+nEvtLumi = 4
+nEvtRun = 2*nEvtLumi
+nStreams = 64
+nEvt = (nStreams/4)*nEvtRun*nEvtLumi
+
+process = cms.Process("TESTGLOBALMODULES")
+
+import FWCore.Framework.test.cmsExceptionsFatalOption_cff
+
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(nStreams)
+)
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(nEvt)
+)
+
+process.source = cms.Source("EmptySource",
+    timeBetweenEvents = cms.untracked.uint64(1000),
+    firstTime = cms.untracked.uint64(1000000),
+    numberEventsInRun = cms.untracked.uint32(nEvtRun),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(nEvtLumi) 
+)
+
+#process.Tracer = cms.Service("Tracer")
+
+process.StreamIntProd = cms.EDProducer("edmtest::global::StreamIntProducer",
+    transitions = cms.int32(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2))
+    ,cachevalue = cms.int32(1)
+)
+
+process.RunIntProd = cms.EDProducer("edmtest::global::RunIntProducer",
+    transitions = cms.int32(2*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvtRun)
+)
+
+process.LumiIntProd = cms.EDProducer("edmtest::global::LumiIntProducer",
+    transitions = cms.int32(2*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.RunSumIntProd = cms.EDProducer("edmtest::global::RunSummaryIntProducer",
+    transitions = cms.int32(nStreams*(nEvt/nEvtRun)+2*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvtRun)
+)
+
+process.LumiSumIntProd = cms.EDProducer("edmtest::global::LumiSummaryIntProducer",
+    transitions = cms.int32(nStreams*(nEvt/nEvtLumi)+2*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.TestBeginRunProd = cms.EDProducer("edmtest::global::TestBeginRunProducer",
+    transitions = cms.int32((nEvt/nEvtRun))
+)
+
+process.TestEndRunProd = cms.EDProducer("edmtest::global::TestEndRunProducer",
+    transitions = cms.int32((nEvt/nEvtRun))
+)
+
+process.TestBeginLumiBlockProd = cms.EDProducer("edmtest::global::TestBeginLumiBlockProducer",
+    transitions = cms.int32((nEvt/nEvtLumi))
+)
+
+process.TestEndLumiBlockProd = cms.EDProducer("edmtest::global::TestEndLumiBlockProducer",
+    transitions = cms.int32((nEvt/nEvtLumi))
+)
+
+process.StreamIntAn = cms.EDAnalyzer("edmtest::global::StreamIntAnalyzer",
+    transitions = cms.int32(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2))
+    ,cachevalue = cms.int32(1)
+)
+
+process.RunIntAn= cms.EDAnalyzer("edmtest::global::RunIntAnalyzer",
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvtRun)
+)
+
+process.LumiIntAn = cms.EDAnalyzer("edmtest::global::LumiIntAnalyzer",
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.RunSumIntAn = cms.EDAnalyzer("edmtest::global::RunSummaryIntAnalyzer",
+    transitions = cms.int32(nEvt+nStreams*((nEvt/nEvtRun)+1)+2*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvtRun)
+)
+
+process.LumiSumIntAn = cms.EDAnalyzer("edmtest::global::LumiSummaryIntAnalyzer",
+    transitions = cms.int32(nEvt+nStreams*((nEvt/nEvtLumi)+1)+2*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.StreamIntFil = cms.EDFilter("edmtest::global::StreamIntFilter",
+    transitions = cms.int32(nEvt+nStreams*(2*(nEvt/nEvtRun)+2*(nEvt/nEvtLumi)+2))
+    ,cachevalue = cms.int32(1)
+)
+
+process.RunIntFil = cms.EDFilter("edmtest::global::RunIntFilter",
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvtRun)
+)
+
+process.LumiIntFil = cms.EDFilter("edmtest::global::LumiIntFilter",
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.RunSumIntFil = cms.EDFilter("edmtest::global::RunSummaryIntFilter",
+    transitions = cms.int32(nEvt+nStreams*((nEvt/nEvtRun)+1)+2*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvtRun)
+)
+
+process.LumiSumIntFil = cms.EDFilter("edmtest::global::LumiSummaryIntFilter",
+    transitions = cms.int32(nEvt+nStreams*((nEvt/nEvtLumi)+1)+2*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.TestBeginRunFil = cms.EDFilter("edmtest::global::TestBeginRunFilter",
+    transitions = cms.int32(nEvt+(nEvt/nEvtRun))
+)
+
+process.TestEndRunFil = cms.EDFilter("edmtest::global::TestEndRunFilter",
+    transitions = cms.int32(nEvt+(nEvt/nEvtRun))
+)
+
+process.TestBeginLumiBlockFil = cms.EDFilter("edmtest::global::TestBeginLumiBlockFilter",
+    transitions = cms.int32(nEvt+(nEvt/nEvtLumi))
+)
+
+process.TestEndLumiBlockFil = cms.EDFilter("edmtest::global::TestEndLumiBlockFilter",
+    transitions = cms.int32(nEvt+(nEvt/nEvtLumi))
+)
+
+
+process.p = cms.Path(process.StreamIntProd+process.RunIntProd+process.LumiIntProd+process.RunSumIntProd+process.LumiSumIntProd+process.TestBeginRunProd+process.TestEndRunProd+process.TestBeginLumiBlockProd+process.TestEndLumiBlockProd+process.StreamIntAn+process.RunIntAn+process.LumiIntAn+process.RunSumIntAn+process.LumiSumIntAn+process.StreamIntFil+process.RunIntFil+process.LumiIntFil+process.RunSumIntFil+process.LumiSumIntFil+process.TestBeginRunFil+process.TestEndRunFil+process.TestBeginLumiBlockFil+process.TestEndLumiBlockFil)
+

--- a/FWCore/Framework/test/test_one_modules_cfg.py
+++ b/FWCore/Framework/test/test_one_modules_cfg.py
@@ -2,8 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 nEvtLumi = 4
 nEvtRun = 2*nEvtLumi
-nStreams = 64
-nEvt = (nStreams/4)*nEvtRun*nEvtLumi
+nStreams = 16
+nEvt = nStreams*nEvtRun*nEvtLumi
 
 process = cms.Process("TESTONEMODULES")
 

--- a/FWCore/Framework/test/test_one_modules_cfg.py
+++ b/FWCore/Framework/test/test_one_modules_cfg.py
@@ -1,0 +1,101 @@
+import FWCore.ParameterSet.Config as cms
+
+nEvtLumi = 4
+nEvtRun = 2*nEvtLumi
+nStreams = 64
+nEvt = (nStreams/4)*nEvtRun*nEvtLumi
+
+process = cms.Process("TESTONEMODULES")
+
+import FWCore.Framework.test.cmsExceptionsFatalOption_cff
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(nStreams)
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(nEvt)
+)
+
+
+process.source = cms.Source("EmptySource",
+    timeBetweenEvents = cms.untracked.uint64(10),
+    firstTime = cms.untracked.uint64(1000000),
+    numberEventsInRun = cms.untracked.uint32(nEvtRun),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(nEvtLumi) 
+)
+
+#process.Tracer = cms.Service("Tracer")
+
+process.SharedResProd = cms.EDProducer("edmtest::one::SharedResourcesProducer",
+    transitions = cms.int32(nEvt)
+)
+
+process.WatchRunProd = cms.EDProducer("edmtest::one::WatchRunsProducer",
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+)
+
+process.WatchLumiBlockProd = cms.EDProducer("edmtest::one::WatchLumiBlocksProducer",
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+)
+
+process.BeginRunProd = cms.EDProducer("edmtest::one::TestBeginRunProducer",
+    transitions = cms.int32(nEvt+(nEvt/nEvtRun))
+)
+
+process.BeginLumiBlockProd = cms.EDProducer("edmtest::one::TestBeginLumiBlockProducer",
+    transitions = cms.int32(nEvt+(nEvt/nEvtLumi))
+)
+
+process.EndRunProd = cms.EDProducer("edmtest::one::TestEndRunProducer",
+    transitions = cms.int32(nEvt+(nEvt/nEvtRun))
+)
+
+process.EndLumiBlockProd = cms.EDProducer("edmtest::one::TestEndLumiBlockProducer",
+    transitions = cms.int32(nEvt+(nEvt/nEvtLumi))
+)
+
+
+process.SharedResAn = cms.EDAnalyzer("edmtest::one::SharedResourcesAnalyzer",
+    transitions = cms.int32(nEvt)
+)
+
+process.WatchRunAn = cms.EDAnalyzer("edmtest::one::WatchRunsAnalyzer",
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+)
+
+process.WatchLumiBlockAn = cms.EDAnalyzer("edmtest::one::WatchLumiBlocksAnalyzer",
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+)
+
+process.SharedResFil = cms.EDFilter("edmtest::one::SharedResourcesFilter",
+    transitions = cms.int32(nEvt)
+)
+
+process.WatchRunFil = cms.EDFilter("edmtest::one::WatchRunsFilter",
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+)
+
+process.WatchLumiBlockFil = cms.EDFilter("edmtest::one::WatchLumiBlocksFilter",
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+)
+
+process.BeginRunFil = cms.EDFilter("edmtest::one::BeginRunFilter",
+    transitions = cms.int32(nEvt+(nEvt/nEvtRun))
+)
+
+process.BeginLumiBlockFil = cms.EDFilter("edmtest::one::BeginLumiBlockFilter",
+    transitions = cms.int32(nEvt+(nEvt/nEvtLumi))
+)
+
+process.EndRunFil = cms.EDFilter("edmtest::one::EndRunFilter",
+    transitions = cms.int32(nEvt+(nEvt/nEvtRun))
+)
+
+process.EndLumiBlockFil = cms.EDFilter("edmtest::one::EndLumiBlockFilter",
+    transitions = cms.int32(nEvt+(nEvt/nEvtLumi))
+)
+
+
+process.p = cms.Path(process.SharedResProd+process.WatchRunProd+process.WatchLumiBlockProd+process.BeginRunProd+process.BeginLumiBlockProd+process.EndRunProd+process.EndLumiBlockProd+process.SharedResAn+process.WatchRunAn+process.WatchLumiBlockAn+process.SharedResFil+process.WatchRunFil+process.WatchLumiBlockFil+process.BeginRunFil+process.BeginLumiBlockFil+process.EndRunFil+process.EndLumiBlockFil)
+
+

--- a/FWCore/Framework/test/test_stream_modules_cfg.py
+++ b/FWCore/Framework/test/test_stream_modules_cfg.py
@@ -1,0 +1,146 @@
+import FWCore.ParameterSet.Config as cms
+
+nEvtLumi = 4
+nEvtRun = 2*nEvtLumi
+nStreams = 64
+nEvt = (nStreams/4)*nEvtRun*nEvtLumi
+
+process = cms.Process("TESTSTREAMMODULES")
+
+import FWCore.Framework.test.cmsExceptionsFatalOption_cff
+process.options = cms.untracked.PSet(
+    numberOfStreams = cms.untracked.uint32(nStreams)
+)
+
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(nEvt)
+)
+process.source = cms.Source("EmptySource",
+    timeBetweenEvents = cms.untracked.uint64(1000),
+    firstTime = cms.untracked.uint64(1000000),
+    numberEventsInRun = cms.untracked.uint32(nEvtRun),
+    numberEventsInLuminosityBlock = cms.untracked.uint32(nEvtLumi) 
+)
+
+#process.Tracer = cms.Service("Tracer")
+
+
+process.GlobIntProd = cms.EDProducer("edmtest::stream::GlobalIntProducer",
+    transitions = cms.int32(nEvt+2)
+    ,cachevalue = cms.int32(nEvt)
+)
+
+process.RunIntProd = cms.EDProducer("edmtest::stream::RunIntProducer",
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvtRun)
+)
+
+process.LumiIntProd = cms.EDProducer("edmtest::stream::LumiIntProducer",
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.RunSumIntProd = cms.EDProducer("edmtest::stream::RunSummaryIntProducer",
+    transitions = cms.int32(nEvt+4*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvtRun)
+)
+
+process.LumiSumIntProd = cms.EDProducer("edmtest::stream::LumiSummaryIntProducer",
+    transitions = cms.int32(nEvt+4*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.TestBeginRunProd = cms.EDProducer("edmtest::stream::TestBeginRunProducer",
+    transitions = cms.int32(nEvt+3*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvt)
+)
+
+process.TestEndRunProd = cms.EDProducer("edmtest::stream::TestEndRunProducer",
+    transitions = cms.int32(nEvt+3*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvt)
+)
+
+process.TestBeginLumiBlockProd = cms.EDProducer("edmtest::stream::TestBeginLumiBlockProducer",
+    transitions = cms.int32(nEvt+3*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvt)
+)
+
+process.TestEndLumiBlockProd = cms.EDProducer("edmtest::stream::TestEndLumiBlockProducer",
+    transitions = cms.int32(nEvt+3*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvt)
+)
+
+
+process.GlobIntAn = cms.EDAnalyzer("edmtest::stream::GlobalIntAnalyzer",
+    transitions = cms.int32(nEvt+2)
+    ,cachevalue = cms.int32(nEvt)
+)
+
+process.RunIntAn= cms.EDAnalyzer("edmtest::stream::RunIntAnalyzer",
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvtRun)
+)
+
+process.LumiIntAn = cms.EDAnalyzer("edmtest::stream::LumiIntAnalyzer",
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.RunSumIntAn = cms.EDAnalyzer("edmtest::stream::RunSummaryIntAnalyzer",
+    transitions = cms.int32(nEvt+4*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvtRun)
+)
+
+process.LumiSumIntAn = cms.EDAnalyzer("edmtest::stream::LumiSummaryIntAnalyzer",
+    transitions = cms.int32(nEvt+4*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.GlobIntFil = cms.EDFilter("edmtest::stream::GlobalIntFilter",
+    transitions = cms.int32(nEvt+2)
+    ,cachevalue = cms.int32(nEvt)
+)
+
+process.RunIntFil = cms.EDFilter("edmtest::stream::RunIntFilter",
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvtRun)
+)
+
+process.LumiIntFil = cms.EDFilter("edmtest::stream::LumiIntFilter",
+    transitions = cms.int32(nEvt+2*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvtLumi)
+)
+
+process.RunSumIntFil = cms.EDFilter("edmtest::stream::RunSummaryIntFilter",
+    transitions = cms.int32(nEvt+4*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvtRun)
+)
+
+process.LumiSumIntFil = cms.EDFilter("edmtest::stream::LumiSummaryIntFilter",
+    transitions = cms.int32(nEvt+4*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvtLumi)
+)
+process.TestBeginRunFil = cms.EDFilter("edmtest::stream::TestBeginRunFilter",
+    transitions = cms.int32(nEvt+3*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvt)
+)
+
+process.TestEndRunFil = cms.EDFilter("edmtest::stream::TestEndRunFilter",
+    transitions = cms.int32(nEvt+3*(nEvt/nEvtRun))
+    ,cachevalue = cms.int32(nEvt)
+)
+
+process.TestBeginLumiBlockFil = cms.EDFilter("edmtest::stream::TestBeginLumiBlockFilter",
+    transitions = cms.int32(nEvt+3*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvt)
+)
+
+process.TestEndLumiBlockFil = cms.EDFilter("edmtest::stream::TestEndLumiBlockFilter",
+    transitions = cms.int32(nEvt+3*(nEvt/nEvtLumi))
+    ,cachevalue = cms.int32(nEvt)
+)
+
+
+process.p = cms.Path(process.GlobIntProd+process.RunIntProd+process.LumiIntProd+process.RunSumIntProd+process.LumiSumIntProd+process.TestBeginRunProd+process.TestEndRunProd+process.TestBeginLumiBlockProd+process.TestEndLumiBlockProd+process.GlobIntAn+process.RunIntAn+process.LumiIntAn+process.RunSumIntAn+process.LumiSumIntAn+process.GlobIntFil+process.RunIntFil+process.LumiIntFil+process.RunSumIntFil+process.LumiSumIntFil+process.TestBeginRunFil+process.TestEndRunFil+process.TestBeginLumiBlockFil+process.TestEndLumiBlockFil)
+

--- a/FWCore/Framework/test/test_stream_modules_cfg.py
+++ b/FWCore/Framework/test/test_stream_modules_cfg.py
@@ -2,8 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 nEvtLumi = 4
 nEvtRun = 2*nEvtLumi
-nStreams = 64
-nEvt = (nStreams/4)*nEvtRun*nEvtLumi
+nStreams = 16
+nEvt = nStreams*nEvtRun*nEvtLumi
 
 process = cms.Process("TESTSTREAMMODULES")
 
@@ -52,22 +52,22 @@ process.LumiSumIntProd = cms.EDProducer("edmtest::stream::LumiSummaryIntProducer
 )
 
 process.TestBeginRunProd = cms.EDProducer("edmtest::stream::TestBeginRunProducer",
-    transitions = cms.int32(nEvt+3*(nEvt/nEvtRun))
+    transitions = cms.int32((nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvt)
 )
 
 process.TestEndRunProd = cms.EDProducer("edmtest::stream::TestEndRunProducer",
-    transitions = cms.int32(nEvt+3*(nEvt/nEvtRun))
+    transitions = cms.int32((nEvt/nEvtRun))
     ,cachevalue = cms.int32(nEvt)
 )
 
 process.TestBeginLumiBlockProd = cms.EDProducer("edmtest::stream::TestBeginLumiBlockProducer",
-    transitions = cms.int32(nEvt+3*(nEvt/nEvtLumi))
+    transitions = cms.int32((nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvt)
 )
 
 process.TestEndLumiBlockProd = cms.EDProducer("edmtest::stream::TestEndLumiBlockProducer",
-    transitions = cms.int32(nEvt+3*(nEvt/nEvtLumi))
+    transitions = cms.int32((nEvt/nEvtLumi))
     ,cachevalue = cms.int32(nEvt)
 )
 


### PR DESCRIPTION
Tests of cache types for EDProducer, EDAnalyzer and EDFilter in the edm::global,edm::stream and edm::one namespaces
