### PR TITLE
Bug fix for boosted top parameter setting. 

### DIFF
--- a/RecoJets/JetProducers/plugins/CATopJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/CATopJetProducer.cc
@@ -41,17 +41,25 @@ CATopJetProducer::CATopJetProducer(edm::ParameterSet const& conf):
 	}
 	else if (tagAlgo_ == FJ_CMS_TOPTAG ) {
 		fjCMSTopTagger_ = std::auto_ptr<fastjet::CMSTopTagger>(
-			new fastjet::CMSTopTagger()
+			new fastjet::CMSTopTagger(conf.getParameter<double> ("ptFrac"),
+						  conf.getParameter<double> ("rFrac"),
+						  conf.getParameter<double> ("adjacencyParam"))
 		);
 	}
 	else if (tagAlgo_ == FJ_HEP_TOPTAG ) {
 		fjHEPTopTagger_ = std::auto_ptr<fastjet::HEPTopTagger>(
-			new fastjet::HEPTopTagger()
+			new fastjet::HEPTopTagger(conf.getParameter<double>("muCut"),
+						  conf.getParameter<double>("maxSubjetMass"),
+						  conf.getParameter<bool>("useSubjetMass")
+						  )
 		);
 	}
 	else if (tagAlgo_ == FJ_JHU_TOPTAG ) {
 		fjJHUTopTagger_ = std::auto_ptr<fastjet::JHTopTagger>(
-			new fastjet::JHTopTagger()
+			new fastjet::JHTopTagger(conf.getParameter<double>("ptFrac"),
+						 conf.getParameter<double>("deltaRCut"),
+						 conf.getParameter<double>("cosThetaWMax")
+						 )
 		);
 	}
 	else if (tagAlgo_ == FJ_NSUB_TAG ) {
@@ -59,7 +67,11 @@ CATopJetProducer::CATopJetProducer(edm::ParameterSet const& conf):
 		fastjet::JetDefinition::Plugin *plugin = new fastjet::SISConePlugin(0.6, 0.75);
 		fastjet::JetDefinition NsubJetDef(plugin);
 		fjNSUBTagger_ = std::auto_ptr<fastjet::RestFrameNSubjettinessTagger>(
-			new fastjet::RestFrameNSubjettinessTagger(NsubJetDef)
+			new fastjet::RestFrameNSubjettinessTagger(NsubJetDef,
+								  conf.getParameter<double>("tau2Cut"),
+								  conf.getParameter<double>("cosThetaSCut"),
+								  conf.getParameter<bool>("useExclusive")
+								  )
 		);
 	}
 				

--- a/RecoJets/JetProducers/python/caTopTaggers_cff.py
+++ b/RecoJets/JetProducers/python/caTopTaggers_cff.py
@@ -20,6 +20,16 @@ cmsTopTagPFJetsCHS = cms.EDProducer(
 
 hepTopTagPFJetsCHS = cmsTopTagPFJetsCHS.clone(
 	rParam = cms.double(1.5),
-	tagAlgo = cms.int32(2)
+	tagAlgo = cms.int32(2),
+        muCut = cms.double(0.8),
+        maxSubjetMass = cms.double(30.0),
+        useSubjetMass = cms.bool(False)
+)
+
+
+jhuTopTagPFJetsCHS = cmsTopTagPFJetsCHS.clone(
+    ptFrac = cms.double(0.05),
+    deltaRCut = cms.double(0.19),
+    cosThetaWMax = cms.double(0.7)
 )
 


### PR DESCRIPTION
Fixing bug where no configuration parameters were passed for a few boosted top algorithms, resulting in only default parameters being possible. Those affected : 

-fastjet "native" implementation of the CMS top tagger (although we still use "our" version by default)
-fastjet "native" implementation of JHU top tagger
-"Our" implementation of the HEP Top Tagger
-fastjet "native" implementation of N-subjettiness rest frame tagger. 
