### PR TITLE
Enable Prefetching

### DIFF
--- a/DQM/TrackingMonitor/src/TrackSplittingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackSplittingMonitor.cc
@@ -30,8 +30,14 @@
 #include <string>
 
 TrackSplittingMonitor::TrackSplittingMonitor(const edm::ParameterSet& iConfig) {
-	dqmStore_ = edm::Service<DQMStore>().operator->();
-	conf_ = iConfig;
+  dqmStore_ = edm::Service<DQMStore>().operator->();
+  conf_ = iConfig;
+
+  splitTracks_ = conf_.getParameter< edm::InputTag >("splitTrackCollection");
+  splitMuons_ = conf_.getParameter< edm::InputTag >("splitMuonCollection");
+
+  splitTracksToken_ = consumes<std::vector<reco::Track> >(splitTracks_);
+  splitMuonsToken_  = mayConsume<std::vector<reco::Muon> >(splitMuons_);
 }
 
 TrackSplittingMonitor::~TrackSplittingMonitor() { 
@@ -43,13 +49,8 @@ void TrackSplittingMonitor::beginJob(void) {
   dqmStore_->setCurrentFolder(MEFolderName);
   
   //get input tags
-  splitTracks_ = conf_.getParameter< edm::InputTag >("splitTrackCollection");
-  splitMuons_ = conf_.getParameter< edm::InputTag >("splitMuonCollection");
   plotMuons_ = conf_.getParameter<bool>("ifPlotMuons");
 
-  splitTracksToken_ = consumes<std::vector<reco::Track> >(splitTracks_);
-  splitMuonsToken_  = mayConsume<std::vector<reco::Muon> >(splitMuons_);
-  
   // cuts
   pixelHitsPerLeg_ = conf_.getParameter<int>("pixelHitsPerLeg");
   totalHitsPerLeg_ = conf_.getParameter<int>("totalHitsPerLeg");

--- a/FWCore/Framework/interface/ModuleContextSentry.h
+++ b/FWCore/Framework/interface/ModuleContextSentry.h
@@ -12,7 +12,7 @@ namespace edm {
     ModuleContextSentry(ModuleCallingContext* moduleCallingContext,
                         ParentContext const& parentContext) :
       moduleCallingContext_(moduleCallingContext) {
-      moduleCallingContext_->setContext(ModuleCallingContext::State::kRunning, parentContext,
+      moduleCallingContext_->setContext(ModuleCallingContext::State::kPrefetching, parentContext,
                                         CurrentModuleOnThread::getCurrentModuleOnThread());
       CurrentModuleOnThread::setCurrentModuleOnThread(moduleCallingContext_);
     }

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -127,6 +127,10 @@ namespace edm {
                            bool& ambiguous,
                            ModuleCallingContext const* mcc) const;
 
+    void prefetch(ProductHolderIndex index,
+                  bool skipCurrentProcess,
+                  ModuleCallingContext const* mcc) const;
+
     void getManyByType(TypeID const& typeID,
                        BasicHandleVec& results,
                        EDConsumerBase const* consumes,

--- a/FWCore/Framework/interface/ProductHolderIndexAndSkipBit.h
+++ b/FWCore/Framework/interface/ProductHolderIndexAndSkipBit.h
@@ -1,0 +1,50 @@
+#ifndef FWCore_Framework_ProductHolderIndexAndSkipBit_h
+#define FWCore_Framework_ProductHolderIndexAndSkipBit_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Framework
+// Class  :     edm::ProductHolderIndexAndSkipBit
+// 
+/**\class edm::ProductHolderIndexAndSkipBit
+
+ Description:  This class holds a ProductIndexHolder and a boolean value
+    to indicate whether the skipCurrentProcess option was set. Internally
+    it bit packs them in an unsigned int. There is a little extra complexity
+    in the implementation to hide the fact that some special values of
+    ProductHolderIndex use the same bit we use for skipCurrentProcess.
+
+ Usage:
+    EDConsumerBase use this and pass a container of them to the Workers
+    to let them know what data will be consumed.
+*/
+//
+// Original Author:  W. David Dagenhart
+//         Created:  3 October 2013
+
+#include "FWCore/Utilities/interface/ProductHolderIndex.h"
+
+namespace edm {
+
+  class ProductHolderIndexAndSkipBit {
+  public:
+    ProductHolderIndexAndSkipBit(ProductHolderIndex productHolderIndex, bool skipCurrentProcess) :
+      value_(skipCurrentProcess ? s_skipMask | productHolderIndex :
+                                  ~s_skipMask & productHolderIndex) { }
+      ProductHolderIndex productHolderIndex() const {
+        bool specialIndexValue = (value_ & ProductHolderIndexValuesBit) != 0;
+        return specialIndexValue ? value_ | s_skipMask :
+                                   value_ & ~s_skipMask;
+      }
+      bool skipCurrentProcess() const { return (value_ & s_skipMask) != 0; }
+
+      bool operator==(ProductHolderIndexAndSkipBit const& r) {
+        return value_ == r.value_;
+      }
+
+  private:
+      static const unsigned int s_skipMask = 1U << 31;
+
+      unsigned int value_;
+  };
+}
+#endif

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -19,6 +19,7 @@
 //
 
 // system include files
+#include <vector>
 
 // user include files
 #include "DataFormats/Provenance/interface/BranchType.h"
@@ -38,6 +39,7 @@ namespace edm {
   class ProductHolderIndexHelper;
   class EDConsumerBase;
   class PreallocationConfiguration;
+  class ProductHolderIndexAndSkipBit;
 
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -45,6 +47,7 @@ namespace edm {
   
   namespace stream {
     class EDAnalyzerBase;
+
     class EDAnalyzerAdaptorBase
     {
       
@@ -73,8 +76,10 @@ namespace edm {
       }
       
       //Same interface as EDConsumerBase
-      void itemsToGet(BranchType, std::vector<ProductHolderIndex>&) const;
-      void itemsMayGet(BranchType, std::vector<ProductHolderIndex>&) const;
+      void itemsToGet(BranchType, std::vector<ProductHolderIndexAndSkipBit>&) const;
+      void itemsMayGet(BranchType, std::vector<ProductHolderIndexAndSkipBit>&) const;
+      std::vector<ProductHolderIndexAndSkipBit> const& itemsToGetFromEvent() const;
+
       void updateLookup(BranchType iBranchType,
                         ProductHolderIndexHelper const&);
       

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -41,6 +41,7 @@ namespace edm {
   class ProductHolderIndexHelper;
   class EDConsumerBase;
   class PreallocationConfiguration;
+  class ProductHolderIndexAndSkipBit;
   
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -68,8 +69,10 @@ namespace edm {
       void
       registerProductsAndCallbacks(ProducingModuleAdaptorBase const*, ProductRegistry* reg);
       
-      void itemsToGet(BranchType, std::vector<ProductHolderIndex>&) const;
-      void itemsMayGet(BranchType, std::vector<ProductHolderIndex>&) const;
+      void itemsToGet(BranchType, std::vector<ProductHolderIndexAndSkipBit>&) const;
+      void itemsMayGet(BranchType, std::vector<ProductHolderIndexAndSkipBit>&) const;
+      std::vector<ProductHolderIndexAndSkipBit> const& itemsToGetFromEvent() const;
+
       void updateLookup(BranchType iBranchType,
                         ProductHolderIndexHelper const&);
 

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -502,6 +502,16 @@ namespace edm {
   }
 
   void
+  Principal::prefetch(ProductHolderIndex index,
+                      bool skipCurrentProcess,
+                      ModuleCallingContext const* mcc) const {
+    boost::shared_ptr<ProductHolderBase> const& productHolder = productHolders_.at(index);
+    assert(0!=productHolder.get());
+    ProductHolderBase::ResolveStatus resolveStatus;
+    productHolder->resolveProduct(resolveStatus, skipCurrentProcess, mcc);
+  }
+
+  void
   Principal::getManyByType(TypeID const& typeID,
                            BasicHandleVec& results,
                            EDConsumerBase const* consumer,
@@ -654,7 +664,7 @@ namespace edm {
       }
       inputTag.tryToCacheIndex(index, typeID, branchType(), &productRegistry());
     }
-    if(unlikely( consumer and (not consumer->registeredToConsume(index,branchType())))) {
+    if(unlikely( consumer and (not consumer->registeredToConsume(index, skipCurrentProcess, branchType())))) {
       failedToRegisterConsumes(kindOfType,typeID,inputTag.label(),inputTag.instance(),inputTag.process());
     }
 
@@ -696,7 +706,7 @@ namespace edm {
       return 0;
     }
     
-    if(unlikely( consumer and (not consumer->registeredToConsume(index,branchType())))) {
+    if(unlikely( consumer and (not consumer->registeredToConsume(index, false, branchType())))) {
       failedToRegisterConsumes(kindOfType,typeID,label,instance,process);
     }
     

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -159,7 +159,9 @@ namespace edm {
   BasicHandle
   PrincipalGetAdapter::getByToken_(TypeID const& id, KindOfType kindOfType, EDGetToken token,
                                    ModuleCallingContext const* mcc) const {
-    ProductHolderIndex index = consumer_->indexFrom(token,InEvent,id);
+    ProductHolderIndexAndSkipBit indexAndBit = consumer_->indexFrom(token,InEvent,id);
+    ProductHolderIndex index = indexAndBit.productHolderIndex();
+    bool skipCurrentProcess = indexAndBit.skipCurrentProcess();
     if( unlikely(index == ProductHolderIndexInvalid)) {
       return makeFailToGetException(kindOfType,id,token);
     } else if( unlikely(index == ProductHolderIndexAmbiguous)) {
@@ -167,7 +169,7 @@ namespace edm {
       throwAmbiguousException(id, token);
     }
     bool ambiguous = false;
-    BasicHandle h = principal_.getByToken(kindOfType,id,index, token.willSkipCurrentProcess(), ambiguous, mcc);
+    BasicHandle h = principal_.getByToken(kindOfType, id, index, skipCurrentProcess, ambiguous, mcc);
     if (ambiguous) {
       // This deals with ambiguities where the process is not specified
       throwAmbiguousException(id, token);

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -17,6 +17,7 @@ WorkerT: Code common to all workers.
 namespace edm {
 
   class ModuleCallingContext;
+  class ProductHolderIndexAndSkipBit;
 
   UnscheduledHandler* getUnscheduledHandler(EventPrincipal const& ep);
 
@@ -95,7 +96,17 @@ namespace edm {
     virtual void implPreForkReleaseResources() override;
     virtual void implPostForkReacquireResources(unsigned int iChildIndex, 
                                                unsigned int iNumberOfChildren) override;
-     virtual std::string workerType() const override;
+    virtual std::string workerType() const override;
+
+    virtual void itemsToGet(BranchType branchType, std::vector<ProductHolderIndexAndSkipBit>& indexes) const {
+      module_->itemsToGet(branchType, indexes);
+    }
+
+    virtual void itemsMayGet(BranchType branchType, std::vector<ProductHolderIndexAndSkipBit>& indexes) const {
+      module_->itemsMayGet(branchType, indexes);
+    }
+
+    virtual std::vector<ProductHolderIndexAndSkipBit> const& itemsToGetFromEvent() const override { return module_->itemsToGetFromEvent(); }
 
     T* module_;
   };

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -82,14 +82,20 @@ EDAnalyzerAdaptorBase::registerProductsAndCallbacks(EDAnalyzerAdaptorBase const*
 }
 
 void
-EDAnalyzerAdaptorBase::itemsToGet(BranchType iType, std::vector<ProductHolderIndex>& iIndices) const {
+EDAnalyzerAdaptorBase::itemsToGet(BranchType iType, std::vector<ProductHolderIndexAndSkipBit>& iIndices) const {
   assert(not m_streamModules.empty());
   m_streamModules[0]->itemsToGet(iType,iIndices);
 }
 void
-EDAnalyzerAdaptorBase::itemsMayGet(BranchType iType, std::vector<ProductHolderIndex>& iIndices) const {
+EDAnalyzerAdaptorBase::itemsMayGet(BranchType iType, std::vector<ProductHolderIndexAndSkipBit>& iIndices) const {
   assert(not m_streamModules.empty());
-  m_streamModules[0]->itemsToGet(iType,iIndices);  
+  m_streamModules[0]->itemsMayGet(iType,iIndices);  
+}
+
+std::vector<edm::ProductHolderIndexAndSkipBit> const&
+EDAnalyzerAdaptorBase::itemsToGetFromEvent() const {
+  assert(not m_streamModules.empty());
+  return m_streamModules[0]->itemsToGetFromEvent();  
 }
 
 void

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -84,16 +84,23 @@ namespace edm {
     
     template< typename T>
     void
-    ProducingModuleAdaptorBase<T>::itemsToGet(BranchType iType, std::vector<ProductHolderIndex>& iIndices) const {
+    ProducingModuleAdaptorBase<T>::itemsToGet(BranchType iType, std::vector<ProductHolderIndexAndSkipBit>& iIndices) const {
       assert(not m_streamModules.empty());
       m_streamModules[0]->itemsToGet(iType,iIndices);
     }
     
     template< typename T>
     void
-    ProducingModuleAdaptorBase<T>::itemsMayGet(BranchType iType, std::vector<ProductHolderIndex>& iIndices) const {
+    ProducingModuleAdaptorBase<T>::itemsMayGet(BranchType iType, std::vector<ProductHolderIndexAndSkipBit>& iIndices) const {
       assert(not m_streamModules.empty());
-      m_streamModules[0]->itemsToGet(iType,iIndices);
+      m_streamModules[0]->itemsMayGet(iType,iIndices);
+    }
+
+    template<typename T>
+    std::vector<edm::ProductHolderIndexAndSkipBit> const&
+    ProducingModuleAdaptorBase<T>::itemsToGetFromEvent() const {
+      assert(not m_streamModules.empty());
+      return m_streamModules[0]->itemsToGetFromEvent();
     }
 
     template< typename T>

--- a/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
+++ b/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
@@ -18,6 +18,7 @@
 #include "cppunit/extensions/HelperMacros.h"
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ProductHolderIndexAndSkipBit.h"
 
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/TypeToGet.h"
@@ -168,18 +169,18 @@ TestEDConsumerBase::testRegularType()
   
     CPPUNIT_ASSERT(intConsumer.m_tokens[0].index()==0);
     CPPUNIT_ASSERT(intConsumer.m_tokens[1].index()==1);
-  
-    CPPUNIT_ASSERT(vint_c == intConsumer.indexFrom(intConsumer.m_tokens[1],edm::InEvent,typeID_vint));
-    CPPUNIT_ASSERT(vint_blank == intConsumer.indexFrom(intConsumer.m_tokens[0],edm::InEvent,typeID_vint));
+
+    CPPUNIT_ASSERT(vint_c == intConsumer.indexFrom(intConsumer.m_tokens[1],edm::InEvent,typeID_vint).productHolderIndex());
+    CPPUNIT_ASSERT(vint_blank == intConsumer.indexFrom(intConsumer.m_tokens[0],edm::InEvent,typeID_vint).productHolderIndex());
     
-    std::vector<edm::ProductHolderIndex> indices;
+    std::vector<edm::ProductHolderIndexAndSkipBit> indices;
     intConsumer.itemsToGet(edm::InEvent,indices);
     
     CPPUNIT_ASSERT(2 == indices.size());
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), vint_c));
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), vint_blank));
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductHolderIndexAndSkipBit(vint_c, false)));
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductHolderIndexAndSkipBit(vint_blank, false)));
 
-    std::vector<edm::ProductHolderIndex> indicesMay;
+    std::vector<edm::ProductHolderIndexAndSkipBit> indicesMay;
     intConsumer.itemsMayGet(edm::InEvent,indicesMay);
     CPPUNIT_ASSERT(0 == indicesMay.size());
 
@@ -191,18 +192,18 @@ TestEDConsumerBase::testRegularType()
     
     CPPUNIT_ASSERT(intConsumer.m_tokens[0].index()==0);
     CPPUNIT_ASSERT(intConsumer.m_tokens[1].index()==1);
+
+    CPPUNIT_ASSERT(vint_c == intConsumer.indexFrom(intConsumer.m_tokens[1],edm::InEvent,typeID_vint).productHolderIndex());
+    CPPUNIT_ASSERT(vint_blank == intConsumer.indexFrom(intConsumer.m_tokens[0],edm::InEvent,typeID_vint).productHolderIndex());
     
-    CPPUNIT_ASSERT(vint_c == intConsumer.indexFrom(intConsumer.m_tokens[1],edm::InEvent,typeID_vint));
-    CPPUNIT_ASSERT(vint_blank == intConsumer.indexFrom(intConsumer.m_tokens[0],edm::InEvent,typeID_vint));
-    
-    std::vector<edm::ProductHolderIndex> indices;
+    std::vector<edm::ProductHolderIndexAndSkipBit> indices;
     intConsumer.itemsToGet(edm::InEvent,indices);
     
     CPPUNIT_ASSERT(2 == indices.size());
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), vint_c));
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), vint_blank));
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductHolderIndexAndSkipBit(vint_c, false)));
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductHolderIndexAndSkipBit(vint_blank, false)));
     
-    std::vector<edm::ProductHolderIndex> indicesMay;
+    std::vector<edm::ProductHolderIndexAndSkipBit> indicesMay;
     intConsumer.itemsMayGet(edm::InEvent,indicesMay);
     CPPUNIT_ASSERT(0 == indicesMay.size());
     
@@ -214,21 +215,21 @@ TestEDConsumerBase::testRegularType()
 
     CPPUNIT_ASSERT(intConsumerRev.m_tokens[0].index()==0);
     CPPUNIT_ASSERT(intConsumerRev.m_tokens[1].index()==1);
-  
-    CPPUNIT_ASSERT(vint_c == intConsumerRev.indexFrom(intConsumerRev.m_tokens[0],edm::InEvent,typeID_vint));
-    CPPUNIT_ASSERT(vint_blank == intConsumerRev.indexFrom(intConsumerRev.m_tokens[1],edm::InEvent,typeID_vint));
 
-    std::vector<edm::ProductHolderIndex> indices;
+    CPPUNIT_ASSERT(vint_c == intConsumerRev.indexFrom(intConsumerRev.m_tokens[0],edm::InEvent,typeID_vint).productHolderIndex());
+    CPPUNIT_ASSERT(vint_blank == intConsumerRev.indexFrom(intConsumerRev.m_tokens[1],edm::InEvent,typeID_vint).productHolderIndex());
+
+    std::vector<edm::ProductHolderIndexAndSkipBit> indices;
     intConsumerRev.itemsToGet(edm::InEvent,indices);
     
     CPPUNIT_ASSERT(2 == indices.size());
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), vint_c));
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), vint_blank));
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductHolderIndexAndSkipBit(vint_c, false)));
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductHolderIndexAndSkipBit(vint_blank, false)));
     
-    std::vector<edm::ProductHolderIndex> indicesMay;
+    std::vector<edm::ProductHolderIndexAndSkipBit> indicesMay;
     intConsumerRev.itemsMayGet(edm::InEvent,indicesMay);
     CPPUNIT_ASSERT(0 == indicesMay.size());
-}
+  }
   {
     std::vector<edm::InputTag> vTagsRev={ {"labelC","instanceC","processC"},{"label","instance","process"} };
     IntsConsumesCollectorConsumer intConsumerRev{vTagsRev};
@@ -236,18 +237,20 @@ TestEDConsumerBase::testRegularType()
     
     CPPUNIT_ASSERT(intConsumerRev.m_tokens[0].index()==0);
     CPPUNIT_ASSERT(intConsumerRev.m_tokens[1].index()==1);
+
+    CPPUNIT_ASSERT(edm::ProductHolderIndexAndSkipBit(vint_c, false) ==
+                   intConsumerRev.indexFrom(intConsumerRev.m_tokens[0],edm::InEvent,typeID_vint));
+    CPPUNIT_ASSERT(edm::ProductHolderIndexAndSkipBit(vint_blank, false) ==
+                   intConsumerRev.indexFrom(intConsumerRev.m_tokens[1],edm::InEvent,typeID_vint));
     
-    CPPUNIT_ASSERT(vint_c == intConsumerRev.indexFrom(intConsumerRev.m_tokens[0],edm::InEvent,typeID_vint));
-    CPPUNIT_ASSERT(vint_blank == intConsumerRev.indexFrom(intConsumerRev.m_tokens[1],edm::InEvent,typeID_vint));
-    
-    std::vector<edm::ProductHolderIndex> indices;
+    std::vector<edm::ProductHolderIndexAndSkipBit> indices;
     intConsumerRev.itemsToGet(edm::InEvent,indices);
     
     CPPUNIT_ASSERT(2 == indices.size());
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), vint_c));
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), vint_blank));
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductHolderIndexAndSkipBit(vint_c, false)));
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductHolderIndexAndSkipBit(vint_blank, false)));
     
-    std::vector<edm::ProductHolderIndex> indicesMay;
+    std::vector<edm::ProductHolderIndexAndSkipBit> indicesMay;
     intConsumerRev.itemsMayGet(edm::InEvent,indicesMay);
     CPPUNIT_ASSERT(0 == indicesMay.size());
   }
@@ -260,23 +263,22 @@ TestEDConsumerBase::testRegularType()
     CPPUNIT_ASSERT(intConsumer.m_tokens[0].index()==0);
     CPPUNIT_ASSERT(intConsumer.m_tokens[1].index()==1);
 
-    CPPUNIT_ASSERT(!intConsumer.m_tokens[0].willSkipCurrentProcess());
-    CPPUNIT_ASSERT(intConsumer.m_tokens[1].willSkipCurrentProcess());
-    
-    CPPUNIT_ASSERT(vint_c_no_proc == intConsumer.indexFrom(intConsumer.m_tokens[1],edm::InEvent,typeID_vint));
-    CPPUNIT_ASSERT(vint_blank_no_proc == intConsumer.indexFrom(intConsumer.m_tokens[0],edm::InEvent,typeID_vint));
+    CPPUNIT_ASSERT(edm::ProductHolderIndexAndSkipBit(vint_c_no_proc, true) ==
+                   intConsumer.indexFrom(intConsumer.m_tokens[1],edm::InEvent,typeID_vint));
+    CPPUNIT_ASSERT(edm::ProductHolderIndexAndSkipBit(vint_blank_no_proc, false) ==
+                   intConsumer.indexFrom(intConsumer.m_tokens[0],edm::InEvent,typeID_vint));
 
-    std::vector<edm::ProductHolderIndex> indices;
+    std::vector<edm::ProductHolderIndexAndSkipBit> indices;
     intConsumer.itemsToGet(edm::InEvent,indices);
     
     CPPUNIT_ASSERT(2 == indices.size());
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), vint_c_no_proc));
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), vint_blank_no_proc));
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductHolderIndexAndSkipBit(vint_c_no_proc, true)));
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductHolderIndexAndSkipBit(vint_blank_no_proc, false)));
     
-    std::vector<edm::ProductHolderIndex> indicesMay;
+    std::vector<edm::ProductHolderIndexAndSkipBit> indicesMay;
     intConsumer.itemsMayGet(edm::InEvent,indicesMay);
     CPPUNIT_ASSERT(0 == indicesMay.size());
-}
+  }
   {
     //Ask for something that doesn't exist
     std::vector<edm::InputTag> vTags={ {"notHere"} };
@@ -284,9 +286,9 @@ TestEDConsumerBase::testRegularType()
     intConsumer.updateLookup(edm::InEvent,helper);
     
     CPPUNIT_ASSERT(intConsumer.m_tokens[0].index()==0);
-    CPPUNIT_ASSERT(edm::ProductHolderIndexInvalid == intConsumer.indexFrom(intConsumer.m_tokens[0],edm::InEvent,typeID_vint));
-    
-    std::vector<edm::ProductHolderIndex> indices;
+    CPPUNIT_ASSERT(edm::ProductHolderIndexInvalid == intConsumer.indexFrom(intConsumer.m_tokens[0],edm::InEvent,typeID_vint).productHolderIndex());
+
+    std::vector<edm::ProductHolderIndexAndSkipBit> indices;
     intConsumer.itemsToGet(edm::InEvent,indices);
     //nothing to get since not here
     CPPUNIT_ASSERT(0 == indices.size());
@@ -339,18 +341,20 @@ TestEDConsumerBase::testViewType()
     TypeToGetConsumer consumer{vT};
     
     consumer.updateLookup(edm::InEvent,helper);
-    CPPUNIT_ASSERT(v_int == consumer.indexFrom(consumer.m_tokens[0],edm::InEvent,typeID_int));
-    CPPUNIT_ASSERT(v_simple == consumer.indexFrom(consumer.m_tokens[1],edm::InEvent,typeID_Simple));
+    CPPUNIT_ASSERT(edm::ProductHolderIndexAndSkipBit(v_int, false) ==
+                   consumer.indexFrom(consumer.m_tokens[0],edm::InEvent,typeID_int));
+    CPPUNIT_ASSERT(edm::ProductHolderIndexAndSkipBit(v_simple, false) ==
+                   consumer.indexFrom(consumer.m_tokens[1],edm::InEvent,typeID_Simple));
 
     {
-      std::vector<edm::ProductHolderIndex> indices;
+      std::vector<edm::ProductHolderIndexAndSkipBit> indices;
       consumer.itemsToGet(edm::InEvent,indices);
     
       CPPUNIT_ASSERT(2 == indices.size());
-      CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), v_int));
-      CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), v_simple));
-    
-      std::vector<edm::ProductHolderIndex> indicesMay;
+      CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductHolderIndexAndSkipBit(v_int, false)));
+      CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductHolderIndexAndSkipBit(v_simple, false)));
+
+      std::vector<edm::ProductHolderIndexAndSkipBit> indicesMay;
       consumer.itemsMayGet(edm::InEvent,indicesMay);
       CPPUNIT_ASSERT(0 == indicesMay.size());
     }
@@ -363,21 +367,21 @@ TestEDConsumerBase::testViewType()
     };
     TypeToGetConsumer consumer{vT};
 
-    CPPUNIT_ASSERT(!consumer.m_tokens[0].willSkipCurrentProcess());
-    CPPUNIT_ASSERT(consumer.m_tokens[1].willSkipCurrentProcess());
-    
     consumer.updateLookup(edm::InEvent,helper);
-    CPPUNIT_ASSERT(v_int_no_proc == consumer.indexFrom(consumer.m_tokens[0],edm::InEvent,typeID_int));
-    CPPUNIT_ASSERT(v_simple_no_proc == consumer.indexFrom(consumer.m_tokens[1],edm::InEvent,typeID_Simple));
+
+    CPPUNIT_ASSERT(edm::ProductHolderIndexAndSkipBit(v_int_no_proc, false) ==
+                   consumer.indexFrom(consumer.m_tokens[0],edm::InEvent,typeID_int));
+    CPPUNIT_ASSERT(edm::ProductHolderIndexAndSkipBit(v_simple_no_proc, true) ==
+                   consumer.indexFrom(consumer.m_tokens[1],edm::InEvent,typeID_Simple));
     {
-      std::vector<edm::ProductHolderIndex> indices;
+      std::vector<edm::ProductHolderIndexAndSkipBit> indices;
       consumer.itemsToGet(edm::InEvent,indices);
       
       CPPUNIT_ASSERT(2 == indices.size());
-      CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), v_int_no_proc));
-      CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), v_simple_no_proc));
+      CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductHolderIndexAndSkipBit(v_int_no_proc, false)));
+      CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductHolderIndexAndSkipBit(v_simple_no_proc, true)));
       
-      std::vector<edm::ProductHolderIndex> indicesMay;
+      std::vector<edm::ProductHolderIndexAndSkipBit> indicesMay;
       consumer.itemsMayGet(edm::InEvent,indicesMay);
       CPPUNIT_ASSERT(0 == indicesMay.size());
     }
@@ -392,9 +396,9 @@ TestEDConsumerBase::testViewType()
     consumer.updateLookup(edm::InEvent,helper);
     
     CPPUNIT_ASSERT(consumer.m_tokens[0].index()==0);
-    CPPUNIT_ASSERT(edm::ProductHolderIndexInvalid == consumer.indexFrom(consumer.m_tokens[0],edm::InEvent,typeID_int));
+    CPPUNIT_ASSERT(edm::ProductHolderIndexInvalid == consumer.indexFrom(consumer.m_tokens[0],edm::InEvent,typeID_int).productHolderIndex());
     {
-      std::vector<edm::ProductHolderIndex> indices;
+      std::vector<edm::ProductHolderIndexAndSkipBit> indices;
       consumer.itemsToGet(edm::InEvent,indices);
       
       CPPUNIT_ASSERT(0 == indices.size());
@@ -440,16 +444,20 @@ TestEDConsumerBase::testMany()
   helper.insert(typeWithDictVSimpleDerived, "labelC", "instanceC", "processC"); // 27, 28, 29, 30
   
   helper.setFrozen();
-  
+
+  edm::TypeID typeID_EventID(typeid(edm::EventID));
+
+  const auto productIndex = helper.index(edm::PRODUCT_TYPE, typeID_EventID, "labelB", "instanceB", "processB");
+
   {
     ManyEventIDConsumer consumer{};
     consumer.updateLookup(edm::InEvent,helper);
 
-    std::vector<edm::ProductHolderIndex> indices;
+    std::vector<edm::ProductHolderIndexAndSkipBit> indices;
     consumer.itemsToGet(edm::InEvent,indices);
 
     CPPUNIT_ASSERT(9 == indices.size());
-
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductHolderIndexAndSkipBit(productIndex, false)));
   }
 }
 
@@ -496,18 +504,20 @@ TestEDConsumerBase::testMay()
     CPPUNIT_ASSERT(consumer.m_tokens[0].index()==0);
     CPPUNIT_ASSERT(consumer.m_tokens[1].index()==1);
     CPPUNIT_ASSERT(consumer.m_mayTokens.size()==0);
-    
-    CPPUNIT_ASSERT(vint_c == consumer.indexFrom(consumer.m_tokens[1],edm::InEvent,typeID_vint));
-    CPPUNIT_ASSERT(vint_blank == consumer.indexFrom(consumer.m_tokens[0],edm::InEvent,typeID_vint));
-    
-    std::vector<edm::ProductHolderIndex> indices;
+
+    CPPUNIT_ASSERT(edm::ProductHolderIndexAndSkipBit(vint_c, false) ==
+                   consumer.indexFrom(consumer.m_tokens[1],edm::InEvent,typeID_vint));
+    CPPUNIT_ASSERT(edm::ProductHolderIndexAndSkipBit(vint_blank, false) ==
+                   consumer.indexFrom(consumer.m_tokens[0],edm::InEvent,typeID_vint));
+
+    std::vector<edm::ProductHolderIndexAndSkipBit> indices;
     consumer.itemsToGet(edm::InEvent,indices);
     
     CPPUNIT_ASSERT(2 == indices.size());
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), vint_c));
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), vint_blank));
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductHolderIndexAndSkipBit(vint_c, false)));
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductHolderIndexAndSkipBit(vint_blank, false)));
     
-    std::vector<edm::ProductHolderIndex> indicesMay;
+    std::vector<edm::ProductHolderIndexAndSkipBit> indicesMay;
     consumer.itemsMayGet(edm::InEvent,indicesMay);
     CPPUNIT_ASSERT(0 == indicesMay.size());
   }
@@ -522,19 +532,19 @@ TestEDConsumerBase::testMay()
     CPPUNIT_ASSERT(consumer.m_mayTokens[0].index()==0);
     CPPUNIT_ASSERT(consumer.m_mayTokens[1].index()==1);
     CPPUNIT_ASSERT(consumer.m_tokens.size()==0);
+
+    CPPUNIT_ASSERT(vint_c == consumer.indexFrom(consumer.m_mayTokens[1],edm::InEvent,typeID_vint).productHolderIndex());
+    CPPUNIT_ASSERT(vint_blank == consumer.indexFrom(consumer.m_mayTokens[0],edm::InEvent,typeID_vint).productHolderIndex());
     
-    CPPUNIT_ASSERT(vint_c == consumer.indexFrom(consumer.m_mayTokens[1],edm::InEvent,typeID_vint));
-    CPPUNIT_ASSERT(vint_blank == consumer.indexFrom(consumer.m_mayTokens[0],edm::InEvent,typeID_vint));
-    
-    std::vector<edm::ProductHolderIndex> indices;
+    std::vector<edm::ProductHolderIndexAndSkipBit> indices;
     consumer.itemsToGet(edm::InEvent,indices);
     CPPUNIT_ASSERT(0 == indices.size());
     
-    std::vector<edm::ProductHolderIndex> indicesMay;
+    std::vector<edm::ProductHolderIndexAndSkipBit> indicesMay;
     consumer.itemsMayGet(edm::InEvent,indicesMay);
     CPPUNIT_ASSERT(2 == indicesMay.size());
-    CPPUNIT_ASSERT(indicesMay.end() != std::find(indicesMay.begin(),indicesMay.end(), vint_c));
-    CPPUNIT_ASSERT(indicesMay.end() != std::find(indicesMay.begin(),indicesMay.end(), vint_blank));
+    CPPUNIT_ASSERT(indicesMay.end() != std::find(indicesMay.begin(),indicesMay.end(), edm::ProductHolderIndexAndSkipBit(vint_c, false)));
+    CPPUNIT_ASSERT(indicesMay.end() != std::find(indicesMay.begin(),indicesMay.end(), edm::ProductHolderIndexAndSkipBit(vint_blank, false)));
   }
 
   {
@@ -547,20 +557,20 @@ TestEDConsumerBase::testMay()
     CPPUNIT_ASSERT(consumer.m_tokens.size()==1);
     CPPUNIT_ASSERT(consumer.m_tokens[0].index()==0);
     CPPUNIT_ASSERT(consumer.m_mayTokens[0].index()==1);
+
+    CPPUNIT_ASSERT(vint_c == consumer.indexFrom(consumer.m_mayTokens[0],edm::InEvent,typeID_vint).productHolderIndex());
+    CPPUNIT_ASSERT(vint_blank == consumer.indexFrom(consumer.m_tokens[0],edm::InEvent,typeID_vint).productHolderIndex());
     
-    CPPUNIT_ASSERT(vint_c == consumer.indexFrom(consumer.m_mayTokens[0],edm::InEvent,typeID_vint));
-    CPPUNIT_ASSERT(vint_blank == consumer.indexFrom(consumer.m_tokens[0],edm::InEvent,typeID_vint));
-    
-    std::vector<edm::ProductHolderIndex> indices;
+    std::vector<edm::ProductHolderIndexAndSkipBit> indices;
     consumer.itemsToGet(edm::InEvent,indices);
     
     CPPUNIT_ASSERT(1 == indices.size());
-    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), vint_blank));
+    CPPUNIT_ASSERT(indices.end() != std::find(indices.begin(),indices.end(), edm::ProductHolderIndexAndSkipBit(vint_blank, false)));
     
-    std::vector<edm::ProductHolderIndex> indicesMay;
+    std::vector<edm::ProductHolderIndexAndSkipBit> indicesMay;
     consumer.itemsMayGet(edm::InEvent,indicesMay);
     CPPUNIT_ASSERT(1 == indicesMay.size());
-    CPPUNIT_ASSERT(indicesMay.end() != std::find(indicesMay.begin(),indicesMay.end(), vint_c));
+    CPPUNIT_ASSERT(indicesMay.end() != std::find(indicesMay.begin(),indicesMay.end(), edm::ProductHolderIndexAndSkipBit(vint_c, false)));
   }
   {
     std::vector<edm::InputTag> vTags={};
@@ -572,12 +582,10 @@ TestEDConsumerBase::testMay()
     CPPUNIT_ASSERT(consumer.m_mayTokens[0].index()==0);
     CPPUNIT_ASSERT(consumer.m_mayTokens[1].index()==1);
     CPPUNIT_ASSERT(consumer.m_tokens.size()==0);
-    
-    CPPUNIT_ASSERT(vint_c_no_proc == consumer.indexFrom(consumer.m_mayTokens[1],edm::InEvent,typeID_vint));
-    CPPUNIT_ASSERT(vint_blank_no_proc == consumer.indexFrom(consumer.m_mayTokens[0],edm::InEvent,typeID_vint));
 
-    CPPUNIT_ASSERT(!consumer.m_mayTokens[0].willSkipCurrentProcess());
-    CPPUNIT_ASSERT(consumer.m_mayTokens[1].willSkipCurrentProcess());
+    CPPUNIT_ASSERT(edm::ProductHolderIndexAndSkipBit(vint_c_no_proc, true) ==
+                   consumer.indexFrom(consumer.m_mayTokens[1],edm::InEvent,typeID_vint));
+    CPPUNIT_ASSERT(edm::ProductHolderIndexAndSkipBit(vint_blank_no_proc, false) ==
+                   consumer.indexFrom(consumer.m_mayTokens[0],edm::InEvent,typeID_vint));
   }
-
 }

--- a/FWCore/Framework/test/run_unscheduled.sh
+++ b/FWCore/Framework/test/run_unscheduled.sh
@@ -12,7 +12,9 @@ F6=${LOCAL_TEST_DIR}/test_onPath_allowUnscheduled_true_cfg.py
 F7=${LOCAL_TEST_DIR}/test_onPath_wrongOrder_allowUnscheduled_false_fail_cfg.py
 F8=${LOCAL_TEST_DIR}/test_onPath_wrongOrder_allowUnscheduled_true_fail_cfg.py
 
-(cmsRun $F1 ) || die "Failure using $F1" $?
+(cmsRun $F1 ) > test_deepCall_allowUnscheduled_true.log || die "Failure using $F1" $?
+diff test_deepCall_allowUnscheduled_true.log ${LOCAL_TEST_DIR}/unit_test_outputs/test_deepCall_allowUnscheduled_true.log || die "comparing test_deepCall_allowUnscheduled_true.log" $?
+
 !(cmsRun $F2 ) || die "Failure using $F2" $?
 !(cmsRun $F3 ) || die "Failure using $F3" $?
 (cmsRun $F4 ) || die "Failure using $F4" $?
@@ -20,5 +22,3 @@ F8=${LOCAL_TEST_DIR}/test_onPath_wrongOrder_allowUnscheduled_true_fail_cfg.py
 (cmsRun $F6 ) || die "Failure using $F6" $?
 !(cmsRun $F7 ) || die "Failure using $F7" $?
 !(cmsRun $F8 ) || die "Failure using $F8" $?
-
-

--- a/FWCore/Framework/test/test_deepCall_allowUnscheduled_true_cfg.py
+++ b/FWCore/Framework/test/test_deepCall_allowUnscheduled_true_cfg.py
@@ -16,7 +16,9 @@ process.source = cms.Source("EmptySource",
     firstTime = cms.untracked.uint64(1000000)
 )
 
-process.Tracer = cms.Service("Tracer")
+process.Tracer = cms.Service('Tracer',
+                             dumpContextForLabel = cms.untracked.string('one')
+)
 
 process.one = cms.EDProducer("IntProducer",
     ivalue = cms.int32(1)

--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_allowUnscheduled_true.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_allowUnscheduled_true.log
@@ -1,0 +1,556 @@
+++ constructing source:EmptySource
+++ construction finished:EmptySource
+++ constructing module: TriggerResults
+++ construction finished: TriggerResults
+++ constructing module: get
+++ construction finished: get
+++ constructing module: one
+Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+++ construction finished: one
+Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+++ constructing module: result1
+++ construction finished: result1
+++ constructing module: result2
+++ construction finished: result2
+++ constructing module: result4
+++ construction finished: result4
+++ ModuleBeginJob: one
+Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+++ ModuleBeginJob finished: one
+Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+++ ModuleBeginJob: result1
+++ ModuleBeginJob finished: result1
+++ ModuleBeginJob: result2
+++ ModuleBeginJob finished: result2
+++ ModuleBeginJob: result4
+++ ModuleBeginJob finished: result4
+++ ModuleBeginJob: get
+++ ModuleBeginJob finished: get
+++ ModuleBeginJob: TriggerResults
+++ ModuleBeginJob finished: TriggerResults
+++ Job started
+++++ ModuleBeginStream: get
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: TriggerResults
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: one
+StreamContext: StreamID = 0 transition = BeginStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+++++ ModuleBeginStream finished
+StreamContext: StreamID = 0 transition = BeginStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+++++ ModuleBeginStream: result1
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: result2
+++++ ModuleBeginStream finished
+++++ ModuleBeginStream: result4
+++++ ModuleBeginStream finished
+++++ source run
+++++ finished: source run
+++++ GlobalBeginRun run: 1 time: 1000000
+++++++ ModuleGlobalBeginRun: one
+GlobalContext: transition = BeginRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    GlobalContext: transition = BeginRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+++++++ ModuleGlobalBeginRun finished: one
+GlobalContext: transition = BeginRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    GlobalContext: transition = BeginRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+++++++ ModuleGlobalBeginRun: result1
+++++++ ModuleGlobalBeginRun finished: result1
+++++++ ModuleGlobalBeginRun: result2
+++++++ ModuleGlobalBeginRun finished: result2
+++++++ ModuleGlobalBeginRun: result4
+++++++ ModuleGlobalBeginRun finished: result4
+++++++ ModuleGlobalBeginRun: get
+++++++ ModuleGlobalBeginRun finished: get
+++++++ ModuleGlobalBeginRun: TriggerResults
+++++++ ModuleGlobalBeginRun finished: TriggerResults
+++++ GlobalBeginRun finished
+++++ StreamBeginRun run: 1 time: 1000000
+++++++ ModuleStreamBeginRun: one
+StreamContext: StreamID = 0 transition = BeginRun
+    run: 1 lumi: 0 event: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    StreamContext: StreamID = 0 transition = BeginRun
+    run: 1 lumi: 0 event: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+++++++ ModuleStreamBeginRun finished: one
+StreamContext: StreamID = 0 transition = BeginRun
+    run: 1 lumi: 0 event: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    StreamContext: StreamID = 0 transition = BeginRun
+    run: 1 lumi: 0 event: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+++++++ ModuleStreamBeginRun: result1
+++++++ ModuleStreamBeginRun finished: result1
+++++++ ModuleStreamBeginRun: result2
+++++++ ModuleStreamBeginRun finished: result2
+++++++ ModuleStreamBeginRun: result4
+++++++ ModuleStreamBeginRun finished: result4
+++++++ ModuleStreamBeginRun: get
+++++++ ModuleStreamBeginRun finished: get
+++++ StreamBeginRun finished
+++++ source lumi
+++++ finished: source lumi
+++++ GlobalBeginLumi run: 1 lumi: 1 time: 1000000
+++++++ ModuleGlobalBeginLumi: one
+GlobalContext: transition = BeginLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    GlobalContext: transition = BeginLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+++++++ ModuleGlobalBeginLumi finished: one
+GlobalContext: transition = BeginLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    GlobalContext: transition = BeginLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+++++++ ModuleGlobalBeginLumi: result1
+++++++ ModuleGlobalBeginLumi finished: result1
+++++++ ModuleGlobalBeginLumi: result2
+++++++ ModuleGlobalBeginLumi finished: result2
+++++++ ModuleGlobalBeginLumi: result4
+++++++ ModuleGlobalBeginLumi finished: result4
+++++++ ModuleGlobalBeginLumi: get
+++++++ ModuleGlobalBeginLumi finished: get
+++++++ ModuleGlobalBeginLumi: TriggerResults
+++++++ ModuleGlobalBeginLumi finished: TriggerResults
+++++ GlobalBeginLumi finished
+++++ StreamBeginLumi run: 1 lumi: 1 time: 1000000
+++++++ ModuleStreamBeginLumi: one
+StreamContext: StreamID = 0 transition = BeginLuminosityBlock
+    run: 1 lumi: 1 event: 0
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    StreamContext: StreamID = 0 transition = BeginLuminosityBlock
+    run: 1 lumi: 1 event: 0
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+++++++ ModuleStreamBeginLumi finished: one
+StreamContext: StreamID = 0 transition = BeginLuminosityBlock
+    run: 1 lumi: 1 event: 0
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    StreamContext: StreamID = 0 transition = BeginLuminosityBlock
+    run: 1 lumi: 1 event: 0
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+++++++ ModuleStreamBeginLumi: result1
+++++++ ModuleStreamBeginLumi finished: result1
+++++++ ModuleStreamBeginLumi: result2
+++++++ ModuleStreamBeginLumi finished: result2
+++++++ ModuleStreamBeginLumi: result4
+++++++ ModuleStreamBeginLumi finished: result4
+++++++ ModuleStreamBeginLumi: get
+++++++ ModuleStreamBeginLumi finished: get
+++++ StreamBeginLumi finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 1 event: 1 time:1000010
+++++++ processing path for event: p
+++++++++ module for event: one
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000010
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=AddIntsProducer, Module label=result1, Parameter Set ID=64c4934d1f57e930d1fb164b456178c4
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=AddIntsProducer, Module label=result2, Parameter Set ID=31cea1f3a347f933ea3d7d1da30c26b3
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=AddIntsProducer, Module label=result4, Parameter Set ID=ba6b6f37cc68b7be2cf72f1a757b6bd0
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=IntTestAnalyzer, Module label=get, Parameter Set ID=fc3c7f32f11cad46f35b1ec6cee8bbbd
+    PlaceInPathContext 0
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000010
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+    previousModuleOnThread: same as parent module
+    previousModuleOnThread: same as parent module
+    previousModuleOnThread: same as parent module
+    previousModuleOnThread: same as parent module
+++++++++ finished module for event: one
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000010
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=AddIntsProducer, Module label=result1, Parameter Set ID=64c4934d1f57e930d1fb164b456178c4
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=AddIntsProducer, Module label=result2, Parameter Set ID=31cea1f3a347f933ea3d7d1da30c26b3
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=AddIntsProducer, Module label=result4, Parameter Set ID=ba6b6f37cc68b7be2cf72f1a757b6bd0
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=IntTestAnalyzer, Module label=get, Parameter Set ID=fc3c7f32f11cad46f35b1ec6cee8bbbd
+    PlaceInPathContext 0
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000010
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+    previousModuleOnThread: same as parent module
+    previousModuleOnThread: same as parent module
+    previousModuleOnThread: same as parent module
+    previousModuleOnThread: same as parent module
+++++++++ module for event: result1
+++++++++ finished module for event: result1
+++++++++ module for event: result2
+++++++++ finished module for event: result2
+++++++++ module for event: result4
+++++++++ finished module for event: result4
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++ path for event finished: p
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 1 event: 2 time:1000020
+++++++ processing path for event: p
+++++++++ module for event: one
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000020
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=AddIntsProducer, Module label=result1, Parameter Set ID=64c4934d1f57e930d1fb164b456178c4
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=AddIntsProducer, Module label=result2, Parameter Set ID=31cea1f3a347f933ea3d7d1da30c26b3
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=AddIntsProducer, Module label=result4, Parameter Set ID=ba6b6f37cc68b7be2cf72f1a757b6bd0
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=IntTestAnalyzer, Module label=get, Parameter Set ID=fc3c7f32f11cad46f35b1ec6cee8bbbd
+    PlaceInPathContext 0
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000020
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+    previousModuleOnThread: same as parent module
+    previousModuleOnThread: same as parent module
+    previousModuleOnThread: same as parent module
+    previousModuleOnThread: same as parent module
+++++++++ finished module for event: one
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000020
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=AddIntsProducer, Module label=result1, Parameter Set ID=64c4934d1f57e930d1fb164b456178c4
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=AddIntsProducer, Module label=result2, Parameter Set ID=31cea1f3a347f933ea3d7d1da30c26b3
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=AddIntsProducer, Module label=result4, Parameter Set ID=ba6b6f37cc68b7be2cf72f1a757b6bd0
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=IntTestAnalyzer, Module label=get, Parameter Set ID=fc3c7f32f11cad46f35b1ec6cee8bbbd
+    PlaceInPathContext 0
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000020
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+    previousModuleOnThread: same as parent module
+    previousModuleOnThread: same as parent module
+    previousModuleOnThread: same as parent module
+    previousModuleOnThread: same as parent module
+++++++++ module for event: result1
+++++++++ finished module for event: result1
+++++++++ module for event: result2
+++++++++ finished module for event: result2
+++++++++ module for event: result4
+++++++++ finished module for event: result4
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++ path for event finished: p
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ source event
+++++ finished: source event
+++++ processing event run: 1 lumi: 1 event: 3 time:1000030
+++++++ processing path for event: p
+++++++++ module for event: one
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=AddIntsProducer, Module label=result1, Parameter Set ID=64c4934d1f57e930d1fb164b456178c4
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=AddIntsProducer, Module label=result2, Parameter Set ID=31cea1f3a347f933ea3d7d1da30c26b3
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=AddIntsProducer, Module label=result4, Parameter Set ID=ba6b6f37cc68b7be2cf72f1a757b6bd0
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=IntTestAnalyzer, Module label=get, Parameter Set ID=fc3c7f32f11cad46f35b1ec6cee8bbbd
+    PlaceInPathContext 0
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+    previousModuleOnThread: same as parent module
+    previousModuleOnThread: same as parent module
+    previousModuleOnThread: same as parent module
+    previousModuleOnThread: same as parent module
+++++++++ finished module for event: one
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=AddIntsProducer, Module label=result1, Parameter Set ID=64c4934d1f57e930d1fb164b456178c4
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=AddIntsProducer, Module label=result2, Parameter Set ID=31cea1f3a347f933ea3d7d1da30c26b3
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=AddIntsProducer, Module label=result4, Parameter Set ID=ba6b6f37cc68b7be2cf72f1a757b6bd0
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=IntTestAnalyzer, Module label=get, Parameter Set ID=fc3c7f32f11cad46f35b1ec6cee8bbbd
+    PlaceInPathContext 0
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+    previousModuleOnThread: same as parent module
+    previousModuleOnThread: same as parent module
+    previousModuleOnThread: same as parent module
+    previousModuleOnThread: same as parent module
+++++++++ module for event: result1
+++++++++ finished module for event: result1
+++++++++ module for event: result2
+++++++++ finished module for event: result2
+++++++++ module for event: result4
+++++++++ finished module for event: result4
+++++++++ module for event: get
+++++++++ finished module for event: get
+++++++ path for event finished: p
+++++++++ module for event: TriggerResults
+++++++++ finished module for event: TriggerResults
+++++ event finished
+++++ StreamEndLumi run: 1 lumi: 1 time: 1000030
+++++++ ModuleStreamEndLumi: one
+StreamContext: StreamID = 0 transition = EndLuminosityBlock
+    run: 1 lumi: 1 event: 0
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    StreamContext: StreamID = 0 transition = EndLuminosityBlock
+    run: 1 lumi: 1 event: 0
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+++++++ ModuleStreamEndLumi finished: one
+StreamContext: StreamID = 0 transition = EndLuminosityBlock
+    run: 1 lumi: 1 event: 0
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    StreamContext: StreamID = 0 transition = EndLuminosityBlock
+    run: 1 lumi: 1 event: 0
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+++++++ ModuleStreamEndLumi: result1
+++++++ ModuleStreamEndLumi finished: result1
+++++++ ModuleStreamEndLumi: result2
+++++++ ModuleStreamEndLumi finished: result2
+++++++ ModuleStreamEndLumi: result4
+++++++ ModuleStreamEndLumi finished: result4
+++++++ ModuleStreamEndLumi: get
+++++++ ModuleStreamEndLumi finished: get
+++++ StreamEndLumi finished
+++++ GlobalEndLumi run: 1 lumi: 1 time: 1000000
+++++++ ModuleGlobalEndLumi: one
+GlobalContext: transition = EndLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    GlobalContext: transition = EndLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+++++++ ModuleGlobalEndLumi finished: one
+GlobalContext: transition = EndLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    GlobalContext: transition = EndLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+++++++ ModuleGlobalEndLumi: result1
+++++++ ModuleGlobalEndLumi finished: result1
+++++++ ModuleGlobalEndLumi: result2
+++++++ ModuleGlobalEndLumi finished: result2
+++++++ ModuleGlobalEndLumi: result4
+++++++ ModuleGlobalEndLumi finished: result4
+++++++ ModuleGlobalEndLumi: get
+++++++ ModuleGlobalEndLumi finished: get
+++++++ ModuleGlobalEndLumi: TriggerResults
+++++++ ModuleGlobalEndLumi finished: TriggerResults
+++++ GlobalEndLumi finished
+++++ StreamEndRun run: 1 time: 1000030
+++++++ ModuleStreamEndRun: one
+StreamContext: StreamID = 0 transition = EndRun
+    run: 1 lumi: 0 event: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    StreamContext: StreamID = 0 transition = EndRun
+    run: 1 lumi: 0 event: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+++++++ ModuleStreamEndRun finished: one
+StreamContext: StreamID = 0 transition = EndRun
+    run: 1 lumi: 0 event: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    StreamContext: StreamID = 0 transition = EndRun
+    run: 1 lumi: 0 event: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+++++++ ModuleStreamEndRun: result1
+++++++ ModuleStreamEndRun finished: result1
+++++++ ModuleStreamEndRun: result2
+++++++ ModuleStreamEndRun finished: result2
+++++++ ModuleStreamEndRun: result4
+++++++ ModuleStreamEndRun finished: result4
+++++++ ModuleStreamEndRun: get
+++++++ ModuleStreamEndRun finished: get
+++++ StreamEndRun finished
+++++ GlobalEndRun run: 1 time: 1000030
+++++++ ModuleGlobalEndRun: one
+GlobalContext: transition = EndRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    GlobalContext: transition = EndRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+++++++ ModuleGlobalEndRun finished: one
+GlobalContext: transition = EndRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    GlobalContext: transition = EndRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+++++++ ModuleGlobalEndRun: result1
+++++++ ModuleGlobalEndRun finished: result1
+++++++ ModuleGlobalEndRun: result2
+++++++ ModuleGlobalEndRun finished: result2
+++++++ ModuleGlobalEndRun: result4
+++++++ ModuleGlobalEndRun finished: result4
+++++++ ModuleGlobalEndRun: get
+++++++ ModuleGlobalEndRun finished: get
+++++++ ModuleGlobalEndRun: TriggerResults
+++++++ ModuleGlobalEndRun finished: TriggerResults
+++++ GlobalEndRun finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+StreamContext: StreamID = 0 transition = EndStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+++++ ModuleEndStream finished
+StreamContext: StreamID = 0 transition = EndStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++++ ModuleEndStream: 
+++++ ModuleEndStream finished
+++ ModuleEndJob: one
+Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+++ ModuleEndJob finished: one
+Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+++ ModuleEndJob: result1
+++ ModuleEndJob finished: result1
+++ ModuleEndJob: result2
+++ ModuleEndJob finished: result2
+++ ModuleEndJob: result4
+++ ModuleEndJob finished: result4
+++ ModuleEndJob: get
+++ ModuleEndJob finished: get
+++ ModuleEndJob: TriggerResults
+++ ModuleEndJob finished: TriggerResults
+++ Job ended

--- a/FWCore/Integration/test/TestFindProduct.cc
+++ b/FWCore/Integration/test/TestFindProduct.cc
@@ -79,6 +79,7 @@ namespace edmtest {
 
   void
   TestFindProduct::analyze(edm::Event const& e, edm::EventSetup const&) {
+
     edm::Handle<IntProduct> h;
     edm::Handle<IntProduct> hToken;
     edm::Handle<edm::View<int> > hView;

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -334,39 +334,39 @@ PathContext: pathName = p pathID = 0
 ++++++++ finished module for event: intProducer
 ++++++++ module for event: a1
 ++++++++ finished module for event: a1
+++++++++ module for event: intProducerA
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
+    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
+    PlaceInPathContext 2
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
+    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+    previousModuleOnThread: same as parent module
+++++++++ finished module for event: intProducerA
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
+    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
+    PlaceInPathContext 2
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
+    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+    previousModuleOnThread: same as parent module
 ++++++++ module for event: a2
-++++++++++ module for event: intProducerA
-StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-    ModuleCallingContext state = Running
-    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
-    PlaceInPathContext 2
-    PathContext: pathName = p pathID = 0
-    StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-    previousModuleOnThread: same as parent module
-++++++++++ finished module for event: intProducerA
-StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-    ModuleCallingContext state = Running
-    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
-    PlaceInPathContext 2
-    PathContext: pathName = p pathID = 0
-    StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
-    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-    previousModuleOnThread: same as parent module
 ++++++++ finished module for event: a2
 ++++++++ module for event: a3
 ++++++++ finished module for event: a3
@@ -392,11 +392,11 @@ PathContext: pathName = e pathID = 0 (EndPath)
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+++++++++ module for event: intProducerU
+++++++++ finished module for event: intProducerU
+++++++++ module for event: intVectorProducer
+++++++++ finished module for event: intVectorProducer
 ++++++++ module for event: out
-++++++++++ module for event: intProducerU
-++++++++++ finished module for event: intProducerU
-++++++++++ module for event: intVectorProducer
-++++++++++ finished module for event: intVectorProducer
 ++++++++ finished module for event: out
 ++++++ path for event finished: e
 StreamContext: StreamID = 0 transition = Event
@@ -446,39 +446,39 @@ PathContext: pathName = p pathID = 0
 ++++++++ finished module for event: intProducer
 ++++++++ module for event: a1
 ++++++++ finished module for event: a1
+++++++++ module for event: intProducerA
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
+    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
+    PlaceInPathContext 2
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
+    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+    previousModuleOnThread: same as parent module
+++++++++ finished module for event: intProducerA
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
+    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
+    PlaceInPathContext 2
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 2
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
+    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+    previousModuleOnThread: same as parent module
 ++++++++ module for event: a2
-++++++++++ module for event: intProducerA
-StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 2
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-    ModuleCallingContext state = Running
-    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
-    PlaceInPathContext 2
-    PathContext: pathName = p pathID = 0
-    StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 2
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-    previousModuleOnThread: same as parent module
-++++++++++ finished module for event: intProducerA
-StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 2
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-    ModuleCallingContext state = Running
-    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
-    PlaceInPathContext 2
-    PathContext: pathName = p pathID = 0
-    StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 2
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
-    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-    previousModuleOnThread: same as parent module
 ++++++++ finished module for event: a2
 ++++++++ module for event: a3
 ++++++++ finished module for event: a3
@@ -504,11 +504,11 @@ PathContext: pathName = e pathID = 0 (EndPath)
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+++++++++ module for event: intProducerU
+++++++++ finished module for event: intProducerU
+++++++++ module for event: intVectorProducer
+++++++++ finished module for event: intVectorProducer
 ++++++++ module for event: out
-++++++++++ module for event: intProducerU
-++++++++++ finished module for event: intProducerU
-++++++++++ module for event: intVectorProducer
-++++++++++ finished module for event: intVectorProducer
 ++++++++ finished module for event: out
 ++++++ path for event finished: e
 StreamContext: StreamID = 0 transition = Event
@@ -558,39 +558,39 @@ PathContext: pathName = p pathID = 0
 ++++++++ finished module for event: intProducer
 ++++++++ module for event: a1
 ++++++++ finished module for event: a1
+++++++++ module for event: intProducerA
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
+    PlaceInPathContext 2
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+    previousModuleOnThread: same as parent module
+++++++++ finished module for event: intProducerA
+StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
+    ModuleCallingContext state = Prefetching
+    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
+    PlaceInPathContext 2
+    PathContext: pathName = p pathID = 0
+    StreamContext: StreamID = 0 transition = Event
+    run: 1 lumi: 1 event: 3
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+    previousModuleOnThread: same as parent module
 ++++++++ module for event: a2
-++++++++++ module for event: intProducerA
-StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 3
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-    ModuleCallingContext state = Running
-    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
-    PlaceInPathContext 2
-    PathContext: pathName = p pathID = 0
-    StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 3
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-    previousModuleOnThread: same as parent module
-++++++++++ finished module for event: intProducerA
-StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 3
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-    ModuleCallingContext state = Running
-    moduleDescription: Module type=TestFindProduct, Module label=a2, Parameter Set ID=d0c7845b00cb5918fdce8e715360b255
-    PlaceInPathContext 2
-    PathContext: pathName = p pathID = 0
-    StreamContext: StreamID = 0 transition = Event
-    run: 1 lumi: 1 event: 3
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-    previousModuleOnThread: same as parent module
 ++++++++ finished module for event: a2
 ++++++++ module for event: a3
 ++++++++ finished module for event: a3
@@ -616,11 +616,11 @@ PathContext: pathName = e pathID = 0 (EndPath)
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+++++++++ module for event: intProducerU
+++++++++ finished module for event: intProducerU
+++++++++ module for event: intVectorProducer
+++++++++ finished module for event: intVectorProducer
 ++++++++ module for event: out
-++++++++++ module for event: intProducerU
-++++++++++ finished module for event: intProducerU
-++++++++++ module for event: intVectorProducer
-++++++++++ finished module for event: intVectorProducer
 ++++++++ finished module for event: out
 ++++++ path for event finished: e
 StreamContext: StreamID = 0 transition = Event

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -275,11 +275,11 @@ PathContext: pathName = e pathID = 0 (EndPath)
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+++++++++ module for event: intProducerU
+++++++++ finished module for event: intProducerU
+++++++++ module for event: intVectorProducer
+++++++++ finished module for event: intVectorProducer
 ++++++++ module for event: out
-++++++++++ module for event: intProducerU
-++++++++++ finished module for event: intProducerU
-++++++++++ module for event: intVectorProducer
-++++++++++ finished module for event: intVectorProducer
 ++++++++ finished module for event: out
 ++++++ path for event finished: e
 StreamContext: StreamID = 0 transition = Event
@@ -361,11 +361,11 @@ PathContext: pathName = e pathID = 0 (EndPath)
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+++++++++ module for event: intProducerU
+++++++++ finished module for event: intProducerU
+++++++++ module for event: intVectorProducer
+++++++++ finished module for event: intVectorProducer
 ++++++++ module for event: out
-++++++++++ module for event: intProducerU
-++++++++++ finished module for event: intProducerU
-++++++++++ module for event: intVectorProducer
-++++++++++ finished module for event: intVectorProducer
 ++++++++ finished module for event: out
 ++++++ path for event finished: e
 StreamContext: StreamID = 0 transition = Event
@@ -447,11 +447,11 @@ PathContext: pathName = e pathID = 0 (EndPath)
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+++++++++ module for event: intProducerU
+++++++++ finished module for event: intProducerU
+++++++++ module for event: intVectorProducer
+++++++++ finished module for event: intVectorProducer
 ++++++++ module for event: out
-++++++++++ module for event: intProducerU
-++++++++++ finished module for event: intProducerU
-++++++++++ module for event: intVectorProducer
-++++++++++ finished module for event: intVectorProducer
 ++++++++ finished module for event: out
 ++++++ path for event finished: e
 StreamContext: StreamID = 0 transition = Event

--- a/FWCore/ServiceRegistry/interface/ModuleCallingContext.h
+++ b/FWCore/ServiceRegistry/interface/ModuleCallingContext.h
@@ -49,6 +49,8 @@ namespace edm {
                     ParentContext const& parent,
                     ModuleCallingContext const* previousOnThread);
 
+    void setState(State state) { state_ = state; }
+
     ModuleDescription const* moduleDescription() const { return moduleDescription_; }
     State state() const { return state_; }
     Type type() const { return parent_.type(); }

--- a/FWCore/Utilities/interface/EDGetToken.h
+++ b/FWCore/Utilities/interface/EDGetToken.h
@@ -43,17 +43,14 @@ namespace edm {
     EDGetToken(EDGetTokenT<T> iOther): m_value{iOther.m_value} {}
 
     // ---------- const member functions ---------------------
-    unsigned int index() const {return m_value & s_indexMask;}
-    bool willSkipCurrentProcess() const { return 0 != (m_value & s_skipMask); }
+    unsigned int index() const { return m_value; }
     bool isUnitialized() const { return m_value == s_uninitializedValue; }
 
   private:
 
     static const unsigned int s_uninitializedValue = 0xFFFFFFFF;
-    static const unsigned int s_indexMask = 0x7FFFFFFF;
-    static const unsigned int s_skipMask = 1U << 31;
 
-    explicit EDGetToken(unsigned int iValue, bool skipCurrentProcess) : m_value{(iValue & s_indexMask) | (skipCurrentProcess ? s_skipMask : 0)} { }
+    explicit EDGetToken(unsigned int iValue) : m_value(iValue) { }
 
     // ---------- member data --------------------------------
     unsigned int m_value;
@@ -70,17 +67,14 @@ namespace edm {
     EDGetTokenT() : m_value{s_uninitializedValue} {}
   
     // ---------- const member functions ---------------------
-    unsigned int index() const {return m_value & s_indexMask;}
-    bool willSkipCurrentProcess() const { return 0 != (m_value & s_skipMask); }
+    unsigned int index() const { return m_value; }
     bool isUnitialized() const { return m_value == s_uninitializedValue; }
 
   private:
 
     static const unsigned int s_uninitializedValue = 0xFFFFFFFF;
-    static const unsigned int s_indexMask = 0x7FFFFFFF;
-    static const unsigned int s_skipMask = 1U << 31;
 
-    explicit EDGetTokenT(unsigned int iValue, bool skipCurrentProcess) : m_value{(iValue & s_indexMask) | (skipCurrentProcess ? s_skipMask : 0)} { }
+    explicit EDGetTokenT(unsigned int iValue) : m_value(iValue) { }
 
     // ---------- member data --------------------------------
     unsigned int m_value;

--- a/FWCore/Utilities/interface/ProductHolderIndex.h
+++ b/FWCore/Utilities/interface/ProductHolderIndex.h
@@ -9,6 +9,11 @@ namespace edm {
 
 #ifndef __GCCXML__
   enum ProductHolderIndexValues {
+
+    // All values of the ProductHolderIndex in this enumeration should
+    // have this bit set to 1, 
+    ProductHolderIndexValuesBit = 1U << 30,
+
     ProductHolderIndexInvalid = std::numeric_limits<unsigned int>::max(),
     ProductHolderIndexInitializing = std::numeric_limits<unsigned int>::max() - 1,
     ProductHolderIndexAmbiguous = std::numeric_limits<unsigned int>::max() - 2

--- a/FWCore/Utilities/test/EDGetToken_t.cpp
+++ b/FWCore/Utilities/test/EDGetToken_t.cpp
@@ -10,86 +10,36 @@ int main() {
 
   edm::EDGetTokenT<int> token1;
   if(!token1.isUnitialized() ||
-     !(token1.index() == 0x7FFFFFFF) ||
-     !token1.willSkipCurrentProcess()) {
-    std::cout << "EDToken no argument constructor failed 1" << std::endl;
+     !(token1.index() == 0xFFFFFFFF)) {
+    std::cout << "EDGetTokenT no argument constructor failed 1" << std::endl;
     abort();
   }
-  edm::EDGetTokenT<int> token2(0x7FFFFFFF, true);
-  if(!token2.isUnitialized() ||
-     !(token2.index() == 0x7FFFFFFF) ||
-     !token2.willSkipCurrentProcess()) {
-    std::cout << "EDToken constructor failed 2" << std::endl;
+
+  edm::EDGetTokenT<int> token2(11);
+  if(token2.isUnitialized() ||
+     !(token2.index() == 11)) {
+    std::cout << "EDGetTokenT 1 argument constructor failed 2" << std::endl;
     abort();
   }
-  edm::EDGetTokenT<int> token3(0x7FFFFFFF, false);
-  if(token3.isUnitialized() ||
-     !(token3.index() == 0x7FFFFFFF) ||
-     token3.willSkipCurrentProcess()) {
-    std::cout << "EDToken constructor failed 3" << std::endl;
-    abort();
-  }
-  edm::EDGetTokenT<int> token4(1, true);
-  if(token4.isUnitialized() ||
-     !(token4.index() == 1) ||
-     !token4.willSkipCurrentProcess()) {
-    std::cout << "EDToken constructor failed 4" << std::endl;
-    abort();
-  }
-  edm::EDGetTokenT<int> token5(1, false);
-  if(token5.isUnitialized() ||
-     !(token5.index() == 1) ||
-     token5.willSkipCurrentProcess()) {
-    std::cout << "EDToken constructor failed 5" << std::endl;
-    abort();
-  }
+
   edm::EDGetToken token10;
   if(!token10.isUnitialized() ||
-     !(token10.index() == 0x7FFFFFFF) ||
-     !token10.willSkipCurrentProcess()) {
-    std::cout << "EDToken no argument constructor failed 10" << std::endl;
+     !(token10.index() == 0xFFFFFFFF)) {
+    std::cout << "EDGetToken no argument constructor failed 10" << std::endl;
     abort();
   }
-  edm::EDGetToken token20(0x7FFFFFFF, true);
-  if(!token20.isUnitialized() ||
-     !(token20.index() == 0x7FFFFFFF) ||
-     !token20.willSkipCurrentProcess()) {
-    std::cout << "EDToken constructor failed 20" << std::endl;
+
+  edm::EDGetToken token11(100);
+  if(token11.isUnitialized() ||
+     !(token11.index() == 100)) {
+    std::cout << "EDGetToken 1 argument constructor failed 11" << std::endl;
     abort();
   }
-  edm::EDGetToken token30(0x7FFFFFFF, false);
-  if(token30.isUnitialized() ||
-     !(token30.index() == 0x7FFFFFFF) ||
-     token30.willSkipCurrentProcess()) {
-    std::cout << "EDToken constructor failed 30" << std::endl;
-    abort();
-  }
-  edm::EDGetToken token40(1, true);
-  if(token40.isUnitialized() ||
-     !(token40.index() == 1) ||
-     !token40.willSkipCurrentProcess()) {
-    std::cout << "EDToken constructor failed 40" << std::endl;
-    abort();
-  }
-  edm::EDGetToken token50(1, false);
-  if(token50.isUnitialized() ||
-     !(token50.index() == 1) ||
-     token50.willSkipCurrentProcess()) {
-    std::cout << "EDToken constructor failed 50" << std::endl;
-    abort();
-  }
-  edm::EDGetToken token60(token4);
-  if(token60.isUnitialized() ||
-     !(token60.index() == 1) ||
-     !token60.willSkipCurrentProcess()) {
-    std::cout << "EDToken constructor failed 60" << std::endl;
-    abort();
-  }
-  edm::EDGetToken token70(token5);
-  if(token70.isUnitialized() ||
-     !(token70.index() == 1) ||
-     token70.willSkipCurrentProcess()) {
-    std::cout << "EDToken constructor failed 70" << std::endl;
+
+  edm::EDGetToken token12(token2);
+  if(token12.isUnitialized() ||
+     !(token12.index() == 11)) {
+    std::cout << "EDGetToken 1 argument constructor failed 12" << std::endl;
     abort();
   }
 }


### PR DESCRIPTION
Modify the Framework to prefetch products that were declared
to be consumed before running a module. This includes both
performing delayed reads of data from the ROOT file and
performing unscheduled execution of producers. Add code
that enforces that consume declarations are only in the module
constructor.

Note the only change external to the Framework (in DQM) is to
move the consumes call from beginJob to the constructor in
one module.
