### PR TITLE
Mixing Modules should be of type 'one'

### DIFF
--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
@@ -1,8 +1,8 @@
 #include "RecoTrackAccumulator.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 
-RecoTrackAccumulator::RecoTrackAccumulator(const edm::ParameterSet& conf, edm::EDProducer& mixMod, edm::ConsumesCollector& iC) :
+RecoTrackAccumulator::RecoTrackAccumulator(const edm::ParameterSet& conf, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
   GeneralTrackInput_(conf.getParameter<edm::InputTag>("GeneralTrackInput")),
   GeneralTrackOutput_(conf.getParameter<std::string>("GeneralTrackOutput"))
 {

--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
@@ -35,13 +35,16 @@ namespace edm {
 namespace edm {
   class ConsumesCollector;
   template<typename T> class Handle;
+  namespace one {
+    class EDProducerBase;
+  }
 }
 
 
 class RecoTrackAccumulator : public DigiAccumulatorMixMod 
 {
  public:
-  explicit RecoTrackAccumulator(const edm::ParameterSet& conf, edm::EDProducer& mixMod, edm::ConsumesCollector& iC);
+  explicit RecoTrackAccumulator(const edm::ParameterSet& conf, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
   virtual ~RecoTrackAccumulator();
   
   virtual void initializeEvent(edm::Event const& e, edm::EventSetup const& c);

--- a/Mixing/Base/interface/BMixingModule.h
+++ b/Mixing/Base/interface/BMixingModule.h
@@ -19,7 +19,7 @@
 
 #include "boost/shared_ptr.hpp"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "Mixing/Base/interface/PileUp.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
@@ -27,7 +27,7 @@
 
 
 namespace edm {
-  class BMixingModule : public edm::EDProducer {
+  class BMixingModule : public edm::one::EDProducer<edm::one::SharedResources, edm::one::WatchRuns, edm::one::WatchLuminosityBlocks> {
     public:
       /** standard constructor*/
       explicit BMixingModule(const edm::ParameterSet& ps);

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.cc
@@ -18,7 +18,7 @@
 #include "DataFormats/HcalDetId/interface/HcalCastorDetId.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
-CastorDigiProducer::CastorDigiProducer(const edm::ParameterSet& ps, edm::EDProducer& mixMod, edm::ConsumesCollector& iC) 
+CastorDigiProducer::CastorDigiProducer(const edm::ParameterSet& ps, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) 
 : theParameterMap(new CastorSimParameterMap(ps)),
   theCastorShape(new CastorShape()),
   theCastorIntegratedShape(new CaloShapeIntegrator(theCastorShape)),

--- a/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
+++ b/SimCalorimetry/CastorSim/plugins/CastorDigiProducer.h
@@ -1,7 +1,7 @@
 #ifndef CastorDigiProducer_h
 #define CastorDigiProducer_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -26,7 +26,7 @@ class PileUpEventPrincipal;
 class CastorDigiProducer : public DigiAccumulatorMixMod {
 public:
 
-  explicit CastorDigiProducer(const edm::ParameterSet& ps, edm::EDProducer& mixMod, edm::ConsumesCollector& iC);
+  explicit CastorDigiProducer(const edm::ParameterSet& ps, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
   virtual ~CastorDigiProducer();
 
   virtual void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;

--- a/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
+++ b/SimCalorimetry/EcalSimProducers/interface/EcalDigiProducer.h
@@ -42,7 +42,9 @@ class PileUpEventPrincipal ;
 
 namespace edm {
   class ConsumesCollector;
-  class EDProducer;
+  namespace one {
+    class EDProducerBase;
+  }
   class Event;
   class EventSetup;
   template<typename T> class Handle;
@@ -52,7 +54,7 @@ namespace edm {
 class EcalDigiProducer : public DigiAccumulatorMixMod {
    public:
 
-      EcalDigiProducer( const edm::ParameterSet& params , edm::EDProducer& mixMod, edm::ConsumesCollector& iC);
+      EcalDigiProducer( const edm::ParameterSet& params , edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
       virtual ~EcalDigiProducer();
 
       virtual void initializeEvent(edm::Event const& e, edm::EventSetup const& c);

--- a/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
+++ b/SimCalorimetry/EcalSimProducers/src/EcalDigiProducer.cc
@@ -19,7 +19,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -48,7 +48,7 @@
 #include "CondFormats/DataRecord/interface/ESPedestalsRcd.h"
 #include "Geometry/EcalAlgo/interface/EcalEndcapGeometry.h"
 
-EcalDigiProducer::EcalDigiProducer( const edm::ParameterSet& params, edm::EDProducer& mixMod, edm::ConsumesCollector& iC) :
+EcalDigiProducer::EcalDigiProducer( const edm::ParameterSet& params, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
    DigiAccumulatorMixMod(),
    m_APDShape         ( params.getParameter<double>( "apdShapeTstart" ) ,
 			params.getParameter<double>( "apdShapeTau"    )   )  ,

--- a/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
+++ b/SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h
@@ -9,7 +9,9 @@
 
 namespace edm {
   class ConsumesCollector;
-  class EDProducer;
+  namespace one {
+    class EDProducerBase;
+  }
   class Event;
   class EventSetup;
   class ParameterSet;
@@ -21,7 +23,7 @@ class EcalTBDigiProducer : public EcalDigiProducer
 {
    public:
 
-      EcalTBDigiProducer( const edm::ParameterSet& params, edm::EDProducer& mixMod, edm::ConsumesCollector& iC) ;
+      EcalTBDigiProducer( const edm::ParameterSet& params, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) ;
       virtual ~EcalTBDigiProducer() ;
 
 

--- a/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
+++ b/SimCalorimetry/EcalTestBeam/src/EcalTBDigiProducer.cc
@@ -2,7 +2,7 @@
 #include "SimCalorimetry/EcalTestBeam/interface/EcalTBDigiProducer.h"
 #include "SimDataFormats/EcalTestBeam/interface/PEcalTBInfo.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -12,7 +12,7 @@
 #include "SimCalorimetry/EcalSimAlgos/interface/EBHitResponse.h"
 #include "SimCalorimetry/EcalSimAlgos/interface/EEHitResponse.h"
 
-EcalTBDigiProducer::EcalTBDigiProducer( const edm::ParameterSet& params, edm::EDProducer& mixMod, edm::ConsumesCollector& iC) :
+EcalTBDigiProducer::EcalTBDigiProducer( const edm::ParameterSet& params, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
    EcalDigiProducer(params, mixMod, iC)
 {
    std::string const instance("simEcalUnsuppressedDigis");

--- a/SimCalorimetry/HcalSimProducers/plugins/HcalDigiProducer.cc
+++ b/SimCalorimetry/HcalSimProducers/plugins/HcalDigiProducer.cc
@@ -1,7 +1,7 @@
 #include "SimCalorimetry/HcalSimProducers/plugins/HcalDigiProducer.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 
-HcalDigiProducer::HcalDigiProducer(edm::ParameterSet const& pset, edm::EDProducer& mixMod, edm::ConsumesCollector& iC) :
+HcalDigiProducer::HcalDigiProducer(edm::ParameterSet const& pset, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
   DigiAccumulatorMixMod(),
   theDigitizer_(pset, iC) {
   mixMod.produces<HBHEDigiCollection>();

--- a/SimCalorimetry/HcalSimProducers/plugins/HcalDigiProducer.h
+++ b/SimCalorimetry/HcalSimProducers/plugins/HcalDigiProducer.h
@@ -6,13 +6,15 @@
 
 namespace edm {
   class ConsumesCollector;
-  class EDProducer;
+  namespace one {
+    class EDProducerBase;
+  }
   class ParameterSet;
 }
 
 class HcalDigiProducer : public DigiAccumulatorMixMod {
 public:
-  HcalDigiProducer(edm::ParameterSet const& pset, edm::EDProducer& mixMod, edm::ConsumesCollector& iC);
+  HcalDigiProducer(edm::ParameterSet const& pset, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
   virtual void initializeEvent(edm::Event const&, edm::EventSetup const&) override;
   virtual void finalizeEvent(edm::Event&, edm::EventSetup const&) override;
   virtual void accumulate(edm::Event const&, edm::EventSetup const&) override;

--- a/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
+++ b/SimCalorimetry/HcalTestBeam/interface/HcalTBDigiProducer.h
@@ -1,7 +1,7 @@
 #ifndef SimCalorimetry_HcalTestBeam_HcalTBDigiProducer_h
 #define SimCalorimetry_HcalTestBeam_HcalTBDigiProducer_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -27,7 +27,7 @@ class PEcalTBInfo;
 class HcalTBDigiProducer : public DigiAccumulatorMixMod {
 public:
 
-  explicit HcalTBDigiProducer(const edm::ParameterSet& ps, edm::EDProducer& mixMod, edm::ConsumesCollector& iC);
+  explicit HcalTBDigiProducer(const edm::ParameterSet& ps, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
   virtual ~HcalTBDigiProducer();
 
   virtual void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;

--- a/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
+++ b/SimCalorimetry/HcalTestBeam/src/HcalTBDigiProducer.cc
@@ -14,7 +14,7 @@
 #include "SimDataFormats/EcalTestBeam/interface/PEcalTBInfo.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
-HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet& ps, edm::EDProducer& mixMod, edm::ConsumesCollector& iC) :
+HcalTBDigiProducer::HcalTBDigiProducer(const edm::ParameterSet& ps, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
   theParameterMap(new HcalTBSimParameterMap(ps)), 
   theHcalShape(new HcalShape()),
   theHcalIntegratedShape(new CaloShapeIntegrator(theHcalShape)),

--- a/SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h
+++ b/SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h
@@ -6,10 +6,12 @@
 
 namespace edm {
   class ConsumesCollector;
-  class EDProducer;
   class ParameterSet;
+  namespace one {
+    class EDProducerBase;
+  }
 
-  typedef DigiAccumulatorMixMod*(DAFunc)(ParameterSet const&, EDProducer&, ConsumesCollector&);
+  typedef DigiAccumulatorMixMod*(DAFunc)(ParameterSet const&, one::EDProducerBase&, ConsumesCollector&);
   typedef edmplugin::PluginFactory<DAFunc> DigiAccumulatorMixModPluginFactory;
 
   class DigiAccumulatorMixModFactory {
@@ -19,7 +21,7 @@ namespace edm {
     static DigiAccumulatorMixModFactory* get();
 
     std::auto_ptr<DigiAccumulatorMixMod>
-      makeDigiAccumulator(ParameterSet const&, EDProducer&, ConsumesCollector&) const;
+      makeDigiAccumulator(ParameterSet const&, one::EDProducerBase&, ConsumesCollector&) const;
 
   private:
     DigiAccumulatorMixModFactory();

--- a/SimGeneral/MixingModule/src/DigiAccumulatorMixModFactory.cc
+++ b/SimGeneral/MixingModule/src/DigiAccumulatorMixModFactory.cc
@@ -9,7 +9,9 @@
 EDM_REGISTER_PLUGINFACTORY(edm::DigiAccumulatorMixModPluginFactory,"DigiAccumulator");
 
 namespace edm {
-  class EDProducer;
+  namespace one {
+    class EDProducerBase;
+  }
 
   DigiAccumulatorMixModFactory::~DigiAccumulatorMixModFactory() {
   }
@@ -28,7 +30,7 @@ namespace edm {
   }
 
   std::auto_ptr<DigiAccumulatorMixMod>
-  DigiAccumulatorMixModFactory::makeDigiAccumulator(ParameterSet const& conf, EDProducer& mixMod, ConsumesCollector& iC) const {
+  DigiAccumulatorMixModFactory::makeDigiAccumulator(ParameterSet const& conf, one::EDProducerBase& mixMod, ConsumesCollector& iC) const {
     std::string accumulatorType = conf.getParameter<std::string>("accumulatorType");
     FDEBUG(1) << "DigiAccumulatorMixModFactory: digi_accumulator_type = " << accumulatorType << std::endl;
     std::auto_ptr<DigiAccumulatorMixMod> wm;

--- a/SimGeneral/TrackingAnalysis/interface/TrackingTruthAccumulator.h
+++ b/SimGeneral/TrackingAnalysis/interface/TrackingTruthAccumulator.h
@@ -13,7 +13,9 @@ namespace edm
 {
 	class ParameterSet;
         class ConsumesCollector;
-	class EDProducer;
+  namespace one {
+	class EDProducerBase;
+  }
 	class Event;
 	class EventSetup;
 }
@@ -65,7 +67,7 @@ class PSimHit;
 class TrackingTruthAccumulator : public DigiAccumulatorMixMod
 {
 public:
-	explicit TrackingTruthAccumulator( const edm::ParameterSet& config, edm::EDProducer& mixMod, edm::ConsumesCollector& iC);
+	explicit TrackingTruthAccumulator( const edm::ParameterSet& config, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
 private:
 	virtual void initializeEvent( const edm::Event& event, const edm::EventSetup& setup );
 	virtual void accumulate( const edm::Event& event, const edm::EventSetup& setup );

--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
@@ -29,7 +29,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "SimGeneral/TrackingAnalysis/interface/EncodedTruthId.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
@@ -214,7 +214,7 @@ namespace
 //---------------------------------------------------------------------------------
 //---------------------------------------------------------------------------------
 
-TrackingTruthAccumulator::TrackingTruthAccumulator( const edm::ParameterSet & config, edm::EDProducer& mixMod, edm::ConsumesCollector& iC) :
+TrackingTruthAccumulator::TrackingTruthAccumulator( const edm::ParameterSet & config, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
 		messageCategory_("TrackingTruthAccumulator"),
 		volumeRadius_( config.getParameter<double>("volumeRadius") ),
 		volumeZ_( config.getParameter<double>("volumeZ") ),

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.cc
@@ -29,7 +29,7 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -86,7 +86,7 @@
 
 namespace cms
 {
-  SiPixelDigitizer::SiPixelDigitizer(const edm::ParameterSet& iConfig, edm::EDProducer& mixMod, edm::ConsumesCollector& iC):
+  SiPixelDigitizer::SiPixelDigitizer(const edm::ParameterSet& iConfig, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC):
     first(true),
     _pixeldigialgo(),
     hitsProducer(iConfig.getParameter<std::string>("hitsProducer")),

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
@@ -27,7 +27,9 @@ namespace CLHEP {
 
 namespace edm {
   class ConsumesCollector;
-  class EDProducer;
+  namespace one {
+    class EDProducerBase;
+  }
   class Event;
   class EventSetup;
   class ParameterSet;
@@ -45,7 +47,7 @@ namespace cms {
   class SiPixelDigitizer : public DigiAccumulatorMixMod {
   public:
 
-    explicit SiPixelDigitizer(const edm::ParameterSet& conf, edm::EDProducer& mixMod, edm::ConsumesCollector& iC);
+    explicit SiPixelDigitizer(const edm::ParameterSet& conf, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
 
     virtual ~SiPixelDigitizer();
 

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.cc
@@ -21,7 +21,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -58,7 +58,7 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "CLHEP/Random/RandomEngine.h"
 
-SiStripDigitizer::SiStripDigitizer(const edm::ParameterSet& conf, edm::EDProducer& mixMod, edm::ConsumesCollector& iC) : 
+SiStripDigitizer::SiStripDigitizer(const edm::ParameterSet& conf, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) : 
   gainLabel(conf.getParameter<std::string>("Gain")),
   hitsProducer(conf.getParameter<std::string>("hitsProducer")),
   trackerContainers(conf.getParameter<std::vector<std::string> >("ROUList")),

--- a/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
+++ b/SimTracker/SiStripDigitizer/plugins/SiStripDigitizer.h
@@ -17,7 +17,9 @@ namespace CLHEP {
 
 namespace edm {
   class ConsumesCollector;
-  class EDProducer;
+  namespace one {
+    class EDProducerBase;
+  }
   class Event;
   class EventSetup;
   class ParameterSet;
@@ -41,7 +43,7 @@ class TrackerGeometry;
  */
 class SiStripDigitizer : public DigiAccumulatorMixMod {
 public:
-  explicit SiStripDigitizer(const edm::ParameterSet& conf, edm::EDProducer& mixMod, edm::ConsumesCollector& iC);
+  explicit SiStripDigitizer(const edm::ParameterSet& conf, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
   
   virtual ~SiStripDigitizer();
   


### PR DESCRIPTION
This pull request makes the mixing module and the data mixing module type one modules, rather than legacy modules.  Tested with checkdeps -a and the full relval matrix.
