### PR TITLE
Class with virtual functions needs virtual destructor

### DIFF
--- a/CondCore/Utilities/interface/CondBasicIter.h
+++ b/CondCore/Utilities/interface/CondBasicIter.h
@@ -12,7 +12,7 @@ class CondBasicIter{
 public:
   
   CondBasicIter();    
-  ~CondBasicIter();    
+  virtual ~CondBasicIter();
   
   
   /**


### PR DESCRIPTION
The class CondBasicIter has virtual functions, and therefore should have a virtual destructor.
This problem causes an error when building a dictionary against ROOT6.  It may also cause splitting upon deletion of an object.

Note: The derived class CondIter was fixed to have a virtual destructor in an earlier pull request, but I missed the fact that CondBasicIter has the same problem.
