### PR TITLE
Add missing include of iostream

### DIFF
--- a/CondCore/ESSources/test/writeExtraData.cpp
+++ b/CondCore/ESSources/test/writeExtraData.cpp
@@ -7,6 +7,7 @@
 #include "CondFormats/Calibration/interface/Pedestals.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
+#include <iostream>
 
 int main(){
   try{


### PR DESCRIPTION
In the previous pull request to add missing includes of iostream, I missed one file.  Add missing include of iostream so that the file will compile against ROOT6.

Please merge this before the CMSSW_7_0_0_pre7 deadline, bypassing signatures if necessary.
