### PR TITLE
Wrapper<T>::getInterface explicitly uses a const static

### DIFF
--- a/DataFormats/Common/interface/Wrapper.h
+++ b/DataFormats/Common/interface/Wrapper.h
@@ -466,7 +466,7 @@ namespace edm {
   template <typename T>
   WrapperInterface<T> const*
   Wrapper<T>::getInterface() {
-    static WrapperInterface<T> instance;
+    static const WrapperInterface<T> instance;
     return &instance;
   }
 }


### PR DESCRIPTION
The value returned from Wrapper<T>::getInterface was always const but internally the function held a non-const static. We now changed it to a ‘const’ static since that was its real behavior and using a ‘const static’ avoids confusing our thread safety checkers
