### PR TITLE
Add missing include

### DIFF
--- a/Fireworks/Core/src/CmsShowMain.cc
+++ b/Fireworks/Core/src/CmsShowMain.cc
@@ -64,6 +64,7 @@
 
 #if defined(R__LINUX)
 #include "TGX11.h" // !!!! AMT has to be at the end to pass build
+#include "X11/Xlib.h"
 #endif
 //
 // constants, enums and typedefs


### PR DESCRIPTION
The file  Fireworks/Core/src/CmsShowMain.cc needs an include of X11/Xlib.h in order to compile.  THis include is missing.  In ROOT 5, the include is included indirectly through the ROOT header TGX11.h. In ROOT 6, TGX11.h does not include X11/Xlib.h, and CmsShowMain.cc does not compile.  This pull request adds the missing include.
