### PR TITLE
Thread safety fix for parser

### DIFF
--- a/CommonTools/Utils/src/returnType.cc
+++ b/CommonTools/Utils/src/returnType.cc
@@ -1,6 +1,8 @@
 #include "CommonTools/Utils/src/returnType.h"
-#include <map>
+#include <vector>
+#include <algorithm>
 #include <string>
+#include <cstring>
 using namespace std;
 using namespace reco::method;
 
@@ -13,28 +15,35 @@ namespace reco {
     return typeCode(returnType(mem));
   }
 
+  //this is already alphabetized
+  static const std::vector<std::pair<char const * const, method::TypeCode> > retTypeVec {
+     {"bool",boolType},
+     {"char",charType},
+     {"double",doubleType},
+     {"float", floatType},
+     {"int", intType},
+     {"long", longType},
+     {"long int", longType},
+     {"short", shortType},
+     {"short int", shortType},
+     {"size_t", uLongType},
+     {"unsigned char", uCharType},
+     {"unsigned int", uIntType},
+     {"unsigned long", uLongType},
+     {"unsigned long int",uLongType},
+     {"unsigned short",uShortType},
+     {"unsigned short int",uShortType}
+  };
+
   TypeCode typeCode(const edm::TypeWithDict & t) {
-    static map<string, method::TypeCode> retTypeMap;
-    if (retTypeMap.size() == 0) {
-      retTypeMap["double"] = doubleType;
-      retTypeMap["float"] = floatType;
-      retTypeMap["int"] = intType;
-      retTypeMap["unsigned int"] = uIntType;
-      retTypeMap["short"] = shortType;
-      retTypeMap["short int"] = shortType;
-      retTypeMap["unsigned short"] = uShortType;
-      retTypeMap["unsigned short int"] = uShortType;
-      retTypeMap["long"] = longType;
-      retTypeMap["long int"] = longType;
-      retTypeMap["unsigned long"] = uLongType;
-      retTypeMap["unsigned long int"] = uLongType;
-      retTypeMap["size_t"] = uLongType;
-      retTypeMap["char"] = charType;
-      retTypeMap["unsigned char"] = uCharType;
-      retTypeMap["bool"] = boolType;
-    }
-    map<string, TypeCode>::const_iterator f = retTypeMap.find(t.name());
-    if (f == retTypeMap.end()) return (t.isEnum() ? enumType : invalid);
-    else return f->second;
+
+    typedef std::pair<const char*const, method::TypeCode> Values;
+    const char* name = t.name().c_str();
+    auto f = std::equal_range(retTypeVec.begin(),retTypeVec.end(),Values{name,enumType},
+                              [] ( Values const& iLHS, Values const& iRHS) -> bool{
+       return std::strcmp(iLHS.first,iRHS.first)<0;
+    });
+    if (f.first == f.second) return (t.isEnum() ? enumType : invalid);
+    else return f.first->second;
   }
 }


### PR DESCRIPTION
Thread safety change: replaced an effectively const function static std::map with a file static const std::vector which is pre-sorted.
