### PR TITLE
Make use of ProcessHistoryRegistry thread safe

### DIFF
--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -57,7 +57,7 @@ namespace edm {
     ~EventPrincipal() {}
 
     void fillEventPrincipal(EventAuxiliary const& aux,
-        ProcessHistoryRegistry& processHistoryRegistry,
+        ProcessHistoryRegistry const& processHistoryRegistry,
         boost::shared_ptr<EventSelectionIDVector> eventSelectionIDs = boost::shared_ptr<EventSelectionIDVector>(),
         boost::shared_ptr<BranchListIndexes> branchListIndexes = boost::shared_ptr<BranchListIndexes>(),
         boost::shared_ptr<BranchMapper> mapper = boost::shared_ptr<BranchMapper>(new BranchMapper),

--- a/FWCore/Framework/interface/HistoryAppender.h
+++ b/FWCore/Framework/interface/HistoryAppender.h
@@ -4,36 +4,12 @@
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 
-#include <map>
+#include "boost/shared_ptr.hpp"
 
 namespace edm {
 
   class ProcessConfiguration;
   class ProcessHistoryRegistry;
-
-  class CachedHistory {
-  public:
-
-    CachedHistory(ProcessHistory const* inputProcessHistory,
-                  ProcessHistory const* processHistory,
-                  ProcessHistoryID const& processHistoryID) :
-      inputProcessHistory_(inputProcessHistory),
-      processHistory_(processHistory),
-      processHistoryID_(processHistoryID) {
-    }
-
-    ProcessHistory const* inputProcessHistory() const { return inputProcessHistory_; }
-    ProcessHistory const* processHistory() const { return processHistory_; }
-    ProcessHistoryID const& processHistoryID () const { return processHistoryID_; }
-
-  private:
-
-    // This class does not own the memory
-    ProcessHistory const* inputProcessHistory_;
-    ProcessHistory const* processHistory_;
-
-    ProcessHistoryID processHistoryID_;
-  };
 
   class HistoryAppender {
   public:
@@ -43,36 +19,22 @@ namespace edm {
     // Used to append the current process to the process history
     // when necessary. Optimized to cache the results so it
     // does not need to repeat the same calculations many times.
-    CachedHistory const&
+    boost::shared_ptr<ProcessHistory const>
     appendToProcessHistory(ProcessHistoryID const& inputPHID,
-                           ProcessConfiguration const& pc,
-                           ProcessHistoryRegistry& processHistoryRegistry);
+                           ProcessHistory const* inputProcessHistory,
+                           ProcessConfiguration const& pc);
 
   private:
-    HistoryAppender(HistoryAppender const&);
-    HistoryAppender& operator=(HistoryAppender const&);
+    HistoryAppender(HistoryAppender const&) = delete;
+    HistoryAppender& operator=(HistoryAppender const&) = delete;
 
     // Throws if the new process name is already in the process
     // process history
     void checkProcessHistory(ProcessHistory const& ph,
                              ProcessConfiguration const& pc) const;
 
-    // The map is intended to have the key be the ProcessHistoryID
-    // read from the input file in one of the Auxiliary objects.
-    // The CachedHistory has the ProcessHistoryID after adding
-    // the current process and the two pointers to the corresponding
-    // ProcessHistory objects in the registry, except if the history
-    // is empty then the pointer is to the data member of this class
-    // because the empty one is never in the registry.
-    typedef std::map<ProcessHistoryID, CachedHistory> HistoryMap;
-    HistoryMap historyMap_;
-
-    // We cache iterator to the previous element for
-    // performance. We expect the IDs to repeat many times
-    // and this avoids the lookup in that case.
-    HistoryMap::const_iterator previous_;
-
-    ProcessHistory emptyHistory_;
+    ProcessHistoryID m_cachedInputPHID;
+    boost::shared_ptr<ProcessHistory const> m_cachedHistory;
   };
 }
 #endif

--- a/FWCore/Framework/interface/LuminosityBlockPrincipal.h
+++ b/FWCore/Framework/interface/LuminosityBlockPrincipal.h
@@ -43,7 +43,7 @@ namespace edm {
 
     ~LuminosityBlockPrincipal() {}
 
-    void fillLuminosityBlockPrincipal(ProcessHistoryRegistry& processHistoryRegistry, DelayedReader* reader = 0);
+    void fillLuminosityBlockPrincipal(ProcessHistoryRegistry const& processHistoryRegistry, DelayedReader* reader = 0);
 
     RunPrincipal const& runPrincipal() const {
       return *runPrincipal_;

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -86,7 +86,7 @@ namespace edm {
 
     void addAliasedProduct(boost::shared_ptr<BranchDescription const> bd);
 
-    void fillPrincipal(ProcessHistoryID const& hist, ProcessHistoryRegistry& phr, DelayedReader* reader);
+    void fillPrincipal(ProcessHistoryID const& hist, ProcessHistoryRegistry const& phr, DelayedReader* reader);
 
     void clearPrincipal();
 
@@ -235,9 +235,7 @@ namespace edm {
 
     virtual bool isComplete_() const {return true;}
 
-    ProcessHistoryRegistry* processHistoryRegistry_; 
-
-    ProcessHistory const* processHistoryPtr_;
+    boost::shared_ptr<ProcessHistory const> processHistoryPtr_;
 
     ProcessHistoryID processHistoryID_;
 
@@ -268,7 +266,6 @@ namespace edm {
     // The Principal does not own this object.
     HistoryAppender* historyAppender_;
 
-    static const ProcessHistory emptyProcessHistory_;
   };
 
   template <typename PROD>

--- a/FWCore/Framework/interface/RunPrincipal.h
+++ b/FWCore/Framework/interface/RunPrincipal.h
@@ -18,6 +18,7 @@ is the DataBlock.
 #include "boost/shared_ptr.hpp"
 
 #include "DataFormats/Provenance/interface/RunAuxiliary.h"
+#include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Framework/interface/Principal.h"
 
@@ -40,7 +41,7 @@ namespace edm {
         unsigned int iRunIndex);
     ~RunPrincipal() {}
 
-    void fillRunPrincipal(ProcessHistoryRegistry& processHistoryRegistry, DelayedReader* reader = 0);
+    void fillRunPrincipal(ProcessHistoryRegistry const& processHistoryRegistry, DelayedReader* reader = 0);
 
     /** Multiple Runs may be processed simultaneously. The
      return value can be used to identify a particular Run.
@@ -59,6 +60,10 @@ namespace edm {
 
     RunNumber_t run() const {
       return aux().run();
+    }
+    
+    ProcessHistoryID const& reducedProcessHistoryID() const {
+      return m_reducedHistoryID;
     }
 
     RunID const& id() const {
@@ -104,8 +109,8 @@ namespace edm {
 
     void resolveProductImmediate(ProductHolderBase const& phb) const;
 
-    // A vector of product holders.
     boost::shared_ptr<RunAuxiliary> aux_;
+    ProcessHistoryID m_reducedHistoryID;
     RunIndex index_;
 
     bool complete_;

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -220,16 +220,20 @@ namespace edm {
     ServiceToken                                  serviceToken_;
     boost::shared_ptr<ProductRegistry const>      parentPreg_;
     boost::shared_ptr<ProductRegistry const>	    preg_;
-    ProcessHistoryRegistry                       processHistoryRegistry_;
     boost::shared_ptr<BranchIDListHelper>         branchIDListHelper_;
     std::unique_ptr<ExceptionToActionTable const> act_table_;
     boost::shared_ptr<ProcessConfiguration const> processConfiguration_;
     ProcessContext                                processContext_;
+    //We require 1 history for each Run, Lumi and Stream
+    // The vectors first hold Stream info, then Lumi then Run
+    unsigned int                                  historyLumiOffset_;
+    unsigned int                                  historyRunOffset_;
+    std::vector<ProcessHistoryRegistry>           processHistoryRegistries_;
+    std::vector<HistoryAppender>                  historyAppenders_;
     PrincipalCache                                principalCache_;
     boost::shared_ptr<eventsetup::EventSetupProvider> esp_;
     std::auto_ptr<Schedule>                       schedule_;
     std::map<ProcessHistoryID, ProcessHistoryID>  parentToChildPhID_;
-    std::unique_ptr<HistoryAppender>              historyAppender_;
     std::auto_ptr<SubProcess>                     subProcess_;
     std::unique_ptr<ParameterSet>                 processParameterSet_;
 

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -37,7 +37,6 @@ namespace edm {
     SubProcess(ParameterSet& parameterSet,
                ParameterSet const& topLevelParameterSet,
                boost::shared_ptr<ProductRegistry const> parentProductRegistry,
-               ProcessHistoryRegistry& processHistoryRegistry,
                boost::shared_ptr<BranchIDListHelper const> parentBranchIDListHelper,
                eventsetup::EventSetupsController& esController,
                ActivityRegistry& parentActReg,
@@ -220,8 +219,8 @@ namespace edm {
     
     ServiceToken                                  serviceToken_;
     boost::shared_ptr<ProductRegistry const>      parentPreg_;
-    boost::shared_ptr<ProductRegistry const>	  preg_;
-    ProcessHistoryRegistry&                       processHistoryRegistry_;
+    boost::shared_ptr<ProductRegistry const>	    preg_;
+    ProcessHistoryRegistry                       processHistoryRegistry_;
     boost::shared_ptr<BranchIDListHelper>         branchIDListHelper_;
     std::unique_ptr<ExceptionToActionTable const> act_table_;
     boost::shared_ptr<ProcessConfiguration const> processConfiguration_;

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -51,7 +51,7 @@ namespace edm {
 
   void
   EventPrincipal::fillEventPrincipal(EventAuxiliary const& aux,
-        ProcessHistoryRegistry& processHistoryRegistry,
+        ProcessHistoryRegistry const& processHistoryRegistry,
         boost::shared_ptr<EventSelectionIDVector> eventSelectionIDs,
         boost::shared_ptr<BranchListIndexes> branchListIndexes,
         boost::shared_ptr<BranchMapper> mapper,

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -523,7 +523,6 @@ namespace edm {
       subProcess_.reset(new SubProcess(*subProcessParameterSet,
                                        *parameterSet,
                                        preg_,
-                                       input_->processHistoryRegistryForUpdate(),
                                        branchIDListHelper_,
                                        *espController_,
                                        *actReg_,
@@ -1706,14 +1705,17 @@ namespace edm {
                                                         historyAppender_.get(),
                                                         0));
     input_->readRun(*rp, *historyAppender_);
+    assert(input_->reducedProcessHistoryID() == rp->reducedProcessHistoryID());
     principalCache_.insert(rp);
-    return statemachine::Run(input_->reducedProcessHistoryID(), input_->run());
+    return statemachine::Run(rp->reducedProcessHistoryID(), input_->run());
   }
 
   statemachine::Run EventProcessor::readAndMergeRun() {
     principalCache_.merge(input_->runAuxiliary(), preg_);
-    input_->readAndMergeRun(*principalCache_.runPrincipalPtr());
-    return statemachine::Run(input_->reducedProcessHistoryID(), input_->run());
+    auto runPrincipal =principalCache_.runPrincipalPtr();
+    input_->readAndMergeRun(*runPrincipal);
+    assert(input_->reducedProcessHistoryID() == runPrincipal->reducedProcessHistoryID());
+    return statemachine::Run(runPrincipal->reducedProcessHistoryID(), input_->run());
   }
 
   int EventProcessor::readLuminosityBlock() {

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -318,12 +318,12 @@ namespace edm {
     // Note: For the moment, we do not support saving and restoring the state of the
     // random number generator if random numbers are generated during processing of runs
     // (e.g. beginRun(), endRun())
-    runPrincipal.fillRunPrincipal(processHistoryRegistryForUpdate());
+    runPrincipal.fillRunPrincipal(processHistoryRegistry());
   }
 
   void
   InputSource::readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal) {
-    lumiPrincipal.fillLuminosityBlockPrincipal(processHistoryRegistryForUpdate());
+    lumiPrincipal.fillLuminosityBlockPrincipal(processHistoryRegistry());
   }
 
   void

--- a/FWCore/Framework/src/LuminosityBlockPrincipal.cc
+++ b/FWCore/Framework/src/LuminosityBlockPrincipal.cc
@@ -23,7 +23,7 @@ namespace edm {
 
   void
   LuminosityBlockPrincipal::fillLuminosityBlockPrincipal(
-      ProcessHistoryRegistry& processHistoryRegistry,
+      ProcessHistoryRegistry const& processHistoryRegistry,
       DelayedReader* reader) {
 
     complete_ = false;

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -29,7 +29,7 @@
 
 namespace edm {
 
-  ProcessHistory const Principal::emptyProcessHistory_;
+  static ProcessHistory const s_emptyProcessHistory;
 
   static
   void
@@ -128,7 +128,7 @@ namespace edm {
                        BranchType bt,
                        HistoryAppender* historyAppender) :
     EDProductGetter(),
-    processHistoryPtr_(nullptr),
+    processHistoryPtr_(),
     processHistoryID_(),
     processConfiguration_(&pc),
     productHolders_(reg->getNextIndexValue(bt), SharedProductPtr()),
@@ -300,7 +300,7 @@ namespace edm {
   // "Zero" the principal so it can be reused for another Event.
   void
   Principal::clearPrincipal() {
-    processHistoryPtr_ = nullptr;
+    processHistoryPtr_.reset();
     processHistoryID_ = ProcessHistoryID();
     reader_ = nullptr;
     for(auto const& prod : *this) {
@@ -323,33 +323,35 @@ namespace edm {
   // Set the principal for the Event, Lumi, or Run.
   void
   Principal::fillPrincipal(ProcessHistoryID const& hist,
-                           ProcessHistoryRegistry& processHistoryRegistry,
+                           ProcessHistoryRegistry const& processHistoryRegistry,
                            DelayedReader* reader) {
     if(reader) {
       reader_ = reader;
     }
 
-    ProcessHistory const* inputProcessHistory = nullptr;
     if (historyAppender_ && productRegistry().anyProductProduced()) {
-      CachedHistory const& cachedHistory = 
+      processHistoryPtr_ =
         historyAppender_->appendToProcessHistory(hist,
-                                                *processConfiguration_,
-                                                processHistoryRegistry);
-      processHistoryPtr_ = cachedHistory.processHistory();
-      processHistoryID_ = cachedHistory.processHistoryID();
-      inputProcessHistory = cachedHistory.inputProcessHistory();
+                                                 processHistoryRegistry.getMapped(hist),
+                                                 *processConfiguration_);
+      processHistoryID_ = processHistoryPtr_->id();
     }
     else {
+      boost::shared_ptr<ProcessHistory const> inputProcessHistory;
       if (hist.isValid()) {
-        inputProcessHistory = processHistoryRegistry.getMapped(hist);
-        if (inputProcessHistory == 0) {
+        //does not own the pointer
+        auto noDel =[](void const*){};
+        inputProcessHistory =
+        boost::shared_ptr<ProcessHistory const>(processHistoryRegistry.getMapped(hist),noDel);
+        if (inputProcessHistory.get() == nullptr) {
           throw Exception(errors::LogicError)
             << "Principal::fillPrincipal\n"
             << "Input ProcessHistory not found in registry\n"
             << "Contact a Framework developer\n";
         }
       } else {
-        inputProcessHistory = &emptyProcessHistory_;
+        //Since this is static we don't want it deleted
+        inputProcessHistory = boost::shared_ptr<ProcessHistory const>(&s_emptyProcessHistory,[](void const*){});
       }
       processHistoryID_ = hist;
       processHistoryPtr_ = inputProcessHistory;        

--- a/FWCore/Framework/src/RunPrincipal.cc
+++ b/FWCore/Framework/src/RunPrincipal.cc
@@ -19,9 +19,10 @@ namespace edm {
   }
 
   void
-  RunPrincipal::fillRunPrincipal(ProcessHistoryRegistry& processHistoryRegistry, DelayedReader* reader) {
+  RunPrincipal::fillRunPrincipal(ProcessHistoryRegistry const& processHistoryRegistry, DelayedReader* reader) {
     complete_ = false;
 
+    m_reducedHistoryID = processHistoryRegistry.reducedProcessHistoryID(aux_->processHistoryID());
     fillPrincipal(aux_->processHistoryID(), processHistoryRegistry, reader);
 
     for(auto const& prod : *this) {

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -45,15 +45,17 @@ namespace edm {
       serviceToken_(),
       parentPreg_(parentProductRegistry),
       preg_(),
-      processHistoryRegistry_(),
       branchIDListHelper_(),
       act_table_(),
       processConfiguration_(),
+      historyLumiOffset_(preallocConfig.numberOfStreams()),
+      historyRunOffset_(historyLumiOffset_+preallocConfig.numberOfLuminosityBlocks()),
+      processHistoryRegistries_(historyRunOffset_+ preallocConfig.numberOfRuns()),
+      historyAppenders_(historyRunOffset_+preallocConfig.numberOfRuns()),
       principalCache_(),
       esp_(),
       schedule_(),
       parentToChildPhID_(),
-      historyAppender_(new HistoryAppender),
       subProcess_(),
       processParameterSet_(),
       productSelectorRules_(parameterSet, "outputCommands", "OutputModule"),
@@ -135,7 +137,10 @@ namespace edm {
     // set the items
     act_table_ = std::move(items.act_table_);
     preg_.reset(items.preg_.release());
-    principalCache_.setProcessHistoryRegistry(processHistoryRegistry_);
+    //CMS-THREADING this only works since Run/Lumis are synchronous so when principalCache asks for
+    // the reducedProcessHistoryID from a full ProcessHistoryID that registry will not be in use by
+    // another thread. We really need to change how this is done in the PrincipalCache.
+    principalCache_.setProcessHistoryRegistry(processHistoryRegistries_[historyRunOffset_]);
     branchIDListHelper_ = items.branchIDListHelper_;
     processConfiguration_ = items.processConfiguration_;
     processContext_.setProcessConfiguration(processConfiguration_.get());
@@ -146,7 +151,7 @@ namespace edm {
       boost::shared_ptr<EventPrincipal> ep(new EventPrincipal(preg_,
                                                               branchIDListHelper_,
                                                               *processConfiguration_,
-                                                              historyAppender_.get(),
+                                                              &(historyAppenders_[index]),
                                                               index));
       principalCache_.insert(ep);
     }
@@ -298,9 +303,10 @@ namespace edm {
     }
 
     EventPrincipal& ep = principalCache_.eventPrincipal(principal.streamID().value());
-    processHistoryRegistry_.registerProcessHistory(principal.processHistory());
+    auto & processHistoryRegistry = processHistoryRegistries_[principal.streamID().value()];
+    processHistoryRegistry.registerProcessHistory(principal.processHistory());
     ep.fillEventPrincipal(aux,
-                          processHistoryRegistry_,
+                          processHistoryRegistry,
                           esids,
                           boost::shared_ptr<BranchListIndexes>(new BranchListIndexes(principal.branchListIndexes())),
                           principal.branchMapperPtr(),
@@ -323,9 +329,10 @@ namespace edm {
   SubProcess::beginRun(RunPrincipal const& principal, IOVSyncValue const& ts) {
     boost::shared_ptr<RunAuxiliary> aux(new RunAuxiliary(principal.aux()));
     aux->setProcessHistoryID(principal.processHistoryID());
-    boost::shared_ptr<RunPrincipal> rpp(new RunPrincipal(aux, preg_, *processConfiguration_, historyAppender_.get(),principal.index()));
-    processHistoryRegistry_.registerProcessHistory(principal.processHistory());
-    rpp->fillRunPrincipal(processHistoryRegistry_, principal.reader());
+    boost::shared_ptr<RunPrincipal> rpp(new RunPrincipal(aux, preg_, *processConfiguration_, &(historyAppenders_[historyRunOffset_+principal.index()]),principal.index()));
+    auto & processHistoryRegistry = processHistoryRegistries_[historyRunOffset_+principal.index()];
+    processHistoryRegistry.registerProcessHistory(principal.processHistory());
+    rpp->fillRunPrincipal(processHistoryRegistry, principal.reader());
     principalCache_.insert(rpp);
 
     ProcessHistoryID const& parentInputReducedPHID = principal.reducedProcessHistoryID();
@@ -382,9 +389,10 @@ namespace edm {
   SubProcess::beginLuminosityBlock(LuminosityBlockPrincipal const& principal, IOVSyncValue const& ts) {
     boost::shared_ptr<LuminosityBlockAuxiliary> aux(new LuminosityBlockAuxiliary(principal.aux()));
     aux->setProcessHistoryID(principal.processHistoryID());
-    boost::shared_ptr<LuminosityBlockPrincipal> lbpp(new LuminosityBlockPrincipal(aux, preg_, *processConfiguration_, historyAppender_.get(),principal.index()));
-    processHistoryRegistry_.registerProcessHistory(principal.processHistory());
-    lbpp->fillLuminosityBlockPrincipal(processHistoryRegistry_, principal.reader());
+    boost::shared_ptr<LuminosityBlockPrincipal> lbpp(new LuminosityBlockPrincipal(aux, preg_, *processConfiguration_, &(historyAppenders_[historyLumiOffset_+principal.index()]),principal.index()));
+    auto & processHistoryRegistry = processHistoryRegistries_[historyLumiOffset_+principal.index()];
+    processHistoryRegistry.registerProcessHistory(principal.processHistory());
+    lbpp->fillLuminosityBlockPrincipal(processHistoryRegistry, principal.reader());
     lbpp->setRunPrincipal(principalCache_.runPrincipalPtr());
     principalCache_.insert(lbpp);
     LuminosityBlockPrincipal& lbp = *principalCache_.lumiPrincipalPtr();

--- a/FWCore/Integration/test/ThrowingSource.cc
+++ b/FWCore/Integration/test/ThrowingSource.cc
@@ -132,7 +132,7 @@ namespace edm {
     assert(eventCached() || processingMode() != RunsLumisAndEvents);
     EventSourceSentry sentry(*this);
     EventAuxiliary aux(eventID(), processGUID(), Timestamp(presentTime()), false, EventAuxiliary::Undefined);
-    eventPrincipal.fillEventPrincipal(aux, processHistoryRegistryForUpdate());
+    eventPrincipal.fillEventPrincipal(aux, processHistoryRegistry());
   }
 }
 

--- a/FWCore/Sources/src/ProducerSourceBase.cc
+++ b/FWCore/Sources/src/ProducerSourceBase.cc
@@ -61,7 +61,7 @@ namespace edm {
     assert(eventCached() || processingMode() != RunsLumisAndEvents);
     EventSourceSentry sentry(*this);
     EventAuxiliary aux(eventID_, processGUID(), Timestamp(presentTime_), isRealData_, eType_);
-    eventPrincipal.fillEventPrincipal(aux, processHistoryRegistryForUpdate());
+    eventPrincipal.fillEventPrincipal(aux, processHistoryRegistry());
     Event e(eventPrincipal, moduleDescription(), nullptr);
     produce(e);
     e.commit_();

--- a/FWCore/Sources/src/RawInputSource.cc
+++ b/FWCore/Sources/src/RawInputSource.cc
@@ -52,7 +52,7 @@ namespace edm {
   void
   RawInputSource::makeEvent(EventPrincipal& eventPrincipal, EventAuxiliary const& eventAuxiliary) {
     EventSourceSentry sentry(*this);
-    eventPrincipal.fillEventPrincipal(eventAuxiliary, processHistoryRegistryForUpdate());
+    eventPrincipal.fillEventPrincipal(eventAuxiliary, processHistoryRegistry());
   }
 
   void

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -270,7 +270,7 @@ namespace edm {
     boost::shared_ptr<EventSelectionIDVector> ids(new EventSelectionIDVector(sendEvent_->eventSelectionIDs()));
     boost::shared_ptr<BranchListIndexes> indexes(new BranchListIndexes(sendEvent_->branchListIndexes()));
     branchIDListHelper()->fixBranchListIndexes(*indexes);
-    eventPrincipal.fillEventPrincipal(sendEvent_->aux(), processHistoryRegistryForUpdate(), ids, indexes);
+    eventPrincipal.fillEventPrincipal(sendEvent_->aux(), processHistoryRegistry(), ids, indexes);
     eventPrincipalHolder_.setEventPrincipal(&eventPrincipal);
 
     // no process name list handling


### PR DESCRIPTION
Made sure that the ProcessHistoryRegistry was replicated sufficiently so that no thread would be updating a registry while a different thread could be attempting to read it.
