### PR TITLE
Multithreaded FloatingPointExceptions Service

### DIFF
--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -38,32 +38,32 @@ private:
     public:
       ModuleBeginStreamSignalSentry(ActivityRegistry* a,
                                     StreamContext const& sc,
-                                    ModuleDescription const& md) : a_(a), sc_(sc), md_(md) {
-        if(a_) a_->preModuleBeginStreamSignal_(sc_, md_);
+                                    ModuleCallingContext const& mcc) : a_(a), sc_(sc), mcc_(mcc) {
+        if(a_) a_->preModuleBeginStreamSignal_(sc_, mcc_);
       }
       ~ModuleBeginStreamSignalSentry() {
-        if(a_) a_->postModuleBeginStreamSignal_(sc_, md_);
+        if(a_) a_->postModuleBeginStreamSignal_(sc_, mcc_);
       }
     private:
       ActivityRegistry* a_;
       StreamContext const& sc_;
-      ModuleDescription const& md_;
+      ModuleCallingContext const& mcc_;
     };
 
     class ModuleEndStreamSignalSentry {
     public:
       ModuleEndStreamSignalSentry(ActivityRegistry* a,
                                   StreamContext const& sc,
-                                  ModuleDescription const& md) : a_(a), sc_(sc), md_(md) {
-        if(a_) a_->preModuleEndStreamSignal_(sc_, md_);
+                                  ModuleCallingContext const& mcc) : a_(a), sc_(sc), mcc_(mcc) {
+        if(a_) a_->preModuleEndStreamSignal_(sc_, mcc_);
       }
       ~ModuleEndStreamSignalSentry() {
-        if(a_) a_->postModuleEndStreamSignal_(sc_, md_);
+        if(a_) a_->postModuleEndStreamSignal_(sc_, mcc_);
       }
     private:
       ActivityRegistry* a_;
       StreamContext const& sc_;
-      ModuleDescription const& md_;
+      ModuleCallingContext const& mcc_;
     };
 
     cms::Exception& exceptionContext(ModuleDescription const& iMD,
@@ -160,7 +160,9 @@ private:
         streamContext.setRunIndex(RunIndex::invalidRunIndex());
         streamContext.setLuminosityBlockIndex(LuminosityBlockIndex::invalidLuminosityBlockIndex());
         streamContext.setTimestamp(Timestamp());
-        ModuleBeginStreamSignalSentry beginSentry(actReg_.get(), streamContext, description());
+        ParentContext parentContext(&streamContext);
+        ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
+        ModuleBeginStreamSignalSentry beginSentry(actReg_.get(), streamContext, moduleCallingContext_);
         implBeginStream(id);
       }
       catch (cms::Exception& e) { throw; }
@@ -187,7 +189,9 @@ private:
         streamContext.setRunIndex(RunIndex::invalidRunIndex());
         streamContext.setLuminosityBlockIndex(LuminosityBlockIndex::invalidLuminosityBlockIndex());
         streamContext.setTimestamp(Timestamp());
-        ModuleEndStreamSignalSentry endSentry(actReg_.get(), streamContext, description());
+        ParentContext parentContext(&streamContext);
+        ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
+        ModuleEndStreamSignalSentry endSentry(actReg_.get(), streamContext, moduleCallingContext_);
         implEndStream(id);
       }
       catch (cms::Exception& e) { throw; }

--- a/FWCore/MessageService/interface/MessageLogger.h
+++ b/FWCore/MessageService/interface/MessageLogger.h
@@ -85,10 +85,10 @@ private:
   void  preModuleEndJob  ( ModuleDescription const & );
   void  postModuleEndJob ( ModuleDescription const & );
 
-  void  preModuleBeginStream  ( StreamContext const&, ModuleDescription const & );
-  void  postModuleBeginStream ( StreamContext const&, ModuleDescription const & );
-  void  preModuleEndStream  ( StreamContext const&, ModuleDescription const & );
-  void  postModuleEndStream ( StreamContext const&, ModuleDescription const & );
+  void  preModuleBeginStream  ( StreamContext const&, ModuleCallingContext const& );
+  void  postModuleBeginStream ( StreamContext const&, ModuleCallingContext const& );
+  void  preModuleEndStream  ( StreamContext const&, ModuleCallingContext const& );
+  void  postModuleEndStream ( StreamContext const&, ModuleCallingContext const& );
 
   void  preModuleStreamBeginRun  ( StreamContext const&, ModuleCallingContext const& );
   void  postModuleStreamBeginRun ( StreamContext const&, ModuleCallingContext const& );

--- a/FWCore/MessageService/src/MessageLogger.cc
+++ b/FWCore/MessageService/src/MessageLogger.cc
@@ -550,13 +550,17 @@ namespace edm {
     { unEstablishModule (iDescription, "AfterSourceConstruction"); }
     
     void
-    MessageLogger::preModuleBeginStream(StreamContext const& stream, const ModuleDescription& desc)
+    MessageLogger::preModuleBeginStream(StreamContext const& stream, ModuleCallingContext const& mcc)
     {
+      ModuleDescription const& desc = *mcc.moduleDescription();
       establishModule (desc,"@beginStream");				// ChangeLog 13
     }
-    void MessageLogger::postModuleBeginStream(StreamContext const& stream, const ModuleDescription& iDescription)
-    { unEstablishModule (iDescription, "AfterModBeginStream"); }
-    
+    void MessageLogger::postModuleBeginStream(StreamContext const& stream, ModuleCallingContext const& mcc)
+    {
+      ModuleDescription const& desc = *mcc.moduleDescription();
+      unEstablishModule (desc, "AfterModBeginStream");
+    }
+
     void
     MessageLogger::preModuleStreamBeginRun(StreamContext const& stream, ModuleCallingContext const& mod)
     {
@@ -641,15 +645,20 @@ namespace edm {
     }
     void MessageLogger::postModuleGlobalEndRun(GlobalContext const& stream, ModuleCallingContext const& mod)
     { unEstablishModule (mod, "AfterModGlobalEndRun"); }
-    
+
     void
-    MessageLogger::preModuleEndStream(StreamContext const&, const ModuleDescription& desc)
+    MessageLogger::preModuleEndStream(StreamContext const&, ModuleCallingContext const& mcc)
     {
+      ModuleDescription const& desc = *mcc.moduleDescription();
       establishModule (desc,"@endStream");				// ChangeLog 13
     }
-    void MessageLogger::postModuleEndStream(StreamContext const&, const ModuleDescription& iDescription)
-    { unEstablishModule (iDescription, "AfterModEndStream"); }
-    
+
+    void MessageLogger::postModuleEndStream(StreamContext const&, ModuleCallingContext const& mcc)
+    {
+      ModuleDescription const& desc = *mcc.moduleDescription();
+      unEstablishModule (desc, "AfterModEndStream");
+    }
+
     void
     MessageLogger::preModuleEndJob(const ModuleDescription& desc)
     {

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -184,28 +184,28 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_2(watchPostCloseFile)
 
-      typedef signalslot::Signal<void(StreamContext const&, ModuleDescription const&)> PreModuleBeginStream;
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleBeginStream;
       PreModuleBeginStream preModuleBeginStreamSignal_;
       void watchPreModuleBeginStream(PreModuleBeginStream::slot_type const& iSlot) {
          preModuleBeginStreamSignal_.connect(iSlot);
       }
       AR_WATCH_USING_METHOD_2(watchPreModuleBeginStream)
         
-      typedef signalslot::Signal<void(StreamContext const&, ModuleDescription const&)> PostModuleBeginStream;
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PostModuleBeginStream;
       PostModuleBeginStream postModuleBeginStreamSignal_;
       void watchPostModuleBeginStream(PostModuleBeginStream::slot_type const& iSlot) {
          postModuleBeginStreamSignal_.connect_front(iSlot);
       }
       AR_WATCH_USING_METHOD_2(watchPostModuleBeginStream)
         
-      typedef signalslot::Signal<void(StreamContext const&, ModuleDescription const&)> PreModuleEndStream;
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PreModuleEndStream;
       PreModuleEndStream preModuleEndStreamSignal_;
       void watchPreModuleEndStream(PreModuleEndStream::slot_type const& iSlot) {
          preModuleEndStreamSignal_.connect(iSlot);
       }
       AR_WATCH_USING_METHOD_2(watchPreModuleEndStream)
         
-      typedef signalslot::Signal<void(StreamContext const&, ModuleDescription const&)> PostModuleEndStream;
+      typedef signalslot::Signal<void(StreamContext const&, ModuleCallingContext const&)> PostModuleEndStream;
       PostModuleEndStream postModuleEndStreamSignal_;
       void watchPostModuleEndStream(PostModuleEndStream::slot_type const& iSlot) {
          postModuleEndStreamSignal_.connect_front(iSlot);

--- a/FWCore/Services/src/EnableFloatingPointExceptions.cc
+++ b/FWCore/Services/src/EnableFloatingPointExceptions.cc
@@ -19,6 +19,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 
 #include <cassert>
 #include <fenv.h>
@@ -31,14 +32,14 @@
 // http://public.kitware.com/Bug/file_download.php?file_id=3215&type=bug
 static int
 fegetexcept (void) {
-  static fenv_t fenv;
+  fenv_t fenv;
 
   return fegetenv (&fenv) ? -1 : (fenv.__control & FE_ALL_EXCEPT);
 }
 
 static int
 feenableexcept (unsigned int excepts) {
-  static fenv_t fenv;
+  fenv_t fenv;
   unsigned int new_excepts = excepts & FE_ALL_EXCEPT,
                old_excepts;  // previous masks
 
@@ -54,7 +55,7 @@ feenableexcept (unsigned int excepts) {
 
 static int
 fedisableexcept (unsigned int excepts) {
-  static fenv_t fenv;
+  fenv_t fenv;
   unsigned int new_excepts = excepts & FE_ALL_EXCEPT,
                old_excepts;  // all previous masks
 
@@ -77,10 +78,8 @@ namespace edm {
     EnableFloatingPointExceptions::
     EnableFloatingPointExceptions(ParameterSet const& pset,
                                   ActivityRegistry & registry):
-      fpuState_(0),
       defaultState_(0),
       stateMap_(),
-      stateStack_(),
       reportSettings_(false) {
 
       reportSettings_ = pset.getUntrackedParameter<bool>("reportSettings", false);
@@ -93,8 +92,6 @@ namespace edm {
 
       establishModuleEnvironments(pset);
 
-      stateStack_.push(defaultState_);
-      fpuState_ = defaultState_;
       enableAndDisableExcept(defaultState_);
 
       setPrecision(precisionDouble);
@@ -103,23 +100,43 @@ namespace edm {
       // This is because the floating point environment may be modified by code outside of this service.
       registry.watchPostEndJob(this, &EnableFloatingPointExceptions::postEndJob);
 
+      registry.watchPreModuleBeginStream(this, &EnableFloatingPointExceptions::preModuleBeginStream);
+      registry.watchPostModuleBeginStream(this, &EnableFloatingPointExceptions::postModuleBeginStream);
+
+      registry.watchPreModuleEndStream(this, &EnableFloatingPointExceptions::preModuleEndStream);
+      registry.watchPostModuleEndStream(this, &EnableFloatingPointExceptions::postModuleEndStream);
+
+      registry.watchPreModuleConstruction(this, &EnableFloatingPointExceptions::preModuleConstruction);
+      registry.watchPostModuleConstruction(this, &EnableFloatingPointExceptions::postModuleConstruction);
+
       registry.watchPreModuleBeginJob(this, &EnableFloatingPointExceptions::preModuleBeginJob);
       registry.watchPostModuleBeginJob(this, &EnableFloatingPointExceptions::postModuleBeginJob);
+
       registry.watchPreModuleEndJob(this, &EnableFloatingPointExceptions::preModuleEndJob);
       registry.watchPostModuleEndJob(this, &EnableFloatingPointExceptions::postModuleEndJob);
 
-      registry.watchPreModuleBeginRun(this, &EnableFloatingPointExceptions::preModuleBeginRun);
-      registry.watchPostModuleBeginRun(this, &EnableFloatingPointExceptions::postModuleBeginRun);
-      registry.watchPreModuleEndRun(this, &EnableFloatingPointExceptions::preModuleEndRun);
-      registry.watchPostModuleEndRun(this, &EnableFloatingPointExceptions::postModuleEndRun);
+      registry.watchPreModuleEvent(this, &EnableFloatingPointExceptions::preModuleEvent);
+      registry.watchPostModuleEvent(this, &EnableFloatingPointExceptions::postModuleEvent);
 
-      registry.watchPreModuleBeginLumi(this, &EnableFloatingPointExceptions::preModuleBeginLumi);
-      registry.watchPostModuleBeginLumi(this, &EnableFloatingPointExceptions::postModuleBeginLumi);
-      registry.watchPreModuleEndLumi(this, &EnableFloatingPointExceptions::preModuleEndLumi);
-      registry.watchPostModuleEndLumi(this, &EnableFloatingPointExceptions::postModuleEndLumi);
+      registry.watchPreModuleStreamBeginRun(this, &EnableFloatingPointExceptions::preModuleStreamBeginRun);
+      registry.watchPostModuleStreamBeginRun(this, &EnableFloatingPointExceptions::postModuleStreamBeginRun);
+      registry.watchPreModuleStreamEndRun(this, &EnableFloatingPointExceptions::preModuleStreamEndRun);
+      registry.watchPostModuleStreamEndRun(this, &EnableFloatingPointExceptions::postModuleStreamEndRun);
 
-      registry.watchPreModule(this, &EnableFloatingPointExceptions::preModule);
-      registry.watchPostModule(this, &EnableFloatingPointExceptions::postModule);
+      registry.watchPreModuleStreamBeginLumi(this, &EnableFloatingPointExceptions::preModuleStreamBeginLumi);
+      registry.watchPostModuleStreamBeginLumi(this, &EnableFloatingPointExceptions::postModuleStreamBeginLumi);
+      registry.watchPreModuleStreamEndLumi(this, &EnableFloatingPointExceptions::preModuleStreamEndLumi);
+      registry.watchPostModuleStreamEndLumi(this, &EnableFloatingPointExceptions::postModuleStreamEndLumi);
+
+      registry.watchPreModuleGlobalBeginRun(this, &EnableFloatingPointExceptions::preModuleGlobalBeginRun);
+      registry.watchPostModuleGlobalBeginRun(this, &EnableFloatingPointExceptions::postModuleGlobalBeginRun);
+      registry.watchPreModuleGlobalEndRun(this, &EnableFloatingPointExceptions::preModuleGlobalEndRun);
+      registry.watchPostModuleGlobalEndRun(this, &EnableFloatingPointExceptions::postModuleGlobalEndRun);
+
+      registry.watchPreModuleGlobalBeginLumi(this, &EnableFloatingPointExceptions::preModuleGlobalBeginLumi);
+      registry.watchPostModuleGlobalBeginLumi(this, &EnableFloatingPointExceptions::postModuleGlobalBeginLumi);
+      registry.watchPreModuleGlobalEndLumi(this, &EnableFloatingPointExceptions::preModuleGlobalEndLumi);
+      registry.watchPostModuleGlobalEndLumi(this, &EnableFloatingPointExceptions::postModuleGlobalEndLumi);
     }
 
     // Establish an environment for each module; default is handled specially.
@@ -151,18 +168,18 @@ namespace edm {
         if(enableUnderFlowEx) flags |= FE_UNDERFLOW;
         enableAndDisableExcept(flags);
 
-        fpuState_ = fegetexcept();
-        assert(flags == fpuState_);
+        fpu_flags_type fpuState = fegetexcept();
+        assert(flags == fpuState);
 
         if(reportSettings_) {
           LogVerbatim("FPE_Enable") << "\nSettings for module " << *it;
           echoState();
         }
         if(*it == def) {
-          defaultState_ = fpuState_;
+          defaultState_ = fpuState;
         }
         else {
-          stateMap_[*it] =  fpuState_;
+          stateMap_[*it] =  fpuState;
         }
       }
     }
@@ -176,90 +193,174 @@ namespace edm {
       }
     }
 
-    void 
+    void
     EnableFloatingPointExceptions::
-    preModuleBeginJob(ModuleDescription const& description) {
-      preActions(description, "beginJob");
-    }
-
-    void 
-    EnableFloatingPointExceptions::
-    postModuleBeginJob(ModuleDescription const& description) {
-      postActions(description, "beginJob");
-    }
-
-    void 
-    EnableFloatingPointExceptions::
-    preModuleEndJob(ModuleDescription const& description) {
-      preActions(description, "endJob");
-    }
-
-    void 
-    EnableFloatingPointExceptions::
-    postModuleEndJob(ModuleDescription const& description) {
-      postActions(description, "endJob");
-    }
-
-    void 
-    EnableFloatingPointExceptions::
-    preModuleBeginRun(ModuleDescription const& description) {
-      preActions(description, "beginRun");
-    }
-
-    void 
-    EnableFloatingPointExceptions::
-    postModuleBeginRun(ModuleDescription const& description) {
-      postActions(description, "beginRun");
-    }
-
-    void 
-    EnableFloatingPointExceptions::
-    preModuleEndRun(ModuleDescription const& description) {
-      preActions(description, "endRun");
-    }
-
-    void 
-    EnableFloatingPointExceptions::
-    postModuleEndRun(ModuleDescription const& description) {
-      postActions(description, "endRun");
+    preModuleConstruction(ModuleDescription const& md) {
+      preActions(md, "construction");
     }
 
     void
     EnableFloatingPointExceptions::
-    preModuleBeginLumi(ModuleDescription const& description) {
-      preActions(description, "beginLumi");
+    postModuleConstruction(ModuleDescription const& md) {
+      postActions(md, "construction");
     }
 
     void 
     EnableFloatingPointExceptions::
-    postModuleBeginLumi(ModuleDescription const& description) {
-      postActions(description, "beginLumi");
+    preModuleBeginJob(ModuleDescription const& md) {
+      preActions(md, "beginJob");
     }
 
     void 
     EnableFloatingPointExceptions::
-    preModuleEndLumi(ModuleDescription const& description) {
-      preActions(description, "endLumi");
+    postModuleBeginJob(ModuleDescription const& md) {
+      postActions(md, "beginJob");
     }
 
-    void 
+    void
     EnableFloatingPointExceptions::
-    postModuleEndLumi(ModuleDescription const& description) {
-      postActions(description, "endLumi");
+    preModuleEndJob(ModuleDescription const& md) {
+      preActions(md, "endJob");
     }
 
-    void 
+    void
     EnableFloatingPointExceptions::
-    preModule(ModuleDescription const& description) {
-      preActions(description, "event");
+    postModuleEndJob(ModuleDescription const& md) {
+      postActions(md, "endJob");
     }
 
-    void 
+    void
     EnableFloatingPointExceptions::
-    postModule(ModuleDescription const& description) {
-      postActions(description, "event");
+    preModuleBeginStream(StreamContext const&, ModuleCallingContext const& mcc) {
+      preActions(mcc, "beginStream");
     }
 
+    void
+    EnableFloatingPointExceptions::
+    postModuleBeginStream(StreamContext const&, ModuleCallingContext const& mcc) {
+      postActions(mcc, "beginStream");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    preModuleEndStream(StreamContext const&, ModuleCallingContext const& mcc) {
+      preActions(mcc, "endStream");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    postModuleEndStream(StreamContext const&, ModuleCallingContext const& mcc) {
+      postActions(mcc, "endStream");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    preModuleGlobalBeginRun(GlobalContext const&, ModuleCallingContext const& mcc) {
+      preActions(mcc, "globalBeginRun");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    postModuleGlobalBeginRun(GlobalContext const&, ModuleCallingContext const& mcc) {
+      postActions(mcc, "globalBeginRun");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    preModuleGlobalEndRun(GlobalContext const&, ModuleCallingContext const& mcc) {
+      preActions(mcc, "globalEndRun");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    postModuleGlobalEndRun(GlobalContext const&, ModuleCallingContext const& mcc) {
+      postActions(mcc, "globalEndRun");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    preModuleGlobalBeginLumi(GlobalContext const&, ModuleCallingContext const& mcc) {
+      preActions(mcc, "globalBeginLumi");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    postModuleGlobalBeginLumi(GlobalContext const&, ModuleCallingContext const& mcc) {
+      postActions(mcc, "globalBeginLumi");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    preModuleGlobalEndLumi(GlobalContext const&, ModuleCallingContext const& mcc) {
+      preActions(mcc, "globalEndLumi");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    postModuleGlobalEndLumi(GlobalContext const&, ModuleCallingContext const& mcc) {
+      postActions(mcc, "globalEndLumi");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    preModuleStreamBeginRun(StreamContext const&, ModuleCallingContext const& mcc) {
+      preActions(mcc, "streamBeginRun");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    postModuleStreamBeginRun(StreamContext const&, ModuleCallingContext const& mcc) {
+      postActions(mcc, "streamBeginRun");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    preModuleStreamEndRun(StreamContext const&, ModuleCallingContext const& mcc) {
+      preActions(mcc, "streamEndRun");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    postModuleStreamEndRun(StreamContext const&, ModuleCallingContext const& mcc) {
+      postActions(mcc, "streamEndRun");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    preModuleStreamBeginLumi(StreamContext const&, ModuleCallingContext const& mcc) {
+      preActions(mcc, "streamBeginLumi");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    postModuleStreamBeginLumi(StreamContext const&, ModuleCallingContext const& mcc) {
+      postActions(mcc, "streamBeginLumi");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    preModuleStreamEndLumi(StreamContext const&, ModuleCallingContext const& mcc) {
+      preActions(mcc, "streamEndLumi");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    postModuleStreamEndLumi(StreamContext const&, ModuleCallingContext const& mcc) {
+      postActions(mcc, "streamEndLumi");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    preModuleEvent(StreamContext const&, ModuleCallingContext const& mcc) {
+      preActions(mcc, "event");
+    }
+
+    void
+    EnableFloatingPointExceptions::
+    postModuleEvent(StreamContext const&, ModuleCallingContext const& mcc) {
+      postActions(mcc, "event");
+    }
+    
     void
     EnableFloatingPointExceptions::
     fillDescriptions(ConfigurationDescriptions & descriptions) {
@@ -295,21 +396,15 @@ namespace edm {
     preActions(ModuleDescription const& description,
                char const* debugInfo) {
 
-      // On entry to a module, find the desired state of the fpu and set it
-      // accordingly. Note that any module whose label does not appear in
-      // our list gets the default settings.
-
       std::string const& moduleLabel = description.moduleLabel();
       std::map<std::string, fpu_flags_type>::const_iterator iModule = stateMap_.find(moduleLabel);
 
-      if(iModule == stateMap_.end())  {
-        fpuState_ = defaultState_;
+      fpu_flags_type fpuState = defaultState_;
+
+      if(iModule != stateMap_.end())  {
+        fpuState = iModule->second;
       }
-      else {
-        fpuState_ = iModule->second;
-      }
-      enableAndDisableExcept(fpuState_);
-      stateStack_.push(fpuState_);
+      enableAndDisableExcept(fpuState);
 
       if(reportSettings_) {
         LogVerbatim("FPE_Enable")
@@ -324,11 +419,8 @@ namespace edm {
     void 
     EnableFloatingPointExceptions::
     postActions(ModuleDescription const& description, char const* debugInfo) {
-      // On exit from a module, set the state of the fpu back to what
-      // it was before entry
-      stateStack_.pop();
-      fpuState_ = stateStack_.top();
-      enableAndDisableExcept(fpuState_);
+
+      enableAndDisableExcept(defaultState_);
 
       if(reportSettings_) {
         LogVerbatim("FPE_Enable")
@@ -340,8 +432,81 @@ namespace edm {
       }
     }
 
+    void 
+    EnableFloatingPointExceptions::
+    preActions(ModuleCallingContext const& mcc,
+               char const* debugInfo) {
+
+      std::string const& moduleLabel = mcc.moduleDescription()->moduleLabel();
+      std::map<std::string, fpu_flags_type>::const_iterator iModule = stateMap_.find(moduleLabel);
+
+      fpu_flags_type fpuState = defaultState_;
+
+      if(iModule != stateMap_.end())  {
+        fpuState = iModule->second;
+      }
+      enableAndDisableExcept(fpuState);
+
+      if(reportSettings_) {
+        LogVerbatim("FPE_Enable")
+          << "\nSettings for module label \""
+          << moduleLabel
+          << "\" before "
+          << debugInfo;
+        echoState();
+      }
+    }
+
+    void 
+    EnableFloatingPointExceptions::
+    postActions(ModuleCallingContext const& mcc, char const* debugInfo) {
+
+      fpu_flags_type fpuState = defaultState_;
+
+      edm::ModuleCallingContext const* previous_mcc = mcc.previousModuleOnThread();
+      if(previous_mcc) {
+        std::map<std::string, fpu_flags_type>::const_iterator iModule = stateMap_.find(previous_mcc->moduleDescription()->moduleLabel());
+        if(iModule != stateMap_.end())  {
+          fpuState = iModule->second;
+        }
+      }
+      enableAndDisableExcept(fpuState);
+
+      if(reportSettings_) {
+        LogVerbatim("FPE_Enable")
+          << "\nSettings for module label \""
+          << mcc.moduleDescription()->moduleLabel()
+          << "\" after "
+          << debugInfo;
+        echoState();
+      }
+    }
+
 #ifdef __linux__
 #ifdef __i386__
+    // Note that __i386__ flag is not set on x86_64 architectures.
+    // As far as I know we use the empty version of the setPrecision
+    // function on all architectures CMS currently supports.
+    // Here is my understanding of this from the articles I found with
+    // google. I should warn that none of those articles were directly
+    // from the compiler writers or Intel or any authoritative
+    // source and I am not really an expert on this subject. We use the
+    // setPrecision function to force the math processor to perform floating
+    // point calculations internally with 64 bits of precision and not use
+    // 80 bit extended precision internally for calculations. 80 bit extended
+    // precision is used with the x87 instruction set which is the default
+    // for most 32 bit Intel architectures. When it is used there are problems
+    // of different sorts such as nonreproducible results, mostly due
+    // to rounding issues. This was important before CMS switched from
+    // 32 bit to 64 bit architectures. On 64 bit x86_64 platforms
+    // SSE instructions are used instead of x87 instructions.
+    // The whole issue is obsolete as SSE instructions do not ever
+    // use extended 80 bit precision in floating point calculations. Although
+    // new CPUs still support the x87 instruction set for floating point
+    // calculations for various reasons (mostly backward compatibility I
+    // think), most compilers write SSE instructions only. It might be
+    // that compiler flags can be set to force use of x87 instructions, but
+    // as far as I know we do not do that for CMS.
     void
     EnableFloatingPointExceptions::setPrecision(bool precisionDouble) {
       if(precisionDouble) {

--- a/FWCore/Services/src/EnableFloatingPointExceptions.h
+++ b/FWCore/Services/src/EnableFloatingPointExceptions.h
@@ -12,7 +12,7 @@
     aspects of the FP environment this service can control: 
 
         1. floating-point exceptions (on a module by module basis if desired)
-        2. precision control on x87 FP processors.
+        2. precision control on x87 FP processors (obsolete for 64 bit x86_64)
 
     If you do not use the service at all, floating point exceptions will not
     be trapped anywhere (FP exceptions will not cause a crash).  Add something
@@ -58,8 +58,29 @@
     floating point value of 'nan' or 'inf' is being generated and is even better
     if the goal is to eliminate them.
 
-    One can also control the precision of floating point operations in x87 FP
-    processors as follows:
+    Warning. The flags that control the behavior of floating point are globally
+    available. Anything could potentially change them at any point in time, including
+    the module itself and third party code that module calls. In a threading
+    environment if the module waits in the middle of execution and others tasks
+    run on the same thread, they could potentially change the behavior.
+    Also if the module internally creates tasks that run on other threads
+    those will run with whatever settings are on that thread unless special code
+    has been written in the module to set the floating point exception control
+    flags.
+
+    Note that we did tests to determine that the floating point exception control
+    of feenableexcept was thread local and therefore could be use with the
+    multithreaded framework. Although the functions in fenv.h that are part
+    of the standard are required to be thread local, we were unable to find
+    any documentation about this for feenableexcept which is an extension
+    of the GCC compiler. Hopefully our test on one machine can be safely
+    extrapolated to all machines ...
+
+    Precision control is obsolete in x86_64 architectures and other architectures
+    CMS currently uses (maybe we should remove this part of the service). It has
+    no effect. The x86_64 architecture uses SSE for floating point calculations,
+    not x87. SSE always uses 64 bit precision.  Precision control  works for x87
+    floating point calculations as follows:
 
       process.EnableFloatingPointExceptions = cms.Service("EnableFloatingPointExceptions",
           setPrecisionDouble = cms.untracked.bool(True)
@@ -72,10 +93,9 @@
     registers (this is the default you get if this service is not used at all).
 
     The precision control only affects Intel and AMD 32 bit CPUs under LINUX.
-    We have not implemented precision control in the service for other CPUs yet
-    (some other CPUs round to 64 bits by default and some other CPUs do not allow
-    control of the precision of floating point calculations, the behavior of
-    other CPUs may need more study in the future).
+    We have not implemented precision control in the service for other CPUs.
+    (most other CPUs round to 64 bits by default and/or do not allow
+    control of the precision of floating point calculations).
 */
 //
 // Original Author:  E. Sexton-Kennedy
@@ -84,53 +104,82 @@
 
 #include <string>
 #include <map>
-#include <stack>
 
 namespace edm {
 
    class ParameterSet;
    class ActivityRegistry;
    class ModuleDescription;
+   class StreamContext;
+   class ModuleCallingContext;
+   class GlobalContext;
    class ConfigurationDescriptions;
 
    namespace service {
 
       class EnableFloatingPointExceptions {
       public:
+
          typedef int fpu_flags_type;
+
          EnableFloatingPointExceptions(ParameterSet const& pset,
                                        ActivityRegistry & registry);
+         void postEndJob();
 
-	 void postEndJob();
+         void preModuleConstruction(ModuleDescription const&);
+         void postModuleConstruction(ModuleDescription const&);
 
-         void preModuleBeginJob(ModuleDescription const& description);
-         void postModuleBeginJob(ModuleDescription const& description);
-         void preModuleEndJob(ModuleDescription const& description);
-         void postModuleEndJob(ModuleDescription const& description);
+         void preModuleBeginJob(ModuleDescription const&);
+         void postModuleBeginJob(ModuleDescription const&);
 
-         void preModuleBeginRun(ModuleDescription const& description);
-         void postModuleBeginRun(ModuleDescription const& description);
-         void preModuleEndRun(ModuleDescription const& description);
-         void postModuleEndRun(ModuleDescription const& description);
+         void preModuleEndJob(ModuleDescription const& md);
+         void postModuleEndJob(ModuleDescription const& md);
 
-         void preModuleBeginLumi(ModuleDescription const& description);
-         void postModuleBeginLumi(ModuleDescription const& description);
-         void preModuleEndLumi(ModuleDescription const& description);
-         void postModuleEndLumi(ModuleDescription const& description);
+         void preModuleBeginStream(StreamContext const&, ModuleCallingContext const&);
+         void postModuleBeginStream(StreamContext const&, ModuleCallingContext const&);
 
-         void preModule(ModuleDescription const& description);
-         void postModule(ModuleDescription const& description);
+         void preModuleEndStream(StreamContext const&, ModuleCallingContext const&);
+         void postModuleEndStream(StreamContext const&, ModuleCallingContext const&);
 
+         void preModuleGlobalBeginRun(GlobalContext const&, ModuleCallingContext const&);
+         void postModuleGlobalBeginRun(GlobalContext const&, ModuleCallingContext const&);
+         void preModuleGlobalEndRun(GlobalContext const&, ModuleCallingContext const&);
+         void postModuleGlobalEndRun(GlobalContext const&, ModuleCallingContext const&);
+
+         void preModuleGlobalBeginLumi(GlobalContext const&, ModuleCallingContext const&);
+         void postModuleGlobalBeginLumi(GlobalContext const&, ModuleCallingContext const&);
+         void preModuleGlobalEndLumi(GlobalContext const&, ModuleCallingContext const&);
+         void postModuleGlobalEndLumi(GlobalContext const&, ModuleCallingContext const&);
+
+         void preModuleStreamBeginRun(StreamContext const&, ModuleCallingContext const&);
+         void postModuleStreamBeginRun(StreamContext const&, ModuleCallingContext const&);
+         void preModuleStreamEndRun(StreamContext const&, ModuleCallingContext const&);
+         void postModuleStreamEndRun(StreamContext const&, ModuleCallingContext const&);
+
+         void preModuleStreamBeginLumi(StreamContext const&, ModuleCallingContext const&);
+         void postModuleStreamBeginLumi(StreamContext const&, ModuleCallingContext const&);
+         void preModuleStreamEndLumi(StreamContext const&, ModuleCallingContext const&);
+         void postModuleStreamEndLumi(StreamContext const&, ModuleCallingContext const&);
+
+         void preModuleEvent(StreamContext const&, ModuleCallingContext const&);
+         void postModuleEvent(StreamContext const&, ModuleCallingContext const&);
+         
          static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
       private:
 
-         void establishModuleEnvironments(ParameterSet const& pset);
+         void establishModuleEnvironments(ParameterSet const&);
 
-         void preActions(ModuleDescription const& description,
+         void preActions(ModuleDescription const&,
                          char const* debugInfo);
 
-         void postActions(ModuleDescription const& description,
+         void postActions(ModuleDescription const&,
+                          char const* debugInfo);
+
+         void preActions(ModuleCallingContext const&,
+                         char const* debugInfo);
+
+         void postActions(ModuleCallingContext const&,
                           char const* debugInfo);
 
          void setPrecision(bool precisionDouble);
@@ -139,10 +188,8 @@ namespace edm {
 
          void echoState() const;
 
-         fpu_flags_type fpuState_;
          fpu_flags_type defaultState_;
          std::map<std::string, fpu_flags_type> stateMap_;
-         std::stack<fpu_flags_type> stateStack_;
          bool reportSettings_;
       };
    }

--- a/FWCore/Services/src/Tracer.cc
+++ b/FWCore/Services/src/Tracer.cc
@@ -242,7 +242,8 @@ Tracer::postCloseFile (std::string const& lfn, bool b) {
 }
 
 void
-Tracer::preModuleBeginStream(StreamContext const& sc, ModuleDescription const& desc) {
+Tracer::preModuleBeginStream(StreamContext const& sc, ModuleCallingContext const& mcc) {
+  ModuleDescription const& desc = *mcc.moduleDescription();
   std::cout << indention_ << indention_ << " ModuleBeginStream: " << desc.moduleLabel(); 
   if(dumpContextForLabel_ == desc.moduleLabel()) {
     std::cout << "\n" << sc;
@@ -252,7 +253,8 @@ Tracer::preModuleBeginStream(StreamContext const& sc, ModuleDescription const& d
 }
 
 void
-Tracer::postModuleBeginStream(StreamContext const& sc, ModuleDescription const& desc) {
+Tracer::postModuleBeginStream(StreamContext const& sc, ModuleCallingContext const& mcc) {
+  ModuleDescription const& desc = *mcc.moduleDescription();
   std::cout << indention_ << indention_ << " ModuleBeginStream finished"; 
   if(dumpContextForLabel_ == desc.moduleLabel()) {
     std::cout << "\n" << sc;
@@ -262,7 +264,8 @@ Tracer::postModuleBeginStream(StreamContext const& sc, ModuleDescription const& 
 }
 
 void
-Tracer::preModuleEndStream(StreamContext const& sc, ModuleDescription const& desc) {
+Tracer::preModuleEndStream(StreamContext const& sc, ModuleCallingContext const& mcc) {
+  ModuleDescription const& desc = *mcc.moduleDescription();
   std::cout << indention_ << indention_ << " ModuleEndStream: "; 
   if(dumpContextForLabel_ == desc.moduleLabel()) {
     std::cout << "\n" << sc;
@@ -272,7 +275,8 @@ Tracer::preModuleEndStream(StreamContext const& sc, ModuleDescription const& des
 }
 
 void
-Tracer::postModuleEndStream(StreamContext const& sc, ModuleDescription const& desc) {
+Tracer::postModuleEndStream(StreamContext const& sc, ModuleCallingContext const& mcc) {
+  ModuleDescription const& desc = *mcc.moduleDescription();
   std::cout << indention_ << indention_ << " ModuleEndStream finished"; 
   if(dumpContextForLabel_ == desc.moduleLabel()) {
     std::cout << "\n" << sc;

--- a/FWCore/Services/src/Tracer.h
+++ b/FWCore/Services/src/Tracer.h
@@ -65,11 +65,11 @@ public:
          void preCloseFile(std::string const& lfn, bool primary);
          void postCloseFile(std::string const&, bool);
 
-         void preModuleBeginStream(StreamContext const&, ModuleDescription const&);
-         void postModuleBeginStream(StreamContext const&, ModuleDescription const&);
+         void preModuleBeginStream(StreamContext const&, ModuleCallingContext const&);
+         void postModuleBeginStream(StreamContext const&, ModuleCallingContext const&);
 
-         void preModuleEndStream(StreamContext const&, ModuleDescription const&);
-         void postModuleEndStream(StreamContext const&, ModuleDescription const&);
+         void preModuleEndStream(StreamContext const&, ModuleCallingContext const&);
+         void postModuleEndStream(StreamContext const&, ModuleCallingContext const&);
 
          void preGlobalBeginRun(GlobalContext const&);
          void postGlobalBeginRun(GlobalContext const&);


### PR DESCRIPTION
Modify the EnableFloatingPointExceptions service to
work with the multithreaded framework. Modify it to
use the new service interface. It now uses the Framework
to keep track of the stack of modules which are currently
running instead of an internal stack.  It does this through
the ModuleCallingContext. Modify the beginStream and
endStream service callbacks to take a ModuleCallingContext
argument. Modify the MessageLogger and Tracer to reflect
that interface change.
