### PR TITLE
Update autoCond.py

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -1,21 +1,21 @@
 autoCond = { 
     # GlobalTag for MC production with perfectly aligned and calibrated detector
-    'mc'                :   'PRE_MC62_V8::All',
+    'mc'                :   'MC_70_V1::All',
     # GlobalTag for MC production with realistic alignment and calibrations
-    'startup'           :   'PRE_ST62_V8::All',
+    'startup'           :   'START70_V1::All',
     # GlobalTag for MC production of Heavy Ions events with realistic alignment and calibrations
-    'starthi'           :   'PRE_SH62_V15::All',
+    'starthi'           :   'STARTHI70_V1::All',
     # GlobalTag for MC production of p-Pb events with realistic alignment and calibrations
-    'startpa'           :   'PRE_SH62_V16::All',
+    'startpa'           :   'STARTHI70_V2::All',
     # GlobalTag for data reprocessing: this should always be the GR_R tag
     'com10'             :   'PRE_62_V8::All',
     # GlobalTag for running HLT on recent data: this should be the GR_P (prompt reco) global tag until a compatible GR_H tag is available, 
     # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
     'hltonline'         :   'PRE_P62_V8::All',
     # GlobalTag for POSTLS1 upgrade studies:
-    'upgradePLS1'       :   'POSTLS162_V1::All',
-    'upgrade2017'       :   'DES17_61_V5::All', # placeholder (GT not meant for 62X)
-    'upgrade2019'       :   'DES19_61_V5::All', # placeholder (GT not meant for 62X)
+    'upgradePLS1'       :   'PRE_PO62_V7::All',
+    'upgrade2017'       :   'DES17_70_V1::All', # placeholder (GT not meant for 62X)
+    'upgrade2019'       :   'DES19_70_V1::All', # placeholder (GT not meant for 62X)
     'upgradePLS3'       :   'POSTLS261_V2::All' # placeholder (GT not meant for 62X)
 }
 

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -13,7 +13,7 @@ autoCond = {
     # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
     'hltonline'         :   'PRE_P62_V8::All',
     # GlobalTag for POSTLS1 upgrade studies:
-    'upgradePLS1'       :   'PRE_PO62_V7::All',
+    'upgradePLS1'       :   'POSTLS162_V1::All',
     'upgrade2017'       :   'DES17_70_V1::All', # placeholder (GT not meant for 62X)
     'upgrade2019'       :   'DES19_70_V1::All', # placeholder (GT not meant for 62X)
     'upgradePLS3'       :   'POSTLS261_V2::All' # placeholder (GT not meant for 62X)


### PR DESCRIPTION
Supersedes #1161

Original description:

Updated all MC GTs migrating all tags to production. Updated HCAL conditions for SiPM photodetectors. Introduced GEM in DES19 GT.
Requires the pull request abdoulline:HO_post-LS1 with software changes for the SiPM upgrade.
