### PR TITLE
 Add missing event content CommonEventContent to FEVTSIM.

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -8,10 +8,10 @@ import FWCore.ParameterSet.Config as cms
 #  LHE:
 #    include pure LHE production
 #
-#  RAW , RECO, AOD: 
+#  RAW , RECO, AOD:
 #    include reconstruction content
 #
-#  RAWSIM, RECOSIM, AODSIM: 
+#  RAWSIM, RECOSIM, AODSIM:
 #    include reconstruction and simulation
 #
 #  GENRAW
@@ -21,7 +21,7 @@ import FWCore.ParameterSet.Config as cms
 #
 #  RAWSIMHLT (RAWSIM + HLTDEBUG)
 #
-#  RAWRECOSIMHLT, RAWRECODEBUGHLT  
+#  RAWRECOSIMHLT, RAWRECODEBUGHLT
 #
 #  FEVT (RAW+RECO), FEVTSIM (RAWSIM+RECOSIM), FEVTDEBUG (FEVTSIM+ALL_SIM_INFO), FEVTDEBUGHLT (FEVTDEBUG+HLTDEBUG)
 #
@@ -53,7 +53,7 @@ from L1Trigger.Configuration.L1Trigger_EventContent_cff import *
 from RecoVertex.BeamSpotProducer.BeamSpot_EventContent_cff import *
 
 # raw2digi that are already the final RECO/AOD products
-from EventFilter.ScalersRawToDigi.Scalers_EventContent_cff import * 
+from EventFilter.ScalersRawToDigi.Scalers_EventContent_cff import *
 
 #DigiToRaw content
 from EventFilter.Configuration.DigiToRaw_EventContent_cff import *
@@ -104,7 +104,7 @@ CommonEventContent = cms.PSet(
 #
 #
 LHEEventContent = cms.PSet(
-    outputCommands = cms.untracked.vstring('drop *'), 
+    outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
     eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
@@ -114,7 +114,7 @@ LHEEventContent = cms.PSet(
 #
 #
 RAWEventContent = cms.PSet(
-    outputCommands = cms.untracked.vstring('drop *', 
+    outputCommands = cms.untracked.vstring('drop *',
         'keep  FEDRawDataCollection_rawDataCollector_*_*',
         'keep  FEDRawDataCollection_source_*_*'),
     splitLevel = cms.untracked.int32(0),
@@ -128,7 +128,7 @@ RAWEventContent = cms.PSet(
 RECOEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)    
+    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
 )
 #
 #
@@ -518,7 +518,7 @@ AODSIMEventContent.outputCommands.extend(RecoGenMETAOD.outputCommands)
 AODSIMEventContent.outputCommands.extend(SimGeneralAOD.outputCommands)
 AODSIMEventContent.outputCommands.extend(MEtoEDMConverterAOD.outputCommands)
 
-RAWRECOSIMHLTEventContent.outputCommands.extend(RAWRECOEventContent.outputCommands) 
+RAWRECOSIMHLTEventContent.outputCommands.extend(RAWRECOEventContent.outputCommands)
 RAWRECOSIMHLTEventContent.outputCommands.extend(GeneratorInterfaceRECO.outputCommands)
 RAWRECOSIMHLTEventContent.outputCommands.extend(RecoGenMETRECO.outputCommands)
 RAWRECOSIMHLTEventContent.outputCommands.extend(RecoGenJetsRECO.outputCommands)
@@ -528,9 +528,9 @@ RAWRECOSIMHLTEventContent.outputCommands.extend(SimMuonRECO.outputCommands)
 RAWRECOSIMHLTEventContent.outputCommands.extend(SimCalorimetryRECO.outputCommands)
 RAWRECOSIMHLTEventContent.outputCommands.extend(SimGeneralRECO.outputCommands)
 RAWRECOSIMHLTEventContent.outputCommands.extend(MEtoEDMConverterRECO.outputCommands)
-RAWRECOSIMHLTEventContent.outputCommands.extend(HLTDebugRAW.outputCommands) 
+RAWRECOSIMHLTEventContent.outputCommands.extend(HLTDebugRAW.outputCommands)
 
-RAWRECODEBUGHLTEventContent.outputCommands.extend(RAWRECOSIMHLTEventContent.outputCommands) 
+RAWRECODEBUGHLTEventContent.outputCommands.extend(RAWRECOSIMHLTEventContent.outputCommands)
 RAWRECODEBUGHLTEventContent.outputCommands.extend(SimGeneralFEVTDEBUG.outputCommands)
 RAWRECODEBUGHLTEventContent.outputCommands.extend(SimTrackerDEBUG.outputCommands)
 
@@ -604,6 +604,7 @@ FEVTSIMEventContent.outputCommands.extend(SimCalorimetryRECO.outputCommands)
 FEVTSIMEventContent.outputCommands.extend(SimGeneralRECO.outputCommands)
 FEVTSIMEventContent.outputCommands.extend(MEtoEDMConverterRECO.outputCommands)
 FEVTSIMEventContent.outputCommands.extend(EvtScalersRECO.outputCommands)
+FEVTSIMEventContent.outputCommands.extend(CommonEventContent.outputCommands)
 RAWDEBUGEventContent.outputCommands.extend(RAWSIMEventContent.outputCommands)
 RAWDEBUGEventContent.outputCommands.extend(SimTrackerDEBUG.outputCommands)
 RAWDEBUGEventContent.outputCommands.extend(SimGeneralFEVTDEBUG.outputCommands)


### PR DESCRIPTION
Backport of #1216:
Add missing CommonEventContent to FEVTSIM and inherited FEVTDEBUG.
