### PR TITLE
Serialize DelayedReader

### DIFF
--- a/FWCore/Framework/interface/DelayedReader.h
+++ b/FWCore/Framework/interface/DelayedReader.h
@@ -16,20 +16,28 @@ namespace edm {
   struct BranchKey;
   class EDProductGetter;
   class WrapperInterfaceBase;
+  class SharedResourcesAcquirer;
   class DelayedReader {
   public:
     virtual ~DelayedReader();
-    WrapperOwningHolder getProduct(BranchKey const& k, WrapperInterfaceBase const* interface, EDProductGetter const* ep) {
-      return getProduct_(k, interface, ep);
-    }
+    WrapperOwningHolder getProduct(BranchKey const& k, WrapperInterfaceBase const* interface, EDProductGetter const* ep);
+    
     void mergeReaders(DelayedReader* other) {mergeReaders_(other);}
     void reset() {reset_();}
+    
+    SharedResourcesAcquirer* sharedResources() const {
+      return sharedResources_();
+    }
+    
+    
+    
   private:
     virtual WrapperOwningHolder getProduct_(BranchKey const& k,
                                             WrapperInterfaceBase const* interface,
                                             EDProductGetter const* ep) const = 0;
     virtual void mergeReaders_(DelayedReader*) = 0;
     virtual void reset_() = 0;
+    virtual SharedResourcesAcquirer* sharedResources_() const;
   };
 }
 

--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -67,6 +67,7 @@ namespace edm {
   class ProcessHistoryRegistry;
   class ProductRegistry;
   class StreamContext;
+  class SharedResourcesAcquirer;
   namespace multicore {
     class MessageReceiverForSource;
   }
@@ -180,6 +181,9 @@ namespace edm {
       remainingEvents_ = maxEvents_;
       remainingLumis_ = maxLumis_;
     }
+    
+    /// Returns nullptr if no resource shared between the Source and a DelayedReader
+    SharedResourcesAcquirer* resourceSharedWithDelayedReader() const;
 
     /// Accessor for maximum number of events to be read.
     /// -1 is used for unlimited.
@@ -400,6 +404,8 @@ namespace edm {
     virtual void endRun(Run&);
     virtual void beginJob();
     virtual void endJob();
+    virtual SharedResourcesAcquirer* resourceSharedWithDelayedReader_() const;
+
     virtual void preForkReleaseResources();
     virtual void postForkReacquireResources(boost::shared_ptr<multicore::MessageReceiverForSource>);
     virtual bool randomAccess_() const;

--- a/FWCore/Framework/src/DelayedReader.cc
+++ b/FWCore/Framework/src/DelayedReader.cc
@@ -1,5 +1,7 @@
 #include "FWCore/Framework/interface/DelayedReader.h"
+#include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
 
+#include <mutex>
 #include <cassert>
 /*----------------------------------------------------------------------
   
@@ -9,4 +11,19 @@
 
 namespace edm {
   DelayedReader::~DelayedReader() {}
+
+  WrapperOwningHolder
+  DelayedReader::getProduct(BranchKey const& k, WrapperInterfaceBase const* interface, EDProductGetter const* ep) {
+    auto sr = sharedResources_();
+    std::unique_lock<SharedResourcesAcquirer> guard;
+    if(sr) {
+      guard =std::unique_lock<SharedResourcesAcquirer>(*sr);
+    }
+    return getProduct_(k, interface, ep);
+  }
+
+  SharedResourcesAcquirer*
+  DelayedReader::sharedResources_() const {
+    return nullptr;
+  }
 }

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1821,25 +1821,37 @@ namespace edm {
           break;
         }
         {
-          //nextItemType and readEvent need to be in same critical section
-          std::lock_guard<std::mutex> sourceGuard(nextTransitionMutex_);
           
-          if(finishedProcessingEvents->load(std::memory_order_acquire)) {
-            //std::cerr<<"finishedProcessingEvents\n";
-            break;
+          
+          {
+            //nextItemType and readEvent need to be in same critical section
+            std::lock_guard<std::mutex> sourceGuard(nextTransitionMutex_);
+            
+            if(finishedProcessingEvents->load(std::memory_order_acquire)) {
+              //std::cerr<<"finishedProcessingEvents\n";
+              break;
+            }
+
+            //If source and DelayedReader share a resource we must serialize them
+            auto sr = input_->resourceSharedWithDelayedReader();
+            std::unique_lock<SharedResourcesAcquirer> delayedReaderGuard;
+            if(sr) {
+              delayedReaderGuard = std::unique_lock<SharedResourcesAcquirer>(*sr);
+            }
+            
+            InputSource::ItemType itemType = input_->nextItemType();
+            if (InputSource::IsEvent !=itemType) {
+              nextItemTypeFromProcessingEvents_ = itemType;
+              finishedProcessingEvents->store(true,std::memory_order_release);
+              //std::cerr<<"next item type "<<itemType<<"\n";
+              break;
+            }
+            if((asyncStopRequestedWhileProcessingEvents_=checkForAsyncStopRequest(asyncStopStatusCodeFromProcessingEvents_))) {
+              //std::cerr<<"task told to async stop\n";
+              break;
+            }
+            readEvent(iStreamIndex);
           }
-          InputSource::ItemType itemType = input_->nextItemType();
-          if (InputSource::IsEvent !=itemType) {
-            nextItemTypeFromProcessingEvents_ = itemType;
-            finishedProcessingEvents->store(true,std::memory_order_release);
-            //std::cerr<<"next item type "<<itemType<<"\n";
-            break;
-          }
-          if((asyncStopRequestedWhileProcessingEvents_=checkForAsyncStopRequest(asyncStopStatusCodeFromProcessingEvents_))) {
-            //std::cerr<<"task told to async stop\n";
-            break;
-          }
-          readEvent(iStreamIndex);
         }
         if(deferredExceptionPtrIsSet_.load(std::memory_order_acquire)) {
           //another thread hit an exception

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -250,6 +250,17 @@ namespace edm {
     endJob();
   }
 
+  SharedResourcesAcquirer*
+  InputSource::resourceSharedWithDelayedReader() const {
+    return resourceSharedWithDelayedReader_();
+  }
+
+  SharedResourcesAcquirer*
+  InputSource::resourceSharedWithDelayedReader_() const {
+    return nullptr;
+  }
+
+  
   void
   InputSource::registerProducts() {
     if(!typeLabelList().empty()) {

--- a/FWCore/Framework/src/SharedResourcesRegistry.cc
+++ b/FWCore/Framework/src/SharedResourcesRegistry.cc
@@ -39,6 +39,17 @@ namespace edm {
   }
   
   SharedResourcesAcquirer
+  SharedResourcesRegistry::createAcquirerForSourceDelayedReader() {
+    if(not resourceForDelayedReader_) {
+      resourceForDelayedReader_.reset(new std::recursive_mutex{});
+    }
+    std::vector<std::recursive_mutex*> mutexes = {resourceForDelayedReader_.get()};
+
+    return SharedResourcesAcquirer(std::move(mutexes));
+  }
+
+  
+  SharedResourcesAcquirer
   SharedResourcesRegistry::createAcquirer(std::vector<std::string> const &  iNames) const {
     //Sort by how often used and then by name
     std::map<std::pair<unsigned int, std::string>, std::recursive_mutex*> sortedResources;

--- a/FWCore/Framework/src/SharedResourcesRegistry.h
+++ b/FWCore/Framework/src/SharedResourcesRegistry.h
@@ -43,6 +43,7 @@ namespace edm {
     // ---------- const member functions ---------------------
     SharedResourcesAcquirer createAcquirer(std::vector<std::string> const&) const;
     
+    SharedResourcesAcquirer createAcquirerForSourceDelayedReader();
     // ---------- static member functions --------------------
     static SharedResourcesRegistry* instance();
     
@@ -63,6 +64,8 @@ namespace edm {
     
     // ---------- member data --------------------------------
     std::map<std::string, std::pair<std::shared_ptr<std::recursive_mutex>,unsigned int>> resourceMap_;
+    
+    std::shared_ptr<std::recursive_mutex> resourceForDelayedReader_;
     
   };
 }

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -9,6 +9,8 @@
 #include "FWCore/Framework/interface/InputSourceDescription.h"
 #include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
+#include "FWCore/Framework/src/SharedResourcesRegistry.h"
+#include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
 #include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -63,7 +65,11 @@ namespace edm {
     secondaryRunPrincipal_(),
     secondaryLumiPrincipal_(),
     secondaryEventPrincipals_(),
-    branchIDsToReplace_() {
+    branchIDsToReplace_(),
+    resourceSharedWithDelayedReaderPtr_(primary()?
+                                        new SharedResourcesAcquirer{SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader()}:
+                                        static_cast<SharedResourcesAcquirer*>(nullptr))
+  {
     if(secondaryFileSequence_) {
       unsigned int nStreams = desc.allocations_->numberOfStreams();
       assert(primary());
@@ -229,6 +235,11 @@ namespace edm {
   void
   PoolSource::preForkReleaseResources() {
     primaryFileSequence_->closeFile_();
+  }
+  
+  SharedResourcesAcquirer*
+  PoolSource::resourceSharedWithDelayedReader_() const {
+    return resourceSharedWithDelayedReaderPtr_.get();
   }
 
   // Rewind to before the first event that was read.

--- a/IOPool/Input/src/PoolSource.h
+++ b/IOPool/Input/src/PoolSource.h
@@ -60,6 +60,9 @@ namespace edm {
     virtual ProcessingController::ForwardState forwardState_() const;
     virtual ProcessingController::ReverseState reverseState_() const;
 
+    SharedResourcesAcquirer* resourceSharedWithDelayedReader_() const override;
+
+    
     RootServiceChecker rootServiceChecker_;
     std::unique_ptr<RootInputFileSequence> primaryFileSequence_;
     std::unique_ptr<RootInputFileSequence> secondaryFileSequence_;
@@ -67,6 +70,8 @@ namespace edm {
     boost::shared_ptr<LuminosityBlockPrincipal> secondaryLumiPrincipal_;
     std::vector<std::unique_ptr<EventPrincipal>> secondaryEventPrincipals_;
     std::array<std::vector<BranchID>, NumBranchTypes>  branchIDsToReplace_;
+    
+    std::unique_ptr<SharedResourcesAcquirer> resourceSharedWithDelayedReaderPtr_;
   }; // class PoolSource
   typedef PoolSource PoolRASource;
 }

--- a/IOPool/Input/src/RootDelayedReader.cc
+++ b/IOPool/Input/src/RootDelayedReader.cc
@@ -7,6 +7,9 @@
 #include "DataFormats/Common/interface/WrapperOwningHolder.h"
 #include "DataFormats/Common/interface/RefCoreStreamer.h"
 
+#include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
+#include "FWCore/Framework/src/SharedResourcesRegistry.h"
+
 #include "TROOT.h"
 #include "TBranch.h"
 #include "TClass.h"
@@ -22,10 +25,16 @@ namespace edm {
    tree_(tree),
    filePtr_(filePtr),
    nextReader_(),
+  resourceAcquirer_(inputType == InputType::Primary ? new SharedResourcesAcquirer(SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader()) : static_cast<SharedResourcesAcquirer*>(nullptr)),
    inputType_(inputType) {
   }
 
   RootDelayedReader::~RootDelayedReader() {
+  }
+
+  SharedResourcesAcquirer*
+  RootDelayedReader::sharedResources_() const {
+    return resourceAcquirer_.get();
   }
 
   WrapperOwningHolder

--- a/IOPool/Input/src/RootDelayedReader.h
+++ b/IOPool/Input/src/RootDelayedReader.h
@@ -19,6 +19,7 @@ RootDelayedReader.h // used by ROOT input sources
 namespace edm {
   class InputFile;
   class RootTree;
+  class SharedResourcesAcquirer;
 
   //------------------------------------------------------------
   // Class RootDelayedReader: pretends to support file reading.
@@ -46,6 +47,8 @@ namespace edm {
                                             EDProductGetter const* ep) const override;
     virtual void mergeReaders_(DelayedReader* other) {nextReader_ = other;}
     virtual void reset_() {nextReader_ = 0;}
+    SharedResourcesAcquirer* sharedResources_() const override;
+
     BranchMap const& branches() const {return tree_.branches();}
     iterator branchIter(BranchKey const& k) const {return branches().find(k);}
     bool found(iterator const& iter) const {return iter != branches().end();}
@@ -55,6 +58,7 @@ namespace edm {
     RootTree const& tree_;
     boost::shared_ptr<InputFile> filePtr_;
     DelayedReader* nextReader_;
+    std::unique_ptr<SharedResourcesAcquirer> resourceAcquirer_;
     InputType inputType_;
   }; // class RootDelayedReader
   //------------------------------------------------------------


### PR DESCRIPTION
The PoolSource needs to synchronize reads between itself and the PoolDelayedReader. This commit adds the ability to do that into the interface and puts the needed synchronization (via SharedResourcesAcquirer) into place.
The full IB should still function fine. All framework unit tests passed.
