### PR TITLE
Don't update global registries in secondary source

### DIFF
--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -161,15 +161,15 @@ namespace edm {
     void overrideRunNumber(EventID& id, bool isRealData);
     std::string const& newBranchToOldBranch(std::string const& newBranch) const;
     void dropOnInput(ProductRegistry& reg, ProductSelectorRules const& rules, bool dropDescendants, InputType inputType);
-    void readParentageTree();
-    void readEntryDescriptionTree(EntryDescriptionMap&); // backward compatibility
+    void readParentageTree(InputType inputType);
+    void readEntryDescriptionTree(EntryDescriptionMap& entryDescriptionMap, InputType inputType); // backward compatibility
     void readEventHistoryTree();
     bool isDuplicateEvent();
 
     void initializeDuplicateChecker(std::vector<boost::shared_ptr<IndexIntoFile> > const& indexesIntoFiles,
                                     std::vector<boost::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile);
 
-    std::unique_ptr<MakeProvenanceReader> makeProvenanceReaderMaker();
+    std::unique_ptr<MakeProvenanceReader> makeProvenanceReaderMaker(InputType inputType);
     boost::shared_ptr<ProductProvenanceRetriever> makeProductProvenanceRetriever();
 
     std::string const file_;


### PR DESCRIPTION
The parameter set and parentage registries are each globals across all threads.  This pull request ensures that a secondary input source will not update either of them.  This is needed for thread safety.
This has been successfully tested with the full relval matrix.
