### PR TITLE
Dropped unnecessary signal connections in PrescaleService

### DIFF
--- a/FWCore/PrescaleService/interface/PrescaleService.h
+++ b/FWCore/PrescaleService/interface/PrescaleService.h
@@ -43,12 +43,6 @@ namespace edm {
       unsigned int getPrescale(std::string const& prescaledPath);
 
       void setIndex(unsigned int lvl1Index){iLvl1IndexDefault_ = lvl1Index;}      
-      void postBeginJob();
-      void postEndJob() {}
-      void preEventProcessing(EventID const&, Timestamp const&) {}
-      void postEventProcessing(Event const&, EventSetup const&) {}
-      void preModule(ModuleDescription const&) {}
-      void postModule(ModuleDescription const&) {}
       
       typedef std::vector<std::string>                          VString_t;
       typedef std::map<std::string, std::vector<unsigned int> > PrescaleTable_t;
@@ -63,6 +57,7 @@ namespace edm {
       //
       // private member functions
       //
+      void postBeginJob();
 
       void configure();
       

--- a/FWCore/PrescaleService/src/PrescaleService.cc
+++ b/FWCore/PrescaleService/src/PrescaleService.cc
@@ -36,13 +36,6 @@ namespace edm {
       , prescaleTable_()
     {
       iReg.watchPostBeginJob(this, &PrescaleService::postBeginJob);
-      iReg.watchPostEndJob(this, &PrescaleService::postEndJob);
-      
-      iReg.watchPreProcessEvent(this, &PrescaleService::preEventProcessing);
-      iReg.watchPostProcessEvent(this, &PrescaleService::postEventProcessing);
-      
-      iReg.watchPreModule(this, &PrescaleService::preModule);
-      iReg.watchPostModule(this, &PrescaleService::postModule);
     }
       
     //______________________________________________________________________________


### PR DESCRIPTION
The PrescaleService told the system it wanted to listen to some obsolete signals but in reality it ignored them. Dropping the empty functions and their registration now makes the service threaded framework compatible.
