### PR TITLE
New feature: LHE Reader can read proposed LHE weights tags (standard in MG5)

### DIFF
--- a/GeneratorInterface/LHEInterface/BuildFile.xml
+++ b/GeneratorInterface/LHEInterface/BuildFile.xml
@@ -12,6 +12,7 @@
 <use name="libhepml"/>
 <use name="fastjet"/>
 <use name="xz"/>
+<use name="boost"/>
 <export>
 	<use name="FWCore/ParameterSet"/>
 	<use name="FWCore/PluginManager"/>

--- a/GeneratorInterface/LHEInterface/BuildFile.xml
+++ b/GeneratorInterface/LHEInterface/BuildFile.xml
@@ -12,7 +12,6 @@
 <use name="libhepml"/>
 <use name="fastjet"/>
 <use name="xz"/>
-<use name="boost"/>
 <export>
 	<use name="FWCore/ParameterSet"/>
 	<use name="FWCore/PluginManager"/>

--- a/GeneratorInterface/LHEInterface/interface/LHEEvent.h
+++ b/GeneratorInterface/LHEInterface/interface/LHEEvent.h
@@ -37,6 +37,7 @@ class LHEEvent {
 	~LHEEvent();
 
 	typedef LHEEventProduct::PDF PDF;
+	typedef LHEEventProduct::WGT WGT;
 
 	const boost::shared_ptr<LHERunInfo> &getRunInfo() const { return runInfo; }
 	const HEPEUP *getHEPEUP() const { return &hepeup; }
@@ -45,7 +46,10 @@ class LHEEvent {
 	const std::vector<std::string> &getComments() const { return comments; }
 	const int getReadAttempts() { return readAttemptCounter; }
 
+	void addWeight(const WGT& wgt) {weights_.push_back(wgt);}
 	void setPDF(std::auto_ptr<PDF> pdf) { this->pdf = pdf; }
+
+	const std::vector<WGT>& weights() const { return weights_; }
 
 	void addComment(const std::string &line) { comments.push_back(line); }
 
@@ -75,6 +79,7 @@ class LHEEvent {
 
 	HEPEUP					hepeup;
 	std::auto_ptr<PDF>			pdf;
+	std::vector<WGT>	          	weights_;
 	std::vector<std::string>		comments;
 	bool					counted;
 	int                                     readAttemptCounter;

--- a/GeneratorInterface/LHEInterface/interface/LHEEvent.h
+++ b/GeneratorInterface/LHEInterface/interface/LHEEvent.h
@@ -25,7 +25,7 @@ namespace lhef {
 class LHEEvent {
     public:
 	LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
-	         std::istream &in);
+	         std::istream &in, const int nweights = 0);
 	LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
 	         const HEPEUP &hepeup);
 	LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,

--- a/GeneratorInterface/LHEInterface/interface/LHEEvent.h
+++ b/GeneratorInterface/LHEInterface/interface/LHEEvent.h
@@ -25,7 +25,7 @@ namespace lhef {
 class LHEEvent {
     public:
 	LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
-	         std::istream &in, const int nweights = 0);
+	         std::istream &in);
 	LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
 	         const HEPEUP &hepeup);
 	LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
@@ -46,7 +46,7 @@ class LHEEvent {
 	const std::vector<std::string> &getComments() const { return comments; }
 	const int getReadAttempts() { return readAttemptCounter; }
 
-	void addWeight(const WGT& wgt) {weights_.push_back(wgt);}
+	void addWeight(const WGT& wgt) { weights_.push_back(wgt); }
 	void setPDF(std::auto_ptr<PDF> pdf) { this->pdf = pdf; }
 
 	const std::vector<WGT>& weights() const { return weights_; }

--- a/GeneratorInterface/LHEInterface/interface/LHEReader.h
+++ b/GeneratorInterface/LHEInterface/interface/LHEReader.h
@@ -33,10 +33,11 @@ class LHEReader {
 	class XMLHandler;
 
 	const std::vector<std::string>	fileURLs;
-    const std::string               strName;
+	const std::string               strName;
 	unsigned int			firstEvent;
 	int				maxEvents;
 	unsigned int			curIndex;
+	std::vector<std::string>        weightsinconfig;
 
 	std::auto_ptr<Source>		curSource;
 	std::auto_ptr<XMLDocument>	curDoc;

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.cc
@@ -66,6 +66,7 @@ void LHESource::nextEvent()
 
 	bool newFileOpened = false;
 	partonLevel = reader->next(&newFileOpened);
+
 	if(newFileOpened) incrementFileIndex();
 	if (!partonLevel) {
 		return;
@@ -152,12 +153,11 @@ LHESource::readEvent_(edm::EventPrincipal& eventPrincipal) {
 			new LHEEventProduct(*partonLevel->getHEPEUP()));
 	if (partonLevel->getPDF()) {
 		product->setPDF(*partonLevel->getPDF());
-        }
-	std::vector<LHEEventProduct::WGT>::const_iterator iwgt = 
-	  partonLevel->weights().begin();
-	for( ; iwgt != partonLevel->weights().end(); ++iwgt ) {
-	  product->addWeight(*iwgt);
-	}
+        }		
+	std::for_each(partonLevel->weights().begin(),
+		      partonLevel->weights().end(),
+		      boost::bind(&LHEEventProduct::addWeight,
+				  product.get(), _1));
 	std::for_each(partonLevel->getComments().begin(),
 	              partonLevel->getComments().end(),
 	              boost::bind(&LHEEventProduct::addComment,

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.cc
@@ -153,6 +153,11 @@ LHESource::readEvent_(edm::EventPrincipal& eventPrincipal) {
 	if (partonLevel->getPDF()) {
 		product->setPDF(*partonLevel->getPDF());
         }
+	std::vector<LHEEventProduct::WGT>::const_iterator iwgt = 
+	  partonLevel->weights().begin();
+	for( ; iwgt != partonLevel->weights().end(); ++iwgt ) {
+	  product->addWeight(*iwgt);
+	}
 	std::for_each(partonLevel->getComments().begin(),
 	              partonLevel->getComments().end(),
 	              boost::bind(&LHEEventProduct::addComment,

--- a/GeneratorInterface/LHEInterface/src/LHEEvent.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEEvent.cc
@@ -34,7 +34,8 @@ static int skipWhitespace(std::istream &in)
 namespace lhef {
 
 LHEEvent::LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
-                   std::istream &in) :
+                   std::istream &in,
+		   const int nweights) :
 	runInfo(runInfo), counted(false), readAttemptCounter(0)
 {
 	hepeup.NUP = 0;

--- a/GeneratorInterface/LHEInterface/src/LHEEvent.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEEvent.cc
@@ -34,9 +34,10 @@ static int skipWhitespace(std::istream &in)
 namespace lhef {
 
 LHEEvent::LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
-                   std::istream &in,
-		   const int nweights) :
-	runInfo(runInfo), counted(false), readAttemptCounter(0)
+                   std::istream &in) :
+  runInfo(runInfo), weights_(0), counted(false), 
+  readAttemptCounter(0)
+  
 {
 	hepeup.NUP = 0;
 	hepeup.XPDWUP.first = hepeup.XPDWUP.second = 0.0;
@@ -137,6 +138,7 @@ LHEEvent::LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
                    const LHEEventProduct &product) :
 	runInfo(runInfo), hepeup(product.hepeup()),
 	pdf(product.pdf() ? new PDF(*product.pdf()) : 0),
+	weights_(product.weights()),
 	comments(product.comments_begin(), product.comments_end()),
 	counted(false), readAttemptCounter(0)
 {

--- a/GeneratorInterface/LHEInterface/src/LHEEvent.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEEvent.cc
@@ -50,7 +50,7 @@ LHEEvent::LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
 	int idwtup = runInfo->getHEPRUP()->IDWTUP;
 	if (idwtup >= 0 && hepeup.XWGTUP < 0) {
 		edm::LogWarning("Generator|LHEInterface")
-			<< "Non-allowed egative event weight encountered."
+			<< "Non-allowed negative event weight encountered."
 			<< std::endl;
 		hepeup.XWGTUP = std::abs(hepeup.XWGTUP);
 	}
@@ -79,42 +79,42 @@ LHEEvent::LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
 	}
 
 	while(skipWhitespace(in) == '#') {
-		std::string line;
-		std::getline(in, line);
-		std::istringstream ss(line);
-		std::string tag;
-		ss >> tag;
-		if (tag == "#pdf") {
-			pdf.reset(new PDF);
-			ss >> pdf->id.first >> pdf->id.second
-			   >> pdf->x.first >> pdf->x.second
-			   >> pdf->scalePDF
-			   >> pdf->xPDF.first >> pdf->xPDF.second;
-			if (ss.bad()) {
-				edm::LogWarning("Generator|LHEInterface")
-					<< "Les Houches event contained"
-					   " unparseable PDF information."
+	  std::string line;
+	  std::getline(in, line);
+	  std::istringstream ss(line);
+	  std::string tag;
+	  ss >> tag;
+	  if (tag == "#pdf") {
+	    pdf.reset(new PDF);
+	    ss >> pdf->id.first >> pdf->id.second
+	       >> pdf->x.first >> pdf->x.second
+	       >> pdf->scalePDF
+	       >> pdf->xPDF.first >> pdf->xPDF.second;
+	    if (ss.bad()) {
+	      edm::LogWarning("Generator|LHEInterface")
+		<< "Les Houches event contained"
+		" unparseable PDF information."
 					<< std::endl;
-				pdf.reset();
-			} else
-				continue;
-		}
-                size_t found = line.find("amcatnlo");
-                double NEVT = 1.0;
-                if ( found != std::string::npos) {
-                    std::string avalue = line.substr(found+1,line.size());
-                    found = avalue.find("_");
-                    avalue = avalue.substr(found+1,avalue.size());
-                    NEVT = atof(avalue.c_str());
-                }
-                hepeup.XWGTUP = hepeup.XWGTUP*NEVT; 
-		comments.push_back(line + "\n");
+	      pdf.reset();
+	    } else
+	      continue;
+	  }
+	  size_t found = line.find("amcatnlo");
+	  double NEVT = 1.0;
+	  if ( found != std::string::npos) {
+	    std::string avalue = line.substr(found+1,line.size());
+	    found = avalue.find("_");
+	    avalue = avalue.substr(found+1,avalue.size());
+	    NEVT = atof(avalue.c_str());
+	  }
+	  hepeup.XWGTUP = hepeup.XWGTUP*NEVT; 
+	  comments.push_back(line + "\n");
 	}
-
+	
 	if (!in.eof())
-		edm::LogWarning("Generator|LHEInterface")
-			<< "Les Houches file contained spurious"
-			   " content after event data." << std::endl;
+	  edm::LogWarning("Generator|LHEInterface")
+	    << "Les Houches file contained spurious"
+	    " content after event data." << std::endl;
 }
 
 LHEEvent::LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,

--- a/GeneratorInterface/LHEInterface/src/LHEReader.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEReader.cc
@@ -492,7 +492,6 @@ LHEReader::~LHEReader()
 	lheevent.reset(new LHEEvent(curRunInfo, data));
 	const XMLHandler::wgt_info& info = handler->weightInfo();
 	for( size_t i=0; i< info.size(); ++i ) {
-	  std::cout << "adding weight: " << info[i].first << ' ' << info[i].second << std::endl;
 	  lheevent->addWeight(gen::WeightsInfo(info[i].first,info[i].second));
 	}
 

--- a/GeneratorInterface/LHEInterface/test/DummyLHEAnalyzer.cc
+++ b/GeneratorInterface/LHEInterface/test/DummyLHEAnalyzer.cc
@@ -59,10 +59,18 @@ private:
                 << std::setw(14) << std::fixed << (pup_[icount])[4] 
                 << std::endl;
     }
-
+    if( evt->weights().size() ) {
+      std::cout << "weights:" << std::endl;
+      for ( size_t iwgt = 0; iwgt < evt->weights().size(); ++iwgt ) {
+	const LHEEventProduct::WGT& wgt = evt->weights().at(iwgt);
+	std::cout << "\t" << wgt.id << ' ' 
+		  << std::scientific << wgt.wgt << std::endl;
+      }
+    }
 
   }
 
+  /*
   void beginRun(edm::Run const& iRun, edm::EventSetup const& es) override {
 
 
@@ -96,6 +104,7 @@ private:
     std::cout << " " << std::endl;
 
   }
+  */
 
   InputTag src_;
 };

--- a/GeneratorInterface/LHEInterface/test/dumpLHE_cfg.py
+++ b/GeneratorInterface/LHEInterface/test/dumpLHE_cfg.py
@@ -7,7 +7,7 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
 )
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:gen.root')
+    fileNames = cms.untracked.vstring('file:lhe.root')
 )
 
 process.dummy = cms.EDAnalyzer("DummyLHEAnalyzer",

--- a/GeneratorInterface/LHEInterface/test/testReader_cfg.py
+++ b/GeneratorInterface/LHEInterface/test/testReader_cfg.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("LHE")
 
 process.source = cms.Source("LHESource",
-	fileNames = cms.untracked.vstring('file:ttbar.lhe')
+	fileNames = cms.untracked.vstring('file:/afs/cern.ch/user/l/lgray/work/public/CMSSW_7_0_0_pre2/src/2.0.0beta4/VBF_HAA_reweight/Events/VBF_HAA_reweight4/unweighted_events.lhe')
 )
 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
@@ -16,7 +16,8 @@ process.configurationMetadata = cms.untracked.PSet(
 )
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
-process.MessageLogger.cerr.threshold = 'INFO'
+#process.MessageLogger.cerr.threshold = 'INFO'
+process.MessageLogger.cout = cms.untracked.PSet( threshold = cms.untracked.string('INFO') )
 
 process.LHE = cms.OutputModule("PoolOutputModule",
 	dataset = cms.untracked.PSet(dataTier = cms.untracked.string('LHE')),

--- a/GeneratorInterface/LHEInterface/test/testReader_cfg.py
+++ b/GeneratorInterface/LHEInterface/test/testReader_cfg.py
@@ -7,7 +7,7 @@ process.source = cms.Source("LHESource",
 	fileNames = cms.untracked.vstring('file:/afs/cern.ch/user/l/lgray/work/public/CMSSW_7_0_0_pre2/src/2.0.0beta4/VBF_HAA_reweight/Events/VBF_HAA_reweight4/unweighted_events.lhe')
 )
 
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 
 process.configurationMetadata = cms.untracked.PSet(
 	version = cms.untracked.string('alpha'),

--- a/GeneratorInterface/LHEInterface/test/testReader_cfg.py
+++ b/GeneratorInterface/LHEInterface/test/testReader_cfg.py
@@ -7,7 +7,7 @@ process.source = cms.Source("LHESource",
 	fileNames = cms.untracked.vstring('file:/afs/cern.ch/user/l/lgray/work/public/CMSSW_7_0_0_pre2/src/2.0.0beta4/VBF_HAA_reweight/Events/VBF_HAA_reweight4/unweighted_events.lhe')
 )
 
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 
 process.configurationMetadata = cms.untracked.PSet(
 	version = cms.untracked.string('alpha'),
@@ -23,5 +23,10 @@ process.LHE = cms.OutputModule("PoolOutputModule",
 	dataset = cms.untracked.PSet(dataTier = cms.untracked.string('LHE')),
 	fileName = cms.untracked.string('lhe.root')
 )
+
+#process.lhedump = cms.EDAnalyzer("DummyLHEAnalyzer",
+#                                 src = cms.InputTag("source")
+#                                 )
+
 
 process.outpath = cms.EndPath(process.LHE)

--- a/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
@@ -23,9 +23,8 @@ class LHEEventProduct {
 	~LHEEventProduct() {}
 
 	void setPDF(const PDF &pdf) { pdf_.reset(new PDF(pdf)); }
-	void setWeights(const std::vector<WGT>& wgts) { 
-	  weights_.clear(); 
-	  weights_.insert(weights_.begin(),wgts.begin(),wgts.end());
+	void addWeight(const WGT& wgt) { 	  
+	  weights_.push_back(wgt);
 	}
 	void addComment(const std::string &line) { comments_.push_back(line); }
 

--- a/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
@@ -7,10 +7,12 @@
 
 #include "SimDataFormats/GeneratorProducts/interface/LesHouches.h"
 #include "SimDataFormats/GeneratorProducts/interface/PdfInfo.h"
+#include "SimDataFormats/GeneratorProducts/interface/WeightsInfo.h"
 
 class LHEEventProduct {
     public:
 	typedef gen::PdfInfo PDF;
+	typedef gen::WeightsInfo WGT;
 
 	typedef std::vector<std::string>::const_iterator
 						comments_const_iterator;
@@ -21,7 +23,13 @@ class LHEEventProduct {
 	~LHEEventProduct() {}
 
 	void setPDF(const PDF &pdf) { pdf_.reset(new PDF(pdf)); }
+	void setWeights(const std::vector<WGT>& wgts) { 
+	  weights_.clear(); 
+	  weights_.insert(weights_.begin(),wgts.begin(),wgts.end());
+	}
 	void addComment(const std::string &line) { comments_.push_back(line); }
+
+	const std::vector<WGT>& weights() const { return weights_; }
 
 	const lhef::HEPEUP &hepeup() const { return hepeup_; }
 	const PDF *pdf() const { return pdf_.get(); }
@@ -73,6 +81,7 @@ class LHEEventProduct {
 	lhef::HEPEUP			hepeup_;
 	std::vector<std::string>	comments_;
 	std::auto_ptr<PDF>		pdf_;
+	std::vector<WGT>                weights_;
 };
 
 #endif // GeneratorEvent_LHEInterface_LHEEventProduct_h

--- a/SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h
@@ -12,6 +12,7 @@
 
 class LHERunInfoProduct {
     public:
+    typedef std::vector<std::pair<std::string,std::string> > weights_defs;
 	class Header {
 	    public:
 		typedef std::vector<std::string>::const_iterator const_iterator;
@@ -110,10 +111,16 @@ class LHERunInfoProduct {
 	const_iterator init() const;
 	inline const_iterator end() const { return const_iterator(); }
 
+
+	void addWeightDefinition(const weights_defs::value_type& wd) {
+	  wgtdefs_.push_back(wd);
+	}
+	const weights_defs& getWeightDefinitions() const { return wgtdefs_; }
+
 	static const std::string &endOfFile();
 
 	bool operator == (const LHERunInfoProduct &other) const
-	{ return heprup_ == other.heprup_ && headers_ == other.headers_ && comments_ == other.comments_; }
+	{ return heprup_ == other.heprup_ && headers_ == other.headers_ && comments_ == other.comments_ && wgtdefs_ == other.wgtdefs_; }
 	inline bool operator != (const LHERunInfoProduct &other) const
 	{ return !(*this == other); }
 
@@ -126,6 +133,7 @@ class LHERunInfoProduct {
 	lhef::HEPRUP			heprup_;
 	std::vector<Header>		headers_;
 	std::vector<std::string>	comments_;
+	weights_defs                    wgtdefs_;
 };
 
 #endif // GeneratorRunInfo_LHEInterface_LHERunInfoProduct_h

--- a/SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h
@@ -111,16 +111,10 @@ class LHERunInfoProduct {
 	const_iterator init() const;
 	inline const_iterator end() const { return const_iterator(); }
 
-
-	void addWeightDefinition(const weights_defs::value_type& wd) {
-	  wgtdefs_.push_back(wd);
-	}
-	const weights_defs& getWeightDefinitions() const { return wgtdefs_; }
-
 	static const std::string &endOfFile();
 
 	bool operator == (const LHERunInfoProduct &other) const
-	{ return heprup_ == other.heprup_ && headers_ == other.headers_ && comments_ == other.comments_ && wgtdefs_ == other.wgtdefs_; }
+	{ return heprup_ == other.heprup_ && headers_ == other.headers_ && comments_ == other.comments_; }
 	inline bool operator != (const LHERunInfoProduct &other) const
 	{ return !(*this == other); }
 
@@ -133,7 +127,6 @@ class LHERunInfoProduct {
 	lhef::HEPRUP			heprup_;
 	std::vector<Header>		headers_;
 	std::vector<std::string>	comments_;
-	weights_defs                    wgtdefs_;
 };
 
 #endif // GeneratorRunInfo_LHEInterface_LHERunInfoProduct_h

--- a/SimDataFormats/GeneratorProducts/interface/WeightsInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/WeightsInfo.h
@@ -8,6 +8,9 @@
 
 namespace gen {
 	struct WeightsInfo {
+	        WeightsInfo(): id(""), wgt(0.) {}
+	        WeightsInfo(const std::string& s, const double w): 
+		  id(s),wgt(w) {}
 		std::string	id;
 		double	        wgt;		
 	};

--- a/SimDataFormats/GeneratorProducts/interface/WeightsInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/WeightsInfo.h
@@ -9,9 +9,11 @@
 namespace gen {
 	struct WeightsInfo {
 	        WeightsInfo(): id(""), wgt(0.) {}
+	        WeightsInfo(const WeightsInfo& o):
+		  id(o.id), wgt(o.wgt) {}
 	        WeightsInfo(const std::string& s, const double w): 
 		  id(s),wgt(w) {}
-		std::string	id;
+	        std::string	id;
 		double	        wgt;		
 	};
 }

--- a/SimDataFormats/GeneratorProducts/interface/WeightsInfo.h
+++ b/SimDataFormats/GeneratorProducts/interface/WeightsInfo.h
@@ -1,0 +1,16 @@
+#ifndef SimDataFormats_GeneratorProducts_WeightsInfo_h
+#define SimDataFormats_GeneratorProducts_WeightsInfo_h
+
+/** \class PdfInfo
+ *
+ */
+#include <string>
+
+namespace gen {
+	struct WeightsInfo {
+		std::string	id;
+		double	        wgt;		
+	};
+}
+
+#endif // SimDataFormats_GeneratorProducts_WeightsInfo_h

--- a/SimDataFormats/GeneratorProducts/src/classes.h
+++ b/SimDataFormats/GeneratorProducts/src/classes.h
@@ -59,6 +59,8 @@ namespace {
 		// LHE products
 
 		edm::Wrapper<LHERunInfoProduct>	wcommon;
+	        gen::WeightsInfo wwgtinfo;
+	        std::vector<gen::WeightsInfo> wvwgtinfo;
 		edm::Wrapper<LHEEventProduct>	wevent;
                 edm::Wrapper<LHEXMLStringProduct> wstring;
 	};

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -130,11 +130,13 @@
  </class> 
  <class name="edm::Wrapper&lt;LHEXMLStringProduct&gt;"/>
 	<class name="std::vector&lt;LHERunInfoProduct::Header&gt;"/>
-	<class name="LHERunInfoProduct" ClassVersion="10">
+	<class name="LHERunInfoProduct" ClassVersion="11">
   <version ClassVersion="10" checksum="2098560362"/>
+  <version ClassVersion="11" checksum="699293988"/>
  </class>
-	<class name="LHEEventProduct" ClassVersion="10">
+	<class name="LHEEventProduct" ClassVersion="11">
   <version ClassVersion="10" checksum="1026978494"/>
+  <version ClassVersion="11" checksum="619154414"/>
  </class>
 	<class name="edm::Wrapper&lt;LHERunInfoProduct&gt;"/>
 	<class name="edm::Wrapper&lt;LHEEventProduct&gt;"/>

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -137,6 +137,8 @@
   <version ClassVersion="10" checksum="1026978494"/>
   <version ClassVersion="11" checksum="619154414"/>
  </class>
+ <class name="gen::WeightsInfo"/>
+ <class name="std::vector<gen::WeightsInfo>"/>
 	<class name="edm::Wrapper&lt;LHERunInfoProduct&gt;"/>
 	<class name="edm::Wrapper&lt;LHEEventProduct&gt;"/>
 

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -130,9 +130,8 @@
  </class> 
  <class name="edm::Wrapper&lt;LHEXMLStringProduct&gt;"/>
 	<class name="std::vector&lt;LHERunInfoProduct::Header&gt;"/>
-	<class name="LHERunInfoProduct" ClassVersion="11">
+	<class name="LHERunInfoProduct" ClassVersion="10">
   <version ClassVersion="10" checksum="2098560362"/>
-  <version ClassVersion="11" checksum="699293988"/>
  </class>
 	<class name="LHEEventProduct" ClassVersion="11">
   <version ClassVersion="10" checksum="1026978494"/>

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -137,7 +137,9 @@
   <version ClassVersion="10" checksum="1026978494"/>
   <version ClassVersion="11" checksum="619154414"/>
  </class>
- <class name="gen::WeightsInfo"/>
+ <class name="gen::WeightsInfo" ClassVersion="10">
+  <version ClassVersion="10" checksum="2663143460"/>
+ </class>
  <class name="std::vector<gen::WeightsInfo>"/>
 	<class name="edm::Wrapper&lt;LHERunInfoProduct&gt;"/>
 	<class name="edm::Wrapper&lt;LHEEventProduct&gt;"/>


### PR DESCRIPTION
The LHESource has been modified to be able to read weights with the structure defined here:
https://cp3.irmp.ucl.ac.be/projects/madgraph/wiki/Reweight

This was tested on 50k events containing embedded weights, and 50k events with no weights.
The reader shows no faulty behavior in the no-weights case, and works to arbitrarily high numbers of weights.

The weights definition header is currently stored in the same way as other headers in the LHERunInfoProduct in CMS.
