### PR TITLE
Add hits associated to DT segments. Fix DT segments in RhoZ view, ...

### DIFF
--- a/Fireworks/Muons/plugins/FWDTSegmentProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWDTSegmentProxyBuilder.cc
@@ -12,6 +12,7 @@
 
 #include "TEveGeoNode.h"
 #include "TEveStraightLineSet.h"
+#include "TEvePointSet.h"
 #include "TGeoArb8.h"
 
 #include "Fireworks/Core/interface/FWSimpleProxyBuilderTemplate.h"
@@ -19,7 +20,10 @@
 #include "Fireworks/Core/interface/FWGeometry.h"
 #include "Fireworks/Core/interface/fwLog.h"
 
+#include "DataFormats/MuonDetId/interface/DTChamberId.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
+
+#include <vector>
 
 class FWDTSegmentProxyBuilder : public FWSimpleProxyBuilderTemplate<DTRecSegment4D>
 {
@@ -27,18 +31,20 @@ public:
    FWDTSegmentProxyBuilder( void ) {}
    virtual ~FWDTSegmentProxyBuilder( void ) {}
 
+  virtual bool haveSingleProduct() const override { return false; }
+
    REGISTER_PROXYBUILDER_METHODS();
 
 private:
    FWDTSegmentProxyBuilder( const FWDTSegmentProxyBuilder& );
    const FWDTSegmentProxyBuilder& operator=( const FWDTSegmentProxyBuilder& );
 
-   void build( const DTRecSegment4D& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext* ) override;
+   void buildViewType( const DTRecSegment4D& iData, unsigned int iIndex, TEveElement& oItemHolder, FWViewType::EType type, const FWViewContext* ) override;
 };
 
 void
-FWDTSegmentProxyBuilder::build( const DTRecSegment4D& iData,           
-				unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext* )
+FWDTSegmentProxyBuilder::buildViewType( const DTRecSegment4D& iData,           
+				unsigned int iIndex, TEveElement& oItemHolder, FWViewType::EType type, const FWViewContext* )
 {
   unsigned int rawid = iData.chamberId().rawId();
   const FWGeometry *geom = item()->getGeom();
@@ -68,6 +74,14 @@ FWDTSegmentProxyBuilder::build( const DTRecSegment4D& iData,
       double localDirectionIn[3]  = {  dir.x(),  dir.y(),  dir.z() };
       double localDirectionOut[3] = { -dir.x(), -dir.y(), -dir.z() };
 
+      // In RhoZ view, draw segments at the middle of the chamber, otherwise they won't align with 1D rechits, 
+      // for which only one coordinate is known.
+      if (type == FWViewType::kRhoZ) { 
+	localPosition[0]=0;
+	localDirectionIn[0]=0;
+	localDirectionOut[0]=0;
+      }
+
       Double_t distIn = box->DistFromInside( localPosition, localDirectionIn );
       Double_t distOut = box->DistFromInside( localPosition, localDirectionOut );
       LocalVector vIn = unit * distIn;
@@ -89,6 +103,37 @@ FWDTSegmentProxyBuilder::build( const DTRecSegment4D& iData,
 
       segmentSet->AddLine( globalSegmentInnerPoint[0], globalSegmentInnerPoint[1], globalSegmentInnerPoint[2],
 			   globalSegmentOuterPoint[0], globalSegmentOuterPoint[1], globalSegmentOuterPoint[2] );
+
+      
+      // Draw hits included in the segment
+      TEvePointSet* pointSet = new TEvePointSet;
+      // FIXME: This should be set elsewhere.
+      pointSet->SetMarkerSize(1.5);
+      setupAddElement( pointSet, &oItemHolder );
+
+      std::vector<DTRecHit1D> recHits;
+      const DTChamberRecSegment2D* phiSeg = iData.phiSegment();      
+      const DTSLRecSegment2D* zSeg = iData.zSegment();
+      if (type == FWViewType::kRhoPhi && phiSeg) {
+	recHits = phiSeg->specificRecHits();
+      }
+      if (type == FWViewType::kRhoZ && zSeg) {
+	recHits = zSeg->specificRecHits();
+      }
+
+      for (std::vector<DTRecHit1D>::const_iterator rh=recHits.begin(); rh!=recHits.end(); ++rh){
+	DTLayerId layerId = (*rh).wireId().layerId();
+	LocalPoint hpos = (*rh).localPosition();
+	float hitLocalPos[3]= {hpos.x(), hpos.y(), hpos.z()};
+	if (layerId.superLayer()==2 && type == FWViewType::kRhoZ) {
+	  // In RhoZ view, draw theta SL hits at the middle of the chamber, otherwise they won't align with 1D rechits, 
+	  // for which only one coordinate is known.
+	  hitLocalPos[1]=0;
+	}
+	float hitGlobalPoint[3];
+	geom->localToGlobal(layerId, hitLocalPos, hitGlobalPoint);
+	pointSet->SetNextPoint(hitGlobalPoint[0], hitGlobalPoint[1], hitGlobalPoint[2]);
+      }
     }
   }
 }


### PR DESCRIPTION
...so that they are displayed aligned to 1D rechits.
The attached picture shows DTSegment with the fix (blue), overlaid to DT 1D rechits (yellow; displayed here just for reference)
![visdtsegments](https://f.cloud.github.com/assets/5168720/1350887/cf1184ba-3714-11e3-80b7-bfffa50f2521.png)
