### PR TITLE
Declare constant statics const

### DIFF
--- a/FWCore/Framework/src/Factory.cc
+++ b/FWCore/Framework/src/Factory.cc
@@ -14,7 +14,7 @@ namespace edm {
     delete v.second;
   }
 
-  Factory Factory::singleInstance_;
+  Factory const Factory::singleInstance_;
   
   Factory::~Factory()
   {
@@ -26,7 +26,7 @@ namespace edm {
   {
   }
 
-  Factory* Factory::get()
+  Factory const* Factory::get()
   {
     return &singleInstance_;
   }

--- a/FWCore/Framework/src/Factory.h
+++ b/FWCore/Framework/src/Factory.h
@@ -21,7 +21,7 @@ namespace edm {
 
     ~Factory();
 
-    static Factory* get();
+    static Factory const* get();
 
     std::shared_ptr<maker::ModuleHolder> makeModule(const MakeModuleParams&,
                                                     signalslot::Signal<void(const ModuleDescription&)>& pre,
@@ -33,7 +33,7 @@ namespace edm {
   private:
     Factory();
     Maker* findMaker(const MakeModuleParams& p) const;
-    static Factory singleInstance_;
+    static Factory const singleInstance_;
     mutable MakerMap makers_;
   };
 

--- a/FWCore/Framework/src/InputSourceFactory.cc
+++ b/FWCore/Framework/src/InputSourceFactory.cc
@@ -18,9 +18,9 @@ namespace edm {
   {
   }
 
-  InputSourceFactory InputSourceFactory::singleInstance_;
+  InputSourceFactory const InputSourceFactory::singleInstance_;
 
-  InputSourceFactory* InputSourceFactory::get()
+  InputSourceFactory const* InputSourceFactory::get()
   {
     // will not work with plugin factories
     //static InputSourceFactory f;

--- a/FWCore/Framework/src/InputSourceFactory.h
+++ b/FWCore/Framework/src/InputSourceFactory.h
@@ -17,7 +17,7 @@ namespace edm {
   public:
     ~InputSourceFactory();
 
-    static InputSourceFactory* get();
+    static InputSourceFactory const* get();
 
     std::auto_ptr<InputSource>
       makeInputSource(ParameterSet const&,
@@ -26,7 +26,7 @@ namespace edm {
 
   private:
     InputSourceFactory();
-    static InputSourceFactory singleInstance_;
+    static InputSourceFactory const singleInstance_;
   };
 
 }

--- a/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetuprecord_t.cppunit.cc
@@ -36,7 +36,7 @@ class DummyRecord : public edm::eventsetup::EventSetupRecordImplementation<Dummy
 HCTYPETAG_HELPER_METHODS(eventsetuprecord_t::DummyRecord)
 
 //create an instance of the factory
-static eventsetup::EventSetupRecordProviderFactoryTemplate<eventsetuprecord_t::DummyRecord> s_factory;
+static eventsetup::EventSetupRecordProviderFactoryTemplate<eventsetuprecord_t::DummyRecord> const s_factory;
 
 namespace eventsetuprecord_t {
 class Dummy {};

--- a/FWCore/PluginManager/bin/refresh.cc
+++ b/FWCore/PluginManager/bin/refresh.cc
@@ -157,7 +157,7 @@ int main (int argc, char **argv) try {
         path shortName(file->path().filename());
         std::string stringName = shortName.string();
 
-        static std::string kPluginPrefix(standard::pluginPrefix());
+        static std::string const kPluginPrefix(standard::pluginPrefix());
         if (stringName.size() < kPluginPrefix.size()) {
           continue;
         }

--- a/FWCore/PluginManager/interface/ProblemTracker.h
+++ b/FWCore/PluginManager/interface/ProblemTracker.h
@@ -18,7 +18,7 @@ namespace edm
   class ProblemTracker
   {
   public:
-    static ProblemTracker* instance();
+    static ProblemTracker const* instance();
 
   private:
     ProblemTracker();
@@ -35,7 +35,7 @@ namespace edm
     ~AssertHandler();
   private:
     AssertHandler(const AssertHandler&);
-    ProblemTracker* pt_;
+    ProblemTracker const* pt_;
   };
 
 }

--- a/FWCore/PluginManager/src/ProblemTracker.cc
+++ b/FWCore/PluginManager/src/ProblemTracker.cc
@@ -31,9 +31,9 @@ namespace edm
     dead_ = true;
   }
 
-  ProblemTracker* ProblemTracker::instance()
+  ProblemTracker const* ProblemTracker::instance()
   {
-    static ProblemTracker pt;
+    static ProblemTracker const pt;
     return &pt;
   }
 

--- a/FWCore/RootAutoLibraryLoader/src/RootAutoLibraryLoader.cc
+++ b/FWCore/RootAutoLibraryLoader/src/RootAutoLibraryLoader.cc
@@ -87,13 +87,13 @@ namespace edm {
 
       void
       addWrapperOfVectorOfBuiltin(std::map<std::string, std::string>& iMap, char const* iBuiltin) {
-         static std::string sReflexPrefix("edm::Wrapper<std::vector<");
-         static std::string sReflexPostfix("> >");
+         static std::string const sReflexPrefix("edm::Wrapper<std::vector<");
+         static std::string const sReflexPostfix("> >");
 
          //Wrapper<vector<float, allocator<float> > >
-         static std::string sCintPrefix("Wrapper<vector<");
-         static std::string sCintMiddle(",allocator<");
-         static std::string sCintPostfix("> > >");
+         static std::string const sCintPrefix("Wrapper<vector<");
+         static std::string const sCintMiddle(",allocator<");
+         static std::string const sCintPostfix("> > >");
 
          std::string type(iBuiltin);
          iMap.insert(make_pair(sCintPrefix + type + sCintMiddle + type + sCintPostfix,

--- a/FWCore/Utilities/interface/GetPassID.h
+++ b/FWCore/Utilities/interface/GetPassID.h
@@ -5,7 +5,7 @@
 
 namespace edm {
   inline
-  std::string const getPassID () {
+  std::string getPassID () {
     static std::string const passID;
     // return empty string for now.
     return passID; 

--- a/FWCore/Utilities/interface/GetPassID.h
+++ b/FWCore/Utilities/interface/GetPassID.h
@@ -5,8 +5,8 @@
 
 namespace edm {
   inline
-  std::string getPassID () {
-    static std::string passID;
+  std::string const getPassID () {
+    static std::string const passID;
     // return empty string for now.
     return passID; 
   }


### PR DESCRIPTION
Declare statics in the framework that are never modified as "const".  These were detected by the static analyzer.
This pull request is just for those found and fixed today.  There will be more.
