### PR TITLE
clear the event selector in a thread safe manner

### DIFF
--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -180,12 +180,12 @@ namespace edm {
   OutputModule::doEvent(EventPrincipal const& ep,
                         EventSetup const&,
                         ModuleCallingContext const* mcc) {
-    detail::TRBESSentry products_sentry(selectors_);
 
     FDEBUG(2) << "writeEvent called\n";
 
     {
       std::lock_guard<std::mutex> guard(mutex_);
+      detail::TRBESSentry products_sentry(selectors_);
       if(!wantAllEvents_) {
         if(!selectors_.wantEvent(ep, mcc)) {
           return true;

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -187,10 +187,10 @@ namespace edm {
     OutputModuleBase::doEvent(EventPrincipal const& ep,
                               EventSetup const&,
                               ModuleCallingContext const* mcc) {
-      detail::TRBESSentry products_sentry(selectors_);
       
       {
         std::lock_guard<std::mutex> guard(mutex_);
+        detail::TRBESSentry products_sentry(selectors_);
         if(!wantAllEvents_) {
           if(!selectors_.wantEvent(ep, mcc)) {
             return true;


### PR DESCRIPTION
Moved the sentry used to clear the event selector at the end of each event processing to be within the mutex. This makes sure all updates on that object are done in the same critical section.
