### PR TITLE
GE1/1 frame rotation fix and 8-partition geometry size

### DIFF
--- a/Geometry/MuonCommonData/data/v4/gemf.xml
+++ b/Geometry/MuonCommonData/data/v4/gemf.xml
@@ -4,14 +4,14 @@
 <ConstantsSection label="gemf.xml" eval="true">
   <Constant name="dzTot" value="50.820*cm"/>
   <Constant name="rPos"  value="(1338*mm+[dzTot])"/>
-  <Constant name="dzS1"  value="5.056*cm"/>
-  <Constant name="dzS2"  value="5.056*cm"/>
-  <Constant name="dzS3"  value="5.190*cm"/>
-  <Constant name="dzS4"  value="5.190*cm"/>
-  <Constant name="dzS5"  value="6.188*cm"/>
-  <Constant name="dzS6"  value="6.188*cm"/>
-  <Constant name="dzS7"  value="7.630*cm"/>
-  <Constant name="dzS8"  value="7.630*cm"/>
+  <Constant name="dzS1"  value="7.630*cm"/>
+  <Constant name="dzS2"  value="7.630*cm"/>
+  <Constant name="dzS3"  value="6.188*cm"/>
+  <Constant name="dzS4"  value="6.188*cm"/>
+  <Constant name="dzS5"  value="5.190*cm"/>
+  <Constant name="dzS6"  value="5.190*cm"/>
+  <Constant name="dzS7"  value="5.056*cm"/>
+  <Constant name="dzS8"  value="5.056*cm"/>
   <Constant name="dzGap" value="0.2500*cm"/>
   <Constant name="dzIn"  value="([dzS1]+[dzS2]+[dzS3]+[dzS4]+[dzS5]+[dzS6]+[dzS7]+[dzS8]+7*[dzGap])"/>
   <Constant name="z10"   value="([dzIn]-[dzS1])"/> 

--- a/Geometry/MuonCommonData/data/v4/gemf_r08_v01.xml
+++ b/Geometry/MuonCommonData/data/v4/gemf_r08_v01.xml
@@ -4,14 +4,14 @@
 <ConstantsSection label="gemf.xml" eval="true">
   <Constant name="dzTot" value="50.820*cm"/>
   <Constant name="rPos"  value="(1338*mm+[dzTot])"/>
-  <Constant name="dzS1"  value="5.056*cm"/>
-  <Constant name="dzS2"  value="5.056*cm"/>
-  <Constant name="dzS3"  value="5.190*cm"/>
-  <Constant name="dzS4"  value="5.190*cm"/>
-  <Constant name="dzS5"  value="6.188*cm"/>
-  <Constant name="dzS6"  value="6.188*cm"/>
-  <Constant name="dzS7"  value="7.630*cm"/>
-  <Constant name="dzS8"  value="7.630*cm"/>
+  <Constant name="dzS1"  value="7.630*cm"/>
+  <Constant name="dzS2"  value="7.630*cm"/>
+  <Constant name="dzS3"  value="6.188*cm"/>
+  <Constant name="dzS4"  value="6.188*cm"/>
+  <Constant name="dzS5"  value="5.190*cm"/>
+  <Constant name="dzS6"  value="5.190*cm"/>
+  <Constant name="dzS7"  value="5.056*cm"/>
+  <Constant name="dzS8"  value="5.056*cm"/>
   <Constant name="dzGap" value="0.2500*cm"/>
   <Constant name="dzIn"  value="([dzS1]+[dzS2]+[dzS3]+[dzS4]+[dzS5]+[dzS6]+[dzS7]+[dzS8]+7*[dzGap])"/>
   <Constant name="z10"   value="([dzIn]-[dzS1])"/> 

--- a/SimG4CMS/Muon/src/MuonGemFrameRotation.cc
+++ b/SimG4CMS/Muon/src/MuonGemFrameRotation.cc
@@ -36,7 +36,8 @@ Local3DPoint MuonGemFrameRotation::transformPoint(const Local3DPoint & point,con
 	    << " Rotation " << rotated << std::endl;
 #endif
   if (rotated) {
-    return Local3DPoint(-point.x(),point.z(),point.y());
+    //    return Local3DPoint(-point.x(),point.z(),point.y());
+    return Local3DPoint(point.x(),point.z(),-point.y());
   } else {
     return Local3DPoint(point.x(),point.z(),-point.y());
   }


### PR DESCRIPTION
Two items
- "more reasonable" arrangement of partition sizes for 8-eta-partition geometry
  -  shorter partitions at higher eta
  - this version is already in 70X
- correct frame rotation so that the transformation from local to global frame is done correctly

Tested with wf 3408 SingleMuPt100+SingleMuPt100_UPG2019+DIGIUP19+RECOUP19+HARVESTUP19 (just that it runs in this case)

```
  runTheMatrix.py -w upgrade -l 3408.0  --command="-n 100" >& run3408.0_100.log &
```
