### PR TITLE
Do not fast copy ROOT files if using multiple threads

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1459,7 +1459,9 @@ namespace edm {
       principalCache_.adjustIndexesAfterProductRegistryAddition();
     }
     principalCache_.adjustEventsToNewProductRegistry(preg_);
-    if(numberOfForkedChildren_ > 0) {
+    if((numberOfForkedChildren_ > 0) or
+       (preallocations_.numberOfStreams()>1 and
+        preallocations_.numberOfThreads()>1)) {
         fb_->setNotFastClonable(FileBlock::ParallelProcesses);
     }
   }


### PR DESCRIPTION
Disabled fast copying of ROOT files when we have multiple threads and multiple Streams. This must be done since fast copying requires the output file to record all the events from the input in the same order as stored in the input. This is not guaranteed when we do multiple threads.
