### PR TITLE
add isolation for electrons and muons from "boosted" tau -> e and tau ->...

### DIFF
--- a/PhysicsTools/IsolationAlgos/interface/EventDependentAbsVetos.h
+++ b/PhysicsTools/IsolationAlgos/interface/EventDependentAbsVetos.h
@@ -55,6 +55,51 @@ namespace reco {
           std::vector<Direction> items_;
           std::auto_ptr<AbsVeto> veto_;
     };
+
+    class OtherJetConstituentsDeltaRVeto : public EventDependentAbsVeto {
+      public:
+          //! Create a veto specifying the input collection of the jets, the candidates, and the deltaR
+          OtherJetConstituentsDeltaRVeto(Direction dir, const edm::InputTag& jets, double dRjet, const edm::InputTag& pfCandAssocMap, double dRconstituent) 
+	    : evt_(0),
+	      vetoDir_(dir), 
+	      srcJets_(jets), 
+	      dR2jet_(dRjet*dRjet), 
+	      srcPFCandAssocMap_(pfCandAssocMap), 
+	      dR2constituent_(dRconstituent*dRconstituent) 
+	  { 
+	    //std::cout << "<OtherJetConstituentsDeltaRVeto::OtherJetConstituentsDeltaRVeto>:" << std::endl;
+	    //std::cout << " vetoDir: eta = " << vetoDir_.eta() << ", phi = " << vetoDir_.phi() << std::endl;
+	    //std::cout << " srcJets = " << srcJets_.label() << ":" << srcJets_.instance() << std::endl;
+	    //std::cout << " dRjet = " << sqrt(dR2jet_) << std::endl;
+	    //std::cout << " srcPFCandAssocMap = " << srcPFCandAssocMap_.label() << ":" << srcPFCandAssocMap_.instance() << std::endl;
+	    //std::cout << " dRconstituent = " << sqrt(dR2constituent_) << std::endl;
+	  }
+   
+          // Virtual destructor (should always be there) 
+          virtual ~OtherJetConstituentsDeltaRVeto() {} 
+
+          //! Return "true" if a deposit at specific (eta,phi) with that value must be vetoed in the sum
+          //! This is true if the deposit is within the stored AbsVeto of any item of the source collection
+          virtual bool veto(double eta, double phi, float value) const;
+
+          //! Set axis for matching jets
+          virtual void centerOn(double eta, double phi);
+
+          //! Picks up the directions of the given candidates
+          virtual void setEvent(const edm::Event& evt, const edm::EventSetup& es);
+
+      private:
+	  void initialize();
+
+	  const edm::Event* evt_;
+
+	  Direction vetoDir_; 
+          edm::InputTag srcJets_;
+	  double dR2jet_;
+	  edm::InputTag srcPFCandAssocMap_;
+	  double dR2constituent_;
+          std::vector<Direction> items_;
+    };     
  }
 }
 #endif

--- a/PhysicsTools/IsolationAlgos/src/IsoDepositVetoFactory.cc
+++ b/PhysicsTools/IsolationAlgos/src/IsoDepositVetoFactory.cc
@@ -96,10 +96,14 @@ IsoDepositVetoFactory::make(const char *string, reco::isodeposit::EventDependent
         numCrystal("NumCrystalVeto\\((\\d+\\.\\d+)\\)"),
         numCrystalEtaPhi("NumCrystalEtaPhiVeto\\((\\d+\\.\\d+),(\\d+\\.\\d+)\\)"),
         otherCandidatesDR("OtherCandidatesByDR\\((\\w+:?\\w*:?\\w*),\\s*(\\d+\\.?|\\d*\\.\\d*)\\)"),
+        otherJetConstituentsDR("OtherJetConstituentsDeltaRVeto\\((\\w+:?\\w*:?\\w*),\\s*(\\d+\\.?|\\d*\\.\\d*),\\s*(\\w+:?\\w*:?\\w*),\\s*(\\d+\\.?|\\d*\\.\\d*)\\)"),
         otherCand("^(.*?):(.*)"),
         number("^(\\d+\\.?|\\d*\\.\\d*)$");
     boost::cmatch match;
     
+    //std::cout << "<IsoDepositVetoFactory::make>:" << std::endl;
+    //std::cout << " string = " << string << std::endl;
+
     evdep = 0; // by default it does not depend on this
     if (regex_match(string, match, ecalSwitch)) {
         return new SwitchingEcalVeto(make(match[2].first), (match[1] == "Barrel") );
@@ -130,6 +134,12 @@ IsoDepositVetoFactory::make(const char *string, reco::isodeposit::EventDependent
     } else if (regex_match(string, match, otherCandidatesDR)) {
         OtherCandidatesDeltaRVeto *ret = new OtherCandidatesDeltaRVeto(edm::InputTag(match[1]), 
                                                                         atof(match[2].first));
+        evdep = ret;
+        return ret;    
+    } else if (regex_match(string, match, otherJetConstituentsDR)) {
+        OtherJetConstituentsDeltaRVeto *ret = new OtherJetConstituentsDeltaRVeto(Direction(), 
+						   edm::InputTag(match[1]), atof(match[2].first),
+						   edm::InputTag(match[3]), atof(match[4].first));
         evdep = ret;
         return ret;
     } else if (regex_match(string, match, otherCand)) {


### PR DESCRIPTION
add isolation for electrons and muons from "boosted" tau -> e and tau -> mu decays:
need to exclude subjet representing 2nd tau when computing isolation of e/mu produced in decay of 1st tau
(this time with rebase to CMSSW_7_0_X branch)
