### PR TITLE
Changed static used in RefHolderBase to ‘const static’

### DIFF
--- a/DataFormats/Common/interface/RefHolderBase.h
+++ b/DataFormats/Common/interface/RefHolderBase.h
@@ -67,7 +67,7 @@ namespace edm {
     T const*
     RefHolderBase::getPtr() const
     {
-      static TypeWithDict s_type(typeid(T));
+      static const TypeWithDict s_type(typeid(T));
       return static_cast<T const*>(pointerToType(s_type));
     }
 


### PR DESCRIPTION
This change will stop the static analyzer from complaining about this code.
