### PR TITLE
Pick different struct name if Reflex dictionary is split (ROOT6)

### DIFF
--- a/DataFormats/JetReco/src/classes_1.h
+++ b/DataFormats/JetReco/src/classes_1.h
@@ -24,7 +24,7 @@
 #include "DataFormats/Common/interface/Ptr.h"
 
 namespace {
-  struct dictionary {
+  struct dictionary1 {
     reco::CaloJetCollection o1;
     reco::CaloJetRef r1;
     reco::CaloJetFwdRef fwdr1;

--- a/DataFormats/JetReco/src/classes_2.h
+++ b/DataFormats/JetReco/src/classes_2.h
@@ -53,7 +53,7 @@
 #include "DataFormats/Common/interface/Ptr.h"
 
 namespace {
-  struct dictionary {
+  struct dictionary2 {
     reco::FFTBasicJet jet_fft_3;
     reco::FFTBasicJetCollection o2_fft_3;
     reco::FFTBasicJetRef r2_fft_3;

--- a/DataFormats/JetReco/src/classes_3.h
+++ b/DataFormats/JetReco/src/classes_3.h
@@ -39,7 +39,7 @@
 #include "DataFormats/Common/interface/Ptr.h"
 
 namespace {
-  struct dictionary {
+  struct dictionary3 {
     reco::TrackJetCollection o6;
     reco::TrackJetRef r6;
     reco::TrackJetFwdRef fwdr6;

--- a/DataFormats/JetReco/src/classes_4.h
+++ b/DataFormats/JetReco/src/classes_4.h
@@ -37,7 +37,7 @@
 #include "DataFormats/Common/interface/Ptr.h"
 
 namespace {
-  struct dictionary {
+  struct dictionary4 {
     // jet id stuff
     reco::JetID jid;
     edm::Ref<std::vector<reco::JetID> > rjid;

--- a/DataFormats/ParticleFlowReco/src/classes_1.h
+++ b/DataFormats/ParticleFlowReco/src/classes_1.h
@@ -64,7 +64,7 @@
 #include <map>
 
 namespace {
-  struct dictionary {
+  struct dictionary1 {
 
     /* NuclearInteraction stuffs  */
     reco::PFNuclearInteraction                                dummy21;

--- a/DataFormats/ParticleFlowReco/src/classes_2.h
+++ b/DataFormats/ParticleFlowReco/src/classes_2.h
@@ -64,7 +64,7 @@
 #include <map>
 
 namespace {
-  struct dictionary {
+  struct dictionary2 {
 
     std::vector<reco::PFCluster>                         dummy1;
     edm::Wrapper< std::vector<reco::PFCluster> >         dummy2;

--- a/DataFormats/PatCandidates/src/classes_objects.h
+++ b/DataFormats/PatCandidates/src/classes_objects.h
@@ -18,7 +18,7 @@
 #include "DataFormats/PatCandidates/interface/Conversion.h"
 
 namespace {
-  struct dictionary {
+  struct dictionaryobjects {
 
   /*   PAT Object Collection Iterators   */
   std::vector<pat::Electron>::const_iterator	    v_p_e_ci;

--- a/DataFormats/PatCandidates/src/classes_other.h
+++ b/DataFormats/PatCandidates/src/classes_other.h
@@ -18,7 +18,7 @@
 #include "DataFormats/PatCandidates/interface/CandKinResolution.h"
 
 namespace {
-  struct dictionary {
+  struct dictionaryother {
 
   std::pair<std::string, std::vector<float> > jcfcf;
   edm::Wrapper<std::pair<std::string, std::vector<float> > > w_jcfcf;

--- a/DataFormats/PatCandidates/src/classes_trigger.h
+++ b/DataFormats/PatCandidates/src/classes_trigger.h
@@ -9,7 +9,7 @@
 #include <vector>
 
 namespace {
-  struct dictionary {
+  struct dictionarytrigger {
 
   pat::TriggerObjectCollection v_p_to;
   pat::TriggerObjectCollection::const_iterator v_p_to_ci;

--- a/DataFormats/PatCandidates/src/classes_user.h
+++ b/DataFormats/PatCandidates/src/classes_user.h
@@ -11,7 +11,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 
 namespace {
-  struct dictionary {
+  struct dictionaryuser {
 
   /*   UserData: Core   */
   pat::UserDataCollection	         ov_p_ud;

--- a/DataFormats/StdDictionaries/src/classes_map.h
+++ b/DataFormats/StdDictionaries/src/classes_map.h
@@ -7,7 +7,7 @@
 #include <vector>
 
 namespace {
-  struct dictionary {
+  struct dictionarymap {
   std::map<int,int> dummywm4;
   std::map<int,std::pair<double,double> > dummymipdd;
   std::map<int,std::pair<unsigned int,unsigned int> > dummyypwmv9;

--- a/DataFormats/StdDictionaries/src/classes_others.h
+++ b/DataFormats/StdDictionaries/src/classes_others.h
@@ -8,7 +8,7 @@
 #include <functional>
 
 namespace {
-  struct dictionary {
+  struct dictionaryothers {
   std::allocator<char> achar;
   std::allocator<double> adouble;
   std::allocator<int> aint;

--- a/DataFormats/StdDictionaries/src/classes_pair.h
+++ b/DataFormats/StdDictionaries/src/classes_pair.h
@@ -7,7 +7,7 @@
 #include <vector>
 
 namespace {
-  struct dictionary {
+  struct dictionarypair {
   std::pair<const int,int> newDummy00;
   std::pair<const int,std::pair<double,double> > newDummy01;
   std::pair<const int,std::pair<unsigned int,unsigned int> > newDummy02;

--- a/DataFormats/StdDictionaries/src/classes_vector.h
+++ b/DataFormats/StdDictionaries/src/classes_vector.h
@@ -7,7 +7,7 @@
 #include <vector>
 
 namespace {
-  struct dictionary {
+  struct dictionaryvector {
   std::vector<bool> dummy13;
   std::vector<char*> dummy6p;
   std::vector<char> dummy6;

--- a/DataFormats/TauReco/src/classes_1.h
+++ b/DataFormats/TauReco/src/classes_1.h
@@ -28,7 +28,7 @@
 #include <map>
 
 namespace {
-  struct dictionary {
+  struct dictionary1 {
     reco::L2TauIsolationInfo                                    l2iI;
     reco::L2TauInfoAssociation                                  l2ts;
     edm::Wrapper<reco::L2TauInfoAssociation>                    wl2ts;

--- a/DataFormats/TauReco/src/classes_2.h
+++ b/DataFormats/TauReco/src/classes_2.h
@@ -28,7 +28,7 @@
 #include <map>
 
 namespace {
-  struct dictionary {
+  struct dictionary2 {
 
     std::vector<reco::PFTau>                                    pft_v;
     edm::Wrapper<std::vector<reco::PFTau> >                     pft_w;

--- a/DataFormats/TauReco/src/classes_3.h
+++ b/DataFormats/TauReco/src/classes_3.h
@@ -28,7 +28,7 @@
 #include <map>
 
 namespace {
-  struct dictionary {
+  struct dictionary4 {
 
     reco::CaloTauDiscriminatorAgainstElectronBase               calotde_b;
     reco::CaloTauDiscriminatorAgainstElectron                   calotde_o;

--- a/DataFormats/TauReco/src/classes_hlt.h
+++ b/DataFormats/TauReco/src/classes_hlt.h
@@ -21,7 +21,7 @@
 #include <map>
 
 namespace {
-  struct dictionary {
+  struct dictionaryhlt {
     //Needed only in HLT-Open
     std::vector<reco::HLTTau>                                  ht_v;
     edm::Wrapper<std::vector<reco::HLTTau> >                   ht_w;


### PR DESCRIPTION
There are 5 packages, which are built in a few chunks in order
to have smaller translation unit and deliver finer granularity.

All chunks are linked together back into a single Reflex dictionary.
In ROOT6 it still has multiple intialization points, and 'struct
dictionary' from anonymous namespace is executed. In ROOT6 it's
done in the same context and causes multiple redefinitions:

```
input_line_35:60:10: error: redefinition of 'dictionary'
 struct dictionary {
        ^
input_line_19:99:10: note: previous definition is here
 struct dictionary {
        ^
input_line_37:73:10: error: redefinition of 'dictionary'
 struct dictionary {
        ^
input_line_19:99:10: note: previous definition is here
 struct dictionary {
        ^
```

Rename structs in each classes_*.h to avoid such conflicts in
ROOT6.

If Reflex dictionary is built in a few chunks, each chunk has to
have a unique struct name (if used).

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
