### PR TITLE
Change empty ProcessHistory static to const static

### DIFF
--- a/FWCore/Framework/src/HistoryAppender.cc
+++ b/FWCore/Framework/src/HistoryAppender.cc
@@ -6,7 +6,7 @@
 #include <string>
 #include <cassert>
 
-static edm::ProcessHistory s_emptyHistory;
+static const edm::ProcessHistory s_emptyHistory;
 
 namespace edm {
 


### PR DESCRIPTION
The thread-safety checker complains about non-const statics. Given that the s_emptyHistory static is only used in a const matter, it was trivial to change to a ‘const static’.
