### PR TITLE
Return IsSynchronize when secondary file is to be opened

### DIFF
--- a/DataFormats/Provenance/src/IndexIntoFile.cc
+++ b/DataFormats/Provenance/src/IndexIntoFile.cc
@@ -254,8 +254,8 @@ namespace edm {
 
       long long beginEventNumbers = 0;
       long long endEventNumbers = 0;
-      EntryNumber_t beginEventEntry = -1LL;
-      EntryNumber_t endEventEntry = -1LL;
+      EntryNumber_t beginEventEntry = invalidEntry;
+      EntryNumber_t endEventEntry = invalidEntry;
       runOrLumi.getRange(beginEventNumbers, endEventNumbers, beginEventEntry, endEventEntry);
 
       // This is true each time one hits a new lumi section (except if the previous lumi had

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -207,6 +207,8 @@ namespace edm {
       ItemType newState = nextItemType_();
       if(newState == IsStop) {
         state_ = IsStop;
+      } else if(newState == IsSynchronize) {
+        state_ = IsSynchronize;
       } else if(newState == IsFile || oldState == IsInvalid) {
         state_ = IsFile;
       } else if(newState == IsRun || oldState == IsFile) {

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -223,7 +223,18 @@ namespace edm {
 
   InputSource::ItemType
   PoolSource::getNextItemType() {
-    return primaryFileSequence_->getNextItemType();;
+    RunNumber_t run = IndexIntoFile::invalidRun;
+    LuminosityBlockNumber_t lumi = IndexIntoFile::invalidLumi;
+    EventNumber_t event = IndexIntoFile::invalidEvent;
+    InputSource::ItemType itemType = primaryFileSequence_->getNextItemType(run, lumi, event);
+    if(secondaryFileSequence_ && (IsSynchronize != state())) {
+      if(itemType == IsRun || itemType == IsLumi || itemType == IsEvent) {
+        if(!secondaryFileSequence_->containedInCurrentFile(run, lumi, event)) {
+          return IsSynchronize;
+        }
+      }
+    }
+    return itemType;
   }
 
   void

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -116,6 +116,7 @@ namespace edm {
     bool setEntryAtItem(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) {
       return event ? setEntryAtEvent(run, lumi, event) : (lumi ? setEntryAtLumi(run, lumi) : setEntryAtRun(run));
     }
+    bool containsItem(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) const;
     bool setEntryAtEvent(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event);
     bool setEntryAtLumi(RunNumber_t run, LuminosityBlockNumber_t lumi);
     bool setEntryAtRun(RunNumber_t run);
@@ -135,7 +136,7 @@ namespace edm {
     bool skipEvents(int& offset);
     bool goToEvent(EventID const& eventID);
     bool nextEventEntry() {return eventTree_.next();}
-    IndexIntoFile::EntryType getNextEntryTypeWanted();
+    IndexIntoFile::EntryType getNextItemType(RunNumber_t& run, LuminosityBlockNumber_t& lumi, EventNumber_t& event);
     boost::shared_ptr<IndexIntoFile> indexIntoFileSharedPtr() const {
       return indexIntoFileSharedPtr_;
     }
@@ -147,13 +148,12 @@ namespace edm {
   private:
     RootTreePtrArray& treePointers() {return treePointers_;}
     bool skipThisEntry();
-    IndexIntoFile::EntryType getEntryTypeWithSkipping();
     void setIfFastClonable(int remainingEvents, int remainingLumis);
     void validateFile(InputType inputType, bool usingGoToEvent);
     void fillIndexIntoFile();
-    void fillEventAuxiliary();
+    bool fillEventAuxiliary(IndexIntoFile::EntryNumber_t entry);
     void fillThisEventAuxiliary();
-    void fillHistory();
+    void fillEventHistory();
     boost::shared_ptr<LuminosityBlockAuxiliary> fillLumiAuxiliary();
     boost::shared_ptr<RunAuxiliary> fillRunAuxiliary();
     void overrideRunNumber(RunID& id);

--- a/IOPool/Input/src/RootInputFileSequence.h
+++ b/IOPool/Input/src/RootInputFileSequence.h
@@ -14,8 +14,8 @@ RootInputFileSequence: This is an InputSource
 #include "FWCore/Sources/interface/VectorInputSource.h"
 #include "FWCore/Utilities/interface/InputType.h"
 #include "DataFormats/Provenance/interface/BranchDescription.h"
-#include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/IndexIntoFile.h"
+#include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 
 #include <memory>
 #include <string>
@@ -55,7 +55,8 @@ namespace edm {
     std::unique_ptr<FileBlock> readFile_();
     void closeFile_();
     void endJob();
-    InputSource::ItemType getNextItemType();
+    InputSource::ItemType getNextItemType(RunNumber_t& run, LuminosityBlockNumber_t& lumi, EventNumber_t& event);
+    bool containedInCurrentFile(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) const;
     bool skipEvents(int offset);
     bool goToEvent(EventID const& eventID);
     bool skipToItem(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event, bool currentFileFirst = true);
@@ -70,12 +71,8 @@ namespace edm {
     void dropUnwantedBranches_(std::vector<std::string> const& wantedBranches);
     boost::shared_ptr<ProductRegistry const> fileProductRegistry() const;
     boost::shared_ptr<BranchIDListHelper const> fileBranchIDListHelper() const;
-    ProcessHistoryRegistry const& processHistoryRegistry() const {
-      return input_.processHistoryRegistry();
-    }
-    ProcessHistoryRegistry& processHistoryRegistryForUpdate() {
-      return input_.processHistoryRegistryForUpdate();
-    }
+    ProcessHistoryRegistry const& processHistoryRegistry() const;
+    ProcessHistoryRegistry& processHistoryRegistryForUpdate();
     static void fillDescription(ParameterSetDescription & desc);
     ProcessingController::ForwardState forwardState() const;
     ProcessingController::ReverseState reverseState() const;

--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -46,7 +46,7 @@ namespace edm {
     triggerSet_(),
     entries_(tree_ ? tree_->GetEntries() : 0),
     entryNumber_(-1),
-    entryNumberForIndex_(new std::vector<EntryNumber>(nIndexes, -1LL)),
+    entryNumberForIndex_(new std::vector<EntryNumber>(nIndexes, IndexIntoFile::invalidEntry)),
     branchNames_(),
     branches_(new BranchMap),
     trainNow_(false),

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -8,6 +8,7 @@ RootTree.h // used by ROOT input sources
 ----------------------------------------------------------------------*/
 
 #include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/IndexIntoFile.h"
 #include "DataFormats/Provenance/interface/ProvenanceFwd.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Utilities/interface/InputType.h"
@@ -37,7 +38,7 @@ namespace edm {
     unsigned int const defaultNonEventCacheSize = 1U * 1024 * 1024;
     unsigned int const defaultLearningEntries = 20U;
     unsigned int const defaultNonEventLearningEntries = 1U;
-    typedef Long64_t EntryNumber;
+    typedef IndexIntoFile::EntryNumber_t EntryNumber;
     struct BranchInfo {
       BranchInfo(BranchDescription const& prod) :
         branchDescription_(prod),
@@ -84,6 +85,7 @@ namespace edm {
     bool next() {return ++entryNumber_ < entries_;}
     bool previous() {return --entryNumber_ >= 0;}
     bool current() const {return entryNumber_ < entries_ && entryNumber_ >= 0;}
+    bool current(EntryNumber entry) const {return entry < entries_ && entry >= 0;}
     void rewind() {entryNumber_ = 0;}
     void close();
     EntryNumber const& entryNumber() const {return entryNumber_;}


### PR DESCRIPTION
In the multithreaded framework, a synchronization point is needed for the one file two file feature before a secondary input file is opened asynchronously with the opening of primary files.  This pull request provides this synchronization.

This pull request also causes getNextItemType() to read the EventAuxiliary when the next item is an event.  Before this pull request, the EventAuxiliary was not read until readEvent() time.
