### PR TITLE
Enable NO_LIB_CHECKING on RFIODPMPlugin target

### DIFF
--- a/Utilities/RFIOAdaptor/plugins/BuildFile.xml
+++ b/Utilities/RFIOAdaptor/plugins/BuildFile.xml
@@ -19,6 +19,7 @@
   # Not linking against libdpm directly since we load it
   # via dlopen at runtime.
   #<use   name="dpm"/>
+  <flags   NO_LIB_CHECKING="yes"/>
   <flags   EDM_PLUGIN="1"/>
   <flags   cppflags="-D_FILE_OFFSET_BITS=64"/>
 </library>


### PR DESCRIPTION
If SCRAM missing symbol check is enabled RFIODPMPlugin will fail
the check. The main library (Utilities/RFIOAdaptor) does not link
directly to castor, but has castor functions marked as extern in
./interface/RFIO.h. Thus castor needs to be loaded explicitly
before loading the library.

UtilitiesRFIOAdaptorPlugin passes as it has NO_LIB_CHECKING.
RFIOCastorPlugin passes as it links directly to castor.

This is minimal change. Otherwise we link to castor directly in
the main library as we do for Darwin.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
