### PR TITLE
7_0_X Fixes in Firewors/Core in data-compatibility check, item accessors, and interface to projection center.

### DIFF
--- a/Fireworks/Core/src/FWFileEntry.cc
+++ b/Fireworks/Core/src/FWFileEntry.cc
@@ -10,6 +10,7 @@
 #include "FWCore/Common/interface/TriggerNames.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/Provenance/interface/ProcessConfiguration.h"
+#include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Provenance/interface/ReleaseVersion.h"
 
 #define private public
@@ -50,10 +51,10 @@ void FWFileEntry::openFile(bool checkVersion)
 
    // check CMSSW relese version for compatibility
    if (checkVersion) {
-      typedef std::vector<edm::ProcessConfiguration> provList;
+      typedef std::vector<edm::ProcessHistory> provList;
   
       TTree   *metaData = dynamic_cast<TTree*>(m_file->Get("MetaData"));
-      TBranch *b = metaData->GetBranch("ProcessConfiguration");
+      TBranch *b = metaData->GetBranch("ProcessHistory");
       provList *x = 0;
       b->SetAddress(&x);
       b->GetEntry(0);
@@ -61,15 +62,18 @@ void FWFileEntry::openFile(bool checkVersion)
       const edm::ProcessConfiguration* dd = 0;
       int latestVersion =0;
       int currentVersionArr[] = {0, 0, 0};
-      for (provList::iterator i = x->begin(); i != x->end(); ++i)
+      for (auto const& processHistory : *x)
       {
-         // std::cout << i->releaseVersion() << "  " << i->processName() << std::endl;
-         TString dcv = i->releaseVersion();
-         fireworks::getDecomposedVersion(dcv, currentVersionArr);
-         int nvv = currentVersionArr[0]*100 + currentVersionArr[1]*10 + currentVersionArr[2];
-         if (nvv > latestVersion) {
-            latestVersion = nvv;
-            dd = &(*i);
+         for (auto const& processConfiguration : processHistory)
+         {
+            // std::cout << processConfiguration.releaseVersion() << "  " << processConfiguration.processName() << std::endl;
+            TString dcv = processConfiguration.releaseVersion();
+            fireworks::getDecomposedVersion(dcv, currentVersionArr);
+            int nvv = currentVersionArr[0]*100 + currentVersionArr[1]*10 + currentVersionArr[2];
+            if (nvv > latestVersion) {
+               latestVersion = nvv;
+               dd = &processConfiguration;
+            }
          }
       }
    

--- a/Fireworks/Core/src/FWItemAccessorFactory.cc
+++ b/Fireworks/Core/src/FWItemAccessorFactory.cc
@@ -204,8 +204,8 @@ FWItemAccessorFactory::hasMemberTVirtualCollectionProxy(const TClass *iClass,
 bool
 FWItemAccessorFactory::hasAccessor(const TClass *iClass, std::string &result)
 {
-   const std::vector<edmplugin::PluginInfo> &available 
-      = FWItemAccessorRegistry::get()->available();
+   const std::vector<edmplugin::PluginInfo> &available
+      = edmplugin::PluginManager::get()->categoryToInfos().find("cmsShow FWItemAccessorBase")->second;
    
    for (size_t i = 0, e = available.size(); i != e; ++i)
    {
@@ -217,7 +217,7 @@ FWItemAccessorFactory::hasAccessor(const TClass *iClass, std::string &result)
          return true;
       }
    }
-   return false; 
+   return false;
 }
 
 /** Helper method which checks if the object will be treated as a collection.

--- a/Fireworks/Core/src/FWItemValueGetter.cc
+++ b/Fireworks/Core/src/FWItemValueGetter.cc
@@ -52,6 +52,12 @@ FWItemValueGetter::FWItemValueGetter(const edm::TypeWithDict& iType, const std::
       addEntry("y0", 2, "y", "cm");
       addEntry("z0", 2, "z", "cm");
    }
+   else if (strstr(iPurpose.c_str(), "Vertices") )
+   {
+      addEntry("x", 2, "x", "cm");
+      addEntry("y", 2, "y", "cm");
+      addEntry("z", 2, "z", "cm");
+   }
    else if (strstr(iPurpose.c_str(), "Conversion") )
    {
       addEntry("pairMomentum().rho()", 1, "pt", "GeV" );


### PR DESCRIPTION
Import bugfix in data compatibility check from Bill. See issue #1053
Bugfix in hasAccessor() which might cause missing collections.
Fix crash when set projection center -> Add x, y, z values in FWItemValueGetter.
