### PR TITLE
Missing include of iostream

### DIFF
--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -20,6 +20,7 @@
 #include "FWCore/Utilities/interface/DebugMacros.h"
 
 #include <cassert>
+#include <iostream>
 
 namespace edm {
 


### PR DESCRIPTION
There is a missing include of iostream which prevents compilation, unless the include is picked up elsewhere by circumstance.  This missing include prevents compilation of OutputModule.cc in the ROOT 6 environment.

This request adds the missing include to the source file. It does not touch the DebugMacros.h header.
