### PR TITLE
No mutables from source in EventPrincipal

### DIFF
--- a/DataFormats/Provenance/interface/BranchIDListHelper.h
+++ b/DataFormats/Provenance/interface/BranchIDListHelper.h
@@ -7,6 +7,7 @@
 #include "DataFormats/Provenance/interface/ProvenanceFwd.h"
 
 #include <map>
+#include <vector>
 
 namespace edm {
     
@@ -14,20 +15,27 @@ namespace edm {
   public:
     typedef std::pair<BranchListIndex, ProductIndex> IndexPair;
     typedef std::multimap<BranchID, IndexPair> BranchIDToIndexMap;
-    typedef std::map<BranchListIndex, BranchListIndex> BranchListIndexMapper;
-    BranchIDListHelper();
-    bool updateFromInput(BranchIDLists const& bidlists);
-    void updateRegistries(ProductRegistry& reg);
-    void fixBranchListIndexes(BranchListIndexes& indexes);
 
-    BranchIDLists const& branchIDLists() const {return branchIDLists_;}
+    BranchIDListHelper();
+
+    //CMS-THREADING called when a new file is opened
+    bool updateFromInput(BranchIDLists const& bidlists);
+    ///Called by sources to convert their read indexes into the indexes used by the job
+    void fixBranchListIndexes(BranchListIndexes& indexes) const;
+
+    void updateRegistries(ProductRegistry& reg);
+
+    //CMS-THREADING this is called in SubJob::beginJob
     BranchIDLists& mutableBranchIDLists() {return branchIDLists_;}
+
+    //Used by the EventPrincipal
+    BranchIDLists const& branchIDLists() const {return branchIDLists_;}
     BranchIDToIndexMap const& branchIDToIndexMap() const {return branchIDToIndexMap_;}
 
   private:
     BranchIDLists branchIDLists_;
     BranchIDToIndexMap branchIDToIndexMap_;
-    BranchListIndexMapper branchListIndexMapper_;
+    std::vector<BranchListIndex> inputIndexToJobIndex_;
   };
 }
 

--- a/DataFormats/Provenance/interface/BranchIDListHelper.h
+++ b/DataFormats/Provenance/interface/BranchIDListHelper.h
@@ -8,6 +8,7 @@
 
 #include <map>
 #include <vector>
+#include <limits>
 
 namespace edm {
     
@@ -23,7 +24,7 @@ namespace edm {
     ///Called by sources to convert their read indexes into the indexes used by the job
     void fixBranchListIndexes(BranchListIndexes& indexes) const;
 
-    void updateRegistries(ProductRegistry& reg);
+    void updateFromRegistry(ProductRegistry const& reg);
 
     //CMS-THREADING this is called in SubJob::beginJob
     BranchIDLists& mutableBranchIDLists() {return branchIDLists_;}
@@ -31,11 +32,16 @@ namespace edm {
     //Used by the EventPrincipal
     BranchIDLists const& branchIDLists() const {return branchIDLists_;}
     BranchIDToIndexMap const& branchIDToIndexMap() const {return branchIDToIndexMap_;}
+    BranchListIndex producedBranchListIndex() const {return producedBranchListIndex_;}
+    bool hasProducedProducts() const {
+      return producedBranchListIndex_ != std::numeric_limits<BranchListIndex>::max();
+    }
 
   private:
     BranchIDLists branchIDLists_;
     BranchIDToIndexMap branchIDToIndexMap_;
     std::vector<BranchListIndex> inputIndexToJobIndex_;
+    BranchListIndex producedBranchListIndex_;
   };
 }
 

--- a/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
+++ b/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
@@ -27,7 +27,7 @@ namespace edm {
 
   class ProductProvenanceRetriever : private boost::noncopyable {
   public:
-    ProductProvenanceRetriever();
+    explicit ProductProvenanceRetriever(unsigned int iTransitionIndex);
 #ifndef __GCCXML__
     explicit ProductProvenanceRetriever(std::unique_ptr<ProvenanceReaderBase> reader);
 #endif
@@ -40,23 +40,29 @@ namespace edm {
 
     void mergeProvenanceRetrievers(boost::shared_ptr<ProductProvenanceRetriever> other);
 
+    void deepSwap(ProductProvenanceRetriever&);
+    
     void reset();
   private:
     void readProvenance() const;
+    void setTransitionIndex(unsigned int transitionIndex) {
+      transitionIndex_=transitionIndex;
+    }
 
     typedef std::set<ProductProvenance> eiSet;
 
     mutable eiSet entryInfoSet_;
     boost::shared_ptr<ProductProvenanceRetriever> nextRetriever_;
+    mutable boost::shared_ptr<ProvenanceReaderBase> provenanceReader_;
+    unsigned int transitionIndex_;
     mutable bool delayedRead_;
-    mutable boost::scoped_ptr<ProvenanceReaderBase> provenanceReader_;
   };
 
   class ProvenanceReaderBase {
   public:
     ProvenanceReaderBase() {}
     virtual ~ProvenanceReaderBase();
-    virtual void readProvenance(ProductProvenanceRetriever const& mapper) const = 0;
+    virtual void readProvenance(ProductProvenanceRetriever const& mapper, unsigned int transitionIndex) const = 0;
   };
   
 }

--- a/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
+++ b/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
@@ -3,7 +3,7 @@
 
 /*----------------------------------------------------------------------
   
-BranchMapper: Manages the per event/lumi/run per product provenance.
+ProductProvenanceRetriever: Manages the per event/lumi/run per product provenance.
 
 ----------------------------------------------------------------------*/
 #include "DataFormats/Provenance/interface/BranchID.h"
@@ -19,26 +19,26 @@ BranchMapper: Manages the per event/lumi/run per product provenance.
 #include <set>
 
 /*
-  BranchMapper
+  ProductProvenanceRetriever
 */
 
 namespace edm {
   class ProvenanceReaderBase;
 
-  class BranchMapper : private boost::noncopyable {
+  class ProductProvenanceRetriever : private boost::noncopyable {
   public:
-    BranchMapper();
+    ProductProvenanceRetriever();
 #ifndef __GCCXML__
-    explicit BranchMapper(std::unique_ptr<ProvenanceReaderBase> reader);
+    explicit ProductProvenanceRetriever(std::unique_ptr<ProvenanceReaderBase> reader);
 #endif
 
-    ~BranchMapper();
+    ~ProductProvenanceRetriever();
 
     ProductProvenance const* branchIDToProvenance(BranchID const& bid) const;
 
     void insertIntoSet(ProductProvenance const& provenanceProduct) const;
 
-    void mergeMappers(boost::shared_ptr<BranchMapper> other);
+    void mergeMappers(boost::shared_ptr<ProductProvenanceRetriever> other);
 
     void reset();
   private:
@@ -47,7 +47,7 @@ namespace edm {
     typedef std::set<ProductProvenance> eiSet;
 
     mutable eiSet entryInfoSet_;
-    boost::shared_ptr<BranchMapper> nextMapper_;
+    boost::shared_ptr<ProductProvenanceRetriever> nextMapper_;
     mutable bool delayedRead_;
     mutable boost::scoped_ptr<ProvenanceReaderBase> provenanceReader_;
   };
@@ -56,7 +56,7 @@ namespace edm {
   public:
     ProvenanceReaderBase() {}
     virtual ~ProvenanceReaderBase();
-    virtual void readProvenance(BranchMapper const& mapper) const = 0;
+    virtual void readProvenance(ProductProvenanceRetriever const& mapper) const = 0;
   };
   
 }

--- a/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
+++ b/DataFormats/Provenance/interface/ProductProvenanceRetriever.h
@@ -38,7 +38,7 @@ namespace edm {
 
     void insertIntoSet(ProductProvenance const& provenanceProduct) const;
 
-    void mergeMappers(boost::shared_ptr<ProductProvenanceRetriever> other);
+    void mergeProvenanceRetrievers(boost::shared_ptr<ProductProvenanceRetriever> other);
 
     void reset();
   private:
@@ -47,7 +47,7 @@ namespace edm {
     typedef std::set<ProductProvenance> eiSet;
 
     mutable eiSet entryInfoSet_;
-    boost::shared_ptr<ProductProvenanceRetriever> nextMapper_;
+    boost::shared_ptr<ProductProvenanceRetriever> nextRetriever_;
     mutable bool delayedRead_;
     mutable boost::scoped_ptr<ProvenanceReaderBase> provenanceReader_;
   };

--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -108,11 +108,6 @@ namespace edm {
 
     bool productProduced(BranchType branchType) const {return transient_.productProduced_[branchType];}
     bool anyProductProduced() const {return transient_.anyProductProduced_;}
-    BranchListIndex producedBranchListIndex() const {return transient_.producedBranchListIndex_;}
-
-    void setProducedBranchListIndex(BranchListIndex blix) {
-      transient_.producedBranchListIndex_ = blix;
-    }
 
     std::vector<std::string> const& missingDictionaries() const {
       return transient_.missingDictionaries_;
@@ -146,8 +141,6 @@ namespace edm {
       ProductHolderIndex runNextIndexValue_;
 
       std::map<BranchID, ProductHolderIndex> branchIDToIndex_;
-
-      BranchListIndex producedBranchListIndex_;
 
       std::vector<std::string> missingDictionaries_;
     };

--- a/DataFormats/Provenance/interface/Provenance.h
+++ b/DataFormats/Provenance/interface/Provenance.h
@@ -9,7 +9,7 @@ existence.
 ----------------------------------------------------------------------*/
 
 #include "DataFormats/Provenance/interface/BranchDescription.h"
-#include "DataFormats/Provenance/interface/BranchMapper.h"
+#include "DataFormats/Provenance/interface/ProductProvenanceRetriever.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/Parentage.h"
@@ -61,7 +61,7 @@ namespace edm {
     std::string const& processName() const {return product().processName();}
     std::string const& productInstanceName() const {return product().productInstanceName();}
     std::string const& friendlyClassName() const {return product().friendlyClassName();}
-    boost::shared_ptr<BranchMapper> const& store() const {return store_;}
+    boost::shared_ptr<ProductProvenanceRetriever> const& store() const {return store_;}
     ProcessHistory const& processHistory() const {return *processHistory_;}
     bool getProcessConfiguration(ProcessConfiguration& pc) const;
     ReleaseVersion releaseVersion() const;
@@ -71,7 +71,7 @@ namespace edm {
 
     void write(std::ostream& os) const;
 
-    void setStore(boost::shared_ptr<BranchMapper> store) const {store_ = store;}
+    void setStore(boost::shared_ptr<ProductProvenanceRetriever> store) const {store_ = store;}
 
     void setProcessHistory(ProcessHistory const& ph) {processHistory_ = &ph;}
 
@@ -97,7 +97,7 @@ namespace edm {
     ProcessHistory const* processHistory_; // We don't own this
     mutable bool productProvenanceValid_;
     mutable boost::shared_ptr<ProductProvenance> productProvenancePtr_;
-    mutable boost::shared_ptr<BranchMapper> store_;
+    mutable boost::shared_ptr<ProductProvenanceRetriever> store_;
   };
 
   inline

--- a/DataFormats/Provenance/interface/ProvenanceFwd.h
+++ b/DataFormats/Provenance/interface/ProvenanceFwd.h
@@ -24,7 +24,7 @@ namespace edm {
   class RunAuxiliary;
   class RunID;
   class Timestamp;
-  class BranchMapper;
+  class ProductProvenanceRetriever;
 }
 
 namespace cms {

--- a/DataFormats/Provenance/src/BranchIDListHelper.cc
+++ b/DataFormats/Provenance/src/BranchIDListHelper.cc
@@ -10,7 +10,9 @@ namespace edm {
   BranchIDListHelper::BranchIDListHelper() :
     branchIDLists_(),
     branchIDToIndexMap_(),
-    inputIndexToJobIndex_() {}
+    inputIndexToJobIndex_(),
+    producedBranchListIndex_(std::numeric_limits<BranchListIndex>::max())
+  {}
 
   bool
   BranchIDListHelper::updateFromInput(BranchIDLists const& bidlists) {
@@ -41,7 +43,7 @@ namespace edm {
   }
 
   void
-  BranchIDListHelper::updateRegistries(ProductRegistry& preg) {
+  BranchIDListHelper::updateFromRegistry(ProductRegistry const& preg) {
     BranchIDList bidlist;
     // Add entries for current process for ProductID to BranchID mapping.
     for(ProductRegistry::ProductList::const_iterator it = preg.productList().begin(), itEnd = preg.productList().end();
@@ -54,8 +56,8 @@ namespace edm {
     }
     if(!bidlist.empty()) {
       BranchListIndex blix = branchIDLists_.size();
-#error "move producedBranchListIndex to this class"
-      preg.setProducedBranchListIndex(blix);
+      producedBranchListIndex_ = blix;
+      //preg.setProducedBranchListIndex(blix);
       branchIDLists_.push_back(bidlist);
       for(BranchIDList::const_iterator i = bidlist.begin(), iEnd = bidlist.end(); i != iEnd; ++i) {
         ProductIndex pix = i - bidlist.begin();

--- a/DataFormats/Provenance/src/BranchIDListHelper.cc
+++ b/DataFormats/Provenance/src/BranchIDListHelper.cc
@@ -3,25 +3,27 @@
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 
+#include <cassert>
+
 namespace edm {
 
   BranchIDListHelper::BranchIDListHelper() :
     branchIDLists_(),
     branchIDToIndexMap_(),
-    branchListIndexMapper_() {}
+    inputIndexToJobIndex_() {}
 
   bool
-  BranchIDListHelper:: updateFromInput(BranchIDLists const& bidlists) {
+  BranchIDListHelper::updateFromInput(BranchIDLists const& bidlists) {
     //The BranchIDLists is a list of lists
     // this routine compares bidlists to branchIDLists_ to see if a list
     // in branchIDLists_ is already in bidlist and if it isn't we insert
     // that new list into branchIDLists_
     bool unchanged = true;
-    branchListIndexMapper_.clear();
-    typedef BranchIDLists::const_iterator Iter;
-    for(Iter it = bidlists.begin(), itEnd = bidlists.end(); it != itEnd; ++it) {
+    inputIndexToJobIndex_.clear();
+    inputIndexToJobIndex_.resize(bidlists.size());
+    for(auto it = bidlists.begin(), itEnd = bidlists.end(); it != itEnd; ++it) {
       BranchListIndex oldBlix = it - bidlists.begin();
-      Iter j = find_in_all(branchIDLists_, *it);
+      auto j = find_in_all(branchIDLists_, *it);
       BranchListIndex blix = j - branchIDLists_.begin();
       if(j == branchIDLists_.end()) {
         branchIDLists_.push_back(*it);
@@ -30,7 +32,7 @@ namespace edm {
           branchIDToIndexMap_.insert(std::make_pair(BranchID(*i), std::make_pair(blix, pix)));
         }
       }
-      branchListIndexMapper_.insert(std::make_pair(oldBlix, blix));
+      inputIndexToJobIndex_[oldBlix]=blix;
       if(oldBlix != blix) {
         unchanged = false;
       }
@@ -52,6 +54,7 @@ namespace edm {
     }
     if(!bidlist.empty()) {
       BranchListIndex blix = branchIDLists_.size();
+#error "move producedBranchListIndex to this class"
       preg.setProducedBranchListIndex(blix);
       branchIDLists_.push_back(bidlist);
       for(BranchIDList::const_iterator i = bidlist.begin(), iEnd = bidlist.end(); i != iEnd; ++i) {
@@ -62,9 +65,10 @@ namespace edm {
   }
 
   void
-  BranchIDListHelper::fixBranchListIndexes(BranchListIndexes& indexes) {
+  BranchIDListHelper::fixBranchListIndexes(BranchListIndexes& indexes) const {
     for(BranchListIndex& i : indexes) {
-      i = branchListIndexMapper_[i];
+      assert(i<inputIndexToJobIndex_.size());
+      i = inputIndexToJobIndex_[i];
     }
   }
 }

--- a/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
+++ b/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
@@ -1,22 +1,22 @@
-#include "DataFormats/Provenance/interface/BranchMapper.h"
+#include "DataFormats/Provenance/interface/ProductProvenanceRetriever.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
 #include <cassert>
 #include <iostream>
 
 /*
-  BranchMapper
+  ProductProvenanceRetriever
 */
 
 namespace edm {
-  BranchMapper::BranchMapper() :
+  ProductProvenanceRetriever::ProductProvenanceRetriever() :
       entryInfoSet_(),
       nextMapper_(),
       delayedRead_(false),
       provenanceReader_() {
   }
 
-  BranchMapper::BranchMapper(std::unique_ptr<ProvenanceReaderBase> reader) :
+  ProductProvenanceRetriever::ProductProvenanceRetriever(std::unique_ptr<ProvenanceReaderBase> reader) :
       entryInfoSet_(),
       nextMapper_(),
       delayedRead_(true),
@@ -24,10 +24,10 @@ namespace edm {
     assert(provenanceReader_);
   }
 
-  BranchMapper::~BranchMapper() {}
+  ProductProvenanceRetriever::~ProductProvenanceRetriever() {}
 
   void
-  BranchMapper::readProvenance() const {
+  ProductProvenanceRetriever::readProvenance() const {
     if(delayedRead_ && provenanceReader_) {
       provenanceReader_->readProvenance(*this);
       delayedRead_ = false; // only read once
@@ -35,13 +35,13 @@ namespace edm {
   }
 
   void
-  BranchMapper::reset() {
+  ProductProvenanceRetriever::reset() {
     entryInfoSet_.clear();
     delayedRead_ = true;
   }
 
   void
-  BranchMapper::insertIntoSet(ProductProvenance const& entryInfo) const {
+  ProductProvenanceRetriever::insertIntoSet(ProductProvenance const& entryInfo) const {
     //NOTE:do not read provenance here because we only need the full
     // provenance when someone tries to access it not when doing the insert
     // doing the delay saves 20% of time when doing an analysis job
@@ -50,12 +50,12 @@ namespace edm {
   }
  
   void
-  BranchMapper::mergeMappers(boost::shared_ptr<BranchMapper> other) {
+  ProductProvenanceRetriever::mergeMappers(boost::shared_ptr<ProductProvenanceRetriever> other) {
     nextMapper_ = other;
   }
 
   ProductProvenance const*
-  BranchMapper::branchIDToProvenance(BranchID const& bid) const {
+  ProductProvenanceRetriever::branchIDToProvenance(BranchID const& bid) const {
     readProvenance();
     ProductProvenance ei(bid);
     eiSet::const_iterator it = entryInfoSet_.find(ei);

--- a/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
+++ b/DataFormats/Provenance/src/ProductProvenanceRetriever.cc
@@ -11,14 +11,14 @@
 namespace edm {
   ProductProvenanceRetriever::ProductProvenanceRetriever() :
       entryInfoSet_(),
-      nextMapper_(),
+      nextRetriever_(),
       delayedRead_(false),
       provenanceReader_() {
   }
 
   ProductProvenanceRetriever::ProductProvenanceRetriever(std::unique_ptr<ProvenanceReaderBase> reader) :
       entryInfoSet_(),
-      nextMapper_(),
+      nextRetriever_(),
       delayedRead_(true),
       provenanceReader_(reader.release()) {
     assert(provenanceReader_);
@@ -50,8 +50,8 @@ namespace edm {
   }
  
   void
-  ProductProvenanceRetriever::mergeMappers(boost::shared_ptr<ProductProvenanceRetriever> other) {
-    nextMapper_ = other;
+  ProductProvenanceRetriever::mergeProvenanceRetrievers(boost::shared_ptr<ProductProvenanceRetriever> other) {
+    nextRetriever_ = other;
   }
 
   ProductProvenance const*
@@ -60,8 +60,8 @@ namespace edm {
     ProductProvenance ei(bid);
     eiSet::const_iterator it = entryInfoSet_.find(ei);
     if(it == entryInfoSet_.end()) {
-      if(nextMapper_) {
-        return nextMapper_->branchIDToProvenance(bid);
+      if(nextRetriever_) {
+        return nextRetriever_->branchIDToProvenance(bid);
       } else {
         return 0;
       }

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -54,7 +54,6 @@ namespace edm {
       runNextIndexValue_(0),
 
       branchIDToIndex_(),
-      producedBranchListIndex_(std::numeric_limits<BranchListIndex>::max()),
       missingDictionaries_() {
     for(bool& isProduced : productProduced_) isProduced = false;
   }
@@ -73,7 +72,6 @@ namespace edm {
     runNextIndexValue_ = 0;
 
     branchIDToIndex_.clear();
-    producedBranchListIndex_ = std::numeric_limits<BranchListIndex>::max();
     missingDictionaries_.clear();
   }
 

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -15,7 +15,7 @@ is the DataBlock.
 #include "DataFormats/Common/interface/WrapperHolder.h"
 #include "DataFormats/Common/interface/WrapperOwningHolder.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
-#include "DataFormats/Provenance/interface/BranchMapper.h"
+#include "DataFormats/Provenance/interface/ProductProvenanceRetriever.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 #include "DataFormats/Provenance/interface/EventSelectionID.h"
 #include "FWCore/Utilities/interface/StreamID.h"
@@ -30,7 +30,7 @@ is the DataBlock.
 
 namespace edm {
   class BranchIDListHelper;
-  class BranchMapper;
+  class ProductProvenanceRetriever;
   class DelayedReader;
   class EventID;
   class HistoryAppender;
@@ -64,7 +64,7 @@ namespace edm {
                             ProcessHistoryRegistry const& processHistoryRegistry,
                             EventSelectionIDVector&& eventSelectionIDs,
                             BranchListIndexes&& branchListIndexes,
-                            boost::shared_ptr<BranchMapper> mapper = boost::shared_ptr<BranchMapper>(new BranchMapper),
+                            boost::shared_ptr<ProductProvenanceRetriever> mapper = boost::shared_ptr<ProductProvenanceRetriever>(new ProductProvenanceRetriever),
                             DelayedReader* reader = 0);
 
     void clearEventPrincipal();
@@ -125,7 +125,7 @@ namespace edm {
 
     RunPrincipal const& runPrincipal() const;
 
-    boost::shared_ptr<BranchMapper> branchMapperPtr() const {return branchMapperPtr_;}
+    boost::shared_ptr<ProductProvenanceRetriever> branchMapperPtr() const {return branchMapperPtr_;}
 
     void setUnscheduledHandler(boost::shared_ptr<UnscheduledHandler> iHandler);
     boost::shared_ptr<UnscheduledHandler> unscheduledHandler() const;
@@ -193,7 +193,7 @@ namespace edm {
     boost::shared_ptr<LuminosityBlockPrincipal> luminosityBlockPrincipal_;
 
     // Pointer to the 'mapper' that will get provenance information from the persistent store.
-    boost::shared_ptr<BranchMapper> branchMapperPtr_;
+    boost::shared_ptr<ProductProvenanceRetriever> branchMapperPtr_;
 
     // Handler for unscheduled modules
     boost::shared_ptr<UnscheduledHandler> unscheduledHandler_;

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -58,10 +58,14 @@ namespace edm {
 
     void fillEventPrincipal(EventAuxiliary const& aux,
         ProcessHistoryRegistry const& processHistoryRegistry,
-        boost::shared_ptr<EventSelectionIDVector> eventSelectionIDs = boost::shared_ptr<EventSelectionIDVector>(),
-        boost::shared_ptr<BranchListIndexes> branchListIndexes = boost::shared_ptr<BranchListIndexes>(),
-        boost::shared_ptr<BranchMapper> mapper = boost::shared_ptr<BranchMapper>(new BranchMapper),
-        DelayedReader* reader = 0);
+                            DelayedReader* reader = 0);
+
+    void fillEventPrincipal(EventAuxiliary const& aux,
+                            ProcessHistoryRegistry const& processHistoryRegistry,
+                            EventSelectionIDVector&& eventSelectionIDs,
+                            BranchListIndexes&& branchListIndexes,
+                            boost::shared_ptr<BranchMapper> mapper = boost::shared_ptr<BranchMapper>(new BranchMapper),
+                            DelayedReader* reader = 0);
 
     void clearEventPrincipal();
 
@@ -196,11 +200,11 @@ namespace edm {
 
     mutable std::vector<std::string> moduleLabelsRunning_;
 
-    boost::shared_ptr<EventSelectionIDVector> eventSelectionIDs_;
+    EventSelectionIDVector eventSelectionIDs_;
 
     boost::shared_ptr<BranchIDListHelper const> branchIDListHelper_;
 
-    boost::shared_ptr<BranchListIndexes> branchListIndexes_;
+    BranchListIndexes branchListIndexes_;
 
     std::map<BranchListIndex, ProcessIndex> branchListIndexToProcessIndex_;
     

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -64,7 +64,7 @@ namespace edm {
                             ProcessHistoryRegistry const& processHistoryRegistry,
                             EventSelectionIDVector&& eventSelectionIDs,
                             BranchListIndexes&& branchListIndexes,
-                            boost::shared_ptr<ProductProvenanceRetriever> mapper = boost::shared_ptr<ProductProvenanceRetriever>(new ProductProvenanceRetriever),
+                            boost::shared_ptr<ProductProvenanceRetriever> provRetriever = boost::shared_ptr<ProductProvenanceRetriever>(new ProductProvenanceRetriever),
                             DelayedReader* reader = 0);
 
     void clearEventPrincipal();
@@ -125,7 +125,7 @@ namespace edm {
 
     RunPrincipal const& runPrincipal() const;
 
-    boost::shared_ptr<ProductProvenanceRetriever> branchMapperPtr() const {return branchMapperPtr_;}
+    boost::shared_ptr<ProductProvenanceRetriever> productProvenanceRetrieverPtr() const {return provRetrieverPtr_;}
 
     void setUnscheduledHandler(boost::shared_ptr<UnscheduledHandler> iHandler);
     boost::shared_ptr<UnscheduledHandler> unscheduledHandler() const;
@@ -154,8 +154,8 @@ namespace edm {
 
     ProductID branchIDToProductID(BranchID const& bid) const;
 
-    void mergeMappers(EventPrincipal const& other) {
-      branchMapperPtr_->mergeMappers(other.branchMapperPtr());
+    void mergeProvenanceRetrievers(EventPrincipal const& other) {
+      provRetrieverPtr_->mergeProvenanceRetrievers(other.productProvenanceRetrieverPtr());
     }
 
     using Base::getProvenance;
@@ -193,7 +193,7 @@ namespace edm {
     boost::shared_ptr<LuminosityBlockPrincipal> luminosityBlockPrincipal_;
 
     // Pointer to the 'mapper' that will get provenance information from the persistent store.
-    boost::shared_ptr<ProductProvenanceRetriever> branchMapperPtr_;
+    boost::shared_ptr<ProductProvenanceRetriever> provRetrieverPtr_;
 
     // Handler for unscheduled modules
     boost::shared_ptr<UnscheduledHandler> unscheduledHandler_;

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -58,15 +58,20 @@ namespace edm {
 
     void fillEventPrincipal(EventAuxiliary const& aux,
         ProcessHistoryRegistry const& processHistoryRegistry,
-                            DelayedReader* reader = 0);
-
+                            DelayedReader* reader = nullptr);
+    void fillEventPrincipal(EventAuxiliary const& aux,
+                            ProcessHistoryRegistry const& processHistoryRegistry,
+                            EventSelectionIDVector&& eventSelectionIDs,
+                            BranchListIndexes&& branchListIndexes);
+    //provRetriever is changed via a call to ProductProvenanceRetriever::deepSwap
     void fillEventPrincipal(EventAuxiliary const& aux,
                             ProcessHistoryRegistry const& processHistoryRegistry,
                             EventSelectionIDVector&& eventSelectionIDs,
                             BranchListIndexes&& branchListIndexes,
-                            boost::shared_ptr<ProductProvenanceRetriever> provRetriever = boost::shared_ptr<ProductProvenanceRetriever>(new ProductProvenanceRetriever),
-                            DelayedReader* reader = 0);
+                            ProductProvenanceRetriever& provRetriever,
+                            DelayedReader* reader = nullptr);
 
+    
     void clearEventPrincipal();
 
     LuminosityBlockPrincipal const& luminosityBlockPrincipal() const {
@@ -192,7 +197,7 @@ namespace edm {
 
     boost::shared_ptr<LuminosityBlockPrincipal> luminosityBlockPrincipal_;
 
-    // Pointer to the 'mapper' that will get provenance information from the persistent store.
+    // Pointer to the 'retriever' that will get provenance information from the persistent store.
     boost::shared_ptr<ProductProvenanceRetriever> provRetrieverPtr_;
 
     // Handler for unscheduled modules

--- a/FWCore/Framework/interface/ProductHolder.h
+++ b/FWCore/Framework/interface/ProductHolder.h
@@ -22,7 +22,7 @@ a set of related EDProducts. This is the storage unit of such information.
 #include <string>
 
 namespace edm {
-  class BranchMapper;
+  class ProductProvenanceRetriever;
   class DelayedReader;
   class ModuleCallingContext;
   class Principal;
@@ -120,7 +120,7 @@ namespace edm {
     Provenance* provenance() const;
 
     // Initializes the event independent portion of the provenance, plus the process history ID, the product ID, and the mapper.
-    void setProvenance(boost::shared_ptr<BranchMapper> mapper, ProcessHistory const& ph, ProductID const& pid) { setProvenance_(mapper, ph, pid); }
+    void setProvenance(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid) { setProvenance_(mapper, ph, pid); }
 
     // Initializes the process history.
     void setProcessHistory(ProcessHistory const& ph) { setProcessHistory_(ph); }
@@ -193,7 +193,7 @@ namespace edm {
     virtual BranchDescription const& branchDescription_() const = 0;
     virtual void resetBranchDescription_(boost::shared_ptr<BranchDescription const> bd) = 0;
     virtual std::string const& resolvedModuleLabel_() const = 0;
-    virtual void setProvenance_(boost::shared_ptr<BranchMapper> mapper, ProcessHistory const& ph, ProductID const& pid) = 0;
+    virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid) = 0;
     virtual void setProcessHistory_(ProcessHistory const& ph) = 0;
     virtual ProductProvenance* productProvenancePtr_() const = 0;
     virtual void resetProductData_() = 0;
@@ -247,7 +247,7 @@ namespace edm {
       virtual BranchDescription const& branchDescription_() const {return *productData().branchDescription();}
       virtual void resetBranchDescription_(boost::shared_ptr<BranchDescription const> bd) {productData().resetBranchDescription(bd);}
       virtual std::string const& resolvedModuleLabel_() const {return moduleLabel();}
-      virtual void setProvenance_(boost::shared_ptr<BranchMapper> mapper, ProcessHistory const& ph, ProductID const& pid);
+      virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid);
       virtual void setProcessHistory_(ProcessHistory const& ph);
       virtual ProductProvenance* productProvenancePtr_() const;
       virtual void resetProductData_();
@@ -297,7 +297,7 @@ namespace edm {
       virtual BranchDescription const& branchDescription_() const {return *productData().branchDescription();}
       virtual void resetBranchDescription_(boost::shared_ptr<BranchDescription const> bd) {productData().resetBranchDescription(bd);}
       virtual std::string const& resolvedModuleLabel_() const {return moduleLabel();}
-      virtual void setProvenance_(boost::shared_ptr<BranchMapper> mapper, ProcessHistory const& ph, ProductID const& pid);
+      virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid);
       virtual void setProcessHistory_(ProcessHistory const& ph);
       virtual ProductProvenance* productProvenancePtr_() const;
       virtual void resetProductData_();
@@ -423,7 +423,7 @@ namespace edm {
       virtual BranchDescription const& branchDescription_() const {return *bd_;}
       virtual void resetBranchDescription_(boost::shared_ptr<BranchDescription const> bd) {bd_ = bd;}
       virtual std::string const& resolvedModuleLabel_() const {return realProduct_.moduleLabel();}
-      virtual void setProvenance_(boost::shared_ptr<BranchMapper> mapper, ProcessHistory const& ph, ProductID const& pid);
+      virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid);
       virtual void setProcessHistory_(ProcessHistory const& ph);
       virtual ProductProvenance* productProvenancePtr_() const;
       virtual void resetProductData_();
@@ -461,7 +461,7 @@ namespace edm {
       virtual BranchDescription const& branchDescription_() const;
       virtual void resetBranchDescription_(boost::shared_ptr<BranchDescription const> bd);
       virtual std::string const& resolvedModuleLabel_() const {return moduleLabel();}
-      virtual void setProvenance_(boost::shared_ptr<BranchMapper> mapper, ProcessHistory const& ph, ProductID const& pid);
+      virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid);
       virtual void setProcessHistory_(ProcessHistory const& ph);
       virtual ProductProvenance* productProvenancePtr_() const;
       virtual void resetProductData_();

--- a/FWCore/Framework/interface/ProductHolder.h
+++ b/FWCore/Framework/interface/ProductHolder.h
@@ -119,8 +119,8 @@ namespace edm {
     // Retrieves pointer to a class containing both the event independent and the per even provenance.
     Provenance* provenance() const;
 
-    // Initializes the event independent portion of the provenance, plus the process history ID, the product ID, and the mapper.
-    void setProvenance(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid) { setProvenance_(mapper, ph, pid); }
+    // Initializes the event independent portion of the provenance, plus the process history ID, the product ID, and the provRetriever.
+    void setProvenance(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) { setProvenance_(provRetriever, ph, pid); }
 
     // Initializes the process history.
     void setProcessHistory(ProcessHistory const& ph) { setProcessHistory_(ph); }
@@ -193,7 +193,7 @@ namespace edm {
     virtual BranchDescription const& branchDescription_() const = 0;
     virtual void resetBranchDescription_(boost::shared_ptr<BranchDescription const> bd) = 0;
     virtual std::string const& resolvedModuleLabel_() const = 0;
-    virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid) = 0;
+    virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) = 0;
     virtual void setProcessHistory_(ProcessHistory const& ph) = 0;
     virtual ProductProvenance* productProvenancePtr_() const = 0;
     virtual void resetProductData_() = 0;
@@ -247,7 +247,7 @@ namespace edm {
       virtual BranchDescription const& branchDescription_() const {return *productData().branchDescription();}
       virtual void resetBranchDescription_(boost::shared_ptr<BranchDescription const> bd) {productData().resetBranchDescription(bd);}
       virtual std::string const& resolvedModuleLabel_() const {return moduleLabel();}
-      virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid);
+      virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid);
       virtual void setProcessHistory_(ProcessHistory const& ph);
       virtual ProductProvenance* productProvenancePtr_() const;
       virtual void resetProductData_();
@@ -297,7 +297,7 @@ namespace edm {
       virtual BranchDescription const& branchDescription_() const {return *productData().branchDescription();}
       virtual void resetBranchDescription_(boost::shared_ptr<BranchDescription const> bd) {productData().resetBranchDescription(bd);}
       virtual std::string const& resolvedModuleLabel_() const {return moduleLabel();}
-      virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid);
+      virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid);
       virtual void setProcessHistory_(ProcessHistory const& ph);
       virtual ProductProvenance* productProvenancePtr_() const;
       virtual void resetProductData_();
@@ -423,7 +423,7 @@ namespace edm {
       virtual BranchDescription const& branchDescription_() const {return *bd_;}
       virtual void resetBranchDescription_(boost::shared_ptr<BranchDescription const> bd) {bd_ = bd;}
       virtual std::string const& resolvedModuleLabel_() const {return realProduct_.moduleLabel();}
-      virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid);
+      virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid);
       virtual void setProcessHistory_(ProcessHistory const& ph);
       virtual ProductProvenance* productProvenancePtr_() const;
       virtual void resetProductData_();
@@ -461,7 +461,7 @@ namespace edm {
       virtual BranchDescription const& branchDescription_() const;
       virtual void resetBranchDescription_(boost::shared_ptr<BranchDescription const> bd);
       virtual std::string const& resolvedModuleLabel_() const {return moduleLabel();}
-      virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid);
+      virtual void setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid);
       virtual void setProcessHistory_(ProcessHistory const& ph);
       virtual ProductProvenance* productProvenancePtr_() const;
       virtual void resetProductData_();

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -27,7 +27,7 @@ namespace edm {
     Base(reg, reg->productLookup(InEvent), pc, InEvent, historyAppender),
           aux_(),
           luminosityBlockPrincipal_(),
-          branchMapperPtr_(new BranchMapper),
+          branchMapperPtr_(new ProductProvenanceRetriever),
           unscheduledHandler_(),
           moduleLabelsRunning_(),
           eventSelectionIDs_(),
@@ -41,7 +41,7 @@ namespace edm {
     clearPrincipal();
     aux_ = EventAuxiliary();
     luminosityBlockPrincipal_.reset();
-    branchMapperPtr_.reset(new BranchMapper);
+    branchMapperPtr_.reset(new ProductProvenanceRetriever);
     unscheduledHandler_.reset();
     moduleLabelsRunning_.clear();
     branchListIndexToProcessIndex_.clear();
@@ -52,7 +52,7 @@ namespace edm {
         ProcessHistoryRegistry const& processHistoryRegistry,
         EventSelectionIDVector&& eventSelectionIDs,
         BranchListIndexes&& branchListIndexes,
-        boost::shared_ptr<BranchMapper> mapper,
+        boost::shared_ptr<ProductProvenanceRetriever> mapper,
         DelayedReader* reader) {
     eventSelectionIDs_ = eventSelectionIDs;
     branchMapperPtr_ = mapper;

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -27,7 +27,7 @@ namespace edm {
     Base(reg, reg->productLookup(InEvent), pc, InEvent, historyAppender),
           aux_(),
           luminosityBlockPrincipal_(),
-          provRetrieverPtr_(new ProductProvenanceRetriever),
+          provRetrieverPtr_(new ProductProvenanceRetriever(streamIndex)),
           unscheduledHandler_(),
           moduleLabelsRunning_(),
           eventSelectionIDs_(),
@@ -41,7 +41,7 @@ namespace edm {
     clearPrincipal();
     aux_ = EventAuxiliary();
     luminosityBlockPrincipal_.reset();
-    provRetrieverPtr_.reset(new ProductProvenanceRetriever);
+    provRetrieverPtr_->reset();
     unscheduledHandler_.reset();
     moduleLabelsRunning_.clear();
     branchListIndexToProcessIndex_.clear();
@@ -52,16 +52,30 @@ namespace edm {
         ProcessHistoryRegistry const& processHistoryRegistry,
         EventSelectionIDVector&& eventSelectionIDs,
         BranchListIndexes&& branchListIndexes,
-        boost::shared_ptr<ProductProvenanceRetriever> provRetriever,
+        ProductProvenanceRetriever& provRetriever,
         DelayedReader* reader) {
     eventSelectionIDs_ = eventSelectionIDs;
-    provRetrieverPtr_ = provRetriever;
+    provRetrieverPtr_->deepSwap(provRetriever);
     branchListIndexes_ = branchListIndexes;
     if(branchIDListHelper_->hasProducedProducts()) {
       // Add index into BranchIDListRegistry for products produced this process
       branchListIndexes_.push_back(branchIDListHelper_->producedBranchListIndex());
     }
     fillEventPrincipal(aux,processHistoryRegistry,reader);
+  }
+
+  void
+  EventPrincipal::fillEventPrincipal(EventAuxiliary const& aux,
+                                     ProcessHistoryRegistry const& processHistoryRegistry,
+                                     EventSelectionIDVector&& eventSelectionIDs,
+                                     BranchListIndexes&& branchListIndexes) {
+    eventSelectionIDs_ = eventSelectionIDs;
+    branchListIndexes_ = branchListIndexes;
+    if(branchIDListHelper_->hasProducedProducts()) {
+      // Add index into BranchIDListRegistry for products produced this process
+      branchListIndexes_.push_back(branchIDListHelper_->producedBranchListIndex());
+    }
+    fillEventPrincipal(aux,processHistoryRegistry,nullptr);
   }
 
   void

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -57,9 +57,9 @@ namespace edm {
     eventSelectionIDs_ = eventSelectionIDs;
     branchMapperPtr_ = mapper;
     branchListIndexes_ = branchListIndexes;
-    if(productRegistry().productProduced(InEvent)) {
+    if(branchIDListHelper_->hasProducedProducts()) {
       // Add index into BranchIDListRegistry for products produced this process
-      branchListIndexes_.push_back(productRegistry().producedBranchListIndex());
+      branchListIndexes_.push_back(branchIDListHelper_->producedBranchListIndex());
     }
     fillEventPrincipal(aux,processHistoryRegistry,reader);
   }
@@ -72,10 +72,10 @@ namespace edm {
     aux_ = aux;
     aux_.setProcessHistoryID(processHistoryID());
     
-    if(branchListIndexes_.empty() and productRegistry().productProduced(InEvent)) {
+    if(branchListIndexes_.empty() and branchIDListHelper_->hasProducedProducts()) {
       // Add index into BranchIDListRegistry for products produced this process
       //  if it hasn't already been filled in by the other fillEventPrincipal or by an earlier call to this function
-      branchListIndexes_.push_back(productRegistry().producedBranchListIndex());
+      branchListIndexes_.push_back(branchIDListHelper_->producedBranchListIndex());
     }
 
     // Fill in helper map for Branch to ProductID mapping

--- a/FWCore/Framework/src/ProductHolder.cc
+++ b/FWCore/Framework/src/ProductHolder.cc
@@ -239,7 +239,7 @@ namespace edm {
     productData().wrapper_ = prod.product();
   }
 
-  void InputProductHolder::setProvenance_(boost::shared_ptr<BranchMapper> mapper, ProcessHistory const& ph, ProductID const& pid) {
+  void InputProductHolder::setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid) {
     productData().prov_.setProductID(pid);
     productData().prov_.setStore(mapper);
     productData().prov_.setProcessHistory(ph);
@@ -313,7 +313,7 @@ namespace edm {
     status() = ProductDeleted;
   }
 
-  void ProducedProductHolder::setProvenance_(boost::shared_ptr<BranchMapper> mapper, ProcessHistory const& ph, ProductID const& pid) {
+  void ProducedProductHolder::setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid) {
     productData().prov_.setProductID(pid);
     productData().prov_.setStore(mapper);
     productData().prov_.setProcessHistory(ph);
@@ -428,7 +428,7 @@ namespace edm {
     return nullptr;
   }
 
-  void AliasProductHolder::setProvenance_(boost::shared_ptr<BranchMapper> mapper, ProcessHistory const& ph, ProductID const& pid) {
+  void AliasProductHolder::setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid) {
     productData().prov_.setProductID(pid);
     productData().prov_.setStore(mapper);
     productData().prov_.setProcessHistory(ph);
@@ -464,7 +464,7 @@ namespace edm {
   void NoProcessProductHolder::resetStatus_() {
   }
 
-  void NoProcessProductHolder::setProvenance_(boost::shared_ptr<BranchMapper> mapper, ProcessHistory const& ph, ProductID const& pid) {
+  void NoProcessProductHolder::setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid) {
   }
 
   void NoProcessProductHolder::setProcessHistory_(ProcessHistory const& ph) {

--- a/FWCore/Framework/src/ProductHolder.cc
+++ b/FWCore/Framework/src/ProductHolder.cc
@@ -239,9 +239,9 @@ namespace edm {
     productData().wrapper_ = prod.product();
   }
 
-  void InputProductHolder::setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid) {
+  void InputProductHolder::setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) {
     productData().prov_.setProductID(pid);
-    productData().prov_.setStore(mapper);
+    productData().prov_.setStore(provRetriever);
     productData().prov_.setProcessHistory(ph);
   }
 
@@ -313,9 +313,9 @@ namespace edm {
     status() = ProductDeleted;
   }
 
-  void ProducedProductHolder::setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid) {
+  void ProducedProductHolder::setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) {
     productData().prov_.setProductID(pid);
-    productData().prov_.setStore(mapper);
+    productData().prov_.setStore(provRetriever);
     productData().prov_.setProcessHistory(ph);
   }
 
@@ -428,9 +428,9 @@ namespace edm {
     return nullptr;
   }
 
-  void AliasProductHolder::setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid) {
+  void AliasProductHolder::setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) {
     productData().prov_.setProductID(pid);
-    productData().prov_.setStore(mapper);
+    productData().prov_.setStore(provRetriever);
     productData().prov_.setProcessHistory(ph);
   }
 
@@ -464,7 +464,7 @@ namespace edm {
   void NoProcessProductHolder::resetStatus_() {
   }
 
-  void NoProcessProductHolder::setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> mapper, ProcessHistory const& ph, ProductID const& pid) {
+  void NoProcessProductHolder::setProvenance_(boost::shared_ptr<ProductProvenanceRetriever> provRetriever, ProcessHistory const& ph, ProductID const& pid) {
   }
 
   void NoProcessProductHolder::setProcessHistory_(ProcessHistory const& ph) {

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -419,7 +419,7 @@ namespace edm {
     // already relied on the WorkerManager being full.
     assert (all_workers_count == allWorkers().size());
 
-    branchIDListHelper.updateRegistries(preg);
+    branchIDListHelper.updateFromRegistry(preg);
 
     preg.setFrozen();
 

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -309,7 +309,7 @@ namespace edm {
                           processHistoryRegistry,
                           std::move(esids),
                           std::move(bli),
-                          principal.branchMapperPtr(),
+                          principal.productProvenanceRetrieverPtr(),
                           principal.reader());
     ep.setLuminosityBlockPrincipal(principalCache_.lumiPrincipalPtr());
     propagateProducts(InEvent, principal, ep);

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -309,7 +309,7 @@ namespace edm {
                           processHistoryRegistry,
                           std::move(esids),
                           std::move(bli),
-                          principal.productProvenanceRetrieverPtr(),
+                          *(principal.productProvenanceRetrieverPtr()),//NOTE: this transfers the per product provenance
                           principal.reader());
     ep.setLuminosityBlockPrincipal(principalCache_.lumiPrincipalPtr());
     propagateProducts(InEvent, principal, ep);

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -296,19 +296,19 @@ namespace edm {
     EventAuxiliary aux(principal.aux());
     aux.setProcessHistoryID(principal.processHistoryID());
 
-    boost::shared_ptr<EventSelectionIDVector> esids(new EventSelectionIDVector);
-    *esids = principal.eventSelectionIDs();
+    EventSelectionIDVector esids{principal.eventSelectionIDs()};
     if (principal.productRegistry().anyProductProduced() || !wantAllEvents_) {
-      esids->push_back(selector_config_id_);
+      esids.push_back(selector_config_id_);
     }
 
     EventPrincipal& ep = principalCache_.eventPrincipal(principal.streamID().value());
     auto & processHistoryRegistry = processHistoryRegistries_[principal.streamID().value()];
     processHistoryRegistry.registerProcessHistory(principal.processHistory());
+    BranchListIndexes bli(principal.branchListIndexes());
     ep.fillEventPrincipal(aux,
                           processHistoryRegistry,
-                          esids,
-                          boost::shared_ptr<BranchListIndexes>(new BranchListIndexes(principal.branchListIndexes())),
+                          std::move(esids),
+                          std::move(bli),
                           principal.branchMapperPtr(),
                           principal.reader());
     ep.setLuminosityBlockPrincipal(principalCache_.lumiPrincipalPtr());

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -296,7 +296,7 @@ testEvent::testEvent() :
 
   // Freeze the product registry before we make the Event.
   availableProducts_->setFrozen();
-  branchIDListHelper_->updateRegistries(*availableProducts_);
+  branchIDListHelper_->updateFromRegistry(*availableProducts_);
 }
 
 testEvent::~testEvent() {

--- a/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
+++ b/FWCore/Framework/test/event_getrefbeforeput_t.cppunit.cc
@@ -67,7 +67,7 @@ void testEventGetRefBeforePut::failGetProductNotRegisteredTest() {
   std::auto_ptr<edm::ProductRegistry> preg(new edm::ProductRegistry);
   preg->setFrozen();
   boost::shared_ptr<edm::BranchIDListHelper> branchIDListHelper(new edm::BranchIDListHelper());
-  branchIDListHelper->updateRegistries(*preg);
+  branchIDListHelper->updateFromRegistry(*preg);
   edm::EventID col(1L, 1L, 1L);
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp fakeTime;
@@ -139,7 +139,7 @@ void testEventGetRefBeforePut::getRefTest() {
   preg->addProduct(product);
   preg->setFrozen();
   boost::shared_ptr<edm::BranchIDListHelper> branchIDListHelper(new edm::BranchIDListHelper());
-  branchIDListHelper->updateRegistries(*preg);
+  branchIDListHelper->updateFromRegistry(*preg);
   edm::EventID col(1L, 1L, 1L);
   std::string uuid = edm::createGlobalIdentifier();
   edm::Timestamp fakeTime;

--- a/FWCore/Framework/test/eventprincipal_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprincipal_t.cppunit.cc
@@ -157,7 +157,7 @@ void test_ep::setUp() {
   pProductRegistry_->addProduct(*fake_single_process_branch("rick", "USER2", "rick"));
   pProductRegistry_->setFrozen();
   boost::shared_ptr<edm::BranchIDListHelper> branchIDListHelper(new edm::BranchIDListHelper());
-  branchIDListHelper->updateRegistries(*pProductRegistry_);
+  branchIDListHelper->updateFromRegistry(*pProductRegistry_);
 
   // Put products we'll look for into the EventPrincipal.
   {

--- a/FWCore/Framework/test/generichandle_t.cppunit.cc
+++ b/FWCore/Framework/test/generichandle_t.cppunit.cc
@@ -91,7 +91,7 @@ void testGenericHandle::failgetbyLabelTest() {
   boost::shared_ptr<edm::LuminosityBlockPrincipal>lbp(new edm::LuminosityBlockPrincipal(lumiAux, preg, pc, &historyAppender_,0));
   lbp->setRunPrincipal(rp);
   boost::shared_ptr<edm::BranchIDListHelper> branchIDListHelper(new edm::BranchIDListHelper());
-  branchIDListHelper->updateRegistries(*preg);
+  branchIDListHelper->updateFromRegistry(*preg);
   edm::EventAuxiliary eventAux(id, uuid, time, true);
   edm::EventPrincipal ep(preg, branchIDListHelper, pc, &historyAppender_,edm::StreamID::invalidStreamID());
   edm::ProcessHistoryRegistry phr; 
@@ -166,7 +166,7 @@ void testGenericHandle::getbyLabelTest() {
   preg->addProduct(product);
   preg->setFrozen();
   boost::shared_ptr<edm::BranchIDListHelper> branchIDListHelper(new edm::BranchIDListHelper());
-  branchIDListHelper->updateRegistries(*preg);
+  branchIDListHelper->updateFromRegistry(*preg);
 
   edm::ProductRegistry::ProductList const& pl = preg->productList();
   edm::BranchKey const bk(product);

--- a/FWCore/Framework/test/global_module_t.cppunit.cc
+++ b/FWCore/Framework/test/global_module_t.cppunit.cc
@@ -345,7 +345,7 @@ m_ep()
 {
   //Setup the principals
   m_prodReg->setFrozen();
-  m_idHelper->updateRegistries(*m_prodReg);
+  m_idHelper->updateFromRegistry(*m_prodReg);
   edm::EventID eventID;
   
   std::string uuid = edm::createGlobalIdentifier();

--- a/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
+++ b/FWCore/Framework/test/one_outputmodule_t.cppunit.cc
@@ -214,7 +214,7 @@ m_ep()
 {
   //Setup the principals
   m_prodReg->setFrozen();
-  m_idHelper->updateRegistries(*m_prodReg);
+  m_idHelper->updateFromRegistry(*m_prodReg);
   edm::EventID eventID;
   
   std::string uuid = edm::createGlobalIdentifier();

--- a/FWCore/Framework/test/stream_module_t.cppunit.cc
+++ b/FWCore/Framework/test/stream_module_t.cppunit.cc
@@ -369,7 +369,7 @@ m_ep()
 {
   //Setup the principals
   m_prodReg->setFrozen();
-  m_idHelper->updateRegistries(*m_prodReg);
+  m_idHelper->updateFromRegistry(*m_prodReg);
   edm::EventID eventID;
   
   std::string uuid = edm::createGlobalIdentifier();

--- a/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
+++ b/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
@@ -106,7 +106,7 @@ namespace edm {
    void
    ProvenanceCheckerOutputModule::write(EventPrincipal const& e, ModuleCallingContext const* mcc) {
       //check ProductProvenance's parents to see if they are in the ProductProvenance list
-      boost::shared_ptr<ProductProvenanceRetriever> mapperPtr = e.branchMapperPtr();
+      boost::shared_ptr<ProductProvenanceRetriever> mapperPtr = e.productProvenanceRetrieverPtr();
 
       std::map<BranchID, bool> seenParentInPrincipal;
       std::set<BranchID> missingFromMapper;

--- a/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
+++ b/FWCore/Modules/src/ProvenanceCheckerOutputModule.cc
@@ -81,7 +81,7 @@ namespace edm {
 
    namespace {
      void markAncestors(ProductProvenance const& iInfo,
-                             BranchMapper const& iMapper,
+                             ProductProvenanceRetriever const& iMapper,
                              std::map<BranchID, bool>& oMap,
                              std::set<BranchID>& oMapperMissing) {
        for(std::vector<BranchID>::const_iterator it = iInfo.parentage().parents().begin(),
@@ -106,7 +106,7 @@ namespace edm {
    void
    ProvenanceCheckerOutputModule::write(EventPrincipal const& e, ModuleCallingContext const* mcc) {
       //check ProductProvenance's parents to see if they are in the ProductProvenance list
-      boost::shared_ptr<BranchMapper> mapperPtr = e.branchMapperPtr();
+      boost::shared_ptr<ProductProvenanceRetriever> mapperPtr = e.branchMapperPtr();
 
       std::map<BranchID, bool> seenParentInPrincipal;
       std::set<BranchID> missingFromMapper;
@@ -166,7 +166,7 @@ namespace edm {
       }
 
       if(missingFromMapper.size()) {
-         LogError("ProvenanceChecker") << "Missing the following BranchIDs from BranchMapper\n";
+         LogError("ProvenanceChecker") << "Missing the following BranchIDs from ProductProvenanceRetriever\n";
          for(std::set<BranchID>::iterator it = missingFromMapper.begin(), itEnd = missingFromMapper.end();
              it != itEnd;
              ++it) {
@@ -203,7 +203,7 @@ namespace edm {
       if(missingFromMapper.size() || missingFromPrincipal.size() || missingProductProvenance.size() || missingFromReg.size()) {
          throw cms::Exception("ProvenanceError")
          << (missingFromMapper.size() || missingFromPrincipal.size() ? "Having missing ancestors" : "")
-         << (missingFromMapper.size() ? " from BranchMapper" : "")
+         << (missingFromMapper.size() ? " from ProductProvenanceRetriever" : "")
          << (missingFromMapper.size() && missingFromPrincipal.size() ? " and" : "")
          << (missingFromPrincipal.size() ? " from EventPrincipal" : "")
          << (missingFromMapper.size() || missingFromPrincipal.size() ? ".\n" : "")

--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -20,7 +20,7 @@
 #include "DataFormats/Provenance/interface/BranchIDList.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/BranchListIndex.h"
-#include "DataFormats/Provenance/interface/BranchMapper.h"
+#include "DataFormats/Provenance/interface/ProductProvenanceRetriever.h"
 #include "DataFormats/Provenance/interface/BranchType.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 #include "DataFormats/Provenance/interface/EventEntryDescription.h" // kludge to allow compilation
@@ -122,7 +122,7 @@ namespace edm {
       reader_(new FWLiteDelayedReader),
       prov_(),
       pointerToBranchBuffer_(),
-      mapper_(new edm::BranchMapper) {
+      mapper_(new edm::ProductProvenanceRetriever) {
         reader_->set(reg_);
       }
       void setTree(TTree* iTree) {
@@ -139,7 +139,7 @@ namespace edm {
       std::vector<EventEntryDescription*> pointerToBranchBuffer_;
       FileFormatVersion fileFormatVersion_;
 
-      boost::shared_ptr<edm::BranchMapper> mapper_;
+      boost::shared_ptr<edm::ProductProvenanceRetriever> mapper_;
       edm::ProcessConfiguration pc_;
       boost::shared_ptr<edm::EventPrincipal> ep_;
       edm::ModuleDescription md_;

--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -122,7 +122,7 @@ namespace edm {
       reader_(new FWLiteDelayedReader),
       prov_(),
       pointerToBranchBuffer_(),
-      provRetriever_(new edm::ProductProvenanceRetriever) {
+      provRetriever_(new edm::ProductProvenanceRetriever(0)) {
         reader_->set(reg_);
       }
       void setTree(TTree* iTree) {
@@ -295,7 +295,7 @@ TFWLiteSelectorBasic::Process(Long64_t iEntry) {
                                     *m_->phreg_,
                                     std::move(eventSelectionIDs),
                                     std::move(branchListIndexes),
-                                    m_->provRetriever_,
+                                    *(m_->provRetriever_),
                                     m_->reader_.get());
          lbp->setRunPrincipal(rp);
          m_->ep_->setLuminosityBlockPrincipal(lbp);

--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -122,7 +122,7 @@ namespace edm {
       reader_(new FWLiteDelayedReader),
       prov_(),
       pointerToBranchBuffer_(),
-      mapper_(new edm::ProductProvenanceRetriever) {
+      provRetriever_(new edm::ProductProvenanceRetriever) {
         reader_->set(reg_);
       }
       void setTree(TTree* iTree) {
@@ -139,7 +139,7 @@ namespace edm {
       std::vector<EventEntryDescription*> pointerToBranchBuffer_;
       FileFormatVersion fileFormatVersion_;
 
-      boost::shared_ptr<edm::ProductProvenanceRetriever> mapper_;
+      boost::shared_ptr<edm::ProductProvenanceRetriever> provRetriever_;
       edm::ProcessConfiguration pc_;
       boost::shared_ptr<edm::EventPrincipal> ep_;
       edm::ModuleDescription md_;
@@ -295,7 +295,7 @@ TFWLiteSelectorBasic::Process(Long64_t iEntry) {
                                     *m_->phreg_,
                                     std::move(eventSelectionIDs),
                                     std::move(branchListIndexes),
-                                    m_->mapper_,
+                                    m_->provRetriever_,
                                     m_->reader_.get());
          lbp->setRunPrincipal(rp);
          m_->ep_->setLuminosityBlockPrincipal(lbp);

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -204,7 +204,7 @@ namespace edm {
         checkConsistency(eventPrincipal, secondaryEventPrincipal);
         checkHistoryConsistency(eventPrincipal, secondaryEventPrincipal);
         eventPrincipal.recombine(secondaryEventPrincipal, branchIDsToReplace_[InEvent]);
-        eventPrincipal.mergeMappers(secondaryEventPrincipal);
+        eventPrincipal.mergeProvenanceRetrievers(secondaryEventPrincipal);
         secondaryEventPrincipal.clearPrincipal();
       } else {
         throw Exception(errors::MismatchedInputFiles, "PoolSource::readEvent_") <<

--- a/IOPool/Input/src/RootDelayedReader.h
+++ b/IOPool/Input/src/RootDelayedReader.h
@@ -47,7 +47,6 @@ namespace edm {
     virtual void mergeReaders_(DelayedReader* other) {nextReader_ = other;}
     virtual void reset_() {nextReader_ = 0;}
     BranchMap const& branches() const {return tree_.branches();}
-    EntryNumber const& entryNumber() const {return tree_.entryNumber();}
     iterator branchIter(BranchKey const& k) const {return branches().find(k);}
     bool found(iterator const& iter) const {return iter != branches().end();}
     BranchInfo const& getBranchInfo(iterator const& iter) const {return iter->second; }

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -401,7 +401,13 @@ namespace edm {
     }
 
     eventTree_.trainCache(BranchTypeToAuxiliaryBranchName(InEvent).c_str());
-
+        
+    // Update the branch id info. This has to be done before validateFile since
+    // depending on the file format, the branchIDListHelper_ may have its fixBranchListIndexes call made
+    if(inputType == InputType::Primary || inputType == InputType::SecondarySource) {
+      branchListIndexesUnchanged_ = branchIDListHelper_->updateFromInput(*branchIDLists_);
+    }
+        
     validateFile(inputType, usingGoToEvent);
 
     // Here, we make the class that will make the ProvenanceReader
@@ -465,11 +471,6 @@ namespace edm {
 
     // Determine if this file is fast clonable.
     setIfFastClonable(remainingEvents, remainingLumis);
-
-    // Update the branch id info.
-    if(inputType == InputType::Primary || inputType == InputType::SecondarySource) {
-      branchListIndexesUnchanged_ = branchIDListHelper_->updateFromInput(*branchIDLists_);
-    }
 
     setRefCoreStreamer(true);  // backward compatibility
 

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -201,7 +201,7 @@ namespace edm {
       duplicateChecker_(duplicateChecker),
       provenanceAdaptor_(),
       provenanceReaderMaker_(),
-      eventBranchMapper_(),
+      eventProductProvenanceRetriever_(),
       parentageIDLookup_(),
       daqProvenanceHelper_() {
 
@@ -1390,7 +1390,7 @@ namespace edm {
                                  *processHistoryRegistry_,
                                  std::move(eventSelectionIDs_),
                                  std::move(branchListIndexes_),
-                                 makeBranchMapper(),
+                                 makeProductProvenanceRetriever(),
                                  eventTree_.rootDelayedReader());
 
     // report event read from file
@@ -1731,12 +1731,12 @@ namespace edm {
   }
 
   boost::shared_ptr<ProductProvenanceRetriever>
-  RootFile::makeBranchMapper() {
-    if(!eventBranchMapper_) {
-      eventBranchMapper_.reset(new ProductProvenanceRetriever(provenanceReaderMaker_->makeReader(eventTree_, daqProvenanceHelper_.get())));
+  RootFile::makeProductProvenanceRetriever() {
+    if(!eventProductProvenanceRetriever_) {
+      eventProductProvenanceRetriever_.reset(new ProductProvenanceRetriever(provenanceReaderMaker_->makeReader(eventTree_, daqProvenanceHelper_.get())));
     }
-    eventBranchMapper_->reset();
-    return eventBranchMapper_;
+    eventProductProvenanceRetriever_->reset();
+    return eventProductProvenanceRetriever_;
   }
 
   class ReducedProvenanceReader : public ProvenanceReaderBase {

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -1730,10 +1730,10 @@ namespace edm {
     }
   }
 
-  boost::shared_ptr<BranchMapper>
+  boost::shared_ptr<ProductProvenanceRetriever>
   RootFile::makeBranchMapper() {
     if(!eventBranchMapper_) {
-      eventBranchMapper_.reset(new BranchMapper(provenanceReaderMaker_->makeReader(eventTree_, daqProvenanceHelper_.get())));
+      eventBranchMapper_.reset(new ProductProvenanceRetriever(provenanceReaderMaker_->makeReader(eventTree_, daqProvenanceHelper_.get())));
     }
     eventBranchMapper_->reset();
     return eventBranchMapper_;
@@ -1743,7 +1743,7 @@ namespace edm {
   public:
     ReducedProvenanceReader(RootTree* iRootTree, std::vector<ParentageID> const& iParentageIDLookup, DaqProvenanceHelper const* daqProvenanceHelper);
   private:
-    virtual void readProvenance(BranchMapper const& mapper) const override;
+    virtual void readProvenance(ProductProvenanceRetriever const& mapper) const override;
     RootTree* rootTree_;
     TBranch* provBranch_;
     StoredProductProvenanceVector provVector_;
@@ -1765,7 +1765,7 @@ namespace edm {
   }
 
   void
-  ReducedProvenanceReader::readProvenance(BranchMapper const& mapper) const {
+  ReducedProvenanceReader::readProvenance(ProductProvenanceRetriever const& mapper) const {
     ReducedProvenanceReader* me = const_cast<ReducedProvenanceReader*>(this);
     me->rootTree_->fillBranchEntry(me->provBranch_, me->pProvVector_);
     setRefCoreStreamer(true);
@@ -1794,7 +1794,7 @@ namespace edm {
     explicit FullProvenanceReader(RootTree* rootTree, DaqProvenanceHelper const* daqProvenanceHelper);
     virtual ~FullProvenanceReader() {}
   private:
-    virtual void readProvenance(BranchMapper const& mapper) const override;
+    virtual void readProvenance(ProductProvenanceRetriever const& mapper) const override;
     RootTree* rootTree_;
     ProductProvenanceVector infoVector_;
     mutable ProductProvenanceVector* pInfoVector_;
@@ -1810,7 +1810,7 @@ namespace edm {
   }
 
   void
-  FullProvenanceReader::readProvenance(BranchMapper const& mapper) const {
+  FullProvenanceReader::readProvenance(ProductProvenanceRetriever const& mapper) const {
     rootTree_->fillBranchEntryMeta(rootTree_->branchEntryInfoBranch(), pInfoVector_);
     setRefCoreStreamer(true);
     if(daqProvenanceHelper_) {
@@ -1830,7 +1830,7 @@ namespace edm {
     explicit OldProvenanceReader(RootTree* rootTree, EntryDescriptionMap const& theMap, DaqProvenanceHelper const* daqProvenanceHelper);
     virtual ~OldProvenanceReader() {}
   private:
-    virtual void readProvenance(BranchMapper const& mapper) const override;
+    virtual void readProvenance(ProductProvenanceRetriever const& mapper) const override;
     RootTree* rootTree_;
     std::vector<EventEntryInfo> infoVector_;
     mutable std::vector<EventEntryInfo> *pInfoVector_;
@@ -1848,7 +1848,7 @@ namespace edm {
   }
 
   void
-  OldProvenanceReader::readProvenance(BranchMapper const& mapper) const {
+  OldProvenanceReader::readProvenance(ProductProvenanceRetriever const& mapper) const {
     rootTree_->branchEntryInfoBranch()->SetAddress(&pInfoVector_);
     roottree::getEntry(rootTree_->branchEntryInfoBranch(), rootTree_->entryNumber());
     setRefCoreStreamer(true);
@@ -1873,7 +1873,7 @@ namespace edm {
     DummyProvenanceReader();
     virtual ~DummyProvenanceReader() {}
   private:
-    virtual void readProvenance(BranchMapper const& mapper) const override;
+    virtual void readProvenance(ProductProvenanceRetriever const& mapper) const override;
   };
 
   DummyProvenanceReader::DummyProvenanceReader() :
@@ -1881,7 +1881,7 @@ namespace edm {
   }
 
   void
-  DummyProvenanceReader::readProvenance(BranchMapper const&) const {
+  DummyProvenanceReader::readProvenance(ProductProvenanceRetriever const&) const {
     // Not providing parentage!!!
   }
 

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -467,7 +467,7 @@ namespace edm {
     setIfFastClonable(remainingEvents, remainingLumis);
 
     // Update the branch id info.
-    if(inputType == InputType::Primary) {
+    if(inputType == InputType::Primary || inputType == InputType::SecondarySource) {
       branchListIndexesUnchanged_ = branchIDListHelper_->updateFromInput(*branchIDLists_);
     }
 

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -1743,7 +1743,7 @@ namespace edm {
   public:
     ReducedProvenanceReader(RootTree* iRootTree, std::vector<ParentageID> const& iParentageIDLookup, DaqProvenanceHelper const* daqProvenanceHelper);
   private:
-    virtual void readProvenance(ProductProvenanceRetriever const& mapper) const override;
+    virtual void readProvenance(ProductProvenanceRetriever const& provRetriever) const override;
     RootTree* rootTree_;
     TBranch* provBranch_;
     StoredProductProvenanceVector provVector_;
@@ -1765,15 +1765,15 @@ namespace edm {
   }
 
   void
-  ReducedProvenanceReader::readProvenance(ProductProvenanceRetriever const& mapper) const {
+  ReducedProvenanceReader::readProvenance(ProductProvenanceRetriever const& provRetriever) const {
     ReducedProvenanceReader* me = const_cast<ReducedProvenanceReader*>(this);
     me->rootTree_->fillBranchEntry(me->provBranch_, me->pProvVector_);
     setRefCoreStreamer(true);
     if(daqProvenanceHelper_) {
       for(auto const& prov : provVector_) {
         BranchID bid(prov.branchID_);
-        mapper.insertIntoSet(ProductProvenance(daqProvenanceHelper_->mapBranchID(BranchID(prov.branchID_)),
-                                               daqProvenanceHelper_->mapParentageID(parentageIDLookup_[prov.parentageIDIndex_])));
+        provRetriever.insertIntoSet(ProductProvenance(daqProvenanceHelper_->mapBranchID(BranchID(prov.branchID_)),
+                                                      daqProvenanceHelper_->mapParentageID(parentageIDLookup_[prov.parentageIDIndex_])));
       }
     } else {
       for(auto const& prov : provVector_) {
@@ -1784,7 +1784,7 @@ namespace edm {
             << "This should never happen.\n"
             << "Please report this to the framework hypernews forum 'hn-cms-edmFramework@cern.ch'.\n";
         }
-        mapper.insertIntoSet(ProductProvenance(BranchID(prov.branchID_), parentageIDLookup_[prov.parentageIDIndex_]));
+        provRetriever.insertIntoSet(ProductProvenance(BranchID(prov.branchID_), parentageIDLookup_[prov.parentageIDIndex_]));
       }
     }
   }
@@ -1794,7 +1794,7 @@ namespace edm {
     explicit FullProvenanceReader(RootTree* rootTree, DaqProvenanceHelper const* daqProvenanceHelper);
     virtual ~FullProvenanceReader() {}
   private:
-    virtual void readProvenance(ProductProvenanceRetriever const& mapper) const override;
+    virtual void readProvenance(ProductProvenanceRetriever const& provRetriever) const override;
     RootTree* rootTree_;
     ProductProvenanceVector infoVector_;
     mutable ProductProvenanceVector* pInfoVector_;
@@ -1810,17 +1810,17 @@ namespace edm {
   }
 
   void
-  FullProvenanceReader::readProvenance(ProductProvenanceRetriever const& mapper) const {
+  FullProvenanceReader::readProvenance(ProductProvenanceRetriever const& provRetriever) const {
     rootTree_->fillBranchEntryMeta(rootTree_->branchEntryInfoBranch(), pInfoVector_);
     setRefCoreStreamer(true);
     if(daqProvenanceHelper_) {
       for(auto const& info : infoVector_) {
-        mapper.insertIntoSet(ProductProvenance(daqProvenanceHelper_->mapBranchID(info.branchID()),
+        provRetriever.insertIntoSet(ProductProvenance(daqProvenanceHelper_->mapBranchID(info.branchID()),
                                                daqProvenanceHelper_->mapParentageID(info.parentageID())));
       }
     } else {
       for(auto const& info : infoVector_) {
-        mapper.insertIntoSet(info);
+        provRetriever.insertIntoSet(info);
       }
     }
   }
@@ -1830,7 +1830,7 @@ namespace edm {
     explicit OldProvenanceReader(RootTree* rootTree, EntryDescriptionMap const& theMap, DaqProvenanceHelper const* daqProvenanceHelper);
     virtual ~OldProvenanceReader() {}
   private:
-    virtual void readProvenance(ProductProvenanceRetriever const& mapper) const override;
+    virtual void readProvenance(ProductProvenanceRetriever const& provRetriever) const override;
     RootTree* rootTree_;
     std::vector<EventEntryInfo> infoVector_;
     mutable std::vector<EventEntryInfo> *pInfoVector_;
@@ -1848,7 +1848,7 @@ namespace edm {
   }
 
   void
-  OldProvenanceReader::readProvenance(ProductProvenanceRetriever const& mapper) const {
+  OldProvenanceReader::readProvenance(ProductProvenanceRetriever const& provRetriever) const {
     rootTree_->branchEntryInfoBranch()->SetAddress(&pInfoVector_);
     roottree::getEntry(rootTree_->branchEntryInfoBranch(), rootTree_->entryNumber());
     setRefCoreStreamer(true);
@@ -1859,10 +1859,10 @@ namespace edm {
       if(daqProvenanceHelper_) {
         ProductProvenance entry(daqProvenanceHelper_->mapBranchID(info.branchID()),
                                 daqProvenanceHelper_->mapParentageID(parentage.id()));
-        mapper.insertIntoSet(entry);
+        provRetriever.insertIntoSet(entry);
       } else {
         ProductProvenance entry(info.branchID(), parentage.id());
-        mapper.insertIntoSet(entry);
+        provRetriever.insertIntoSet(entry);
       }
     
     }
@@ -1873,7 +1873,7 @@ namespace edm {
     DummyProvenanceReader();
     virtual ~DummyProvenanceReader() {}
   private:
-    virtual void readProvenance(ProductProvenanceRetriever const& mapper) const override;
+    virtual void readProvenance(ProductProvenanceRetriever const& provRetriever) const override;
   };
 
   DummyProvenanceReader::DummyProvenanceReader() :

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -1390,7 +1390,7 @@ namespace edm {
                                  *processHistoryRegistry_,
                                  std::move(eventSelectionIDs_),
                                  std::move(branchListIndexes_),
-                                 makeProductProvenanceRetriever(),
+                                 *(makeProductProvenanceRetriever()),
                                  eventTree_.rootDelayedReader());
 
     // report event read from file
@@ -1743,7 +1743,7 @@ namespace edm {
   public:
     ReducedProvenanceReader(RootTree* iRootTree, std::vector<ParentageID> const& iParentageIDLookup, DaqProvenanceHelper const* daqProvenanceHelper);
   private:
-    virtual void readProvenance(ProductProvenanceRetriever const& provRetriever) const override;
+    virtual void readProvenance(ProductProvenanceRetriever const& provRetriever, unsigned int) const override;
     RootTree* rootTree_;
     TBranch* provBranch_;
     StoredProductProvenanceVector provVector_;
@@ -1765,9 +1765,9 @@ namespace edm {
   }
 
   void
-  ReducedProvenanceReader::readProvenance(ProductProvenanceRetriever const& provRetriever) const {
+  ReducedProvenanceReader::readProvenance(ProductProvenanceRetriever const& provRetriever, unsigned int transitionIndex) const {
     ReducedProvenanceReader* me = const_cast<ReducedProvenanceReader*>(this);
-    me->rootTree_->fillBranchEntry(me->provBranch_, me->pProvVector_);
+    me->rootTree_->fillBranchEntry(me->provBranch_, me->rootTree_->entryNumberForIndex(transitionIndex), me->pProvVector_);
     setRefCoreStreamer(true);
     if(daqProvenanceHelper_) {
       for(auto const& prov : provVector_) {
@@ -1794,7 +1794,7 @@ namespace edm {
     explicit FullProvenanceReader(RootTree* rootTree, DaqProvenanceHelper const* daqProvenanceHelper);
     virtual ~FullProvenanceReader() {}
   private:
-    virtual void readProvenance(ProductProvenanceRetriever const& provRetriever) const override;
+    virtual void readProvenance(ProductProvenanceRetriever const& provRetriever, unsigned int transitionIndex) const override;
     RootTree* rootTree_;
     ProductProvenanceVector infoVector_;
     mutable ProductProvenanceVector* pInfoVector_;
@@ -1810,8 +1810,8 @@ namespace edm {
   }
 
   void
-  FullProvenanceReader::readProvenance(ProductProvenanceRetriever const& provRetriever) const {
-    rootTree_->fillBranchEntryMeta(rootTree_->branchEntryInfoBranch(), pInfoVector_);
+  FullProvenanceReader::readProvenance(ProductProvenanceRetriever const& provRetriever, unsigned int transitionIndex) const {
+    rootTree_->fillBranchEntryMeta(rootTree_->branchEntryInfoBranch(), rootTree_->entryNumberForIndex(transitionIndex), pInfoVector_);
     setRefCoreStreamer(true);
     if(daqProvenanceHelper_) {
       for(auto const& info : infoVector_) {
@@ -1830,7 +1830,7 @@ namespace edm {
     explicit OldProvenanceReader(RootTree* rootTree, EntryDescriptionMap const& theMap, DaqProvenanceHelper const* daqProvenanceHelper);
     virtual ~OldProvenanceReader() {}
   private:
-    virtual void readProvenance(ProductProvenanceRetriever const& provRetriever) const override;
+    virtual void readProvenance(ProductProvenanceRetriever const& provRetriever, unsigned int transitionIndex) const override;
     RootTree* rootTree_;
     std::vector<EventEntryInfo> infoVector_;
     mutable std::vector<EventEntryInfo> *pInfoVector_;
@@ -1848,9 +1848,9 @@ namespace edm {
   }
 
   void
-  OldProvenanceReader::readProvenance(ProductProvenanceRetriever const& provRetriever) const {
+  OldProvenanceReader::readProvenance(ProductProvenanceRetriever const& provRetriever, unsigned int transitionIndex) const {
     rootTree_->branchEntryInfoBranch()->SetAddress(&pInfoVector_);
-    roottree::getEntry(rootTree_->branchEntryInfoBranch(), rootTree_->entryNumber());
+    roottree::getEntry(rootTree_->branchEntryInfoBranch(), rootTree_->entryNumberForIndex(transitionIndex));
     setRefCoreStreamer(true);
     for(auto const& info : infoVector_) {
       EntryDescriptionMap::const_iterator iter = entryDescriptionMap_.find(info.entryDescriptionID());
@@ -1873,7 +1873,7 @@ namespace edm {
     DummyProvenanceReader();
     virtual ~DummyProvenanceReader() {}
   private:
-    virtual void readProvenance(ProductProvenanceRetriever const& provRetriever) const override;
+    virtual void readProvenance(ProductProvenanceRetriever const& provRetriever,unsigned int) const override;
   };
 
   DummyProvenanceReader::DummyProvenanceReader() :
@@ -1881,7 +1881,7 @@ namespace edm {
   }
 
   void
-  DummyProvenanceReader::readProvenance(ProductProvenanceRetriever const&) const {
+  DummyProvenanceReader::readProvenance(ProductProvenanceRetriever const&, unsigned int) const {
     // Not providing parentage!!!
   }
 

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -36,7 +36,7 @@ namespace edm {
   // Class RootFile: supports file reading.
 
   class BranchIDListHelper;
-  class BranchMapper;
+  class ProductProvenanceRetriever;
   class DaqProvenanceHelper;
   class DuplicateChecker;
   class EventSkipperByID;
@@ -170,7 +170,7 @@ namespace edm {
                                     std::vector<boost::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile);
 
     std::unique_ptr<MakeProvenanceReader> makeProvenanceReaderMaker();
-    boost::shared_ptr<BranchMapper> makeBranchMapper();
+    boost::shared_ptr<ProductProvenanceRetriever> makeBranchMapper();
 
     std::string const file_;
     std::string const logicalFile_;
@@ -214,7 +214,7 @@ namespace edm {
     boost::shared_ptr<DuplicateChecker> duplicateChecker_;
     std::unique_ptr<ProvenanceAdaptor> provenanceAdaptor_; // backward comatibility
     std::unique_ptr<MakeProvenanceReader> provenanceReaderMaker_;
-    mutable boost::shared_ptr<BranchMapper> eventBranchMapper_;
+    mutable boost::shared_ptr<ProductProvenanceRetriever> eventBranchMapper_;
     std::vector<ParentageID> parentageIDLookup_;
     std::unique_ptr<DaqProvenanceHelper> daqProvenanceHelper_;
   }; // class RootFile

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -170,7 +170,7 @@ namespace edm {
                                     std::vector<boost::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile);
 
     std::unique_ptr<MakeProvenanceReader> makeProvenanceReaderMaker();
-    boost::shared_ptr<ProductProvenanceRetriever> makeBranchMapper();
+    boost::shared_ptr<ProductProvenanceRetriever> makeProductProvenanceRetriever();
 
     std::string const file_;
     std::string const logicalFile_;
@@ -214,7 +214,7 @@ namespace edm {
     boost::shared_ptr<DuplicateChecker> duplicateChecker_;
     std::unique_ptr<ProvenanceAdaptor> provenanceAdaptor_; // backward comatibility
     std::unique_ptr<MakeProvenanceReader> provenanceReaderMaker_;
-    mutable boost::shared_ptr<ProductProvenanceRetriever> eventBranchMapper_;
+    mutable boost::shared_ptr<ProductProvenanceRetriever> eventProductProvenanceRetriever_;
     std::vector<ParentageID> parentageIDLookup_;
     std::unique_ptr<DaqProvenanceHelper> daqProvenanceHelper_;
   }; // class RootFile

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -207,8 +207,8 @@ namespace edm {
     int forcedRunOffset_;
     std::map<std::string, std::string> newBranchToOldBranch_;
     TTree* eventHistoryTree_;			// backward compatibility
-    boost::shared_ptr<EventSelectionIDVector> eventSelectionIDs_;
-    boost::shared_ptr<BranchListIndexes> branchListIndexes_;
+    EventSelectionIDVector eventSelectionIDs_;
+    BranchListIndexes branchListIndexes_;
     std::unique_ptr<History> history_; // backward compatibility
     boost::shared_ptr<BranchChildren> branchChildren_;
     boost::shared_ptr<DuplicateChecker> duplicateChecker_;

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -115,6 +115,23 @@ namespace edm {
       getEntry(branch, entryNumber_);
     }
 
+    template <typename T>
+    void fillBranchEntryMeta(TBranch* branch, EntryNumber entryNumber, T*& pbuf) {
+      if (metaTree_ != 0) {
+        // Metadata was in separate tree.  Not cached.
+        branch->SetAddress(&pbuf);
+        roottree::getEntry(branch, entryNumber);
+      } else {
+        fillBranchEntry<T>(branch, entryNumber, pbuf);
+      }
+    }
+    
+    template <typename T>
+    void fillBranchEntry(TBranch* branch, EntryNumber entryNumber, T*& pbuf) {
+      branch->SetAddress(&pbuf);
+      getEntry(branch, entryNumber);
+    }
+    
     TTree const* tree() const {return tree_;}
     TTree* tree() {return tree_;}
     TTree const* metaTree() const {return metaTree_;}

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -649,7 +649,7 @@ namespace edm {
     assert(om_->dropMetaData() != PoolOutputModule::DropAll);
     assert(produced || om_->dropMetaData() != PoolOutputModule::DropPrior);
     if(om_->dropMetaData() == PoolOutputModule::DropDroppedPrior && !produced) return;
-    ProductProvenanceRetriever const& iMapper = *principal.branchMapperPtr();
+    ProductProvenanceRetriever const& iMapper = *principal.productProvenanceRetrieverPtr();
     std::vector<BranchID> const& parentIDs = iGetParents.parentage().parents();
     for(auto const& parentID : parentIDs) {
       branchesWithStoredHistory_.insert(parentID);
@@ -701,7 +701,7 @@ namespace edm {
         insertProductProvenance(*oh.productProvenance(),provenanceToKeep);
         //provenanceToKeep.insert(*oh.productProvenance());
         EventPrincipal const& eventPrincipal = dynamic_cast<EventPrincipal const&>(principal);
-        assert(eventPrincipal.branchMapperPtr());
+        assert(eventPrincipal.productProvenanceRetrieverPtr());
         insertAncestors(*oh.productProvenance(), eventPrincipal, produced, provenanceToKeep, mcc);
       }
       product = oh.wrapper();

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -649,7 +649,7 @@ namespace edm {
     assert(om_->dropMetaData() != PoolOutputModule::DropAll);
     assert(produced || om_->dropMetaData() != PoolOutputModule::DropPrior);
     if(om_->dropMetaData() == PoolOutputModule::DropDroppedPrior && !produced) return;
-    BranchMapper const& iMapper = *principal.branchMapperPtr();
+    ProductProvenanceRetriever const& iMapper = *principal.branchMapperPtr();
     std::vector<BranchID> const& parentIDs = iGetParents.parentage().parents();
     for(auto const& parentID : parentIDs) {
       branchesWithStoredHistory_.insert(parentID);

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -267,10 +267,10 @@ namespace edm {
       assert(eventOK);
       adjustEventToNewProductRegistry_ = false;
     }
-    boost::shared_ptr<EventSelectionIDVector> ids(new EventSelectionIDVector(sendEvent_->eventSelectionIDs()));
-    boost::shared_ptr<BranchListIndexes> indexes(new BranchListIndexes(sendEvent_->branchListIndexes()));
-    branchIDListHelper()->fixBranchListIndexes(*indexes);
-    eventPrincipal.fillEventPrincipal(sendEvent_->aux(), processHistoryRegistry(), ids, indexes);
+    EventSelectionIDVector ids(sendEvent_->eventSelectionIDs());
+    BranchListIndexes indexes(sendEvent_->branchListIndexes());
+    branchIDListHelper()->fixBranchListIndexes(indexes);
+    eventPrincipal.fillEventPrincipal(sendEvent_->aux(), processHistoryRegistry(), std::move(ids), std::move(indexes));
     eventPrincipalHolder_.setEventPrincipal(&eventPrincipal);
 
     // no process name list handling


### PR DESCRIPTION
Several structures were shared between the Source and the EventPrincipal (and even with Schedule). These structures could be updated on a per event basis and therefore can not be shared in the threaded framework. This change removes all the known mutable sharing and has each EventPrincipal hold onto its own copy of the data.
