### PR TITLE
Changed beginStream of stream module to take StreamID

### DIFF
--- a/FWCore/Framework/interface/stream/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerBase.h
@@ -59,7 +59,7 @@ namespace edm {
       
       void registerProductsAndCallbacks(EDAnalyzerBase const*, ProductRegistry* reg);
       
-      virtual void beginStream() {}
+      virtual void beginStream(StreamID) {}
       virtual void beginRun(edm::Run const&, edm::EventSetup const&) {}
       virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
       virtual void analyze(Event const&, EventSetup const&) = 0;

--- a/FWCore/Framework/interface/stream/EDFilterBase.h
+++ b/FWCore/Framework/interface/stream/EDFilterBase.h
@@ -56,7 +56,7 @@ namespace edm {
       
       const EDFilterBase& operator=(const EDFilterBase&) = delete; // stop default
       
-      virtual void beginStream() {}
+      virtual void beginStream(StreamID) {}
       virtual void beginRun(edm::Run const&, edm::EventSetup const&) {}
       virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
       virtual bool filter(Event&, EventSetup const&) = 0;

--- a/FWCore/Framework/interface/stream/EDProducerBase.h
+++ b/FWCore/Framework/interface/stream/EDProducerBase.h
@@ -56,7 +56,7 @@ namespace edm {
       
       const EDProducerBase& operator=(const EDProducerBase&) = delete; // stop default
       
-      virtual void beginStream() {}
+      virtual void beginStream(StreamID) {}
       virtual void beginRun(edm::Run const&, edm::EventSetup const&) {}
       virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) {}
       virtual void produce(Event&, EventSetup const&) = 0;

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -129,7 +129,7 @@ EDAnalyzerAdaptorBase::doBeginJob() {
 
 void
 EDAnalyzerAdaptorBase::doBeginStream(StreamID id) {
-  m_streamModules[id]->beginStream();
+  m_streamModules[id]->beginStream(id);
 }
 void
 EDAnalyzerAdaptorBase::doEndStream(StreamID id) {

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -121,7 +121,7 @@ namespace edm {
     template< typename T>
     void
     ProducingModuleAdaptorBase<T>::doBeginStream(StreamID id) {
-      m_streamModules[id]->beginStream();
+      m_streamModules[id]->beginStream(id);
     }
     template< typename T>
     void


### PR DESCRIPTION
Marco Rovere requested stream modules be able to know the StreamID to which they are associated. This is needed for the new DQM design.
