### PR TITLE
Make a static data member non-static and declare another static const.

### DIFF
--- a/Mixing/Base/interface/BMixingModule.h
+++ b/Mixing/Base/interface/BMixingModule.h
@@ -77,7 +77,7 @@ namespace edm {
       virtual void endJob() override;
       //      std::string type_;
       int bunchSpace_;
-      static int vertexoffset;
+      int vertexOffset_;
       bool checktof_;
       int minBunch_;
       int maxBunch_;

--- a/Mixing/Base/src/BMixingModule.cc
+++ b/Mixing/Base/src/BMixingModule.cc
@@ -17,9 +17,6 @@
 #include "TFile.h"
 #include "TH1F.h"
 
-using namespace std;
-
-int edm::BMixingModule::vertexoffset = 0;
 const unsigned int edm::BMixingModule::maxNbSources_ =4;
 
 namespace
@@ -37,8 +34,8 @@ namespace
         std::string histoFileName=" ";
 	std::string histoName =" ";
 	TH1F * h = new TH1F("h","h",10,0,10);
-	vector<int> dataProbFunctionVar;
-	vector<double> dataProb;
+	std::vector<int> dataProbFunctionVar;
+	std::vector<double> dataProb;
 	
 	
 	const edm::ParameterSet & psin=ps.getParameter<edm::ParameterSet>(sourceName);
@@ -91,15 +88,15 @@ namespace
 		  type_="probFunction";
 		}
 
-	        dataProbFunctionVar = psin_average.getParameter<vector<int> >("probFunctionVariable");
-  		dataProb = psin_average.getParameter<vector<double> >("probValue");
+	        dataProbFunctionVar = psin_average.getParameter<std::vector<int> >("probFunctionVariable");
+  		dataProb = psin_average.getParameter<std::vector<double> >("probValue");
 	        histoFileName = psin_average.getUntrackedParameter<std::string>("histoFileName"); 
 							
 		int varSize = (int) dataProbFunctionVar.size();
 		int probSize = (int) dataProb.size();
 		
 		if ((dataProbFunctionVar[0] != 0) || (dataProbFunctionVar[varSize - 1] != (varSize - 1))) 
-		  throw cms::Exception("BadProbFunction") << "Please, check the variables of the probability function! The first variable should be 0 and the difference between two variables should be 1." << endl;
+		  throw cms::Exception("BadProbFunction") << "Please, check the variables of the probability function! The first variable should be 0 and the difference between two variables should be 1." << std::endl;
 		
 		// Complete the vector containing the probability  function data
 		// with the values "0"
@@ -130,7 +127,7 @@ namespace
 				
 		// Check if the histogram is normalized
 		if ( ((hprob->Integral() - 1) > 1.0e-02) && ((hprob->Integral() - 1) < -1.0e-02)){ 
-		  throw cms::Exception("BadProbFunction") << "The probability function should be normalized!!! " << endl;
+		  throw cms::Exception("BadProbFunction") << "The probability function should be normalized!!! " << std::endl;
 		}
 		
 		averageNumber = hprob->GetMean();
@@ -168,6 +165,7 @@ namespace edm {
   // Constructor 
   BMixingModule::BMixingModule(const edm::ParameterSet& pset) :
     bunchSpace_(pset.getParameter<int>("bunchspace")),
+    vertexOffset_(0),
     minBunch_((pset.getParameter<int>("minBunch")*25)/pset.getParameter<int>("bunchspace")),
     maxBunch_((pset.getParameter<int>("maxBunch")*25)/pset.getParameter<int>("bunchspace")),
     mixProdStep1_(pset.getParameter<bool>("mixProdStep1")),

--- a/SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h
+++ b/SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h
@@ -18,14 +18,14 @@ namespace edm {
   public:
     ~DigiAccumulatorMixModFactory();
 
-    static DigiAccumulatorMixModFactory* get();
+    static DigiAccumulatorMixModFactory const* get();
 
     std::auto_ptr<DigiAccumulatorMixMod>
       makeDigiAccumulator(ParameterSet const&, one::EDProducerBase&, ConsumesCollector&) const;
 
   private:
     DigiAccumulatorMixModFactory();
-    static DigiAccumulatorMixModFactory singleInstance_;
+    static DigiAccumulatorMixModFactory const singleInstance_;
   };
 }
 

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -296,7 +296,7 @@ namespace edm {
       LogDebug("MixingModule") <<" merging Event:  id " << eventPrincipal.id();
       //      std::cout <<"PILEALLWORKERS merging Event:  id " << eventPrincipal.id() << std::endl;
 
-      workers_[ii]->addPileups(bunchCrossing,eventPrincipal, &moduleCallingContext, eventId, vertexoffset);
+      workers_[ii]->addPileups(bunchCrossing,eventPrincipal, &moduleCallingContext, eventId, vertexOffset_);
     }
   }
 

--- a/SimGeneral/MixingModule/src/DigiAccumulatorMixModFactory.cc
+++ b/SimGeneral/MixingModule/src/DigiAccumulatorMixModFactory.cc
@@ -19,9 +19,9 @@ namespace edm {
   DigiAccumulatorMixModFactory::DigiAccumulatorMixModFactory() {
   }
 
-  DigiAccumulatorMixModFactory DigiAccumulatorMixModFactory::singleInstance_;
+  DigiAccumulatorMixModFactory const DigiAccumulatorMixModFactory::singleInstance_;
 
-  DigiAccumulatorMixModFactory* DigiAccumulatorMixModFactory::get() {
+  DigiAccumulatorMixModFactory const* DigiAccumulatorMixModFactory::get() {
     // will not work with plugin factories
     //static DigiAccumulatorMixModFactory f;
     //return &f;


### PR DESCRIPTION
The base class for the mixing modules has a static non-const data member, "vertexoffset".  There is no reason that this data member needs to be static.  Even in the unlikely case of multiple instances of the mixing module in a job, the value can be set separately for each.  So this pull request changes the static data member "vertexoffset" to a non-static data member vertexOffset_.

This pull request also declares the static DigiAccumulatorMixModFactory::singleInstance_  to be const.
