### PR TITLE
Pv constraint

### DIFF
--- a/HLTrigger/Configuration/test/OnLine_HLT_8E33v2.py
+++ b/HLTrigger/Configuration/test/OnLine_HLT_8E33v2.py
@@ -8108,7 +8108,8 @@ process.hltPFJetPixelSeedsFromPixelTracks = cms.EDProducer( "SeedGeneratorFromPr
     InputVertexCollection = cms.InputTag( "hltPixelVertices" ),
     TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
     InputCollection = cms.InputTag( "hltPixelTracks" ),
-    originRadius = cms.double( 0.1 )
+    originRadius = cms.double( 0.1 ),
+    usePV = cms.bool(True)
 )
 process.hltPFJetCkfTrackCandidates = cms.EDProducer( "CkfTrackCandidateMaker",
     src = cms.InputTag( "hltPFJetPixelSeedsFromPixelTracks" ),
@@ -18178,8 +18179,9 @@ process.hltTau3MuPixelSeedsFromPixelTracks = cms.EDProducer( "SeedGeneratorFromP
     InputVertexCollection = cms.InputTag( "hltDisplacedmumuFilterDoubleMuTau2Mu" ),
     TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
     InputCollection = cms.InputTag( "hltRegionalPixelTracks" ),
-    originRadius = cms.double( 0.1 )
-)
+    originRadius = cms.double( 0.1 ),
+    usePV = cms.bool(True)
+                                                             )
 process.hltTau3MuCkfTrackCandidates = cms.EDProducer( "CkfTrackCandidateMaker",
     src = cms.InputTag( "hltTau3MuPixelSeedsFromPixelTracks" ),
     maxSeedsBeforeCleaning = cms.uint32( 1000 ),
@@ -19172,8 +19174,9 @@ process.hltMuTrackSeeds = cms.EDProducer( "SeedGeneratorFromProtoTracksEDProduce
     InputVertexCollection = cms.InputTag( "" ),
     TTRHBuilder = cms.string( "hltESPTTRHBWithTrackAngle" ),
     InputCollection = cms.InputTag( "hltPixelTracks" ),
-    originRadius = cms.double( 1.0E9 )
-)
+    originRadius = cms.double( 1.0E9 ),
+    usePV = cms.bool(True)
+                                          )
 process.hltMuCkfTrackCandidates = cms.EDProducer( "CkfTrackCandidateMaker",
     src = cms.InputTag( "hltMuTrackSeeds" ),
     maxSeedsBeforeCleaning = cms.uint32( 1000 ),
@@ -19920,8 +19923,9 @@ process.hltMuTrackJpsiTrackSeeds = cms.EDProducer( "SeedGeneratorFromProtoTracks
     InputVertexCollection = cms.InputTag( "" ),
     TTRHBuilder = cms.string( "hltESPTTRHBWithTrackAngle" ),
     InputCollection = cms.InputTag( "hltMuTrackJpsiPixelTrackSelector" ),
-    originRadius = cms.double( 1.0E9 )
-)
+    originRadius = cms.double( 1.0E9 ),
+    usePV = cms.bool(True)
+                                                   )
 process.hltMuTrackJpsiEffCkfTrackCandidates = cms.EDProducer( "CkfTrackCandidateMaker",
     src = cms.InputTag( "hltMuTrackJpsiTrackSeeds" ),
     maxSeedsBeforeCleaning = cms.uint32( 1000 ),
@@ -20240,8 +20244,9 @@ process.hltMuTrackTrackSeedsOnia = cms.EDProducer( "SeedGeneratorFromProtoTracks
     InputVertexCollection = cms.InputTag( "" ),
     TTRHBuilder = cms.string( "hltESPTTRHBWithTrackAngle" ),
     InputCollection = cms.InputTag( "hltMuTrackPixelTrackSelectorOnia" ),
-    originRadius = cms.double( 1.0E9 )
-)
+    originRadius = cms.double( 1.0E9 ),
+    usePV = cms.bool(True)
+                                                   )
 process.hltMuTrackCkfTrackCandidatesOnia = cms.EDProducer( "CkfTrackCandidateMaker",
     src = cms.InputTag( "hltMuTrackTrackSeedsOnia" ),
     maxSeedsBeforeCleaning = cms.uint32( 1000 ),
@@ -32309,8 +32314,9 @@ process.hltPFJetPixelSeedsFromPixelTracksReg = cms.EDProducer( "SeedGeneratorFro
     InputVertexCollection = cms.InputTag( "hltPixelVerticesReg" ),
     TTRHBuilder = cms.string( "hltESPTTRHBuilderPixelOnly" ),
     InputCollection = cms.InputTag( "hltPixelTracksReg" ),
-    originRadius = cms.double( 0.1 )
-)
+    originRadius = cms.double( 0.1 ),
+    usePV = cms.bool(True)
+                                                               )
 process.hltPFJetCkfTrackCandidatesReg = cms.EDProducer( "CkfTrackCandidateMaker",
     src = cms.InputTag( "hltPFJetPixelSeedsFromPixelTracksReg" ),
     maxSeedsBeforeCleaning = cms.uint32( 1000 ),

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
@@ -41,9 +41,11 @@ SeedGeneratorFromProtoTracksEDProducer::SeedGeneratorFromProtoTracksEDProducer(c
     useProtoTrackKinematics(cfg.getParameter<bool>("useProtoTrackKinematics")),
     useEventsWithNoVertex(cfg.getParameter<bool>("useEventsWithNoVertex")),
     builderName(cfg.getParameter<std::string>("TTRHBuilder"))
-
+  
 {
-  produces<TrajectorySeedCollection>();
+  produces<TrajectorySeedCollection>(); 
+  if(cfg.exists("usePV")) usePV_ = cfg.getParameter<bool>( "usePV" );
+ 
 }
 
 void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::EventSetup& es)
@@ -69,7 +71,16 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
     bool keepTrack = false;
     if ( !foundVertices ) { 
 	  if (useEventsWithNoVertex) keepTrack = true;
-    } else { 
+    } 
+    else if (usePV_){
+      GlobalPoint aPV(vertices->begin()->position().x(),vertices->begin()->position().y(),vertices->begin()->position().z());
+      double distR2 = sqr(vtx.x()-aPV.x()) +sqr(vtx.y()-aPV.y());
+      double distZ = fabs(vtx.z()-aPV.z());
+      if ( distR2 < sqr(originRadius) && distZ < originHalfLength ) {
+        keepTrack = true;
+      }
+    }
+    else { 
       for (reco::VertexCollection::const_iterator iv=vertices->begin(); iv!= vertices->end(); ++iv) {
         GlobalPoint aPV(iv->position().x(),iv->position().y(),iv->position().z());
 	double distR2 = sqr(vtx.x()-aPV.x()) +sqr(vtx.y()-aPV.y());

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.h
@@ -22,5 +22,6 @@ private:
   bool useProtoTrackKinematics;
   bool useEventsWithNoVertex;
   std::string builderName;
+  bool usePV_;
 };
 #endif


### PR DESCRIPTION
added the possibility to propagate only tracks from the PV in the first iteration of the iterative tracking. Intended to use in HLT. 
For the moment the parameter is not needed in the HLT config file. It will be added when validation is performed. 
