### PR TITLE
Have PoolOutputModule inherit from one::OutputModule

### DIFF
--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -215,6 +215,8 @@ namespace edm {
       virtual bool isFileOpen() const { return true; }
       virtual void reallyOpenFile() {}
       
+      virtual void preForkReleaseResources();
+      virtual void postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/);
 
       virtual void doBeginRun_(RunPrincipal const&, ModuleCallingContext const*){}
       virtual void doEndRun_(RunPrincipal const&, ModuleCallingContext const*){}

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -254,13 +254,20 @@ namespace edm {
     
     void
     OutputModuleBase::doPreForkReleaseResources() {
-      //doPreForkReleaseResources();
+      preForkReleaseResources();
     }
     
     void
     OutputModuleBase::doPostForkReacquireResources(unsigned int iChildIndex, unsigned int iNumberOfChildren) {
-      //postForkReacquireResources_(iChildIndex, iNumberOfChildren);
+      postForkReacquireResources(iChildIndex, iNumberOfChildren);
     }
+    
+    void
+    OutputModuleBase::preForkReleaseResources() {}
+    
+    void
+    OutputModuleBase::postForkReacquireResources(unsigned int /*iChildIndex*/, unsigned int /*iNumberOfChildren*/) {}
+
     
     void OutputModuleBase::maybeOpenFile() {
       if(!isFileOpen()) reallyOpenFile();

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -17,7 +17,7 @@
 
 #include "IOPool/Common/interface/RootServiceChecker.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/OutputModule.h"
+#include "FWCore/Framework/interface/one/OutputModule.h"
 
 class TTree;
 namespace edm {
@@ -27,7 +27,7 @@ namespace edm {
   class RootOutputFile;
   class ConfigurationDescriptions;
 
-  class PoolOutputModule : public OutputModule {
+  class PoolOutputModule : public one::OutputModule<WatchInputFiles> {
   public:
     enum DropMetaData { DropNone, DropDroppedPrior, DropPrior, DropAll };
     explicit PoolOutputModule(ParameterSet const& ps);

--- a/IOPool/Output/src/PoolOutputModule.cc
+++ b/IOPool/Output/src/PoolOutputModule.cc
@@ -28,7 +28,8 @@
 
 namespace edm {
   PoolOutputModule::PoolOutputModule(ParameterSet const& pset) :
-    OutputModule(pset),
+  edm::one::OutputModuleBase::OutputModuleBase(pset),
+  one::OutputModule<WatchInputFiles>(pset),
     rootServiceChecker_(),
     auxItems_(),
     selectedOutputItemList_(),

--- a/IOPool/Output/src/TimeoutPoolOutputModule.cc
+++ b/IOPool/Output/src/TimeoutPoolOutputModule.cc
@@ -9,6 +9,7 @@ namespace edm {
   }
   
   TimeoutPoolOutputModule::TimeoutPoolOutputModule(ParameterSet const& ps):
+      edm::one::OutputModuleBase::OutputModuleBase(ps),
       PoolOutputModule(ps), 
       m_lastEvent(time(NULL)),
       eventsWrittenInCurrentFile(0),


### PR DESCRIPTION
Changed PoolOutputModule so it inherits from edm::one::OutputModule<>. This will allow each instance of PoolOutputModule in a job to run independently. Writing to independent TFiles from different threads is supported by ROOT.
