### PR TITLE
fix the path to the input file in SmearedJetProducer for 70X

### DIFF
--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -157,7 +157,7 @@ class SmearedJetProducerT : public edm::EDProducer
 
     edm::FileInPath inputFileName = cfg.getParameter<edm::FileInPath>("inputFileName");
     std::string lutName = cfg.getParameter<std::string>("lutName");
-    if ( !inputFileName.isLocal() ) 
+    if (inputFileName.location() == edm::FileInPath::Unknown)
       throw cms::Exception("JetMETsmearInputProducer") 
         << " Failed to find File = " << inputFileName << " !!\n";
 


### PR DESCRIPTION
The same requst as in https://github.com/cms-sw/cmssw/pull/967 but for 70X.
