### PR TITLE
Missing virtual destructor

### DIFF
--- a/CondFormats/L1TObjects/interface/L1MuPacking.h
+++ b/CondFormats/L1TObjects/interface/L1MuPacking.h
@@ -31,6 +31,7 @@
 
 class L1MuPacking {
  public:
+  virtual ~L1MuPacking() {}
   /// get the sign from the packed notation (0=positive, 1=negative)
   virtual int signFromPacked(unsigned packed) const = 0;
   /// get the value from the packed notation


### PR DESCRIPTION
The class L1MuPacking is an abstract base class with all functions virtual.  However, it does not have a virtual destructor, as it should.  This will likely not cause splitting, because the class has no data members.  However, it does prevent the ROOT6 dictionary from compiling.

This pull request adds the missing virtual destructor.
