### PR TITLE
Remove unneeded statics.

### DIFF
--- a/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftAlgo.cc
+++ b/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftAlgo.cc
@@ -197,19 +197,3 @@ bool DTLinearDriftAlgo::compute(const DTLayer* layer,
     return false;
   }
 }
-
-
-float DTLinearDriftAlgo::vDrift;
-//float DTLinearDriftAlgo::vDriftMB1W1;
-
-  
-float DTLinearDriftAlgo::hitResolution;
-
-  
-float DTLinearDriftAlgo::minTime;
-
-  
-float DTLinearDriftAlgo::maxTime;
-
-  
-bool DTLinearDriftAlgo::debug;

--- a/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftAlgo.h
+++ b/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftAlgo.h
@@ -81,21 +81,21 @@ class DTLinearDriftAlgo : public DTRecHitBaseAlgo {
 
 
   // The Drift Velocity (cm/ns)
-  static float vDrift;
+  float vDrift;
   // // The Drift Velocity (cm/ns) for MB1 Wheel1 (non fluxed chamber) 21-Dec-2006 SL
-  // static float vDriftMB1W1;
+  // float vDriftMB1W1;
 
   // The resolution on the Hits (cm)
-  static float hitResolution;
+  float hitResolution;
 
   // Times below MinTime (ns) are considered as coming from previous BXs.
-  static float minTime;
+  float minTime;
 
   // Times above MaxTime (ns) are considered as coming from following BXs
-  static float maxTime;
+  float maxTime;
 
   // Switch on/off the verbosity
-  static bool debug;
+  bool debug;
 };
 #endif
 

--- a/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.cc
+++ b/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.cc
@@ -240,11 +240,3 @@ bool DTLinearDriftFromDBAlgo::compute(const DTLayer* layer,
     return false;
   }
 }
-
-float DTLinearDriftFromDBAlgo::minTime;
-
-  
-float DTLinearDriftFromDBAlgo::maxTime;
-
-  
-bool DTLinearDriftFromDBAlgo::debug;

--- a/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.h
+++ b/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.h
@@ -80,13 +80,13 @@ class DTLinearDriftFromDBAlgo : public DTRecHitBaseAlgo {
 		       int step) const;
 
   //Map of meantimes
-   const DTMtime *mTimeMap;
+  const DTMtime *mTimeMap;
  
   // Times below MinTime (ns) are considered as coming from previous BXs.
-  static float minTime;
+  float minTime;
 
   // Times above MaxTime (ns) are considered as coming from following BXs
-  static float maxTime;
+  float maxTime;
   
   // Perform a correction to vDrift for the external wheels
   bool doVdriftCorr;
@@ -96,7 +96,7 @@ class DTLinearDriftFromDBAlgo : public DTRecHitBaseAlgo {
   bool stepTwoFromDigi;
 
   // Switch on/off the verbosity
-  static bool debug;
+  bool debug;
 };
 #endif
 

--- a/RecoLocalMuon/DTRecHit/plugins/DTNoDriftAlgo.cc
+++ b/RecoLocalMuon/DTRecHit/plugins/DTNoDriftAlgo.cc
@@ -233,18 +233,3 @@ bool DTNoDriftAlgo::compute(const DTLayer* layer,
     return false;
   }
 }
-
-
-float DTNoDriftAlgo::fixedDrift;
-
-  
-float DTNoDriftAlgo::hitResolution;
-
-  
-float DTNoDriftAlgo::minTime;
-
-  
-float DTNoDriftAlgo::maxTime;
-
-  
-bool DTNoDriftAlgo::debug;

--- a/RecoLocalMuon/DTRecHit/plugins/DTNoDriftAlgo.h
+++ b/RecoLocalMuon/DTRecHit/plugins/DTNoDriftAlgo.h
@@ -90,19 +90,19 @@ class DTNoDriftAlgo : public DTRecHitBaseAlgo {
 
 
   // The Drift Velocity (cm/ns)
-  static float fixedDrift;
+  float fixedDrift;
 
   // The resolution on the Hits (cm)
-  static float hitResolution;
+  float hitResolution;
 
   // Times below MinTime (ns) are considered as coming from previous BXs.
-  static float minTime;
+  float minTime;
 
   // Times above MaxTime (ns) are considered as coming from following BXs
-  static float maxTime;
+  float maxTime;
 
   // Switch on/off the verbosity
-  static bool debug;
+  bool debug;
 };
 #endif
 

--- a/RecoLocalMuon/DTRecHit/plugins/DTParametrizedDriftAlgo.cc
+++ b/RecoLocalMuon/DTRecHit/plugins/DTParametrizedDriftAlgo.cc
@@ -160,7 +160,7 @@ bool DTParametrizedDriftAlgo::compute(const DTLayer* layer,
   // Calculate the drift distance and the resolution from the parametrization
   
   DTTime2DriftParametrization::drift_distance DX;
-  static DTTime2DriftParametrization par;
+  static const DTTime2DriftParametrization par;
 
   bool parStatus =
     par.computeDriftDistance_mean(driftTime, angle, By, Bz, interpolate, &DX);
@@ -365,15 +365,3 @@ bool DTParametrizedDriftAlgo::compute(const DTLayer* layer,
     return false;
   }
 }
-
-
-bool DTParametrizedDriftAlgo::interpolate;
-
-
-float DTParametrizedDriftAlgo::minTime;
-
-  
-float DTParametrizedDriftAlgo::maxTime;
-
-  
-bool DTParametrizedDriftAlgo::debug;

--- a/RecoLocalMuon/DTRecHit/plugins/DTParametrizedDriftAlgo.h
+++ b/RecoLocalMuon/DTRecHit/plugins/DTParametrizedDriftAlgo.h
@@ -68,13 +68,13 @@ class DTParametrizedDriftAlgo : public DTRecHitBaseAlgo {
 
  private:
   // Interpolate parametrization function
-  static bool interpolate;
+  bool interpolate;
 
   // Times below MinTime (ns) are considered as coming from previous BXs.
-  static float minTime;
+  float minTime;
   
   // Times above MaxTime (ns) are considered as coming from following BXs
-  static float maxTime;
+  float maxTime;
   
   // Do the actual work.
   virtual bool compute(const DTLayer* layer,
@@ -97,7 +97,7 @@ class DTParametrizedDriftAlgo : public DTRecHitBaseAlgo {
 		       int step) const;
 
   // Switch on/off the verbosity
-  static bool debug;
+  bool debug;
 
 
   // Pointer to the magnetic field (read from ES once per event)

--- a/RecoLocalMuon/DTRecHit/plugins/DTRecHitProducer.cc
+++ b/RecoLocalMuon/DTRecHit/plugins/DTRecHitProducer.cc
@@ -95,8 +95,3 @@ void DTRecHitProducer::produce(Event& event, const EventSetup& setup) {
 
   event.put(recHitCollection);
 }
-
-
-
-bool
-DTRecHitProducer::debug;

--- a/RecoLocalMuon/DTRecHit/plugins/DTRecHitProducer.h
+++ b/RecoLocalMuon/DTRecHit/plugins/DTRecHitProducer.h
@@ -33,7 +33,7 @@ public:
 
 private:
   // Switch on verbosity
-  static bool debug;
+  bool debug;
   // The label to be used to retrieve DT digis from the event
   edm::InputTag theDTDigiLabel;
   // The reconstruction algorithm


### PR DESCRIPTION
Most of these probably come from ORCA days, no reason for them not being member variables now.
