### PR TITLE
add missing include of iostream

### DIFF
--- a/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstants.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstants.cc
@@ -18,6 +18,7 @@
 
 
 // system include files
+#include <iostream>
 
 // user include files
 

--- a/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstantsMC.cc
+++ b/CalibCalorimetry/CaloMiscalibTools/plugins/WriteEcalMiscalibConstantsMC.cc
@@ -18,6 +18,7 @@
 
 
 // system include files
+#include <iostream>
 
 // user include files
 

--- a/CalibMuon/DTCalibration/interface/DTCalibDBUtils.h
+++ b/CalibMuon/DTCalibration/interface/DTCalibDBUtils.h
@@ -7,6 +7,7 @@
  *  \author G. Cerminara - INFN Torino
  */
 
+#include <iostream>
 #include <string>
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"

--- a/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.cc
@@ -5,6 +5,8 @@
  *  \author G. Cerminara - INFN Torino
  */
 
+#include <iostream>
+
 #include "DumpFileToDB.h"
 #include "DTCalibrationMap.h"
 

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalO2OManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalO2OManager.cc
@@ -10,6 +10,7 @@
 //         Created:  Sun Aug 16 20:44:05 CEST 2009
 //
 
+#include <iostream>
 
 #include "CaloOnlineTools/HcalOnlineDb/interface/HcalO2OManager.h"
 

--- a/CondCore/DBOutputService/test/stubs/IOVPayloadAnalyzer.cc
+++ b/CondCore/DBOutputService/test/stubs/IOVPayloadAnalyzer.cc
@@ -7,6 +7,7 @@
 
 
 #include "IOVPayloadAnalyzer.h"
+#include <iostream>
 
 
 IOVPayloadAnalyzer::IOVPayloadAnalyzer(const edm::ParameterSet& iConfig ):

--- a/CondCore/DBOutputService/test/stubs/IOVPayloadEndOfJob.cc
+++ b/CondCore/DBOutputService/test/stubs/IOVPayloadEndOfJob.cc
@@ -7,6 +7,7 @@
 
 #include "IOVPayloadEndOfJob.h"
 #include <cstdlib>
+#include <iostream>
 
 IOVPayloadEndOfJob::IOVPayloadEndOfJob(const edm::ParameterSet& iConfig ):
   m_record(iConfig.getParameter< std::string >("record")){

--- a/CondCore/DBOutputService/test/stubs/MyDataAnalyzer.cc
+++ b/CondCore/DBOutputService/test/stubs/MyDataAnalyzer.cc
@@ -12,6 +12,7 @@
 
 #include "MyDataAnalyzer.h"
 #include <cstdlib>
+#include <iostream>
 MyDataAnalyzer::MyDataAnalyzer(const edm::ParameterSet& iConfig ):
   m_record(iConfig.getParameter< std::string >("record")),
   m_LoggingOn(false){

--- a/CondCore/DBOutputService/test/stubs/Timestamp.cc
+++ b/CondCore/DBOutputService/test/stubs/Timestamp.cc
@@ -6,6 +6,7 @@
 #include "CondFormats/Calibration/interface/Pedestals.h"
 
 #include "Timestamp.h"
+#include <iostream>
 
 Timestamp::Timestamp(const edm::ParameterSet& iConfig ):
   m_record(iConfig.getParameter< std::string >("record")){

--- a/CondCore/DBOutputService/test/stubs/writeBlobComplex.cc
+++ b/CondCore/DBOutputService/test/stubs/writeBlobComplex.cc
@@ -5,6 +5,7 @@
 #include "CondFormats/Calibration/interface/BlobComplex.h"
 #include "writeBlobComplex.h"
 
+#include <iostream>
 
 writeBlobComplex::writeBlobComplex(const edm::ParameterSet& iConfig):
   m_RecordName("BlobComplexRcd")

--- a/CondCore/DBOutputService/test/stubs/writeKeyed.cc
+++ b/CondCore/DBOutputService/test/stubs/writeKeyed.cc
@@ -1,4 +1,5 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
+#include <iostream>
 #include <string>
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"

--- a/CondCore/DTPlugins/src/DTConfigPluginHandler.cc
+++ b/CondCore/DTPlugins/src/DTConfigPluginHandler.cc
@@ -1,8 +1,6 @@
 /*
  *  See header file for a description of this class.
  *
- *  $Date: 2011/06/06 17:23:42 $
- *  $Revision: 1.3 $
  *  \author Paolo Ronchese INFN Padova
  *
  */
@@ -28,8 +26,8 @@
 //---------------
 // C++ Headers --
 //---------------
-//#include <iostream>
 #include <cstdio>
+#include <iostream>
 
 //-------------------
 // Initializations --

--- a/CondCore/ESSources/test/testWriteCondData.cpp
+++ b/CondCore/ESSources/test/testWriteCondData.cpp
@@ -7,6 +7,7 @@
 #include "CondFormats/Calibration/interface/Pedestals.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
+#include <iostream>
 
 int main(){
   try{

--- a/CondCore/ESSources/test/writeBasicData.cpp
+++ b/CondCore/ESSources/test/writeBasicData.cpp
@@ -7,6 +7,7 @@
 #include "CondFormats/Calibration/interface/Pedestals.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
+#include <iostream>
 
 int main(){
   try{

--- a/CondCore/IOVService/test/testqueryPContainer.cc
+++ b/CondCore/IOVService/test/testqueryPContainer.cc
@@ -6,6 +6,7 @@
 #include "CondCore/DBCommon/interface/DbTransaction.h"
 #include "CondCore/IOVService/interface/IOVEditor.h"
 #include "testPayloadObj.h"
+#include <iostream>
 int main(){
   edmplugin::PluginManager::Config config;
   try{

--- a/CondCore/ORA/bin/ora_database_manager.cpp
+++ b/CondCore/ORA/bin/ora_database_manager.cpp
@@ -11,6 +11,7 @@
 #include <fstream>
 #include <iomanip>
 #include <cstdlib>
+#include <iostream>
 
 // externals
 #include "CoralCommon/CommandLine.h"

--- a/CondCore/ORA/test/TestBase.h
+++ b/CondCore/ORA/test/TestBase.h
@@ -4,6 +4,7 @@
 #include "CondCore/ORA/interface/SchemaUtils.h"
 #include "CondCore/ORA/interface/Exception.h"
 #include <cstdlib>
+#include <iostream>
 //
 
 namespace ora {

--- a/CondCore/Utilities/bin/cmscond_export_database.cpp
+++ b/CondCore/Utilities/bin/cmscond_export_database.cpp
@@ -17,6 +17,8 @@
 #include "CoralBase/Attribute.h"
 #include "CoralBase/AttributeList.h"
 
+#include <iostream>
+
 namespace cond {
   class ExportAccountUtilities : public Utilities {
     public:

--- a/CondCore/Utilities/src/Utilities.cc
+++ b/CondCore/Utilities/src/Utilities.cc
@@ -13,6 +13,7 @@
 #include "CondCore/ORA/interface/SharedLibraryName.h"
 #include <boost/foreach.hpp>                   
 #include <fstream>
+#include <iostream>
 
 #include "CondCore/DBCommon/interface/Auth.h"
 

--- a/CondTools/DT/src/DTKeyedConfigHandler.cc
+++ b/CondTools/DT/src/DTKeyedConfigHandler.cc
@@ -1,8 +1,6 @@
 /*
  *  See header file for a description of this class.
  *
- *  $Date: 2011/05/18 16:20:14 $
- *  $Revision: 1.8 $
  *  \author Paolo Ronchese INFN Padova
  *
  */
@@ -38,6 +36,7 @@
 // C++ Headers --
 //---------------
 
+#include <iostream>
 
 //-------------------
 // Initializations --

--- a/CondTools/DT/src/DTLVStatusHandler.cc
+++ b/CondTools/DT/src/DTLVStatusHandler.cc
@@ -1,8 +1,6 @@
 /*
  *  See header file for a description of this class.
  *
- *  $Date: 2010/07/21 16:06:53 $
- *  $Revision: 1.4 $
  *  \author Paolo Ronchese INFN Padova
  *
  */
@@ -32,6 +30,7 @@
 // C++ Headers --
 //---------------
 
+#include <iostream>
 
 //-------------------
 // Initializations --

--- a/CondTools/DT/src/DTUserKeyedConfigHandler.cc
+++ b/CondTools/DT/src/DTUserKeyedConfigHandler.cc
@@ -1,8 +1,6 @@
 /*
  *  See header file for a description of this class.
  *
- *  $Date: 2010/07/21 16:06:53 $
- *  $Revision: 1.7 $
  *  \author Paolo Ronchese INFN Padova
  *
  */
@@ -38,6 +36,7 @@
 // C++ Headers --
 //---------------
 
+#include <iostream>
 
 //-------------------
 // Initializations --

--- a/CondTools/L1Trigger/plugins/L1GtRunSettingsViewer.cc
+++ b/CondTools/L1Trigger/plugins/L1GtRunSettingsViewer.cc
@@ -18,6 +18,7 @@
 
 
 // system include files
+#include <iostream>
 #include <memory>
 #include <sstream>
 

--- a/CondTools/L1Trigger/plugins/L1O2OTestAnalyzer.cc
+++ b/CondTools/L1Trigger/plugins/L1O2OTestAnalyzer.cc
@@ -13,12 +13,12 @@
 //
 // Original Author:  Werner Man-Li Sun
 //         Created:  Thu Nov  6 23:00:43 CET 2008
-// $Id: L1O2OTestAnalyzer.cc,v 1.6 2009/12/17 23:43:58 wmtan Exp $
 //
 //
 
 
 // system include files
+#include <iostream>
 #include <memory>
 #include <sstream>
 

--- a/CondTools/SiPixel/test/SiPixelCPEGenericErrorParmUploader.cc
+++ b/CondTools/SiPixel/test/SiPixelCPEGenericErrorParmUploader.cc
@@ -4,6 +4,7 @@
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
+#include <iostream>
 
 SiPixelCPEGenericErrorParmUploader::SiPixelCPEGenericErrorParmUploader(const edm::ParameterSet& iConfig):
 	theFileName( iConfig.getParameter<edm::FileInPath>("fileName") ),

--- a/L1TriggerConfig/RCTConfigProducers/src/L1RCTChannelMaskOnlineProd.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/L1RCTChannelMaskOnlineProd.cc
@@ -19,6 +19,7 @@
 
 
 // system include files
+#include <iostream>
 
 // user include files
 #include "CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h"

--- a/L1TriggerConfig/RCTConfigProducers/src/RCTObjectKeysOnlineProd.cc
+++ b/L1TriggerConfig/RCTConfigProducers/src/RCTObjectKeysOnlineProd.cc
@@ -18,6 +18,7 @@
 
 
 // system include files
+#include <iostream>
 
 // user include files
 #include "CondTools/L1Trigger/interface/L1ObjectKeysOnlineProdBase.h"

--- a/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSRCondTools.cc
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSRCondTools.cc
@@ -19,6 +19,7 @@
 
 #include <string>
 #include <fstream>
+#include <iostream>
 #include <algorithm>
 
 constexpr int tccNum[12][12] = {


### PR DESCRIPTION
While working with ROOT6, I discovered 28 more CMSSW files that failed to compile because of a missing include of iostream.  This pull request adds the missing include to each of these files.  It also removes any remaining CVS tokens (e.g. $Id) in these files only.
Tested with checkdeps -a and the relvals.
Note, two of the affected files are header files, but cout is used explicitly in both headers, so the include is needed for the header to compile.
Please include this trivial technical fix in CMSSW_7_0_0_pre7, bypassing signatures if necessary to make pre7.
