### PR TITLE
Misc cleanups.

### DIFF
--- a/CondCore/CondDB/interface/Types.h
+++ b/CondCore/CondDB/interface/Types.h
@@ -30,11 +30,6 @@ namespace cond {
 
   SynchronizationType synchronizationTypeFromName( const std::string& name );
 
-  template <typename T> 
-  std::pair<const std::string,T> enumPair( std::string name, T value ){
-    return std::make_pair( name, value );
-  }
-
   typedef std::string Hash;
   static constexpr unsigned int HASH_SIZE = 40;
 

--- a/CondCore/CondDB/src/Time.cc
+++ b/CondCore/CondDB/src/Time.cc
@@ -9,23 +9,22 @@
 namespace cond {
 
   namespace time {
-    static auto s_timeTypeMap = { enumPair( "Run",cond::runnumber ),
-				  enumPair( "Time",cond::timestamp ),
-				  enumPair( "Lumi",cond::lumiid ),
-				  enumPair( "Hash",cond::hash ),
-				  enumPair( "User",cond::userid ) };
+    static const std::pair<const char*, TimeType> s_timeTypeMap[] = { std::make_pair("Run", cond::runnumber),
+                                                                      std::make_pair("Time", cond::timestamp ),
+                                                                      std::make_pair("Lumi", cond::lumiid ),
+                                                                      std::make_pair("Hash", cond::hash ),
+                                                                      std::make_pair("User", cond::userid ) };
 
     std::string timeTypeName(TimeType type) {
-      std::vector<std::pair<const std::string,TimeType> > tmp( s_timeTypeMap );
       if( type==invalid ) return "";
-      return tmp[type].first;
+      return s_timeTypeMap[type].first;
     }
 
     TimeType timeTypeFromName( const std::string& name ){
-      std::map<std::string,TimeType> tmp( s_timeTypeMap );
-      auto t = tmp.find( name );
-      if( t == tmp.end() ) throwException( "TimeType \""+name+"\" is unknown.","timeTypeFromName");
-      return t->second;
+      for (auto const &i : s_timeTypeMap)
+        if (name.compare(i.first))
+          return i.second;
+      throwException( "TimeType \""+name+"\" is unknown.","timeTypeFromName");
     }
 
     Time_t tillTimeFromNextSince( Time_t nextSince, TimeType timeType ){

--- a/CondCore/CondDB/src/Types.cc
+++ b/CondCore/CondDB/src/Types.cc
@@ -29,21 +29,19 @@ namespace cond {
     lastValidatedTime = time::MIN;
   }
 
-  static auto s_synchronizationTypeMap = { enumPair( "Offline",OFFLINE ),
-					   enumPair( "HLT",HLT ),
-					   enumPair( "Prompt",PROMPT ),
-					   enumPair( "PCL",PCL ) };
-
+  static std::pair<const char *, SynchronizationType> s_synchronizationTypeArray[] = { std::make_pair("Offline", OFFLINE),
+                                                                                       std::make_pair("HLT", HLT),
+                                                                                       std::make_pair("Prompt", PROMPT),
+                                                                                       std::make_pair("PCL", PCL) };
   std::string synchronizationTypeNames(SynchronizationType type) {
-    std::vector<std::pair<const std::string, SynchronizationType> > tmp( s_synchronizationTypeMap );
-    return tmp[type].first;
+    return s_synchronizationTypeArray[type].first;
   }
 
   SynchronizationType synchronizationTypeFromName( const std::string& name ){
-    std::map<std::string,SynchronizationType> tmp( s_synchronizationTypeMap );
-    auto t = tmp.find( name );
-    if( t == tmp.end() ) throwException( "SynchronizationType \""+name+"\" is unknown.","synchronizationTypeFromName");
-    return t->second;
+    for (auto const &i : s_synchronizationTypeArray)
+      if (name.compare(i.first))
+        return i.second;
+    throwException( "SynchronizationType \""+name+"\" is unknown.","synchronizationTypeFromName");
   }
 
 }


### PR DESCRIPTION
- Make the static mapping const.
- Avoid copying map into a vector just to do an index lookup.
