### PR TITLE
Use tbb thread safe containers to protect plugin system data structures

### DIFF
--- a/FWCore/PluginManager/BuildFile.xml
+++ b/FWCore/PluginManager/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="boost"/>
+<use   name="tbb"/>
 <use   name="boost_filesystem"/>
 <use   name="FWCore/Utilities"/>
 <export>

--- a/FWCore/PluginManager/interface/PluginManager.h
+++ b/FWCore/PluginManager/interface/PluginManager.h
@@ -26,9 +26,10 @@
 
 #include <boost/filesystem/path.hpp>
 #include "boost/shared_ptr.hpp"
-#include "FWCore/Utilities/interface/Signal.h"
+#include "tbb/concurrent_unordered_map.h"
 
 // user include files
+#include "FWCore/Utilities/interface/Signal.h"
 #include "FWCore/PluginManager/interface/SharedLibrary.h"
 #include "FWCore/PluginManager/interface/PluginInfo.h"
 
@@ -36,6 +37,14 @@
 namespace edmplugin {
   class DummyFriend;
   class PluginFactoryBase;
+  
+  struct PluginManagerPathHasher {
+    size_t operator()(boost::filesystem::path const& iPath) const {
+      tbb::tbb_hash<std::string> hasher;
+      return hasher( iPath.native() );
+    }
+  };
+  
 class PluginManager
 {
    friend class DummyFriend;
@@ -113,7 +122,7 @@ class PluginManager
                                                   bool& ioThrowIfFailElseSucceedStatus);
       // ---------- member data --------------------------------
       SearchPath searchPath_;
-      std::map<boost::filesystem::path, boost::shared_ptr<SharedLibrary> > loadables_;
+      tbb::concurrent_unordered_map<boost::filesystem::path, boost::shared_ptr<SharedLibrary>, PluginManagerPathHasher > loadables_;
       
       CategoryToInfos categoryToInfos_;
       std::recursive_mutex pluginLoadMutex_;


### PR DESCRIPTION
PluginFactoryBase no longer needs to use a mutex to protect its data structure. This avoids problems where PluginFactoryBase and PluginManager may acquire their locks in different order based on the activity going on.
PluginManager also uses thread-safe containers however the mutex is still used to protect dlopen calls as well as access to loadingLibraryNamed_ value. Using the thread-safe container does mean we no longer have to take a lock if the shared library in question has already been loaded.
