### PR TITLE
Job Report bug fix

### DIFF
--- a/FWCore/MessageLogger/interface/JobReport.h
+++ b/FWCore/MessageLogger/interface/JobReport.h
@@ -250,7 +250,7 @@ namespace edm {
         std::map<std::string, long long> readBranchesSecFile_;
         tbb::concurrent_unordered_map<std::string, AtomicLongLong> readBranchesSecSource_;
         bool printedReadBranches_;
-        std::set<std::string>* fastClonedBranches_;
+        std::vector<InputFile>::size_type lastOpenedPrimaryInputFile_;
         std::ostream* ost_;
       };
 

--- a/FWCore/MessageLogger/src/JobReport.cc
+++ b/FWCore/MessageLogger/src/JobReport.cc
@@ -418,7 +418,7 @@ namespace edm {
     }
     
     if(theInputType == InputType::Primary) {
-      impl_->fastClonedBranches_ = &newFile->fastClonedBranches;
+      impl_->lastOpenedPrimaryInputFile_ = impl_->inputFiles_.size() - 1;
     }
     newFile->logicalFileName      = logicalFileName;
     newFile->physicalFileName     = physicalFileName;
@@ -694,7 +694,8 @@ namespace edm {
   JobReport::reportReadBranch(InputType inputType, std::string const& branchName) {
     if(inputType == InputType::Primary) {
       // Fast cloned branches have already been reported.
-      if(impl_->fastClonedBranches_->find(branchName) == impl_->fastClonedBranches_->end()) {
+      std::set<std::string> const& clonedBranches = impl_->inputFiles_.at(impl_->lastOpenedPrimaryInputFile_).fastClonedBranches;
+      if(clonedBranches.find(branchName) == clonedBranches.end()) {
         ++impl_->readBranches_[branchName];
       }
     } else if (inputType == InputType::SecondaryFile) {
@@ -706,9 +707,10 @@ namespace edm {
 
   void
   JobReport::reportFastClonedBranches(std::set<std::string> const& fastClonedBranches, long long nEvents) {
+    std::set<std::string>& clonedBranches = impl_->inputFiles_.at(impl_->lastOpenedPrimaryInputFile_).fastClonedBranches;
     for(std::set<std::string>::const_iterator it = fastClonedBranches.begin(), itEnd = fastClonedBranches.end();
         it != itEnd; ++it) {
-      if(impl_->fastClonedBranches_->insert(*it).second) {
+      if(clonedBranches.insert(*it).second) {
         impl_->readBranches_[*it] += nEvents;
       }
     }


### PR DESCRIPTION
Bug fix. Affects jobs with secondary file input since pull
request #905 was merged 4 days ago in 7_0_X only. A pointer
was pointing into a vector element that could move as the vector
grew. (note this bug caused the tests for pull request #952 to fail
although was totally unrelated to the changes in #952)
