### PR TITLE
Recursive mutex for PluginManager

### DIFF
--- a/FWCore/PluginManager/interface/PluginFactory.h
+++ b/FWCore/PluginManager/interface/PluginFactory.h
@@ -56,16 +56,16 @@ class PluginFactory<R*(Args...)> : public PluginFactoryBase
       virtual const std::string& category() const ;
       
       R* create(const std::string& iName, Args... args) const {
-        return reinterpret_cast<PMakerBase*>(PluginFactoryBase::findPMaker(iName)->second.front().first)->create(std::forward<Args>(args)...);
+        return reinterpret_cast<PMakerBase*>(PluginFactoryBase::findPMaker(iName))->create(std::forward<Args>(args)...);
       }
 
       ///like above but returns 0 if iName is unknown
       R* tryToCreate(const std::string& iName, Args... args) const {
-        typename Plugins::const_iterator itFound = PluginFactoryBase::tryToFindPMaker(iName);
-        if(itFound ==m_plugins.end() ) {
-          return 0;
+        auto found = PluginFactoryBase::tryToFindPMaker(iName);
+        if(found ==nullptr) {
+          return nullptr;
         }
-        return reinterpret_cast<PMakerBase*>(itFound->second.front().first)->create(args...);
+        return reinterpret_cast<PMakerBase*>(found)->create(args...);
       }
       // ---------- static member functions --------------------
 

--- a/FWCore/PluginManager/interface/PluginFactoryBase.h
+++ b/FWCore/PluginManager/interface/PluginFactoryBase.h
@@ -23,6 +23,8 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <mutex>
+
 #include "FWCore/Utilities/interface/Signal.h"
 // user include files
 #include "FWCore/PluginManager/interface/PluginInfo.h"
@@ -87,6 +89,7 @@ class PluginFactoryBase
       void checkProperLoadable(const std::string& iName, const std::string& iLoadedFrom) const;
       // ---------- member data --------------------------------
       Plugins m_plugins;
+      mutable std::recursive_mutex m_mutex;
   
 
 };

--- a/FWCore/PluginManager/interface/PluginFactoryBase.h
+++ b/FWCore/PluginManager/interface/PluginFactoryBase.h
@@ -66,10 +66,10 @@ class PluginFactoryBase
       //since each inheriting class has its own Container type to hold their PMakers
       // this function allows them to share the same code when doing the lookup
       // this routine will throw an exception if iName is unknown therefore the return value is always valid
-      Plugins::const_iterator findPMaker(const std::string& iName) const;
+      void* findPMaker(const std::string& iName) const;
 
       //similar to findPMaker but will return 'end()' if iName is known
-      Plugins::const_iterator tryToFindPMaker(const std::string& iName) const;
+      void* tryToFindPMaker(const std::string& iName) const;
       
       void fillInfo(const PMakers &makers,
                     PluginInfo& iInfo,

--- a/FWCore/PluginManager/interface/PluginFactoryBase.h
+++ b/FWCore/PluginManager/interface/PluginFactoryBase.h
@@ -79,8 +79,6 @@ class PluginFactoryBase
 
       void registerPMaker(void* iPMaker, const std::string& iName);
       
-      Plugins m_plugins;
-      
    private:
       PluginFactoryBase(const PluginFactoryBase&); // stop default
 
@@ -88,6 +86,8 @@ class PluginFactoryBase
 
       void checkProperLoadable(const std::string& iName, const std::string& iLoadedFrom) const;
       // ---------- member data --------------------------------
+      Plugins m_plugins;
+  
 
 };
 

--- a/FWCore/PluginManager/interface/PluginManager.h
+++ b/FWCore/PluginManager/interface/PluginManager.h
@@ -22,6 +22,8 @@
 #include <vector>
 #include <map>
 #include <string>
+#include <mutex>
+
 #include <boost/filesystem/path.hpp>
 #include "boost/shared_ptr.hpp"
 #include "FWCore/Utilities/interface/Signal.h"
@@ -103,7 +105,9 @@ class PluginManager
       void newFactory(const PluginFactoryBase* );
       static std::string& loadingLibraryNamed_();
       static PluginManager*& singleton();
-      
+  
+      std::recursive_mutex& pluginLoadMutex() {return pluginLoadMutex_;}
+  
       const boost::filesystem::path& loadableFor_(const std::string& iCategory,
                                                   const std::string& iPlugin,
                                                   bool& ioThrowIfFailElseSucceedStatus);
@@ -112,6 +116,7 @@ class PluginManager
       std::map<boost::filesystem::path, boost::shared_ptr<SharedLibrary> > loadables_;
       
       CategoryToInfos categoryToInfos_;
+      std::recursive_mutex pluginLoadMutex_;
 };
 
 }

--- a/FWCore/PluginManager/src/PluginFactoryBase.cc
+++ b/FWCore/PluginManager/src/PluginFactoryBase.cc
@@ -75,6 +75,7 @@ PluginFactoryBase::newPlugin(const std::string& iName)
 void*
 PluginFactoryBase::findPMaker(const std::string& iName) const
 {
+  std::lock_guard<std::recursive_mutex> guard(m_mutex);
   //do we already have it?
   Plugins::const_iterator itFound = m_plugins.find(iName);
   if(itFound == m_plugins.end()) {
@@ -94,6 +95,7 @@ PluginFactoryBase::findPMaker(const std::string& iName) const
 void*
 PluginFactoryBase::tryToFindPMaker(const std::string& iName) const
 {
+  std::lock_guard<std::recursive_mutex> guard(m_mutex);
   //do we already have it?
   Plugins::const_iterator itFound = m_plugins.find(iName);
   if(itFound == m_plugins.end()) {
@@ -127,6 +129,7 @@ PluginFactoryBase::fillInfo(const PMakers &makers,
 void 
 PluginFactoryBase::fillAvailable(std::vector<PluginInfo>& iReturn) const {
   PluginInfo info;
+  std::lock_guard<std::recursive_mutex> guard(m_mutex);
   for( Plugins::const_iterator it = m_plugins.begin();
       it != m_plugins.end();
       ++it) {
@@ -156,6 +159,7 @@ PluginFactoryBase::checkProperLoadable(const std::string& iName, const std::stri
 
 void 
 PluginFactoryBase::registerPMaker(void* iPMaker, const std::string& iName) {
+  std::lock_guard<std::recursive_mutex> guard(m_mutex);
   m_plugins[iName].push_back(std::pair<void*,std::string>(iPMaker,PluginManager::loadingFile()));
   newPlugin(iName);
 }

--- a/FWCore/PluginManager/src/PluginFactoryBase.cc
+++ b/FWCore/PluginManager/src/PluginFactoryBase.cc
@@ -72,7 +72,7 @@ PluginFactoryBase::newPlugin(const std::string& iName)
 }
 
 
-PluginFactoryBase::Plugins::const_iterator 
+void*
 PluginFactoryBase::findPMaker(const std::string& iName) const
 {
   //do we already have it?
@@ -87,11 +87,11 @@ PluginFactoryBase::findPMaker(const std::string& iName) const
   } else {
     checkProperLoadable(iName,itFound->second.front().second);
   }
-  return itFound;
+  return itFound->second.front().first;
 }
 
 
-PluginFactoryBase::Plugins::const_iterator 
+void*
 PluginFactoryBase::tryToFindPMaker(const std::string& iName) const
 {
   //do we already have it?
@@ -109,7 +109,7 @@ PluginFactoryBase::tryToFindPMaker(const std::string& iName) const
   } else {
     checkProperLoadable(iName,itFound->second.front().second);
   }
-  return itFound;
+  return itFound != m_plugins.end()? itFound->second.front().first : nullptr;
 }
 
 void 


### PR DESCRIPTION
This fixes the problem with the previous commit which added thread safety to the plugin system. The last commit failed becuase a plugin was requested to be loaded while we were in the process of loading an earlier plugin request. This code uses a recursive mutex which will allow the job to proceed.
