### PR TITLE
Missing include of iostream

### DIFF
--- a/FWCore/Utilities/interface/DebugMacros.h
+++ b/FWCore/Utilities/interface/DebugMacros.h
@@ -1,5 +1,6 @@
-#ifndef Utilities_DebugMacros_h
-#define Utilities_DebugMacros_h
+#ifndef FWCore_Utilities_DebugMacros_h
+#define FWCore_Utilities_DebugMacros_h
+#include <iostream>
 
 namespace edm {
   struct debugvalue {


### PR DESCRIPTION
Missing include of <iostream> can cause compilation failures. Added it.
Also standardized the name of the include guards.
