### PR TITLE
For ROOT6 dictionary generation, nested class/struct must be public.

### DIFF
--- a/DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h
+++ b/DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h
@@ -8,9 +8,7 @@
  *  the id of the Det defining the surface.
  */
 class PTrajectoryStateOnDet {
-private:
-  // we assume that id cannot be calo! (i.e. det<4)
-  static const unsigned int idMask = 0x3fffffff;
+public:
   // little endian...
   struct Packing {
     unsigned int rest : 30;
@@ -21,6 +19,9 @@ private:
     unsigned char sub : 3;
     unsigned char det : 4;
   };
+private:
+  // we assume that id cannot be calo! (i.e. det<4)
+  static const unsigned int idMask = 0x3fffffff;
   union Pack {
     Pack(){}
     Pack(unsigned int pack) : packed(pack){}

--- a/DataFormats/VertexReco/interface/Vertex.h
+++ b/DataFormats/VertexReco/interface/Vertex.h
@@ -140,7 +140,6 @@ namespace reco {
     /// Returns the number of tracks in the vertex with weight above minWeight
     unsigned int nTracks(float minWeight=0.5) const; 
 
-  private:
     class TrackEqual {
       public:
 	TrackEqual( const Track & t) : track_( t ) { }
@@ -148,6 +147,8 @@ namespace reco {
       private:
 	const Track & track_;
     };
+
+  private:
     /// chi-sqared
     float chi2_;
     /// number of degrees of freedom

--- a/PhysicsTools/MVAComputer/interface/MVAComputer.h
+++ b/PhysicsTools/MVAComputer/interface/MVAComputer.h
@@ -92,7 +92,6 @@ class MVAComputer {
 	/// construct a discriminator computer from C++ input stream
 	MVAComputer(std::istream &is);
 
-    private:
 	/** \class InputVar
 	 * \short input variable configuration object
 	 */
@@ -175,6 +174,7 @@ class MVAComputer {
 		unsigned int			n_;
 	};
 	
+    private:
 	/// construct processors from calibration and setup variables
 	void setup(const Calibration::MVAComputer *calib);
 

--- a/PhysicsTools/MVAComputer/interface/TreeReader.h
+++ b/PhysicsTools/MVAComputer/interface/TreeReader.h
@@ -56,24 +56,11 @@ class TreeReader {
 
 	static const double	kOptVal;
 
-    private:
-	TTree				*tree;
-
 	struct Bool {
 		inline Bool() : value(0) {}
 		inline operator Bool_t() const { return value; }
 		Bool_t	value;
 	};
-
-	std::vector<std::pair<void*, std::vector<Double_t> > >	multiDouble;
-	std::vector<std::pair<void*, std::vector<Float_t> > >	multiFloat;
-	std::vector<std::pair<void*, std::vector<Int_t> > >	multiInt;
-	std::vector<std::pair<void*, std::vector<Bool_t> > >	multiBool;
-
-	std::vector<Double_t>		singleDouble;
-	std::vector<Float_t>		singleFloat;
-	std::vector<Int_t>		singleInt;
-	std::vector<Bool>		singleBool;
 
 	class Value {
 	    public:
@@ -104,6 +91,19 @@ class TreeReader {
 	};
 
 	friend class Value;
+
+    private:
+	TTree				*tree;
+
+	std::vector<std::pair<void*, std::vector<Double_t> > >	multiDouble;
+	std::vector<std::pair<void*, std::vector<Float_t> > >	multiFloat;
+	std::vector<std::pair<void*, std::vector<Int_t> > >	multiInt;
+	std::vector<std::pair<void*, std::vector<Bool_t> > >	multiBool;
+
+	std::vector<Double_t>		singleDouble;
+	std::vector<Float_t>		singleFloat;
+	std::vector<Int_t>		singleInt;
+	std::vector<Bool>		singleBool;
 
 	std::map<AtomicId, Value>	valueMap;
 	Variable::ValueList		values;

--- a/PhysicsTools/MVATrainer/interface/MVATrainer.h
+++ b/PhysicsTools/MVATrainer/interface/MVATrainer.h
@@ -59,12 +59,6 @@ class MVATrainer {
 	static const AtomicId kTargetId;
 	static const AtomicId kWeightId;
 
-    private:
-	SourceVariable *getVariable(AtomicId source, AtomicId name) const;
-
-	SourceVariable *createVariable(Source *source, AtomicId name,
-	                               Variable::Flags flags);
-
 	struct CalibratedProcessor {
 		CalibratedProcessor(TrainProcessor *processor,
 		                    Calibration::VarProcessor *calib) :
@@ -73,6 +67,12 @@ class MVATrainer {
 		TrainProcessor			*processor;
 		Calibration::VarProcessor	*calib;
 	};
+
+    private:
+	SourceVariable *getVariable(AtomicId source, AtomicId name) const;
+
+	SourceVariable *createVariable(Source *source, AtomicId name,
+	                               Variable::Flags flags);
 
 	void fillInputVars(SourceVariableSet &vars,
 	                   XERCES_CPP_NAMESPACE_QUALIFIER DOMElement *xml);

--- a/SimDataFormats/DigiSimLinks/interface/DTDigiSimLink.h
+++ b/SimDataFormats/DigiSimLinks/interface/DTDigiSimLink.h
@@ -42,16 +42,16 @@ class DTDigiSimLink {
   // Return the Encoded Event Id
   EncodedEventId eventId()  const;
 
-private:
-  // The value of one TDC count in ns
-  static const double reso;
-
   // Used to repack the channel number to an int
   struct ChannelPacking {
     uint16_t wi;
     uint16_t num;
   };
   
+private:
+  // The value of one TDC count in ns
+  static const double reso;
+
  private:
   uint16_t theWire;       // wire number
   uint16_t theDigiNumber; // digi number on the wire


### PR DESCRIPTION
ROOT 6 cannot create a dictionary for any class that has a private nested class/struct definition.
This pull request makes all  nested class/struct definitions public for classes for which there is a dictionary specification.
Note that this pull request does not make any data members public.  It only makes the definitions of the nested class/struct public.
This has been tested with checkdeps -a and the relval matrix.

In some cases, the declarations were moved to keep the public and private sections of the class each contiguous.
