### PR TITLE
Fix statics DataFormats/EcalDet

### DIFF
--- a/DataFormats/EcalDetId/interface/EcalContainer.h
+++ b/DataFormats/EcalDetId/interface/EcalContainer.h
@@ -43,7 +43,7 @@ class EcalContainer {
 
                 inline Item & operator[](uint32_t rawId) {
 		  checkAndResize();
-		  static Item dummy{};
+		  static Item dummy;
 		  DetId id(rawId);
 		  if ( !isValidId(id) ) return dummy;
 		  return m_items[id.hashedIndex()];
@@ -71,9 +71,8 @@ class EcalContainer {
 		  //	  std::cout << "resizing to " << DetId::kSizeForDenseIndexing << std::endl;
                   //              m_items.resize((size_t) DetId::kSizeForDenseIndexing);
                   //      }
-                        static const Item dummy{};
                         DetId id(rawId);
-                        if ( !isValidId(id) ) return dummy;
+                        if ( !isValidId(id) ) return dummy_item();
                         return m_items[id.hashedIndex()];
                 }
 
@@ -97,6 +96,16 @@ class EcalContainer {
 
         private:
 
+		//Cint can't parse the new C++11 initialization syntax
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+
+		static const Item& dummy_item() {
+		  static const Item s_dummy{};
+		  return s_dummy;
+		}
+#else
+		static const Item& dummy_item();
+#endif
                 // not protected on EB <--> EE swap -- FIXME?
                 inline bool isValidId(const DetId id) const {
                         return id.det() == ::DetId::Ecal;

--- a/DataFormats/EcalDetId/interface/EcalContainer.h
+++ b/DataFormats/EcalDetId/interface/EcalContainer.h
@@ -43,7 +43,7 @@ class EcalContainer {
 
                 inline Item & operator[](uint32_t rawId) {
 		  checkAndResize();
-		  static Item dummy;
+		  static Item dummy{};
 		  DetId id(rawId);
 		  if ( !isValidId(id) ) return dummy;
 		  return m_items[id.hashedIndex()];
@@ -71,7 +71,7 @@ class EcalContainer {
 		  //	  std::cout << "resizing to " << DetId::kSizeForDenseIndexing << std::endl;
                   //              m_items.resize((size_t) DetId::kSizeForDenseIndexing);
                   //      }
-                        static Item dummy;
+                        static const Item dummy{};
                         DetId id(rawId);
                         if ( !isValidId(id) ) return dummy;
                         return m_items[id.hashedIndex()];

--- a/DataFormats/EcalDetId/src/EEDetId.cc
+++ b/DataFormats/EcalDetId/src/EEDetId.cc
@@ -303,7 +303,7 @@ EEDetId::isc( int jx, int jy )
       const int iCol = ( 1 == iquad || 4 == iquad ? jx - 10 : 11 - jx ) ;
       const int iRow = ( 1 == iquad || 2 == iquad ? jy - 10 : 11 - jy ) ;
 
-      static int nSCinQuadrant = ISC_MAX/4;
+      static const int nSCinQuadrant = ISC_MAX/4;
 
       const int yOff ( iYoffset[iCol] ) ;
 


### PR DESCRIPTION
Fixed items found by thread-safety checkers. This includes
-changing 'static' to 'const static' where appropriate
-using std::call_once to safely fill a static array that is only used in a 'const' way after it is filled.
