### PR TITLE
Multithreaded Tracer Service

### DIFF
--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -162,6 +162,7 @@ private:
         streamContext.setTimestamp(Timestamp());
         ParentContext parentContext(&streamContext);
         ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
+        moduleCallingContext_.setState(ModuleCallingContext::State::kRunning);
         ModuleBeginStreamSignalSentry beginSentry(actReg_.get(), streamContext, moduleCallingContext_);
         implBeginStream(id);
       }
@@ -191,6 +192,7 @@ private:
         streamContext.setTimestamp(Timestamp());
         ParentContext parentContext(&streamContext);
         ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
+        moduleCallingContext_.setState(ModuleCallingContext::State::kRunning);
         ModuleEndStreamSignalSentry endSentry(actReg_.get(), streamContext, moduleCallingContext_);
         implEndStream(id);
       }

--- a/FWCore/Framework/test/test_deepCall_allowUnscheduled_true_cfg.py
+++ b/FWCore/Framework/test/test_deepCall_allowUnscheduled_true_cfg.py
@@ -20,6 +20,23 @@ process.Tracer = cms.Service('Tracer',
                              dumpContextForLabel = cms.untracked.string('one')
 )
 
+process.MessageLogger = cms.Service("MessageLogger",
+    destinations   = cms.untracked.vstring('cout',
+                                           'cerr'
+    ),
+    categories = cms.untracked.vstring(
+        'Tracer'
+    ),
+    cout = cms.untracked.PSet(
+        default = cms.untracked.PSet (
+            limit = cms.untracked.int32(0)
+        ),
+        Tracer = cms.untracked.PSet(
+            limit=cms.untracked.int32(100000000)
+        )
+    )
+)
+
 process.one = cms.EDProducer("IntProducer",
     ivalue = cms.int32(1)
 )

--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_allowUnscheduled_true.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_allowUnscheduled_true.log
@@ -1,60 +1,72 @@
-++ constructing source:EmptySource
-++ construction finished:EmptySource
-++ constructing module: TriggerResults
-++ construction finished: TriggerResults
-++ constructing module: get
-++ construction finished: get
-++ constructing module: one
+++ starting: constructing source: EmptySource
+++ finished: constructing source: EmptySource
+++++ starting: constructing module with label 'TriggerResults'
+++++ finished: constructing module with label 'TriggerResults'
+++++ starting: constructing module with label 'get'
+++++ finished: constructing module with label 'get'
+++++ starting: constructing module with label 'one'
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++ construction finished: one
+++++ finished: constructing module with label 'one'
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++ constructing module: result1
-++ construction finished: result1
-++ constructing module: result2
-++ construction finished: result2
-++ constructing module: result4
-++ construction finished: result4
-++ ModuleBeginJob: one
+++++ starting: constructing module with label 'result1'
+++++ finished: constructing module with label 'result1'
+++++ starting: constructing module with label 'result2'
+++++ finished: constructing module with label 'result2'
+++++ starting: constructing module with label 'result4'
+++++ finished: constructing module with label 'result4'
+++++ starting: begin job for module with label 'one'
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++ ModuleBeginJob finished: one
+++++ finished: begin job for module with label 'one'
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++ ModuleBeginJob: result1
-++ ModuleBeginJob finished: result1
-++ ModuleBeginJob: result2
-++ ModuleBeginJob finished: result2
-++ ModuleBeginJob: result4
-++ ModuleBeginJob finished: result4
-++ ModuleBeginJob: get
-++ ModuleBeginJob finished: get
-++ ModuleBeginJob: TriggerResults
-++ ModuleBeginJob finished: TriggerResults
-++ Job started
-++++ ModuleBeginStream: get
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: TriggerResults
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: one
+++++ starting: begin job for module with label 'result1'
+++++ finished: begin job for module with label 'result1'
+++++ starting: begin job for module with label 'result2'
+++++ finished: begin job for module with label 'result2'
+++++ starting: begin job for module with label 'result4'
+++++ finished: begin job for module with label 'result4'
+++++ starting: begin job for module with label 'get'
+++++ finished: begin job for module with label 'get'
+++++ starting: begin job for module with label 'TriggerResults'
+++++ finished: begin job for module with label 'TriggerResults'
+++ finished: begin job
+++++ starting: begin stream for module: stream = 0 label = 'get'
+++++ finished: begin stream for module: stream = 0 label = 'get'
+++++ starting: begin stream for module: stream = 0 label = 'TriggerResults'
+++++ finished: begin stream for module: stream = 0 label = 'TriggerResults'
+++++ starting: begin stream for module: stream = 0 label = 'one'
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++++ ModuleBeginStream finished
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    StreamContext: StreamID = 0 transition = BeginStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+
+++++ finished: begin stream for module: stream = 0 label = 'one'
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++++ ModuleBeginStream: result1
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: result2
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: result4
-++++ ModuleBeginStream finished
-++++ source run
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    StreamContext: StreamID = 0 transition = BeginStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+
+++++ starting: begin stream for module: stream = 0 label = 'result1'
+++++ finished: begin stream for module: stream = 0 label = 'result1'
+++++ starting: begin stream for module: stream = 0 label = 'result2'
+++++ finished: begin stream for module: stream = 0 label = 'result2'
+++++ starting: begin stream for module: stream = 0 label = 'result4'
+++++ finished: begin stream for module: stream = 0 label = 'result4'
+++++ starting: source run
 ++++ finished: source run
-++++ GlobalBeginRun run: 1 time: 1000000
-++++++ ModuleGlobalBeginRun: one
+++++ starting: global begin run 1 : time = 1000000
+++++++ starting: global begin run for module: label = 'one'
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
@@ -65,7 +77,8 @@ ModuleCallingContext state = Running
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-++++++ ModuleGlobalBeginRun finished: one
+
+++++++ finished: global begin run for module: label = 'one'
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
@@ -76,19 +89,20 @@ ModuleCallingContext state = Running
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-++++++ ModuleGlobalBeginRun: result1
-++++++ ModuleGlobalBeginRun finished: result1
-++++++ ModuleGlobalBeginRun: result2
-++++++ ModuleGlobalBeginRun finished: result2
-++++++ ModuleGlobalBeginRun: result4
-++++++ ModuleGlobalBeginRun finished: result4
-++++++ ModuleGlobalBeginRun: get
-++++++ ModuleGlobalBeginRun finished: get
-++++++ ModuleGlobalBeginRun: TriggerResults
-++++++ ModuleGlobalBeginRun finished: TriggerResults
-++++ GlobalBeginRun finished
-++++ StreamBeginRun run: 1 time: 1000000
-++++++ ModuleStreamBeginRun: one
+
+++++++ starting: global begin run for module: label = 'result1'
+++++++ finished: global begin run for module: label = 'result1'
+++++++ starting: global begin run for module: label = 'result2'
+++++++ finished: global begin run for module: label = 'result2'
+++++++ starting: global begin run for module: label = 'result4'
+++++++ finished: global begin run for module: label = 'result4'
+++++++ starting: global begin run for module: label = 'get'
+++++++ finished: global begin run for module: label = 'get'
+++++++ starting: global begin run for module: label = 'TriggerResults'
+++++++ finished: global begin run for module: label = 'TriggerResults'
+++++ finished: global begin run 1 : time = 1000000
+++++ starting: begin run: stream = 0 run = 1 time = 1000000
+++++++ starting: begin run for module: stream = 0 label = 'one'
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
@@ -99,7 +113,8 @@ ModuleCallingContext state = Running
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-++++++ ModuleStreamBeginRun finished: one
+
+++++++ finished: begin run for module: stream = 0 label = 'one'
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
@@ -110,19 +125,20 @@ ModuleCallingContext state = Running
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-++++++ ModuleStreamBeginRun: result1
-++++++ ModuleStreamBeginRun finished: result1
-++++++ ModuleStreamBeginRun: result2
-++++++ ModuleStreamBeginRun finished: result2
-++++++ ModuleStreamBeginRun: result4
-++++++ ModuleStreamBeginRun finished: result4
-++++++ ModuleStreamBeginRun: get
-++++++ ModuleStreamBeginRun finished: get
-++++ StreamBeginRun finished
-++++ source lumi
+
+++++++ starting: begin run for module: stream = 0 label = 'result1'
+++++++ finished: begin run for module: stream = 0 label = 'result1'
+++++++ starting: begin run for module: stream = 0 label = 'result2'
+++++++ finished: begin run for module: stream = 0 label = 'result2'
+++++++ starting: begin run for module: stream = 0 label = 'result4'
+++++++ finished: begin run for module: stream = 0 label = 'result4'
+++++++ starting: begin run for module: stream = 0 label = 'get'
+++++++ finished: begin run for module: stream = 0 label = 'get'
+++++ finished: begin run: stream = 0 run = 1 time = 1000000
+++++ starting: source lumi
 ++++ finished: source lumi
-++++ GlobalBeginLumi run: 1 lumi: 1 time: 1000000
-++++++ ModuleGlobalBeginLumi: one
+++++ starting: global begin lumi: run = 1 lumi = 1 time = 1000000
+++++++ starting: global begin lumi for module: label = 'one'
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
@@ -133,7 +149,8 @@ ModuleCallingContext state = Running
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-++++++ ModuleGlobalBeginLumi finished: one
+
+++++++ finished: global begin lumi for module: label = 'one'
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
@@ -144,19 +161,20 @@ ModuleCallingContext state = Running
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-++++++ ModuleGlobalBeginLumi: result1
-++++++ ModuleGlobalBeginLumi finished: result1
-++++++ ModuleGlobalBeginLumi: result2
-++++++ ModuleGlobalBeginLumi finished: result2
-++++++ ModuleGlobalBeginLumi: result4
-++++++ ModuleGlobalBeginLumi finished: result4
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ StreamBeginLumi run: 1 lumi: 1 time: 1000000
-++++++ ModuleStreamBeginLumi: one
+
+++++++ starting: global begin lumi for module: label = 'result1'
+++++++ finished: global begin lumi for module: label = 'result1'
+++++++ starting: global begin lumi for module: label = 'result2'
+++++++ finished: global begin lumi for module: label = 'result2'
+++++++ starting: global begin lumi for module: label = 'result4'
+++++++ finished: global begin lumi for module: label = 'result4'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 1 lumi = 1 time = 1000000
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
+++++++ starting: begin lumi for module: stream = 0 label = 'one'
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
@@ -167,7 +185,8 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-++++++ ModuleStreamBeginLumi finished: one
+
+++++++ finished: begin lumi for module: stream = 0 label = 'one'
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
@@ -178,20 +197,21 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-++++++ ModuleStreamBeginLumi: result1
-++++++ ModuleStreamBeginLumi finished: result1
-++++++ ModuleStreamBeginLumi: result2
-++++++ ModuleStreamBeginLumi finished: result2
-++++++ ModuleStreamBeginLumi: result4
-++++++ ModuleStreamBeginLumi finished: result4
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++ StreamBeginLumi finished
-++++ source event
+
+++++++ starting: begin lumi for module: stream = 0 label = 'result1'
+++++++ finished: begin lumi for module: stream = 0 label = 'result1'
+++++++ starting: begin lumi for module: stream = 0 label = 'result2'
+++++++ finished: begin lumi for module: stream = 0 label = 'result2'
+++++++ starting: begin lumi for module: stream = 0 label = 'result4'
+++++++ finished: begin lumi for module: stream = 0 label = 'result4'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 1 event: 1 time:1000010
-++++++ processing path for event: p
-++++++++ module for event: one
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 1000010
+++++++ starting: processing path 'p' : stream = 0
+++++++++++++++++ starting: processing event for module: stream = 0 label = 'one'
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000010
@@ -216,7 +236,8 @@ ModuleCallingContext state = Running
     previousModuleOnThread: same as parent module
     previousModuleOnThread: same as parent module
     previousModuleOnThread: same as parent module
-++++++++ finished module for event: one
+
+++++++++++++++++ finished: processing event for module: stream = 0 label = 'one'
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000010
@@ -241,23 +262,24 @@ ModuleCallingContext state = Running
     previousModuleOnThread: same as parent module
     previousModuleOnThread: same as parent module
     previousModuleOnThread: same as parent module
-++++++++ module for event: result1
-++++++++ finished module for event: result1
-++++++++ module for event: result2
-++++++++ finished module for event: result2
-++++++++ module for event: result4
-++++++++ finished module for event: result4
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++ path for event finished: p
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ source event
+
+++++++++++++++ starting: processing event for module: stream = 0 label = 'result1'
+++++++++++++++ finished: processing event for module: stream = 0 label = 'result1'
+++++++++++++ starting: processing event for module: stream = 0 label = 'result2'
+++++++++++++ finished: processing event for module: stream = 0 label = 'result2'
+++++++++++ starting: processing event for module: stream = 0 label = 'result4'
+++++++++++ finished: processing event for module: stream = 0 label = 'result4'
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++ finished: processing path 'p' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 1000010
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 1 event: 2 time:1000020
-++++++ processing path for event: p
-++++++++ module for event: one
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 1000020
+++++++ starting: processing path 'p' : stream = 0
+++++++++++++++++ starting: processing event for module: stream = 0 label = 'one'
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000020
@@ -282,7 +304,8 @@ ModuleCallingContext state = Running
     previousModuleOnThread: same as parent module
     previousModuleOnThread: same as parent module
     previousModuleOnThread: same as parent module
-++++++++ finished module for event: one
+
+++++++++++++++++ finished: processing event for module: stream = 0 label = 'one'
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000020
@@ -307,23 +330,24 @@ ModuleCallingContext state = Running
     previousModuleOnThread: same as parent module
     previousModuleOnThread: same as parent module
     previousModuleOnThread: same as parent module
-++++++++ module for event: result1
-++++++++ finished module for event: result1
-++++++++ module for event: result2
-++++++++ finished module for event: result2
-++++++++ module for event: result4
-++++++++ finished module for event: result4
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++ path for event finished: p
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ source event
+
+++++++++++++++ starting: processing event for module: stream = 0 label = 'result1'
+++++++++++++++ finished: processing event for module: stream = 0 label = 'result1'
+++++++++++++ starting: processing event for module: stream = 0 label = 'result2'
+++++++++++++ finished: processing event for module: stream = 0 label = 'result2'
+++++++++++ starting: processing event for module: stream = 0 label = 'result4'
+++++++++++ finished: processing event for module: stream = 0 label = 'result4'
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++ finished: processing path 'p' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 1000020
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 1 event: 3 time:1000030
-++++++ processing path for event: p
-++++++++ module for event: one
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 1000030
+++++++ starting: processing path 'p' : stream = 0
+++++++++++++++++ starting: processing event for module: stream = 0 label = 'one'
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
@@ -348,7 +372,8 @@ ModuleCallingContext state = Running
     previousModuleOnThread: same as parent module
     previousModuleOnThread: same as parent module
     previousModuleOnThread: same as parent module
-++++++++ finished module for event: one
+
+++++++++++++++++ finished: processing event for module: stream = 0 label = 'one'
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
@@ -373,20 +398,21 @@ ModuleCallingContext state = Running
     previousModuleOnThread: same as parent module
     previousModuleOnThread: same as parent module
     previousModuleOnThread: same as parent module
-++++++++ module for event: result1
-++++++++ finished module for event: result1
-++++++++ module for event: result2
-++++++++ finished module for event: result2
-++++++++ module for event: result4
-++++++++ finished module for event: result4
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++ path for event finished: p
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ StreamEndLumi run: 1 lumi: 1 time: 1000030
-++++++ ModuleStreamEndLumi: one
+
+++++++++++++++ starting: processing event for module: stream = 0 label = 'result1'
+++++++++++++++ finished: processing event for module: stream = 0 label = 'result1'
+++++++++++++ starting: processing event for module: stream = 0 label = 'result2'
+++++++++++++ finished: processing event for module: stream = 0 label = 'result2'
+++++++++++ starting: processing event for module: stream = 0 label = 'result4'
+++++++++++ finished: processing event for module: stream = 0 label = 'result4'
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++ finished: processing path 'p' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 1000030
+++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
+++++++ starting: end lumi for module: stream = 0 label = 'one'
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
@@ -397,7 +423,8 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-++++++ ModuleStreamEndLumi finished: one
+
+++++++ finished: end lumi for module: stream = 0 label = 'one'
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
@@ -408,17 +435,18 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-++++++ ModuleStreamEndLumi: result1
-++++++ ModuleStreamEndLumi finished: result1
-++++++ ModuleStreamEndLumi: result2
-++++++ ModuleStreamEndLumi finished: result2
-++++++ ModuleStreamEndLumi: result4
-++++++ ModuleStreamEndLumi finished: result4
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++ StreamEndLumi finished
-++++ GlobalEndLumi run: 1 lumi: 1 time: 1000000
-++++++ ModuleGlobalEndLumi: one
+
+++++++ starting: end lumi for module: stream = 0 label = 'result1'
+++++++ finished: end lumi for module: stream = 0 label = 'result1'
+++++++ starting: end lumi for module: stream = 0 label = 'result2'
+++++++ finished: end lumi for module: stream = 0 label = 'result2'
+++++++ starting: end lumi for module: stream = 0 label = 'result4'
+++++++ finished: end lumi for module: stream = 0 label = 'result4'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
+++++ starting: global end lumi: run = 1 lumi = 1 time = 1000000
+++++++ starting: global end lumi for module: label = 'one'
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
@@ -429,7 +457,8 @@ ModuleCallingContext state = Running
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-++++++ ModuleGlobalEndLumi finished: one
+
+++++++ finished: global end lumi for module: label = 'one'
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
@@ -440,19 +469,20 @@ ModuleCallingContext state = Running
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-++++++ ModuleGlobalEndLumi: result1
-++++++ ModuleGlobalEndLumi finished: result1
-++++++ ModuleGlobalEndLumi: result2
-++++++ ModuleGlobalEndLumi finished: result2
-++++++ ModuleGlobalEndLumi: result4
-++++++ ModuleGlobalEndLumi finished: result4
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ StreamEndRun run: 1 time: 1000030
-++++++ ModuleStreamEndRun: one
+
+++++++ starting: global end lumi for module: label = 'result1'
+++++++ finished: global end lumi for module: label = 'result1'
+++++++ starting: global end lumi for module: label = 'result2'
+++++++ finished: global end lumi for module: label = 'result2'
+++++++ starting: global end lumi for module: label = 'result4'
+++++++ finished: global end lumi for module: label = 'result4'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
+++++ starting: end run: stream = 0 run = 1 time = 1000030
+++++++ starting: end run for module: stream = 0 label = 'one'
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
@@ -463,7 +493,8 @@ ModuleCallingContext state = Running
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-++++++ ModuleStreamEndRun finished: one
+
+++++++ finished: end run for module: stream = 0 label = 'one'
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
@@ -474,17 +505,18 @@ ModuleCallingContext state = Running
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-++++++ ModuleStreamEndRun: result1
-++++++ ModuleStreamEndRun finished: result1
-++++++ ModuleStreamEndRun: result2
-++++++ ModuleStreamEndRun finished: result2
-++++++ ModuleStreamEndRun: result4
-++++++ ModuleStreamEndRun finished: result4
-++++++ ModuleStreamEndRun: get
-++++++ ModuleStreamEndRun finished: get
-++++ StreamEndRun finished
-++++ GlobalEndRun run: 1 time: 1000030
-++++++ ModuleGlobalEndRun: one
+
+++++++ starting: end run for module: stream = 0 label = 'result1'
+++++++ finished: end run for module: stream = 0 label = 'result1'
+++++++ starting: end run for module: stream = 0 label = 'result2'
+++++++ finished: end run for module: stream = 0 label = 'result2'
+++++++ starting: end run for module: stream = 0 label = 'result4'
+++++++ finished: end run for module: stream = 0 label = 'result4'
+++++++ starting: end run for module: stream = 0 label = 'get'
+++++++ finished: end run for module: stream = 0 label = 'get'
+++++ finished: end run: stream = 0 run = 1 time = 1000030
+++++ starting: global end run 1 : time = 1000030
+++++++ starting: global end run for module: label = 'one'
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
@@ -495,7 +527,8 @@ ModuleCallingContext state = Running
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-++++++ ModuleGlobalEndRun finished: one
+
+++++++ finished: global end run for module: label = 'one'
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
@@ -506,51 +539,64 @@ ModuleCallingContext state = Running
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-++++++ ModuleGlobalEndRun: result1
-++++++ ModuleGlobalEndRun finished: result1
-++++++ ModuleGlobalEndRun: result2
-++++++ ModuleGlobalEndRun finished: result2
-++++++ ModuleGlobalEndRun: result4
-++++++ ModuleGlobalEndRun finished: result4
-++++++ ModuleGlobalEndRun: get
-++++++ ModuleGlobalEndRun finished: get
-++++++ ModuleGlobalEndRun: TriggerResults
-++++++ ModuleGlobalEndRun finished: TriggerResults
-++++ GlobalEndRun finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
+
+++++++ starting: global end run for module: label = 'result1'
+++++++ finished: global end run for module: label = 'result1'
+++++++ starting: global end run for module: label = 'result2'
+++++++ finished: global end run for module: label = 'result2'
+++++++ starting: global end run for module: label = 'result4'
+++++++ finished: global end run for module: label = 'result4'
+++++++ starting: global end run for module: label = 'get'
+++++++ finished: global end run for module: label = 'get'
+++++++ starting: global end run for module: label = 'TriggerResults'
+++++++ finished: global end run for module: label = 'TriggerResults'
+++++ finished: global end run 1 : time = 1000030
+++++ starting: end stream for module: stream = 0 label = 'get'
+++++ finished: end stream for module: stream = 0 label = 'get'
+++++ starting: end stream for module: stream = 0 label = 'TriggerResults'
+++++ finished: end stream for module: stream = 0 label = 'TriggerResults'
+++++ starting: end stream for module: stream = 0 label = 'one'
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
-Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++++ ModuleEndStream finished
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    StreamContext: StreamID = 0 transition = EndStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+
+++++ finished: end stream for module: stream = 0 label = 'one'
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
+    StreamContext: StreamID = 0 transition = EndStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
+
+++++ starting: end stream for module: stream = 0 label = 'result1'
+++++ finished: end stream for module: stream = 0 label = 'result1'
+++++ starting: end stream for module: stream = 0 label = 'result2'
+++++ finished: end stream for module: stream = 0 label = 'result2'
+++++ starting: end stream for module: stream = 0 label = 'result4'
+++++ finished: end stream for module: stream = 0 label = 'result4'
+++++ starting: end job for module with label 'one'
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++ ModuleEndJob: one
+++++ finished: end job for module with label 'one'
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++ ModuleEndJob finished: one
-Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++ ModuleEndJob: result1
-++ ModuleEndJob finished: result1
-++ ModuleEndJob: result2
-++ ModuleEndJob finished: result2
-++ ModuleEndJob: result4
-++ ModuleEndJob finished: result4
-++ ModuleEndJob: get
-++ ModuleEndJob finished: get
-++ ModuleEndJob: TriggerResults
-++ ModuleEndJob finished: TriggerResults
-++ Job ended
+++++ starting: end job for module with label 'result1'
+++++ finished: end job for module with label 'result1'
+++++ starting: end job for module with label 'result2'
+++++ finished: end job for module with label 'result2'
+++++ starting: end job for module with label 'result4'
+++++ finished: end job for module with label 'result4'
+++++ starting: end job for module with label 'get'
+++++ finished: end job for module with label 'get'
+++++ starting: end job for module with label 'TriggerResults'
+++++ finished: end job for module with label 'TriggerResults'
+++ finished: end job

--- a/FWCore/Integration/test/run_SubProcess.sh
+++ b/FWCore/Integration/test/run_SubProcess.sh
@@ -10,7 +10,7 @@ pushd ${LOCAL_TMP_DIR}
   rm -f ${test}.log
 
   echo cmsRun testSubProcess_cfg.py
-  cmsRun -p ${LOCAL_TEST_DIR}/${test}_cfg.py > ${test}.log 2>&1 || die "cmsRun ${test}_cfg.py" $?
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}_cfg.py >& ${test}.log 2>&1 || die "cmsRun ${test}_cfg.py" $?
   grep Doodad ${test}.log > testSubProcess.grep.txt
   diff ${LOCAL_TEST_DIR}/unit_test_outputs/testSubProcess.grep.txt testSubProcess.grep.txt || die "comparing testSubProcess.grep.txt" $?
   grep "++" ${test}.log > testSubProcess.grep2.txt

--- a/FWCore/Integration/test/run_TestGetBy.sh
+++ b/FWCore/Integration/test/run_TestGetBy.sh
@@ -10,7 +10,8 @@ pushd ${LOCAL_TMP_DIR}
   diff ${LOCAL_TMP_DIR}/testGetBy1.log ${LOCAL_TEST_DIR}/unit_test_outputs/testGetBy1.log || die "comparing testGetBy1.log" $?
 
   cmsRun -p ${LOCAL_TEST_DIR}/${test}2_cfg.py > testGetBy2.log || die "cmsRun ${test}2_cfg.py" $?
-  diff ${LOCAL_TMP_DIR}/testGetBy2.log ${LOCAL_TEST_DIR}/unit_test_outputs/testGetBy2.log || die "comparing testGetBy2.log" $?
+  grep -v "Initiating request to open file" testGetBy2.log | grep -v "Successfully opened file" | grep -v "Closed file" > testGetBy2_1.log
+  diff testGetBy2_1.log ${LOCAL_TEST_DIR}/unit_test_outputs/testGetBy2.log || die "comparing testGetBy2.log" $?
 
   cmsRun -p ${LOCAL_TEST_DIR}/${test}3_cfg.py || die "cmsRun ${test}3_cfg.py" $?
 

--- a/FWCore/Integration/test/testGetBy1_cfg.py
+++ b/FWCore/Integration/test/testGetBy1_cfg.py
@@ -7,6 +7,23 @@ process.Tracer = cms.Service('Tracer',
                              dumpNonModuleContext = cms.untracked.bool(True)
 )
 
+process.MessageLogger = cms.Service("MessageLogger",
+    destinations   = cms.untracked.vstring('cout',
+                                           'cerr'
+    ),
+    categories = cms.untracked.vstring(
+        'Tracer'
+    ),
+    cout = cms.untracked.PSet(
+        default = cms.untracked.PSet (
+            limit = cms.untracked.int32(0)
+        ),
+        Tracer = cms.untracked.PSet(
+            limit=cms.untracked.int32(100000000)
+        )
+    )
+)
+
 process.options = cms.untracked.PSet( allowUnscheduled = cms.untracked.bool(True) )
 
 process.source = cms.Source("IntSource")

--- a/FWCore/Integration/test/testGetBy2_cfg.py
+++ b/FWCore/Integration/test/testGetBy2_cfg.py
@@ -7,6 +7,23 @@ process.Tracer = cms.Service('Tracer',
                              dumpNonModuleContext = cms.untracked.bool(True)
 )
 
+process.MessageLogger = cms.Service("MessageLogger",
+    destinations   = cms.untracked.vstring('cout',
+                                           'cerr'
+    ),
+    categories = cms.untracked.vstring(
+        'Tracer'
+    ),
+    cout = cms.untracked.PSet(
+        default = cms.untracked.PSet (
+            limit = cms.untracked.int32(0)
+        ),
+        Tracer = cms.untracked.PSet(
+            limit=cms.untracked.int32(100000000)
+        )
+    )
+)
+
 process.options = cms.untracked.PSet( allowUnscheduled = cms.untracked.bool(True) )
 
 process.source = cms.Source("PoolSource",

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -1,95 +1,97 @@
-++ constructing source:IntSource
+++ starting: constructing source: IntSource
 Module type=IntSource, Module label=source, Parameter Set ID=031810a3ee2992e7936b85708f83a8b2
-++ construction finished:IntSource
+++ finished: constructing source: IntSource
 Module type=IntSource, Module label=source, Parameter Set ID=031810a3ee2992e7936b85708f83a8b2
-++ constructing module: TriggerResults
-++ construction finished: TriggerResults
-++ constructing module: intProducer
-++ construction finished: intProducer
-++ constructing module: a1
-++ construction finished: a1
-++ constructing module: a2
-++ construction finished: a2
-++ constructing module: a3
-++ construction finished: a3
-++ constructing module: out
-++ construction finished: out
-++ constructing module: intProducerA
+++++ starting: constructing module with label 'TriggerResults'
+++++ finished: constructing module with label 'TriggerResults'
+++++ starting: constructing module with label 'intProducer'
+++++ finished: constructing module with label 'intProducer'
+++++ starting: constructing module with label 'a1'
+++++ finished: constructing module with label 'a1'
+++++ starting: constructing module with label 'a2'
+++++ finished: constructing module with label 'a2'
+++++ starting: constructing module with label 'a3'
+++++ finished: constructing module with label 'a3'
+++++ starting: constructing module with label 'out'
+++++ finished: constructing module with label 'out'
+++++ starting: constructing module with label 'intProducerA'
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++ construction finished: intProducerA
+++++ finished: constructing module with label 'intProducerA'
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++ constructing module: intProducerU
-++ construction finished: intProducerU
-++ constructing module: intVectorProducer
-++ construction finished: intVectorProducer
-++ ModuleBeginJob: intProducerA
+++++ starting: constructing module with label 'intProducerU'
+++++ finished: constructing module with label 'intProducerU'
+++++ starting: constructing module with label 'intVectorProducer'
+++++ finished: constructing module with label 'intVectorProducer'
+++++ starting: begin job for module with label 'intProducerA'
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++ ModuleBeginJob finished: intProducerA
+++++ finished: begin job for module with label 'intProducerA'
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++ ModuleBeginJob: intProducerU
-++ ModuleBeginJob finished: intProducerU
-++ ModuleBeginJob: intVectorProducer
-++ ModuleBeginJob finished: intVectorProducer
-++ ModuleBeginJob: intProducer
-++ ModuleBeginJob finished: intProducer
-++ ModuleBeginJob: a1
-++ ModuleBeginJob finished: a1
-++ ModuleBeginJob: a2
-++ ModuleBeginJob finished: a2
-++ ModuleBeginJob: a3
-++ ModuleBeginJob finished: a3
-++ ModuleBeginJob: out
-++ ModuleBeginJob finished: out
-++ ModuleBeginJob: TriggerResults
-++ ModuleBeginJob finished: TriggerResults
-++ Job started
-++++ ModuleBeginStream: intProducer
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: a1
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: a2
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: a3
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: TriggerResults
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: out
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: intProducerA
+++++ starting: begin job for module with label 'intProducerU'
+++++ finished: begin job for module with label 'intProducerU'
+++++ starting: begin job for module with label 'intVectorProducer'
+++++ finished: begin job for module with label 'intVectorProducer'
+++++ starting: begin job for module with label 'intProducer'
+++++ finished: begin job for module with label 'intProducer'
+++++ starting: begin job for module with label 'a1'
+++++ finished: begin job for module with label 'a1'
+++++ starting: begin job for module with label 'a2'
+++++ finished: begin job for module with label 'a2'
+++++ starting: begin job for module with label 'a3'
+++++ finished: begin job for module with label 'a3'
+++++ starting: begin job for module with label 'out'
+++++ finished: begin job for module with label 'out'
+++++ starting: begin job for module with label 'TriggerResults'
+++++ finished: begin job for module with label 'TriggerResults'
+++ finished: begin job
+++++ starting: begin stream for module: stream = 0 label = 'intProducer'
+++++ finished: begin stream for module: stream = 0 label = 'intProducer'
+++++ starting: begin stream for module: stream = 0 label = 'a1'
+++++ finished: begin stream for module: stream = 0 label = 'a1'
+++++ starting: begin stream for module: stream = 0 label = 'a2'
+++++ finished: begin stream for module: stream = 0 label = 'a2'
+++++ starting: begin stream for module: stream = 0 label = 'a3'
+++++ finished: begin stream for module: stream = 0 label = 'a3'
+++++ starting: begin stream for module: stream = 0 label = 'TriggerResults'
+++++ finished: begin stream for module: stream = 0 label = 'TriggerResults'
+++++ starting: begin stream for module: stream = 0 label = 'out'
+++++ finished: begin stream for module: stream = 0 label = 'out'
+++++ starting: begin stream for module: stream = 0 label = 'intProducerA'
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++++ ModuleBeginStream finished
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
+    StreamContext: StreamID = 0 transition = BeginStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+
+++++ finished: begin stream for module: stream = 0 label = 'intProducerA'
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++++ ModuleBeginStream: intProducerU
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: intVectorProducer
-++++ ModuleBeginStream finished
-++++ source run
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
+    StreamContext: StreamID = 0 transition = BeginStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+
+++++ starting: begin stream for module: stream = 0 label = 'intProducerU'
+++++ finished: begin stream for module: stream = 0 label = 'intProducerU'
+++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer'
+++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer'
+++++ starting: source run
 ++++ finished: source run
-++++ GlobalBeginRun run: 1 time: 1
+++++ starting: global begin run 1 : time = 1
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleGlobalBeginRun: intProducerA
-GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-    GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleGlobalBeginRun finished: intProducerA
+
+++++++ starting: global begin run for module: label = 'intProducerA'
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -100,45 +102,62 @@ ModuleCallingContext state = Running
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleGlobalBeginRun: intProducerU
-++++++ ModuleGlobalBeginRun finished: intProducerU
-++++++ ModuleGlobalBeginRun: intVectorProducer
-++++++ ModuleGlobalBeginRun finished: intVectorProducer
-++++++ ModuleGlobalBeginRun: intProducer
-++++++ ModuleGlobalBeginRun finished: intProducer
-++++++ ModuleGlobalBeginRun: a1
-++++++ ModuleGlobalBeginRun finished: a1
-++++++ ModuleGlobalBeginRun: a2
-++++++ ModuleGlobalBeginRun finished: a2
-++++++ ModuleGlobalBeginRun: a3
-++++++ ModuleGlobalBeginRun finished: a3
-++++++ ModuleGlobalBeginRun: out
-++++++ ModuleGlobalBeginRun finished: out
-++++++ ModuleGlobalBeginRun: TriggerResults
-++++++ ModuleGlobalBeginRun finished: TriggerResults
-++++ GlobalBeginRun finished
+
+++++++ finished: global begin run for module: label = 'intProducerA'
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ GlobalBeginRun run: 1 time: 1
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
+    GlobalContext: transition = BeginRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+
+++++++ starting: global begin run for module: label = 'intProducerU'
+++++++ finished: global begin run for module: label = 'intProducerU'
+++++++ starting: global begin run for module: label = 'intVectorProducer'
+++++++ finished: global begin run for module: label = 'intVectorProducer'
+++++++ starting: global begin run for module: label = 'intProducer'
+++++++ finished: global begin run for module: label = 'intProducer'
+++++++ starting: global begin run for module: label = 'a1'
+++++++ finished: global begin run for module: label = 'a1'
+++++++ starting: global begin run for module: label = 'a2'
+++++++ finished: global begin run for module: label = 'a2'
+++++++ starting: global begin run for module: label = 'a3'
+++++++ finished: global begin run for module: label = 'a3'
+++++++ starting: global begin run for module: label = 'out'
+++++++ finished: global begin run for module: label = 'out'
+++++++ starting: global begin run for module: label = 'TriggerResults'
+++++++ finished: global begin run for module: label = 'TriggerResults'
+++++ finished: global begin run 1 : time = 1
+GlobalContext: transition = BeginRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+
+++++ starting: global begin run 1 : time = 1
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ GlobalBeginRun finished
+
+++++ finished: global begin run 1 : time = 1
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ StreamBeginRun run: 1 time: 1
+
+++++ starting: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleStreamBeginRun: intProducerA
+
+++++++ starting: begin run for module: stream = 0 label = 'intProducerA'
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -149,7 +168,8 @@ ModuleCallingContext state = Running
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleStreamBeginRun finished: intProducerA
+
+++++++ finished: begin run for module: stream = 0 label = 'intProducerA'
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -160,45 +180,50 @@ ModuleCallingContext state = Running
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleStreamBeginRun: intProducerU
-++++++ ModuleStreamBeginRun finished: intProducerU
-++++++ ModuleStreamBeginRun: intVectorProducer
-++++++ ModuleStreamBeginRun finished: intVectorProducer
-++++++ ModuleStreamBeginRun: intProducer
-++++++ ModuleStreamBeginRun finished: intProducer
-++++++ ModuleStreamBeginRun: a1
-++++++ ModuleStreamBeginRun finished: a1
-++++++ ModuleStreamBeginRun: a2
-++++++ ModuleStreamBeginRun finished: a2
-++++++ ModuleStreamBeginRun: a3
-++++++ ModuleStreamBeginRun finished: a3
-++++++ ModuleStreamBeginRun: out
-++++++ ModuleStreamBeginRun finished: out
-++++ StreamBeginRun finished
+
+++++++ starting: begin run for module: stream = 0 label = 'intProducerU'
+++++++ finished: begin run for module: stream = 0 label = 'intProducerU'
+++++++ starting: begin run for module: stream = 0 label = 'intVectorProducer'
+++++++ finished: begin run for module: stream = 0 label = 'intVectorProducer'
+++++++ starting: begin run for module: stream = 0 label = 'intProducer'
+++++++ finished: begin run for module: stream = 0 label = 'intProducer'
+++++++ starting: begin run for module: stream = 0 label = 'a1'
+++++++ finished: begin run for module: stream = 0 label = 'a1'
+++++++ starting: begin run for module: stream = 0 label = 'a2'
+++++++ finished: begin run for module: stream = 0 label = 'a2'
+++++++ starting: begin run for module: stream = 0 label = 'a3'
+++++++ finished: begin run for module: stream = 0 label = 'a3'
+++++++ starting: begin run for module: stream = 0 label = 'out'
+++++++ finished: begin run for module: stream = 0 label = 'out'
+++++ finished: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ StreamBeginRun run: 1 time: 1
+
+++++ starting: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ StreamBeginRun finished
+
+++++ finished: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ source lumi
+
+++++ starting: source lumi
 ++++ finished: source lumi
-++++ GlobalBeginLumi run: 1 lumi: 1 time: 1
+++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleGlobalBeginLumi: intProducerA
+
+++++++ starting: global begin lumi for module: label = 'intProducerA'
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -209,7 +234,8 @@ ModuleCallingContext state = Running
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleGlobalBeginLumi finished: intProducerA
+
+++++++ finished: global begin lumi for module: label = 'intProducerA'
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -220,45 +246,50 @@ ModuleCallingContext state = Running
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleGlobalBeginLumi: intProducerU
-++++++ ModuleGlobalBeginLumi finished: intProducerU
-++++++ ModuleGlobalBeginLumi: intVectorProducer
-++++++ ModuleGlobalBeginLumi finished: intVectorProducer
-++++++ ModuleGlobalBeginLumi: intProducer
-++++++ ModuleGlobalBeginLumi finished: intProducer
-++++++ ModuleGlobalBeginLumi: a1
-++++++ ModuleGlobalBeginLumi finished: a1
-++++++ ModuleGlobalBeginLumi: a2
-++++++ ModuleGlobalBeginLumi finished: a2
-++++++ ModuleGlobalBeginLumi: a3
-++++++ ModuleGlobalBeginLumi finished: a3
-++++++ ModuleGlobalBeginLumi: out
-++++++ ModuleGlobalBeginLumi finished: out
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
+
+++++++ starting: global begin lumi for module: label = 'intProducerU'
+++++++ finished: global begin lumi for module: label = 'intProducerU'
+++++++ starting: global begin lumi for module: label = 'intVectorProducer'
+++++++ finished: global begin lumi for module: label = 'intVectorProducer'
+++++++ starting: global begin lumi for module: label = 'intProducer'
+++++++ finished: global begin lumi for module: label = 'intProducer'
+++++++ starting: global begin lumi for module: label = 'a1'
+++++++ finished: global begin lumi for module: label = 'a1'
+++++++ starting: global begin lumi for module: label = 'a2'
+++++++ finished: global begin lumi for module: label = 'a2'
+++++++ starting: global begin lumi for module: label = 'a3'
+++++++ finished: global begin lumi for module: label = 'a3'
+++++++ starting: global begin lumi for module: label = 'out'
+++++++ finished: global begin lumi for module: label = 'out'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ GlobalBeginLumi run: 1 lumi: 1 time: 1
+
+++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ GlobalBeginLumi finished
+
+++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ StreamBeginLumi run: 1 lumi: 1 time: 1
+
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleStreamBeginLumi: intProducerA
+
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerA'
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -269,7 +300,8 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleStreamBeginLumi finished: intProducerA
+
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerA'
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -280,47 +312,50 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleStreamBeginLumi: intProducerU
-++++++ ModuleStreamBeginLumi finished: intProducerU
-++++++ ModuleStreamBeginLumi: intVectorProducer
-++++++ ModuleStreamBeginLumi finished: intVectorProducer
-++++++ ModuleStreamBeginLumi: intProducer
-++++++ ModuleStreamBeginLumi finished: intProducer
-++++++ ModuleStreamBeginLumi: a1
-++++++ ModuleStreamBeginLumi finished: a1
-++++++ ModuleStreamBeginLumi: a2
-++++++ ModuleStreamBeginLumi finished: a2
-++++++ ModuleStreamBeginLumi: a3
-++++++ ModuleStreamBeginLumi finished: a3
-++++++ ModuleStreamBeginLumi: out
-++++++ ModuleStreamBeginLumi finished: out
-++++ StreamBeginLumi finished
 
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU'
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU'
+++++++ starting: begin lumi for module: stream = 0 label = 'intVectorProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'intVectorProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'a1'
+++++++ finished: begin lumi for module: stream = 0 label = 'a1'
+++++++ starting: begin lumi for module: stream = 0 label = 'a2'
+++++++ finished: begin lumi for module: stream = 0 label = 'a2'
+++++++ starting: begin lumi for module: stream = 0 label = 'a3'
+++++++ finished: begin lumi for module: stream = 0 label = 'a3'
+++++++ starting: begin lumi for module: stream = 0 label = 'out'
+++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ StreamBeginLumi run: 1 lumi: 1 time: 1
-StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
-    parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ StreamBeginLumi finished
 
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ source event
+
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+StreamContext: StreamID = 0 transition = BeginLuminosityBlock
+    run: 1 lumi: 1 event: 0
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
+    parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 1 event: 1 time:5000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ processing path for event: p
+
+++++++ starting: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -330,11 +365,12 @@ PathContext: pathName = p pathID = 0
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++++ module for event: intProducer
-++++++++ finished module for event: intProducer
-++++++++ module for event: a1
-++++++++ finished module for event: a1
-++++++++ module for event: intProducerA
+
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'a1'
+++++++++ finished: processing event for module: stream = 0 label = 'a1'
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA'
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -350,7 +386,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
     previousModuleOnThread: same as parent module
-++++++++ finished module for event: intProducerA
+
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA'
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -366,11 +403,12 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
     previousModuleOnThread: same as parent module
-++++++++ module for event: a2
-++++++++ finished module for event: a2
-++++++++ module for event: a3
-++++++++ finished module for event: a3
-++++++ path for event finished: p
+
+++++++++ starting: processing event for module: stream = 0 label = 'a2'
+++++++++ finished: processing event for module: stream = 0 label = 'a2'
+++++++++ starting: processing event for module: stream = 0 label = 'a3'
+++++++++ finished: processing event for module: stream = 0 label = 'a3'
+++++++ finished: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -380,9 +418,10 @@ PathContext: pathName = p pathID = 0
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: e
+
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -392,13 +431,14 @@ PathContext: pathName = e pathID = 0 (EndPath)
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++++ module for event: intProducerU
-++++++++ finished module for event: intProducerU
-++++++++ module for event: intVectorProducer
-++++++++ finished module for event: intVectorProducer
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: e
+
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU'
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU'
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer'
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -408,31 +448,36 @@ PathContext: pathName = e pathID = 0 (EndPath)
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ event finished
+
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ processing event run: 1 lumi: 1 event: 1 time:5000001
+
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ event finished
+
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ source event
+
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 1 event: 2 time:10000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ processing path for event: p
+
+++++++ starting: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -442,11 +487,12 @@ PathContext: pathName = p pathID = 0
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++++ module for event: intProducer
-++++++++ finished module for event: intProducer
-++++++++ module for event: a1
-++++++++ finished module for event: a1
-++++++++ module for event: intProducerA
+
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'a1'
+++++++++ finished: processing event for module: stream = 0 label = 'a1'
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA'
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -462,7 +508,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
     previousModuleOnThread: same as parent module
-++++++++ finished module for event: intProducerA
+
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA'
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -478,11 +525,12 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
     previousModuleOnThread: same as parent module
-++++++++ module for event: a2
-++++++++ finished module for event: a2
-++++++++ module for event: a3
-++++++++ finished module for event: a3
-++++++ path for event finished: p
+
+++++++++ starting: processing event for module: stream = 0 label = 'a2'
+++++++++ finished: processing event for module: stream = 0 label = 'a2'
+++++++++ starting: processing event for module: stream = 0 label = 'a3'
+++++++++ finished: processing event for module: stream = 0 label = 'a3'
+++++++ finished: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -492,9 +540,10 @@ PathContext: pathName = p pathID = 0
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: e
+
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -504,13 +553,14 @@ PathContext: pathName = e pathID = 0 (EndPath)
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++++ module for event: intProducerU
-++++++++ finished module for event: intProducerU
-++++++++ module for event: intVectorProducer
-++++++++ finished module for event: intVectorProducer
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: e
+
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU'
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU'
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer'
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -520,31 +570,36 @@ PathContext: pathName = e pathID = 0 (EndPath)
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ event finished
+
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ processing event run: 1 lumi: 1 event: 2 time:10000001
+
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ event finished
+
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ source event
+
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 1 event: 3 time:15000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ processing path for event: p
+
+++++++ starting: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -554,11 +609,12 @@ PathContext: pathName = p pathID = 0
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++++ module for event: intProducer
-++++++++ finished module for event: intProducer
-++++++++ module for event: a1
-++++++++ finished module for event: a1
-++++++++ module for event: intProducerA
+
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'a1'
+++++++++ finished: processing event for module: stream = 0 label = 'a1'
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA'
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -574,7 +630,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
     previousModuleOnThread: same as parent module
-++++++++ finished module for event: intProducerA
+
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA'
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -590,11 +647,12 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
     previousModuleOnThread: same as parent module
-++++++++ module for event: a2
-++++++++ finished module for event: a2
-++++++++ module for event: a3
-++++++++ finished module for event: a3
-++++++ path for event finished: p
+
+++++++++ starting: processing event for module: stream = 0 label = 'a2'
+++++++++ finished: processing event for module: stream = 0 label = 'a2'
+++++++++ starting: processing event for module: stream = 0 label = 'a3'
+++++++++ finished: processing event for module: stream = 0 label = 'a3'
+++++++ finished: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -604,9 +662,10 @@ PathContext: pathName = p pathID = 0
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: e
+
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -616,13 +675,14 @@ PathContext: pathName = e pathID = 0 (EndPath)
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++++ module for event: intProducerU
-++++++++ finished module for event: intProducerU
-++++++++ module for event: intVectorProducer
-++++++++ finished module for event: intVectorProducer
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: e
+
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU'
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU'
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer'
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -632,29 +692,34 @@ PathContext: pathName = e pathID = 0 (EndPath)
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ event finished
+
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ processing event run: 1 lumi: 1 event: 3 time:15000001
+
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ event finished
+
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ StreamEndLumi run: 1 lumi: 1 time: 15000001
+
+++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleStreamEndLumi: intProducerA
+
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerA'
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -665,7 +730,8 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleStreamEndLumi finished: intProducerA
+
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerA'
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -676,43 +742,48 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleStreamEndLumi: intProducerU
-++++++ ModuleStreamEndLumi finished: intProducerU
-++++++ ModuleStreamEndLumi: intVectorProducer
-++++++ ModuleStreamEndLumi finished: intVectorProducer
-++++++ ModuleStreamEndLumi: intProducer
-++++++ ModuleStreamEndLumi finished: intProducer
-++++++ ModuleStreamEndLumi: a1
-++++++ ModuleStreamEndLumi finished: a1
-++++++ ModuleStreamEndLumi: a2
-++++++ ModuleStreamEndLumi finished: a2
-++++++ ModuleStreamEndLumi: a3
-++++++ ModuleStreamEndLumi finished: a3
-++++++ ModuleStreamEndLumi: out
-++++++ ModuleStreamEndLumi finished: out
-++++ StreamEndLumi finished
+
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerU'
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerU'
+++++++ starting: end lumi for module: stream = 0 label = 'intVectorProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'intVectorProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'intProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'intProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'a1'
+++++++ finished: end lumi for module: stream = 0 label = 'a1'
+++++++ starting: end lumi for module: stream = 0 label = 'a2'
+++++++ finished: end lumi for module: stream = 0 label = 'a2'
+++++++ starting: end lumi for module: stream = 0 label = 'a3'
+++++++ finished: end lumi for module: stream = 0 label = 'a3'
+++++++ starting: end lumi for module: stream = 0 label = 'out'
+++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ StreamEndLumi run: 1 lumi: 1 time: 0
+
+++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 0
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ StreamEndLumi finished
+
+++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 0
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ GlobalEndLumi run: 1 lumi: 1 time: 1
+
+++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleGlobalEndLumi: intProducerA
+
+++++++ starting: global end lumi for module: label = 'intProducerA'
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -723,7 +794,8 @@ ModuleCallingContext state = Running
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleGlobalEndLumi finished: intProducerA
+
+++++++ finished: global end lumi for module: label = 'intProducerA'
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -734,45 +806,50 @@ ModuleCallingContext state = Running
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleGlobalEndLumi: intProducerU
-++++++ ModuleGlobalEndLumi finished: intProducerU
-++++++ ModuleGlobalEndLumi: intVectorProducer
-++++++ ModuleGlobalEndLumi finished: intVectorProducer
-++++++ ModuleGlobalEndLumi: intProducer
-++++++ ModuleGlobalEndLumi finished: intProducer
-++++++ ModuleGlobalEndLumi: a1
-++++++ ModuleGlobalEndLumi finished: a1
-++++++ ModuleGlobalEndLumi: a2
-++++++ ModuleGlobalEndLumi finished: a2
-++++++ ModuleGlobalEndLumi: a3
-++++++ ModuleGlobalEndLumi finished: a3
-++++++ ModuleGlobalEndLumi: out
-++++++ ModuleGlobalEndLumi finished: out
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
+
+++++++ starting: global end lumi for module: label = 'intProducerU'
+++++++ finished: global end lumi for module: label = 'intProducerU'
+++++++ starting: global end lumi for module: label = 'intVectorProducer'
+++++++ finished: global end lumi for module: label = 'intVectorProducer'
+++++++ starting: global end lumi for module: label = 'intProducer'
+++++++ finished: global end lumi for module: label = 'intProducer'
+++++++ starting: global end lumi for module: label = 'a1'
+++++++ finished: global end lumi for module: label = 'a1'
+++++++ starting: global end lumi for module: label = 'a2'
+++++++ finished: global end lumi for module: label = 'a2'
+++++++ starting: global end lumi for module: label = 'a3'
+++++++ finished: global end lumi for module: label = 'a3'
+++++++ starting: global end lumi for module: label = 'out'
+++++++ finished: global end lumi for module: label = 'out'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ GlobalEndLumi run: 1 lumi: 1 time: 1
+
+++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ GlobalEndLumi finished
+
+++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ StreamEndRun run: 1 time: 15000001
+
+++++ starting: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleStreamEndRun: intProducerA
+
+++++++ starting: end run for module: stream = 0 label = 'intProducerA'
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -783,7 +860,8 @@ ModuleCallingContext state = Running
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleStreamEndRun finished: intProducerA
+
+++++++ finished: end run for module: stream = 0 label = 'intProducerA'
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -794,43 +872,48 @@ ModuleCallingContext state = Running
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleStreamEndRun: intProducerU
-++++++ ModuleStreamEndRun finished: intProducerU
-++++++ ModuleStreamEndRun: intVectorProducer
-++++++ ModuleStreamEndRun finished: intVectorProducer
-++++++ ModuleStreamEndRun: intProducer
-++++++ ModuleStreamEndRun finished: intProducer
-++++++ ModuleStreamEndRun: a1
-++++++ ModuleStreamEndRun finished: a1
-++++++ ModuleStreamEndRun: a2
-++++++ ModuleStreamEndRun finished: a2
-++++++ ModuleStreamEndRun: a3
-++++++ ModuleStreamEndRun finished: a3
-++++++ ModuleStreamEndRun: out
-++++++ ModuleStreamEndRun finished: out
-++++ StreamEndRun finished
+
+++++++ starting: end run for module: stream = 0 label = 'intProducerU'
+++++++ finished: end run for module: stream = 0 label = 'intProducerU'
+++++++ starting: end run for module: stream = 0 label = 'intVectorProducer'
+++++++ finished: end run for module: stream = 0 label = 'intVectorProducer'
+++++++ starting: end run for module: stream = 0 label = 'intProducer'
+++++++ finished: end run for module: stream = 0 label = 'intProducer'
+++++++ starting: end run for module: stream = 0 label = 'a1'
+++++++ finished: end run for module: stream = 0 label = 'a1'
+++++++ starting: end run for module: stream = 0 label = 'a2'
+++++++ finished: end run for module: stream = 0 label = 'a2'
+++++++ starting: end run for module: stream = 0 label = 'a3'
+++++++ finished: end run for module: stream = 0 label = 'a3'
+++++++ starting: end run for module: stream = 0 label = 'out'
+++++++ finished: end run for module: stream = 0 label = 'out'
+++++ finished: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ StreamEndRun run: 1 time: 0
+
+++++ starting: end run: stream = 0 run = 1 time = 0
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ StreamEndRun finished
+
+++++ finished: end run: stream = 0 run = 1 time = 0
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ GlobalEndRun run: 1 time: 15000001
+
+++++ starting: global end run 1 : time = 15000001
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleGlobalEndRun: intProducerA
+
+++++++ starting: global end run for module: label = 'intProducerA'
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -841,7 +924,8 @@ ModuleCallingContext state = Running
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleGlobalEndRun finished: intProducerA
+
+++++++ finished: global end run for module: label = 'intProducerA'
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -852,88 +936,104 @@ ModuleCallingContext state = Running
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++++ ModuleGlobalEndRun: intProducerU
-++++++ ModuleGlobalEndRun finished: intProducerU
-++++++ ModuleGlobalEndRun: intVectorProducer
-++++++ ModuleGlobalEndRun finished: intVectorProducer
-++++++ ModuleGlobalEndRun: intProducer
-++++++ ModuleGlobalEndRun finished: intProducer
-++++++ ModuleGlobalEndRun: a1
-++++++ ModuleGlobalEndRun finished: a1
-++++++ ModuleGlobalEndRun: a2
-++++++ ModuleGlobalEndRun finished: a2
-++++++ ModuleGlobalEndRun: a3
-++++++ ModuleGlobalEndRun finished: a3
-++++++ ModuleGlobalEndRun: out
-++++++ ModuleGlobalEndRun finished: out
-++++++ ModuleGlobalEndRun: TriggerResults
-++++++ ModuleGlobalEndRun finished: TriggerResults
-++++ GlobalEndRun finished
+
+++++++ starting: global end run for module: label = 'intProducerU'
+++++++ finished: global end run for module: label = 'intProducerU'
+++++++ starting: global end run for module: label = 'intVectorProducer'
+++++++ finished: global end run for module: label = 'intVectorProducer'
+++++++ starting: global end run for module: label = 'intProducer'
+++++++ finished: global end run for module: label = 'intProducer'
+++++++ starting: global end run for module: label = 'a1'
+++++++ finished: global end run for module: label = 'a1'
+++++++ starting: global end run for module: label = 'a2'
+++++++ finished: global end run for module: label = 'a2'
+++++++ starting: global end run for module: label = 'a3'
+++++++ finished: global end run for module: label = 'a3'
+++++++ starting: global end run for module: label = 'out'
+++++++ finished: global end run for module: label = 'out'
+++++++ starting: global end run for module: label = 'TriggerResults'
+++++++ finished: global end run for module: label = 'TriggerResults'
+++++ finished: global end run 1 : time = 15000001
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ GlobalEndRun run: 1 time: 0
+
+++++ starting: global end run 1 : time = 0
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ GlobalEndRun finished
+
+++++ finished: global end run 1 : time = 0
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
+
+++++ starting: end stream for module: stream = 0 label = 'intProducer'
+++++ finished: end stream for module: stream = 0 label = 'intProducer'
+++++ starting: end stream for module: stream = 0 label = 'a1'
+++++ finished: end stream for module: stream = 0 label = 'a1'
+++++ starting: end stream for module: stream = 0 label = 'a2'
+++++ finished: end stream for module: stream = 0 label = 'a2'
+++++ starting: end stream for module: stream = 0 label = 'a3'
+++++ finished: end stream for module: stream = 0 label = 'a3'
+++++ starting: end stream for module: stream = 0 label = 'TriggerResults'
+++++ finished: end stream for module: stream = 0 label = 'TriggerResults'
+++++ starting: end stream for module: stream = 0 label = 'out'
+++++ finished: end stream for module: stream = 0 label = 'out'
+++++ starting: end stream for module: stream = 0 label = 'intProducerA'
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
-Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++++ ModuleEndStream finished
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
+    StreamContext: StreamID = 0 transition = EndStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+
+++++ finished: end stream for module: stream = 0 label = 'intProducerA'
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
+    StreamContext: StreamID = 0 transition = EndStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
+
+++++ starting: end stream for module: stream = 0 label = 'intProducerU'
+++++ finished: end stream for module: stream = 0 label = 'intProducerU'
+++++ starting: end stream for module: stream = 0 label = 'intVectorProducer'
+++++ finished: end stream for module: stream = 0 label = 'intVectorProducer'
+++++ starting: end job for module with label 'intProducerA'
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++ ModuleEndJob: intProducerA
+++++ finished: end job for module with label 'intProducerA'
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++ ModuleEndJob finished: intProducerA
-Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++ ModuleEndJob: intProducerU
-++ ModuleEndJob finished: intProducerU
-++ ModuleEndJob: intVectorProducer
-++ ModuleEndJob finished: intVectorProducer
-++ ModuleEndJob: intProducer
-++ ModuleEndJob finished: intProducer
-++ ModuleEndJob: a1
+++++ starting: end job for module with label 'intProducerU'
+++++ finished: end job for module with label 'intProducerU'
+++++ starting: end job for module with label 'intVectorProducer'
+++++ finished: end job for module with label 'intVectorProducer'
+++++ starting: end job for module with label 'intProducer'
+++++ finished: end job for module with label 'intProducer'
+++++ starting: end job for module with label 'a1'
 TestFindProduct sum = 12
-++ ModuleEndJob finished: a1
-++ ModuleEndJob: a2
+++++ finished: end job for module with label 'a1'
+++++ starting: end job for module with label 'a2'
 TestFindProduct sum = 300
-++ ModuleEndJob finished: a2
-++ ModuleEndJob: a3
+++++ finished: end job for module with label 'a2'
+++++ starting: end job for module with label 'a3'
 TestFindProduct sum = 300
-++ ModuleEndJob finished: a3
-++ ModuleEndJob: out
-++ ModuleEndJob finished: out
-++ ModuleEndJob: TriggerResults
-++ ModuleEndJob finished: TriggerResults
-++ Job ended
+++++ finished: end job for module with label 'a3'
+++++ starting: end job for module with label 'out'
+++++ finished: end job for module with label 'out'
+++++ starting: end job for module with label 'TriggerResults'
+++++ finished: end job for module with label 'TriggerResults'
+++ finished: end job

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -1,223 +1,251 @@
-++ constructing source:PoolSource
+++ starting: constructing source: PoolSource
 Module type=PoolSource, Module label=source, Parameter Set ID=079a79e873959edf4ff4f335f14507fa
-++++ open input file: file:testGetBy1.root usedFallBack = 0
-++++ finished: open input file: file:testGetBy1.root usedFallBack = 0
-++ construction finished:PoolSource
+++++ starting: open input file: lfn = file:testGetBy1.root usedFallBack = 0
+++++ finished: open input file: lfn = file:testGetBy1.root usedFallBack = 0
+++ finished: constructing source: PoolSource
 Module type=PoolSource, Module label=source, Parameter Set ID=079a79e873959edf4ff4f335f14507fa
-++ constructing module: TriggerResults
-++ construction finished: TriggerResults
-++ constructing module: intProducer
+++++ starting: constructing module with label 'TriggerResults'
+++++ finished: constructing module with label 'TriggerResults'
+++++ starting: constructing module with label 'intProducer'
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++ construction finished: intProducer
+++++ finished: constructing module with label 'intProducer'
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++ constructing module: out
-++ construction finished: out
-++ constructing module: intProducerU
-++ construction finished: intProducerU
-++ constructing module: intVectorProducer
-++ construction finished: intVectorProducer
-++ ModuleBeginJob: intProducerU
-++ ModuleBeginJob finished: intProducerU
-++ ModuleBeginJob: intVectorProducer
-++ ModuleBeginJob finished: intVectorProducer
-++ ModuleBeginJob: intProducer
+++++ starting: constructing module with label 'out'
+++++ finished: constructing module with label 'out'
+++++ starting: constructing module with label 'intProducerU'
+++++ finished: constructing module with label 'intProducerU'
+++++ starting: constructing module with label 'intVectorProducer'
+++++ finished: constructing module with label 'intVectorProducer'
+++++ starting: begin job for module with label 'intProducerU'
+++++ finished: begin job for module with label 'intProducerU'
+++++ starting: begin job for module with label 'intVectorProducer'
+++++ finished: begin job for module with label 'intVectorProducer'
+++++ starting: begin job for module with label 'intProducer'
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++ ModuleBeginJob finished: intProducer
+++++ finished: begin job for module with label 'intProducer'
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++ ModuleBeginJob: out
-++ ModuleBeginJob finished: out
-++ ModuleBeginJob: TriggerResults
-++ ModuleBeginJob finished: TriggerResults
-++ Job started
-++++ ModuleBeginStream: intProducer
+++++ starting: begin job for module with label 'out'
+++++ finished: begin job for module with label 'out'
+++++ starting: begin job for module with label 'TriggerResults'
+++++ finished: begin job for module with label 'TriggerResults'
+++ finished: begin job
+++++ starting: begin stream for module: stream = 0 label = 'intProducer'
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++++ ModuleBeginStream finished
-StreamContext: StreamID = 0 transition = BeginStream
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++++ ModuleBeginStream: TriggerResults
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: out
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: intProducerU
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: intVectorProducer
-++++ ModuleBeginStream finished
-++++ source run
-++++ finished: source run
-++++ GlobalBeginRun run: 1 time: 1
-GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleGlobalBeginRun: intProducerU
-++++++ ModuleGlobalBeginRun finished: intProducerU
-++++++ ModuleGlobalBeginRun: intVectorProducer
-++++++ ModuleGlobalBeginRun finished: intVectorProducer
-++++++ ModuleGlobalBeginRun: intProducer
-GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-    GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleGlobalBeginRun finished: intProducer
-GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-    GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleGlobalBeginRun: out
-++++++ ModuleGlobalBeginRun finished: out
-++++++ ModuleGlobalBeginRun: TriggerResults
-++++++ ModuleGlobalBeginRun finished: TriggerResults
-++++ GlobalBeginRun finished
-GlobalContext: transition = BeginRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++ StreamBeginRun run: 1 time: 1
-StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleStreamBeginRun: intProducerU
-++++++ ModuleStreamBeginRun finished: intProducerU
-++++++ ModuleStreamBeginRun: intVectorProducer
-++++++ ModuleStreamBeginRun finished: intVectorProducer
-++++++ ModuleStreamBeginRun: intProducer
-StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-    StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleStreamBeginRun finished: intProducer
-StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-    StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleStreamBeginRun: out
-++++++ ModuleStreamBeginRun finished: out
-++++ StreamBeginRun finished
-StreamContext: StreamID = 0 transition = BeginRun
-    run: 1 lumi: 0 event: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++ source lumi
-++++ finished: source lumi
-++++ GlobalBeginLumi run: 1 lumi: 1 time: 1
-GlobalContext: transition = BeginLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleGlobalBeginLumi: intProducerU
-++++++ ModuleGlobalBeginLumi finished: intProducerU
-++++++ ModuleGlobalBeginLumi: intVectorProducer
-++++++ ModuleGlobalBeginLumi finished: intVectorProducer
-++++++ ModuleGlobalBeginLumi: intProducer
-GlobalContext: transition = BeginLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-    GlobalContext: transition = BeginLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleGlobalBeginLumi finished: intProducer
-GlobalContext: transition = BeginLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-    GlobalContext: transition = BeginLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleGlobalBeginLumi: out
-++++++ ModuleGlobalBeginLumi finished: out
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-GlobalContext: transition = BeginLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++ StreamBeginLumi run: 1 lumi: 1 time: 1
-StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleStreamBeginLumi: intProducerU
-++++++ ModuleStreamBeginLumi finished: intProducerU
-++++++ ModuleStreamBeginLumi: intVectorProducer
-++++++ ModuleStreamBeginLumi finished: intVectorProducer
-++++++ ModuleStreamBeginLumi: intProducer
-StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-    StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleStreamBeginLumi finished: intProducer
-StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-    StreamContext: StreamID = 0 transition = BeginLuminosityBlock
-    run: 1 lumi: 1 event: 0
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleStreamBeginLumi: out
-++++++ ModuleStreamBeginLumi finished: out
-++++ StreamBeginLumi finished
 
+++++ finished: begin stream for module: stream = 0 label = 'intProducer'
+StreamContext: StreamID = 0 transition = BeginStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    StreamContext: StreamID = 0 transition = BeginStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++ starting: begin stream for module: stream = 0 label = 'TriggerResults'
+++++ finished: begin stream for module: stream = 0 label = 'TriggerResults'
+++++ starting: begin stream for module: stream = 0 label = 'out'
+++++ finished: begin stream for module: stream = 0 label = 'out'
+++++ starting: begin stream for module: stream = 0 label = 'intProducerU'
+++++ finished: begin stream for module: stream = 0 label = 'intProducerU'
+++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer'
+++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer'
+++++ starting: source run
+++++ finished: source run
+++++ starting: global begin run 1 : time = 1
+GlobalContext: transition = BeginRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++++ starting: global begin run for module: label = 'intProducerU'
+++++++ finished: global begin run for module: label = 'intProducerU'
+++++++ starting: global begin run for module: label = 'intVectorProducer'
+++++++ finished: global begin run for module: label = 'intVectorProducer'
+++++++ starting: global begin run for module: label = 'intProducer'
+GlobalContext: transition = BeginRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    GlobalContext: transition = BeginRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++++ finished: global begin run for module: label = 'intProducer'
+GlobalContext: transition = BeginRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    GlobalContext: transition = BeginRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++++ starting: global begin run for module: label = 'out'
+++++++ finished: global begin run for module: label = 'out'
+++++++ starting: global begin run for module: label = 'TriggerResults'
+++++++ finished: global begin run for module: label = 'TriggerResults'
+++++ finished: global begin run 1 : time = 1
+GlobalContext: transition = BeginRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++ starting: begin run: stream = 0 run = 1 time = 1
+StreamContext: StreamID = 0 transition = BeginRun
+    run: 1 lumi: 0 event: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++++ starting: begin run for module: stream = 0 label = 'intProducerU'
+++++++ finished: begin run for module: stream = 0 label = 'intProducerU'
+++++++ starting: begin run for module: stream = 0 label = 'intVectorProducer'
+++++++ finished: begin run for module: stream = 0 label = 'intVectorProducer'
+++++++ starting: begin run for module: stream = 0 label = 'intProducer'
+StreamContext: StreamID = 0 transition = BeginRun
+    run: 1 lumi: 0 event: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    StreamContext: StreamID = 0 transition = BeginRun
+    run: 1 lumi: 0 event: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++++ finished: begin run for module: stream = 0 label = 'intProducer'
+StreamContext: StreamID = 0 transition = BeginRun
+    run: 1 lumi: 0 event: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    StreamContext: StreamID = 0 transition = BeginRun
+    run: 1 lumi: 0 event: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++++ starting: begin run for module: stream = 0 label = 'out'
+++++++ finished: begin run for module: stream = 0 label = 'out'
+++++ finished: begin run: stream = 0 run = 1 time = 1
+StreamContext: StreamID = 0 transition = BeginRun
+    run: 1 lumi: 0 event: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++ starting: source lumi
+++++ finished: source lumi
+++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
+GlobalContext: transition = BeginLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++++ starting: global begin lumi for module: label = 'intProducerU'
+++++++ finished: global begin lumi for module: label = 'intProducerU'
+++++++ starting: global begin lumi for module: label = 'intVectorProducer'
+++++++ finished: global begin lumi for module: label = 'intVectorProducer'
+++++++ starting: global begin lumi for module: label = 'intProducer'
+GlobalContext: transition = BeginLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    GlobalContext: transition = BeginLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++++ finished: global begin lumi for module: label = 'intProducer'
+GlobalContext: transition = BeginLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    GlobalContext: transition = BeginLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++++ starting: global begin lumi for module: label = 'out'
+++++++ finished: global begin lumi for module: label = 'out'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
+GlobalContext: transition = BeginLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++ source event
+
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU'
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU'
+++++++ starting: begin lumi for module: stream = 0 label = 'intVectorProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'intVectorProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducer'
+StreamContext: StreamID = 0 transition = BeginLuminosityBlock
+    run: 1 lumi: 1 event: 0
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    StreamContext: StreamID = 0 transition = BeginLuminosityBlock
+    run: 1 lumi: 1 event: 0
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducer'
+StreamContext: StreamID = 0 transition = BeginLuminosityBlock
+    run: 1 lumi: 1 event: 0
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    StreamContext: StreamID = 0 transition = BeginLuminosityBlock
+    run: 1 lumi: 1 event: 0
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++++ starting: begin lumi for module: stream = 0 label = 'out'
+++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+StreamContext: StreamID = 0 transition = BeginLuminosityBlock
+    run: 1 lumi: 1 event: 0
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 1 event: 1 time:5000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ processing path for event: p
+
+++++++ starting: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -227,7 +255,8 @@ PathContext: pathName = p pathID = 0
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++++ module for event: intProducer
+
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer'
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -240,7 +269,8 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++++ finished module for event: intProducer
+
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer'
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -253,7 +283,8 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ path for event finished: p
+
+++++++ finished: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -263,9 +294,10 @@ PathContext: pathName = p pathID = 0
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: e
+
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -275,13 +307,14 @@ PathContext: pathName = e pathID = 0 (EndPath)
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++++ module for event: intProducerU
-++++++++ finished module for event: intProducerU
-++++++++ module for event: intVectorProducer
-++++++++ finished module for event: intVectorProducer
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: e
+
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU'
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU'
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer'
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -291,19 +324,22 @@ PathContext: pathName = e pathID = 0 (EndPath)
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++ event finished
+
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++ source event
+
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 1 event: 2 time:10000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ processing path for event: p
+
+++++++ starting: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -313,7 +349,8 @@ PathContext: pathName = p pathID = 0
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++++ module for event: intProducer
+
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer'
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -326,7 +363,8 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++++ finished module for event: intProducer
+
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer'
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -339,7 +377,8 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ path for event finished: p
+
+++++++ finished: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -349,9 +388,10 @@ PathContext: pathName = p pathID = 0
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: e
+
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -361,13 +401,14 @@ PathContext: pathName = e pathID = 0 (EndPath)
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++++ module for event: intProducerU
-++++++++ finished module for event: intProducerU
-++++++++ module for event: intVectorProducer
-++++++++ finished module for event: intVectorProducer
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: e
+
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU'
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU'
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer'
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -377,19 +418,22 @@ PathContext: pathName = e pathID = 0 (EndPath)
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++ event finished
+
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++ source event
+
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 1 event: 3 time:15000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ processing path for event: p
+
+++++++ starting: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -399,7 +443,8 @@ PathContext: pathName = p pathID = 0
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++++ module for event: intProducer
+
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer'
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -412,7 +457,8 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++++ finished module for event: intProducer
+
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer'
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -425,7 +471,8 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ path for event finished: p
+
+++++++ finished: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -435,9 +482,10 @@ PathContext: pathName = p pathID = 0
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: e
+
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -447,13 +495,14 @@ PathContext: pathName = e pathID = 0 (EndPath)
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++++ module for event: intProducerU
-++++++++ finished module for event: intProducerU
-++++++++ module for event: intVectorProducer
-++++++++ finished module for event: intVectorProducer
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: e
+
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU'
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU'
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer'
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -463,21 +512,24 @@ PathContext: pathName = e pathID = 0 (EndPath)
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++ event finished
+
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++ StreamEndLumi run: 1 lumi: 1 time: 15000001
+
+++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleStreamEndLumi: intProducerU
-++++++ ModuleStreamEndLumi finished: intProducerU
-++++++ ModuleStreamEndLumi: intVectorProducer
-++++++ ModuleStreamEndLumi finished: intVectorProducer
-++++++ ModuleStreamEndLumi: intProducer
+
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerU'
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerU'
+++++++ starting: end lumi for module: stream = 0 label = 'intVectorProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'intVectorProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'intProducer'
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -488,7 +540,8 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleStreamEndLumi finished: intProducer
+
+++++++ finished: end lumi for module: stream = 0 label = 'intProducer'
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -499,34 +552,26 @@ ModuleCallingContext state = Running
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleStreamEndLumi: out
-++++++ ModuleStreamEndLumi finished: out
-++++ StreamEndLumi finished
+
+++++++ starting: end lumi for module: stream = 0 label = 'out'
+++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++ GlobalEndLumi run: 1 lumi: 1 time: 1
+
+++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleGlobalEndLumi: intProducerU
-++++++ ModuleGlobalEndLumi finished: intProducerU
-++++++ ModuleGlobalEndLumi: intVectorProducer
-++++++ ModuleGlobalEndLumi finished: intVectorProducer
-++++++ ModuleGlobalEndLumi: intProducer
-GlobalContext: transition = EndLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-    GlobalContext: transition = EndLuminosityBlock
-    run: 1 luminosityBlock: 1
-    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleGlobalEndLumi finished: intProducer
+
+++++++ starting: global end lumi for module: label = 'intProducerU'
+++++++ finished: global end lumi for module: label = 'intProducerU'
+++++++ starting: global end lumi for module: label = 'intVectorProducer'
+++++++ finished: global end lumi for module: label = 'intVectorProducer'
+++++++ starting: global end lumi for module: label = 'intProducer'
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -537,25 +582,40 @@ ModuleCallingContext state = Running
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleGlobalEndLumi: out
-++++++ ModuleGlobalEndLumi finished: out
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
+
+++++++ finished: global end lumi for module: label = 'intProducer'
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++ StreamEndRun run: 1 time: 15000001
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    GlobalContext: transition = EndLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++++ starting: global end lumi for module: label = 'out'
+++++++ finished: global end lumi for module: label = 'out'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 1 lumi = 1 time = 1
+GlobalContext: transition = EndLuminosityBlock
+    run: 1 luminosityBlock: 1
+    runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++ starting: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleStreamEndRun: intProducerU
-++++++ ModuleStreamEndRun finished: intProducerU
-++++++ ModuleStreamEndRun: intVectorProducer
-++++++ ModuleStreamEndRun finished: intVectorProducer
-++++++ ModuleStreamEndRun: intProducer
+
+++++++ starting: end run for module: stream = 0 label = 'intProducerU'
+++++++ finished: end run for module: stream = 0 label = 'intProducerU'
+++++++ starting: end run for module: stream = 0 label = 'intVectorProducer'
+++++++ finished: end run for module: stream = 0 label = 'intVectorProducer'
+++++++ starting: end run for module: stream = 0 label = 'intProducer'
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -566,7 +626,8 @@ ModuleCallingContext state = Running
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleStreamEndRun finished: intProducer
+
+++++++ finished: end run for module: stream = 0 label = 'intProducer'
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -577,34 +638,26 @@ ModuleCallingContext state = Running
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleStreamEndRun: out
-++++++ ModuleStreamEndRun finished: out
-++++ StreamEndRun finished
+
+++++++ starting: end run for module: stream = 0 label = 'out'
+++++++ finished: end run for module: stream = 0 label = 'out'
+++++ finished: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++ GlobalEndRun run: 1 time: 15000001
+
+++++ starting: global end run 1 : time = 15000001
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleGlobalEndRun: intProducerU
-++++++ ModuleGlobalEndRun finished: intProducerU
-++++++ ModuleGlobalEndRun: intVectorProducer
-++++++ ModuleGlobalEndRun finished: intVectorProducer
-++++++ ModuleGlobalEndRun: intProducer
-GlobalContext: transition = EndRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-ModuleCallingContext state = Running
-    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-    GlobalContext: transition = EndRun
-    run: 1 luminosityBlock: 0
-    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
-    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleGlobalEndRun finished: intProducer
+
+++++++ starting: global end run for module: label = 'intProducerU'
+++++++ finished: global end run for module: label = 'intProducerU'
+++++++ starting: global end run for module: label = 'intVectorProducer'
+++++++ finished: global end run for module: label = 'intVectorProducer'
+++++++ starting: global end run for module: label = 'intProducer'
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -615,47 +668,73 @@ ModuleCallingContext state = Running
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++++ ModuleGlobalEndRun: out
-++++++ ModuleGlobalEndRun finished: out
-++++++ ModuleGlobalEndRun: TriggerResults
-++++++ ModuleGlobalEndRun finished: TriggerResults
-++++ GlobalEndRun finished
+
+++++++ finished: global end run for module: label = 'intProducer'
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-++++ close input file: file:testGetBy1.root usedFallBack = 0
-++++ finished: close input file: file:testGetBy1.root usedFallBack = 0
-++++ ModuleEndStream: 
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    GlobalContext: transition = EndRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++++ starting: global end run for module: label = 'out'
+++++++ finished: global end run for module: label = 'out'
+++++++ starting: global end run for module: label = 'TriggerResults'
+++++++ finished: global end run for module: label = 'TriggerResults'
+++++ finished: global end run 1 : time = 15000001
+GlobalContext: transition = EndRun
+    run: 1 luminosityBlock: 0
+    runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++ starting: close input file: lfn = file:testGetBy1.root usedFallBack = 0
+++++ finished: close input file: lfn = file:testGetBy1.root usedFallBack = 0
+++++ starting: end stream for module: stream = 0 label = 'intProducer'
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
-Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++++ ModuleEndStream finished
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    StreamContext: StreamID = 0 transition = EndStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++ finished: end stream for module: stream = 0 label = 'intProducer'
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+ModuleCallingContext state = Running
+    moduleDescription: Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
+    StreamContext: StreamID = 0 transition = EndStream
+    run: 0 lumi: 0 event: 0
+    runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
+    ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
+
+++++ starting: end stream for module: stream = 0 label = 'TriggerResults'
+++++ finished: end stream for module: stream = 0 label = 'TriggerResults'
+++++ starting: end stream for module: stream = 0 label = 'out'
+++++ finished: end stream for module: stream = 0 label = 'out'
+++++ starting: end stream for module: stream = 0 label = 'intProducerU'
+++++ finished: end stream for module: stream = 0 label = 'intProducerU'
+++++ starting: end stream for module: stream = 0 label = 'intVectorProducer'
+++++ finished: end stream for module: stream = 0 label = 'intVectorProducer'
+++++ starting: end job for module with label 'intProducerU'
+++++ finished: end job for module with label 'intProducerU'
+++++ starting: end job for module with label 'intVectorProducer'
+++++ finished: end job for module with label 'intVectorProducer'
+++++ starting: end job for module with label 'intProducer'
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++ ModuleEndJob: intProducerU
-++ ModuleEndJob finished: intProducerU
-++ ModuleEndJob: intVectorProducer
-++ ModuleEndJob finished: intVectorProducer
-++ ModuleEndJob: intProducer
+++++ finished: end job for module with label 'intProducer'
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++ ModuleEndJob finished: intProducer
-Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++ ModuleEndJob: out
-++ ModuleEndJob finished: out
-++ ModuleEndJob: TriggerResults
-++ ModuleEndJob finished: TriggerResults
-++ Job ended
+++++ starting: end job for module with label 'out'
+++++ finished: end job for module with label 'out'
+++++ starting: end job for module with label 'TriggerResults'
+++++ finished: end job for module with label 'TriggerResults'
+++ finished: end job

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -1,3908 +1,3908 @@
-++ constructing source:EmptySource
-++ construction finished:EmptySource
-++ constructing module: TriggerResults
-++ construction finished: TriggerResults
-++ constructing module: thingWithMergeProducer
-++ construction finished: thingWithMergeProducer
-++ constructing module: get
-++ construction finished: get
-++ constructing module: putInt
-++ construction finished: putInt
-++ constructing module: putInt2
-++ construction finished: putInt2
-++ constructing module: putInt3
-++ construction finished: putInt3
-++ constructing module: getInt
-++ construction finished: getInt
-++ constructing module: noPut
-++ construction finished: noPut
-++ constructing module: TriggerResults
-++ construction finished: TriggerResults
-++ constructing module: thingWithMergeProducer
-++ construction finished: thingWithMergeProducer
-++ constructing module: test
-++ construction finished: test
-++ constructing module: testmerge
-++ construction finished: testmerge
-++ constructing module: get
-++ construction finished: get
-++ constructing module: getInt
-++ construction finished: getInt
-++ constructing module: dependsOnNoPut
-++ construction finished: dependsOnNoPut
-++ constructing module: out
-++ construction finished: out
-++ ModuleBeginJob: thingWithMergeProducer
-++ ModuleBeginJob finished: thingWithMergeProducer
-++ ModuleBeginJob: get
-++ ModuleBeginJob finished: get
-++ ModuleBeginJob: putInt
-++ ModuleBeginJob finished: putInt
-++ ModuleBeginJob: putInt2
-++ ModuleBeginJob finished: putInt2
-++ ModuleBeginJob: putInt3
-++ ModuleBeginJob finished: putInt3
-++ ModuleBeginJob: getInt
-++ ModuleBeginJob finished: getInt
-++ ModuleBeginJob: noPut
-++ ModuleBeginJob finished: noPut
-++ ModuleBeginJob: TriggerResults
-++ ModuleBeginJob finished: TriggerResults
-++ ModuleBeginJob: thingWithMergeProducer
-++ ModuleBeginJob finished: thingWithMergeProducer
-++ ModuleBeginJob: test
-++ ModuleBeginJob finished: test
-++ ModuleBeginJob: testmerge
-++ ModuleBeginJob finished: testmerge
-++ ModuleBeginJob: get
-++ ModuleBeginJob finished: get
-++ ModuleBeginJob: getInt
-++ ModuleBeginJob finished: getInt
-++ ModuleBeginJob: dependsOnNoPut
-++ ModuleBeginJob finished: dependsOnNoPut
-++ ModuleBeginJob: out
-++ ModuleBeginJob finished: out
-++ ModuleBeginJob: TriggerResults
-++ ModuleBeginJob finished: TriggerResults
-++ Job started
-++++ ModuleBeginStream: thingWithMergeProducer
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: get
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: putInt
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: putInt2
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: putInt3
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: getInt
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: noPut
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: TriggerResults
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: thingWithMergeProducer
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: test
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: testmerge
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: get
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: getInt
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: dependsOnNoPut
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: TriggerResults
-++++ ModuleBeginStream finished
-++++ ModuleBeginStream: out
-++++ ModuleBeginStream finished
-++++ source run
+++ starting: constructing source: EmptySource
+++ finished: constructing source: EmptySource
+++++ starting: constructing module with label 'TriggerResults'
+++++ finished: constructing module with label 'TriggerResults'
+++++ starting: constructing module with label 'thingWithMergeProducer'
+++++ finished: constructing module with label 'thingWithMergeProducer'
+++++ starting: constructing module with label 'get'
+++++ finished: constructing module with label 'get'
+++++ starting: constructing module with label 'putInt'
+++++ finished: constructing module with label 'putInt'
+++++ starting: constructing module with label 'putInt2'
+++++ finished: constructing module with label 'putInt2'
+++++ starting: constructing module with label 'putInt3'
+++++ finished: constructing module with label 'putInt3'
+++++ starting: constructing module with label 'getInt'
+++++ finished: constructing module with label 'getInt'
+++++ starting: constructing module with label 'noPut'
+++++ finished: constructing module with label 'noPut'
+++++ starting: constructing module with label 'TriggerResults'
+++++ finished: constructing module with label 'TriggerResults'
+++++ starting: constructing module with label 'thingWithMergeProducer'
+++++ finished: constructing module with label 'thingWithMergeProducer'
+++++ starting: constructing module with label 'test'
+++++ finished: constructing module with label 'test'
+++++ starting: constructing module with label 'testmerge'
+++++ finished: constructing module with label 'testmerge'
+++++ starting: constructing module with label 'get'
+++++ finished: constructing module with label 'get'
+++++ starting: constructing module with label 'getInt'
+++++ finished: constructing module with label 'getInt'
+++++ starting: constructing module with label 'dependsOnNoPut'
+++++ finished: constructing module with label 'dependsOnNoPut'
+++++ starting: constructing module with label 'out'
+++++ finished: constructing module with label 'out'
+++++ starting: begin job for module with label 'thingWithMergeProducer'
+++++ finished: begin job for module with label 'thingWithMergeProducer'
+++++ starting: begin job for module with label 'get'
+++++ finished: begin job for module with label 'get'
+++++ starting: begin job for module with label 'putInt'
+++++ finished: begin job for module with label 'putInt'
+++++ starting: begin job for module with label 'putInt2'
+++++ finished: begin job for module with label 'putInt2'
+++++ starting: begin job for module with label 'putInt3'
+++++ finished: begin job for module with label 'putInt3'
+++++ starting: begin job for module with label 'getInt'
+++++ finished: begin job for module with label 'getInt'
+++++ starting: begin job for module with label 'noPut'
+++++ finished: begin job for module with label 'noPut'
+++++ starting: begin job for module with label 'TriggerResults'
+++++ finished: begin job for module with label 'TriggerResults'
+++++ starting: begin job for module with label 'thingWithMergeProducer'
+++++ finished: begin job for module with label 'thingWithMergeProducer'
+++++ starting: begin job for module with label 'test'
+++++ finished: begin job for module with label 'test'
+++++ starting: begin job for module with label 'testmerge'
+++++ finished: begin job for module with label 'testmerge'
+++++ starting: begin job for module with label 'get'
+++++ finished: begin job for module with label 'get'
+++++ starting: begin job for module with label 'getInt'
+++++ finished: begin job for module with label 'getInt'
+++++ starting: begin job for module with label 'dependsOnNoPut'
+++++ finished: begin job for module with label 'dependsOnNoPut'
+++++ starting: begin job for module with label 'out'
+++++ finished: begin job for module with label 'out'
+++++ starting: begin job for module with label 'TriggerResults'
+++++ finished: begin job for module with label 'TriggerResults'
+++ finished: begin job
+++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer'
+++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer'
+++++ starting: begin stream for module: stream = 0 label = 'get'
+++++ finished: begin stream for module: stream = 0 label = 'get'
+++++ starting: begin stream for module: stream = 0 label = 'putInt'
+++++ finished: begin stream for module: stream = 0 label = 'putInt'
+++++ starting: begin stream for module: stream = 0 label = 'putInt2'
+++++ finished: begin stream for module: stream = 0 label = 'putInt2'
+++++ starting: begin stream for module: stream = 0 label = 'putInt3'
+++++ finished: begin stream for module: stream = 0 label = 'putInt3'
+++++ starting: begin stream for module: stream = 0 label = 'getInt'
+++++ finished: begin stream for module: stream = 0 label = 'getInt'
+++++ starting: begin stream for module: stream = 0 label = 'noPut'
+++++ finished: begin stream for module: stream = 0 label = 'noPut'
+++++ starting: begin stream for module: stream = 0 label = 'TriggerResults'
+++++ finished: begin stream for module: stream = 0 label = 'TriggerResults'
+++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer'
+++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer'
+++++ starting: begin stream for module: stream = 0 label = 'test'
+++++ finished: begin stream for module: stream = 0 label = 'test'
+++++ starting: begin stream for module: stream = 0 label = 'testmerge'
+++++ finished: begin stream for module: stream = 0 label = 'testmerge'
+++++ starting: begin stream for module: stream = 0 label = 'get'
+++++ finished: begin stream for module: stream = 0 label = 'get'
+++++ starting: begin stream for module: stream = 0 label = 'getInt'
+++++ finished: begin stream for module: stream = 0 label = 'getInt'
+++++ starting: begin stream for module: stream = 0 label = 'dependsOnNoPut'
+++++ finished: begin stream for module: stream = 0 label = 'dependsOnNoPut'
+++++ starting: begin stream for module: stream = 0 label = 'TriggerResults'
+++++ finished: begin stream for module: stream = 0 label = 'TriggerResults'
+++++ starting: begin stream for module: stream = 0 label = 'out'
+++++ finished: begin stream for module: stream = 0 label = 'out'
+++++ starting: source run
 ++++ finished: source run
-++++ GlobalBeginRun run: 1 time: 1
-++++ GlobalBeginRun finished
-++++ GlobalBeginRun run: 1 time: 1
-++++ GlobalBeginRun finished
-++++ GlobalBeginRun run: 1 time: 1
-++++++ ModuleGlobalBeginRun: thingWithMergeProducer
-++++++ ModuleGlobalBeginRun finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginRun: get
-++++++ ModuleGlobalBeginRun finished: get
-++++++ ModuleGlobalBeginRun: putInt
-++++++ ModuleGlobalBeginRun finished: putInt
-++++++ ModuleGlobalBeginRun: putInt2
-++++++ ModuleGlobalBeginRun finished: putInt2
-++++++ ModuleGlobalBeginRun: putInt3
-++++++ ModuleGlobalBeginRun finished: putInt3
-++++++ ModuleGlobalBeginRun: getInt
-++++++ ModuleGlobalBeginRun finished: getInt
-++++++ ModuleGlobalBeginRun: noPut
-++++++ ModuleGlobalBeginRun finished: noPut
-++++++ ModuleGlobalBeginRun: TriggerResults
-++++++ ModuleGlobalBeginRun finished: TriggerResults
-++++ GlobalBeginRun finished
-++++ GlobalBeginRun run: 1 time: 1
-++++ GlobalBeginRun finished
-++++ GlobalBeginRun run: 1 time: 1
-++++++ ModuleGlobalBeginRun: thingWithMergeProducer
-++++++ ModuleGlobalBeginRun finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginRun: test
-++++++ ModuleGlobalBeginRun finished: test
-++++++ ModuleGlobalBeginRun: testmerge
-++++++ ModuleGlobalBeginRun finished: testmerge
-++++++ ModuleGlobalBeginRun: get
-++++++ ModuleGlobalBeginRun finished: get
-++++++ ModuleGlobalBeginRun: getInt
-++++++ ModuleGlobalBeginRun finished: getInt
-++++++ ModuleGlobalBeginRun: dependsOnNoPut
-++++++ ModuleGlobalBeginRun finished: dependsOnNoPut
-++++++ ModuleGlobalBeginRun: out
-++++++ ModuleGlobalBeginRun finished: out
-++++++ ModuleGlobalBeginRun: TriggerResults
-++++++ ModuleGlobalBeginRun finished: TriggerResults
-++++ GlobalBeginRun finished
-++++ StreamBeginRun run: 1 time: 1
-++++ StreamBeginRun finished
-++++ StreamBeginRun run: 1 time: 1
-++++ StreamBeginRun finished
-++++ StreamBeginRun run: 1 time: 1
-++++++ ModuleStreamBeginRun: thingWithMergeProducer
-++++++ ModuleStreamBeginRun finished: thingWithMergeProducer
-++++++ ModuleStreamBeginRun: get
-++++++ ModuleStreamBeginRun finished: get
-++++++ ModuleStreamBeginRun: putInt
-++++++ ModuleStreamBeginRun finished: putInt
-++++++ ModuleStreamBeginRun: putInt2
-++++++ ModuleStreamBeginRun finished: putInt2
-++++++ ModuleStreamBeginRun: putInt3
-++++++ ModuleStreamBeginRun finished: putInt3
-++++++ ModuleStreamBeginRun: getInt
-++++++ ModuleStreamBeginRun finished: getInt
-++++++ ModuleStreamBeginRun: noPut
-++++++ ModuleStreamBeginRun finished: noPut
-++++ StreamBeginRun finished
-++++ StreamBeginRun run: 1 time: 1
-++++ StreamBeginRun finished
-++++ StreamBeginRun run: 1 time: 1
-++++++ ModuleStreamBeginRun: thingWithMergeProducer
-++++++ ModuleStreamBeginRun finished: thingWithMergeProducer
-++++++ ModuleStreamBeginRun: test
-++++++ ModuleStreamBeginRun finished: test
-++++++ ModuleStreamBeginRun: testmerge
-++++++ ModuleStreamBeginRun finished: testmerge
-++++++ ModuleStreamBeginRun: get
-++++++ ModuleStreamBeginRun finished: get
-++++++ ModuleStreamBeginRun: getInt
-++++++ ModuleStreamBeginRun finished: getInt
-++++++ ModuleStreamBeginRun: dependsOnNoPut
-++++++ ModuleStreamBeginRun finished: dependsOnNoPut
-++++++ ModuleStreamBeginRun: out
-++++++ ModuleStreamBeginRun finished: out
-++++ StreamBeginRun finished
-++++ source lumi
+++++ starting: global begin run 1 : time = 1
+++++ finished: global begin run 1 : time = 1
+++++ starting: global begin run 1 : time = 1
+++++ finished: global begin run 1 : time = 1
+++++ starting: global begin run 1 : time = 1
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin run for module: label = 'get'
+++++++ finished: global begin run for module: label = 'get'
+++++++ starting: global begin run for module: label = 'putInt'
+++++++ finished: global begin run for module: label = 'putInt'
+++++++ starting: global begin run for module: label = 'putInt2'
+++++++ finished: global begin run for module: label = 'putInt2'
+++++++ starting: global begin run for module: label = 'putInt3'
+++++++ finished: global begin run for module: label = 'putInt3'
+++++++ starting: global begin run for module: label = 'getInt'
+++++++ finished: global begin run for module: label = 'getInt'
+++++++ starting: global begin run for module: label = 'noPut'
+++++++ finished: global begin run for module: label = 'noPut'
+++++++ starting: global begin run for module: label = 'TriggerResults'
+++++++ finished: global begin run for module: label = 'TriggerResults'
+++++ finished: global begin run 1 : time = 1
+++++ starting: global begin run 1 : time = 1
+++++ finished: global begin run 1 : time = 1
+++++ starting: global begin run 1 : time = 1
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin run for module: label = 'test'
+++++++ finished: global begin run for module: label = 'test'
+++++++ starting: global begin run for module: label = 'testmerge'
+++++++ finished: global begin run for module: label = 'testmerge'
+++++++ starting: global begin run for module: label = 'get'
+++++++ finished: global begin run for module: label = 'get'
+++++++ starting: global begin run for module: label = 'getInt'
+++++++ finished: global begin run for module: label = 'getInt'
+++++++ starting: global begin run for module: label = 'dependsOnNoPut'
+++++++ finished: global begin run for module: label = 'dependsOnNoPut'
+++++++ starting: global begin run for module: label = 'out'
+++++++ finished: global begin run for module: label = 'out'
+++++++ starting: global begin run for module: label = 'TriggerResults'
+++++++ finished: global begin run for module: label = 'TriggerResults'
+++++ finished: global begin run 1 : time = 1
+++++ starting: begin run: stream = 0 run = 1 time = 1
+++++ finished: begin run: stream = 0 run = 1 time = 1
+++++ starting: begin run: stream = 0 run = 1 time = 1
+++++ finished: begin run: stream = 0 run = 1 time = 1
+++++ starting: begin run: stream = 0 run = 1 time = 1
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin run for module: stream = 0 label = 'get'
+++++++ finished: begin run for module: stream = 0 label = 'get'
+++++++ starting: begin run for module: stream = 0 label = 'putInt'
+++++++ finished: begin run for module: stream = 0 label = 'putInt'
+++++++ starting: begin run for module: stream = 0 label = 'putInt2'
+++++++ finished: begin run for module: stream = 0 label = 'putInt2'
+++++++ starting: begin run for module: stream = 0 label = 'putInt3'
+++++++ finished: begin run for module: stream = 0 label = 'putInt3'
+++++++ starting: begin run for module: stream = 0 label = 'getInt'
+++++++ finished: begin run for module: stream = 0 label = 'getInt'
+++++++ starting: begin run for module: stream = 0 label = 'noPut'
+++++++ finished: begin run for module: stream = 0 label = 'noPut'
+++++ finished: begin run: stream = 0 run = 1 time = 1
+++++ starting: begin run: stream = 0 run = 1 time = 1
+++++ finished: begin run: stream = 0 run = 1 time = 1
+++++ starting: begin run: stream = 0 run = 1 time = 1
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin run for module: stream = 0 label = 'test'
+++++++ finished: begin run for module: stream = 0 label = 'test'
+++++++ starting: begin run for module: stream = 0 label = 'testmerge'
+++++++ finished: begin run for module: stream = 0 label = 'testmerge'
+++++++ starting: begin run for module: stream = 0 label = 'get'
+++++++ finished: begin run for module: stream = 0 label = 'get'
+++++++ starting: begin run for module: stream = 0 label = 'getInt'
+++++++ finished: begin run for module: stream = 0 label = 'getInt'
+++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: begin run for module: stream = 0 label = 'out'
+++++++ finished: begin run for module: stream = 0 label = 'out'
+++++ finished: begin run: stream = 0 run = 1 time = 1
+++++ starting: source lumi
 ++++ finished: source lumi
-++++ GlobalBeginLumi run: 1 lumi: 1 time: 1
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 1 lumi: 1 time: 1
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 1 lumi: 1 time: 1
-++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: putInt
-++++++ ModuleGlobalBeginLumi finished: putInt
-++++++ ModuleGlobalBeginLumi: putInt2
-++++++ ModuleGlobalBeginLumi finished: putInt2
-++++++ ModuleGlobalBeginLumi: putInt3
-++++++ ModuleGlobalBeginLumi finished: putInt3
-++++++ ModuleGlobalBeginLumi: getInt
-++++++ ModuleGlobalBeginLumi finished: getInt
-++++++ ModuleGlobalBeginLumi: noPut
-++++++ ModuleGlobalBeginLumi finished: noPut
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 1 lumi: 1 time: 1
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 1 lumi: 1 time: 1
-++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi: test
-++++++ ModuleGlobalBeginLumi finished: test
-++++++ ModuleGlobalBeginLumi: testmerge
-++++++ ModuleGlobalBeginLumi finished: testmerge
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: getInt
-++++++ ModuleGlobalBeginLumi finished: getInt
-++++++ ModuleGlobalBeginLumi: dependsOnNoPut
-++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
-++++++ ModuleGlobalBeginLumi: out
-++++++ ModuleGlobalBeginLumi finished: out
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ StreamBeginLumi run: 1 lumi: 1 time: 1
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 1 lumi: 1 time: 1
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 1 lumi: 1 time: 1
-++++++ ModuleStreamBeginLumi: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++++ ModuleStreamBeginLumi: putInt
-++++++ ModuleStreamBeginLumi finished: putInt
-++++++ ModuleStreamBeginLumi: putInt2
-++++++ ModuleStreamBeginLumi finished: putInt2
-++++++ ModuleStreamBeginLumi: putInt3
-++++++ ModuleStreamBeginLumi finished: putInt3
-++++++ ModuleStreamBeginLumi: getInt
-++++++ ModuleStreamBeginLumi finished: getInt
-++++++ ModuleStreamBeginLumi: noPut
-++++++ ModuleStreamBeginLumi finished: noPut
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 1 lumi: 1 time: 1
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 1 lumi: 1 time: 1
-++++++ ModuleStreamBeginLumi: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi: test
-++++++ ModuleStreamBeginLumi finished: test
-++++++ ModuleStreamBeginLumi: testmerge
-++++++ ModuleStreamBeginLumi finished: testmerge
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++++ ModuleStreamBeginLumi: getInt
-++++++ ModuleStreamBeginLumi finished: getInt
-++++++ ModuleStreamBeginLumi: dependsOnNoPut
-++++++ ModuleStreamBeginLumi finished: dependsOnNoPut
-++++++ ModuleStreamBeginLumi: out
-++++++ ModuleStreamBeginLumi finished: out
-++++ StreamBeginLumi finished
-++++ source event
+++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
+++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
+++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
+++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
+++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'putInt'
+++++++ finished: global begin lumi for module: label = 'putInt'
+++++++ starting: global begin lumi for module: label = 'putInt2'
+++++++ finished: global begin lumi for module: label = 'putInt2'
+++++++ starting: global begin lumi for module: label = 'putInt3'
+++++++ finished: global begin lumi for module: label = 'putInt3'
+++++++ starting: global begin lumi for module: label = 'getInt'
+++++++ finished: global begin lumi for module: label = 'getInt'
+++++++ starting: global begin lumi for module: label = 'noPut'
+++++++ finished: global begin lumi for module: label = 'noPut'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
+++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
+++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
+++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin lumi for module: label = 'test'
+++++++ finished: global begin lumi for module: label = 'test'
+++++++ starting: global begin lumi for module: label = 'testmerge'
+++++++ finished: global begin lumi for module: label = 'testmerge'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'getInt'
+++++++ finished: global begin lumi for module: label = 'getInt'
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut'
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut'
+++++++ starting: global begin lumi for module: label = 'out'
+++++++ finished: global begin lumi for module: label = 'out'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3'
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut'
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut'
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'test'
+++++++ finished: begin lumi for module: stream = 0 label = 'test'
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge'
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: begin lumi for module: stream = 0 label = 'out'
+++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 1 event: 1 time:5000001
-++++ event finished
-++++ processing event run: 1 lumi: 1 event: 1 time:5000001
-++++ event finished
-++++ processing event run: 1 lumi: 1 event: 1 time:5000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 1 lumi: 1 event: 1 time:5000001
-++++ event finished
-++++ processing event run: 1 lumi: 1 event: 1 time:5000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 1 event: 2 time:10000001
-++++ event finished
-++++ processing event run: 1 lumi: 1 event: 2 time:10000001
-++++ event finished
-++++ processing event run: 1 lumi: 1 event: 2 time:10000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 1 lumi: 1 event: 2 time:10000001
-++++ event finished
-++++ processing event run: 1 lumi: 1 event: 2 time:10000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 1 event: 3 time:15000001
-++++ event finished
-++++ processing event run: 1 lumi: 1 event: 3 time:15000001
-++++ event finished
-++++ processing event run: 1 lumi: 1 event: 3 time:15000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 1 lumi: 1 event: 3 time:15000001
-++++ event finished
-++++ processing event run: 1 lumi: 1 event: 3 time:15000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 1 event: 4 time:20000001
-++++ event finished
-++++ processing event run: 1 lumi: 1 event: 4 time:20000001
-++++ event finished
-++++ processing event run: 1 lumi: 1 event: 4 time:20000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 1 lumi: 1 event: 4 time:20000001
-++++ event finished
-++++ processing event run: 1 lumi: 1 event: 4 time:20000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ StreamEndLumi run: 1 lumi: 1 time: 20000001
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 1 lumi: 1 time: 0
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 1 lumi: 1 time: 0
-++++++ ModuleStreamEndLumi: thingWithMergeProducer
-++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++++ ModuleStreamEndLumi: putInt
-++++++ ModuleStreamEndLumi finished: putInt
-++++++ ModuleStreamEndLumi: putInt2
-++++++ ModuleStreamEndLumi finished: putInt2
-++++++ ModuleStreamEndLumi: putInt3
-++++++ ModuleStreamEndLumi finished: putInt3
-++++++ ModuleStreamEndLumi: getInt
-++++++ ModuleStreamEndLumi finished: getInt
-++++++ ModuleStreamEndLumi: noPut
-++++++ ModuleStreamEndLumi finished: noPut
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 1 lumi: 1 time: 0
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 1 lumi: 1 time: 0
-++++++ ModuleStreamEndLumi: thingWithMergeProducer
-++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
-++++++ ModuleStreamEndLumi: test
-++++++ ModuleStreamEndLumi finished: test
-++++++ ModuleStreamEndLumi: testmerge
-++++++ ModuleStreamEndLumi finished: testmerge
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++++ ModuleStreamEndLumi: getInt
-++++++ ModuleStreamEndLumi finished: getInt
-++++++ ModuleStreamEndLumi: dependsOnNoPut
-++++++ ModuleStreamEndLumi finished: dependsOnNoPut
-++++++ ModuleStreamEndLumi: out
-++++++ ModuleStreamEndLumi finished: out
-++++ StreamEndLumi finished
-++++ GlobalEndLumi run: 1 lumi: 1 time: 1
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 1 lumi: 1 time: 1
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 1 lumi: 1 time: 1
-++++++ ModuleGlobalEndLumi: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: putInt
-++++++ ModuleGlobalEndLumi finished: putInt
-++++++ ModuleGlobalEndLumi: putInt2
-++++++ ModuleGlobalEndLumi finished: putInt2
-++++++ ModuleGlobalEndLumi: putInt3
-++++++ ModuleGlobalEndLumi finished: putInt3
-++++++ ModuleGlobalEndLumi: getInt
-++++++ ModuleGlobalEndLumi finished: getInt
-++++++ ModuleGlobalEndLumi: noPut
-++++++ ModuleGlobalEndLumi finished: noPut
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 1 lumi: 1 time: 1
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 1 lumi: 1 time: 1
-++++++ ModuleGlobalEndLumi: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi: test
-++++++ ModuleGlobalEndLumi finished: test
-++++++ ModuleGlobalEndLumi: testmerge
-++++++ ModuleGlobalEndLumi finished: testmerge
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: getInt
-++++++ ModuleGlobalEndLumi finished: getInt
-++++++ ModuleGlobalEndLumi: dependsOnNoPut
-++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
-++++++ ModuleGlobalEndLumi: out
-++++++ ModuleGlobalEndLumi finished: out
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ source lumi
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
+++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 20000001
+++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 20000001
+++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
+++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
+++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3'
+++++++ starting: end lumi for module: stream = 0 label = 'getInt'
+++++++ finished: end lumi for module: stream = 0 label = 'getInt'
+++++++ starting: end lumi for module: stream = 0 label = 'noPut'
+++++++ finished: end lumi for module: stream = 0 label = 'noPut'
+++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
+++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
+++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
+++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'test'
+++++++ finished: end lumi for module: stream = 0 label = 'test'
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge'
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'getInt'
+++++++ finished: end lumi for module: stream = 0 label = 'getInt'
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: end lumi for module: stream = 0 label = 'out'
+++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
+++++ starting: global end lumi: run = 1 lumi = 1 time = 1
+++++ finished: global end lumi: run = 1 lumi = 1 time = 1
+++++ starting: global end lumi: run = 1 lumi = 1 time = 1
+++++ finished: global end lumi: run = 1 lumi = 1 time = 1
+++++ starting: global end lumi: run = 1 lumi = 1 time = 1
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'putInt'
+++++++ finished: global end lumi for module: label = 'putInt'
+++++++ starting: global end lumi for module: label = 'putInt2'
+++++++ finished: global end lumi for module: label = 'putInt2'
+++++++ starting: global end lumi for module: label = 'putInt3'
+++++++ finished: global end lumi for module: label = 'putInt3'
+++++++ starting: global end lumi for module: label = 'getInt'
+++++++ finished: global end lumi for module: label = 'getInt'
+++++++ starting: global end lumi for module: label = 'noPut'
+++++++ finished: global end lumi for module: label = 'noPut'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 1 lumi = 1 time = 1
+++++ starting: global end lumi: run = 1 lumi = 1 time = 1
+++++ finished: global end lumi: run = 1 lumi = 1 time = 1
+++++ starting: global end lumi: run = 1 lumi = 1 time = 1
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global end lumi for module: label = 'test'
+++++++ finished: global end lumi for module: label = 'test'
+++++++ starting: global end lumi for module: label = 'testmerge'
+++++++ finished: global end lumi for module: label = 'testmerge'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'getInt'
+++++++ finished: global end lumi for module: label = 'getInt'
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut'
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut'
+++++++ starting: global end lumi for module: label = 'out'
+++++++ finished: global end lumi for module: label = 'out'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 1 lumi = 1 time = 1
+++++ starting: source lumi
 ++++ finished: source lumi
-++++ GlobalBeginLumi run: 1 lumi: 2 time: 25000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 1 lumi: 2 time: 25000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 1 lumi: 2 time: 25000001
-++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: putInt
-++++++ ModuleGlobalBeginLumi finished: putInt
-++++++ ModuleGlobalBeginLumi: putInt2
-++++++ ModuleGlobalBeginLumi finished: putInt2
-++++++ ModuleGlobalBeginLumi: putInt3
-++++++ ModuleGlobalBeginLumi finished: putInt3
-++++++ ModuleGlobalBeginLumi: getInt
-++++++ ModuleGlobalBeginLumi finished: getInt
-++++++ ModuleGlobalBeginLumi: noPut
-++++++ ModuleGlobalBeginLumi finished: noPut
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 1 lumi: 2 time: 25000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 1 lumi: 2 time: 25000001
-++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi: test
-++++++ ModuleGlobalBeginLumi finished: test
-++++++ ModuleGlobalBeginLumi: testmerge
-++++++ ModuleGlobalBeginLumi finished: testmerge
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: getInt
-++++++ ModuleGlobalBeginLumi finished: getInt
-++++++ ModuleGlobalBeginLumi: dependsOnNoPut
-++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
-++++++ ModuleGlobalBeginLumi: out
-++++++ ModuleGlobalBeginLumi finished: out
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ StreamBeginLumi run: 1 lumi: 2 time: 25000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 1 lumi: 2 time: 25000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 1 lumi: 2 time: 25000001
-++++++ ModuleStreamBeginLumi: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++++ ModuleStreamBeginLumi: putInt
-++++++ ModuleStreamBeginLumi finished: putInt
-++++++ ModuleStreamBeginLumi: putInt2
-++++++ ModuleStreamBeginLumi finished: putInt2
-++++++ ModuleStreamBeginLumi: putInt3
-++++++ ModuleStreamBeginLumi finished: putInt3
-++++++ ModuleStreamBeginLumi: getInt
-++++++ ModuleStreamBeginLumi finished: getInt
-++++++ ModuleStreamBeginLumi: noPut
-++++++ ModuleStreamBeginLumi finished: noPut
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 1 lumi: 2 time: 25000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 1 lumi: 2 time: 25000001
-++++++ ModuleStreamBeginLumi: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi: test
-++++++ ModuleStreamBeginLumi finished: test
-++++++ ModuleStreamBeginLumi: testmerge
-++++++ ModuleStreamBeginLumi finished: testmerge
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++++ ModuleStreamBeginLumi: getInt
-++++++ ModuleStreamBeginLumi finished: getInt
-++++++ ModuleStreamBeginLumi: dependsOnNoPut
-++++++ ModuleStreamBeginLumi finished: dependsOnNoPut
-++++++ ModuleStreamBeginLumi: out
-++++++ ModuleStreamBeginLumi finished: out
-++++ StreamBeginLumi finished
-++++ source event
+++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
+++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
+++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'putInt'
+++++++ finished: global begin lumi for module: label = 'putInt'
+++++++ starting: global begin lumi for module: label = 'putInt2'
+++++++ finished: global begin lumi for module: label = 'putInt2'
+++++++ starting: global begin lumi for module: label = 'putInt3'
+++++++ finished: global begin lumi for module: label = 'putInt3'
+++++++ starting: global begin lumi for module: label = 'getInt'
+++++++ finished: global begin lumi for module: label = 'getInt'
+++++++ starting: global begin lumi for module: label = 'noPut'
+++++++ finished: global begin lumi for module: label = 'noPut'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
+++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin lumi for module: label = 'test'
+++++++ finished: global begin lumi for module: label = 'test'
+++++++ starting: global begin lumi for module: label = 'testmerge'
+++++++ finished: global begin lumi for module: label = 'testmerge'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'getInt'
+++++++ finished: global begin lumi for module: label = 'getInt'
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut'
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut'
+++++++ starting: global begin lumi for module: label = 'out'
+++++++ finished: global begin lumi for module: label = 'out'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3'
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut'
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut'
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'test'
+++++++ finished: begin lumi for module: stream = 0 label = 'test'
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge'
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: begin lumi for module: stream = 0 label = 'out'
+++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 2 event: 5 time:25000001
-++++ event finished
-++++ processing event run: 1 lumi: 2 event: 5 time:25000001
-++++ event finished
-++++ processing event run: 1 lumi: 2 event: 5 time:25000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 1 lumi: 2 event: 5 time:25000001
-++++ event finished
-++++ processing event run: 1 lumi: 2 event: 5 time:25000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 2 event: 6 time:30000001
-++++ event finished
-++++ processing event run: 1 lumi: 2 event: 6 time:30000001
-++++ event finished
-++++ processing event run: 1 lumi: 2 event: 6 time:30000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 1 lumi: 2 event: 6 time:30000001
-++++ event finished
-++++ processing event run: 1 lumi: 2 event: 6 time:30000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 2 event: 7 time:35000001
-++++ event finished
-++++ processing event run: 1 lumi: 2 event: 7 time:35000001
-++++ event finished
-++++ processing event run: 1 lumi: 2 event: 7 time:35000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 1 lumi: 2 event: 7 time:35000001
-++++ event finished
-++++ processing event run: 1 lumi: 2 event: 7 time:35000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 2 event: 8 time:40000001
-++++ event finished
-++++ processing event run: 1 lumi: 2 event: 8 time:40000001
-++++ event finished
-++++ processing event run: 1 lumi: 2 event: 8 time:40000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 1 lumi: 2 event: 8 time:40000001
-++++ event finished
-++++ processing event run: 1 lumi: 2 event: 8 time:40000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ StreamEndLumi run: 1 lumi: 2 time: 40000001
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 1 lumi: 2 time: 0
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 1 lumi: 2 time: 0
-++++++ ModuleStreamEndLumi: thingWithMergeProducer
-++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++++ ModuleStreamEndLumi: putInt
-++++++ ModuleStreamEndLumi finished: putInt
-++++++ ModuleStreamEndLumi: putInt2
-++++++ ModuleStreamEndLumi finished: putInt2
-++++++ ModuleStreamEndLumi: putInt3
-++++++ ModuleStreamEndLumi finished: putInt3
-++++++ ModuleStreamEndLumi: getInt
-++++++ ModuleStreamEndLumi finished: getInt
-++++++ ModuleStreamEndLumi: noPut
-++++++ ModuleStreamEndLumi finished: noPut
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 1 lumi: 2 time: 0
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 1 lumi: 2 time: 0
-++++++ ModuleStreamEndLumi: thingWithMergeProducer
-++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
-++++++ ModuleStreamEndLumi: test
-++++++ ModuleStreamEndLumi finished: test
-++++++ ModuleStreamEndLumi: testmerge
-++++++ ModuleStreamEndLumi finished: testmerge
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++++ ModuleStreamEndLumi: getInt
-++++++ ModuleStreamEndLumi finished: getInt
-++++++ ModuleStreamEndLumi: dependsOnNoPut
-++++++ ModuleStreamEndLumi finished: dependsOnNoPut
-++++++ ModuleStreamEndLumi: out
-++++++ ModuleStreamEndLumi finished: out
-++++ StreamEndLumi finished
-++++ GlobalEndLumi run: 1 lumi: 2 time: 25000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 1 lumi: 2 time: 25000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 1 lumi: 2 time: 25000001
-++++++ ModuleGlobalEndLumi: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: putInt
-++++++ ModuleGlobalEndLumi finished: putInt
-++++++ ModuleGlobalEndLumi: putInt2
-++++++ ModuleGlobalEndLumi finished: putInt2
-++++++ ModuleGlobalEndLumi: putInt3
-++++++ ModuleGlobalEndLumi finished: putInt3
-++++++ ModuleGlobalEndLumi: getInt
-++++++ ModuleGlobalEndLumi finished: getInt
-++++++ ModuleGlobalEndLumi: noPut
-++++++ ModuleGlobalEndLumi finished: noPut
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 1 lumi: 2 time: 25000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 1 lumi: 2 time: 25000001
-++++++ ModuleGlobalEndLumi: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi: test
-++++++ ModuleGlobalEndLumi finished: test
-++++++ ModuleGlobalEndLumi: testmerge
-++++++ ModuleGlobalEndLumi finished: testmerge
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: getInt
-++++++ ModuleGlobalEndLumi finished: getInt
-++++++ ModuleGlobalEndLumi: dependsOnNoPut
-++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
-++++++ ModuleGlobalEndLumi: out
-++++++ ModuleGlobalEndLumi finished: out
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ source lumi
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
+++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 40000001
+++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 40000001
+++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
+++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
+++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3'
+++++++ starting: end lumi for module: stream = 0 label = 'getInt'
+++++++ finished: end lumi for module: stream = 0 label = 'getInt'
+++++++ starting: end lumi for module: stream = 0 label = 'noPut'
+++++++ finished: end lumi for module: stream = 0 label = 'noPut'
+++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
+++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
+++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
+++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'test'
+++++++ finished: end lumi for module: stream = 0 label = 'test'
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge'
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'getInt'
+++++++ finished: end lumi for module: stream = 0 label = 'getInt'
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: end lumi for module: stream = 0 label = 'out'
+++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
+++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
+++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
+++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'putInt'
+++++++ finished: global end lumi for module: label = 'putInt'
+++++++ starting: global end lumi for module: label = 'putInt2'
+++++++ finished: global end lumi for module: label = 'putInt2'
+++++++ starting: global end lumi for module: label = 'putInt3'
+++++++ finished: global end lumi for module: label = 'putInt3'
+++++++ starting: global end lumi for module: label = 'getInt'
+++++++ finished: global end lumi for module: label = 'getInt'
+++++++ starting: global end lumi for module: label = 'noPut'
+++++++ finished: global end lumi for module: label = 'noPut'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
+++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global end lumi for module: label = 'test'
+++++++ finished: global end lumi for module: label = 'test'
+++++++ starting: global end lumi for module: label = 'testmerge'
+++++++ finished: global end lumi for module: label = 'testmerge'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'getInt'
+++++++ finished: global end lumi for module: label = 'getInt'
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut'
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut'
+++++++ starting: global end lumi for module: label = 'out'
+++++++ finished: global end lumi for module: label = 'out'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
+++++ starting: source lumi
 ++++ finished: source lumi
-++++ GlobalBeginLumi run: 1 lumi: 3 time: 45000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 1 lumi: 3 time: 45000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 1 lumi: 3 time: 45000001
-++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: putInt
-++++++ ModuleGlobalBeginLumi finished: putInt
-++++++ ModuleGlobalBeginLumi: putInt2
-++++++ ModuleGlobalBeginLumi finished: putInt2
-++++++ ModuleGlobalBeginLumi: putInt3
-++++++ ModuleGlobalBeginLumi finished: putInt3
-++++++ ModuleGlobalBeginLumi: getInt
-++++++ ModuleGlobalBeginLumi finished: getInt
-++++++ ModuleGlobalBeginLumi: noPut
-++++++ ModuleGlobalBeginLumi finished: noPut
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 1 lumi: 3 time: 45000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 1 lumi: 3 time: 45000001
-++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi: test
-++++++ ModuleGlobalBeginLumi finished: test
-++++++ ModuleGlobalBeginLumi: testmerge
-++++++ ModuleGlobalBeginLumi finished: testmerge
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: getInt
-++++++ ModuleGlobalBeginLumi finished: getInt
-++++++ ModuleGlobalBeginLumi: dependsOnNoPut
-++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
-++++++ ModuleGlobalBeginLumi: out
-++++++ ModuleGlobalBeginLumi finished: out
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ StreamBeginLumi run: 1 lumi: 3 time: 45000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 1 lumi: 3 time: 45000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 1 lumi: 3 time: 45000001
-++++++ ModuleStreamBeginLumi: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++++ ModuleStreamBeginLumi: putInt
-++++++ ModuleStreamBeginLumi finished: putInt
-++++++ ModuleStreamBeginLumi: putInt2
-++++++ ModuleStreamBeginLumi finished: putInt2
-++++++ ModuleStreamBeginLumi: putInt3
-++++++ ModuleStreamBeginLumi finished: putInt3
-++++++ ModuleStreamBeginLumi: getInt
-++++++ ModuleStreamBeginLumi finished: getInt
-++++++ ModuleStreamBeginLumi: noPut
-++++++ ModuleStreamBeginLumi finished: noPut
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 1 lumi: 3 time: 45000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 1 lumi: 3 time: 45000001
-++++++ ModuleStreamBeginLumi: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi: test
-++++++ ModuleStreamBeginLumi finished: test
-++++++ ModuleStreamBeginLumi: testmerge
-++++++ ModuleStreamBeginLumi finished: testmerge
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++++ ModuleStreamBeginLumi: getInt
-++++++ ModuleStreamBeginLumi finished: getInt
-++++++ ModuleStreamBeginLumi: dependsOnNoPut
-++++++ ModuleStreamBeginLumi finished: dependsOnNoPut
-++++++ ModuleStreamBeginLumi: out
-++++++ ModuleStreamBeginLumi finished: out
-++++ StreamBeginLumi finished
-++++ source event
+++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
+++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
+++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'putInt'
+++++++ finished: global begin lumi for module: label = 'putInt'
+++++++ starting: global begin lumi for module: label = 'putInt2'
+++++++ finished: global begin lumi for module: label = 'putInt2'
+++++++ starting: global begin lumi for module: label = 'putInt3'
+++++++ finished: global begin lumi for module: label = 'putInt3'
+++++++ starting: global begin lumi for module: label = 'getInt'
+++++++ finished: global begin lumi for module: label = 'getInt'
+++++++ starting: global begin lumi for module: label = 'noPut'
+++++++ finished: global begin lumi for module: label = 'noPut'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
+++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin lumi for module: label = 'test'
+++++++ finished: global begin lumi for module: label = 'test'
+++++++ starting: global begin lumi for module: label = 'testmerge'
+++++++ finished: global begin lumi for module: label = 'testmerge'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'getInt'
+++++++ finished: global begin lumi for module: label = 'getInt'
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut'
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut'
+++++++ starting: global begin lumi for module: label = 'out'
+++++++ finished: global begin lumi for module: label = 'out'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3'
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut'
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut'
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
+++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'test'
+++++++ finished: begin lumi for module: stream = 0 label = 'test'
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge'
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: begin lumi for module: stream = 0 label = 'out'
+++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 3 event: 9 time:45000001
-++++ event finished
-++++ processing event run: 1 lumi: 3 event: 9 time:45000001
-++++ event finished
-++++ processing event run: 1 lumi: 3 event: 9 time:45000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 1 lumi: 3 event: 9 time:45000001
-++++ event finished
-++++ processing event run: 1 lumi: 3 event: 9 time:45000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 1 lumi: 3 event: 10 time:50000001
-++++ event finished
-++++ processing event run: 1 lumi: 3 event: 10 time:50000001
-++++ event finished
-++++ processing event run: 1 lumi: 3 event: 10 time:50000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 1 lumi: 3 event: 10 time:50000001
-++++ event finished
-++++ processing event run: 1 lumi: 3 event: 10 time:50000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ StreamEndLumi run: 1 lumi: 3 time: 50000001
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 1 lumi: 3 time: 0
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 1 lumi: 3 time: 0
-++++++ ModuleStreamEndLumi: thingWithMergeProducer
-++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++++ ModuleStreamEndLumi: putInt
-++++++ ModuleStreamEndLumi finished: putInt
-++++++ ModuleStreamEndLumi: putInt2
-++++++ ModuleStreamEndLumi finished: putInt2
-++++++ ModuleStreamEndLumi: putInt3
-++++++ ModuleStreamEndLumi finished: putInt3
-++++++ ModuleStreamEndLumi: getInt
-++++++ ModuleStreamEndLumi finished: getInt
-++++++ ModuleStreamEndLumi: noPut
-++++++ ModuleStreamEndLumi finished: noPut
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 1 lumi: 3 time: 0
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 1 lumi: 3 time: 0
-++++++ ModuleStreamEndLumi: thingWithMergeProducer
-++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
-++++++ ModuleStreamEndLumi: test
-++++++ ModuleStreamEndLumi finished: test
-++++++ ModuleStreamEndLumi: testmerge
-++++++ ModuleStreamEndLumi finished: testmerge
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++++ ModuleStreamEndLumi: getInt
-++++++ ModuleStreamEndLumi finished: getInt
-++++++ ModuleStreamEndLumi: dependsOnNoPut
-++++++ ModuleStreamEndLumi finished: dependsOnNoPut
-++++++ ModuleStreamEndLumi: out
-++++++ ModuleStreamEndLumi finished: out
-++++ StreamEndLumi finished
-++++ GlobalEndLumi run: 1 lumi: 3 time: 45000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 1 lumi: 3 time: 45000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 1 lumi: 3 time: 45000001
-++++++ ModuleGlobalEndLumi: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: putInt
-++++++ ModuleGlobalEndLumi finished: putInt
-++++++ ModuleGlobalEndLumi: putInt2
-++++++ ModuleGlobalEndLumi finished: putInt2
-++++++ ModuleGlobalEndLumi: putInt3
-++++++ ModuleGlobalEndLumi finished: putInt3
-++++++ ModuleGlobalEndLumi: getInt
-++++++ ModuleGlobalEndLumi finished: getInt
-++++++ ModuleGlobalEndLumi: noPut
-++++++ ModuleGlobalEndLumi finished: noPut
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 1 lumi: 3 time: 45000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 1 lumi: 3 time: 45000001
-++++++ ModuleGlobalEndLumi: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi: test
-++++++ ModuleGlobalEndLumi finished: test
-++++++ ModuleGlobalEndLumi: testmerge
-++++++ ModuleGlobalEndLumi finished: testmerge
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: getInt
-++++++ ModuleGlobalEndLumi finished: getInt
-++++++ ModuleGlobalEndLumi: dependsOnNoPut
-++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
-++++++ ModuleGlobalEndLumi: out
-++++++ ModuleGlobalEndLumi finished: out
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ StreamEndRun run: 1 time: 50000001
-++++ StreamEndRun finished
-++++ StreamEndRun run: 1 time: 0
-++++ StreamEndRun finished
-++++ StreamEndRun run: 1 time: 0
-++++++ ModuleStreamEndRun: thingWithMergeProducer
-++++++ ModuleStreamEndRun finished: thingWithMergeProducer
-++++++ ModuleStreamEndRun: get
-++++++ ModuleStreamEndRun finished: get
-++++++ ModuleStreamEndRun: putInt
-++++++ ModuleStreamEndRun finished: putInt
-++++++ ModuleStreamEndRun: putInt2
-++++++ ModuleStreamEndRun finished: putInt2
-++++++ ModuleStreamEndRun: putInt3
-++++++ ModuleStreamEndRun finished: putInt3
-++++++ ModuleStreamEndRun: getInt
-++++++ ModuleStreamEndRun finished: getInt
-++++++ ModuleStreamEndRun: noPut
-++++++ ModuleStreamEndRun finished: noPut
-++++ StreamEndRun finished
-++++ StreamEndRun run: 1 time: 0
-++++ StreamEndRun finished
-++++ StreamEndRun run: 1 time: 0
-++++++ ModuleStreamEndRun: thingWithMergeProducer
-++++++ ModuleStreamEndRun finished: thingWithMergeProducer
-++++++ ModuleStreamEndRun: test
-++++++ ModuleStreamEndRun finished: test
-++++++ ModuleStreamEndRun: testmerge
-++++++ ModuleStreamEndRun finished: testmerge
-++++++ ModuleStreamEndRun: get
-++++++ ModuleStreamEndRun finished: get
-++++++ ModuleStreamEndRun: getInt
-++++++ ModuleStreamEndRun finished: getInt
-++++++ ModuleStreamEndRun: dependsOnNoPut
-++++++ ModuleStreamEndRun finished: dependsOnNoPut
-++++++ ModuleStreamEndRun: out
-++++++ ModuleStreamEndRun finished: out
-++++ StreamEndRun finished
-++++ GlobalEndRun run: 1 time: 50000001
-++++ GlobalEndRun finished
-++++ GlobalEndRun run: 1 time: 0
-++++ GlobalEndRun finished
-++++ GlobalEndRun run: 1 time: 0
-++++++ ModuleGlobalEndRun: thingWithMergeProducer
-++++++ ModuleGlobalEndRun finished: thingWithMergeProducer
-++++++ ModuleGlobalEndRun: get
-++++++ ModuleGlobalEndRun finished: get
-++++++ ModuleGlobalEndRun: putInt
-++++++ ModuleGlobalEndRun finished: putInt
-++++++ ModuleGlobalEndRun: putInt2
-++++++ ModuleGlobalEndRun finished: putInt2
-++++++ ModuleGlobalEndRun: putInt3
-++++++ ModuleGlobalEndRun finished: putInt3
-++++++ ModuleGlobalEndRun: getInt
-++++++ ModuleGlobalEndRun finished: getInt
-++++++ ModuleGlobalEndRun: noPut
-++++++ ModuleGlobalEndRun finished: noPut
-++++++ ModuleGlobalEndRun: TriggerResults
-++++++ ModuleGlobalEndRun finished: TriggerResults
-++++ GlobalEndRun finished
-++++ GlobalEndRun run: 1 time: 0
-++++ GlobalEndRun finished
-++++ GlobalEndRun run: 1 time: 0
-++++++ ModuleGlobalEndRun: thingWithMergeProducer
-++++++ ModuleGlobalEndRun finished: thingWithMergeProducer
-++++++ ModuleGlobalEndRun: test
-++++++ ModuleGlobalEndRun finished: test
-++++++ ModuleGlobalEndRun: testmerge
-++++++ ModuleGlobalEndRun finished: testmerge
-++++++ ModuleGlobalEndRun: get
-++++++ ModuleGlobalEndRun finished: get
-++++++ ModuleGlobalEndRun: getInt
-++++++ ModuleGlobalEndRun finished: getInt
-++++++ ModuleGlobalEndRun: dependsOnNoPut
-++++++ ModuleGlobalEndRun finished: dependsOnNoPut
-++++++ ModuleGlobalEndRun: out
-++++++ ModuleGlobalEndRun finished: out
-++++++ ModuleGlobalEndRun: TriggerResults
-++++++ ModuleGlobalEndRun finished: TriggerResults
-++++ GlobalEndRun finished
-++++ source run
+++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
+++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 50000001
+++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 50000001
+++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
+++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
+++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3'
+++++++ starting: end lumi for module: stream = 0 label = 'getInt'
+++++++ finished: end lumi for module: stream = 0 label = 'getInt'
+++++++ starting: end lumi for module: stream = 0 label = 'noPut'
+++++++ finished: end lumi for module: stream = 0 label = 'noPut'
+++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
+++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
+++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
+++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'test'
+++++++ finished: end lumi for module: stream = 0 label = 'test'
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge'
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'getInt'
+++++++ finished: end lumi for module: stream = 0 label = 'getInt'
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: end lumi for module: stream = 0 label = 'out'
+++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
+++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
+++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
+++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'putInt'
+++++++ finished: global end lumi for module: label = 'putInt'
+++++++ starting: global end lumi for module: label = 'putInt2'
+++++++ finished: global end lumi for module: label = 'putInt2'
+++++++ starting: global end lumi for module: label = 'putInt3'
+++++++ finished: global end lumi for module: label = 'putInt3'
+++++++ starting: global end lumi for module: label = 'getInt'
+++++++ finished: global end lumi for module: label = 'getInt'
+++++++ starting: global end lumi for module: label = 'noPut'
+++++++ finished: global end lumi for module: label = 'noPut'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
+++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global end lumi for module: label = 'test'
+++++++ finished: global end lumi for module: label = 'test'
+++++++ starting: global end lumi for module: label = 'testmerge'
+++++++ finished: global end lumi for module: label = 'testmerge'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'getInt'
+++++++ finished: global end lumi for module: label = 'getInt'
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut'
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut'
+++++++ starting: global end lumi for module: label = 'out'
+++++++ finished: global end lumi for module: label = 'out'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
+++++ starting: end run: stream = 0 run = 1 time = 50000001
+++++ finished: end run: stream = 0 run = 1 time = 50000001
+++++ starting: end run: stream = 0 run = 1 time = 0
+++++ finished: end run: stream = 0 run = 1 time = 0
+++++ starting: end run: stream = 0 run = 1 time = 0
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end run for module: stream = 0 label = 'get'
+++++++ finished: end run for module: stream = 0 label = 'get'
+++++++ starting: end run for module: stream = 0 label = 'putInt'
+++++++ finished: end run for module: stream = 0 label = 'putInt'
+++++++ starting: end run for module: stream = 0 label = 'putInt2'
+++++++ finished: end run for module: stream = 0 label = 'putInt2'
+++++++ starting: end run for module: stream = 0 label = 'putInt3'
+++++++ finished: end run for module: stream = 0 label = 'putInt3'
+++++++ starting: end run for module: stream = 0 label = 'getInt'
+++++++ finished: end run for module: stream = 0 label = 'getInt'
+++++++ starting: end run for module: stream = 0 label = 'noPut'
+++++++ finished: end run for module: stream = 0 label = 'noPut'
+++++ finished: end run: stream = 0 run = 1 time = 0
+++++ starting: end run: stream = 0 run = 1 time = 0
+++++ finished: end run: stream = 0 run = 1 time = 0
+++++ starting: end run: stream = 0 run = 1 time = 0
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end run for module: stream = 0 label = 'test'
+++++++ finished: end run for module: stream = 0 label = 'test'
+++++++ starting: end run for module: stream = 0 label = 'testmerge'
+++++++ finished: end run for module: stream = 0 label = 'testmerge'
+++++++ starting: end run for module: stream = 0 label = 'get'
+++++++ finished: end run for module: stream = 0 label = 'get'
+++++++ starting: end run for module: stream = 0 label = 'getInt'
+++++++ finished: end run for module: stream = 0 label = 'getInt'
+++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: end run for module: stream = 0 label = 'out'
+++++++ finished: end run for module: stream = 0 label = 'out'
+++++ finished: end run: stream = 0 run = 1 time = 0
+++++ starting: global end run 1 : time = 50000001
+++++ finished: global end run 1 : time = 50000001
+++++ starting: global end run 1 : time = 0
+++++ finished: global end run 1 : time = 0
+++++ starting: global end run 1 : time = 0
+++++++ starting: global end run for module: label = 'thingWithMergeProducer'
+++++++ finished: global end run for module: label = 'thingWithMergeProducer'
+++++++ starting: global end run for module: label = 'get'
+++++++ finished: global end run for module: label = 'get'
+++++++ starting: global end run for module: label = 'putInt'
+++++++ finished: global end run for module: label = 'putInt'
+++++++ starting: global end run for module: label = 'putInt2'
+++++++ finished: global end run for module: label = 'putInt2'
+++++++ starting: global end run for module: label = 'putInt3'
+++++++ finished: global end run for module: label = 'putInt3'
+++++++ starting: global end run for module: label = 'getInt'
+++++++ finished: global end run for module: label = 'getInt'
+++++++ starting: global end run for module: label = 'noPut'
+++++++ finished: global end run for module: label = 'noPut'
+++++++ starting: global end run for module: label = 'TriggerResults'
+++++++ finished: global end run for module: label = 'TriggerResults'
+++++ finished: global end run 1 : time = 0
+++++ starting: global end run 1 : time = 0
+++++ finished: global end run 1 : time = 0
+++++ starting: global end run 1 : time = 0
+++++++ starting: global end run for module: label = 'thingWithMergeProducer'
+++++++ finished: global end run for module: label = 'thingWithMergeProducer'
+++++++ starting: global end run for module: label = 'test'
+++++++ finished: global end run for module: label = 'test'
+++++++ starting: global end run for module: label = 'testmerge'
+++++++ finished: global end run for module: label = 'testmerge'
+++++++ starting: global end run for module: label = 'get'
+++++++ finished: global end run for module: label = 'get'
+++++++ starting: global end run for module: label = 'getInt'
+++++++ finished: global end run for module: label = 'getInt'
+++++++ starting: global end run for module: label = 'dependsOnNoPut'
+++++++ finished: global end run for module: label = 'dependsOnNoPut'
+++++++ starting: global end run for module: label = 'out'
+++++++ finished: global end run for module: label = 'out'
+++++++ starting: global end run for module: label = 'TriggerResults'
+++++++ finished: global end run for module: label = 'TriggerResults'
+++++ finished: global end run 1 : time = 0
+++++ starting: source run
 ++++ finished: source run
-++++ GlobalBeginRun run: 2 time: 55000001
-++++ GlobalBeginRun finished
-++++ GlobalBeginRun run: 2 time: 55000001
-++++ GlobalBeginRun finished
-++++ GlobalBeginRun run: 2 time: 55000001
-++++++ ModuleGlobalBeginRun: thingWithMergeProducer
-++++++ ModuleGlobalBeginRun finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginRun: get
-++++++ ModuleGlobalBeginRun finished: get
-++++++ ModuleGlobalBeginRun: putInt
-++++++ ModuleGlobalBeginRun finished: putInt
-++++++ ModuleGlobalBeginRun: putInt2
-++++++ ModuleGlobalBeginRun finished: putInt2
-++++++ ModuleGlobalBeginRun: putInt3
-++++++ ModuleGlobalBeginRun finished: putInt3
-++++++ ModuleGlobalBeginRun: getInt
-++++++ ModuleGlobalBeginRun finished: getInt
-++++++ ModuleGlobalBeginRun: noPut
-++++++ ModuleGlobalBeginRun finished: noPut
-++++++ ModuleGlobalBeginRun: TriggerResults
-++++++ ModuleGlobalBeginRun finished: TriggerResults
-++++ GlobalBeginRun finished
-++++ GlobalBeginRun run: 2 time: 55000001
-++++ GlobalBeginRun finished
-++++ GlobalBeginRun run: 2 time: 55000001
-++++++ ModuleGlobalBeginRun: thingWithMergeProducer
-++++++ ModuleGlobalBeginRun finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginRun: test
-++++++ ModuleGlobalBeginRun finished: test
-++++++ ModuleGlobalBeginRun: testmerge
-++++++ ModuleGlobalBeginRun finished: testmerge
-++++++ ModuleGlobalBeginRun: get
-++++++ ModuleGlobalBeginRun finished: get
-++++++ ModuleGlobalBeginRun: getInt
-++++++ ModuleGlobalBeginRun finished: getInt
-++++++ ModuleGlobalBeginRun: dependsOnNoPut
-++++++ ModuleGlobalBeginRun finished: dependsOnNoPut
-++++++ ModuleGlobalBeginRun: out
-++++++ ModuleGlobalBeginRun finished: out
-++++++ ModuleGlobalBeginRun: TriggerResults
-++++++ ModuleGlobalBeginRun finished: TriggerResults
-++++ GlobalBeginRun finished
-++++ StreamBeginRun run: 2 time: 55000001
-++++ StreamBeginRun finished
-++++ StreamBeginRun run: 2 time: 55000001
-++++ StreamBeginRun finished
-++++ StreamBeginRun run: 2 time: 55000001
-++++++ ModuleStreamBeginRun: thingWithMergeProducer
-++++++ ModuleStreamBeginRun finished: thingWithMergeProducer
-++++++ ModuleStreamBeginRun: get
-++++++ ModuleStreamBeginRun finished: get
-++++++ ModuleStreamBeginRun: putInt
-++++++ ModuleStreamBeginRun finished: putInt
-++++++ ModuleStreamBeginRun: putInt2
-++++++ ModuleStreamBeginRun finished: putInt2
-++++++ ModuleStreamBeginRun: putInt3
-++++++ ModuleStreamBeginRun finished: putInt3
-++++++ ModuleStreamBeginRun: getInt
-++++++ ModuleStreamBeginRun finished: getInt
-++++++ ModuleStreamBeginRun: noPut
-++++++ ModuleStreamBeginRun finished: noPut
-++++ StreamBeginRun finished
-++++ StreamBeginRun run: 2 time: 55000001
-++++ StreamBeginRun finished
-++++ StreamBeginRun run: 2 time: 55000001
-++++++ ModuleStreamBeginRun: thingWithMergeProducer
-++++++ ModuleStreamBeginRun finished: thingWithMergeProducer
-++++++ ModuleStreamBeginRun: test
-++++++ ModuleStreamBeginRun finished: test
-++++++ ModuleStreamBeginRun: testmerge
-++++++ ModuleStreamBeginRun finished: testmerge
-++++++ ModuleStreamBeginRun: get
-++++++ ModuleStreamBeginRun finished: get
-++++++ ModuleStreamBeginRun: getInt
-++++++ ModuleStreamBeginRun finished: getInt
-++++++ ModuleStreamBeginRun: dependsOnNoPut
-++++++ ModuleStreamBeginRun finished: dependsOnNoPut
-++++++ ModuleStreamBeginRun: out
-++++++ ModuleStreamBeginRun finished: out
-++++ StreamBeginRun finished
-++++ source lumi
+++++ starting: global begin run 2 : time = 55000001
+++++ finished: global begin run 2 : time = 55000001
+++++ starting: global begin run 2 : time = 55000001
+++++ finished: global begin run 2 : time = 55000001
+++++ starting: global begin run 2 : time = 55000001
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin run for module: label = 'get'
+++++++ finished: global begin run for module: label = 'get'
+++++++ starting: global begin run for module: label = 'putInt'
+++++++ finished: global begin run for module: label = 'putInt'
+++++++ starting: global begin run for module: label = 'putInt2'
+++++++ finished: global begin run for module: label = 'putInt2'
+++++++ starting: global begin run for module: label = 'putInt3'
+++++++ finished: global begin run for module: label = 'putInt3'
+++++++ starting: global begin run for module: label = 'getInt'
+++++++ finished: global begin run for module: label = 'getInt'
+++++++ starting: global begin run for module: label = 'noPut'
+++++++ finished: global begin run for module: label = 'noPut'
+++++++ starting: global begin run for module: label = 'TriggerResults'
+++++++ finished: global begin run for module: label = 'TriggerResults'
+++++ finished: global begin run 2 : time = 55000001
+++++ starting: global begin run 2 : time = 55000001
+++++ finished: global begin run 2 : time = 55000001
+++++ starting: global begin run 2 : time = 55000001
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin run for module: label = 'test'
+++++++ finished: global begin run for module: label = 'test'
+++++++ starting: global begin run for module: label = 'testmerge'
+++++++ finished: global begin run for module: label = 'testmerge'
+++++++ starting: global begin run for module: label = 'get'
+++++++ finished: global begin run for module: label = 'get'
+++++++ starting: global begin run for module: label = 'getInt'
+++++++ finished: global begin run for module: label = 'getInt'
+++++++ starting: global begin run for module: label = 'dependsOnNoPut'
+++++++ finished: global begin run for module: label = 'dependsOnNoPut'
+++++++ starting: global begin run for module: label = 'out'
+++++++ finished: global begin run for module: label = 'out'
+++++++ starting: global begin run for module: label = 'TriggerResults'
+++++++ finished: global begin run for module: label = 'TriggerResults'
+++++ finished: global begin run 2 : time = 55000001
+++++ starting: begin run: stream = 0 run = 2 time = 55000001
+++++ finished: begin run: stream = 0 run = 2 time = 55000001
+++++ starting: begin run: stream = 0 run = 2 time = 55000001
+++++ finished: begin run: stream = 0 run = 2 time = 55000001
+++++ starting: begin run: stream = 0 run = 2 time = 55000001
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin run for module: stream = 0 label = 'get'
+++++++ finished: begin run for module: stream = 0 label = 'get'
+++++++ starting: begin run for module: stream = 0 label = 'putInt'
+++++++ finished: begin run for module: stream = 0 label = 'putInt'
+++++++ starting: begin run for module: stream = 0 label = 'putInt2'
+++++++ finished: begin run for module: stream = 0 label = 'putInt2'
+++++++ starting: begin run for module: stream = 0 label = 'putInt3'
+++++++ finished: begin run for module: stream = 0 label = 'putInt3'
+++++++ starting: begin run for module: stream = 0 label = 'getInt'
+++++++ finished: begin run for module: stream = 0 label = 'getInt'
+++++++ starting: begin run for module: stream = 0 label = 'noPut'
+++++++ finished: begin run for module: stream = 0 label = 'noPut'
+++++ finished: begin run: stream = 0 run = 2 time = 55000001
+++++ starting: begin run: stream = 0 run = 2 time = 55000001
+++++ finished: begin run: stream = 0 run = 2 time = 55000001
+++++ starting: begin run: stream = 0 run = 2 time = 55000001
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin run for module: stream = 0 label = 'test'
+++++++ finished: begin run for module: stream = 0 label = 'test'
+++++++ starting: begin run for module: stream = 0 label = 'testmerge'
+++++++ finished: begin run for module: stream = 0 label = 'testmerge'
+++++++ starting: begin run for module: stream = 0 label = 'get'
+++++++ finished: begin run for module: stream = 0 label = 'get'
+++++++ starting: begin run for module: stream = 0 label = 'getInt'
+++++++ finished: begin run for module: stream = 0 label = 'getInt'
+++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: begin run for module: stream = 0 label = 'out'
+++++++ finished: begin run for module: stream = 0 label = 'out'
+++++ finished: begin run: stream = 0 run = 2 time = 55000001
+++++ starting: source lumi
 ++++ finished: source lumi
-++++ GlobalBeginLumi run: 2 lumi: 1 time: 55000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 2 lumi: 1 time: 55000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 2 lumi: 1 time: 55000001
-++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: putInt
-++++++ ModuleGlobalBeginLumi finished: putInt
-++++++ ModuleGlobalBeginLumi: putInt2
-++++++ ModuleGlobalBeginLumi finished: putInt2
-++++++ ModuleGlobalBeginLumi: putInt3
-++++++ ModuleGlobalBeginLumi finished: putInt3
-++++++ ModuleGlobalBeginLumi: getInt
-++++++ ModuleGlobalBeginLumi finished: getInt
-++++++ ModuleGlobalBeginLumi: noPut
-++++++ ModuleGlobalBeginLumi finished: noPut
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 2 lumi: 1 time: 55000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 2 lumi: 1 time: 55000001
-++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi: test
-++++++ ModuleGlobalBeginLumi finished: test
-++++++ ModuleGlobalBeginLumi: testmerge
-++++++ ModuleGlobalBeginLumi finished: testmerge
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: getInt
-++++++ ModuleGlobalBeginLumi finished: getInt
-++++++ ModuleGlobalBeginLumi: dependsOnNoPut
-++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
-++++++ ModuleGlobalBeginLumi: out
-++++++ ModuleGlobalBeginLumi finished: out
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ StreamBeginLumi run: 2 lumi: 1 time: 55000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 2 lumi: 1 time: 55000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 2 lumi: 1 time: 55000001
-++++++ ModuleStreamBeginLumi: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++++ ModuleStreamBeginLumi: putInt
-++++++ ModuleStreamBeginLumi finished: putInt
-++++++ ModuleStreamBeginLumi: putInt2
-++++++ ModuleStreamBeginLumi finished: putInt2
-++++++ ModuleStreamBeginLumi: putInt3
-++++++ ModuleStreamBeginLumi finished: putInt3
-++++++ ModuleStreamBeginLumi: getInt
-++++++ ModuleStreamBeginLumi finished: getInt
-++++++ ModuleStreamBeginLumi: noPut
-++++++ ModuleStreamBeginLumi finished: noPut
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 2 lumi: 1 time: 55000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 2 lumi: 1 time: 55000001
-++++++ ModuleStreamBeginLumi: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi: test
-++++++ ModuleStreamBeginLumi finished: test
-++++++ ModuleStreamBeginLumi: testmerge
-++++++ ModuleStreamBeginLumi finished: testmerge
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++++ ModuleStreamBeginLumi: getInt
-++++++ ModuleStreamBeginLumi finished: getInt
-++++++ ModuleStreamBeginLumi: dependsOnNoPut
-++++++ ModuleStreamBeginLumi finished: dependsOnNoPut
-++++++ ModuleStreamBeginLumi: out
-++++++ ModuleStreamBeginLumi finished: out
-++++ StreamBeginLumi finished
-++++ source event
+++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
+++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
+++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'putInt'
+++++++ finished: global begin lumi for module: label = 'putInt'
+++++++ starting: global begin lumi for module: label = 'putInt2'
+++++++ finished: global begin lumi for module: label = 'putInt2'
+++++++ starting: global begin lumi for module: label = 'putInt3'
+++++++ finished: global begin lumi for module: label = 'putInt3'
+++++++ starting: global begin lumi for module: label = 'getInt'
+++++++ finished: global begin lumi for module: label = 'getInt'
+++++++ starting: global begin lumi for module: label = 'noPut'
+++++++ finished: global begin lumi for module: label = 'noPut'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
+++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin lumi for module: label = 'test'
+++++++ finished: global begin lumi for module: label = 'test'
+++++++ starting: global begin lumi for module: label = 'testmerge'
+++++++ finished: global begin lumi for module: label = 'testmerge'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'getInt'
+++++++ finished: global begin lumi for module: label = 'getInt'
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut'
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut'
+++++++ starting: global begin lumi for module: label = 'out'
+++++++ finished: global begin lumi for module: label = 'out'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3'
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut'
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut'
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'test'
+++++++ finished: begin lumi for module: stream = 0 label = 'test'
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge'
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: begin lumi for module: stream = 0 label = 'out'
+++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 2 lumi: 1 event: 1 time:55000001
-++++ event finished
-++++ processing event run: 2 lumi: 1 event: 1 time:55000001
-++++ event finished
-++++ processing event run: 2 lumi: 1 event: 1 time:55000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 2 lumi: 1 event: 1 time:55000001
-++++ event finished
-++++ processing event run: 2 lumi: 1 event: 1 time:55000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 2 lumi: 1 event: 2 time:60000001
-++++ event finished
-++++ processing event run: 2 lumi: 1 event: 2 time:60000001
-++++ event finished
-++++ processing event run: 2 lumi: 1 event: 2 time:60000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 2 lumi: 1 event: 2 time:60000001
-++++ event finished
-++++ processing event run: 2 lumi: 1 event: 2 time:60000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 2 lumi: 1 event: 3 time:65000001
-++++ event finished
-++++ processing event run: 2 lumi: 1 event: 3 time:65000001
-++++ event finished
-++++ processing event run: 2 lumi: 1 event: 3 time:65000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 2 lumi: 1 event: 3 time:65000001
-++++ event finished
-++++ processing event run: 2 lumi: 1 event: 3 time:65000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 2 lumi: 1 event: 4 time:70000001
-++++ event finished
-++++ processing event run: 2 lumi: 1 event: 4 time:70000001
-++++ event finished
-++++ processing event run: 2 lumi: 1 event: 4 time:70000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 2 lumi: 1 event: 4 time:70000001
-++++ event finished
-++++ processing event run: 2 lumi: 1 event: 4 time:70000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ StreamEndLumi run: 2 lumi: 1 time: 70000001
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 2 lumi: 1 time: 0
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 2 lumi: 1 time: 0
-++++++ ModuleStreamEndLumi: thingWithMergeProducer
-++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++++ ModuleStreamEndLumi: putInt
-++++++ ModuleStreamEndLumi finished: putInt
-++++++ ModuleStreamEndLumi: putInt2
-++++++ ModuleStreamEndLumi finished: putInt2
-++++++ ModuleStreamEndLumi: putInt3
-++++++ ModuleStreamEndLumi finished: putInt3
-++++++ ModuleStreamEndLumi: getInt
-++++++ ModuleStreamEndLumi finished: getInt
-++++++ ModuleStreamEndLumi: noPut
-++++++ ModuleStreamEndLumi finished: noPut
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 2 lumi: 1 time: 0
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 2 lumi: 1 time: 0
-++++++ ModuleStreamEndLumi: thingWithMergeProducer
-++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
-++++++ ModuleStreamEndLumi: test
-++++++ ModuleStreamEndLumi finished: test
-++++++ ModuleStreamEndLumi: testmerge
-++++++ ModuleStreamEndLumi finished: testmerge
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++++ ModuleStreamEndLumi: getInt
-++++++ ModuleStreamEndLumi finished: getInt
-++++++ ModuleStreamEndLumi: dependsOnNoPut
-++++++ ModuleStreamEndLumi finished: dependsOnNoPut
-++++++ ModuleStreamEndLumi: out
-++++++ ModuleStreamEndLumi finished: out
-++++ StreamEndLumi finished
-++++ GlobalEndLumi run: 2 lumi: 1 time: 55000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 2 lumi: 1 time: 55000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 2 lumi: 1 time: 55000001
-++++++ ModuleGlobalEndLumi: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: putInt
-++++++ ModuleGlobalEndLumi finished: putInt
-++++++ ModuleGlobalEndLumi: putInt2
-++++++ ModuleGlobalEndLumi finished: putInt2
-++++++ ModuleGlobalEndLumi: putInt3
-++++++ ModuleGlobalEndLumi finished: putInt3
-++++++ ModuleGlobalEndLumi: getInt
-++++++ ModuleGlobalEndLumi finished: getInt
-++++++ ModuleGlobalEndLumi: noPut
-++++++ ModuleGlobalEndLumi finished: noPut
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 2 lumi: 1 time: 55000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 2 lumi: 1 time: 55000001
-++++++ ModuleGlobalEndLumi: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi: test
-++++++ ModuleGlobalEndLumi finished: test
-++++++ ModuleGlobalEndLumi: testmerge
-++++++ ModuleGlobalEndLumi finished: testmerge
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: getInt
-++++++ ModuleGlobalEndLumi finished: getInt
-++++++ ModuleGlobalEndLumi: dependsOnNoPut
-++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
-++++++ ModuleGlobalEndLumi: out
-++++++ ModuleGlobalEndLumi finished: out
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ source lumi
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
+++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 70000001
+++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 70000001
+++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
+++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
+++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3'
+++++++ starting: end lumi for module: stream = 0 label = 'getInt'
+++++++ finished: end lumi for module: stream = 0 label = 'getInt'
+++++++ starting: end lumi for module: stream = 0 label = 'noPut'
+++++++ finished: end lumi for module: stream = 0 label = 'noPut'
+++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
+++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
+++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
+++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'test'
+++++++ finished: end lumi for module: stream = 0 label = 'test'
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge'
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'getInt'
+++++++ finished: end lumi for module: stream = 0 label = 'getInt'
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: end lumi for module: stream = 0 label = 'out'
+++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
+++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
+++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
+++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'putInt'
+++++++ finished: global end lumi for module: label = 'putInt'
+++++++ starting: global end lumi for module: label = 'putInt2'
+++++++ finished: global end lumi for module: label = 'putInt2'
+++++++ starting: global end lumi for module: label = 'putInt3'
+++++++ finished: global end lumi for module: label = 'putInt3'
+++++++ starting: global end lumi for module: label = 'getInt'
+++++++ finished: global end lumi for module: label = 'getInt'
+++++++ starting: global end lumi for module: label = 'noPut'
+++++++ finished: global end lumi for module: label = 'noPut'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
+++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global end lumi for module: label = 'test'
+++++++ finished: global end lumi for module: label = 'test'
+++++++ starting: global end lumi for module: label = 'testmerge'
+++++++ finished: global end lumi for module: label = 'testmerge'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'getInt'
+++++++ finished: global end lumi for module: label = 'getInt'
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut'
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut'
+++++++ starting: global end lumi for module: label = 'out'
+++++++ finished: global end lumi for module: label = 'out'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
+++++ starting: source lumi
 ++++ finished: source lumi
-++++ GlobalBeginLumi run: 2 lumi: 2 time: 75000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 2 lumi: 2 time: 75000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 2 lumi: 2 time: 75000001
-++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: putInt
-++++++ ModuleGlobalBeginLumi finished: putInt
-++++++ ModuleGlobalBeginLumi: putInt2
-++++++ ModuleGlobalBeginLumi finished: putInt2
-++++++ ModuleGlobalBeginLumi: putInt3
-++++++ ModuleGlobalBeginLumi finished: putInt3
-++++++ ModuleGlobalBeginLumi: getInt
-++++++ ModuleGlobalBeginLumi finished: getInt
-++++++ ModuleGlobalBeginLumi: noPut
-++++++ ModuleGlobalBeginLumi finished: noPut
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 2 lumi: 2 time: 75000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 2 lumi: 2 time: 75000001
-++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi: test
-++++++ ModuleGlobalBeginLumi finished: test
-++++++ ModuleGlobalBeginLumi: testmerge
-++++++ ModuleGlobalBeginLumi finished: testmerge
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: getInt
-++++++ ModuleGlobalBeginLumi finished: getInt
-++++++ ModuleGlobalBeginLumi: dependsOnNoPut
-++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
-++++++ ModuleGlobalBeginLumi: out
-++++++ ModuleGlobalBeginLumi finished: out
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ StreamBeginLumi run: 2 lumi: 2 time: 75000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 2 lumi: 2 time: 75000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 2 lumi: 2 time: 75000001
-++++++ ModuleStreamBeginLumi: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++++ ModuleStreamBeginLumi: putInt
-++++++ ModuleStreamBeginLumi finished: putInt
-++++++ ModuleStreamBeginLumi: putInt2
-++++++ ModuleStreamBeginLumi finished: putInt2
-++++++ ModuleStreamBeginLumi: putInt3
-++++++ ModuleStreamBeginLumi finished: putInt3
-++++++ ModuleStreamBeginLumi: getInt
-++++++ ModuleStreamBeginLumi finished: getInt
-++++++ ModuleStreamBeginLumi: noPut
-++++++ ModuleStreamBeginLumi finished: noPut
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 2 lumi: 2 time: 75000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 2 lumi: 2 time: 75000001
-++++++ ModuleStreamBeginLumi: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi: test
-++++++ ModuleStreamBeginLumi finished: test
-++++++ ModuleStreamBeginLumi: testmerge
-++++++ ModuleStreamBeginLumi finished: testmerge
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++++ ModuleStreamBeginLumi: getInt
-++++++ ModuleStreamBeginLumi finished: getInt
-++++++ ModuleStreamBeginLumi: dependsOnNoPut
-++++++ ModuleStreamBeginLumi finished: dependsOnNoPut
-++++++ ModuleStreamBeginLumi: out
-++++++ ModuleStreamBeginLumi finished: out
-++++ StreamBeginLumi finished
-++++ source event
+++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
+++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
+++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'putInt'
+++++++ finished: global begin lumi for module: label = 'putInt'
+++++++ starting: global begin lumi for module: label = 'putInt2'
+++++++ finished: global begin lumi for module: label = 'putInt2'
+++++++ starting: global begin lumi for module: label = 'putInt3'
+++++++ finished: global begin lumi for module: label = 'putInt3'
+++++++ starting: global begin lumi for module: label = 'getInt'
+++++++ finished: global begin lumi for module: label = 'getInt'
+++++++ starting: global begin lumi for module: label = 'noPut'
+++++++ finished: global begin lumi for module: label = 'noPut'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
+++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin lumi for module: label = 'test'
+++++++ finished: global begin lumi for module: label = 'test'
+++++++ starting: global begin lumi for module: label = 'testmerge'
+++++++ finished: global begin lumi for module: label = 'testmerge'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'getInt'
+++++++ finished: global begin lumi for module: label = 'getInt'
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut'
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut'
+++++++ starting: global begin lumi for module: label = 'out'
+++++++ finished: global begin lumi for module: label = 'out'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3'
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut'
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut'
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'test'
+++++++ finished: begin lumi for module: stream = 0 label = 'test'
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge'
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: begin lumi for module: stream = 0 label = 'out'
+++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 2 lumi: 2 event: 5 time:75000001
-++++ event finished
-++++ processing event run: 2 lumi: 2 event: 5 time:75000001
-++++ event finished
-++++ processing event run: 2 lumi: 2 event: 5 time:75000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 2 lumi: 2 event: 5 time:75000001
-++++ event finished
-++++ processing event run: 2 lumi: 2 event: 5 time:75000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 2 lumi: 2 event: 6 time:80000001
-++++ event finished
-++++ processing event run: 2 lumi: 2 event: 6 time:80000001
-++++ event finished
-++++ processing event run: 2 lumi: 2 event: 6 time:80000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 2 lumi: 2 event: 6 time:80000001
-++++ event finished
-++++ processing event run: 2 lumi: 2 event: 6 time:80000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 2 lumi: 2 event: 7 time:85000001
-++++ event finished
-++++ processing event run: 2 lumi: 2 event: 7 time:85000001
-++++ event finished
-++++ processing event run: 2 lumi: 2 event: 7 time:85000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 2 lumi: 2 event: 7 time:85000001
-++++ event finished
-++++ processing event run: 2 lumi: 2 event: 7 time:85000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 2 lumi: 2 event: 8 time:90000001
-++++ event finished
-++++ processing event run: 2 lumi: 2 event: 8 time:90000001
-++++ event finished
-++++ processing event run: 2 lumi: 2 event: 8 time:90000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 2 lumi: 2 event: 8 time:90000001
-++++ event finished
-++++ processing event run: 2 lumi: 2 event: 8 time:90000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ StreamEndLumi run: 2 lumi: 2 time: 90000001
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 2 lumi: 2 time: 0
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 2 lumi: 2 time: 0
-++++++ ModuleStreamEndLumi: thingWithMergeProducer
-++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++++ ModuleStreamEndLumi: putInt
-++++++ ModuleStreamEndLumi finished: putInt
-++++++ ModuleStreamEndLumi: putInt2
-++++++ ModuleStreamEndLumi finished: putInt2
-++++++ ModuleStreamEndLumi: putInt3
-++++++ ModuleStreamEndLumi finished: putInt3
-++++++ ModuleStreamEndLumi: getInt
-++++++ ModuleStreamEndLumi finished: getInt
-++++++ ModuleStreamEndLumi: noPut
-++++++ ModuleStreamEndLumi finished: noPut
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 2 lumi: 2 time: 0
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 2 lumi: 2 time: 0
-++++++ ModuleStreamEndLumi: thingWithMergeProducer
-++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
-++++++ ModuleStreamEndLumi: test
-++++++ ModuleStreamEndLumi finished: test
-++++++ ModuleStreamEndLumi: testmerge
-++++++ ModuleStreamEndLumi finished: testmerge
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++++ ModuleStreamEndLumi: getInt
-++++++ ModuleStreamEndLumi finished: getInt
-++++++ ModuleStreamEndLumi: dependsOnNoPut
-++++++ ModuleStreamEndLumi finished: dependsOnNoPut
-++++++ ModuleStreamEndLumi: out
-++++++ ModuleStreamEndLumi finished: out
-++++ StreamEndLumi finished
-++++ GlobalEndLumi run: 2 lumi: 2 time: 75000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 2 lumi: 2 time: 75000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 2 lumi: 2 time: 75000001
-++++++ ModuleGlobalEndLumi: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: putInt
-++++++ ModuleGlobalEndLumi finished: putInt
-++++++ ModuleGlobalEndLumi: putInt2
-++++++ ModuleGlobalEndLumi finished: putInt2
-++++++ ModuleGlobalEndLumi: putInt3
-++++++ ModuleGlobalEndLumi finished: putInt3
-++++++ ModuleGlobalEndLumi: getInt
-++++++ ModuleGlobalEndLumi finished: getInt
-++++++ ModuleGlobalEndLumi: noPut
-++++++ ModuleGlobalEndLumi finished: noPut
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 2 lumi: 2 time: 75000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 2 lumi: 2 time: 75000001
-++++++ ModuleGlobalEndLumi: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi: test
-++++++ ModuleGlobalEndLumi finished: test
-++++++ ModuleGlobalEndLumi: testmerge
-++++++ ModuleGlobalEndLumi finished: testmerge
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: getInt
-++++++ ModuleGlobalEndLumi finished: getInt
-++++++ ModuleGlobalEndLumi: dependsOnNoPut
-++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
-++++++ ModuleGlobalEndLumi: out
-++++++ ModuleGlobalEndLumi finished: out
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ source lumi
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
+++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 90000001
+++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 90000001
+++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
+++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
+++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3'
+++++++ starting: end lumi for module: stream = 0 label = 'getInt'
+++++++ finished: end lumi for module: stream = 0 label = 'getInt'
+++++++ starting: end lumi for module: stream = 0 label = 'noPut'
+++++++ finished: end lumi for module: stream = 0 label = 'noPut'
+++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
+++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
+++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
+++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'test'
+++++++ finished: end lumi for module: stream = 0 label = 'test'
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge'
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'getInt'
+++++++ finished: end lumi for module: stream = 0 label = 'getInt'
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: end lumi for module: stream = 0 label = 'out'
+++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
+++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
+++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
+++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'putInt'
+++++++ finished: global end lumi for module: label = 'putInt'
+++++++ starting: global end lumi for module: label = 'putInt2'
+++++++ finished: global end lumi for module: label = 'putInt2'
+++++++ starting: global end lumi for module: label = 'putInt3'
+++++++ finished: global end lumi for module: label = 'putInt3'
+++++++ starting: global end lumi for module: label = 'getInt'
+++++++ finished: global end lumi for module: label = 'getInt'
+++++++ starting: global end lumi for module: label = 'noPut'
+++++++ finished: global end lumi for module: label = 'noPut'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
+++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global end lumi for module: label = 'test'
+++++++ finished: global end lumi for module: label = 'test'
+++++++ starting: global end lumi for module: label = 'testmerge'
+++++++ finished: global end lumi for module: label = 'testmerge'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'getInt'
+++++++ finished: global end lumi for module: label = 'getInt'
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut'
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut'
+++++++ starting: global end lumi for module: label = 'out'
+++++++ finished: global end lumi for module: label = 'out'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
+++++ starting: source lumi
 ++++ finished: source lumi
-++++ GlobalBeginLumi run: 2 lumi: 3 time: 95000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 2 lumi: 3 time: 95000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 2 lumi: 3 time: 95000001
-++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: putInt
-++++++ ModuleGlobalBeginLumi finished: putInt
-++++++ ModuleGlobalBeginLumi: putInt2
-++++++ ModuleGlobalBeginLumi finished: putInt2
-++++++ ModuleGlobalBeginLumi: putInt3
-++++++ ModuleGlobalBeginLumi finished: putInt3
-++++++ ModuleGlobalBeginLumi: getInt
-++++++ ModuleGlobalBeginLumi finished: getInt
-++++++ ModuleGlobalBeginLumi: noPut
-++++++ ModuleGlobalBeginLumi finished: noPut
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 2 lumi: 3 time: 95000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 2 lumi: 3 time: 95000001
-++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi: test
-++++++ ModuleGlobalBeginLumi finished: test
-++++++ ModuleGlobalBeginLumi: testmerge
-++++++ ModuleGlobalBeginLumi finished: testmerge
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: getInt
-++++++ ModuleGlobalBeginLumi finished: getInt
-++++++ ModuleGlobalBeginLumi: dependsOnNoPut
-++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
-++++++ ModuleGlobalBeginLumi: out
-++++++ ModuleGlobalBeginLumi finished: out
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ StreamBeginLumi run: 2 lumi: 3 time: 95000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 2 lumi: 3 time: 95000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 2 lumi: 3 time: 95000001
-++++++ ModuleStreamBeginLumi: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++++ ModuleStreamBeginLumi: putInt
-++++++ ModuleStreamBeginLumi finished: putInt
-++++++ ModuleStreamBeginLumi: putInt2
-++++++ ModuleStreamBeginLumi finished: putInt2
-++++++ ModuleStreamBeginLumi: putInt3
-++++++ ModuleStreamBeginLumi finished: putInt3
-++++++ ModuleStreamBeginLumi: getInt
-++++++ ModuleStreamBeginLumi finished: getInt
-++++++ ModuleStreamBeginLumi: noPut
-++++++ ModuleStreamBeginLumi finished: noPut
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 2 lumi: 3 time: 95000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 2 lumi: 3 time: 95000001
-++++++ ModuleStreamBeginLumi: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi: test
-++++++ ModuleStreamBeginLumi finished: test
-++++++ ModuleStreamBeginLumi: testmerge
-++++++ ModuleStreamBeginLumi finished: testmerge
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++++ ModuleStreamBeginLumi: getInt
-++++++ ModuleStreamBeginLumi finished: getInt
-++++++ ModuleStreamBeginLumi: dependsOnNoPut
-++++++ ModuleStreamBeginLumi finished: dependsOnNoPut
-++++++ ModuleStreamBeginLumi: out
-++++++ ModuleStreamBeginLumi finished: out
-++++ StreamBeginLumi finished
-++++ source event
+++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
+++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
+++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'putInt'
+++++++ finished: global begin lumi for module: label = 'putInt'
+++++++ starting: global begin lumi for module: label = 'putInt2'
+++++++ finished: global begin lumi for module: label = 'putInt2'
+++++++ starting: global begin lumi for module: label = 'putInt3'
+++++++ finished: global begin lumi for module: label = 'putInt3'
+++++++ starting: global begin lumi for module: label = 'getInt'
+++++++ finished: global begin lumi for module: label = 'getInt'
+++++++ starting: global begin lumi for module: label = 'noPut'
+++++++ finished: global begin lumi for module: label = 'noPut'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
+++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin lumi for module: label = 'test'
+++++++ finished: global begin lumi for module: label = 'test'
+++++++ starting: global begin lumi for module: label = 'testmerge'
+++++++ finished: global begin lumi for module: label = 'testmerge'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'getInt'
+++++++ finished: global begin lumi for module: label = 'getInt'
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut'
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut'
+++++++ starting: global begin lumi for module: label = 'out'
+++++++ finished: global begin lumi for module: label = 'out'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3'
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut'
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut'
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
+++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'test'
+++++++ finished: begin lumi for module: stream = 0 label = 'test'
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge'
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: begin lumi for module: stream = 0 label = 'out'
+++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 2 lumi: 3 event: 9 time:95000001
-++++ event finished
-++++ processing event run: 2 lumi: 3 event: 9 time:95000001
-++++ event finished
-++++ processing event run: 2 lumi: 3 event: 9 time:95000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 2 lumi: 3 event: 9 time:95000001
-++++ event finished
-++++ processing event run: 2 lumi: 3 event: 9 time:95000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 2 lumi: 3 event: 10 time:100000001
-++++ event finished
-++++ processing event run: 2 lumi: 3 event: 10 time:100000001
-++++ event finished
-++++ processing event run: 2 lumi: 3 event: 10 time:100000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 2 lumi: 3 event: 10 time:100000001
-++++ event finished
-++++ processing event run: 2 lumi: 3 event: 10 time:100000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ StreamEndLumi run: 2 lumi: 3 time: 100000001
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 2 lumi: 3 time: 0
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 2 lumi: 3 time: 0
-++++++ ModuleStreamEndLumi: thingWithMergeProducer
-++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++++ ModuleStreamEndLumi: putInt
-++++++ ModuleStreamEndLumi finished: putInt
-++++++ ModuleStreamEndLumi: putInt2
-++++++ ModuleStreamEndLumi finished: putInt2
-++++++ ModuleStreamEndLumi: putInt3
-++++++ ModuleStreamEndLumi finished: putInt3
-++++++ ModuleStreamEndLumi: getInt
-++++++ ModuleStreamEndLumi finished: getInt
-++++++ ModuleStreamEndLumi: noPut
-++++++ ModuleStreamEndLumi finished: noPut
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 2 lumi: 3 time: 0
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 2 lumi: 3 time: 0
-++++++ ModuleStreamEndLumi: thingWithMergeProducer
-++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
-++++++ ModuleStreamEndLumi: test
-++++++ ModuleStreamEndLumi finished: test
-++++++ ModuleStreamEndLumi: testmerge
-++++++ ModuleStreamEndLumi finished: testmerge
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++++ ModuleStreamEndLumi: getInt
-++++++ ModuleStreamEndLumi finished: getInt
-++++++ ModuleStreamEndLumi: dependsOnNoPut
-++++++ ModuleStreamEndLumi finished: dependsOnNoPut
-++++++ ModuleStreamEndLumi: out
-++++++ ModuleStreamEndLumi finished: out
-++++ StreamEndLumi finished
-++++ GlobalEndLumi run: 2 lumi: 3 time: 95000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 2 lumi: 3 time: 95000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 2 lumi: 3 time: 95000001
-++++++ ModuleGlobalEndLumi: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: putInt
-++++++ ModuleGlobalEndLumi finished: putInt
-++++++ ModuleGlobalEndLumi: putInt2
-++++++ ModuleGlobalEndLumi finished: putInt2
-++++++ ModuleGlobalEndLumi: putInt3
-++++++ ModuleGlobalEndLumi finished: putInt3
-++++++ ModuleGlobalEndLumi: getInt
-++++++ ModuleGlobalEndLumi finished: getInt
-++++++ ModuleGlobalEndLumi: noPut
-++++++ ModuleGlobalEndLumi finished: noPut
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 2 lumi: 3 time: 95000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 2 lumi: 3 time: 95000001
-++++++ ModuleGlobalEndLumi: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi: test
-++++++ ModuleGlobalEndLumi finished: test
-++++++ ModuleGlobalEndLumi: testmerge
-++++++ ModuleGlobalEndLumi finished: testmerge
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: getInt
-++++++ ModuleGlobalEndLumi finished: getInt
-++++++ ModuleGlobalEndLumi: dependsOnNoPut
-++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
-++++++ ModuleGlobalEndLumi: out
-++++++ ModuleGlobalEndLumi finished: out
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ StreamEndRun run: 2 time: 100000001
-++++ StreamEndRun finished
-++++ StreamEndRun run: 2 time: 0
-++++ StreamEndRun finished
-++++ StreamEndRun run: 2 time: 0
-++++++ ModuleStreamEndRun: thingWithMergeProducer
-++++++ ModuleStreamEndRun finished: thingWithMergeProducer
-++++++ ModuleStreamEndRun: get
-++++++ ModuleStreamEndRun finished: get
-++++++ ModuleStreamEndRun: putInt
-++++++ ModuleStreamEndRun finished: putInt
-++++++ ModuleStreamEndRun: putInt2
-++++++ ModuleStreamEndRun finished: putInt2
-++++++ ModuleStreamEndRun: putInt3
-++++++ ModuleStreamEndRun finished: putInt3
-++++++ ModuleStreamEndRun: getInt
-++++++ ModuleStreamEndRun finished: getInt
-++++++ ModuleStreamEndRun: noPut
-++++++ ModuleStreamEndRun finished: noPut
-++++ StreamEndRun finished
-++++ StreamEndRun run: 2 time: 0
-++++ StreamEndRun finished
-++++ StreamEndRun run: 2 time: 0
-++++++ ModuleStreamEndRun: thingWithMergeProducer
-++++++ ModuleStreamEndRun finished: thingWithMergeProducer
-++++++ ModuleStreamEndRun: test
-++++++ ModuleStreamEndRun finished: test
-++++++ ModuleStreamEndRun: testmerge
-++++++ ModuleStreamEndRun finished: testmerge
-++++++ ModuleStreamEndRun: get
-++++++ ModuleStreamEndRun finished: get
-++++++ ModuleStreamEndRun: getInt
-++++++ ModuleStreamEndRun finished: getInt
-++++++ ModuleStreamEndRun: dependsOnNoPut
-++++++ ModuleStreamEndRun finished: dependsOnNoPut
-++++++ ModuleStreamEndRun: out
-++++++ ModuleStreamEndRun finished: out
-++++ StreamEndRun finished
-++++ GlobalEndRun run: 2 time: 100000001
-++++ GlobalEndRun finished
-++++ GlobalEndRun run: 2 time: 0
-++++ GlobalEndRun finished
-++++ GlobalEndRun run: 2 time: 0
-++++++ ModuleGlobalEndRun: thingWithMergeProducer
-++++++ ModuleGlobalEndRun finished: thingWithMergeProducer
-++++++ ModuleGlobalEndRun: get
-++++++ ModuleGlobalEndRun finished: get
-++++++ ModuleGlobalEndRun: putInt
-++++++ ModuleGlobalEndRun finished: putInt
-++++++ ModuleGlobalEndRun: putInt2
-++++++ ModuleGlobalEndRun finished: putInt2
-++++++ ModuleGlobalEndRun: putInt3
-++++++ ModuleGlobalEndRun finished: putInt3
-++++++ ModuleGlobalEndRun: getInt
-++++++ ModuleGlobalEndRun finished: getInt
-++++++ ModuleGlobalEndRun: noPut
-++++++ ModuleGlobalEndRun finished: noPut
-++++++ ModuleGlobalEndRun: TriggerResults
-++++++ ModuleGlobalEndRun finished: TriggerResults
-++++ GlobalEndRun finished
-++++ GlobalEndRun run: 2 time: 0
-++++ GlobalEndRun finished
-++++ GlobalEndRun run: 2 time: 0
-++++++ ModuleGlobalEndRun: thingWithMergeProducer
-++++++ ModuleGlobalEndRun finished: thingWithMergeProducer
-++++++ ModuleGlobalEndRun: test
-++++++ ModuleGlobalEndRun finished: test
-++++++ ModuleGlobalEndRun: testmerge
-++++++ ModuleGlobalEndRun finished: testmerge
-++++++ ModuleGlobalEndRun: get
-++++++ ModuleGlobalEndRun finished: get
-++++++ ModuleGlobalEndRun: getInt
-++++++ ModuleGlobalEndRun finished: getInt
-++++++ ModuleGlobalEndRun: dependsOnNoPut
-++++++ ModuleGlobalEndRun finished: dependsOnNoPut
-++++++ ModuleGlobalEndRun: out
-++++++ ModuleGlobalEndRun finished: out
-++++++ ModuleGlobalEndRun: TriggerResults
-++++++ ModuleGlobalEndRun finished: TriggerResults
-++++ GlobalEndRun finished
-++++ source run
+++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
+++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 100000001
+++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 100000001
+++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
+++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
+++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3'
+++++++ starting: end lumi for module: stream = 0 label = 'getInt'
+++++++ finished: end lumi for module: stream = 0 label = 'getInt'
+++++++ starting: end lumi for module: stream = 0 label = 'noPut'
+++++++ finished: end lumi for module: stream = 0 label = 'noPut'
+++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
+++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
+++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
+++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'test'
+++++++ finished: end lumi for module: stream = 0 label = 'test'
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge'
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'getInt'
+++++++ finished: end lumi for module: stream = 0 label = 'getInt'
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: end lumi for module: stream = 0 label = 'out'
+++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
+++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
+++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
+++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'putInt'
+++++++ finished: global end lumi for module: label = 'putInt'
+++++++ starting: global end lumi for module: label = 'putInt2'
+++++++ finished: global end lumi for module: label = 'putInt2'
+++++++ starting: global end lumi for module: label = 'putInt3'
+++++++ finished: global end lumi for module: label = 'putInt3'
+++++++ starting: global end lumi for module: label = 'getInt'
+++++++ finished: global end lumi for module: label = 'getInt'
+++++++ starting: global end lumi for module: label = 'noPut'
+++++++ finished: global end lumi for module: label = 'noPut'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
+++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global end lumi for module: label = 'test'
+++++++ finished: global end lumi for module: label = 'test'
+++++++ starting: global end lumi for module: label = 'testmerge'
+++++++ finished: global end lumi for module: label = 'testmerge'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'getInt'
+++++++ finished: global end lumi for module: label = 'getInt'
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut'
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut'
+++++++ starting: global end lumi for module: label = 'out'
+++++++ finished: global end lumi for module: label = 'out'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
+++++ starting: end run: stream = 0 run = 2 time = 100000001
+++++ finished: end run: stream = 0 run = 2 time = 100000001
+++++ starting: end run: stream = 0 run = 2 time = 0
+++++ finished: end run: stream = 0 run = 2 time = 0
+++++ starting: end run: stream = 0 run = 2 time = 0
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end run for module: stream = 0 label = 'get'
+++++++ finished: end run for module: stream = 0 label = 'get'
+++++++ starting: end run for module: stream = 0 label = 'putInt'
+++++++ finished: end run for module: stream = 0 label = 'putInt'
+++++++ starting: end run for module: stream = 0 label = 'putInt2'
+++++++ finished: end run for module: stream = 0 label = 'putInt2'
+++++++ starting: end run for module: stream = 0 label = 'putInt3'
+++++++ finished: end run for module: stream = 0 label = 'putInt3'
+++++++ starting: end run for module: stream = 0 label = 'getInt'
+++++++ finished: end run for module: stream = 0 label = 'getInt'
+++++++ starting: end run for module: stream = 0 label = 'noPut'
+++++++ finished: end run for module: stream = 0 label = 'noPut'
+++++ finished: end run: stream = 0 run = 2 time = 0
+++++ starting: end run: stream = 0 run = 2 time = 0
+++++ finished: end run: stream = 0 run = 2 time = 0
+++++ starting: end run: stream = 0 run = 2 time = 0
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end run for module: stream = 0 label = 'test'
+++++++ finished: end run for module: stream = 0 label = 'test'
+++++++ starting: end run for module: stream = 0 label = 'testmerge'
+++++++ finished: end run for module: stream = 0 label = 'testmerge'
+++++++ starting: end run for module: stream = 0 label = 'get'
+++++++ finished: end run for module: stream = 0 label = 'get'
+++++++ starting: end run for module: stream = 0 label = 'getInt'
+++++++ finished: end run for module: stream = 0 label = 'getInt'
+++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: end run for module: stream = 0 label = 'out'
+++++++ finished: end run for module: stream = 0 label = 'out'
+++++ finished: end run: stream = 0 run = 2 time = 0
+++++ starting: global end run 2 : time = 100000001
+++++ finished: global end run 2 : time = 100000001
+++++ starting: global end run 2 : time = 0
+++++ finished: global end run 2 : time = 0
+++++ starting: global end run 2 : time = 0
+++++++ starting: global end run for module: label = 'thingWithMergeProducer'
+++++++ finished: global end run for module: label = 'thingWithMergeProducer'
+++++++ starting: global end run for module: label = 'get'
+++++++ finished: global end run for module: label = 'get'
+++++++ starting: global end run for module: label = 'putInt'
+++++++ finished: global end run for module: label = 'putInt'
+++++++ starting: global end run for module: label = 'putInt2'
+++++++ finished: global end run for module: label = 'putInt2'
+++++++ starting: global end run for module: label = 'putInt3'
+++++++ finished: global end run for module: label = 'putInt3'
+++++++ starting: global end run for module: label = 'getInt'
+++++++ finished: global end run for module: label = 'getInt'
+++++++ starting: global end run for module: label = 'noPut'
+++++++ finished: global end run for module: label = 'noPut'
+++++++ starting: global end run for module: label = 'TriggerResults'
+++++++ finished: global end run for module: label = 'TriggerResults'
+++++ finished: global end run 2 : time = 0
+++++ starting: global end run 2 : time = 0
+++++ finished: global end run 2 : time = 0
+++++ starting: global end run 2 : time = 0
+++++++ starting: global end run for module: label = 'thingWithMergeProducer'
+++++++ finished: global end run for module: label = 'thingWithMergeProducer'
+++++++ starting: global end run for module: label = 'test'
+++++++ finished: global end run for module: label = 'test'
+++++++ starting: global end run for module: label = 'testmerge'
+++++++ finished: global end run for module: label = 'testmerge'
+++++++ starting: global end run for module: label = 'get'
+++++++ finished: global end run for module: label = 'get'
+++++++ starting: global end run for module: label = 'getInt'
+++++++ finished: global end run for module: label = 'getInt'
+++++++ starting: global end run for module: label = 'dependsOnNoPut'
+++++++ finished: global end run for module: label = 'dependsOnNoPut'
+++++++ starting: global end run for module: label = 'out'
+++++++ finished: global end run for module: label = 'out'
+++++++ starting: global end run for module: label = 'TriggerResults'
+++++++ finished: global end run for module: label = 'TriggerResults'
+++++ finished: global end run 2 : time = 0
+++++ starting: source run
 ++++ finished: source run
-++++ GlobalBeginRun run: 3 time: 105000001
-++++ GlobalBeginRun finished
-++++ GlobalBeginRun run: 3 time: 105000001
-++++ GlobalBeginRun finished
-++++ GlobalBeginRun run: 3 time: 105000001
-++++++ ModuleGlobalBeginRun: thingWithMergeProducer
-++++++ ModuleGlobalBeginRun finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginRun: get
-++++++ ModuleGlobalBeginRun finished: get
-++++++ ModuleGlobalBeginRun: putInt
-++++++ ModuleGlobalBeginRun finished: putInt
-++++++ ModuleGlobalBeginRun: putInt2
-++++++ ModuleGlobalBeginRun finished: putInt2
-++++++ ModuleGlobalBeginRun: putInt3
-++++++ ModuleGlobalBeginRun finished: putInt3
-++++++ ModuleGlobalBeginRun: getInt
-++++++ ModuleGlobalBeginRun finished: getInt
-++++++ ModuleGlobalBeginRun: noPut
-++++++ ModuleGlobalBeginRun finished: noPut
-++++++ ModuleGlobalBeginRun: TriggerResults
-++++++ ModuleGlobalBeginRun finished: TriggerResults
-++++ GlobalBeginRun finished
-++++ GlobalBeginRun run: 3 time: 105000001
-++++ GlobalBeginRun finished
-++++ GlobalBeginRun run: 3 time: 105000001
-++++++ ModuleGlobalBeginRun: thingWithMergeProducer
-++++++ ModuleGlobalBeginRun finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginRun: test
-++++++ ModuleGlobalBeginRun finished: test
-++++++ ModuleGlobalBeginRun: testmerge
-++++++ ModuleGlobalBeginRun finished: testmerge
-++++++ ModuleGlobalBeginRun: get
-++++++ ModuleGlobalBeginRun finished: get
-++++++ ModuleGlobalBeginRun: getInt
-++++++ ModuleGlobalBeginRun finished: getInt
-++++++ ModuleGlobalBeginRun: dependsOnNoPut
-++++++ ModuleGlobalBeginRun finished: dependsOnNoPut
-++++++ ModuleGlobalBeginRun: out
-++++++ ModuleGlobalBeginRun finished: out
-++++++ ModuleGlobalBeginRun: TriggerResults
-++++++ ModuleGlobalBeginRun finished: TriggerResults
-++++ GlobalBeginRun finished
-++++ StreamBeginRun run: 3 time: 105000001
-++++ StreamBeginRun finished
-++++ StreamBeginRun run: 3 time: 105000001
-++++ StreamBeginRun finished
-++++ StreamBeginRun run: 3 time: 105000001
-++++++ ModuleStreamBeginRun: thingWithMergeProducer
-++++++ ModuleStreamBeginRun finished: thingWithMergeProducer
-++++++ ModuleStreamBeginRun: get
-++++++ ModuleStreamBeginRun finished: get
-++++++ ModuleStreamBeginRun: putInt
-++++++ ModuleStreamBeginRun finished: putInt
-++++++ ModuleStreamBeginRun: putInt2
-++++++ ModuleStreamBeginRun finished: putInt2
-++++++ ModuleStreamBeginRun: putInt3
-++++++ ModuleStreamBeginRun finished: putInt3
-++++++ ModuleStreamBeginRun: getInt
-++++++ ModuleStreamBeginRun finished: getInt
-++++++ ModuleStreamBeginRun: noPut
-++++++ ModuleStreamBeginRun finished: noPut
-++++ StreamBeginRun finished
-++++ StreamBeginRun run: 3 time: 105000001
-++++ StreamBeginRun finished
-++++ StreamBeginRun run: 3 time: 105000001
-++++++ ModuleStreamBeginRun: thingWithMergeProducer
-++++++ ModuleStreamBeginRun finished: thingWithMergeProducer
-++++++ ModuleStreamBeginRun: test
-++++++ ModuleStreamBeginRun finished: test
-++++++ ModuleStreamBeginRun: testmerge
-++++++ ModuleStreamBeginRun finished: testmerge
-++++++ ModuleStreamBeginRun: get
-++++++ ModuleStreamBeginRun finished: get
-++++++ ModuleStreamBeginRun: getInt
-++++++ ModuleStreamBeginRun finished: getInt
-++++++ ModuleStreamBeginRun: dependsOnNoPut
-++++++ ModuleStreamBeginRun finished: dependsOnNoPut
-++++++ ModuleStreamBeginRun: out
-++++++ ModuleStreamBeginRun finished: out
-++++ StreamBeginRun finished
-++++ source lumi
+++++ starting: global begin run 3 : time = 105000001
+++++ finished: global begin run 3 : time = 105000001
+++++ starting: global begin run 3 : time = 105000001
+++++ finished: global begin run 3 : time = 105000001
+++++ starting: global begin run 3 : time = 105000001
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin run for module: label = 'get'
+++++++ finished: global begin run for module: label = 'get'
+++++++ starting: global begin run for module: label = 'putInt'
+++++++ finished: global begin run for module: label = 'putInt'
+++++++ starting: global begin run for module: label = 'putInt2'
+++++++ finished: global begin run for module: label = 'putInt2'
+++++++ starting: global begin run for module: label = 'putInt3'
+++++++ finished: global begin run for module: label = 'putInt3'
+++++++ starting: global begin run for module: label = 'getInt'
+++++++ finished: global begin run for module: label = 'getInt'
+++++++ starting: global begin run for module: label = 'noPut'
+++++++ finished: global begin run for module: label = 'noPut'
+++++++ starting: global begin run for module: label = 'TriggerResults'
+++++++ finished: global begin run for module: label = 'TriggerResults'
+++++ finished: global begin run 3 : time = 105000001
+++++ starting: global begin run 3 : time = 105000001
+++++ finished: global begin run 3 : time = 105000001
+++++ starting: global begin run 3 : time = 105000001
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin run for module: label = 'test'
+++++++ finished: global begin run for module: label = 'test'
+++++++ starting: global begin run for module: label = 'testmerge'
+++++++ finished: global begin run for module: label = 'testmerge'
+++++++ starting: global begin run for module: label = 'get'
+++++++ finished: global begin run for module: label = 'get'
+++++++ starting: global begin run for module: label = 'getInt'
+++++++ finished: global begin run for module: label = 'getInt'
+++++++ starting: global begin run for module: label = 'dependsOnNoPut'
+++++++ finished: global begin run for module: label = 'dependsOnNoPut'
+++++++ starting: global begin run for module: label = 'out'
+++++++ finished: global begin run for module: label = 'out'
+++++++ starting: global begin run for module: label = 'TriggerResults'
+++++++ finished: global begin run for module: label = 'TriggerResults'
+++++ finished: global begin run 3 : time = 105000001
+++++ starting: begin run: stream = 0 run = 3 time = 105000001
+++++ finished: begin run: stream = 0 run = 3 time = 105000001
+++++ starting: begin run: stream = 0 run = 3 time = 105000001
+++++ finished: begin run: stream = 0 run = 3 time = 105000001
+++++ starting: begin run: stream = 0 run = 3 time = 105000001
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin run for module: stream = 0 label = 'get'
+++++++ finished: begin run for module: stream = 0 label = 'get'
+++++++ starting: begin run for module: stream = 0 label = 'putInt'
+++++++ finished: begin run for module: stream = 0 label = 'putInt'
+++++++ starting: begin run for module: stream = 0 label = 'putInt2'
+++++++ finished: begin run for module: stream = 0 label = 'putInt2'
+++++++ starting: begin run for module: stream = 0 label = 'putInt3'
+++++++ finished: begin run for module: stream = 0 label = 'putInt3'
+++++++ starting: begin run for module: stream = 0 label = 'getInt'
+++++++ finished: begin run for module: stream = 0 label = 'getInt'
+++++++ starting: begin run for module: stream = 0 label = 'noPut'
+++++++ finished: begin run for module: stream = 0 label = 'noPut'
+++++ finished: begin run: stream = 0 run = 3 time = 105000001
+++++ starting: begin run: stream = 0 run = 3 time = 105000001
+++++ finished: begin run: stream = 0 run = 3 time = 105000001
+++++ starting: begin run: stream = 0 run = 3 time = 105000001
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin run for module: stream = 0 label = 'test'
+++++++ finished: begin run for module: stream = 0 label = 'test'
+++++++ starting: begin run for module: stream = 0 label = 'testmerge'
+++++++ finished: begin run for module: stream = 0 label = 'testmerge'
+++++++ starting: begin run for module: stream = 0 label = 'get'
+++++++ finished: begin run for module: stream = 0 label = 'get'
+++++++ starting: begin run for module: stream = 0 label = 'getInt'
+++++++ finished: begin run for module: stream = 0 label = 'getInt'
+++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: begin run for module: stream = 0 label = 'out'
+++++++ finished: begin run for module: stream = 0 label = 'out'
+++++ finished: begin run: stream = 0 run = 3 time = 105000001
+++++ starting: source lumi
 ++++ finished: source lumi
-++++ GlobalBeginLumi run: 3 lumi: 1 time: 105000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 3 lumi: 1 time: 105000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 3 lumi: 1 time: 105000001
-++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: putInt
-++++++ ModuleGlobalBeginLumi finished: putInt
-++++++ ModuleGlobalBeginLumi: putInt2
-++++++ ModuleGlobalBeginLumi finished: putInt2
-++++++ ModuleGlobalBeginLumi: putInt3
-++++++ ModuleGlobalBeginLumi finished: putInt3
-++++++ ModuleGlobalBeginLumi: getInt
-++++++ ModuleGlobalBeginLumi finished: getInt
-++++++ ModuleGlobalBeginLumi: noPut
-++++++ ModuleGlobalBeginLumi finished: noPut
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 3 lumi: 1 time: 105000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 3 lumi: 1 time: 105000001
-++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi: test
-++++++ ModuleGlobalBeginLumi finished: test
-++++++ ModuleGlobalBeginLumi: testmerge
-++++++ ModuleGlobalBeginLumi finished: testmerge
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: getInt
-++++++ ModuleGlobalBeginLumi finished: getInt
-++++++ ModuleGlobalBeginLumi: dependsOnNoPut
-++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
-++++++ ModuleGlobalBeginLumi: out
-++++++ ModuleGlobalBeginLumi finished: out
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ StreamBeginLumi run: 3 lumi: 1 time: 105000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 3 lumi: 1 time: 105000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 3 lumi: 1 time: 105000001
-++++++ ModuleStreamBeginLumi: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++++ ModuleStreamBeginLumi: putInt
-++++++ ModuleStreamBeginLumi finished: putInt
-++++++ ModuleStreamBeginLumi: putInt2
-++++++ ModuleStreamBeginLumi finished: putInt2
-++++++ ModuleStreamBeginLumi: putInt3
-++++++ ModuleStreamBeginLumi finished: putInt3
-++++++ ModuleStreamBeginLumi: getInt
-++++++ ModuleStreamBeginLumi finished: getInt
-++++++ ModuleStreamBeginLumi: noPut
-++++++ ModuleStreamBeginLumi finished: noPut
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 3 lumi: 1 time: 105000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 3 lumi: 1 time: 105000001
-++++++ ModuleStreamBeginLumi: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi: test
-++++++ ModuleStreamBeginLumi finished: test
-++++++ ModuleStreamBeginLumi: testmerge
-++++++ ModuleStreamBeginLumi finished: testmerge
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++++ ModuleStreamBeginLumi: getInt
-++++++ ModuleStreamBeginLumi finished: getInt
-++++++ ModuleStreamBeginLumi: dependsOnNoPut
-++++++ ModuleStreamBeginLumi finished: dependsOnNoPut
-++++++ ModuleStreamBeginLumi: out
-++++++ ModuleStreamBeginLumi finished: out
-++++ StreamBeginLumi finished
-++++ source event
+++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
+++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
+++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'putInt'
+++++++ finished: global begin lumi for module: label = 'putInt'
+++++++ starting: global begin lumi for module: label = 'putInt2'
+++++++ finished: global begin lumi for module: label = 'putInt2'
+++++++ starting: global begin lumi for module: label = 'putInt3'
+++++++ finished: global begin lumi for module: label = 'putInt3'
+++++++ starting: global begin lumi for module: label = 'getInt'
+++++++ finished: global begin lumi for module: label = 'getInt'
+++++++ starting: global begin lumi for module: label = 'noPut'
+++++++ finished: global begin lumi for module: label = 'noPut'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
+++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin lumi for module: label = 'test'
+++++++ finished: global begin lumi for module: label = 'test'
+++++++ starting: global begin lumi for module: label = 'testmerge'
+++++++ finished: global begin lumi for module: label = 'testmerge'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'getInt'
+++++++ finished: global begin lumi for module: label = 'getInt'
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut'
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut'
+++++++ starting: global begin lumi for module: label = 'out'
+++++++ finished: global begin lumi for module: label = 'out'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3'
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut'
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut'
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'test'
+++++++ finished: begin lumi for module: stream = 0 label = 'test'
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge'
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: begin lumi for module: stream = 0 label = 'out'
+++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 3 lumi: 1 event: 1 time:105000001
-++++ event finished
-++++ processing event run: 3 lumi: 1 event: 1 time:105000001
-++++ event finished
-++++ processing event run: 3 lumi: 1 event: 1 time:105000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 3 lumi: 1 event: 1 time:105000001
-++++ event finished
-++++ processing event run: 3 lumi: 1 event: 1 time:105000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 3 lumi: 1 event: 2 time:110000001
-++++ event finished
-++++ processing event run: 3 lumi: 1 event: 2 time:110000001
-++++ event finished
-++++ processing event run: 3 lumi: 1 event: 2 time:110000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 3 lumi: 1 event: 2 time:110000001
-++++ event finished
-++++ processing event run: 3 lumi: 1 event: 2 time:110000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 3 lumi: 1 event: 3 time:115000001
-++++ event finished
-++++ processing event run: 3 lumi: 1 event: 3 time:115000001
-++++ event finished
-++++ processing event run: 3 lumi: 1 event: 3 time:115000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 3 lumi: 1 event: 3 time:115000001
-++++ event finished
-++++ processing event run: 3 lumi: 1 event: 3 time:115000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 3 lumi: 1 event: 4 time:120000001
-++++ event finished
-++++ processing event run: 3 lumi: 1 event: 4 time:120000001
-++++ event finished
-++++ processing event run: 3 lumi: 1 event: 4 time:120000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 3 lumi: 1 event: 4 time:120000001
-++++ event finished
-++++ processing event run: 3 lumi: 1 event: 4 time:120000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ StreamEndLumi run: 3 lumi: 1 time: 120000001
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 3 lumi: 1 time: 0
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 3 lumi: 1 time: 0
-++++++ ModuleStreamEndLumi: thingWithMergeProducer
-++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++++ ModuleStreamEndLumi: putInt
-++++++ ModuleStreamEndLumi finished: putInt
-++++++ ModuleStreamEndLumi: putInt2
-++++++ ModuleStreamEndLumi finished: putInt2
-++++++ ModuleStreamEndLumi: putInt3
-++++++ ModuleStreamEndLumi finished: putInt3
-++++++ ModuleStreamEndLumi: getInt
-++++++ ModuleStreamEndLumi finished: getInt
-++++++ ModuleStreamEndLumi: noPut
-++++++ ModuleStreamEndLumi finished: noPut
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 3 lumi: 1 time: 0
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 3 lumi: 1 time: 0
-++++++ ModuleStreamEndLumi: thingWithMergeProducer
-++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
-++++++ ModuleStreamEndLumi: test
-++++++ ModuleStreamEndLumi finished: test
-++++++ ModuleStreamEndLumi: testmerge
-++++++ ModuleStreamEndLumi finished: testmerge
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++++ ModuleStreamEndLumi: getInt
-++++++ ModuleStreamEndLumi finished: getInt
-++++++ ModuleStreamEndLumi: dependsOnNoPut
-++++++ ModuleStreamEndLumi finished: dependsOnNoPut
-++++++ ModuleStreamEndLumi: out
-++++++ ModuleStreamEndLumi finished: out
-++++ StreamEndLumi finished
-++++ GlobalEndLumi run: 3 lumi: 1 time: 105000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 3 lumi: 1 time: 105000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 3 lumi: 1 time: 105000001
-++++++ ModuleGlobalEndLumi: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: putInt
-++++++ ModuleGlobalEndLumi finished: putInt
-++++++ ModuleGlobalEndLumi: putInt2
-++++++ ModuleGlobalEndLumi finished: putInt2
-++++++ ModuleGlobalEndLumi: putInt3
-++++++ ModuleGlobalEndLumi finished: putInt3
-++++++ ModuleGlobalEndLumi: getInt
-++++++ ModuleGlobalEndLumi finished: getInt
-++++++ ModuleGlobalEndLumi: noPut
-++++++ ModuleGlobalEndLumi finished: noPut
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 3 lumi: 1 time: 105000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 3 lumi: 1 time: 105000001
-++++++ ModuleGlobalEndLumi: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi: test
-++++++ ModuleGlobalEndLumi finished: test
-++++++ ModuleGlobalEndLumi: testmerge
-++++++ ModuleGlobalEndLumi finished: testmerge
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: getInt
-++++++ ModuleGlobalEndLumi finished: getInt
-++++++ ModuleGlobalEndLumi: dependsOnNoPut
-++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
-++++++ ModuleGlobalEndLumi: out
-++++++ ModuleGlobalEndLumi finished: out
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ source lumi
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
+++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 120000001
+++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 120000001
+++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
+++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
+++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3'
+++++++ starting: end lumi for module: stream = 0 label = 'getInt'
+++++++ finished: end lumi for module: stream = 0 label = 'getInt'
+++++++ starting: end lumi for module: stream = 0 label = 'noPut'
+++++++ finished: end lumi for module: stream = 0 label = 'noPut'
+++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
+++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
+++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
+++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'test'
+++++++ finished: end lumi for module: stream = 0 label = 'test'
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge'
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'getInt'
+++++++ finished: end lumi for module: stream = 0 label = 'getInt'
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: end lumi for module: stream = 0 label = 'out'
+++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
+++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
+++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
+++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'putInt'
+++++++ finished: global end lumi for module: label = 'putInt'
+++++++ starting: global end lumi for module: label = 'putInt2'
+++++++ finished: global end lumi for module: label = 'putInt2'
+++++++ starting: global end lumi for module: label = 'putInt3'
+++++++ finished: global end lumi for module: label = 'putInt3'
+++++++ starting: global end lumi for module: label = 'getInt'
+++++++ finished: global end lumi for module: label = 'getInt'
+++++++ starting: global end lumi for module: label = 'noPut'
+++++++ finished: global end lumi for module: label = 'noPut'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
+++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global end lumi for module: label = 'test'
+++++++ finished: global end lumi for module: label = 'test'
+++++++ starting: global end lumi for module: label = 'testmerge'
+++++++ finished: global end lumi for module: label = 'testmerge'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'getInt'
+++++++ finished: global end lumi for module: label = 'getInt'
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut'
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut'
+++++++ starting: global end lumi for module: label = 'out'
+++++++ finished: global end lumi for module: label = 'out'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
+++++ starting: source lumi
 ++++ finished: source lumi
-++++ GlobalBeginLumi run: 3 lumi: 2 time: 125000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 3 lumi: 2 time: 125000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 3 lumi: 2 time: 125000001
-++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: putInt
-++++++ ModuleGlobalBeginLumi finished: putInt
-++++++ ModuleGlobalBeginLumi: putInt2
-++++++ ModuleGlobalBeginLumi finished: putInt2
-++++++ ModuleGlobalBeginLumi: putInt3
-++++++ ModuleGlobalBeginLumi finished: putInt3
-++++++ ModuleGlobalBeginLumi: getInt
-++++++ ModuleGlobalBeginLumi finished: getInt
-++++++ ModuleGlobalBeginLumi: noPut
-++++++ ModuleGlobalBeginLumi finished: noPut
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 3 lumi: 2 time: 125000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 3 lumi: 2 time: 125000001
-++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi: test
-++++++ ModuleGlobalBeginLumi finished: test
-++++++ ModuleGlobalBeginLumi: testmerge
-++++++ ModuleGlobalBeginLumi finished: testmerge
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: getInt
-++++++ ModuleGlobalBeginLumi finished: getInt
-++++++ ModuleGlobalBeginLumi: dependsOnNoPut
-++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
-++++++ ModuleGlobalBeginLumi: out
-++++++ ModuleGlobalBeginLumi finished: out
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ StreamBeginLumi run: 3 lumi: 2 time: 125000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 3 lumi: 2 time: 125000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 3 lumi: 2 time: 125000001
-++++++ ModuleStreamBeginLumi: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++++ ModuleStreamBeginLumi: putInt
-++++++ ModuleStreamBeginLumi finished: putInt
-++++++ ModuleStreamBeginLumi: putInt2
-++++++ ModuleStreamBeginLumi finished: putInt2
-++++++ ModuleStreamBeginLumi: putInt3
-++++++ ModuleStreamBeginLumi finished: putInt3
-++++++ ModuleStreamBeginLumi: getInt
-++++++ ModuleStreamBeginLumi finished: getInt
-++++++ ModuleStreamBeginLumi: noPut
-++++++ ModuleStreamBeginLumi finished: noPut
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 3 lumi: 2 time: 125000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 3 lumi: 2 time: 125000001
-++++++ ModuleStreamBeginLumi: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi: test
-++++++ ModuleStreamBeginLumi finished: test
-++++++ ModuleStreamBeginLumi: testmerge
-++++++ ModuleStreamBeginLumi finished: testmerge
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++++ ModuleStreamBeginLumi: getInt
-++++++ ModuleStreamBeginLumi finished: getInt
-++++++ ModuleStreamBeginLumi: dependsOnNoPut
-++++++ ModuleStreamBeginLumi finished: dependsOnNoPut
-++++++ ModuleStreamBeginLumi: out
-++++++ ModuleStreamBeginLumi finished: out
-++++ StreamBeginLumi finished
-++++ source event
+++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
+++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
+++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'putInt'
+++++++ finished: global begin lumi for module: label = 'putInt'
+++++++ starting: global begin lumi for module: label = 'putInt2'
+++++++ finished: global begin lumi for module: label = 'putInt2'
+++++++ starting: global begin lumi for module: label = 'putInt3'
+++++++ finished: global begin lumi for module: label = 'putInt3'
+++++++ starting: global begin lumi for module: label = 'getInt'
+++++++ finished: global begin lumi for module: label = 'getInt'
+++++++ starting: global begin lumi for module: label = 'noPut'
+++++++ finished: global begin lumi for module: label = 'noPut'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
+++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin lumi for module: label = 'test'
+++++++ finished: global begin lumi for module: label = 'test'
+++++++ starting: global begin lumi for module: label = 'testmerge'
+++++++ finished: global begin lumi for module: label = 'testmerge'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'getInt'
+++++++ finished: global begin lumi for module: label = 'getInt'
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut'
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut'
+++++++ starting: global begin lumi for module: label = 'out'
+++++++ finished: global begin lumi for module: label = 'out'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3'
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut'
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut'
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'test'
+++++++ finished: begin lumi for module: stream = 0 label = 'test'
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge'
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: begin lumi for module: stream = 0 label = 'out'
+++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 3 lumi: 2 event: 5 time:125000001
-++++ event finished
-++++ processing event run: 3 lumi: 2 event: 5 time:125000001
-++++ event finished
-++++ processing event run: 3 lumi: 2 event: 5 time:125000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 3 lumi: 2 event: 5 time:125000001
-++++ event finished
-++++ processing event run: 3 lumi: 2 event: 5 time:125000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 3 lumi: 2 event: 6 time:130000001
-++++ event finished
-++++ processing event run: 3 lumi: 2 event: 6 time:130000001
-++++ event finished
-++++ processing event run: 3 lumi: 2 event: 6 time:130000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 3 lumi: 2 event: 6 time:130000001
-++++ event finished
-++++ processing event run: 3 lumi: 2 event: 6 time:130000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 3 lumi: 2 event: 7 time:135000001
-++++ event finished
-++++ processing event run: 3 lumi: 2 event: 7 time:135000001
-++++ event finished
-++++ processing event run: 3 lumi: 2 event: 7 time:135000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 3 lumi: 2 event: 7 time:135000001
-++++ event finished
-++++ processing event run: 3 lumi: 2 event: 7 time:135000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 3 lumi: 2 event: 8 time:140000001
-++++ event finished
-++++ processing event run: 3 lumi: 2 event: 8 time:140000001
-++++ event finished
-++++ processing event run: 3 lumi: 2 event: 8 time:140000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 3 lumi: 2 event: 8 time:140000001
-++++ event finished
-++++ processing event run: 3 lumi: 2 event: 8 time:140000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ StreamEndLumi run: 3 lumi: 2 time: 140000001
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 3 lumi: 2 time: 0
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 3 lumi: 2 time: 0
-++++++ ModuleStreamEndLumi: thingWithMergeProducer
-++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++++ ModuleStreamEndLumi: putInt
-++++++ ModuleStreamEndLumi finished: putInt
-++++++ ModuleStreamEndLumi: putInt2
-++++++ ModuleStreamEndLumi finished: putInt2
-++++++ ModuleStreamEndLumi: putInt3
-++++++ ModuleStreamEndLumi finished: putInt3
-++++++ ModuleStreamEndLumi: getInt
-++++++ ModuleStreamEndLumi finished: getInt
-++++++ ModuleStreamEndLumi: noPut
-++++++ ModuleStreamEndLumi finished: noPut
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 3 lumi: 2 time: 0
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 3 lumi: 2 time: 0
-++++++ ModuleStreamEndLumi: thingWithMergeProducer
-++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
-++++++ ModuleStreamEndLumi: test
-++++++ ModuleStreamEndLumi finished: test
-++++++ ModuleStreamEndLumi: testmerge
-++++++ ModuleStreamEndLumi finished: testmerge
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++++ ModuleStreamEndLumi: getInt
-++++++ ModuleStreamEndLumi finished: getInt
-++++++ ModuleStreamEndLumi: dependsOnNoPut
-++++++ ModuleStreamEndLumi finished: dependsOnNoPut
-++++++ ModuleStreamEndLumi: out
-++++++ ModuleStreamEndLumi finished: out
-++++ StreamEndLumi finished
-++++ GlobalEndLumi run: 3 lumi: 2 time: 125000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 3 lumi: 2 time: 125000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 3 lumi: 2 time: 125000001
-++++++ ModuleGlobalEndLumi: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: putInt
-++++++ ModuleGlobalEndLumi finished: putInt
-++++++ ModuleGlobalEndLumi: putInt2
-++++++ ModuleGlobalEndLumi finished: putInt2
-++++++ ModuleGlobalEndLumi: putInt3
-++++++ ModuleGlobalEndLumi finished: putInt3
-++++++ ModuleGlobalEndLumi: getInt
-++++++ ModuleGlobalEndLumi finished: getInt
-++++++ ModuleGlobalEndLumi: noPut
-++++++ ModuleGlobalEndLumi finished: noPut
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 3 lumi: 2 time: 125000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 3 lumi: 2 time: 125000001
-++++++ ModuleGlobalEndLumi: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi: test
-++++++ ModuleGlobalEndLumi finished: test
-++++++ ModuleGlobalEndLumi: testmerge
-++++++ ModuleGlobalEndLumi finished: testmerge
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: getInt
-++++++ ModuleGlobalEndLumi finished: getInt
-++++++ ModuleGlobalEndLumi: dependsOnNoPut
-++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
-++++++ ModuleGlobalEndLumi: out
-++++++ ModuleGlobalEndLumi finished: out
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ source lumi
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
+++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 140000001
+++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 140000001
+++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
+++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
+++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3'
+++++++ starting: end lumi for module: stream = 0 label = 'getInt'
+++++++ finished: end lumi for module: stream = 0 label = 'getInt'
+++++++ starting: end lumi for module: stream = 0 label = 'noPut'
+++++++ finished: end lumi for module: stream = 0 label = 'noPut'
+++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
+++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
+++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
+++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'test'
+++++++ finished: end lumi for module: stream = 0 label = 'test'
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge'
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'getInt'
+++++++ finished: end lumi for module: stream = 0 label = 'getInt'
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: end lumi for module: stream = 0 label = 'out'
+++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
+++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
+++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
+++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'putInt'
+++++++ finished: global end lumi for module: label = 'putInt'
+++++++ starting: global end lumi for module: label = 'putInt2'
+++++++ finished: global end lumi for module: label = 'putInt2'
+++++++ starting: global end lumi for module: label = 'putInt3'
+++++++ finished: global end lumi for module: label = 'putInt3'
+++++++ starting: global end lumi for module: label = 'getInt'
+++++++ finished: global end lumi for module: label = 'getInt'
+++++++ starting: global end lumi for module: label = 'noPut'
+++++++ finished: global end lumi for module: label = 'noPut'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
+++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global end lumi for module: label = 'test'
+++++++ finished: global end lumi for module: label = 'test'
+++++++ starting: global end lumi for module: label = 'testmerge'
+++++++ finished: global end lumi for module: label = 'testmerge'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'getInt'
+++++++ finished: global end lumi for module: label = 'getInt'
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut'
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut'
+++++++ starting: global end lumi for module: label = 'out'
+++++++ finished: global end lumi for module: label = 'out'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
+++++ starting: source lumi
 ++++ finished: source lumi
-++++ GlobalBeginLumi run: 3 lumi: 3 time: 145000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 3 lumi: 3 time: 145000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 3 lumi: 3 time: 145000001
-++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: putInt
-++++++ ModuleGlobalBeginLumi finished: putInt
-++++++ ModuleGlobalBeginLumi: putInt2
-++++++ ModuleGlobalBeginLumi finished: putInt2
-++++++ ModuleGlobalBeginLumi: putInt3
-++++++ ModuleGlobalBeginLumi finished: putInt3
-++++++ ModuleGlobalBeginLumi: getInt
-++++++ ModuleGlobalBeginLumi finished: getInt
-++++++ ModuleGlobalBeginLumi: noPut
-++++++ ModuleGlobalBeginLumi finished: noPut
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 3 lumi: 3 time: 145000001
-++++ GlobalBeginLumi finished
-++++ GlobalBeginLumi run: 3 lumi: 3 time: 145000001
-++++++ ModuleGlobalBeginLumi: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalBeginLumi: test
-++++++ ModuleGlobalBeginLumi finished: test
-++++++ ModuleGlobalBeginLumi: testmerge
-++++++ ModuleGlobalBeginLumi finished: testmerge
-++++++ ModuleGlobalBeginLumi: get
-++++++ ModuleGlobalBeginLumi finished: get
-++++++ ModuleGlobalBeginLumi: getInt
-++++++ ModuleGlobalBeginLumi finished: getInt
-++++++ ModuleGlobalBeginLumi: dependsOnNoPut
-++++++ ModuleGlobalBeginLumi finished: dependsOnNoPut
-++++++ ModuleGlobalBeginLumi: out
-++++++ ModuleGlobalBeginLumi finished: out
-++++++ ModuleGlobalBeginLumi: TriggerResults
-++++++ ModuleGlobalBeginLumi finished: TriggerResults
-++++ GlobalBeginLumi finished
-++++ StreamBeginLumi run: 3 lumi: 3 time: 145000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 3 lumi: 3 time: 145000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 3 lumi: 3 time: 145000001
-++++++ ModuleStreamBeginLumi: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++++ ModuleStreamBeginLumi: putInt
-++++++ ModuleStreamBeginLumi finished: putInt
-++++++ ModuleStreamBeginLumi: putInt2
-++++++ ModuleStreamBeginLumi finished: putInt2
-++++++ ModuleStreamBeginLumi: putInt3
-++++++ ModuleStreamBeginLumi finished: putInt3
-++++++ ModuleStreamBeginLumi: getInt
-++++++ ModuleStreamBeginLumi finished: getInt
-++++++ ModuleStreamBeginLumi: noPut
-++++++ ModuleStreamBeginLumi finished: noPut
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 3 lumi: 3 time: 145000001
-++++ StreamBeginLumi finished
-++++ StreamBeginLumi run: 3 lumi: 3 time: 145000001
-++++++ ModuleStreamBeginLumi: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi finished: thingWithMergeProducer
-++++++ ModuleStreamBeginLumi: test
-++++++ ModuleStreamBeginLumi finished: test
-++++++ ModuleStreamBeginLumi: testmerge
-++++++ ModuleStreamBeginLumi finished: testmerge
-++++++ ModuleStreamBeginLumi: get
-++++++ ModuleStreamBeginLumi finished: get
-++++++ ModuleStreamBeginLumi: getInt
-++++++ ModuleStreamBeginLumi finished: getInt
-++++++ ModuleStreamBeginLumi: dependsOnNoPut
-++++++ ModuleStreamBeginLumi finished: dependsOnNoPut
-++++++ ModuleStreamBeginLumi: out
-++++++ ModuleStreamBeginLumi finished: out
-++++ StreamBeginLumi finished
-++++ source event
+++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
+++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
+++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'putInt'
+++++++ finished: global begin lumi for module: label = 'putInt'
+++++++ starting: global begin lumi for module: label = 'putInt2'
+++++++ finished: global begin lumi for module: label = 'putInt2'
+++++++ starting: global begin lumi for module: label = 'putInt3'
+++++++ finished: global begin lumi for module: label = 'putInt3'
+++++++ starting: global begin lumi for module: label = 'getInt'
+++++++ finished: global begin lumi for module: label = 'getInt'
+++++++ starting: global begin lumi for module: label = 'noPut'
+++++++ finished: global begin lumi for module: label = 'noPut'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
+++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global begin lumi for module: label = 'test'
+++++++ finished: global begin lumi for module: label = 'test'
+++++++ starting: global begin lumi for module: label = 'testmerge'
+++++++ finished: global begin lumi for module: label = 'testmerge'
+++++++ starting: global begin lumi for module: label = 'get'
+++++++ finished: global begin lumi for module: label = 'get'
+++++++ starting: global begin lumi for module: label = 'getInt'
+++++++ finished: global begin lumi for module: label = 'getInt'
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut'
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut'
+++++++ starting: global begin lumi for module: label = 'out'
+++++++ finished: global begin lumi for module: label = 'out'
+++++++ starting: global begin lumi for module: label = 'TriggerResults'
+++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2'
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3'
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3'
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut'
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut'
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
+++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'test'
+++++++ finished: begin lumi for module: stream = 0 label = 'test'
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge'
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge'
+++++++ starting: begin lumi for module: stream = 0 label = 'get'
+++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: begin lumi for module: stream = 0 label = 'out'
+++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 3 lumi: 3 event: 9 time:145000001
-++++ event finished
-++++ processing event run: 3 lumi: 3 event: 9 time:145000001
-++++ event finished
-++++ processing event run: 3 lumi: 3 event: 9 time:145000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 3 lumi: 3 event: 9 time:145000001
-++++ event finished
-++++ processing event run: 3 lumi: 3 event: 9 time:145000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ source event
+++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
+++++ starting: source event
 ++++ finished: source event
-++++ processing event run: 3 lumi: 3 event: 10 time:150000001
-++++ event finished
-++++ processing event run: 3 lumi: 3 event: 10 time:150000001
-++++ event finished
-++++ processing event run: 3 lumi: 3 event: 10 time:150000001
-++++++ processing path for event: p1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: p1
-++++++ processing path for event: path1
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: putInt
-++++++++ finished module for event: putInt
-++++++++ module for event: putInt2
-++++++++ finished module for event: putInt2
-++++++++ module for event: putInt3
-++++++++ finished module for event: putInt3
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: noPut
-++++++++ finished module for event: noPut
-++++++ path for event finished: path2
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++ event finished
-++++ processing event run: 3 lumi: 3 event: 10 time:150000001
-++++ event finished
-++++ processing event run: 3 lumi: 3 event: 10 time:150000001
-++++++ processing path for event: path1
-++++++++ module for event: thingWithMergeProducer
-++++++++ finished module for event: thingWithMergeProducer
-++++++ path for event finished: path1
-++++++ processing path for event: path2
-++++++++ module for event: test
-++++++++ finished module for event: test
-++++++++ module for event: testmerge
-++++++++ finished module for event: testmerge
-++++++ path for event finished: path2
-++++++ processing path for event: path3
-++++++++ module for event: get
-++++++++ finished module for event: get
-++++++++ module for event: getInt
-++++++++ finished module for event: getInt
-++++++ path for event finished: path3
-++++++ processing path for event: path4
-++++++++ module for event: dependsOnNoPut
-++++++++ finished module for event: dependsOnNoPut
-++++++ path for event finished: path4
-++++++++ module for event: TriggerResults
-++++++++ finished module for event: TriggerResults
-++++++ processing path for event: endPath1
-++++++++ module for event: out
-++++++++ finished module for event: out
-++++++ path for event finished: endPath1
-++++ event finished
-++++ StreamEndLumi run: 3 lumi: 3 time: 150000001
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 3 lumi: 3 time: 0
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 3 lumi: 3 time: 0
-++++++ ModuleStreamEndLumi: thingWithMergeProducer
-++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++++ ModuleStreamEndLumi: putInt
-++++++ ModuleStreamEndLumi finished: putInt
-++++++ ModuleStreamEndLumi: putInt2
-++++++ ModuleStreamEndLumi finished: putInt2
-++++++ ModuleStreamEndLumi: putInt3
-++++++ ModuleStreamEndLumi finished: putInt3
-++++++ ModuleStreamEndLumi: getInt
-++++++ ModuleStreamEndLumi finished: getInt
-++++++ ModuleStreamEndLumi: noPut
-++++++ ModuleStreamEndLumi finished: noPut
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 3 lumi: 3 time: 0
-++++ StreamEndLumi finished
-++++ StreamEndLumi run: 3 lumi: 3 time: 0
-++++++ ModuleStreamEndLumi: thingWithMergeProducer
-++++++ ModuleStreamEndLumi finished: thingWithMergeProducer
-++++++ ModuleStreamEndLumi: test
-++++++ ModuleStreamEndLumi finished: test
-++++++ ModuleStreamEndLumi: testmerge
-++++++ ModuleStreamEndLumi finished: testmerge
-++++++ ModuleStreamEndLumi: get
-++++++ ModuleStreamEndLumi finished: get
-++++++ ModuleStreamEndLumi: getInt
-++++++ ModuleStreamEndLumi finished: getInt
-++++++ ModuleStreamEndLumi: dependsOnNoPut
-++++++ ModuleStreamEndLumi finished: dependsOnNoPut
-++++++ ModuleStreamEndLumi: out
-++++++ ModuleStreamEndLumi finished: out
-++++ StreamEndLumi finished
-++++ GlobalEndLumi run: 3 lumi: 3 time: 145000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 3 lumi: 3 time: 145000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 3 lumi: 3 time: 145000001
-++++++ ModuleGlobalEndLumi: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: putInt
-++++++ ModuleGlobalEndLumi finished: putInt
-++++++ ModuleGlobalEndLumi: putInt2
-++++++ ModuleGlobalEndLumi finished: putInt2
-++++++ ModuleGlobalEndLumi: putInt3
-++++++ ModuleGlobalEndLumi finished: putInt3
-++++++ ModuleGlobalEndLumi: getInt
-++++++ ModuleGlobalEndLumi finished: getInt
-++++++ ModuleGlobalEndLumi: noPut
-++++++ ModuleGlobalEndLumi finished: noPut
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 3 lumi: 3 time: 145000001
-++++ GlobalEndLumi finished
-++++ GlobalEndLumi run: 3 lumi: 3 time: 145000001
-++++++ ModuleGlobalEndLumi: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi finished: thingWithMergeProducer
-++++++ ModuleGlobalEndLumi: test
-++++++ ModuleGlobalEndLumi finished: test
-++++++ ModuleGlobalEndLumi: testmerge
-++++++ ModuleGlobalEndLumi finished: testmerge
-++++++ ModuleGlobalEndLumi: get
-++++++ ModuleGlobalEndLumi finished: get
-++++++ ModuleGlobalEndLumi: getInt
-++++++ ModuleGlobalEndLumi finished: getInt
-++++++ ModuleGlobalEndLumi: dependsOnNoPut
-++++++ ModuleGlobalEndLumi finished: dependsOnNoPut
-++++++ ModuleGlobalEndLumi: out
-++++++ ModuleGlobalEndLumi finished: out
-++++++ ModuleGlobalEndLumi: TriggerResults
-++++++ ModuleGlobalEndLumi finished: TriggerResults
-++++ GlobalEndLumi finished
-++++ StreamEndRun run: 3 time: 150000001
-++++ StreamEndRun finished
-++++ StreamEndRun run: 3 time: 0
-++++ StreamEndRun finished
-++++ StreamEndRun run: 3 time: 0
-++++++ ModuleStreamEndRun: thingWithMergeProducer
-++++++ ModuleStreamEndRun finished: thingWithMergeProducer
-++++++ ModuleStreamEndRun: get
-++++++ ModuleStreamEndRun finished: get
-++++++ ModuleStreamEndRun: putInt
-++++++ ModuleStreamEndRun finished: putInt
-++++++ ModuleStreamEndRun: putInt2
-++++++ ModuleStreamEndRun finished: putInt2
-++++++ ModuleStreamEndRun: putInt3
-++++++ ModuleStreamEndRun finished: putInt3
-++++++ ModuleStreamEndRun: getInt
-++++++ ModuleStreamEndRun finished: getInt
-++++++ ModuleStreamEndRun: noPut
-++++++ ModuleStreamEndRun finished: noPut
-++++ StreamEndRun finished
-++++ StreamEndRun run: 3 time: 0
-++++ StreamEndRun finished
-++++ StreamEndRun run: 3 time: 0
-++++++ ModuleStreamEndRun: thingWithMergeProducer
-++++++ ModuleStreamEndRun finished: thingWithMergeProducer
-++++++ ModuleStreamEndRun: test
-++++++ ModuleStreamEndRun finished: test
-++++++ ModuleStreamEndRun: testmerge
-++++++ ModuleStreamEndRun finished: testmerge
-++++++ ModuleStreamEndRun: get
-++++++ ModuleStreamEndRun finished: get
-++++++ ModuleStreamEndRun: getInt
-++++++ ModuleStreamEndRun finished: getInt
-++++++ ModuleStreamEndRun: dependsOnNoPut
-++++++ ModuleStreamEndRun finished: dependsOnNoPut
-++++++ ModuleStreamEndRun: out
-++++++ ModuleStreamEndRun finished: out
-++++ StreamEndRun finished
-++++ GlobalEndRun run: 3 time: 150000001
-++++ GlobalEndRun finished
-++++ GlobalEndRun run: 3 time: 0
-++++ GlobalEndRun finished
-++++ GlobalEndRun run: 3 time: 0
-++++++ ModuleGlobalEndRun: thingWithMergeProducer
-++++++ ModuleGlobalEndRun finished: thingWithMergeProducer
-++++++ ModuleGlobalEndRun: get
-++++++ ModuleGlobalEndRun finished: get
-++++++ ModuleGlobalEndRun: putInt
-++++++ ModuleGlobalEndRun finished: putInt
-++++++ ModuleGlobalEndRun: putInt2
-++++++ ModuleGlobalEndRun finished: putInt2
-++++++ ModuleGlobalEndRun: putInt3
-++++++ ModuleGlobalEndRun finished: putInt3
-++++++ ModuleGlobalEndRun: getInt
-++++++ ModuleGlobalEndRun finished: getInt
-++++++ ModuleGlobalEndRun: noPut
-++++++ ModuleGlobalEndRun finished: noPut
-++++++ ModuleGlobalEndRun: TriggerResults
-++++++ ModuleGlobalEndRun finished: TriggerResults
-++++ GlobalEndRun finished
-++++ GlobalEndRun run: 3 time: 0
-++++ GlobalEndRun finished
-++++ GlobalEndRun run: 3 time: 0
-++++++ ModuleGlobalEndRun: thingWithMergeProducer
-++++++ ModuleGlobalEndRun finished: thingWithMergeProducer
-++++++ ModuleGlobalEndRun: test
-++++++ ModuleGlobalEndRun finished: test
-++++++ ModuleGlobalEndRun: testmerge
-++++++ ModuleGlobalEndRun finished: testmerge
-++++++ ModuleGlobalEndRun: get
-++++++ ModuleGlobalEndRun finished: get
-++++++ ModuleGlobalEndRun: getInt
-++++++ ModuleGlobalEndRun finished: getInt
-++++++ ModuleGlobalEndRun: dependsOnNoPut
-++++++ ModuleGlobalEndRun finished: dependsOnNoPut
-++++++ ModuleGlobalEndRun: out
-++++++ ModuleGlobalEndRun finished: out
-++++++ ModuleGlobalEndRun: TriggerResults
-++++++ ModuleGlobalEndRun finished: TriggerResults
-++++ GlobalEndRun finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++++ ModuleEndStream: 
-++++ ModuleEndStream finished
-++ ModuleEndJob: thingWithMergeProducer
-++ ModuleEndJob finished: thingWithMergeProducer
-++ ModuleEndJob: get
-++ ModuleEndJob finished: get
-++ ModuleEndJob: putInt
-++ ModuleEndJob finished: putInt
-++ ModuleEndJob: putInt2
-++ ModuleEndJob finished: putInt2
-++ ModuleEndJob: putInt3
-++ ModuleEndJob finished: putInt3
-++ ModuleEndJob: getInt
-++ ModuleEndJob finished: getInt
-++ ModuleEndJob: noPut
-++ ModuleEndJob finished: noPut
-++ ModuleEndJob: TriggerResults
-++ ModuleEndJob finished: TriggerResults
-++ ModuleEndJob: thingWithMergeProducer
-++ ModuleEndJob finished: thingWithMergeProducer
-++ ModuleEndJob: test
-++ ModuleEndJob finished: test
-++ ModuleEndJob: testmerge
-++ ModuleEndJob finished: testmerge
-++ ModuleEndJob: get
-++ ModuleEndJob finished: get
-++ ModuleEndJob: getInt
-++ ModuleEndJob finished: getInt
-++ ModuleEndJob: dependsOnNoPut
-++ ModuleEndJob finished: dependsOnNoPut
-++ ModuleEndJob: out
-++ ModuleEndJob finished: out
-++ ModuleEndJob: TriggerResults
-++ ModuleEndJob finished: TriggerResults
-++ Job ended
+++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++++ starting: processing path 'p1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'p1' : stream = 0
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'noPut'
+++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++ finished: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++++ starting: processing path 'path1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: processing path 'path1' : stream = 0
+++++++ starting: processing path 'path2' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'test'
+++++++++ finished: processing event for module: stream = 0 label = 'test'
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++ finished: processing path 'path2' : stream = 0
+++++++ starting: processing path 'path3' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'get'
+++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++ starting: processing event for module: stream = 0 label = 'getInt'
+++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++ finished: processing path 'path3' : stream = 0
+++++++ starting: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: processing path 'path4' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++ starting: processing path 'endPath1' : stream = 0
+++++++++ starting: processing event for module: stream = 0 label = 'out'
+++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++ finished: processing path 'endPath1' : stream = 0
+++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
+++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 150000001
+++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 150000001
+++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
+++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
+++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2'
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3'
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3'
+++++++ starting: end lumi for module: stream = 0 label = 'getInt'
+++++++ finished: end lumi for module: stream = 0 label = 'getInt'
+++++++ starting: end lumi for module: stream = 0 label = 'noPut'
+++++++ finished: end lumi for module: stream = 0 label = 'noPut'
+++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
+++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
+++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
+++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'test'
+++++++ finished: end lumi for module: stream = 0 label = 'test'
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge'
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge'
+++++++ starting: end lumi for module: stream = 0 label = 'get'
+++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'getInt'
+++++++ finished: end lumi for module: stream = 0 label = 'getInt'
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: end lumi for module: stream = 0 label = 'out'
+++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
+++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
+++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
+++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'putInt'
+++++++ finished: global end lumi for module: label = 'putInt'
+++++++ starting: global end lumi for module: label = 'putInt2'
+++++++ finished: global end lumi for module: label = 'putInt2'
+++++++ starting: global end lumi for module: label = 'putInt3'
+++++++ finished: global end lumi for module: label = 'putInt3'
+++++++ starting: global end lumi for module: label = 'getInt'
+++++++ finished: global end lumi for module: label = 'getInt'
+++++++ starting: global end lumi for module: label = 'noPut'
+++++++ finished: global end lumi for module: label = 'noPut'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
+++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
+++++++ starting: global end lumi for module: label = 'test'
+++++++ finished: global end lumi for module: label = 'test'
+++++++ starting: global end lumi for module: label = 'testmerge'
+++++++ finished: global end lumi for module: label = 'testmerge'
+++++++ starting: global end lumi for module: label = 'get'
+++++++ finished: global end lumi for module: label = 'get'
+++++++ starting: global end lumi for module: label = 'getInt'
+++++++ finished: global end lumi for module: label = 'getInt'
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut'
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut'
+++++++ starting: global end lumi for module: label = 'out'
+++++++ finished: global end lumi for module: label = 'out'
+++++++ starting: global end lumi for module: label = 'TriggerResults'
+++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
+++++ starting: end run: stream = 0 run = 3 time = 150000001
+++++ finished: end run: stream = 0 run = 3 time = 150000001
+++++ starting: end run: stream = 0 run = 3 time = 0
+++++ finished: end run: stream = 0 run = 3 time = 0
+++++ starting: end run: stream = 0 run = 3 time = 0
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end run for module: stream = 0 label = 'get'
+++++++ finished: end run for module: stream = 0 label = 'get'
+++++++ starting: end run for module: stream = 0 label = 'putInt'
+++++++ finished: end run for module: stream = 0 label = 'putInt'
+++++++ starting: end run for module: stream = 0 label = 'putInt2'
+++++++ finished: end run for module: stream = 0 label = 'putInt2'
+++++++ starting: end run for module: stream = 0 label = 'putInt3'
+++++++ finished: end run for module: stream = 0 label = 'putInt3'
+++++++ starting: end run for module: stream = 0 label = 'getInt'
+++++++ finished: end run for module: stream = 0 label = 'getInt'
+++++++ starting: end run for module: stream = 0 label = 'noPut'
+++++++ finished: end run for module: stream = 0 label = 'noPut'
+++++ finished: end run: stream = 0 run = 3 time = 0
+++++ starting: end run: stream = 0 run = 3 time = 0
+++++ finished: end run: stream = 0 run = 3 time = 0
+++++ starting: end run: stream = 0 run = 3 time = 0
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer'
+++++++ starting: end run for module: stream = 0 label = 'test'
+++++++ finished: end run for module: stream = 0 label = 'test'
+++++++ starting: end run for module: stream = 0 label = 'testmerge'
+++++++ finished: end run for module: stream = 0 label = 'testmerge'
+++++++ starting: end run for module: stream = 0 label = 'get'
+++++++ finished: end run for module: stream = 0 label = 'get'
+++++++ starting: end run for module: stream = 0 label = 'getInt'
+++++++ finished: end run for module: stream = 0 label = 'getInt'
+++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut'
+++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut'
+++++++ starting: end run for module: stream = 0 label = 'out'
+++++++ finished: end run for module: stream = 0 label = 'out'
+++++ finished: end run: stream = 0 run = 3 time = 0
+++++ starting: global end run 3 : time = 150000001
+++++ finished: global end run 3 : time = 150000001
+++++ starting: global end run 3 : time = 0
+++++ finished: global end run 3 : time = 0
+++++ starting: global end run 3 : time = 0
+++++++ starting: global end run for module: label = 'thingWithMergeProducer'
+++++++ finished: global end run for module: label = 'thingWithMergeProducer'
+++++++ starting: global end run for module: label = 'get'
+++++++ finished: global end run for module: label = 'get'
+++++++ starting: global end run for module: label = 'putInt'
+++++++ finished: global end run for module: label = 'putInt'
+++++++ starting: global end run for module: label = 'putInt2'
+++++++ finished: global end run for module: label = 'putInt2'
+++++++ starting: global end run for module: label = 'putInt3'
+++++++ finished: global end run for module: label = 'putInt3'
+++++++ starting: global end run for module: label = 'getInt'
+++++++ finished: global end run for module: label = 'getInt'
+++++++ starting: global end run for module: label = 'noPut'
+++++++ finished: global end run for module: label = 'noPut'
+++++++ starting: global end run for module: label = 'TriggerResults'
+++++++ finished: global end run for module: label = 'TriggerResults'
+++++ finished: global end run 3 : time = 0
+++++ starting: global end run 3 : time = 0
+++++ finished: global end run 3 : time = 0
+++++ starting: global end run 3 : time = 0
+++++++ starting: global end run for module: label = 'thingWithMergeProducer'
+++++++ finished: global end run for module: label = 'thingWithMergeProducer'
+++++++ starting: global end run for module: label = 'test'
+++++++ finished: global end run for module: label = 'test'
+++++++ starting: global end run for module: label = 'testmerge'
+++++++ finished: global end run for module: label = 'testmerge'
+++++++ starting: global end run for module: label = 'get'
+++++++ finished: global end run for module: label = 'get'
+++++++ starting: global end run for module: label = 'getInt'
+++++++ finished: global end run for module: label = 'getInt'
+++++++ starting: global end run for module: label = 'dependsOnNoPut'
+++++++ finished: global end run for module: label = 'dependsOnNoPut'
+++++++ starting: global end run for module: label = 'out'
+++++++ finished: global end run for module: label = 'out'
+++++++ starting: global end run for module: label = 'TriggerResults'
+++++++ finished: global end run for module: label = 'TriggerResults'
+++++ finished: global end run 3 : time = 0
+++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer'
+++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer'
+++++ starting: end stream for module: stream = 0 label = 'get'
+++++ finished: end stream for module: stream = 0 label = 'get'
+++++ starting: end stream for module: stream = 0 label = 'putInt'
+++++ finished: end stream for module: stream = 0 label = 'putInt'
+++++ starting: end stream for module: stream = 0 label = 'putInt2'
+++++ finished: end stream for module: stream = 0 label = 'putInt2'
+++++ starting: end stream for module: stream = 0 label = 'putInt3'
+++++ finished: end stream for module: stream = 0 label = 'putInt3'
+++++ starting: end stream for module: stream = 0 label = 'getInt'
+++++ finished: end stream for module: stream = 0 label = 'getInt'
+++++ starting: end stream for module: stream = 0 label = 'noPut'
+++++ finished: end stream for module: stream = 0 label = 'noPut'
+++++ starting: end stream for module: stream = 0 label = 'TriggerResults'
+++++ finished: end stream for module: stream = 0 label = 'TriggerResults'
+++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer'
+++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer'
+++++ starting: end stream for module: stream = 0 label = 'test'
+++++ finished: end stream for module: stream = 0 label = 'test'
+++++ starting: end stream for module: stream = 0 label = 'testmerge'
+++++ finished: end stream for module: stream = 0 label = 'testmerge'
+++++ starting: end stream for module: stream = 0 label = 'get'
+++++ finished: end stream for module: stream = 0 label = 'get'
+++++ starting: end stream for module: stream = 0 label = 'getInt'
+++++ finished: end stream for module: stream = 0 label = 'getInt'
+++++ starting: end stream for module: stream = 0 label = 'dependsOnNoPut'
+++++ finished: end stream for module: stream = 0 label = 'dependsOnNoPut'
+++++ starting: end stream for module: stream = 0 label = 'TriggerResults'
+++++ finished: end stream for module: stream = 0 label = 'TriggerResults'
+++++ starting: end stream for module: stream = 0 label = 'out'
+++++ finished: end stream for module: stream = 0 label = 'out'
+++++ starting: end job for module with label 'thingWithMergeProducer'
+++++ finished: end job for module with label 'thingWithMergeProducer'
+++++ starting: end job for module with label 'get'
+++++ finished: end job for module with label 'get'
+++++ starting: end job for module with label 'putInt'
+++++ finished: end job for module with label 'putInt'
+++++ starting: end job for module with label 'putInt2'
+++++ finished: end job for module with label 'putInt2'
+++++ starting: end job for module with label 'putInt3'
+++++ finished: end job for module with label 'putInt3'
+++++ starting: end job for module with label 'getInt'
+++++ finished: end job for module with label 'getInt'
+++++ starting: end job for module with label 'noPut'
+++++ finished: end job for module with label 'noPut'
+++++ starting: end job for module with label 'TriggerResults'
+++++ finished: end job for module with label 'TriggerResults'
+++++ starting: end job for module with label 'thingWithMergeProducer'
+++++ finished: end job for module with label 'thingWithMergeProducer'
+++++ starting: end job for module with label 'test'
+++++ finished: end job for module with label 'test'
+++++ starting: end job for module with label 'testmerge'
+++++ finished: end job for module with label 'testmerge'
+++++ starting: end job for module with label 'get'
+++++ finished: end job for module with label 'get'
+++++ starting: end job for module with label 'getInt'
+++++ finished: end job for module with label 'getInt'
+++++ starting: end job for module with label 'dependsOnNoPut'
+++++ finished: end job for module with label 'dependsOnNoPut'
+++++ starting: end job for module with label 'out'
+++++ finished: end job for module with label 'out'
+++++ starting: end job for module with label 'TriggerResults'
+++++ finished: end job for module with label 'TriggerResults'
+++ finished: end job

--- a/FWCore/ServiceRegistry/interface/ModuleCallingContext.h
+++ b/FWCore/ServiceRegistry/interface/ModuleCallingContext.h
@@ -72,6 +72,10 @@ namespace edm {
     // pointer to itself.
     ModuleCallingContext const* getTopModuleCallingContext() const;
 
+    // Returns the number of ModuleCallingContexts above this ModuleCallingContext
+    // in the series of linked context objects.
+    unsigned depth() const;
+
     ModuleCallingContext const* previousModuleOnThread() const { return previousModuleOnThread_; }
 
   private:

--- a/FWCore/ServiceRegistry/src/ModuleCallingContext.cc
+++ b/FWCore/ServiceRegistry/src/ModuleCallingContext.cc
@@ -70,6 +70,25 @@ namespace edm {
     return mcc;
   }
 
+  unsigned
+  ModuleCallingContext::depth() const {
+    unsigned depth = 0;
+    ModuleCallingContext const* mcc = this;
+    while(mcc->type() == ParentContext::Type::kModule) {
+      ++depth;
+      mcc = mcc->moduleCallingContext();
+    }
+    if(mcc->type() == ParentContext::Type::kInternal) {
+      ++depth;
+      mcc = mcc->internalContext()->moduleCallingContext();
+    }
+    while(mcc->type() == ParentContext::Type::kModule) {
+      ++depth;
+      mcc = mcc->moduleCallingContext();
+    }
+    return depth;
+  }
+
   std::ostream& operator<<(std::ostream& os, ModuleCallingContext const& mcc) {
     os << "ModuleCallingContext state = ";
     switch (mcc.state()) {

--- a/FWCore/Services/src/Tracer.cc
+++ b/FWCore/Services/src/Tracer.cc
@@ -10,10 +10,10 @@
 //         Created:  Thu Sep  8 14:17:58 EDT 2005
 //
 
-// user include files
 #include "FWCore/Services/src/Tracer.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/LuminosityBlockID.h"
@@ -28,800 +28,755 @@
 #include "FWCore/ServiceRegistry/interface/PathContext.h"
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "DataFormats/Common/interface/HLTPathStatus.h"
-// system include files
+
 #include <iostream>
 
 using namespace edm::service;
-//
-// constants, enums and typedefs
-//
 
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
 Tracer::Tracer(ParameterSet const& iPS, ActivityRegistry&iRegistry) :
   indention_(iPS.getUntrackedParameter<std::string>("indention")),
-  depth_(0),
   dumpContextForLabel_(iPS.getUntrackedParameter<std::string>("dumpContextForLabel")),
   dumpNonModuleContext_(iPS.getUntrackedParameter<bool>("dumpNonModuleContext"))
- {
-   iRegistry.watchPostBeginJob(this, &Tracer::postBeginJob);
-   iRegistry.watchPostEndJob(this, &Tracer::postEndJob);
+{
+  iRegistry.watchPostBeginJob(this, &Tracer::postBeginJob);
+  iRegistry.watchPostEndJob(this, &Tracer::postEndJob);
 
-   iRegistry.watchPreSource(this, &Tracer::preSource);
-   iRegistry.watchPostSource(this, &Tracer::postSource);
+  iRegistry.watchPreSource(this, &Tracer::preSource);
+  iRegistry.watchPostSource(this, &Tracer::postSource);
 
-   iRegistry.watchPreSourceLumi(this, &Tracer::preSourceLumi);
-   iRegistry.watchPostSourceLumi(this, &Tracer::postSourceLumi);
+  iRegistry.watchPreSourceLumi(this, &Tracer::preSourceLumi);
+  iRegistry.watchPostSourceLumi(this, &Tracer::postSourceLumi);
 
-   iRegistry.watchPreSourceRun(this, &Tracer::preSourceRun);
-   iRegistry.watchPostSourceRun(this, &Tracer::postSourceRun);
+  iRegistry.watchPreSourceRun(this, &Tracer::preSourceRun);
+  iRegistry.watchPostSourceRun(this, &Tracer::postSourceRun);
 
-   iRegistry.watchPreOpenFile(this, &Tracer::preOpenFile);
-   iRegistry.watchPostOpenFile(this, &Tracer::postOpenFile);
+  iRegistry.watchPreOpenFile(this, &Tracer::preOpenFile);
+  iRegistry.watchPostOpenFile(this, &Tracer::postOpenFile);
 
-   iRegistry.watchPreCloseFile(this, &Tracer::preCloseFile);
-   iRegistry.watchPostCloseFile(this, &Tracer::postCloseFile);
+  iRegistry.watchPreCloseFile(this, &Tracer::preCloseFile);
+  iRegistry.watchPostCloseFile(this, &Tracer::postCloseFile);
 
-   iRegistry.watchPreModuleBeginStream(this, &Tracer::preModuleBeginStream);
-   iRegistry.watchPostModuleBeginStream(this, &Tracer::postModuleBeginStream);
+  iRegistry.watchPreModuleBeginStream(this, &Tracer::preModuleBeginStream);
+  iRegistry.watchPostModuleBeginStream(this, &Tracer::postModuleBeginStream);
 
-   iRegistry.watchPreModuleEndStream(this, &Tracer::preModuleEndStream);
-   iRegistry.watchPostModuleEndStream(this, &Tracer::postModuleEndStream);
+  iRegistry.watchPreModuleEndStream(this, &Tracer::preModuleEndStream);
+  iRegistry.watchPostModuleEndStream(this, &Tracer::postModuleEndStream);
 
-   iRegistry.watchPreGlobalBeginRun(this, &Tracer::preGlobalBeginRun);
-   iRegistry.watchPostGlobalBeginRun(this, &Tracer::postGlobalBeginRun);
+  iRegistry.watchPreGlobalBeginRun(this, &Tracer::preGlobalBeginRun);
+  iRegistry.watchPostGlobalBeginRun(this, &Tracer::postGlobalBeginRun);
 
-   iRegistry.watchPreGlobalEndRun(this, &Tracer::preGlobalEndRun);
-   iRegistry.watchPostGlobalEndRun(this, &Tracer::postGlobalEndRun);
+  iRegistry.watchPreGlobalEndRun(this, &Tracer::preGlobalEndRun);
+  iRegistry.watchPostGlobalEndRun(this, &Tracer::postGlobalEndRun);
 
-   iRegistry.watchPreStreamBeginRun(this, &Tracer::preStreamBeginRun);
-   iRegistry.watchPostStreamBeginRun(this, &Tracer::postStreamBeginRun);
+  iRegistry.watchPreStreamBeginRun(this, &Tracer::preStreamBeginRun);
+  iRegistry.watchPostStreamBeginRun(this, &Tracer::postStreamBeginRun);
 
-   iRegistry.watchPreStreamEndRun(this, &Tracer::preStreamEndRun);
-   iRegistry.watchPostStreamEndRun(this, &Tracer::postStreamEndRun);
+  iRegistry.watchPreStreamEndRun(this, &Tracer::preStreamEndRun);
+  iRegistry.watchPostStreamEndRun(this, &Tracer::postStreamEndRun);
 
-   iRegistry.watchPreGlobalBeginLumi(this, &Tracer::preGlobalBeginLumi);
-   iRegistry.watchPostGlobalBeginLumi(this, &Tracer::postGlobalBeginLumi);
+  iRegistry.watchPreGlobalBeginLumi(this, &Tracer::preGlobalBeginLumi);
+  iRegistry.watchPostGlobalBeginLumi(this, &Tracer::postGlobalBeginLumi);
 
-   iRegistry.watchPreGlobalEndLumi(this, &Tracer::preGlobalEndLumi);
-   iRegistry.watchPostGlobalEndLumi(this, &Tracer::postGlobalEndLumi);
+  iRegistry.watchPreGlobalEndLumi(this, &Tracer::preGlobalEndLumi);
+  iRegistry.watchPostGlobalEndLumi(this, &Tracer::postGlobalEndLumi);
 
-   iRegistry.watchPreStreamBeginLumi(this, &Tracer::preStreamBeginLumi);
-   iRegistry.watchPostStreamBeginLumi(this, &Tracer::postStreamBeginLumi);
+  iRegistry.watchPreStreamBeginLumi(this, &Tracer::preStreamBeginLumi);
+  iRegistry.watchPostStreamBeginLumi(this, &Tracer::postStreamBeginLumi);
 
-   iRegistry.watchPreStreamEndLumi(this, &Tracer::preStreamEndLumi);
-   iRegistry.watchPostStreamEndLumi(this, &Tracer::postStreamEndLumi);
+  iRegistry.watchPreStreamEndLumi(this, &Tracer::preStreamEndLumi);
+  iRegistry.watchPostStreamEndLumi(this, &Tracer::postStreamEndLumi);
 
-   iRegistry.watchPreEvent(this, &Tracer::preEvent);
-   iRegistry.watchPostEvent(this, &Tracer::postEvent);
+  iRegistry.watchPreEvent(this, &Tracer::preEvent);
+  iRegistry.watchPostEvent(this, &Tracer::postEvent);
 
-   iRegistry.watchPrePathEvent(this, &Tracer::prePathEvent);
-   iRegistry.watchPostPathEvent(this, &Tracer::postPathEvent);
+  iRegistry.watchPrePathEvent(this, &Tracer::prePathEvent);
+  iRegistry.watchPostPathEvent(this, &Tracer::postPathEvent);
 
-   iRegistry.watchPreModuleConstruction(this, &Tracer::preModuleConstruction);
-   iRegistry.watchPostModuleConstruction(this, &Tracer::postModuleConstruction);
+  iRegistry.watchPreModuleConstruction(this, &Tracer::preModuleConstruction);
+  iRegistry.watchPostModuleConstruction(this, &Tracer::postModuleConstruction);
 
-   iRegistry.watchPreModuleBeginJob(this, &Tracer::preModuleBeginJob);
-   iRegistry.watchPostModuleBeginJob(this, &Tracer::postModuleBeginJob);
+  iRegistry.watchPreModuleBeginJob(this, &Tracer::preModuleBeginJob);
+  iRegistry.watchPostModuleBeginJob(this, &Tracer::postModuleBeginJob);
 
-   iRegistry.watchPreModuleEndJob(this, &Tracer::preModuleEndJob);
-   iRegistry.watchPostModuleEndJob(this, &Tracer::postModuleEndJob);
+  iRegistry.watchPreModuleEndJob(this, &Tracer::preModuleEndJob);
+  iRegistry.watchPostModuleEndJob(this, &Tracer::postModuleEndJob);
 
-   iRegistry.watchPreModuleEvent(this, &Tracer::preModuleEvent);
-   iRegistry.watchPostModuleEvent(this, &Tracer::postModuleEvent);
+  iRegistry.watchPreModuleEvent(this, &Tracer::preModuleEvent);
+  iRegistry.watchPostModuleEvent(this, &Tracer::postModuleEvent);
 
-   iRegistry.watchPreModuleStreamBeginRun(this, &Tracer::preModuleStreamBeginRun);
-   iRegistry.watchPostModuleStreamBeginRun(this, &Tracer::postModuleStreamBeginRun);
-   iRegistry.watchPreModuleStreamEndRun(this, &Tracer::preModuleStreamEndRun);
-   iRegistry.watchPostModuleStreamEndRun(this, &Tracer::postModuleStreamEndRun);
+  iRegistry.watchPreModuleStreamBeginRun(this, &Tracer::preModuleStreamBeginRun);
+  iRegistry.watchPostModuleStreamBeginRun(this, &Tracer::postModuleStreamBeginRun);
+  iRegistry.watchPreModuleStreamEndRun(this, &Tracer::preModuleStreamEndRun);
+  iRegistry.watchPostModuleStreamEndRun(this, &Tracer::postModuleStreamEndRun);
 
-   iRegistry.watchPreModuleStreamBeginLumi(this, &Tracer::preModuleStreamBeginLumi);
-   iRegistry.watchPostModuleStreamBeginLumi(this, &Tracer::postModuleStreamBeginLumi);
-   iRegistry.watchPreModuleStreamEndLumi(this, &Tracer::preModuleStreamEndLumi);
-   iRegistry.watchPostModuleStreamEndLumi(this, &Tracer::postModuleStreamEndLumi);
+  iRegistry.watchPreModuleStreamBeginLumi(this, &Tracer::preModuleStreamBeginLumi);
+  iRegistry.watchPostModuleStreamBeginLumi(this, &Tracer::postModuleStreamBeginLumi);
+  iRegistry.watchPreModuleStreamEndLumi(this, &Tracer::preModuleStreamEndLumi);
+  iRegistry.watchPostModuleStreamEndLumi(this, &Tracer::postModuleStreamEndLumi);
 
-   iRegistry.watchPreModuleGlobalBeginRun(this, &Tracer::preModuleGlobalBeginRun);
-   iRegistry.watchPostModuleGlobalBeginRun(this, &Tracer::postModuleGlobalBeginRun);
-   iRegistry.watchPreModuleGlobalEndRun(this, &Tracer::preModuleGlobalEndRun);
-   iRegistry.watchPostModuleGlobalEndRun(this, &Tracer::postModuleGlobalEndRun);
+  iRegistry.watchPreModuleGlobalBeginRun(this, &Tracer::preModuleGlobalBeginRun);
+  iRegistry.watchPostModuleGlobalBeginRun(this, &Tracer::postModuleGlobalBeginRun);
+  iRegistry.watchPreModuleGlobalEndRun(this, &Tracer::preModuleGlobalEndRun);
+  iRegistry.watchPostModuleGlobalEndRun(this, &Tracer::postModuleGlobalEndRun);
 
-   iRegistry.watchPreModuleGlobalBeginLumi(this, &Tracer::preModuleGlobalBeginLumi);
-   iRegistry.watchPostModuleGlobalBeginLumi(this, &Tracer::postModuleGlobalBeginLumi);
-   iRegistry.watchPreModuleGlobalEndLumi(this, &Tracer::preModuleGlobalEndLumi);
-   iRegistry.watchPostModuleGlobalEndLumi(this, &Tracer::postModuleGlobalEndLumi);
+  iRegistry.watchPreModuleGlobalBeginLumi(this, &Tracer::preModuleGlobalBeginLumi);
+  iRegistry.watchPostModuleGlobalBeginLumi(this, &Tracer::postModuleGlobalBeginLumi);
+  iRegistry.watchPreModuleGlobalEndLumi(this, &Tracer::preModuleGlobalEndLumi);
+  iRegistry.watchPostModuleGlobalEndLumi(this, &Tracer::postModuleGlobalEndLumi);
 
-   iRegistry.watchPreSourceConstruction(this, &Tracer::preSourceConstruction);
-   iRegistry.watchPostSourceConstruction(this, &Tracer::postSourceConstruction);
+  iRegistry.watchPreSourceConstruction(this, &Tracer::preSourceConstruction);
+  iRegistry.watchPostSourceConstruction(this, &Tracer::postSourceConstruction);
 }
-
-// Tracer::Tracer(Tracer const& rhs)
-// {
-//    // do actual copying here;
-// }
-
-//Tracer::~Tracer()
-//{
-//}
 
 void
 Tracer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
 
-    edm::ParameterSetDescription desc;
-    desc.addUntracked<std::string>("indention", "++")->setComment("Prefix characters for output. The characters are repeated to form the indentation.");
-    desc.addUntracked<std::string>("dumpContextForLabel", "")->setComment("Prints context information to cout for the module transitions associated with this module label");
-    desc.addUntracked<bool>("dumpNonModuleContext", false)->setComment("Prints context information to cout for the transitions not associated with any module label");
-    descriptions.add("Tracer", desc);
-    descriptions.setComment("This service prints each phase the framework is processing, e.g. constructing a module,running a module, etc.");
+  edm::ParameterSetDescription desc;
+  desc.addUntracked<std::string>("indention", "++")->setComment("Prefix characters for output. The characters are repeated to form the indentation.");
+  desc.addUntracked<std::string>("dumpContextForLabel", "")->setComment("Prints context information to cout for the module transitions associated with this module label");
+  desc.addUntracked<bool>("dumpNonModuleContext", false)->setComment("Prints context information to cout for the transitions not associated with any module label");
+  descriptions.add("Tracer", desc);
+  descriptions.setComment("This service prints each phase the framework is processing, e.g. constructing a module,running a module, etc.");
 }
 
-//
-// assignment operators
-//
-// Tracer const& Tracer::operator=(Tracer const& rhs)
-// {
-//   //An exception safe implementation is
-//   Tracer temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
-
-//
-// member functions
-//
 void 
 Tracer::postBeginJob() {
-   std::cout << indention_ << " Job started" << std::endl;
+  LogAbsolute("Tracer") << indention_ << " finished: begin job";
 }
 
 void 
 Tracer::postEndJob() {
-   std::cout << indention_ << " Job ended" << std::endl;
+  LogAbsolute("Tracer") << indention_ << " finished: end job";
 }
 
 void
 Tracer::preSource() {
-  std::cout << indention_ << indention_ << " source event" << std::endl;
+  LogAbsolute("Tracer") << indention_ << indention_ << " starting: source event";
 }
 
 void
 Tracer::postSource() {
-  std::cout << indention_ << indention_ << " finished: source event" << std::endl;
+  LogAbsolute("Tracer") << indention_ << indention_ << " finished: source event";
 }
 
 void
 Tracer::preSourceLumi() {
-  std::cout << indention_ << indention_ << " source lumi" << std::endl;
+  LogAbsolute("Tracer") << indention_ << indention_ << " starting: source lumi";
 }
 
 void
 Tracer::postSourceLumi () {
-  std::cout << indention_ << indention_ << " finished: source lumi" << std::endl;
+  LogAbsolute("Tracer") << indention_ << indention_ << " finished: source lumi";
 }
 
 void
 Tracer::preSourceRun() {
-  std::cout << indention_ << indention_ << " source run" << std::endl;
+  LogAbsolute("Tracer") << indention_ << indention_ << " starting: source run";
 }
 
 void
 Tracer::postSourceRun () {
-  std::cout << indention_ << indention_ << " finished: source run" << std::endl;
+  LogAbsolute("Tracer") << indention_ << indention_ << " finished: source run";
 }
 
 void
 Tracer::preOpenFile(std::string const& lfn, bool b) {
-  std::cout << indention_ << indention_ << " open input file: " << lfn;
-  if(dumpNonModuleContext_) std::cout << " usedFallBack = " << b;
-  std::cout << std::endl;
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " starting: open input file: lfn = " << lfn;
+  if(dumpNonModuleContext_) out << " usedFallBack = " << b;
 }
 
 void
 Tracer::postOpenFile (std::string const& lfn, bool b) {
-  std::cout << indention_ << indention_ << " finished: open input file";
-  if(dumpNonModuleContext_) std::cout << ": " << lfn << " usedFallBack = " << b;
-  std::cout << std::endl;
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " finished: open input file: lfn = " << lfn;
+  if(dumpNonModuleContext_) out << " usedFallBack = " << b;
 }
 
 void
 Tracer::preCloseFile(std::string const & lfn, bool b) {
-  std::cout << indention_ << indention_ << " close input file: " << lfn;
-  if(dumpNonModuleContext_) std::cout << " usedFallBack = " << b;
-  std::cout << std::endl;
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " starting: close input file: lfn = " << lfn;
+  if(dumpNonModuleContext_) out << " usedFallBack = " << b;
 }
 void
 Tracer::postCloseFile (std::string const& lfn, bool b) {
-  std::cout << indention_ << indention_ << " finished: close input file";
-  if(dumpNonModuleContext_) std::cout << ": " << lfn << " usedFallBack = " << b;
-  std::cout << std::endl;
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " finished: close input file: lfn = " << lfn;
+  if(dumpNonModuleContext_) out << " usedFallBack = " << b;
 }
 
 void
 Tracer::preModuleBeginStream(StreamContext const& sc, ModuleCallingContext const& mcc) {
   ModuleDescription const& desc = *mcc.moduleDescription();
-  std::cout << indention_ << indention_ << " ModuleBeginStream: " << desc.moduleLabel(); 
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " starting: begin stream for module: stream = " << sc.streamID() << " label = '" << desc.moduleLabel() << "'";
   if(dumpContextForLabel_ == desc.moduleLabel()) {
-    std::cout << "\n" << sc;
-    std::cout << desc;
+    out << "\n" << sc;
+    out << mcc;
   }
-  std::cout << std::endl;
 }
 
 void
 Tracer::postModuleBeginStream(StreamContext const& sc, ModuleCallingContext const& mcc) {
   ModuleDescription const& desc = *mcc.moduleDescription();
-  std::cout << indention_ << indention_ << " ModuleBeginStream finished"; 
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " finished: begin stream for module: stream = " << sc.streamID() << " label = '" << desc.moduleLabel() << "'";
   if(dumpContextForLabel_ == desc.moduleLabel()) {
-    std::cout << "\n" << sc;
-    std::cout << desc;
+    out << "\n" << sc;
+    out << mcc;
   }
-  std::cout << std::endl;
 }
 
 void
 Tracer::preModuleEndStream(StreamContext const& sc, ModuleCallingContext const& mcc) {
   ModuleDescription const& desc = *mcc.moduleDescription();
-  std::cout << indention_ << indention_ << " ModuleEndStream: "; 
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " starting: end stream for module: stream = " << sc.streamID() << " label = '" << desc.moduleLabel() << "'";
   if(dumpContextForLabel_ == desc.moduleLabel()) {
-    std::cout << "\n" << sc;
-    std::cout << desc;
+    out << "\n" << sc;
+    out << mcc;
   }
-  std::cout << std::endl;
 }
 
 void
 Tracer::postModuleEndStream(StreamContext const& sc, ModuleCallingContext const& mcc) {
   ModuleDescription const& desc = *mcc.moduleDescription();
-  std::cout << indention_ << indention_ << " ModuleEndStream finished"; 
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " finished: end stream for module: stream = " << sc.streamID() << " label = '" << desc.moduleLabel() << "'";
   if(dumpContextForLabel_ == desc.moduleLabel()) {
-    std::cout << "\n" << sc;
-    std::cout << desc;
+    out << "\n" << sc;
+    out << mcc;
   }
-  std::cout << std::endl;
 }
 
 void
 Tracer::preGlobalBeginRun(GlobalContext const& gc) {
-  std::cout << indention_ << indention_ << " GlobalBeginRun run: " << gc.luminosityBlockID().run() 
-            << " time: " << gc.timestamp().value() << "\n"; 
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " starting: global begin run " << gc.luminosityBlockID().run()
+      << " : time = " << gc.timestamp().value();
   if(dumpNonModuleContext_) {
-    std::cout << gc;
+    out << "\n" << gc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::postGlobalBeginRun(GlobalContext const& gc) {
-  std::cout << indention_ << indention_ << " GlobalBeginRun finished\n"; 
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " finished: global begin run " << gc.luminosityBlockID().run()
+      << " : time = " << gc.timestamp().value();
   if(dumpNonModuleContext_) {
-    std::cout << gc;
+    out << "\n" << gc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::preGlobalEndRun(GlobalContext const& gc) {
-  std::cout << indention_ << indention_ << " GlobalEndRun run: " << gc.luminosityBlockID().run() 
-            << " time: " << gc.timestamp().value() << "\n"; 
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " starting: global end run " << gc.luminosityBlockID().run()
+      << " : time = " << gc.timestamp().value();
   if(dumpNonModuleContext_) {
-    std::cout << gc;
+    out << "\n" << gc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::postGlobalEndRun(GlobalContext const& gc) {
-  std::cout << indention_ << indention_ << " GlobalEndRun finished\n"; 
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " finished: global end run " << gc.luminosityBlockID().run()
+      << " : time = " << gc.timestamp().value();
   if(dumpNonModuleContext_) {
-    std::cout << gc;
+    out << "\n" << gc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::preStreamBeginRun(StreamContext const& sc) {
-  std::cout << indention_ << indention_ << " StreamBeginRun run: " << sc.eventID().run() 
-            << " time: " << sc.timestamp().value() << "\n"; 
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " starting: begin run: stream = " << sc.streamID() << " run = " << sc.eventID().run()
+      << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
-    std::cout << sc;
+    out << "\n" << sc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::postStreamBeginRun(StreamContext const& sc) {
-  std::cout << indention_ << indention_ << " StreamBeginRun finished\n"; 
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " finished: begin run: stream = " << sc.streamID() << " run = " << sc.eventID().run()
+      << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
-    std::cout << sc;
+    out << "\n" << sc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::preStreamEndRun(StreamContext const& sc) {
-  std::cout << indention_ << indention_ << " StreamEndRun run: " << sc.eventID().run() 
-            << " time: " << sc.timestamp().value() << "\n"; 
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " starting: end run: stream = " << sc.streamID() << " run = " << sc.eventID().run()
+      << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
-    std::cout << sc;
+    out << "\n" << sc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::postStreamEndRun(StreamContext const& sc) {
-  std::cout << indention_ << indention_ << " StreamEndRun finished\n"; 
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " finished: end run: stream = " << sc.streamID() << " run = " << sc.eventID().run()
+      << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
-    std::cout << sc;
+    out << "\n" << sc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::preGlobalBeginLumi(GlobalContext const& gc) {
-  std::cout << indention_ << indention_ << " GlobalBeginLumi run: " << gc.luminosityBlockID().run() 
-            << " lumi: " << gc.luminosityBlockID().luminosityBlock() << " time: " << gc.timestamp().value() << "\n"; 
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " starting: global begin lumi: run = " << gc.luminosityBlockID().run()
+      << " lumi = " << gc.luminosityBlockID().luminosityBlock() << " time = " << gc.timestamp().value();
   if(dumpNonModuleContext_) {
-    std::cout << gc;
+    out << "\n" << gc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::postGlobalBeginLumi(GlobalContext const& gc) {
-  std::cout << indention_ << indention_ << " GlobalBeginLumi finished\n";  
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " finished: global begin lumi: run = " << gc.luminosityBlockID().run()
+      << " lumi = " << gc.luminosityBlockID().luminosityBlock() << " time = " << gc.timestamp().value();
   if(dumpNonModuleContext_) {
-    std::cout << gc;
+    out << "\n" << gc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::preGlobalEndLumi(GlobalContext const& gc) {
-  std::cout << indention_ << indention_ << " GlobalEndLumi run: " << gc.luminosityBlockID().run() 
-            << " lumi: " << gc.luminosityBlockID().luminosityBlock() << " time: " << gc.timestamp().value() << "\n"; 
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " starting: global end lumi: run = " << gc.luminosityBlockID().run()
+      << " lumi = " << gc.luminosityBlockID().luminosityBlock() << " time = " << gc.timestamp().value();
   if(dumpNonModuleContext_) {
-    std::cout << gc;
+    out << "\n" << gc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::postGlobalEndLumi(GlobalContext const& gc) {
-  std::cout << indention_ << indention_ << " GlobalEndLumi finished\n";
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " finished: global end lumi: run = " << gc.luminosityBlockID().run()
+      << " lumi = " << gc.luminosityBlockID().luminosityBlock() << " time = " << gc.timestamp().value();
   if(dumpNonModuleContext_) {
-    std::cout << gc;
+    out << "\n" << gc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::preStreamBeginLumi(StreamContext const& sc) {
-  std::cout << indention_ << indention_ << " StreamBeginLumi run: " << sc.eventID().run() 
-            << " lumi: " << sc.eventID().luminosityBlock() << " time: " << sc.timestamp().value() << "\n";  
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " starting: begin lumi: stream = " << sc.streamID() << " run = " << sc.eventID().run()
+      << " lumi = " << sc.eventID().luminosityBlock() << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
-    std::cout << sc;
+    out << "\n" << sc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::postStreamBeginLumi(StreamContext const& sc) {
-  std::cout << indention_ << indention_ << " StreamBeginLumi finished\n";  
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " finished: begin lumi: stream = " << sc.streamID() << " run = " << sc.eventID().run()
+      << " lumi = " << sc.eventID().luminosityBlock() << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
-    std::cout << "\n" << sc;
+    out << "\n" << sc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::preStreamEndLumi(StreamContext const& sc) {
-  std::cout << indention_ << indention_ << " StreamEndLumi run: " << sc.eventID().run() 
-            << " lumi: " << sc.eventID().luminosityBlock() << " time: " << sc.timestamp().value() << "\n";
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " starting: end lumi: stream = " << sc.streamID() << " run = " << sc.eventID().run()
+      << " lumi = " << sc.eventID().luminosityBlock() << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
-    std::cout << sc;
+    out << "\n" << sc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::postStreamEndLumi(StreamContext const& sc) {
-  std::cout << indention_ << indention_ << " StreamEndLumi finished\n"; 
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " finished: end lumi: stream = " << sc.streamID() << " run = " << sc.eventID().run()
+      << " lumi = " << sc.eventID().luminosityBlock() << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
-    std::cout << sc;
+    out << "\n" << sc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::preEvent(StreamContext const& sc) {
-  std::cout << indention_ << indention_ << " processing event " << sc.eventID() << " time:" << sc.timestamp().value() << "\n";
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " starting: processing event : stream = " << sc.streamID() << " run = " << sc.eventID().run()
+      << " lumi = " << sc.eventID().luminosityBlock() << " event = " << sc.eventID().event() << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
-    std::cout << sc;
+    out << "\n" << sc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::postEvent(StreamContext const& sc) {
-  std::cout << indention_ << indention_ << " event finished\n";
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " finished: processing event : stream = " << sc.streamID() << " run = " << sc.eventID().run()
+      << " lumi = " << sc.eventID().luminosityBlock() << " event = " << sc.eventID().event() << " time = " << sc.timestamp().value();
   if(dumpNonModuleContext_) {
-    std::cout << sc;
+    out << "\n" << sc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::prePathEvent(StreamContext const& sc, PathContext const& pc) {
-  std::cout << indention_ << indention_ << indention_ << " processing path for event: " << pc.pathName() << "\n";
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << indention_ << " starting: processing path '" << pc.pathName() << "' : stream = " << sc.streamID();
   if(dumpNonModuleContext_) {
-    std::cout << sc;
-    std::cout << pc;
+    out << "\n" << sc;
+    out << pc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::postPathEvent(StreamContext const& sc, PathContext const& pc, HLTPathStatus const& hlts) {
-  std::cout << indention_ << indention_ << indention_ << " path for event finished: " << pc.pathName() << "\n";
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << indention_ << " finished: processing path '" << pc.pathName() << "' : stream = " << sc.streamID();
   if(dumpNonModuleContext_) {
-    std::cout << sc;
-    std::cout << pc;
+    out << "\n" << sc;
+    out << pc;
   }
-  std::cout.flush();
 }
 
 void 
 Tracer::preModuleConstruction(ModuleDescription const& desc) {
-  std::cout << indention_;
-  std::cout << " constructing module: " << desc.moduleLabel();
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " starting: constructing module with label '" << desc.moduleLabel() << "'";
   if(dumpContextForLabel_ == desc.moduleLabel()) {
-    std::cout << "\n" << desc;
+    out << "\n" << desc;
   }
-  std::cout << std::endl;  
 }
 
 void 
 Tracer::postModuleConstruction(ModuleDescription const& desc) {
-  std::cout << indention_;
-  std::cout << " construction finished: " << desc.moduleLabel();
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_ << " finished: constructing module with label '" << desc.moduleLabel() << "'";
   if(dumpContextForLabel_ == desc.moduleLabel()) {
-    std::cout << "\n" << desc;
+    out << "\n" << desc;
   }
-  std::cout << std::endl;  
 }
 
 void 
 Tracer::preModuleBeginJob(ModuleDescription const& desc) {
-  std::cout << indention_;
-  std::cout << " ModuleBeginJob: " << desc.moduleLabel();
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_;
+  out << " starting: begin job for module with label '" << desc.moduleLabel() << "'";
   if(dumpContextForLabel_ == desc.moduleLabel()) {
-    std::cout << "\n" << desc;
+    out << "\n" << desc;
   }
-  std::cout << std::endl;  
 }
 
 void 
 Tracer::postModuleBeginJob(ModuleDescription const& desc) {
-  std::cout << indention_;
-  std::cout << " ModuleBeginJob finished: " << desc.moduleLabel();
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_;
+  out << " finished: begin job for module with label '" << desc.moduleLabel() << "'";
   if(dumpContextForLabel_ == desc.moduleLabel()) {
-    std::cout << "\n" << desc;
+    out << "\n" << desc;
   }
-  std::cout << std::endl;  
 }
 
 void 
 Tracer::preModuleEndJob(ModuleDescription const& desc) {
-  std::cout << indention_;
-  std::cout << " ModuleEndJob: " << desc.moduleLabel();
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_;
+  out << " starting: end job for module with label '" << desc.moduleLabel() << "'";
   if(dumpContextForLabel_ == desc.moduleLabel()) {
-    std::cout << "\n" << desc;
+    out << "\n" << desc;
   }
-  std::cout << std::endl;  
 }
 
 void 
 Tracer::postModuleEndJob(ModuleDescription const& desc) {
-  std::cout << indention_;
-  std::cout << " ModuleEndJob finished: " << desc.moduleLabel();
+  LogAbsolute out("Tracer");
+  out << indention_ << indention_;
+  out << " finished: end job for module with label '" << desc.moduleLabel() << "'";
   if(dumpContextForLabel_ == desc.moduleLabel()) {
-    std::cout << "\n" << desc;
+    out << "\n" << desc;
   }
-  std::cout << std::endl;  
 }
 
 void 
 Tracer::preModuleEvent(StreamContext const& sc, ModuleCallingContext const& mcc) {
-  ++depth_;
-  std::cout << indention_ << indention_ << indention_;
-  for(unsigned int depth = 0; depth !=depth_; ++depth) {
-    std::cout << indention_;
+  LogAbsolute out("Tracer");
+  unsigned int nIndents = mcc.depth() + 4;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
   }
-  std::cout << " module for event: " << mcc.moduleDescription()->moduleLabel() << "\n";
+  out << " starting: processing event for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "'";
   if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
-    std::cout << sc;
-    std::cout << mcc;
+    out << "\n" << sc;
+    out << mcc;
   }
-  std::cout.flush();
 }
 
 void 
 Tracer::postModuleEvent(StreamContext const& sc, ModuleCallingContext const& mcc) {
-  --depth_;
-  std::cout << indention_ << indention_ << indention_ << indention_;
-  for(unsigned int depth = 0; depth !=depth_; ++depth) {
-    std::cout << indention_;
+  LogAbsolute out("Tracer");
+  unsigned int nIndents = mcc.depth() + 4;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
   }
-  std::cout << " finished module for event: " << mcc.moduleDescription()->moduleLabel() << "\n";
+  out << " finished: processing event for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "'";
   if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
-    std::cout << sc;
-    std::cout << mcc;
+    out << "\n" << sc;
+    out << mcc;
   }
-  std::cout.flush();
 }
 
 
 void
 Tracer::preModuleStreamBeginRun(StreamContext const& sc, ModuleCallingContext const& mcc) {
-  ++depth_;
-  std::cout << indention_ << indention_;
-  for(unsigned int depth = 0; depth !=depth_; ++depth) {
-    std::cout << indention_;
+  LogAbsolute out("Tracer");
+  unsigned int nIndents = mcc.depth() + 3;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
   }
-  std::cout << " ModuleStreamBeginRun: " << mcc.moduleDescription()->moduleLabel() << "\n";
+  out << " starting: begin run for module: stream = " << sc.streamID() <<  " label = '" << mcc.moduleDescription()->moduleLabel() << "'";
   if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
-    std::cout << sc;
-    std::cout << mcc;
+    out << "\n" << sc;
+    out << mcc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::postModuleStreamBeginRun(StreamContext const& sc, ModuleCallingContext const& mcc) {
-  --depth_;
-  std::cout << indention_ << indention_ << indention_;
-  for(unsigned int depth = 0; depth !=depth_; ++depth) {
-    std::cout << indention_;
-  }   
-  std::cout << " ModuleStreamBeginRun finished: " << mcc.moduleDescription()->moduleLabel() << "\n";
-  if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
-    std::cout << sc;
-    std::cout << mcc;
+  LogAbsolute out("Tracer");
+  unsigned int nIndents = mcc.depth() + 3;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
   }
-  std::cout.flush();
+  out << " finished: begin run for module: stream = " << sc.streamID() <<  " label = '" << mcc.moduleDescription()->moduleLabel() << "'";
+  if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
+    out << "\n" << sc;
+    out << mcc;
+  }
 }
 
 void
 Tracer::preModuleStreamEndRun(StreamContext const& sc, ModuleCallingContext const& mcc) {
-  ++depth_;
-  std::cout << indention_ << indention_;
-  for(unsigned int depth = 0; depth !=depth_; ++depth) {
-    std::cout << indention_;
+  LogAbsolute out("Tracer");
+  unsigned int nIndents = mcc.depth() + 3;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
   }
-  std::cout << " ModuleStreamEndRun: " << mcc.moduleDescription()->moduleLabel() << "\n";
+  out << " starting: end run for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "'";
   if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
-    std::cout << sc;
-    std::cout << mcc;
+    out << "\n" << sc;
+    out << mcc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::postModuleStreamEndRun(StreamContext const& sc, ModuleCallingContext const& mcc) {
-  --depth_;
-  std::cout << indention_ << indention_ << indention_;
-  for(unsigned int depth = 0; depth !=depth_; ++depth) {
-    std::cout << indention_;
-  }   
-  std::cout << " ModuleStreamEndRun finished: " << mcc.moduleDescription()->moduleLabel() << "\n";
-  if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
-    std::cout << sc;
-    std::cout << mcc;
+  LogAbsolute out("Tracer");
+  unsigned int nIndents = mcc.depth() + 3;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
   }
-  std::cout.flush();
+  out << " finished: end run for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "'";
+  if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
+    out << "\n" << sc;
+    out << mcc;
+  }
 }
 
 void
 Tracer::preModuleStreamBeginLumi(StreamContext const& sc, ModuleCallingContext const& mcc) {
-  ++depth_;
-  std::cout << indention_ << indention_;
-  for(unsigned int depth = 0; depth !=depth_; ++depth) {
-    std::cout << indention_;
+  LogAbsolute out("Tracer");
+  unsigned int nIndents = mcc.depth() + 3;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
   }
-  std::cout << " ModuleStreamBeginLumi: " << mcc.moduleDescription()->moduleLabel() << "\n";
+  out << " starting: begin lumi for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "'";
   if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
-    std::cout << sc;
-    std::cout << mcc;
+    out << "\n" << sc;
+    out << mcc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::postModuleStreamBeginLumi(StreamContext const& sc, ModuleCallingContext const& mcc) {
-  --depth_;
-  std::cout << indention_ << indention_ << indention_;
-  for(unsigned int depth = 0; depth !=depth_; ++depth) {
-    std::cout << indention_;
-  }   
-  std::cout << " ModuleStreamBeginLumi finished: " << mcc.moduleDescription()->moduleLabel() << "\n";
-  if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
-    std::cout << sc;
-    std::cout << mcc;
+  LogAbsolute out("Tracer");
+  unsigned int nIndents = mcc.depth() + 3;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
   }
-  std::cout.flush();
+  out << " finished: begin lumi for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "'";
+  if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
+    out << "\n" << sc;
+    out << mcc;
+  }
 }
 
 void
 Tracer::preModuleStreamEndLumi(StreamContext const& sc, ModuleCallingContext const& mcc) {
-  ++depth_;
-  std::cout << indention_ << indention_;
-  for(unsigned int depth = 0; depth !=depth_; ++depth) {
-    std::cout << indention_;
+  LogAbsolute out("Tracer");
+  unsigned int nIndents = mcc.depth() + 3;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
   }
-  std::cout << " ModuleStreamEndLumi: " << mcc.moduleDescription()->moduleLabel() << "\n";
+  out << " starting: end lumi for module: stream = " << sc.streamID() << " label = '"<< mcc.moduleDescription()->moduleLabel() << "'";
   if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
-    std::cout << sc;
-    std::cout << mcc;
+    out << "\n" << sc;
+    out << mcc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::postModuleStreamEndLumi(StreamContext const& sc, ModuleCallingContext const& mcc) {
-  --depth_;
-  std::cout << indention_ << indention_ << indention_;
-  for(unsigned int depth = 0; depth !=depth_; ++depth) {
-    std::cout << indention_;
-  }   
-  std::cout << " ModuleStreamEndLumi finished: " << mcc.moduleDescription()->moduleLabel() << "\n";
-  if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
-    std::cout << sc;
-    std::cout << mcc;
+  LogAbsolute out("Tracer");
+  unsigned int nIndents = mcc.depth() + 3;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
   }
-  std::cout.flush();
+  out << " finished: end lumi for module: stream = " << sc.streamID() << " label = '"<< mcc.moduleDescription()->moduleLabel() << "'";
+  if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
+    out << "\n" << sc;
+    out << mcc;
+  }
 }
 
 void
 Tracer::preModuleGlobalBeginRun(GlobalContext const& gc, ModuleCallingContext const& mcc) {
-  ++depth_;
-  std::cout << indention_ << indention_;
-  for(unsigned int depth = 0; depth !=depth_; ++depth) {
-    std::cout << indention_;
+  LogAbsolute out("Tracer");
+  unsigned int nIndents = mcc.depth() + 3;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
   }
-  std::cout << " ModuleGlobalBeginRun: " << mcc.moduleDescription()->moduleLabel() << "\n";
+  out << " starting: global begin run for module: label = '" << mcc.moduleDescription()->moduleLabel() << "'";
   if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
-    std::cout << gc;
-    std::cout << mcc;
+    out << "\n" << gc;
+    out << mcc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::postModuleGlobalBeginRun(GlobalContext const& gc, ModuleCallingContext const& mcc) {
-  --depth_;
-  std::cout << indention_ << indention_ << indention_;
-  for(unsigned int depth = 0; depth !=depth_; ++depth) {
-    std::cout << indention_;
-  }   
-  std::cout << " ModuleGlobalBeginRun finished: " << mcc.moduleDescription()->moduleLabel() << "\n";
-  if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
-    std::cout << gc;
-    std::cout << mcc;
+  LogAbsolute out("Tracer");
+  unsigned int nIndents = mcc.depth() + 3;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
   }
-  std::cout.flush();
+  out << " finished: global begin run for module: label = '" << mcc.moduleDescription()->moduleLabel() << "'";
+  if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
+    out << "\n" << gc;
+    out << mcc;
+  }
 }
 
 void
 Tracer::preModuleGlobalEndRun(GlobalContext const& gc, ModuleCallingContext const& mcc) {
-  ++depth_;
-  std::cout << indention_ << indention_;
-  for(unsigned int depth = 0; depth !=depth_; ++depth) {
-    std::cout << indention_;
+  LogAbsolute out("Tracer");
+  unsigned int nIndents = mcc.depth() + 3;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
   }
-  std::cout << " ModuleGlobalEndRun: " << mcc.moduleDescription()->moduleLabel() << "\n";
+  out << " starting: global end run for module: label = '" << mcc.moduleDescription()->moduleLabel() << "'";
   if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
-    std::cout << gc;
-    std::cout << mcc;
+    out << "\n" << gc;
+    out << mcc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::postModuleGlobalEndRun(GlobalContext const& gc, ModuleCallingContext const& mcc) {
-  --depth_;
-  std::cout << indention_ << indention_ << indention_;
-  for(unsigned int depth = 0; depth !=depth_; ++depth) {
-    std::cout << indention_;
-  }   
-  std::cout << " ModuleGlobalEndRun finished: " << mcc.moduleDescription()->moduleLabel() << "\n";
-  if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
-    std::cout << gc;
-    std::cout << mcc;
+  LogAbsolute out("Tracer");
+  unsigned int nIndents = mcc.depth() + 3;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
   }
-  std::cout.flush();
+  out << " finished: global end run for module: label = '" << mcc.moduleDescription()->moduleLabel() << "'";
+  if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
+    out << "\n" << gc;
+    out << mcc;
+  }
 }
 
 void
 Tracer::preModuleGlobalBeginLumi(GlobalContext const& gc, ModuleCallingContext const& mcc) {
-  ++depth_;
-  std::cout << indention_ << indention_;
-  for(unsigned int depth = 0; depth !=depth_; ++depth) {
-    std::cout << indention_;
+  LogAbsolute out("Tracer");
+  unsigned int nIndents = mcc.depth() + 3;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
   }
-  std::cout << " ModuleGlobalBeginLumi: " << mcc.moduleDescription()->moduleLabel() << "\n";
+  out << " starting: global begin lumi for module: label = '" << mcc.moduleDescription()->moduleLabel() << "'";
   if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
-    std::cout << gc;
-    std::cout << mcc;
+    out << "\n" << gc;
+    out << mcc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::postModuleGlobalBeginLumi(GlobalContext const& gc, ModuleCallingContext const& mcc) {
-  --depth_;
-  std::cout << indention_ << indention_ << indention_;
-  for(unsigned int depth = 0; depth !=depth_; ++depth) {
-    std::cout << indention_;
-  }   
-  std::cout << " ModuleGlobalBeginLumi finished: " << mcc.moduleDescription()->moduleLabel() << "\n";
-  if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
-    std::cout << gc;
-    std::cout << mcc;
+  LogAbsolute out("Tracer");
+  unsigned int nIndents = mcc.depth() + 3;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
   }
-  std::cout.flush();
+  out << " finished: global begin lumi for module: label = '" << mcc.moduleDescription()->moduleLabel() << "'";
+  if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
+    out << "\n" << gc;
+    out << mcc;
+  }
 }
 
 void
 Tracer::preModuleGlobalEndLumi(GlobalContext const& gc, ModuleCallingContext const& mcc) {
-  ++depth_;
-  std::cout << indention_ << indention_;
-  for(unsigned int depth = 0; depth !=depth_; ++depth) {
-    std::cout << indention_;
+  LogAbsolute out("Tracer");
+  unsigned int nIndents = mcc.depth() + 3;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
   }
-  std::cout << " ModuleGlobalEndLumi: " << mcc.moduleDescription()->moduleLabel() << "\n";
+  out << " starting: global end lumi for module: label = '" << mcc.moduleDescription()->moduleLabel() << "'";
   if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
-    std::cout << gc;
-    std::cout << mcc;
+    out << "\n" << gc;
+    out << mcc;
   }
-  std::cout.flush();
 }
 
 void
 Tracer::postModuleGlobalEndLumi(GlobalContext const& gc, ModuleCallingContext const& mcc) {
-  --depth_;
-  std::cout << indention_ << indention_ << indention_;
-  for(unsigned int depth = 0; depth !=depth_; ++depth) {
-    std::cout << indention_;
-  }   
-  std::cout << " ModuleGlobalEndLumi finished: " << mcc.moduleDescription()->moduleLabel() << "\n";
+  LogAbsolute out("Tracer");
+  unsigned int nIndents = mcc.depth() + 3;
+  for(unsigned int i = 0; i < nIndents; ++i) {
+    out << indention_;
+  }
+  out << " finished: global end lumi for module: label = '" << mcc.moduleDescription()->moduleLabel() << "'";
   if(dumpContextForLabel_ == mcc.moduleDescription()->moduleLabel()) {
-    std::cout << gc;
-    std::cout << mcc;
+    out << "\n" << gc;
+    out << mcc;
   }
-  std::cout.flush();
 }
 
-void 
+void
 Tracer::preSourceConstruction(ModuleDescription const& desc) {
-  std::cout << indention_;
-  std::cout << " constructing source:" << desc.moduleName();
+  LogAbsolute out("Tracer");
+  out << indention_;
+  out << " starting: constructing source: " << desc.moduleName();
   if(dumpNonModuleContext_) {
-    std::cout << "\n" << desc;
+    out << "\n" << desc;
   }
-  std::cout << std::endl;
 }
 
-void 
+void
 Tracer::postSourceConstruction(ModuleDescription const& desc) {
-  std::cout << indention_;
-  std::cout << " construction finished:" << desc.moduleName();
+  LogAbsolute out("Tracer");
+  out << indention_;
+  out << " finished: constructing source: " << desc.moduleName();
   if(dumpNonModuleContext_) {
-    std::cout << "\n" << desc;
+    out << "\n" << desc;
   }
-  std::cout << std::endl;
 }

--- a/FWCore/Services/src/Tracer.h
+++ b/FWCore/Services/src/Tracer.h
@@ -5,7 +5,7 @@
 // Package:     Services
 // Class  :     Tracer
 // 
-/**\class Tracer Tracer.h FWCore/Services/interface/Tracer.h
+/**\class edm::service::Tracer
 
  Description: <one line class summary>
 
@@ -42,7 +42,7 @@ namespace edm {
 
    namespace service {
       class Tracer {
-public:
+      public:
          Tracer(const ParameterSet&,ActivityRegistry&);
          
          static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
@@ -136,9 +136,8 @@ public:
          void preSourceConstruction(ModuleDescription const& md);
          void postSourceConstruction(ModuleDescription const& md);
 
-private:
+      private:
          std::string indention_;
-         unsigned int depth_;
          std::string dumpContextForLabel_;
          bool dumpNonModuleContext_;
       };


### PR DESCRIPTION
Modify the Tracer Service to work with the multithreaded
Framework. The depth data member is removed to avoid data
races. The ModuleCallingContext is used instead to
determine indentation. Use MessageLogger
LogAbsolute instead of printing directly to cout
to better serialize message printing. Also reformatted
message style so the messages have a more consistent
style and improved alignment to be more readable.
Modified unit tests that used the Tracer to work
with the modifications.
