### PR TITLE
Avoid data race condition in MessageLogger

### DIFF
--- a/FWCore/MessageService/src/MessageLogger.cc
+++ b/FWCore/MessageService/src/MessageLogger.cc
@@ -323,6 +323,12 @@ namespace edm {
       iRegistry.watchPrePathEvent(this,&MessageLogger::prePathEvent);
       iRegistry.watchPostPathEvent(this,&MessageLogger::postPathEvent);
       
+      
+      MessageDrop* messageDrop = MessageDrop::instance();
+      nonModule_debugEnabled   = messageDrop->debugEnabled;
+      nonModule_infoEnabled    = messageDrop->infoEnabled;
+      nonModule_warningEnabled = messageDrop->warningEnabled;
+      nonModule_errorEnabled   = messageDrop->errorEnabled;
     } // ctor
     
     //
@@ -334,10 +340,6 @@ namespace edm {
                                    const char * whichPhase)	// ChangeLog 13, 17
     {
       MessageDrop* messageDrop = MessageDrop::instance();
-      nonModule_debugEnabled   = messageDrop->debugEnabled;
-      nonModule_infoEnabled    = messageDrop->infoEnabled;
-      nonModule_warningEnabled = messageDrop->warningEnabled;
-      nonModule_errorEnabled   = messageDrop->errorEnabled;         // change log 20
       
       // std::cerr << "establishModule( " << desc.moduleName() << ")\n";
       // Change Log 17
@@ -375,10 +377,6 @@ namespace edm {
                                    const char * whichPhase)	// ChangeLog 13, 17
     {
       MessageDrop* messageDrop = MessageDrop::instance();
-      nonModule_debugEnabled   = messageDrop->debugEnabled;
-      nonModule_infoEnabled    = messageDrop->infoEnabled;
-      nonModule_warningEnabled = messageDrop->warningEnabled;
-      nonModule_errorEnabled   = messageDrop->errorEnabled;         // change log 20
       
       // std::cerr << "establishModule( " << desc.moduleName() << ")\n";
       // Change Log 17


### PR DESCRIPTION
Previously the code was caching into MessageLogger itself the previous state of the MessageDrop before entering a module. This was used to then attempt to reset the state after leaving the module. This doesn’t work correctly in a threaded environment. The state being remembered was just the default state between modules and is actually known at construction time. Therefore the default values are now only set at construction time. [Found by helgrind.]
