### PR TITLE
Remove unnecessary dependency on Reflex

### DIFF
--- a/CondCore/RegressionTest/interface/TestFunct.h
+++ b/CondCore/RegressionTest/interface/TestFunct.h
@@ -10,8 +10,6 @@
 #include "CondCore/ORA/interface/Transaction.h"
 #include "CondCore/ORA/interface/Exception.h"
 #include "CondCore/ORA/interface/IBlobStreamingService.h"
-#include "Reflex/Member.h"
-#include "Reflex/Object.h"
 #include "CoralBase/Blob.h"
 
 #include "CondCore/DBCommon/interface/DbConnection.h"

--- a/CondCore/RegressionTest/test/BuildFile.xml
+++ b/CondCore/RegressionTest/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <flags   GENREFLEX_ARGS="--"/>
-<use   name="rootrflx"/>
 <use   name="CondCore/RegressionTest"/>
 <use   name="CondCore/Utilities"/>
 <use   name="DataFormats/StdDictionaries"/>


### PR DESCRIPTION
The package CondCore/RegressionTest contains two unnecessary includes of Reflex headers, and the test BuildFile contains an unnecessary declaration of a link dependency on rootrflx.
This pull request removes the unnecessary includes and dependencies.
Unnecessary includes can be considered a bug, so I view this as a bug fix.
