### PR TITLE
Thread safe Xerces-C setup / termination.

### DIFF
--- a/FWCore/Concurrency/BuildFile.xml
+++ b/FWCore/Concurrency/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="tbb"/>
+<use   name="xerces-c"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/FWCore/Concurrency/interface/Xerces.h
+++ b/FWCore/Concurrency/interface/Xerces.h
@@ -1,0 +1,14 @@
+#ifndef FWCore_Concurrency_h
+#define FWCore_Concurrency_h
+
+namespace cms {
+  namespace concurrency {
+    // Use these in place of XMLPlatformUtils::Initialize and
+    // XMLPlatformUtils::Terminate. They are guaranteed to work correctly with
+    // a multithreaded environment.
+    void xercesInitialize();
+    void xercesTerminate();
+  }
+}
+
+#endif // FWCore_Concurrency_h

--- a/FWCore/Concurrency/src/Xerces.cc
+++ b/FWCore/Concurrency/src/Xerces.cc
@@ -1,0 +1,28 @@
+#include "FWCore/Concurrency/interface/Xerces.h"
+#include <xercesc/util/PlatformUtils.hpp>
+#include <mutex>
+#include <thread>
+XERCES_CPP_NAMESPACE_USE
+
+namespace cms {
+  namespace concurrency {
+    namespace {
+      std::mutex g_xerces_mutex;
+    }
+    // We need to make sure these these are serialized are only called by one
+    // thread at the time.  Until the first Init succeeds the other threads
+    // should not be allowed to proceed.  We also do not want two different
+    // threads calling Init and Finalize at the same time. We therefore simply
+    // use a global mutex to serialize everything.
+    void xercesInitialize() {
+      std::unique_lock<std::mutex> l(g_xerces_mutex);
+      XMLPlatformUtils::Initialize();
+    }
+
+    void xercesTerminate() {
+      std::unique_lock<std::mutex> l(g_xerces_mutex);
+      XMLPlatformUtils::Terminate();
+    }
+  }
+}
+

--- a/FWCore/Concurrency/test/BuildFile.xml
+++ b/FWCore/Concurrency/test/BuildFile.xml
@@ -3,3 +3,7 @@
   <use   name="boost"/>
   <use   name="FWCore/Concurrency"/>
 </bin>
+<bin file="test_xercesInitialize.cpp">
+  <use   name="FWCore/Concurrency"/>
+</bin>
+

--- a/FWCore/Concurrency/test/test_xercesInitialize.cpp
+++ b/FWCore/Concurrency/test/test_xercesInitialize.cpp
@@ -1,0 +1,31 @@
+#include "FWCore/Concurrency/interface/Xerces.h"
+#include <xercesc/parsers/XercesDOMParser.hpp>
+#include <vector>
+#include <thread>
+#include <iostream>
+
+XERCES_CPP_NAMESPACE_USE
+
+void
+testInit()
+{
+  cms::concurrency::xercesInitialize();
+  {
+      std::cerr << std::this_thread::get_id() << std::endl;
+      XercesDOMParser parser;
+  }
+  cms::concurrency::xercesTerminate();
+}
+
+int
+main()
+{
+  std::vector<std::thread> threads;
+  threads.emplace_back(testInit);
+  threads.emplace_back(testInit);
+  threads.emplace_back(testInit);
+  threads.emplace_back(testInit);
+
+  for (auto &thread : threads) 
+    thread.join();
+}


### PR DESCRIPTION
See http://xerces.apache.org/xerces-c/faq-parse-3.html#faq-6 for the limitations
on Xerces-C.

I ended up to use a single mutex both for initialization and termination because I need to guarantee the following:
- No thread can continue after Initialize (possibly invoking Xerces functionality) without at least one thread finishing the initialisation itself.
- No thread can invoke Terminate while something else might be calling Initialise at the same time.

@Dr15Jones, if you agree with the implementation, I can go ahead and clean-up all the bits which call the original Xerces-C functions.
