### PR TITLE
update static local check for clang 3.3

### DIFF
--- a/Utilities/StaticAnalyzers/src/StaticLocalChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/StaticLocalChecker.cpp
@@ -18,7 +18,7 @@ void StaticLocalChecker::checkASTDecl(const clang::VarDecl *D,
 {
 	clang::QualType t =  D->getType();
 
-	if ( D->isStaticLocal() && ! support::isConst( t ) )
+	if ( (D->isStaticLocal() && D->getTSCSpec() != clang::ThreadStorageClassSpecifier::TSCS_thread_local) && ! support::isConst( t ) )
 	{
 	    clang::ento::PathDiagnosticLocation DLoc = clang::ento::PathDiagnosticLocation::createBegin(D, BR.getSourceManager());
 

--- a/Utilities/StaticAnalyzers/src/StaticLocalChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/StaticLocalChecker.cpp
@@ -18,7 +18,7 @@ void StaticLocalChecker::checkASTDecl(const clang::VarDecl *D,
 {
 	clang::QualType t =  D->getType();
 
-	if ( (D->isStaticLocal() && D->getTSCSpec() != clang::ThreadStorageClassSpecifier::TSCS_thread_local) && ! support::isConst( t ) )
+	if ( ( (D->isStaticLocal() || D->isStaticDataMember() )  && D->getTSCSpec() != clang::ThreadStorageClassSpecifier::TSCS_thread_local) && ! support::isConst( t ) )
 	{
 	    clang::ento::PathDiagnosticLocation DLoc = clang::ento::PathDiagnosticLocation::createBegin(D, BR.getSourceManager());
 


### PR DESCRIPTION
clang 3.3 extends VarDecl::isStaticLocal() to include C++11 thread_local (Implies 'static' at block scope, but not at class scope.) 

Added check to make sure that these C++11 thread local storage variables are not flagged by the StaticLocal checker.
