### PR TITLE
Thread safe changes for CaloGeometry and dependent packages

### DIFF
--- a/Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h
+++ b/Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h
@@ -117,7 +117,7 @@ class CaloSubdetectorGeometry {
 			      const GlobalPoint& p2  ) 
       { return reco::deltaR( p1, p2 ) ; }
 
-      mutable std::vector<DetId> m_validIds ;
+      void addValidID(const DetId& id);
 
    private:
 
@@ -129,7 +129,7 @@ class CaloSubdetectorGeometry {
       CaloSubdetectorGeometry(            const CaloSubdetectorGeometry& ) ;
       CaloSubdetectorGeometry& operator=( const CaloSubdetectorGeometry& ) ;
 
-      mutable std::atomic<bool> m_sortedIds ;
+      std::vector<DetId> m_validIds ;
 
       mutable std::atomic<std::vector<CCGFloat>*>  m_deltaPhi ;
       mutable std::atomic<std::vector<CCGFloat>*>  m_deltaEta ;

--- a/Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h
+++ b/Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h
@@ -3,6 +3,7 @@
 
 #include <vector>
 #include <set>
+#include <atomic>
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
@@ -128,10 +129,10 @@ class CaloSubdetectorGeometry {
       CaloSubdetectorGeometry(            const CaloSubdetectorGeometry& ) ;
       CaloSubdetectorGeometry& operator=( const CaloSubdetectorGeometry& ) ;
 
-      mutable bool m_sortedIds ;
+      mutable std::atomic<bool> m_sortedIds ;
 
-      mutable std::vector<CCGFloat>*  m_deltaPhi ;
-      mutable std::vector<CCGFloat>*  m_deltaEta ;
+      mutable std::atomic<std::vector<CCGFloat>*>  m_deltaPhi ;
+      mutable std::atomic<std::vector<CCGFloat>*>  m_deltaEta ;
 };
 
 

--- a/Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h
+++ b/Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h
@@ -3,7 +3,9 @@
 
 #include <vector>
 #include <set>
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include <atomic>
+#endif
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
@@ -131,8 +133,13 @@ class CaloSubdetectorGeometry {
 
       std::vector<DetId> m_validIds ;
 
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
       mutable std::atomic<std::vector<CCGFloat>*>  m_deltaPhi ;
       mutable std::atomic<std::vector<CCGFloat>*>  m_deltaEta ;
+#else
+      mutable std::vector<CCGFloat>*  m_deltaPhi ;
+      mutable std::vector<CCGFloat>*  m_deltaEta ;
+#endif
 };
 
 

--- a/Geometry/CaloGeometry/src/CaloSubdetectorGeometry.cc
+++ b/Geometry/CaloGeometry/src/CaloSubdetectorGeometry.cc
@@ -13,7 +13,6 @@ typedef CaloSubdetectorGeometry::CCGFloat CCGFloat ;
 CaloSubdetectorGeometry::CaloSubdetectorGeometry() : 
    m_parMgr ( 0 ) ,
    m_cmgr   ( 0 ) ,
-   m_sortedIds (false) ,
    m_deltaPhi  (nullptr) ,
    m_deltaEta  (nullptr)
 {}
@@ -27,15 +26,17 @@ CaloSubdetectorGeometry::~CaloSubdetectorGeometry()
    if (m_deltaEta) delete m_deltaEta ;
 }
 
+void
+CaloSubdetectorGeometry::addValidID(const DetId& id)
+{
+    m_validIds.push_back(id);
+    std::sort( m_validIds.begin(), m_validIds.end() ) ;
+}
+
 const std::vector<DetId>& 
 CaloSubdetectorGeometry::getValidDetIds( DetId::Detector /*det*/    , 
 					 int             /*subdet*/   ) const 
 {
-   if( !m_sortedIds )
-   {
-      std::sort( m_validIds.begin(), m_validIds.end() ) ;
-      m_sortedIds.store(true);
-   }
    return m_validIds ;
 }
 

--- a/Geometry/CaloGeometry/src/CaloSubdetectorGeometry.cc
+++ b/Geometry/CaloGeometry/src/CaloSubdetectorGeometry.cc
@@ -29,8 +29,8 @@ CaloSubdetectorGeometry::~CaloSubdetectorGeometry()
 void
 CaloSubdetectorGeometry::addValidID(const DetId& id)
 {
-    m_validIds.push_back(id);
-    std::sort( m_validIds.begin(), m_validIds.end() ) ;
+    auto pos = std::lower_bound(m_validIds.begin(), m_validIds.end(), id);
+    m_validIds.insert(pos, id);
 }
 
 const std::vector<DetId>& 

--- a/Geometry/CaloGeometry/src/CaloSubdetectorGeometry.cc
+++ b/Geometry/CaloGeometry/src/CaloSubdetectorGeometry.cc
@@ -222,7 +222,7 @@ CaloSubdetectorGeometry::deltaPhi( const DetId& detId ) const
 {
    const CaloGenericDetId cgId ( detId ) ;
 
-   if(!m_deltaPhi )
+   if(!m_deltaPhi.load(std::memory_order_acquire))
    {
      const uint32_t kSize ( sizeForDenseIndex(detId));
      auto ptr = new std::vector<CCGFloat>(kSize);
@@ -264,17 +264,17 @@ CaloSubdetectorGeometry::deltaPhi( const DetId& detId ) const
 	 }
       }
     std::vector<CCGFloat>* expect = nullptr;
-    bool exchanged = m_deltaPhi.compare_exchange_strong(expect, ptr);
+    bool exchanged = m_deltaPhi.compare_exchange_strong(expect, ptr, std::memory_order_acq_rel);
     if (!exchanged) delete ptr;
    }
-   return (*m_deltaPhi)[ indexFor(detId) ] ;
+   return (*m_deltaPhi.load(std::memory_order_acquire))[ indexFor(detId) ] ;
 }
 
 CCGFloat 
 CaloSubdetectorGeometry::deltaEta( const DetId& detId ) const
 {
 
-   if(!m_deltaEta )
+   if(!m_deltaEta.load(std::memory_order_acquire))
    {
      const uint32_t kSize ( sizeForDenseIndex(detId));
      auto ptr = new std::vector<CCGFloat> ( kSize ) ;
@@ -314,10 +314,10 @@ CaloSubdetectorGeometry::deltaEta( const DetId& detId ) const
 	 }
       }
     std::vector<CCGFloat>* expect = nullptr;
-    bool exchanged = m_deltaEta.compare_exchange_strong(expect, ptr);
+    bool exchanged = m_deltaEta.compare_exchange_strong(expect, ptr, std::memory_order_acq_rel);
     if (!exchanged) delete ptr;
    }
-   return (*m_deltaEta)[ indexFor(detId)];
+   return (*m_deltaEta.load(std::memory_order_acquire))[ indexFor(detId)];
 }
 
 

--- a/Geometry/EcalAlgo/src/EcalBarrelGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalBarrelGeometry.cc
@@ -461,7 +461,7 @@ EcalBarrelGeometry::newCell( const GlobalPoint& f1 ,
    const unsigned int cellIndex ( EBDetId( detId ).denseIndex() ) ;
    m_cellVec[ cellIndex ] =
       TruncatedPyramid( cornersMgr(), f1, f2, f3, parm ) ;
-   m_validIds.push_back( detId ) ;
+   addValidID( detId ) ;
 }
 
 CCGFloat 

--- a/Geometry/EcalAlgo/src/EcalEndcapGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalEndcapGeometry.cc
@@ -481,7 +481,7 @@ EcalEndcapGeometry::newCell( const GlobalPoint& f1 ,
    const unsigned int cellIndex ( EEDetId( detId ).denseIndex() ) ;
    m_cellVec[ cellIndex ] =
       TruncatedPyramid( cornersMgr(), f1, f2, f3, parm ) ;
-   m_validIds.push_back( detId ) ;
+   addValidID( detId ) ;
 }
 
 

--- a/Geometry/EcalAlgo/src/EcalPreshowerGeometry.cc
+++ b/Geometry/EcalAlgo/src/EcalPreshowerGeometry.cc
@@ -253,7 +253,7 @@ EcalPreshowerGeometry::newCell( const GlobalPoint& f1 ,
 {
    const unsigned int cellIndex ( ESDetId( detId ).denseIndex() ) ;
    m_cellVec[ cellIndex ] = PreshowerStrip( f1, cornersMgr(), parm ) ;
-   m_validIds.push_back( detId ) ;
+   addValidID( detId ) ;
 }
 
 const CaloCellGeometry* 

--- a/Geometry/EcalTestBeam/src/EcalTBHodoscopeGeometry.cc
+++ b/Geometry/EcalTestBeam/src/EcalTBHodoscopeGeometry.cc
@@ -65,7 +65,7 @@ EcalTBHodoscopeGeometry::newCell( const GlobalPoint& f1 ,
    const unsigned int cellIndex ( hid.denseIndex() ) ;
 
    m_cellVec[ cellIndex ] = PreshowerStrip( f1, cornersMgr(), parm ) ;
-   m_validIds.push_back( detId ) ;
+   addValidID( detId ) ;
 }
 
 const EcalTBHodoscopeGeometry::fibre_pos 

--- a/Geometry/ForwardGeometry/src/CastorGeometry.cc
+++ b/Geometry/ForwardGeometry/src/CastorGeometry.cc
@@ -91,7 +91,7 @@ CastorGeometry::newCell( const GlobalPoint& f1 ,
    const unsigned int di ( cgid.denseIndex() ) ;
 
    m_cellVec[ di ] = IdealCastorTrapezoid( f1, cornersMgr(), parm ) ;
-   m_validIds.push_back( detId ) ;
+   addValidID( detId ) ;
 }
 
 const CaloCellGeometry* 

--- a/Geometry/ForwardGeometry/src/ZdcGeometry.cc
+++ b/Geometry/ForwardGeometry/src/ZdcGeometry.cc
@@ -87,7 +87,7 @@ ZdcGeometry::newCell( const GlobalPoint& f1 ,
    const unsigned int di ( cgid.denseIndex() ) ;
 
    m_cellVec[ di ] = IdealZDCTrapezoid( f1, cornersMgr(), parm ) ;
-   m_validIds.push_back( detId ) ;
+   addValidID( detId ) ;
 }
 
 const CaloCellGeometry* 

--- a/Geometry/HcalTowerAlgo/src/CaloTowerGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/CaloTowerGeometry.cc
@@ -66,7 +66,7 @@ CaloTowerGeometry::newCell( const GlobalPoint& f1 ,
    const unsigned int di ( cgid.denseIndex() ) ;
 
    m_cellVec[ di ] = IdealObliquePrism( f1, cornersMgr(), parm ) ;
-   m_validIds.push_back( detId ) ;
+   addValidID( detId ) ;
 }
 
 const CaloCellGeometry* 

--- a/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalGeometry.cc
@@ -485,7 +485,7 @@ HcalGeometry::newCell( const GlobalPoint& f1 ,
     m_hfCellVec[ index ] = IdealZPrism( f1, cornersMgr(), parm ) ;
   }
 
-  m_validIds.push_back( detId ) ; 
+  addValidID( detId ) ;
   m_dins.push_back( din );
 }
 


### PR DESCRIPTION
Please find thread safe changes for CaloGeometry. Due to the change of internal member data (m_validIds) into a method, I modified dependent packages which used this member data directly. I did not modified HcalDDDGeometry class though based on discussion with package maintainers (Ianna).
