### PR TITLE
turn FTSFromVertexToPointFactory::operator() into a static method

### DIFF
--- a/HLTrigger/Egamma/interface/HLTPMMassFilter.h
+++ b/HLTrigger/Egamma/interface/HLTPMMassFilter.h
@@ -64,7 +64,6 @@ class HLTPMMassFilter : public HLTFilter {
    private:
       TLorentzVector approxMomAtVtx( const MagneticField *magField, const GlobalPoint& xvert, const reco::SuperClusterRef sc, int charge) ;
 
-      FTSFromVertexToPointFactory theFTSFactory;
       edm::ESHandle<MagneticField> theMagField;
 
       edm::InputTag candTag_;     // input tag identifying product contains filtered egammas

--- a/HLTrigger/Egamma/src/HLTPMMassFilter.cc
+++ b/HLTrigger/Egamma/src/HLTPMMassFilter.cc
@@ -189,8 +189,7 @@ TLorentzVector HLTPMMassFilter::approxMomAtVtx( const MagneticField *magField, c
 		    sc->position().y(),
 		    sc->position().z());
     float energy = sc->energy();
-    FreeTrajectoryState theFTS = theFTSFactory(magField, xsc, xvert, 
-					       energy, charge);
+    FreeTrajectoryState theFTS = FTSFromVertexToPointFactory::get(*magField, xsc, xvert, energy, charge);
     float theApproxMomMod = theFTS.momentum().x()*theFTS.momentum().x() +
                             theFTS.momentum().y()*theFTS.momentum().y() +
                             theFTS.momentum().z()*theFTS.momentum().z();

--- a/RecoEgamma/EgammaElectronAlgos/interface/FTSFromVertexToPointFactory.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/FTSFromVertexToPointFactory.h
@@ -21,16 +21,14 @@
 //         Created:  Mon Mar 27 13:22:06 CEST 2006
 //
 //
+
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
+
 class MagneticField;
 
 class FTSFromVertexToPointFactory{
 public:
-  FTSFromVertexToPointFactory() { };
-  FreeTrajectoryState operator()(const MagneticField *magField, const GlobalPoint& xmeas,  
-                                 const GlobalPoint& xvert, 
-                                 float momentum, TrackCharge charge);
-
+  static FreeTrajectoryState get( MagneticField const & magField, GlobalPoint const & xmeas, GlobalPoint const & xvert, float momentum, TrackCharge charge);
 };
 
 #endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/PixelHitMatcher.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/PixelHitMatcher.h
@@ -186,7 +186,6 @@ class PixelHitMatcher
 
     std::vector<CLHEP::Hep3Vector> pred1Meas ;
     std::vector<CLHEP::Hep3Vector> pred2Meas ;
-    FTSFromVertexToPointFactory myFTS ;
     BarrelMeasurementEstimator meas1stBLayer ;
     BarrelMeasurementEstimator meas2ndBLayer ;
     ForwardMeasurementEstimator meas1stFLayer ;

--- a/RecoEgamma/EgammaElectronAlgos/interface/SeedFilter.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/SeedFilter.h
@@ -51,7 +51,6 @@ class SeedFilter {
   edm::EDGetTokenT<std::vector<reco::Vertex> > vertexSrc_;
 
   edm::ESHandle<MagneticField> theMagField;
-  FTSFromVertexToPointFactory myFTS;
 
   int hitsfactoryMode_;
 

--- a/RecoEgamma/EgammaElectronAlgos/src/FTSFromVertexToPointFactory.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/FTSFromVertexToPointFactory.cc
@@ -19,13 +19,14 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
 
 
-FreeTrajectoryState FTSFromVertexToPointFactory::operator()(const MagneticField *magField, const GlobalPoint& xmeas,  
-                                                            const GlobalPoint& xvert, 
-                                                            float momentum, 
-							    TrackCharge charge)
+FreeTrajectoryState FTSFromVertexToPointFactory::get( MagneticField const & magField, 
+                                                      GlobalPoint const & xmeas, 
+                                                      GlobalPoint const & xvert, 
+                                                      float momentum, 
+                                                      TrackCharge charge )
 {
-  double BInTesla = magField->inTesla(xmeas).z();
-  GlobalVector xdiff = xmeas -xvert;
+  double BInTesla = magField.inTesla(xmeas).z();
+  GlobalVector xdiff = xmeas - xvert;
   double theta = xdiff.theta();
   double phi= xdiff.phi();
   double pt = momentum*sin(theta);
@@ -42,16 +43,10 @@ FreeTrajectoryState FTSFromVertexToPointFactory::operator()(const MagneticField 
   double pyNew =  -sa*pxOld + ca*pyOld;
   GlobalVector pNew(pxNew, pyNew, pz);  
 
-  GlobalTrajectoryParameters gp(xmeas, pNew, charge, magField);
+  GlobalTrajectoryParameters gp(xmeas, pNew, charge, & magField);
   
   AlgebraicSymMatrix55 C = AlgebraicMatrixID();
   FreeTrajectoryState VertexToPoint(gp,CurvilinearTrajectoryError(C));
 
   return VertexToPoint;
 }
-
-
-
-
-
-

--- a/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
@@ -104,7 +104,7 @@ PixelHitMatcher::compatibleSeeds
  {
   int charge = int(fcharge) ;
 
-  FreeTrajectoryState fts = myFTS(theMagField,xmeas, vprim, energy, charge);
+  FreeTrajectoryState fts = FTSFromVertexToPointFactory::get(*theMagField, xmeas, vprim, energy, charge);
   PerpendicularBoundPlaneBuilder bpb;
   TrajectoryStateOnSurface tsos(fts, *bpb(fts.position(), fts.momentum()));
 
@@ -196,7 +196,7 @@ PixelHitMatcher::compatibleSeeds
            { zVertex = vprim.z() ; }
 
           GlobalPoint vertex(vprim.x(),vprim.y(),zVertex) ;
-          FreeTrajectoryState fts2 = myFTS(theMagField,hitPos,vertex,energy, charge) ;
+          FreeTrajectoryState fts2 = FTSFromVertexToPointFactory::get(*theMagField, hitPos, vertex, energy, charge) ;
 
           found = false;
           std::vector<std::pair< std::pair<const GeomDet *,GlobalPoint>, TrajectoryStateOnSurface> >::iterator itTsos2 ;
@@ -275,8 +275,7 @@ PixelHitMatcher::compatibleHits
   typedef vector<BarrelDetLayer*>::const_iterator BarrelLayerIterator;
   BarrelLayerIterator firstLayer = startLayers.firstBLayer();
 
-  FreeTrajectoryState fts =myFTS(theMagField,xmeas, vprim,
-				 energy, charge);
+  FreeTrajectoryState fts = FTSFromVertexToPointFactory::get(*theMagField,xmeas, vprim, energy, charge);
 
   PerpendicularBoundPlaneBuilder bpb;
   TrajectoryStateOnSurface tsos(fts, *bpb(fts.position(), fts.momentum()));
@@ -430,7 +429,7 @@ PixelHitMatcher::compatibleHits
     GlobalPoint vertexPred(vprim.x(),vprim.y(),zVertex) ;
     GlobalPoint hitPos( validMeasurements[i].recHit()->det()->surface().toGlobal( validMeasurements[i].recHit()->localPosition() ) ) ;
 
-    FreeTrajectoryState secondFTS=myFTS(theMagField,hitPos,vertexPred,energy, charge);
+    FreeTrajectoryState secondFTS = FTSFromVertexToPointFactory::get(*theMagField, hitPos, vertexPred, energy, charge);
 
     PixelMatchNextLayers secondHit(&theLayerMeasurements, newLayer, secondFTS,
 				   prop2ndLayer, &meas2ndBLayer,&meas2ndFLayer,

--- a/RecoEgamma/EgammaElectronAlgos/src/SeedFilter.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/SeedFilter.cc
@@ -131,7 +131,7 @@ void SeedFilter::seeds(edm::Event& e, const edm::EventSetup& setup, const reco::
   //===============================================
 
   TrackCharge aCharge = -1 ;
-  FreeTrajectoryState fts = myFTS(&(*theMagField), clusterPos, vtxPos, energy, aCharge);
+  FreeTrajectoryState fts = FTSFromVertexToPointFactory::get(*theMagField, clusterPos, vtxPos, energy, aCharge);
 
   RectangularEtaPhiTrackingRegion etaphiRegionMinus(fts.momentum(),
                                                     vtxPos,
@@ -158,7 +158,7 @@ void SeedFilter::seeds(edm::Event& e, const edm::EventSetup& setup, const reco::
   //===============================================
 
   TrackCharge aChargep = 1 ;
-  fts = myFTS(&(*theMagField), clusterPos, vtxPos, energy, aChargep);
+  fts = FTSFromVertexToPointFactory::get(*theMagField, clusterPos, vtxPos, energy, aChargep);
 
   RectangularEtaPhiTrackingRegion etaphiRegionPlus(fts.momentum(),
                                                    vtxPos,

--- a/RecoEgamma/Examples/plugins/ElectronSeedAnalyzer.cc
+++ b/RecoEgamma/Examples/plugins/ElectronSeedAnalyzer.cc
@@ -210,7 +210,6 @@ void ElectronSeedAnalyzer::analyze( const edm::Event& e, const edm::EventSetup& 
   edm::LogInfo("")<<"\n\n =================> Treating event "<<e.id()<<" Number of seeds "<<elSeeds.product()->size();
   int is=0;
 
-  FTSFromVertexToPointFactory   myFTS;
   float mass=.000511; // electron propagation
   PropagatorWithMaterial* prop1stLayer = new PropagatorWithMaterial(oppositeToMomentum,mass,&(*theMagField));
   PropagatorWithMaterial* prop2ndLayer = new PropagatorWithMaterial(alongMomentum,mass,&(*theMagField));
@@ -269,8 +268,7 @@ void ElectronSeedAnalyzer::analyze( const edm::Event& e, const edm::EventSetup& 
     GlobalPoint vprim(theBeamSpot->position().x(),theBeamSpot->position().y(),theBeamSpot->position().z());
     float energy = theClus->energy();
 
-    FreeTrajectoryState fts = myFTS(&(*theMagField),xmeas, vprim,
-				 energy, charge);
+    FreeTrajectoryState fts = FTSFromVertexToPointFactory::get(*theMagField, xmeas, vprim, energy, charge);
     //std::cout << "[PixelHitMatcher::compatibleSeeds] fts position, momentum " <<
     // fts.parameters().position() << " " << fts.parameters().momentum() << std::endl;
 
@@ -328,7 +326,7 @@ void ElectronSeedAnalyzer::analyze( const edm::Event& e, const edm::EventSetup& 
 
       GlobalPoint vertexPred(vprim.x(),vprim.y(),zVertexPred);
 
-      FreeTrajectoryState fts2 = myFTS(&(*theMagField),hitPos,vertexPred,energy, charge);
+      FreeTrajectoryState fts2 = FTSFromVertexToPointFactory::get(*theMagField, hitPos, vertexPred, energy, charge);
       tsos2 = prop2ndLayer->propagate(fts2,geomdet2->surface()) ;
 
       if (tsos2.isValid()) {


### PR DESCRIPTION
FTSFromVertexToPointFactory does not have any data members, and a single (currently non-const) method, FTSFromVertexToPointFactory::operator() .
This patch changes that single method into a static method, FTSFromVertexToPointFactory::get(), and propagates the change to downstream code.
