### PR TITLE
Changed static to static const to avoid complaints from the thread-safety checker

### DIFF
--- a/DataFormats/L1GlobalTrigger/src/L1GlobalTriggerReadoutRecord.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GlobalTriggerReadoutRecord.cc
@@ -238,7 +238,7 @@ const cms_uint16_t L1GlobalTriggerReadoutRecord::finalOR() const
 const DecisionWord &
 L1GlobalTriggerReadoutRecord::decisionWord(int bxInEventValue) const
 {
-    static DecisionWord emptyDecisionWord;
+    const static DecisionWord emptyDecisionWord;
 
     for (std::vector<L1GtFdlWord>::const_iterator itBx = m_gtFdlWord.begin();
             itBx != m_gtFdlWord.end(); ++itBx) {
@@ -273,7 +273,7 @@ L1GlobalTriggerReadoutRecord::decisionWord() const
 
 const TechnicalTriggerWord & 
 L1GlobalTriggerReadoutRecord::technicalTriggerWord(int bxInEventValue) const {
-    static TechnicalTriggerWord emptyTechnicalTriggerWord;
+    const static TechnicalTriggerWord emptyTechnicalTriggerWord;
 
     for (std::vector<L1GtFdlWord>::const_iterator itBx = m_gtFdlWord.begin();
             itBx != m_gtFdlWord.end(); ++itBx) {

--- a/DataFormats/L1GlobalTrigger/src/L1GtObject.cc
+++ b/DataFormats/L1GlobalTrigger/src/L1GtObject.cc
@@ -23,7 +23,7 @@
 
 L1GtObject l1GtObjectStringToEnum(const std::string& label) {
 
-    static L1GtObjectStringToEnum l1GtObjectStringToEnumMap[] = {
+    static const L1GtObjectStringToEnum l1GtObjectStringToEnumMap[] = {
             {"Mu", Mu},
             {"NoIsoEG", NoIsoEG},
             {"IsoEG", IsoEG},


### PR DESCRIPTION
The Thread-safety checker looks for uses of non-const statics in the code and complains when they are found. This code had such statics, however the are only ever used to read and never to change. Therefore it was perfectly safe to change them to 'const static'.
