### PR TITLE
Root6 cannot create dictionary for nested private structs (yet again)

### DIFF
--- a/Fireworks/Core/interface/CmsShowMainBase.h
+++ b/Fireworks/Core/interface/CmsShowMainBase.h
@@ -123,7 +123,6 @@ public:
 
    void setAutoSaveAllViewsFormat(const std::string& fmt) { m_autoSaveAllViewsFormat = fmt; }
 
-protected: 
    class SignalTimer : public TTimer {
    public:
       virtual Bool_t Notify() {
@@ -133,6 +132,7 @@ protected:
       sigc::signal<void> timeout_;
    };
 
+protected: 
    void eventChangedSlot();
    virtual void eventChangedImp();
    void sendVersionInfo();

--- a/Fireworks/Core/interface/FWDetailViewManager.h
+++ b/Fireworks/Core/interface/FWDetailViewManager.h
@@ -39,16 +39,6 @@ public:
    void newEventCallback();
    void eveWindowDestroyed(TEveWindow*);
 
-protected:
-   FWColorManager                *m_colorManager;
-
-private:
-
-   FWDetailViewManager(const FWDetailViewManager&);    // stop default
-   const FWDetailViewManager& operator=(const FWDetailViewManager&);    // stop default
-
-   std::vector<std::string> findViewersFor(const std::string&) const;
-
    struct ViewFrame 
    {
       TEveCompositeFrameInMainFrame *m_eveFrame;
@@ -58,6 +48,16 @@ private:
       ViewFrame(TEveCompositeFrameInMainFrame *f, FWDetailViewBase* v, TEveWindow* w):
          m_eveFrame(f), m_detailView(v), m_eveWindow(w) {}
    };
+
+protected:
+   FWColorManager                *m_colorManager;
+
+private:
+
+   FWDetailViewManager(const FWDetailViewManager&);    // stop default
+   const FWDetailViewManager& operator=(const FWDetailViewManager&);    // stop default
+
+   std::vector<std::string> findViewersFor(const std::string&) const;
 
    typedef std::vector<ViewFrame> vViews_t;
    typedef vViews_t::iterator     vViews_i;

--- a/Fireworks/Core/interface/FWEveViewManager.h
+++ b/Fireworks/Core/interface/FWEveViewManager.h
@@ -42,7 +42,7 @@ typedef std::set<FWModelId> FWModelIds;
 
 class FWEveViewManager : public FWViewManagerBase
 {
-private:
+public:
    struct BuilderInfo
    {
       std::string m_name;
@@ -54,7 +54,6 @@ private:
       {}
    };
 
-public:
    FWEveViewManager(FWGUIManager*);
    virtual ~FWEveViewManager();
 


### PR DESCRIPTION
This pull request covers only Fireworks/Core, which was missed in the previous pull requests for this issue.

ROOT 6 cannot create a dictionary for any class that has a private nested class/struct definition.
This pull request makes all nested class/struct definitions public for classes for which there is a dictionary specification.
Note that this pull request does not make any data members public. It only makes the definitions of the nested class/struct public.
This has been tested with checkdeps -a and the relval matrix.

In some cases, the declarations were moved to keep the public and private sections of the class each contiguous.
