### PR TITLE
Fixes to make happy the static analizer

### DIFF
--- a/CondCore/CondDB/interface/Exception.h
+++ b/CondCore/CondDB/interface/Exception.h
@@ -2,7 +2,6 @@
 #define CondCore_CondDB_Exception_h
 
 #include "FWCore/Utilities/interface/Exception.h"
-#include <typeinfo>
 
 namespace conddb {
 
@@ -15,7 +14,7 @@ namespace conddb {
     virtual ~Exception() throw() {}
   };
 
-  void throwException( const std::string& message, const std::string& methodName );
+  void throwException [[noreturn]] ( const std::string& message, const std::string& methodName );
 
 }
 

--- a/CondCore/DBCommon/interface/Exception.h
+++ b/CondCore/DBCommon/interface/Exception.h
@@ -31,6 +31,6 @@ namespace cond{
     virtual ~TransactionException() throw(){}
   };
   
-  void throwException( std::string const& message, std::string const& methodName );
+  void throwException [[noreturn]] ( std::string const& message, std::string const& methodName );
 }
 #endif

--- a/CondCore/DBCommon/src/Cipher.cc
+++ b/CondCore/DBCommon/src/Cipher.cc
@@ -24,6 +24,12 @@ size_t cond::Cipher::bf_process_alloc( const unsigned char* input,
   unsigned int j = sizeof(uInt32);
 
   unsigned int output_size=0;
+
+  if( !input_size ) {
+    output = 0;
+    return 0;
+  }
+
   for ( unsigned int i=0; i < input_size; i+=(j*2)){
     output_size = i+2*j;
   }
@@ -60,10 +66,15 @@ size_t cond::Cipher::bf_process_alloc( const unsigned char* input,
 }
     
 size_t cond::Cipher::encrypt( const std::string& input, unsigned char*& output ){
+  if( input.empty() ) {
+    output = 0;
+    return 0;
+  }
   return bf_process_alloc( reinterpret_cast<const unsigned char*>(input.c_str()), input.size(), output, false );;
 }
 
 std::string cond::Cipher::decrypt( const unsigned char* input, size_t inputSize ){
+  if( !inputSize ) return ""; 
   unsigned char* out = 0;
   size_t outSize = bf_process_alloc( input, inputSize, out, true );
   size_t i = 0;
@@ -89,6 +100,7 @@ std::string cond::Cipher::decrypt( const unsigned char* input, size_t inputSize 
 }
 
 std::string cond::Cipher::b64encrypt( const std::string& input ){
+  if( input.empty() ) return "";
   unsigned char* out = 0;
   size_t outSize = bf_process_alloc( reinterpret_cast<const unsigned char*>(input.c_str()), input.size(), out, false );
   char* b64out = 0;
@@ -100,6 +112,7 @@ std::string cond::Cipher::b64encrypt( const std::string& input ){
 }
 
 std::string cond::Cipher::b64decrypt( const std::string& b64in ){
+  if( b64in.empty() ) return "";
   char* input = 0;
   size_t inputSize = 0;
   if( !base64_decode_alloc( b64in.c_str(), b64in.size(), &input, &inputSize ) ){

--- a/CondCore/DBCommon/test/testCipher.cc
+++ b/CondCore/DBCommon/test/testCipher.cc
@@ -4,6 +4,19 @@
 
 int main(){
   cond::KeyGenerator gen;
+  // empty string to encode
+  std::string empty("");
+  std::string k0 = gen.makeWithRandomSize( 100 );
+  cond::Cipher c_en( k0 );
+  std::string e = c_en.b64encrypt( empty );
+  cond::Cipher c_de( k0 );
+  std::string d = c_de.b64decrypt(e);
+  if( empty != d ){
+    std::cout <<"##### Error: encoded ["<<empty<<"] (size="<<empty.size()<<") with key="<<k0<<"; decoded=["<<d<<"] (size="<<d.size()<<") "<<std::endl;
+  } else {
+    std::cout <<"TEST OK: encoded size "<<e.size()<<" with key size="<<k0.size()<<std::endl;
+  }
+
   for( unsigned int i = 0; i<200; i++ ){
     std::string word = gen.makeWithRandomSize( 200 );
     std::string k = gen.makeWithRandomSize( 100 );

--- a/CondCore/ORA/interface/Exception.h
+++ b/CondCore/ORA/interface/Exception.h
@@ -15,9 +15,9 @@ namespace ora {
     virtual ~Exception() throw() {}
   };
 
-  void throwException( const std::string& message, const std::string& methodName );
+  void throwException( const std::string& message, const std::string& methodName )__attribute__((noreturn));
 
-  void throwException( const std::string& message, const std::type_info& sourceType, const std::string& methodName  );
+  void throwException( const std::string& message, const std::type_info& sourceType, const std::string& methodName  )__attribute__((noreturn));
 
 }
 


### PR DESCRIPTION
Control flow have been checked for zero-size strings in DBCommon/Cipher class. Functions throwing exceptions have been marked as _noreturn_
