### PR TITLE
nested structs of persistent classes must be public in ROOT 6 (again)

### DIFF
--- a/AnalysisDataFormats/TopObjects/interface/TtEvent.h
+++ b/AnalysisDataFormats/TopObjects/interface/TtEvent.h
@@ -31,10 +31,10 @@ class TtEvent {
   enum HypoClassKey {kGeom, kWMassMaxSumPt, kMaxSumPtWMass, kGenMatch, kMVADisc, kKinFit, kKinSolution, kWMassDeltaTopMass, kHitFit};
   /// pair of hypothesis and lepton jet combinatorics for a given hypothesis
   typedef std::pair<reco::CompositeCandidate, std::vector<int> > HypoCombPair;
-
- protected:
    /// a lightweight map for selection type string label and enum value
    struct HypoClassKeyStringToEnum { const char* label; HypoClassKey value; };
+
+ protected:
    /// return the corresponding enum value from a string 
    HypoClassKey hypoClassKeyFromString(const std::string& label) const;
   

--- a/CondFormats/SiStripObjects/interface/SiStripLatency.h
+++ b/CondFormats/SiStripObjects/interface/SiStripLatency.h
@@ -114,8 +114,6 @@ class SiStripLatency
   /// Prints the full list of all ranges and corresponding values of latency and mode
   void printDebug(std::stringstream & ss) const;
 
- private:
-
   struct OrderByDetIdAndApv
   {
     bool operator()(const Latency & lat1, const uint32_t detIdAndApv) const {
@@ -139,6 +137,8 @@ class SiStripLatency
       return( (lat1.latency == lat2.latency) && (lat1.mode == lat2.mode) );
     }
   };
+
+ private:
 
   /// Used to compute the position with the lower_bound binary search
   // If put in the cc file it will not know about the typedefs and the Latency class

--- a/DataFormats/METReco/interface/HcalNoiseRBX.h
+++ b/DataFormats/METReco/interface/HcalNoiseRBX.h
@@ -93,6 +93,14 @@ namespace reco {
     double caloTowerTotalE(void) const;
     double caloTowerEmFraction(void) const;
     
+    // helper function to get the unique calotowers
+    struct twrcomp {
+      inline bool operator() ( const CaloTower & t1, const CaloTower & t2 ) {
+	return t1.id() < t2.id();
+      }
+    };
+    typedef std::set<CaloTower, twrcomp> towerset_t;
+
   private:
     
     // members
@@ -103,14 +111,6 @@ namespace reco {
 
     // the charge
     std::vector<float> allCharge_;
-
-    // helper function to get the unique calotowers
-    struct twrcomp {
-      inline bool operator() ( const CaloTower & t1, const CaloTower & t2 ) {
-	return t1.id() < t2.id();
-      }
-    };
-    typedef std::set<CaloTower, twrcomp> towerset_t;
 
     void uniqueTowers(towerset_t& twrs_) const;
   };

--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -149,15 +149,6 @@ namespace pat {
           return pfMET_[0];
       }
 
-    protected:
-
-      // ---- GenMET holder ----
-      std::vector<reco::GenMET> genMET_;
-      // ---- holder for CaloMET specific info ---
-      std::vector<SpecificCaloMETData> caloMET_;
-      // ---- holder for pfMET specific info ---
-      std::vector<SpecificPFMETData> pfMET_;
-
       // ---- members for MET corrections ----
       struct UncorInfo {
 	UncorInfo(): corEx(0), corEy(0), corSumEt(0), pt(0), phi(0) {}
@@ -167,6 +158,16 @@ namespace pat {
 	float pt;
 	float phi;
       };
+
+    protected:
+
+      // ---- GenMET holder ----
+      std::vector<reco::GenMET> genMET_;
+      // ---- holder for CaloMET specific info ---
+      std::vector<SpecificCaloMETData> caloMET_;
+      // ---- holder for pfMET specific info ---
+      std::vector<SpecificPFMETData> pfMET_;
+
       // uncorrection transients
       mutable std::vector<UncorInfo> uncorInfo_;
       mutable unsigned int nCorrections_;

--- a/DataFormats/PatCandidates/interface/StringMap.h
+++ b/DataFormats/PatCandidates/interface/StringMap.h
@@ -32,8 +32,6 @@ class StringMap {
         const_iterator end() const { return entries_.end(); }
     
         size_t size() const { return entries_.size(); }
-    private:
-        std::vector< std::pair<std::string, int32_t> > entries_;
         class MatchByString {
             public:
                 MatchByString() {}
@@ -50,6 +48,8 @@ class StringMap {
             private:
                 int32_t number_;
         };
+    private:
+        std::vector< std::pair<std::string, int32_t> > entries_;
         
 } ;
 


### PR DESCRIPTION
This pull request covers classes that were missed in the previous pull request for various reasons:

ROOT 6 cannot create a dictionary for any class that has a private nested class/struct definition.
This pull request makes all nested class/struct definitions public for classes for which there is a dictionary specification.
Note that this pull request does not make any data members public. It only makes the definitions of the nested class/struct public.
This has been tested with checkdeps -a and the relval matrix.

In some cases, the declarations were moved to keep the public and private sections of the class each contiguous.
