### PR TITLE
Pv constraint v2

### DIFF
--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
@@ -41,11 +41,12 @@ SeedGeneratorFromProtoTracksEDProducer::SeedGeneratorFromProtoTracksEDProducer(c
     useProtoTrackKinematics(cfg.getParameter<bool>("useProtoTrackKinematics")),
     useEventsWithNoVertex(cfg.getParameter<bool>("useEventsWithNoVertex")),
     builderName(cfg.getParameter<std::string>("TTRHBuilder"))
-
+  
 {
-  produces<TrajectorySeedCollection>();
+  produces<TrajectorySeedCollection>(); 
+  usePV_ = (cfg.exists("usePV") ? cfg.getParameter<bool>( "usePV" ) : false);
 }
-
+    
 void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::EventSetup& es)
 {
   std::auto_ptr<TrajectorySeedCollection> result(new TrajectorySeedCollection());
@@ -69,7 +70,16 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
     bool keepTrack = false;
     if ( !foundVertices ) { 
 	  if (useEventsWithNoVertex) keepTrack = true;
-    } else { 
+    } 
+    else if (usePV_){
+      GlobalPoint aPV(vertices->begin()->position().x(),vertices->begin()->position().y(),vertices->begin()->position().z());
+      double distR2 = sqr(vtx.x()-aPV.x()) +sqr(vtx.y()-aPV.y());
+      double distZ = fabs(vtx.z()-aPV.z());
+      if ( distR2 < sqr(originRadius) && distZ < originHalfLength ) {
+        keepTrack = true;
+      }
+    }
+    else { 
       for (reco::VertexCollection::const_iterator iv=vertices->begin(); iv!= vertices->end(); ++iv) {
         GlobalPoint aPV(iv->position().x(),iv->position().y(),iv->position().z());
 	double distR2 = sqr(vtx.x()-aPV.x()) +sqr(vtx.y()-aPV.y());

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.h
@@ -22,5 +22,6 @@ private:
   bool useProtoTrackKinematics;
   bool useEventsWithNoVertex;
   std::string builderName;
+  bool usePV_;
 };
 #endif

--- a/RecoTracker/TkSeedGenerator/python/SeedGeneratorFromProtoTracksEDProducer_cfi.py
+++ b/RecoTracker/TkSeedGenerator/python/SeedGeneratorFromProtoTracksEDProducer_cfi.py
@@ -7,7 +7,9 @@ seedsFromProtoTracks = cms.EDProducer("SeedGeneratorFromProtoTracksEDProducer",
   originRadius = cms.double(1E9),
   useProtoTrackKinematics = cms.bool(False),
   useEventsWithNoVertex = cms.bool(True),
-  TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets') 
+  TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
+  usePV = cms.bool(False)                                      
+
 )
 
 


### PR DESCRIPTION
added the possibility to propagate only tracks from the PV in the first iteration of the iterative tracking. Intended to use in HLT. 
For the moment the parameter should be set to False in the HLT config file. 
