### PR TITLE
Add consumes interface to mixing module

### DIFF
--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
@@ -1,12 +1,14 @@
 #include "RecoTrackAccumulator.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 
-RecoTrackAccumulator::RecoTrackAccumulator(const edm::ParameterSet& conf, edm::EDProducer& mixMod) {
-    
-  GeneralTrackInput_ = conf.getParameter<edm::InputTag>("GeneralTrackInput");
-  GeneralTrackOutput_  = conf.getParameter<std::string>("GeneralTrackOutput");
+RecoTrackAccumulator::RecoTrackAccumulator(const edm::ParameterSet& conf, edm::EDProducer& mixMod, edm::ConsumesCollector& iC) :
+  GeneralTrackInput_(conf.getParameter<edm::InputTag>("GeneralTrackInput")),
+  GeneralTrackOutput_(conf.getParameter<std::string>("GeneralTrackOutput"))
+{
 
   mixMod.produces<reco::TrackCollection>(GeneralTrackOutput_);
+  iC.consumes<reco::TrackCollection>(GeneralTrackInput_);
 }
   
 RecoTrackAccumulator::~RecoTrackAccumulator() {
@@ -26,8 +28,8 @@ void RecoTrackAccumulator::accumulate(edm::Event const& e, edm::EventSetup const
   e.getByLabel(GeneralTrackInput_, tracks);
   
   if (tracks.isValid()) {
-    for (reco::TrackCollection::const_iterator track = tracks->begin();  track != tracks->end();  ++track) {
-      NewTrackList_->push_back(*track);
+    for (auto const& track : *tracks) {
+      NewTrackList_->push_back(track);
     }
   }
 

--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
@@ -33,6 +33,7 @@ namespace edm {
 }
 */
 namespace edm {
+  class ConsumesCollector;
   template<typename T> class Handle;
 }
 
@@ -40,7 +41,7 @@ namespace edm {
 class RecoTrackAccumulator : public DigiAccumulatorMixMod 
 {
  public:
-  explicit RecoTrackAccumulator(const edm::ParameterSet& conf, edm::EDProducer& mixMod);
+  explicit RecoTrackAccumulator(const edm::ParameterSet& conf, edm::EDProducer& mixMod, edm::ConsumesCollector& iC);
   virtual ~RecoTrackAccumulator();
   
   virtual void initializeEvent(edm::Event const& e, edm::EventSetup const& c);

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
@@ -1,6 +1,6 @@
 #include "SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h"
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -18,7 +18,7 @@
 #include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
-CastorDigiProducer::CastorDigiProducer(const edm::ParameterSet& ps, edm::EDProducer& mixMod) 
+CastorDigiProducer::CastorDigiProducer(const edm::ParameterSet& ps, edm::EDProducer& mixMod, edm::ConsumesCollector& iC) 
 : theParameterMap(new CastorSimParameterMap(ps)),
   theCastorShape(new CastorShape()),
   theCastorIntegratedShape(new CaloShapeIntegrator(theCastorShape)),
@@ -30,6 +30,7 @@ CastorDigiProducer::CastorDigiProducer(const edm::ParameterSet& ps, edm::EDProdu
   theCastorDigitizer(0),
   theCastorHits()
 {
+  iC.consumes<std::vector<PCaloHit> >(edm::InputTag("g4SimHits", "CastorFI"));
   
   mixMod.produces<CastorDigiCollection>();
 
@@ -103,18 +104,16 @@ void CastorDigiProducer::accumulateCaloHits(std::vector<PCaloHit> const& hcalHit
 
 void CastorDigiProducer::accumulate(edm::Event const& e, edm::EventSetup const&) {
   // Step A: Get and accumulate digitized hits 
-  edm::InputTag castorTag("g4SimHits", "CastorFI");
   edm::Handle<std::vector<PCaloHit> > castorHandle;
-  e.getByLabel(castorTag, castorHandle);
+  e.getByLabel(edm::InputTag("g4SimHits", "CastorFI"), castorHandle);
 
   accumulateCaloHits(*castorHandle.product(), 0);
 }
 
 void CastorDigiProducer::accumulate(PileUpEventPrincipal const& e, edm::EventSetup const&) {
   // Step A: Get and accumulate digitized hits 
-  edm::InputTag castorTag("g4SimHits", "CastorFI");
   edm::Handle<std::vector<PCaloHit> > castorHandle;
-  e.getByLabel(castorTag, castorHandle);
+  e.getByLabel(edm::InputTag("g4SimHits", "CastorFI"), castorHandle);
 
   accumulateCaloHits(*castorHandle.product(), e.bunchCrossing());
 }

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
@@ -26,7 +26,7 @@ class PileUpEventPrincipal;
 class CastorDigiProducer : public DigiAccumulatorMixMod {
 public:
 
-  explicit CastorDigiProducer(const edm::ParameterSet& ps, edm::EDProducer& mixMod);
+  explicit CastorDigiProducer(const edm::ParameterSet& ps, edm::EDProducer& mixMod, edm::ConsumesCollector& iC);
   virtual ~CastorDigiProducer();
 
   virtual void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;

--- a/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
+++ b/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
@@ -41,6 +41,7 @@ class ESDigiCollection ;
 class PileUpEventPrincipal ;
 
 namespace edm {
+  class ConsumesCollector;
   class EDProducer;
   class Event;
   class EventSetup;
@@ -51,7 +52,7 @@ namespace edm {
 class EcalDigiProducer : public DigiAccumulatorMixMod {
    public:
 
-      EcalDigiProducer( const edm::ParameterSet& params , edm::EDProducer& mixMod);
+      EcalDigiProducer( const edm::ParameterSet& params , edm::EDProducer& mixMod, edm::ConsumesCollector& iC);
       virtual ~EcalDigiProducer();
 
       virtual void initializeEvent(edm::Event const& e, edm::EventSetup const& c);

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -18,6 +18,7 @@
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -47,7 +48,7 @@
 #include "CondFormats/DataRecord/interface/ESPedestalsRcd.h"
 #include "Geometry/EcalAlgo/interface/EcalEndcapGeometry.h"
 
-EcalDigiProducer::EcalDigiProducer( const edm::ParameterSet& params, edm::EDProducer& mixMod ) :
+EcalDigiProducer::EcalDigiProducer( const edm::ParameterSet& params, edm::EDProducer& mixMod, edm::ConsumesCollector& iC) :
    DigiAccumulatorMixMod(),
    m_APDShape         ( params.getParameter<double>( "apdShapeTstart" ) ,
 			params.getParameter<double>( "apdShapeTau"    )   )  ,
@@ -141,6 +142,9 @@ EcalDigiProducer::EcalDigiProducer( const edm::ParameterSet& params, edm::EDProd
    mixMod.produces<EBDigiCollection>(m_EBdigiCollection);
    mixMod.produces<EEDigiCollection>(m_EEdigiCollection);
    mixMod.produces<ESDigiCollection>(m_ESdigiCollection);
+   iC.consumes<std::vector<PCaloHit> >(edm::InputTag(m_hitsProducerTag, "EcalHitsEB"));
+   iC.consumes<std::vector<PCaloHit> >(edm::InputTag(m_hitsProducerTag, "EcalHitsEE"));
+   iC.consumes<std::vector<PCaloHit> >(edm::InputTag(m_hitsProducerTag, "EcalHitsES"));
 
    const std::vector<double> ebCorMatG12 = params.getParameter< std::vector<double> >("EBCorrNoiseMatrixG12");
    const std::vector<double> eeCorMatG12 = params.getParameter< std::vector<double> >("EECorrNoiseMatrixG12");

--- a/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
+++ b/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
@@ -8,18 +8,20 @@
 #include "TBDataFormats/EcalTBObjects/interface/EcalTBTDCRawInfo.h"
 
 namespace edm {
+  class ConsumesCollector;
   class EDProducer;
   class Event;
   class EventSetup;
   class ParameterSet;
 }
+class PEcalTBInfo;
 class PileUpEventPrincipal;
 
 class EcalTBDigiProducer : public EcalDigiProducer
 {
    public:
 
-      EcalTBDigiProducer( const edm::ParameterSet& params, edm::EDProducer& mixMod ) ;
+      EcalTBDigiProducer( const edm::ParameterSet& params, edm::EDProducer& mixMod, edm::ConsumesCollector& iC) ;
       virtual ~EcalTBDigiProducer() ;
 
 

--- a/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
+++ b/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
@@ -1,6 +1,7 @@
 
 #include "SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h"
 #include "SimDataFormats/EcalTestBeam/interface/PEcalTBInfo.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -11,8 +12,8 @@
 #include "SimCalorimetry/EcalSimAlgos/interface/EBHitResponse.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EEHitResponse.h"
 
-EcalTBDigiProducer::EcalTBDigiProducer( const edm::ParameterSet& params, edm::EDProducer& mixMod ) :
-   EcalDigiProducer( params, mixMod )
+EcalTBDigiProducer::EcalTBDigiProducer( const edm::ParameterSet& params, edm::EDProducer& mixMod, edm::ConsumesCollector& iC) :
+   EcalDigiProducer(params, mixMod, iC)
 {
    std::string const instance("simEcalUnsuppressedDigis");
    m_EBdigiFinalTag = params.getParameter<std::string>( "EBdigiFinalCollection" ) ;
@@ -54,6 +55,11 @@ EcalTBDigiProducer::EcalTBDigiProducer( const edm::ParameterSet& params, edm::ED
    m_theTBReadout = new EcalTBReadout( m_ecalTBInfoLabel ) ;
 
    m_tunePhaseShift =  params.getParameter<double>( "tunePhaseShift" ) ;
+
+   if( m_doPhaseShift )
+   {
+     iC.consumes<PEcalTBInfo>(edm::InputTag(params.getUntrackedParameter<std::string>("EcalTBInfoLabel","SimEcalTBG4Object")));
+   }
 }
 
 EcalTBDigiProducer::~EcalTBDigiProducer()

--- a/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
+++ b/SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h
@@ -31,11 +31,15 @@ class HcalShapes;
 class PCaloHit;
 class PileUpEventPrincipal;
 
+namespace edm {
+  class ConsumesCollector;
+}
+
 class HcalDigitizer
 {
 public:
 
-  explicit HcalDigitizer(const edm::ParameterSet& ps);
+  explicit HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector& iC);
   virtual ~HcalDigitizer();
 
   /**Produces the EDM products,*/

--- a/SimCalorimetry/HcalSimProducers/plugins/HcalDigiProducer.cc
+++ b/SimCalorimetry/HcalSimProducers/plugins/HcalDigiProducer.cc
@@ -1,15 +1,16 @@
 #include "SimCalorimetry/HcalSimProducers/plugins/HcalDigiProducer.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 
-HcalDigiProducer::HcalDigiProducer(edm::ParameterSet const& pset, edm::EDProducer& mixMod) :
+HcalDigiProducer::HcalDigiProducer(edm::ParameterSet const& pset, edm::EDProducer& mixMod, edm::ConsumesCollector& iC) :
   DigiAccumulatorMixMod(),
-  theDigitizer_(pset) {
+  theDigitizer_(pset, iC) {
   mixMod.produces<HBHEDigiCollection>();
   mixMod.produces<HODigiCollection>();
   mixMod.produces<HFDigiCollection>();
   mixMod.produces<ZDCDigiCollection>();
   mixMod.produces<HBHEUpgradeDigiCollection>("HBHEUpgradeDigiCollection");
   mixMod.produces<HFUpgradeDigiCollection>("HFUpgradeDigiCollection");
+
 }
 
 void

--- a/SimCalorimetry/HcalSimProducers/plugins/HcalDigiProducer.h
+++ b/SimCalorimetry/HcalSimProducers/plugins/HcalDigiProducer.h
@@ -5,13 +5,14 @@
 #include "SimCalorimetry/HcalSimProducers/interface/HcalDigitizer.h"
 
 namespace edm {
+  class ConsumesCollector;
   class EDProducer;
   class ParameterSet;
 }
 
 class HcalDigiProducer : public DigiAccumulatorMixMod {
 public:
-  HcalDigiProducer(edm::ParameterSet const& pset, edm::EDProducer& mixMod);
+  HcalDigiProducer(edm::ParameterSet const& pset, edm::EDProducer& mixMod, edm::ConsumesCollector& iC);
   virtual void initializeEvent(edm::Event const&, edm::EventSetup const&) override;
   virtual void finalizeEvent(edm::Event&, edm::EventSetup const&) override;
   virtual void accumulate(edm::Event const&, edm::EventSetup const&) override;

--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -17,6 +17,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -82,7 +83,7 @@ namespace HcalDigitizerImpl {
 } // namespace HcaiDigitizerImpl
 
 
-HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps) :
+HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps, edm::ConsumesCollector& iC) :
   theGeometry(0),
   theParameterMap(new HcalSimParameterMap(ps)),
   theShapes(new HcalShapes()),
@@ -128,11 +129,15 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps) :
   hbhegeo(true),
   hogeo(true),
   hfgeo(true),
+  hitsProducer_(ps.getParameter<std::string>("hitsProducer")),
   theHOSiPMCode(ps.getParameter<edm::ParameterSet>("ho").getParameter<int>("siPMCode")),
   deliveredLumi(0.),
   m_HEDarkening(0),
   m_HFRecalibration(0)
 {
+  iC.consumes<std::vector<PCaloHit> >(edm::InputTag(hitsProducer_, "ZDCHITS"));
+  iC.consumes<std::vector<PCaloHit> >(edm::InputTag(hitsProducer_, "HcalHits"));
+
   bool doNoise = ps.getParameter<bool>("doNoise");
   bool useOldNoiseHB = ps.getParameter<bool>("useOldHB");
   bool useOldNoiseHE = ps.getParameter<bool>("useOldHE");
@@ -322,8 +327,6 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps) :
   theZDCDigitizer->setRandomEngine(engine);
 
   if (theHitCorrection!=0) theHitCorrection->setRandomEngine(engine);
-
-  hitsProducer_ = ps.getParameter<std::string>("hitsProducer");
   
   if(agingFlagHE) m_HEDarkening = new HEDarkening();
   if(agingFlagHF) m_HFRecalibration = new HFRecalibration();

--- a/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
+++ b/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
@@ -22,10 +22,12 @@
 #include<vector>
 #include<string>
 
+class PEcalTBInfo;
+
 class HcalTBDigiProducer : public DigiAccumulatorMixMod {
 public:
 
-  explicit HcalTBDigiProducer(const edm::ParameterSet& ps, edm::EDProducer& mixMod);
+  explicit HcalTBDigiProducer(const edm::ParameterSet& ps, edm::EDProducer& mixMod, edm::ConsumesCollector& iC);
   virtual ~HcalTBDigiProducer();
 
   virtual void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;

--- a/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
+++ b/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
@@ -1,6 +1,7 @@
 #include "SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "SimCalorimetry/CaloSimAlgos/interface/CaloTDigitizer.h"
@@ -13,7 +14,7 @@
 #include "SimDataFormats/EcalTestBeam/interface/PEcalTBInfo.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
-HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet& ps, edm::EDProducer& mixMod) :
+HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet& ps, edm::EDProducer& mixMod, edm::ConsumesCollector& iC) :
   theParameterMap(new HcalTBSimParameterMap(ps)), 
   theHcalShape(new HcalShape()),
   theHcalIntegratedShape(new CaloShapeIntegrator(theHcalShape)),
@@ -25,6 +26,7 @@ HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet& ps, edm::EDProdu
   std::string const instance("simHcalDigis");
   mixMod.produces<HBHEDigiCollection>(instance);
   mixMod.produces<HODigiCollection>(instance);
+  iC.consumes<std::vector<PCaloHit> >(edm::InputTag("g4SimHits", "HcalHits"));
 
   DetId detId(DetId::Hcal, 1);
   bool syncPhase = (theParameterMap->simParameters(detId)).syncPhase();
@@ -56,6 +58,9 @@ HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet& ps, edm::EDProdu
 			  << " and doPhaseShift = " << doPhaseShift
 			  << " tunePhasShift = " << tunePhaseShift;
 
+  if (doPhaseShift) {
+    iC.consumes<PEcalTBInfo>(edm::InputTag(ecalTBInfoLabel, ""));
+  }
 }
 
 HcalTBDigiProducer::~HcalTBDigiProducer() {

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.cc
@@ -4,6 +4,7 @@
 //
 //--------------------------------------------
 
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "DataMixingHcalDigiWorkerProd.h"
@@ -12,7 +13,7 @@
 using namespace std;
 namespace edm {
   // Constructor 
-  DataMixingHcalDigiWorkerProd::DataMixingHcalDigiWorkerProd(const edm::ParameterSet& ps) : 
+  DataMixingHcalDigiWorkerProd::DataMixingHcalDigiWorkerProd(const edm::ParameterSet& ps, edm::ConsumesCollector& iC) : 
     HBHEPileInputTag_(ps.getParameter<edm::InputTag>("HBHEPileInputTag")),
     HOPileInputTag_(ps.getParameter<edm::InputTag>("HOPileInputTag")),
     HFPileInputTag_(ps.getParameter<edm::InputTag>("HFPileInputTag")),
@@ -40,7 +41,7 @@ namespace edm {
 
     // initialize HcalDigitizer here...
 
-    myHcalDigitizer_ = new HcalDigitizer( ps );
+    myHcalDigitizer_ = new HcalDigitizer( ps, iC );
 
     myHcalDigitizer_->setHBHENoiseSignalGenerator( & theHBHESignalGenerator );
     myHcalDigitizer_->setHFNoiseSignalGenerator( & theHFSignalGenerator );

--- a/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingHcalDigiWorkerProd.h
@@ -37,6 +37,7 @@
 
 namespace edm
 {
+  class ConsumesCollector;
   class ModuleCallingContext;
 
   class DataMixingHcalDigiWorkerProd
@@ -44,7 +45,7 @@ namespace edm
     public:
 
      /** standard constructor*/
-      explicit DataMixingHcalDigiWorkerProd(const edm::ParameterSet& ps);
+      explicit DataMixingHcalDigiWorkerProd(const edm::ParameterSet& ps, edm::ConsumesCollector& iC);
 
       /**Default destructor*/
       virtual ~DataMixingHcalDigiWorkerProd();

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
@@ -10,6 +10,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/ModuleContextSentry.h"
 #include "FWCore/ServiceRegistry/interface/InternalContext.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
@@ -163,7 +164,8 @@ namespace edm
       produces< ZDCDigiCollection >();
 
       if(MergeHcalDigisProd_) {
-	HcalDigiWorkerProd_ = new DataMixingHcalDigiWorkerProd(ps);
+        edm::ConsumesCollector iC(consumesCollector());
+	HcalDigiWorkerProd_ = new DataMixingHcalDigiWorkerProd(ps, iC);
 	HcalDigiWorkerProd_->setHBHEAccess(tok_hbhe_);
 	HcalDigiWorkerProd_->setHOAccess(tok_ho_);
 	HcalDigiWorkerProd_->setHFAccess(tok_hf_);

--- a/SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h
+++ b/SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h
@@ -5,10 +5,11 @@
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 
 namespace edm {
+  class ConsumesCollector;
   class EDProducer;
   class ParameterSet;
 
-  typedef DigiAccumulatorMixMod*(DAFunc)(ParameterSet const&, EDProducer&);
+  typedef DigiAccumulatorMixMod*(DAFunc)(ParameterSet const&, EDProducer&, ConsumesCollector&);
   typedef edmplugin::PluginFactory<DAFunc> DigiAccumulatorMixModPluginFactory;
 
   class DigiAccumulatorMixModFactory {
@@ -18,7 +19,7 @@ namespace edm {
     static DigiAccumulatorMixModFactory* get();
 
     std::auto_ptr<DigiAccumulatorMixMod>
-      makeDigiAccumulator(ParameterSet const&, EDProducer&) const;
+      makeDigiAccumulator(ParameterSet const&, EDProducer&, ConsumesCollector&) const;
 
   private:
     DigiAccumulatorMixModFactory();

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -11,6 +11,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ModuleContextSentry.h"
@@ -54,7 +55,10 @@ namespace edm {
     if (labelPlayback.empty()) {
       labelPlayback = ps_mix.getParameter<std::string>("@module_label");
     }
-    inputTagPlayback_ = InputTag(labelPlayback, "", edm::InputTag::kSkipCurrentProcess);
+    if (playback_) {
+      inputTagPlayback_ = InputTag(labelPlayback, "", edm::InputTag::kSkipCurrentProcess);
+      consumes<CrossingFramePlaybackInfoExtended>(inputTagPlayback_);
+    }
 
     ParameterSet ps=ps_mix.getParameter<ParameterSet>("mixObjects");
     std::vector<std::string> names = ps.getParameterNames();
@@ -79,6 +83,7 @@ namespace edm {
             if(makeCrossingFrame) {
               workersObjects_.push_back(new MixingWorker<SimTrack>(minBunch_,maxBunch_,bunchSpace_,std::string(""),label,labelCF,maxNbSources_,tag,tagCF));
               produces<CrossingFrame<SimTrack> >(label);
+              consumes<std::vector<SimTrack> >(tag);
             }
 
             LogInfo("MixingModule") <<"Will mix "<<object<<"s with InputTag= "<<tag.encode()<<", label will be "<<label;
@@ -105,6 +110,7 @@ namespace edm {
             if(makeCrossingFrame) {
               workersObjects_.push_back(new MixingWorker<SimVertex>(minBunch_,maxBunch_,bunchSpace_,std::string(""),label,labelCF,maxNbSources_,tag,tagCF));
               produces<CrossingFrame<SimVertex> >(label);
+              consumes<std::vector<SimVertex> >(tag);
             }
 
             LogInfo("MixingModule") <<"Will mix "<<object<<"s with InputTag "<<tag.encode()<<", label will be "<<label;
@@ -120,6 +126,7 @@ namespace edm {
             if(makeCrossingFrame) {
               workersObjects_.push_back(new MixingWorker<HepMCProduct>(minBunch_,maxBunch_,bunchSpace_,std::string(""),label,labelCF,maxNbSources_,tag,tagCF));
               produces<CrossingFrame<HepMCProduct> >(label);
+              consumes<HepMCProduct>(tag);
             }
 
             LogInfo("MixingModule") <<"Will mix "<<object<<"s with InputTag= "<<tag.encode()<<", label will be "<<label;
@@ -139,6 +146,7 @@ namespace edm {
               if(binary_search_all(crossingFrames, tag.instance())) {
                 workersObjects_.push_back(new MixingWorker<PCaloHit>(minBunch_,maxBunch_,bunchSpace_,subdets[ii],label,labelCF,maxNbSources_,tag,tagCF));
                 produces<CrossingFrame<PCaloHit> >(label);
+                consumes<std::vector<PCaloHit> >(tag);
               }
 
               LogInfo("MixingModule") <<"Will mix "<<object<<"s with InputTag= "<<tag.encode()<<", label will be "<<label;
@@ -160,6 +168,7 @@ namespace edm {
               if(binary_search_all(crossingFrames, tag.instance())) {
                 workersObjects_.push_back(new MixingWorker<PSimHit>(minBunch_,maxBunch_,bunchSpace_,subdets[ii],label,labelCF,maxNbSources_,tag,tagCF));
                 produces<CrossingFrame<PSimHit> >(label);
+                consumes<std::vector<PSimHit> >(tag);
               }
 
               LogInfo("MixingModule") <<"Will mix "<<object<<"s with InputTag= "<<tag.encode()<<", label will be "<<label;
@@ -173,23 +182,25 @@ namespace edm {
 
     sort_all(wantedBranches_);
     for (unsigned int branch=0;branch<wantedBranches_.size();++branch) LogDebug("MixingModule")<<"Will keep branch "<<wantedBranches_[branch]<<" for mixing ";
-dropUnwantedBranches(wantedBranches_);
+
+    dropUnwantedBranches(wantedBranches_);
 
     produces<PileupMixingContent>();
 
     produces<CrossingFramePlaybackInfoExtended>();
 
+    edm::ConsumesCollector iC(consumesCollector());
     // Create and configure digitizers
-    createDigiAccumulators(ps_mix);
+    createDigiAccumulators(ps_mix, iC);
   }
 
 
-  void MixingModule::createDigiAccumulators(const edm::ParameterSet& mixingPSet) {
+  void MixingModule::createDigiAccumulators(const edm::ParameterSet& mixingPSet, edm::ConsumesCollector& iC) {
     ParameterSet const& digiPSet = mixingPSet.getParameterSet("digitizers");
     std::vector<std::string> digiNames = digiPSet.getParameterNames();
     for(auto const& digiName : digiNames) {
         ParameterSet const& pset = digiPSet.getParameterSet(digiName);
-        std::auto_ptr<DigiAccumulatorMixMod> accumulator = std::auto_ptr<DigiAccumulatorMixMod>(DigiAccumulatorMixModFactory::get()->makeDigiAccumulator(pset, *this));
+        std::auto_ptr<DigiAccumulatorMixMod> accumulator = std::auto_ptr<DigiAccumulatorMixMod>(DigiAccumulatorMixModFactory::get()->makeDigiAccumulator(pset, *this, iC));
         // Create appropriate DigiAccumulator
         if(accumulator.get() != 0) {
           digiAccumulators_.push_back(accumulator.release());

--- a/SimGeneral/MixingModule/plugins/MixingModule.h
+++ b/SimGeneral/MixingModule/plugins/MixingModule.h
@@ -40,6 +40,7 @@ class DigiAccumulatorMixMod;
 class PileUpEventPrincipal;
 
 namespace edm {
+  class ConsumesCollector;
   class MixingWorkerBase;
   class ModuleCallingContext;
 
@@ -82,7 +83,7 @@ namespace edm {
       virtual void doPileUp(edm::Event &e, const edm::EventSetup& es);
       void pileAllWorkers(EventPrincipal const& ep, ModuleCallingContext const*, int bcr, int id, int& offset,
 			  const edm::EventSetup& setup);
-      void createDigiAccumulators( const edm::ParameterSet& mixingPSet ) ;
+      void createDigiAccumulators(const edm::ParameterSet& mixingPSet, edm::ConsumesCollector& iC);
 
       InputTag inputTagPlayback_;
       bool mixProdStep2_;

--- a/SimGeneral/MixingModule/src/DigiAccumulatorMixModFactory.cc
+++ b/SimGeneral/MixingModule/src/DigiAccumulatorMixModFactory.cc
@@ -28,11 +28,11 @@ namespace edm {
   }
 
   std::auto_ptr<DigiAccumulatorMixMod>
-  DigiAccumulatorMixModFactory::makeDigiAccumulator(ParameterSet const& conf, EDProducer& mixMod) const {
+  DigiAccumulatorMixModFactory::makeDigiAccumulator(ParameterSet const& conf, EDProducer& mixMod, ConsumesCollector& iC) const {
     std::string accumulatorType = conf.getParameter<std::string>("accumulatorType");
     FDEBUG(1) << "DigiAccumulatorMixModFactory: digi_accumulator_type = " << accumulatorType << std::endl;
     std::auto_ptr<DigiAccumulatorMixMod> wm;
-    wm = std::auto_ptr<DigiAccumulatorMixMod>(DigiAccumulatorMixModPluginFactory::get()->create(accumulatorType, conf, mixMod));
+    wm = std::auto_ptr<DigiAccumulatorMixMod>(DigiAccumulatorMixModPluginFactory::get()->create(accumulatorType, conf, mixMod, iC));
     
     if(wm.get()==0) {
 	throw edm::Exception(errors::Configuration,"NoSourceModule")

--- a/SimGeneral/TrackingAnalysis/interface/TrackingTruthAccumulator.h
+++ b/SimGeneral/TrackingAnalysis/interface/TrackingTruthAccumulator.h
@@ -12,6 +12,7 @@
 namespace edm
 {
 	class ParameterSet;
+        class ConsumesCollector;
 	class EDProducer;
 	class Event;
 	class EventSetup;
@@ -64,7 +65,7 @@ class PSimHit;
 class TrackingTruthAccumulator : public DigiAccumulatorMixMod
 {
 public:
-	explicit TrackingTruthAccumulator( const edm::ParameterSet& config, edm::EDProducer& mixMod );
+	explicit TrackingTruthAccumulator( const edm::ParameterSet& config, edm::EDProducer& mixMod, edm::ConsumesCollector& iC);
 private:
 	virtual void initializeEvent( const edm::Event& event, const edm::EventSetup& setup );
 	virtual void accumulate( const edm::Event& event, const edm::EventSetup& setup );
@@ -99,7 +100,7 @@ private:
 	const bool removeDeadModules_;
 	const edm::InputTag simTrackLabel_;
 	const edm::InputTag simVertexLabel_;
-	edm::ParameterSet simHitCollectionConfig_;
+        std::vector<edm::InputTag> collectionTags_;
 	edm::InputTag genParticleLabel_;
 
 	bool selectorFlag_;

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
@@ -22,12 +22,13 @@
  */
 #include "SimGeneral/TrackingAnalysis/interface/TrackingTruthAccumulator.h"
 
-#include <SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h>
-#include <FWCore/MessageLogger/interface/MessageLogger.h>
-#include <FWCore/Framework/interface/Event.h>
-#include <FWCore/Framework/interface/EventSetup.h>
-#include <FWCore/ParameterSet/interface/ParameterSet.h>
-#include <SimGeneral/MixingModule/interface/PileUpEventPrincipal.h>
+#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "SimGeneral/TrackingAnalysis/interface/EncodedTruthId.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
@@ -213,7 +214,7 @@ namespace
 //---------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------
 
-TrackingTruthAccumulator::TrackingTruthAccumulator( const edm::ParameterSet & config, edm::EDProducer& mixMod ) :
+TrackingTruthAccumulator::TrackingTruthAccumulator( const edm::ParameterSet & config, edm::EDProducer& mixMod, edm::ConsumesCollector& iC) :
 		messageCategory_("TrackingTruthAccumulator"),
 		volumeRadius_( config.getParameter<double>("volumeRadius") ),
 		volumeZ_( config.getParameter<double>("volumeZ") ),
@@ -226,7 +227,7 @@ TrackingTruthAccumulator::TrackingTruthAccumulator( const edm::ParameterSet & co
 		removeDeadModules_( config.getParameter<bool>("removeDeadModules") ),
 		simTrackLabel_( config.getParameter<edm::InputTag>("simTrackCollection") ),
 		simVertexLabel_( config.getParameter<edm::InputTag>("simVertexCollection") ),
-		simHitCollectionConfig_( config.getParameter<edm::ParameterSet>("simHitCollections") ),
+		collectionTags_( ),
 		genParticleLabel_( config.getParameter<edm::InputTag>("genParticleCollection") ),
 		allowDifferentProcessTypeForDifferentDetectors_( config.getParameter<bool>("allowDifferentSimHitProcesses") )
 {
@@ -238,8 +239,6 @@ TrackingTruthAccumulator::TrackingTruthAccumulator( const edm::ParameterSet & co
 		edm::LogError(messageCategory_) << "Both \"createUnmergedCollection\" and \"createMergedBremsstrahlung\" have been"
 			<< "set to false, which means no collections will be created";
 
-
-	//
 	// Initialize selection for building TrackingParticles
 	//
 	if( config.exists( "select" ) )
@@ -285,6 +284,26 @@ TrackingTruthAccumulator::TrackingTruthAccumulator( const edm::ParameterSet & co
 		mixMod.produces<TrackingParticleCollection>("MergedTrackTruth");
 		mixMod.produces<TrackingVertexCollection>("MergedTrackTruth");
 	}
+
+        iC.consumes<std::vector<SimTrack> >(simTrackLabel_);
+        iC.consumes<std::vector<SimVertex> >(simVertexLabel_);
+        iC.consumes<std::vector<reco::GenParticle> >(genParticleLabel_);
+        iC.consumes<std::vector<int> >(genParticleLabel_);
+
+	// Fill the collection tags
+        const edm::ParameterSet& simHitCollectionConfig=config.getParameterSet("simHitCollections");
+	std::vector<std::string> parameterNames=simHitCollectionConfig.getParameterNames();
+
+	for( const auto& parameterName : parameterNames )
+	{
+           std::vector<edm::InputTag> tags=simHitCollectionConfig.getParameter<std::vector<edm::InputTag> >(parameterName);
+           collectionTags_.insert(collectionTags_.end(), tags.begin(), tags.end());
+        }
+
+	for( const auto& collectionTag : collectionTags_ ) {
+	  iC.consumes<std::vector<PSimHit> >(collectionTag);
+        }
+
 }
 
 void TrackingTruthAccumulator::initializeEvent( edm::Event const& event, edm::EventSetup const& setup )
@@ -434,27 +453,19 @@ template<class T> void TrackingTruthAccumulator::accumulateEvent( const T& event
 
 template<class T> void TrackingTruthAccumulator::fillSimHits( std::vector<const PSimHit*>& returnValue, const T& event, const edm::EventSetup& setup )
 {
-	std::vector<std::string> parameterNames=simHitCollectionConfig_.getParameterNames();
-
-	// loop over the different parameter collections. The names of these are unimportant but
-	// usually set to the sub-detectors, e.g. "muon", "pixel" etcetera.
-	for( const auto& parameterName : parameterNames )
+	// loop over the collections
+	for( const auto& collectionTag : collectionTags_ )
 	{
-		std::vector<edm::InputTag> collectionTags=simHitCollectionConfig_.getParameter<std::vector<edm::InputTag> >(parameterName);
+		edm::Handle< std::vector<PSimHit> > hSimHits;
+		event.getByLabel( collectionTag, hSimHits );
 
-		for( const auto& collectionTag : collectionTags )
+		// TODO - implement removing the dead modules
+		for( const auto& simHit : *hSimHits )
 		{
-			edm::Handle< std::vector<PSimHit> > hSimHits;
-			event.getByLabel( collectionTag, hSimHits );
+			returnValue.push_back( &simHit );
+		}
 
-			// TODO - implement removing the dead modules
-			for( const auto& simHit : *hSimHits )
-			{
-				returnValue.push_back( &simHit );
-			}
-
-		} // end of loop over InputTags
-	} // end of loop over parameter names. These are arbitrary but usually "muon", "pixel" etcetera.
+	} // end of loop over InputTags
 }
 
 

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -28,6 +28,7 @@
 
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -85,7 +86,7 @@
 
 namespace cms
 {
-  SiPixelDigitizer::SiPixelDigitizer(const edm::ParameterSet& iConfig, edm::EDProducer& mixMod):
+  SiPixelDigitizer::SiPixelDigitizer(const edm::ParameterSet& iConfig, edm::EDProducer& mixMod, edm::ConsumesCollector& iC):
     first(true),
     _pixeldigialgo(),
     hitsProducer(iConfig.getParameter<std::string>("hitsProducer")),
@@ -98,6 +99,10 @@ namespace cms
     
     mixMod.produces<edm::DetSetVector<PixelDigi> >().setBranchAlias(alias);
     mixMod.produces<edm::DetSetVector<PixelDigiSimLink> >().setBranchAlias(alias + "siPixelDigiSimLink");
+    for(auto const& trackerContainer : trackerContainers) {
+      edm::InputTag tag(hitsProducer, trackerContainer);
+      iC.consumes<std::vector<PSimHit> >(edm::InputTag(hitsProducer, trackerContainer));
+    }
     edm::Service<edm::RandomNumberGenerator> rng;
     if ( ! rng.isAvailable()) {
       throw cms::Exception("Configuration")

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
@@ -26,6 +26,7 @@ namespace CLHEP {
 }
 
 namespace edm {
+  class ConsumesCollector;
   class EDProducer;
   class Event;
   class EventSetup;
@@ -44,7 +45,7 @@ namespace cms {
   class SiPixelDigitizer : public DigiAccumulatorMixMod {
   public:
 
-    explicit SiPixelDigitizer(const edm::ParameterSet& conf, edm::EDProducer& mixMod);
+    explicit SiPixelDigitizer(const edm::ParameterSet& conf, edm::EDProducer& mixMod, edm::ConsumesCollector& iC);
 
     virtual ~SiPixelDigitizer();
 

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
@@ -16,6 +16,7 @@ namespace CLHEP {
 }
 
 namespace edm {
+  class ConsumesCollector;
   class EDProducer;
   class Event;
   class EventSetup;
@@ -40,7 +41,7 @@ class TrackerGeometry;
  */
 class SiStripDigitizer : public DigiAccumulatorMixMod {
 public:
-  explicit SiStripDigitizer(const edm::ParameterSet& conf, edm::EDProducer& mixMod);
+  explicit SiStripDigitizer(const edm::ParameterSet& conf, edm::EDProducer& mixMod, edm::ConsumesCollector& iC);
   
   virtual ~SiStripDigitizer();
   


### PR DESCRIPTION
This pull request adds the consumes interface to the mixing module.
Some relevant forward declarations were added to FWCore/Framework/interface/Frameworkfwd.h, and a duplicate forward declaration was removed.
