### PR TITLE
Get by token for b-tagging DQM packages.

### DIFF
--- a/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.cc
+++ b/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.cc
@@ -36,13 +36,11 @@ BTagPerformanceAnalyzerOnData::BTagPerformanceAnalyzerOnData(const edm::Paramete
   allHisto(pSet.getParameter<bool>( "allHistograms" )),
   finalize(pSet.getParameter< bool >("finalizePlots")),
   finalizeOnly(pSet.getParameter< bool >("finalizeOnly")),
-  //slInfoTag(pSet.getParameter<edm::InputTag>("softLeptonInfo")),
   moduleConfig(pSet.getParameter< vector<edm::ParameterSet> >("tagConfig")),
   mcPlots_(pSet.getParameter< unsigned int >("mcPlots"))
 {
   if(!finalizeOnly) mcPlots_ = 0; //analyzer not designed to produce flavour histograms but could be used for harvesting 
 
-  //consume
   slInfoToken = consumes<SoftLeptonTagInfoCollection>(pSet.getParameter<InputTag>("softLeptonInfo"));
   for (vector<edm::ParameterSet>::const_iterator iModule = moduleConfig.begin();
        iModule != moduleConfig.end(); ++iModule) {
@@ -293,15 +291,13 @@ void BTagPerformanceAnalyzerOnData::analyze(const edm::Event& iEvent, const edm:
   //no flavour map needed here
 
   edm::Handle<reco::SoftLeptonTagInfoCollection> infoHandle;
-  //iEvent.getByLabel(slInfoTag, infoHandle);
-  iEvent.getByToken(slInfoToken, infoHandle); //consume
+  iEvent.getByToken(slInfoToken, infoHandle);
 
 // Look first at the jetTags
 
   for (unsigned int iJetLabel = 0; iJetLabel != jetTagInputTags.size(); ++iJetLabel) {
     edm::Handle<reco::JetTagCollection> tagHandle;
-    //iEvent.getByLabel(jetTagInputTags[iJetLabel], tagHandle);
-    iEvent.getByToken(jetTagToken[iJetLabel], tagHandle); //consume
+    iEvent.getByToken(jetTagToken[iJetLabel], tagHandle);
     //
     // insert check on the presence of the collections
     //
@@ -333,16 +329,13 @@ void BTagPerformanceAnalyzerOnData::analyze(const edm::Event& iEvent, const edm:
 
 // Now look at Tag Correlations
   for (unsigned int iJetLabel = 0; iJetLabel != tagCorrelationInputTags.size(); ++iJetLabel) {
-    //const std::pair<edm::InputTag, edm::InputTag>& inputTags = tagCorrelationInputTags[iJetLabel];
-    const std::pair< edm::EDGetTokenT<reco::JetTagCollection>, edm::EDGetTokenT<reco::JetTagCollection> >& inputTokens = tagCorrelationToken[iJetLabel]; //consume
+    const std::pair< edm::EDGetTokenT<reco::JetTagCollection>, edm::EDGetTokenT<reco::JetTagCollection> >& inputTokens = tagCorrelationToken[iJetLabel];
     edm::Handle<reco::JetTagCollection> tagHandle1;
-    //iEvent.getByLabel(inputTags.first, tagHandle1);
-    iEvent.getByToken(inputTokens.first, tagHandle1); //consume
+    iEvent.getByToken(inputTokens.first, tagHandle1);
     const reco::JetTagCollection& tagColl1 = *(tagHandle1.product());
 
     edm::Handle<reco::JetTagCollection> tagHandle2;
-    //iEvent.getByLabel(inputTags.second, tagHandle2);
-    iEvent.getByToken(inputTokens.second, tagHandle2); //consume
+    iEvent.getByToken(inputTokens.second, tagHandle2);
     const reco::JetTagCollection& tagColl2 = *(tagHandle2.product());
 
     int plotterSize = binTagCorrelationPlotters[iJetLabel].size();
@@ -392,8 +385,7 @@ void BTagPerformanceAnalyzerOnData::analyze(const edm::Event& iEvent, const edm:
     if(nInputTags!=tokens.size()) throw cms::Exception("Configuration") << "Different number of Tag Infos than expected" << endl;
     for (unsigned int iInputTags = 0; iInputTags < tokens.size(); ++iInputTags) {
       edm::Handle< View<BaseTagInfo> > & tagInfoHandle = tagInfoHandles[iInputTags];
-      //iEvent.getByLabel(inputTags[iInputTags], tagInfoHandle);
-      iEvent.getByToken(tokens[iInputTags], tagInfoHandle); //consume
+      iEvent.getByToken(tokens[iInputTags], tagInfoHandle); 
       //
       // protect against missing products
       //

--- a/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.h
+++ b/DQMOffline/RecoB/plugins/BTagPerformanceAnalyzerOnData.h
@@ -82,6 +82,12 @@ class BTagPerformanceAnalyzerOnData : public edm::EDAnalyzer {
 
   unsigned int mcPlots_;
 
+  //add consumes
+  edm::EDGetTokenT<reco::SoftLeptonTagInfoCollection> slInfoToken;
+  std::vector< edm::EDGetTokenT<reco::JetTagCollection> > jetTagToken;
+  std::vector< std::pair<edm::EDGetTokenT<reco::JetTagCollection>, edm::EDGetTokenT<reco::JetTagCollection>> > tagCorrelationToken;
+  std::vector<std::vector <edm::EDGetTokenT<edm::View<reco::BaseTagInfo>> >> tagInfoToken;
+
 };
 
 

--- a/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
+++ b/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
@@ -13,9 +13,10 @@ using namespace edm;
 
 PrimaryVertexMonitor::PrimaryVertexMonitor(const edm::ParameterSet& pSet)
 {
-  moduleLabel = pSet.getParameter<InputTag>("vertexLabel");
-  beamSpotLabel = pSet.getParameter<InputTag>("beamSpotLabel");
-
+  //moduleLabel = pSet.getParameter<InputTag>("vertexLabel");
+  //beamSpotLabel = pSet.getParameter<InputTag>("beamSpotLabel");
+  vtxToken = consumes<reco::VertexCollection>(pSet.getParameter<InputTag>("vertexLabel"));
+  bsToken = consumes<reco::BeamSpot>(pSet.getParameter<InputTag>("beamSpotLabel"));
   //
   // Book all histograms.
   //
@@ -98,10 +99,12 @@ PrimaryVertexMonitor::~PrimaryVertexMonitor()
 void PrimaryVertexMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
   Handle<reco::VertexCollection> recVtxs;
-  iEvent.getByLabel(moduleLabel, recVtxs);
+  //iEvent.getByLabel(moduleLabel, recVtxs);
+  iEvent.getByToken(vtxToken, recVtxs); //consume
 
   edm::Handle<reco::BeamSpot> beamSpotHandle;
-  iEvent.getByLabel(beamSpotLabel,beamSpotHandle);
+  //iEvent.getByLabel(beamSpotLabel,beamSpotHandle);
+  iEvent.getByToken(bsToken, beamSpotHandle); //consume
 
   //
   // check for absent products and simply "return" in that case

--- a/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
+++ b/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.cc
@@ -13,8 +13,6 @@ using namespace edm;
 
 PrimaryVertexMonitor::PrimaryVertexMonitor(const edm::ParameterSet& pSet)
 {
-  //moduleLabel = pSet.getParameter<InputTag>("vertexLabel");
-  //beamSpotLabel = pSet.getParameter<InputTag>("beamSpotLabel");
   vtxToken = consumes<reco::VertexCollection>(pSet.getParameter<InputTag>("vertexLabel"));
   bsToken = consumes<reco::BeamSpot>(pSet.getParameter<InputTag>("beamSpotLabel"));
   //
@@ -99,12 +97,10 @@ PrimaryVertexMonitor::~PrimaryVertexMonitor()
 void PrimaryVertexMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
   Handle<reco::VertexCollection> recVtxs;
-  //iEvent.getByLabel(moduleLabel, recVtxs);
-  iEvent.getByToken(vtxToken, recVtxs); //consume
+  iEvent.getByToken(vtxToken, recVtxs); 
 
   edm::Handle<reco::BeamSpot> beamSpotHandle;
-  //iEvent.getByLabel(beamSpotLabel,beamSpotHandle);
-  iEvent.getByToken(bsToken, beamSpotHandle); //consume
+  iEvent.getByToken(bsToken, beamSpotHandle);
 
   //
   // check for absent products and simply "return" in that case

--- a/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.h
+++ b/DQMOffline/RecoB/plugins/PrimaryVertexMonitor.h
@@ -12,6 +12,7 @@
 #include "DQMServices/Core/interface/MonitorElement.h"
 
 #include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h" 
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
 
@@ -47,6 +48,10 @@ class PrimaryVertexMonitor : public edm::EDAnalyzer {
   MonitorElement *vtxchi2[2] , *vtxndf[2], *vtxprob[2] , *nans[2];
   MonitorElement *type[2];
   MonitorElement *bsX, *bsY, *bsZ, *bsSigmaZ, *bsDxdz, *bsDydz, *bsBeamWidthX, *bsBeamWidthY, *bsType;
+
+  //consume
+  edm::EDGetTokenT<reco::VertexCollection> vtxToken;
+  edm::EDGetTokenT<reco::BeamSpot> bsToken;
 };
 
 

--- a/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.cc
+++ b/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.cc
@@ -8,6 +8,14 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
+//added for consume
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
+#include "RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h"
+#include "DQMOffline/RecoB/interface/MVAJetTagPlotter.h"
+
+
+
 using namespace reco;
 using namespace edm;
 using namespace std;
@@ -16,7 +24,7 @@ using namespace RecoBTag;
 
 typedef std::pair<Jet, reco::JetFlavour> JetWithFlavour;
 
-BTagPerformanceAnalyzerMC::BTagPerformanceAnalyzerMC(const edm::ParameterSet& pSet) :
+BTagPerformanceAnalyzerMC::BTagPerformanceAnalyzerMC(const edm::ParameterSet& pSet/*, const edm::EventSetup & setup*/) :
   partonKinematics(pSet.getParameter< bool >("partonKinematics")),
   ptPartonMin(pSet.getParameter<double>("ptPartonMin")),
   ptPartonMax(pSet.getParameter<double>("ptPartonMax")),
@@ -39,8 +47,8 @@ BTagPerformanceAnalyzerMC::BTagPerformanceAnalyzerMC(const edm::ParameterSet& pS
   finalize(pSet.getParameter< bool >("finalizePlots")),
   finalizeOnly(pSet.getParameter< bool >("finalizeOnly")),
   ptHatWeight(pSet.getParameter< bool >("applyPtHatWeight")),
-  jetMCSrc(pSet.getParameter<edm::InputTag>("jetMCSrc")),
-  slInfoTag(pSet.getParameter<edm::InputTag>("softLeptonInfo")),
+  //jetMCSrc(pSet.getParameter<edm::InputTag>("jetMCSrc")),
+  //slInfoTag(pSet.getParameter<edm::InputTag>("softLeptonInfo")),
   moduleConfig(pSet.getParameter< vector<edm::ParameterSet> >("tagConfig")),
   flavPlots_(pSet.getParameter< std::string >("flavPlots")),
   makeDiffPlots_(pSet.getParameter< bool >("differentialPlots")),
@@ -64,6 +72,41 @@ BTagPerformanceAnalyzerMC::BTagPerformanceAnalyzerMC(const edm::ParameterSet& pS
     case 13: muonPlots = true; electronPlots = false; tauPlots = false; break;
     case 15: tauPlots = true; electronPlots = false; tauPlots = false; break;
     default: electronPlots = false; muonPlots = false; tauPlots = false;
+  }
+  
+  //add consumes
+  genToken = mayConsume<GenEventInfoProduct>(edm::InputTag("generator"));
+  jetToken = consumes<JetFlavourMatchingCollection>(pSet.getParameter<InputTag>("jetMCSrc"));
+  slInfoToken = consumes<SoftLeptonTagInfoCollection>(pSet.getParameter<InputTag>("softLeptonInfo"));
+  for (vector<edm::ParameterSet>::const_iterator iModule = moduleConfig.begin();
+       iModule != moduleConfig.end(); ++iModule) {
+
+    const string& dataFormatType = iModule->exists("type") ?
+                                   iModule->getParameter<string>("type") :
+                                   "JetTag";
+    if (dataFormatType == "JetTag") {
+      const InputTag& moduleLabel = iModule->getParameter<InputTag>("label");
+      jetTagToken.push_back(consumes<JetTagCollection>(moduleLabel)); 
+    } 
+    else if(dataFormatType == "TagCorrelation") {
+      const InputTag& label1 = iModule->getParameter<InputTag>("label1");
+      const InputTag& label2 = iModule->getParameter<InputTag>("label2");
+      tagCorrelationToken.push_back(std::pair< edm::EDGetTokenT<reco::JetTagCollection>, edm::EDGetTokenT<reco::JetTagCollection> >(consumes<JetTagCollection>(label1), consumes<JetTagCollection>(label2)));
+    }
+    else {
+      std::vector< edm::EDGetTokenT<edm::View<reco::BaseTagInfo>> > tokens; 
+      if(dataFormatType == "GenericMVA") {
+	const InputTag& ipinfo = iModule->getParameter<InputTag>("ipTagInfos");
+	const InputTag& svinfo = iModule->getParameter<InputTag>("svTagInfos");
+	tokens.push_back(consumes< View<BaseTagInfo> >(ipinfo));
+	tokens.push_back(consumes< View<BaseTagInfo> >(svinfo));
+      }
+      else {
+	const InputTag& moduleLabel = iModule->getParameter<InputTag>("label");
+	tokens.push_back(consumes< View<BaseTagInfo> >(moduleLabel));
+      }
+      tagInfoToken.push_back(tokens);
+    }
   }
 }
 
@@ -282,8 +325,9 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
     /* APPLY PTHAT EVENT  WEIGHT */
 
     edm::Handle<GenEventInfoProduct> genInfoHandle;
-    iEvent.getByLabel("generator", genInfoHandle);
-    
+    //iEvent.getByLabel("generator", genInfoHandle);
+    iEvent.getByToken(genToken, genInfoHandle); //consume
+
     if( genInfoHandle.isValid() ) {
       weight = weight*static_cast<float>(genInfoHandle->weight());
     
@@ -298,7 +342,8 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
   FlavourMap flavours;
   LeptonMap leptons;
 
-  iEvent.getByLabel(jetMCSrc, jetMC);
+  //iEvent.getByLabel(jetMCSrc, jetMC);
+  iEvent.getByToken(jetToken, jetMC); //consume
   for (JetFlavourMatchingCollection::const_iterator iter = jetMC->begin();
        iter != jetMC->end(); ++iter) {
     unsigned int fl = std::abs(iter->second.getFlavour());
@@ -308,12 +353,14 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
   }
 
   edm::Handle<reco::SoftLeptonTagInfoCollection> infoHandle;
-  iEvent.getByLabel(slInfoTag, infoHandle);
+  //iEvent.getByLabel(slInfoTag, infoHandle);
+  iEvent.getByToken(slInfoToken, infoHandle); //consume
 
 // Look first at the jetTags
   for (unsigned int iJetLabel = 0; iJetLabel != jetTagInputTags.size(); ++iJetLabel) {
     edm::Handle<reco::JetTagCollection> tagHandle;
-    iEvent.getByLabel(jetTagInputTags[iJetLabel], tagHandle);
+    //iEvent.getByLabel(jetTagInputTags[iJetLabel], tagHandle);
+    iEvent.getByToken(jetTagToken[iJetLabel], tagHandle); //consume
     const reco::JetTagCollection & tagColl = *(tagHandle.product());
     LogDebug("Info") << "Found " << tagColl.size() << " B candidates in collection " << jetTagInputTags[iJetLabel];
 
@@ -354,13 +401,16 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
 
 // Now look at Tag Correlations
   for (unsigned int iJetLabel = 0; iJetLabel != tagCorrelationInputTags.size(); ++iJetLabel) {
-    const std::pair<edm::InputTag, edm::InputTag>& inputTags = tagCorrelationInputTags[iJetLabel];
+    //const std::pair<edm::InputTag, edm::InputTag>& inputTags = tagCorrelationInputTags[iJetLabel];
+    const std::pair< edm::EDGetTokenT<reco::JetTagCollection>, edm::EDGetTokenT<reco::JetTagCollection> >& inputTokens = tagCorrelationToken[iJetLabel]; //consume
     edm::Handle<reco::JetTagCollection> tagHandle1;
-    iEvent.getByLabel(inputTags.first, tagHandle1);
+    //iEvent.getByLabel(inputTags.first, tagHandle1);
+    iEvent.getByToken(inputTokens.first, tagHandle1); //consume
     const reco::JetTagCollection& tagColl1 = *(tagHandle1.product());
 
     edm::Handle<reco::JetTagCollection> tagHandle2;
-    iEvent.getByLabel(inputTags.second, tagHandle2);
+    //iEvent.getByLabel(inputTags.second, tagHandle2);
+    iEvent.getByToken(inputTokens.second, tagHandle2); //consume
     const reco::JetTagCollection& tagColl2 = *(tagHandle2.product());
 
     int plotterSize = binTagCorrelationPlotters[iJetLabel].size();
@@ -402,7 +452,7 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
     int plotterSize = binTagInfoPlotters[iJetLabel].size();
     for (int iPlotter = 0; iPlotter != plotterSize; ++iPlotter)
       binTagInfoPlotters[iJetLabel][iPlotter]->setEventSetup(iSetup);
-
+    
     vector<edm::InputTag> & inputTags = tagInfoInputTags[iJetLabel];
     if (inputTags.empty()) {
       // deferred retrieval of input tags
@@ -418,14 +468,17 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
         inputTags.push_back(inputTag);
       }
     }
-
+    
     unsigned int nInputTags = inputTags.size();
     vector< edm::Handle< View<BaseTagInfo> > > tagInfoHandles(nInputTags);
     edm::ProductID jetProductID;
     unsigned int nTagInfos = 0;
-    for (unsigned int iInputTags = 0; iInputTags < inputTags.size(); ++iInputTags) {
+    vector<edm::EDGetTokenT<edm::View<reco::BaseTagInfo>> > & tokens = tagInfoToken[iJetLabel];
+    if(nInputTags!=tokens.size()) throw cms::Exception("Configuration") << "Different number of Tag Infos than expected" << endl;
+    for (unsigned int iInputTags = 0; iInputTags < tokens.size(); ++iInputTags) {
       edm::Handle< View<BaseTagInfo> > & tagInfoHandle = tagInfoHandles[iInputTags];
-      iEvent.getByLabel(inputTags[iInputTags], tagInfoHandle);
+      //iEvent.getByLabel(inputTags[iInputTags], tagInfoHandle);
+      iEvent.getByToken(tokens[iInputTags], tagInfoHandle); //consume
       unsigned int size = tagInfoHandle->size();
       LogDebug("Info") << "Found " << size << " B candidates in collection " << inputTags[iInputTags];
 

--- a/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.cc
+++ b/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.cc
@@ -39,8 +39,6 @@ BTagPerformanceAnalyzerMC::BTagPerformanceAnalyzerMC(const edm::ParameterSet& pS
   finalize(pSet.getParameter< bool >("finalizePlots")),
   finalizeOnly(pSet.getParameter< bool >("finalizeOnly")),
   ptHatWeight(pSet.getParameter< bool >("applyPtHatWeight")),
-  //jetMCSrc(pSet.getParameter<edm::InputTag>("jetMCSrc")),
-  //slInfoTag(pSet.getParameter<edm::InputTag>("softLeptonInfo")),
   moduleConfig(pSet.getParameter< vector<edm::ParameterSet> >("tagConfig")),
   flavPlots_(pSet.getParameter< std::string >("flavPlots")),
   makeDiffPlots_(pSet.getParameter< bool >("differentialPlots")),
@@ -66,7 +64,6 @@ BTagPerformanceAnalyzerMC::BTagPerformanceAnalyzerMC(const edm::ParameterSet& pS
     default: electronPlots = false; muonPlots = false; tauPlots = false;
   }
   
-  //add consumes
   genToken = mayConsume<GenEventInfoProduct>(edm::InputTag("generator"));
   jetToken = consumes<JetFlavourMatchingCollection>(pSet.getParameter<InputTag>("jetMCSrc"));
   slInfoToken = consumes<SoftLeptonTagInfoCollection>(pSet.getParameter<InputTag>("softLeptonInfo"));
@@ -317,8 +314,7 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
     /* APPLY PTHAT EVENT  WEIGHT */
 
     edm::Handle<GenEventInfoProduct> genInfoHandle;
-    //iEvent.getByLabel("generator", genInfoHandle);
-    iEvent.getByToken(genToken, genInfoHandle); //consume
+    iEvent.getByToken(genToken, genInfoHandle);
 
     if( genInfoHandle.isValid() ) {
       weight = weight*static_cast<float>(genInfoHandle->weight());
@@ -334,8 +330,7 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
   FlavourMap flavours;
   LeptonMap leptons;
 
-  //iEvent.getByLabel(jetMCSrc, jetMC);
-  iEvent.getByToken(jetToken, jetMC); //consume
+  iEvent.getByToken(jetToken, jetMC); 
   for (JetFlavourMatchingCollection::const_iterator iter = jetMC->begin();
        iter != jetMC->end(); ++iter) {
     unsigned int fl = std::abs(iter->second.getFlavour());
@@ -345,14 +340,12 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
   }
 
   edm::Handle<reco::SoftLeptonTagInfoCollection> infoHandle;
-  //iEvent.getByLabel(slInfoTag, infoHandle);
-  iEvent.getByToken(slInfoToken, infoHandle); //consume
+  iEvent.getByToken(slInfoToken, infoHandle);
 
 // Look first at the jetTags
   for (unsigned int iJetLabel = 0; iJetLabel != jetTagInputTags.size(); ++iJetLabel) {
     edm::Handle<reco::JetTagCollection> tagHandle;
-    //iEvent.getByLabel(jetTagInputTags[iJetLabel], tagHandle);
-    iEvent.getByToken(jetTagToken[iJetLabel], tagHandle); //consume
+    iEvent.getByToken(jetTagToken[iJetLabel], tagHandle); 
     const reco::JetTagCollection & tagColl = *(tagHandle.product());
     LogDebug("Info") << "Found " << tagColl.size() << " B candidates in collection " << jetTagInputTags[iJetLabel];
 
@@ -393,16 +386,13 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
 
 // Now look at Tag Correlations
   for (unsigned int iJetLabel = 0; iJetLabel != tagCorrelationInputTags.size(); ++iJetLabel) {
-    //const std::pair<edm::InputTag, edm::InputTag>& inputTags = tagCorrelationInputTags[iJetLabel];
-    const std::pair< edm::EDGetTokenT<reco::JetTagCollection>, edm::EDGetTokenT<reco::JetTagCollection> >& inputTokens = tagCorrelationToken[iJetLabel]; //consume
+    const std::pair< edm::EDGetTokenT<reco::JetTagCollection>, edm::EDGetTokenT<reco::JetTagCollection> >& inputTokens = tagCorrelationToken[iJetLabel];
     edm::Handle<reco::JetTagCollection> tagHandle1;
-    //iEvent.getByLabel(inputTags.first, tagHandle1);
-    iEvent.getByToken(inputTokens.first, tagHandle1); //consume
+    iEvent.getByToken(inputTokens.first, tagHandle1); 
     const reco::JetTagCollection& tagColl1 = *(tagHandle1.product());
 
     edm::Handle<reco::JetTagCollection> tagHandle2;
-    //iEvent.getByLabel(inputTags.second, tagHandle2);
-    iEvent.getByToken(inputTokens.second, tagHandle2); //consume
+    iEvent.getByToken(inputTokens.second, tagHandle2);
     const reco::JetTagCollection& tagColl2 = *(tagHandle2.product());
 
     int plotterSize = binTagCorrelationPlotters[iJetLabel].size();
@@ -469,8 +459,7 @@ void BTagPerformanceAnalyzerMC::analyze(const edm::Event& iEvent, const edm::Eve
     if(nInputTags!=tokens.size()) throw cms::Exception("Configuration") << "Different number of Tag Infos than expected" << endl;
     for (unsigned int iInputTags = 0; iInputTags < tokens.size(); ++iInputTags) {
       edm::Handle< View<BaseTagInfo> > & tagInfoHandle = tagInfoHandles[iInputTags];
-      //iEvent.getByLabel(inputTags[iInputTags], tagInfoHandle);
-      iEvent.getByToken(tokens[iInputTags], tagInfoHandle); //consume
+      iEvent.getByToken(tokens[iInputTags], tagInfoHandle); 
       unsigned int size = tagInfoHandle->size();
       LogDebug("Info") << "Found " << size << " B candidates in collection " << inputTags[iInputTags];
 

--- a/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.cc
+++ b/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.cc
@@ -8,14 +8,6 @@
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
-//added for consume
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
-#include "RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h"
-#include "DQMOffline/RecoB/interface/MVAJetTagPlotter.h"
-
-
-
 using namespace reco;
 using namespace edm;
 using namespace std;
@@ -24,7 +16,7 @@ using namespace RecoBTag;
 
 typedef std::pair<Jet, reco::JetFlavour> JetWithFlavour;
 
-BTagPerformanceAnalyzerMC::BTagPerformanceAnalyzerMC(const edm::ParameterSet& pSet/*, const edm::EventSetup & setup*/) :
+BTagPerformanceAnalyzerMC::BTagPerformanceAnalyzerMC(const edm::ParameterSet& pSet) :
   partonKinematics(pSet.getParameter< bool >("partonKinematics")),
   ptPartonMin(pSet.getParameter<double>("ptPartonMin")),
   ptPartonMax(pSet.getParameter<double>("ptPartonMax")),

--- a/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.h
+++ b/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.h
@@ -44,7 +44,7 @@
 
 class BTagPerformanceAnalyzerMC : public edm::EDAnalyzer {
    public:
-      explicit BTagPerformanceAnalyzerMC(const edm::ParameterSet& pSet/*, const edm::EventSetup & setup*/);
+      explicit BTagPerformanceAnalyzerMC(const edm::ParameterSet& pSet);
 
       ~BTagPerformanceAnalyzerMC();
 

--- a/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.h
+++ b/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.h
@@ -44,7 +44,7 @@
 
 class BTagPerformanceAnalyzerMC : public edm::EDAnalyzer {
    public:
-      explicit BTagPerformanceAnalyzerMC(const edm::ParameterSet& pSet);
+      explicit BTagPerformanceAnalyzerMC(const edm::ParameterSet& pSet/*, const edm::EventSetup & setup*/);
 
       ~BTagPerformanceAnalyzerMC();
 
@@ -112,6 +112,15 @@ typedef std::map<edm::RefToBase<reco::Jet>, reco::JetFlavour::Leptons, JetRefCom
 
   bool eventInitialized;
   bool electronPlots, muonPlots, tauPlots;
+
+  //add consumes 
+  edm::EDGetTokenT<GenEventInfoProduct> genToken;
+  edm::EDGetTokenT<reco::JetFlavourMatchingCollection> jetToken;
+  edm::EDGetTokenT<reco::SoftLeptonTagInfoCollection> slInfoToken;
+  std::vector< edm::EDGetTokenT<reco::JetTagCollection> > jetTagToken;
+  std::vector< std::pair<edm::EDGetTokenT<reco::JetTagCollection>, edm::EDGetTokenT<reco::JetTagCollection>> > tagCorrelationToken;
+  std::vector<std::vector <edm::EDGetTokenT<edm::View<reco::BaseTagInfo>> >> tagInfoToken;
+
 };
 
 

--- a/Validation/RecoB/plugins/recoBSVTagInfoValidationAnalyzer.cc
+++ b/Validation/RecoB/plugins/recoBSVTagInfoValidationAnalyzer.cc
@@ -85,6 +85,10 @@ private:
     // Histogram handlers
     std::map<std::string, MonitorElement *> HistIndex_;
 
+  //consumes
+  edm::EDGetTokenT<reco::SecondaryVertexTagInfoCollection> svInfoToken;
+  edm::EDGetTokenT<TrackingVertexCollection> tvToken;
+
 };
 
 
@@ -115,11 +119,11 @@ recoBSVTagInfoValidationAnalyzer::recoBSVTagInfoValidationAnalyzer(const edm::Pa
 
 
     // Get the track collection
-    svTagInfoProducer_ = config.getUntrackedParameter<edm::InputTag> ( "svTagInfoProducer" );
-
+    //svTagInfoProducer_ = config.getUntrackedParameter<edm::InputTag> ( "svTagInfoProducer" );
+    svInfoToken = consumes<reco::SecondaryVertexTagInfoCollection>(config.getParameter<InputTag>("svTagInfoProducer"));//consume
     // Name of the traking pariticle collection
-    trackingTruth_ = config.getUntrackedParameter<edm::InputTag> ( "trackingTruth" );
-
+    //trackingTruth_ = config.getUntrackedParameter<edm::InputTag> ( "trackingTruth" );
+    tvToken = consumes<TrackingVertexCollection>(config.getParameter<InputTag>("trackingTruth")); //consume
     // Number of track categories
     numberVertexClassifier_ = VertexCategories::Unknown+1;
 
@@ -192,8 +196,8 @@ void recoBSVTagInfoValidationAnalyzer::analyze(const edm::Event& event, const ed
 
   // Vertex collection
   edm::Handle<reco::SecondaryVertexTagInfoCollection> svTagInfoCollection;
-  event.getByLabel(svTagInfoProducer_, svTagInfoCollection);
-
+  //event.getByLabel(svTagInfoProducer_, svTagInfoCollection);
+  event.getByToken(svInfoToken, svTagInfoCollection); //consume
   // Get a constant reference to the track history associated to the classifier
   VertexHistory const & tracer = classifier_.history();
 
@@ -305,8 +309,8 @@ void recoBSVTagInfoValidationAnalyzer::analyze(const edm::Event& event, const ed
 
   // Vertex collection
   edm::Handle<TrackingVertexCollection>  TVCollection;
-  event.getByLabel(trackingTruth_, TVCollection);
-    
+  //event.getByLabel(trackingTruth_, TVCollection);
+  event.getByToken(tvToken, TVCollection);//consume
   // Loop over the TV collection.
   for (std::size_t index = 0; index < TVCollection->size(); ++index){
         

--- a/Validation/RecoB/plugins/recoBSVTagInfoValidationAnalyzer.cc
+++ b/Validation/RecoB/plugins/recoBSVTagInfoValidationAnalyzer.cc
@@ -119,11 +119,9 @@ recoBSVTagInfoValidationAnalyzer::recoBSVTagInfoValidationAnalyzer(const edm::Pa
 
 
     // Get the track collection
-    //svTagInfoProducer_ = config.getUntrackedParameter<edm::InputTag> ( "svTagInfoProducer" );
-    svInfoToken = consumes<reco::SecondaryVertexTagInfoCollection>(config.getParameter<InputTag>("svTagInfoProducer"));//consume
+    svInfoToken = consumes<reco::SecondaryVertexTagInfoCollection>(config.getParameter<InputTag>("svTagInfoProducer"));
     // Name of the traking pariticle collection
-    //trackingTruth_ = config.getUntrackedParameter<edm::InputTag> ( "trackingTruth" );
-    tvToken = consumes<TrackingVertexCollection>(config.getParameter<InputTag>("trackingTruth")); //consume
+    tvToken = consumes<TrackingVertexCollection>(config.getParameter<InputTag>("trackingTruth")); 
     // Number of track categories
     numberVertexClassifier_ = VertexCategories::Unknown+1;
 
@@ -196,8 +194,7 @@ void recoBSVTagInfoValidationAnalyzer::analyze(const edm::Event& event, const ed
 
   // Vertex collection
   edm::Handle<reco::SecondaryVertexTagInfoCollection> svTagInfoCollection;
-  //event.getByLabel(svTagInfoProducer_, svTagInfoCollection);
-  event.getByToken(svInfoToken, svTagInfoCollection); //consume
+  event.getByToken(svInfoToken, svTagInfoCollection);
   // Get a constant reference to the track history associated to the classifier
   VertexHistory const & tracer = classifier_.history();
 
@@ -309,8 +306,7 @@ void recoBSVTagInfoValidationAnalyzer::analyze(const edm::Event& event, const ed
 
   // Vertex collection
   edm::Handle<TrackingVertexCollection>  TVCollection;
-  //event.getByLabel(trackingTruth_, TVCollection);
-  event.getByToken(tvToken, TVCollection);//consume
+  event.getByToken(tvToken, TVCollection);
   // Loop over the TV collection.
   for (std::size_t index = 0; index < TVCollection->size(); ++index){
         


### PR DESCRIPTION
Validation/RecoB and DQMOffline/RecoB updated with getByToken instead of getByLabel.
