### PR TITLE
Changed MagFields verbose::debugOut to constexpr to avoid threading problems

### DIFF
--- a/MagneticField/Layers/interface/MagVerbosity.h
+++ b/MagneticField/Layers/interface/MagVerbosity.h
@@ -9,7 +9,7 @@
 
 
 struct verbose {
-  static bool debugOut;
+  static constexpr bool debugOut = false;
 };
 
 #endif

--- a/MagneticField/Layers/src/MagVerbosity.cc
+++ b/MagneticField/Layers/src/MagVerbosity.cc
@@ -1,3 +1,0 @@
-#include "MagneticField/Layers/interface/MagVerbosity.h"
-
-bool verbose::debugOut=false;


### PR DESCRIPTION
The thread-safey checker complains about the static verbose::debugOut.
Given that no code exists which changes the value after it is initialized
changing this to a constexpr has no functional effect. The default remains
the same 'false'. If one wants the debug output they have to edit the code
and recompile.
