### PR TITLE
Simulation improvements -- Fixed warnings, added processType to SimVertex

### DIFF
--- a/SimDataFormats/Vertex/interface/SimVertex.h
+++ b/SimDataFormats/Vertex/interface/SimVertex.h
@@ -36,9 +36,13 @@ class SimVertex : public CoreSimVertex
   void setVertexId(unsigned int n) {vtxId = n;}
   unsigned int vertexId() const { return  vtxId; }  
 
+  void setProcessType(unsigned int ty) {procType = ty;}
+  unsigned int processType() const { return procType; }  
+
 private: 
   int itrack;
   unsigned int vtxId; 
+  unsigned int procType;
 };
 
 #include <iosfwd>

--- a/SimDataFormats/Vertex/src/SimVertex.cc
+++ b/SimDataFormats/Vertex/src/SimVertex.cc
@@ -1,24 +1,24 @@
 #include "SimDataFormats/Vertex/interface/SimVertex.h"
 
-SimVertex::SimVertex() :vtxId(0){}
+SimVertex::SimVertex() : itrack(-1), vtxId(0), procType(0) {}
  
 SimVertex::SimVertex(const math::XYZVectorD& v, float tof) :
-    Core(v,tof), itrack(-1), vtxId(0) {}
+  Core(v,tof), itrack(-1), vtxId(0), procType(0) {}
 
 SimVertex::SimVertex(const math::XYZVectorD& v, float tof, int it) :
-    Core(v,tof), itrack(it), vtxId(0) {}
+    Core(v,tof), itrack(it), vtxId(0), procType(0) {}
 
 SimVertex::SimVertex(const CoreSimVertex & v, int it) :
-    Core(v), itrack(it), vtxId(0) {}
+    Core(v), itrack(it), vtxId(0), procType(0) {}
 
 SimVertex::SimVertex(const math::XYZVectorD& v, float tof, unsigned int vId) :
-    Core(v,tof), itrack(-1), vtxId(vId) {}
+    Core(v,tof), itrack(-1), vtxId(vId), procType(0) {}
  
 SimVertex::SimVertex(const math::XYZVectorD& v, float tof, int it, unsigned int vId) :
-    Core(v,tof), itrack(it), vtxId(vId) {}
+    Core(v,tof), itrack(it), vtxId(vId), procType(0) {}
  
 SimVertex::SimVertex(const CoreSimVertex & v, int it, unsigned int vId) :
-    Core(v), itrack(it), vtxId(vId) {}
+    Core(v), itrack(it), vtxId(vId), procType(0) {}
  
 std::ostream & operator <<(std::ostream & o , const SimVertex & v) 
 { return o << (SimVertex::Core)(v) << ", " <<  v.parentIndex() <<", "<<v.vertexId(); }

--- a/SimDataFormats/Vertex/src/classes_def.xml
+++ b/SimDataFormats/Vertex/src/classes_def.xml
@@ -3,8 +3,8 @@
   <class name="CoreSimVertex" ClassVersion="10">
    <version ClassVersion="10" checksum="4012086828"/>
   </class>
-  <class name="SimVertex" ClassVersion="10">
-   <version ClassVersion="10" checksum="586095193"/>
+  <class name="SimVertex" ClassVersion="11">
+   <version ClassVersion="11" checksum="801220081"/>
   </class>
   <class pattern="edm::Ref<std::vector<SimVertex>,*>" />
   <class name="std::vector<const SimVertex*>"/>

--- a/SimTracker/TrackHistory/src/HistoryBase.cc
+++ b/SimTracker/TrackHistory/src/HistoryBase.cc
@@ -41,15 +41,17 @@ bool HistoryBase::traceSimHistory(TrackingParticleRef const & trackingParticle, 
     // first stop condition: if the required depth is reached
     if ( depth == depth_ && depth_ >= 0 ) return true;
 
-    // sencond stop condition: if a gen particle is associated to the TP
+    // second stop condition: if a gen particle is associated to the TP
     if ( !trackingParticle->genParticles().empty() )
     {
-        LogDebug("TrackHistory") << "Particle " << trackingParticle->pdgId() << " has a GenParicle image." << std::endl;
-#warning "This file has been modified just to get it to compile without any regard as to whether it still functions as intended"
-#ifdef REMOVED_JUST_TO_GET_IT_TO_COMPILE__THIS_CODE_NEEDS_TO_BE_CHECKED
-        traceGenHistory(&(**(trackingParticle->genParticle_begin())));
-#endif
-        return true;
+        LogDebug("TrackHistory") << "Particle " << trackingParticle->pdgId() << " has a GenParicle image." 
+				 << std::endl;
+	//#warning "This file has been modified just to get it to compile without any regard as to whether it still functions as intended"
+	// this code does not compile likely due to the wrong type of iterator
+	#ifdef REMOVED_JUST_TO_GET_IT_TO_COMPILE__THIS_CODE_NEEDS_TO_BE_CHECKED
+	traceGenHistory(&(**(trackingParticle->genParticle_begin()))); 
+	#endif
+
     }
 
     LogDebug("TrackHistory") << "No GenParticle image for " << trackingParticle->pdgId() << std::endl;

--- a/SimTracker/TrackHistory/src/TrackClassifier.cc
+++ b/SimTracker/TrackHistory/src/TrackClassifier.cc
@@ -383,18 +383,14 @@ void TrackClassifier::processesAtSimulation()
                 pdgid = 0;
         }
 
-        // Check for the number of psimhit if different from zero
-        if ((*iparticle)->numberOfHits()) continue;
-
-        // Collect the G4 process of the first psimhit (it should be the same for all of them)
-#warning "This file has been modified just to get it to compile without any regard as to whether it still functions as intended"
-#ifdef REMOVED_JUST_TO_GET_IT_TO_COMPILE__THIS_CODE_NEEDS_TO_BE_CHECKED
-        unsigned short process = (*iparticle)->pSimHit_begin()->processType();
-#else
         unsigned short process = 0;
-#endif
-        // Flagging all the different processes
 
+	// Check existence of SimVerteces assigned
+        if(parentVertex->nG4Vertices() > 0) {
+	  process = (*(parentVertex->g4Vertices_begin())).processType();
+	}
+
+        // Flagging all the different processes
         update(
             flags_[KnownProcess],
             process != G4::Undefined &&

--- a/SimTracker/TrackHistory/src/TrackQuality.cc
+++ b/SimTracker/TrackHistory/src/TrackQuality.cc
@@ -230,7 +230,8 @@ void TrackQuality::evaluate(SimParticleTrail const &spt,
 
     std::vector<MatchedHit>::size_type size = matchedHits.size();
 
-#warning "This file has been modified just to get it to compile without any regard as to whether it still functions as intended"
+    //#warning "This file has been modified just to get it to compile without any regard as to whether it still functions as intended"
+    // This warning is disabled because there is no anymore PSimHit vector associated with TrackingParticle
 #ifdef REMOVED_JUST_TO_GET_IT_TO_COMPILE__THIS_CODE_NEEDS_TO_BE_CHECKED
     // now iterate over simulated hits and compare (tracks in chain first)
     for (SimParticleTrail::const_iterator track = spt.begin();

--- a/SimTracker/TrackHistory/src/VertexClassifier.cc
+++ b/SimTracker/TrackHistory/src/VertexClassifier.cc
@@ -209,6 +209,39 @@ void VertexClassifier::processesAtSimulation()
         else
             pdgid = 0;
 
+	// Geant4 process type is selected using first Geant4 vertex assigned to 
+        // the TrackingVertex
+	unsigned short process = 0;
+        if((*ivertex)->nG4Vertices() > 0) {
+	  process = (*(*ivertex)->g4Vertices_begin()).processType();
+	}
+	// Flagging all the different processes
+	update(
+	       flags_[KnownProcess],
+	       process != G4::Undefined &&
+	       process != G4::Unknown &&
+	       process != G4::Primary
+	       );
+
+	update(flags_[UndefinedProcess], process == G4::Undefined);
+	update(flags_[UnknownProcess], process == G4::Unknown);
+	update(flags_[PrimaryProcess], process == G4::Primary);
+	update(flags_[HadronicProcess], process == G4::Hadronic);
+	update(flags_[DecayProcess], process == G4::Decay);
+	update(flags_[ComptonProcess], process == G4::Compton);
+	update(flags_[AnnihilationProcess], process == G4::Annihilation);
+	update(flags_[EIoniProcess], process == G4::EIoni);
+	update(flags_[HIoniProcess], process == G4::HIoni);
+	update(flags_[MuIoniProcess], process == G4::MuIoni);
+	update(flags_[PhotonProcess], process == G4::Photon);
+	update(flags_[MuPairProdProcess], process == G4::MuPairProd);
+	update(flags_[ConversionsProcess], process == G4::Conversions);
+	update(flags_[EBremProcess], process == G4::EBrem);
+	update(flags_[SynchrotronRadiationProcess], process == G4::SynchrotronRadiation);
+	update(flags_[MuBremProcess], process == G4::MuBrem);
+	update(flags_[MuNuclProcess], process == G4::MuNucl);
+
+
         // Loop over the simulated particles
         for (
             TrackingVertex::tp_iterator iparticle = (*ivertex)->daughterTracks_begin();
@@ -219,39 +252,6 @@ void VertexClassifier::processesAtSimulation()
 
             if ( (*iparticle)->numberOfTrackerLayers() )
             {
-#warning "This file has been modified just to get it to compile without any regard as to whether it still functions as intended"
-#ifdef REMOVED_JUST_TO_GET_IT_TO_COMPILE__THIS_CODE_NEEDS_TO_BE_CHECKED
-                // Collect the G4 process of the first psimhit (it should be the same for all of them)
-                unsigned short process = (*iparticle)->pSimHit_begin()->processType();
-#else
-                unsigned short process = 0;
-#endif
-                // Flagging all the different processes
-
-                update(
-                    flags_[KnownProcess],
-                    process != G4::Undefined &&
-                    process != G4::Unknown &&
-                    process != G4::Primary
-                );
-
-                update(flags_[UndefinedProcess], process == G4::Undefined);
-                update(flags_[UnknownProcess], process == G4::Unknown);
-                update(flags_[PrimaryProcess], process == G4::Primary);
-                update(flags_[HadronicProcess], process == G4::Hadronic);
-                update(flags_[DecayProcess], process == G4::Decay);
-                update(flags_[ComptonProcess], process == G4::Compton);
-                update(flags_[AnnihilationProcess], process == G4::Annihilation);
-                update(flags_[EIoniProcess], process == G4::EIoni);
-                update(flags_[HIoniProcess], process == G4::HIoni);
-                update(flags_[MuIoniProcess], process == G4::MuIoni);
-                update(flags_[PhotonProcess], process == G4::Photon);
-                update(flags_[MuPairProdProcess], process == G4::MuPairProd);
-                update(flags_[ConversionsProcess], process == G4::Conversions);
-                update(flags_[EBremProcess], process == G4::EBrem);
-                update(flags_[SynchrotronRadiationProcess], process == G4::SynchrotronRadiation);
-                update(flags_[MuBremProcess], process == G4::MuBrem);
-                update(flags_[MuNuclProcess], process == G4::MuNucl);
 
                 // Special treatment for decays
                 if (process == G4::Decay)


### PR DESCRIPTION
After migration to the new TrackingParticle number of forced compillation warning where left in Tracker/History sub-package. Partially these warnings are connected with the fact that  the new TrackingParticle does not keep vector of PSimHits anymore. Other warnings were due to absence access to Geant4 process type. This type is added to SimVertex because it is a natural property of verteces and not of hits. All warning disabled, no change of real results. 
