### PR TITLE
Fix thread problems with ErrorObj

### DIFF
--- a/FWCore/MessageLogger/interface/ErrorObj.h
+++ b/FWCore/MessageLogger/interface/ErrorObj.h
@@ -30,6 +30,7 @@
 
 #include <sstream>
 #include <string>
+#include <atomic>
 
 namespace edm {       
 
@@ -97,7 +98,7 @@ public:
 private:
   // ---  class-wide serial number stamper:
   //
-  static int     ourSerial;
+  static std::atomic<int>     ourSerial;
 
   // ---  data members:
   //

--- a/FWCore/MessageLogger/interface/ErrorObj.h
+++ b/FWCore/MessageLogger/interface/ErrorObj.h
@@ -30,7 +30,6 @@
 
 #include <sstream>
 #include <string>
-#include <atomic>
 
 namespace edm {       
 
@@ -96,9 +95,6 @@ public:
   virtual void  setReactedTo ( bool r );
 
 private:
-  // ---  class-wide serial number stamper:
-  //
-  static std::atomic<int>     ourSerial;
 
   // ---  data members:
   //

--- a/FWCore/MessageLogger/src/ErrorObj.cc
+++ b/FWCore/MessageLogger/src/ErrorObj.cc
@@ -66,7 +66,7 @@ namespace edm
 // Class static and class-wide parameter:
 // ----------------------------------------------------------------------
 
-int  ErrorObj::ourSerial(  0 );
+std::atomic<int>  ErrorObj::ourSerial(  0 );
 const unsigned int  maxIDlength( 200 );		// changed 4/28/06 from 20
 
 

--- a/FWCore/MessageLogger/src/ErrorObj.cc
+++ b/FWCore/MessageLogger/src/ErrorObj.cc
@@ -39,6 +39,7 @@
 //
 // ----------------------------------------------------------------------
 
+#include <atomic>
 
 #include "FWCore/MessageLogger/interface/ErrorObj.h"
 
@@ -66,7 +67,9 @@ namespace edm
 // Class static and class-wide parameter:
 // ----------------------------------------------------------------------
 
-std::atomic<int>  ErrorObj::ourSerial(  0 );
+  // ---  class-wide serial number stamper:
+  //
+static std::atomic<int>  ourSerial(  0 );
 const unsigned int  maxIDlength( 200 );		// changed 4/28/06 from 20
 
 


### PR DESCRIPTION
Fixed two problems with ErrorObj found while running the preliminary threaded cmsRun via helgrind. These are not a problem for the single threaded framework but it helps to keep the two aligned.
