### PR TITLE
Update unit test reference files

### DIFF
--- a/FWCore/Framework/test/run_unscheduled.sh
+++ b/FWCore/Framework/test/run_unscheduled.sh
@@ -13,7 +13,7 @@ F7=${LOCAL_TEST_DIR}/test_onPath_wrongOrder_allowUnscheduled_false_fail_cfg.py
 F8=${LOCAL_TEST_DIR}/test_onPath_wrongOrder_allowUnscheduled_true_fail_cfg.py
 
 (cmsRun $F1 ) > test_deepCall_allowUnscheduled_true.log || die "Failure using $F1" $?
-diff test_deepCall_allowUnscheduled_true.log ${LOCAL_TEST_DIR}/unit_test_outputs/test_deepCall_allowUnscheduled_true.log || die "comparing test_deepCall_allowUnscheduled_true.log" $?
+diff ${LOCAL_TEST_DIR}/unit_test_outputs/test_deepCall_allowUnscheduled_true.log test_deepCall_allowUnscheduled_true.log || die "comparing test_deepCall_allowUnscheduled_true.log" $?
 
 !(cmsRun $F2 ) || die "Failure using $F2" $?
 !(cmsRun $F3 ) || die "Failure using $F3" $?

--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_allowUnscheduled_true.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_allowUnscheduled_true.log
@@ -1,39 +1,39 @@
 ++ starting: constructing source: EmptySource
 ++ finished: constructing source: EmptySource
-++++ starting: constructing module with label 'TriggerResults'
-++++ finished: constructing module with label 'TriggerResults'
-++++ starting: constructing module with label 'get'
-++++ finished: constructing module with label 'get'
-++++ starting: constructing module with label 'one'
+++++ starting: constructing module with label 'TriggerResults' id = 1
+++++ finished: constructing module with label 'TriggerResults' id = 1
+++++ starting: constructing module with label 'get' id = 2
+++++ finished: constructing module with label 'get' id = 2
+++++ starting: constructing module with label 'one' id = 3
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++++ finished: constructing module with label 'one'
+++++ finished: constructing module with label 'one' id = 3
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++++ starting: constructing module with label 'result1'
-++++ finished: constructing module with label 'result1'
-++++ starting: constructing module with label 'result2'
-++++ finished: constructing module with label 'result2'
-++++ starting: constructing module with label 'result4'
-++++ finished: constructing module with label 'result4'
-++++ starting: begin job for module with label 'one'
+++++ starting: constructing module with label 'result1' id = 4
+++++ finished: constructing module with label 'result1' id = 4
+++++ starting: constructing module with label 'result2' id = 5
+++++ finished: constructing module with label 'result2' id = 5
+++++ starting: constructing module with label 'result4' id = 6
+++++ finished: constructing module with label 'result4' id = 6
+++++ starting: begin job for module with label 'one' id = 3
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++++ finished: begin job for module with label 'one'
+++++ finished: begin job for module with label 'one' id = 3
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++++ starting: begin job for module with label 'result1'
-++++ finished: begin job for module with label 'result1'
-++++ starting: begin job for module with label 'result2'
-++++ finished: begin job for module with label 'result2'
-++++ starting: begin job for module with label 'result4'
-++++ finished: begin job for module with label 'result4'
-++++ starting: begin job for module with label 'get'
-++++ finished: begin job for module with label 'get'
-++++ starting: begin job for module with label 'TriggerResults'
-++++ finished: begin job for module with label 'TriggerResults'
+++++ starting: begin job for module with label 'result1' id = 4
+++++ finished: begin job for module with label 'result1' id = 4
+++++ starting: begin job for module with label 'result2' id = 5
+++++ finished: begin job for module with label 'result2' id = 5
+++++ starting: begin job for module with label 'result4' id = 6
+++++ finished: begin job for module with label 'result4' id = 6
+++++ starting: begin job for module with label 'get' id = 2
+++++ finished: begin job for module with label 'get' id = 2
+++++ starting: begin job for module with label 'TriggerResults' id = 1
+++++ finished: begin job for module with label 'TriggerResults' id = 1
 ++ finished: begin job
-++++ starting: begin stream for module: stream = 0 label = 'get'
-++++ finished: begin stream for module: stream = 0 label = 'get'
-++++ starting: begin stream for module: stream = 0 label = 'TriggerResults'
-++++ finished: begin stream for module: stream = 0 label = 'TriggerResults'
-++++ starting: begin stream for module: stream = 0 label = 'one'
+++++ starting: begin stream for module: stream = 0 label = 'get' id = 2
+++++ finished: begin stream for module: stream = 0 label = 'get' id = 2
+++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
+++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
+++++ starting: begin stream for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -45,7 +45,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++ finished: begin stream for module: stream = 0 label = 'one'
+++++ finished: begin stream for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -57,16 +57,16 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++ starting: begin stream for module: stream = 0 label = 'result1'
-++++ finished: begin stream for module: stream = 0 label = 'result1'
-++++ starting: begin stream for module: stream = 0 label = 'result2'
-++++ finished: begin stream for module: stream = 0 label = 'result2'
-++++ starting: begin stream for module: stream = 0 label = 'result4'
-++++ finished: begin stream for module: stream = 0 label = 'result4'
+++++ starting: begin stream for module: stream = 0 label = 'result1' id = 4
+++++ finished: begin stream for module: stream = 0 label = 'result1' id = 4
+++++ starting: begin stream for module: stream = 0 label = 'result2' id = 5
+++++ finished: begin stream for module: stream = 0 label = 'result2' id = 5
+++++ starting: begin stream for module: stream = 0 label = 'result4' id = 6
+++++ finished: begin stream for module: stream = 0 label = 'result4' id = 6
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1000000
-++++++ starting: global begin run for module: label = 'one'
+++++++ starting: global begin run for module: label = 'one' id = 3
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
@@ -78,7 +78,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ finished: global begin run for module: label = 'one'
+++++++ finished: global begin run for module: label = 'one' id = 3
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
@@ -90,19 +90,19 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: global begin run for module: label = 'result1'
-++++++ finished: global begin run for module: label = 'result1'
-++++++ starting: global begin run for module: label = 'result2'
-++++++ finished: global begin run for module: label = 'result2'
-++++++ starting: global begin run for module: label = 'result4'
-++++++ finished: global begin run for module: label = 'result4'
-++++++ starting: global begin run for module: label = 'get'
-++++++ finished: global begin run for module: label = 'get'
-++++++ starting: global begin run for module: label = 'TriggerResults'
-++++++ finished: global begin run for module: label = 'TriggerResults'
+++++++ starting: global begin run for module: label = 'result1' id = 4
+++++++ finished: global begin run for module: label = 'result1' id = 4
+++++++ starting: global begin run for module: label = 'result2' id = 5
+++++++ finished: global begin run for module: label = 'result2' id = 5
+++++++ starting: global begin run for module: label = 'result4' id = 6
+++++++ finished: global begin run for module: label = 'result4' id = 6
+++++++ starting: global begin run for module: label = 'get' id = 2
+++++++ finished: global begin run for module: label = 'get' id = 2
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin run 1 : time = 1000000
 ++++ starting: begin run: stream = 0 run = 1 time = 1000000
-++++++ starting: begin run for module: stream = 0 label = 'one'
+++++++ starting: begin run for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
@@ -114,7 +114,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ finished: begin run for module: stream = 0 label = 'one'
+++++++ finished: begin run for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
@@ -126,19 +126,19 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: begin run for module: stream = 0 label = 'result1'
-++++++ finished: begin run for module: stream = 0 label = 'result1'
-++++++ starting: begin run for module: stream = 0 label = 'result2'
-++++++ finished: begin run for module: stream = 0 label = 'result2'
-++++++ starting: begin run for module: stream = 0 label = 'result4'
-++++++ finished: begin run for module: stream = 0 label = 'result4'
-++++++ starting: begin run for module: stream = 0 label = 'get'
-++++++ finished: begin run for module: stream = 0 label = 'get'
+++++++ starting: begin run for module: stream = 0 label = 'result1' id = 4
+++++++ finished: begin run for module: stream = 0 label = 'result1' id = 4
+++++++ starting: begin run for module: stream = 0 label = 'result2' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'result2' id = 5
+++++++ starting: begin run for module: stream = 0 label = 'result4' id = 6
+++++++ finished: begin run for module: stream = 0 label = 'result4' id = 6
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 2
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 2
 ++++ finished: begin run: stream = 0 run = 1 time = 1000000
 ++++ starting: source lumi
 ++++ finished: source lumi
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1000000
-++++++ starting: global begin lumi for module: label = 'one'
+++++++ starting: global begin lumi for module: label = 'one' id = 3
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
@@ -150,7 +150,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ finished: global begin lumi for module: label = 'one'
+++++++ finished: global begin lumi for module: label = 'one' id = 3
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
@@ -162,19 +162,19 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: global begin lumi for module: label = 'result1'
-++++++ finished: global begin lumi for module: label = 'result1'
-++++++ starting: global begin lumi for module: label = 'result2'
-++++++ finished: global begin lumi for module: label = 'result2'
-++++++ starting: global begin lumi for module: label = 'result4'
-++++++ finished: global begin lumi for module: label = 'result4'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'result1' id = 4
+++++++ finished: global begin lumi for module: label = 'result1' id = 4
+++++++ starting: global begin lumi for module: label = 'result2' id = 5
+++++++ finished: global begin lumi for module: label = 'result2' id = 5
+++++++ starting: global begin lumi for module: label = 'result4' id = 6
+++++++ finished: global begin lumi for module: label = 'result4' id = 6
+++++++ starting: global begin lumi for module: label = 'get' id = 2
+++++++ finished: global begin lumi for module: label = 'get' id = 2
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
-++++++ starting: begin lumi for module: stream = 0 label = 'one'
+++++++ starting: begin lumi for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
@@ -186,7 +186,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ finished: begin lumi for module: stream = 0 label = 'one'
+++++++ finished: begin lumi for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
@@ -198,20 +198,20 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: begin lumi for module: stream = 0 label = 'result1'
-++++++ finished: begin lumi for module: stream = 0 label = 'result1'
-++++++ starting: begin lumi for module: stream = 0 label = 'result2'
-++++++ finished: begin lumi for module: stream = 0 label = 'result2'
-++++++ starting: begin lumi for module: stream = 0 label = 'result4'
-++++++ finished: begin lumi for module: stream = 0 label = 'result4'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
+++++++ starting: begin lumi for module: stream = 0 label = 'result1' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'result1' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'result2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'result2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'result4' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'result4' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 2
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1000000
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 1000010
 ++++++ starting: processing path 'p' : stream = 0
-++++++++++++++++ starting: processing event for module: stream = 0 label = 'one'
+++++++++++++++++ starting: processing event for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000010
@@ -237,7 +237,7 @@ ModuleCallingContext state = Running
     previousModuleOnThread: same as parent module
     previousModuleOnThread: same as parent module
 
-++++++++++++++++ finished: processing event for module: stream = 0 label = 'one'
+++++++++++++++++ finished: processing event for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000010
@@ -263,23 +263,23 @@ ModuleCallingContext state = Running
     previousModuleOnThread: same as parent module
     previousModuleOnThread: same as parent module
 
-++++++++++++++ starting: processing event for module: stream = 0 label = 'result1'
-++++++++++++++ finished: processing event for module: stream = 0 label = 'result1'
-++++++++++++ starting: processing event for module: stream = 0 label = 'result2'
-++++++++++++ finished: processing event for module: stream = 0 label = 'result2'
-++++++++++ starting: processing event for module: stream = 0 label = 'result4'
-++++++++++ finished: processing event for module: stream = 0 label = 'result4'
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++++++++ starting: processing event for module: stream = 0 label = 'result1' id = 4
+++++++++++++++ finished: processing event for module: stream = 0 label = 'result1' id = 4
+++++++++++++ starting: processing event for module: stream = 0 label = 'result2' id = 5
+++++++++++++ finished: processing event for module: stream = 0 label = 'result2' id = 5
+++++++++++ starting: processing event for module: stream = 0 label = 'result4' id = 6
+++++++++++ finished: processing event for module: stream = 0 label = 'result4' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 2
 ++++++ finished: processing path 'p' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 1000010
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 1000020
 ++++++ starting: processing path 'p' : stream = 0
-++++++++++++++++ starting: processing event for module: stream = 0 label = 'one'
+++++++++++++++++ starting: processing event for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000020
@@ -305,7 +305,7 @@ ModuleCallingContext state = Running
     previousModuleOnThread: same as parent module
     previousModuleOnThread: same as parent module
 
-++++++++++++++++ finished: processing event for module: stream = 0 label = 'one'
+++++++++++++++++ finished: processing event for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000020
@@ -331,23 +331,23 @@ ModuleCallingContext state = Running
     previousModuleOnThread: same as parent module
     previousModuleOnThread: same as parent module
 
-++++++++++++++ starting: processing event for module: stream = 0 label = 'result1'
-++++++++++++++ finished: processing event for module: stream = 0 label = 'result1'
-++++++++++++ starting: processing event for module: stream = 0 label = 'result2'
-++++++++++++ finished: processing event for module: stream = 0 label = 'result2'
-++++++++++ starting: processing event for module: stream = 0 label = 'result4'
-++++++++++ finished: processing event for module: stream = 0 label = 'result4'
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++++++++ starting: processing event for module: stream = 0 label = 'result1' id = 4
+++++++++++++++ finished: processing event for module: stream = 0 label = 'result1' id = 4
+++++++++++++ starting: processing event for module: stream = 0 label = 'result2' id = 5
+++++++++++++ finished: processing event for module: stream = 0 label = 'result2' id = 5
+++++++++++ starting: processing event for module: stream = 0 label = 'result4' id = 6
+++++++++++ finished: processing event for module: stream = 0 label = 'result4' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 2
 ++++++ finished: processing path 'p' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 1000020
 ++++ starting: source event
 ++++ finished: source event
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 1000030
 ++++++ starting: processing path 'p' : stream = 0
-++++++++++++++++ starting: processing event for module: stream = 0 label = 'one'
+++++++++++++++++ starting: processing event for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
@@ -373,7 +373,7 @@ ModuleCallingContext state = Running
     previousModuleOnThread: same as parent module
     previousModuleOnThread: same as parent module
 
-++++++++++++++++ finished: processing event for module: stream = 0 label = 'one'
+++++++++++++++++ finished: processing event for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
@@ -399,20 +399,20 @@ ModuleCallingContext state = Running
     previousModuleOnThread: same as parent module
     previousModuleOnThread: same as parent module
 
-++++++++++++++ starting: processing event for module: stream = 0 label = 'result1'
-++++++++++++++ finished: processing event for module: stream = 0 label = 'result1'
-++++++++++++ starting: processing event for module: stream = 0 label = 'result2'
-++++++++++++ finished: processing event for module: stream = 0 label = 'result2'
-++++++++++ starting: processing event for module: stream = 0 label = 'result4'
-++++++++++ finished: processing event for module: stream = 0 label = 'result4'
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
+++++++++++++++ starting: processing event for module: stream = 0 label = 'result1' id = 4
+++++++++++++++ finished: processing event for module: stream = 0 label = 'result1' id = 4
+++++++++++++ starting: processing event for module: stream = 0 label = 'result2' id = 5
+++++++++++++ finished: processing event for module: stream = 0 label = 'result2' id = 5
+++++++++++ starting: processing event for module: stream = 0 label = 'result4' id = 6
+++++++++++ finished: processing event for module: stream = 0 label = 'result4' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 2
 ++++++ finished: processing path 'p' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 1000030
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
-++++++ starting: end lumi for module: stream = 0 label = 'one'
+++++++ starting: end lumi for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
@@ -424,7 +424,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ finished: end lumi for module: stream = 0 label = 'one'
+++++++ finished: end lumi for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
@@ -436,17 +436,17 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: end lumi for module: stream = 0 label = 'result1'
-++++++ finished: end lumi for module: stream = 0 label = 'result1'
-++++++ starting: end lumi for module: stream = 0 label = 'result2'
-++++++ finished: end lumi for module: stream = 0 label = 'result2'
-++++++ starting: end lumi for module: stream = 0 label = 'result4'
-++++++ finished: end lumi for module: stream = 0 label = 'result4'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
+++++++ starting: end lumi for module: stream = 0 label = 'result1' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'result1' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'result2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'result2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'result4' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'result4' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 2
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 1000030
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1000000
-++++++ starting: global end lumi for module: label = 'one'
+++++++ starting: global end lumi for module: label = 'one' id = 3
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
@@ -458,7 +458,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ finished: global end lumi for module: label = 'one'
+++++++ finished: global end lumi for module: label = 'one' id = 3
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
@@ -470,19 +470,19 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1000000
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: global end lumi for module: label = 'result1'
-++++++ finished: global end lumi for module: label = 'result1'
-++++++ starting: global end lumi for module: label = 'result2'
-++++++ finished: global end lumi for module: label = 'result2'
-++++++ starting: global end lumi for module: label = 'result4'
-++++++ finished: global end lumi for module: label = 'result4'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'result1' id = 4
+++++++ finished: global end lumi for module: label = 'result1' id = 4
+++++++ starting: global end lumi for module: label = 'result2' id = 5
+++++++ finished: global end lumi for module: label = 'result2' id = 5
+++++++ starting: global end lumi for module: label = 'result4' id = 6
+++++++ finished: global end lumi for module: label = 'result4' id = 6
+++++++ starting: global end lumi for module: label = 'get' id = 2
+++++++ finished: global end lumi for module: label = 'get' id = 2
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1000000
 ++++ starting: end run: stream = 0 run = 1 time = 1000030
-++++++ starting: end run for module: stream = 0 label = 'one'
+++++++ starting: end run for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
@@ -494,7 +494,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ finished: end run for module: stream = 0 label = 'one'
+++++++ finished: end run for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
@@ -506,17 +506,17 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: end run for module: stream = 0 label = 'result1'
-++++++ finished: end run for module: stream = 0 label = 'result1'
-++++++ starting: end run for module: stream = 0 label = 'result2'
-++++++ finished: end run for module: stream = 0 label = 'result2'
-++++++ starting: end run for module: stream = 0 label = 'result4'
-++++++ finished: end run for module: stream = 0 label = 'result4'
-++++++ starting: end run for module: stream = 0 label = 'get'
-++++++ finished: end run for module: stream = 0 label = 'get'
+++++++ starting: end run for module: stream = 0 label = 'result1' id = 4
+++++++ finished: end run for module: stream = 0 label = 'result1' id = 4
+++++++ starting: end run for module: stream = 0 label = 'result2' id = 5
+++++++ finished: end run for module: stream = 0 label = 'result2' id = 5
+++++++ starting: end run for module: stream = 0 label = 'result4' id = 6
+++++++ finished: end run for module: stream = 0 label = 'result4' id = 6
+++++++ starting: end run for module: stream = 0 label = 'get' id = 2
+++++++ finished: end run for module: stream = 0 label = 'get' id = 2
 ++++ finished: end run: stream = 0 run = 1 time = 1000030
 ++++ starting: global end run 1 : time = 1000030
-++++++ starting: global end run for module: label = 'one'
+++++++ starting: global end run for module: label = 'one' id = 3
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
@@ -528,7 +528,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ finished: global end run for module: label = 'one'
+++++++ finished: global end run for module: label = 'one' id = 3
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
@@ -540,22 +540,22 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1000030
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++++ starting: global end run for module: label = 'result1'
-++++++ finished: global end run for module: label = 'result1'
-++++++ starting: global end run for module: label = 'result2'
-++++++ finished: global end run for module: label = 'result2'
-++++++ starting: global end run for module: label = 'result4'
-++++++ finished: global end run for module: label = 'result4'
-++++++ starting: global end run for module: label = 'get'
-++++++ finished: global end run for module: label = 'get'
-++++++ starting: global end run for module: label = 'TriggerResults'
-++++++ finished: global end run for module: label = 'TriggerResults'
+++++++ starting: global end run for module: label = 'result1' id = 4
+++++++ finished: global end run for module: label = 'result1' id = 4
+++++++ starting: global end run for module: label = 'result2' id = 5
+++++++ finished: global end run for module: label = 'result2' id = 5
+++++++ starting: global end run for module: label = 'result4' id = 6
+++++++ finished: global end run for module: label = 'result4' id = 6
+++++++ starting: global end run for module: label = 'get' id = 2
+++++++ finished: global end run for module: label = 'get' id = 2
+++++++ starting: global end run for module: label = 'TriggerResults' id = 1
+++++++ finished: global end run for module: label = 'TriggerResults' id = 1
 ++++ finished: global end run 1 : time = 1000030
-++++ starting: end stream for module: stream = 0 label = 'get'
-++++ finished: end stream for module: stream = 0 label = 'get'
-++++ starting: end stream for module: stream = 0 label = 'TriggerResults'
-++++ finished: end stream for module: stream = 0 label = 'TriggerResults'
-++++ starting: end stream for module: stream = 0 label = 'one'
+++++ starting: end stream for module: stream = 0 label = 'get' id = 2
+++++ finished: end stream for module: stream = 0 label = 'get' id = 2
+++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 1
+++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 1
+++++ starting: end stream for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -567,7 +567,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++ finished: end stream for module: stream = 0 label = 'one'
+++++ finished: end stream for module: stream = 0 label = 'one' id = 3
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -579,24 +579,24 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: TEST 0879c0d316e266ea880036ce316ef5aa
 
-++++ starting: end stream for module: stream = 0 label = 'result1'
-++++ finished: end stream for module: stream = 0 label = 'result1'
-++++ starting: end stream for module: stream = 0 label = 'result2'
-++++ finished: end stream for module: stream = 0 label = 'result2'
-++++ starting: end stream for module: stream = 0 label = 'result4'
-++++ finished: end stream for module: stream = 0 label = 'result4'
-++++ starting: end job for module with label 'one'
+++++ starting: end stream for module: stream = 0 label = 'result1' id = 4
+++++ finished: end stream for module: stream = 0 label = 'result1' id = 4
+++++ starting: end stream for module: stream = 0 label = 'result2' id = 5
+++++ finished: end stream for module: stream = 0 label = 'result2' id = 5
+++++ starting: end stream for module: stream = 0 label = 'result4' id = 6
+++++ finished: end stream for module: stream = 0 label = 'result4' id = 6
+++++ starting: end job for module with label 'one' id = 3
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++++ finished: end job for module with label 'one'
+++++ finished: end job for module with label 'one' id = 3
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
-++++ starting: end job for module with label 'result1'
-++++ finished: end job for module with label 'result1'
-++++ starting: end job for module with label 'result2'
-++++ finished: end job for module with label 'result2'
-++++ starting: end job for module with label 'result4'
-++++ finished: end job for module with label 'result4'
-++++ starting: end job for module with label 'get'
-++++ finished: end job for module with label 'get'
-++++ starting: end job for module with label 'TriggerResults'
-++++ finished: end job for module with label 'TriggerResults'
+++++ starting: end job for module with label 'result1' id = 4
+++++ finished: end job for module with label 'result1' id = 4
+++++ starting: end job for module with label 'result2' id = 5
+++++ finished: end job for module with label 'result2' id = 5
+++++ starting: end job for module with label 'result4' id = 6
+++++ finished: end job for module with label 'result4' id = 6
+++++ starting: end job for module with label 'get' id = 2
+++++ finished: end job for module with label 'get' id = 2
+++++ starting: end job for module with label 'TriggerResults' id = 1
+++++ finished: end job for module with label 'TriggerResults' id = 1
 ++ finished: end job

--- a/FWCore/Integration/test/run_TestGetBy.sh
+++ b/FWCore/Integration/test/run_TestGetBy.sh
@@ -7,11 +7,11 @@ function die { echo Failure $1: status $2 ; exit $2 ; }
 pushd ${LOCAL_TMP_DIR}
 
   cmsRun -p ${LOCAL_TEST_DIR}/${test}1_cfg.py > testGetBy1.log || die "cmsRun ${test}1_cfg.py" $?
-  diff ${LOCAL_TMP_DIR}/testGetBy1.log ${LOCAL_TEST_DIR}/unit_test_outputs/testGetBy1.log || die "comparing testGetBy1.log" $?
+  diff ${LOCAL_TEST_DIR}/unit_test_outputs/testGetBy1.log testGetBy1.log || die "comparing testGetBy1.log" $?
 
   cmsRun -p ${LOCAL_TEST_DIR}/${test}2_cfg.py > testGetBy2.log || die "cmsRun ${test}2_cfg.py" $?
   grep -v "Initiating request to open file" testGetBy2.log | grep -v "Successfully opened file" | grep -v "Closed file" > testGetBy2_1.log
-  diff testGetBy2_1.log ${LOCAL_TEST_DIR}/unit_test_outputs/testGetBy2.log || die "comparing testGetBy2.log" $?
+  diff ${LOCAL_TEST_DIR}/unit_test_outputs/testGetBy2.log testGetBy2_1.log || die "comparing testGetBy2.log" $?
 
   cmsRun -p ${LOCAL_TEST_DIR}/${test}3_cfg.py || die "cmsRun ${test}3_cfg.py" $?
 

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -2,60 +2,60 @@
 Module type=IntSource, Module label=source, Parameter Set ID=031810a3ee2992e7936b85708f83a8b2
 ++ finished: constructing source: IntSource
 Module type=IntSource, Module label=source, Parameter Set ID=031810a3ee2992e7936b85708f83a8b2
-++++ starting: constructing module with label 'TriggerResults'
-++++ finished: constructing module with label 'TriggerResults'
-++++ starting: constructing module with label 'intProducer'
-++++ finished: constructing module with label 'intProducer'
-++++ starting: constructing module with label 'a1'
-++++ finished: constructing module with label 'a1'
-++++ starting: constructing module with label 'a2'
-++++ finished: constructing module with label 'a2'
-++++ starting: constructing module with label 'a3'
-++++ finished: constructing module with label 'a3'
-++++ starting: constructing module with label 'out'
-++++ finished: constructing module with label 'out'
-++++ starting: constructing module with label 'intProducerA'
+++++ starting: constructing module with label 'TriggerResults' id = 1
+++++ finished: constructing module with label 'TriggerResults' id = 1
+++++ starting: constructing module with label 'intProducer' id = 2
+++++ finished: constructing module with label 'intProducer' id = 2
+++++ starting: constructing module with label 'a1' id = 3
+++++ finished: constructing module with label 'a1' id = 3
+++++ starting: constructing module with label 'a2' id = 4
+++++ finished: constructing module with label 'a2' id = 4
+++++ starting: constructing module with label 'a3' id = 5
+++++ finished: constructing module with label 'a3' id = 5
+++++ starting: constructing module with label 'out' id = 6
+++++ finished: constructing module with label 'out' id = 6
+++++ starting: constructing module with label 'intProducerA' id = 7
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++++ finished: constructing module with label 'intProducerA'
+++++ finished: constructing module with label 'intProducerA' id = 7
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++++ starting: constructing module with label 'intProducerU'
-++++ finished: constructing module with label 'intProducerU'
-++++ starting: constructing module with label 'intVectorProducer'
-++++ finished: constructing module with label 'intVectorProducer'
-++++ starting: begin job for module with label 'intProducerA'
+++++ starting: constructing module with label 'intProducerU' id = 8
+++++ finished: constructing module with label 'intProducerU' id = 8
+++++ starting: constructing module with label 'intVectorProducer' id = 9
+++++ finished: constructing module with label 'intVectorProducer' id = 9
+++++ starting: begin job for module with label 'intProducerA' id = 7
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++++ finished: begin job for module with label 'intProducerA'
+++++ finished: begin job for module with label 'intProducerA' id = 7
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++++ starting: begin job for module with label 'intProducerU'
-++++ finished: begin job for module with label 'intProducerU'
-++++ starting: begin job for module with label 'intVectorProducer'
-++++ finished: begin job for module with label 'intVectorProducer'
-++++ starting: begin job for module with label 'intProducer'
-++++ finished: begin job for module with label 'intProducer'
-++++ starting: begin job for module with label 'a1'
-++++ finished: begin job for module with label 'a1'
-++++ starting: begin job for module with label 'a2'
-++++ finished: begin job for module with label 'a2'
-++++ starting: begin job for module with label 'a3'
-++++ finished: begin job for module with label 'a3'
-++++ starting: begin job for module with label 'out'
-++++ finished: begin job for module with label 'out'
-++++ starting: begin job for module with label 'TriggerResults'
-++++ finished: begin job for module with label 'TriggerResults'
+++++ starting: begin job for module with label 'intProducerU' id = 8
+++++ finished: begin job for module with label 'intProducerU' id = 8
+++++ starting: begin job for module with label 'intVectorProducer' id = 9
+++++ finished: begin job for module with label 'intVectorProducer' id = 9
+++++ starting: begin job for module with label 'intProducer' id = 2
+++++ finished: begin job for module with label 'intProducer' id = 2
+++++ starting: begin job for module with label 'a1' id = 3
+++++ finished: begin job for module with label 'a1' id = 3
+++++ starting: begin job for module with label 'a2' id = 4
+++++ finished: begin job for module with label 'a2' id = 4
+++++ starting: begin job for module with label 'a3' id = 5
+++++ finished: begin job for module with label 'a3' id = 5
+++++ starting: begin job for module with label 'out' id = 6
+++++ finished: begin job for module with label 'out' id = 6
+++++ starting: begin job for module with label 'TriggerResults' id = 1
+++++ finished: begin job for module with label 'TriggerResults' id = 1
 ++ finished: begin job
-++++ starting: begin stream for module: stream = 0 label = 'intProducer'
-++++ finished: begin stream for module: stream = 0 label = 'intProducer'
-++++ starting: begin stream for module: stream = 0 label = 'a1'
-++++ finished: begin stream for module: stream = 0 label = 'a1'
-++++ starting: begin stream for module: stream = 0 label = 'a2'
-++++ finished: begin stream for module: stream = 0 label = 'a2'
-++++ starting: begin stream for module: stream = 0 label = 'a3'
-++++ finished: begin stream for module: stream = 0 label = 'a3'
-++++ starting: begin stream for module: stream = 0 label = 'TriggerResults'
-++++ finished: begin stream for module: stream = 0 label = 'TriggerResults'
-++++ starting: begin stream for module: stream = 0 label = 'out'
-++++ finished: begin stream for module: stream = 0 label = 'out'
-++++ starting: begin stream for module: stream = 0 label = 'intProducerA'
+++++ starting: begin stream for module: stream = 0 label = 'intProducer' id = 2
+++++ finished: begin stream for module: stream = 0 label = 'intProducer' id = 2
+++++ starting: begin stream for module: stream = 0 label = 'a1' id = 3
+++++ finished: begin stream for module: stream = 0 label = 'a1' id = 3
+++++ starting: begin stream for module: stream = 0 label = 'a2' id = 4
+++++ finished: begin stream for module: stream = 0 label = 'a2' id = 4
+++++ starting: begin stream for module: stream = 0 label = 'a3' id = 5
+++++ finished: begin stream for module: stream = 0 label = 'a3' id = 5
+++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
+++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
+++++ starting: begin stream for module: stream = 0 label = 'out' id = 6
+++++ finished: begin stream for module: stream = 0 label = 'out' id = 6
+++++ starting: begin stream for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -67,7 +67,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++ finished: begin stream for module: stream = 0 label = 'intProducerA'
+++++ finished: begin stream for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -79,10 +79,10 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++ starting: begin stream for module: stream = 0 label = 'intProducerU'
-++++ finished: begin stream for module: stream = 0 label = 'intProducerU'
-++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer'
-++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer'
+++++ starting: begin stream for module: stream = 0 label = 'intProducerU' id = 8
+++++ finished: begin stream for module: stream = 0 label = 'intProducerU' id = 8
+++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer' id = 9
+++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer' id = 9
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1
@@ -91,7 +91,7 @@ GlobalContext: transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ starting: global begin run for module: label = 'intProducerA'
+++++++ starting: global begin run for module: label = 'intProducerA' id = 7
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -103,7 +103,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ finished: global begin run for module: label = 'intProducerA'
+++++++ finished: global begin run for module: label = 'intProducerA' id = 7
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -115,22 +115,22 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ starting: global begin run for module: label = 'intProducerU'
-++++++ finished: global begin run for module: label = 'intProducerU'
-++++++ starting: global begin run for module: label = 'intVectorProducer'
-++++++ finished: global begin run for module: label = 'intVectorProducer'
-++++++ starting: global begin run for module: label = 'intProducer'
-++++++ finished: global begin run for module: label = 'intProducer'
-++++++ starting: global begin run for module: label = 'a1'
-++++++ finished: global begin run for module: label = 'a1'
-++++++ starting: global begin run for module: label = 'a2'
-++++++ finished: global begin run for module: label = 'a2'
-++++++ starting: global begin run for module: label = 'a3'
-++++++ finished: global begin run for module: label = 'a3'
-++++++ starting: global begin run for module: label = 'out'
-++++++ finished: global begin run for module: label = 'out'
-++++++ starting: global begin run for module: label = 'TriggerResults'
-++++++ finished: global begin run for module: label = 'TriggerResults'
+++++++ starting: global begin run for module: label = 'intProducerU' id = 8
+++++++ finished: global begin run for module: label = 'intProducerU' id = 8
+++++++ starting: global begin run for module: label = 'intVectorProducer' id = 9
+++++++ finished: global begin run for module: label = 'intVectorProducer' id = 9
+++++++ starting: global begin run for module: label = 'intProducer' id = 2
+++++++ finished: global begin run for module: label = 'intProducer' id = 2
+++++++ starting: global begin run for module: label = 'a1' id = 3
+++++++ finished: global begin run for module: label = 'a1' id = 3
+++++++ starting: global begin run for module: label = 'a2' id = 4
+++++++ finished: global begin run for module: label = 'a2' id = 4
+++++++ starting: global begin run for module: label = 'a3' id = 5
+++++++ finished: global begin run for module: label = 'a3' id = 5
+++++++ starting: global begin run for module: label = 'out' id = 6
+++++++ finished: global begin run for module: label = 'out' id = 6
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin run 1 : time = 1
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
@@ -157,7 +157,7 @@ StreamContext: StreamID = 0 transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ starting: begin run for module: stream = 0 label = 'intProducerA'
+++++++ starting: begin run for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -169,7 +169,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ finished: begin run for module: stream = 0 label = 'intProducerA'
+++++++ finished: begin run for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -181,20 +181,20 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ starting: begin run for module: stream = 0 label = 'intProducerU'
-++++++ finished: begin run for module: stream = 0 label = 'intProducerU'
-++++++ starting: begin run for module: stream = 0 label = 'intVectorProducer'
-++++++ finished: begin run for module: stream = 0 label = 'intVectorProducer'
-++++++ starting: begin run for module: stream = 0 label = 'intProducer'
-++++++ finished: begin run for module: stream = 0 label = 'intProducer'
-++++++ starting: begin run for module: stream = 0 label = 'a1'
-++++++ finished: begin run for module: stream = 0 label = 'a1'
-++++++ starting: begin run for module: stream = 0 label = 'a2'
-++++++ finished: begin run for module: stream = 0 label = 'a2'
-++++++ starting: begin run for module: stream = 0 label = 'a3'
-++++++ finished: begin run for module: stream = 0 label = 'a3'
-++++++ starting: begin run for module: stream = 0 label = 'out'
-++++++ finished: begin run for module: stream = 0 label = 'out'
+++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 8
+++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 8
+++++++ starting: begin run for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++ finished: begin run for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 2
+++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 2
+++++++ starting: begin run for module: stream = 0 label = 'a1' id = 3
+++++++ finished: begin run for module: stream = 0 label = 'a1' id = 3
+++++++ starting: begin run for module: stream = 0 label = 'a2' id = 4
+++++++ finished: begin run for module: stream = 0 label = 'a2' id = 4
+++++++ starting: begin run for module: stream = 0 label = 'a3' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'a3' id = 5
+++++++ starting: begin run for module: stream = 0 label = 'out' id = 6
+++++++ finished: begin run for module: stream = 0 label = 'out' id = 6
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -223,7 +223,7 @@ GlobalContext: transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ starting: global begin lumi for module: label = 'intProducerA'
+++++++ starting: global begin lumi for module: label = 'intProducerA' id = 7
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -235,7 +235,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ finished: global begin lumi for module: label = 'intProducerA'
+++++++ finished: global begin lumi for module: label = 'intProducerA' id = 7
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -247,22 +247,22 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ starting: global begin lumi for module: label = 'intProducerU'
-++++++ finished: global begin lumi for module: label = 'intProducerU'
-++++++ starting: global begin lumi for module: label = 'intVectorProducer'
-++++++ finished: global begin lumi for module: label = 'intVectorProducer'
-++++++ starting: global begin lumi for module: label = 'intProducer'
-++++++ finished: global begin lumi for module: label = 'intProducer'
-++++++ starting: global begin lumi for module: label = 'a1'
-++++++ finished: global begin lumi for module: label = 'a1'
-++++++ starting: global begin lumi for module: label = 'a2'
-++++++ finished: global begin lumi for module: label = 'a2'
-++++++ starting: global begin lumi for module: label = 'a3'
-++++++ finished: global begin lumi for module: label = 'a3'
-++++++ starting: global begin lumi for module: label = 'out'
-++++++ finished: global begin lumi for module: label = 'out'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'intProducerU' id = 8
+++++++ finished: global begin lumi for module: label = 'intProducerU' id = 8
+++++++ starting: global begin lumi for module: label = 'intVectorProducer' id = 9
+++++++ finished: global begin lumi for module: label = 'intVectorProducer' id = 9
+++++++ starting: global begin lumi for module: label = 'intProducer' id = 2
+++++++ finished: global begin lumi for module: label = 'intProducer' id = 2
+++++++ starting: global begin lumi for module: label = 'a1' id = 3
+++++++ finished: global begin lumi for module: label = 'a1' id = 3
+++++++ starting: global begin lumi for module: label = 'a2' id = 4
+++++++ finished: global begin lumi for module: label = 'a2' id = 4
+++++++ starting: global begin lumi for module: label = 'a3' id = 5
+++++++ finished: global begin lumi for module: label = 'a3' id = 5
+++++++ starting: global begin lumi for module: label = 'out' id = 6
+++++++ finished: global begin lumi for module: label = 'out' id = 6
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -289,7 +289,7 @@ StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerA'
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -301,7 +301,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerA'
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -313,20 +313,20 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU'
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU'
-++++++ starting: begin lumi for module: stream = 0 label = 'intVectorProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'intVectorProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'a1'
-++++++ finished: begin lumi for module: stream = 0 label = 'a1'
-++++++ starting: begin lumi for module: stream = 0 label = 'a2'
-++++++ finished: begin lumi for module: stream = 0 label = 'a2'
-++++++ starting: begin lumi for module: stream = 0 label = 'a3'
-++++++ finished: begin lumi for module: stream = 0 label = 'a3'
-++++++ starting: begin lumi for module: stream = 0 label = 'out'
-++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 8
+++++++ starting: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++ finished: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'a1' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'a1' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'a2' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'a2' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'a3' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'a3' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 6
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -366,11 +366,11 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer'
-++++++++ starting: processing event for module: stream = 0 label = 'a1'
-++++++++ finished: processing event for module: stream = 0 label = 'a1'
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA'
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 2
+++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 3
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -387,7 +387,7 @@ ModuleCallingContext state = Running
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
     previousModuleOnThread: same as parent module
 
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA'
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -404,10 +404,10 @@ ModuleCallingContext state = Running
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
     previousModuleOnThread: same as parent module
 
-++++++++ starting: processing event for module: stream = 0 label = 'a2'
-++++++++ finished: processing event for module: stream = 0 label = 'a2'
-++++++++ starting: processing event for module: stream = 0 label = 'a3'
-++++++++ finished: processing event for module: stream = 0 label = 'a3'
+++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'a3' id = 5
 ++++++ finished: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -419,8 +419,8 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++ starting: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -432,12 +432,12 @@ PathContext: pathName = e pathID = 0 (EndPath)
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU'
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU'
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer'
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer'
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 8
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 8
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 6
 ++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -488,11 +488,11 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer'
-++++++++ starting: processing event for module: stream = 0 label = 'a1'
-++++++++ finished: processing event for module: stream = 0 label = 'a1'
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA'
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 2
+++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 3
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -509,7 +509,7 @@ ModuleCallingContext state = Running
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
     previousModuleOnThread: same as parent module
 
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA'
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -526,10 +526,10 @@ ModuleCallingContext state = Running
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
     previousModuleOnThread: same as parent module
 
-++++++++ starting: processing event for module: stream = 0 label = 'a2'
-++++++++ finished: processing event for module: stream = 0 label = 'a2'
-++++++++ starting: processing event for module: stream = 0 label = 'a3'
-++++++++ finished: processing event for module: stream = 0 label = 'a3'
+++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'a3' id = 5
 ++++++ finished: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -541,8 +541,8 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++ starting: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -554,12 +554,12 @@ PathContext: pathName = e pathID = 0 (EndPath)
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU'
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU'
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer'
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer'
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 8
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 8
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 6
 ++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -610,11 +610,11 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer'
-++++++++ starting: processing event for module: stream = 0 label = 'a1'
-++++++++ finished: processing event for module: stream = 0 label = 'a1'
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA'
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 2
+++++++++ starting: processing event for module: stream = 0 label = 'a1' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'a1' id = 3
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -631,7 +631,7 @@ ModuleCallingContext state = Running
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
     previousModuleOnThread: same as parent module
 
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA'
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -648,10 +648,10 @@ ModuleCallingContext state = Running
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
     previousModuleOnThread: same as parent module
 
-++++++++ starting: processing event for module: stream = 0 label = 'a2'
-++++++++ finished: processing event for module: stream = 0 label = 'a2'
-++++++++ starting: processing event for module: stream = 0 label = 'a3'
-++++++++ finished: processing event for module: stream = 0 label = 'a3'
+++++++++ starting: processing event for module: stream = 0 label = 'a2' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'a2' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'a3' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'a3' id = 5
 ++++++ finished: processing path 'p' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -663,8 +663,8 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++ starting: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -676,12 +676,12 @@ PathContext: pathName = e pathID = 0 (EndPath)
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU'
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU'
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer'
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer'
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 8
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 8
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 6
 ++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -719,7 +719,7 @@ StreamContext: StreamID = 0 transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerA'
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -731,7 +731,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerA'
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -743,20 +743,20 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerU'
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerU'
-++++++ starting: end lumi for module: stream = 0 label = 'intVectorProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'intVectorProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'intProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'intProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'a1'
-++++++ finished: end lumi for module: stream = 0 label = 'a1'
-++++++ starting: end lumi for module: stream = 0 label = 'a2'
-++++++ finished: end lumi for module: stream = 0 label = 'a2'
-++++++ starting: end lumi for module: stream = 0 label = 'a3'
-++++++ finished: end lumi for module: stream = 0 label = 'a3'
-++++++ starting: end lumi for module: stream = 0 label = 'out'
-++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 8
+++++++ starting: end lumi for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++ finished: end lumi for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'a1' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'a1' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'a2' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'a2' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'a3' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'a3' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 6
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -783,7 +783,7 @@ GlobalContext: transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ starting: global end lumi for module: label = 'intProducerA'
+++++++ starting: global end lumi for module: label = 'intProducerA' id = 7
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -795,7 +795,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ finished: global end lumi for module: label = 'intProducerA'
+++++++ finished: global end lumi for module: label = 'intProducerA' id = 7
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -807,22 +807,22 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ starting: global end lumi for module: label = 'intProducerU'
-++++++ finished: global end lumi for module: label = 'intProducerU'
-++++++ starting: global end lumi for module: label = 'intVectorProducer'
-++++++ finished: global end lumi for module: label = 'intVectorProducer'
-++++++ starting: global end lumi for module: label = 'intProducer'
-++++++ finished: global end lumi for module: label = 'intProducer'
-++++++ starting: global end lumi for module: label = 'a1'
-++++++ finished: global end lumi for module: label = 'a1'
-++++++ starting: global end lumi for module: label = 'a2'
-++++++ finished: global end lumi for module: label = 'a2'
-++++++ starting: global end lumi for module: label = 'a3'
-++++++ finished: global end lumi for module: label = 'a3'
-++++++ starting: global end lumi for module: label = 'out'
-++++++ finished: global end lumi for module: label = 'out'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'intProducerU' id = 8
+++++++ finished: global end lumi for module: label = 'intProducerU' id = 8
+++++++ starting: global end lumi for module: label = 'intVectorProducer' id = 9
+++++++ finished: global end lumi for module: label = 'intVectorProducer' id = 9
+++++++ starting: global end lumi for module: label = 'intProducer' id = 2
+++++++ finished: global end lumi for module: label = 'intProducer' id = 2
+++++++ starting: global end lumi for module: label = 'a1' id = 3
+++++++ finished: global end lumi for module: label = 'a1' id = 3
+++++++ starting: global end lumi for module: label = 'a2' id = 4
+++++++ finished: global end lumi for module: label = 'a2' id = 4
+++++++ starting: global end lumi for module: label = 'a3' id = 5
+++++++ finished: global end lumi for module: label = 'a3' id = 5
+++++++ starting: global end lumi for module: label = 'out' id = 6
+++++++ finished: global end lumi for module: label = 'out' id = 6
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -849,7 +849,7 @@ StreamContext: StreamID = 0 transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ starting: end run for module: stream = 0 label = 'intProducerA'
+++++++ starting: end run for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -861,7 +861,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ finished: end run for module: stream = 0 label = 'intProducerA'
+++++++ finished: end run for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -873,20 +873,20 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ starting: end run for module: stream = 0 label = 'intProducerU'
-++++++ finished: end run for module: stream = 0 label = 'intProducerU'
-++++++ starting: end run for module: stream = 0 label = 'intVectorProducer'
-++++++ finished: end run for module: stream = 0 label = 'intVectorProducer'
-++++++ starting: end run for module: stream = 0 label = 'intProducer'
-++++++ finished: end run for module: stream = 0 label = 'intProducer'
-++++++ starting: end run for module: stream = 0 label = 'a1'
-++++++ finished: end run for module: stream = 0 label = 'a1'
-++++++ starting: end run for module: stream = 0 label = 'a2'
-++++++ finished: end run for module: stream = 0 label = 'a2'
-++++++ starting: end run for module: stream = 0 label = 'a3'
-++++++ finished: end run for module: stream = 0 label = 'a3'
-++++++ starting: end run for module: stream = 0 label = 'out'
-++++++ finished: end run for module: stream = 0 label = 'out'
+++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 8
+++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 8
+++++++ starting: end run for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++ finished: end run for module: stream = 0 label = 'intVectorProducer' id = 9
+++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 2
+++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 2
+++++++ starting: end run for module: stream = 0 label = 'a1' id = 3
+++++++ finished: end run for module: stream = 0 label = 'a1' id = 3
+++++++ starting: end run for module: stream = 0 label = 'a2' id = 4
+++++++ finished: end run for module: stream = 0 label = 'a2' id = 4
+++++++ starting: end run for module: stream = 0 label = 'a3' id = 5
+++++++ finished: end run for module: stream = 0 label = 'a3' id = 5
+++++++ starting: end run for module: stream = 0 label = 'out' id = 6
+++++++ finished: end run for module: stream = 0 label = 'out' id = 6
 ++++ finished: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
@@ -913,7 +913,7 @@ GlobalContext: transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ starting: global end run for module: label = 'intProducerA'
+++++++ starting: global end run for module: label = 'intProducerA' id = 7
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -925,7 +925,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ finished: global end run for module: label = 'intProducerA'
+++++++ finished: global end run for module: label = 'intProducerA' id = 7
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -937,22 +937,22 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++++ starting: global end run for module: label = 'intProducerU'
-++++++ finished: global end run for module: label = 'intProducerU'
-++++++ starting: global end run for module: label = 'intVectorProducer'
-++++++ finished: global end run for module: label = 'intVectorProducer'
-++++++ starting: global end run for module: label = 'intProducer'
-++++++ finished: global end run for module: label = 'intProducer'
-++++++ starting: global end run for module: label = 'a1'
-++++++ finished: global end run for module: label = 'a1'
-++++++ starting: global end run for module: label = 'a2'
-++++++ finished: global end run for module: label = 'a2'
-++++++ starting: global end run for module: label = 'a3'
-++++++ finished: global end run for module: label = 'a3'
-++++++ starting: global end run for module: label = 'out'
-++++++ finished: global end run for module: label = 'out'
-++++++ starting: global end run for module: label = 'TriggerResults'
-++++++ finished: global end run for module: label = 'TriggerResults'
+++++++ starting: global end run for module: label = 'intProducerU' id = 8
+++++++ finished: global end run for module: label = 'intProducerU' id = 8
+++++++ starting: global end run for module: label = 'intVectorProducer' id = 9
+++++++ finished: global end run for module: label = 'intVectorProducer' id = 9
+++++++ starting: global end run for module: label = 'intProducer' id = 2
+++++++ finished: global end run for module: label = 'intProducer' id = 2
+++++++ starting: global end run for module: label = 'a1' id = 3
+++++++ finished: global end run for module: label = 'a1' id = 3
+++++++ starting: global end run for module: label = 'a2' id = 4
+++++++ finished: global end run for module: label = 'a2' id = 4
+++++++ starting: global end run for module: label = 'a3' id = 5
+++++++ finished: global end run for module: label = 'a3' id = 5
+++++++ starting: global end run for module: label = 'out' id = 6
+++++++ finished: global end run for module: label = 'out' id = 6
+++++++ starting: global end run for module: label = 'TriggerResults' id = 1
+++++++ finished: global end run for module: label = 'TriggerResults' id = 1
 ++++ finished: global end run 1 : time = 15000001
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
@@ -973,19 +973,19 @@ GlobalContext: transition = EndRun
     ProcessContext: COPY 5ea2a17b2b2eaa97af73c630882cd994
     parent ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++ starting: end stream for module: stream = 0 label = 'intProducer'
-++++ finished: end stream for module: stream = 0 label = 'intProducer'
-++++ starting: end stream for module: stream = 0 label = 'a1'
-++++ finished: end stream for module: stream = 0 label = 'a1'
-++++ starting: end stream for module: stream = 0 label = 'a2'
-++++ finished: end stream for module: stream = 0 label = 'a2'
-++++ starting: end stream for module: stream = 0 label = 'a3'
-++++ finished: end stream for module: stream = 0 label = 'a3'
-++++ starting: end stream for module: stream = 0 label = 'TriggerResults'
-++++ finished: end stream for module: stream = 0 label = 'TriggerResults'
-++++ starting: end stream for module: stream = 0 label = 'out'
-++++ finished: end stream for module: stream = 0 label = 'out'
-++++ starting: end stream for module: stream = 0 label = 'intProducerA'
+++++ starting: end stream for module: stream = 0 label = 'intProducer' id = 2
+++++ finished: end stream for module: stream = 0 label = 'intProducer' id = 2
+++++ starting: end stream for module: stream = 0 label = 'a1' id = 3
+++++ finished: end stream for module: stream = 0 label = 'a1' id = 3
+++++ starting: end stream for module: stream = 0 label = 'a2' id = 4
+++++ finished: end stream for module: stream = 0 label = 'a2' id = 4
+++++ starting: end stream for module: stream = 0 label = 'a3' id = 5
+++++ finished: end stream for module: stream = 0 label = 'a3' id = 5
+++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 1
+++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 1
+++++ starting: end stream for module: stream = 0 label = 'out' id = 6
+++++ finished: end stream for module: stream = 0 label = 'out' id = 6
+++++ starting: end stream for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -997,7 +997,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++ finished: end stream for module: stream = 0 label = 'intProducerA'
+++++ finished: end stream for module: stream = 0 label = 'intProducerA' id = 7
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -1009,31 +1009,31 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD1 3c616240b8a4afc0d41892991162754d
 
-++++ starting: end stream for module: stream = 0 label = 'intProducerU'
-++++ finished: end stream for module: stream = 0 label = 'intProducerU'
-++++ starting: end stream for module: stream = 0 label = 'intVectorProducer'
-++++ finished: end stream for module: stream = 0 label = 'intVectorProducer'
-++++ starting: end job for module with label 'intProducerA'
+++++ starting: end stream for module: stream = 0 label = 'intProducerU' id = 8
+++++ finished: end stream for module: stream = 0 label = 'intProducerU' id = 8
+++++ starting: end stream for module: stream = 0 label = 'intVectorProducer' id = 9
+++++ finished: end stream for module: stream = 0 label = 'intVectorProducer' id = 9
+++++ starting: end job for module with label 'intProducerA' id = 7
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++++ finished: end job for module with label 'intProducerA'
+++++ finished: end job for module with label 'intProducerA' id = 7
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
-++++ starting: end job for module with label 'intProducerU'
-++++ finished: end job for module with label 'intProducerU'
-++++ starting: end job for module with label 'intVectorProducer'
-++++ finished: end job for module with label 'intVectorProducer'
-++++ starting: end job for module with label 'intProducer'
-++++ finished: end job for module with label 'intProducer'
-++++ starting: end job for module with label 'a1'
+++++ starting: end job for module with label 'intProducerU' id = 8
+++++ finished: end job for module with label 'intProducerU' id = 8
+++++ starting: end job for module with label 'intVectorProducer' id = 9
+++++ finished: end job for module with label 'intVectorProducer' id = 9
+++++ starting: end job for module with label 'intProducer' id = 2
+++++ finished: end job for module with label 'intProducer' id = 2
+++++ starting: end job for module with label 'a1' id = 3
 TestFindProduct sum = 12
-++++ finished: end job for module with label 'a1'
-++++ starting: end job for module with label 'a2'
+++++ finished: end job for module with label 'a1' id = 3
+++++ starting: end job for module with label 'a2' id = 4
 TestFindProduct sum = 300
-++++ finished: end job for module with label 'a2'
-++++ starting: end job for module with label 'a3'
+++++ finished: end job for module with label 'a2' id = 4
+++++ starting: end job for module with label 'a3' id = 5
 TestFindProduct sum = 300
-++++ finished: end job for module with label 'a3'
-++++ starting: end job for module with label 'out'
-++++ finished: end job for module with label 'out'
-++++ starting: end job for module with label 'TriggerResults'
-++++ finished: end job for module with label 'TriggerResults'
+++++ finished: end job for module with label 'a3' id = 5
+++++ starting: end job for module with label 'out' id = 6
+++++ finished: end job for module with label 'out' id = 6
+++++ starting: end job for module with label 'TriggerResults' id = 1
+++++ finished: end job for module with label 'TriggerResults' id = 1
 ++ finished: end job

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -4,32 +4,32 @@ Module type=PoolSource, Module label=source, Parameter Set ID=079a79e873959edf4f
 ++++ finished: open input file: lfn = file:testGetBy1.root usedFallBack = 0
 ++ finished: constructing source: PoolSource
 Module type=PoolSource, Module label=source, Parameter Set ID=079a79e873959edf4ff4f335f14507fa
-++++ starting: constructing module with label 'TriggerResults'
-++++ finished: constructing module with label 'TriggerResults'
-++++ starting: constructing module with label 'intProducer'
+++++ starting: constructing module with label 'TriggerResults' id = 1
+++++ finished: constructing module with label 'TriggerResults' id = 1
+++++ starting: constructing module with label 'intProducer' id = 2
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++++ finished: constructing module with label 'intProducer'
+++++ finished: constructing module with label 'intProducer' id = 2
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++++ starting: constructing module with label 'out'
-++++ finished: constructing module with label 'out'
-++++ starting: constructing module with label 'intProducerU'
-++++ finished: constructing module with label 'intProducerU'
-++++ starting: constructing module with label 'intVectorProducer'
-++++ finished: constructing module with label 'intVectorProducer'
-++++ starting: begin job for module with label 'intProducerU'
-++++ finished: begin job for module with label 'intProducerU'
-++++ starting: begin job for module with label 'intVectorProducer'
-++++ finished: begin job for module with label 'intVectorProducer'
-++++ starting: begin job for module with label 'intProducer'
+++++ starting: constructing module with label 'out' id = 3
+++++ finished: constructing module with label 'out' id = 3
+++++ starting: constructing module with label 'intProducerU' id = 4
+++++ finished: constructing module with label 'intProducerU' id = 4
+++++ starting: constructing module with label 'intVectorProducer' id = 5
+++++ finished: constructing module with label 'intVectorProducer' id = 5
+++++ starting: begin job for module with label 'intProducerU' id = 4
+++++ finished: begin job for module with label 'intProducerU' id = 4
+++++ starting: begin job for module with label 'intVectorProducer' id = 5
+++++ finished: begin job for module with label 'intVectorProducer' id = 5
+++++ starting: begin job for module with label 'intProducer' id = 2
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++++ finished: begin job for module with label 'intProducer'
+++++ finished: begin job for module with label 'intProducer' id = 2
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++++ starting: begin job for module with label 'out'
-++++ finished: begin job for module with label 'out'
-++++ starting: begin job for module with label 'TriggerResults'
-++++ finished: begin job for module with label 'TriggerResults'
+++++ starting: begin job for module with label 'out' id = 3
+++++ finished: begin job for module with label 'out' id = 3
+++++ starting: begin job for module with label 'TriggerResults' id = 1
+++++ finished: begin job for module with label 'TriggerResults' id = 1
 ++ finished: begin job
-++++ starting: begin stream for module: stream = 0 label = 'intProducer'
+++++ starting: begin stream for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -41,7 +41,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++ finished: begin stream for module: stream = 0 label = 'intProducer'
+++++ finished: begin stream for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = BeginStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -53,14 +53,14 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++ starting: begin stream for module: stream = 0 label = 'TriggerResults'
-++++ finished: begin stream for module: stream = 0 label = 'TriggerResults'
-++++ starting: begin stream for module: stream = 0 label = 'out'
-++++ finished: begin stream for module: stream = 0 label = 'out'
-++++ starting: begin stream for module: stream = 0 label = 'intProducerU'
-++++ finished: begin stream for module: stream = 0 label = 'intProducerU'
-++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer'
-++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer'
+++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
+++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
+++++ starting: begin stream for module: stream = 0 label = 'out' id = 3
+++++ finished: begin stream for module: stream = 0 label = 'out' id = 3
+++++ starting: begin stream for module: stream = 0 label = 'intProducerU' id = 4
+++++ finished: begin stream for module: stream = 0 label = 'intProducerU' id = 4
+++++ starting: begin stream for module: stream = 0 label = 'intVectorProducer' id = 5
+++++ finished: begin stream for module: stream = 0 label = 'intVectorProducer' id = 5
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1
@@ -69,11 +69,11 @@ GlobalContext: transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ starting: global begin run for module: label = 'intProducerU'
-++++++ finished: global begin run for module: label = 'intProducerU'
-++++++ starting: global begin run for module: label = 'intVectorProducer'
-++++++ finished: global begin run for module: label = 'intVectorProducer'
-++++++ starting: global begin run for module: label = 'intProducer'
+++++++ starting: global begin run for module: label = 'intProducerU' id = 4
+++++++ finished: global begin run for module: label = 'intProducerU' id = 4
+++++++ starting: global begin run for module: label = 'intVectorProducer' id = 5
+++++++ finished: global begin run for module: label = 'intVectorProducer' id = 5
+++++++ starting: global begin run for module: label = 'intProducer' id = 2
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -85,7 +85,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ finished: global begin run for module: label = 'intProducer'
+++++++ finished: global begin run for module: label = 'intProducer' id = 2
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -97,10 +97,10 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ starting: global begin run for module: label = 'out'
-++++++ finished: global begin run for module: label = 'out'
-++++++ starting: global begin run for module: label = 'TriggerResults'
-++++++ finished: global begin run for module: label = 'TriggerResults'
+++++++ starting: global begin run for module: label = 'out' id = 3
+++++++ finished: global begin run for module: label = 'out' id = 3
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin run 1 : time = 1
 GlobalContext: transition = BeginRun
     run: 1 luminosityBlock: 0
@@ -113,11 +113,11 @@ StreamContext: StreamID = 0 transition = BeginRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ starting: begin run for module: stream = 0 label = 'intProducerU'
-++++++ finished: begin run for module: stream = 0 label = 'intProducerU'
-++++++ starting: begin run for module: stream = 0 label = 'intVectorProducer'
-++++++ finished: begin run for module: stream = 0 label = 'intVectorProducer'
-++++++ starting: begin run for module: stream = 0 label = 'intProducer'
+++++++ starting: begin run for module: stream = 0 label = 'intProducerU' id = 4
+++++++ finished: begin run for module: stream = 0 label = 'intProducerU' id = 4
+++++++ starting: begin run for module: stream = 0 label = 'intVectorProducer' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'intVectorProducer' id = 5
+++++++ starting: begin run for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -129,7 +129,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ finished: begin run for module: stream = 0 label = 'intProducer'
+++++++ finished: begin run for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
@@ -141,8 +141,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ starting: begin run for module: stream = 0 label = 'out'
-++++++ finished: begin run for module: stream = 0 label = 'out'
+++++++ starting: begin run for module: stream = 0 label = 'out' id = 3
+++++++ finished: begin run for module: stream = 0 label = 'out' id = 3
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginRun
     run: 1 lumi: 0 event: 0
@@ -157,11 +157,11 @@ GlobalContext: transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ starting: global begin lumi for module: label = 'intProducerU'
-++++++ finished: global begin lumi for module: label = 'intProducerU'
-++++++ starting: global begin lumi for module: label = 'intVectorProducer'
-++++++ finished: global begin lumi for module: label = 'intVectorProducer'
-++++++ starting: global begin lumi for module: label = 'intProducer'
+++++++ starting: global begin lumi for module: label = 'intProducerU' id = 4
+++++++ finished: global begin lumi for module: label = 'intProducerU' id = 4
+++++++ starting: global begin lumi for module: label = 'intVectorProducer' id = 5
+++++++ finished: global begin lumi for module: label = 'intVectorProducer' id = 5
+++++++ starting: global begin lumi for module: label = 'intProducer' id = 2
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -173,7 +173,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ finished: global begin lumi for module: label = 'intProducer'
+++++++ finished: global begin lumi for module: label = 'intProducer' id = 2
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -185,10 +185,10 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ starting: global begin lumi for module: label = 'out'
-++++++ finished: global begin lumi for module: label = 'out'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'out' id = 3
+++++++ finished: global begin lumi for module: label = 'out' id = 3
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = BeginLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -201,11 +201,11 @@ StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU'
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU'
-++++++ starting: begin lumi for module: stream = 0 label = 'intVectorProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'intVectorProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'intProducer'
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducerU' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducerU' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'intVectorProducer' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -217,7 +217,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ finished: begin lumi for module: stream = 0 label = 'intProducer'
+++++++ finished: begin lumi for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -229,8 +229,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ starting: begin lumi for module: stream = 0 label = 'out'
-++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 3
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 StreamContext: StreamID = 0 transition = BeginLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -256,7 +256,7 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -270,7 +270,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
@@ -295,8 +295,8 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++ starting: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -308,12 +308,12 @@ PathContext: pathName = e pathID = 0 (EndPath)
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 5000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU'
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU'
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer'
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer'
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 4
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 4
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 5
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 3
 ++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 1
@@ -350,7 +350,7 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -364,7 +364,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
@@ -389,8 +389,8 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++ starting: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -402,12 +402,12 @@ PathContext: pathName = e pathID = 0 (EndPath)
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 10000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU'
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU'
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer'
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer'
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 4
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 4
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 5
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 3
 ++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 2
@@ -444,7 +444,7 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++++ starting: processing event for module: stream = 0 label = 'intProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -458,7 +458,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++++ finished: processing event for module: stream = 0 label = 'intProducer'
+++++++++ finished: processing event for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -483,8 +483,8 @@ PathContext: pathName = p pathID = 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++++ starting: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -496,12 +496,12 @@ PathContext: pathName = e pathID = 0 (EndPath)
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU'
-++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU'
-++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer'
-++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer'
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++++ starting: processing event for module: stream = 0 label = 'intProducerU' id = 4
+++++++++++ finished: processing event for module: stream = 0 label = 'intProducerU' id = 4
+++++++++++ starting: processing event for module: stream = 0 label = 'intVectorProducer' id = 5
+++++++++++ finished: processing event for module: stream = 0 label = 'intVectorProducer' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 3
 ++++++ finished: processing path 'e' : stream = 0
 StreamContext: StreamID = 0 transition = Event
     run: 1 lumi: 1 event: 3
@@ -525,11 +525,11 @@ StreamContext: StreamID = 0 transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ starting: end lumi for module: stream = 0 label = 'intProducerU'
-++++++ finished: end lumi for module: stream = 0 label = 'intProducerU'
-++++++ starting: end lumi for module: stream = 0 label = 'intVectorProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'intVectorProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'intProducer'
+++++++ starting: end lumi for module: stream = 0 label = 'intProducerU' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'intProducerU' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'intVectorProducer' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'intVectorProducer' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -541,7 +541,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ finished: end lumi for module: stream = 0 label = 'intProducer'
+++++++ finished: end lumi for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
@@ -553,8 +553,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ starting: end lumi for module: stream = 0 label = 'out'
-++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 3
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndLuminosityBlock
     run: 1 lumi: 1 event: 0
@@ -567,11 +567,11 @@ GlobalContext: transition = EndLuminosityBlock
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ starting: global end lumi for module: label = 'intProducerU'
-++++++ finished: global end lumi for module: label = 'intProducerU'
-++++++ starting: global end lumi for module: label = 'intVectorProducer'
-++++++ finished: global end lumi for module: label = 'intVectorProducer'
-++++++ starting: global end lumi for module: label = 'intProducer'
+++++++ starting: global end lumi for module: label = 'intProducerU' id = 4
+++++++ finished: global end lumi for module: label = 'intProducerU' id = 4
+++++++ starting: global end lumi for module: label = 'intVectorProducer' id = 5
+++++++ finished: global end lumi for module: label = 'intVectorProducer' id = 5
+++++++ starting: global end lumi for module: label = 'intProducer' id = 2
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -583,7 +583,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ finished: global end lumi for module: label = 'intProducer'
+++++++ finished: global end lumi for module: label = 'intProducer' id = 2
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
@@ -595,10 +595,10 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 0  unixTime = 0 microsecondOffset = 1
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ starting: global end lumi for module: label = 'out'
-++++++ finished: global end lumi for module: label = 'out'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'out' id = 3
+++++++ finished: global end lumi for module: label = 'out' id = 3
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 GlobalContext: transition = EndLuminosityBlock
     run: 1 luminosityBlock: 1
@@ -611,11 +611,11 @@ StreamContext: StreamID = 0 transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ starting: end run for module: stream = 0 label = 'intProducerU'
-++++++ finished: end run for module: stream = 0 label = 'intProducerU'
-++++++ starting: end run for module: stream = 0 label = 'intVectorProducer'
-++++++ finished: end run for module: stream = 0 label = 'intVectorProducer'
-++++++ starting: end run for module: stream = 0 label = 'intProducer'
+++++++ starting: end run for module: stream = 0 label = 'intProducerU' id = 4
+++++++ finished: end run for module: stream = 0 label = 'intProducerU' id = 4
+++++++ starting: end run for module: stream = 0 label = 'intVectorProducer' id = 5
+++++++ finished: end run for module: stream = 0 label = 'intVectorProducer' id = 5
+++++++ starting: end run for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -627,7 +627,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ finished: end run for module: stream = 0 label = 'intProducer'
+++++++ finished: end run for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -639,8 +639,8 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ starting: end run for module: stream = 0 label = 'out'
-++++++ finished: end run for module: stream = 0 label = 'out'
+++++++ starting: end run for module: stream = 0 label = 'out' id = 3
+++++++ finished: end run for module: stream = 0 label = 'out' id = 3
 ++++ finished: end run: stream = 0 run = 1 time = 15000001
 StreamContext: StreamID = 0 transition = EndRun
     run: 1 lumi: 0 event: 0
@@ -653,11 +653,11 @@ GlobalContext: transition = EndRun
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ starting: global end run for module: label = 'intProducerU'
-++++++ finished: global end run for module: label = 'intProducerU'
-++++++ starting: global end run for module: label = 'intVectorProducer'
-++++++ finished: global end run for module: label = 'intVectorProducer'
-++++++ starting: global end run for module: label = 'intProducer'
+++++++ starting: global end run for module: label = 'intProducerU' id = 4
+++++++ finished: global end run for module: label = 'intProducerU' id = 4
+++++++ starting: global end run for module: label = 'intVectorProducer' id = 5
+++++++ finished: global end run for module: label = 'intVectorProducer' id = 5
+++++++ starting: global end run for module: label = 'intProducer' id = 2
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -669,7 +669,7 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ finished: global end run for module: label = 'intProducer'
+++++++ finished: global end run for module: label = 'intProducer' id = 2
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
@@ -681,10 +681,10 @@ ModuleCallingContext state = Running
     runIndex = 0  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 15000001
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++++ starting: global end run for module: label = 'out'
-++++++ finished: global end run for module: label = 'out'
-++++++ starting: global end run for module: label = 'TriggerResults'
-++++++ finished: global end run for module: label = 'TriggerResults'
+++++++ starting: global end run for module: label = 'out' id = 3
+++++++ finished: global end run for module: label = 'out' id = 3
+++++++ starting: global end run for module: label = 'TriggerResults' id = 1
+++++++ finished: global end run for module: label = 'TriggerResults' id = 1
 ++++ finished: global end run 1 : time = 15000001
 GlobalContext: transition = EndRun
     run: 1 luminosityBlock: 0
@@ -693,7 +693,7 @@ GlobalContext: transition = EndRun
 
 ++++ starting: close input file: lfn = file:testGetBy1.root usedFallBack = 0
 ++++ finished: close input file: lfn = file:testGetBy1.root usedFallBack = 0
-++++ starting: end stream for module: stream = 0 label = 'intProducer'
+++++ starting: end stream for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -705,7 +705,7 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++ finished: end stream for module: stream = 0 label = 'intProducer'
+++++ finished: end stream for module: stream = 0 label = 'intProducer' id = 2
 StreamContext: StreamID = 0 transition = EndStream
     run: 0 lumi: 0 event: 0
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
@@ -717,24 +717,24 @@ ModuleCallingContext state = Running
     runIndex = 4294967295  luminosityBlockIndex = 4294967295  unixTime = 0 microsecondOffset = 0
     ProcessContext: PROD2 c301df4e8d1235b0ad4e7c2cf9431532
 
-++++ starting: end stream for module: stream = 0 label = 'TriggerResults'
-++++ finished: end stream for module: stream = 0 label = 'TriggerResults'
-++++ starting: end stream for module: stream = 0 label = 'out'
-++++ finished: end stream for module: stream = 0 label = 'out'
-++++ starting: end stream for module: stream = 0 label = 'intProducerU'
-++++ finished: end stream for module: stream = 0 label = 'intProducerU'
-++++ starting: end stream for module: stream = 0 label = 'intVectorProducer'
-++++ finished: end stream for module: stream = 0 label = 'intVectorProducer'
-++++ starting: end job for module with label 'intProducerU'
-++++ finished: end job for module with label 'intProducerU'
-++++ starting: end job for module with label 'intVectorProducer'
-++++ finished: end job for module with label 'intVectorProducer'
-++++ starting: end job for module with label 'intProducer'
+++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 1
+++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 1
+++++ starting: end stream for module: stream = 0 label = 'out' id = 3
+++++ finished: end stream for module: stream = 0 label = 'out' id = 3
+++++ starting: end stream for module: stream = 0 label = 'intProducerU' id = 4
+++++ finished: end stream for module: stream = 0 label = 'intProducerU' id = 4
+++++ starting: end stream for module: stream = 0 label = 'intVectorProducer' id = 5
+++++ finished: end stream for module: stream = 0 label = 'intVectorProducer' id = 5
+++++ starting: end job for module with label 'intProducerU' id = 4
+++++ finished: end job for module with label 'intProducerU' id = 4
+++++ starting: end job for module with label 'intVectorProducer' id = 5
+++++ finished: end job for module with label 'intVectorProducer' id = 5
+++++ starting: end job for module with label 'intProducer' id = 2
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++++ finished: end job for module with label 'intProducer'
+++++ finished: end job for module with label 'intProducer' id = 2
 Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196ea2e10cdd947af547d0ea
-++++ starting: end job for module with label 'out'
-++++ finished: end job for module with label 'out'
-++++ starting: end job for module with label 'TriggerResults'
-++++ finished: end job for module with label 'TriggerResults'
+++++ starting: end job for module with label 'out' id = 3
+++++ finished: end job for module with label 'out' id = 3
+++++ starting: end job for module with label 'TriggerResults' id = 1
+++++ finished: end job for module with label 'TriggerResults' id = 1
 ++ finished: end job

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -1,102 +1,102 @@
 ++ starting: constructing source: EmptySource
 ++ finished: constructing source: EmptySource
-++++ starting: constructing module with label 'TriggerResults'
-++++ finished: constructing module with label 'TriggerResults'
-++++ starting: constructing module with label 'thingWithMergeProducer'
-++++ finished: constructing module with label 'thingWithMergeProducer'
-++++ starting: constructing module with label 'get'
-++++ finished: constructing module with label 'get'
-++++ starting: constructing module with label 'putInt'
-++++ finished: constructing module with label 'putInt'
-++++ starting: constructing module with label 'putInt2'
-++++ finished: constructing module with label 'putInt2'
-++++ starting: constructing module with label 'putInt3'
-++++ finished: constructing module with label 'putInt3'
-++++ starting: constructing module with label 'getInt'
-++++ finished: constructing module with label 'getInt'
-++++ starting: constructing module with label 'noPut'
-++++ finished: constructing module with label 'noPut'
-++++ starting: constructing module with label 'TriggerResults'
-++++ finished: constructing module with label 'TriggerResults'
-++++ starting: constructing module with label 'thingWithMergeProducer'
-++++ finished: constructing module with label 'thingWithMergeProducer'
-++++ starting: constructing module with label 'test'
-++++ finished: constructing module with label 'test'
-++++ starting: constructing module with label 'testmerge'
-++++ finished: constructing module with label 'testmerge'
-++++ starting: constructing module with label 'get'
-++++ finished: constructing module with label 'get'
-++++ starting: constructing module with label 'getInt'
-++++ finished: constructing module with label 'getInt'
-++++ starting: constructing module with label 'dependsOnNoPut'
-++++ finished: constructing module with label 'dependsOnNoPut'
-++++ starting: constructing module with label 'out'
-++++ finished: constructing module with label 'out'
-++++ starting: begin job for module with label 'thingWithMergeProducer'
-++++ finished: begin job for module with label 'thingWithMergeProducer'
-++++ starting: begin job for module with label 'get'
-++++ finished: begin job for module with label 'get'
-++++ starting: begin job for module with label 'putInt'
-++++ finished: begin job for module with label 'putInt'
-++++ starting: begin job for module with label 'putInt2'
-++++ finished: begin job for module with label 'putInt2'
-++++ starting: begin job for module with label 'putInt3'
-++++ finished: begin job for module with label 'putInt3'
-++++ starting: begin job for module with label 'getInt'
-++++ finished: begin job for module with label 'getInt'
-++++ starting: begin job for module with label 'noPut'
-++++ finished: begin job for module with label 'noPut'
-++++ starting: begin job for module with label 'TriggerResults'
-++++ finished: begin job for module with label 'TriggerResults'
-++++ starting: begin job for module with label 'thingWithMergeProducer'
-++++ finished: begin job for module with label 'thingWithMergeProducer'
-++++ starting: begin job for module with label 'test'
-++++ finished: begin job for module with label 'test'
-++++ starting: begin job for module with label 'testmerge'
-++++ finished: begin job for module with label 'testmerge'
-++++ starting: begin job for module with label 'get'
-++++ finished: begin job for module with label 'get'
-++++ starting: begin job for module with label 'getInt'
-++++ finished: begin job for module with label 'getInt'
-++++ starting: begin job for module with label 'dependsOnNoPut'
-++++ finished: begin job for module with label 'dependsOnNoPut'
-++++ starting: begin job for module with label 'out'
-++++ finished: begin job for module with label 'out'
-++++ starting: begin job for module with label 'TriggerResults'
-++++ finished: begin job for module with label 'TriggerResults'
+++++ starting: constructing module with label 'TriggerResults' id = 1
+++++ finished: constructing module with label 'TriggerResults' id = 1
+++++ starting: constructing module with label 'thingWithMergeProducer' id = 2
+++++ finished: constructing module with label 'thingWithMergeProducer' id = 2
+++++ starting: constructing module with label 'get' id = 3
+++++ finished: constructing module with label 'get' id = 3
+++++ starting: constructing module with label 'putInt' id = 4
+++++ finished: constructing module with label 'putInt' id = 4
+++++ starting: constructing module with label 'putInt2' id = 5
+++++ finished: constructing module with label 'putInt2' id = 5
+++++ starting: constructing module with label 'putInt3' id = 6
+++++ finished: constructing module with label 'putInt3' id = 6
+++++ starting: constructing module with label 'getInt' id = 7
+++++ finished: constructing module with label 'getInt' id = 7
+++++ starting: constructing module with label 'noPut' id = 8
+++++ finished: constructing module with label 'noPut' id = 8
+++++ starting: constructing module with label 'TriggerResults' id = 9
+++++ finished: constructing module with label 'TriggerResults' id = 9
+++++ starting: constructing module with label 'thingWithMergeProducer' id = 10
+++++ finished: constructing module with label 'thingWithMergeProducer' id = 10
+++++ starting: constructing module with label 'test' id = 11
+++++ finished: constructing module with label 'test' id = 11
+++++ starting: constructing module with label 'testmerge' id = 12
+++++ finished: constructing module with label 'testmerge' id = 12
+++++ starting: constructing module with label 'get' id = 13
+++++ finished: constructing module with label 'get' id = 13
+++++ starting: constructing module with label 'getInt' id = 14
+++++ finished: constructing module with label 'getInt' id = 14
+++++ starting: constructing module with label 'dependsOnNoPut' id = 15
+++++ finished: constructing module with label 'dependsOnNoPut' id = 15
+++++ starting: constructing module with label 'out' id = 16
+++++ finished: constructing module with label 'out' id = 16
+++++ starting: begin job for module with label 'thingWithMergeProducer' id = 2
+++++ finished: begin job for module with label 'thingWithMergeProducer' id = 2
+++++ starting: begin job for module with label 'get' id = 3
+++++ finished: begin job for module with label 'get' id = 3
+++++ starting: begin job for module with label 'putInt' id = 4
+++++ finished: begin job for module with label 'putInt' id = 4
+++++ starting: begin job for module with label 'putInt2' id = 5
+++++ finished: begin job for module with label 'putInt2' id = 5
+++++ starting: begin job for module with label 'putInt3' id = 6
+++++ finished: begin job for module with label 'putInt3' id = 6
+++++ starting: begin job for module with label 'getInt' id = 7
+++++ finished: begin job for module with label 'getInt' id = 7
+++++ starting: begin job for module with label 'noPut' id = 8
+++++ finished: begin job for module with label 'noPut' id = 8
+++++ starting: begin job for module with label 'TriggerResults' id = 1
+++++ finished: begin job for module with label 'TriggerResults' id = 1
+++++ starting: begin job for module with label 'thingWithMergeProducer' id = 10
+++++ finished: begin job for module with label 'thingWithMergeProducer' id = 10
+++++ starting: begin job for module with label 'test' id = 11
+++++ finished: begin job for module with label 'test' id = 11
+++++ starting: begin job for module with label 'testmerge' id = 12
+++++ finished: begin job for module with label 'testmerge' id = 12
+++++ starting: begin job for module with label 'get' id = 13
+++++ finished: begin job for module with label 'get' id = 13
+++++ starting: begin job for module with label 'getInt' id = 14
+++++ finished: begin job for module with label 'getInt' id = 14
+++++ starting: begin job for module with label 'dependsOnNoPut' id = 15
+++++ finished: begin job for module with label 'dependsOnNoPut' id = 15
+++++ starting: begin job for module with label 'out' id = 16
+++++ finished: begin job for module with label 'out' id = 16
+++++ starting: begin job for module with label 'TriggerResults' id = 9
+++++ finished: begin job for module with label 'TriggerResults' id = 9
 ++ finished: begin job
-++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer'
-++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer'
-++++ starting: begin stream for module: stream = 0 label = 'get'
-++++ finished: begin stream for module: stream = 0 label = 'get'
-++++ starting: begin stream for module: stream = 0 label = 'putInt'
-++++ finished: begin stream for module: stream = 0 label = 'putInt'
-++++ starting: begin stream for module: stream = 0 label = 'putInt2'
-++++ finished: begin stream for module: stream = 0 label = 'putInt2'
-++++ starting: begin stream for module: stream = 0 label = 'putInt3'
-++++ finished: begin stream for module: stream = 0 label = 'putInt3'
-++++ starting: begin stream for module: stream = 0 label = 'getInt'
-++++ finished: begin stream for module: stream = 0 label = 'getInt'
-++++ starting: begin stream for module: stream = 0 label = 'noPut'
-++++ finished: begin stream for module: stream = 0 label = 'noPut'
-++++ starting: begin stream for module: stream = 0 label = 'TriggerResults'
-++++ finished: begin stream for module: stream = 0 label = 'TriggerResults'
-++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer'
-++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer'
-++++ starting: begin stream for module: stream = 0 label = 'test'
-++++ finished: begin stream for module: stream = 0 label = 'test'
-++++ starting: begin stream for module: stream = 0 label = 'testmerge'
-++++ finished: begin stream for module: stream = 0 label = 'testmerge'
-++++ starting: begin stream for module: stream = 0 label = 'get'
-++++ finished: begin stream for module: stream = 0 label = 'get'
-++++ starting: begin stream for module: stream = 0 label = 'getInt'
-++++ finished: begin stream for module: stream = 0 label = 'getInt'
-++++ starting: begin stream for module: stream = 0 label = 'dependsOnNoPut'
-++++ finished: begin stream for module: stream = 0 label = 'dependsOnNoPut'
-++++ starting: begin stream for module: stream = 0 label = 'TriggerResults'
-++++ finished: begin stream for module: stream = 0 label = 'TriggerResults'
-++++ starting: begin stream for module: stream = 0 label = 'out'
-++++ finished: begin stream for module: stream = 0 label = 'out'
+++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++ starting: begin stream for module: stream = 0 label = 'get' id = 3
+++++ finished: begin stream for module: stream = 0 label = 'get' id = 3
+++++ starting: begin stream for module: stream = 0 label = 'putInt' id = 4
+++++ finished: begin stream for module: stream = 0 label = 'putInt' id = 4
+++++ starting: begin stream for module: stream = 0 label = 'putInt2' id = 5
+++++ finished: begin stream for module: stream = 0 label = 'putInt2' id = 5
+++++ starting: begin stream for module: stream = 0 label = 'putInt3' id = 6
+++++ finished: begin stream for module: stream = 0 label = 'putInt3' id = 6
+++++ starting: begin stream for module: stream = 0 label = 'getInt' id = 7
+++++ finished: begin stream for module: stream = 0 label = 'getInt' id = 7
+++++ starting: begin stream for module: stream = 0 label = 'noPut' id = 8
+++++ finished: begin stream for module: stream = 0 label = 'noPut' id = 8
+++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
+++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 1
+++++ starting: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++ finished: begin stream for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++ starting: begin stream for module: stream = 0 label = 'test' id = 11
+++++ finished: begin stream for module: stream = 0 label = 'test' id = 11
+++++ starting: begin stream for module: stream = 0 label = 'testmerge' id = 12
+++++ finished: begin stream for module: stream = 0 label = 'testmerge' id = 12
+++++ starting: begin stream for module: stream = 0 label = 'get' id = 13
+++++ finished: begin stream for module: stream = 0 label = 'get' id = 13
+++++ starting: begin stream for module: stream = 0 label = 'getInt' id = 14
+++++ finished: begin stream for module: stream = 0 label = 'getInt' id = 14
+++++ starting: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++ finished: begin stream for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++ starting: begin stream for module: stream = 0 label = 'TriggerResults' id = 9
+++++ finished: begin stream for module: stream = 0 label = 'TriggerResults' id = 9
+++++ starting: begin stream for module: stream = 0 label = 'out' id = 16
+++++ finished: begin stream for module: stream = 0 label = 'out' id = 16
 ++++ starting: source run
 ++++ finished: source run
 ++++ starting: global begin run 1 : time = 1
@@ -104,80 +104,80 @@
 ++++ starting: global begin run 1 : time = 1
 ++++ finished: global begin run 1 : time = 1
 ++++ starting: global begin run 1 : time = 1
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin run for module: label = 'get'
-++++++ finished: global begin run for module: label = 'get'
-++++++ starting: global begin run for module: label = 'putInt'
-++++++ finished: global begin run for module: label = 'putInt'
-++++++ starting: global begin run for module: label = 'putInt2'
-++++++ finished: global begin run for module: label = 'putInt2'
-++++++ starting: global begin run for module: label = 'putInt3'
-++++++ finished: global begin run for module: label = 'putInt3'
-++++++ starting: global begin run for module: label = 'getInt'
-++++++ finished: global begin run for module: label = 'getInt'
-++++++ starting: global begin run for module: label = 'noPut'
-++++++ finished: global begin run for module: label = 'noPut'
-++++++ starting: global begin run for module: label = 'TriggerResults'
-++++++ finished: global begin run for module: label = 'TriggerResults'
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global begin run for module: label = 'get' id = 3
+++++++ finished: global begin run for module: label = 'get' id = 3
+++++++ starting: global begin run for module: label = 'putInt' id = 4
+++++++ finished: global begin run for module: label = 'putInt' id = 4
+++++++ starting: global begin run for module: label = 'putInt2' id = 5
+++++++ finished: global begin run for module: label = 'putInt2' id = 5
+++++++ starting: global begin run for module: label = 'putInt3' id = 6
+++++++ finished: global begin run for module: label = 'putInt3' id = 6
+++++++ starting: global begin run for module: label = 'getInt' id = 7
+++++++ finished: global begin run for module: label = 'getInt' id = 7
+++++++ starting: global begin run for module: label = 'noPut' id = 8
+++++++ finished: global begin run for module: label = 'noPut' id = 8
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin run 1 : time = 1
 ++++ starting: global begin run 1 : time = 1
 ++++ finished: global begin run 1 : time = 1
 ++++ starting: global begin run 1 : time = 1
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin run for module: label = 'test'
-++++++ finished: global begin run for module: label = 'test'
-++++++ starting: global begin run for module: label = 'testmerge'
-++++++ finished: global begin run for module: label = 'testmerge'
-++++++ starting: global begin run for module: label = 'get'
-++++++ finished: global begin run for module: label = 'get'
-++++++ starting: global begin run for module: label = 'getInt'
-++++++ finished: global begin run for module: label = 'getInt'
-++++++ starting: global begin run for module: label = 'dependsOnNoPut'
-++++++ finished: global begin run for module: label = 'dependsOnNoPut'
-++++++ starting: global begin run for module: label = 'out'
-++++++ finished: global begin run for module: label = 'out'
-++++++ starting: global begin run for module: label = 'TriggerResults'
-++++++ finished: global begin run for module: label = 'TriggerResults'
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin run for module: label = 'test' id = 11
+++++++ finished: global begin run for module: label = 'test' id = 11
+++++++ starting: global begin run for module: label = 'testmerge' id = 12
+++++++ finished: global begin run for module: label = 'testmerge' id = 12
+++++++ starting: global begin run for module: label = 'get' id = 13
+++++++ finished: global begin run for module: label = 'get' id = 13
+++++++ starting: global begin run for module: label = 'getInt' id = 14
+++++++ finished: global begin run for module: label = 'getInt' id = 14
+++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin run for module: label = 'out' id = 16
+++++++ finished: global begin run for module: label = 'out' id = 16
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin run 1 : time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin run for module: stream = 0 label = 'get'
-++++++ finished: begin run for module: stream = 0 label = 'get'
-++++++ starting: begin run for module: stream = 0 label = 'putInt'
-++++++ finished: begin run for module: stream = 0 label = 'putInt'
-++++++ starting: begin run for module: stream = 0 label = 'putInt2'
-++++++ finished: begin run for module: stream = 0 label = 'putInt2'
-++++++ starting: begin run for module: stream = 0 label = 'putInt3'
-++++++ finished: begin run for module: stream = 0 label = 'putInt3'
-++++++ starting: begin run for module: stream = 0 label = 'getInt'
-++++++ finished: begin run for module: stream = 0 label = 'getInt'
-++++++ starting: begin run for module: stream = 0 label = 'noPut'
-++++++ finished: begin run for module: stream = 0 label = 'noPut'
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin run for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: begin run for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: begin run: stream = 0 run = 1 time = 1
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin run for module: stream = 0 label = 'test'
-++++++ finished: begin run for module: stream = 0 label = 'test'
-++++++ starting: begin run for module: stream = 0 label = 'testmerge'
-++++++ finished: begin run for module: stream = 0 label = 'testmerge'
-++++++ starting: begin run for module: stream = 0 label = 'get'
-++++++ finished: begin run for module: stream = 0 label = 'get'
-++++++ starting: begin run for module: stream = 0 label = 'getInt'
-++++++ finished: begin run for module: stream = 0 label = 'getInt'
-++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: begin run for module: stream = 0 label = 'out'
-++++++ finished: begin run for module: stream = 0 label = 'out'
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin run for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin run for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin run for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin run for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin run: stream = 0 run = 1 time = 1
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -186,80 +186,80 @@
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'putInt'
-++++++ finished: global begin lumi for module: label = 'putInt'
-++++++ starting: global begin lumi for module: label = 'putInt2'
-++++++ finished: global begin lumi for module: label = 'putInt2'
-++++++ starting: global begin lumi for module: label = 'putInt3'
-++++++ finished: global begin lumi for module: label = 'putInt3'
-++++++ starting: global begin lumi for module: label = 'getInt'
-++++++ finished: global begin lumi for module: label = 'getInt'
-++++++ starting: global begin lumi for module: label = 'noPut'
-++++++ finished: global begin lumi for module: label = 'noPut'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global begin lumi for module: label = 'get' id = 3
+++++++ finished: global begin lumi for module: label = 'get' id = 3
+++++++ starting: global begin lumi for module: label = 'putInt' id = 4
+++++++ finished: global begin lumi for module: label = 'putInt' id = 4
+++++++ starting: global begin lumi for module: label = 'putInt2' id = 5
+++++++ finished: global begin lumi for module: label = 'putInt2' id = 5
+++++++ starting: global begin lumi for module: label = 'putInt3' id = 6
+++++++ finished: global begin lumi for module: label = 'putInt3' id = 6
+++++++ starting: global begin lumi for module: label = 'getInt' id = 7
+++++++ finished: global begin lumi for module: label = 'getInt' id = 7
+++++++ starting: global begin lumi for module: label = 'noPut' id = 8
+++++++ finished: global begin lumi for module: label = 'noPut' id = 8
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global begin lumi: run = 1 lumi = 1 time = 1
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin lumi for module: label = 'test'
-++++++ finished: global begin lumi for module: label = 'test'
-++++++ starting: global begin lumi for module: label = 'testmerge'
-++++++ finished: global begin lumi for module: label = 'testmerge'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'getInt'
-++++++ finished: global begin lumi for module: label = 'getInt'
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut'
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut'
-++++++ starting: global begin lumi for module: label = 'out'
-++++++ finished: global begin lumi for module: label = 'out'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin lumi for module: label = 'test' id = 11
+++++++ finished: global begin lumi for module: label = 'test' id = 11
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
+++++++ starting: global begin lumi for module: label = 'get' id = 13
+++++++ finished: global begin lumi for module: label = 'get' id = 13
+++++++ starting: global begin lumi for module: label = 'getInt' id = 14
+++++++ finished: global begin lumi for module: label = 'getInt' id = 14
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin lumi for module: label = 'out' id = 16
+++++++ finished: global begin lumi for module: label = 'out' id = 16
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3'
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut'
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut'
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'test'
-++++++ finished: begin lumi for module: stream = 0 label = 'test'
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge'
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: begin lumi for module: stream = 0 label = 'out'
-++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 1 time = 1
 ++++ starting: source event
 ++++ finished: source event
@@ -269,56 +269,56 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 1 time = 5000001
 ++++ starting: source event
@@ -329,56 +329,56 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 2 time = 10000001
 ++++ starting: source event
@@ -389,56 +389,56 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 3 time = 15000001
 ++++ starting: source event
@@ -449,56 +449,56 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 1 event = 4 time = 20000001
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 20000001
@@ -506,80 +506,80 @@
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3'
-++++++ starting: end lumi for module: stream = 0 label = 'getInt'
-++++++ finished: end lumi for module: stream = 0 label = 'getInt'
-++++++ starting: end lumi for module: stream = 0 label = 'noPut'
-++++++ finished: end lumi for module: stream = 0 label = 'noPut'
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'test'
-++++++ finished: end lumi for module: stream = 0 label = 'test'
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge'
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
-++++++ starting: end lumi for module: stream = 0 label = 'getInt'
-++++++ finished: end lumi for module: stream = 0 label = 'getInt'
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: end lumi for module: stream = 0 label = 'out'
-++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 1 time = 0
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'putInt'
-++++++ finished: global end lumi for module: label = 'putInt'
-++++++ starting: global end lumi for module: label = 'putInt2'
-++++++ finished: global end lumi for module: label = 'putInt2'
-++++++ starting: global end lumi for module: label = 'putInt3'
-++++++ finished: global end lumi for module: label = 'putInt3'
-++++++ starting: global end lumi for module: label = 'getInt'
-++++++ finished: global end lumi for module: label = 'getInt'
-++++++ starting: global end lumi for module: label = 'noPut'
-++++++ finished: global end lumi for module: label = 'noPut'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global end lumi for module: label = 'get' id = 3
+++++++ finished: global end lumi for module: label = 'get' id = 3
+++++++ starting: global end lumi for module: label = 'putInt' id = 4
+++++++ finished: global end lumi for module: label = 'putInt' id = 4
+++++++ starting: global end lumi for module: label = 'putInt2' id = 5
+++++++ finished: global end lumi for module: label = 'putInt2' id = 5
+++++++ starting: global end lumi for module: label = 'putInt3' id = 6
+++++++ finished: global end lumi for module: label = 'putInt3' id = 6
+++++++ starting: global end lumi for module: label = 'getInt' id = 7
+++++++ finished: global end lumi for module: label = 'getInt' id = 7
+++++++ starting: global end lumi for module: label = 'noPut' id = 8
+++++++ finished: global end lumi for module: label = 'noPut' id = 8
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: global end lumi: run = 1 lumi = 1 time = 1
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global end lumi for module: label = 'test'
-++++++ finished: global end lumi for module: label = 'test'
-++++++ starting: global end lumi for module: label = 'testmerge'
-++++++ finished: global end lumi for module: label = 'testmerge'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'getInt'
-++++++ finished: global end lumi for module: label = 'getInt'
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut'
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut'
-++++++ starting: global end lumi for module: label = 'out'
-++++++ finished: global end lumi for module: label = 'out'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global end lumi for module: label = 'test' id = 11
+++++++ finished: global end lumi for module: label = 'test' id = 11
+++++++ starting: global end lumi for module: label = 'testmerge' id = 12
+++++++ finished: global end lumi for module: label = 'testmerge' id = 12
+++++++ starting: global end lumi for module: label = 'get' id = 13
+++++++ finished: global end lumi for module: label = 'get' id = 13
+++++++ starting: global end lumi for module: label = 'getInt' id = 14
+++++++ finished: global end lumi for module: label = 'getInt' id = 14
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global end lumi for module: label = 'out' id = 16
+++++++ finished: global end lumi for module: label = 'out' id = 16
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 1 lumi = 1 time = 1
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -588,80 +588,80 @@
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'putInt'
-++++++ finished: global begin lumi for module: label = 'putInt'
-++++++ starting: global begin lumi for module: label = 'putInt2'
-++++++ finished: global begin lumi for module: label = 'putInt2'
-++++++ starting: global begin lumi for module: label = 'putInt3'
-++++++ finished: global begin lumi for module: label = 'putInt3'
-++++++ starting: global begin lumi for module: label = 'getInt'
-++++++ finished: global begin lumi for module: label = 'getInt'
-++++++ starting: global begin lumi for module: label = 'noPut'
-++++++ finished: global begin lumi for module: label = 'noPut'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global begin lumi for module: label = 'get' id = 3
+++++++ finished: global begin lumi for module: label = 'get' id = 3
+++++++ starting: global begin lumi for module: label = 'putInt' id = 4
+++++++ finished: global begin lumi for module: label = 'putInt' id = 4
+++++++ starting: global begin lumi for module: label = 'putInt2' id = 5
+++++++ finished: global begin lumi for module: label = 'putInt2' id = 5
+++++++ starting: global begin lumi for module: label = 'putInt3' id = 6
+++++++ finished: global begin lumi for module: label = 'putInt3' id = 6
+++++++ starting: global begin lumi for module: label = 'getInt' id = 7
+++++++ finished: global begin lumi for module: label = 'getInt' id = 7
+++++++ starting: global begin lumi for module: label = 'noPut' id = 8
+++++++ finished: global begin lumi for module: label = 'noPut' id = 8
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global begin lumi: run = 1 lumi = 2 time = 25000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin lumi for module: label = 'test'
-++++++ finished: global begin lumi for module: label = 'test'
-++++++ starting: global begin lumi for module: label = 'testmerge'
-++++++ finished: global begin lumi for module: label = 'testmerge'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'getInt'
-++++++ finished: global begin lumi for module: label = 'getInt'
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut'
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut'
-++++++ starting: global begin lumi for module: label = 'out'
-++++++ finished: global begin lumi for module: label = 'out'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin lumi for module: label = 'test' id = 11
+++++++ finished: global begin lumi for module: label = 'test' id = 11
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
+++++++ starting: global begin lumi for module: label = 'get' id = 13
+++++++ finished: global begin lumi for module: label = 'get' id = 13
+++++++ starting: global begin lumi for module: label = 'getInt' id = 14
+++++++ finished: global begin lumi for module: label = 'getInt' id = 14
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin lumi for module: label = 'out' id = 16
+++++++ finished: global begin lumi for module: label = 'out' id = 16
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3'
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut'
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut'
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'test'
-++++++ finished: begin lumi for module: stream = 0 label = 'test'
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge'
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: begin lumi for module: stream = 0 label = 'out'
-++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 2 time = 25000001
 ++++ starting: source event
 ++++ finished: source event
@@ -671,56 +671,56 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 5 time = 25000001
 ++++ starting: source event
@@ -731,56 +731,56 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 6 time = 30000001
 ++++ starting: source event
@@ -791,56 +791,56 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 7 time = 35000001
 ++++ starting: source event
@@ -851,56 +851,56 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 2 event = 8 time = 40000001
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 40000001
@@ -908,80 +908,80 @@
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3'
-++++++ starting: end lumi for module: stream = 0 label = 'getInt'
-++++++ finished: end lumi for module: stream = 0 label = 'getInt'
-++++++ starting: end lumi for module: stream = 0 label = 'noPut'
-++++++ finished: end lumi for module: stream = 0 label = 'noPut'
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'test'
-++++++ finished: end lumi for module: stream = 0 label = 'test'
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge'
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
-++++++ starting: end lumi for module: stream = 0 label = 'getInt'
-++++++ finished: end lumi for module: stream = 0 label = 'getInt'
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: end lumi for module: stream = 0 label = 'out'
-++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 2 time = 0
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'putInt'
-++++++ finished: global end lumi for module: label = 'putInt'
-++++++ starting: global end lumi for module: label = 'putInt2'
-++++++ finished: global end lumi for module: label = 'putInt2'
-++++++ starting: global end lumi for module: label = 'putInt3'
-++++++ finished: global end lumi for module: label = 'putInt3'
-++++++ starting: global end lumi for module: label = 'getInt'
-++++++ finished: global end lumi for module: label = 'getInt'
-++++++ starting: global end lumi for module: label = 'noPut'
-++++++ finished: global end lumi for module: label = 'noPut'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global end lumi for module: label = 'get' id = 3
+++++++ finished: global end lumi for module: label = 'get' id = 3
+++++++ starting: global end lumi for module: label = 'putInt' id = 4
+++++++ finished: global end lumi for module: label = 'putInt' id = 4
+++++++ starting: global end lumi for module: label = 'putInt2' id = 5
+++++++ finished: global end lumi for module: label = 'putInt2' id = 5
+++++++ starting: global end lumi for module: label = 'putInt3' id = 6
+++++++ finished: global end lumi for module: label = 'putInt3' id = 6
+++++++ starting: global end lumi for module: label = 'getInt' id = 7
+++++++ finished: global end lumi for module: label = 'getInt' id = 7
+++++++ starting: global end lumi for module: label = 'noPut' id = 8
+++++++ finished: global end lumi for module: label = 'noPut' id = 8
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: global end lumi: run = 1 lumi = 2 time = 25000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global end lumi for module: label = 'test'
-++++++ finished: global end lumi for module: label = 'test'
-++++++ starting: global end lumi for module: label = 'testmerge'
-++++++ finished: global end lumi for module: label = 'testmerge'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'getInt'
-++++++ finished: global end lumi for module: label = 'getInt'
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut'
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut'
-++++++ starting: global end lumi for module: label = 'out'
-++++++ finished: global end lumi for module: label = 'out'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global end lumi for module: label = 'test' id = 11
+++++++ finished: global end lumi for module: label = 'test' id = 11
+++++++ starting: global end lumi for module: label = 'testmerge' id = 12
+++++++ finished: global end lumi for module: label = 'testmerge' id = 12
+++++++ starting: global end lumi for module: label = 'get' id = 13
+++++++ finished: global end lumi for module: label = 'get' id = 13
+++++++ starting: global end lumi for module: label = 'getInt' id = 14
+++++++ finished: global end lumi for module: label = 'getInt' id = 14
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global end lumi for module: label = 'out' id = 16
+++++++ finished: global end lumi for module: label = 'out' id = 16
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 1 lumi = 2 time = 25000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -990,80 +990,80 @@
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'putInt'
-++++++ finished: global begin lumi for module: label = 'putInt'
-++++++ starting: global begin lumi for module: label = 'putInt2'
-++++++ finished: global begin lumi for module: label = 'putInt2'
-++++++ starting: global begin lumi for module: label = 'putInt3'
-++++++ finished: global begin lumi for module: label = 'putInt3'
-++++++ starting: global begin lumi for module: label = 'getInt'
-++++++ finished: global begin lumi for module: label = 'getInt'
-++++++ starting: global begin lumi for module: label = 'noPut'
-++++++ finished: global begin lumi for module: label = 'noPut'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global begin lumi for module: label = 'get' id = 3
+++++++ finished: global begin lumi for module: label = 'get' id = 3
+++++++ starting: global begin lumi for module: label = 'putInt' id = 4
+++++++ finished: global begin lumi for module: label = 'putInt' id = 4
+++++++ starting: global begin lumi for module: label = 'putInt2' id = 5
+++++++ finished: global begin lumi for module: label = 'putInt2' id = 5
+++++++ starting: global begin lumi for module: label = 'putInt3' id = 6
+++++++ finished: global begin lumi for module: label = 'putInt3' id = 6
+++++++ starting: global begin lumi for module: label = 'getInt' id = 7
+++++++ finished: global begin lumi for module: label = 'getInt' id = 7
+++++++ starting: global begin lumi for module: label = 'noPut' id = 8
+++++++ finished: global begin lumi for module: label = 'noPut' id = 8
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global begin lumi: run = 1 lumi = 3 time = 45000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin lumi for module: label = 'test'
-++++++ finished: global begin lumi for module: label = 'test'
-++++++ starting: global begin lumi for module: label = 'testmerge'
-++++++ finished: global begin lumi for module: label = 'testmerge'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'getInt'
-++++++ finished: global begin lumi for module: label = 'getInt'
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut'
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut'
-++++++ starting: global begin lumi for module: label = 'out'
-++++++ finished: global begin lumi for module: label = 'out'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin lumi for module: label = 'test' id = 11
+++++++ finished: global begin lumi for module: label = 'test' id = 11
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
+++++++ starting: global begin lumi for module: label = 'get' id = 13
+++++++ finished: global begin lumi for module: label = 'get' id = 13
+++++++ starting: global begin lumi for module: label = 'getInt' id = 14
+++++++ finished: global begin lumi for module: label = 'getInt' id = 14
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin lumi for module: label = 'out' id = 16
+++++++ finished: global begin lumi for module: label = 'out' id = 16
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3'
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut'
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut'
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'test'
-++++++ finished: begin lumi for module: stream = 0 label = 'test'
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge'
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: begin lumi for module: stream = 0 label = 'out'
-++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 1 lumi = 3 time = 45000001
 ++++ starting: source event
 ++++ finished: source event
@@ -1073,56 +1073,56 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 9 time = 45000001
 ++++ starting: source event
@@ -1133,56 +1133,56 @@
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++ starting: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 1 lumi = 3 event = 10 time = 50000001
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 50000001
@@ -1190,160 +1190,160 @@
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3'
-++++++ starting: end lumi for module: stream = 0 label = 'getInt'
-++++++ finished: end lumi for module: stream = 0 label = 'getInt'
-++++++ starting: end lumi for module: stream = 0 label = 'noPut'
-++++++ finished: end lumi for module: stream = 0 label = 'noPut'
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 1 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'test'
-++++++ finished: end lumi for module: stream = 0 label = 'test'
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge'
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
-++++++ starting: end lumi for module: stream = 0 label = 'getInt'
-++++++ finished: end lumi for module: stream = 0 label = 'getInt'
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: end lumi for module: stream = 0 label = 'out'
-++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 1 lumi = 3 time = 0
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'putInt'
-++++++ finished: global end lumi for module: label = 'putInt'
-++++++ starting: global end lumi for module: label = 'putInt2'
-++++++ finished: global end lumi for module: label = 'putInt2'
-++++++ starting: global end lumi for module: label = 'putInt3'
-++++++ finished: global end lumi for module: label = 'putInt3'
-++++++ starting: global end lumi for module: label = 'getInt'
-++++++ finished: global end lumi for module: label = 'getInt'
-++++++ starting: global end lumi for module: label = 'noPut'
-++++++ finished: global end lumi for module: label = 'noPut'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global end lumi for module: label = 'get' id = 3
+++++++ finished: global end lumi for module: label = 'get' id = 3
+++++++ starting: global end lumi for module: label = 'putInt' id = 4
+++++++ finished: global end lumi for module: label = 'putInt' id = 4
+++++++ starting: global end lumi for module: label = 'putInt2' id = 5
+++++++ finished: global end lumi for module: label = 'putInt2' id = 5
+++++++ starting: global end lumi for module: label = 'putInt3' id = 6
+++++++ finished: global end lumi for module: label = 'putInt3' id = 6
+++++++ starting: global end lumi for module: label = 'getInt' id = 7
+++++++ finished: global end lumi for module: label = 'getInt' id = 7
+++++++ starting: global end lumi for module: label = 'noPut' id = 8
+++++++ finished: global end lumi for module: label = 'noPut' id = 8
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: global end lumi: run = 1 lumi = 3 time = 45000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global end lumi for module: label = 'test'
-++++++ finished: global end lumi for module: label = 'test'
-++++++ starting: global end lumi for module: label = 'testmerge'
-++++++ finished: global end lumi for module: label = 'testmerge'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'getInt'
-++++++ finished: global end lumi for module: label = 'getInt'
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut'
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut'
-++++++ starting: global end lumi for module: label = 'out'
-++++++ finished: global end lumi for module: label = 'out'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global end lumi for module: label = 'test' id = 11
+++++++ finished: global end lumi for module: label = 'test' id = 11
+++++++ starting: global end lumi for module: label = 'testmerge' id = 12
+++++++ finished: global end lumi for module: label = 'testmerge' id = 12
+++++++ starting: global end lumi for module: label = 'get' id = 13
+++++++ finished: global end lumi for module: label = 'get' id = 13
+++++++ starting: global end lumi for module: label = 'getInt' id = 14
+++++++ finished: global end lumi for module: label = 'getInt' id = 14
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global end lumi for module: label = 'out' id = 16
+++++++ finished: global end lumi for module: label = 'out' id = 16
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 1 lumi = 3 time = 45000001
 ++++ starting: end run: stream = 0 run = 1 time = 50000001
 ++++ finished: end run: stream = 0 run = 1 time = 50000001
 ++++ starting: end run: stream = 0 run = 1 time = 0
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: end run: stream = 0 run = 1 time = 0
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end run for module: stream = 0 label = 'get'
-++++++ finished: end run for module: stream = 0 label = 'get'
-++++++ starting: end run for module: stream = 0 label = 'putInt'
-++++++ finished: end run for module: stream = 0 label = 'putInt'
-++++++ starting: end run for module: stream = 0 label = 'putInt2'
-++++++ finished: end run for module: stream = 0 label = 'putInt2'
-++++++ starting: end run for module: stream = 0 label = 'putInt3'
-++++++ finished: end run for module: stream = 0 label = 'putInt3'
-++++++ starting: end run for module: stream = 0 label = 'getInt'
-++++++ finished: end run for module: stream = 0 label = 'getInt'
-++++++ starting: end run for module: stream = 0 label = 'noPut'
-++++++ finished: end run for module: stream = 0 label = 'noPut'
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end run for module: stream = 0 label = 'get' id = 3
+++++++ finished: end run for module: stream = 0 label = 'get' id = 3
+++++++ starting: end run for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end run for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end run for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: end run for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: end run: stream = 0 run = 1 time = 0
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: end run: stream = 0 run = 1 time = 0
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end run for module: stream = 0 label = 'test'
-++++++ finished: end run for module: stream = 0 label = 'test'
-++++++ starting: end run for module: stream = 0 label = 'testmerge'
-++++++ finished: end run for module: stream = 0 label = 'testmerge'
-++++++ starting: end run for module: stream = 0 label = 'get'
-++++++ finished: end run for module: stream = 0 label = 'get'
-++++++ starting: end run for module: stream = 0 label = 'getInt'
-++++++ finished: end run for module: stream = 0 label = 'getInt'
-++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: end run for module: stream = 0 label = 'out'
-++++++ finished: end run for module: stream = 0 label = 'out'
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end run for module: stream = 0 label = 'test' id = 11
+++++++ finished: end run for module: stream = 0 label = 'test' id = 11
+++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end run for module: stream = 0 label = 'get' id = 13
+++++++ finished: end run for module: stream = 0 label = 'get' id = 13
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end run for module: stream = 0 label = 'out' id = 16
+++++++ finished: end run for module: stream = 0 label = 'out' id = 16
 ++++ finished: end run: stream = 0 run = 1 time = 0
 ++++ starting: global end run 1 : time = 50000001
 ++++ finished: global end run 1 : time = 50000001
 ++++ starting: global end run 1 : time = 0
 ++++ finished: global end run 1 : time = 0
 ++++ starting: global end run 1 : time = 0
-++++++ starting: global end run for module: label = 'thingWithMergeProducer'
-++++++ finished: global end run for module: label = 'thingWithMergeProducer'
-++++++ starting: global end run for module: label = 'get'
-++++++ finished: global end run for module: label = 'get'
-++++++ starting: global end run for module: label = 'putInt'
-++++++ finished: global end run for module: label = 'putInt'
-++++++ starting: global end run for module: label = 'putInt2'
-++++++ finished: global end run for module: label = 'putInt2'
-++++++ starting: global end run for module: label = 'putInt3'
-++++++ finished: global end run for module: label = 'putInt3'
-++++++ starting: global end run for module: label = 'getInt'
-++++++ finished: global end run for module: label = 'getInt'
-++++++ starting: global end run for module: label = 'noPut'
-++++++ finished: global end run for module: label = 'noPut'
-++++++ starting: global end run for module: label = 'TriggerResults'
-++++++ finished: global end run for module: label = 'TriggerResults'
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global end run for module: label = 'get' id = 3
+++++++ finished: global end run for module: label = 'get' id = 3
+++++++ starting: global end run for module: label = 'putInt' id = 4
+++++++ finished: global end run for module: label = 'putInt' id = 4
+++++++ starting: global end run for module: label = 'putInt2' id = 5
+++++++ finished: global end run for module: label = 'putInt2' id = 5
+++++++ starting: global end run for module: label = 'putInt3' id = 6
+++++++ finished: global end run for module: label = 'putInt3' id = 6
+++++++ starting: global end run for module: label = 'getInt' id = 7
+++++++ finished: global end run for module: label = 'getInt' id = 7
+++++++ starting: global end run for module: label = 'noPut' id = 8
+++++++ finished: global end run for module: label = 'noPut' id = 8
+++++++ starting: global end run for module: label = 'TriggerResults' id = 1
+++++++ finished: global end run for module: label = 'TriggerResults' id = 1
 ++++ finished: global end run 1 : time = 0
 ++++ starting: global end run 1 : time = 0
 ++++ finished: global end run 1 : time = 0
 ++++ starting: global end run 1 : time = 0
-++++++ starting: global end run for module: label = 'thingWithMergeProducer'
-++++++ finished: global end run for module: label = 'thingWithMergeProducer'
-++++++ starting: global end run for module: label = 'test'
-++++++ finished: global end run for module: label = 'test'
-++++++ starting: global end run for module: label = 'testmerge'
-++++++ finished: global end run for module: label = 'testmerge'
-++++++ starting: global end run for module: label = 'get'
-++++++ finished: global end run for module: label = 'get'
-++++++ starting: global end run for module: label = 'getInt'
-++++++ finished: global end run for module: label = 'getInt'
-++++++ starting: global end run for module: label = 'dependsOnNoPut'
-++++++ finished: global end run for module: label = 'dependsOnNoPut'
-++++++ starting: global end run for module: label = 'out'
-++++++ finished: global end run for module: label = 'out'
-++++++ starting: global end run for module: label = 'TriggerResults'
-++++++ finished: global end run for module: label = 'TriggerResults'
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global end run for module: label = 'test' id = 11
+++++++ finished: global end run for module: label = 'test' id = 11
+++++++ starting: global end run for module: label = 'testmerge' id = 12
+++++++ finished: global end run for module: label = 'testmerge' id = 12
+++++++ starting: global end run for module: label = 'get' id = 13
+++++++ finished: global end run for module: label = 'get' id = 13
+++++++ starting: global end run for module: label = 'getInt' id = 14
+++++++ finished: global end run for module: label = 'getInt' id = 14
+++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global end run for module: label = 'out' id = 16
+++++++ finished: global end run for module: label = 'out' id = 16
+++++++ starting: global end run for module: label = 'TriggerResults' id = 9
+++++++ finished: global end run for module: label = 'TriggerResults' id = 9
 ++++ finished: global end run 1 : time = 0
 ++++ starting: source run
 ++++ finished: source run
@@ -1352,80 +1352,80 @@
 ++++ starting: global begin run 2 : time = 55000001
 ++++ finished: global begin run 2 : time = 55000001
 ++++ starting: global begin run 2 : time = 55000001
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin run for module: label = 'get'
-++++++ finished: global begin run for module: label = 'get'
-++++++ starting: global begin run for module: label = 'putInt'
-++++++ finished: global begin run for module: label = 'putInt'
-++++++ starting: global begin run for module: label = 'putInt2'
-++++++ finished: global begin run for module: label = 'putInt2'
-++++++ starting: global begin run for module: label = 'putInt3'
-++++++ finished: global begin run for module: label = 'putInt3'
-++++++ starting: global begin run for module: label = 'getInt'
-++++++ finished: global begin run for module: label = 'getInt'
-++++++ starting: global begin run for module: label = 'noPut'
-++++++ finished: global begin run for module: label = 'noPut'
-++++++ starting: global begin run for module: label = 'TriggerResults'
-++++++ finished: global begin run for module: label = 'TriggerResults'
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global begin run for module: label = 'get' id = 3
+++++++ finished: global begin run for module: label = 'get' id = 3
+++++++ starting: global begin run for module: label = 'putInt' id = 4
+++++++ finished: global begin run for module: label = 'putInt' id = 4
+++++++ starting: global begin run for module: label = 'putInt2' id = 5
+++++++ finished: global begin run for module: label = 'putInt2' id = 5
+++++++ starting: global begin run for module: label = 'putInt3' id = 6
+++++++ finished: global begin run for module: label = 'putInt3' id = 6
+++++++ starting: global begin run for module: label = 'getInt' id = 7
+++++++ finished: global begin run for module: label = 'getInt' id = 7
+++++++ starting: global begin run for module: label = 'noPut' id = 8
+++++++ finished: global begin run for module: label = 'noPut' id = 8
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin run 2 : time = 55000001
 ++++ starting: global begin run 2 : time = 55000001
 ++++ finished: global begin run 2 : time = 55000001
 ++++ starting: global begin run 2 : time = 55000001
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin run for module: label = 'test'
-++++++ finished: global begin run for module: label = 'test'
-++++++ starting: global begin run for module: label = 'testmerge'
-++++++ finished: global begin run for module: label = 'testmerge'
-++++++ starting: global begin run for module: label = 'get'
-++++++ finished: global begin run for module: label = 'get'
-++++++ starting: global begin run for module: label = 'getInt'
-++++++ finished: global begin run for module: label = 'getInt'
-++++++ starting: global begin run for module: label = 'dependsOnNoPut'
-++++++ finished: global begin run for module: label = 'dependsOnNoPut'
-++++++ starting: global begin run for module: label = 'out'
-++++++ finished: global begin run for module: label = 'out'
-++++++ starting: global begin run for module: label = 'TriggerResults'
-++++++ finished: global begin run for module: label = 'TriggerResults'
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin run for module: label = 'test' id = 11
+++++++ finished: global begin run for module: label = 'test' id = 11
+++++++ starting: global begin run for module: label = 'testmerge' id = 12
+++++++ finished: global begin run for module: label = 'testmerge' id = 12
+++++++ starting: global begin run for module: label = 'get' id = 13
+++++++ finished: global begin run for module: label = 'get' id = 13
+++++++ starting: global begin run for module: label = 'getInt' id = 14
+++++++ finished: global begin run for module: label = 'getInt' id = 14
+++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin run for module: label = 'out' id = 16
+++++++ finished: global begin run for module: label = 'out' id = 16
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin run 2 : time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin run for module: stream = 0 label = 'get'
-++++++ finished: begin run for module: stream = 0 label = 'get'
-++++++ starting: begin run for module: stream = 0 label = 'putInt'
-++++++ finished: begin run for module: stream = 0 label = 'putInt'
-++++++ starting: begin run for module: stream = 0 label = 'putInt2'
-++++++ finished: begin run for module: stream = 0 label = 'putInt2'
-++++++ starting: begin run for module: stream = 0 label = 'putInt3'
-++++++ finished: begin run for module: stream = 0 label = 'putInt3'
-++++++ starting: begin run for module: stream = 0 label = 'getInt'
-++++++ finished: begin run for module: stream = 0 label = 'getInt'
-++++++ starting: begin run for module: stream = 0 label = 'noPut'
-++++++ finished: begin run for module: stream = 0 label = 'noPut'
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin run for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: begin run for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: begin run: stream = 0 run = 2 time = 55000001
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin run for module: stream = 0 label = 'test'
-++++++ finished: begin run for module: stream = 0 label = 'test'
-++++++ starting: begin run for module: stream = 0 label = 'testmerge'
-++++++ finished: begin run for module: stream = 0 label = 'testmerge'
-++++++ starting: begin run for module: stream = 0 label = 'get'
-++++++ finished: begin run for module: stream = 0 label = 'get'
-++++++ starting: begin run for module: stream = 0 label = 'getInt'
-++++++ finished: begin run for module: stream = 0 label = 'getInt'
-++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: begin run for module: stream = 0 label = 'out'
-++++++ finished: begin run for module: stream = 0 label = 'out'
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin run for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin run for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin run for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin run for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin run: stream = 0 run = 2 time = 55000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -1434,80 +1434,80 @@
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'putInt'
-++++++ finished: global begin lumi for module: label = 'putInt'
-++++++ starting: global begin lumi for module: label = 'putInt2'
-++++++ finished: global begin lumi for module: label = 'putInt2'
-++++++ starting: global begin lumi for module: label = 'putInt3'
-++++++ finished: global begin lumi for module: label = 'putInt3'
-++++++ starting: global begin lumi for module: label = 'getInt'
-++++++ finished: global begin lumi for module: label = 'getInt'
-++++++ starting: global begin lumi for module: label = 'noPut'
-++++++ finished: global begin lumi for module: label = 'noPut'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global begin lumi for module: label = 'get' id = 3
+++++++ finished: global begin lumi for module: label = 'get' id = 3
+++++++ starting: global begin lumi for module: label = 'putInt' id = 4
+++++++ finished: global begin lumi for module: label = 'putInt' id = 4
+++++++ starting: global begin lumi for module: label = 'putInt2' id = 5
+++++++ finished: global begin lumi for module: label = 'putInt2' id = 5
+++++++ starting: global begin lumi for module: label = 'putInt3' id = 6
+++++++ finished: global begin lumi for module: label = 'putInt3' id = 6
+++++++ starting: global begin lumi for module: label = 'getInt' id = 7
+++++++ finished: global begin lumi for module: label = 'getInt' id = 7
+++++++ starting: global begin lumi for module: label = 'noPut' id = 8
+++++++ finished: global begin lumi for module: label = 'noPut' id = 8
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global begin lumi: run = 2 lumi = 1 time = 55000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin lumi for module: label = 'test'
-++++++ finished: global begin lumi for module: label = 'test'
-++++++ starting: global begin lumi for module: label = 'testmerge'
-++++++ finished: global begin lumi for module: label = 'testmerge'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'getInt'
-++++++ finished: global begin lumi for module: label = 'getInt'
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut'
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut'
-++++++ starting: global begin lumi for module: label = 'out'
-++++++ finished: global begin lumi for module: label = 'out'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin lumi for module: label = 'test' id = 11
+++++++ finished: global begin lumi for module: label = 'test' id = 11
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
+++++++ starting: global begin lumi for module: label = 'get' id = 13
+++++++ finished: global begin lumi for module: label = 'get' id = 13
+++++++ starting: global begin lumi for module: label = 'getInt' id = 14
+++++++ finished: global begin lumi for module: label = 'getInt' id = 14
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin lumi for module: label = 'out' id = 16
+++++++ finished: global begin lumi for module: label = 'out' id = 16
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3'
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut'
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut'
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'test'
-++++++ finished: begin lumi for module: stream = 0 label = 'test'
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge'
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: begin lumi for module: stream = 0 label = 'out'
-++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 1 time = 55000001
 ++++ starting: source event
 ++++ finished: source event
@@ -1517,56 +1517,56 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 1 time = 55000001
 ++++ starting: source event
@@ -1577,56 +1577,56 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 2 time = 60000001
 ++++ starting: source event
@@ -1637,56 +1637,56 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 3 time = 65000001
 ++++ starting: source event
@@ -1697,56 +1697,56 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 1 event = 4 time = 70000001
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 70000001
@@ -1754,80 +1754,80 @@
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3'
-++++++ starting: end lumi for module: stream = 0 label = 'getInt'
-++++++ finished: end lumi for module: stream = 0 label = 'getInt'
-++++++ starting: end lumi for module: stream = 0 label = 'noPut'
-++++++ finished: end lumi for module: stream = 0 label = 'noPut'
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'test'
-++++++ finished: end lumi for module: stream = 0 label = 'test'
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge'
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
-++++++ starting: end lumi for module: stream = 0 label = 'getInt'
-++++++ finished: end lumi for module: stream = 0 label = 'getInt'
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: end lumi for module: stream = 0 label = 'out'
-++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 1 time = 0
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'putInt'
-++++++ finished: global end lumi for module: label = 'putInt'
-++++++ starting: global end lumi for module: label = 'putInt2'
-++++++ finished: global end lumi for module: label = 'putInt2'
-++++++ starting: global end lumi for module: label = 'putInt3'
-++++++ finished: global end lumi for module: label = 'putInt3'
-++++++ starting: global end lumi for module: label = 'getInt'
-++++++ finished: global end lumi for module: label = 'getInt'
-++++++ starting: global end lumi for module: label = 'noPut'
-++++++ finished: global end lumi for module: label = 'noPut'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global end lumi for module: label = 'get' id = 3
+++++++ finished: global end lumi for module: label = 'get' id = 3
+++++++ starting: global end lumi for module: label = 'putInt' id = 4
+++++++ finished: global end lumi for module: label = 'putInt' id = 4
+++++++ starting: global end lumi for module: label = 'putInt2' id = 5
+++++++ finished: global end lumi for module: label = 'putInt2' id = 5
+++++++ starting: global end lumi for module: label = 'putInt3' id = 6
+++++++ finished: global end lumi for module: label = 'putInt3' id = 6
+++++++ starting: global end lumi for module: label = 'getInt' id = 7
+++++++ finished: global end lumi for module: label = 'getInt' id = 7
+++++++ starting: global end lumi for module: label = 'noPut' id = 8
+++++++ finished: global end lumi for module: label = 'noPut' id = 8
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: global end lumi: run = 2 lumi = 1 time = 55000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global end lumi for module: label = 'test'
-++++++ finished: global end lumi for module: label = 'test'
-++++++ starting: global end lumi for module: label = 'testmerge'
-++++++ finished: global end lumi for module: label = 'testmerge'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'getInt'
-++++++ finished: global end lumi for module: label = 'getInt'
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut'
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut'
-++++++ starting: global end lumi for module: label = 'out'
-++++++ finished: global end lumi for module: label = 'out'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global end lumi for module: label = 'test' id = 11
+++++++ finished: global end lumi for module: label = 'test' id = 11
+++++++ starting: global end lumi for module: label = 'testmerge' id = 12
+++++++ finished: global end lumi for module: label = 'testmerge' id = 12
+++++++ starting: global end lumi for module: label = 'get' id = 13
+++++++ finished: global end lumi for module: label = 'get' id = 13
+++++++ starting: global end lumi for module: label = 'getInt' id = 14
+++++++ finished: global end lumi for module: label = 'getInt' id = 14
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global end lumi for module: label = 'out' id = 16
+++++++ finished: global end lumi for module: label = 'out' id = 16
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 2 lumi = 1 time = 55000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -1836,80 +1836,80 @@
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'putInt'
-++++++ finished: global begin lumi for module: label = 'putInt'
-++++++ starting: global begin lumi for module: label = 'putInt2'
-++++++ finished: global begin lumi for module: label = 'putInt2'
-++++++ starting: global begin lumi for module: label = 'putInt3'
-++++++ finished: global begin lumi for module: label = 'putInt3'
-++++++ starting: global begin lumi for module: label = 'getInt'
-++++++ finished: global begin lumi for module: label = 'getInt'
-++++++ starting: global begin lumi for module: label = 'noPut'
-++++++ finished: global begin lumi for module: label = 'noPut'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global begin lumi for module: label = 'get' id = 3
+++++++ finished: global begin lumi for module: label = 'get' id = 3
+++++++ starting: global begin lumi for module: label = 'putInt' id = 4
+++++++ finished: global begin lumi for module: label = 'putInt' id = 4
+++++++ starting: global begin lumi for module: label = 'putInt2' id = 5
+++++++ finished: global begin lumi for module: label = 'putInt2' id = 5
+++++++ starting: global begin lumi for module: label = 'putInt3' id = 6
+++++++ finished: global begin lumi for module: label = 'putInt3' id = 6
+++++++ starting: global begin lumi for module: label = 'getInt' id = 7
+++++++ finished: global begin lumi for module: label = 'getInt' id = 7
+++++++ starting: global begin lumi for module: label = 'noPut' id = 8
+++++++ finished: global begin lumi for module: label = 'noPut' id = 8
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global begin lumi: run = 2 lumi = 2 time = 75000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin lumi for module: label = 'test'
-++++++ finished: global begin lumi for module: label = 'test'
-++++++ starting: global begin lumi for module: label = 'testmerge'
-++++++ finished: global begin lumi for module: label = 'testmerge'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'getInt'
-++++++ finished: global begin lumi for module: label = 'getInt'
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut'
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut'
-++++++ starting: global begin lumi for module: label = 'out'
-++++++ finished: global begin lumi for module: label = 'out'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin lumi for module: label = 'test' id = 11
+++++++ finished: global begin lumi for module: label = 'test' id = 11
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
+++++++ starting: global begin lumi for module: label = 'get' id = 13
+++++++ finished: global begin lumi for module: label = 'get' id = 13
+++++++ starting: global begin lumi for module: label = 'getInt' id = 14
+++++++ finished: global begin lumi for module: label = 'getInt' id = 14
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin lumi for module: label = 'out' id = 16
+++++++ finished: global begin lumi for module: label = 'out' id = 16
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3'
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut'
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut'
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'test'
-++++++ finished: begin lumi for module: stream = 0 label = 'test'
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge'
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: begin lumi for module: stream = 0 label = 'out'
-++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 2 time = 75000001
 ++++ starting: source event
 ++++ finished: source event
@@ -1919,56 +1919,56 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 5 time = 75000001
 ++++ starting: source event
@@ -1979,56 +1979,56 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 6 time = 80000001
 ++++ starting: source event
@@ -2039,56 +2039,56 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 7 time = 85000001
 ++++ starting: source event
@@ -2099,56 +2099,56 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 2 event = 8 time = 90000001
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 90000001
@@ -2156,80 +2156,80 @@
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3'
-++++++ starting: end lumi for module: stream = 0 label = 'getInt'
-++++++ finished: end lumi for module: stream = 0 label = 'getInt'
-++++++ starting: end lumi for module: stream = 0 label = 'noPut'
-++++++ finished: end lumi for module: stream = 0 label = 'noPut'
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'test'
-++++++ finished: end lumi for module: stream = 0 label = 'test'
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge'
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
-++++++ starting: end lumi for module: stream = 0 label = 'getInt'
-++++++ finished: end lumi for module: stream = 0 label = 'getInt'
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: end lumi for module: stream = 0 label = 'out'
-++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 2 time = 0
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'putInt'
-++++++ finished: global end lumi for module: label = 'putInt'
-++++++ starting: global end lumi for module: label = 'putInt2'
-++++++ finished: global end lumi for module: label = 'putInt2'
-++++++ starting: global end lumi for module: label = 'putInt3'
-++++++ finished: global end lumi for module: label = 'putInt3'
-++++++ starting: global end lumi for module: label = 'getInt'
-++++++ finished: global end lumi for module: label = 'getInt'
-++++++ starting: global end lumi for module: label = 'noPut'
-++++++ finished: global end lumi for module: label = 'noPut'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global end lumi for module: label = 'get' id = 3
+++++++ finished: global end lumi for module: label = 'get' id = 3
+++++++ starting: global end lumi for module: label = 'putInt' id = 4
+++++++ finished: global end lumi for module: label = 'putInt' id = 4
+++++++ starting: global end lumi for module: label = 'putInt2' id = 5
+++++++ finished: global end lumi for module: label = 'putInt2' id = 5
+++++++ starting: global end lumi for module: label = 'putInt3' id = 6
+++++++ finished: global end lumi for module: label = 'putInt3' id = 6
+++++++ starting: global end lumi for module: label = 'getInt' id = 7
+++++++ finished: global end lumi for module: label = 'getInt' id = 7
+++++++ starting: global end lumi for module: label = 'noPut' id = 8
+++++++ finished: global end lumi for module: label = 'noPut' id = 8
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: global end lumi: run = 2 lumi = 2 time = 75000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global end lumi for module: label = 'test'
-++++++ finished: global end lumi for module: label = 'test'
-++++++ starting: global end lumi for module: label = 'testmerge'
-++++++ finished: global end lumi for module: label = 'testmerge'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'getInt'
-++++++ finished: global end lumi for module: label = 'getInt'
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut'
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut'
-++++++ starting: global end lumi for module: label = 'out'
-++++++ finished: global end lumi for module: label = 'out'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global end lumi for module: label = 'test' id = 11
+++++++ finished: global end lumi for module: label = 'test' id = 11
+++++++ starting: global end lumi for module: label = 'testmerge' id = 12
+++++++ finished: global end lumi for module: label = 'testmerge' id = 12
+++++++ starting: global end lumi for module: label = 'get' id = 13
+++++++ finished: global end lumi for module: label = 'get' id = 13
+++++++ starting: global end lumi for module: label = 'getInt' id = 14
+++++++ finished: global end lumi for module: label = 'getInt' id = 14
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global end lumi for module: label = 'out' id = 16
+++++++ finished: global end lumi for module: label = 'out' id = 16
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 2 lumi = 2 time = 75000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -2238,80 +2238,80 @@
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'putInt'
-++++++ finished: global begin lumi for module: label = 'putInt'
-++++++ starting: global begin lumi for module: label = 'putInt2'
-++++++ finished: global begin lumi for module: label = 'putInt2'
-++++++ starting: global begin lumi for module: label = 'putInt3'
-++++++ finished: global begin lumi for module: label = 'putInt3'
-++++++ starting: global begin lumi for module: label = 'getInt'
-++++++ finished: global begin lumi for module: label = 'getInt'
-++++++ starting: global begin lumi for module: label = 'noPut'
-++++++ finished: global begin lumi for module: label = 'noPut'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global begin lumi for module: label = 'get' id = 3
+++++++ finished: global begin lumi for module: label = 'get' id = 3
+++++++ starting: global begin lumi for module: label = 'putInt' id = 4
+++++++ finished: global begin lumi for module: label = 'putInt' id = 4
+++++++ starting: global begin lumi for module: label = 'putInt2' id = 5
+++++++ finished: global begin lumi for module: label = 'putInt2' id = 5
+++++++ starting: global begin lumi for module: label = 'putInt3' id = 6
+++++++ finished: global begin lumi for module: label = 'putInt3' id = 6
+++++++ starting: global begin lumi for module: label = 'getInt' id = 7
+++++++ finished: global begin lumi for module: label = 'getInt' id = 7
+++++++ starting: global begin lumi for module: label = 'noPut' id = 8
+++++++ finished: global begin lumi for module: label = 'noPut' id = 8
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global begin lumi: run = 2 lumi = 3 time = 95000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin lumi for module: label = 'test'
-++++++ finished: global begin lumi for module: label = 'test'
-++++++ starting: global begin lumi for module: label = 'testmerge'
-++++++ finished: global begin lumi for module: label = 'testmerge'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'getInt'
-++++++ finished: global begin lumi for module: label = 'getInt'
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut'
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut'
-++++++ starting: global begin lumi for module: label = 'out'
-++++++ finished: global begin lumi for module: label = 'out'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin lumi for module: label = 'test' id = 11
+++++++ finished: global begin lumi for module: label = 'test' id = 11
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
+++++++ starting: global begin lumi for module: label = 'get' id = 13
+++++++ finished: global begin lumi for module: label = 'get' id = 13
+++++++ starting: global begin lumi for module: label = 'getInt' id = 14
+++++++ finished: global begin lumi for module: label = 'getInt' id = 14
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin lumi for module: label = 'out' id = 16
+++++++ finished: global begin lumi for module: label = 'out' id = 16
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3'
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut'
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut'
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'test'
-++++++ finished: begin lumi for module: stream = 0 label = 'test'
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge'
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: begin lumi for module: stream = 0 label = 'out'
-++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 2 lumi = 3 time = 95000001
 ++++ starting: source event
 ++++ finished: source event
@@ -2321,56 +2321,56 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 9 time = 95000001
 ++++ starting: source event
@@ -2381,56 +2381,56 @@
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++ starting: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 2 lumi = 3 event = 10 time = 100000001
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 100000001
@@ -2438,160 +2438,160 @@
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3'
-++++++ starting: end lumi for module: stream = 0 label = 'getInt'
-++++++ finished: end lumi for module: stream = 0 label = 'getInt'
-++++++ starting: end lumi for module: stream = 0 label = 'noPut'
-++++++ finished: end lumi for module: stream = 0 label = 'noPut'
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 2 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'test'
-++++++ finished: end lumi for module: stream = 0 label = 'test'
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge'
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
-++++++ starting: end lumi for module: stream = 0 label = 'getInt'
-++++++ finished: end lumi for module: stream = 0 label = 'getInt'
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: end lumi for module: stream = 0 label = 'out'
-++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 2 lumi = 3 time = 0
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'putInt'
-++++++ finished: global end lumi for module: label = 'putInt'
-++++++ starting: global end lumi for module: label = 'putInt2'
-++++++ finished: global end lumi for module: label = 'putInt2'
-++++++ starting: global end lumi for module: label = 'putInt3'
-++++++ finished: global end lumi for module: label = 'putInt3'
-++++++ starting: global end lumi for module: label = 'getInt'
-++++++ finished: global end lumi for module: label = 'getInt'
-++++++ starting: global end lumi for module: label = 'noPut'
-++++++ finished: global end lumi for module: label = 'noPut'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global end lumi for module: label = 'get' id = 3
+++++++ finished: global end lumi for module: label = 'get' id = 3
+++++++ starting: global end lumi for module: label = 'putInt' id = 4
+++++++ finished: global end lumi for module: label = 'putInt' id = 4
+++++++ starting: global end lumi for module: label = 'putInt2' id = 5
+++++++ finished: global end lumi for module: label = 'putInt2' id = 5
+++++++ starting: global end lumi for module: label = 'putInt3' id = 6
+++++++ finished: global end lumi for module: label = 'putInt3' id = 6
+++++++ starting: global end lumi for module: label = 'getInt' id = 7
+++++++ finished: global end lumi for module: label = 'getInt' id = 7
+++++++ starting: global end lumi for module: label = 'noPut' id = 8
+++++++ finished: global end lumi for module: label = 'noPut' id = 8
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: global end lumi: run = 2 lumi = 3 time = 95000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global end lumi for module: label = 'test'
-++++++ finished: global end lumi for module: label = 'test'
-++++++ starting: global end lumi for module: label = 'testmerge'
-++++++ finished: global end lumi for module: label = 'testmerge'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'getInt'
-++++++ finished: global end lumi for module: label = 'getInt'
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut'
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut'
-++++++ starting: global end lumi for module: label = 'out'
-++++++ finished: global end lumi for module: label = 'out'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global end lumi for module: label = 'test' id = 11
+++++++ finished: global end lumi for module: label = 'test' id = 11
+++++++ starting: global end lumi for module: label = 'testmerge' id = 12
+++++++ finished: global end lumi for module: label = 'testmerge' id = 12
+++++++ starting: global end lumi for module: label = 'get' id = 13
+++++++ finished: global end lumi for module: label = 'get' id = 13
+++++++ starting: global end lumi for module: label = 'getInt' id = 14
+++++++ finished: global end lumi for module: label = 'getInt' id = 14
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global end lumi for module: label = 'out' id = 16
+++++++ finished: global end lumi for module: label = 'out' id = 16
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 2 lumi = 3 time = 95000001
 ++++ starting: end run: stream = 0 run = 2 time = 100000001
 ++++ finished: end run: stream = 0 run = 2 time = 100000001
 ++++ starting: end run: stream = 0 run = 2 time = 0
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: end run: stream = 0 run = 2 time = 0
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end run for module: stream = 0 label = 'get'
-++++++ finished: end run for module: stream = 0 label = 'get'
-++++++ starting: end run for module: stream = 0 label = 'putInt'
-++++++ finished: end run for module: stream = 0 label = 'putInt'
-++++++ starting: end run for module: stream = 0 label = 'putInt2'
-++++++ finished: end run for module: stream = 0 label = 'putInt2'
-++++++ starting: end run for module: stream = 0 label = 'putInt3'
-++++++ finished: end run for module: stream = 0 label = 'putInt3'
-++++++ starting: end run for module: stream = 0 label = 'getInt'
-++++++ finished: end run for module: stream = 0 label = 'getInt'
-++++++ starting: end run for module: stream = 0 label = 'noPut'
-++++++ finished: end run for module: stream = 0 label = 'noPut'
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end run for module: stream = 0 label = 'get' id = 3
+++++++ finished: end run for module: stream = 0 label = 'get' id = 3
+++++++ starting: end run for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end run for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end run for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: end run for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: end run: stream = 0 run = 2 time = 0
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: end run: stream = 0 run = 2 time = 0
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end run for module: stream = 0 label = 'test'
-++++++ finished: end run for module: stream = 0 label = 'test'
-++++++ starting: end run for module: stream = 0 label = 'testmerge'
-++++++ finished: end run for module: stream = 0 label = 'testmerge'
-++++++ starting: end run for module: stream = 0 label = 'get'
-++++++ finished: end run for module: stream = 0 label = 'get'
-++++++ starting: end run for module: stream = 0 label = 'getInt'
-++++++ finished: end run for module: stream = 0 label = 'getInt'
-++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: end run for module: stream = 0 label = 'out'
-++++++ finished: end run for module: stream = 0 label = 'out'
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end run for module: stream = 0 label = 'test' id = 11
+++++++ finished: end run for module: stream = 0 label = 'test' id = 11
+++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end run for module: stream = 0 label = 'get' id = 13
+++++++ finished: end run for module: stream = 0 label = 'get' id = 13
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end run for module: stream = 0 label = 'out' id = 16
+++++++ finished: end run for module: stream = 0 label = 'out' id = 16
 ++++ finished: end run: stream = 0 run = 2 time = 0
 ++++ starting: global end run 2 : time = 100000001
 ++++ finished: global end run 2 : time = 100000001
 ++++ starting: global end run 2 : time = 0
 ++++ finished: global end run 2 : time = 0
 ++++ starting: global end run 2 : time = 0
-++++++ starting: global end run for module: label = 'thingWithMergeProducer'
-++++++ finished: global end run for module: label = 'thingWithMergeProducer'
-++++++ starting: global end run for module: label = 'get'
-++++++ finished: global end run for module: label = 'get'
-++++++ starting: global end run for module: label = 'putInt'
-++++++ finished: global end run for module: label = 'putInt'
-++++++ starting: global end run for module: label = 'putInt2'
-++++++ finished: global end run for module: label = 'putInt2'
-++++++ starting: global end run for module: label = 'putInt3'
-++++++ finished: global end run for module: label = 'putInt3'
-++++++ starting: global end run for module: label = 'getInt'
-++++++ finished: global end run for module: label = 'getInt'
-++++++ starting: global end run for module: label = 'noPut'
-++++++ finished: global end run for module: label = 'noPut'
-++++++ starting: global end run for module: label = 'TriggerResults'
-++++++ finished: global end run for module: label = 'TriggerResults'
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global end run for module: label = 'get' id = 3
+++++++ finished: global end run for module: label = 'get' id = 3
+++++++ starting: global end run for module: label = 'putInt' id = 4
+++++++ finished: global end run for module: label = 'putInt' id = 4
+++++++ starting: global end run for module: label = 'putInt2' id = 5
+++++++ finished: global end run for module: label = 'putInt2' id = 5
+++++++ starting: global end run for module: label = 'putInt3' id = 6
+++++++ finished: global end run for module: label = 'putInt3' id = 6
+++++++ starting: global end run for module: label = 'getInt' id = 7
+++++++ finished: global end run for module: label = 'getInt' id = 7
+++++++ starting: global end run for module: label = 'noPut' id = 8
+++++++ finished: global end run for module: label = 'noPut' id = 8
+++++++ starting: global end run for module: label = 'TriggerResults' id = 1
+++++++ finished: global end run for module: label = 'TriggerResults' id = 1
 ++++ finished: global end run 2 : time = 0
 ++++ starting: global end run 2 : time = 0
 ++++ finished: global end run 2 : time = 0
 ++++ starting: global end run 2 : time = 0
-++++++ starting: global end run for module: label = 'thingWithMergeProducer'
-++++++ finished: global end run for module: label = 'thingWithMergeProducer'
-++++++ starting: global end run for module: label = 'test'
-++++++ finished: global end run for module: label = 'test'
-++++++ starting: global end run for module: label = 'testmerge'
-++++++ finished: global end run for module: label = 'testmerge'
-++++++ starting: global end run for module: label = 'get'
-++++++ finished: global end run for module: label = 'get'
-++++++ starting: global end run for module: label = 'getInt'
-++++++ finished: global end run for module: label = 'getInt'
-++++++ starting: global end run for module: label = 'dependsOnNoPut'
-++++++ finished: global end run for module: label = 'dependsOnNoPut'
-++++++ starting: global end run for module: label = 'out'
-++++++ finished: global end run for module: label = 'out'
-++++++ starting: global end run for module: label = 'TriggerResults'
-++++++ finished: global end run for module: label = 'TriggerResults'
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global end run for module: label = 'test' id = 11
+++++++ finished: global end run for module: label = 'test' id = 11
+++++++ starting: global end run for module: label = 'testmerge' id = 12
+++++++ finished: global end run for module: label = 'testmerge' id = 12
+++++++ starting: global end run for module: label = 'get' id = 13
+++++++ finished: global end run for module: label = 'get' id = 13
+++++++ starting: global end run for module: label = 'getInt' id = 14
+++++++ finished: global end run for module: label = 'getInt' id = 14
+++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global end run for module: label = 'out' id = 16
+++++++ finished: global end run for module: label = 'out' id = 16
+++++++ starting: global end run for module: label = 'TriggerResults' id = 9
+++++++ finished: global end run for module: label = 'TriggerResults' id = 9
 ++++ finished: global end run 2 : time = 0
 ++++ starting: source run
 ++++ finished: source run
@@ -2600,80 +2600,80 @@
 ++++ starting: global begin run 3 : time = 105000001
 ++++ finished: global begin run 3 : time = 105000001
 ++++ starting: global begin run 3 : time = 105000001
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin run for module: label = 'get'
-++++++ finished: global begin run for module: label = 'get'
-++++++ starting: global begin run for module: label = 'putInt'
-++++++ finished: global begin run for module: label = 'putInt'
-++++++ starting: global begin run for module: label = 'putInt2'
-++++++ finished: global begin run for module: label = 'putInt2'
-++++++ starting: global begin run for module: label = 'putInt3'
-++++++ finished: global begin run for module: label = 'putInt3'
-++++++ starting: global begin run for module: label = 'getInt'
-++++++ finished: global begin run for module: label = 'getInt'
-++++++ starting: global begin run for module: label = 'noPut'
-++++++ finished: global begin run for module: label = 'noPut'
-++++++ starting: global begin run for module: label = 'TriggerResults'
-++++++ finished: global begin run for module: label = 'TriggerResults'
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global begin run for module: label = 'get' id = 3
+++++++ finished: global begin run for module: label = 'get' id = 3
+++++++ starting: global begin run for module: label = 'putInt' id = 4
+++++++ finished: global begin run for module: label = 'putInt' id = 4
+++++++ starting: global begin run for module: label = 'putInt2' id = 5
+++++++ finished: global begin run for module: label = 'putInt2' id = 5
+++++++ starting: global begin run for module: label = 'putInt3' id = 6
+++++++ finished: global begin run for module: label = 'putInt3' id = 6
+++++++ starting: global begin run for module: label = 'getInt' id = 7
+++++++ finished: global begin run for module: label = 'getInt' id = 7
+++++++ starting: global begin run for module: label = 'noPut' id = 8
+++++++ finished: global begin run for module: label = 'noPut' id = 8
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 1
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin run 3 : time = 105000001
 ++++ starting: global begin run 3 : time = 105000001
 ++++ finished: global begin run 3 : time = 105000001
 ++++ starting: global begin run 3 : time = 105000001
-++++++ starting: global begin run for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin run for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin run for module: label = 'test'
-++++++ finished: global begin run for module: label = 'test'
-++++++ starting: global begin run for module: label = 'testmerge'
-++++++ finished: global begin run for module: label = 'testmerge'
-++++++ starting: global begin run for module: label = 'get'
-++++++ finished: global begin run for module: label = 'get'
-++++++ starting: global begin run for module: label = 'getInt'
-++++++ finished: global begin run for module: label = 'getInt'
-++++++ starting: global begin run for module: label = 'dependsOnNoPut'
-++++++ finished: global begin run for module: label = 'dependsOnNoPut'
-++++++ starting: global begin run for module: label = 'out'
-++++++ finished: global begin run for module: label = 'out'
-++++++ starting: global begin run for module: label = 'TriggerResults'
-++++++ finished: global begin run for module: label = 'TriggerResults'
+++++++ starting: global begin run for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin run for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin run for module: label = 'test' id = 11
+++++++ finished: global begin run for module: label = 'test' id = 11
+++++++ starting: global begin run for module: label = 'testmerge' id = 12
+++++++ finished: global begin run for module: label = 'testmerge' id = 12
+++++++ starting: global begin run for module: label = 'get' id = 13
+++++++ finished: global begin run for module: label = 'get' id = 13
+++++++ starting: global begin run for module: label = 'getInt' id = 14
+++++++ finished: global begin run for module: label = 'getInt' id = 14
+++++++ starting: global begin run for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin run for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin run for module: label = 'out' id = 16
+++++++ finished: global begin run for module: label = 'out' id = 16
+++++++ starting: global begin run for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin run for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin run 3 : time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin run for module: stream = 0 label = 'get'
-++++++ finished: begin run for module: stream = 0 label = 'get'
-++++++ starting: begin run for module: stream = 0 label = 'putInt'
-++++++ finished: begin run for module: stream = 0 label = 'putInt'
-++++++ starting: begin run for module: stream = 0 label = 'putInt2'
-++++++ finished: begin run for module: stream = 0 label = 'putInt2'
-++++++ starting: begin run for module: stream = 0 label = 'putInt3'
-++++++ finished: begin run for module: stream = 0 label = 'putInt3'
-++++++ starting: begin run for module: stream = 0 label = 'getInt'
-++++++ finished: begin run for module: stream = 0 label = 'getInt'
-++++++ starting: begin run for module: stream = 0 label = 'noPut'
-++++++ finished: begin run for module: stream = 0 label = 'noPut'
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin run for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin run for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin run for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin run for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin run for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin run for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin run for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: begin run for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: begin run: stream = 0 run = 3 time = 105000001
-++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin run for module: stream = 0 label = 'test'
-++++++ finished: begin run for module: stream = 0 label = 'test'
-++++++ starting: begin run for module: stream = 0 label = 'testmerge'
-++++++ finished: begin run for module: stream = 0 label = 'testmerge'
-++++++ starting: begin run for module: stream = 0 label = 'get'
-++++++ finished: begin run for module: stream = 0 label = 'get'
-++++++ starting: begin run for module: stream = 0 label = 'getInt'
-++++++ finished: begin run for module: stream = 0 label = 'getInt'
-++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: begin run for module: stream = 0 label = 'out'
-++++++ finished: begin run for module: stream = 0 label = 'out'
+++++++ starting: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin run for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin run for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin run for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin run for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin run for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin run for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin run for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin run for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin run for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin run for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin run: stream = 0 run = 3 time = 105000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -2682,80 +2682,80 @@
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'putInt'
-++++++ finished: global begin lumi for module: label = 'putInt'
-++++++ starting: global begin lumi for module: label = 'putInt2'
-++++++ finished: global begin lumi for module: label = 'putInt2'
-++++++ starting: global begin lumi for module: label = 'putInt3'
-++++++ finished: global begin lumi for module: label = 'putInt3'
-++++++ starting: global begin lumi for module: label = 'getInt'
-++++++ finished: global begin lumi for module: label = 'getInt'
-++++++ starting: global begin lumi for module: label = 'noPut'
-++++++ finished: global begin lumi for module: label = 'noPut'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global begin lumi for module: label = 'get' id = 3
+++++++ finished: global begin lumi for module: label = 'get' id = 3
+++++++ starting: global begin lumi for module: label = 'putInt' id = 4
+++++++ finished: global begin lumi for module: label = 'putInt' id = 4
+++++++ starting: global begin lumi for module: label = 'putInt2' id = 5
+++++++ finished: global begin lumi for module: label = 'putInt2' id = 5
+++++++ starting: global begin lumi for module: label = 'putInt3' id = 6
+++++++ finished: global begin lumi for module: label = 'putInt3' id = 6
+++++++ starting: global begin lumi for module: label = 'getInt' id = 7
+++++++ finished: global begin lumi for module: label = 'getInt' id = 7
+++++++ starting: global begin lumi for module: label = 'noPut' id = 8
+++++++ finished: global begin lumi for module: label = 'noPut' id = 8
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global begin lumi: run = 3 lumi = 1 time = 105000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin lumi for module: label = 'test'
-++++++ finished: global begin lumi for module: label = 'test'
-++++++ starting: global begin lumi for module: label = 'testmerge'
-++++++ finished: global begin lumi for module: label = 'testmerge'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'getInt'
-++++++ finished: global begin lumi for module: label = 'getInt'
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut'
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut'
-++++++ starting: global begin lumi for module: label = 'out'
-++++++ finished: global begin lumi for module: label = 'out'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin lumi for module: label = 'test' id = 11
+++++++ finished: global begin lumi for module: label = 'test' id = 11
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
+++++++ starting: global begin lumi for module: label = 'get' id = 13
+++++++ finished: global begin lumi for module: label = 'get' id = 13
+++++++ starting: global begin lumi for module: label = 'getInt' id = 14
+++++++ finished: global begin lumi for module: label = 'getInt' id = 14
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin lumi for module: label = 'out' id = 16
+++++++ finished: global begin lumi for module: label = 'out' id = 16
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3'
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut'
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut'
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'test'
-++++++ finished: begin lumi for module: stream = 0 label = 'test'
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge'
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: begin lumi for module: stream = 0 label = 'out'
-++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 1 time = 105000001
 ++++ starting: source event
 ++++ finished: source event
@@ -2765,56 +2765,56 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 1 time = 105000001
 ++++ starting: source event
@@ -2825,56 +2825,56 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 2 time = 110000001
 ++++ starting: source event
@@ -2885,56 +2885,56 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 3 time = 115000001
 ++++ starting: source event
@@ -2945,56 +2945,56 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 1 event = 4 time = 120000001
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 120000001
@@ -3002,80 +3002,80 @@
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3'
-++++++ starting: end lumi for module: stream = 0 label = 'getInt'
-++++++ finished: end lumi for module: stream = 0 label = 'getInt'
-++++++ starting: end lumi for module: stream = 0 label = 'noPut'
-++++++ finished: end lumi for module: stream = 0 label = 'noPut'
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 1 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'test'
-++++++ finished: end lumi for module: stream = 0 label = 'test'
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge'
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
-++++++ starting: end lumi for module: stream = 0 label = 'getInt'
-++++++ finished: end lumi for module: stream = 0 label = 'getInt'
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: end lumi for module: stream = 0 label = 'out'
-++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 1 time = 0
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'putInt'
-++++++ finished: global end lumi for module: label = 'putInt'
-++++++ starting: global end lumi for module: label = 'putInt2'
-++++++ finished: global end lumi for module: label = 'putInt2'
-++++++ starting: global end lumi for module: label = 'putInt3'
-++++++ finished: global end lumi for module: label = 'putInt3'
-++++++ starting: global end lumi for module: label = 'getInt'
-++++++ finished: global end lumi for module: label = 'getInt'
-++++++ starting: global end lumi for module: label = 'noPut'
-++++++ finished: global end lumi for module: label = 'noPut'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global end lumi for module: label = 'get' id = 3
+++++++ finished: global end lumi for module: label = 'get' id = 3
+++++++ starting: global end lumi for module: label = 'putInt' id = 4
+++++++ finished: global end lumi for module: label = 'putInt' id = 4
+++++++ starting: global end lumi for module: label = 'putInt2' id = 5
+++++++ finished: global end lumi for module: label = 'putInt2' id = 5
+++++++ starting: global end lumi for module: label = 'putInt3' id = 6
+++++++ finished: global end lumi for module: label = 'putInt3' id = 6
+++++++ starting: global end lumi for module: label = 'getInt' id = 7
+++++++ finished: global end lumi for module: label = 'getInt' id = 7
+++++++ starting: global end lumi for module: label = 'noPut' id = 8
+++++++ finished: global end lumi for module: label = 'noPut' id = 8
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: global end lumi: run = 3 lumi = 1 time = 105000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global end lumi for module: label = 'test'
-++++++ finished: global end lumi for module: label = 'test'
-++++++ starting: global end lumi for module: label = 'testmerge'
-++++++ finished: global end lumi for module: label = 'testmerge'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'getInt'
-++++++ finished: global end lumi for module: label = 'getInt'
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut'
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut'
-++++++ starting: global end lumi for module: label = 'out'
-++++++ finished: global end lumi for module: label = 'out'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global end lumi for module: label = 'test' id = 11
+++++++ finished: global end lumi for module: label = 'test' id = 11
+++++++ starting: global end lumi for module: label = 'testmerge' id = 12
+++++++ finished: global end lumi for module: label = 'testmerge' id = 12
+++++++ starting: global end lumi for module: label = 'get' id = 13
+++++++ finished: global end lumi for module: label = 'get' id = 13
+++++++ starting: global end lumi for module: label = 'getInt' id = 14
+++++++ finished: global end lumi for module: label = 'getInt' id = 14
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global end lumi for module: label = 'out' id = 16
+++++++ finished: global end lumi for module: label = 'out' id = 16
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 3 lumi = 1 time = 105000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -3084,80 +3084,80 @@
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'putInt'
-++++++ finished: global begin lumi for module: label = 'putInt'
-++++++ starting: global begin lumi for module: label = 'putInt2'
-++++++ finished: global begin lumi for module: label = 'putInt2'
-++++++ starting: global begin lumi for module: label = 'putInt3'
-++++++ finished: global begin lumi for module: label = 'putInt3'
-++++++ starting: global begin lumi for module: label = 'getInt'
-++++++ finished: global begin lumi for module: label = 'getInt'
-++++++ starting: global begin lumi for module: label = 'noPut'
-++++++ finished: global begin lumi for module: label = 'noPut'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global begin lumi for module: label = 'get' id = 3
+++++++ finished: global begin lumi for module: label = 'get' id = 3
+++++++ starting: global begin lumi for module: label = 'putInt' id = 4
+++++++ finished: global begin lumi for module: label = 'putInt' id = 4
+++++++ starting: global begin lumi for module: label = 'putInt2' id = 5
+++++++ finished: global begin lumi for module: label = 'putInt2' id = 5
+++++++ starting: global begin lumi for module: label = 'putInt3' id = 6
+++++++ finished: global begin lumi for module: label = 'putInt3' id = 6
+++++++ starting: global begin lumi for module: label = 'getInt' id = 7
+++++++ finished: global begin lumi for module: label = 'getInt' id = 7
+++++++ starting: global begin lumi for module: label = 'noPut' id = 8
+++++++ finished: global begin lumi for module: label = 'noPut' id = 8
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global begin lumi: run = 3 lumi = 2 time = 125000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin lumi for module: label = 'test'
-++++++ finished: global begin lumi for module: label = 'test'
-++++++ starting: global begin lumi for module: label = 'testmerge'
-++++++ finished: global begin lumi for module: label = 'testmerge'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'getInt'
-++++++ finished: global begin lumi for module: label = 'getInt'
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut'
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut'
-++++++ starting: global begin lumi for module: label = 'out'
-++++++ finished: global begin lumi for module: label = 'out'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin lumi for module: label = 'test' id = 11
+++++++ finished: global begin lumi for module: label = 'test' id = 11
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
+++++++ starting: global begin lumi for module: label = 'get' id = 13
+++++++ finished: global begin lumi for module: label = 'get' id = 13
+++++++ starting: global begin lumi for module: label = 'getInt' id = 14
+++++++ finished: global begin lumi for module: label = 'getInt' id = 14
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin lumi for module: label = 'out' id = 16
+++++++ finished: global begin lumi for module: label = 'out' id = 16
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3'
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut'
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut'
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'test'
-++++++ finished: begin lumi for module: stream = 0 label = 'test'
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge'
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: begin lumi for module: stream = 0 label = 'out'
-++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 2 time = 125000001
 ++++ starting: source event
 ++++ finished: source event
@@ -3167,56 +3167,56 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 5 time = 125000001
 ++++ starting: source event
@@ -3227,56 +3227,56 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 6 time = 130000001
 ++++ starting: source event
@@ -3287,56 +3287,56 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 7 time = 135000001
 ++++ starting: source event
@@ -3347,56 +3347,56 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 2 event = 8 time = 140000001
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 140000001
@@ -3404,80 +3404,80 @@
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3'
-++++++ starting: end lumi for module: stream = 0 label = 'getInt'
-++++++ finished: end lumi for module: stream = 0 label = 'getInt'
-++++++ starting: end lumi for module: stream = 0 label = 'noPut'
-++++++ finished: end lumi for module: stream = 0 label = 'noPut'
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 2 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'test'
-++++++ finished: end lumi for module: stream = 0 label = 'test'
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge'
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
-++++++ starting: end lumi for module: stream = 0 label = 'getInt'
-++++++ finished: end lumi for module: stream = 0 label = 'getInt'
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: end lumi for module: stream = 0 label = 'out'
-++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 2 time = 0
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'putInt'
-++++++ finished: global end lumi for module: label = 'putInt'
-++++++ starting: global end lumi for module: label = 'putInt2'
-++++++ finished: global end lumi for module: label = 'putInt2'
-++++++ starting: global end lumi for module: label = 'putInt3'
-++++++ finished: global end lumi for module: label = 'putInt3'
-++++++ starting: global end lumi for module: label = 'getInt'
-++++++ finished: global end lumi for module: label = 'getInt'
-++++++ starting: global end lumi for module: label = 'noPut'
-++++++ finished: global end lumi for module: label = 'noPut'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global end lumi for module: label = 'get' id = 3
+++++++ finished: global end lumi for module: label = 'get' id = 3
+++++++ starting: global end lumi for module: label = 'putInt' id = 4
+++++++ finished: global end lumi for module: label = 'putInt' id = 4
+++++++ starting: global end lumi for module: label = 'putInt2' id = 5
+++++++ finished: global end lumi for module: label = 'putInt2' id = 5
+++++++ starting: global end lumi for module: label = 'putInt3' id = 6
+++++++ finished: global end lumi for module: label = 'putInt3' id = 6
+++++++ starting: global end lumi for module: label = 'getInt' id = 7
+++++++ finished: global end lumi for module: label = 'getInt' id = 7
+++++++ starting: global end lumi for module: label = 'noPut' id = 8
+++++++ finished: global end lumi for module: label = 'noPut' id = 8
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: global end lumi: run = 3 lumi = 2 time = 125000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global end lumi for module: label = 'test'
-++++++ finished: global end lumi for module: label = 'test'
-++++++ starting: global end lumi for module: label = 'testmerge'
-++++++ finished: global end lumi for module: label = 'testmerge'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'getInt'
-++++++ finished: global end lumi for module: label = 'getInt'
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut'
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut'
-++++++ starting: global end lumi for module: label = 'out'
-++++++ finished: global end lumi for module: label = 'out'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global end lumi for module: label = 'test' id = 11
+++++++ finished: global end lumi for module: label = 'test' id = 11
+++++++ starting: global end lumi for module: label = 'testmerge' id = 12
+++++++ finished: global end lumi for module: label = 'testmerge' id = 12
+++++++ starting: global end lumi for module: label = 'get' id = 13
+++++++ finished: global end lumi for module: label = 'get' id = 13
+++++++ starting: global end lumi for module: label = 'getInt' id = 14
+++++++ finished: global end lumi for module: label = 'getInt' id = 14
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global end lumi for module: label = 'out' id = 16
+++++++ finished: global end lumi for module: label = 'out' id = 16
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 3 lumi = 2 time = 125000001
 ++++ starting: source lumi
 ++++ finished: source lumi
@@ -3486,80 +3486,80 @@
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'putInt'
-++++++ finished: global begin lumi for module: label = 'putInt'
-++++++ starting: global begin lumi for module: label = 'putInt2'
-++++++ finished: global begin lumi for module: label = 'putInt2'
-++++++ starting: global begin lumi for module: label = 'putInt3'
-++++++ finished: global begin lumi for module: label = 'putInt3'
-++++++ starting: global begin lumi for module: label = 'getInt'
-++++++ finished: global begin lumi for module: label = 'getInt'
-++++++ starting: global begin lumi for module: label = 'noPut'
-++++++ finished: global begin lumi for module: label = 'noPut'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global begin lumi for module: label = 'get' id = 3
+++++++ finished: global begin lumi for module: label = 'get' id = 3
+++++++ starting: global begin lumi for module: label = 'putInt' id = 4
+++++++ finished: global begin lumi for module: label = 'putInt' id = 4
+++++++ starting: global begin lumi for module: label = 'putInt2' id = 5
+++++++ finished: global begin lumi for module: label = 'putInt2' id = 5
+++++++ starting: global begin lumi for module: label = 'putInt3' id = 6
+++++++ finished: global begin lumi for module: label = 'putInt3' id = 6
+++++++ starting: global begin lumi for module: label = 'getInt' id = 7
+++++++ finished: global begin lumi for module: label = 'getInt' id = 7
+++++++ starting: global begin lumi for module: label = 'noPut' id = 8
+++++++ finished: global begin lumi for module: label = 'noPut' id = 8
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global begin lumi: run = 3 lumi = 3 time = 145000001
-++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global begin lumi for module: label = 'test'
-++++++ finished: global begin lumi for module: label = 'test'
-++++++ starting: global begin lumi for module: label = 'testmerge'
-++++++ finished: global begin lumi for module: label = 'testmerge'
-++++++ starting: global begin lumi for module: label = 'get'
-++++++ finished: global begin lumi for module: label = 'get'
-++++++ starting: global begin lumi for module: label = 'getInt'
-++++++ finished: global begin lumi for module: label = 'getInt'
-++++++ starting: global begin lumi for module: label = 'dependsOnNoPut'
-++++++ finished: global begin lumi for module: label = 'dependsOnNoPut'
-++++++ starting: global begin lumi for module: label = 'out'
-++++++ finished: global begin lumi for module: label = 'out'
-++++++ starting: global begin lumi for module: label = 'TriggerResults'
-++++++ finished: global begin lumi for module: label = 'TriggerResults'
+++++++ starting: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global begin lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global begin lumi for module: label = 'test' id = 11
+++++++ finished: global begin lumi for module: label = 'test' id = 11
+++++++ starting: global begin lumi for module: label = 'testmerge' id = 12
+++++++ finished: global begin lumi for module: label = 'testmerge' id = 12
+++++++ starting: global begin lumi for module: label = 'get' id = 13
+++++++ finished: global begin lumi for module: label = 'get' id = 13
+++++++ starting: global begin lumi for module: label = 'getInt' id = 14
+++++++ finished: global begin lumi for module: label = 'getInt' id = 14
+++++++ starting: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global begin lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global begin lumi for module: label = 'out' id = 16
+++++++ finished: global begin lumi for module: label = 'out' id = 16
+++++++ starting: global begin lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global begin lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global begin lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt2'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt2'
-++++++ starting: begin lumi for module: stream = 0 label = 'putInt3'
-++++++ finished: begin lumi for module: stream = 0 label = 'putInt3'
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'noPut'
-++++++ finished: begin lumi for module: stream = 0 label = 'noPut'
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: begin lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: begin lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: begin lumi for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
-++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: begin lumi for module: stream = 0 label = 'test'
-++++++ finished: begin lumi for module: stream = 0 label = 'test'
-++++++ starting: begin lumi for module: stream = 0 label = 'testmerge'
-++++++ finished: begin lumi for module: stream = 0 label = 'testmerge'
-++++++ starting: begin lumi for module: stream = 0 label = 'get'
-++++++ finished: begin lumi for module: stream = 0 label = 'get'
-++++++ starting: begin lumi for module: stream = 0 label = 'getInt'
-++++++ finished: begin lumi for module: stream = 0 label = 'getInt'
-++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: begin lumi for module: stream = 0 label = 'out'
-++++++ finished: begin lumi for module: stream = 0 label = 'out'
+++++++ starting: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: begin lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: begin lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: begin lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: begin lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: begin lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: begin lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: begin lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: begin lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: begin lumi: stream = 0 run = 3 lumi = 3 time = 145000001
 ++++ starting: source event
 ++++ finished: source event
@@ -3569,56 +3569,56 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 9 time = 145000001
 ++++ starting: source event
@@ -3629,56 +3629,56 @@
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++++ starting: processing path 'p1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 2
 ++++++ finished: processing path 'p1' : stream = 0
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt2'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt2'
-++++++++ starting: processing event for module: stream = 0 label = 'putInt3'
-++++++++ finished: processing event for module: stream = 0 label = 'putInt3'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 3
+++++++++ starting: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ finished: processing event for module: stream = 0 label = 'putInt' id = 4
+++++++++ starting: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ finished: processing event for module: stream = 0 label = 'putInt2' id = 5
+++++++++ starting: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ finished: processing event for module: stream = 0 label = 'putInt3' id = 6
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 7
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 7
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'noPut'
-++++++++ finished: processing event for module: stream = 0 label = 'noPut'
+++++++++ starting: processing event for module: stream = 0 label = 'noPut' id = 8
+++++++++ finished: processing event for module: stream = 0 label = 'noPut' id = 8
 ++++++ finished: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 1
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 1
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++ starting: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++++ starting: processing path 'path1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer'
-++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer'
+++++++++ starting: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++++ finished: processing event for module: stream = 0 label = 'thingWithMergeProducer' id = 10
 ++++++ finished: processing path 'path1' : stream = 0
 ++++++ starting: processing path 'path2' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'test'
-++++++++ finished: processing event for module: stream = 0 label = 'test'
-++++++++ starting: processing event for module: stream = 0 label = 'testmerge'
-++++++++ finished: processing event for module: stream = 0 label = 'testmerge'
+++++++++ starting: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ finished: processing event for module: stream = 0 label = 'test' id = 11
+++++++++ starting: processing event for module: stream = 0 label = 'testmerge' id = 12
+++++++++ finished: processing event for module: stream = 0 label = 'testmerge' id = 12
 ++++++ finished: processing path 'path2' : stream = 0
 ++++++ starting: processing path 'path3' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'get'
-++++++++ finished: processing event for module: stream = 0 label = 'get'
-++++++++ starting: processing event for module: stream = 0 label = 'getInt'
-++++++++ finished: processing event for module: stream = 0 label = 'getInt'
+++++++++ starting: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ finished: processing event for module: stream = 0 label = 'get' id = 13
+++++++++ starting: processing event for module: stream = 0 label = 'getInt' id = 14
+++++++++ finished: processing event for module: stream = 0 label = 'getInt' id = 14
 ++++++ finished: processing path 'path3' : stream = 0
 ++++++ starting: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut'
-++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut'
+++++++++ starting: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++++ finished: processing event for module: stream = 0 label = 'dependsOnNoPut' id = 15
 ++++++ finished: processing path 'path4' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults'
-++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults'
+++++++++ starting: processing event for module: stream = 0 label = 'TriggerResults' id = 9
+++++++++ finished: processing event for module: stream = 0 label = 'TriggerResults' id = 9
 ++++++ starting: processing path 'endPath1' : stream = 0
-++++++++ starting: processing event for module: stream = 0 label = 'out'
-++++++++ finished: processing event for module: stream = 0 label = 'out'
+++++++++ starting: processing event for module: stream = 0 label = 'out' id = 16
+++++++++ finished: processing event for module: stream = 0 label = 'out' id = 16
 ++++++ finished: processing path 'endPath1' : stream = 0
 ++++ finished: processing event : stream = 0 run = 3 lumi = 3 event = 10 time = 150000001
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 150000001
@@ -3686,223 +3686,223 @@
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt2'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt2'
-++++++ starting: end lumi for module: stream = 0 label = 'putInt3'
-++++++ finished: end lumi for module: stream = 0 label = 'putInt3'
-++++++ starting: end lumi for module: stream = 0 label = 'getInt'
-++++++ finished: end lumi for module: stream = 0 label = 'getInt'
-++++++ starting: end lumi for module: stream = 0 label = 'noPut'
-++++++ finished: end lumi for module: stream = 0 label = 'noPut'
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 3
+++++++ starting: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end lumi for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end lumi for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end lumi for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end lumi for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: end lumi for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: end lumi: stream = 0 run = 3 lumi = 3 time = 0
-++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end lumi for module: stream = 0 label = 'test'
-++++++ finished: end lumi for module: stream = 0 label = 'test'
-++++++ starting: end lumi for module: stream = 0 label = 'testmerge'
-++++++ finished: end lumi for module: stream = 0 label = 'testmerge'
-++++++ starting: end lumi for module: stream = 0 label = 'get'
-++++++ finished: end lumi for module: stream = 0 label = 'get'
-++++++ starting: end lumi for module: stream = 0 label = 'getInt'
-++++++ finished: end lumi for module: stream = 0 label = 'getInt'
-++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: end lumi for module: stream = 0 label = 'out'
-++++++ finished: end lumi for module: stream = 0 label = 'out'
+++++++ starting: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end lumi for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ finished: end lumi for module: stream = 0 label = 'test' id = 11
+++++++ starting: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end lumi for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ finished: end lumi for module: stream = 0 label = 'get' id = 13
+++++++ starting: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end lumi for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end lumi for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end lumi for module: stream = 0 label = 'out' id = 16
+++++++ finished: end lumi for module: stream = 0 label = 'out' id = 16
 ++++ finished: end lumi: stream = 0 run = 3 lumi = 3 time = 0
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'putInt'
-++++++ finished: global end lumi for module: label = 'putInt'
-++++++ starting: global end lumi for module: label = 'putInt2'
-++++++ finished: global end lumi for module: label = 'putInt2'
-++++++ starting: global end lumi for module: label = 'putInt3'
-++++++ finished: global end lumi for module: label = 'putInt3'
-++++++ starting: global end lumi for module: label = 'getInt'
-++++++ finished: global end lumi for module: label = 'getInt'
-++++++ starting: global end lumi for module: label = 'noPut'
-++++++ finished: global end lumi for module: label = 'noPut'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global end lumi for module: label = 'get' id = 3
+++++++ finished: global end lumi for module: label = 'get' id = 3
+++++++ starting: global end lumi for module: label = 'putInt' id = 4
+++++++ finished: global end lumi for module: label = 'putInt' id = 4
+++++++ starting: global end lumi for module: label = 'putInt2' id = 5
+++++++ finished: global end lumi for module: label = 'putInt2' id = 5
+++++++ starting: global end lumi for module: label = 'putInt3' id = 6
+++++++ finished: global end lumi for module: label = 'putInt3' id = 6
+++++++ starting: global end lumi for module: label = 'getInt' id = 7
+++++++ finished: global end lumi for module: label = 'getInt' id = 7
+++++++ starting: global end lumi for module: label = 'noPut' id = 8
+++++++ finished: global end lumi for module: label = 'noPut' id = 8
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 1
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 1
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: global end lumi: run = 3 lumi = 3 time = 145000001
-++++++ starting: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ finished: global end lumi for module: label = 'thingWithMergeProducer'
-++++++ starting: global end lumi for module: label = 'test'
-++++++ finished: global end lumi for module: label = 'test'
-++++++ starting: global end lumi for module: label = 'testmerge'
-++++++ finished: global end lumi for module: label = 'testmerge'
-++++++ starting: global end lumi for module: label = 'get'
-++++++ finished: global end lumi for module: label = 'get'
-++++++ starting: global end lumi for module: label = 'getInt'
-++++++ finished: global end lumi for module: label = 'getInt'
-++++++ starting: global end lumi for module: label = 'dependsOnNoPut'
-++++++ finished: global end lumi for module: label = 'dependsOnNoPut'
-++++++ starting: global end lumi for module: label = 'out'
-++++++ finished: global end lumi for module: label = 'out'
-++++++ starting: global end lumi for module: label = 'TriggerResults'
-++++++ finished: global end lumi for module: label = 'TriggerResults'
+++++++ starting: global end lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global end lumi for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global end lumi for module: label = 'test' id = 11
+++++++ finished: global end lumi for module: label = 'test' id = 11
+++++++ starting: global end lumi for module: label = 'testmerge' id = 12
+++++++ finished: global end lumi for module: label = 'testmerge' id = 12
+++++++ starting: global end lumi for module: label = 'get' id = 13
+++++++ finished: global end lumi for module: label = 'get' id = 13
+++++++ starting: global end lumi for module: label = 'getInt' id = 14
+++++++ finished: global end lumi for module: label = 'getInt' id = 14
+++++++ starting: global end lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global end lumi for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global end lumi for module: label = 'out' id = 16
+++++++ finished: global end lumi for module: label = 'out' id = 16
+++++++ starting: global end lumi for module: label = 'TriggerResults' id = 9
+++++++ finished: global end lumi for module: label = 'TriggerResults' id = 9
 ++++ finished: global end lumi: run = 3 lumi = 3 time = 145000001
 ++++ starting: end run: stream = 0 run = 3 time = 150000001
 ++++ finished: end run: stream = 0 run = 3 time = 150000001
 ++++ starting: end run: stream = 0 run = 3 time = 0
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: end run: stream = 0 run = 3 time = 0
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end run for module: stream = 0 label = 'get'
-++++++ finished: end run for module: stream = 0 label = 'get'
-++++++ starting: end run for module: stream = 0 label = 'putInt'
-++++++ finished: end run for module: stream = 0 label = 'putInt'
-++++++ starting: end run for module: stream = 0 label = 'putInt2'
-++++++ finished: end run for module: stream = 0 label = 'putInt2'
-++++++ starting: end run for module: stream = 0 label = 'putInt3'
-++++++ finished: end run for module: stream = 0 label = 'putInt3'
-++++++ starting: end run for module: stream = 0 label = 'getInt'
-++++++ finished: end run for module: stream = 0 label = 'getInt'
-++++++ starting: end run for module: stream = 0 label = 'noPut'
-++++++ finished: end run for module: stream = 0 label = 'noPut'
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++++ starting: end run for module: stream = 0 label = 'get' id = 3
+++++++ finished: end run for module: stream = 0 label = 'get' id = 3
+++++++ starting: end run for module: stream = 0 label = 'putInt' id = 4
+++++++ finished: end run for module: stream = 0 label = 'putInt' id = 4
+++++++ starting: end run for module: stream = 0 label = 'putInt2' id = 5
+++++++ finished: end run for module: stream = 0 label = 'putInt2' id = 5
+++++++ starting: end run for module: stream = 0 label = 'putInt3' id = 6
+++++++ finished: end run for module: stream = 0 label = 'putInt3' id = 6
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 7
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 7
+++++++ starting: end run for module: stream = 0 label = 'noPut' id = 8
+++++++ finished: end run for module: stream = 0 label = 'noPut' id = 8
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: end run: stream = 0 run = 3 time = 0
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: end run: stream = 0 run = 3 time = 0
-++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer'
-++++++ starting: end run for module: stream = 0 label = 'test'
-++++++ finished: end run for module: stream = 0 label = 'test'
-++++++ starting: end run for module: stream = 0 label = 'testmerge'
-++++++ finished: end run for module: stream = 0 label = 'testmerge'
-++++++ starting: end run for module: stream = 0 label = 'get'
-++++++ finished: end run for module: stream = 0 label = 'get'
-++++++ starting: end run for module: stream = 0 label = 'getInt'
-++++++ finished: end run for module: stream = 0 label = 'getInt'
-++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut'
-++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut'
-++++++ starting: end run for module: stream = 0 label = 'out'
-++++++ finished: end run for module: stream = 0 label = 'out'
+++++++ starting: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ finished: end run for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++++ starting: end run for module: stream = 0 label = 'test' id = 11
+++++++ finished: end run for module: stream = 0 label = 'test' id = 11
+++++++ starting: end run for module: stream = 0 label = 'testmerge' id = 12
+++++++ finished: end run for module: stream = 0 label = 'testmerge' id = 12
+++++++ starting: end run for module: stream = 0 label = 'get' id = 13
+++++++ finished: end run for module: stream = 0 label = 'get' id = 13
+++++++ starting: end run for module: stream = 0 label = 'getInt' id = 14
+++++++ finished: end run for module: stream = 0 label = 'getInt' id = 14
+++++++ starting: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ finished: end run for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++++ starting: end run for module: stream = 0 label = 'out' id = 16
+++++++ finished: end run for module: stream = 0 label = 'out' id = 16
 ++++ finished: end run: stream = 0 run = 3 time = 0
 ++++ starting: global end run 3 : time = 150000001
 ++++ finished: global end run 3 : time = 150000001
 ++++ starting: global end run 3 : time = 0
 ++++ finished: global end run 3 : time = 0
 ++++ starting: global end run 3 : time = 0
-++++++ starting: global end run for module: label = 'thingWithMergeProducer'
-++++++ finished: global end run for module: label = 'thingWithMergeProducer'
-++++++ starting: global end run for module: label = 'get'
-++++++ finished: global end run for module: label = 'get'
-++++++ starting: global end run for module: label = 'putInt'
-++++++ finished: global end run for module: label = 'putInt'
-++++++ starting: global end run for module: label = 'putInt2'
-++++++ finished: global end run for module: label = 'putInt2'
-++++++ starting: global end run for module: label = 'putInt3'
-++++++ finished: global end run for module: label = 'putInt3'
-++++++ starting: global end run for module: label = 'getInt'
-++++++ finished: global end run for module: label = 'getInt'
-++++++ starting: global end run for module: label = 'noPut'
-++++++ finished: global end run for module: label = 'noPut'
-++++++ starting: global end run for module: label = 'TriggerResults'
-++++++ finished: global end run for module: label = 'TriggerResults'
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 2
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 2
+++++++ starting: global end run for module: label = 'get' id = 3
+++++++ finished: global end run for module: label = 'get' id = 3
+++++++ starting: global end run for module: label = 'putInt' id = 4
+++++++ finished: global end run for module: label = 'putInt' id = 4
+++++++ starting: global end run for module: label = 'putInt2' id = 5
+++++++ finished: global end run for module: label = 'putInt2' id = 5
+++++++ starting: global end run for module: label = 'putInt3' id = 6
+++++++ finished: global end run for module: label = 'putInt3' id = 6
+++++++ starting: global end run for module: label = 'getInt' id = 7
+++++++ finished: global end run for module: label = 'getInt' id = 7
+++++++ starting: global end run for module: label = 'noPut' id = 8
+++++++ finished: global end run for module: label = 'noPut' id = 8
+++++++ starting: global end run for module: label = 'TriggerResults' id = 1
+++++++ finished: global end run for module: label = 'TriggerResults' id = 1
 ++++ finished: global end run 3 : time = 0
 ++++ starting: global end run 3 : time = 0
 ++++ finished: global end run 3 : time = 0
 ++++ starting: global end run 3 : time = 0
-++++++ starting: global end run for module: label = 'thingWithMergeProducer'
-++++++ finished: global end run for module: label = 'thingWithMergeProducer'
-++++++ starting: global end run for module: label = 'test'
-++++++ finished: global end run for module: label = 'test'
-++++++ starting: global end run for module: label = 'testmerge'
-++++++ finished: global end run for module: label = 'testmerge'
-++++++ starting: global end run for module: label = 'get'
-++++++ finished: global end run for module: label = 'get'
-++++++ starting: global end run for module: label = 'getInt'
-++++++ finished: global end run for module: label = 'getInt'
-++++++ starting: global end run for module: label = 'dependsOnNoPut'
-++++++ finished: global end run for module: label = 'dependsOnNoPut'
-++++++ starting: global end run for module: label = 'out'
-++++++ finished: global end run for module: label = 'out'
-++++++ starting: global end run for module: label = 'TriggerResults'
-++++++ finished: global end run for module: label = 'TriggerResults'
+++++++ starting: global end run for module: label = 'thingWithMergeProducer' id = 10
+++++++ finished: global end run for module: label = 'thingWithMergeProducer' id = 10
+++++++ starting: global end run for module: label = 'test' id = 11
+++++++ finished: global end run for module: label = 'test' id = 11
+++++++ starting: global end run for module: label = 'testmerge' id = 12
+++++++ finished: global end run for module: label = 'testmerge' id = 12
+++++++ starting: global end run for module: label = 'get' id = 13
+++++++ finished: global end run for module: label = 'get' id = 13
+++++++ starting: global end run for module: label = 'getInt' id = 14
+++++++ finished: global end run for module: label = 'getInt' id = 14
+++++++ starting: global end run for module: label = 'dependsOnNoPut' id = 15
+++++++ finished: global end run for module: label = 'dependsOnNoPut' id = 15
+++++++ starting: global end run for module: label = 'out' id = 16
+++++++ finished: global end run for module: label = 'out' id = 16
+++++++ starting: global end run for module: label = 'TriggerResults' id = 9
+++++++ finished: global end run for module: label = 'TriggerResults' id = 9
 ++++ finished: global end run 3 : time = 0
-++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer'
-++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer'
-++++ starting: end stream for module: stream = 0 label = 'get'
-++++ finished: end stream for module: stream = 0 label = 'get'
-++++ starting: end stream for module: stream = 0 label = 'putInt'
-++++ finished: end stream for module: stream = 0 label = 'putInt'
-++++ starting: end stream for module: stream = 0 label = 'putInt2'
-++++ finished: end stream for module: stream = 0 label = 'putInt2'
-++++ starting: end stream for module: stream = 0 label = 'putInt3'
-++++ finished: end stream for module: stream = 0 label = 'putInt3'
-++++ starting: end stream for module: stream = 0 label = 'getInt'
-++++ finished: end stream for module: stream = 0 label = 'getInt'
-++++ starting: end stream for module: stream = 0 label = 'noPut'
-++++ finished: end stream for module: stream = 0 label = 'noPut'
-++++ starting: end stream for module: stream = 0 label = 'TriggerResults'
-++++ finished: end stream for module: stream = 0 label = 'TriggerResults'
-++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer'
-++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer'
-++++ starting: end stream for module: stream = 0 label = 'test'
-++++ finished: end stream for module: stream = 0 label = 'test'
-++++ starting: end stream for module: stream = 0 label = 'testmerge'
-++++ finished: end stream for module: stream = 0 label = 'testmerge'
-++++ starting: end stream for module: stream = 0 label = 'get'
-++++ finished: end stream for module: stream = 0 label = 'get'
-++++ starting: end stream for module: stream = 0 label = 'getInt'
-++++ finished: end stream for module: stream = 0 label = 'getInt'
-++++ starting: end stream for module: stream = 0 label = 'dependsOnNoPut'
-++++ finished: end stream for module: stream = 0 label = 'dependsOnNoPut'
-++++ starting: end stream for module: stream = 0 label = 'TriggerResults'
-++++ finished: end stream for module: stream = 0 label = 'TriggerResults'
-++++ starting: end stream for module: stream = 0 label = 'out'
-++++ finished: end stream for module: stream = 0 label = 'out'
-++++ starting: end job for module with label 'thingWithMergeProducer'
-++++ finished: end job for module with label 'thingWithMergeProducer'
-++++ starting: end job for module with label 'get'
-++++ finished: end job for module with label 'get'
-++++ starting: end job for module with label 'putInt'
-++++ finished: end job for module with label 'putInt'
-++++ starting: end job for module with label 'putInt2'
-++++ finished: end job for module with label 'putInt2'
-++++ starting: end job for module with label 'putInt3'
-++++ finished: end job for module with label 'putInt3'
-++++ starting: end job for module with label 'getInt'
-++++ finished: end job for module with label 'getInt'
-++++ starting: end job for module with label 'noPut'
-++++ finished: end job for module with label 'noPut'
-++++ starting: end job for module with label 'TriggerResults'
-++++ finished: end job for module with label 'TriggerResults'
-++++ starting: end job for module with label 'thingWithMergeProducer'
-++++ finished: end job for module with label 'thingWithMergeProducer'
-++++ starting: end job for module with label 'test'
-++++ finished: end job for module with label 'test'
-++++ starting: end job for module with label 'testmerge'
-++++ finished: end job for module with label 'testmerge'
-++++ starting: end job for module with label 'get'
-++++ finished: end job for module with label 'get'
-++++ starting: end job for module with label 'getInt'
-++++ finished: end job for module with label 'getInt'
-++++ starting: end job for module with label 'dependsOnNoPut'
-++++ finished: end job for module with label 'dependsOnNoPut'
-++++ starting: end job for module with label 'out'
-++++ finished: end job for module with label 'out'
-++++ starting: end job for module with label 'TriggerResults'
-++++ finished: end job for module with label 'TriggerResults'
+++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 2
+++++ starting: end stream for module: stream = 0 label = 'get' id = 3
+++++ finished: end stream for module: stream = 0 label = 'get' id = 3
+++++ starting: end stream for module: stream = 0 label = 'putInt' id = 4
+++++ finished: end stream for module: stream = 0 label = 'putInt' id = 4
+++++ starting: end stream for module: stream = 0 label = 'putInt2' id = 5
+++++ finished: end stream for module: stream = 0 label = 'putInt2' id = 5
+++++ starting: end stream for module: stream = 0 label = 'putInt3' id = 6
+++++ finished: end stream for module: stream = 0 label = 'putInt3' id = 6
+++++ starting: end stream for module: stream = 0 label = 'getInt' id = 7
+++++ finished: end stream for module: stream = 0 label = 'getInt' id = 7
+++++ starting: end stream for module: stream = 0 label = 'noPut' id = 8
+++++ finished: end stream for module: stream = 0 label = 'noPut' id = 8
+++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 1
+++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 1
+++++ starting: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++ finished: end stream for module: stream = 0 label = 'thingWithMergeProducer' id = 10
+++++ starting: end stream for module: stream = 0 label = 'test' id = 11
+++++ finished: end stream for module: stream = 0 label = 'test' id = 11
+++++ starting: end stream for module: stream = 0 label = 'testmerge' id = 12
+++++ finished: end stream for module: stream = 0 label = 'testmerge' id = 12
+++++ starting: end stream for module: stream = 0 label = 'get' id = 13
+++++ finished: end stream for module: stream = 0 label = 'get' id = 13
+++++ starting: end stream for module: stream = 0 label = 'getInt' id = 14
+++++ finished: end stream for module: stream = 0 label = 'getInt' id = 14
+++++ starting: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++ finished: end stream for module: stream = 0 label = 'dependsOnNoPut' id = 15
+++++ starting: end stream for module: stream = 0 label = 'TriggerResults' id = 9
+++++ finished: end stream for module: stream = 0 label = 'TriggerResults' id = 9
+++++ starting: end stream for module: stream = 0 label = 'out' id = 16
+++++ finished: end stream for module: stream = 0 label = 'out' id = 16
+++++ starting: end job for module with label 'thingWithMergeProducer' id = 2
+++++ finished: end job for module with label 'thingWithMergeProducer' id = 2
+++++ starting: end job for module with label 'get' id = 3
+++++ finished: end job for module with label 'get' id = 3
+++++ starting: end job for module with label 'putInt' id = 4
+++++ finished: end job for module with label 'putInt' id = 4
+++++ starting: end job for module with label 'putInt2' id = 5
+++++ finished: end job for module with label 'putInt2' id = 5
+++++ starting: end job for module with label 'putInt3' id = 6
+++++ finished: end job for module with label 'putInt3' id = 6
+++++ starting: end job for module with label 'getInt' id = 7
+++++ finished: end job for module with label 'getInt' id = 7
+++++ starting: end job for module with label 'noPut' id = 8
+++++ finished: end job for module with label 'noPut' id = 8
+++++ starting: end job for module with label 'TriggerResults' id = 1
+++++ finished: end job for module with label 'TriggerResults' id = 1
+++++ starting: end job for module with label 'thingWithMergeProducer' id = 10
+++++ finished: end job for module with label 'thingWithMergeProducer' id = 10
+++++ starting: end job for module with label 'test' id = 11
+++++ finished: end job for module with label 'test' id = 11
+++++ starting: end job for module with label 'testmerge' id = 12
+++++ finished: end job for module with label 'testmerge' id = 12
+++++ starting: end job for module with label 'get' id = 13
+++++ finished: end job for module with label 'get' id = 13
+++++ starting: end job for module with label 'getInt' id = 14
+++++ finished: end job for module with label 'getInt' id = 14
+++++ starting: end job for module with label 'dependsOnNoPut' id = 15
+++++ finished: end job for module with label 'dependsOnNoPut' id = 15
+++++ starting: end job for module with label 'out' id = 16
+++++ finished: end job for module with label 'out' id = 16
+++++ starting: end job for module with label 'TriggerResults' id = 9
+++++ finished: end job for module with label 'TriggerResults' id = 9
 ++ finished: end job

--- a/FWCore/Services/src/Tracer.cc
+++ b/FWCore/Services/src/Tracer.cc
@@ -517,7 +517,7 @@ Tracer::preModuleEvent(StreamContext const& sc, ModuleCallingContext const& mcc)
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
   }
-  out << " starting: processing event for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "'" << "' id = " << mcc.moduleDescription()->id();
+  out << " starting: processing event for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
   if(dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << sc;
     out << mcc;
@@ -531,7 +531,7 @@ Tracer::postModuleEvent(StreamContext const& sc, ModuleCallingContext const& mcc
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
   }
-  out << " finished: processing event for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "'" << "' id = " << mcc.moduleDescription()->id();
+  out << " finished: processing event for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
   if(dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << sc;
     out << mcc;
@@ -546,7 +546,7 @@ Tracer::preModuleStreamBeginRun(StreamContext const& sc, ModuleCallingContext co
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
   }
-  out << " starting: begin run for module: stream = " << sc.streamID() <<  " label = '" << mcc.moduleDescription()->moduleLabel() << "'" << "' id = " << mcc.moduleDescription()->id();
+  out << " starting: begin run for module: stream = " << sc.streamID() <<  " label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
   if(dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << sc;
     out << mcc;
@@ -560,7 +560,7 @@ Tracer::postModuleStreamBeginRun(StreamContext const& sc, ModuleCallingContext c
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
   }
-  out << " finished: begin run for module: stream = " << sc.streamID() <<  " label = '" << mcc.moduleDescription()->moduleLabel() << "'" << "' id = " << mcc.moduleDescription()->id();
+  out << " finished: begin run for module: stream = " << sc.streamID() <<  " label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
   if(dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << sc;
     out << mcc;
@@ -574,7 +574,7 @@ Tracer::preModuleStreamEndRun(StreamContext const& sc, ModuleCallingContext cons
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
   }
-  out << " starting: end run for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "'" << "' id = " << mcc.moduleDescription()->id();
+  out << " starting: end run for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
   if(dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << sc;
     out << mcc;
@@ -588,7 +588,7 @@ Tracer::postModuleStreamEndRun(StreamContext const& sc, ModuleCallingContext con
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
   }
-  out << " finished: end run for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "'" << "' id = " << mcc.moduleDescription()->id();
+  out << " finished: end run for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
   if(dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << sc;
     out << mcc;
@@ -602,7 +602,7 @@ Tracer::preModuleStreamBeginLumi(StreamContext const& sc, ModuleCallingContext c
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
   }
-  out << " starting: begin lumi for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "'" << "' id = " << mcc.moduleDescription()->id();
+  out << " starting: begin lumi for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
   if(dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << sc;
     out << mcc;
@@ -616,7 +616,7 @@ Tracer::postModuleStreamBeginLumi(StreamContext const& sc, ModuleCallingContext 
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
   }
-  out << " finished: begin lumi for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "'" << "' id = " << mcc.moduleDescription()->id();
+  out << " finished: begin lumi for module: stream = " << sc.streamID() << " label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
   if(dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << sc;
     out << mcc;
@@ -630,7 +630,7 @@ Tracer::preModuleStreamEndLumi(StreamContext const& sc, ModuleCallingContext con
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
   }
-  out << " starting: end lumi for module: stream = " << sc.streamID() << " label = '"<< mcc.moduleDescription()->moduleLabel() << "'" << "' id = " << mcc.moduleDescription()->id();
+  out << " starting: end lumi for module: stream = " << sc.streamID() << " label = '"<< mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
   if(dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << sc;
     out << mcc;
@@ -644,7 +644,7 @@ Tracer::postModuleStreamEndLumi(StreamContext const& sc, ModuleCallingContext co
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
   }
-  out << " finished: end lumi for module: stream = " << sc.streamID() << " label = '"<< mcc.moduleDescription()->moduleLabel() << "'" << "' id = " << mcc.moduleDescription()->id();
+  out << " finished: end lumi for module: stream = " << sc.streamID() << " label = '"<< mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
   if(dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << sc;
     out << mcc;
@@ -658,7 +658,7 @@ Tracer::preModuleGlobalBeginRun(GlobalContext const& gc, ModuleCallingContext co
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
   }
-  out << " starting: global begin run for module: label = '" << mcc.moduleDescription()->moduleLabel() << "'" << "' id = " << mcc.moduleDescription()->id();
+  out << " starting: global begin run for module: label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
   if(dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << gc;
     out << mcc;
@@ -672,7 +672,7 @@ Tracer::postModuleGlobalBeginRun(GlobalContext const& gc, ModuleCallingContext c
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
   }
-  out << " finished: global begin run for module: label = '" << mcc.moduleDescription()->moduleLabel() << "'" << "' id = " << mcc.moduleDescription()->id();
+  out << " finished: global begin run for module: label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
   if(dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << gc;
     out << mcc;
@@ -686,7 +686,7 @@ Tracer::preModuleGlobalEndRun(GlobalContext const& gc, ModuleCallingContext cons
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
   }
-  out << " starting: global end run for module: label = '" << mcc.moduleDescription()->moduleLabel() << "'" << "' id = " << mcc.moduleDescription()->id();
+  out << " starting: global end run for module: label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
   if(dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << gc;
     out << mcc;
@@ -700,7 +700,7 @@ Tracer::postModuleGlobalEndRun(GlobalContext const& gc, ModuleCallingContext con
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
   }
-  out << " finished: global end run for module: label = '" << mcc.moduleDescription()->moduleLabel() << "'" << "' id = " << mcc.moduleDescription()->id();
+  out << " finished: global end run for module: label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
   if(dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << gc;
     out << mcc;
@@ -714,7 +714,7 @@ Tracer::preModuleGlobalBeginLumi(GlobalContext const& gc, ModuleCallingContext c
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
   }
-  out << " starting: global begin lumi for module: label = '" << mcc.moduleDescription()->moduleLabel() << "'" << "' id = " << mcc.moduleDescription()->id();
+  out << " starting: global begin lumi for module: label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
   if(dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << gc;
     out << mcc;
@@ -728,7 +728,7 @@ Tracer::postModuleGlobalBeginLumi(GlobalContext const& gc, ModuleCallingContext 
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
   }
-  out << " finished: global begin lumi for module: label = '" << mcc.moduleDescription()->moduleLabel() << "'" << "' id = " << mcc.moduleDescription()->id();
+  out << " finished: global begin lumi for module: label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
   if(dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << gc;
     out << mcc;
@@ -742,7 +742,7 @@ Tracer::preModuleGlobalEndLumi(GlobalContext const& gc, ModuleCallingContext con
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
   }
-  out << " starting: global end lumi for module: label = '" << mcc.moduleDescription()->moduleLabel() << "'" << "' id = " << mcc.moduleDescription()->id();
+  out << " starting: global end lumi for module: label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
   if(dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << gc;
     out << mcc;
@@ -756,7 +756,7 @@ Tracer::postModuleGlobalEndLumi(GlobalContext const& gc, ModuleCallingContext co
   for(unsigned int i = 0; i < nIndents; ++i) {
     out << indention_;
   }
-  out << " finished: global end lumi for module: label = '" << mcc.moduleDescription()->moduleLabel() << "'" << "' id = " << mcc.moduleDescription()->id();
+  out << " finished: global end lumi for module: label = '" << mcc.moduleDescription()->moduleLabel() << "' id = " << mcc.moduleDescription()->id();
   if(dumpContextForLabels_.find(mcc.moduleDescription()->moduleLabel()) != dumpContextForLabels_.end()) {
     out << "\n" << gc;
     out << mcc;


### PR DESCRIPTION
Update unit test reference files to be consistent with
the recent change adding the module ID to the Tracer
output. Remove an extraneous quotation mark from the
Tracer output. Reverse the file order in the diff's to
make the failure output clearer.
