### PR TITLE
Use new calibrated energy member in reco::CaloCluster

### DIFF
--- a/DataFormats/EgammaReco/interface/SuperCluster.h
+++ b/DataFormats/EgammaReco/interface/SuperCluster.h
@@ -19,7 +19,6 @@
 namespace reco {
   class SuperCluster : public CaloCluster {
   public:
-    typedef std::vector<std::pair<CaloClusterPtr::key_type,CaloClusterPtr> > EEtoPSAssociation;
     typedef math::XYZPoint Point;
 
     /// default constructor

--- a/DataFormats/EgammaReco/src/classes.h
+++ b/DataFormats/EgammaReco/src/classes.h
@@ -36,11 +36,7 @@ namespace {
     edm::RefProd<reco::BasicClusterCollection> rp1;
     edm::Wrapper<edm::RefVector<reco::BasicClusterCollection> > wrv1;
     std::vector<reco::BasicClusterRef> vr1;
-
-    reco::SuperCluster::EEtoPSAssociation sceepsassoc;
-    edm::Wrapper<reco::SuperCluster::EEtoPSAssociation> wsceepsassoc;
-    std::pair<unsigned long,std::vector<size_t> > sceepsassocintval;
-    std::pair<reco::CaloClusterPtr::key_type,reco::CaloClusterPtr> sceepsassocval;
+    
     std::vector<reco::SuperCluster> sv3;
     reco::SuperClusterCollection v3;
     edm::Wrapper<reco::SuperClusterCollection> w3;

--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -39,9 +39,6 @@
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::BasicCluster>,reco::BasicCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster> > >"/>
   <class name="std::vector<edm::Ref<std::vector<reco::BasicCluster>,reco::BasicCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster> > >"/>
 
-  <class name="std::pair<edm::Ptr<reco::CaloCluster>::key_type,edm::Ptr<reco::CaloCluster> >"/>
-  <class name="reco::SuperCluster::EEtoPSAssociation"/>
-  <class name="edm::Wrapper<reco::SuperCluster::EEtoPSAssociation>"/>
   <class name="reco::SuperCluster" ClassVersion="12">
    <version ClassVersion="12" checksum="83023066"/>
    <version ClassVersion="11" checksum="83023066"/>

--- a/DataFormats/ParticleFlowReco/interface/PFCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFCluster.h
@@ -42,7 +42,7 @@ namespace reco {
   class PFCluster : public CaloCluster {
   public:
 
-
+    typedef std::vector<std::pair<CaloClusterPtr::key_type,edm::Ptr<PFCluster> > EEtoPSAssociation;
     typedef ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t> > REPPoint;
   
     PFCluster() : CaloCluster(CaloCluster::particleFlow), color_(1) {}
@@ -50,8 +50,6 @@ namespace reco {
     /// constructor
     PFCluster(PFLayer::Layer layer, double energy,
 	      double x, double y, double z );
-
-
 
     /// resets clusters parameters
     void reset();

--- a/DataFormats/ParticleFlowReco/interface/PFCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFCluster.h
@@ -1,6 +1,7 @@
 #ifndef DataFormats_ParticleFlowReco_PFCluster_h
 #define DataFormats_ParticleFlowReco_PFCluster_h
 
+#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 
 #include "Math/GenVector/PositionVector3D.h"
@@ -42,7 +43,7 @@ namespace reco {
   class PFCluster : public CaloCluster {
   public:
 
-    typedef std::vector<std::pair<CaloClusterPtr::key_type,edm::Ptr<PFCluster> > EEtoPSAssociation;
+    typedef std::vector<std::pair<CaloClusterPtr::key_type,edm::Ptr<PFCluster> > > EEtoPSAssociation;
     typedef ROOT::Math::PositionVector3D<ROOT::Math::CylindricalEta3D<Double32_t> > REPPoint;
   
     PFCluster() : CaloCluster(CaloCluster::particleFlow), color_(1) {}

--- a/DataFormats/ParticleFlowReco/src/classes_2.h
+++ b/DataFormats/ParticleFlowReco/src/classes_2.h
@@ -69,6 +69,11 @@ namespace {
     std::vector<reco::PFCluster>                         dummy1;
     edm::Wrapper< std::vector<reco::PFCluster> >         dummy2;
 
+    reco::PFCluster::EEtoPSAssociation sceepsassoc;
+    edm::Wrapper<reco::PFCluster::EEtoPSAssociation> wsceepsassoc;    
+    std::pair<reco::CaloClusterPtr::key_type,reco::CaloClusterPtr> 
+      sceepsassocval;
+
     std::vector<reco::PFRecHit>                          dummy3;
     edm::Ref< std::vector<reco::PFRecHit> >              dummy4;
     edm::Wrapper< std::vector<reco::PFRecHit> >          dummy5;

--- a/DataFormats/ParticleFlowReco/src/classes_2.h
+++ b/DataFormats/ParticleFlowReco/src/classes_2.h
@@ -71,7 +71,7 @@ namespace {
 
     reco::PFCluster::EEtoPSAssociation sceepsassoc;
     edm::Wrapper<reco::PFCluster::EEtoPSAssociation> wsceepsassoc;    
-    std::pair<reco::CaloClusterPtr::key_type,reco::CaloClusterPtr> 
+    std::pair<reco::CaloClusterPtr::key_type,edm::Ptr<reco::PFCluster> > 
       sceepsassocval;
 
     std::vector<reco::PFRecHit>                          dummy3;

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -10,7 +10,7 @@
   <class name="std::vector<reco::PFCluster>"/>
   <class name="edm::Wrapper<std::vector<reco::PFCluster> >"/>
 
-  <class name="std::pair<edm::Ptr<reco::CaloCluster>::key_type,edm::Ptr<reco::CaloCluster> >"/>
+  <class name="std::pair<edm::Ptr<reco::CaloCluster>::key_type,edm::Ptr<reco::PFCluster> >"/>
   <class name="reco::PFCluster::EEtoPSAssociation"/>
   <class name="edm::Wrapper<reco::PFCluster::EEtoPSAssociation>"/>
 

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -10,6 +10,10 @@
   <class name="std::vector<reco::PFCluster>"/>
   <class name="edm::Wrapper<std::vector<reco::PFCluster> >"/>
 
+  <class name="std::pair<edm::Ptr<reco::CaloCluster>::key_type,edm::Ptr<reco::CaloCluster> >"/>
+  <class name="reco::PFCluster::EEtoPSAssociation"/>
+  <class name="edm::Wrapper<reco::PFCluster::EEtoPSAssociation>"/>
+
   <class name="reco::PFRecHitFraction" ClassVersion="10">
    <version ClassVersion="10" checksum="3960206"/>
   </class>

--- a/RecoEcal/EgammaClusterAlgos/interface/PFECALSuperClusterAlgo.h
+++ b/RecoEcal/EgammaClusterAlgos/interface/PFECALSuperClusterAlgo.h
@@ -44,21 +44,17 @@ class PFECALSuperClusterAlgo {
   // simple class for associating calibrated energies
   class CalibratedPFCluster {
   public:
-    CalibratedPFCluster(const edm::Ptr<reco::PFCluster>& p,
-			const double ce) : cluptr(p), calib_e(ce) {}
+    CalibratedPFCluster(const edm::Ptr<reco::PFCluster>& p) : cluptr(p) {}
     
-    double energy() const { return calib_e; }
+    double energy() const { return cluptr->correctedEnergy(); }
     double energy_nocalib() const { return cluptr->energy(); }
     double eta() const { return cluptr->positionREP().eta(); }
     double phi() const { return cluptr->positionREP().phi(); }
     
-    void resetCalibratedEnergy(const double ce) { calib_e = ce; }
-   
     edm::Ptr<reco::PFCluster> the_ptr() const { return cluptr; }
 
   private:
-    edm::Ptr<reco::PFCluster> cluptr;
-    double calib_e;
+    edm::Ptr<reco::PFCluster> cluptr;    
   };
   typedef std::shared_ptr<CalibratedPFCluster> CalibratedClusterPtr;
   typedef std::vector<CalibratedClusterPtr> CalibratedClusterPtrVector;
@@ -103,12 +99,10 @@ class PFECALSuperClusterAlgo {
   std::auto_ptr<reco::SuperClusterCollection>
     getEBOutputSCCollection() { return superClustersEB_; }
   std::auto_ptr<reco::SuperClusterCollection>
-    getEEOutputSCCollection() { return superClustersEE_; } 
-  std::auto_ptr<reco::SuperCluster::EEtoPSAssociation>
-    getEEtoPSAssociation() { return EEtoPS_; } 
+    getEEOutputSCCollection() { return superClustersEE_; }
 
   void loadAndSortPFClusters(const edm::View<reco::PFCluster>& ecalclusters,
-			     const edm::View<reco::PFCluster>& psclusters);
+			     const reco::PFCluster::EEtoPSAssociation& psclusters);
   
   void run();
 
@@ -118,7 +112,7 @@ class PFECALSuperClusterAlgo {
   CalibratedClusterPtrVector _clustersEE;
   std::auto_ptr<reco::SuperClusterCollection> superClustersEB_;
   std::auto_ptr<reco::SuperClusterCollection> superClustersEE_;
-  std::auto_ptr<reco::SuperCluster::EEtoPSAssociation> EEtoPS_;
+  const reco::PFCluster::EEtoPSAssociation* EEtoPS_;
   std::shared_ptr<PFEnergyCalibration> _pfEnergyCalibration;
   clustering_type _clustype;
   energy_weight   _eweight;

--- a/RecoEcal/EgammaClusterProducers/interface/PFECALSuperClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/PFECALSuperClusterProducer.h
@@ -19,6 +19,8 @@
 
 #include "RecoEcal/EgammaClusterAlgos/interface/PFECALSuperClusterAlgo.h"
 
+#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
+
 /**\class PFECALSuperClusterProducer 
 
 \author Nicolas Chanon
@@ -55,7 +57,7 @@ class PFECALSuperClusterProducer : public edm::EDProducer {
   bool   verbose_;
   
   edm::EDGetTokenT<edm::View<reco::PFCluster> >   inputTagPFClusters_;
-  edm::EDGetTokenT<edm::View<reco::PFCluster> >   inputTagPFClustersES_;
+  edm::EDGetTokenT<reco::PFCluster::EEtoPSAssociation>   inputTagPFClustersES_;
 
   std::string PFBasicClusterCollectionBarrel_;
   std::string PFSuperClusterCollectionBarrel_;

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -14,7 +14,7 @@ particleFlowSuperClusterECALBox = cms.EDProducer(
     
     #PFClusters collection
     PFClusters = cms.InputTag("particleFlowClusterECAL"),
-    ESAssociation = cms.InputTag("particleFlowClusterPS"),
+    ESAssociation = cms.InputTag("particleFlowClusterECAL"),
                                               
     PFBasicClusterCollectionBarrel = cms.string("particleFlowBasicClusterECALBarrel"),                                       
     PFSuperClusterCollectionBarrel = cms.string("particleFlowSuperClusterECALBarrel"),
@@ -73,7 +73,7 @@ particleFlowSuperClusterECALMustache = cms.EDProducer(
                                               
     #PFClusters collection
     PFClusters = cms.InputTag("particleFlowClusterECAL"),
-    ESAssociation = cms.InputTag("particleFlowClusterPS"),
+    ESAssociation = cms.InputTag("particleFlowClusterECAL"),
                                               
     PFBasicClusterCollectionBarrel = cms.string("particleFlowBasicClusterECALBarrel"),                                       
     PFSuperClusterCollectionBarrel = cms.string("particleFlowSuperClusterECALBarrel"),

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -73,7 +73,7 @@ particleFlowSuperClusterECALMustache = cms.EDProducer(
                                               
     #PFClusters collection
     PFClusters = cms.InputTag("particleFlowClusterECAL"),
-    PFClustersES = cms.InputTag("particleFlowClusterPS"),
+    ESAssociation = cms.InputTag("particleFlowClusterPS"),
                                               
     PFBasicClusterCollectionBarrel = cms.string("particleFlowBasicClusterECALBarrel"),                                       
     PFSuperClusterCollectionBarrel = cms.string("particleFlowSuperClusterECALBarrel"),

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -14,7 +14,7 @@ particleFlowSuperClusterECALBox = cms.EDProducer(
     
     #PFClusters collection
     PFClusters = cms.InputTag("particleFlowClusterECAL"),
-    PFClustersES = cms.InputTag("particleFlowClusterPS"),
+    ESAssociation = cms.InputTag("particleFlowClusterPS"),
                                               
     PFBasicClusterCollectionBarrel = cms.string("particleFlowBasicClusterECALBarrel"),                                       
     PFSuperClusterCollectionBarrel = cms.string("particleFlowSuperClusterECALBarrel"),

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -128,7 +128,7 @@ PFECALSuperClusterProducer::PFECALSuperClusterProducer(const edm::ParameterSet& 
   inputTagPFClusters_ = 
     consumes<edm::View<reco::PFCluster> >(iConfig.getParameter<InputTag>("PFClusters"));
   inputTagPFClustersES_ = 
-    consumes<edm::View<reco::PFCluster> >(iConfig.getParameter<InputTag>("PFClustersES"));
+    consumes<edm::View<reco::PFCluster> >(iConfig.getParameter<InputTag>("ESAssociation"));
 
   PFBasicClusterCollectionBarrel_ = iConfig.getParameter<string>("PFBasicClusterCollectionBarrel");
   PFSuperClusterCollectionBarrel_ = iConfig.getParameter<string>("PFSuperClusterCollectionBarrel");
@@ -158,13 +158,13 @@ void PFECALSuperClusterProducer::produce(edm::Event& iEvent,
   edm::Handle<edm::View<reco::PFCluster> > pfclustersHandle;
   iEvent.getByToken( inputTagPFClusters_, pfclustersHandle );  
 
-  edm::Handle<edm::View<reco::PFCluster> > preshowerpfclustersHandle;
-  iEvent.getByToken( inputTagPFClustersES_,  preshowerpfclustersHandle);
+  edm::Handle<reco::PFCluster::EEtoPSAssociation > psAssociationHandle;
+  iEvent.getByToken( inputTagPFClustersES_,  psAssociationHandle);
 
 
   // do clustering
   superClusterAlgo_.loadAndSortPFClusters(*pfclustersHandle,
-					  *preshowerpfclustersHandle);
+					  *psAssociationHandle);
   superClusterAlgo_.run();
 
   //store in the event

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -5,7 +5,7 @@
 #include "RecoEcal/EgammaClusterAlgos/interface/PFECALSuperClusterAlgo.h"
 
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
-#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
+
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 
 #include "DataFormats/EgammaReco/interface/SuperCluster.h"
@@ -128,7 +128,7 @@ PFECALSuperClusterProducer::PFECALSuperClusterProducer(const edm::ParameterSet& 
   inputTagPFClusters_ = 
     consumes<edm::View<reco::PFCluster> >(iConfig.getParameter<InputTag>("PFClusters"));
   inputTagPFClustersES_ = 
-    consumes<edm::View<reco::PFCluster> >(iConfig.getParameter<InputTag>("ESAssociation"));
+    consumes<reco::PFCluster::EEtoPSAssociation>(iConfig.getParameter<InputTag>("ESAssociation"));
 
   PFBasicClusterCollectionBarrel_ = iConfig.getParameter<string>("PFBasicClusterCollectionBarrel");
   PFSuperClusterCollectionBarrel_ = iConfig.getParameter<string>("PFSuperClusterCollectionBarrel");

--- a/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/PFECALSuperClusterProducer.cc
@@ -141,7 +141,6 @@ PFECALSuperClusterProducer::PFECALSuperClusterProducer(const edm::ParameterSet& 
 
   produces<reco::SuperClusterCollection>(PFSuperClusterCollectionBarrel_);  
   produces<reco::SuperClusterCollection>(PFSuperClusterCollectionEndcapWithPreshower_);   
-  produces<reco::SuperCluster::EEtoPSAssociation>("eetops");
 }
 
 
@@ -173,8 +172,6 @@ void PFECALSuperClusterProducer::produce(edm::Event& iEvent,
 	     PFSuperClusterCollectionBarrel_);
   iEvent.put(superClusterAlgo_.getEEOutputSCCollection(), 
 	     PFSuperClusterCollectionEndcapWithPreshower_);
-  iEvent.put(superClusterAlgo_.getEEtoPSAssociation(), 
-	     "eetops");
 }
   
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterAlgo.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterAlgo.h
@@ -31,7 +31,7 @@ class TH2F;
 class PFClusterAlgo {
 
  public:
-
+  typedef edm::Handle<std::vector<reco::PFCluster> > PFClusterHandle;
   /// constructor
   PFClusterAlgo();
 
@@ -53,7 +53,13 @@ class PFClusterAlgo {
 
   /// perform clustering in full framework
   void doClustering( const PFRecHitHandle& rechitsHandle );
-  void doClustering( const PFRecHitHandle& rechitsHandle, const std::vector<bool> & mask );
+  void doClustering( const PFRecHitHandle& rechitsHandle,
+		     const PFClusterHandle& psClustersHandle );
+  void doClustering( const PFRecHitHandle& rechitsHandle, 
+		     const std::vector<bool> & mask );
+  void doClustering( const PFRecHitHandle& rechitsHandle, 
+		     const PFClusterHandle& psClustersHandle,
+		     const std::vector<bool> & mask );
   
   /// setters -------------------------------------------------------
   
@@ -171,6 +177,10 @@ class PFClusterAlgo {
   std::auto_ptr< std::vector< reco::PFRecHit > >& rechitsCleaned()  
     {return pfRecHitsCleaned_;}
 
+  /// \return EE->PS association
+  std::auto_ptr<reco::PFCluster::EEtoPSAssociation>& eeToPSAssoc()
+    {return eeToPSAssoc_;}
+
   /// \return threshold, seed threshold, (gaussian width, p1 ??)
   /// for a given zone (endcap, barrel, VFCAL ??)
 
@@ -207,6 +217,8 @@ class PFClusterAlgo {
  private:
   /// perform clustering
   void doClusteringWorker( const reco::PFRecHitCollection& rechits );
+  void doClusteringWorker( const reco::PFRecHitCollection& rechits,
+			   const std::vector<reco::PFCluster>& psClusters );
 
   /// Clean HCAL readout box noise and HPD discharge
   void cleanRBXAndHPD( const reco::PFRecHitCollection& rechits );
@@ -244,6 +256,7 @@ class PFClusterAlgo {
   
 
   PFRecHitHandle           rechitsHandle_;   
+  PFClusterHandle          psclustersHandle_;
 
   /// ids of rechits used in seed search
   std::set<unsigned>       idUsedRecHits_;
@@ -279,6 +292,9 @@ class PFClusterAlgo {
   /// particle flow rechits cleaned
   std::auto_ptr< std::vector<reco::PFRecHit> > pfRecHitsCleaned_;
   
+  // ee to ps association
+  std::auto_ptr<reco::PFCluster::EEtoPSAssociation> eeToPSAssoc_;
+
   ///  barrel threshold
   double threshBarrel_;
   double threshPtBarrel_;

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterAlgo.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterAlgo.h
@@ -31,7 +31,7 @@ class TH2F;
 class PFClusterAlgo {
 
  public:
-  typedef edm::Handle<std::vector<reco::PFCluster> > PFClusterHandle;
+  typedef edm::Handle<edm::View<reco::PFCluster> > PFClusterHandle;
   /// constructor
   PFClusterAlgo();
 
@@ -49,18 +49,14 @@ class PFClusterAlgo {
   
   /// perform clustering
   void doClustering( const reco::PFRecHitCollection& rechits );
-  void doClustering( const reco::PFRecHitCollection& rechits, const std::vector<bool> & mask );
+  void doClustering( const reco::PFRecHitCollection& rechits, 
+		     const std::vector<bool> & mask );
 
   /// perform clustering in full framework
-  void doClustering( const PFRecHitHandle& rechitsHandle );
-  void doClustering( const PFRecHitHandle& rechitsHandle,
-		     const PFClusterHandle& psClustersHandle );
+  void doClustering( const PFRecHitHandle& rechitsHandle );  
   void doClustering( const PFRecHitHandle& rechitsHandle, 
 		     const std::vector<bool> & mask );
-  void doClustering( const PFRecHitHandle& rechitsHandle, 
-		     const PFClusterHandle& psClustersHandle,
-		     const std::vector<bool> & mask );
-  
+    
   /// setters -------------------------------------------------------
   
   /// set barrel threshold
@@ -176,11 +172,7 @@ class PFClusterAlgo {
   /// \return cleaned rechits
   std::auto_ptr< std::vector< reco::PFRecHit > >& rechitsCleaned()  
     {return pfRecHitsCleaned_;}
-
-  /// \return EE->PS association
-  std::auto_ptr<reco::PFCluster::EEtoPSAssociation>& eeToPSAssoc()
-    {return eeToPSAssoc_;}
-
+  
   /// \return threshold, seed threshold, (gaussian width, p1 ??)
   /// for a given zone (endcap, barrel, VFCAL ??)
 
@@ -216,9 +208,7 @@ class PFClusterAlgo {
 
  private:
   /// perform clustering
-  void doClusteringWorker( const reco::PFRecHitCollection& rechits );
-  void doClusteringWorker( const reco::PFRecHitCollection& rechits,
-			   const std::vector<reco::PFCluster>& psClusters );
+  void doClusteringWorker( const reco::PFRecHitCollection& rechits );  
 
   /// Clean HCAL readout box noise and HPD discharge
   void cleanRBXAndHPD( const reco::PFRecHitCollection& rechits );
@@ -252,11 +242,9 @@ class PFClusterAlgo {
   void paint( unsigned rhi, unsigned color=1 );
 
   /// distance to a crack in the ECAL barrel in eta and phi direction
-  std::pair<double,double> dCrack(double phi, double eta);
-  
+  std::pair<double,double> dCrack(double phi, double eta);  
 
   PFRecHitHandle           rechitsHandle_;   
-  PFClusterHandle          psclustersHandle_;
 
   /// ids of rechits used in seed search
   std::set<unsigned>       idUsedRecHits_;
@@ -290,10 +278,7 @@ class PFClusterAlgo {
   std::auto_ptr< std::vector<reco::PFCluster> > pfClusters_;
   
   /// particle flow rechits cleaned
-  std::auto_ptr< std::vector<reco::PFRecHit> > pfRecHitsCleaned_;
-  
-  // ee to ps association
-  std::auto_ptr<reco::PFCluster::EEtoPSAssociation> eeToPSAssoc_;
+  std::auto_ptr< std::vector<reco::PFRecHit> > pfRecHitsCleaned_;  
 
   ///  barrel threshold
   double threshBarrel_;

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
@@ -141,12 +141,18 @@ PFClusterProducer::PFClusterProducer(const edm::ParameterSet& iConfig)
   inputTagPFRecHits_ = 
     iConfig.getParameter<InputTag>("PFRecHits");
   //---ab
+  produces_eeps = iConfig.existsAs<InputTag>("PFClustersPS");
+  if( produces_eeps ) {    
+    inputTagPFClustersPS_ = 
+      iConfig.getParameter<InputTag>("PFClustersPS");
+    produces<reco::PFCluster::EEtoPSAssociation>("eetops");
+  }
 
   //inputTagClusterCollectionName_ =  iConfig.getParameter<string>("PFClusterCollectionName");    
  
   // produces<reco::PFClusterCollection>(inputTagClusterCollectionName_);
    produces<reco::PFClusterCollection>();
-   produces<reco::PFRecHitCollection>("Cleaned");
+   produces<reco::PFRecHitCollection>("Cleaned");   
 
     //---ab
 }
@@ -191,7 +197,12 @@ void PFClusterProducer::produce(edm::Event& iEvent,
   auto_ptr< vector<reco::PFCluster> > outClusters( clusterAlgo_.clusters() ); 
   auto_ptr< vector<reco::PFRecHit> > recHitsCleaned ( clusterAlgo_.rechitsCleaned() ); 
   iEvent.put( outClusters );    
-  iEvent.put( recHitsCleaned, "Cleaned" );    
+  iEvent.put( recHitsCleaned, "Cleaned" ); 
+  if( produces_eeps ) {
+    std::auto_ptr<reco::PFCluster::EEtoPSAssociation> 
+      outEEPS(clusterAlgo_.eeToPSAssoc());
+    iEvent.put(outEEPS);
+  }
 
 }
   

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
@@ -1,8 +1,10 @@
 #include "RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.h"
+#include "RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h"
 
 #include <memory>
 
 #include "RecoParticleFlow/PFClusterProducer/interface/PFClusterAlgo.h"
+#include "RecoParticleFlow/PFClusterTools/interface/LinkByRecHit.h"
 
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
@@ -11,16 +13,51 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
+#include "TVector2.h"
+
 using namespace std;
 using namespace edm;
+
+namespace {
+  typedef reco::PFCluster::EEtoPSAssociation::value_type EEPSPair;
+  bool sortByKey(const EEPSPair& a, const EEPSPair& b) {
+    return a.first < b.first;
+  } 
+  double testPreshowerDistance(const edm::Ptr<reco::PFCluster>& eeclus,
+			       const edm::Ptr<reco::PFCluster>& psclus) {
+    if( psclus.isNull() ) return -1.0;
+    /* 
+    // commented out since PFCluster::layer() uses a lot of CPU
+    // and since 
+    if( PFLayer::ECAL_ENDCAP != eeclus->layer() ) return -1.0;
+    if( PFLayer::PS1 != psclus->layer() &&
+	PFLayer::PS2 != psclus->layer()    ) {
+      throw cms::Exception("testPreshowerDistance")
+	<< "The second argument passed to this function was "
+	<< "not a preshower cluster!" << std::endl;
+    } 
+    */
+    const reco::PFCluster::REPPoint& pspos = psclus->positionREP();
+    const reco::PFCluster::REPPoint& eepos = eeclus->positionREP();
+    // lazy continue based on geometry
+    if( eeclus->z()*psclus->z() < 0 ) return -1.0;
+    const double dphi= std::abs(TVector2::Phi_mpi_pi(eepos.phi() - 
+						     pspos.phi()));
+    if( dphi > 0.6 ) return -1.0;    
+    const double deta= std::abs(eepos.eta() - pspos.eta());    
+    if( deta > 0.3 ) return -1.0; 
+    return LinkByRecHit::testECALAndPSByRecHit(*eeclus,*psclus,false);
+  }
+}
 
 PFClusterProducer::PFClusterProducer(const edm::ParameterSet& iConfig)
 {
     
   verbose_ = 
     iConfig.getUntrackedParameter<bool>("verbose",false);
-
-
+  
+  pfEnergyCalibration_ = 
+    std::shared_ptr<PFEnergyCalibration>(new PFEnergyCalibration());
 
   // parameters for clustering
   
@@ -145,6 +182,9 @@ PFClusterProducer::PFClusterProducer(const edm::ParameterSet& iConfig)
   if( produces_eeps ) {    
     inputTagPFClustersPS_ = 
       iConfig.getParameter<InputTag>("PFClustersPS");
+    threshPFClusterES_ = iConfig.getParameter<double>("thresh_Preshower");
+    applyCrackCorrections_ = 
+      iConfig.getParameter<bool>("applyCractionCorrections");
     produces<reco::PFCluster::EEtoPSAssociation>("eetops");
   }
 
@@ -169,9 +209,11 @@ void PFClusterProducer::produce(edm::Event& iEvent,
   
 
   edm::Handle< reco::PFRecHitCollection > rechitsHandle;
+  edm::Handle< edm::View<reco::PFCluster> > psclustersHandle;
   
   // access the rechits in the event
   bool found = iEvent.getByLabel( inputTagPFRecHits_, rechitsHandle );  
+  
 
   if(!found ) {
 
@@ -192,18 +234,90 @@ void PFClusterProducer::produce(edm::Event& iEvent,
       <<clusterAlgo_<<endl;
   }    
   
-  // get clusters out of the clustering algorithm 
-  // and put them in the event. There is no copy.
-  auto_ptr< vector<reco::PFCluster> > outClusters( clusterAlgo_.clusters() ); 
-  auto_ptr< vector<reco::PFRecHit> > recHitsCleaned ( clusterAlgo_.rechitsCleaned() ); 
-  iEvent.put( outClusters );    
-  iEvent.put( recHitsCleaned, "Cleaned" ); 
+  std::auto_ptr< std::vector<reco::PFCluster> > clusters = 
+    clusterAlgo_.clusters();
+
   if( produces_eeps ) {
+    iEvent.getByLabel( inputTagPFClustersPS_, psclustersHandle );
+    // associate psclusters to ecal rechits
     std::auto_ptr<reco::PFCluster::EEtoPSAssociation> 
-      outEEPS(clusterAlgo_.eeToPSAssoc());
+      outEEPS( new reco::PFCluster::EEtoPSAssociation );
+    // make the association map of ECAL clusters to preshower clusters  
+    edm::PtrVector<reco::PFCluster> clusterPtrsPS = 
+      psclustersHandle->ptrVector();
+    double dist = -1.0, min_dist = -1.0;
+    // match PS clusters to EE clusters, minimum distance to EE is ensured
+    // since the inner loop is over the EE clusters
+    for( const auto& psclus : clusterPtrsPS ) {   
+      if( psclus->energy() < threshPFClusterES_ ) continue;        
+      switch( psclus->layer() ) { // just in case this isn't the ES...
+      case PFLayer::PS1:
+      case PFLayer::PS2:
+	break;
+      default:
+	continue;
+      }    
+      edm::Ptr<reco::PFCluster> eematch,eeclus;
+      dist = min_dist = -1.0; // reset
+      for( size_t ic = 0; ic < clusters->size(); ++ic ) {
+	if( eeclus->layer() != PFLayer::ECAL_ENDCAP ) continue;
+	eeclus = edm::Ptr<reco::PFCluster>(clusters.get(),ic);
+	dist = testPreshowerDistance(eeclus,psclus);      
+	if( dist == -1.0 || (min_dist != -1.0 && dist > min_dist) ) continue;
+	if( dist < min_dist || min_dist == -1.0 ) {
+	  eematch = eeclus;
+	  min_dist = dist;
+	}
+      } // loop on EE clusters      
+      if( eematch.isNonnull() ) {
+	outEEPS->push_back(std::make_pair(eematch.key(),psclus));
+      }
+    } // loop on PS clusters    
+    //sort the ps association
+    std::sort(outEEPS->begin(),outEEPS->end(),sortByKey);
+    
+    std::vector<double> ps1_energies,ps2_energies;
+    double ePS1, ePS2;
+    for( size_t ic = 0 ; ic < clusters->size(); ++ic ) {
+      ps1_energies.clear();
+      ps2_energies.clear();
+      ePS1 = ePS2 = 0;
+      auto ee_key_val = std::make_pair(ic,edm::Ptr<reco::PFCluster>());
+      const auto clustops = std::equal_range(outEEPS->begin(),
+					     outEEPS->end(),
+					     ee_key_val,
+					     sortByKey);
+      for( auto i_ps = clustops.first; i_ps != clustops.second; ++i_ps) {
+	edm::Ptr<reco::PFCluster> psclus(i_ps->second);
+	switch( psclus->layer() ) {
+	case PFLayer::PS1:
+	  ps1_energies.push_back(psclus->energy());
+	  break;
+	case PFLayer::PS2:
+	  ps2_energies.push_back(psclus->energy());
+	  break;
+	default:
+	  break;
+	}
+      }
+      const double eCorr= 
+	pfEnergyCalibration_->energyEm(clusters->at(ic),
+				       ps1_energies,ps2_energies,
+				       ePS1,ePS2,
+				       applyCrackCorrections_);
+      clusters->at(ic).setCorrectedEnergy(eCorr);
+    }
+
     iEvent.put(outEEPS);
   }
 
+  // get clusters out of the clustering algorithm 
+  // and put them in the event. There is no copy.
+  //auto_ptr< vector<reco::PFCluster> > outClusters( clusters ); 
+  auto_ptr< vector<reco::PFRecHit> > recHitsCleaned ( clusterAlgo_.rechitsCleaned() ); 
+  edm::OrphanHandle<reco::PFClusterCollection> outHandle = 
+    iEvent.put( clusters );    
+  iEvent.put( recHitsCleaned, "Cleaned" ); 
 }
   
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
@@ -184,7 +184,7 @@ PFClusterProducer::PFClusterProducer(const edm::ParameterSet& iConfig)
       iConfig.getParameter<InputTag>("PFClustersPS");
     threshPFClusterES_ = iConfig.getParameter<double>("thresh_Preshower");
     applyCrackCorrections_ = 
-      iConfig.getParameter<bool>("applyCractionCorrections");
+      iConfig.getParameter<bool>("applyCrackCorrections");
     produces<reco::PFCluster::EEtoPSAssociation>("eetops");
   }
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
@@ -185,7 +185,7 @@ PFClusterProducer::PFClusterProducer(const edm::ParameterSet& iConfig)
     threshPFClusterES_ = iConfig.getParameter<double>("thresh_Preshower");
     applyCrackCorrections_ = 
       iConfig.getParameter<bool>("applyCrackCorrections");
-    produces<reco::PFCluster::EEtoPSAssociation>("eetops");
+    produces<reco::PFCluster::EEtoPSAssociation>();
   }
 
   //inputTagClusterCollectionName_ =  iConfig.getParameter<string>("PFClusterCollectionName");    
@@ -212,8 +212,7 @@ void PFClusterProducer::produce(edm::Event& iEvent,
   edm::Handle< edm::View<reco::PFCluster> > psclustersHandle;
   
   // access the rechits in the event
-  bool found = iEvent.getByLabel( inputTagPFRecHits_, rechitsHandle );  
-  
+  bool found = iEvent.getByLabel( inputTagPFRecHits_, rechitsHandle );   
 
   if(!found ) {
 
@@ -223,7 +222,6 @@ void PFClusterProducer::produce(edm::Event& iEvent,
     
     throw cms::Exception( "MissingProduct", err.str());
   }
-
 
   // do clustering
   clusterAlgo_.doClustering( rechitsHandle );
@@ -260,8 +258,8 @@ void PFClusterProducer::produce(edm::Event& iEvent,
       edm::Ptr<reco::PFCluster> eematch,eeclus;
       dist = min_dist = -1.0; // reset
       for( size_t ic = 0; ic < clusters->size(); ++ic ) {
-	if( eeclus->layer() != PFLayer::ECAL_ENDCAP ) continue;
 	eeclus = edm::Ptr<reco::PFCluster>(clusters.get(),ic);
+	if( eeclus->layer() != PFLayer::ECAL_ENDCAP ) continue;	
 	dist = testPreshowerDistance(eeclus,psclus);      
 	if( dist == -1.0 || (min_dist != -1.0 && dist > min_dist) ) continue;
 	if( dist < min_dist || min_dist == -1.0 ) {

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.h
@@ -18,6 +18,7 @@
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 
 #include "RecoParticleFlow/PFClusterProducer/interface/PFClusterAlgo.h"
+#include "RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h"
 
 /**\class PFClusterProducer 
 \brief Producer for particle flow  clusters (PFCluster). 
@@ -53,7 +54,8 @@ class PFClusterProducer : public edm::EDProducer {
 
   /// clustering algorithm 
   PFClusterAlgo    clusterAlgo_;
-
+  bool applyCrackCorrections_;
+  std::shared_ptr<PFEnergyCalibration> pfEnergyCalibration_;
 
   /// verbose ?
   bool   verbose_;
@@ -62,6 +64,7 @@ class PFClusterProducer : public edm::EDProducer {
   edm::InputTag    inputTagPFRecHits_;
   bool produces_eeps;
   edm::InputTag    inputTagPFClustersPS_;
+  double threshPFClusterES_;
   //---ab
   //std::string    inputTagClusterCollectionName_;
   //---ab

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.h
@@ -60,6 +60,8 @@ class PFClusterProducer : public edm::EDProducer {
   
   // ----------access to event data
   edm::InputTag    inputTagPFRecHits_;
+  bool produces_eeps;
+  edm::InputTag    inputTagPFClustersPS_;
   //---ab
   //std::string    inputTagClusterCollectionName_;
   //---ab

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECAL_cfi.py
@@ -5,6 +5,7 @@ particleFlowClusterECAL = cms.EDProducer("PFClusterProducer",
     verbose = cms.untracked.bool(False),
     # PFRecHit collection          
     PFRecHits = cms.InputTag("particleFlowRecHitECAL"),
+    PFClustersPS = cms.InputTag('particleFlowClusterPS'), #for EE->PS assoc.
     #PFCluster Collection name
     #PFClusterCollectionName =  cms.string("ECAL"),                                
     #----all thresholds are in GeV

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECAL_cfi.py
@@ -3,9 +3,12 @@ import FWCore.ParameterSet.Config as cms
 particleFlowClusterECAL = cms.EDProducer("PFClusterProducer",
     # verbosity 
     verbose = cms.untracked.bool(False),
+    #corrections
+    applyCrackCorrections = cms.bool(False),
     # PFRecHit collection          
     PFRecHits = cms.InputTag("particleFlowRecHitECAL"),
     PFClustersPS = cms.InputTag('particleFlowClusterPS'), #for EE->PS assoc.
+    thresh_Preshower = cms.double(0.0),
     #PFCluster Collection name
     #PFClusterCollectionName =  cms.string("ECAL"),                                
     #----all thresholds are in GeV

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
@@ -81,18 +81,18 @@ towerMakerPF.AllowMissingInputs = False
 particleFlowClusterWithoutHO = cms.Sequence(
     #caloTowersRec*
     towerMakerPF*
+    pfClusteringPS*
     pfClusteringECAL*
-    pfClusteringHCAL*
-    pfClusteringPS
+    pfClusteringHCAL    
 )
 
 particleFlowCluster = cms.Sequence(
     #caloTowersRec*
     towerMakerPF*
+    pfClusteringPS*
     pfClusteringECAL*
     pfClusteringHCAL*
-    pfClusteringHO*
-    pfClusteringPS
+    pfClusteringHO    
 )
 
 

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterAlgo.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterAlgo.cc
@@ -77,7 +77,8 @@ void PFClusterAlgo::doClustering( const PFRecHitHandle& rechitsHandle ) {
   doClusteringWorker( rechits );
 }
 
-void PFClusterAlgo::doClustering( const PFRecHitHandle& rechitsHandle, const std::vector<bool> & mask ) {
+void PFClusterAlgo::doClustering( const PFRecHitHandle& rechitsHandle, 
+				  const std::vector<bool> & mask ) {
 
   const reco::PFRecHitCollection& rechits = * rechitsHandle;
 
@@ -132,7 +133,6 @@ void PFClusterAlgo::doClustering( const reco::PFRecHitCollection& rechits, const
   doClusteringWorker( rechits );
 
 }
-
 
 void PFClusterAlgo::doClusteringWorker( const reco::PFRecHitCollection& rechits ) {
 

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h
@@ -12,6 +12,7 @@
 
 #include "DataFormats/ParticleFlowReco/interface/PFBlockFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFBlock.h"
+#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidatePhotonExtra.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidatePhotonExtraFwd.h"
@@ -49,7 +50,7 @@ class PFEnergyCalibration;
 
 class PFEGammaAlgo {
  public:
-  typedef reco::SuperCluster::EEtoPSAssociation EEtoPSAssociation;
+  typedef reco::PFCluster::EEtoPSAssociation EEtoPSAssociation;
   typedef reco::PFBlockElementSuperCluster PFSCElement;
   typedef reco::PFBlockElementBrem PFBremElement;
   typedef reco::PFBlockElementGsfTrack PFGSFElement;
@@ -199,7 +200,7 @@ private:
 
   // useful pre-cached mappings:
   // hopefully we get an enum that lets us just make an array in the future
-  edm::Handle<reco::SuperCluster::EEtoPSAssociation> eetops_;
+  edm::Handle<reco::PFCluster::EEtoPSAssociation> eetops_;
   reco::PFBlockRef _currentblock;
   reco::PFBlock::LinkData _currentlinks;  
   // keep a map of pf indices to the splayed block for convenience

--- a/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
@@ -48,7 +48,7 @@ PFEGammaProducer::PFEGammaProducer(const edm::ParameterSet& iConfig) {
   inputTagBlocks_ 
     = consumes<reco::PFBlockCollection>(iConfig.getParameter<edm::InputTag>("blocks"));
 
-  eetopsSrc_ = consumes<reco::SuperCluster::EEtoPSAssociation>(iConfig.getParameter<edm::InputTag>("EEtoPS_source"));
+  eetopsSrc_ = consumes<reco::PFCluster::EEtoPSAssociation>(iConfig.getParameter<edm::InputTag>("EEtoPS_source"));
 
   algo_config.useReg
     =  iConfig.getParameter<bool>("usePhotonReg");
@@ -250,7 +250,7 @@ PFEGammaProducer::produce(edm::Event& iEvent,
   sClusters_.reset( new reco::SuperClusterCollection );      
     
   // Get the EE-PS associations
-  edm::Handle<reco::SuperCluster::EEtoPSAssociation> eetops;
+  edm::Handle<reco::PFCluster::EEtoPSAssociation> eetops;
   iEvent.getByToken(eetopsSrc_,eetops);
 
   // Get The vertices from the event

--- a/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.h
@@ -73,7 +73,7 @@ class PFEGammaProducer : public edm::EDProducer {
 			     );   
   
   edm::EDGetTokenT<reco::PFBlockCollection>  inputTagBlocks_;
-  edm::EDGetTokenT<reco::SuperCluster::EEtoPSAssociation> eetopsSrc_;
+  edm::EDGetTokenT<reco::PFCluster::EEtoPSAssociation> eetopsSrc_;
   edm::EDGetTokenT<reco::VertexCollection>  vertices_;
 
   //Use of HO clusters and links in PF Reconstruction

--- a/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cfi.py
@@ -6,7 +6,7 @@ particleFlowEGamma = cms.EDProducer("PFEGammaProducer",
     blocks = cms.InputTag("particleFlowBlock"),
 
     #EE to PS association
-    EEtoPS_source = cms.InputTag("particleFlowSuperClusterECAL","eetops"),
+    EEtoPS_source = cms.InputTag("particleFlowClusterECAL","eetops"),
 
     #allow building of candidates with no input or output supercluster?
     produceEGCandsWithNoSuperCluster = cms.bool(False),

--- a/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/particleFlowEGamma_cfi.py
@@ -6,7 +6,7 @@ particleFlowEGamma = cms.EDProducer("PFEGammaProducer",
     blocks = cms.InputTag("particleFlowBlock"),
 
     #EE to PS association
-    EEtoPS_source = cms.InputTag("particleFlowClusterECAL","eetops"),
+    EEtoPS_source = cms.InputTag("particleFlowClusterECAL"),
 
     #allow building of candidates with no input or output supercluster?
     produceEGCandsWithNoSuperCluster = cms.bool(False),

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -1421,8 +1421,8 @@ unwrapSuperCluster(const PFSCElement* thesc,
 
 
 int PFEGammaAlgo::attachPSClusters(const PFSCElement* thesc,
-				      const ClusterElement* ecalclus,
-				      ClusterMap::mapped_type& eslist) {  
+				   const ClusterElement* ecalclus,
+				   ClusterMap::mapped_type& eslist) {  
   if( ecalclus->clusterRef()->layer() == PFLayer::ECAL_BARREL ) return 0;
   SuperClusterRef::key_type sc_key = ecalclus->clusterRef().key();
   edm::Ptr<reco::CaloCluster> clusptr = refToPtr(ecalclus->clusterRef());
@@ -1432,7 +1432,7 @@ int PFEGammaAlgo::attachPSClusters(const PFSCElement* thesc,
 				  ecalkey,
 				  comparePSMapByKey);
   for( const auto& ps1 : _splayedblock[reco::PFBlockElement::PS1] ) {
-    edm::Ptr<reco::CaloCluster> temp = refToPtr(ps1.first->clusterRef());
+    edm::Ptr<reco::PFCluster> temp = refToPtr(ps1.first->clusterRef());
     for( auto pscl = assc_ps.first; pscl != assc_ps.second; ++pscl ) {
       if( pscl->second == temp ) {
 	const ClusterElement* pstemp = 
@@ -1442,7 +1442,7 @@ int PFEGammaAlgo::attachPSClusters(const PFSCElement* thesc,
     }
   }
   for( const auto& ps2 : _splayedblock[reco::PFBlockElement::PS2] ) {
-    edm::Ptr<reco::CaloCluster> temp = refToPtr(ps2.first->clusterRef());
+    edm::Ptr<reco::PFCluster> temp = refToPtr(ps2.first->clusterRef());
     for( auto pscl = assc_ps.first; pscl != assc_ps.second; ++pscl ) {
       if( pscl->second == temp ) {
 	const ClusterElement* pstemp = 


### PR DESCRIPTION
Merge ontop of : CMSSW_7_0_X_2013-10-14-1400

This is just a reshuffling of EE-PS cluster association into particleFlowClusterECAL.
particleFlowSuperClusterECAL timing will decrease, particleFlowClusterECAL timing will increase.
Please double check that the above changes as anticipated.

Could possibly cause some minor changes to EE mustache superclusters, this is a bug fix for those SCs.
Originally not using corrected energy for seeding thresholds (no PS info), now this is by default.

This PR passes the short matrix. 
There will be a follow up PR related to some now-possible PFEGamma changes.
