### PR TITLE
Backport Fix for EDAlias and failing edm::Refs

### DIFF
--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -113,10 +113,6 @@ namespace edm {
       return droppedBranchIDToKeptBranchID_;
     }
 
-    std::map<BranchID::value_type, BranchID::value_type> const& keptBranchIDToDroppedBranchID() {
-      return keptBranchIDToDroppedBranchID_;
-    }
-
   private:
 
     int maxEvents_;
@@ -161,7 +157,6 @@ namespace edm {
     // needed because of possible EDAliases.
     // filled in only if key and value are different.
     std::map<BranchID::value_type, BranchID::value_type> droppedBranchIDToKeptBranchID_;
-    std::map<BranchID::value_type, BranchID::value_type> keptBranchIDToDroppedBranchID_;
     std::unique_ptr<BranchIDLists> branchIDLists_;
     BranchIDLists const* origBranchIDLists_;
 

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -117,7 +117,6 @@ namespace edm {
     selectors_(),
     selector_config_id_(),
     droppedBranchIDToKeptBranchID_(),
-    keptBranchIDToDroppedBranchID_(),
     branchIDLists_(new BranchIDLists),
     origBranchIDLists_(nullptr),
     branchParents_(),
@@ -249,7 +248,6 @@ namespace edm {
         if(keptBranchID != branchID) {
           // An EDAlias branch was persisted.
           droppedBranchIDToKeptBranchID_.insert(std::make_pair(branchID.id(), keptBranchID.id()));
-          keptBranchIDToDroppedBranchID_.insert(std::make_pair(keptBranchID.id(), branchID.id()));
         }
       }
     }
@@ -454,11 +452,6 @@ namespace edm {
       // Check for branches dropped while an EDAlias was kept.
       for(BranchIDList& branchIDList : *branchIDLists_) {
         for(BranchID::value_type& branchID : branchIDList) {
-          // Replace BranchID of each kept alias branch with zero, so only the product ID of the original branch will be accessible.
-          std::map<BranchID::value_type, BranchID::value_type>::const_iterator kiter = keptBranchIDToDroppedBranchID_.find(branchID);
-          if(kiter != keptBranchIDToDroppedBranchID_.end()) {
-            branchID = 0;
-          }
           // Replace BranchID of each dropped branch with that of the kept alias, so the alias branch will have the product ID of the original branch.
           std::map<BranchID::value_type, BranchID::value_type>::const_iterator iter = droppedBranchIDToKeptBranchID_.find(branchID);
           if(iter != droppedBranchIDToKeptBranchID_.end()) {


### PR DESCRIPTION
Nicola Pozzobon reported a problem with edm::Refs which was ultimately traced back to a bug in the handling of EDAlias. See https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/3159/1/1/1/1/1/1/1.html. This fix was successfully integrated into CMSSW_7_0_X but needs to be backported to CMSSW_6_2_X_SLHC since that is where the problem was originally discovered.
