### PR TITLE
Fix bug in drawing DT simhits + improvements

### DIFF
--- a/Fireworks/Muons/plugins/FWDTSegmentProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWDTSegmentProxyBuilder.cc
@@ -114,21 +114,27 @@ FWDTSegmentProxyBuilder::buildViewType( const DTRecSegment4D& iData,
       std::vector<DTRecHit1D> recHits;
       const DTChamberRecSegment2D* phiSeg = iData.phiSegment();      
       const DTSLRecSegment2D* zSeg = iData.zSegment();
-      if (type == FWViewType::kRhoPhi && phiSeg) {
-	recHits = phiSeg->specificRecHits();
+      if (phiSeg) {
+	std::vector<DTRecHit1D> phiRecHits = phiSeg->specificRecHits();
+	copy(phiRecHits.begin(), phiRecHits.end(), back_inserter(recHits));
       }
-      if (type == FWViewType::kRhoZ && zSeg) {
-	recHits = zSeg->specificRecHits();
+      if (zSeg) {
+	std::vector<DTRecHit1D> zRecHits = zSeg->specificRecHits();
+	copy(zRecHits.begin(), zRecHits.end(), back_inserter(recHits));
       }
 
       for (std::vector<DTRecHit1D>::const_iterator rh=recHits.begin(); rh!=recHits.end(); ++rh){
 	DTLayerId layerId = (*rh).wireId().layerId();
 	LocalPoint hpos = (*rh).localPosition();
 	float hitLocalPos[3]= {hpos.x(), hpos.y(), hpos.z()};
-	if (layerId.superLayer()==2 && type == FWViewType::kRhoZ) {
-	  // In RhoZ view, draw theta SL hits at the middle of the chamber, otherwise they won't align with 1D rechits, 
-	  // for which only one coordinate is known.
-	  hitLocalPos[1]=0;
+	if (type == FWViewType::kRhoZ) {
+	  // In RhoZ view, draw hits at the middle of the layer in the global Z coordinate,
+	  // otherwise they won't align with 1D rechits, for which only one coordinate is known.
+	  if (layerId.superLayer()==2) {
+	    hitLocalPos[1]=0;
+	  } else {
+	    hitLocalPos[0]=0;
+	  }
 	}
 	float hitGlobalPoint[3];
 	geom->localToGlobal(layerId, hitLocalPos, hitGlobalPoint);

--- a/Fireworks/SimData/plugins/FWPSimHitProxyBuilder.cc
+++ b/Fireworks/SimData/plugins/FWPSimHitProxyBuilder.cc
@@ -11,6 +11,7 @@
 #include "Fireworks/Core/interface/FWGeometry.h"
 #include "Fireworks/Core/interface/fwLog.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
+#include <DataFormats/MuonDetId/interface/DTWireId.h>
 
 #include "TEvePointSet.h"
 
@@ -20,6 +21,8 @@ public:
    FWPSimHitProxyBuilder( void ) {} 
    virtual ~FWPSimHitProxyBuilder( void ) {}
 
+   virtual bool haveSingleProduct() const override { return false; }
+
    REGISTER_PROXYBUILDER_METHODS();
 
 private:
@@ -28,11 +31,11 @@ private:
    // Disable default assignment operator
    const FWPSimHitProxyBuilder& operator=( const FWPSimHitProxyBuilder& );
 
-   void build( const PSimHit& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext* ) override;
+   void buildViewType( const PSimHit& iData, unsigned int iIndex, TEveElement& oItemHolder, FWViewType::EType type, const FWViewContext* ) override;
 };
 
 void
-FWPSimHitProxyBuilder::build( const PSimHit& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext* )
+FWPSimHitProxyBuilder::buildViewType( const PSimHit& iData, unsigned int iIndex, TEveElement& oItemHolder, FWViewType::EType type, const FWViewContext* )
 {
    TEvePointSet* pointSet = new TEvePointSet;
    setupAddElement( pointSet, &oItemHolder );
@@ -48,6 +51,26 @@ FWPSimHitProxyBuilder::build( const PSimHit& iData, unsigned int iIndex, TEveEle
    
    float local[3] = { iData.localPosition().x(), iData.localPosition().y(), iData.localPosition().z() };
    float global[3];
+
+   // Specialized for DT simhits
+   DetId id(rawid);
+   if (id.det()==DetId::Muon && id.subdetId()==1) {   
+     DTWireId wId(rawid);
+     rawid = wId.layerId().rawId(); // DT simhits are in the RF of the DTLayer, but their ID is the id of the wire!
+     if (abs(iData.particleType())!=13){
+       pointSet->SetMarkerStyle(26); // Draw non-muon simhits (e.g. delta rays) with a different marker
+     } 
+     if (type == FWViewType::kRhoZ) { // 
+       // In RhoZ view, draw hits at the middle of the layer in the global Z coordinate, 
+       // otherwise they won't align with 1D rechits, for which only one coordinate is known.
+       if (wId.superLayer()==2) {
+	 local[1]=0;
+       } else {
+	 local[0]=0;
+       }
+     }
+   }
+
    geom->localToGlobal( rawid, local, global );
    pointSet->SetNextPoint( global[0], global[1], global[2] );
 }


### PR DESCRIPTION
The detid returned by the simhit is the wire ID, but the position is in the ref fame of the DTLayer. This was not taken into account so the simhits were drawn in random places. An example before the fix (green=simhits, blue=reconstructed segments): 
![vis_before_2](https://f.cloud.github.com/assets/5168720/1377337/7036ce48-3aa5-11e3-98ff-6b1a81c11914.png)

After the fix the simhits are correctly aligned:
![vis_after_2](https://f.cloud.github.com/assets/5168720/1377338/77e7708e-3aa5-11e3-85b9-076c45604548.png)

Also: 
-Fix DT simhits in RhoZ view, so that they are displayed aligned to 1D rechits. 
-Draw rechits associated to segments also in the 3D view.
