### PR TITLE
Change name of nested struct to avoid name clash with member function

### DIFF
--- a/DataFormats/BTauReco/interface/SoftLeptonTagInfo.h
+++ b/DataFormats/BTauReco/interface/SoftLeptonTagInfo.h
@@ -34,7 +34,7 @@ public:
     float ratio;                            // momentum over jet energy
     float ratioRel;                         // momentum parallel to jet axis over jet energy
 
-    struct quality {
+    struct Quality {
         static const float undef;
 
 	// these first two entries work for both electrons and muons,
@@ -66,21 +66,21 @@ public:
     // check to see if quality has been set
 
     inline float hasQuality() const
-    { return quality() != quality::undef; }
-    inline float hasQuality(quality::Generic qual) const
-    { return quality((unsigned int)qual, false) != quality::undef; }
-    inline float hasQuality(quality::Muon qual) const
-    { return quality((unsigned int)qual, false) != quality::undef; }
-    inline float hasQuality(quality::Electron qual) const
-    { return quality((unsigned int)qual, false) != quality::undef; }
+    { return quality() != Quality::undef; }
+    inline float hasQuality(Quality::Generic qual) const
+    { return quality((unsigned int)qual, false) != Quality::undef; }
+    inline float hasQuality(Quality::Muon qual) const
+    { return quality((unsigned int)qual, false) != Quality::undef; }
+    inline float hasQuality(Quality::Electron qual) const
+    { return quality((unsigned int)qual, false) != Quality::undef; }
 
     // retrieve lepton quality
 
-    inline float quality(quality::Generic qual, bool throwIfUndefined = true) const
+    inline float quality(Quality::Generic qual, bool throwIfUndefined = true) const
     { return quality((unsigned int)qual, throwIfUndefined); }
-    inline float quality(quality::Muon qual, bool throwIfUndefined = true) const
+    inline float quality(Quality::Muon qual, bool throwIfUndefined = true) const
     { return quality((unsigned int)qual, throwIfUndefined); }
-    inline float quality(quality::Electron qual, bool throwIfUndefined = true) const
+    inline float quality(Quality::Electron qual, bool throwIfUndefined = true) const
     { return quality((unsigned int)qual, throwIfUndefined); }
 
     // default value
@@ -88,11 +88,11 @@ public:
 
     // set lepton quality
 
-    inline void setQuality(quality::Generic qual, float value)
+    inline void setQuality(Quality::Generic qual, float value)
     { setQuality((unsigned int)qual, value); }
-    inline void setQuality(quality::Muon qual, float value)
+    inline void setQuality(Quality::Muon qual, float value)
     { setQuality((unsigned int)qual, value); }
-    inline void setQuality(quality::Electron qual, float value)
+    inline void setQuality(Quality::Electron qual, float value)
     { setQuality((unsigned int)qual, value); }
 
 private:

--- a/DataFormats/BTauReco/src/SoftLeptonTagInfo.cc
+++ b/DataFormats/BTauReco/src/SoftLeptonTagInfo.cc
@@ -11,9 +11,9 @@ namespace reco {
 
 using namespace btau;
 
-const float SoftLeptonProperties::quality::undef = -999.0;
+const float SoftLeptonProperties::Quality::undef = -999.0;
 
-unsigned int SoftLeptonProperties::quality::internalByName(const char *name)
+unsigned int SoftLeptonProperties::Quality::internalByName(const char *name)
 {
   if (std::strcmp(name, "") == 0)
     return 0;
@@ -35,19 +35,19 @@ unsigned int SoftLeptonProperties::quality::internalByName(const char *name)
 
   throw edm::Exception(edm::errors::Configuration) 
     << "Requested lepton quality \"" << name
-    << "\" not found in SoftLeptonProperties::quality:byName"
+    << "\" not found in SoftLeptonProperties::Quality::byName"
     << std::endl;
 }
 
 float SoftLeptonProperties::quality(unsigned int index, bool throwIfUndefined) const
 {
-  float qual = quality::undef;
+  float qual = Quality::undef;
   if (index < qualities_.size())
     qual = qualities_[index];
 
-  if (qual == quality::undef && throwIfUndefined)
+  if (qual == Quality::undef && throwIfUndefined)
     throw edm::Exception(edm::errors::InvalidReference)
-      << "Requested lepton quality not found in SoftLeptonProperties::quality"
+      << "Requested lepton quality not found in SoftLeptonProperties::Quality"
       << std::endl;
 
   return qual;
@@ -56,7 +56,7 @@ float SoftLeptonProperties::quality(unsigned int index, bool throwIfUndefined) c
 void SoftLeptonProperties::setQuality(unsigned int index, float qual)
 {
   if (qualities_.size() <= index)
-    qualities_.resize(index + 1, quality::undef);
+    qualities_.resize(index + 1, Quality::undef);
 
   qualities_[index] = qual;
 }
@@ -77,8 +77,8 @@ TaggingVariableList SoftLeptonTagInfo::taggingVariables(void) const {
     list.insert( TaggingVariable(trackPhi,       track.phi()),   true );
     list.insert( TaggingVariable(trackChi2,      track.normalizedChi2()), true );
     const SoftLeptonProperties & data = m_leptons[i].second;
-    list.insert( TaggingVariable(leptonQuality,  data.quality(SoftLeptonProperties::quality::leptonId, false)), true );
-    list.insert( TaggingVariable(leptonQuality2, data.quality(SoftLeptonProperties::quality::btagLeptonCands, false)), true );
+    list.insert( TaggingVariable(leptonQuality,  data.quality(SoftLeptonProperties::Quality::leptonId, false)), true );
+    list.insert( TaggingVariable(leptonQuality2, data.quality(SoftLeptonProperties::Quality::btagLeptonCands, false)), true );
     list.insert( TaggingVariable(trackSip2dSig,  data.sip2d),    true );
     list.insert( TaggingVariable(trackSip3dSig,  data.sip3d),    true );
     list.insert( TaggingVariable(trackPtRel,     data.ptRel),    true );

--- a/RecoBTag/SoftLepton/interface/LeptonSelector.h
+++ b/RecoBTag/SoftLepton/interface/LeptonSelector.h
@@ -32,7 +32,7 @@ class LeptonSelector {
     static sign option(const std::string & election);
 
     sign                                         m_sign;
-    reco::SoftLeptonProperties::quality::Generic m_leptonId;
+    reco::SoftLeptonProperties::Quality::Generic m_leptonId;
     float                                        m_qualityCut;
 };
 

--- a/RecoBTag/SoftLepton/plugins/SoftLepton.cc
+++ b/RecoBTag/SoftLepton/plugins/SoftLepton.cc
@@ -155,19 +155,19 @@ SoftLepton::produce(edm::Event & event, const edm::EventSetup & setup) {
 
   // try to access the input collection as a collection of GsfElectrons, Muons or Tracks
 
-  unsigned int leptonId = SoftLeptonProperties::quality::leptonId;
+  unsigned int leptonId = SoftLeptonProperties::Quality::leptonId;
   do { {
     // look for View<GsfElectron>
     Handle<GsfElectronView> h_electrons;
     event.getByToken(token_gsfElectrons, h_electrons);
 
     if (h_electrons.isValid()) {
-      leptonId = SoftLeptonProperties::quality::egammaElectronId;
+      leptonId = SoftLeptonProperties::Quality::egammaElectronId;
       for (GsfElectronView::const_iterator electron = h_electrons->begin(); electron != h_electrons->end(); ++electron) {
         LeptonIds &id = leptons[reco::TrackBaseRef(electron->gsfTrack())];
-        id[SoftLeptonProperties::quality::pfElectronId] = electron->mva();
+        id[SoftLeptonProperties::Quality::pfElectronId] = electron->mva();
         if (haveLeptonCands)
-          id[SoftLeptonProperties::quality::btagElectronCands] = (*h_leptonCands)[h_electrons->refAt(electron - h_electrons->begin())];
+          id[SoftLeptonProperties::Quality::btagElectronCands] = (*h_leptonCands)[h_electrons->refAt(electron - h_electrons->begin())];
       }
       break;
     }
@@ -177,11 +177,11 @@ SoftLepton::produce(edm::Event & event, const edm::EventSetup & setup) {
     Handle<ElectronView> h_electrons;
     event.getByToken(token_electrons, h_electrons);
     if (h_electrons.isValid()) {
-      leptonId = SoftLeptonProperties::quality::egammaElectronId;
+      leptonId = SoftLeptonProperties::Quality::egammaElectronId;
       for (ElectronView::const_iterator electron = h_electrons->begin(); electron != h_electrons->end(); ++electron) {
         LeptonIds &id = leptons[reco::TrackBaseRef(electron->track())];
         if (haveLeptonCands)
-          id[SoftLeptonProperties::quality::btagElectronCands] = (*h_leptonCands)[h_electrons->refAt(electron - h_electrons->begin())];
+          id[SoftLeptonProperties::Quality::btagElectronCands] = (*h_leptonCands)[h_electrons->refAt(electron - h_electrons->begin())];
       }
       break;
     }
@@ -191,7 +191,7 @@ SoftLepton::produce(edm::Event & event, const edm::EventSetup & setup) {
     Handle<reco::PFCandidateCollection> h_electrons;
     event.getByToken(token_pfElectrons, h_electrons);
     if (h_electrons.isValid()) {
-      leptonId = SoftLeptonProperties::quality::egammaElectronId;
+      leptonId = SoftLeptonProperties::Quality::egammaElectronId;
       for (reco::PFCandidateCollection::const_iterator electron = h_electrons->begin(); electron != h_electrons->end(); ++electron) {
         LeptonIds *id;
         if (electron->gsfTrackRef().isNonnull())
@@ -200,9 +200,9 @@ SoftLepton::produce(edm::Event & event, const edm::EventSetup & setup) {
           id = &leptons[reco::TrackBaseRef(electron->trackRef())];
         else
           continue;
-        (*id)[SoftLeptonProperties::quality::pfElectronId] = electron->mva_e_pi();
+        (*id)[SoftLeptonProperties::Quality::pfElectronId] = electron->mva_e_pi();
         if (haveLeptonCands)
-          (*id)[SoftLeptonProperties::quality::btagElectronCands] = (*h_leptonCands)[reco::PFCandidateRef(h_electrons, electron - h_electrons->begin())];
+          (*id)[SoftLeptonProperties::Quality::btagElectronCands] = (*h_leptonCands)[reco::PFCandidateRef(h_electrons, electron - h_electrons->begin())];
       }
       break;
     }
@@ -225,7 +225,7 @@ SoftLepton::produce(edm::Event & event, const edm::EventSetup & setup) {
           else
             continue;
           if (haveLeptonCands)
-            (*id)[SoftLeptonProperties::quality::btagMuonCands] = (*h_leptonCands)[h_muons->refAt(muon - h_muons->begin())];
+            (*id)[SoftLeptonProperties::Quality::btagMuonCands] = (*h_leptonCands)[h_muons->refAt(muon - h_muons->begin())];
         }
       }
       break;
@@ -238,7 +238,7 @@ SoftLepton::produce(edm::Event & event, const edm::EventSetup & setup) {
       for (unsigned int i = 0; i < h_tracks->size(); i++) {
         LeptonIds &id = leptons[h_tracks->refAt(i)];
         if (haveLeptonCands)
-          id[SoftLeptonProperties::quality::btagLeptonCands] = (*h_leptonCands)[h_tracks->refAt(i)];
+          id[SoftLeptonProperties::Quality::btagLeptonCands] = (*h_leptonCands)[h_tracks->refAt(i)];
       }
       break;
     }
@@ -296,7 +296,7 @@ reco::SoftLeptonTagInfo SoftLepton::tag (
     properties.ratioRel = lepton_momentum.Dot(axis) / axis.Mag2();
 
     for(LeptonIds::const_iterator iter = lepton->second.begin(); iter != lepton->second.end(); ++iter)
-      properties.setQuality(static_cast<SoftLeptonProperties::quality::Generic>(iter->first), iter->second);
+      properties.setQuality(static_cast<SoftLeptonProperties::Quality::Generic>(iter->first), iter->second);
 
     info.insert( lepton->first, properties );
   }

--- a/RecoBTag/SoftLepton/src/LeptonSelector.cc
+++ b/RecoBTag/SoftLepton/src/LeptonSelector.cc
@@ -11,12 +11,12 @@ using namespace btag;
 
 LeptonSelector::LeptonSelector(const edm::ParameterSet &params) :
   m_sign(option(params.getParameter<std::string>("ipSign"))),
-  m_leptonId(reco::SoftLeptonProperties::quality::btagLeptonCands),
+  m_leptonId(reco::SoftLeptonProperties::Quality::btagLeptonCands),
   m_qualityCut(0.5)
 {
   if (params.exists("leptonId") || params.exists("qualityCut")) {
     std::string leptonId = params.getParameter<std::string>("leptonId");
-    m_leptonId = reco::SoftLeptonProperties::quality::byName<reco::SoftLeptonProperties::quality::Generic>(leptonId.c_str());
+    m_leptonId = reco::SoftLeptonProperties::Quality::byName<reco::SoftLeptonProperties::Quality::Generic>(leptonId.c_str());
     m_qualityCut = params.getParameter<double>("qualityCut");
   }
 }
@@ -32,9 +32,9 @@ bool LeptonSelector::operator() (const reco::SoftLeptonProperties &properties, b
       (isNegative() && sip >= 0.0))
     return false;
 
-  bool candSelection = (m_leptonId == reco::SoftLeptonProperties::quality::btagLeptonCands);
+  bool candSelection = (m_leptonId == reco::SoftLeptonProperties::Quality::btagLeptonCands);
   float quality = properties.quality(m_leptonId, !candSelection);
-  if (candSelection && quality == reco::SoftLeptonProperties::quality::undef)
+  if (candSelection && quality == reco::SoftLeptonProperties::Quality::undef)
    return true;		// for backwards compatibility
 
   return quality > m_qualityCut;


### PR DESCRIPTION
The persistent class reco::SoftLeptonProperties has a nested struct named "quality", and also member functions named "quality".  Although this is legal C++ (although poor style), it confuses the dictionary generation of ROOT6, which produces a dictionary that will not compile.  Although ROOT6 should fix this problem (a ticket will be written against ROOT6), we can easily avoid the problem by giving the nested struct a distinct name from the member functions.  This pull request renames the nested struct from "quality" to "Quality".
This avoids poor C++ style, avoids a ROOT 6 problem, and also makes the code more compliant with the CMS practice of naming classes and structs beginning with a capital letter.
Tested with git cms-checkdeps -a and the relval matrix.
