### PR TITLE
Validation/HcalHits/HcalSimHitsValidation ecal token omission fix

### DIFF
--- a/Validation/HcalHits/interface/HcalSimHitsValidation.h
+++ b/Validation/HcalHits/interface/HcalSimHitsValidation.h
@@ -60,7 +60,8 @@ private:
 
   edm::EDGetTokenT<edm::HepMCProduct> tok_evt_;
   edm::EDGetTokenT<edm::PCaloHitContainer> tok_hcal_;
-  edm::EDGetTokenT<edm::PCaloHitContainer> tok_ecal_;
+  edm::EDGetTokenT<edm::PCaloHitContainer> tok_ecalEB_;
+  edm::EDGetTokenT<edm::PCaloHitContainer> tok_ecalEE_;
 
 
   // Hits counters

--- a/Validation/HcalHits/src/HcalSimHitsValidation.cc
+++ b/Validation/HcalHits/src/HcalSimHitsValidation.cc
@@ -9,7 +9,8 @@ HcalSimHitsValidation::HcalSimHitsValidation(edm::ParameterSet const& conf) {
   // register for data access
   tok_evt_ = consumes<edm::HepMCProduct>(edm::InputTag("generator"));
   tok_hcal_ = consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits","HcalHits"));
-  tok_ecal_ = consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits","EcalHitsEE"));
+  tok_ecalEB_ = consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits","EcalHitsEB"));
+  tok_ecalEE_ = consumes<edm::PCaloHitContainer>(edm::InputTag("g4SimHits","EcalHitsEE"));
   
   if ( outputFile_.size() != 0 ) {    edm::LogInfo("OutputInfo") << " Hcal SimHit Task histograms will be saved to '" << outputFile_.c_str() << "'";
   } else {
@@ -294,7 +295,7 @@ void HcalSimHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
 
   //Ecal EB SimHits
   edm::Handle<PCaloHitContainer> ecalEBHits;
-  ev.getByToken(tok_ecal_,ecalEBHits);
+  ev.getByToken(tok_ecalEB_,ecalEBHits);
   const PCaloHitContainer * SimHitResultEB = ecalEBHits.product () ;
 
   double EcalCone = 0;
@@ -315,7 +316,7 @@ void HcalSimHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
 
   //Ecal EE SimHits
   edm::Handle<PCaloHitContainer> ecalEEHits;
-  ev.getByToken(tok_ecal_,ecalEEHits);
+  ev.getByToken(tok_ecalEE_,ecalEEHits);
   const PCaloHitContainer * SimHitResultEE = ecalEEHits.product () ;
 
   for (std::vector<PCaloHit>::const_iterator SimHits = SimHitResultEE->begin () ; SimHits != SimHitResultEE->end(); ++SimHits) {


### PR DESCRIPTION
Minor fix as an aftermath of major HCAL consumenrs update, in the auxiliary/private valiation analyser     
