### PR TITLE
Make statics value visible inline to avoid possible race conditions and

### DIFF
--- a/DataFormats/L1CaloTrigger/interface/L1CaloRegionDetId.h
+++ b/DataFormats/L1CaloTrigger/interface/L1CaloRegionDetId.h
@@ -19,8 +19,8 @@ class L1CaloRegionDetId : public DetId {
 
  public:
 
-  static const unsigned N_PHI;
-  static const unsigned N_ETA;
+  static const unsigned N_PHI = 18;
+  static const unsigned N_ETA = 22;
 
   /// create null id
   L1CaloRegionDetId();

--- a/DataFormats/L1CaloTrigger/src/L1CaloRegionDetId.cc
+++ b/DataFormats/L1CaloTrigger/src/L1CaloRegionDetId.cc
@@ -2,10 +2,6 @@
 
 #include "DataFormats/L1CaloTrigger/interface/L1CaloRegionDetId.h"
 
-unsigned const L1CaloRegionDetId::N_PHI=18;
-unsigned const L1CaloRegionDetId::N_ETA=22;
-
-
 // default constructor - null DetId
 L1CaloRegionDetId::L1CaloRegionDetId() : DetId() { }
 


### PR DESCRIPTION
subsequent clang static analyzer complains. These should really be a constexpr,
but we cannot do it until ROOT6.
