### PR TITLE
Migration to 'getByToken', part II.

### DIFF
--- a/PhysicsTools/PatAlgos/interface/BaseIsolator.h
+++ b/PhysicsTools/PatAlgos/interface/BaseIsolator.h
@@ -4,19 +4,20 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 namespace pat { namespace helper {
 class BaseIsolator {
     public:
         typedef edm::ValueMap<float> Isolation;
         BaseIsolator() {}
-        BaseIsolator(const edm::ParameterSet &conf, bool withCut) ;
+        BaseIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut) ;
         virtual ~BaseIsolator() {}
         virtual void beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup) = 0;
         virtual void endEvent() = 0;
 
         /// Tests if the value associated to this item is strictly below the cut.
-        template<typename AnyRef> bool test(const AnyRef &ref) const { 
+        template<typename AnyRef> bool test(const AnyRef &ref) const {
             bool ok = (getValue(ref.id(), ref.key()) < cut_);
             try_++; if (!ok) fail_++;
             return ok;
@@ -31,13 +32,14 @@ class BaseIsolator {
     protected:
         virtual float getValue(const edm::ProductID &id, size_t index) const = 0;
         edm::InputTag input_;
+        edm::EDGetTokenT<Isolation> inputToken_;
         float cut_;
         mutable uint64_t try_, fail_;
 }; // class BaseIsolator
 } } // namespaces
 
-inline std::ostream & operator<<(std::ostream &stream, const pat::helper::BaseIsolator &iso) {  
-    iso.print(stream); 
+inline std::ostream & operator<<(std::ostream &stream, const pat::helper::BaseIsolator &iso) {
+    iso.print(stream);
     return stream;
 }
 #endif

--- a/PhysicsTools/PatAlgos/interface/EfficiencyLoader.h
+++ b/PhysicsTools/PatAlgos/interface/EfficiencyLoader.h
@@ -7,6 +7,7 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -18,11 +19,11 @@ class EfficiencyLoader {
         EfficiencyLoader() {}
 
         /// Constructor from a PSet
-        EfficiencyLoader(const edm::ParameterSet &iConfig) ;
+        EfficiencyLoader(const edm::ParameterSet &iConfig, edm::ConsumesCollector && iC) ;
 
         /// 'true' if this there is at least one efficiency configured
         bool enabled() const { return !names_.empty(); }
-     
+
         /// To be called for each new event, reads in the ValueMaps for efficiencies
         void newEvent(const edm::Event &event) const ;
 
@@ -32,7 +33,7 @@ class EfficiencyLoader {
 
     private:
         std::vector<std::string>   names_;
-        std::vector<edm::InputTag> tags_;
+        std::vector<edm::EDGetTokenT<edm::ValueMap<pat::LookupTableRecord> > > tokens_;
         mutable std::vector<edm::Handle< edm::ValueMap<pat::LookupTableRecord> > > handles_;
 }; // class
 

--- a/PhysicsTools/PatAlgos/interface/IsoDepositIsolator.h
+++ b/PhysicsTools/PatAlgos/interface/IsoDepositIsolator.h
@@ -10,9 +10,9 @@ namespace pat { namespace helper {
 class IsoDepositIsolator : public BaseIsolator {
     public:
         typedef edm::ValueMap<reco::IsoDeposit> Isolation;
- 
+
         IsoDepositIsolator() {}
-        IsoDepositIsolator(const edm::ParameterSet &conf, bool withCut) ;
+        IsoDepositIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut) ;
         virtual ~IsoDepositIsolator() ;
         virtual void beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup) ;
         virtual void endEvent() ;
@@ -27,6 +27,7 @@ class IsoDepositIsolator : public BaseIsolator {
         reco::isodeposit::AbsVetos vetos_;
         reco::isodeposit::EventDependentAbsVetos evdepVetos_; // subset of the above, don't delete twice
         bool skipDefaultVeto_;
+        edm::EDGetTokenT<Isolation> inputIsoDepositToken_;
 
         virtual float getValue(const edm::ProductID &id, size_t index) const ;
 }; // class IsoDepositIsolator

--- a/PhysicsTools/PatAlgos/interface/MultiIsolator.h
+++ b/PhysicsTools/PatAlgos/interface/MultiIsolator.h
@@ -15,22 +15,22 @@ class MultiIsolator {
     public:
         typedef std::vector<std::pair<pat::IsolationKeys,float> > IsolationValuePairs;
         MultiIsolator() {}
-        MultiIsolator(const edm::ParameterSet &conf, bool cuts=true) ;
+        MultiIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector && iC, bool cuts=true) ;
         ~MultiIsolator() {}
 
         // adds an isolator (and takes onwership of the pointer)
         void addIsolator(BaseIsolator *iso, uint32_t mask, pat::IsolationKeys key) ;
 
         // parses an isolator and adds it to the list
-        void addIsolator(const edm::ParameterSet &conf, bool withCut, uint32_t mask, pat::IsolationKeys key) ;
+        void addIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut, uint32_t mask, pat::IsolationKeys key) ;
 
         // Parses out an isolator, and returns a pointer to it.
         // For an empty PSet, it returns a null pointer.
         // You own the returned pointer!
-        static BaseIsolator * make(const edm::ParameterSet &conf, bool withCut) ;
-       
+        static BaseIsolator * make(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut) ;
+
         void beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup);
-        void endEvent() ; 
+        void endEvent() ;
 
         template<typename T>
         uint32_t test(const edm::View<T> &coll, int idx) const;
@@ -55,7 +55,7 @@ class MultiIsolator {
 };
 
     template<typename T>
-    uint32_t 
+    uint32_t
     MultiIsolator::test(const edm::View<T> &coll, int idx) const {
         uint32_t retval = 0;
         edm::RefToBase<T> rb = coll.refAt(idx); // edm::Ptr<T> in a shiny new future to come one remote day ;-)
@@ -66,26 +66,26 @@ class MultiIsolator {
     }
 
     template<typename RefType>
-    void 
-    MultiIsolator::fill(const RefType &rb, IsolationValuePairs & isolations) const 
+    void
+    MultiIsolator::fill(const RefType &rb, IsolationValuePairs & isolations) const
     {
         isolations.resize(isolators_.size());
         for (size_t i = 0, n = isolators_.size(); i < n; ++i) {
            isolations[i].first  = keys_[i];
-           isolations[i].second = isolators_[i].getValue(rb); 
+           isolations[i].second = isolators_[i].getValue(rb);
         }
     }
 
 
     template<typename T>
-    void 
-    MultiIsolator::fill(const edm::View<T> &coll, int idx, IsolationValuePairs & isolations) const 
+    void
+    MultiIsolator::fill(const edm::View<T> &coll, int idx, IsolationValuePairs & isolations) const
     {
-        edm::RefToBase<T> rb = coll.refAt(idx); 
+        edm::RefToBase<T> rb = coll.refAt(idx);
         fill(rb, isolations);
     }
 
 }} // namespace
 
 #endif
- 
+

--- a/PhysicsTools/PatAlgos/interface/PATUserDataHelper.h
+++ b/PhysicsTools/PatAlgos/interface/PATUserDataHelper.h
@@ -17,9 +17,9 @@
 	    * ValueMap<Ptr<UserData> >
 	    * ValueMap<CandidatePtr>
 
-	    This is accomplished by using PATUserDataMergers. 
+	    This is accomplished by using PATUserDataMergers.
 
-	    This also can add "in situ" string-parser-based methods directly. 
+	    This also can add "in situ" string-parser-based methods directly.
 
   \author   Salvatore Rappoccio
   \version  $Id: PATUserDataHelper.h,v 1.8 2010/02/20 21:00:13 wmtan Exp $
@@ -28,6 +28,7 @@
 
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Common/interface/View.h"
@@ -50,13 +51,13 @@ namespace pat {
 
   template<class ObjectType>
   class PATUserDataHelper {
-    
+
   public:
 
     typedef StringObjectFunction<ObjectType>                      function_type;
 
     PATUserDataHelper() {}
-    PATUserDataHelper(const edm::ParameterSet & iConfig);
+    PATUserDataHelper(const edm::ParameterSet & iConfig, edm::ConsumesCollector && iC);
     ~PATUserDataHelper() {}
 
     static void fillDescription(edm::ParameterSetDescription & iDesc);
@@ -76,7 +77,7 @@ namespace pat {
     pat::PATUserDataMerger<ObjectType, pat::helper::AddUserInt>      userIntMerger_;
     // User candidate ptrs
     pat::PATUserDataMerger<ObjectType, pat::helper::AddUserCand>     userCandMerger_;
-    
+
     // Inline functions that operate on ObjectType
     std::vector<std::string>                                          functionNames_;
     std::vector<std::string>                                          functionLabels_;
@@ -86,11 +87,11 @@ namespace pat {
 
 // Constructor: Initilize user data src
 template<class ObjectType>
-PATUserDataHelper<ObjectType>::PATUserDataHelper(const edm::ParameterSet & iConfig) :
-  userDataMerger_   (iConfig.getParameter<edm::ParameterSet>("userClasses")),
-  userFloatMerger_  (iConfig.getParameter<edm::ParameterSet>("userFloats")),
-  userIntMerger_    (iConfig.getParameter<edm::ParameterSet>("userInts")),
-  userCandMerger_   (iConfig.getParameter<edm::ParameterSet>("userCands")),
+PATUserDataHelper<ObjectType>::PATUserDataHelper(const edm::ParameterSet & iConfig, edm::ConsumesCollector && iC) :
+  userDataMerger_   (iConfig.getParameter<edm::ParameterSet>("userClasses"), iC),
+  userFloatMerger_  (iConfig.getParameter<edm::ParameterSet>("userFloats"), iC),
+  userIntMerger_    (iConfig.getParameter<edm::ParameterSet>("userInts"), iC),
+  userCandMerger_   (iConfig.getParameter<edm::ParameterSet>("userCands"), iC),
   functionNames_    (iConfig.getParameter<std::vector<std::string> >("userFunctions")),
   functionLabels_   (iConfig.getParameter<std::vector<std::string> >("userFunctionLabels"))
 {
@@ -99,7 +100,7 @@ PATUserDataHelper<ObjectType>::PATUserDataHelper(const edm::ParameterSet & iConf
   if ( functionNames_.size() != functionLabels_.size() ) {
     throw cms::Exception("Size mismatch") << "userFunctions and userFunctionLabels do not have the same size, they must be the same\n";
   }
-  // Loop over the function names, create a new string-parser function object 
+  // Loop over the function names, create a new string-parser function object
   // with all of them. This operates on ObjectType
   std::vector<std::string>::const_iterator funcBegin = functionNames_.begin(),
     funcEnd = functionNames_.end(),
@@ -111,7 +112,7 @@ PATUserDataHelper<ObjectType>::PATUserDataHelper(const edm::ParameterSet & iConf
 
 
 /* ==================================================================================
-     PATUserDataHelper::add 
+     PATUserDataHelper::add
             This expects four inputs:
 	        patObject:         PATObject<ObjectType> to add to
 		recoObject:        The base for the value maps
@@ -123,8 +124,8 @@ PATUserDataHelper<ObjectType>::PATUserDataHelper(const edm::ParameterSet & iConf
 
 template<class ObjectType>
 void PATUserDataHelper<ObjectType>::add(ObjectType & patObject,
-					edm::Event const & iEvent, 
-					const edm::EventSetup& iSetup) 
+					edm::Event const & iEvent,
+					const edm::EventSetup& iSetup)
 {
 
   // Add "complex" user data to the PAT object
@@ -144,7 +145,7 @@ void PATUserDataHelper<ObjectType>::add(ObjectType & patObject,
     }
   }
 
-  
+
 }
 
 

--- a/PhysicsTools/PatAlgos/interface/PATUserDataMerger.h
+++ b/PhysicsTools/PatAlgos/interface/PATUserDataMerger.h
@@ -22,8 +22,10 @@
 
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/transform.h"
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Common/interface/Ptr.h"
 #include "DataFormats/Common/interface/Association.h"
@@ -74,7 +76,7 @@ namespace pat {
   public:
 
     PATUserDataMerger() {}
-    PATUserDataMerger(const edm::ParameterSet & iConfig);
+    PATUserDataMerger(const edm::ParameterSet & iConfig, edm::ConsumesCollector & iC);
     ~PATUserDataMerger() {}
 
     static void fillDescription(edm::ParameterSetDescription & iDesc);
@@ -86,7 +88,8 @@ namespace pat {
   private:
 
     // configurables
-    std::vector<edm::InputTag>  userDataSrc_;   // ValueMap containing the user data
+    std::vector<edm::InputTag> userDataSrc_;
+    std::vector<edm::EDGetTokenT<typename Operation::product_type> > userDataSrcTokens_;
     Operation                   loader_;
 
   };
@@ -95,9 +98,12 @@ namespace pat {
 
 // Constructor: Initilize user data src
 template<typename ObjectType, typename Operation>
-pat::PATUserDataMerger<ObjectType, Operation>::PATUserDataMerger(const edm::ParameterSet & iConfig) :
-  userDataSrc_(iConfig.getParameter<std::vector<edm::InputTag> >("src") )
+pat::PATUserDataMerger<ObjectType, Operation>::PATUserDataMerger(const edm::ParameterSet & iConfig, edm::ConsumesCollector & iC) :
+  userDataSrc_(iConfig.getParameter<std::vector<edm::InputTag> >("src"))
 {
+  for ( std::vector<edm::InputTag>::const_iterator input_it = userDataSrc_.begin(); input_it !=  userDataSrc_.end(); ++input_it ) {
+    userDataSrcTokens_.push_back( iC.consumes< typename Operation::product_type >( *input_it ) );
+  }
 }
 
 
@@ -124,11 +130,10 @@ pat::PATUserDataMerger<ObjectType, Operation>::add(ObjectType & patObject,
 						   const edm::EventSetup& iSetup)
 {
 
-  std::vector<edm::InputTag>::const_iterator input_it = userDataSrc_.begin(),
-//     input_begin = userDataSrc_.begin(), // warning from gcc461: variable 'input_begin' set but not used [-Wunused-but-set-variable]
-    input_end = userDataSrc_.end();
+  typename std::vector<edm::EDGetTokenT<typename Operation::product_type> >::const_iterator token_begin = userDataSrcTokens_.begin(), token_it = userDataSrcTokens_.begin(), token_end = userDataSrcTokens_.end();
 
-  for ( ; input_it != input_end; ++input_it ) {
+  for ( ; token_it != token_end; ++token_it ) {
+    const std::string encoded( userDataSrc_.at(token_it - token_begin).encode() );
 
     // Declare the object handles:
     // ValueMap containing the values, or edm::Ptr's to the UserData that
@@ -136,12 +141,12 @@ pat::PATUserDataMerger<ObjectType, Operation>::add(ObjectType & patObject,
     edm::Handle<typename Operation::product_type> userData;
 
     // Get the objects by label
-    if ( input_it->encode().size() == 0 ) continue;
-    iEvent.getByLabel( *input_it, userData );
+    if ( encoded.size() == 0 ) continue;
+    iEvent.getByToken( *token_it, userData );
 
     edm::Ptr<reco::Candidate> recoObject = patObject.originalObjectRef();
     if ( userData->contains( recoObject.id() ) ) {
-      loader_.addData( patObject, input_it->encode(), (*userData)[recoObject]);
+      loader_.addData( patObject, encoded, (*userData)[recoObject]);
     }
 
   }

--- a/PhysicsTools/PatAlgos/interface/SimpleIsolator.h
+++ b/PhysicsTools/PatAlgos/interface/SimpleIsolator.h
@@ -8,7 +8,7 @@ class SimpleIsolator : public BaseIsolator {
     public:
         typedef edm::ValueMap<double> IsoValueMap;
         SimpleIsolator() {}
-        SimpleIsolator(const edm::ParameterSet &conf, bool withCut) ;
+        SimpleIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut) ;
         virtual ~SimpleIsolator() {}
         virtual void beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup) ;
         virtual void endEvent() ;
@@ -16,6 +16,7 @@ class SimpleIsolator : public BaseIsolator {
         virtual std::string description() const { return input_.encode(); }
     protected:
         edm::Handle<IsoValueMap> handle_;
+        edm::EDGetTokenT<IsoValueMap> inputDoubleToken_;
         virtual float getValue(const edm::ProductID &id, size_t index) const {
             return handle_->get(id, index);
         }

--- a/PhysicsTools/PatAlgos/plugins/DuplicatedElectronCleaner.cc
+++ b/PhysicsTools/PatAlgos/plugins/DuplicatedElectronCleaner.cc
@@ -10,7 +10,7 @@
    Among the two, the one with |E/P| nearest to 1 is kept.
    This is performed by the DuplicatedElectronRemover in PhysicsTools/PatUtils
 
-   The output is an edm::RefVector<reco:::GsfElectron>, 
+   The output is an edm::RefVector<reco:::GsfElectron>,
    which can be read through edm::View<reco::GsfElectron>
 
   \author   Giovanni Petrucciani
@@ -33,20 +33,20 @@ namespace pat{
   class DuplicatedElectronCleaner : public edm::EDProducer{
   public:
     explicit DuplicatedElectronCleaner(const edm::ParameterSet & iConfig);
-    ~DuplicatedElectronCleaner();  
-    
+    ~DuplicatedElectronCleaner();
+
     virtual void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
     virtual void endJob() override;
-    
+
   private:
-    edm::InputTag electronSrc_;
-    pat::DuplicatedElectronRemover duplicateRemover_; 
+    edm::EDGetTokenT<edm::View<reco::GsfElectron> > electronSrcToken_;
+    pat::DuplicatedElectronRemover duplicateRemover_;
     uint64_t try_, pass_;
   };
 } // namespace
 
 pat::DuplicatedElectronCleaner::DuplicatedElectronCleaner(const edm::ParameterSet & iConfig):
-  electronSrc_(iConfig.getParameter<edm::InputTag>("electronSource")),
+  electronSrcToken_(consumes<edm::View<reco::GsfElectron> >(iConfig.getParameter<edm::InputTag>("electronSource"))),
   try_(0), pass_(0)
 {
   //produces<edm::RefVector<reco::GsfElectronCollection> >();
@@ -58,19 +58,19 @@ pat::DuplicatedElectronCleaner::~DuplicatedElectronCleaner()
 {
 }
 
-void 
+void
 pat::DuplicatedElectronCleaner::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
 {
   using namespace edm;
   Handle<View<reco::GsfElectron> > electrons;
-  iEvent.getByLabel(electronSrc_, electrons);
+  iEvent.getByToken(electronSrcToken_, electrons);
   try_ += electrons->size();
-  
+
   //std::auto_ptr<RefVector<reco::GsfElectronCollection> > result(new RefVector<reco::GsfElectronCollection>());
   std::auto_ptr<RefToBaseVector<reco::GsfElectron> > result(new RefToBaseVector<reco::GsfElectron>());
   //std::auto_ptr<PtrVector<reco::GsfElectron> > result(new PtrVector<reco::GsfElectron>());
   std::auto_ptr< std::vector<size_t> > duplicates = duplicateRemover_.duplicatesToRemove(*electrons);
-  
+
   std::vector<size_t>::const_iterator itdup = duplicates->begin(), enddup = duplicates->end();
   for (size_t i = 0, n = electrons->size(); i < n; ++i) {
     while ((itdup != enddup) && (*itdup < i)) { ++itdup; }
@@ -79,13 +79,13 @@ pat::DuplicatedElectronCleaner::produce(edm::Event & iEvent, const edm::EventSet
     result->push_back(electrons->refAt(i));
     //result->push_back(electrons->ptrAt(i));
   }
-  pass_ += result->size(); 
+  pass_ += result->size();
   iEvent.put(result);
 }
 
-void 
-pat::DuplicatedElectronCleaner::endJob() 
-{ 
+void
+pat::DuplicatedElectronCleaner::endJob()
+{
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
@@ -20,22 +20,22 @@
 using namespace pat;
 
 JetCorrFactorsProducer::JetCorrFactorsProducer(const edm::ParameterSet& cfg):
-  emf_(cfg.getParameter<bool>( "emf" )), 
-  src_(cfg.getParameter<edm::InputTag>( "src" )),
+  emf_(cfg.getParameter<bool>( "emf" )),
+  srcToken_(consumes<edm::View<reco::Jet> >(cfg.getParameter<edm::InputTag>( "src" ))),
   type_ (cfg.getParameter<std::string>("flavorType")),
   label_(cfg.getParameter<std::string>( "@module_label" )),
   payload_( cfg.getParameter<std::string>("payload") ),
   useNPV_(cfg.getParameter<bool>("useNPV")),
   useRho_(cfg.getParameter<bool>("useRho"))
 {
-  std::vector<std::string> levels = cfg.getParameter<std::vector<std::string> >("levels"); 
-  // fill the std::map for levels_, which might be flavor dependent or not; 
-  // flavor dependency is determined from the fact whether the std::string 
+  std::vector<std::string> levels = cfg.getParameter<std::vector<std::string> >("levels");
+  // fill the std::map for levels_, which might be flavor dependent or not;
+  // flavor dependency is determined from the fact whether the std::string
   // L5Flavor or L7Parton can be found in levels; if flavor dependent four
-  // vectors of strings will be filled into the map corresponding to GLUON, 
+  // vectors of strings will be filled into the map corresponding to GLUON,
   // UDS, CHARM and BOTTOM (according to JetCorrFactors::Flavor), 'L5Flavor'
-  // and 'L7Parton' will be expanded accordingly; if not levels_ is filled 
-  // with only one vector of strings according to NONE. This vector will be 
+  // and 'L7Parton' will be expanded accordingly; if not levels_ is filled
+  // with only one vector of strings according to NONE. This vector will be
   // equivalent to the original vector of strings.
   if(std::find(levels.begin(), levels.end(), "L5Flavor")!=levels.end() || std::find(levels.begin(), levels.end(), "L7Parton")!=levels.end()){
     levels_[JetCorrFactors::GLUON ] = expand(levels, JetCorrFactors::GLUON );
@@ -46,7 +46,7 @@ JetCorrFactorsProducer::JetCorrFactorsProducer(const edm::ParameterSet& cfg):
   else{
     levels_[JetCorrFactors::NONE  ] = levels;
   }
-  // if the std::string L1JPTOffset can be found in levels an additional 
+  // if the std::string L1JPTOffset can be found in levels an additional
   // parameter extraJPTOffset is needed, which should pass on the the usual
   // L1Offset correction, which is an additional input to the L1JPTOffset
   // corrector
@@ -55,7 +55,7 @@ JetCorrFactorsProducer::JetCorrFactorsProducer(const edm::ParameterSet& cfg):
       extraJPTOffset_.push_back(cfg.getParameter<std::string>("extraJPTOffset"));
     }
     else{
-      throw cms::Exception("No parameter extraJPTOffset specified") 
+      throw cms::Exception("No parameter extraJPTOffset specified")
 	<< "The configured correction levels contain a L1JPTOffset correction, which re- \n"
 	<< "quires the additional parameter extraJPTOffset or type std::string. This     \n"
 	<< "string should correspond to the L1Offset corrections that should be applied  \n"
@@ -65,14 +65,15 @@ JetCorrFactorsProducer::JetCorrFactorsProducer(const edm::ParameterSet& cfg):
   }
   // if the std::string L1Offset can be found in levels an additional para-
   // meter primaryVertices is needed, which should pass on the offline pri-
-  // mary vertex collection. The size of this collection is needed for the 
+  // mary vertex collection. The size of this collection is needed for the
   // L1Offset correction.
   if(useNPV_){
     if(cfg.existsAs<edm::InputTag>("primaryVertices")){
       primaryVertices_=cfg.getParameter<edm::InputTag>("primaryVertices");
+      primaryVerticesToken_=mayConsume<std::vector<reco::Vertex> >(primaryVertices_);
     }
     else{
-      throw cms::Exception("No primaryVertices specified") 
+      throw cms::Exception("No primaryVertices specified")
 	<< "The configured correction levels contain an L1Offset or L1FastJet correction, \n"
 	<< "which requires the number of offlinePrimaryVertices. Please specify this col- \n"
 	<< "lection as additional optional parameter primaryVertices of type edm::InputTag\n"
@@ -80,15 +81,16 @@ JetCorrFactorsProducer::JetCorrFactorsProducer(const edm::ParameterSet& cfg):
     }
   }
   // if the std::string L1FastJet can be found in levels an additional
-  // parameter rho is needed, which should pass on the energy density 
+  // parameter rho is needed, which should pass on the energy density
   // parameter for the corresponding jet collection.
   if(useRho_){
     if((!extraJPTOffset_.empty() && extraJPTOffset_.front()==std::string("L1FastJet")) || std::find(levels.begin(), levels.end(), "L1FastJet")!=levels.end()){
       if(cfg.existsAs<edm::InputTag>("rho")){
 	rho_=cfg.getParameter<edm::InputTag>("rho");
+	rhoToken_=mayConsume<double>(rho_);
       }
       else{
-	throw cms::Exception("No parameter rho specified") 
+	throw cms::Exception("No parameter rho specified")
 	  << "The configured correction levels contain a L1FastJet correction, which re- \n"
 	  << "quires the energy density parameter rho. Please specify this collection as \n"
 	  << "additional optional parameter rho of type edm::InputTag in the jetCorrFac- \n"
@@ -118,27 +120,27 @@ JetCorrFactorsProducer::expand(const std::vector<std::string>& levels, const Jet
 		  << "For this combination there is no GLUON correction available. The    \n"
 		  << "correction for this flavor type will be taken from 'J'.";
 	}
-	expand.push_back(std::string(*level).append("_").append("g").append("J"));	
+	expand.push_back(std::string(*level).append("_").append("g").append("J"));
       }
-      if(flavor==JetCorrFactors::UDS   ) expand.push_back(std::string(*level).append("_").append("q").append(type_));	
-      if(flavor==JetCorrFactors::CHARM ) expand.push_back(std::string(*level).append("_").append("c").append(type_));	
+      if(flavor==JetCorrFactors::UDS   ) expand.push_back(std::string(*level).append("_").append("q").append(type_));
+      if(flavor==JetCorrFactors::CHARM ) expand.push_back(std::string(*level).append("_").append("c").append(type_));
       if(flavor==JetCorrFactors::BOTTOM) expand.push_back(std::string(*level).append("_").append("b").append(type_));
     }
     else{
-      expand.push_back(*level); 
+      expand.push_back(*level);
     }
   }
   return expand;
 }
 
 std::vector<JetCorrectorParameters>
-JetCorrFactorsProducer::params(const JetCorrectorParametersCollection& parameters, const std::vector<std::string>& levels) const 
+JetCorrFactorsProducer::params(const JetCorrectorParametersCollection& parameters, const std::vector<std::string>& levels) const
 {
   std::vector<JetCorrectorParameters> params;
-  for(std::vector<std::string>::const_iterator level=levels.begin(); level!=levels.end(); ++level){ 
+  for(std::vector<std::string>::const_iterator level=levels.begin(); level!=levels.end(); ++level){
     const JetCorrectorParameters& ip = parameters[*level]; //ip.printScreen();
-    params.push_back(ip); 
-  } 
+    params.push_back(ip);
+  }
   return params;
 }
 
@@ -150,14 +152,14 @@ JetCorrFactorsProducer::evaluate(edm::View<reco::Jet>::const_iterator& jet, boos
   if( jpt ){
     TLorentzVector p4; p4.SetPtEtaPhiE(jpt->getCaloJetRef()->pt(), jpt->getCaloJetRef()->eta(), jpt->getCaloJetRef()->phi(), jpt->getCaloJetRef()->energy());
     if( extraJPTOffset ){
-      extraJPTOffset->setJPTrawP4(p4); 
+      extraJPTOffset->setJPTrawP4(p4);
       corrector->setJPTrawOff(extraJPTOffset->getSubCorrections()[0]);
     }
-    corrector->setJPTrawP4(p4); 
+    corrector->setJPTrawP4(p4);
   }
-  corrector->setJetEta(jet->eta()); corrector->setJetPt(jet->pt()); corrector->setJetE(jet->energy()); 
-  if( emf_ && dynamic_cast<const reco::CaloJet*>(&*jet)){ 
-    corrector->setJetEMF(dynamic_cast<const reco::CaloJet*>(&*jet)->emEnergyFraction()); 
+  corrector->setJetEta(jet->eta()); corrector->setJetPt(jet->pt()); corrector->setJetE(jet->energy());
+  if( emf_ && dynamic_cast<const reco::CaloJet*>(&*jet)){
+    corrector->setJetEMF(dynamic_cast<const reco::CaloJet*>(&*jet)->emEnergyFraction());
   }
   return corrector->getSubCorrections()[level];
 }
@@ -168,24 +170,24 @@ JetCorrFactorsProducer::payload()
   return payload_;
 }
 
-void 
-JetCorrFactorsProducer::produce(edm::Event& event, const edm::EventSetup& setup) 
+void
+JetCorrFactorsProducer::produce(edm::Event& event, const edm::EventSetup& setup)
 {
   // get jet collection from the event
   edm::Handle<edm::View<reco::Jet> > jets;
-  event.getByLabel(src_, jets);
+  event.getByToken(srcToken_, jets);
 
   // get primary vertices for L1Offset correction level if needed
   edm::Handle<std::vector<reco::Vertex> > primaryVertices;
-  if(!primaryVertices_.label().empty()) event.getByLabel(primaryVertices_, primaryVertices);
+  if(!primaryVertices_.label().empty()) event.getByToken(primaryVerticesToken_, primaryVertices);
 
   // get parameter rho for L1FastJet correction level if needed
   edm::Handle<double> rho;
-  if(!rho_.label().empty()) event.getByLabel(rho_, rho);
+  if(!rho_.label().empty()) event.getByToken(rhoToken_, rho);
 
-  // retreive parameters from the DB 
+  // retreive parameters from the DB
   edm::ESHandle<JetCorrectorParametersCollection> parameters;
-  setup.get<JetCorrectionsRecord>().get(payload(), parameters); 
+  setup.get<JetCorrectionsRecord>().get(payload(), parameters);
 
   // initialize jet correctors
   std::map<JetCorrFactors::Flavor, boost::shared_ptr<FactorizedJetCorrector> > corrector;
@@ -203,69 +205,69 @@ JetCorrFactorsProducer::produce(edm::Event& event, const edm::EventSetup& setup)
   std::vector<JetCorrFactors> jcfs;
   for(edm::View<reco::Jet>::const_iterator jet = jets->begin(); jet!=jets->end(); ++jet){
     // the JetCorrFactors::CorrectionFactor is a std::pair<std::string, std::vector<float> >
-    // the string corresponds to the label of the correction level, the vector contains four 
+    // the string corresponds to the label of the correction level, the vector contains four
     // floats if flavor dependent and one float else. Per construction jet energy corrections
     // will be flavor independent up to the first flavor dependent correction and flavor de-
-    // pendent afterwards. The first correction level is predefined with label 'Uncorrected'. 
+    // pendent afterwards. The first correction level is predefined with label 'Uncorrected'.
     // Per definition it is flavor independent. The correction factor is 1.
     std::vector<JetCorrFactors::CorrectionFactor> jec;
     jec.push_back(std::make_pair<std::string, std::vector<float> >(std::string("Uncorrected"), std::vector<float>(1, 1)));
 
-    // pick the first element in the map (which could be the only one) and loop all jec 
-    // levels listed for that element. If this is not the only element all jec levels, which 
+    // pick the first element in the map (which could be the only one) and loop all jec
+    // levels listed for that element. If this is not the only element all jec levels, which
     // are flavor independent will give the same correction factors until the first flavor
     // dependent correction level is reached. So the first element is still a good choice.
     FlavorCorrLevelMap::const_iterator corrLevel=levels_.begin();
     if(corrLevel==levels_.end()){
       throw cms::Exception("No JECFactors") << "You request to create a jetCorrFactors object with no JEC Levels indicated. \n"
 					    << "This makes no sense, either you should correct this or drop the module from \n"
-					    << "the sequence."; 
+					    << "the sequence.";
     }
     for(unsigned int idx=0; idx<corrLevel->second.size(); ++idx){
       bool flavorDependent=false;
       std::vector<float> factors;
-      if(flavorDependent || 
-	 corrLevel->second[idx].find("L5Flavor")!=std::string::npos || 
+      if(flavorDependent ||
+	 corrLevel->second[idx].find("L5Flavor")!=std::string::npos ||
 	 corrLevel->second[idx].find("L7Parton")!=std::string::npos){
 	flavorDependent=true;
 	// after the first encounter all subsequent correction levels are flavor dependent
 	for(FlavorCorrLevelMap::const_iterator flavor=corrLevel; flavor!=levels_.end(); ++flavor){
 	  if(!primaryVertices_.label().empty()){
-	    // if primaryVertices_ has a value the number of primary vertices needs to be 
+	    // if primaryVerticesToken_ has a value the number of primary vertices needs to be
 	    // specified
 	    corrector.find(flavor->first)->second->setNPV(numberOf(primaryVertices));
 	  }
 	  if(!rho_.label().empty()){
-	    // if rho_ has a value the energy density parameter rho and the jet area need
+	    // if rhoToken_ has a value the energy density parameter rho and the jet area need
 	    //  to be specified
 	    corrector.find(flavor->first)->second->setRho(*rho);
 	    corrector.find(flavor->first)->second->setJetA(jet->jetArea());
 	  }
-	  factors.push_back(evaluate(jet, corrector.find(flavor->first)->second, extraJPTOffset, idx)); 
+	  factors.push_back(evaluate(jet, corrector.find(flavor->first)->second, extraJPTOffset, idx));
 	}
       }
       else{
 	if(!primaryVertices_.label().empty()){
-	  // if primaryVertices_ has a value the number of primary vertices needs to be 
+	  // if primaryVerticesToken_ has a value the number of primary vertices needs to be
 	  // specified
 	  corrector.find(corrLevel->first)->second->setNPV(numberOf(primaryVertices));
 	}
 	if(!rho_.label().empty()){
-	  // if rho_ has a value the energy density parameter rho and the jet area need
+	  // if rhoToken_ has a value the energy density parameter rho and the jet area need
 	  // to be specified
 	  corrector.find(corrLevel->first)->second->setRho(*rho);
 	  corrector.find(corrLevel->first)->second->setJetA(jet->jetArea());
 	}
 	factors.push_back(evaluate(jet, corrector.find(corrLevel->first)->second, extraJPTOffset, idx));
       }
-      // push back the set of JetCorrFactors: the first entry corresponds to the label 
+      // push back the set of JetCorrFactors: the first entry corresponds to the label
       // of the correction level, which is taken from the first element in levels_. For
       // L5Flavor and L7Parton the part including the first '_' indicating the flavor
-      // of the first element in levels_ is chopped of from the label to avoid confusion 
-      // of the correction levels. The second parameter corresponds to the set of jec 
-      // factors, which might be flavor dependent or not. In the default configuration 
-      // the CorrectionFactor will look like this: 'Uncorrected': 1 ; 'L2Relative': x ; 
-      // 'L3Absolute': x ; 'L5Flavor': v, x, y, z ; 'L7Parton': v, x, y, z 
+      // of the first element in levels_ is chopped of from the label to avoid confusion
+      // of the correction levels. The second parameter corresponds to the set of jec
+      // factors, which might be flavor dependent or not. In the default configuration
+      // the CorrectionFactor will look like this: 'Uncorrected': 1 ; 'L2Relative': x ;
+      // 'L3Absolute': x ; 'L5Flavor': v, x, y, z ; 'L7Parton': v, x, y, z
       jec.push_back(std::make_pair((corrLevel->second[idx]).substr(0, (corrLevel->second[idx]).find("_")), factors));
     }
     // create the actual object with the scale factors we want the valuemap to refer to
@@ -298,11 +300,11 @@ JetCorrFactorsProducer::fillDescriptions(edm::ConfigurationDescriptions & descri
   iDesc.add<std::string>("extraJPTOffset", "L1Offset");
 
   std::vector<std::string> levels;
-  levels.push_back(std::string("L1Offset"  )); 
-  levels.push_back(std::string("L2Relative")); 
-  levels.push_back(std::string("L3Absolute")); 
-  levels.push_back(std::string("L5Flavor"  )); 
-  levels.push_back(std::string("L7Parton"  )); 
+  levels.push_back(std::string("L1Offset"  ));
+  levels.push_back(std::string("L2Relative"));
+  levels.push_back(std::string("L3Absolute"));
+  levels.push_back(std::string("L5Flavor"  ));
+  levels.push_back(std::string("L7Parton"  ));
   iDesc.add<std::vector<std::string> >("levels", levels);
   descriptions.add("JetCorrFactorsProducer", iDesc);
 }

--- a/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.h
@@ -5,15 +5,15 @@
   \class    pat::JetCorrFactorsProducer JetCorrFactorsProducer.h "PhysicsTools/PatAlgos/interface/JetCorrFactorsProducer.h"
   \brief    Produces a ValueMap between JetCorrFactors and the to the originating reco jets
 
-   The JetCorrFactorsProducer produces a set of correction factors, defined in the class pat::JetCorrFactors. This vector 
-   is linked to the originating reco jets through an edm::ValueMap. The initializing parameters of the module can be found 
-   in the recoLayer1/jetCorrFactors_cfi.py of the PatAlgos package. In the standard PAT workflow the module has to be run 
-   before the creation of the pat::Jet. The edm::ValueMap will then be embedded into the pat::Jet. 
+   The JetCorrFactorsProducer produces a set of correction factors, defined in the class pat::JetCorrFactors. This vector
+   is linked to the originating reco jets through an edm::ValueMap. The initializing parameters of the module can be found
+   in the recoLayer1/jetCorrFactors_cfi.py of the PatAlgos package. In the standard PAT workflow the module has to be run
+   before the creation of the pat::Jet. The edm::ValueMap will then be embedded into the pat::Jet.
 
-   Jets corrected up to a given correction level can then be accessed via the pat::Jet member function correctedJet. For 
+   Jets corrected up to a given correction level can then be accessed via the pat::Jet member function correctedJet. For
    more details have a look into the class description of the pat::Jet.
 
-   ATTENTION: available options for flavor corrections are 
+   ATTENTION: available options for flavor corrections are
     * L5Flavor_gJ        L7Parton_gJ         gluon   from dijets
     * L5Flavor_qJ/_qT    L7Parton_qJ/_qT     quark   from dijets/top
     * L5Flavor_cJ/_cT    L7Parton_cJ/_cT     charm   from dijets/top
@@ -21,14 +21,14 @@
     *                    L7Parton_jJ/_tT     mixture from dijets/top
 
    where mixture refers to the flavor mixture as determined from the MC sample the flavor dependent corrections have been
-   derived from. 'J' and 'T' stand for a typical dijet (ttbar) sample. 
+   derived from. 'J' and 'T' stand for a typical dijet (ttbar) sample.
 
-   L1Offset corrections require the collection of _offlinePrimaryVertices_, which are supposed to be added as an additional 
-   optional parameter _primaryVertices_ in the jetCorrFactors_cfi.py file.  
+   L1Offset corrections require the collection of _offlinePrimaryVertices_, which are supposed to be added as an additional
+   optional parameter _primaryVertices_ in the jetCorrFactors_cfi.py file.
 
-   L1FastJet corrections, which are an alternative to the standard L1Offset correction as recommended by the JetMET PAG the 
-   energy density parameter _rho_ is supposed to be added as an additional optional parameter _rho_ in the 
-   jetCorrFactors_cfi.py file.  
+   L1FastJet corrections, which are an alternative to the standard L1Offset correction as recommended by the JetMET PAG the
+   energy density parameter _rho_ is supposed to be added as an additional optional parameter _rho_ in the
+   jetCorrFactors_cfi.py file.
 
    NOTE:
     * the mixed mode (mc input mixture from dijets/ttbar) only exists for parton level corrections.
@@ -72,14 +72,14 @@ namespace pat {
     virtual void produce(edm::Event& event, const edm::EventSetup& setup) override;
     /// description of configuration file parameters
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-    
+
   private:
     /// return true if the jec levels contain at least one flavor dependent correction level
-    bool flavorDependent() const { return (levels_.size()>1); }; 
+    bool flavorDependent() const { return (levels_.size()>1); };
     /// return the jec parameters as input to the FactorizedJetCorrector for different flavors
     std::vector<JetCorrectorParameters> params(const JetCorrectorParametersCollection& parameters, const std::vector<std::string>& levels) const;
     /// return an expanded version of correction levels for different flavors; the result should
-    /// be of type ['L2Relative', 'L3Absolute', 'L5FLavor_gJ', 'L7Parton_gJ']; L7Parton_gT will 
+    /// be of type ['L2Relative', 'L3Absolute', 'L5FLavor_gJ', 'L7Parton_gJ']; L7Parton_gT will
     /// result in an empty string as this correction level is not available
     std::vector<std::string> expand(const std::vector<std::string>& levels, const JetCorrFactors::Flavor& flavor);
     /// evaluate jet correction factor up to a given level
@@ -88,12 +88,12 @@ namespace pat {
     int numberOf(const edm::Handle<std::vector<reco::Vertex> >& primaryVertices);
     /// map jet algorithm to payload in DB
     std::string payload();
-    
+
   private:
     /// use electromagnetic fraction for jet energy corrections or not (will only have an effect for jets CaloJets)
     bool emf_;
     /// input jet collection
-    edm::InputTag src_;
+    edm::EDGetTokenT<edm::View<reco::Jet> > srcToken_;
     /// type of flavor dependent JEC factors (only 'J' and 'T' are allowed)
     std::string type_;
     /// label of jec factors
@@ -105,12 +105,14 @@ namespace pat {
     std::vector<std::string> extraJPTOffset_;
     /// label for L1Offset primaryVertex collection
     edm::InputTag primaryVertices_;
+    edm::EDGetTokenT<std::vector<reco::Vertex> > primaryVerticesToken_;
     /// label for L1FastJet energy density parameter rho
     edm::InputTag rho_;
+    edm::EDGetTokenT<double> rhoToken_;
     /// use the NPV and rho with the JEC? (used for L1Offset/L1FastJet and L1FastJet, resp.)
     bool useNPV_;
     bool useRho_;
-    /// jec levels for different flavors. In the default configuration 
+    /// jec levels for different flavors. In the default configuration
     /// this map would look like this:
     /// GLUON  : 'L2Relative', 'L3Absolute', 'L5FLavor_jg', L7Parton_jg'
     /// UDS    : 'L2Relative', 'L3Absolute', 'L5FLavor_jq', L7Parton_jq'
@@ -119,11 +121,11 @@ namespace pat {
     /// or just like this:
     /// NONE   : 'L2Relative', 'L3Absolute', 'L2L3Residual'
     /// per definition the vectors for all elements in this map should
-    /// have the same size 
+    /// have the same size
     FlavorCorrLevelMap levels_;
   };
 
-  inline int 
+  inline int
   JetCorrFactorsProducer::numberOf(const edm::Handle<std::vector<reco::Vertex> >& primaryVertices)
   {
     int npv=0;

--- a/PhysicsTools/PatAlgos/plugins/PATCleaner.h
+++ b/PhysicsTools/PatAlgos/plugins/PATCleaner.h
@@ -6,7 +6,7 @@
 /**
   \class    pat::PATCleaner PATCleaner.h "PhysicsTools/PatAlgos/interface/PATCleaner.h"
   \brief    PAT Cleaner module for PAT Objects
-            
+
             The same module is used for all collections.
 
   \author   Giovanni Petrucciani
@@ -48,7 +48,8 @@ namespace pat {
       typedef StringCutObjectSelector<PATObjType> Selector;
 
       edm::InputTag src_;
-      bool doPreselection_, doFinalCut_;  
+      edm::EDGetTokenT<edm::View<PATObjType> > srcToken_;
+      bool doPreselection_, doFinalCut_;
       Selector preselectionCut_;
       Selector finalCut_;
 
@@ -62,6 +63,7 @@ namespace pat {
 template <class PATObjType>
 pat::PATCleaner<PATObjType>::PATCleaner(const edm::ParameterSet & iConfig) :
     src_(iConfig.getParameter<edm::InputTag>("src")),
+    srcToken_(consumes<edm::View<PATObjType> >(src_)),
     preselectionCut_(iConfig.getParameter<std::string>("preselection")),
     finalCut_(iConfig.getParameter<std::string>("finalCut"))
 {
@@ -74,30 +76,30 @@ pat::PATCleaner<PATObjType>::PATCleaner(const edm::ParameterSet & iConfig) :
         // retrieve configuration
         edm::ParameterSet cfg = overlapPSet.getParameter<edm::ParameterSet>(*itn);
         // skip empty parameter sets
-        if (cfg.empty()) continue; 
+        if (cfg.empty()) continue;
         // get the name of the algorithm to use
         std::string algorithm = cfg.getParameter<std::string>("algorithm");
         // create the appropriate OverlapTest
         if (algorithm == "byDeltaR") {
-            overlapTests_.push_back(new pat::helper::BasicOverlapTest(*itn, cfg));
+            overlapTests_.push_back(new pat::helper::BasicOverlapTest(*itn, cfg, consumesCollector()));
         } else if (algorithm == "bySuperClusterSeed") {
-            overlapTests_.push_back(new pat::helper::OverlapBySuperClusterSeed(*itn, cfg));
+            overlapTests_.push_back(new pat::helper::OverlapBySuperClusterSeed(*itn, cfg, consumesCollector()));
         } else {
             throw cms::Exception("Configuration") << "PATCleaner for " << src_ << ": unsupported algorithm '" << algorithm << "'\n";
         }
     }
-        
+
 
     produces<std::vector<PATObjType> >();
 }
 
 template <class PATObjType>
-void 
+void
 pat::PATCleaner<PATObjType>::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
 
   // Read the input. We use edm::View<> in case the input happes to be something different than a std::vector<>
   edm::Handle<edm::View<PATObjType> > candidates;
-  iEvent.getByLabel(src_, candidates);
+  iEvent.getByToken(srcToken_, candidates);
 
   // Prepare a collection for the output
   std::auto_ptr< std::vector<PATObjType> > output(new std::vector<PATObjType>());
@@ -109,7 +111,7 @@ pat::PATCleaner<PATObjType>::produce(edm::Event & iEvent, const edm::EventSetup 
 
   for (typename edm::View<PATObjType>::const_iterator it = candidates->begin(), ed = candidates->end(); it != ed; ++it) {
       // Apply a preselection to the inputs and copy them in the output
-      if (!preselectionCut_(*it)) continue; 
+      if (!preselectionCut_(*it)) continue;
 
       // Add it to the list and take a reference to it, so it can be modified (e.g. to set the overlaps)
       // If at some point I'll decide to drop this item, I'll use pop_back to remove it
@@ -121,7 +123,7 @@ pat::PATCleaner<PATObjType>::produce(edm::Event & iEvent, const edm::EventSetup 
       for (boost::ptr_vector<OverlapTest>::iterator itov = overlapTests_.begin(), edov = overlapTests_.end(); itov != edov; ++itov) {
         reco::CandidatePtrVector overlaps;
         bool hasOverlap = itov->fillOverlapsForItem(obj, overlaps);
-        if (hasOverlap && itov->requireNoOverlaps()) { 
+        if (hasOverlap && itov->requireNoOverlaps()) {
             badForOverlap = true; // mark for discarding
             break; // no point in checking the others, as this item will be discarded
         }

--- a/PhysicsTools/PatAlgos/plugins/PATCompositeCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATCompositeCandidateProducer.cc
@@ -18,10 +18,10 @@ using namespace std;
 using namespace edm;
 
 PATCompositeCandidateProducer::PATCompositeCandidateProducer(const ParameterSet & iConfig) :
-  userDataHelper_( iConfig.getParameter<edm::ParameterSet>("userData") )
+  userDataHelper_( iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector() )
 {
   // initialize the configurables
-  src_ = iConfig.getParameter<InputTag>( "src" );
+  srcToken_ = consumes<edm::View<reco::CompositeCandidate> >(iConfig.getParameter<InputTag>( "src" ));
 
   useUserData_ = false;
   if ( iConfig.exists("userData") ) {
@@ -31,7 +31,7 @@ PATCompositeCandidateProducer::PATCompositeCandidateProducer(const ParameterSet 
   // Efficiency configurables
   addEfficiencies_ = iConfig.getParameter<bool>("addEfficiencies");
   if (addEfficiencies_) {
-     efficiencyLoader_ = pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"));
+     efficiencyLoader_ = pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
   }
 
   // Resolution configurables
@@ -52,7 +52,7 @@ PATCompositeCandidateProducer::~PATCompositeCandidateProducer() {
 void PATCompositeCandidateProducer::produce(Event & iEvent, const EventSetup & iSetup) {
   // Get the vector of CompositeCandidate's from the event
   Handle<View<reco::CompositeCandidate> > cands;
-  iEvent.getByLabel(src_, cands);
+  iEvent.getByToken(srcToken_, cands);
 
   if (efficiencyLoader_.enabled()) efficiencyLoader_.newEvent(iEvent);
   if (resolutionLoader_.enabled()) resolutionLoader_.newEvent(iEvent, iSetup);
@@ -66,7 +66,7 @@ void PATCompositeCandidateProducer::produce(Event & iEvent, const EventSetup & i
     for ( ; i != iend; ++i ) {
 
       pat::CompositeCandidate cand(*i);
-      
+
       if ( useUserData_ ) {
 	userDataHelper_.add( cand, iEvent, iSetup );
       }

--- a/PhysicsTools/PatAlgos/plugins/PATCompositeCandidateProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATCompositeCandidateProducer.h
@@ -49,14 +49,14 @@ namespace pat {
     private:
 
       // configurables
-      edm::InputTag src_;     // list of reco::CompositeCandidates
+      edm::EDGetTokenT<edm::View<reco::CompositeCandidate> > srcToken_;     // list of reco::CompositeCandidates
 
       bool useUserData_;
       pat::PATUserDataHelper<pat::CompositeCandidate> userDataHelper_;
 
       bool addEfficiencies_;
       pat::helper::EfficiencyLoader efficiencyLoader_;
-      
+
       bool addResolutions_;
       pat::helper::KinResolutionsLoader resolutionLoader_;
   };

--- a/PhysicsTools/PatAlgos/plugins/PATConversionProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATConversionProducer.cc
@@ -46,7 +46,9 @@ using namespace std;
 PATConversionProducer::PATConversionProducer(const edm::ParameterSet & iConfig){
 
   // general configurables
-  electronSrc_      = iConfig.getParameter<edm::InputTag>( "electronSource" );
+  electronToken_    = consumes<edm::View<reco::GsfElectron> >(iConfig.getParameter<edm::InputTag>( "electronSource" ));
+  bsToken_          = consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"));
+  conversionsToken_ = consumes<reco::ConversionCollection>(edm::InputTag("allConversions"));
 
   // produces vector of muons
   produces<std::vector<Conversion> >();
@@ -62,15 +64,15 @@ void PATConversionProducer::produce(edm::Event & iEvent, const edm::EventSetup &
 
   // Get the collection of electrons from the event
   edm::Handle<edm::View<reco::GsfElectron> > electrons;
-  iEvent.getByLabel(electronSrc_, electrons);
+  iEvent.getByToken(electronToken_, electrons);
 
   edm::Handle<reco::BeamSpot> bsHandle;
-  iEvent.getByLabel("offlineBeamSpot", bsHandle);
+  iEvent.getByToken(bsToken_, bsHandle);
   const reco::BeamSpot &beamspot = *bsHandle.product();
 
-  // for conversion veto selection  
+  // for conversion veto selection
   edm::Handle<reco::ConversionCollection> hConversions;
-  iEvent.getByLabel("allConversions", hConversions);
+  iEvent.getByToken(conversionsToken_, hConversions);
 
   std::vector<Conversion> * patConversions = new std::vector<Conversion>();
 
@@ -78,7 +80,7 @@ void PATConversionProducer::produce(edm::Event & iEvent, const edm::EventSetup &
 
     reco::Vertex vtx = conv->conversionVertex();
 
-    int index = 0; 
+    int index = 0;
     for (edm::View<reco::GsfElectron>::const_iterator itElectron = electrons->begin(); itElectron != electrons->end(); ++itElectron) {
 
       //find matched conversions with electron and save those conversions with matched electron index
@@ -86,7 +88,7 @@ void PATConversionProducer::produce(edm::Event & iEvent, const edm::EventSetup &
 
         double vtxProb = TMath::Prob( vtx.chi2(), vtx.ndof());
         math::XYZVector mom(conv->refittedPairMomentum());
-        double dbsx = vtx.x() - beamspot.position().x();   
+        double dbsx = vtx.x() - beamspot.position().x();
         double dbsy = vtx.y() - beamspot.position().y();
         double lxy = (mom.x()*dbsx + mom.y()*dbsy)/mom.rho();
         int nHitsMax = 0;
@@ -95,7 +97,7 @@ void PATConversionProducer::produce(edm::Event & iEvent, const edm::EventSetup &
           if ((*it) > nHitsMax) nHitsMax = (*it);
         }
 
-        pat::Conversion anConversion( index ); 
+        pat::Conversion anConversion( index );
         anConversion.setVtxProb( vtxProb );
         anConversion.setLxy( lxy );
         anConversion.setNHitsMax(  nHitsMax );
@@ -105,7 +107,7 @@ void PATConversionProducer::produce(edm::Event & iEvent, const edm::EventSetup &
       }
       index++;
     }
-    
+
   }
 
   // add the electrons to the event output

--- a/PhysicsTools/PatAlgos/plugins/PATConversionProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATConversionProducer.h
@@ -46,7 +46,9 @@ namespace pat {
     private:
 
       // configurables
-      edm::InputTag electronSrc_;
+      edm::EDGetTokenT<edm::View<reco::GsfElectron> > electronToken_;
+      edm::EDGetTokenT<reco::BeamSpot>                bsToken_;
+      edm::EDGetTokenT<reco::ConversionCollection>    conversionsToken_;
 
   };
 

--- a/PhysicsTools/PatAlgos/plugins/PATGenericParticleProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATGenericParticleProducer.cc
@@ -4,16 +4,17 @@
 #include "PhysicsTools/PatAlgos/plugins/PATGenericParticleProducer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Common/interface/View.h"
+#include "FWCore/Utilities/interface/transform.h"
 #include <memory>
 
 using namespace pat;
 
 PATGenericParticleProducer::PATGenericParticleProducer(const edm::ParameterSet & iConfig) :
-  isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation") : edm::ParameterSet(), false),
-  userDataHelper_ ( iConfig.getParameter<edm::ParameterSet>("userData") )
+  isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation") : edm::ParameterSet(), consumesCollector(), false),
+  userDataHelper_ ( iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector() )
 {
   // initialize the configurables
-  src_ = iConfig.getParameter<edm::InputTag>( "src" );
+  srcToken_ = consumes<edm::View<reco::Candidate> >(iConfig.getParameter<edm::InputTag>( "src" ));
 
   // RECO embedding
   embedTrack_        = iConfig.getParameter<bool>( "embedTrack" );
@@ -23,21 +24,21 @@ PATGenericParticleProducer::PATGenericParticleProducer(const edm::ParameterSet &
   embedSuperCluster_ = iConfig.getParameter<bool>( "embedSuperCluster" );
   embedTracks_       = iConfig.getParameter<bool>( "embedMultipleTracks" );
   embedCaloTower_    = iConfig.getParameter<bool>( "embedCaloTower" );
-  
+
   // MC matching configurables
   addGenMatch_   = iConfig.getParameter<bool>( "addGenMatch" );
   if (addGenMatch_) {
-      embedGenMatch_ = iConfig.getParameter<bool>         ( "embedGenMatch" );
+      embedGenMatch_ = iConfig.getParameter<bool>( "embedGenMatch" );
       if (iConfig.existsAs<edm::InputTag>("genParticleMatch")) {
-          genMatchSrc_.push_back(iConfig.getParameter<edm::InputTag>( "genParticleMatch" ));
+        genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection> >(iConfig.getParameter<edm::InputTag>( "genParticleMatch" )));
       } else {
-          genMatchSrc_ = iConfig.getParameter<std::vector<edm::InputTag> >( "genParticleMatch" );
+        genMatchTokens_ = edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag> >( "genParticleMatch" ), [this](edm::InputTag const & tag){return consumes<edm::Association<reco::GenParticleCollection> >(tag);});
       }
   }
 
   // quality
   addQuality_ = iConfig.getParameter<bool>("addQuality");
-  qualitySrc_ = iConfig.getParameter<edm::InputTag>("qualitySource");
+  qualitySrcToken_ = mayConsume<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("qualitySource"));
 
   // produces vector of particles
   produces<std::vector<GenericParticle> >();
@@ -56,11 +57,12 @@ PATGenericParticleProducer::PATGenericParticleProducer(const edm::ParameterSet &
         }
      }
   }
+  isoDepositTokens_ = edm::vector_transform(isoDepositLabels_, [this](std::pair<IsolationKeys,edm::InputTag> const & label){return consumes<edm::ValueMap<IsoDeposit> >(label.second);});
 
   // Efficiency configurables
   addEfficiencies_ = iConfig.getParameter<bool>("addEfficiencies");
   if (addEfficiencies_) {
-     efficiencyLoader_ = pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"));
+     efficiencyLoader_ = pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
   }
 
   // Resolution configurables
@@ -70,7 +72,7 @@ PATGenericParticleProducer::PATGenericParticleProducer(const edm::ParameterSet &
   }
 
   if (iConfig.exists("vertexing")) {
-     vertexingHelper_ = pat::helper::VertexingHelper(iConfig.getParameter<edm::ParameterSet>("vertexing")); 
+     vertexingHelper_ = pat::helper::VertexingHelper(iConfig.getParameter<edm::ParameterSet>("vertexing"), consumesCollector());
   }
 
   // Check to see if the user wants to add user data
@@ -86,7 +88,7 @@ PATGenericParticleProducer::~PATGenericParticleProducer() {
 void PATGenericParticleProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
   // Get the vector of GenericParticle's from the event
   edm::Handle<edm::View<reco::Candidate> > cands;
-  iEvent.getByLabel(src_, cands);
+  iEvent.getByToken(srcToken_, cands);
 
   // prepare isolation
   if (isolator_.enabled()) isolator_.beginEvent(iEvent,iSetup);
@@ -96,25 +98,25 @@ void PATGenericParticleProducer::produce(edm::Event & iEvent, const edm::EventSe
   if (vertexingHelper_.enabled())  vertexingHelper_.newEvent(iEvent,iSetup);
 
   // prepare IsoDeposits
-  std::vector<edm::Handle<edm::ValueMap<IsoDeposit> > > deposits(isoDepositLabels_.size());
+  std::vector<edm::Handle<edm::ValueMap<IsoDeposit> > > deposits(isoDepositTokens_.size());
   for (size_t j = 0, nd = deposits.size(); j < nd; ++j) {
-    iEvent.getByLabel(isoDepositLabels_[j].second, deposits[j]);
+    iEvent.getByToken(isoDepositTokens_[j], deposits[j]);
   }
 
   // prepare the MC matching
-  std::vector<edm::Handle<edm::Association<reco::GenParticleCollection> > > genMatches(genMatchSrc_.size());
+  std::vector<edm::Handle<edm::Association<reco::GenParticleCollection> > > genMatches(genMatchTokens_.size());
   if (addGenMatch_) {
-        for (size_t j = 0, nd = genMatchSrc_.size(); j < nd; ++j) {
-            iEvent.getByLabel(genMatchSrc_[j], genMatches[j]);
+        for (size_t j = 0, nd = genMatchTokens_.size(); j < nd; ++j) {
+            iEvent.getByToken(genMatchTokens_[j], genMatches[j]);
         }
   }
 
   // prepare the quality
   edm::Handle<edm::ValueMap<float> > qualities;
-  if (addQuality_) iEvent.getByLabel(qualitySrc_, qualities);
+  if (addQuality_) iEvent.getByToken(qualitySrcToken_, qualities);
 
   // loop over cands
-  std::vector<GenericParticle> * PATGenericParticles = new std::vector<GenericParticle>(); 
+  std::vector<GenericParticle> * PATGenericParticles = new std::vector<GenericParticle>();
   for (edm::View<reco::Candidate>::const_iterator itGenericParticle = cands->begin(); itGenericParticle != cands->end(); itGenericParticle++) {
     // construct the GenericParticle from the ref -> save ref to original object
     unsigned int idx = itGenericParticle - cands->begin();

--- a/PhysicsTools/PatAlgos/plugins/PATGenericParticleProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATGenericParticleProducer.h
@@ -51,28 +51,29 @@ namespace pat {
     private:
 
       // configurables
-      edm::InputTag src_;
+      edm::EDGetTokenT<edm::View<reco::Candidate> > srcToken_;
 
       // embed RECo objects
       bool embedSuperCluster_, embedTrack_, embedTracks_, embedGsfTrack_, embedCaloTower_, embedStandalone_, embedCombined_;
 
       bool addQuality_;
-      edm::InputTag qualitySrc_;
+      edm::EDGetTokenT<edm::ValueMap<float> > qualitySrcToken_;
 
       bool addGenMatch_;
       bool embedGenMatch_;
-      std::vector<edm::InputTag> genMatchSrc_;
+      std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > > genMatchTokens_;
 
       // tools
       GreaterByEt<GenericParticle> eTComparator_;
 
-      pat::helper::MultiIsolator isolator_; 
+      pat::helper::MultiIsolator isolator_;
       pat::helper::MultiIsolator::IsolationValuePairs isolatorTmpStorage_; // better here than recreate at each event
       std::vector<std::pair<pat::IsolationKeys,edm::InputTag> > isoDepositLabels_;
+      std::vector<edm::EDGetTokenT<edm::ValueMap<IsoDeposit> > > isoDepositTokens_;
 
       bool addEfficiencies_;
       pat::helper::EfficiencyLoader efficiencyLoader_;
-      
+
       bool addResolutions_;
       pat::helper::KinResolutionsLoader resolutionLoader_;
 

--- a/PhysicsTools/PatAlgos/plugins/PATHemisphereProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATHemisphereProducer.cc
@@ -3,7 +3,7 @@
 //
 // Package:    PatShapeAna
 // Class:      PatShapeAna
-// 
+//
 /**\class PatShapeAna PatShapeAna.cc PhysicsTools/PatShapeAna/src/PatShapeAna.cc
 
  Description: <one line class summary>
@@ -53,22 +53,22 @@ using namespace pat;
 // constructors and destructor
 //
 PATHemisphereProducer::PATHemisphereProducer(const edm::ParameterSet& iConfig) :
-  _patJets       ( iConfig.getParameter<edm::InputTag>( "patJets" ) ),
-  _patMuons      ( iConfig.getParameter<edm::InputTag>( "patMuons" ) ),
-  _patElectrons  ( iConfig.getParameter<edm::InputTag>( "patElectrons" ) ),
-  _patPhotons    ( iConfig.getParameter<edm::InputTag>( "patPhotons" ) ),
-  _patTaus       ( iConfig.getParameter<edm::InputTag>( "patTaus" ) ),
+  _patJetsToken       ( consumes<reco::CandidateView> ( iConfig.getParameter<edm::InputTag>( "patJets" ) ) ),
+  _patMuonsToken      ( consumes<reco::CandidateView> ( iConfig.getParameter<edm::InputTag>( "patMuons" ) ) ),
+  _patElectronsToken  ( consumes<reco::CandidateView> ( iConfig.getParameter<edm::InputTag>( "patElectrons" ) ) ),
+  _patPhotonsToken    ( consumes<reco::CandidateView> ( iConfig.getParameter<edm::InputTag>( "patPhotons" ) ) ),
+  _patTausToken       ( consumes<reco::CandidateView> ( iConfig.getParameter<edm::InputTag>( "patTaus" ) ) ),
 
   _minJetEt       ( iConfig.getParameter<double>("minJetEt") ),
   _minMuonEt       ( iConfig.getParameter<double>("minMuonEt") ),
   _minElectronEt       ( iConfig.getParameter<double>("minElectronEt") ),
-  _minTauEt       ( iConfig.getParameter<double>("minTauEt") ), 
+  _minTauEt       ( iConfig.getParameter<double>("minTauEt") ),
   _minPhotonEt       ( iConfig.getParameter<double>("minPhotonEt") ),
 
   _maxJetEta       ( iConfig.getParameter<double>("maxJetEta") ),
   _maxMuonEta       ( iConfig.getParameter<double>("maxMuonEta") ),
   _maxElectronEta       ( iConfig.getParameter<double>("maxElectronEta") ),
-  _maxTauEta       ( iConfig.getParameter<double>("maxTauEta") ), 
+  _maxTauEta       ( iConfig.getParameter<double>("maxTauEta") ),
   _maxPhotonEta       ( iConfig.getParameter<double>("maxPhotonEta") ),
 
   _seedMethod    ( iConfig.getParameter<int>("seedMethod") ),
@@ -83,7 +83,7 @@ PATHemisphereProducer::PATHemisphereProducer(const edm::ParameterSet& iConfig) :
 
 PATHemisphereProducer::~PATHemisphereProducer()
 {
- 
+
    // do anything here that needs to be done at desctruction time
    // (e.g. close files, deallocate resources etc.)
 
@@ -101,58 +101,58 @@ PATHemisphereProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
    using namespace edm;
    using namespace std;
 
-   //Jets   
+   //Jets
    Handle<reco::CandidateView> pJets;
-   iEvent.getByLabel(_patJets,pJets);
+   iEvent.getByToken(_patJetsToken,pJets);
 
-   //Muons   
+   //Muons
    Handle<reco::CandidateView> pMuons;
-   iEvent.getByLabel(_patMuons,pMuons);
+   iEvent.getByToken(_patMuonsToken,pMuons);
 
-   //Electrons   
+   //Electrons
    Handle<reco::CandidateView> pElectrons;
-   iEvent.getByLabel(_patElectrons,pElectrons);
+   iEvent.getByToken(_patElectronsToken,pElectrons);
 
-   //Photons   
+   //Photons
    Handle<reco::CandidateView> pPhotons;
-   iEvent.getByLabel(_patPhotons,pPhotons);
+   iEvent.getByToken(_patPhotonsToken,pPhotons);
 
-   //Taus   
+   //Taus
    Handle<reco::CandidateView> pTaus;
-   iEvent.getByLabel(_patTaus,pTaus);
+   iEvent.getByToken(_patTausToken,pTaus);
 
 
    //fill e,p vector with information from all objects (hopefully cleaned before)
    for(int i = 0; i < (int) (*pJets).size() ; i++){
      if((*pJets)[i].pt() <  _minJetEt || fabs((*pJets)[i].eta()) >  _maxJetEta) continue;
-   
+
      componentPtrs_.push_back(pJets->ptrAt(i));
    }
 
    for(int i = 0; i < (int) (*pMuons).size() ; i++){
-     if((*pMuons)[i].pt() <  _minMuonEt || fabs((*pMuons)[i].eta()) >  _maxMuonEta) continue; 
- 
+     if((*pMuons)[i].pt() <  _minMuonEt || fabs((*pMuons)[i].eta()) >  _maxMuonEta) continue;
+
      componentPtrs_.push_back(pMuons->ptrAt(i));
    }
-  
+
    for(int i = 0; i < (int) (*pElectrons).size() ; i++){
-     if((*pElectrons)[i].pt() <  _minElectronEt || fabs((*pElectrons)[i].eta()) >  _maxElectronEta) continue;  
-    
+     if((*pElectrons)[i].pt() <  _minElectronEt || fabs((*pElectrons)[i].eta()) >  _maxElectronEta) continue;
+
      componentPtrs_.push_back(pElectrons->ptrAt(i));
-   } 
+   }
 
    for(int i = 0; i < (int) (*pPhotons).size() ; i++){
-     if((*pPhotons)[i].pt() <  _minPhotonEt || fabs((*pPhotons)[i].eta()) >  _maxPhotonEta) continue;   
-    
+     if((*pPhotons)[i].pt() <  _minPhotonEt || fabs((*pPhotons)[i].eta()) >  _maxPhotonEta) continue;
+
      componentPtrs_.push_back(pPhotons->ptrAt(i));
-   } 
+   }
 
    //aren't taus included in jets?
    for(int i = 0; i < (int) (*pTaus).size() ; i++){
-     if((*pTaus)[i].pt() <  _minTauEt || fabs((*pTaus)[i].eta()) >  _maxTauEta) continue;   
-    
+     if((*pTaus)[i].pt() <  _minTauEt || fabs((*pTaus)[i].eta()) >  _maxTauEta) continue;
+
      componentPtrs_.push_back(pTaus->ptrAt(i));
-   }  
+   }
 
    // create product
    std::auto_ptr< std::vector<Hemisphere> > hemispheres(new std::vector<Hemisphere>);;
@@ -161,7 +161,7 @@ PATHemisphereProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   //calls HemiAlgorithm for seed method 3 (transv. inv. Mass) and association method 3 (Lund algo)
   HemisphereAlgo myHemi(componentPtrs_,_seedMethod,_combinationMethod);
 
-  //get Hemisphere Axis 
+  //get Hemisphere Axis
   vA1 = myHemi.getAxis1();
   vA2 = myHemi.getAxis2();
 
@@ -170,9 +170,9 @@ PATHemisphereProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
 
   reco::Particle::LorentzVector p2(vA2[0]*vA2[3],vA2[1]*vA2[3],vA2[2]*vA2[3],vA2[4]);
   hemispheres->push_back(Hemisphere(p2));
- 
+
   //get information to which Hemisphere each object belongs
-  vgroups = myHemi.getGrouping(); 
+  vgroups = myHemi.getGrouping();
 
   for ( unsigned int i=0; i<vgroups.size(); ++i ) {
     if ( vgroups[i]==1 ) {
@@ -199,9 +199,9 @@ PATHemisphereProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
 
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
+void
 PATHemisphereProducer::endJob() {
-  
+
 }
 
 //define this as a plug-in

--- a/PhysicsTools/PatAlgos/plugins/PATHemisphereProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATHemisphereProducer.h
@@ -2,7 +2,7 @@
 //
 // Package:    PatShapeAna
 // Class:      PatShapeAna
-// 
+//
 /**\class PatShapeAna PatShapeAna.h PhysicsTools/PatShapeAna/interface/PatShapeAna.h
 
  Description: <one line class summary>
@@ -32,7 +32,7 @@
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "PhysicsTools/UtilAlgos/interface/ParameterAdapter.h"
 
-#include "PhysicsTools/PatAlgos/interface/HemisphereAlgo.h" 
+#include "PhysicsTools/PatAlgos/interface/HemisphereAlgo.h"
 //
 // class decleration
 //
@@ -45,44 +45,44 @@ class PATHemisphereProducer : public edm::EDProducer {
    private:
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
       virtual void endJob() ;
-      
+
       // ----------member data ---------------------------
       /// Input: All PAT objects that are to cross-clean  or needed for that
-      edm::InputTag _patJets;
-      edm::InputTag _patMets;
-      edm::InputTag _patMuons;
-      edm::InputTag _patElectrons;
-      edm::InputTag _patPhotons;
-      edm::InputTag _patTaus;
+      edm::EDGetTokenT<reco::CandidateView> _patJetsToken;
+//       edm::EDGetTokenT<reco::CandidateView> _patMetsToken;
+      edm::EDGetTokenT<reco::CandidateView> _patMuonsToken;
+      edm::EDGetTokenT<reco::CandidateView> _patElectronsToken;
+      edm::EDGetTokenT<reco::CandidateView> _patPhotonsToken;
+      edm::EDGetTokenT<reco::CandidateView> _patTausToken;
 
   float _minJetEt;
-  float _minMuonEt;       
-  float _minElectronEt;       
-  float _minTauEt;       
-  float _minPhotonEt;      
+  float _minMuonEt;
+  float _minElectronEt;
+  float _minTauEt;
+  float _minPhotonEt;
 
-  float _maxJetEta;      
-  float _maxMuonEta;       
-  float _maxElectronEta;     
-  float _maxTauEta;       
-  float _maxPhotonEta;      
+  float _maxJetEta;
+  float _maxMuonEta;
+  float _maxElectronEta;
+  float _maxTauEta;
+  float _maxPhotonEta;
 
-      int _seedMethod; 
+      int _seedMethod;
       int _combinationMethod;
 
       HemisphereAlgo* myHemi;
-      
-      std::vector<float> vPx, vPy, vPz, vE; 
+
+      std::vector<float> vPx, vPy, vPz, vE;
       std::vector<float> vA1, vA2;
       std::vector<int> vgroups;
   std::vector<reco::CandidatePtr> componentPtrs_;
 
-  
+
   typedef std::vector<float> HemiAxis;
- 
-      
-   
-    
+
+
+
+
 };
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATJetProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATJetProducer.h
@@ -22,6 +22,8 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/Common/interface/View.h"
 
+#include "SimDataFormats/JetMatching/interface/JetFlavourMatching.h"
+
 #include "CommonTools/Utils/interface/PtComparator.h"
 
 #include "DataFormats/PatCandidates/interface/Jet.h"
@@ -55,35 +57,37 @@ namespace pat {
     private:
 
       // configurables
-      edm::InputTag            jetsSrc_;
+      edm::EDGetTokenT<edm::View<reco::Jet> > jetsToken_;
       bool                     embedCaloTowers_;
       bool                     embedPFCandidates_;
       bool                     getJetMCFlavour_;
-      edm::InputTag            jetPartonMapSource_;
+      edm::EDGetTokenT<reco::JetFlavourMatchingCollection> jetPartonMapToken_;
       bool                     addGenPartonMatch_;
       bool                     embedGenPartonMatch_;
-      edm::InputTag            genPartonSrc_;
+      edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > genPartonToken_;
       bool                     addGenJetMatch_;
       bool                     embedGenJetMatch_;
-      edm::InputTag            genJetSrc_;
+      edm::EDGetTokenT<edm::Association<reco::GenJetCollection> > genJetToken_;
       bool                     addPartonJetMatch_;
-      edm::InputTag            partonJetSrc_;
+//       edm::EDGetTokenT<edm::View<reco::SomePartonJetType> > partonJetToken_;
       bool                     addJetCorrFactors_;
-      std::vector<edm::InputTag> jetCorrFactorsSrc_;
+      std::vector<edm::EDGetTokenT<edm::ValueMap<JetCorrFactors> > > jetCorrFactorsTokens_;
 
       bool                       addBTagInfo_;
-      bool                       addDiscriminators_; 
+      bool                       addDiscriminators_;
       std::vector<edm::InputTag> discriminatorTags_;
+      std::vector<edm::EDGetTokenT<reco::JetFloatAssociation::Container> > discriminatorTokens_;
       std::vector<std::string>   discriminatorLabels_;
-      bool                       addTagInfos_; 
+      bool                       addTagInfos_;
       std::vector<edm::InputTag> tagInfoTags_;
+      std::vector<edm::EDGetTokenT<edm::View<reco::BaseTagInfo> > > tagInfoTokens_;
       std::vector<std::string>   tagInfoLabels_;
       bool                       addAssociatedTracks_;
-      edm::InputTag              trackAssociation_;
+      edm::EDGetTokenT<reco::JetTracksAssociation::Container> trackAssociationToken_;
       bool                       addJetCharge_;
-      edm::InputTag              jetCharge_;
+      edm::EDGetTokenT<reco::JetFloatAssociation::Container> jetChargeToken_;
       bool                       addJetID_;
-      edm::InputTag              jetIDMapLabel_;
+      edm::EDGetTokenT<reco::JetIDValueMap> jetIDMapToken_;
       // tools
       GreaterByPt<Jet>                   pTComparator_;
       GreaterByPt<CaloTower>             caloPTComparator_;
@@ -97,7 +101,7 @@ namespace pat {
       bool useUserData_;
       pat::PATUserDataHelper<pat::Jet>      userDataHelper_;
 
-      
+
 
   };
 

--- a/PhysicsTools/PatAlgos/plugins/PATJetSelector.h
+++ b/PhysicsTools/PatAlgos/plugins/PATJetSelector.h
@@ -25,9 +25,9 @@ namespace pat {
   public:
 
 
-  PATJetSelector( edm::ParameterSet const & params ) : 
+  PATJetSelector( edm::ParameterSet const & params ) :
     edm::EDFilter( ),
-      src_( params.getParameter<edm::InputTag>("src") ),
+      srcToken_(consumes<edm::View<pat::Jet> >( params.getParameter<edm::InputTag>("src") )),
       cut_( params.getParameter<std::string>("cut") ),
       filter_(false),
       selector_( cut_ )
@@ -47,15 +47,15 @@ namespace pat {
 
     virtual void beginJob() {}
     virtual void endJob() {}
-    
+
     virtual bool filter(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
 
-      std::auto_ptr< std::vector<Jet> > patJets ( new std::vector<Jet>() ); 
+      std::auto_ptr< std::vector<Jet> > patJets ( new std::vector<Jet>() );
 
       std::auto_ptr<reco::GenJetCollection > genJetsOut ( new reco::GenJetCollection() );
       std::auto_ptr<std::vector<CaloTower>  >  caloTowersOut( new std::vector<CaloTower> () );
       std::auto_ptr<reco::PFCandidateCollection > pfCandidatesOut( new reco::PFCandidateCollection() );
-      std::auto_ptr<edm::OwnVector<reco::BaseTagInfo> > tagInfosOut ( new edm::OwnVector<reco::BaseTagInfo>() );  
+      std::auto_ptr<edm::OwnVector<reco::BaseTagInfo> > tagInfosOut ( new edm::OwnVector<reco::BaseTagInfo>() );
 
 
       edm::RefProd<reco::GenJetCollection > h_genJetsOut = iEvent.getRefBeforePut<reco::GenJetCollection >( "genJets" );
@@ -64,7 +64,7 @@ namespace pat {
       edm::RefProd<edm::OwnVector<reco::BaseTagInfo> > h_tagInfosOut = iEvent.getRefBeforePut<edm::OwnVector<reco::BaseTagInfo> > ( "tagInfos" );
 
       edm::Handle< edm::View<pat::Jet> > h_jets;
-      iEvent.getByLabel( src_, h_jets );
+      iEvent.getByToken( srcToken_, h_jets );
 
       // First loop over the products and make the secondary output collections
       for ( edm::View<pat::Jet>::const_iterator ibegin = h_jets->begin(),
@@ -72,7 +72,7 @@ namespace pat {
 	    ijet != iend; ++ijet ) {
 
 	// Check the selection
-	if ( selector_(*ijet) ) {	  
+	if ( selector_(*ijet) ) {
 	  // Copy over the calo towers
 	  for ( CaloTowerFwdPtrVector::const_iterator itowerBegin = ijet->caloTowersFwdPtr().begin(),
 		  itowerEnd = ijet->caloTowersFwdPtr().end(), itower = itowerBegin;
@@ -81,7 +81,7 @@ namespace pat {
 	    caloTowersOut->push_back( **itower );
 	  }
 
-	  
+
 	  // Copy over the pf candidates
 	  for ( reco::PFCandidateFwdPtrVector::const_iterator icandBegin = ijet->pfCandidatesFwdPtr().begin(),
 		  icandEnd = ijet->pfCandidatesFwdPtr().end(), icand = icandBegin;
@@ -89,7 +89,7 @@ namespace pat {
 	    // Add to global pf candidate list
 	    pfCandidatesOut->push_back( **icand );
 	  }
-	  
+
 	  // Copy the tag infos
 	  for ( TagInfoFwdPtrCollection::const_iterator iinfoBegin = ijet->tagInfosFwdPtr().begin(),
 		  iinfoEnd = ijet->tagInfosFwdPtr().end(), iinfo = iinfoBegin;
@@ -107,7 +107,7 @@ namespace pat {
       }
 
 
-      // Output the secondary collections. 
+      // Output the secondary collections.
       edm::OrphanHandle<reco::GenJetCollection>  oh_genJetsOut = iEvent.put( genJetsOut, "genJets" );
       edm::OrphanHandle<std::vector<CaloTower> > oh_caloTowersOut = iEvent.put( caloTowersOut, "caloTowers" );
       edm::OrphanHandle<reco::PFCandidateCollection> oh_pfCandidatesOut = iEvent.put( pfCandidatesOut, "pfCandidates" );
@@ -121,7 +121,7 @@ namespace pat {
       unsigned int pfCandidateIndex = 0;
       unsigned int tagInfoIndex = 0;
       unsigned int genJetIndex = 0;
-      // Now set the Ptrs with the orphan handles. 
+      // Now set the Ptrs with the orphan handles.
       for ( edm::View<pat::Jet>::const_iterator ibegin = h_jets->begin(),
 	      iend = h_jets->end(), ijet = ibegin;
 	    ijet != iend; ++ijet ) {
@@ -130,45 +130,45 @@ namespace pat {
 	if ( selector_(*ijet) ) {
 	  // Add the jets that pass to the output collection
 	  patJets->push_back( *ijet );
-	  
+
 	  // Copy over the calo towers
 	  for ( CaloTowerFwdPtrVector::const_iterator itowerBegin = ijet->caloTowersFwdPtr().begin(),
 		  itowerEnd = ijet->caloTowersFwdPtr().end(), itower = itowerBegin;
 		itower != itowerEnd; ++itower ) {
-	    // Update the "forward" bit of the FwdPtr to point at the new tower collection. 
+	    // Update the "forward" bit of the FwdPtr to point at the new tower collection.
 
-	    //  ptr to "this" tower in the global list	
-	    edm::Ptr<CaloTower> outPtr( oh_caloTowersOut, caloTowerIndex);     
-	    patJets->back().updateFwdCaloTowerFwdPtr( itower - itowerBegin,// index of "this" tower in the jet 
+	    //  ptr to "this" tower in the global list
+	    edm::Ptr<CaloTower> outPtr( oh_caloTowersOut, caloTowerIndex);
+	    patJets->back().updateFwdCaloTowerFwdPtr( itower - itowerBegin,// index of "this" tower in the jet
 						      outPtr
 						      );
 	    ++caloTowerIndex;
 	  }
 
-	  
+
 	  // Copy over the pf candidates
 	  for ( reco::PFCandidateFwdPtrVector::const_iterator icandBegin = ijet->pfCandidatesFwdPtr().begin(),
 		  icandEnd = ijet->pfCandidatesFwdPtr().end(), icand = icandBegin;
 		icand != icandEnd; ++icand ) {
-	    // Update the "forward" bit of the FwdPtr to point at the new tower collection. 
+	    // Update the "forward" bit of the FwdPtr to point at the new tower collection.
 
 	    // ptr to "this" cand in the global list
 	    edm::Ptr<reco::PFCandidate> outPtr( oh_pfCandidatesOut, pfCandidateIndex );
-	    patJets->back().updateFwdPFCandidateFwdPtr( icand - icandBegin,// index of "this" tower in the jet 
+	    patJets->back().updateFwdPFCandidateFwdPtr( icand - icandBegin,// index of "this" tower in the jet
 							outPtr
 							);
 	    ++pfCandidateIndex;
 	  }
-	  
+
 	  // Copy the tag infos
 	  for ( TagInfoFwdPtrCollection::const_iterator iinfoBegin = ijet->tagInfosFwdPtr().begin(),
 		  iinfoEnd = ijet->tagInfosFwdPtr().end(), iinfo = iinfoBegin;
 		iinfo != iinfoEnd; ++iinfo ) {
-	    // Update the "forward" bit of the FwdPtr to point at the new tower collection. 
+	    // Update the "forward" bit of the FwdPtr to point at the new tower collection.
 
 	    // ptr to "this" info in the global list
 	    edm::Ptr<reco::BaseTagInfo > outPtr( oh_tagInfosOut, tagInfoIndex );
-	    patJets->back().updateFwdTagInfoFwdPtr( iinfo - iinfoBegin,// index of "this" tower in the jet 
+	    patJets->back().updateFwdTagInfoFwdPtr( iinfo - iinfoBegin,// index of "this" tower in the jet
 						    outPtr
 						    );
 	    ++tagInfoIndex;
@@ -189,14 +189,14 @@ namespace pat {
       bool pass = patJets->size() > 0;
       iEvent.put(patJets);
 
-      if ( filter_ ) 
+      if ( filter_ )
 	return pass;
-      else 
+      else
 	return true;
     }
 
   protected:
-    edm::InputTag                  src_;
+    edm::EDGetTokenT<edm::View<pat::Jet> > srcToken_;
     std::string                    cut_;
     bool                           filter_;
     StringCutObjectSelector<Jet>   selector_;

--- a/PhysicsTools/PatAlgos/plugins/PATLeptonCountFilter.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLeptonCountFilter.cc
@@ -4,20 +4,15 @@
 #include "PhysicsTools/PatAlgos/plugins/PATLeptonCountFilter.h"
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/Common/interface/View.h"
-
-#include "DataFormats/PatCandidates/interface/Electron.h"
-#include "DataFormats/PatCandidates/interface/Muon.h"
-#include "DataFormats/PatCandidates/interface/Tau.h"
 
 
 using namespace pat;
 
 
 PATLeptonCountFilter::PATLeptonCountFilter(const edm::ParameterSet & iConfig) {
-  electronSource_ = iConfig.getParameter<edm::InputTag>( "electronSource" );
-  muonSource_     = iConfig.getParameter<edm::InputTag>( "muonSource" );
-  tauSource_      = iConfig.getParameter<edm::InputTag>( "tauSource" );
+  electronToken_  = mayConsume<edm::View<Electron> >(iConfig.getParameter<edm::InputTag>( "electronSource" ));
+  muonToken_      = mayConsume<edm::View<Muon> >(iConfig.getParameter<edm::InputTag>( "muonSource" ));
+  tauToken_       = mayConsume<edm::View<Tau> >(iConfig.getParameter<edm::InputTag>( "tauSource" ));
   countElectrons_ = iConfig.getParameter<bool>         ( "countElectrons" );
   countMuons_     = iConfig.getParameter<bool>         ( "countMuons" );
   countTaus_      = iConfig.getParameter<bool>         ( "countTaus" );
@@ -32,11 +27,11 @@ PATLeptonCountFilter::~PATLeptonCountFilter() {
 
 bool PATLeptonCountFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup) {
   edm::Handle<edm::View<Electron> > electrons;
-  if (countElectrons_) iEvent.getByLabel(electronSource_, electrons);
+  if (countElectrons_) iEvent.getByToken(electronToken_, electrons);
   edm::Handle<edm::View<Muon> > muons;
-  if (countMuons_) iEvent.getByLabel(muonSource_, muons);
+  if (countMuons_) iEvent.getByToken(muonToken_, muons);
   edm::Handle<edm::View<Tau> > taus;
-  if (countTaus_) iEvent.getByLabel(tauSource_, taus);
+  if (countTaus_) iEvent.getByToken(tauToken_, taus);
   unsigned int nrLeptons = 0;
   nrLeptons += (countElectrons_ ? electrons->size() : 0);
   nrLeptons += (countMuons_     ? muons->size()     : 0);

--- a/PhysicsTools/PatAlgos/plugins/PATLeptonCountFilter.h
+++ b/PhysicsTools/PatAlgos/plugins/PATLeptonCountFilter.h
@@ -9,6 +9,12 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "DataFormats/Common/interface/View.h"
+
+#include "DataFormats/PatCandidates/interface/Electron.h"
+#include "DataFormats/PatCandidates/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/Tau.h"
+
 
 namespace pat {
 
@@ -26,9 +32,9 @@ namespace pat {
 
     private:
 
-      edm::InputTag electronSource_;
-      edm::InputTag muonSource_;
-      edm::InputTag tauSource_;
+      edm::EDGetTokenT<edm::View<Electron> > electronToken_;
+      edm::EDGetTokenT<edm::View<Muon> > muonToken_;
+      edm::EDGetTokenT<edm::View<Tau> > tauToken_;
       bool          countElectrons_;
       bool          countMuons_;
       bool          countTaus_;

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
@@ -48,8 +48,9 @@ namespace pat {
 
       // configurables
       edm::InputTag metSrc_;
+      edm::EDGetTokenT<edm::View<reco::MET> > metToken_;
       bool          addGenMET_;
-      edm::InputTag genMETSrc_;
+      edm::EDGetTokenT<edm::View<reco::GenMET> > genMETToken_;
       bool          addResolutions_;
       pat::helper::KinResolutionsLoader resolutionLoader_;
       bool          addMuonCorr_;

--- a/PhysicsTools/PatAlgos/plugins/PATMHTProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMHTProducer.cc
@@ -8,12 +8,12 @@ pat::PATMHTProducer::PATMHTProducer(const edm::ParameterSet & iConfig){
   // Initialize the configurables
   verbose_ = iConfig.getParameter<double>("verbose");
 
-  jetLabel_ = iConfig.getUntrackedParameter<edm::InputTag>("jetTag");
-  eleLabel_ = iConfig.getUntrackedParameter<edm::InputTag>("electronTag");
-  muoLabel_ = iConfig.getUntrackedParameter<edm::InputTag>("muonTag");
-  tauLabel_ = iConfig.getUntrackedParameter<edm::InputTag>("tauTag");
-  phoLabel_ = iConfig.getUntrackedParameter<edm::InputTag>("photonTag");
-  
+  jetToken_ = consumes<edm::View<pat::Jet> >(iConfig.getUntrackedParameter<edm::InputTag>("jetTag"));
+  eleToken_ = consumes<edm::View<pat::Electron> >(iConfig.getUntrackedParameter<edm::InputTag>("electronTag"));
+  muoToken_ = consumes<edm::View<pat::Muon> >(iConfig.getUntrackedParameter<edm::InputTag>("muonTag"));
+  tauToken_ = consumes<edm::View<pat::Tau> >(iConfig.getUntrackedParameter<edm::InputTag>("tauTag"));
+  phoToken_ = consumes<edm::View<pat::Photon> >(iConfig.getUntrackedParameter<edm::InputTag>("photonTag"));
+
   uncertaintyScaleFactor_ = iConfig.getParameter<double>( "uncertaintyScaleFactor") ;
   controlledUncertainty_  = iConfig.getParameter<bool>( "controlledUncertainty") ;
 
@@ -25,24 +25,24 @@ pat::PATMHTProducer::PATMHTProducer(const edm::ParameterSet & iConfig){
   muonPtMin_    = iConfig.getParameter<double>("muonPtMin");
   muonEtaMax_   = iConfig.getParameter<double>("muonEtaMax");
 
-  jetEtUncertaintyParameter0_ =  iConfig.getParameter<double>( "jetEtUncertaintyParameter0") ; 
-  jetEtUncertaintyParameter1_ =  iConfig.getParameter<double>( "jetEtUncertaintyParameter1") ; 
-  jetEtUncertaintyParameter2_ =  iConfig.getParameter<double>( "jetEtUncertaintyParameter2") ; 
-  jetPhiUncertaintyParameter0_=  iConfig.getParameter<double>( "jetPhiUncertaintyParameter0"); 
-  jetPhiUncertaintyParameter1_=  iConfig.getParameter<double>( "jetPhiUncertaintyParameter1"); 
-  jetPhiUncertaintyParameter2_=  iConfig.getParameter<double>( "jetPhiUncertaintyParameter2"); 
-    
-  eleEtUncertaintyParameter0_  =  iConfig.getParameter<double>( "eleEtUncertaintyParameter0") ; 
-  elePhiUncertaintyParameter0_ =  iConfig.getParameter<double>( "elePhiUncertaintyParameter0") ; 
+  jetEtUncertaintyParameter0_ =  iConfig.getParameter<double>( "jetEtUncertaintyParameter0") ;
+  jetEtUncertaintyParameter1_ =  iConfig.getParameter<double>( "jetEtUncertaintyParameter1") ;
+  jetEtUncertaintyParameter2_ =  iConfig.getParameter<double>( "jetEtUncertaintyParameter2") ;
+  jetPhiUncertaintyParameter0_=  iConfig.getParameter<double>( "jetPhiUncertaintyParameter0");
+  jetPhiUncertaintyParameter1_=  iConfig.getParameter<double>( "jetPhiUncertaintyParameter1");
+  jetPhiUncertaintyParameter2_=  iConfig.getParameter<double>( "jetPhiUncertaintyParameter2");
 
-  muonEtUncertaintyParameter0_  =  iConfig.getParameter<double>( "muonEtUncertaintyParameter0") ; 
-  muonPhiUncertaintyParameter0_ =  iConfig.getParameter<double>( "muonPhiUncertaintyParameter0") ; 
+  eleEtUncertaintyParameter0_  =  iConfig.getParameter<double>( "eleEtUncertaintyParameter0") ;
+  elePhiUncertaintyParameter0_ =  iConfig.getParameter<double>( "elePhiUncertaintyParameter0") ;
+
+  muonEtUncertaintyParameter0_  =  iConfig.getParameter<double>( "muonEtUncertaintyParameter0") ;
+  muonPhiUncertaintyParameter0_ =  iConfig.getParameter<double>( "muonPhiUncertaintyParameter0") ;
 
   CaloTowerTag_  = iConfig.getParameter<edm::InputTag>("CaloTowerTag");
-  noHF_ = iConfig.getParameter<bool>( "noHF"); 
-  
+  noHF_ = iConfig.getParameter<bool>( "noHF");
+
   //  muonCalo_ = iConfig.getParameter<bool>("muonCalo");
-  towerEtThreshold_ = iConfig.getParameter<double>( "towerEtThreshold") ; 
+  towerEtThreshold_ = iConfig.getParameter<double>( "towerEtThreshold") ;
   useHO_ = iConfig.getParameter<bool>("useHO");
 
   produces<pat::MHTCollection>();
@@ -60,15 +60,15 @@ void pat::PATMHTProducer::endJob() {
 }
 
 
-void 
-pat::PATMHTProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) 
+void
+pat::PATMHTProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
 {
   // make sure the SigInputObj container is empty
   while(physobjvector_.size()>0){
     physobjvector_.erase(physobjvector_.begin(),physobjvector_.end());
   }
 
-  // Clean the clustered towers 
+  // Clean the clustered towers
   s_clusteredTowers.clear();
 
   double number_of_jets = getJets(iEvent, iSetup);
@@ -88,25 +88,25 @@ pat::PATMHTProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
   double met_et=0;
   double met_phi=0;
   double met_set=0;
-  
-  
+
+
   std::auto_ptr<pat::MHTCollection>  themetsigcoll (new pat::MHTCollection);
 
-  if(physobjvector_.size() >= 1) { // Only when the vector is not empty 
+  if(physobjvector_.size() >= 1) { // Only when the vector is not empty
 
     // calculate the MHT significance
 
     metsig::significanceAlgo signifAlgo;
     signifAlgo.addObjects(physobjvector_);
     double significance = signifAlgo.significance(met_et,met_phi,met_set);
-    
+
     met_x=met_et*cos(met_phi);
     met_y=met_et*sin(met_phi);
-  
+
     if (verbose_ == 1.) {
       std::cout << ">>>----> MHT Sgificance = " << significance << std::endl;
     }
- 
+
     pat::MHT themetsigobj(reco::Particle::LorentzVector(met_x,met_y,0,met_et),met_set,significance);
 
 
@@ -117,18 +117,18 @@ pat::PATMHTProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup
 
     themetsigcoll->push_back(themetsigobj);
 
-  } // If the vector is empty, just put empty product. 
+  } // If the vector is empty, just put empty product.
 
 
   iEvent.put( themetsigcoll);
 
-  
-}  
+
+}
 
 // --------------------------------------------------
 //  Fill Input Vector with Jets
 // --------------------------------------------------
-double 
+double
 pat::PATMHTProducer::getJets(edm::Event& iEvent, const edm::EventSetup & iSetup){
 
   std::string objectname="jet";
@@ -136,31 +136,31 @@ pat::PATMHTProducer::getJets(edm::Event& iEvent, const edm::EventSetup & iSetup)
   double number_of_jets_ = 0.0;
 
   edm::Handle<edm::View<pat::Jet> > jetHandle;
-  iEvent.getByLabel(jetLabel_,jetHandle);
+  iEvent.getByToken(jetToken_,jetHandle);
   edm::View<pat::Jet> jets = *jetHandle;
 
-  // Fill Input Vector with Jets 
+  // Fill Input Vector with Jets
   for(edm::View<pat::Jet>::const_iterator jet_iter = jets.begin(); jet_iter!=jets.end(); ++jet_iter){
-    
+
     if( (jet_iter->pt()  < jetPtMin_) ||
-	(TMath::Abs(jet_iter->eta()) > jetEtaMax_) || 
+	(TMath::Abs(jet_iter->eta()) > jetEtaMax_) ||
         (jet_iter->emEnergyFraction() > jetEMfracMax_ ) )
-      continue; 
-    
+      continue;
+
     double jet_et = jet_iter->et();
     double jet_phi = jet_iter->phi();
-    
+
     if (verbose_ == 3.) {
-      std::cout << "jet pt : " << jet_iter->pt() << " eta : " << jet_iter->eta() 
+      std::cout << "jet pt : " << jet_iter->pt() << " eta : " << jet_iter->eta()
 		<< " EMF: "  << jet_iter->emEnergyFraction() <<  std::endl;
     }
-    
+
     double sigma_et, sigma_phi ;
 
     if (controlledUncertainty_) {
       sigma_et  = jetUncertainty.etUncertainty->Eval(jet_et);
       sigma_phi = jetUncertainty.phiUncertainty->Eval(jet_et);
-    } 
+    }
     else {
       sigma_et = 0.0 ; // jet_iter->resolutionEt();
       sigma_phi =  0.0 ; //jet_iter->resolutionPhi();
@@ -171,27 +171,27 @@ pat::PATMHTProducer::getJets(edm::Event& iEvent, const edm::EventSetup & iSetup)
     }
 
     if(sigma_et<=0 || sigma_phi<=0)
-      edm::LogWarning("PATMHTProducer") << 
+      edm::LogWarning("PATMHTProducer") <<
 	" uncertainties for "  << objectname <<
 	" are (et, phi): " << sigma_et << "," << sigma_phi << " (et,phi): " << jet_et << "," << jet_phi;
     // try to read out the jet resolution from the root file at PatUtils
     //-- Store jet for Significance Calculation --//
-    
+
     if (uncertaintyScaleFactor_ != 1.0){
       sigma_et  = sigma_et  * uncertaintyScaleFactor_;
       sigma_phi = sigma_phi * uncertaintyScaleFactor_;
       // edm::LogWarning("PATMHTProducer") << " using uncertainty scale factor: " << uncertaintyScaleFactor_ <<
-      //" , uncertainties for " << objectname <<" changed to (et, phi): " << sigma_et << "," << sigma_phi; 
+      //" , uncertainties for " << objectname <<" changed to (et, phi): " << sigma_et << "," << sigma_phi;
     }
 
 
     if (verbose_ == 101.) { // Study the Jets behavior
 
-      std::cout << "v101> " <<  number_of_jets_ << "  " 
+      std::cout << "v101> " <<  number_of_jets_ << "  "
 		<< jet_et   << "  "  <<  sigma_et << "  "
 		<< jet_phi  << "  "  <<  sigma_phi << std::endl;
     }
-  
+
 
     metsig::SigInputObj tmp_jet(objectname,jet_et,jet_phi,sigma_et,sigma_phi);
     physobjvector_.push_back(tmp_jet);
@@ -207,11 +207,11 @@ pat::PATMHTProducer::getJets(edm::Event& iEvent, const edm::EventSetup & iSetup)
     }
 
   }
-  
+
   if (verbose_ == 101.) { // Study the Jets behavior - seperate events
     std::cout << "v101> --------------------------------------------" << std::endl;
   }
- 
+
   return number_of_jets_;
 
 }
@@ -232,19 +232,19 @@ pat::PATMHTProducer::getElectrons(edm::Event& iEvent, const edm::EventSetup & iS
   // const CaloTowerConstituentsMap* caloTowerMap = cttopo.product();
 
   edm::Handle<edm::View<pat::Electron> > electronHandle;
-  iEvent.getByLabel(eleLabel_,electronHandle);
+  iEvent.getByToken(eleToken_,electronHandle);
   edm::View<pat::Electron> electrons = *electronHandle;
   DetId nullDetId;
 
-  // Fill Input Vector with Electrons 
+  // Fill Input Vector with Electrons
   for(edm::View<pat::Electron>::const_iterator electron_iter = electrons.begin(); electron_iter!=electrons.end(); ++electron_iter){
 
     // Select electrons
-    if (electron_iter->et() < elePtMin_ || 
-	TMath::Abs(electron_iter->eta()) > eleEtaMax_  ) continue; 
+    if (electron_iter->et() < elePtMin_ ||
+	TMath::Abs(electron_iter->eta()) > eleEtaMax_  ) continue;
 
     if (verbose_ == 3.) {
-      std::cout << "electron pt = " << electron_iter->pt()  << " eta : " << electron_iter->eta() 
+      std::cout << "electron pt = " << electron_iter->pt()  << " eta : " << electron_iter->eta()
 		<<  std::endl;
     }
 
@@ -256,7 +256,7 @@ pat::PATMHTProducer::getElectrons(edm::Event& iEvent, const edm::EventSetup & iS
     if (controlledUncertainty_) {
       sigma_et  = eleUncertainty.etUncertainty->Eval(electron_et);
       sigma_phi = eleUncertainty.phiUncertainty->Eval(electron_et);
-    } 
+    }
     else {
       sigma_et = 0.0; //electron_iter->resolutionEt();
       sigma_phi = 0.0; // electron_iter->resolutionPhi();
@@ -267,11 +267,11 @@ pat::PATMHTProducer::getElectrons(edm::Event& iEvent, const edm::EventSetup & iS
 		<<  std::endl;}
 
     if(sigma_et< 0 || sigma_phi< 0)
-      edm::LogWarning("PATMHTProducer") << " uncertainties for "  << objectname 
-					<<" are (et, phi): " << sigma_et 
-					<< "," << sigma_phi <<  " (et,phi): " 
+      edm::LogWarning("PATMHTProducer") << " uncertainties for "  << objectname
+					<<" are (et, phi): " << sigma_et
+					<< "," << sigma_phi <<  " (et,phi): "
 					<< electron_et << "," << electron_phi;
-    
+
     if (uncertaintyScaleFactor_ != 1.0){
       sigma_et  = sigma_et  * uncertaintyScaleFactor_;
       sigma_phi = sigma_phi * uncertaintyScaleFactor_;
@@ -279,14 +279,14 @@ pat::PATMHTProducer::getElectrons(edm::Event& iEvent, const edm::EventSetup & iS
 
     metsig::SigInputObj tmp_electron(objectname,electron_et,electron_phi,sigma_et,sigma_phi);
     physobjvector_.push_back(tmp_electron);
-    number_of_electrons_ ++; 
-    
+    number_of_electrons_ ++;
+
     //-- Store tower DetId's to be removed from Calo Tower sum later --//
     /*
     const reco::SuperCluster& eleSC = *( electron_iter->superCluster() );
-    
+
     std::vector<DetId> v_eleDetIds = eleSC.getHitsByDetId();
-    
+
     //-- Convert cells to calo towers and add to set --//
     for( std::vector<DetId>::iterator cellId = v_eleDetIds.begin();
          cellId != v_eleDetIds.end();
@@ -305,7 +305,7 @@ pat::PATMHTProducer::getElectrons(edm::Event& iEvent, const edm::EventSetup & iS
 
   }
 
-  return number_of_electrons_; 
+  return number_of_electrons_;
 }
 
 
@@ -318,7 +318,7 @@ double pat::PATMHTProducer::getMuons(edm::Event& iEvent, const edm::EventSetup &
 
   std::string objectname="muon";
   edm::Handle<edm::View<pat::Muon> > muonHandle;
-  iEvent.getByLabel(muoLabel_,muonHandle);
+  iEvent.getByToken(muoToken_,muonHandle);
   edm::View<pat::Muon> muons = *muonHandle;
 
   if ( !muonHandle.isValid() ) {
@@ -331,7 +331,7 @@ double pat::PATMHTProducer::getMuons(edm::Event& iEvent, const edm::EventSetup &
 
   for(edm::View<pat::Muon>::const_iterator muon_iter = muons.begin(); muon_iter!=muons.end(); ++muon_iter){
 
-    if (muon_iter->pt() < muonPtMin_ || TMath::Abs(muon_iter->eta()) > muonEtaMax_  ) continue; 
+    if (muon_iter->pt() < muonPtMin_ || TMath::Abs(muon_iter->eta()) > muonEtaMax_  ) continue;
 
     if (verbose_ == 3.) {
       std::cout << "muon pt = " << muon_iter->pt() << " eta : " << muon_iter->eta() <<  std::endl;
@@ -345,7 +345,7 @@ double pat::PATMHTProducer::getMuons(edm::Event& iEvent, const edm::EventSetup &
     if (controlledUncertainty_) {
        sigma_et  = muonUncertainty.etUncertainty->Eval(muon_pt);
        sigma_phi = muonUncertainty.phiUncertainty->Eval(muon_pt);
-    } 
+    }
     else {
       sigma_et  = 0.0; //muon_iter->resolutionEt();
       sigma_phi = 0.0; // muon_iter->resolutionPhi();
@@ -357,7 +357,7 @@ double pat::PATMHTProducer::getMuons(edm::Event& iEvent, const edm::EventSetup &
 		<<  std::endl;}
 
    if(sigma_et< 0 || sigma_phi< 0)
-      edm::LogWarning("PATMHTProducer") << 
+      edm::LogWarning("PATMHTProducer") <<
 	" uncertainties for "  << objectname << " are (et, phi): " << sigma_et << "," <<
 	sigma_phi << " (pt,phi): " << muon_pt << "," << muon_phi;
 
@@ -452,13 +452,13 @@ void pat::PATMHTProducer::setUncertaintyParameters(){
   //jetUncertainty.phiUncertainty = new TF1("jetPhiFunc","[0]*x",1);
   //jetUncertainty.phiUncertainty->SetParameter(0, jetPhiUncertaintyParameter0_);
 
-  //-- phi Functions and values from 
+  //-- phi Functions and values from
   // http://indico.cern.ch/getFile.py/access?contribId=9&sessionId=0&resId=0&materialId=slides&confId=46394
   jetUncertainty.phiUncertainty = new TF1("jetPhiFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3);
   jetUncertainty.phiUncertainty->SetParameter(0, jetPhiUncertaintyParameter0_);
   jetUncertainty.phiUncertainty->SetParameter(1, jetPhiUncertaintyParameter1_);
   jetUncertainty.phiUncertainty->SetParameter(2, jetPhiUncertaintyParameter2_);
-  
+
 
 
   //-- Jet corrections are assumed not to have an error --//
@@ -473,10 +473,10 @@ void pat::PATMHTProducer::setUncertaintyParameters(){
   // the egamma group keeps track of these here:
   // https://twiki.cern.ch/twiki/bin/view/CMS/EgammaCMSSWVal
   // electron resolution in energy is around 3.4%, measured for 10 < pT < 50 at realistic events with pile-up.
-  
+
   eleUncertainty.etUncertainty = new TF1("eleEtFunc","[0] * x",1);
-  //  eleUncertainty.etUncertainty->SetParameter(0,0.034); 
-  eleUncertainty.etUncertainty->SetParameter(0, eleEtUncertaintyParameter0_); 
+  //  eleUncertainty.etUncertainty->SetParameter(0,0.034);
+  eleUncertainty.etUncertainty->SetParameter(0, eleEtUncertaintyParameter0_);
 
 
   eleUncertainty.phiUncertainty = new TF1("elePhiFunc","[0] * x",1);
@@ -485,7 +485,7 @@ void pat::PATMHTProducer::setUncertaintyParameters(){
 
   //--- Muon Uncertainty Functions ------------------------------------//
   // and ambiguious values for the muons...
-  
+
   muonUncertainty.etUncertainty = new TF1("muonEtFunc","[0] * x",1);
   //  muonUncertainty.etUncertainty->SetParameter(0,0.01);
   muonUncertainty.etUncertainty->SetParameter(0, muonEtUncertaintyParameter0_);
@@ -498,10 +498,10 @@ void pat::PATMHTProducer::setUncertaintyParameters(){
   muonCorrUncertainty.etUncertainty->SetParameter(0,0.0);
   muonCorrUncertainty.phiUncertainty = new TF1("muonCorrPhiFunc","[0] * x",1);
   muonCorrUncertainty.phiUncertainty->SetParameter(0,0.0*(3.14159/180.)); */
- 
+
 }
 
 
-using namespace pat; 
+using namespace pat;
 DEFINE_FWK_MODULE(PATMHTProducer);
 

--- a/PhysicsTools/PatAlgos/plugins/PATMHTProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMHTProducer.h
@@ -2,8 +2,8 @@
 //
 // Package:    PATMHTProducer
 // Class:      PATMHTProducer
-// 
-/**\class PATMHTProducer 
+//
+/**\class PATMHTProducer
 
  Description: <one line class summary>
 
@@ -34,7 +34,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "FWCore/ParameterSet/interface/FileInPath.h"
-#include "FWCore/Utilities/interface/InputTag.h" 
+#include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 
@@ -65,36 +65,36 @@ namespace pat {
   public:
     explicit PATMHTProducer(const edm::ParameterSet&);
     ~PATMHTProducer();
-    
+
   private:
     virtual void beginJob() ;
     virtual void produce(edm::Event&, const edm::EventSetup&) override;
     virtual void endJob() ;
-    
+
     double getJets(edm::Event&, const edm::EventSetup&);
     double getElectrons(edm::Event&, const edm::EventSetup&);
     double getMuons(edm::Event&, const edm::EventSetup&);
     void   getTowers(edm::Event&, const edm::EventSetup&);
-    
-    
+
+
     // ----------member data ---------------------------
-    
+
     double verbose_;
-    
+
     // input tags.
     edm::InputTag mhtLabel_;
-    edm::InputTag jetLabel_;
-    edm::InputTag eleLabel_;
-    edm::InputTag muoLabel_;
-    edm::InputTag tauLabel_;
-    edm::InputTag phoLabel_;
-  
+    edm::EDGetTokenT<edm::View<pat::Jet> > jetToken_;
+    edm::EDGetTokenT<edm::View<pat::Electron> > eleToken_;
+    edm::EDGetTokenT<edm::View<pat::Muon> > muoToken_;
+    edm::EDGetTokenT<edm::View<pat::Tau> > tauToken_;
+    edm::EDGetTokenT<edm::View<pat::Photon> > phoToken_;
+
     std::vector<metsig::SigInputObj> physobjvector_ ;
 
     double uncertaintyScaleFactor_; // scale factor for the uncertainty parameters.
     bool    controlledUncertainty_; // use controlled uncertainty parameters.
 
- 
+
     //--- test the uncertainty parameters ---//
 
     class uncertaintyFunctions{
@@ -123,7 +123,7 @@ namespace pat {
     bool useJets_;
     bool useElectrons_;
     bool useMuons_;
-    std::set<CaloTowerDetId> s_clusteredTowers; 
+    std::set<CaloTowerDetId> s_clusteredTowers;
 
     bool noHF_;
 
@@ -144,21 +144,21 @@ namespace pat {
 
     //  double uncertaintyScaleFactor_; // scale factor for the uncertainty parameters.
 
-    double jetEtUncertaintyParameter0_ ; 
-    double jetEtUncertaintyParameter1_ ; 
-    double jetEtUncertaintyParameter2_ ; 
+    double jetEtUncertaintyParameter0_ ;
+    double jetEtUncertaintyParameter1_ ;
+    double jetEtUncertaintyParameter2_ ;
 
-    double jetPhiUncertaintyParameter0_ ; 
-    double jetPhiUncertaintyParameter1_ ; 
-    double jetPhiUncertaintyParameter2_ ; 
+    double jetPhiUncertaintyParameter0_ ;
+    double jetPhiUncertaintyParameter1_ ;
+    double jetPhiUncertaintyParameter2_ ;
 
-    double eleEtUncertaintyParameter0_ ; 
-    double elePhiUncertaintyParameter0_ ; 
+    double eleEtUncertaintyParameter0_ ;
+    double elePhiUncertaintyParameter0_ ;
 
-    double muonEtUncertaintyParameter0_ ; 
-    double muonPhiUncertaintyParameter0_ ; 
+    double muonEtUncertaintyParameter0_ ;
+    double muonPhiUncertaintyParameter0_ ;
 
-    edm::InputTag CaloJetAlgorithmTag_; 
+    edm::InputTag CaloJetAlgorithmTag_;
     edm::InputTag CorJetAlgorithmTag_;
     std::string   JetCorrectionService_;
     edm::InputTag MuonTag_;
@@ -168,11 +168,11 @@ namespace pat {
     std::string significanceLabel_;
 
     //--- For Muon Calo Deposits ---//
-    //TrackDetectorAssociator   trackAssociator_; 
+    //TrackDetectorAssociator   trackAssociator_;
     //TrackAssociatorParameters trackAssociatorParameters_;
 
-    double towerEtThreshold_ ; 
-    bool useHO_ ; 
+    double towerEtThreshold_ ;
+    bool useHO_ ;
 
 
   };

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.cc
@@ -23,7 +23,6 @@
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 
-
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
@@ -32,8 +31,9 @@
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/IPTools/interface/IPTools.h"
 
-
 #include "TMath.h"
+
+#include "FWCore/Utilities/interface/transform.h"
 
 #include <vector>
 #include <memory>
@@ -43,11 +43,11 @@ using namespace pat;
 using namespace std;
 
 
-PATMuonProducer::PATMuonProducer(const edm::ParameterSet & iConfig) : useUserData_(iConfig.exists("userData")), 
-  isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation") : edm::ParameterSet(), false)
+PATMuonProducer::PATMuonProducer(const edm::ParameterSet & iConfig) : useUserData_(iConfig.exists("userData")),
+  isolator_(iConfig.exists("userIsolation") ? iConfig.getParameter<edm::ParameterSet>("userIsolation") : edm::ParameterSet(), consumesCollector(), false)
 {
   // input source
-  muonSrc_ = iConfig.getParameter<edm::InputTag>( "muonSource" );
+  muonToken_ = consumes<edm::View<reco::Muon> >(iConfig.getParameter<edm::InputTag>( "muonSource" ));
   // embedding of tracks
   embedBestTrack_ = iConfig.getParameter<bool>( "embedMuonBestTrack" );
   embedTrack_ = iConfig.getParameter<bool>( "embedTrack" );
@@ -56,30 +56,31 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet & iConfig) : useUserDat
   // embedding of muon MET correction information
   embedCaloMETMuonCorrs_ = iConfig.getParameter<bool>("embedCaloMETMuonCorrs" );
   embedTcMETMuonCorrs_ = iConfig.getParameter<bool>("embedTcMETMuonCorrs"   );
-  caloMETMuonCorrs_ = iConfig.getParameter<edm::InputTag>("caloMETMuonCorrs" );
-  tcMETMuonCorrs_ = iConfig.getParameter<edm::InputTag>("tcMETMuonCorrs"   );
+  caloMETMuonCorrsToken_ = mayConsume<edm::ValueMap<reco::MuonMETCorrectionData> >(iConfig.getParameter<edm::InputTag>("caloMETMuonCorrs" ));
+  tcMETMuonCorrsToken_ = mayConsume<edm::ValueMap<reco::MuonMETCorrectionData> >(iConfig.getParameter<edm::InputTag>("tcMETMuonCorrs"   ));
   // pflow specific configurables
   useParticleFlow_ = iConfig.getParameter<bool>( "useParticleFlow" );
   embedPFCandidate_ = iConfig.getParameter<bool>( "embedPFCandidate" );
-  pfMuonSrc_ = iConfig.getParameter<edm::InputTag>( "pfMuonSource" );
+  pfMuonToken_ = mayConsume<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>( "pfMuonSource" ));
   // embedding of tracks from TeV refit
   embedPickyMuon_ = iConfig.getParameter<bool>( "embedPickyMuon" );
   embedTpfmsMuon_ = iConfig.getParameter<bool>( "embedTpfmsMuon" );
   embedDytMuon_ = iConfig.getParameter<bool>( "embedDytMuon" );
   // Monte Carlo matching
   addGenMatch_ = iConfig.getParameter<bool>( "addGenMatch" );
-  if(addGenMatch_){
+  if (addGenMatch_) {
     embedGenMatch_ = iConfig.getParameter<bool>( "embedGenMatch" );
-    if(iConfig.existsAs<edm::InputTag>("genParticleMatch")){
-      genMatchSrc_.push_back(iConfig.getParameter<edm::InputTag>( "genParticleMatch" ));
-    } else {
-      genMatchSrc_ = iConfig.getParameter<std::vector<edm::InputTag> >( "genParticleMatch" );
+    if (iConfig.existsAs<edm::InputTag>("genParticleMatch")) {
+      genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection> >(iConfig.getParameter<edm::InputTag>( "genParticleMatch" )));
+    }
+    else {
+      genMatchTokens_ = edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag> >( "genParticleMatch" ), [this](edm::InputTag const & tag){return consumes<edm::Association<reco::GenParticleCollection> >(tag);});
     }
   }
   // efficiencies
   addEfficiencies_ = iConfig.getParameter<bool>("addEfficiencies");
   if(addEfficiencies_){
-    efficiencyLoader_ = pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"));
+    efficiencyLoader_ = pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
   }
   // resolutions
   addResolutions_ = iConfig.getParameter<bool>("addResolutions");
@@ -87,40 +88,40 @@ PATMuonProducer::PATMuonProducer(const edm::ParameterSet & iConfig) : useUserDat
     resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
   }
   // read isoDeposit labels, for direct embedding
-  readIsolationLabels(iConfig, "isoDeposits", isoDepositLabels_);
+  readIsolationLabels(iConfig, "isoDeposits", isoDepositLabels_, isoDepositTokens_);
   // read isolation value labels, for direct embedding
-  readIsolationLabels(iConfig, "isolationValues", isolationValueLabels_);
+  readIsolationLabels(iConfig, "isolationValues", isolationValueLabels_, isolationValueTokens_);
   // check to see if the user wants to add user data
   if( useUserData_ ){
-    userDataHelper_ = PATUserDataHelper<Muon>(iConfig.getParameter<edm::ParameterSet>("userData"));
+    userDataHelper_ = PATUserDataHelper<Muon>(iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector());
   }
   // embed high level selection variables
   usePV_ = true;
   embedHighLevelSelection_ = iConfig.getParameter<bool>("embedHighLevelSelection");
   if ( embedHighLevelSelection_ ) {
-    beamLineSrc_ = iConfig.getParameter<edm::InputTag>("beamLineSrc");
+    beamLineToken_ = consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamLineSrc"));
     usePV_ = iConfig.getParameter<bool>("usePV");
-    pvSrc_ = iConfig.getParameter<edm::InputTag>("pvSrc");
+    pvToken_ = consumes<std::vector<reco::Vertex> >(iConfig.getParameter<edm::InputTag>("pvSrc"));
   }
   // produces vector of muons
   produces<std::vector<Muon> >();
 }
 
 
-PATMuonProducer::~PATMuonProducer() 
+PATMuonProducer::~PATMuonProducer()
 {
 }
 
-void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) 
-{ 
-  // switch off embedding (in unschedules mode) 
+void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
+{
+  // switch off embedding (in unschedules mode)
   if (iEvent.isRealData()){
     addGenMatch_   = false;
     embedGenMatch_ = false;
   }
 
   edm::Handle<edm::View<reco::Muon> > muons;
-  iEvent.getByLabel(muonSrc_, muons);
+  iEvent.getByToken(muonToken_, muons);
 
   // get the ESHandle for the transient track builder,
   // if needed for high level selection embedding
@@ -130,21 +131,21 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
   if(efficiencyLoader_.enabled()) efficiencyLoader_.newEvent(iEvent);
   if(resolutionLoader_.enabled()) resolutionLoader_.newEvent(iEvent, iSetup);
 
-  IsoDepositMaps deposits(isoDepositLabels_.size());
-  for (size_t j = 0; j<isoDepositLabels_.size(); ++j) {
-    iEvent.getByLabel(isoDepositLabels_[j].second, deposits[j]);
+  IsoDepositMaps deposits(isoDepositTokens_.size());
+  for (size_t j = 0; j<isoDepositTokens_.size(); ++j) {
+    iEvent.getByToken(isoDepositTokens_[j], deposits[j]);
   }
 
-  IsolationValueMaps isolationValues(isolationValueLabels_.size());
-  for (size_t j = 0; j<isolationValueLabels_.size(); ++j) {
-    iEvent.getByLabel(isolationValueLabels_[j].second, isolationValues[j]);
-  }  
+  IsolationValueMaps isolationValues(isolationValueTokens_.size());
+  for (size_t j = 0; j<isolationValueTokens_.size(); ++j) {
+    iEvent.getByToken(isolationValueTokens_[j], isolationValues[j]);
+  }
 
-  // prepare the MC matching
-  GenAssociations  genMatches(genMatchSrc_.size());
+  // prepare the MC genMatchTokens_
+  GenAssociations  genMatches(genMatchTokens_.size());
   if (addGenMatch_) {
-    for (size_t j = 0, nd = genMatchSrc_.size(); j < nd; ++j) {
-      iEvent.getByLabel(genMatchSrc_[j], genMatches[j]);
+    for (size_t j = 0, nd = genMatchTokens_.size(); j < nd; ++j) {
+      iEvent.getByToken(genMatchTokens_[j], genMatches[j]);
     }
   }
 
@@ -158,11 +159,11 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
   if ( embedHighLevelSelection_ ) {
     // get the beamspot
     edm::Handle<reco::BeamSpot> beamSpotHandle;
-    iEvent.getByLabel(beamLineSrc_, beamSpotHandle);
+    iEvent.getByToken(beamLineToken_, beamSpotHandle);
 
     // get the primary vertex
     edm::Handle< std::vector<reco::Vertex> > pvHandle;
-    iEvent.getByLabel( pvSrc_, pvHandle );
+    iEvent.getByToken( pvToken_, pvHandle );
 
     if( beamSpotHandle.isValid() ){
       beamSpot = *beamSpotHandle;
@@ -187,9 +188,9 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
   std::vector<Muon> * patMuons = new std::vector<Muon>();
 
   if( useParticleFlow_ ){
-    // get the PFCandidates of type muons 
+    // get the PFCandidates of type muons
     edm::Handle< reco::PFCandidateCollection >  pfMuons;
-    iEvent.getByLabel(pfMuonSrc_, pfMuons);
+    iEvent.getByToken(pfMuonToken_, pfMuons);
 
     unsigned index=0;
     for( reco::PFCandidateConstIterator i = pfMuons->begin(); i != pfMuons->end(); ++i, ++index) {
@@ -213,7 +214,7 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 	reco::TrackRef bestTrack  = muonBaseRef->muonBestTrack();
 	reco::TrackRef chosenTrack = innerTrack;
 	// Make sure the collection it points to is there
-	if ( bestTrack.isNonnull() && bestTrack.isAvailable() ) 
+	if ( bestTrack.isNonnull() && bestTrack.isAvailable() )
 	  chosenTrack = bestTrack;
 
 	if ( chosenTrack.isNonnull() && chosenTrack.isAvailable() ) {
@@ -221,7 +222,7 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 	  aMuon.setNumberOfValidHits( nhits );
 
 	  reco::TransientTrack tt = trackBuilder->build(chosenTrack);
-	  embedHighLevel( aMuon, 
+	  embedHighLevel( aMuon,
 			  chosenTrack,
 			  tt,
 			  primaryVertex,
@@ -248,37 +249,37 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
       }
       reco::PFCandidateRef pfRef(pfMuons,index);
       //reco::PFCandidatePtr ptrToMother(pfMuons,index);
-      reco::CandidateBaseRef pfBaseRef( pfRef ); 
+      reco::CandidateBaseRef pfBaseRef( pfRef );
 
-      aMuon.setPFCandidateRef( pfRef  );     
+      aMuon.setPFCandidateRef( pfRef  );
       if( embedPFCandidate_ ) aMuon.embedPFCandidate();
       fillMuon( aMuon, muonBaseRef, pfBaseRef, genMatches, deposits, isolationValues );
-      patMuons->push_back(aMuon); 
+      patMuons->push_back(aMuon);
     }
   }
   else {
     edm::Handle<edm::View<reco::Muon> > muons;
-    iEvent.getByLabel(muonSrc_, muons);
+    iEvent.getByToken(muonToken_, muons);
 
     // embedding of muon MET corrections
     edm::Handle<edm::ValueMap<reco::MuonMETCorrectionData> > caloMETMuonCorrs;
     //edm::ValueMap<reco::MuonMETCorrectionData> caloMETmuCorValueMap;
     if(embedCaloMETMuonCorrs_){
-      iEvent.getByLabel(caloMETMuonCorrs_, caloMETMuonCorrs);
+      iEvent.getByToken(caloMETMuonCorrsToken_, caloMETMuonCorrs);
       //caloMETmuCorValueMap  = *caloMETmuCorValueMap_h;
     }
     edm::Handle<edm::ValueMap<reco::MuonMETCorrectionData> > tcMETMuonCorrs;
     //edm::ValueMap<reco::MuonMETCorrectionData> tcMETmuCorValueMap;
     if(embedTcMETMuonCorrs_) {
-      iEvent.getByLabel(tcMETMuonCorrs_, tcMETMuonCorrs);
+      iEvent.getByToken(tcMETMuonCorrsToken_, tcMETMuonCorrs);
       //tcMETmuCorValueMap  = *tcMETmuCorValueMap_h;
     }
     for (edm::View<reco::Muon>::const_iterator itMuon = muons->begin(); itMuon != muons->end(); ++itMuon) {
       // construct the Muon from the ref -> save ref to original object
       unsigned int idx = itMuon - muons->begin();
       MuonBaseRef muonRef = muons->refAt(idx);
-      reco::CandidateBaseRef muonBaseRef( muonRef ); 
-      
+      reco::CandidateBaseRef muonBaseRef( muonRef );
+
       Muon aMuon(muonRef);
       fillMuon( aMuon, muonRef, muonBaseRef, genMatches, deposits, isolationValues);
 
@@ -292,9 +293,9 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 	  aMuon.setIsolation(it->first, it->second);
 	}
       }
- 
+
       //       for (size_t j = 0, nd = deposits.size(); j < nd; ++j) {
-      // 	aMuon.setIsoDeposit(isoDepositLabels_[j].first, 
+      // 	aMuon.setIsoDeposit(isoDepositLabels_[j].first,
       // 			    (*deposits[j])[muonRef]);
       //       }
 
@@ -319,7 +320,7 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 	  aMuon.setNumberOfValidHits( nhits );
 
 	  reco::TransientTrack tt = trackBuilder->build(chosenTrack);
-	  embedHighLevel( aMuon, 
+	  embedHighLevel( aMuon,
 			  chosenTrack,
 			  tt,
 			  primaryVertex,
@@ -347,7 +348,7 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 
       // embed MET muon corrections
       if( embedCaloMETMuonCorrs_ ) aMuon.embedCaloMETMuonCorrs((*caloMETMuonCorrs)[muonRef]);
-      if( embedTcMETMuonCorrs_ ) aMuon.embedTcMETMuonCorrs((*tcMETMuonCorrs  )[muonRef]);      
+      if( embedTcMETMuonCorrs_ ) aMuon.embedTcMETMuonCorrs((*tcMETMuonCorrs  )[muonRef]);
 
       patMuons->push_back(aMuon);
     }
@@ -364,14 +365,14 @@ void PATMuonProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
 }
 
 
-void PATMuonProducer::fillMuon( Muon& aMuon, const MuonBaseRef& muonRef, const reco::CandidateBaseRef& baseRef, const GenAssociations& genMatches, const IsoDepositMaps& deposits, const IsolationValueMaps& isolationValues ) const 
+void PATMuonProducer::fillMuon( Muon& aMuon, const MuonBaseRef& muonRef, const reco::CandidateBaseRef& baseRef, const GenAssociations& genMatches, const IsoDepositMaps& deposits, const IsolationValueMaps& isolationValues ) const
 {
-  // in the particle flow algorithm, 
-  // the muon momentum is recomputed. 
-  // the new value is stored as the momentum of the 
-  // resulting PFCandidate of type Muon, and choosen 
+  // in the particle flow algorithm,
+  // the muon momentum is recomputed.
+  // the new value is stored as the momentum of the
+  // resulting PFCandidate of type Muon, and choosen
   // as the pat::Muon momentum
-  if (useParticleFlow_) 
+  if (useParticleFlow_)
     aMuon.setP4( aMuon.pfCandidateRef()->p4() );
   if (embedBestTrack_)      aMuon.embedMuonBestTrack();
   if (embedTrack_)          aMuon.embedTrack();
@@ -390,7 +391,7 @@ void PATMuonProducer::fillMuon( Muon& aMuon, const MuonBaseRef& muonRef, const r
 
   // store the match to the generated final state muons
   if (addGenMatch_) {
-    for(size_t i = 0, n = genMatches.size(); i < n; ++i) {      
+    for(size_t i = 0, n = genMatches.size(); i < n; ++i) {
       reco::GenParticleRef genMuon = (*genMatches[i])[baseRef];
       aMuon.addGenParticleRef(genMuon);
     }
@@ -406,8 +407,8 @@ void PATMuonProducer::fillMuon( Muon& aMuon, const MuonBaseRef& muonRef, const r
 	aMuon.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[baseRef]);
       } else if (deposits[j]->contains(muonRef.id())){
 	aMuon.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[muonRef]);
-      } else {  
-	reco::CandidatePtr source = aMuon.pfCandidateRef()->sourceCandidatePtr(0); 
+      } else {
+	reco::CandidatePtr source = aMuon.pfCandidateRef()->sourceCandidatePtr(0);
 	aMuon.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[source]);
       }
     }
@@ -415,15 +416,15 @@ void PATMuonProducer::fillMuon( Muon& aMuon, const MuonBaseRef& muonRef, const r
       aMuon.setIsoDeposit(isoDepositLabels_[j].first, (*deposits[j])[muonRef]);
     }
   }
-  
+
   for (size_t j = 0; j<isolationValues.size(); ++j) {
     if(useParticleFlow_) {
       if (isolationValues[j]->contains(baseRef.id())) {
 	aMuon.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[baseRef]);
       } else if (isolationValues[j]->contains(muonRef.id())) {
-	aMuon.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[muonRef]);	
+	aMuon.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[muonRef]);
       } else {
-	reco::CandidatePtr source = aMuon.pfCandidateRef()->sourceCandidatePtr(0);      
+	reco::CandidatePtr source = aMuon.pfCandidateRef()->sourceCandidatePtr(0);
 	aMuon.setIsolation(isolationValueLabels_[j].first, (*isolationValues[j])[source]);
       }
     }
@@ -443,7 +444,7 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
   edm::ParameterSetDescription iDesc;
   iDesc.setComment("PAT muon producer module");
 
-  // input source 
+  // input source
   iDesc.add<edm::InputTag>("muonSource", edm::InputTag("no default"))->setComment("input collection");
 
   // embedding
@@ -470,7 +471,7 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
   iDesc.add<bool>("addGenMatch", true)->setComment("add MC matching");
   iDesc.add<bool>("embedGenMatch", false)->setComment("embed MC matched MC information");
   std::vector<edm::InputTag> emptySourceVector;
-  iDesc.addNode( edm::ParameterDescription<edm::InputTag>("genParticleMatch", edm::InputTag(), true) xor 
+  iDesc.addNode( edm::ParameterDescription<edm::InputTag>("genParticleMatch", edm::InputTag(), true) xor
                  edm::ParameterDescription<std::vector<edm::InputTag> >("genParticleMatch", emptySourceVector, true)
 		 )->setComment("input with MC match information");
 
@@ -478,7 +479,7 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
 
   // IsoDeposit configurables
   edm::ParameterSetDescription isoDepositsPSet;
-  isoDepositsPSet.addOptional<edm::InputTag>("tracker"); 
+  isoDepositsPSet.addOptional<edm::InputTag>("tracker");
   isoDepositsPSet.addOptional<edm::InputTag>("ecal");
   isoDepositsPSet.addOptional<edm::InputTag>("hcal");
   isoDepositsPSet.addOptional<edm::InputTag>("particle");
@@ -492,7 +493,7 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
 
   // isolation values configurables
   edm::ParameterSetDescription isolationValuesPSet;
-  isolationValuesPSet.addOptional<edm::InputTag>("tracker"); 
+  isolationValuesPSet.addOptional<edm::InputTag>("tracker");
   isolationValuesPSet.addOptional<edm::InputTag>("ecal");
   isolationValuesPSet.addOptional<edm::InputTag>("hcal");
   isolationValuesPSet.addOptional<edm::InputTag>("particle");
@@ -521,61 +522,21 @@ void PATMuonProducer::fillDescriptions(edm::ConfigurationDescriptions & descript
   iDesc.add<bool>("embedHighLevelSelection", true)->setComment("embed high level selection");
   edm::ParameterSetDescription highLevelPSet;
   highLevelPSet.setAllowAnything();
-  iDesc.addNode( edm::ParameterDescription<edm::InputTag>("beamLineSrc", edm::InputTag(), true) 
+  iDesc.addNode( edm::ParameterDescription<edm::InputTag>("beamLineSrc", edm::InputTag(), true)
                  )->setComment("input with high level selection");
-  iDesc.addNode( edm::ParameterDescription<edm::InputTag>("pvSrc", edm::InputTag(), true) 
+  iDesc.addNode( edm::ParameterDescription<edm::InputTag>("pvSrc", edm::InputTag(), true)
                  )->setComment("input with high level selection");
-  iDesc.addNode( edm::ParameterDescription<bool>("usePV", bool(), true) 
+  iDesc.addNode( edm::ParameterDescription<bool>("usePV", bool(), true)
                  )->setComment("input with high level selection, use primary vertex (true) or beam line (false)");
 
   //descriptions.add("PATMuonProducer", iDesc);
 }
 
 
-void PATMuonProducer::readIsolationLabels( const edm::ParameterSet & iConfig, const char* psetName, IsolationLabels& labels) 
-{
-  labels.clear();
-  
-  if (iConfig.exists( psetName )) {
-    edm::ParameterSet depconf = iConfig.getParameter<edm::ParameterSet>(psetName);
-
-    if (depconf.exists("tracker")) labels.push_back(std::make_pair(pat::TrackIso, depconf.getParameter<edm::InputTag>("tracker")));
-    if (depconf.exists("ecal"))    labels.push_back(std::make_pair(pat::EcalIso, depconf.getParameter<edm::InputTag>("ecal")));
-    if (depconf.exists("hcal"))    labels.push_back(std::make_pair(pat::HcalIso, depconf.getParameter<edm::InputTag>("hcal")));
-    if (depconf.exists("pfAllParticles"))  {
-      labels.push_back(std::make_pair(pat::PfAllParticleIso, depconf.getParameter<edm::InputTag>("pfAllParticles")));
-    }
-    if (depconf.exists("pfChargedHadrons"))  {
-      labels.push_back(std::make_pair(pat::PfChargedHadronIso, depconf.getParameter<edm::InputTag>("pfChargedHadrons")));
-    }
-    if (depconf.exists("pfChargedAll"))  {
-      labels.push_back(std::make_pair(pat::PfChargedAllIso, depconf.getParameter<edm::InputTag>("pfChargedAll")));
-    } 
-    if (depconf.exists("pfPUChargedHadrons"))  {
-      labels.push_back(std::make_pair(pat::PfPUChargedHadronIso, depconf.getParameter<edm::InputTag>("pfPUChargedHadrons")));
-    }
-    if (depconf.exists("pfNeutralHadrons"))  {
-      labels.push_back(std::make_pair(pat::PfNeutralHadronIso, depconf.getParameter<edm::InputTag>("pfNeutralHadrons")));
-    }
-    if (depconf.exists("pfPhotons")) {
-      labels.push_back(std::make_pair(pat::PfGammaIso, depconf.getParameter<edm::InputTag>("pfPhotons")));
-    }
-    if (depconf.exists("user")) {
-      std::vector<edm::InputTag> userdeps = depconf.getParameter<std::vector<edm::InputTag> >("user");
-      std::vector<edm::InputTag>::const_iterator it = userdeps.begin(), ed = userdeps.end();
-      int key = UserBaseIso;
-      for ( ; it != ed; ++it, ++key) {
-	labels.push_back(std::make_pair(IsolationKeys(key), *it));
-      }
-    }
-  }  
-}
-
-
 
 // embed various impact parameters with errors
 // embed high level selection
-void PATMuonProducer::embedHighLevel( pat::Muon & aMuon, 
+void PATMuonProducer::embedHighLevel( pat::Muon & aMuon,
 				      reco::TrackRef track,
 				      reco::TransientTrack & tt,
 				      reco::Vertex & primaryVertex,
@@ -592,7 +553,7 @@ void PATMuonProducer::embedHighLevel( pat::Muon & aMuon,
 					     GlobalVector(track->px(),
 							  track->py(),
 							  track->pz()),
-					     primaryVertex); 
+					     primaryVertex);
   double d0_corr = result.second.value();
   double d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
   aMuon.setDB( d0_corr, d0_err, pat::Muon::PV2D);
@@ -608,12 +569,12 @@ void PATMuonProducer::embedHighLevel( pat::Muon & aMuon,
   d0_corr = result.second.value();
   d0_err = primaryVertexIsValid ? result.second.error() : -1.0;
   aMuon.setDB( d0_corr, d0_err, pat::Muon::PV3D);
-  
+
 
   // Correct to beam spot
   // make a fake vertex out of beam spot
   reco::Vertex vBeamspot(beamspot.position(), beamspot.rotatedCovariance3D());
-  
+
   // BS2D
   result =
     IPTools::signedTransverseImpactParameter(tt,
@@ -624,7 +585,7 @@ void PATMuonProducer::embedHighLevel( pat::Muon & aMuon,
   d0_corr = result.second.value();
   d0_err = beamspotIsValid ? result.second.error() : -1.0;
   aMuon.setDB( d0_corr, d0_err, pat::Muon::BS2D);
-  
+
     // BS3D
   result =
     IPTools::signedImpactParameter3D(tt,

--- a/PhysicsTools/PatAlgos/plugins/PATPFParticleProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPFParticleProducer.cc
@@ -23,26 +23,27 @@ using namespace pat;
 
 
 PATPFParticleProducer::PATPFParticleProducer(const edm::ParameterSet & iConfig) :
-    userDataHelper_ ( iConfig.getParameter<edm::ParameterSet>("userData") )
+    userDataHelper_ ( iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector() )
 {
   // general configurables
-  pfCandidateSrc_ = iConfig.getParameter<edm::InputTag>( "pfCandidateSource" );
- 
+  pfCandidateToken_ = consumes<edm::View<reco::PFCandidate> >(iConfig.getParameter<edm::InputTag>( "pfCandidateSource" ));
+
   // MC matching configurables
-  addGenMatch_   = iConfig.getParameter<bool>         ( "addGenMatch" );
+  addGenMatch_   = iConfig.getParameter<bool> ( "addGenMatch" );
   if (addGenMatch_) {
-      embedGenMatch_ = iConfig.getParameter<bool>         ( "embedGenMatch" );
-      if (iConfig.existsAs<edm::InputTag>("genParticleMatch")) {
-          genMatchSrc_.push_back(iConfig.getParameter<edm::InputTag>( "genParticleMatch" ));
-      } else {
-          genMatchSrc_ = iConfig.getParameter<std::vector<edm::InputTag> >( "genParticleMatch" );
-      }
+    embedGenMatch_ = iConfig.getParameter<bool>( "embedGenMatch" );
+    if (iConfig.existsAs<edm::InputTag>("genParticleMatch")) {
+      genMatchTokens_.push_back(consumes<edm::Association<reco::GenParticleCollection> >(iConfig.getParameter<edm::InputTag>( "genParticleMatch" )));
+    }
+    else {
+      genMatchTokens_ = edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag> >( "genParticleMatch" ), [this](edm::InputTag const & tag){return consumes<edm::Association<reco::GenParticleCollection> >(tag);});
+    }
   }
 
   // Efficiency configurables
   addEfficiencies_ = iConfig.getParameter<bool>("addEfficiencies");
   if (addEfficiencies_) {
-     efficiencyLoader_ = pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"));
+     efficiencyLoader_ = pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
   }
 
   // Resolution configurables
@@ -67,22 +68,19 @@ PATPFParticleProducer::~PATPFParticleProducer() {
 }
 
 
-void PATPFParticleProducer::produce(edm::Event & iEvent, 
+void PATPFParticleProducer::produce(edm::Event & iEvent,
 				    const edm::EventSetup & iSetup) {
 
   // Get the collection of PFCandidates from the event
   edm::Handle<edm::View<reco::PFCandidate> > pfCandidates;
-
-  fetchCandidateCollection(pfCandidates, 
-			   pfCandidateSrc_, 
-			   iEvent );
+  iEvent.getByToken(pfCandidateToken_, pfCandidates);
 
   // prepare the MC matching
-  std::vector<edm::Handle<edm::Association<reco::GenParticleCollection> > > genMatches(genMatchSrc_.size());
+  std::vector<edm::Handle<edm::Association<reco::GenParticleCollection> > > genMatches(genMatchTokens_.size());
   if (addGenMatch_) {
-        for (size_t j = 0, nd = genMatchSrc_.size(); j < nd; ++j) {
-            iEvent.getByLabel(genMatchSrc_[j], genMatches[j]);
-        }
+    for (size_t j = 0, nd = genMatchTokens_.size(); j < nd; ++j) {
+      iEvent.getByToken(genMatchTokens_[j], genMatches[j]);
+    }
   }
 
   if (efficiencyLoader_.enabled()) efficiencyLoader_.newEvent(iEvent);
@@ -90,9 +88,9 @@ void PATPFParticleProducer::produce(edm::Event & iEvent,
 
   // loop over PFCandidates
   std::vector<PFParticle> * patPFParticles = new std::vector<PFParticle>();
-  for (edm::View<reco::PFCandidate>::const_iterator 
-	 itPFParticle = pfCandidates->begin(); 
-       itPFParticle != pfCandidates->end(); 
+  for (edm::View<reco::PFCandidate>::const_iterator
+	 itPFParticle = pfCandidates->begin();
+       itPFParticle != pfCandidates->end();
        ++itPFParticle) {
 
     // construct the PFParticle from the ref -> save ref to original object
@@ -108,7 +106,7 @@ void PATPFParticleProducer::produce(edm::Event & iEvent,
       }
       if (embedGenMatch_) aPFParticle.embedGenParticle();
     }
-      
+
     if (efficiencyLoader_.enabled()) {
         efficiencyLoader_.setEfficiencies( aPFParticle, pfCandidatesRef );
     }
@@ -133,23 +131,6 @@ void PATPFParticleProducer::produce(edm::Event & iEvent,
   std::auto_ptr<std::vector<PFParticle> > ptr(patPFParticles);
   iEvent.put(ptr);
 
-}
-
-void 
-PATPFParticleProducer::fetchCandidateCollection( edm::Handle<edm::View<reco::PFCandidate> >& c, 
-						 const edm::InputTag& tag, 
-						 const edm::Event& iEvent) const {
-  
-  bool found = iEvent.getByLabel(tag, c);
-  
-  if(!found ) {
-    std::ostringstream  err;
-    err<<" cannot get PFCandidates: "
-       <<tag<<std::endl;
-    edm::LogError("PFCandidates")<<err.str();
-    throw cms::Exception( "MissingProduct", err.str());
-  }
-  
 }
 
 

--- a/PhysicsTools/PatAlgos/plugins/PATPFParticleProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATPFParticleProducer.h
@@ -50,30 +50,26 @@ namespace pat {
       virtual void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
 
     private:
-      void 
-	fetchCandidateCollection(edm::Handle< edm::View<reco::PFCandidate> >& c, 
-				 const edm::InputTag& tag, 
-				 const edm::Event& iSetup) const;
 
       // configurables
-      edm::InputTag pfCandidateSrc_;
+      edm::EDGetTokenT<edm::View<reco::PFCandidate> > pfCandidateToken_;
       bool          embedPFCandidate_;
       bool          addGenMatch_;
       bool          embedGenMatch_;
-      std::vector<edm::InputTag> genMatchSrc_;
+      std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > > genMatchTokens_;
       // tools
       GreaterByPt<PFParticle>      pTComparator_;
 
       bool addEfficiencies_;
       pat::helper::EfficiencyLoader efficiencyLoader_;
-      
+
       bool addResolutions_;
       pat::helper::KinResolutionsLoader resolutionLoader_;
 
       bool useUserData_;
       pat::PATUserDataHelper<pat::PFParticle> userDataHelper_;
 
- 
+
   };
 
 

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.h
@@ -48,29 +48,31 @@ namespace pat {
     private:
 
       // configurables
-      edm::InputTag photonSrc_;
+      edm::EDGetTokenT<edm::View<reco::Photon> > photonToken_;
       bool embedSuperCluster_;
 
       bool addGenMatch_;
       bool embedGenMatch_;
-      std::vector<edm::InputTag> genMatchSrc_;
+      std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > > genMatchTokens_;
 
       // tools
       GreaterByEt<Photon> eTComparator_;
 
-      pat::helper::MultiIsolator isolator_; 
+      pat::helper::MultiIsolator isolator_;
       pat::helper::MultiIsolator::IsolationValuePairs isolatorTmpStorage_; // better here than recreate at each event
       std::vector<std::pair<pat::IsolationKeys,edm::InputTag> > isoDepositLabels_;
+      std::vector<edm::EDGetTokenT<edm::ValueMap<IsoDeposit> > > isoDepositTokens_;
 
       bool addEfficiencies_;
       pat::helper::EfficiencyLoader efficiencyLoader_;
-      
+
       bool addResolutions_;
       pat::helper::KinResolutionsLoader resolutionLoader_;
 
       bool          addPhotonID_;
       typedef std::pair<std::string, edm::InputTag> NameTag;
       std::vector<NameTag> photIDSrcs_;
+      std::vector<edm::EDGetTokenT<edm::ValueMap<Bool_t> > > photIDTokens_;
 
       bool useUserData_;
       pat::PATUserDataHelper<pat::Photon>      userDataHelper_;

--- a/PhysicsTools/PatAlgos/plugins/PATSingleVertexSelector.h
+++ b/PhysicsTools/PatAlgos/plugins/PATSingleVertexSelector.h
@@ -43,11 +43,11 @@ namespace pat {
       bool hasMode_(Mode mode) const ;
       // configurables
       std::vector<Mode> modes_; // mode + optional fallbacks
-      edm::InputTag vertices_;
-      std::vector<edm::InputTag> candidates_;
+      edm::EDGetTokenT<std::vector<reco::Vertex> > verticesToken_;
+      std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > candidatesToken_;
       std::auto_ptr<VtxSel > vtxPreselection_;
       std::auto_ptr<CandSel> candPreselection_;
-      edm::InputTag beamSpot_;
+      edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
       // transient data. meaningful while 'filter()' is on the stack
       std::vector<const reco::Vertex *> selVtxs_;
       const reco::Candidate *           bestCand_;

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.h
@@ -32,7 +32,6 @@
 #include "DataFormats/PatCandidates/interface/Tau.h"
 
 #include "DataFormats/PatCandidates/interface/UserData.h"
-#include "PhysicsTools/PatAlgos/interface/PATUserDataMerger.h"
 #include "PhysicsTools/PatAlgos/interface/PATUserDataHelper.h"
 
 #include "DataFormats/TauReco/interface/CaloTauDiscriminator.h"
@@ -57,47 +56,52 @@ namespace pat {
     private:
 
       // configurables
-      edm::InputTag tauSrc_;
+      edm::EDGetTokenT<edm::View<reco::BaseTau> > baseTauToken_;
+      edm::EDGetTokenT<reco::PFTauCollection> pfTauToken_;
+      edm::EDGetTokenT<reco::CaloTauCollection> caloTauToken_;
       bool embedIsolationTracks_;
       bool embedLeadTrack_;
       bool embedSignalTracks_;
-      bool embedLeadPFCand_; 
-      bool embedLeadPFChargedHadrCand_; 
-      bool embedLeadPFNeutralCand_; 
-      bool embedSignalPFCands_; 
-      bool embedSignalPFChargedHadrCands_; 
-      bool embedSignalPFNeutralHadrCands_; 
-      bool embedSignalPFGammaCands_; 
-      bool embedIsolationPFCands_; 
-      bool embedIsolationPFChargedHadrCands_; 
-      bool embedIsolationPFNeutralHadrCands_; 
-      bool embedIsolationPFGammaCands_; 
+      bool embedLeadPFCand_;
+      bool embedLeadPFChargedHadrCand_;
+      bool embedLeadPFNeutralCand_;
+      bool embedSignalPFCands_;
+      bool embedSignalPFChargedHadrCands_;
+      bool embedSignalPFNeutralHadrCands_;
+      bool embedSignalPFGammaCands_;
+      bool embedIsolationPFCands_;
+      bool embedIsolationPFChargedHadrCands_;
+      bool embedIsolationPFNeutralHadrCands_;
+      bool embedIsolationPFGammaCands_;
 
       bool          addGenMatch_;
       bool          embedGenMatch_;
-      std::vector<edm::InputTag> genMatchSrc_;
+      std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > > genMatchTokens_;
 
       bool          addGenJetMatch_;
       bool          embedGenJetMatch_;
-      edm::InputTag genJetMatchSrc_;
+      edm::EDGetTokenT<edm::Association<reco::GenJetCollection> > genJetMatchToken_;
 
       bool          addTauJetCorrFactors_;
-      std::vector<edm::InputTag> tauJetCorrFactorsSrc_;
+      std::vector<edm::EDGetTokenT<edm::ValueMap<TauJetCorrFactors> > > tauJetCorrFactorsTokens_;
 
       bool          addTauID_;
       typedef std::pair<std::string, edm::InputTag> NameTag;
       std::vector<NameTag> tauIDSrcs_;
+      std::vector<edm::EDGetTokenT<reco::CaloTauDiscriminator> > caloTauIDTokens_;
+      std::vector<edm::EDGetTokenT<reco::PFTauDiscriminator> > pfTauIDTokens_;
 
       // tools
       GreaterByPt<Tau>       pTTauComparator_;
 
-      pat::helper::MultiIsolator isolator_; 
+      pat::helper::MultiIsolator isolator_;
       pat::helper::MultiIsolator::IsolationValuePairs isolatorTmpStorage_; // better here than recreate at each event
       std::vector<std::pair<pat::IsolationKeys,edm::InputTag> > isoDepositLabels_;
+      std::vector<edm::EDGetTokenT<edm::ValueMap<IsoDeposit> > > isoDepositTokens_;
 
       bool addEfficiencies_;
       pat::helper::EfficiencyLoader efficiencyLoader_;
-      
+
       bool addResolutions_;
       pat::helper::KinResolutionsLoader resolutionLoader_;
 

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.h
@@ -37,7 +37,10 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
+#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
+#include "DataFormats/PatCandidates/interface/TriggerEvent.h"
 #include "DataFormats/Common/interface/ConditionsInEdm.h"
+#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 
 
@@ -59,16 +62,27 @@ namespace pat {
       std::string                  nameProcess_;        // configuration
       bool                         autoProcessName_;
       edm::InputTag                tagTriggerProducer_; // configuration (optional with default)
+      edm::EDGetTokenT< TriggerAlgorithmCollection > triggerAlgorithmCollectionToken_;
+      edm::EDGetTokenT< TriggerConditionCollection > triggerConditionCollectionToken_;
+      edm::EDGetTokenT< TriggerPathCollection >      triggerPathCollectionToken_;
+      edm::EDGetTokenT< TriggerFilterCollection >    triggerFilterCollectionToken_;
+      edm::EDGetTokenT< TriggerObjectCollection >    triggerObjectCollectionToken_;
       std::vector< edm::InputTag > tagsTriggerMatcher_; // configuration (optional)
+      std::vector< edm::EDGetTokenT< TriggerObjectStandAloneMatch > > triggerMatcherTokens_;
       // L1
       edm::InputTag                tagL1Gt_;            // configuration (optional with default)
+      edm::EDGetTokenT< L1GlobalTriggerReadoutRecord > l1GtToken_;
       // HLT
       HLTConfigProvider            hltConfig_;
       bool                         hltConfigInit_;
       edm::InputTag                tagTriggerResults_;  // configuration (optional with default)
+//       edm::EDGetTokenT< edm::TriggerResults > triggerResultsToken_;
       edm::InputTag                tagTriggerEvent_;    // configuration (optional with default)
       // Conditions
       edm::InputTag                tagCondGt_;          // configuration (optional with default)
+      edm::EDGetTokenT< edm::ConditionsInRunBlock > tagCondGtRunToken_;
+      edm::EDGetTokenT< edm::ConditionsInLumiBlock > tagCondGtLumiToken_;
+      edm::EDGetTokenT< edm::ConditionsInEventBlock > tagCondGtEventToken_;
       edm::ConditionsInRunBlock    condRun_;
       edm::ConditionsInLumiBlock   condLumi_;
       bool                         gtCondRunInit_;

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
@@ -15,9 +15,6 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetup.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
-#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMaps.h"
-#include "DataFormats/Common/interface/TriggerResults.h"
-#include "DataFormats/HLTReco/interface/TriggerEvent.h"
 #include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
@@ -26,7 +23,6 @@
 #include "DataFormats/PatCandidates/interface/TriggerCondition.h"
 #include "DataFormats/PatCandidates/interface/TriggerPath.h"
 #include "DataFormats/PatCandidates/interface/TriggerFilter.h"
-#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -84,6 +80,7 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
   // L1 configuration parameters
   if ( iConfig.exists( "addL1Algos" ) ) addL1Algos_ = iConfig.getParameter< bool >( "addL1Algos" );
   if ( iConfig.exists( "l1GlobalTriggerObjectMaps" ) ) tagL1GlobalTriggerObjectMaps_ = iConfig.getParameter< InputTag >( "l1GlobalTriggerObjectMaps" );
+  l1GlobalTriggerObjectMapsToken_ = mayConsume< L1GlobalTriggerObjectMaps >( tagL1GlobalTriggerObjectMaps_ );
   if ( iConfig.exists( "l1ExtraMu" ) ) {
     tagL1ExtraMu_ = iConfig.getParameter< InputTag >( "l1ExtraMu" );
     if ( tagL1ExtraMu_.process() == "*" ) {
@@ -198,25 +195,38 @@ void PATTriggerProducer::beginRun(const Run & iRun, const EventSetup & iSetup )
     }
     LogInfo( "autoProcessName" ) << "HLT process name' " << nameProcess_ << "' used for PAT trigger information";
   }
+//   hltPrescaleTableRunToken_   = mayConsume< trigger::HLTPrescaleTable, InRun >( InputTag( labelHltPrescaleTable_, "Run", nameProcess_ ) ); // FIXME: This works only in the c'tor!
+//   hltPrescaleTableLumiToken_  = mayConsume< trigger::HLTPrescaleTable, InLumi >( InputTag( labelHltPrescaleTable_, "Lumi", nameProcess_ ) ); // FIXME: This works only in the c'tor!
+//   hltPrescaleTableEventToken_ = mayConsume< trigger::HLTPrescaleTable >( InputTag( labelHltPrescaleTable_, "Event", nameProcess_ ) ); // FIXME: This works only in the c'tor!
   // adapt configuration of used input tags
   if ( tagTriggerResults_.process().empty() || tagTriggerResults_.process() == "*" ) {
     tagTriggerResults_ = InputTag( tagTriggerResults_.label(), tagTriggerResults_.instance(), nameProcess_ );
   } else if ( tagTriggerEvent_.process() != nameProcess_ ) {
     LogWarning( "inputTags" ) << "TriggerResults process name '" << tagTriggerResults_.process() << "' differs from HLT process name '" << nameProcess_ << "'";
   }
+//   triggerResultsToken_ = mayConsume< edm::TriggerResults >( tagTriggerResults_ ); // FIXME: This works only in the c'tor!
   if ( tagTriggerEvent_.process().empty() || tagTriggerEvent_.process()   == "*" ) {
     tagTriggerEvent_ = InputTag( tagTriggerEvent_.label(), tagTriggerEvent_.instance(), nameProcess_ );
   } else if ( tagTriggerEvent_.process() != nameProcess_ ) {
     LogWarning( "inputTags" ) << "TriggerEvent process name '" << tagTriggerEvent_.process() << "' differs from HLT process name '" << nameProcess_ << "'";
   }
+//   triggerEventToken_ = mayConsume< trigger::TriggerEvent >( tagTriggerEvent_ ); // FIXME: This works only in the c'tor!
   if ( autoProcessNameL1ExtraMu_ )      tagL1ExtraMu_      = InputTag( tagL1ExtraMu_.label()     , tagL1ExtraMu_.instance()     , nameProcess_ );
+//   l1ExtraMuToken_ = mayConsume< l1extra::L1MuonParticleCollection >( tagL1ExtraMu_ ); // FIXME: This works only in the c'tor!
   if ( autoProcessNameL1ExtraNoIsoEG_ ) tagL1ExtraNoIsoEG_ = InputTag( tagL1ExtraNoIsoEG_.label(), tagL1ExtraNoIsoEG_.instance(), nameProcess_ );
+//   l1ExtraNoIsoEGToken_ = mayConsume< l1extra::L1EmParticleCollection >( tagL1ExtraNoIsoEG_ ); // FIXME: This works only in the c'tor!
   if ( autoProcessNameL1ExtraIsoEG_ )   tagL1ExtraIsoEG_   = InputTag( tagL1ExtraIsoEG_.label()  , tagL1ExtraIsoEG_.instance()  , nameProcess_ );
+//   l1ExtraIsoEGToken_ = mayConsume< l1extra::L1EmParticleCollection >( tagL1ExtraIsoEG_ ); // FIXME: This works only in the c'tor!
   if ( autoProcessNameL1ExtraCenJet_ )  tagL1ExtraCenJet_  = InputTag( tagL1ExtraCenJet_.label() , tagL1ExtraCenJet_.instance() , nameProcess_ );
+//   l1ExtraCenJetToken_ = mayConsume< l1extra::L1JetParticleCollection >( tagL1ExtraCenJet_ ); // FIXME: This works only in the c'tor!
   if ( autoProcessNameL1ExtraForJet_ )  tagL1ExtraForJet_  = InputTag( tagL1ExtraForJet_.label() , tagL1ExtraForJet_.instance() , nameProcess_ );
+//   l1ExtraForJetToken_ = mayConsume< l1extra::L1JetParticleCollection >( tagL1ExtraForJet_ ); // FIXME: This works only in the c'tor!
   if ( autoProcessNameL1ExtraTauJet_ )  tagL1ExtraTauJet_  = InputTag( tagL1ExtraTauJet_.label() , tagL1ExtraTauJet_.instance() , nameProcess_ );
+//   l1ExtraTauJetToken_ = mayConsume< l1extra::L1JetParticleCollection >( tagL1ExtraTauJet_ ); // FIXME: This works only in the c'tor!
   if ( autoProcessNameL1ExtraETM_ )     tagL1ExtraETM_     = InputTag( tagL1ExtraETM_.label()    , tagL1ExtraETM_.instance()    , nameProcess_ );
+//   l1ExtraETMToken_ = mayConsume< l1extra::L1EtMissParticleCollection >( tagL1ExtraETM_ ); // FIXME: This works only in the c'tor!
   if ( autoProcessNameL1ExtraHTM_ )     tagL1ExtraHTM_     = InputTag( tagL1ExtraHTM_.label()    , tagL1ExtraHTM_.instance()    , nameProcess_ );
+//   l1ExtraHTMToken_ = mayConsume< l1extra::L1EtMissParticleCollection >( tagL1ExtraHTM_ ); // FIXME: This works only in the c'tor!
 
   // Initialize HLTConfigProvider
   bool changed( true );
@@ -237,6 +247,7 @@ void PATTriggerProducer::beginRun(const Run & iRun, const EventSetup & iSetup )
     if ( ! labelHltPrescaleTable_.empty() ) {
       Handle< trigger::HLTPrescaleTable > handleHltPrescaleTable;
       iRun.getByLabel( InputTag( labelHltPrescaleTable_, "Run", nameProcess_ ), handleHltPrescaleTable );
+//       iRun.getByToken( hltPrescaleTableRunToken_, handleHltPrescaleTable );
       if ( handleHltPrescaleTable.isValid() ) {
         hltPrescaleTableRun_ = trigger::HLTPrescaleTable( handleHltPrescaleTable->set(), handleHltPrescaleTable->labels(), handleHltPrescaleTable->table() );
       }
@@ -260,6 +271,7 @@ void PATTriggerProducer::beginLuminosityBlock(const LuminosityBlock & iLuminosit
     if ( ! labelHltPrescaleTable_.empty() ) {
       Handle< trigger::HLTPrescaleTable > handleHltPrescaleTable;
       iLuminosityBlock.getByLabel( InputTag( labelHltPrescaleTable_, "Lumi", nameProcess_ ), handleHltPrescaleTable );
+//       iLuminosityBlock.getByToken( hltPrescaleTableLumiToken_, handleHltPrescaleTable );
       if ( handleHltPrescaleTable.isValid() ) {
         hltPrescaleTableLumi_ = trigger::HLTPrescaleTable( handleHltPrescaleTable->set(), handleHltPrescaleTable->labels(), handleHltPrescaleTable->table() );
       }
@@ -283,8 +295,10 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   // Get and check HLT event data
   Handle< trigger::TriggerEvent > handleTriggerEvent;
   iEvent.getByLabel( tagTriggerEvent_, handleTriggerEvent );
+//   iEvent.getByToken( triggerEventToken_, handleTriggerEvent );
   Handle< TriggerResults > handleTriggerResults;
   iEvent.getByLabel( tagTriggerResults_, handleTriggerResults );
+//   iEvent.getByToken( triggerResultsToken_, handleTriggerResults );
   bool goodHlt( hltConfigInit_ );
   if ( goodHlt ) {
     if( ! handleTriggerResults.isValid() ) {
@@ -309,6 +323,7 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
     if ( ! labelHltPrescaleTable_.empty() ) {
       Handle< trigger::HLTPrescaleTable > handleHltPrescaleTable;
       iEvent.getByLabel( InputTag( labelHltPrescaleTable_, "Event", nameProcess_ ), handleHltPrescaleTable );
+//       iEvent.getByToken( hltPrescaleTableEventToken_, handleHltPrescaleTable );
       if ( handleHltPrescaleTable.isValid() ) {
         hltPrescaleTable = trigger::HLTPrescaleTable( handleHltPrescaleTable->set(), handleHltPrescaleTable->labels(), handleHltPrescaleTable->table() );
       }
@@ -530,6 +545,7 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   if ( ! tagL1ExtraMu_.label().empty() ) {
     Handle< l1extra::L1MuonParticleCollection > handleL1ExtraMu;
     iEvent.getByLabel( tagL1ExtraMu_, handleL1ExtraMu );
+//     iEvent.getByToken( l1ExtraMuToken_, handleL1ExtraMu );
     if ( handleL1ExtraMu.isValid() ) {
       std::vector< unsigned > muKeys;
       for ( size_t l1Mu = 0; l1Mu < handleL1ExtraMu->size(); ++l1Mu ) {
@@ -555,6 +571,7 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   if ( ! tagL1ExtraNoIsoEG_.label().empty() ) {
     Handle< l1extra::L1EmParticleCollection > handleL1ExtraNoIsoEG;
     iEvent.getByLabel( tagL1ExtraNoIsoEG_, handleL1ExtraNoIsoEG );
+//     iEvent.getByToken( l1ExtraNoIsoEGToken_, handleL1ExtraNoIsoEG );
     if ( handleL1ExtraNoIsoEG.isValid() ) {
       std::vector< unsigned > noIsoEGKeys;
       for ( size_t l1NoIsoEG = 0; l1NoIsoEG < handleL1ExtraNoIsoEG->size(); ++l1NoIsoEG ) {
@@ -580,6 +597,7 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   if ( ! tagL1ExtraIsoEG_.label().empty() ) {
     Handle< l1extra::L1EmParticleCollection > handleL1ExtraIsoEG;
     iEvent.getByLabel( tagL1ExtraIsoEG_, handleL1ExtraIsoEG );
+//     iEvent.getByToken( l1ExtraIsoEGToken_, handleL1ExtraIsoEG );
     if ( handleL1ExtraIsoEG.isValid() ) {
       std::vector< unsigned > isoEGKeys;
       for ( size_t l1IsoEG = 0; l1IsoEG < handleL1ExtraIsoEG->size(); ++l1IsoEG ) {
@@ -605,6 +623,7 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   if ( ! tagL1ExtraCenJet_.label().empty() ) {
     Handle< l1extra::L1JetParticleCollection > handleL1ExtraCenJet;
     iEvent.getByLabel( tagL1ExtraCenJet_, handleL1ExtraCenJet );
+//     iEvent.getByToken( l1ExtraCenJetToken_, handleL1ExtraCenJet );
     if ( handleL1ExtraCenJet.isValid() ) {
       std::vector< unsigned > cenJetKeys;
       for ( size_t l1CenJet = 0; l1CenJet < handleL1ExtraCenJet->size(); ++l1CenJet ) {
@@ -630,6 +649,7 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   if ( ! tagL1ExtraForJet_.label().empty() ) {
     Handle< l1extra::L1JetParticleCollection > handleL1ExtraForJet;
     iEvent.getByLabel( tagL1ExtraForJet_, handleL1ExtraForJet );
+//     iEvent.getByToken( l1ExtraForJetToken_, handleL1ExtraForJet );
     if ( handleL1ExtraForJet.isValid() ) {
       std::vector< unsigned > forJetKeys;
       for ( size_t l1ForJet = 0; l1ForJet < handleL1ExtraForJet->size(); ++l1ForJet ) {
@@ -655,6 +675,7 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   if ( ! tagL1ExtraTauJet_.label().empty() ) {
     Handle< l1extra::L1JetParticleCollection > handleL1ExtraTauJet;
     iEvent.getByLabel( tagL1ExtraTauJet_, handleL1ExtraTauJet );
+//     iEvent.getByToken( l1ExtraTauJetToken_, handleL1ExtraTauJet );
     if ( handleL1ExtraTauJet.isValid() ) {
       std::vector< unsigned > tauJetKeys;
       for ( size_t l1TauJet = 0; l1TauJet < handleL1ExtraTauJet->size(); ++l1TauJet ) {
@@ -680,6 +701,7 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   if ( ! tagL1ExtraETM_ .label().empty()) {
     Handle< l1extra::L1EtMissParticleCollection > handleL1ExtraETM;
     iEvent.getByLabel( tagL1ExtraETM_, handleL1ExtraETM );
+//     iEvent.getByToken( l1ExtraETMToken_, handleL1ExtraETM );
     if ( handleL1ExtraETM.isValid() ) {
       std::vector< unsigned > etmKeys;
       for ( size_t l1ETM = 0; l1ETM < handleL1ExtraETM->size(); ++l1ETM ) {
@@ -705,6 +727,7 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   if ( ! tagL1ExtraHTM_.label().empty() ) {
     Handle< l1extra::L1EtMissParticleCollection > handleL1ExtraHTM;
     iEvent.getByLabel( tagL1ExtraHTM_, handleL1ExtraHTM );
+//     iEvent.getByToken( l1ExtraHTMToken_, handleL1ExtraHTM );
     if ( handleL1ExtraHTM.isValid() ) {
       std::vector< unsigned > htmKeys;
       for ( size_t l1HTM = 0; l1HTM < handleL1ExtraHTM->size(); ++l1HTM ) {
@@ -762,7 +785,7 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
       }
       triggerAlgos->reserve( l1GtAlgorithms.size() + l1GtTechTriggers.size() );
       Handle< L1GlobalTriggerObjectMaps > handleL1GlobalTriggerObjectMaps;
-      iEvent.getByLabel( tagL1GlobalTriggerObjectMaps_, handleL1GlobalTriggerObjectMaps );
+      iEvent.getByToken( l1GlobalTriggerObjectMapsToken_, handleL1GlobalTriggerObjectMaps );
       if( ! handleL1GlobalTriggerObjectMaps.isValid() ) {
         LogError( "l1ObjectMap" ) << "L1GlobalTriggerObjectMaps product with InputTag '" << tagL1GlobalTriggerObjectMaps_.encode() << "' not in event\n"
                                     << "No L1 objects and GTL results available for physics algorithms";

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.h
@@ -47,6 +47,11 @@
 #include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 
+#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMaps.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+#include "DataFormats/PatCandidates/interface/TriggerObjectStandAlone.h"
+
 namespace pat {
 
   class PATTriggerProducer : public edm::EDProducer {
@@ -71,14 +76,23 @@ namespace pat {
       edm::ParameterSet * l1PSet_;
       bool                addL1Algos_;                    // configuration (optional with default)
       edm::InputTag       tagL1GlobalTriggerObjectMaps_;  // configuration (optional with default)
+      edm::EDGetTokenT< L1GlobalTriggerObjectMaps > l1GlobalTriggerObjectMapsToken_;
       edm::InputTag       tagL1ExtraMu_;                  // configuration (optional)
+//       edm::EDGetTokenT< l1extra::L1MuonParticleCollection > l1ExtraMuToken_;
       edm::InputTag       tagL1ExtraNoIsoEG_;             // configuration (optional)
+//       edm::EDGetTokenT< l1extra::L1EmParticleCollection > l1ExtraNoIsoEGToken_;
       edm::InputTag       tagL1ExtraIsoEG_;               // configuration (optional)
+//       edm::EDGetTokenT< l1extra::L1EmParticleCollection > l1ExtraIsoEGToken_;
       edm::InputTag       tagL1ExtraCenJet_;              // configuration (optional)
+//       edm::EDGetTokenT< l1extra::L1JetParticleCollection > l1ExtraCenJetToken_;
       edm::InputTag       tagL1ExtraForJet_;              // configuration (optional)
+//       edm::EDGetTokenT< l1extra::L1JetParticleCollection > l1ExtraForJetToken_;
       edm::InputTag       tagL1ExtraTauJet_;              // configuration (optional)
+//       edm::EDGetTokenT< l1extra::L1JetParticleCollection > l1ExtraTauJetToken_;
       edm::InputTag       tagL1ExtraETM_;                 // configuration (optional)
+//       edm::EDGetTokenT< l1extra::L1EtMissParticleCollection > l1ExtraETMToken_;
       edm::InputTag       tagL1ExtraHTM_;                 // configuration (optional)
+//       edm::EDGetTokenT< l1extra::L1EtMissParticleCollection > l1ExtraHTMToken_;
       bool                autoProcessNameL1ExtraMu_;
       bool                autoProcessNameL1ExtraNoIsoEG_;
       bool                autoProcessNameL1ExtraIsoEG_;
@@ -93,9 +107,14 @@ namespace pat {
       HLTConfigProvider         hltConfig_;
       bool                      hltConfigInit_;
       edm::InputTag             tagTriggerResults_;     // configuration (optional with default)
+//       edm::EDGetTokenT< edm::TriggerResults > triggerResultsToken_;
       edm::InputTag             tagTriggerEvent_;       // configuration (optional with default)
+//       edm::EDGetTokenT< trigger::TriggerEvent > triggerEventToken_;
       std::string               hltPrescaleLabel_;      // configuration (optional)
       std::string               labelHltPrescaleTable_; // configuration (optional)
+//       edm::EDGetTokenT< trigger::HLTPrescaleTable > hltPrescaleTableRunToken_;
+//       edm::EDGetTokenT< trigger::HLTPrescaleTable > hltPrescaleTableLumiToken_;
+//       edm::EDGetTokenT< trigger::HLTPrescaleTable > hltPrescaleTableEventToken_;
       trigger::HLTPrescaleTable hltPrescaleTableRun_;
       trigger::HLTPrescaleTable hltPrescaleTableLumi_;
       bool                       addPathModuleLabels_;  // configuration (optional with default)

--- a/PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.h
@@ -5,12 +5,12 @@
   \class    pat::TauJetCorrFactorsProducer TauJetCorrFactorsProducer.h "PhysicsTools/PatAlgos/interface/TauJetCorrFactorsProducer.h"
   \brief    Produces a ValueMap between TauJetCorrFactors and the originating reco taus
 
-   The TauJetCorrFactorsProducer produces a set of tau-jet energy correction factors, defined in the class pat::TauJetCorrFactors. 
-   This vector is linked to the originating reco taus through an edm::ValueMap. The initializing parameters of the module can be found 
-   in the recoLayer1/tauJetCorrFactors_cfi.py of the PatAlgos package. In the standard PAT workflow the module has to be run 
-   before the creation of the pat::Tau. The edm::ValueMap will then be embedded into the pat::Tau. 
+   The TauJetCorrFactorsProducer produces a set of tau-jet energy correction factors, defined in the class pat::TauJetCorrFactors.
+   This vector is linked to the originating reco taus through an edm::ValueMap. The initializing parameters of the module can be found
+   in the recoLayer1/tauJetCorrFactors_cfi.py of the PatAlgos package. In the standard PAT workflow the module has to be run
+   before the creation of the pat::Tau. The edm::ValueMap will then be embedded into the pat::Tau.
 
-   Jets corrected up to a given correction level can then be accessed via the pat::Tau member function correctedJet. For 
+   Jets corrected up to a given correction level can then be accessed via the pat::Tau member function correctedJet. For
    more details have a look into the class description of the pat::Tau.
 */
 
@@ -35,7 +35,7 @@
 
 namespace pat {
 
-  class TauJetCorrFactorsProducer : public edm::EDProducer 
+  class TauJetCorrFactorsProducer : public edm::EDProducer
   {
    public:
     /// value map for JetCorrFactors (to be written into the event)
@@ -49,26 +49,26 @@ namespace pat {
 
     /// everything that needs to be done per event
     virtual void produce(edm::Event&, const edm::EventSetup&) override;
-    
+
    private:
     /// return the jec parameters as input to the FactorizedJetCorrector for different flavors
     std::vector<JetCorrectorParameters> params(const JetCorrectorParametersCollection&, const std::vector<std::string>&) const;
 
     /// evaluate jet correction factor up to a given level
     float evaluate(edm::View<reco::BaseTau>::const_iterator&, boost::shared_ptr<FactorizedJetCorrector>&, int);
-    
+
   private:
     /// python label of this TauJetCorrFactorsProducer module
     std::string moduleLabel_;
 
      /// input tau-jet collection
-    edm::InputTag src_;
+    edm::EDGetTokenT<edm::View<reco::BaseTau> > srcToken_;
 
     /// mapping of reconstructed tau decay modes to payloads
     typedef std::vector<int> vint;
     struct payloadMappingType
     {
-      /// reconstructed tau decay modes associated to this payload, 
+      /// reconstructed tau decay modes associated to this payload,
       /// as defined in DataFormats/TauReco/interface/PFTau.h
       vint decayModes_;
 
@@ -84,7 +84,7 @@ namespace pat {
     ///
     std::string defaultPayload_;
 
-    /// jec levels 
+    /// jec levels
     typedef std::vector<std::string> vstring;
     vstring levels_;
   };

--- a/PhysicsTools/PatAlgos/plugins/VertexAssociationProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/VertexAssociationProducer.cc
@@ -6,7 +6,7 @@
    The PATVertexAssociationProducer produces a set of vertex associations for one or more
    collection of Candidates, and saves them in a ValueMap in the event.
 
-   These can be retrieved in PAT Layer 1 to be embedded in PAT Objects 
+   These can be retrieved in PAT Layer 1 to be embedded in PAT Objects
 
   \author   Giovanni Petrucciani
   \version  $Id: VertexAssociationProducer.cc,v 1.2 2010/02/20 21:00:29 wmtan Exp $
@@ -41,8 +41,9 @@ namespace pat {
       typedef std::vector<edm::InputTag> VInputTag;
       // configurables
       std::vector<edm::InputTag>   particles_;
+      std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > particlesTokens_;
       pat::helper::VertexingHelper vertexing_;
-  
+
   };
 
 }
@@ -53,8 +54,11 @@ PATVertexAssociationProducer::PATVertexAssociationProducer(const edm::ParameterS
   particles_( iConfig.existsAs<VInputTag>("candidates") ?       // if it's a VInputTag
                 iConfig.getParameter<VInputTag>("candidates") :
                 VInputTag(1, iConfig.getParameter<edm::InputTag>("candidates")) ),
-  vertexing_(iConfig) 
+  vertexing_(iConfig, consumesCollector())
 {
+  for (VInputTag::const_iterator it = particles_.begin(), end = particles_.end(); it != end; ++it) {
+    particlesTokens_.push_back( consumes<edm::View<reco::Candidate> >( *it ) );
+  }
     produces<VertexAssociationMap>();
 }
 
@@ -64,7 +68,7 @@ PATVertexAssociationProducer::~PATVertexAssociationProducer() {
 
 
 void PATVertexAssociationProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
-  using namespace edm; using namespace std; 
+  using namespace edm; using namespace std;
   // read in vertices and EventSetup
   vertexing_.newEvent(iEvent, iSetup);
 
@@ -72,13 +76,13 @@ void PATVertexAssociationProducer::produce(edm::Event & iEvent, const edm::Event
   auto_ptr<VertexAssociationMap> result(new VertexAssociationMap());
   VertexAssociationMap::Filler filler(*result);
   vector<pat::VertexAssociation> assos;
- 
-  // loop on input tags  
-  for (VInputTag::const_iterator it = particles_.begin(), end = particles_.end(); it != end; ++it) {
+
+  // loop on input tags
+  for (std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator it = particlesTokens_.begin(), end = particlesTokens_.end(); it != end; ++it) {
       // read candidates
       Handle<View<reco::Candidate> > cands;
-      iEvent.getByLabel(*it, cands);
-      assos.clear(); assos.reserve(cands->size()); 
+      iEvent.getByToken(*it, cands);
+      assos.clear(); assos.reserve(cands->size());
       // loop on candidates
       for (size_t i = 0, n = cands->size(); i < n; ++i) {
         assos.push_back( vertexing_(cands->refAt(i)) );
@@ -88,7 +92,7 @@ void PATVertexAssociationProducer::produce(edm::Event & iEvent, const edm::Event
   }
 
   // do the real filling
-  filler.fill(); 
+  filler.fill();
 
   // put our produced stuff in the event
   iEvent.put(result);

--- a/PhysicsTools/PatAlgos/src/BaseIsolator.cc
+++ b/PhysicsTools/PatAlgos/src/BaseIsolator.cc
@@ -4,14 +4,15 @@
 
 using pat::helper::BaseIsolator;
 
-BaseIsolator::BaseIsolator(const edm::ParameterSet &conf, bool withCut) :
+BaseIsolator::BaseIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut) :
     input_(conf.getParameter<edm::InputTag>("src")),
+    inputToken_(iC.consumes<Isolation>(input_)),
     cut_(withCut ? conf.getParameter<double>("cut") : -2.0),
     try_(0), fail_(0)
 {
 }
 
-void 
+void
 BaseIsolator::print(std::ostream &out) const {
     using namespace std;
     out << description() << " < " << cut_ << ": try " << try_ << ", fail " << fail_;

--- a/PhysicsTools/PatAlgos/src/EfficiencyLoader.cc
+++ b/PhysicsTools/PatAlgos/src/EfficiencyLoader.cc
@@ -4,15 +4,15 @@
 
 using pat::helper::EfficiencyLoader;
 
-EfficiencyLoader::EfficiencyLoader(const edm::ParameterSet &iConfig) 
+EfficiencyLoader::EfficiencyLoader(const edm::ParameterSet &iConfig, edm::ConsumesCollector && iC)
 {
     // Get the names (sorted)
     names_ = iConfig.getParameterNamesForType<edm::InputTag>();
     std::sort(names_.begin(), names_.end());
-    
+
     // get the InputTags
     for (std::vector<std::string>::const_iterator it = names_.begin(), ed = names_.end(); it != ed; ++it) {
-        tags_.push_back( iConfig.getParameter<edm::InputTag>(*it) );
+        tokens_.push_back( iC.consumes<edm::ValueMap<pat::LookupTableRecord> >(iConfig.getParameter<edm::InputTag>(*it) ));
     }
 
     // prepare the Handles
@@ -22,6 +22,6 @@ EfficiencyLoader::EfficiencyLoader(const edm::ParameterSet &iConfig)
 void
 EfficiencyLoader::newEvent(const edm::Event &iEvent) const {
     for (size_t i = 0, n = names_.size(); i < n; ++i) {
-        iEvent.getByLabel(tags_[i], handles_[i]);
-    }    
+        iEvent.getByToken(tokens_[i], handles_[i]);
+    }
 }

--- a/PhysicsTools/PatAlgos/src/MultiIsolator.cc
+++ b/PhysicsTools/PatAlgos/src/MultiIsolator.cc
@@ -6,58 +6,58 @@
 
 using namespace pat::helper;
 
-MultiIsolator::MultiIsolator(const edm::ParameterSet &conf, bool cuts) {
+MultiIsolator::MultiIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector && iC, bool cuts) {
     using pat::Flags;
-    if (conf.exists("tracker")) addIsolator(conf.getParameter<edm::ParameterSet>("tracker"), cuts, Flags::Isolation::Tracker, pat::TrackIso);
-    if (conf.exists("ecal"))    addIsolator(conf.getParameter<edm::ParameterSet>("ecal"),    cuts, Flags::Isolation::ECal, pat::EcalIso);
-    if (conf.exists("hcal"))    addIsolator(conf.getParameter<edm::ParameterSet>("hcal"),    cuts, Flags::Isolation::HCal, pat::HcalIso);
-    if (conf.exists("calo"))    addIsolator(conf.getParameter<edm::ParameterSet>("calo"),    cuts, Flags::Isolation::Calo, pat::CaloIso);
+    if (conf.exists("tracker")) addIsolator(conf.getParameter<edm::ParameterSet>("tracker"), iC, cuts, Flags::Isolation::Tracker, pat::TrackIso);
+    if (conf.exists("ecal"))    addIsolator(conf.getParameter<edm::ParameterSet>("ecal"),    iC, cuts, Flags::Isolation::ECal, pat::EcalIso);
+    if (conf.exists("hcal"))    addIsolator(conf.getParameter<edm::ParameterSet>("hcal"),    iC, cuts, Flags::Isolation::HCal, pat::HcalIso);
+    if (conf.exists("calo"))    addIsolator(conf.getParameter<edm::ParameterSet>("calo"),    iC, cuts, Flags::Isolation::Calo, pat::CaloIso);
     if (conf.exists("calo") && (conf.exists("ecal") || conf.exists("hcal"))) {
-        throw cms::Exception("Configuration") << 
+        throw cms::Exception("Configuration") <<
             "MultiIsolator: you can't specify both 'calo' isolation and 'ecal'/'hcal', " <<
-            "as the 'calo' isolation flag is just the logical OR of 'ecal' and 'hcal'.\n";                            
+            "as the 'calo' isolation flag is just the logical OR of 'ecal' and 'hcal'.\n";
     }
-    if (conf.exists("pfAllParticles"))  addIsolator(conf.getParameter<edm::ParameterSet>("pfAllParticles"), cuts,Flags::Isolation::Calo, pat::PfAllParticleIso); 	 
-    if (conf.exists("pfChargedHadron")) addIsolator(conf.getParameter<edm::ParameterSet>("pfChargedHadron"), cuts,Flags::Isolation::Calo, pat::PfChargedHadronIso); 	 
-    if (conf.exists("pfNeutralHadron")) addIsolator(conf.getParameter<edm::ParameterSet>("pfNeutralHadron"), cuts,Flags::Isolation::Calo, pat::PfNeutralHadronIso); 	 
-    if (conf.exists("pfGamma"))         addIsolator(conf.getParameter<edm::ParameterSet>("pfGamma"), cuts,Flags::Isolation::Calo, pat::PfGammaIso);
+    if (conf.exists("pfAllParticles"))  addIsolator(conf.getParameter<edm::ParameterSet>("pfAllParticles"), iC, cuts,Flags::Isolation::Calo, pat::PfAllParticleIso);
+    if (conf.exists("pfChargedHadron")) addIsolator(conf.getParameter<edm::ParameterSet>("pfChargedHadron"), iC, cuts,Flags::Isolation::Calo, pat::PfChargedHadronIso);
+    if (conf.exists("pfNeutralHadron")) addIsolator(conf.getParameter<edm::ParameterSet>("pfNeutralHadron"), iC, cuts,Flags::Isolation::Calo, pat::PfNeutralHadronIso);
+    if (conf.exists("pfGamma"))         addIsolator(conf.getParameter<edm::ParameterSet>("pfGamma"), iC, cuts,Flags::Isolation::Calo, pat::PfGammaIso);
     if (conf.exists("user")) {
-   
+
         std::vector<edm::ParameterSet> psets = conf.getParameter<std::vector<edm::ParameterSet> >("user");
         if (psets.size() > 5) {
-            throw cms::Exception("Configuration") << 
-                "MultiIsolator: you can specify at most 5 user isolation collections.\n";            
+            throw cms::Exception("Configuration") <<
+                "MultiIsolator: you can specify at most 5 user isolation collections.\n";
         }
         uint32_t bit = Flags::Isolation::User1;
         for (std::vector<edm::ParameterSet>::const_iterator it = psets.begin(), ed = psets.end(); it != ed; ++it, bit <<= 1) {
-            addIsolator(*it, cuts, bit, pat::IsolationKeys(pat::UserBaseIso + (it - psets.begin())));
+            addIsolator(*it, iC, cuts, bit, pat::IsolationKeys(pat::UserBaseIso + (it - psets.begin())));
         }
     }
 }
 
 
-void 
+void
 MultiIsolator::addIsolator(BaseIsolator *iso, uint32_t mask, pat::IsolationKeys key) {
     isolators_.push_back(iso);
-    masks_.push_back(mask); 
+    masks_.push_back(mask);
     keys_.push_back(key);
 }
 
-BaseIsolator * 
-MultiIsolator::make(const edm::ParameterSet &conf, bool withCut) {
+BaseIsolator *
+MultiIsolator::make(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut) {
     if (conf.empty()) return 0;
     if (conf.exists("placeholder") && conf.getParameter<bool>("placeholder")) return 0;
     if (conf.exists("deltaR")) {
-        return new IsoDepositIsolator(conf, withCut);
+        return new IsoDepositIsolator(conf, iC, withCut);
     } else {
-        return new SimpleIsolator(conf, withCut);
+        return new SimpleIsolator(conf, iC, withCut);
     }
 }
 
 
-void 
-MultiIsolator::addIsolator(const edm::ParameterSet &conf, bool withCut, uint32_t mask, pat::IsolationKeys key) {
-   BaseIsolator * iso = make(conf, withCut);
+void
+MultiIsolator::addIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut, uint32_t mask, pat::IsolationKeys key) {
+   BaseIsolator * iso = make(conf, iC, withCut);
     if (iso) addIsolator(iso, mask, key);
 }
 
@@ -80,13 +80,13 @@ void
 MultiIsolator::print(std::ostream &out) const {
     for (boost::ptr_vector<BaseIsolator>::const_iterator it = isolators_.begin(), ed = isolators_.end(); it != ed; ++it) {
         out << " * ";
-        it->print(out); 
+        it->print(out);
         out << ": Flag " << pat::Flags::bitToString( masks_[it - isolators_.begin()] ) << "\n";
-    }    
+    }
     out << "\n";
 }
 
-std::string 
+std::string
 MultiIsolator::printSummary() const {
     std::ostringstream isoSumm;
     print(isoSumm);

--- a/PhysicsTools/PatAlgos/src/OverlapTest.cc
+++ b/PhysicsTools/PatAlgos/src/OverlapTest.cc
@@ -7,9 +7,9 @@
 using namespace pat::helper;
 
 void
-BasicOverlapTest::readInput(const edm::Event & iEvent, const edm::EventSetup &iSetup) 
+BasicOverlapTest::readInput(const edm::Event & iEvent, const edm::EventSetup &iSetup)
 {
-    iEvent.getByLabel(src_, candidates_);
+    iEvent.getByToken(srcToken_, candidates_);
     isPreselected_.resize(candidates_->size());
     size_t idx = 0;
     for (reco::CandidateView::const_iterator it = candidates_->begin(); it != candidates_->end(); ++it, ++idx) {
@@ -20,7 +20,7 @@ BasicOverlapTest::readInput(const edm::Event & iEvent, const edm::EventSetup &iS
 }
 
 bool
-BasicOverlapTest::fillOverlapsForItem(const reco::Candidate &item, reco::CandidatePtrVector &overlapsToFill) const 
+BasicOverlapTest::fillOverlapsForItem(const reco::Candidate &item, reco::CandidatePtrVector &overlapsToFill) const
 {
     size_t idx = 0;
     std::vector<std::pair<float,size_t> > matches;
@@ -52,7 +52,7 @@ bool
 OverlapBySuperClusterSeed::fillOverlapsForItem(const reco::Candidate &item, reco::CandidatePtrVector &overlapsToFill) const
 {
     const reco::RecoCandidate * input = dynamic_cast<const reco::RecoCandidate *>(&item);
-    if (input == 0) throw cms::Exception("Type Error") << "Input to OverlapBySuperClusterSeed is not a RecoCandidate. " 
+    if (input == 0) throw cms::Exception("Type Error") << "Input to OverlapBySuperClusterSeed is not a RecoCandidate. "
                                                        << "It's a " << typeid(item).name() << "\n";
     reco::SuperClusterRef mySC = input->superCluster();
     if (mySC.isNull() || !mySC.isAvailable()) {
@@ -64,8 +64,10 @@ OverlapBySuperClusterSeed::fillOverlapsForItem(const reco::Candidate &item, reco
     }
     bool hasOverlaps = false;
     size_t idx = 0;
-    for (edm::View<reco::RecoCandidate>::const_iterator it = others_->begin(); it != others_->end(); ++it, ++idx) {
-        reco::SuperClusterRef otherSc = it->superCluster();
+//     for (edm::View<reco::RecoCandidate>::const_iterator it = others_->begin(); it != others_->end(); ++it, ++idx) {
+    for (reco::CandidateView::const_iterator it = others_->begin(); it != others_->end(); ++it, ++idx) {
+        const reco::RecoCandidate * other = dynamic_cast<const reco::RecoCandidate *>(&*it);
+        reco::SuperClusterRef otherSc = other->superCluster();
         if (otherSc.isNull() || !otherSc.isAvailable()) {
             throw cms::Exception("Bad Reference") << "One item in the OverlapBySuperClusterSeed input list has a null or dangling superCluster reference\n";
         }

--- a/PhysicsTools/PatAlgos/src/SimpleIsolator.cc
+++ b/PhysicsTools/PatAlgos/src/SimpleIsolator.cc
@@ -5,14 +5,14 @@ using pat::helper::SimpleIsolator;
 using pat::helper::BaseIsolator;
 
 
-SimpleIsolator::SimpleIsolator(const edm::ParameterSet &conf, bool withCut) :
-    BaseIsolator(conf, withCut)
+SimpleIsolator::SimpleIsolator(const edm::ParameterSet &conf, edm::ConsumesCollector & iC, bool withCut) :
+    BaseIsolator(conf, iC, withCut)
 {
 }
 
 void
 SimpleIsolator::beginEvent(const edm::Event &event, const edm::EventSetup &eventSetup) {
-    event.getByLabel(input_, handle_);
+    event.getByToken(inputDoubleToken_, handle_);
 }
 
 void

--- a/PhysicsTools/PatUtils/interface/LeptonJetIsolationAngle.h
+++ b/PhysicsTools/PatUtils/interface/LeptonJetIsolationAngle.h
@@ -13,11 +13,11 @@
    CMS Note 2006/024
 
   \author   Steven Lowette
-  \version  $Id: LeptonJetIsolationAngle.h,v 1.3 2008/03/05 14:51:02 fronga Exp $
 */
 
 
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "CLHEP/Vector/LorentzVector.h"
 
@@ -34,7 +34,7 @@ namespace pat {
 
     public:
 
-      LeptonJetIsolationAngle();
+      LeptonJetIsolationAngle(edm::ConsumesCollector && iC);
       ~LeptonJetIsolationAngle();
 
       float calculate(const Electron & anElectron, const edm::Handle<edm::View<reco::Track> > & trackHandle, const edm::Event & iEvent);
@@ -48,6 +48,8 @@ namespace pat {
     private:
 
       TrackerIsolationPt trkIsolator_;
+      edm::EDGetTokenT<reco::CaloJetCollection>         jetToken_;
+      edm::EDGetTokenT<std::vector<reco::GsfElectron> > electronsToken_;
 
   };
 

--- a/PhysicsTools/PatUtils/interface/LeptonVertexSignificance.h
+++ b/PhysicsTools/PatUtils/interface/LeptonVertexSignificance.h
@@ -12,8 +12,12 @@
    of the lepton to a given vertex, as defined in CMS Note 2006/024
 
   \author   Steven Lowette
-  \version  $Id: LeptonVertexSignificance.h,v 1.2 2008/02/28 14:54:24 llista Exp $
 */
+
+
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 class TransientTrackBuilder;
 
@@ -33,15 +37,16 @@ namespace pat {
   class LeptonVertexSignificance {
   public:
     LeptonVertexSignificance();
-    LeptonVertexSignificance(const edm::EventSetup & iSetup);
+    LeptonVertexSignificance(const edm::EventSetup & iSetup, edm::ConsumesCollector && iC);
     ~LeptonVertexSignificance();
-    
+
     float calculate(const Electron & anElectron, const edm::Event & iEvent);
     float calculate(const Muon & aMuon, const edm::Event & iEvent);
-    
+
   private:
     float calculate(const reco::Track & track, const edm::Event & iEvent);
     TransientTrackBuilder * theTrackBuilder_;
+    edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
   };
 
 }

--- a/PhysicsTools/PatUtils/interface/ShiftedParticleProducerT.h
+++ b/PhysicsTools/PatUtils/interface/ShiftedParticleProducerT.h
@@ -3,7 +3,7 @@
 
 /** \class ShiftedParticleProducerT
  *
- * Vary energy of electrons/muons/tau-jets by +/- 1 standard deviation, 
+ * Vary energy of electrons/muons/tau-jets by +/- 1 standard deviation,
  * in order to estimate resulting uncertainty on MET
  *
  * NOTE: energy scale uncertainties need to be specified in python config
@@ -27,7 +27,7 @@
 #include <vector>
 
 template <typename T>
-class ShiftedParticleProducerT : public edm::EDProducer  
+class ShiftedParticleProducerT : public edm::EDProducer
 {
   typedef std::vector<T> ParticleCollection;
 
@@ -36,7 +36,7 @@ class ShiftedParticleProducerT : public edm::EDProducer
   explicit ShiftedParticleProducerT(const edm::ParameterSet& cfg)
     : moduleLabel_(cfg.getParameter<std::string>("@module_label"))
   {
-    src_ = cfg.getParameter<edm::InputTag>("src");
+    srcToken_ = consumes<ParticleCollection>(cfg.getParameter<edm::InputTag>("src"));
 
     shiftBy_ = cfg.getParameter<double>("shiftBy");
 
@@ -51,7 +51,7 @@ class ShiftedParticleProducerT : public edm::EDProducer
       double uncertainty = cfg.getParameter<double>("uncertainty");
       binning_.push_back(new binningEntryType(uncertainty));
     }
-    
+
     produces<ParticleCollection>();
   }
   ~ShiftedParticleProducerT()
@@ -61,13 +61,13 @@ class ShiftedParticleProducerT : public edm::EDProducer
       delete (*it);
     }
   }
-    
+
  private:
 
   void produce(edm::Event& evt, const edm::EventSetup& es)
   {
     edm::Handle<ParticleCollection> originalParticles;
-    evt.getByLabel(src_, originalParticles);
+    evt.getByToken(srcToken_, originalParticles);
 
     std::auto_ptr<ParticleCollection> shiftedParticles(new ParticleCollection);
 
@@ -82,13 +82,13 @@ class ShiftedParticleProducerT : public edm::EDProducer
 	  break;
 	}
       }
-      
+
       double shift = shiftBy_*uncertainty;
 
       reco::Candidate::LorentzVector shiftedParticleP4 = originalParticle->p4();
       shiftedParticleP4 *= (1. + shift);
 
-      T shiftedParticle(*originalParticle);      
+      T shiftedParticle(*originalParticle);
       shiftedParticle.setP4(shiftedParticleP4);
 
       shiftedParticles->push_back(shiftedParticle);
@@ -99,7 +99,7 @@ class ShiftedParticleProducerT : public edm::EDProducer
 
   std::string moduleLabel_;
 
-  edm::InputTag src_; 
+  edm::EDGetTokenT<ParticleCollection> srcToken_;
 
   struct binningEntryType
   {
@@ -111,7 +111,7 @@ class ShiftedParticleProducerT : public edm::EDProducer
     : binSelection_(new StringCutObjectSelector<T>(cfg.getParameter<std::string>("binSelection"))),
       binUncertainty_(cfg.getParameter<double>("binUncertainty"))
     {}
-    ~binningEntryType() 
+    ~binningEntryType()
     {
       delete binSelection_;
     }
@@ -126,5 +126,5 @@ class ShiftedParticleProducerT : public edm::EDProducer
 #endif
 
 
- 
+
 

--- a/PhysicsTools/PatUtils/plugins/ShiftedMETcorrInputProducer.h
+++ b/PhysicsTools/PatUtils/plugins/ShiftedMETcorrInputProducer.h
@@ -18,15 +18,17 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
+#include "DataFormats/METReco/interface/CorrMETData.h"
+
 #include <string>
 
-class ShiftedMETcorrInputProducer : public edm::EDProducer  
+class ShiftedMETcorrInputProducer : public edm::EDProducer
 {
  public:
 
   explicit ShiftedMETcorrInputProducer(const edm::ParameterSet&);
   ~ShiftedMETcorrInputProducer();
-    
+
  private:
 
   void produce(edm::Event&, const edm::EventSetup&);
@@ -34,7 +36,8 @@ class ShiftedMETcorrInputProducer : public edm::EDProducer
   std::string moduleLabel_;
 
   typedef std::vector<edm::InputTag> vInputTag;
-  vInputTag src_; 
+  vInputTag src_;
+  std::vector<edm::EDGetTokenT<CorrMETData> > srcTokens_;
 
   struct binningEntryType
   {
@@ -65,5 +68,5 @@ class ShiftedMETcorrInputProducer : public edm::EDProducer
 #endif
 
 
- 
+
 

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForNoPileUpPFMEt.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForNoPileUpPFMEt.cc
@@ -4,25 +4,20 @@
 #include "JetMETCorrections/Objects/interface/JetCorrectionsRecord.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
-#include "DataFormats/JetReco/interface/PFJet.h"
-#include "DataFormats/JetReco/interface/PFJetCollection.h"
-#include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
 ShiftedPFCandidateProducerForNoPileUpPFMEt::ShiftedPFCandidateProducerForNoPileUpPFMEt(const edm::ParameterSet& cfg)
   : moduleLabel_(cfg.getParameter<std::string>("@module_label"))
+  , srcPFCandidatesToken_(consumes<reco::PFCandidateCollection>(cfg.getParameter<edm::InputTag>("srcPFCandidates")))
+  , srcJetsToken_(consumes<reco::PFJetCollection>(cfg.getParameter<edm::InputTag>("srcJets")))
 {
-  srcPFCandidates_ = cfg.getParameter<edm::InputTag>("srcPFCandidates");
-  srcJets_ = cfg.getParameter<edm::InputTag>("srcJets");
 
   jetCorrUncertaintyTag_ = cfg.getParameter<std::string>("jetCorrUncertaintyTag");
   if ( cfg.exists("jetCorrInputFileName") ) {
     jetCorrInputFileName_ = cfg.getParameter<edm::FileInPath>("jetCorrInputFileName");
-    if ( jetCorrInputFileName_.location() == edm::FileInPath::Unknown) throw cms::Exception("ShiftedJetProducerT") 
+    if ( jetCorrInputFileName_.location() == edm::FileInPath::Unknown) throw cms::Exception("ShiftedJetProducerT")
       << " Failed to find JEC parameter file = " << jetCorrInputFileName_ << " !!\n";
-    std::cout << "Reading JEC parameters = " << jetCorrUncertaintyTag_  
+    std::cout << "Reading JEC parameters = " << jetCorrUncertaintyTag_
 	      << " from file = " << jetCorrInputFileName_.fullPath() << "." << std::endl;
     jetCorrParameters_ = new JetCorrectorParameters(jetCorrInputFileName_.fullPath().data(), jetCorrUncertaintyTag_);
     jecUncertainty_ = new JetCorrectionUncertainty(*jetCorrParameters_);
@@ -35,7 +30,7 @@ ShiftedPFCandidateProducerForNoPileUpPFMEt::ShiftedPFCandidateProducerForNoPileU
   minJetPt_ = cfg.getParameter<double>("minJetPt");
 
   shiftBy_ = cfg.getParameter<double>("shiftBy");
-  
+
   unclEnUncertainty_ = cfg.getParameter<double>("unclEnUncertainty");
 
   produces<reco::PFCandidateCollection>();
@@ -49,10 +44,10 @@ ShiftedPFCandidateProducerForNoPileUpPFMEt::~ShiftedPFCandidateProducerForNoPile
 void ShiftedPFCandidateProducerForNoPileUpPFMEt::produce(edm::Event& evt, const edm::EventSetup& es)
 {
   edm::Handle<reco::PFCandidateCollection> originalPFCandidates;
-  evt.getByLabel(srcPFCandidates_, originalPFCandidates);
+  evt.getByToken(srcPFCandidatesToken_, originalPFCandidates);
 
   edm::Handle<reco::PFJetCollection> jets;
-  evt.getByLabel(srcJets_, jets);
+  evt.getByToken(srcJetsToken_, jets);
 
   std::vector<const reco::PFJet*> selectedJets;
   for ( reco::PFJetCollection::const_iterator jet = jets->begin();
@@ -62,7 +57,7 @@ void ShiftedPFCandidateProducerForNoPileUpPFMEt::produce(edm::Event& evt, const 
 
   if ( jetCorrPayloadName_ != "" ) {
       edm::ESHandle<JetCorrectorParametersCollection> jetCorrParameterSet;
-      es.get<JetCorrectionsRecord>().get(jetCorrPayloadName_, jetCorrParameterSet); 
+      es.get<JetCorrectionsRecord>().get(jetCorrPayloadName_, jetCorrParameterSet);
       const JetCorrectorParameters& jetCorrParameters = (*jetCorrParameterSet)[jetCorrUncertaintyTag_];
       delete jecUncertainty_;
       jecUncertainty_ = new JetCorrectionUncertainty(jetCorrParameters);
@@ -72,7 +67,7 @@ void ShiftedPFCandidateProducerForNoPileUpPFMEt::produce(edm::Event& evt, const 
 
   for ( reco::PFCandidateCollection::const_iterator originalPFCandidate = originalPFCandidates->begin();
 	originalPFCandidate != originalPFCandidates->end(); ++originalPFCandidate ) {
-    
+
     const reco::PFJet* jet_matched = 0;
     for ( std::vector<const reco::PFJet*>::iterator jet = selectedJets.begin();
 	  jet != selectedJets.end(); ++jet ) {
@@ -87,23 +82,23 @@ void ShiftedPFCandidateProducerForNoPileUpPFMEt::produce(edm::Event& evt, const 
     if ( jet_matched ) {
       jecUncertainty_->setJetEta(jet_matched->eta());
       jecUncertainty_->setJetPt(jet_matched->pt());
-      
+
       shift = jecUncertainty_->getUncertainty(true);
     } else {
       shift = unclEnUncertainty_;
     }
 
     shift *= shiftBy_;
-    
+
     reco::Candidate::LorentzVector shiftedPFCandidateP4 = originalPFCandidate->p4();
     shiftedPFCandidateP4 *= (1. + shift);
-    
-    reco::PFCandidate shiftedPFCandidate(*originalPFCandidate);      
+
+    reco::PFCandidate shiftedPFCandidate(*originalPFCandidate);
     shiftedPFCandidate.setP4(shiftedPFCandidateP4);
-    
+
     shiftedPFCandidates->push_back(shiftedPFCandidate);
   }
-  
+
   evt.put(shiftedPFCandidates);
 }
 
@@ -112,4 +107,4 @@ void ShiftedPFCandidateProducerForNoPileUpPFMEt::produce(edm::Event& evt, const 
 DEFINE_FWK_MODULE(ShiftedPFCandidateProducerForNoPileUpPFMEt);
 
 
- 
+

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForNoPileUpPFMEt.h
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForNoPileUpPFMEt.h
@@ -3,10 +3,10 @@
 
 /** \class ShiftedPFCandidateProducerForNoPileUpPFMEt
  *
- * Vary energy of PFCandidates which are (are not) within jets of Pt > 10 GeV 
+ * Vary energy of PFCandidates which are (are not) within jets of Pt > 10 GeV
  * by jet energy uncertainty (by 10% "unclustered" energy uncertainty)
  *
- * NOTE: Auxiliary class specific to estimating systematic uncertainty 
+ * NOTE: Auxiliary class specific to estimating systematic uncertainty
  *       on PFMET reconstructed by no-PU MET reconstruction algorithm
  *      (implemented in JetMETCorrections/Type1MET/src/NoPileUpPFMETProducer.cc)
  *
@@ -31,25 +31,29 @@
 #include "CondFormats/JetMETObjects/interface/JetCorrectionUncertainty.h"
 
 #include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/JetReco/interface/PFJetCollection.h"
 
 #include <string>
 #include <vector>
 
-class ShiftedPFCandidateProducerForNoPileUpPFMEt : public edm::EDProducer  
+class ShiftedPFCandidateProducerForNoPileUpPFMEt : public edm::EDProducer
 {
  public:
 
   explicit ShiftedPFCandidateProducerForNoPileUpPFMEt(const edm::ParameterSet&);
   ~ShiftedPFCandidateProducerForNoPileUpPFMEt();
-    
+
  private:
 
   void produce(edm::Event&, const edm::EventSetup&);
 
   std::string moduleLabel_;
 
-  edm::InputTag srcPFCandidates_; 
-  edm::InputTag srcJets_;
+  edm::EDGetTokenT<reco::PFCandidateCollection> srcPFCandidatesToken_;
+  edm::EDGetTokenT<reco::PFJetCollection>       srcJetsToken_;
 
   edm::FileInPath jetCorrInputFileName_;
   std::string jetCorrPayloadName_;
@@ -60,12 +64,12 @@ class ShiftedPFCandidateProducerForNoPileUpPFMEt : public edm::EDProducer
   double minJetPt_;
 
   double shiftBy_;
-  
+
   double unclEnUncertainty_;
 };
 
 #endif
 
 
- 
+
 

--- a/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFMEtMVA.h
+++ b/PhysicsTools/PatUtils/plugins/ShiftedPFCandidateProducerForPFMEtMVA.h
@@ -6,7 +6,7 @@
  * Vary energy of PFCandidates coinciding in eta-phi with selected electrons/muons/tau-jets/jets
  * by electron/muon/tau-jet/jet energy uncertainty.
  *
- * NOTE: Auxiliary class specific to estimating systematic uncertainty 
+ * NOTE: Auxiliary class specific to estimating systematic uncertainty
  *       on PFMET reconstructed by MVA-based algorithm
  *      (implemented in RecoMET/METProducers/src/PFMETProducerMVA.cc)
  *
@@ -22,34 +22,38 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
+#include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 
 #include <string>
 #include <vector>
 
-class ShiftedPFCandidateProducerForPFMEtMVA : public edm::EDProducer  
+class ShiftedPFCandidateProducerForPFMEtMVA : public edm::EDProducer
 {
  public:
 
   explicit ShiftedPFCandidateProducerForPFMEtMVA(const edm::ParameterSet&);
   ~ShiftedPFCandidateProducerForPFMEtMVA();
-    
+
  private:
+  typedef edm::View<reco::Candidate> CandidateView;
 
   void produce(edm::Event&, const edm::EventSetup&);
 
   std::string moduleLabel_;
 
-  edm::InputTag srcPFCandidates_; 
-  edm::InputTag srcUnshiftedObjects_; 
-  edm::InputTag srcShiftedObjects_; 
+  edm::EDGetTokenT<reco::PFCandidateCollection> srcPFCandidatesToken_;
+  edm::EDGetTokenT<CandidateView>               srcUnshiftedObjectsToken_;
+  edm::EDGetTokenT<CandidateView>               srcShiftedObjectsToken_;
 
   double dRmatch_PFCandidate_;
   double dRmatch_Object_;
 
   struct objectEntryType
   {
-    objectEntryType(const reco::Candidate::LorentzVector& shiftedObjectP4, 
+    objectEntryType(const reco::Candidate::LorentzVector& shiftedObjectP4,
 		    const reco::Candidate::LorentzVector& unshiftedObjectP4, double dRmatch)
       : shiftedObjectP4_(shiftedObjectP4),
 	unshiftedObjectP4_(unshiftedObjectP4),
@@ -75,5 +79,5 @@ class ShiftedPFCandidateProducerForPFMEtMVA : public edm::EDProducer
 #endif
 
 
- 
+
 

--- a/PhysicsTools/PatUtils/plugins/ShiftedParticleMETcorrInputProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedParticleMETcorrInputProducer.cc
@@ -1,31 +1,25 @@
 #include "PhysicsTools/PatUtils/plugins/ShiftedParticleMETcorrInputProducer.h"
 
-#include "DataFormats/Common/interface/View.h"
-#include "DataFormats/Candidate/interface/Candidate.h"
-
 ShiftedParticleMETcorrInputProducer::ShiftedParticleMETcorrInputProducer(const edm::ParameterSet& cfg)
   : moduleLabel_(cfg.getParameter<std::string>("@module_label"))
+  , srcOriginalToken_(consumes<CandidateView>(cfg.getParameter<edm::InputTag>("srcOriginal")))
+  , srcShiftedToken_(consumes<CandidateView>(cfg.getParameter<edm::InputTag>("srcShifted")))
 {
-  srcOriginal_ = cfg.getParameter<edm::InputTag>("srcOriginal");
-  srcShifted_ = cfg.getParameter<edm::InputTag>("srcShifted");
-  
   produces<CorrMETData>();
 }
- 
+
 ShiftedParticleMETcorrInputProducer::~ShiftedParticleMETcorrInputProducer()
 {
 // nothing to be done yet...
 }
-    
+
 void ShiftedParticleMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 {
-  typedef edm::View<reco::Candidate> CandidateView;
-
   edm::Handle<CandidateView> originalParticles;
-  evt.getByLabel(srcOriginal_, originalParticles);
+  evt.getByToken(srcOriginalToken_, originalParticles);
 
   edm::Handle<CandidateView> shiftedParticles;
-  evt.getByLabel(srcShifted_, shiftedParticles);
+  evt.getByToken(srcShiftedToken_, shiftedParticles);
 
   std::auto_ptr<CorrMETData> metCorrection(new CorrMETData());
 
@@ -49,5 +43,5 @@ void ShiftedParticleMETcorrInputProducer::produce(edm::Event& evt, const edm::Ev
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 DEFINE_FWK_MODULE(ShiftedParticleMETcorrInputProducer);
- 
+
 

--- a/PhysicsTools/PatUtils/plugins/ShiftedParticleMETcorrInputProducer.h
+++ b/PhysicsTools/PatUtils/plugins/ShiftedParticleMETcorrInputProducer.h
@@ -18,29 +18,32 @@
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "DataFormats/METReco/interface/CorrMETData.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
 
 #include <string>
 #include <vector>
 
-class ShiftedParticleMETcorrInputProducer : public edm::EDProducer  
+class ShiftedParticleMETcorrInputProducer : public edm::EDProducer
 {
  public:
 
   explicit ShiftedParticleMETcorrInputProducer(const edm::ParameterSet&);
   ~ShiftedParticleMETcorrInputProducer();
-    
+
  private:
+  typedef edm::View<reco::Candidate> CandidateView;
 
   void produce(edm::Event&, const edm::EventSetup&);
 
   std::string moduleLabel_;
 
-  edm::InputTag srcOriginal_;
-  edm::InputTag srcShifted_;
+  edm::EDGetTokenT<CandidateView> srcOriginalToken_;
+  edm::EDGetTokenT<CandidateView> srcShiftedToken_;
 };
 
 #endif
 
 
- 
+
 

--- a/PhysicsTools/PatUtils/plugins/SmearedPATJetProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/SmearedPATJetProducer.cc
@@ -16,7 +16,7 @@ namespace SmearedJetProducer_namespace
   {
     public:
 
-     GenJetMatcherT(const edm::ParameterSet& cfg)
+     GenJetMatcherT(const edm::ParameterSet& cfg, edm::ConsumesCollector && iC)
        : dRmaxGenJetMatch_(0)
      {
        TString dRmaxGenJetMatch_formula = cfg.getParameter<std::string>("dRmaxGenJetMatch").data();
@@ -33,7 +33,7 @@ namespace SmearedJetProducer_namespace
        const reco::GenJet* retVal = 0;
 
        // CV: apply matching criterion which is tighter than PAT default,
-       //     in order to avoid "accidental" matches for which the difference between genJetPt and recJetPt is large 
+       //     in order to avoid "accidental" matches for which the difference between genJetPt and recJetPt is large
        //    (the large effect of such bad matches on the MEt smearing is "unphysical",
        //     because the large difference between genJetPt and recJetPt results from the matching
        //     and not from the particle/jet reconstruction)
@@ -43,12 +43,12 @@ namespace SmearedJetProducer_namespace
 	 double dR = deltaR(jet.p4(), genJet->p4());
 	 if ( dR < dRmaxGenJetMatch_->Eval(genJet->pt()) ) retVal = genJet;
        }
-       
+
        return retVal;
      }
 
     private:
-    
+
      TFormula* dRmaxGenJetMatch_;
   };
 
@@ -57,7 +57,7 @@ namespace SmearedJetProducer_namespace
   {
     public:
 
-     JetResolutionExtractorT(const edm::ParameterSet& cfg) 
+     JetResolutionExtractorT(const edm::ParameterSet& cfg)
        : jetResolutions_(cfg)
      {}
      ~JetResolutionExtractorT() {}

--- a/PhysicsTools/PatUtils/src/LeptonJetIsolationAngle.cc
+++ b/PhysicsTools/PatUtils/src/LeptonJetIsolationAngle.cc
@@ -1,6 +1,3 @@
-//
-//
-
 #include "PhysicsTools/PatUtils/interface/LeptonJetIsolationAngle.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -14,7 +11,10 @@ using namespace pat;
 
 
 // constructor
-LeptonJetIsolationAngle::LeptonJetIsolationAngle() {
+LeptonJetIsolationAngle::LeptonJetIsolationAngle(edm::ConsumesCollector && iC)
+: jetToken_( iC.consumes< reco::CaloJetCollection >( edm::InputTag( "iterativeCone5CaloJets" ) ) )
+, electronsToken_( iC.consumes< std::vector<reco::GsfElectron > >( edm::InputTag( "pixelMatchGsfElectrons" ) ) )
+{
 }
 
 
@@ -39,11 +39,11 @@ float LeptonJetIsolationAngle::calculate(const CLHEP::HepLorentzVector & aLepton
   // FIXME: this is an ugly temporary workaround, JetMET+egamma should come up with a better tool
   // retrieve the jets
   edm::Handle<reco::CaloJetCollection> jetHandle;
-  iEvent.getByLabel("iterativeCone5CaloJets", jetHandle);
+  iEvent.getByToken(jetToken_, jetHandle);
   reco::CaloJetCollection jetColl = *(jetHandle.product());
   // retrieve the electrons which might be in the jet list
   edm::Handle<std::vector<reco::GsfElectron> > electronsHandle;
-  iEvent.getByLabel("pixelMatchGsfElectrons", electronsHandle);
+  iEvent.getByToken(electronsToken_, electronsHandle);
   std::vector<reco::GsfElectron> electrons = *electronsHandle;
   // determine the set of isolated electrons
   std::vector<Electron> isoElectrons;

--- a/PhysicsTools/PatUtils/src/LeptonVertexSignificance.cc
+++ b/PhysicsTools/PatUtils/src/LeptonVertexSignificance.cc
@@ -1,6 +1,3 @@
-//
-//
-
 #include "PhysicsTools/PatUtils/interface/LeptonVertexSignificance.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -10,9 +7,7 @@
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "TrackingTools/TransientTrack/interface/TransientTrack.h"
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "DataFormats/GsfTrackReco/interface/GsfTrack.h" 
+#include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/PatCandidates/interface/Electron.h"
@@ -21,7 +16,9 @@
 using namespace pat;
 
 // constructor
-LeptonVertexSignificance::LeptonVertexSignificance(const edm::EventSetup & iSetup) {
+LeptonVertexSignificance::LeptonVertexSignificance(const edm::EventSetup & iSetup, edm::ConsumesCollector && iC)
+: vertexToken_( iC.consumes< reco::VertexCollection >( edm::InputTag( "offlinePrimaryVerticesFromCTFTracks" ) ) )
+{
   // instantiate the transient-track builder
   edm::ESHandle<TransientTrackBuilder> builder;
   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", builder);
@@ -47,7 +44,7 @@ float LeptonVertexSignificance::calculate(const reco::Track & theTrack, const ed
   // FIXME: think more about how to handle events without vertices
   // lepton LR calculation should have nothing to do with event selection
   edm::Handle<reco::VertexCollection> vertexHandle;
-  iEvent.getByLabel("offlinePrimaryVerticesFromCTFTracks", vertexHandle);
+  iEvent.getByToken(vertexToken_, vertexHandle);
   if (vertexHandle.product()->size() == 0) return 0;
   reco::Vertex theVertex = vertexHandle.product()->front();
   // calculate the track-vertex association significance


### PR DESCRIPTION
Migration of the PAT to 'consumes'/'getByToken'-API.
