### PR TITLE
Use threads with ROOT

### DIFF
--- a/DataFormats/Common/interface/RefCoreStreamer.h
+++ b/DataFormats/Common/interface/RefCoreStreamer.h
@@ -15,6 +15,8 @@ namespace edm {
 
     void operator() (TBuffer &R__b, void *objp);
 
+    TClassStreamer* Generate() const;
+    
   private:
     TClassRef cl_;
   };
@@ -24,7 +26,8 @@ namespace edm {
     explicit RefCoreWithIndexStreamer() : cl_("edm::RefCoreWithIndex"){}
     
     void operator() (TBuffer &R__b, void *objp);
-    
+
+    TClassStreamer* Generate() const;
   private:
     TClassRef cl_;
   };

--- a/DataFormats/Common/src/RefCoreStreamer.cc
+++ b/DataFormats/Common/src/RefCoreStreamer.cc
@@ -63,7 +63,15 @@ namespace edm {
     }
   }
 
-  
+  TClassStreamer*
+  RefCoreStreamer::Generate() const {
+    return new RefCoreStreamer(*this);
+  }
+
+  TClassStreamer*
+  RefCoreWithIndexStreamer::Generate() const {
+    return new RefCoreWithIndexStreamer(*this);
+  }
 
 
   void setRefCoreStreamer(bool resetAll) {

--- a/DataFormats/Streamer/interface/StreamedProductStreamer.h
+++ b/DataFormats/Streamer/interface/StreamedProductStreamer.h
@@ -10,6 +10,7 @@ namespace edm {
 
     void operator() (TBuffer &R__b, void *objp);
 
+    TClassStreamer* Generate() const;
   private:
     TClassRef cl_;
   };

--- a/DataFormats/Streamer/src/StreamedProductStreamer.cc
+++ b/DataFormats/Streamer/src/StreamedProductStreamer.cc
@@ -27,6 +27,11 @@ namespace edm {
       }
     }
   }
+  
+  TClassStreamer*
+  StreamedProductStreamer::Generate() const {
+    return new StreamedProductStreamer(*this);
+  }
 
   void
   setStreamedProductStreamer() {

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -89,6 +89,9 @@
 //Needed for introspection
 #include "Cintex/Cintex.h"
 
+//FIXME: Threading problems with ROOT
+#include "TThread.h"
+
 namespace edm {
 
   // ---------------------------------------------------------------
@@ -1804,6 +1807,9 @@ namespace edm {
   
   void EventProcessor::processEventsForStreamAsync(unsigned int iStreamIndex,
                                                    std::atomic<bool>* finishedProcessingEvents) {
+    //FIXME: ROOT requires a dummy TThread be created on each thread which could talk to ROOT
+    static thread_local TThread guard;
+    
     try {
       // make the services available
       ServiceRegistry::Operate operate(serviceToken_);

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -55,6 +55,7 @@
 #include "FWCore/Utilities/interface/UnixSignalHandlers.h"
 #include "FWCore/Utilities/interface/ExceptionCollector.h"
 #include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/RootHandlers.h"
 
 #include "MessageForSource.h"
 #include "MessageForParent.h"
@@ -88,9 +89,6 @@
 
 //Needed for introspection
 #include "Cintex/Cintex.h"
-
-//FIXME: Threading problems with ROOT
-#include "TThread.h"
 
 namespace edm {
 
@@ -479,6 +477,11 @@ namespace edm {
 
     //make the services available
     ServiceRegistry::Operate operate(serviceToken_);
+    
+    if(nStreams>1) {
+      edm::Service<RootHandlers> handler;
+      handler->willBeUsingThreads();
+    }
 
     // intialize miscellaneous items
     boost::shared_ptr<CommonParams> common(items.initMisc(*parameterSet));
@@ -1807,13 +1810,14 @@ namespace edm {
   
   void EventProcessor::processEventsForStreamAsync(unsigned int iStreamIndex,
                                                    std::atomic<bool>* finishedProcessingEvents) {
-    //FIXME: ROOT requires a dummy TThread be created on each thread which could talk to ROOT
-    static thread_local TThread guard;
-    
     try {
       // make the services available
       ServiceRegistry::Operate operate(serviceToken_);
-
+      if(preallocations_.numberOfStreams()>1) {
+        edm::Service<RootHandlers> handler;
+        handler->initializeThisThreadForUse();
+      }
+      
       if(iStreamIndex==0) {
         processEvent(0);
       }

--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -26,6 +26,7 @@
 #include "TSystem.h"
 #include "TUnixSystem.h"
 #include "TTree.h"
+#include "TThread.h"
 
 namespace {
   enum class SeverityLevel {
@@ -116,7 +117,10 @@ namespace {
           (el_location.find("TDecompChol::Solve") != std::string::npos) ||
           (el_location.find("THistPainter::PaintInit") != std::string::npos) ||
           (el_location.find("TUnixSystem::SetDisplay") != std::string::npos) ||
-          (el_location.find("TGClient::GetFontByName") != std::string::npos)) {
+          (el_location.find("TGClient::GetFontByName") != std::string::npos) ||
+          (level < kError and
+           (el_location.find("CINTTypedefBuilder::Setup")!= std::string::npos) and
+           (el_message.find("possible entries are in use!") != std::string::npos))) {
         el_severity = SeverityLevel::kInfo;
       }
 
@@ -197,8 +201,12 @@ namespace edm {
       : RootHandlers(),
         unloadSigHandler_(pset.getUntrackedParameter<bool> ("UnloadRootSigHandler")),
         resetErrHandler_(pset.getUntrackedParameter<bool> ("ResetRootErrHandler")),
-        autoLibraryLoader_(pset.getUntrackedParameter<bool> ("AutoLibraryLoader")) {
-
+        loadAllDictionaries_(pset.getUntrackedParameter<bool>("LoadAllDictionaries")),
+        autoLibraryLoader_(loadAllDictionaries_ or pset.getUntrackedParameter<bool> ("AutoLibraryLoader"))
+    {
+      //Tell Root we want to be multi-threaded
+      TThread::Initialize();
+      
       if(unloadSigHandler_) {
       // Deactivate all the Root signal handlers and restore the system defaults
         gSystem->ResetSignal(kSigChild);
@@ -231,6 +239,9 @@ namespace edm {
       // Enable automatic Root library loading.
       if(autoLibraryLoader_) {
         RootAutoLibraryLoader::enable();
+        if(loadAllDictionaries_) {
+          RootAutoLibraryLoader::loadAll();
+        }
       }
 
       // Enable Cintex.
@@ -271,6 +282,8 @@ namespace edm {
           ->setComment("If True, ROOT messages (e.g. errors, warnings) are handled by this service, rather than by ROOT.");
       desc.addUntracked<bool>("AutoLibraryLoader", true)
           ->setComment("If True, enables automatic loading of data dictionaries.");
+      desc.addUntracked<bool>("LoadAllDictionaries",false)
+          ->setComment("If True, loads all ROOT dictionaries.");
       desc.addUntracked<bool>("AbortOnSignal",true)
       ->setComment("If True, do an abort when a signal occurs that causes a crash. If False, ROOT will do an exit which attempts to do a clean shutdown.");
       descriptions.add("InitRootHandlers", desc);

--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -204,10 +204,6 @@ namespace edm {
         loadAllDictionaries_(pset.getUntrackedParameter<bool>("LoadAllDictionaries")),
         autoLibraryLoader_(loadAllDictionaries_ or pset.getUntrackedParameter<bool> ("AutoLibraryLoader"))
     {
-      //Tell Root we want to be multi-threaded
-      TThread::Initialize();
-      //When threading, also have to keep ROOT from logging all TObjects into a list
-      TObject::SetObjectStat(false);
       
       if(unloadSigHandler_) {
       // Deactivate all the Root signal handlers and restore the system defaults
@@ -273,6 +269,23 @@ namespace edm {
         TFile* f = dynamic_cast<TFile*>(iter.Next());
         if(f) f->Close();
       }
+    }
+    
+    void InitRootHandlers::willBeUsingThreads() {
+      //Tell Root we want to be multi-threaded
+      TThread::Initialize();
+      //When threading, also have to keep ROOT from logging all TObjects into a list
+      TObject::SetObjectStat(false);
+      if(not this->autoLibraryLoader_) {
+        RootAutoLibraryLoader::enable();
+      }
+      if(not this->loadAllDictionaries_) {
+        RootAutoLibraryLoader::loadAll();
+      }
+    }
+    
+    void InitRootHandlers::initializeThisThreadForUse() {
+      static thread_local TThread guard;
     }
 
     void InitRootHandlers::fillDescriptions(ConfigurationDescriptions& descriptions) {

--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -206,6 +206,8 @@ namespace edm {
     {
       //Tell Root we want to be multi-threaded
       TThread::Initialize();
+      //When threading, also have to keep ROOT from logging all TObjects into a list
+      TObject::SetObjectStat(false);
       
       if(unloadSigHandler_) {
       // Deactivate all the Root signal handlers and restore the system defaults

--- a/FWCore/Services/src/InitRootHandlers.h
+++ b/FWCore/Services/src/InitRootHandlers.h
@@ -21,6 +21,7 @@ namespace edm {
       virtual void ignoreWarnings_() override;
       bool unloadSigHandler_;
       bool resetErrHandler_;
+      bool loadAllDictionaries_;
       bool autoLibraryLoader_;
     };
 

--- a/FWCore/Services/src/InitRootHandlers.h
+++ b/FWCore/Services/src/InitRootHandlers.h
@@ -19,6 +19,9 @@ namespace edm {
     private:
       virtual void enableWarnings_() override;
       virtual void ignoreWarnings_() override;
+      virtual void willBeUsingThreads() override;
+      virtual void initializeThisThreadForUse() override;
+
       bool unloadSigHandler_;
       bool resetErrHandler_;
       bool loadAllDictionaries_;

--- a/FWCore/Utilities/interface/RootHandlers.h
+++ b/FWCore/Utilities/interface/RootHandlers.h
@@ -2,6 +2,7 @@
 #define FWCore_Utilities_RootHandlers_h
 
 namespace edm {
+  class EventProcessor;
   class RootHandlers {
   private:
     struct WarningSentry {
@@ -14,6 +15,7 @@ namespace edm {
       RootHandlers* m_handler;
     };
     friend struct edm::RootHandlers::WarningSentry;
+    friend class edm::EventProcessor;
 
   public:
     RootHandlers () {}
@@ -24,7 +26,11 @@ namespace edm {
       WarningSentry sentry(this);
       iFunc();
     }
-  private: 
+    
+  private:
+    virtual void willBeUsingThreads() = 0;
+    virtual void initializeThisThreadForUse() = 0;
+    
     virtual void enableWarnings_() = 0;
     virtual void ignoreWarnings_() = 0;
   };


### PR DESCRIPTION
Use InitRootHandlers to make all the necessary calls to ROOT to enable ROOT's "thread safe" mode. This includes telling ROOT early that we will be using threads and then on each thread creating a dummy instance of TThread. The actual order of calling is handled by EventProcessor by calling through to the appropriate virtual function of RootHandlers. Also, all classes which inherit from TClassStreamer need to have a proper Generate() method since it is now called to create a copy of that class for each thread.
