### PR TITLE
Replaced boost::thread_specific_ptr with thread_local

### DIFF
--- a/FWCore/MessageLogger/src/MessageDrop.cc
+++ b/FWCore/MessageLogger/src/MessageDrop.cc
@@ -11,7 +11,6 @@
 //
 
 // system include files
-#include "boost/thread/tss.hpp"
 #include <cstring>
 #include <limits>
 
@@ -60,18 +59,8 @@ std::string MessageDrop::jobMode{};
 MessageDrop *
 MessageDrop::instance()
 {
-  //needs gcc4.8.1
-  //thread_local static s_drop{};
-  //return &s_drop;
-  
-  static boost::thread_specific_ptr<MessageDrop> drops;
-  MessageDrop* drop = drops.get();
-  if(drop==0) { 
-    drops.reset(new MessageDrop);
-    drop=drops.get(); 
-  }
-  return drop;
-  
+  thread_local static MessageDrop s_drop{};
+  return &s_drop;
 }
 namespace  {
   const std::string kBlankString{" "};

--- a/FWCore/ServiceRegistry/src/ServiceRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ServiceRegistry.cc
@@ -15,7 +15,6 @@
 #include "FWCore/PythonParameterSet/interface/MakeParameterSets.h"
 
 // system include files
-#include "boost/thread/tss.hpp"
 
 namespace edm {
    //
@@ -106,10 +105,7 @@ namespace edm {
 
    ServiceRegistry& 
    ServiceRegistry::instance() {
-      static boost::thread_specific_ptr<ServiceRegistry> s_registry;
-      if(0 == s_registry.get()){
-         s_registry.reset(new ServiceRegistry);
-      }
-      return *s_registry;
+      static thread_local ServiceRegistry s_registry;
+      return s_registry;
    }
 }

--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -9,7 +9,6 @@
 #include <boost/regex.hpp>
 #include <iostream>
 #include <map>
-#include "boost/thread/tss.hpp"
 
 //NOTE:  This should probably be rewritten so that we break the class name into a tree where the template arguments are the node.  On the way down the tree
 // we look for '<' or ',' and on the way up (caused by finding a '>') we can apply the transformation to the output string based on the class name for the
@@ -135,13 +134,10 @@ namespace edm {
     }
     std::string friendlyName(std::string const& iFullName) {
        typedef std::map<std::string, std::string> Map;
-       static boost::thread_specific_ptr<Map> s_fillToFriendlyName;
-       if(0 == s_fillToFriendlyName.get()){
-          s_fillToFriendlyName.reset(new Map);
-       }
-       Map::const_iterator itFound = s_fillToFriendlyName->find(iFullName);
-       if(s_fillToFriendlyName->end()==itFound) {
-          itFound = s_fillToFriendlyName->insert(Map::value_type(iFullName, handleNamespaces(subFriendlyName(standardRenames(iFullName))))).first;
+       static thread_local Map s_fillToFriendlyName;
+       auto itFound = s_fillToFriendlyName.find(iFullName);
+       if(s_fillToFriendlyName.end()==itFound) {
+          itFound = s_fillToFriendlyName.insert(Map::value_type(iFullName, handleNamespaces(subFriendlyName(standardRenames(iFullName))))).first;
        }
        return itFound->second;
     }

--- a/FWCore/Utilities/src/TypeID.cc
+++ b/FWCore/Utilities/src/TypeID.cc
@@ -8,7 +8,6 @@
 #include "FWCore/Utilities/interface/FriendlyName.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/TypeDemangler.h"
-#include "boost/thread/tss.hpp"
 
 namespace edm {
   void
@@ -39,13 +38,11 @@ namespace {
   std::string const&
   TypeID::className() const {
     typedef std::map<edm::TypeID, std::string> Map;
-    static boost::thread_specific_ptr<Map> s_typeToName;
-    if(0 == s_typeToName.get()){
-      s_typeToName.reset(new Map);
-    }
-    Map::const_iterator itFound = s_typeToName->find(*this);
-    if(s_typeToName->end() == itFound) {
-      itFound = s_typeToName->insert(Map::value_type(*this, typeToClassName(typeInfo()))).first;
+    static thread_local Map s_typeToName;
+
+    auto itFound = s_typeToName.find(*this);
+    if(s_typeToName.end() == itFound) {
+      itFound = s_typeToName.insert(Map::value_type(*this, typeToClassName(typeInfo()))).first;
     }
     return itFound->second;
   }


### PR DESCRIPTION
Our static analyzer ignores thread_local but not boost::thread_specific_ptr. It will be changed to also ignore the latter but given thread_local is part of the C++ standard and better reflects what the code was doing, I’ve switched to thread_local.
