### PR TITLE
 remove warning in 7_0_X  Fireworks/SimData (issue #997)

### DIFF
--- a/Fireworks/FWInterface/plugins/BuildFile.xml
+++ b/Fireworks/FWInterface/plugins/BuildFile.xml
@@ -3,6 +3,12 @@
 <use name="Fireworks/FWInterface"/>
 <use name="CondFormats/DataRecord"/>
 <use name="CondFormats/RunInfo"/>
+ <use name="SimDataFormats/Track"/>
+ <use name="SimDataFormats/TrackingHit"/>
+ <use name="SimDataFormats/CaloHit"/>
+ <use name="SimDataFormats/Vertex"/>
+ <use name="SimDataFormats/TrackingAnalysis"/  >
+ <use name="SimGeneral/TrackingAnalysis"/>
 <use name="rootcore"/>
 <lib name="Geom"/>
 <lib name="Eve"/>

--- a/Fireworks/FWInterface/plugins/FWTrackingParticleProxyBuilderFF.cc
+++ b/Fireworks/FWInterface/plugins/FWTrackingParticleProxyBuilderFF.cc
@@ -71,11 +71,10 @@ FWTrackingParticleProxyBuilderFF::getAssocList()
    }
    catch (const std::exception& e) {
       std::cerr << " Can't get asociation list " << e.what() <<  std::endl;
+      return;
    }   
 
-   if (simHitsTPAssoc.isValid()) {
       m_assocList = &*simHitsTPAssoc;
-   }
 }
 //______________________________________________________________________________
 
@@ -89,7 +88,7 @@ FWTrackingParticleProxyBuilderFF::build(const FWEventItem* iItem, TEveElementLis
    }
 
    getAssocList();
-   fflush(stdout);
+   if (!m_assocList) return;
 
    gEve->GetBrowser()->MapWindow();
    

--- a/Fireworks/FWInterface/plugins/FWTrackingParticleProxyBuilderFF.cc
+++ b/Fireworks/FWInterface/plugins/FWTrackingParticleProxyBuilderFF.cc
@@ -171,4 +171,4 @@ FWTrackingParticleProxyBuilderFF::build(const FWEventItem* iItem, TEveElementLis
 
 }
 
-REGISTER_FWPROXYBUILDER( FWTrackingParticleProxyBuilderFF, TrackingParticleCollection, "TrackingParticlesFF", FWViewType::kAll3DBits | FWViewType::kAllRPZBits );
+REGISTER_FWPROXYBUILDER( FWTrackingParticleProxyBuilderFF, TrackingParticleCollection, "TrackingParticlesFF", FWViewType::kAll3DBits | FWViewType::kAllRPZBits);

--- a/Fireworks/FWInterface/plugins/FWTrackingParticleProxyBuilderFF.cc
+++ b/Fireworks/FWInterface/plugins/FWTrackingParticleProxyBuilderFF.cc
@@ -51,8 +51,7 @@ private:
 
    const SimHitTPAssociationProducer::SimHitTPAssociationList* m_assocList;
 
-   void getAssocList1();
-   void getAssocList2();
+   void getAssocList();
 };
 
 //______________________________________________________________________________
@@ -60,23 +59,22 @@ private:
 
 
 void
-FWTrackingParticleProxyBuilderFF::getAssocList1()
+FWTrackingParticleProxyBuilderFF::getAssocList()
 {
    edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc; 
    const edm::Event* event = (const edm::Event*)item()->getEvent();
+
+   // AMT todo: check if there is any other way getting the list other than this
+   //           ifnot, set proces name as a configurable parameter
    try {
       event->getByLabel("xxx", simHitsTPAssoc);
    }
    catch (const std::exception& e) {
-      std::cout << "===== ERROR #1 " << e.what() <<  std::endl;
+      std::cerr << " Can't get asociation list " << e.what() <<  std::endl;
    }   
 
    if (simHitsTPAssoc.isValid()) {
       m_assocList = &*simHitsTPAssoc;
-   }
-   //else 
-   {
-      printf("HAVE ASSOC LIST SIZE %d \n", (int)simHitsTPAssoc->size() );
    }
 }
 //______________________________________________________________________________
@@ -90,7 +88,7 @@ FWTrackingParticleProxyBuilderFF::build(const FWEventItem* iItem, TEveElementLis
       return;
    }
 
-   getAssocList1();
+   getAssocList();
    fflush(stdout);
 
    gEve->GetBrowser()->MapWindow();
@@ -138,7 +136,7 @@ FWTrackingParticleProxyBuilderFF::build(const FWEventItem* iItem, TEveElementLis
       int alistIdx = 0;
       std::pair<TrackingParticleRef, TrackPSimHitRef> clusterTPpairWithDummyTP(tpr,TrackPSimHitRef());
       auto range = std::equal_range(m_assocList->begin(), m_assocList->end(), clusterTPpairWithDummyTP, SimHitTPAssociationProducer::simHitTPAssociationListGreater);      
-      printf("TrackingParticle[%d] matches %d hits\n",tpIdx,(int)(range.second-range.first ));
+      // printf("TrackingParticle[%d] matches %d hits\n",tpIdx,(int)(range.second-range.first ));
       for (SimHitTPAssociationProducer::SimHitTPAssociationList::const_iterator ai = range.first; ai != range.second; ++ai, ++alistIdx)
       {
                TrackPSimHitRef phit = ai->second;

--- a/Fireworks/FWInterface/plugins/FWTrackingParticleProxyBuilderFF.cc
+++ b/Fireworks/FWInterface/plugins/FWTrackingParticleProxyBuilderFF.cc
@@ -89,8 +89,6 @@ FWTrackingParticleProxyBuilderFF::build(const FWEventItem* iItem, TEveElementLis
    if (item()->getEvent() == 0 ) {
       return;
    }
-   const TrackingParticleCollection * tracks = 0;
-   iItem->get( tracks );
 
    getAssocList1();
    fflush(stdout);
@@ -110,7 +108,7 @@ FWTrackingParticleProxyBuilderFF::build(const FWEventItem* iItem, TEveElementLis
    event->getByLabel(coltag, tpch);
 
    unsigned int tpIdx = 0;
-   for (TrackingParticleCollection::const_iterator it = tracks->begin(); it != tracks->end(); ++it, ++tpIdx)
+   for (TrackingParticleCollection::const_iterator it = tpch->begin(); it != tpch->end(); ++it, ++tpIdx) 
    {
       TEveCompound* comp = createCompound();
       setupAddElement( comp, product );

--- a/Fireworks/FWInterface/plugins/FWTrackingParticleProxyBuilderFF.cc
+++ b/Fireworks/FWInterface/plugins/FWTrackingParticleProxyBuilderFF.cc
@@ -133,42 +133,28 @@ FWTrackingParticleProxyBuilderFF::build(const FWEventItem* iItem, TEveElementLis
       TEvePointSet* pointSet = new TEvePointSet;
       setupAddElement( pointSet, comp );
 
-      /*
-        TrackingParticleRef tpr(tpch, tpIdx);
-        std::pair<TrackingParticleRef, TrackPSimHitRef> clusterTPpairWithDummyTP(tpr,TrackPSimHitRef());//SimHit is dummy: for simHitTPAssociationListGreater 
-        auto range = std::equal_range(m_assocList->begin(), m_assocList->end(), 
-        clusterTPpairWithDummyTP, SimHitTPAssociationProducer::simHitTPAssociationListGreater);
-      */
 
-       int alistIdx = 0;
-      for (SimHitTPAssociationProducer::SimHitTPAssociationList::const_iterator ai = m_assocList->begin(); ai != m_assocList->end(); ++ai, ++alistIdx)
+      TrackingParticleRef tpr(tpch, tpIdx);
+      int alistIdx = 0;
+      std::pair<TrackingParticleRef, TrackPSimHitRef> clusterTPpairWithDummyTP(tpr,TrackPSimHitRef());
+      auto range = std::equal_range(m_assocList->begin(), m_assocList->end(), clusterTPpairWithDummyTP, SimHitTPAssociationProducer::simHitTPAssociationListGreater);      
+      printf("TrackingParticle[%d] matches %d hits\n",tpIdx,(int)(range.second-range.first ));
+      for (SimHitTPAssociationProducer::SimHitTPAssociationList::const_iterator ai = range.first; ai != range.second; ++ai, ++alistIdx)
       {
-         const edm::PSimHitContainer* l = ai->second.product();
-         const TrackingParticle* tp = ai->first.get();
-         printf("assoc list entry %d has %d TrackingParticles in TrackingParticleRef \n", alistIdx, (int)ai->first.product()->size());
-         if (&iData == tp) {
-            printf("TrackingParticle[%d] matches [%d] associantion pair, the pair has %d hits\n",tpIdx, alistIdx, (int)l->size());
-            for (edm::PSimHitContainer::const_iterator hi = l->begin(); hi != l->end(); ++hi)
-            {
-               const PSimHit& phit = (*hi);
-
-               if (phit.trackId() != tpIdx)
-                  continue;
-
-               local[0] = phit.localPosition().x();
-               local[1] = phit.localPosition().y();
-               local[2] = phit.localPosition().z();
-               localDir[0] = phit.momentumAtEntry().x();
-               localDir[1] = phit.momentumAtEntry().y();
-               localDir[2] = phit.momentumAtEntry().z();
-               geom->localToGlobal( phit.detUnitId(), local, global );
-               geom->localToGlobal( phit.detUnitId(), localDir, globalDir );
+               TrackPSimHitRef phit = ai->second;
+               local[0] = phit->localPosition().x();
+               local[1] = phit->localPosition().y();
+               local[2] = phit->localPosition().z();
+               localDir[0] = phit->momentumAtEntry().x();
+               localDir[1] = phit->momentumAtEntry().y();
+               localDir[2] = phit->momentumAtEntry().z();
+               geom->localToGlobal( phit->detUnitId(), local, global );
+               geom->localToGlobal( phit->detUnitId(), localDir, globalDir );
                pointSet->SetNextPoint( global[0], global[1], global[2] );
                track->AddPathMark( TEvePathMark( TEvePathMark::kReference, TEveVector( global[0], global[1], global[2] ),
                                                  TEveVector( globalDir[0], globalDir[1], globalDir[2] )));
-            }
-         }
       }
+
 
       track->MakeTrack();
    }

--- a/Fireworks/FWInterface/plugins/FWTrackingParticleProxyBuilderFF.cc
+++ b/Fireworks/FWInterface/plugins/FWTrackingParticleProxyBuilderFF.cc
@@ -1,0 +1,148 @@
+
+/*
+ *  FWTrackingParticleProxyBuilder.cc
+ *  FWorks
+ *
+ *  Created by Ianna Osborne on 9/9/10.
+ *
+ */
+
+#include "Fireworks/Core/interface/FWProxyBuilderBase.h"
+#include "Fireworks/Core/interface/Context.h"
+#include "Fireworks/Core/interface/FWEventItem.h"
+#include "Fireworks/Core/interface/FWGeometry.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
+#include "SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h"
+
+#include "DataFormats/DetId/interface/DetId.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Common/interface/EventBase.h"
+#include "DataFormats/DetId/interface/DetId.h"
+
+#include "Fireworks/Core/interface/FWProxyBuilderConfiguration.h"
+#include "Fireworks/Core/interface/FWParameters.h"
+
+#include "TEveTrack.h"
+#include "TEveCompound.h"
+// #include <boost/exception.hpp>
+
+class FWTrackingParticleProxyBuilderFF : public FWProxyBuilderBase
+{
+public:
+
+   FWTrackingParticleProxyBuilderFF( void ):m_assocList(0) {} 
+   virtual ~FWTrackingParticleProxyBuilderFF( void ) {}
+
+   void build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext*) override;
+  
+   REGISTER_PROXYBUILDER_METHODS();
+
+private:
+   FWTrackingParticleProxyBuilderFF( const FWTrackingParticleProxyBuilderFF& );
+   const FWTrackingParticleProxyBuilderFF& operator=( const FWTrackingParticleProxyBuilderFF& );
+
+
+   const SimHitTPAssociationProducer::SimHitTPAssociationList* m_assocList;
+
+   void getAssocList1();
+   void getAssocList2();
+};
+
+//______________________________________________________________________________
+
+
+
+void
+FWTrackingParticleProxyBuilderFF::getAssocList1()
+{
+   edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc; 
+   const edm::Event* event = (const edm::Event*)item()->getEvent();
+   try {
+      event->getByLabel("simHitTPAssocProducer", simHitsTPAssoc);
+   }
+   catch (const std::exception& e) {
+      std::cout << "===== ERROR #1 " << e.what() <<  std::endl;
+   }   
+
+   if (simHitsTPAssoc.isValid()) {
+      m_assocList = &*simHitsTPAssoc;
+   }
+}
+//______________________________________________________________________________
+
+
+void
+FWTrackingParticleProxyBuilderFF::getAssocList2()
+{ 
+   edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc; 
+   const edm::Event* event = (const edm::Event*)item()->getEvent();
+ 
+   try {
+      edm::ParameterSet confProcess;
+      bool ok = event->getProcessParameterSet("DISPLAY", confProcess);
+      printf("OK for DISPLAY process PS [%d], dump: \n", ok);
+      // confProcess.dump();
+
+     
+
+      // now try to get the simhit ParameterSet
+      const edm::ParameterSet& conf_ = confProcess.getParameterSet("xxx");
+      // conf_.dump();
+      
+      const std::vector<std::string> pnames =  conf_.getParameterNames();
+      for (std::vector<std::string>::const_iterator it = pnames.begin(); it != pnames.end(); ++it)
+         std::cout << *it << std::endl;
+
+      edm::InputTag _simHitTpMapTag(conf_.getParameter<edm::InputTag>("g4SimHits"));
+      event->getByLabel( _simHitTpMapTag, simHitsTPAssoc);
+
+   }
+   catch (const std::exception& e) {
+      std::cout << "======= ERROR #2 " << e.what() <<  std::endl;
+   }
+
+   if (simHitsTPAssoc.isValid()) {
+      m_assocList = &*simHitsTPAssoc;
+   }
+   else {
+      printf("HAVCE LIST SIZE %d \n", (int)simHitsTPAssoc->size() );
+   }
+}
+//______________________________________________________________________________
+
+
+void
+FWTrackingParticleProxyBuilderFF::build(const FWEventItem* iItem, TEveElementList* product, const FWViewContext* vc)
+{
+   //getAssocList1();
+   if (!m_assocList)
+      getAssocList2();
+
+   
+   const TrackingParticleCollection * tracks = 0;
+   iItem->get( tracks );
+   for (TrackingParticleCollection::const_iterator it = tracks->begin(); it != tracks->end(); ++it)
+   {
+      TEveCompound* comp = createCompound();
+      setupAddElement( comp, product );
+      continue;
+
+      const TrackingParticle& iData = *it;
+      TEveRecTrack t;
+      t.fBeta = 1.0;
+      t.fP = TEveVector( iData.px(), iData.py(), iData.pz() );
+      t.fV = TEveVector( iData.vx(), iData.vy(), iData.vz() );
+      t.fSign = iData.charge();
+  
+      TEveTrack* track = new TEveTrack(&t, context().getTrackPropagator());
+      if( t.fSign == 0 )
+         track->SetLineStyle( 7 );
+      track->MakeTrack();
+      setupAddElement( track, comp );
+   }
+
+}
+
+REGISTER_FWPROXYBUILDER( FWTrackingParticleProxyBuilderFF, TrackingParticleCollection, "TrackingParticlesFF", FWViewType::kAll3DBits | FWViewType::kAllRPZBits );

--- a/Fireworks/FWInterface/python/testFFW_cfg.py
+++ b/Fireworks/FWInterface/python/testFFW_cfg.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("DISPLAY")
 
+
 #process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.autoCond import autoCond
@@ -9,23 +10,48 @@ process.GlobalTag.globaltag = autoCond['mc']
 process.load("Configuration.StandardSequences.Geometry_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 
+
 ### Expects test.root in current directory.
+# fileNames=cms.untracked.vstring('file:/home/alja/cms-dev/tracking.root')
 process.source = cms.Source(
-    "PoolSource",
-    fileNames=cms.untracked.vstring('file:test.root')
+    "PoolSource",  
+     fileNames=cms.untracked.vstring('root://xrootd.t2.ucsd.edu//tas-5/cerati/TTbarEventsPU/step2_ttbar_45PU25ns.root')
 )
 
 process.POurFilter = cms.EDFilter("RandomFilter",
                                     acceptRate = cms.untracked.double(1.0))
-# process.maxEvents = cms.untracked.PSet(
-#         input = cms.untracked.int32(1)
-#         )
 
-### For running on pre 3.6 files the current needed to determine the
-### magnetic field is taken from Conditions DB.
-# process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-### specify tag:
-# process.GlobalTag.globaltag = 'START36_V10::All'
-### or use auto-cond:
-# from Configuration.AlCa.autoCond import autoCond
-# process.GlobalTag.globaltag = autoCond['mc']
+
+
+from SimGeneral.TrackingAnalysis.simHitTPAssociation_cfi import *
+process.load("SimGeneral.TrackingAnalysis.simHitTPAssociation_cfi")
+
+# process.xxx = cms.Sequence(simHitTPAssocProducer)
+# process.yyy = cms.Path(process.xxx)
+# process.schedule = cms.Schedule(process.yyy)
+
+
+process.xxx=cms.EDProducer('SimHitTPAssociationProducer',
+simHitSrc = cms.VInputTag(cms.InputTag('g4SimHits','MuonDTHits'),
+cms.InputTag('g4SimHits','MuonCSCHits'),
+cms.InputTag('g4SimHits','MuonRPCHits'),
+cms.InputTag('g4SimHits','TrackerHitsTIBLowTof'),
+cms.InputTag('g4SimHits','TrackerHitsTIBHighTof'),
+cms.InputTag('g4SimHits','TrackerHitsTIDLowTof'),
+cms.InputTag('g4SimHits','TrackerHitsTIDHighTof'),
+cms.InputTag('g4SimHits','TrackerHitsTOBLowTof'),
+cms.InputTag('g4SimHits','TrackerHitsTOBHighTof'),
+cms.InputTag('g4SimHits','TrackerHitsTECLowTof'),
+cms.InputTag('g4SimHits','TrackerHitsTECHighTof'),
+cms.InputTag( 'g4SimHits','TrackerHitsPixelBarrelLowTof'),
+cms.InputTag('g4SimHits','TrackerHitsPixelBarrelHighTof'),
+cms.InputTag('g4SimHits','TrackerHitsPixelEndcapLowTof'),
+cms.InputTag('g4SimHits','TrackerHitsPixelEndcapHighTof') ),
+trackingParticleSrc = cms.InputTag('mix', 'MergedTrackTruth'),
+simHitTpMapTag = cms.InputTag("simHitTPAssocProducer")
+)
+
+
+process.mypath = cms.Path(process.xxx)
+
+

--- a/Fireworks/SimData/plugins/FWTrackingParticleProxyBuilder.cc
+++ b/Fireworks/SimData/plugins/FWTrackingParticleProxyBuilder.cc
@@ -52,51 +52,6 @@ FWTrackingParticleProxyBuilder::build( const TrackingParticle& iData, unsigned i
    if( t.fSign == 0 )
       track->SetLineStyle( 7 );
    
-   TEvePointSet* pointSet = new TEvePointSet;
-   setupAddElement( pointSet, track );
-   pointSet->SetMarkerSize(item()->getConfig()->value<long>("Point Size"));
-#warning "This file has been modified just to get it to compile without any regard as to whether it still functions as intended"
-#ifdef REMOVED_JUST_TO_GET_IT_TO_COMPILE__THIS_CODE_NEEDS_TO_BE_CHECKED
-   const FWGeometry *geom = item()->getGeom();
-   const std::vector<PSimHit>& hits = iData.trackPSimHit();
-
-   float local[3];
-   float localDir[3];
-   float global[3] = { 0.0, 0.0, 0.0 };
-   float globalDir[3] = { 0.0, 0.0, 0.0 };
-   std::vector<PSimHit>::const_iterator it = hits.begin();
-   std::vector<PSimHit>::const_iterator end = hits.end();
-   if( it != end )
-   {
-      unsigned int trackid = hits.begin()->trackId();
-
-      for( ; it != end; ++it )
-      {
-	 const PSimHit& phit = (*it);
-	 if( phit.trackId() != trackid )
-	 {
-	    trackid = phit.trackId();
-	    track->AddPathMark( TEvePathMark( TEvePathMark::kDecay, TEveVector( global[0], global[1], global[2] ),
-					      TEveVector( globalDir[0], globalDir[1], globalDir[2] )));
-	 }
-	 local[0] = phit.localPosition().x();
-	 local[1] = phit.localPosition().y();
-	 local[2] = phit.localPosition().z();
-	 localDir[0] = phit.momentumAtEntry().x();
-	 localDir[1] = phit.momentumAtEntry().y();
-	 localDir[2] = phit.momentumAtEntry().z();
-	 geom->localToGlobal( phit.detUnitId(), local, global );
-	 geom->localToGlobal( phit.detUnitId(), localDir, globalDir );
-	 pointSet->SetNextPoint( global[0], global[1], global[2] );
-	 track->AddPathMark( TEvePathMark( TEvePathMark::kReference/*kDaughter*/, TEveVector( global[0], global[1], global[2] ),
-					   TEveVector( globalDir[0], globalDir[1], globalDir[2] )));
-      }
-      if( hits.size() > 1 )
-	 track->AddPathMark( TEvePathMark( TEvePathMark::kDecay, TEveVector( global[0], global[1], global[2] ),
-					   TEveVector( globalDir[0], globalDir[1], globalDir[2] )));
-   }
-#endif
-   
    track->MakeTrack();
    setupAddElement( track, &oItemHolder );
 }


### PR DESCRIPTION
Move visualisation of TP with hits in new cmsShowFF PB.
Note: hits are only drown, but not fitted to track. This is a todo for the next pull request.

Remove warning in Fireworks/SimData 
