### PR TITLE
make HLTFilters global modules - part 1

### DIFF
--- a/CaloOnlineTools/EcalTools/plugins/EcalFEDErrorFilter.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalFEDErrorFilter.cc
@@ -2,7 +2,7 @@
 //
 // Package:    EcalFEDErrorFilter
 // Class:      EcalFEDErrorFilter
-// 
+//
 /**\class EcalFEDErrorFilter EcalFEDErrorFilter.cc filter/EcalFEDErrorFilter/src/EcalFEDErrorFilter.cc
 
 Description: <one line class summary>
@@ -29,7 +29,7 @@ EcalFEDErrorFilter::EcalFEDErrorFilter(const edm::ParameterSet& iConfig) :
 
   DataLabel_     = iConfig.getParameter<edm::InputTag>("InputLabel");
   fedUnpackList_ = iConfig.getUntrackedParameter< std::vector<int> >("FEDs", std::vector<int>());
-  if (fedUnpackList_.empty()) 
+  if (fedUnpackList_.empty())
     for (int i=FEDNumbering::MINECALFEDID; i<=FEDNumbering::MAXECALFEDID; i++)
       fedUnpackList_.push_back(i);
 }
@@ -37,7 +37,7 @@ EcalFEDErrorFilter::EcalFEDErrorFilter(const edm::ParameterSet& iConfig) :
 
 EcalFEDErrorFilter::~EcalFEDErrorFilter()
 {
- 
+
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 
@@ -50,23 +50,23 @@ EcalFEDErrorFilter::~EcalFEDErrorFilter()
 
 // ------------ method called on each new Event  ------------
 bool
-EcalFEDErrorFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+EcalFEDErrorFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace edm;
 
-  edm::Handle<FEDRawDataCollection> rawdata;  
+  edm::Handle<FEDRawDataCollection> rawdata;
   iEvent.getByLabel(DataLabel_,rawdata);
 
   // get fed raw data and SM id
 
   // loop over FEDS
-  for (std::vector<int>::const_iterator i=fedUnpackList_.begin(); i!=fedUnpackList_.end(); i++) 
+  for (std::vector<int>::const_iterator i=fedUnpackList_.begin(); i!=fedUnpackList_.end(); i++)
     {
 
       // get fed raw data and SM id
       const FEDRawData & fedData = rawdata->FEDData(*i);
       int length = fedData.size()/sizeof(uint64_t);
-      
+
       //    LogDebug("EcalRawToDigi") << "raw data length: " << length ;
       //if data size is not null interpret data
       if ( length >= 1 )
@@ -74,7 +74,7 @@ EcalFEDErrorFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
       	    uint64_t * pData = (uint64_t *)(fedData.data());
 	    //When crc error is found return true
 	    uint64_t * fedTrailer = pData + (length - 1);
-	    bool crcError = (*fedTrailer >> 2 ) & 0x1; 
+	    bool crcError = (*fedTrailer >> 2 ) & 0x1;
 	    if (crcError)
 	      {
 		std::cout << "CRCERROR in FED " << *i << " trailer is " << std::setw(8)   << std::hex << (*fedTrailer) << std::endl;
@@ -82,6 +82,6 @@ EcalFEDErrorFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
 	      }
 	}
     }
-  
+
   return false;
 }

--- a/CaloOnlineTools/EcalTools/plugins/EcalFEDErrorFilter.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalFEDErrorFilter.cc
@@ -50,7 +50,7 @@ EcalFEDErrorFilter::~EcalFEDErrorFilter()
 
 // ------------ method called on each new Event  ------------
 bool
-EcalFEDErrorFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+EcalFEDErrorFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace edm;
 

--- a/CaloOnlineTools/EcalTools/plugins/EcalFEDErrorFilter.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalFEDErrorFilter.h
@@ -2,7 +2,7 @@
 //
 // Package:    EcalFEDErrorFilter
 // Class:      EcalFEDErrorFilter
-// 
+//
 /**\class EcalFEDErrorFilter EcalFEDErrorFilter.cc filter/EcalFEDErrorFilter/src/EcalFEDErrorFilter.cc
 
 Description: <one line class summary>
@@ -46,13 +46,13 @@ class EcalFEDErrorFilter : public HLTFilter {
 public:
   explicit EcalFEDErrorFilter(const edm::ParameterSet&);
   ~EcalFEDErrorFilter();
-  
+
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
-  
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+
   // ----------member data ---------------------------
-  
+
   edm::InputTag     DataLabel_;
   std::vector<int> fedUnpackList_;
-  
+
 };

--- a/CaloOnlineTools/EcalTools/plugins/EcalFEDErrorFilter.h
+++ b/CaloOnlineTools/EcalTools/plugins/EcalFEDErrorFilter.h
@@ -48,7 +48,7 @@ public:
   ~EcalFEDErrorFilter();
   
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
   
   // ----------member data ---------------------------
   

--- a/DPGAnalysis/Skims/interface/HLTMuonPtFilter.h
+++ b/DPGAnalysis/Skims/interface/HLTMuonPtFilter.h
@@ -35,7 +35,7 @@ class HLTMuonPtFilter : public HLTFilter {
     ~HLTMuonPtFilter() ;
 
 /* Operations */ 
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
   private:
     std::string theSTAMuonLabel; // label of muons 

--- a/DPGAnalysis/Skims/interface/HLTMuonPtFilter.h
+++ b/DPGAnalysis/Skims/interface/HLTMuonPtFilter.h
@@ -34,12 +34,12 @@ class HLTMuonPtFilter : public HLTFilter {
 /// Destructorquer
     ~HLTMuonPtFilter() ;
 
-/* Operations */ 
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+/* Operations */
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
   private:
-    std::string theSTAMuonLabel; // label of muons 
-    double theMinPt;    // minimum pt required 
+    std::string theSTAMuonLabel; // label of muons
+    double theMinPt;    // minimum pt required
 
 
 };

--- a/DPGAnalysis/Skims/src/HLTMuonPtFilter.cc
+++ b/DPGAnalysis/Skims/src/HLTMuonPtFilter.cc
@@ -32,7 +32,7 @@ HLTMuonPtFilter::HLTMuonPtFilter(const edm::ParameterSet& pset) :
 
   theMinPt = pset.getParameter<double>("minPt"); // pt min (GeV)
 
-  LogDebug("HLTMuonPt") << " SALabel : " << theSTAMuonLabel 
+  LogDebug("HLTMuonPt") << " SALabel : " << theSTAMuonLabel
     << " Min Pt : " << theMinPt;
 }
 
@@ -40,14 +40,14 @@ HLTMuonPtFilter::HLTMuonPtFilter(const edm::ParameterSet& pset) :
 HLTMuonPtFilter::~HLTMuonPtFilter() {
 }
 
-/* Operations */ 
-bool HLTMuonPtFilter::hltFilter(edm::Event& event, const edm::EventSetup& eventSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+/* Operations */
+bool HLTMuonPtFilter::hltFilter(edm::Event& event, const edm::EventSetup& eventSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
   // Get the RecTrack collection from the event
   Handle<reco::TrackCollection> staTracks;
   event.getByLabel(theSTAMuonLabel, staTracks);
-  
+
   reco::TrackCollection::const_iterator staTrack;
-  
+
   for (staTrack = staTracks->begin(); staTrack != staTracks->end(); ++staTrack) {
     if (staTrack->pt()>theMinPt)
       return true;

--- a/DPGAnalysis/Skims/src/HLTMuonPtFilter.cc
+++ b/DPGAnalysis/Skims/src/HLTMuonPtFilter.cc
@@ -41,7 +41,7 @@ HLTMuonPtFilter::~HLTMuonPtFilter() {
 }
 
 /* Operations */ 
-bool HLTMuonPtFilter::hltFilter(edm::Event& event, const edm::EventSetup& eventSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+bool HLTMuonPtFilter::hltFilter(edm::Event& event, const edm::EventSetup& eventSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
   // Get the RecTrack collection from the event
   Handle<reco::TrackCollection> staTracks;
   event.getByLabel(theSTAMuonLabel, staTracks);

--- a/DQM/DTMonitorModule/src/DTDataErrorFilter.cc
+++ b/DQM/DTMonitorModule/src/DTDataErrorFilter.cc
@@ -19,7 +19,7 @@ DTDataErrorFilter::DTDataErrorFilter(const edm::ParameterSet & config) :
 DTDataErrorFilter::~DTDataErrorFilter(){}
 
 
-bool DTDataErrorFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+bool DTDataErrorFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
   // check the event error flag 
   if (dataMonitor->eventHasErrors()) return true;
   return false;

--- a/DQM/DTMonitorModule/src/DTDataErrorFilter.cc
+++ b/DQM/DTMonitorModule/src/DTDataErrorFilter.cc
@@ -19,8 +19,8 @@ DTDataErrorFilter::DTDataErrorFilter(const edm::ParameterSet & config) :
 DTDataErrorFilter::~DTDataErrorFilter(){}
 
 
-bool DTDataErrorFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
-  // check the event error flag 
+bool DTDataErrorFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+  // check the event error flag
   if (dataMonitor->eventHasErrors()) return true;
   return false;
 }

--- a/DQM/DTMonitorModule/src/DTDataErrorFilter.h
+++ b/DQM/DTMonitorModule/src/DTDataErrorFilter.h
@@ -21,14 +21,14 @@ public:
   virtual ~DTDataErrorFilter();
 
   // Operations
-  virtual bool hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
-  
+  virtual bool hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+
 protected:
 
 private:
   DTDataIntegrityTask * dataMonitor;
 
-  
+
 };
 #endif
 

--- a/DQM/DTMonitorModule/src/DTDataErrorFilter.h
+++ b/DQM/DTMonitorModule/src/DTDataErrorFilter.h
@@ -21,7 +21,7 @@ public:
   virtual ~DTDataErrorFilter();
 
   // Operations
-  virtual bool hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
   
 protected:
 

--- a/DQM/DTMonitorModule/src/DTROMonitorFilter.cc
+++ b/DQM/DTMonitorModule/src/DTROMonitorFilter.cc
@@ -28,7 +28,7 @@ DTROMonitorFilter::DTROMonitorFilter(const edm::ParameterSet& pset) :
 DTROMonitorFilter::~DTROMonitorFilter(){}
 
 
-bool DTROMonitorFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+bool DTROMonitorFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
 
   // get the raw data
   edm::Handle<FEDRawDataCollection> rawdata;
@@ -44,16 +44,16 @@ bool DTROMonitorFilter::hltFilter(edm::Event& event, const edm::EventSetup& setu
 
   for (int dduID=FEDIDmin; dduID<=FEDIDMax; ++dduID) {  // loop over all feds
     const FEDRawData& feddata = rawdata->FEDData(dduID);
-    const int datasize = feddata.size();    
+    const int datasize = feddata.size();
     if (datasize){ // check the FED payload
       const unsigned int* index32 = reinterpret_cast<const unsigned int*>(feddata.data());
       const int numberOf32Words = datasize/wordSize_32;
-      
+
       const unsigned char* index8 = reinterpret_cast<const unsigned char*>(index32);
 
       // Check Status Words (1 x ROS)
       for (int rosId = 0; rosId < 12; rosId++ ) {
-	int wordIndex8 = numberOf32Words*wordSize_32 - 3*wordSize_64 + rosId; 
+	int wordIndex8 = numberOf32Words*wordSize_32 - 3*wordSize_64 + rosId;
 	DTDDUFirstStatusWord statusWord(index8[wordIndex8]);
 	// check the error bit
 	if(statusWord.errorFromROS() != 0) return true;
@@ -61,6 +61,6 @@ bool DTROMonitorFilter::hltFilter(edm::Event& event, const edm::EventSetup& setu
     }
   }
 
-  // check the event error flag 
+  // check the event error flag
   return false;
 }

--- a/DQM/DTMonitorModule/src/DTROMonitorFilter.cc
+++ b/DQM/DTMonitorModule/src/DTROMonitorFilter.cc
@@ -28,10 +28,11 @@ DTROMonitorFilter::DTROMonitorFilter(const edm::ParameterSet& pset) :
 DTROMonitorFilter::~DTROMonitorFilter(){}
 
 
-bool DTROMonitorFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+bool DTROMonitorFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+
   // get the raw data
+  edm::Handle<FEDRawDataCollection> rawdata;
   event.getByLabel(inputLabel, rawdata);
-  
 
   // Loop over the DT FEDs
   int FEDIDmin = FEDNumbering::MINDTFEDID;

--- a/DQM/DTMonitorModule/src/DTROMonitorFilter.h
+++ b/DQM/DTMonitorModule/src/DTROMonitorFilter.h
@@ -21,8 +21,8 @@ public:
   virtual ~DTROMonitorFilter();
 
   // Operations
-  virtual bool hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
-  
+  virtual bool hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+
 protected:
 
 private:

--- a/DQM/DTMonitorModule/src/DTROMonitorFilter.h
+++ b/DQM/DTMonitorModule/src/DTROMonitorFilter.h
@@ -21,14 +21,11 @@ public:
   virtual ~DTROMonitorFilter();
 
   // Operations
-  virtual bool hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
   
 protected:
 
 private:
-  // Get the data integrity service
-  edm::Handle<FEDRawDataCollection> rawdata;
-
   /// if not you need the label
   edm::InputTag inputLabel;
 

--- a/EventFilter/Cosmics/BuildFile.xml
+++ b/EventFilter/Cosmics/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/ParameterSet"/>
+<use   name="FWCore/Utilities"/>
 <use   name="HLTrigger/HLTcore"/>
 <use   name="RecoMuon/TrackingTools"/>
 <use   name="TrackingTools/TransientTrack"/>

--- a/EventFilter/Cosmics/interface/HLTMuonPointingFilter.h
+++ b/EventFilter/Cosmics/interface/HLTMuonPointingFilter.h
@@ -28,28 +28,28 @@ class Propagator;
 class HLTMuonPointingFilter : public HLTFilter {
 
 public:
-  
+
   /// Constructor
   HLTMuonPointingFilter(const edm::ParameterSet&) ;
-  
+
   /// Destructor
   ~HLTMuonPointingFilter() ;
-  
-  /* Operations */ 
+
+  /* Operations */
   virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
-  
+
 private:
-  std::string theSTAMuonLabel; // label of muons 
-  std::string thePropagatorName; // name of propagator to be used
-    double theRadius;  // radius of cylinder
-  double theMaxZ;    // half lenght of cylinder
-  
+  const std::string theSTAMuonLabel;        // label of muons
+  const std::string thePropagatorName;      // name of propagator to be used
+  const double theRadius;                   // radius of cylinder
+  const double theMaxZ;                     // half length of cylinder
+
   Cylinder::CylinderPointer theCyl;
-  Plane::PlanePointer thePosPlane,theNegPlane;
-  
+  Plane::PlanePointer thePosPlane, theNegPlane;
+
   mutable Propagator* thePropagator;
   unsigned long long  m_cacheRecordId;
-  
+
 };
 #endif // Muon_HLTMuonPointingFilter_h
 

--- a/EventFilter/Cosmics/interface/HLTMuonPointingFilter.h
+++ b/EventFilter/Cosmics/interface/HLTMuonPointingFilter.h
@@ -3,7 +3,7 @@
 
 /** \class HLTMuonPointingFilter
  *
- * HLTFilter to select muons that points to a cylinder of configurable radius
+ * EDFilter to select muons that points to a cylinder of configurable radius
  * and lenght.
  *
  * \author Stefano Lacaprara - INFN Legnaro <stefano.lacaprara@pd.infn.it>
@@ -11,7 +11,7 @@
  */
 
 /* Base Class Headers */
-#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+#include "FWCore/Framework/interface/EDFilter.h"
 
 /* Collaborating Class Declarations */
 class Propagator;
@@ -25,7 +25,7 @@ class Propagator;
 
 /* Class HLTMuonPointingFilter Interface */
 
-class HLTMuonPointingFilter : public HLTFilter {
+class HLTMuonPointingFilter : public edm::EDFilter {
 
 public:
 
@@ -36,7 +36,7 @@ public:
   ~HLTMuonPointingFilter() ;
 
   /* Operations */
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool filter(edm::Event &, edm::EventSetup const &) override;
 
 private:
   const std::string theSTAMuonLabel;        // label of muons

--- a/EventFilter/Cosmics/src/EcalMIPRecHitFilter.cc
+++ b/EventFilter/Cosmics/src/EcalMIPRecHitFilter.cc
@@ -58,7 +58,7 @@ class EcalMIPRecHitFilter : public HLTFilter {
 
    private:
       virtual void beginJob() override ;
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       virtual void endJob() override ;
 
       // ----------member data ---------------------------
@@ -103,7 +103,7 @@ EcalMIPRecHitFilter::~EcalMIPRecHitFilter()
 
 // ------------ method called on each new Event  ------------
 bool
-EcalMIPRecHitFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+EcalMIPRecHitFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
    using namespace edm;
 

--- a/EventFilter/Cosmics/src/EcalMIPRecHitFilter.cc
+++ b/EventFilter/Cosmics/src/EcalMIPRecHitFilter.cc
@@ -58,7 +58,7 @@ class EcalMIPRecHitFilter : public HLTFilter {
 
    private:
       virtual void beginJob() override ;
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
       virtual void endJob() override ;
       
       // ----------member data ---------------------------
@@ -103,7 +103,7 @@ EcalMIPRecHitFilter::~EcalMIPRecHitFilter()
 
 // ------------ method called on each new Event  ------------
 bool
-EcalMIPRecHitFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+EcalMIPRecHitFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
    using namespace edm;
 

--- a/EventFilter/Cosmics/src/EcalSimpleUncalibRecHitFilter.cc
+++ b/EventFilter/Cosmics/src/EcalSimpleUncalibRecHitFilter.cc
@@ -2,7 +2,7 @@
 //
 // Package:    EcalSimpleUncalibRecHitFilter
 // Class:      EcalSimpleUncalibRecHitFilter
-// 
+//
 /**\class EcalSimpleUncalibRecHitFilter EcalSimpleUncalibRecHitFilter.cc Work/EcalSimpleUncalibRecHitFilter/src/EcalSimpleUncalibRecHitFilter.cc
 
  Description: <one line class summary>
@@ -46,7 +46,7 @@ class EcalSimpleUncalibRecHitFilter : public HLTFilter {
       virtual void beginJob() override ;
       virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
       virtual void endJob() override ;
-      
+
       // ----------member data ---------------------------
 
   edm::InputTag EcalUncalibRecHitCollection_;
@@ -70,7 +70,7 @@ EcalSimpleUncalibRecHitFilter::EcalSimpleUncalibRecHitFilter(const edm::Paramete
 
 EcalSimpleUncalibRecHitFilter::~EcalSimpleUncalibRecHitFilter()
 {
- 
+
    // do anything here that needs to be done at desctruction time
    // (e.g. close files, deallocate resources etc.)
 
@@ -95,46 +95,45 @@ EcalSimpleUncalibRecHitFilter::hltFilter(edm::Event& iEvent, const edm::EventSet
      LogWarning("EcalSimpleUncalibRecHitFilter") << EcalUncalibRecHitCollection_ << " not available";
    }
 
-   
-   bool thereIsSignal = false;  
+
+   bool thereIsSignal = false;
    // loop on crude rechits
    for ( EcalUncalibratedRecHitCollection::const_iterator hitItr = crudeHits->begin(); hitItr != crudeHits->end(); ++hitItr ) {
-     
+
      EcalUncalibratedRecHit hit = (*hitItr);
-     
+
      // masking noisy channels
-     std::vector<int>::iterator result;
-     result = find( maskedList_.begin(), maskedList_.end(), EBDetId(hit.id()).hashedIndex() );    
-     if  (result != maskedList_.end()) 
+     std::vector<int>::const_iterator result = std::find( maskedList_.begin(), maskedList_.end(), EBDetId(hit.id()).hashedIndex() );
+     if  (result != maskedList_.end())
        // LogWarning("EcalFilter") << "skipping uncalRecHit for channel: " << ic << " with amplitude " << ampli_ ;
-       continue; 
-     
+       continue;
+
      float ampli_ = hit.amplitude();
-     
+
      // seeking channels with signal and displaced jitter
-     if (ampli_ >= minAdc_  ) 
+     if (ampli_ >= minAdc_  )
        {
 	 thereIsSignal = true;
-	 // LogWarning("EcalFilter")  << "at evet: " << iEvent.id().event() 
-	 // 				       << " and run: " << iEvent.id().run() 
-	 // 				       << " there is OUT OF TIME signal at chanel: " << ic 
+	 // LogWarning("EcalFilter")  << "at evet: " << iEvent.id().event()
+	 // 				       << " and run: " << iEvent.id().run()
+	 // 				       << " there is OUT OF TIME signal at chanel: " << ic
 	 // 				       << " with amplitude " << ampli_  << " and max at: " << jitter_;
 	 break;
        }
-     
+
    }
-   
+
    return thereIsSignal;
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
+void
 EcalSimpleUncalibRecHitFilter::beginJob()
 {
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
+void
 EcalSimpleUncalibRecHitFilter::endJob() {
 }
 

--- a/EventFilter/Cosmics/src/EcalSimpleUncalibRecHitFilter.cc
+++ b/EventFilter/Cosmics/src/EcalSimpleUncalibRecHitFilter.cc
@@ -44,7 +44,7 @@ class EcalSimpleUncalibRecHitFilter : public HLTFilter {
 
    private:
       virtual void beginJob() override ;
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
       virtual void endJob() override ;
       
       // ----------member data ---------------------------
@@ -83,7 +83,7 @@ EcalSimpleUncalibRecHitFilter::~EcalSimpleUncalibRecHitFilter()
 
 // ------------ method called on each new Event  ------------
 bool
-EcalSimpleUncalibRecHitFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+EcalSimpleUncalibRecHitFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
    using namespace edm;
 

--- a/EventFilter/Cosmics/src/EcalSimpleUncalibRecHitFilter.cc
+++ b/EventFilter/Cosmics/src/EcalSimpleUncalibRecHitFilter.cc
@@ -44,7 +44,7 @@ class EcalSimpleUncalibRecHitFilter : public HLTFilter {
 
    private:
       virtual void beginJob() override ;
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       virtual void endJob() override ;
 
       // ----------member data ---------------------------
@@ -83,7 +83,7 @@ EcalSimpleUncalibRecHitFilter::~EcalSimpleUncalibRecHitFilter()
 
 // ------------ method called on each new Event  ------------
 bool
-EcalSimpleUncalibRecHitFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+EcalSimpleUncalibRecHitFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
    using namespace edm;
 

--- a/EventFilter/Cosmics/src/HLTMuonPointingFilter.cc
+++ b/EventFilter/Cosmics/src/HLTMuonPointingFilter.cc
@@ -34,7 +34,6 @@ using namespace edm;
 
 /// Constructor
 HLTMuonPointingFilter::HLTMuonPointingFilter(const edm::ParameterSet& pset) :
-  HLTFilter(pset),
   theSTAMuonLabel(  pset.getParameter<string>("SALabel") ),             // the name of the STA rec hits collection
   thePropagatorName(pset.getParameter<std::string>("PropagatorName") ),
   theRadius(        pset.getParameter<double>("radius") ),              // cyl's radius (cm)
@@ -63,7 +62,7 @@ HLTMuonPointingFilter::~HLTMuonPointingFilter() {
 }
 
 /* Operations */
-bool HLTMuonPointingFilter::hltFilter(edm::Event& event, const edm::EventSetup& eventSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+bool HLTMuonPointingFilter::filter(edm::Event& event, const edm::EventSetup& eventSetup) {
   bool accept = false;
 
   const TrackingComponentsRecord & tkRec = eventSetup.get<TrackingComponentsRecord>();
@@ -132,8 +131,6 @@ bool HLTMuonPointingFilter::hltFilter(edm::Event& event, const edm::EventSetup& 
   }
 
   return accept;
-
-
 }
 
 // define this as a plug-in

--- a/EventFilter/Cosmics/src/HLTMuonPointingFilter.cc
+++ b/EventFilter/Cosmics/src/HLTMuonPointingFilter.cc
@@ -12,6 +12,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetupRecord.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 
@@ -33,31 +34,26 @@ using namespace edm;
 
 /// Constructor
 HLTMuonPointingFilter::HLTMuonPointingFilter(const edm::ParameterSet& pset) :
-   HLTFilter(pset),
-   m_cacheRecordId(0) 
+  HLTFilter(pset),
+  theSTAMuonLabel(  pset.getParameter<string>("SALabel") ),             // the name of the STA rec hits collection
+  thePropagatorName(pset.getParameter<std::string>("PropagatorName") ),
+  theRadius(        pset.getParameter<double>("radius") ),              // cyl's radius (cm)
+  theMaxZ(          pset.getParameter<double>("maxZ") ),                // cyl's half lenght (cm)
+  thePropagator(nullptr),
+  m_cacheRecordId(0)
 {
-  // the name of the STA rec hits collection
-  theSTAMuonLabel = pset.getParameter<string>("SALabel");
-
-  thePropagatorName = pset.getParameter<std::string>("PropagatorName");
-  thePropagator = 0;
-
-  theRadius = pset.getParameter<double>("radius"); // cyl's radius (cm)
-  theMaxZ = pset.getParameter<double>("maxZ"); // cyl's half lenght (cm)
-
-
   // Get a surface (here a cylinder of radius 1290mm) ECAL
   Cylinder::PositionType pos0;
   Cylinder::RotationType rot0;
   theCyl = Cylinder::build(theRadius, pos0, rot0);
-    
+
   Plane::PositionType posPos(0,0,theMaxZ);
   Plane::PositionType posNeg(0,0,-theMaxZ);
 
   thePosPlane = Plane::build(posPos,rot0);
   theNegPlane = Plane::build(posNeg,rot0);
 
-  LogDebug("HLTMuonPointing") << " SALabel : " << theSTAMuonLabel 
+  LogDebug("HLTMuonPointing") << " SALabel : " << theSTAMuonLabel
     << " Radius : " << theRadius
     << " Half lenght : " << theMaxZ;
 }
@@ -66,16 +62,21 @@ HLTMuonPointingFilter::HLTMuonPointingFilter(const edm::ParameterSet& pset) :
 HLTMuonPointingFilter::~HLTMuonPointingFilter() {
 }
 
-/* Operations */ 
+/* Operations */
 bool HLTMuonPointingFilter::hltFilter(edm::Event& event, const edm::EventSetup& eventSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
   bool accept = false;
 
   const TrackingComponentsRecord & tkRec = eventSetup.get<TrackingComponentsRecord>();
   if (not thePropagator or tkRec.cacheIdentifier() != m_cacheRecordId) {
-    ESHandle<Propagator> prop;
-    tkRec.get(thePropagatorName, prop);
-    thePropagator = prop->clone();
-    thePropagator->setPropagationDirection(anyDirection);
+    // delete the old propagator
+    delete thePropagator;
+
+    // get the new propagator from the EventSetup and clone it (for thread safety)
+    ESHandle<Propagator> propagatorHandle;
+    tkRec.get(thePropagatorName, propagatorHandle);
+    thePropagator = propagatorHandle.product()->clone();
+    if (thePropagator->propagationDirection() != anyDirection)
+      throw cms::Exception("Configuration") << "the propagator " << thePropagatorName << " should be configured with PropagationDirection = \"anyDirection\"" << std::endl;
     m_cacheRecordId = tkRec.cacheIdentifier();
   }
 
@@ -107,7 +108,7 @@ bool HLTMuonPointingFilter::hltFilter(edm::Event& event, const edm::EventSetup& 
         accept=true;
         return accept;
       }
-      else { 
+      else {
         LogDebug("HLTMuonPointing") << " extrap TSOS z too big " << tsosAtCyl.globalPosition().z();
 	TrajectoryStateOnSurface tsosAtPlane;
 	if (tsosAtCyl.globalPosition().z()>0)

--- a/HLTrigger/Egamma/interface/HLTDisplacedEgammaFilter.h
+++ b/HLTrigger/Egamma/interface/HLTDisplacedEgammaFilter.h
@@ -26,7 +26,7 @@ class HLTDisplacedEgammaFilter : public HLTFilter {
       explicit HLTDisplacedEgammaFilter(const edm::ParameterSet&);
       ~HLTDisplacedEgammaFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       edm::InputTag inputTag_; // input tag identifying product contains egammas

--- a/HLTrigger/Egamma/interface/HLTDisplacedEgammaFilter.h
+++ b/HLTrigger/Egamma/interface/HLTDisplacedEgammaFilter.h
@@ -26,21 +26,21 @@ class HLTDisplacedEgammaFilter : public HLTFilter {
       explicit HLTDisplacedEgammaFilter(const edm::ParameterSet&);
       ~HLTDisplacedEgammaFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       edm::InputTag inputTag_; // input tag identifying product contains egammas
       edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken_;
       int    ncandcut_;        // number of egammas required
       bool   relaxed_;
-      edm::InputTag L1IsoCollTag_; 
-      edm::InputTag L1NonIsoCollTag_; 
+      edm::InputTag L1IsoCollTag_;
+      edm::InputTag L1NonIsoCollTag_;
       edm::InputTag rechitsEB ;
       edm::InputTag rechitsEE ;
       edm::EDGetTokenT<EcalRecHitCollection> rechitsEBToken_;
       edm::EDGetTokenT<EcalRecHitCollection> rechitsEEToken_;
 
-      bool EBOnly ; 
+      bool EBOnly ;
       double sMin_min ;
       double sMin_max ;
       double sMaj_min ;

--- a/HLTrigger/Egamma/interface/HLTEgammaAllCombMassFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaAllCombMassFilter.h
@@ -20,10 +20,10 @@ class HLTEgammaAllCombMassFilter : public HLTFilter {
  public:
   explicit HLTEgammaAllCombMassFilter(const edm::ParameterSet&);
   ~HLTEgammaAllCombMassFilter();
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
   static void getP4OfLegCands(const edm::Event& iEvent, const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs>& filterToken, std::vector<math::XYZTLorentzVector>& p4s);
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  
+
  private:
   edm::InputTag firstLegLastFilterTag_;
   edm::InputTag secondLegLastFilterTag_;
@@ -32,6 +32,6 @@ class HLTEgammaAllCombMassFilter : public HLTFilter {
   double minMass_;
 };
 
-#endif 
+#endif
 
 

--- a/HLTrigger/Egamma/interface/HLTEgammaAllCombMassFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaAllCombMassFilter.h
@@ -20,7 +20,7 @@ class HLTEgammaAllCombMassFilter : public HLTFilter {
  public:
   explicit HLTEgammaAllCombMassFilter(const edm::ParameterSet&);
   ~HLTEgammaAllCombMassFilter();
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
   static void getP4OfLegCands(const edm::Event& iEvent, const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs>& filterToken, std::vector<math::XYZTLorentzVector>& p4s);
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
   

--- a/HLTrigger/Egamma/interface/HLTEgammaCaloIsolFilterPairs.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaCaloIsolFilterPairs.h
@@ -30,7 +30,7 @@ class HLTEgammaCaloIsolFilterPairs : public HLTFilter {
   public:
     explicit HLTEgammaCaloIsolFilterPairs(const edm::ParameterSet&);
     ~HLTEgammaCaloIsolFilterPairs();
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
   private:

--- a/HLTrigger/Egamma/interface/HLTEgammaCaloIsolFilterPairs.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaCaloIsolFilterPairs.h
@@ -30,7 +30,7 @@ class HLTEgammaCaloIsolFilterPairs : public HLTFilter {
    public:
       explicit HLTEgammaCaloIsolFilterPairs(const edm::ParameterSet&);
       ~HLTEgammaCaloIsolFilterPairs();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTEgammaCaloIsolFilterPairs.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaCaloIsolFilterPairs.h
@@ -27,37 +27,37 @@ namespace edm {
 
 class HLTEgammaCaloIsolFilterPairs : public HLTFilter {
 
-   public:
-      explicit HLTEgammaCaloIsolFilterPairs(const edm::ParameterSet&);
-      ~HLTEgammaCaloIsolFilterPairs();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
-      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  public:
+    explicit HLTEgammaCaloIsolFilterPairs(const edm::ParameterSet&);
+    ~HLTEgammaCaloIsolFilterPairs();
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
-   private:
-      edm::InputTag candTag_; // input tag identifying product contains filtered egammas
-      edm::InputTag isoTag_; // input tag identifying product contains ecal isolation map
-      edm::InputTag nonIsoTag_; // input tag identifying product contains ecal isolation map
-      edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> candToken_;
-      edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> isoToken_;
-      edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> nonIsoToken_;
+  private:
+    edm::InputTag candTag_; // input tag identifying product contains filtered egammas
+    edm::InputTag isoTag_; // input tag identifying product contains ecal isolation map
+    edm::InputTag nonIsoTag_; // input tag identifying product contains ecal isolation map
+    edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> candToken_;
+    edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> isoToken_;
+    edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> nonIsoToken_;
 
-      double isolcut_EB1; 
-      double FracCut_EB1;
-      double IsoloEt2_EB1;
-      double isolcut_EE1; 
-      double FracCut_EE1;
-      double IsoloEt2_EE1;
+    double isolcut_EB1;
+    double FracCut_EB1;
+    double IsoloEt2_EB1;
+    double isolcut_EE1;
+    double FracCut_EE1;
+    double IsoloEt2_EE1;
 
-      double isolcut_EB2; 
-      double FracCut_EB2;
-      double IsoloEt2_EB2;
-      double isolcut_EE2; 
-      double FracCut_EE2;
-      double IsoloEt2_EE2;
+    double isolcut_EB2;
+    double FracCut_EB2;
+    double IsoloEt2_EB2;
+    double isolcut_EE2;
+    double FracCut_EE2;
+    double IsoloEt2_EE2;
 
-   
-      bool AlsoNonIso_1,AlsoNonIso_2;
-    bool PassCaloIsolation(edm::Ref<reco::RecoEcalCandidateCollection> ref,const reco::RecoEcalCandidateIsolationMap& IsoMap,const reco::RecoEcalCandidateIsolationMap& NonIsoMap, int which, bool ChekAlsoNonIso);
+    bool AlsoNonIso_1, AlsoNonIso_2;
+
+    bool PassCaloIsolation(edm::Ref<reco::RecoEcalCandidateCollection> ref,const reco::RecoEcalCandidateIsolationMap& IsoMap,const reco::RecoEcalCandidateIsolationMap& NonIsoMap, int which, bool ChekAlsoNonIso) const;
 };
 
 #endif //HLTEgammaCaloIsolFilterPairs_h

--- a/HLTrigger/Egamma/interface/HLTEgammaCombMassFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaCombMassFilter.h
@@ -21,10 +21,10 @@ class HLTEgammaCombMassFilter : public HLTFilter {
  public:
   explicit HLTEgammaCombMassFilter(const edm::ParameterSet&);
   ~HLTEgammaCombMassFilter();
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
   static void getP4OfLegCands(const edm::Event& iEvent, const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs>& filterToken, std::vector<math::XYZTLorentzVector>& p4s);
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
- 
+
  private:
   edm::InputTag firstLegLastFilterTag_;
   edm::InputTag secondLegLastFilterTag_;
@@ -33,6 +33,6 @@ class HLTEgammaCombMassFilter : public HLTFilter {
   double minMass_;
 };
 
-#endif 
+#endif
 
 

--- a/HLTrigger/Egamma/interface/HLTEgammaCombMassFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaCombMassFilter.h
@@ -21,7 +21,7 @@ class HLTEgammaCombMassFilter : public HLTFilter {
  public:
   explicit HLTEgammaCombMassFilter(const edm::ParameterSet&);
   ~HLTEgammaCombMassFilter();
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
   static void getP4OfLegCands(const edm::Event& iEvent, const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs>& filterToken, std::vector<math::XYZTLorentzVector>& p4s);
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
  

--- a/HLTrigger/Egamma/interface/HLTEgammaDoubleEtDeltaPhiFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaDoubleEtDeltaPhiFilter.h
@@ -24,17 +24,17 @@ class HLTEgammaDoubleEtDeltaPhiFilter : public HLTFilter {
    public:
       explicit HLTEgammaDoubleEtDeltaPhiFilter(const edm::ParameterSet&);
       ~HLTEgammaDoubleEtDeltaPhiFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:
       edm::InputTag inputTag_; // input tag identifying product contains filtered candidates
       edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs>  inputToken_;
-      double etcut_;           // Et threshold in GeV 
+      double etcut_;           // Et threshold in GeV
       double minDeltaPhi_;    // minimum deltaPhi
- //   int    ncandcut_;        // number of egammas required 
+ //   int    ncandcut_;        // number of egammas required
       bool   relaxed_;
-      edm::InputTag L1IsoCollTag_; 
+      edm::InputTag L1IsoCollTag_;
       edm::InputTag L1NonIsoCollTag_;
 };
 

--- a/HLTrigger/Egamma/interface/HLTEgammaDoubleEtDeltaPhiFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaDoubleEtDeltaPhiFilter.h
@@ -24,7 +24,7 @@ class HLTEgammaDoubleEtDeltaPhiFilter : public HLTFilter {
    public:
       explicit HLTEgammaDoubleEtDeltaPhiFilter(const edm::ParameterSet&);
       ~HLTEgammaDoubleEtDeltaPhiFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTEgammaDoubleEtFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaDoubleEtFilter.h
@@ -28,18 +28,18 @@ class HLTEgammaDoubleEtFilter : public HLTFilter {
  public:
   explicit HLTEgammaDoubleEtFilter(const edm::ParameterSet&);
   ~HLTEgammaDoubleEtFilter();
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
  private:
   edm::InputTag candTag_; // input tag identifying product contains filtered candidates
   edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs>  candToken_;
-  double etcut1_;           // Et threshold in GeV 
-  double etcut2_;           // Et threshold in GeV 
+  double etcut1_;           // Et threshold in GeV
+  double etcut2_;           // Et threshold in GeV
   int    npaircut_;        // number of egammas required
   bool   relaxed_;
-  edm::InputTag L1IsoCollTag_; 
-  edm::InputTag L1NonIsoCollTag_; 
+  edm::InputTag L1IsoCollTag_;
+  edm::InputTag L1NonIsoCollTag_;
 };
 
 #endif //HLTEgammaDoubleEtFilter_h

--- a/HLTrigger/Egamma/interface/HLTEgammaDoubleEtFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaDoubleEtFilter.h
@@ -28,7 +28,7 @@ class HLTEgammaDoubleEtFilter : public HLTFilter {
  public:
   explicit HLTEgammaDoubleEtFilter(const edm::ParameterSet&);
   ~HLTEgammaDoubleEtFilter();
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
  private:

--- a/HLTrigger/Egamma/interface/HLTEgammaDoubleEtPhiFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaDoubleEtPhiFilter.h
@@ -28,20 +28,20 @@ class HLTEgammaDoubleEtPhiFilter : public HLTFilter {
  public:
   explicit HLTEgammaDoubleEtPhiFilter(const edm::ParameterSet&);
   ~HLTEgammaDoubleEtPhiFilter();
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
  private:
   edm::InputTag candTag_; // input tag identifying product contains filtered candidates
   edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs>  candToken_;
-  double etcut1_;           // Et threshold in GeV 
-  double etcut2_;           // Et threshold in GeV 
+  double etcut1_;           // Et threshold in GeV
+  double etcut2_;           // Et threshold in GeV
   double min_Acop_;         // minimum acoplanarity
   double max_Acop_;         // maximum acoplanarity
-  double min_EtBalance_;    // minimum Et difference 
+  double min_EtBalance_;    // minimum Et difference
   double max_EtBalance_;    // maximum Et difference
   int    npaircut_;        // number of egammas required
-  
+
 };
 
 #endif //HLTEgammaDoubleEtPhiFilter_h

--- a/HLTrigger/Egamma/interface/HLTEgammaDoubleEtPhiFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaDoubleEtPhiFilter.h
@@ -28,7 +28,7 @@ class HLTEgammaDoubleEtPhiFilter : public HLTFilter {
  public:
   explicit HLTEgammaDoubleEtPhiFilter(const edm::ParameterSet&);
   ~HLTEgammaDoubleEtPhiFilter();
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
  private:

--- a/HLTrigger/Egamma/interface/HLTEgammaDoubleLegCombFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaDoubleLegCombFilter.h
@@ -21,7 +21,7 @@ class HLTEgammaDoubleLegCombFilter : public HLTFilter {
  public:
   explicit HLTEgammaDoubleLegCombFilter(const edm::ParameterSet&);
   ~HLTEgammaDoubleLegCombFilter();
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
   void matchCands(const std::vector<math::XYZPoint>& firstLegP3s,const std::vector<math::XYZPoint>& secondLegP3s,std::vector<std::pair<int,int> >&matchedCands);

--- a/HLTrigger/Egamma/interface/HLTEgammaDoubleLegCombFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaDoubleLegCombFilter.h
@@ -21,7 +21,7 @@ class HLTEgammaDoubleLegCombFilter : public HLTFilter {
  public:
   explicit HLTEgammaDoubleLegCombFilter(const edm::ParameterSet&);
   ~HLTEgammaDoubleLegCombFilter();
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
   void matchCands(const std::vector<math::XYZPoint>& firstLegP3s,const std::vector<math::XYZPoint>& secondLegP3s,std::vector<std::pair<int,int> >&matchedCands) const;

--- a/HLTrigger/Egamma/interface/HLTEgammaDoubleLegCombFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaDoubleLegCombFilter.h
@@ -24,9 +24,9 @@ class HLTEgammaDoubleLegCombFilter : public HLTFilter {
   virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
-  void matchCands(const std::vector<math::XYZPoint>& firstLegP3s,const std::vector<math::XYZPoint>& secondLegP3s,std::vector<std::pair<int,int> >&matchedCands);
+  void matchCands(const std::vector<math::XYZPoint>& firstLegP3s,const std::vector<math::XYZPoint>& secondLegP3s,std::vector<std::pair<int,int> >&matchedCands) const;
   static void getP3OfLegCands(const edm::Event& iEvent, const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs>& filterToken, std::vector<math::XYZPoint>& p3s);
-  
+
  private:
   edm::InputTag firstLegLastFilterTag_;
   edm::InputTag secondLegLastFilterTag_;
@@ -38,6 +38,6 @@ class HLTEgammaDoubleLegCombFilter : public HLTFilter {
   double maxMatchDR_;
 };
 
-#endif 
+#endif
 
 

--- a/HLTrigger/Egamma/interface/HLTEgammaEtFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaEtFilter.h
@@ -24,18 +24,18 @@ class HLTEgammaEtFilter : public HLTFilter {
    public:
       explicit HLTEgammaEtFilter(const edm::ParameterSet&);
       ~HLTEgammaEtFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:
       edm::InputTag inputTag_; // input tag identifying product contains egammas
       edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken_;
-      double etcutEB_;           // Barrel Et threshold in GeV 
-      double etcutEE_;           // Endcap Et threshold in GeV 
+      double etcutEB_;           // Barrel Et threshold in GeV
+      double etcutEE_;           // Endcap Et threshold in GeV
       int    ncandcut_;        // number of egammas required
       bool   relaxed_;
-      edm::InputTag L1IsoCollTag_; 
-      edm::InputTag L1NonIsoCollTag_; 
+      edm::InputTag L1IsoCollTag_;
+      edm::InputTag L1NonIsoCollTag_;
 };
 
 #endif //HLTEgammaEtFilter_h

--- a/HLTrigger/Egamma/interface/HLTEgammaEtFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaEtFilter.h
@@ -24,7 +24,7 @@ class HLTEgammaEtFilter : public HLTFilter {
    public:
       explicit HLTEgammaEtFilter(const edm::ParameterSet&);
       ~HLTEgammaEtFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTEgammaEtFilterPairs.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaEtFilterPairs.h
@@ -24,7 +24,7 @@ class HLTEgammaEtFilterPairs : public HLTFilter {
    public:
       explicit HLTEgammaEtFilterPairs(const edm::ParameterSet&);
       ~HLTEgammaEtFilterPairs();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTEgammaEtFilterPairs.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaEtFilterPairs.h
@@ -3,7 +3,7 @@
 
 /** \class HLTEgammaEtFilterPairs
  *
- *  \author Alessio Ghezzi 
+ *  \author Alessio Ghezzi
  *
  */
 
@@ -24,19 +24,19 @@ class HLTEgammaEtFilterPairs : public HLTFilter {
    public:
       explicit HLTEgammaEtFilterPairs(const edm::ParameterSet&);
       ~HLTEgammaEtFilterPairs();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:
       edm::InputTag inputTag_; // input tag identifying product contains egammas
       edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken_;
-      double etcutEB1_;           // Et threshold in GeV 
-      double etcutEB2_;           // Et threshold in GeV 
-      double etcutEE1_;           // Et threshold in GeV 
-      double etcutEE2_;           // Et threshold in GeV 
+      double etcutEB1_;           // Et threshold in GeV
+      double etcutEB2_;           // Et threshold in GeV
+      double etcutEE1_;           // Et threshold in GeV
+      double etcutEE2_;           // Et threshold in GeV
       bool   relaxed_;
-      edm::InputTag L1IsoCollTag_; 
-      edm::InputTag L1NonIsoCollTag_; 
+      edm::InputTag L1IsoCollTag_;
+      edm::InputTag L1NonIsoCollTag_;
 };
 
 #endif //HLTEgammaEtFilterPairs_h

--- a/HLTrigger/Egamma/interface/HLTEgammaGenericFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaGenericFilter.h
@@ -25,7 +25,7 @@ class HLTEgammaGenericFilter : public HLTFilter {
    public:
       explicit HLTEgammaGenericFilter(const edm::ParameterSet&);
       ~HLTEgammaGenericFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTEgammaGenericFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaGenericFilter.h
@@ -25,7 +25,7 @@ class HLTEgammaGenericFilter : public HLTFilter {
    public:
       explicit HLTEgammaGenericFilter(const edm::ParameterSet&);
       ~HLTEgammaGenericFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:
@@ -37,17 +37,17 @@ class HLTEgammaGenericFilter : public HLTFilter {
       edm::EDGetTokenT<reco::RecoEcalCandidateIsolationMap> nonIsoToken_;
       bool lessThan_;           // the cut is "<" or ">" ?
       bool useEt_;              // use E or Et in relative isolation cuts
-      double thrRegularEB_;     // threshold for regular cut (x < thr) - ECAL barrel 
+      double thrRegularEB_;     // threshold for regular cut (x < thr) - ECAL barrel
       double thrRegularEE_;     // threshold for regular cut (x < thr) - ECAL endcap
-      double thrOverEEB_;       // threshold for x/E < thr cut (isolations) - ECAL barrel 
-      double thrOverEEE_;       // threshold for x/E < thr cut (isolations) - ECAL endcap 
-      double thrOverE2EB_;      // threshold for x/E^2 < thr cut (isolations) - ECAL barrel 
-      double thrOverE2EE_;      // threshold for x/E^2 < thr cut (isolations) - ECAL endcap 
+      double thrOverEEB_;       // threshold for x/E < thr cut (isolations) - ECAL barrel
+      double thrOverEEE_;       // threshold for x/E < thr cut (isolations) - ECAL endcap
+      double thrOverE2EB_;      // threshold for x/E^2 < thr cut (isolations) - ECAL barrel
+      double thrOverE2EE_;      // threshold for x/E^2 < thr cut (isolations) - ECAL endcap
       int    ncandcut_;        // number of photons required
       bool doIsolated_;
 
-      edm::InputTag L1IsoCollTag_; 
-      edm::InputTag L1NonIsoCollTag_; 
+      edm::InputTag L1IsoCollTag_;
+      edm::InputTag L1NonIsoCollTag_;
 };
 
 #endif //HLTEgammaGenericFilter_h

--- a/HLTrigger/Egamma/interface/HLTEgammaGenericQuadraticEtaFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaGenericQuadraticEtaFilter.h
@@ -25,7 +25,7 @@ class HLTEgammaGenericQuadraticEtaFilter : public HLTFilter {
    public:
       explicit HLTEgammaGenericQuadraticEtaFilter(const edm::ParameterSet&);
       ~HLTEgammaGenericQuadraticEtaFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:
@@ -42,7 +42,7 @@ class HLTEgammaGenericQuadraticEtaFilter : public HLTFilter {
     Endcap quadratic threshold function:
       vali (<= or >=) thrRegularEE_ + (E or Et)*thrOverEEE_ + (E or Et)*(E or Et)*thrOverE2EE_
 */
-      double etaBoundaryEB12_;     //eta Boundary between Regions 1 and 2 - ECAL barrel 
+      double etaBoundaryEB12_;     //eta Boundary between Regions 1 and 2 - ECAL barrel
       double etaBoundaryEE12_;     //eta Boundary between Regions 1 and 2 - ECAL endcap
       double thrRegularEB1_;     // threshold value for zeroth order term - ECAL barrel region 1
       double thrRegularEE1_;     // threshold value for zeroth order term - ECAL endcap region 1
@@ -60,8 +60,8 @@ class HLTEgammaGenericQuadraticEtaFilter : public HLTFilter {
       bool doIsolated_;
 
       bool   store_;
-      edm::InputTag L1IsoCollTag_; 
-      edm::InputTag L1NonIsoCollTag_; 
+      edm::InputTag L1IsoCollTag_;
+      edm::InputTag L1NonIsoCollTag_;
 };
 
 #endif //HLTEgammaGenericQuadraticEtaFilter_h

--- a/HLTrigger/Egamma/interface/HLTEgammaGenericQuadraticEtaFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaGenericQuadraticEtaFilter.h
@@ -25,7 +25,7 @@ class HLTEgammaGenericQuadraticEtaFilter : public HLTFilter {
    public:
       explicit HLTEgammaGenericQuadraticEtaFilter(const edm::ParameterSet&);
       ~HLTEgammaGenericQuadraticEtaFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTEgammaGenericQuadraticFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaGenericQuadraticFilter.h
@@ -25,7 +25,7 @@ class HLTEgammaGenericQuadraticFilter : public HLTFilter {
    public:
       explicit HLTEgammaGenericQuadraticFilter(const edm::ParameterSet&);
       ~HLTEgammaGenericQuadraticFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:
@@ -42,17 +42,17 @@ class HLTEgammaGenericQuadraticFilter : public HLTFilter {
     Endcap quadratic threshold function:
       vali (<= or >=) thrRegularEE_ + (E or Et)*thrOverEEE_ + (E or Et)*(E or Et)*thrOverE2EE_
 */
-      double thrRegularEB_;     // threshold value for zeroth order term - ECAL barrel 
+      double thrRegularEB_;     // threshold value for zeroth order term - ECAL barrel
       double thrRegularEE_;     // threshold value for zeroth order term - ECAL endcap
-      double thrOverEEB_;       // coefficient for first order term - ECAL barrel 
-      double thrOverEEE_;       // coefficient for first order term - ECAL endcap 
-      double thrOverE2EB_;      // coefficient for second order term - ECAL barrel 
-      double thrOverE2EE_;      // coefficient for second order term - ECAL endcap 
+      double thrOverEEB_;       // coefficient for first order term - ECAL barrel
+      double thrOverEEE_;       // coefficient for first order term - ECAL endcap
+      double thrOverE2EB_;      // coefficient for second order term - ECAL barrel
+      double thrOverE2EE_;      // coefficient for second order term - ECAL endcap
       int    ncandcut_;        // number of photons required
       bool doIsolated_;
 
-      edm::InputTag L1IsoCollTag_; 
-      edm::InputTag L1NonIsoCollTag_; 
+      edm::InputTag L1IsoCollTag_;
+      edm::InputTag L1NonIsoCollTag_;
 };
 
 #endif //HLTEgammaGenericQuadraticFilter_h

--- a/HLTrigger/Egamma/interface/HLTEgammaGenericQuadraticFilter.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaGenericQuadraticFilter.h
@@ -25,7 +25,7 @@ class HLTEgammaGenericQuadraticFilter : public HLTFilter {
    public:
       explicit HLTEgammaGenericQuadraticFilter(const edm::ParameterSet&);
       ~HLTEgammaGenericQuadraticFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTEgammaL1MatchFilterPairs.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaL1MatchFilterPairs.h
@@ -28,7 +28,7 @@ class HLTEgammaL1MatchFilterPairs : public HLTFilter {
    public:
       explicit HLTEgammaL1MatchFilterPairs(const edm::ParameterSet&);
       ~HLTEgammaL1MatchFilterPairs();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTEgammaL1MatchFilterPairs.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaL1MatchFilterPairs.h
@@ -32,7 +32,8 @@ class HLTEgammaL1MatchFilterPairs : public HLTFilter {
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:
-      bool CheckL1Matching(edm::Ref<reco::RecoEcalCandidateCollection>ref,std::vector<l1extra::L1EmParticleRef >& l1EGIso,std::vector<l1extra::L1EmParticleRef >& l1EGNonIso);
+      bool CheckL1Matching(edm::Ref<reco::RecoEcalCandidateCollection>ref,std::vector<l1extra::L1EmParticleRef >& l1EGIso,std::vector<l1extra::L1EmParticleRef >& l1EGNonIso) const;
+
       edm::InputTag candIsolatedTag_; // input tag identifying product contains egammas
       edm::InputTag l1IsolatedTag_; // input tag identifying product contains egammas
       edm::InputTag candNonIsolatedTag_; // input tag identifying product contains egammas
@@ -42,7 +43,7 @@ class HLTEgammaL1MatchFilterPairs : public HLTFilter {
 
       edm::InputTag L1SeedFilterTag_;
       edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> L1SeedFilterToken_;
-      bool AlsoNonIsolatedFirst_, AlsoNonIsolatedSecond_; 
+      bool AlsoNonIsolatedFirst_, AlsoNonIsolatedSecond_;
 
       // L1 matching cuts
       double region_eta_size_;

--- a/HLTrigger/Egamma/interface/HLTEgammaL1MatchFilterPairs.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaL1MatchFilterPairs.h
@@ -28,7 +28,7 @@ class HLTEgammaL1MatchFilterPairs : public HLTFilter {
    public:
       explicit HLTEgammaL1MatchFilterPairs(const edm::ParameterSet&);
       ~HLTEgammaL1MatchFilterPairs();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTEgammaL1MatchFilterRegional.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaL1MatchFilterRegional.h
@@ -25,34 +25,34 @@ namespace edm {
 
 class HLTEgammaL1MatchFilterRegional : public HLTFilter {
 
-   public:
-      explicit HLTEgammaL1MatchFilterRegional(const edm::ParameterSet&);
-      ~HLTEgammaL1MatchFilterRegional();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
-      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+  public:
+    explicit HLTEgammaL1MatchFilterRegional(const edm::ParameterSet&);
+    ~HLTEgammaL1MatchFilterRegional();
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
-   private:
-      edm::InputTag candIsolatedTag_; // input tag identifying product contains egammas
-      edm::InputTag l1IsolatedTag_; // input tag identifying product contains egammas
-      edm::InputTag candNonIsolatedTag_; // input tag identifying product contains egammas
-      edm::InputTag l1NonIsolatedTag_; // input tag identifying product contains egammas
-      edm::EDGetTokenT<reco::RecoEcalCandidateCollection> candIsolatedToken_;
-      edm::EDGetTokenT<reco::RecoEcalCandidateCollection> candNonIsolatedToken_;
+  private:
+    edm::InputTag candIsolatedTag_;         // input tag identifying product contains egammas
+    edm::InputTag l1IsolatedTag_;           // input tag identifying product contains egammas
+    edm::InputTag candNonIsolatedTag_;      // input tag identifying product contains egammas
+    edm::InputTag l1NonIsolatedTag_;         // input tag identifying product contains egammas
+    edm::EDGetTokenT<reco::RecoEcalCandidateCollection> candIsolatedToken_;
+    edm::EDGetTokenT<reco::RecoEcalCandidateCollection> candNonIsolatedToken_;
 
-      edm::InputTag L1SeedFilterTag_;
-      edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> L1SeedFilterToken_;
-      bool doIsolated_;
+    edm::InputTag L1SeedFilterTag_;
+    edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> L1SeedFilterToken_;
+    bool doIsolated_;
 
-      int    ncandcut_;        // number of egammas required
-      // L1 matching cuts
-      double region_eta_size_;
-      double region_eta_size_ecap_;
-      double region_phi_size_;
-      double barrel_end_;
-      double endcap_end_;
+    int    ncandcut_;        // number of egammas required
+    // L1 matching cuts
+    double region_eta_size_;
+    double region_eta_size_ecap_;
+    double region_phi_size_;
+    double barrel_end_;
+    double endcap_end_;
 
- public:
-      bool matchedToL1Cand(const std::vector<l1extra::L1EmParticleRef >& l1Cands,const float scEta,const float scPhi);
+  private:
+    bool matchedToL1Cand(const std::vector<l1extra::L1EmParticleRef >& l1Cands,const float scEta,const float scPhi) const;
 
 };
 

--- a/HLTrigger/Egamma/interface/HLTEgammaL1MatchFilterRegional.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaL1MatchFilterRegional.h
@@ -28,7 +28,7 @@ class HLTEgammaL1MatchFilterRegional : public HLTFilter {
    public:
       explicit HLTEgammaL1MatchFilterRegional(const edm::ParameterSet&);
       ~HLTEgammaL1MatchFilterRegional();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTEgammaL1MatchFilterRegional.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaL1MatchFilterRegional.h
@@ -28,7 +28,7 @@ class HLTEgammaL1MatchFilterRegional : public HLTFilter {
   public:
     explicit HLTEgammaL1MatchFilterRegional(const edm::ParameterSet&);
     ~HLTEgammaL1MatchFilterRegional();
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
   private:

--- a/HLTrigger/Egamma/interface/HLTEgammaTriggerFilterObjectWrapper.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaTriggerFilterObjectWrapper.h
@@ -25,7 +25,7 @@ class HLTEgammaTriggerFilterObjectWrapper : public HLTFilter {
    public:
       explicit HLTEgammaTriggerFilterObjectWrapper(const edm::ParameterSet&);
       ~HLTEgammaTriggerFilterObjectWrapper();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTEgammaTriggerFilterObjectWrapper.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaTriggerFilterObjectWrapper.h
@@ -25,7 +25,7 @@ class HLTEgammaTriggerFilterObjectWrapper : public HLTFilter {
    public:
       explicit HLTEgammaTriggerFilterObjectWrapper(const edm::ParameterSet&);
       ~HLTEgammaTriggerFilterObjectWrapper();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTElectronEoverpFilterRegional.h
+++ b/HLTrigger/Egamma/interface/HLTElectronEoverpFilterRegional.h
@@ -25,7 +25,7 @@ class HLTElectronEoverpFilterRegional : public HLTFilter {
    public:
       explicit HLTElectronEoverpFilterRegional(const edm::ParameterSet&);
       ~HLTElectronEoverpFilterRegional();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTElectronEoverpFilterRegional.h
+++ b/HLTrigger/Egamma/interface/HLTElectronEoverpFilterRegional.h
@@ -25,7 +25,7 @@ class HLTElectronEoverpFilterRegional : public HLTFilter {
    public:
       explicit HLTElectronEoverpFilterRegional(const edm::ParameterSet&);
       ~HLTElectronEoverpFilterRegional();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTElectronEtFilter.h
+++ b/HLTrigger/Egamma/interface/HLTElectronEtFilter.h
@@ -24,20 +24,20 @@ class HLTElectronEtFilter : public HLTFilter {
    public:
       explicit HLTElectronEtFilter(const edm::ParameterSet&);
       ~HLTElectronEtFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:
       edm::InputTag candTag_; // input tag identifying product that contains filtered electrons
       edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> candToken_;
-      
-      double EtEB_;     // threshold for regular cut (x < thr) - ECAL barrel 
+
+      double EtEB_;     // threshold for regular cut (x < thr) - ECAL barrel
       double EtEE_;     // threshold for regular cut (x < thr) - ECAL endcap
-      
+
       bool doIsolated_;
 
-      edm::InputTag L1IsoCollTag_; 
-      edm::InputTag L1NonIsoCollTag_; 
+      edm::InputTag L1IsoCollTag_;
+      edm::InputTag L1NonIsoCollTag_;
       int ncandcut_;
 };
 

--- a/HLTrigger/Egamma/interface/HLTElectronEtFilter.h
+++ b/HLTrigger/Egamma/interface/HLTElectronEtFilter.h
@@ -24,7 +24,7 @@ class HLTElectronEtFilter : public HLTFilter {
    public:
       explicit HLTElectronEtFilter(const edm::ParameterSet&);
       ~HLTElectronEtFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTElectronGenericFilter.h
+++ b/HLTrigger/Egamma/interface/HLTElectronGenericFilter.h
@@ -25,7 +25,7 @@ class HLTElectronGenericFilter : public HLTFilter {
    public:
       explicit HLTElectronGenericFilter(const edm::ParameterSet&);
       ~HLTElectronGenericFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTElectronGenericFilter.h
+++ b/HLTrigger/Egamma/interface/HLTElectronGenericFilter.h
@@ -25,7 +25,7 @@ class HLTElectronGenericFilter : public HLTFilter {
    public:
       explicit HLTElectronGenericFilter(const edm::ParameterSet&);
       ~HLTElectronGenericFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:
@@ -36,17 +36,17 @@ class HLTElectronGenericFilter : public HLTFilter {
       edm::EDGetTokenT<reco::ElectronIsolationMap> isoToken_;
       edm::EDGetTokenT<reco::ElectronIsolationMap> nonIsoToken_;
       bool lessThan_;           // the cut is "<" or ">" ?
-      double thrRegularEB_;     // threshold for regular cut (x < thr) - ECAL barrel 
+      double thrRegularEB_;     // threshold for regular cut (x < thr) - ECAL barrel
       double thrRegularEE_;     // threshold for regular cut (x < thr) - ECAL endcap
-      double thrOverPtEB_;       // threshold for x/p_T < thr cut (isolations) - ECAL barrel 
-      double thrOverPtEE_;       // threshold for x/p_T < thr cut (isolations) - ECAL endcap 
-      double thrTimesPtEB_;      // threshold for x*p_T < thr cut (isolations) - ECAL barrel 
-      double thrTimesPtEE_;      // threshold for x*p_T < thr cut (isolations) - ECAL endcap 
+      double thrOverPtEB_;       // threshold for x/p_T < thr cut (isolations) - ECAL barrel
+      double thrOverPtEE_;       // threshold for x/p_T < thr cut (isolations) - ECAL endcap
+      double thrTimesPtEB_;      // threshold for x*p_T < thr cut (isolations) - ECAL barrel
+      double thrTimesPtEE_;      // threshold for x*p_T < thr cut (isolations) - ECAL endcap
       int    ncandcut_;        // number of electrons required
       bool doIsolated_;
 
-      edm::InputTag L1IsoCollTag_; 
-      edm::InputTag L1NonIsoCollTag_; 
+      edm::InputTag L1IsoCollTag_;
+      edm::InputTag L1NonIsoCollTag_;
 };
 
 #endif //HLTElectronGenericFilter_h

--- a/HLTrigger/Egamma/interface/HLTElectronMissingHitsFilter.h
+++ b/HLTrigger/Egamma/interface/HLTElectronMissingHitsFilter.h
@@ -17,7 +17,7 @@ class HLTElectronMissingHitsFilter : public HLTFilter {
  public:
       explicit HLTElectronMissingHitsFilter(const edm::ParameterSet&);
       ~HLTElectronMissingHitsFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
  private:

--- a/HLTrigger/Egamma/interface/HLTElectronMissingHitsFilter.h
+++ b/HLTrigger/Egamma/interface/HLTElectronMissingHitsFilter.h
@@ -17,7 +17,7 @@ class HLTElectronMissingHitsFilter : public HLTFilter {
  public:
       explicit HLTElectronMissingHitsFilter(const edm::ParameterSet&);
       ~HLTElectronMissingHitsFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
  private:

--- a/HLTrigger/Egamma/interface/HLTElectronMuonInvMassFilter.h
+++ b/HLTrigger/Egamma/interface/HLTElectronMuonInvMassFilter.h
@@ -41,7 +41,7 @@ class HLTElectronMuonInvMassFilter : public HLTFilter {
    public:
       explicit HLTElectronMuonInvMassFilter(const edm::ParameterSet&);
       ~HLTElectronMuonInvMassFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);      
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;      
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTElectronMuonInvMassFilter.h
+++ b/HLTrigger/Egamma/interface/HLTElectronMuonInvMassFilter.h
@@ -41,12 +41,12 @@ class HLTElectronMuonInvMassFilter : public HLTFilter {
    public:
       explicit HLTElectronMuonInvMassFilter(const edm::ParameterSet&);
       ~HLTElectronMuonInvMassFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;      
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:
       edm::InputTag eleCandTag_;
-      edm::InputTag muonCandTag_; 
+      edm::InputTag muonCandTag_;
       edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> eleCandToken_;
       edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> muonCandToken_;
 
@@ -54,9 +54,9 @@ class HLTElectronMuonInvMassFilter : public HLTFilter {
       double upperMassCut_;
       int ncandcut_;
       bool relaxed_;
-      edm::InputTag L1IsoCollTag_; 
-      edm::InputTag L1NonIsoCollTag_; 
-      edm::InputTag MuonCollTag_; 
+      edm::InputTag L1IsoCollTag_;
+      edm::InputTag L1NonIsoCollTag_;
+      edm::InputTag MuonCollTag_;
 };
 
 #endif //HLTElectronMuonInvMassFilter_h

--- a/HLTrigger/Egamma/interface/HLTElectronOneOEMinusOneOPFilterRegional.h
+++ b/HLTrigger/Egamma/interface/HLTElectronOneOEMinusOneOPFilterRegional.h
@@ -25,7 +25,7 @@ class HLTElectronOneOEMinusOneOPFilterRegional : public HLTFilter {
    public:
       explicit HLTElectronOneOEMinusOneOPFilterRegional(const edm::ParameterSet&);
       ~HLTElectronOneOEMinusOneOPFilterRegional();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTElectronOneOEMinusOneOPFilterRegional.h
+++ b/HLTrigger/Egamma/interface/HLTElectronOneOEMinusOneOPFilterRegional.h
@@ -25,7 +25,7 @@ class HLTElectronOneOEMinusOneOPFilterRegional : public HLTFilter {
    public:
       explicit HLTElectronOneOEMinusOneOPFilterRegional(const edm::ParameterSet&);
       ~HLTElectronOneOEMinusOneOPFilterRegional();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTElectronPFMTFilter.h
+++ b/HLTrigger/Egamma/interface/HLTElectronPFMTFilter.h
@@ -47,7 +47,7 @@ class HLTElectronPFMTFilter : public HLTFilter {
       explicit HLTElectronPFMTFilter(const edm::ParameterSet&);
       ~HLTElectronPFMTFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       edm::InputTag inputMetTag_; // input tag identifying jets

--- a/HLTrigger/Egamma/interface/HLTElectronPFMTFilter.h
+++ b/HLTrigger/Egamma/interface/HLTElectronPFMTFilter.h
@@ -47,7 +47,7 @@ class HLTElectronPFMTFilter : public HLTFilter {
       explicit HLTElectronPFMTFilter(const edm::ParameterSet&);
       ~HLTElectronPFMTFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       edm::InputTag inputMetTag_; // input tag identifying jets

--- a/HLTrigger/Egamma/interface/HLTElectronPixelMatchFilter.h
+++ b/HLTrigger/Egamma/interface/HLTElectronPixelMatchFilter.h
@@ -27,7 +27,7 @@ class HLTElectronPixelMatchFilter : public HLTFilter {
    public:
       explicit HLTElectronPixelMatchFilter(const edm::ParameterSet&);
       ~HLTElectronPixelMatchFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:
@@ -44,10 +44,10 @@ class HLTElectronPixelMatchFilter : public HLTFilter {
 
       double npixelmatchcut_;     // number of pixelmatch hits
       int    ncandcut_;           // number of electrons required
-      
+
       bool doIsolated_;
-      edm::InputTag L1IsoCollTag_; 
-      edm::InputTag L1NonIsoCollTag_; 
+      edm::InputTag L1IsoCollTag_;
+      edm::InputTag L1NonIsoCollTag_;
 };
 
 #endif //HLTElectronPixelMatchFilter_h

--- a/HLTrigger/Egamma/interface/HLTElectronPixelMatchFilter.h
+++ b/HLTrigger/Egamma/interface/HLTElectronPixelMatchFilter.h
@@ -27,7 +27,7 @@ class HLTElectronPixelMatchFilter : public HLTFilter {
    public:
       explicit HLTElectronPixelMatchFilter(const edm::ParameterSet&);
       ~HLTElectronPixelMatchFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTPMDocaFilter.h
+++ b/HLTrigger/Egamma/interface/HLTPMDocaFilter.h
@@ -4,9 +4,9 @@
 /** \class HLTPMDocaFilter
  *
  *  Original Author: Jeremy Werner
- *  Institution: Princeton University, USA                        
- *  Contact: Jeremy.Werner@cern.ch 
- *  Date: February 21, 2007  
+ *  Institution: Princeton University, USA
+ *  Contact: Jeremy.Werner@cern.ch
+ *  Date: February 21, 2007
  *
  */
 
@@ -27,7 +27,7 @@ class HLTPMDocaFilter : public HLTFilter {
    public:
       explicit HLTPMDocaFilter(const edm::ParameterSet&);
       ~HLTPMDocaFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTPMDocaFilter.h
+++ b/HLTrigger/Egamma/interface/HLTPMDocaFilter.h
@@ -27,7 +27,7 @@ class HLTPMDocaFilter : public HLTFilter {
    public:
       explicit HLTPMDocaFilter(const edm::ParameterSet&);
       ~HLTPMDocaFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTPMMassFilter.h
+++ b/HLTrigger/Egamma/interface/HLTPMMassFilter.h
@@ -57,7 +57,7 @@ class HLTPMMassFilter : public HLTFilter {
    public:
       explicit HLTPMMassFilter(const edm::ParameterSet&);
       ~HLTPMMassFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/interface/HLTPMMassFilter.h
+++ b/HLTrigger/Egamma/interface/HLTPMMassFilter.h
@@ -3,7 +3,7 @@
 
 /** \class HLTPMMassFilter
  *
- *  Original Author: Jeremy Werner 
+ *  Original Author: Jeremy Werner
  *  Institution: Princeton University, USA
  *  Contact: Jeremy.Werner@cern.ch
  *  Date: February 21, 2007
@@ -17,7 +17,6 @@
 #include "DataFormats/Math/interface/Point3D.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
@@ -58,13 +57,11 @@ class HLTPMMassFilter : public HLTFilter {
    public:
       explicit HLTPMMassFilter(const edm::ParameterSet&);
       ~HLTPMMassFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;      
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:
-      TLorentzVector approxMomAtVtx( const MagneticField *magField, const GlobalPoint& xvert, const reco::SuperClusterRef sc, int charge) ;
-
-      edm::ESHandle<MagneticField> theMagField;
+      TLorentzVector approxMomAtVtx( const MagneticField *magField, const GlobalPoint& xvert, const reco::SuperClusterRef sc, int charge) const;
 
       edm::InputTag candTag_;     // input tag identifying product contains filtered egammas
       edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> candToken_;
@@ -78,8 +75,8 @@ class HLTPMMassFilter : public HLTFilter {
       bool   relaxed_;
       bool   isElectron1_;
       bool   isElectron2_;
-      edm::InputTag L1IsoCollTag_; 
-      edm::InputTag L1NonIsoCollTag_; 
+      edm::InputTag L1IsoCollTag_;
+      edm::InputTag L1NonIsoCollTag_;
 
 };
 

--- a/HLTrigger/Egamma/interface/HLTPMMassFilter.h
+++ b/HLTrigger/Egamma/interface/HLTPMMassFilter.h
@@ -58,7 +58,7 @@ class HLTPMMassFilter : public HLTFilter {
    public:
       explicit HLTPMMassFilter(const edm::ParameterSet&);
       ~HLTPMMassFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);      
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;      
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/Egamma/src/HLTDisplacedEgammaFilter.cc
+++ b/HLTrigger/Egamma/src/HLTDisplacedEgammaFilter.cc
@@ -19,13 +19,13 @@
 //
 // constructors and destructor
 //
-HLTDisplacedEgammaFilter::HLTDisplacedEgammaFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTDisplacedEgammaFilter::HLTDisplacedEgammaFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   inputTag_    = iConfig.getParameter< edm::InputTag > ("inputTag");
   ncandcut_    = iConfig.getParameter<int> ("ncandcut");
   relaxed_     = iConfig.getParameter<bool> ("relaxed") ;
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand"); 
-  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand"); 
+  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand");
+  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
 
   inputTrk   = iConfig.getParameter< edm::InputTag > ("inputTrack");
   trkPtCut   = iConfig.getParameter<double> ("trackPtCut");
@@ -34,7 +34,7 @@ HLTDisplacedEgammaFilter::HLTDisplacedEgammaFilter(const edm::ParameterSet& iCon
 
   rechitsEB  = iConfig.getParameter< edm::InputTag > ("RecHitsEB");
   rechitsEE  = iConfig.getParameter< edm::InputTag > ("RecHitsEE");
-  
+
   EBOnly       = iConfig.getParameter<bool> ("EBOnly") ;
   sMin_min     = iConfig.getParameter<double> ("sMin_min");
   sMin_max     = iConfig.getParameter<double> ("sMin_max");
@@ -52,7 +52,7 @@ HLTDisplacedEgammaFilter::HLTDisplacedEgammaFilter(const edm::ParameterSet& iCon
 
 HLTDisplacedEgammaFilter::~HLTDisplacedEgammaFilter(){}
 
-void 
+void
 HLTDisplacedEgammaFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
    edm::ParameterSetDescription desc;
    makeHLTFilterDescription(desc);
@@ -80,7 +80,7 @@ HLTDisplacedEgammaFilter::fillDescriptions(edm::ConfigurationDescriptions& descr
 // ------------ method called to produce the data  ------------
 
 bool
-HLTDisplacedEgammaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTDisplacedEgammaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace trigger;
 
@@ -108,14 +108,14 @@ HLTDisplacedEgammaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
   iEvent.getByToken( rechitsEBToken_, rechitsEB_ );
   iEvent.getByToken( rechitsEEToken_, rechitsEE_ );
 
-  std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > recoecalcands;   
+  std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > recoecalcands;
   PrevFilterOutput->getObjects(TriggerCluster, recoecalcands);
- 
+
   // look at all candidates,  check cuts and add to filter object
   int n(0);
 
   for (unsigned int i=0; i<recoecalcands.size(); i++) {
-    
+
     ref = recoecalcands[i] ;
     if ( EBOnly &&  std::abs( ref->eta() ) >= 1.479  ) continue ;
 
@@ -130,15 +130,15 @@ HLTDisplacedEgammaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
     if ( sMin < sMin_min || sMin > sMin_max ) continue ;
     if ( sMaj < sMaj_min || sMaj > sMaj_max ) continue ;
 
-    // seed Time 
+    // seed Time
     std::pair<DetId, float> maxRH = EcalClusterTools::getMaximum( *SCseed, rechits );
     DetId seedCrystalId = maxRH.first;
     EcalRecHitCollection::const_iterator seedRH = rechits->find(seedCrystalId);
     float seedTime = (float)seedRH->time();
     if ( seedTime < seedTimeMin || seedTime > seedTimeMax ) continue ;
- 
+
     //Track Veto
-    
+
     int nTrk = 0 ;
     for (reco::TrackCollection::const_iterator it = tracks->begin(); it != tracks->end(); it++ )  {
         if ( it->pt() < trkPtCut ) continue ;
@@ -147,17 +147,17 @@ HLTDisplacedEgammaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
         if ( dR < trkdRCut )  nTrk++ ;
         if ( nTrk > maxTrkCut ) break ;
     }
-    if ( nTrk > maxTrkCut ) continue ;     
-    
+    if ( nTrk > maxTrkCut ) continue ;
+
 
     n++;
     // std::cout << "Passed eta: " << ref->eta() << std::endl;
     filterproduct.addObject(TriggerCluster, ref);
   }
-  
-  
+
+
   // filter decision
   bool accept(n>=ncandcut_);
-  
+
   return accept;
 }

--- a/HLTrigger/Egamma/src/HLTDisplacedEgammaFilter.cc
+++ b/HLTrigger/Egamma/src/HLTDisplacedEgammaFilter.cc
@@ -80,7 +80,7 @@ HLTDisplacedEgammaFilter::fillDescriptions(edm::ConfigurationDescriptions& descr
 // ------------ method called to produce the data  ------------
 
 bool
-HLTDisplacedEgammaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTDisplacedEgammaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace trigger;
 

--- a/HLTrigger/Egamma/src/HLTEgammaAllCombMassFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaAllCombMassFilter.cc
@@ -44,7 +44,7 @@ HLTEgammaAllCombMassFilter::fillDescriptions(edm::ConfigurationDescriptions& des
 
 // ------------ method called to produce the data  ------------
 
-bool HLTEgammaAllCombMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTEgammaAllCombMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   //right, issue 1, we dont know if this is a TriggerElectron, TriggerPhoton, TriggerCluster (should never be a TriggerCluster btw as that implies the 4-vectors are not stored in AOD)
 

--- a/HLTrigger/Egamma/src/HLTEgammaAllCombMassFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaAllCombMassFilter.cc
@@ -20,7 +20,7 @@
 //
 // constructors and destructor
 //
-HLTEgammaAllCombMassFilter::HLTEgammaAllCombMassFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTEgammaAllCombMassFilter::HLTEgammaAllCombMassFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   firstLegLastFilterTag_ = iConfig.getParameter<edm::InputTag>("firstLegLastFilter");
   secondLegLastFilterTag_= iConfig.getParameter<edm::InputTag>("secondLegLastFilter");
@@ -44,13 +44,13 @@ HLTEgammaAllCombMassFilter::fillDescriptions(edm::ConfigurationDescriptions& des
 
 // ------------ method called to produce the data  ------------
 
-bool HLTEgammaAllCombMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTEgammaAllCombMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   //right, issue 1, we dont know if this is a TriggerElectron, TriggerPhoton, TriggerCluster (should never be a TriggerCluster btw as that implies the 4-vectors are not stored in AOD)
 
   //trigger::TriggerObjectType firstLegTrigType;
   std::vector<math::XYZTLorentzVector> firstLegP4s;
-  
+
   //trigger::TriggerObjectType secondLegTrigType;
   std::vector<math::XYZTLorentzVector> secondLegP4s;
 
@@ -60,36 +60,36 @@ bool HLTEgammaAllCombMassFilter::hltFilter(edm::Event& iEvent, const edm::EventS
   getP4OfLegCands(iEvent,secondLegLastFilterToken_,secondLegP4s);
 
   bool accept=false;
-  for(size_t firstLegNr=0;firstLegNr<firstLegP4s.size();firstLegNr++){ 
+  for(size_t firstLegNr=0;firstLegNr<firstLegP4s.size();firstLegNr++){
     for(size_t secondLegNr=0;secondLegNr<secondLegP4s.size();secondLegNr++){
       math::XYZTLorentzVector pairP4 = firstLegP4s[firstLegNr] + secondLegP4s[secondLegNr];
       double mass = pairP4.M();
       if(mass>=minMass_) accept=true;
     }
   }
-  for(size_t firstLegNr=0;firstLegNr<firstLegP4s.size();firstLegNr++){ 
+  for(size_t firstLegNr=0;firstLegNr<firstLegP4s.size();firstLegNr++){
     for(size_t secondLegNr=0;secondLegNr<firstLegP4s.size();secondLegNr++){
       math::XYZTLorentzVector pairP4 = firstLegP4s[firstLegNr] + firstLegP4s[secondLegNr];
       double mass = pairP4.M();
       if(mass>=minMass_) accept=true;
     }
   }
-  for(size_t firstLegNr=0;firstLegNr<secondLegP4s.size();firstLegNr++){ 
+  for(size_t firstLegNr=0;firstLegNr<secondLegP4s.size();firstLegNr++){
     for(size_t secondLegNr=0;secondLegNr<secondLegP4s.size();secondLegNr++){
       math::XYZTLorentzVector pairP4 = secondLegP4s[firstLegNr] + secondLegP4s[secondLegNr];
       double mass = pairP4.M();
       if(mass>=minMass_) accept=true;
     }
   }
-  
+
   return accept;
 }
 
 void  HLTEgammaAllCombMassFilter::getP4OfLegCands(const edm::Event& iEvent, const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs>& filterToken, std::vector<math::XYZTLorentzVector>& p4s)
-{ 
+{
   edm::Handle<trigger::TriggerFilterObjectWithRefs> filterOutput;
   iEvent.getByToken(filterToken,filterOutput);
-  
+
   //its easier on the if statement flow if I try everything at once, shouldnt add to timing
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > phoCands;
   filterOutput->getObjects(trigger::TriggerPhoton,phoCands);

--- a/HLTrigger/Egamma/src/HLTEgammaCaloIsolFilterPairs.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaCaloIsolFilterPairs.cc
@@ -72,7 +72,7 @@ HLTEgammaCaloIsolFilterPairs::fillDescriptions(edm::ConfigurationDescriptions& d
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaCaloIsolFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTEgammaCaloIsolFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace trigger;
 

--- a/HLTrigger/Egamma/src/HLTEgammaCaloIsolFilterPairs.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaCaloIsolFilterPairs.cc
@@ -1,6 +1,6 @@
 /** \class EgammaHLTCaloIsolFilterPairs
  *
- * 
+ *
  *  \author Alessio Ghezzi
  *
  */
@@ -16,7 +16,7 @@
 //
 // constructors and destructor
 //
-HLTEgammaCaloIsolFilterPairs::HLTEgammaCaloIsolFilterPairs(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTEgammaCaloIsolFilterPairs::HLTEgammaCaloIsolFilterPairs(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   candTag_ = iConfig.getParameter< edm::InputTag > ("candTag");
   isoTag_ = iConfig.getParameter< edm::InputTag > ("isoTag");
@@ -46,7 +46,7 @@ HLTEgammaCaloIsolFilterPairs::HLTEgammaCaloIsolFilterPairs(const edm::ParameterS
 
 HLTEgammaCaloIsolFilterPairs::~HLTEgammaCaloIsolFilterPairs(){}
 
-void 
+void
 HLTEgammaCaloIsolFilterPairs::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
    edm::ParameterSetDescription desc;
    makeHLTFilterDescription(desc);
@@ -85,11 +85,11 @@ HLTEgammaCaloIsolFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetu
   //get hold of ecal isolation association map
   edm::Handle<reco::RecoEcalCandidateIsolationMap> depMap;
   iEvent.getByToken (isoToken_,depMap);
-  
+
   //get hold of ecal isolation association map
   edm::Handle<reco::RecoEcalCandidateIsolationMap> depNonIsoMap;
   if(AlsoNonIso_1 || AlsoNonIso_2) iEvent.getByToken (nonIsoToken_,depNonIsoMap);
-  
+
 
   int n = 0;
    // the list should be interpreted as pairs:
@@ -100,7 +100,7 @@ HLTEgammaCaloIsolFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetu
 
   // Should I check that the size of recoecalcands is even ?
   for (unsigned int i=0; i<recoecalcands.size(); i=i+2) {
-    
+
     edm::Ref<reco::RecoEcalCandidateCollection> r1 = recoecalcands[i];
     edm::Ref<reco::RecoEcalCandidateCollection> r2 = recoecalcands[i+1];
     // std::cout<<"CaloIsol 1) Et Eta phi: "<<r1->et()<<" "<<r1->eta()<<" "<<r1->phi()<<" 2) Et eta phi: "<<r2->et()<<" "<<r2->eta()<<" "<<r2->phi()<<std::endl;
@@ -112,20 +112,20 @@ HLTEgammaCaloIsolFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetu
 	filterproduct.addObject(TriggerCluster, r2);
       }
   }
-  
+
   // filter decision
   bool accept(n>=1);
-  
+
   return accept;
 }
 
-bool HLTEgammaCaloIsolFilterPairs::PassCaloIsolation(edm::Ref<reco::RecoEcalCandidateCollection> ref,const reco::RecoEcalCandidateIsolationMap& IsoMap,const reco::RecoEcalCandidateIsolationMap& NonIsoMap, int which, bool ChekAlsoNonIso){
+bool HLTEgammaCaloIsolFilterPairs::PassCaloIsolation(edm::Ref<reco::RecoEcalCandidateCollection> ref,const reco::RecoEcalCandidateIsolationMap& IsoMap,const reco::RecoEcalCandidateIsolationMap& NonIsoMap, int which, bool ChekAlsoNonIso) const {
 
-  
+
   reco::RecoEcalCandidateIsolationMap::const_iterator mapi = IsoMap.find( ref );
 
   if(mapi==IsoMap.end()) {
-    if(ChekAlsoNonIso) mapi = NonIsoMap.find( ref ); 
+    if(ChekAlsoNonIso) mapi = NonIsoMap.find( ref );
   }
 
   float vali = mapi->val;
@@ -141,7 +141,7 @@ bool HLTEgammaCaloIsolFilterPairs::PassCaloIsolation(edm::Ref<reco::RecoEcalCand
     else if(which==2){
       isolcut = isolcut_EB2;
       FracCut =  FracCut_EB2;
-      IsoloEt2  =  IsoloEt2_EB2;    
+      IsoloEt2  =  IsoloEt2_EB2;
     }
     else {return false;}
   }
@@ -154,11 +154,11 @@ bool HLTEgammaCaloIsolFilterPairs::PassCaloIsolation(edm::Ref<reco::RecoEcalCand
     else if(which==2){
       isolcut = isolcut_EE2;
       FracCut =  FracCut_EE2;
-      IsoloEt2 = IsoloEt2_EE2;    
+      IsoloEt2 = IsoloEt2_EE2;
     }
-    else {return false;}   
+    else {return false;}
   }
-  
+
   if ( vali < isolcut || IsoOE < FracCut || IsoOE2 < IsoloEt2 ) { return true;}
   return false;
 }

--- a/HLTrigger/Egamma/src/HLTEgammaCaloIsolFilterPairs.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaCaloIsolFilterPairs.cc
@@ -72,7 +72,7 @@ HLTEgammaCaloIsolFilterPairs::fillDescriptions(edm::ConfigurationDescriptions& d
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaCaloIsolFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTEgammaCaloIsolFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace trigger;
 

--- a/HLTrigger/Egamma/src/HLTEgammaCombMassFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaCombMassFilter.cc
@@ -20,7 +20,7 @@
 //
 // constructors and destructor
 //
-HLTEgammaCombMassFilter::HLTEgammaCombMassFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTEgammaCombMassFilter::HLTEgammaCombMassFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   firstLegLastFilterTag_ = iConfig.getParameter<edm::InputTag>("firstLegLastFilter");
   secondLegLastFilterTag_= iConfig.getParameter<edm::InputTag>("secondLegLastFilter");
@@ -42,13 +42,13 @@ HLTEgammaCombMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descri
 }
 
 // ------------ method called to produce the data  ------------
-bool HLTEgammaCombMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTEgammaCombMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   //right, issue 1, we dont know if this is a TriggerElectron, TriggerPhoton, TriggerCluster (should never be a TriggerCluster btw as that implies the 4-vectors are not stored in AOD)
 
   //trigger::TriggerObjectType firstLegTrigType;
   std::vector<math::XYZTLorentzVector> firstLegP4s;
-  
+
   //trigger::TriggerObjectType secondLegTrigType;
   std::vector<math::XYZTLorentzVector> secondLegP4s;
 
@@ -58,22 +58,22 @@ bool HLTEgammaCombMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetu
   getP4OfLegCands(iEvent,secondLegLastFilterToken_,secondLegP4s);
 
   bool accept=false;
-  for(size_t firstLegNr=0;firstLegNr<firstLegP4s.size();firstLegNr++){ 
+  for(size_t firstLegNr=0;firstLegNr<firstLegP4s.size();firstLegNr++){
     for(size_t secondLegNr=0;secondLegNr<secondLegP4s.size();secondLegNr++){
       math::XYZTLorentzVector pairP4 = firstLegP4s[firstLegNr] + secondLegP4s[secondLegNr];
       double mass = pairP4.M();
       if(mass>=minMass_) accept=true;
     }
   }
-  
+
   return accept;
 }
 
 void  HLTEgammaCombMassFilter::getP4OfLegCands(const edm::Event& iEvent, const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs>& filterToken, std::vector<math::XYZTLorentzVector>& p4s)
-{ 
+{
   edm::Handle<trigger::TriggerFilterObjectWithRefs> filterOutput;
   iEvent.getByToken(filterToken,filterOutput);
-  
+
   //its easier on the if statement flow if I try everything at once, shouldnt add to timing
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > phoCands;
   filterOutput->getObjects(trigger::TriggerPhoton,phoCands);

--- a/HLTrigger/Egamma/src/HLTEgammaCombMassFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaCombMassFilter.cc
@@ -42,7 +42,7 @@ HLTEgammaCombMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descri
 }
 
 // ------------ method called to produce the data  ------------
-bool HLTEgammaCombMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTEgammaCombMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   //right, issue 1, we dont know if this is a TriggerElectron, TriggerPhoton, TriggerCluster (should never be a TriggerCluster btw as that implies the 4-vectors are not stored in AOD)
 

--- a/HLTrigger/Egamma/src/HLTEgammaDoubleEtDeltaPhiFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaDoubleEtDeltaPhiFilter.cc
@@ -1,7 +1,7 @@
 /** \class HLTEgammaDoubleEtDeltaPhiFilter
- *  This filter will require only two HLT photons and 
+ *  This filter will require only two HLT photons and
  *  DeltaPhi between the two photons larger than 2.5
- * 
+ *
  *  \author Li Wenbo (PKU)
  *
  */
@@ -19,20 +19,20 @@
 //
 // constructors and destructor
 //
-HLTEgammaDoubleEtDeltaPhiFilter::HLTEgammaDoubleEtDeltaPhiFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTEgammaDoubleEtDeltaPhiFilter::HLTEgammaDoubleEtDeltaPhiFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
    inputTag_ = iConfig.getParameter< edm::InputTag > ("inputTag");
    etcut_  = iConfig.getParameter<double> ("etcut");
    minDeltaPhi_ =   iConfig.getParameter<double> ("minDeltaPhi");
    relaxed_ = iConfig.getUntrackedParameter<bool> ("relaxed",true) ;
-   L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand"); 
+   L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand");
    L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
    inputToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(inputTag_);
 }
 
 HLTEgammaDoubleEtDeltaPhiFilter::~HLTEgammaDoubleEtDeltaPhiFilter(){}
 
-void 
+void
 HLTEgammaDoubleEtDeltaPhiFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
    edm::ParameterSetDescription desc;
    makeHLTFilterDescription(desc);
@@ -47,7 +47,7 @@ HLTEgammaDoubleEtDeltaPhiFilter::fillDescriptions(edm::ConfigurationDescriptions
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaDoubleEtDeltaPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTEgammaDoubleEtDeltaPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
    using namespace trigger;
    // The filter object
@@ -59,11 +59,11 @@ HLTEgammaDoubleEtDeltaPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventS
    // get hold of filtered candidates
    edm::Handle<trigger::TriggerFilterObjectWithRefs> PrevFilterOutput;
    iEvent.getByToken (inputToken_,PrevFilterOutput);
-  
+
    std::vector<edm::Ref<reco::RecoEcalCandidateCollection> >  recoecalcands;
    PrevFilterOutput->getObjects(TriggerCluster,  recoecalcands);
    if(recoecalcands.empty()) PrevFilterOutput->getObjects(TriggerPhoton,recoecalcands);  //we dont know if its type trigger cluster or trigger photon
- 
+
    // Refs to the two Candidate objects used to calculate deltaPhi
    edm::Ref<reco::RecoEcalCandidateCollection> ref1, ref2;
 
@@ -78,19 +78,19 @@ HLTEgammaDoubleEtDeltaPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventS
       }
    }
 
-   // if there are only two Candidate objects, calculate deltaPhi  
+   // if there are only two Candidate objects, calculate deltaPhi
    double deltaPhi(0.0);
    if(n==2) {
       deltaPhi = fabs(ref1->phi()-ref2->phi());
       if(deltaPhi>M_PI) deltaPhi = 2*M_PI - deltaPhi;
 
       filterproduct.addObject(TriggerCluster, ref1);
-      filterproduct.addObject(TriggerCluster, ref2);  
-   } 
-        
+      filterproduct.addObject(TriggerCluster, ref2);
+   }
+
    // filter decision
    bool accept(n==2 && deltaPhi>minDeltaPhi_);
-  
+
    return accept;
 }
 

--- a/HLTrigger/Egamma/src/HLTEgammaDoubleEtDeltaPhiFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaDoubleEtDeltaPhiFilter.cc
@@ -47,7 +47,7 @@ HLTEgammaDoubleEtDeltaPhiFilter::fillDescriptions(edm::ConfigurationDescriptions
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaDoubleEtDeltaPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTEgammaDoubleEtDeltaPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
    using namespace trigger;
    // The filter object

--- a/HLTrigger/Egamma/src/HLTEgammaDoubleEtFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaDoubleEtFilter.cc
@@ -57,7 +57,7 @@ HLTEgammaDoubleEtFilter::fillDescriptions(edm::ConfigurationDescriptions& descri
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaDoubleEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTEgammaDoubleEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace trigger;
 

--- a/HLTrigger/Egamma/src/HLTEgammaDoubleEtFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaDoubleEtFilter.cc
@@ -27,21 +27,21 @@ public:
 //
 // constructors and destructor
 //
-HLTEgammaDoubleEtFilter::HLTEgammaDoubleEtFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTEgammaDoubleEtFilter::HLTEgammaDoubleEtFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   candTag_ = iConfig.getParameter< edm::InputTag > ("candTag");
   etcut1_  = iConfig.getParameter<double> ("etcut1");
   etcut2_  = iConfig.getParameter<double> ("etcut2");
   npaircut_  = iConfig.getParameter<int> ("npaircut");
   relaxed_ = iConfig.getUntrackedParameter<bool> ("relaxed",true) ;
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand"); 
-  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand"); 
+  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand");
+  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
   candToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(candTag_);
 }
 
 HLTEgammaDoubleEtFilter::~HLTEgammaDoubleEtFilter(){}
 
-void 
+void
 HLTEgammaDoubleEtFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
    edm::ParameterSetDescription desc;
    makeHLTFilterDescription(desc);
@@ -57,7 +57,7 @@ HLTEgammaDoubleEtFilter::fillDescriptions(edm::ConfigurationDescriptions& descri
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaDoubleEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTEgammaDoubleEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace trigger;
 
@@ -76,7 +76,7 @@ HLTEgammaDoubleEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iS
 
   // look at all candidates,  check cuts and add to filter object
   int n(0);
-  
+
   // Sort the list
   std::sort(mysortedrecoecalcands.begin(), mysortedrecoecalcands.end(), EgammaHLTEtSortCriterium());
   edm::Ref<reco::RecoEcalCandidateCollection> ref1, ref2;
@@ -93,13 +93,13 @@ HLTEgammaDoubleEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iS
       }
     }
   }
-  
+
 
   // filter decision
   bool accept(n>=npaircut_);
-  
+
   return accept;
 }
 
 
-  
+

--- a/HLTrigger/Egamma/src/HLTEgammaDoubleEtPhiFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaDoubleEtPhiFilter.cc
@@ -25,7 +25,7 @@ public:
 //
 // constructors and destructor
 //
-HLTEgammaDoubleEtPhiFilter::HLTEgammaDoubleEtPhiFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTEgammaDoubleEtPhiFilter::HLTEgammaDoubleEtPhiFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
    candTag_ = iConfig.getParameter< edm::InputTag > ("candTag");
    etcut1_  = iConfig.getParameter<double> ("etcut1");
@@ -40,7 +40,7 @@ HLTEgammaDoubleEtPhiFilter::HLTEgammaDoubleEtPhiFilter(const edm::ParameterSet& 
 
 HLTEgammaDoubleEtPhiFilter::~HLTEgammaDoubleEtPhiFilter(){}
 
-void 
+void
 HLTEgammaDoubleEtPhiFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
    edm::ParameterSetDescription desc;
    makeHLTFilterDescription(desc);
@@ -57,7 +57,7 @@ HLTEgammaDoubleEtPhiFilter::fillDescriptions(edm::ConfigurationDescriptions& des
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaDoubleEtPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTEgammaDoubleEtPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace trigger;
 
@@ -66,7 +66,7 @@ HLTEgammaDoubleEtPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup&
 
   edm::Handle<trigger::TriggerFilterObjectWithRefs> PrevFilterOutput;
   iEvent.getByToken (candToken_,PrevFilterOutput);
-  
+
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> >  mysortedrecoecalcands;
   PrevFilterOutput->getObjects(TriggerCluster,  mysortedrecoecalcands);
   if(mysortedrecoecalcands.empty()) PrevFilterOutput->getObjects(TriggerCluster,mysortedrecoecalcands);  //we dont know if its type trigger cluster or trigger photon
@@ -78,11 +78,11 @@ HLTEgammaDoubleEtPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup&
   for (unsigned int i=0; i<mysortedrecoecalcands.size(); i++) {
     ref1 = mysortedrecoecalcands[i];
     if( ref1->et() >= etcut1_){
-      
+
       for (unsigned int j=i+1; j<mysortedrecoecalcands.size(); j++) {
 	ref2 = mysortedrecoecalcands[j];
 	if( ref2->et() >= etcut2_ ){
-	  
+	
 	  // Acoplanarity
 	  double acop = fabs(ref1->phi()-ref2->phi());
 	  if (acop>M_PI) acop = 2*M_PI - acop;
@@ -108,9 +108,9 @@ HLTEgammaDoubleEtPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup&
 
   // filter decision
   bool accept(n>=npaircut_);
-  
+
   return accept;
 }
 
 
-  
+

--- a/HLTrigger/Egamma/src/HLTEgammaDoubleEtPhiFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaDoubleEtPhiFilter.cc
@@ -57,7 +57,7 @@ HLTEgammaDoubleEtPhiFilter::fillDescriptions(edm::ConfigurationDescriptions& des
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaDoubleEtPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTEgammaDoubleEtPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace trigger;
 

--- a/HLTrigger/Egamma/src/HLTEgammaDoubleLegCombFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaDoubleLegCombFilter.cc
@@ -52,7 +52,7 @@ HLTEgammaDoubleLegCombFilter::~HLTEgammaDoubleLegCombFilter(){}
 
 
 // ------------ method called to produce the data  ------------
-bool HLTEgammaDoubleLegCombFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTEgammaDoubleLegCombFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   //right, issue 1, we dont know if this is a TriggerElectron, TriggerPhoton, TriggerCluster (should never be a TriggerCluster btw as that implies the 4-vectors are not stored in AOD)
 

--- a/HLTrigger/Egamma/src/HLTEgammaDoubleLegCombFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaDoubleLegCombFilter.cc
@@ -52,7 +52,7 @@ HLTEgammaDoubleLegCombFilter::~HLTEgammaDoubleLegCombFilter(){}
 
 
 // ------------ method called to produce the data  ------------
-bool HLTEgammaDoubleLegCombFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTEgammaDoubleLegCombFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   //right, issue 1, we dont know if this is a TriggerElectron, TriggerPhoton, TriggerCluster (should never be a TriggerCluster btw as that implies the 4-vectors are not stored in AOD)
 

--- a/HLTrigger/Egamma/src/HLTEgammaDoubleLegCombFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaDoubleLegCombFilter.cc
@@ -23,7 +23,7 @@
 //
 // constructors and destructor
 //
-HLTEgammaDoubleLegCombFilter::HLTEgammaDoubleLegCombFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTEgammaDoubleLegCombFilter::HLTEgammaDoubleLegCombFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   firstLegLastFilterTag_ = iConfig.getParameter<edm::InputTag>("firstLegLastFilter");
   secondLegLastFilterTag_= iConfig.getParameter<edm::InputTag>("secondLegLastFilter");
@@ -58,48 +58,48 @@ bool HLTEgammaDoubleLegCombFilter::hltFilter(edm::Event& iEvent, const edm::Even
 
   //trigger::TriggerObjectType firstLegTrigType;
   std::vector<math::XYZPoint> firstLegP3s;
-  
+
   //trigger::TriggerObjectType secondLegTrigType;
   std::vector<math::XYZPoint> secondLegP3s;
 
   getP3OfLegCands(iEvent,firstLegLastFilterToken_,firstLegP3s);
   getP3OfLegCands(iEvent,secondLegLastFilterToken_,secondLegP3s);
 
-  std::vector<std::pair<int,int> > matchedCands; 
+  std::vector<std::pair<int,int> > matchedCands;
   matchCands(firstLegP3s,secondLegP3s,matchedCands);
 
 
   int nr1stLegOnly=0;
   int nr2ndLegOnly=0;
   int nrBoth=0;;
-  
+
   for(size_t candNr=0;candNr<matchedCands.size();candNr++){
     if(matchedCands[candNr].first>=0){ //we found a first leg cand
       if(matchedCands[candNr].second>=0) nrBoth++;//we also found a second leg cand
       else nr1stLegOnly++; //we didnt find a second leg cand
     }else if(matchedCands[candNr].second>=0) nr2ndLegOnly++; //we found a second leg cand but we didnt find a first leg
-    
+
   }
-  
+
   bool accept=false;
   if(nr1stLegOnly + nr2ndLegOnly + nrBoth >= nrRequiredUniqueLeg_) {
     if(nr1stLegOnly>=nrRequiredFirstLeg_ && nr2ndLegOnly>=nrRequiredSecondLeg_) accept=true;
-    else{ 
+    else{
       int nrNeededFirstLeg = std::max(0,nrRequiredFirstLeg_ - nr1stLegOnly);
       int nrNeededSecondLeg = std::max(0,nrRequiredSecondLeg_ - nr2ndLegOnly);
-    
+
       if(nrBoth >= nrNeededFirstLeg + nrNeededSecondLeg) accept = true;
     }
   }
-  
+
   return accept;
 }
 
 //-1 if no match is found
-void  HLTEgammaDoubleLegCombFilter::matchCands(const std::vector<math::XYZPoint>& firstLegP3s,const std::vector<math::XYZPoint>& secondLegP3s,std::vector<std::pair<int,int> >&matchedCands)
+void  HLTEgammaDoubleLegCombFilter::matchCands(const std::vector<math::XYZPoint>& firstLegP3s,const std::vector<math::XYZPoint>& secondLegP3s,std::vector<std::pair<int,int> >&matchedCands) const
 {
   std::vector<size_t> matched2ndLegs;
-  for(size_t firstLegNr=0;firstLegNr<firstLegP3s.size();firstLegNr++){ 
+  for(size_t firstLegNr=0;firstLegNr<firstLegP3s.size();firstLegNr++){
     int matchedNr = -1;
     for(size_t secondLegNr=0;secondLegNr<secondLegP3s.size() && matchedNr==-1;secondLegNr++){
       if(reco::deltaR2(firstLegP3s[firstLegNr],secondLegP3s[secondLegNr])<maxMatchDR_*maxMatchDR_) matchedNr=secondLegNr;
@@ -108,7 +108,7 @@ void  HLTEgammaDoubleLegCombFilter::matchCands(const std::vector<math::XYZPoint>
     if(matchedNr>=0) matched2ndLegs.push_back(static_cast<size_t>(matchedNr));
   }
   std::sort(matched2ndLegs.begin(),matched2ndLegs.end());
-  
+
   for(size_t secondLegNr=0;secondLegNr<secondLegP3s.size();secondLegNr++){
     if(!std::binary_search(matched2ndLegs.begin(),matched2ndLegs.end(),secondLegNr)){ //wasnt matched already
       matchedCands.push_back(std::make_pair<int,int>(-1,secondLegNr));
@@ -118,10 +118,10 @@ void  HLTEgammaDoubleLegCombFilter::matchCands(const std::vector<math::XYZPoint>
 
 //we use position and p3 interchangably here, we only use eta/phi so its alright
 void  HLTEgammaDoubleLegCombFilter::getP3OfLegCands(const edm::Event& iEvent,const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs>& filterToken,std::vector<math::XYZPoint>& p3s)
-{ 
+{
   edm::Handle<trigger::TriggerFilterObjectWithRefs> filterOutput;
   iEvent.getByToken(filterToken,filterOutput);
-  
+
   //its easier on the if statement flow if I try everything at once, shouldnt add to timing
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > phoCands;
   filterOutput->getObjects(trigger::TriggerPhoton,phoCands);
@@ -131,7 +131,7 @@ void  HLTEgammaDoubleLegCombFilter::getP3OfLegCands(const edm::Event& iEvent,con
   filterOutput->getObjects(trigger::TriggerElectron,eleCands);
   std::vector<edm::Ref<reco::CaloJetCollection> > jetCands;
   filterOutput->getObjects(trigger::TriggerJet,jetCands);
- 
+
   if(!phoCands.empty()){ //its photons
     for(size_t candNr=0;candNr<phoCands.size();candNr++){
       p3s.push_back(phoCands[candNr]->superCluster()->position());

--- a/HLTrigger/Egamma/src/HLTEgammaEtFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaEtFilter.cc
@@ -18,19 +18,19 @@
 //
 // constructors and destructor
 //
-HLTEgammaEtFilter::HLTEgammaEtFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTEgammaEtFilter::HLTEgammaEtFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   inputTag_ = iConfig.getParameter< edm::InputTag > ("inputTag");
   etcutEB_  = iConfig.getParameter<double> ("etcutEB");
   etcutEE_  = iConfig.getParameter<double> ("etcutEE");
   ncandcut_  = iConfig.getParameter<int> ("ncandcut");
   relaxed_ = iConfig.getUntrackedParameter<bool> ("relaxed",true) ;
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand"); 
-  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand"); 
+  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand");
+  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
   inputToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(inputTag_);
 }
 
-void 
+void
 HLTEgammaEtFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
    edm::ParameterSetDescription desc;
    makeHLTFilterDescription(desc);
@@ -49,7 +49,7 @@ HLTEgammaEtFilter::~HLTEgammaEtFilter(){}
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTEgammaEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace trigger;
 
@@ -70,24 +70,24 @@ HLTEgammaEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > recoecalcands;                // vref with your specific C++ collection type
   PrevFilterOutput->getObjects(TriggerCluster, recoecalcands);
   if(recoecalcands.empty()) PrevFilterOutput->getObjects(TriggerPhoton,recoecalcands);  //we dont know if its type trigger cluster or trigger photon
-  
+
   // look at all candidates,  check cuts and add to filter object
   int n(0);
 
   for (unsigned int i=0; i<recoecalcands.size(); i++) {
-    
+
     ref = recoecalcands[i] ;
-    
+
     if( ( fabs(ref->eta()) < 1.479 &&  ref->et()  >= etcutEB_ ) || ( fabs(ref->eta()) >= 1.479 &&  ref->et()  >= etcutEE_ ) ){
       n++;
       // std::cout << "Passed eta: " << ref->eta() << std::endl;
       filterproduct.addObject(TriggerCluster, ref);
     }
   }
-  
-  
+
+
   // filter decision
   bool accept(n>=ncandcut_);
-  
+
   return accept;
 }

--- a/HLTrigger/Egamma/src/HLTEgammaEtFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaEtFilter.cc
@@ -49,7 +49,7 @@ HLTEgammaEtFilter::~HLTEgammaEtFilter(){}
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTEgammaEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace trigger;
 

--- a/HLTrigger/Egamma/src/HLTEgammaEtFilterPairs.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaEtFilterPairs.cc
@@ -51,7 +51,7 @@ HLTEgammaEtFilterPairs::~HLTEgammaEtFilterPairs(){}
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaEtFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTEgammaEtFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace trigger;
   // The filter object

--- a/HLTrigger/Egamma/src/HLTEgammaEtFilterPairs.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaEtFilterPairs.cc
@@ -18,7 +18,7 @@
 //
 // constructors and destructor
 //
-HLTEgammaEtFilterPairs::HLTEgammaEtFilterPairs(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTEgammaEtFilterPairs::HLTEgammaEtFilterPairs(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
    inputTag_ = iConfig.getParameter< edm::InputTag > ("inputTag");
    etcutEB1_  = iConfig.getParameter<double> ("etcut1EB");
@@ -26,12 +26,12 @@ HLTEgammaEtFilterPairs::HLTEgammaEtFilterPairs(const edm::ParameterSet& iConfig)
    etcutEB2_  = iConfig.getParameter<double> ("etcut2EB");
    etcutEE2_  = iConfig.getParameter<double> ("etcut2EE");
    relaxed_ = iConfig.getUntrackedParameter<bool> ("relaxed",true) ;
-   L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand"); 
-   L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand"); 
+   L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand");
+   L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
    inputToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(inputTag_);
 }
 
-void 
+void
 HLTEgammaEtFilterPairs::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
    edm::ParameterSetDescription desc;
    makeHLTFilterDescription(desc);
@@ -51,7 +51,7 @@ HLTEgammaEtFilterPairs::~HLTEgammaEtFilterPairs(){}
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaEtFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTEgammaEtFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace trigger;
   // The filter object
@@ -75,7 +75,7 @@ HLTEgammaEtFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
   int n(0);
 
   for (unsigned int i=0; i<recoecalcands.size(); i=i+2) {
-    
+
      edm::Ref<reco::RecoEcalCandidateCollection> r1 = recoecalcands[i];
      edm::Ref<reco::RecoEcalCandidateCollection> r2 = recoecalcands[i+1];
      //  std::cout<<"EtFilter: 1) Et Eta phi: "<<r1->et()<<" "<<r1->eta()<<" "<<r1->phi()<<" 2) Et eta phi: "<<r2->et()<<" "<<r2->eta()<<" "<<r2->phi()<<std::endl;
@@ -89,9 +89,9 @@ HLTEgammaEtFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
     }
   }
 
-  
+
   // filter decision
   bool accept(n>=1);
-  
+
   return accept;
 }

--- a/HLTrigger/Egamma/src/HLTEgammaGenericFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaGenericFilter.cc
@@ -27,18 +27,18 @@ HLTEgammaGenericFilter::HLTEgammaGenericFilter(const edm::ParameterSet& iConfig)
   isoTag_ = iConfig.getParameter< edm::InputTag > ("isoTag");
   nonIsoTag_ = iConfig.getParameter< edm::InputTag > ("nonIsoTag");
 
-  lessThan_ = iConfig.getParameter<bool> ("lessThan");			  
-  useEt_ = iConfig.getParameter<bool> ("useEt");			  
-  thrRegularEB_ = iConfig.getParameter<double> ("thrRegularEB");	  
-  thrRegularEE_ = iConfig.getParameter<double> ("thrRegularEE");	  
-  thrOverEEB_ = iConfig.getParameter<double> ("thrOverEEB");		  
-  thrOverEEE_ = iConfig.getParameter<double> ("thrOverEEE");		  
-  thrOverE2EB_ = iConfig.getParameter<double> ("thrOverE2EB");		  
-  thrOverE2EE_ = iConfig.getParameter<double> ("thrOverE2EE");		  
-  ncandcut_  = iConfig.getParameter<int> ("ncandcut");			  
-  doIsolated_ = iConfig.getParameter<bool> ("doIsolated");		  
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand"); 	  
-  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand"); 
+  lessThan_ = iConfig.getParameter<bool> ("lessThan");			
+  useEt_ = iConfig.getParameter<bool> ("useEt");			
+  thrRegularEB_ = iConfig.getParameter<double> ("thrRegularEB");	
+  thrRegularEE_ = iConfig.getParameter<double> ("thrRegularEE");	
+  thrOverEEB_ = iConfig.getParameter<double> ("thrOverEEB");		
+  thrOverEEE_ = iConfig.getParameter<double> ("thrOverEEE");		
+  thrOverE2EB_ = iConfig.getParameter<double> ("thrOverE2EB");		
+  thrOverE2EE_ = iConfig.getParameter<double> ("thrOverE2EE");		
+  ncandcut_  = iConfig.getParameter<int> ("ncandcut");			
+  doIsolated_ = iConfig.getParameter<bool> ("doIsolated");		
+  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand"); 	
+  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
 
   candToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(candTag_);
   isoToken_ = consumes<reco::RecoEcalCandidateIsolationMap>(isoTag_);
@@ -72,7 +72,7 @@ HLTEgammaGenericFilter::~HLTEgammaGenericFilter(){}
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaGenericFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTEgammaGenericFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace trigger;
   if (saveTags()) {
@@ -83,7 +83,7 @@ HLTEgammaGenericFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
   // Ref to Candidate object to be recorded in filter object
   edm::Ref<reco::RecoEcalCandidateCollection> ref;
 
-  // Set output format 
+  // Set output format
   int trigger_type = trigger::TriggerCluster;
   if (saveTags()) trigger_type = trigger::TriggerPhoton;
 
@@ -93,29 +93,29 @@ HLTEgammaGenericFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > recoecalcands;
   PrevFilterOutput->getObjects(TriggerCluster, recoecalcands);
   if(recoecalcands.empty()) PrevFilterOutput->getObjects(TriggerPhoton,recoecalcands);  //we dont know if its type trigger cluster or trigger photon
- 
+
   //get hold of isolated association map
   edm::Handle<reco::RecoEcalCandidateIsolationMap> depMap;
   iEvent.getByToken (isoToken_,depMap);
-  
+
   //get hold of non-isolated association map
   edm::Handle<reco::RecoEcalCandidateIsolationMap> depNonIsoMap;
   if(!doIsolated_) iEvent.getByToken (nonIsoToken_,depNonIsoMap);
-  
+
   // look at all photons, check cuts and add to filter object
   int n = 0;
-  
+
   for (unsigned int i=0; i<recoecalcands.size(); i++) {
-    
+
     ref = recoecalcands[i];
-    reco::RecoEcalCandidateIsolationMap::const_iterator mapi = (*depMap).find( ref );    
-    if (mapi==(*depMap).end() && !doIsolated_) mapi = (*depNonIsoMap).find( ref ); 
-   
+    reco::RecoEcalCandidateIsolationMap::const_iterator mapi = (*depMap).find( ref );
+    if (mapi==(*depMap).end() && !doIsolated_) mapi = (*depNonIsoMap).find( ref );
+
     float vali = mapi->val;
     float energy = ref->superCluster()->energy();
     float EtaSC = ref->eta();
-    if (useEt_) energy = energy * sin (2*atan(exp(-EtaSC)));   
-    
+    if (useEt_) energy = energy * sin (2*atan(exp(-EtaSC)));
+
     if ( lessThan_ ) {
       if ( (fabs(EtaSC) < 1.479 && vali <= thrRegularEB_) || (fabs(EtaSC) >= 1.479 && vali <= thrRegularEE_) ) {
 	n++;
@@ -152,7 +152,7 @@ HLTEgammaGenericFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
       }
     }
   }
-  
+
   // filter decision
   bool accept(n>=ncandcut_);
 

--- a/HLTrigger/Egamma/src/HLTEgammaGenericFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaGenericFilter.cc
@@ -72,7 +72,7 @@ HLTEgammaGenericFilter::~HLTEgammaGenericFilter(){}
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaGenericFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTEgammaGenericFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace trigger;
   if (saveTags()) {

--- a/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticEtaFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticEtaFilter.cc
@@ -27,28 +27,28 @@ HLTEgammaGenericQuadraticEtaFilter::HLTEgammaGenericQuadraticEtaFilter(const edm
   isoTag_ = iConfig.getParameter< edm::InputTag > ("isoTag");
   nonIsoTag_ = iConfig.getParameter< edm::InputTag > ("nonIsoTag");
 
-  lessThan_ = iConfig.getParameter<bool> ("lessThan");			  
-  useEt_ = iConfig.getParameter<bool> ("useEt");			  
-  etaBoundaryEB12_ = iConfig.getParameter<double> ("etaBoundaryEB12");	  
-  etaBoundaryEE12_ = iConfig.getParameter<double> ("etaBoundaryEE12");	  
-  thrRegularEB1_ = iConfig.getParameter<double> ("thrRegularEB1");	  
-  thrRegularEE1_ = iConfig.getParameter<double> ("thrRegularEE1");	  
-  thrOverEEB1_ = iConfig.getParameter<double> ("thrOverEEB1");		  
-  thrOverEEE1_ = iConfig.getParameter<double> ("thrOverEEE1");		  
-  thrOverE2EB1_ = iConfig.getParameter<double> ("thrOverE2EB1");		  
-  thrOverE2EE1_ = iConfig.getParameter<double> ("thrOverE2EE1");		  
-  thrRegularEB2_ = iConfig.getParameter<double> ("thrRegularEB2");	  
-  thrRegularEE2_ = iConfig.getParameter<double> ("thrRegularEE2");	  
-  thrOverEEB2_ = iConfig.getParameter<double> ("thrOverEEB2");		  
-  thrOverEEE2_ = iConfig.getParameter<double> ("thrOverEEE2");		  
-  thrOverE2EB2_ = iConfig.getParameter<double> ("thrOverE2EB2");		  
-  thrOverE2EE2_ = iConfig.getParameter<double> ("thrOverE2EE2");		  
-  				     	  
-  ncandcut_  = iConfig.getParameter<int> ("ncandcut");			  
-  doIsolated_ = iConfig.getParameter<bool> ("doIsolated");		  
-			     				  
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand"); 	  
-  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand"); 
+  lessThan_ = iConfig.getParameter<bool> ("lessThan");			
+  useEt_ = iConfig.getParameter<bool> ("useEt");			
+  etaBoundaryEB12_ = iConfig.getParameter<double> ("etaBoundaryEB12");	
+  etaBoundaryEE12_ = iConfig.getParameter<double> ("etaBoundaryEE12");	
+  thrRegularEB1_ = iConfig.getParameter<double> ("thrRegularEB1");	
+  thrRegularEE1_ = iConfig.getParameter<double> ("thrRegularEE1");	
+  thrOverEEB1_ = iConfig.getParameter<double> ("thrOverEEB1");		
+  thrOverEEE1_ = iConfig.getParameter<double> ("thrOverEEE1");		
+  thrOverE2EB1_ = iConfig.getParameter<double> ("thrOverE2EB1");		
+  thrOverE2EE1_ = iConfig.getParameter<double> ("thrOverE2EE1");		
+  thrRegularEB2_ = iConfig.getParameter<double> ("thrRegularEB2");	
+  thrRegularEE2_ = iConfig.getParameter<double> ("thrRegularEE2");	
+  thrOverEEB2_ = iConfig.getParameter<double> ("thrOverEEB2");		
+  thrOverEEE2_ = iConfig.getParameter<double> ("thrOverEEE2");		
+  thrOverE2EB2_ = iConfig.getParameter<double> ("thrOverE2EB2");		
+  thrOverE2EE2_ = iConfig.getParameter<double> ("thrOverE2EE2");		
+  				     	
+  ncandcut_  = iConfig.getParameter<int> ("ncandcut");			
+  doIsolated_ = iConfig.getParameter<bool> ("doIsolated");		
+			     				
+  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand"); 	
+  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
 
   candToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(candTag_);
   isoToken_ = consumes<reco::RecoEcalCandidateIsolationMap>(isoTag_);
@@ -93,7 +93,7 @@ HLTEgammaGenericQuadraticEtaFilter::~HLTEgammaGenericQuadraticEtaFilter(){}
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaGenericQuadraticEtaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTEgammaGenericQuadraticEtaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace trigger;
   if ( saveTags() ) {
@@ -105,7 +105,7 @@ HLTEgammaGenericQuadraticEtaFilter::hltFilter(edm::Event& iEvent, const edm::Eve
   // Ref to Candidate object to be recorded in filter object
   edm::Ref<reco::RecoEcalCandidateCollection> ref;
 
-  // Set output format 
+  // Set output format
   int trigger_type = trigger::TriggerCluster;
   if ( saveTags() ) trigger_type = trigger::TriggerPhoton;
 
@@ -120,26 +120,26 @@ HLTEgammaGenericQuadraticEtaFilter::hltFilter(edm::Event& iEvent, const edm::Eve
   //get hold of isolated association map
   edm::Handle<reco::RecoEcalCandidateIsolationMap> depMap;
   iEvent.getByToken (isoToken_,depMap);
-  
+
   //get hold of non-isolated association map
   edm::Handle<reco::RecoEcalCandidateIsolationMap> depNonIsoMap;
   if(!doIsolated_) iEvent.getByToken (nonIsoToken_,depNonIsoMap);
-  
+
   // look at all photons, check cuts and add to filter object
   int n = 0;
-  
+
   for (unsigned int i=0; i<recoecalcands.size(); i++) {
-    
+
     ref = recoecalcands[i];
-    reco::RecoEcalCandidateIsolationMap::const_iterator mapi = (*depMap).find( ref );    
-    if (mapi==(*depMap).end() && !doIsolated_) mapi = (*depNonIsoMap).find( ref ); 
-   
+    reco::RecoEcalCandidateIsolationMap::const_iterator mapi = (*depMap).find( ref );
+    if (mapi==(*depMap).end() && !doIsolated_) mapi = (*depNonIsoMap).find( ref );
+
     float vali = mapi->val;
     float energy = ref->superCluster()->energy();
     float EtaSC = ref->eta();
-    if (useEt_) energy = energy * sin (2*atan(exp(-EtaSC)));   
+    if (useEt_) energy = energy * sin (2*atan(exp(-EtaSC)));
     if (energy < 0.) energy=0.; /* first and second order terms assume non-negative energies */
-    
+
     if ( lessThan_ ) {
       if (fabs(EtaSC) < etaBoundaryEB12_) {
           if ( vali <= thrRegularEB1_ + energy*thrOverEEB1_ + energy*energy*thrOverE2EB1_) {
@@ -190,7 +190,7 @@ HLTEgammaGenericQuadraticEtaFilter::hltFilter(edm::Event& iEvent, const edm::Eve
       }
     }
   }
-  
+
   // filter decision
   bool accept(n>=ncandcut_);
 

--- a/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticEtaFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticEtaFilter.cc
@@ -93,7 +93,7 @@ HLTEgammaGenericQuadraticEtaFilter::~HLTEgammaGenericQuadraticEtaFilter(){}
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaGenericQuadraticEtaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTEgammaGenericQuadraticEtaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace trigger;
   if ( saveTags() ) {

--- a/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticFilter.cc
@@ -27,20 +27,20 @@ HLTEgammaGenericQuadraticFilter::HLTEgammaGenericQuadraticFilter(const edm::Para
   isoTag_ = iConfig.getParameter< edm::InputTag > ("isoTag");
   nonIsoTag_ = iConfig.getParameter< edm::InputTag > ("nonIsoTag");
 
-  lessThan_ = iConfig.getParameter<bool> ("lessThan");			  
-  useEt_ = iConfig.getParameter<bool> ("useEt");			  
-  thrRegularEB_ = iConfig.getParameter<double> ("thrRegularEB");	  
-  thrRegularEE_ = iConfig.getParameter<double> ("thrRegularEE");	  
-  thrOverEEB_ = iConfig.getParameter<double> ("thrOverEEB");		  
-  thrOverEEE_ = iConfig.getParameter<double> ("thrOverEEE");		  
-  thrOverE2EB_ = iConfig.getParameter<double> ("thrOverE2EB");		  
-  thrOverE2EE_ = iConfig.getParameter<double> ("thrOverE2EE");		  
-  				     	  
-  ncandcut_  = iConfig.getParameter<int> ("ncandcut");			  
-  doIsolated_ = iConfig.getParameter<bool> ("doIsolated");		  
-			     				  
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand"); 	  
-  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand"); 
+  lessThan_ = iConfig.getParameter<bool> ("lessThan");			
+  useEt_ = iConfig.getParameter<bool> ("useEt");			
+  thrRegularEB_ = iConfig.getParameter<double> ("thrRegularEB");	
+  thrRegularEE_ = iConfig.getParameter<double> ("thrRegularEE");	
+  thrOverEEB_ = iConfig.getParameter<double> ("thrOverEEB");		
+  thrOverEEE_ = iConfig.getParameter<double> ("thrOverEEE");		
+  thrOverE2EB_ = iConfig.getParameter<double> ("thrOverE2EB");		
+  thrOverE2EE_ = iConfig.getParameter<double> ("thrOverE2EE");		
+  				     	
+  ncandcut_  = iConfig.getParameter<int> ("ncandcut");			
+  doIsolated_ = iConfig.getParameter<bool> ("doIsolated");		
+			     				
+  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand"); 	
+  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
 
   candToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(candTag_);
   isoToken_ = consumes<reco::RecoEcalCandidateIsolationMap>(isoTag_);
@@ -74,7 +74,7 @@ HLTEgammaGenericQuadraticFilter::~HLTEgammaGenericQuadraticFilter(){}
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaGenericQuadraticFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTEgammaGenericQuadraticFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace trigger;
   if (saveTags()) {
@@ -85,7 +85,7 @@ HLTEgammaGenericQuadraticFilter::hltFilter(edm::Event& iEvent, const edm::EventS
   // Ref to Candidate object to be recorded in filter object
   edm::Ref<reco::RecoEcalCandidateCollection> ref;
 
-  // Set output format 
+  // Set output format
   int trigger_type = trigger::TriggerCluster;
   if (saveTags()) trigger_type = trigger::TriggerPhoton;
 
@@ -99,26 +99,26 @@ HLTEgammaGenericQuadraticFilter::hltFilter(edm::Event& iEvent, const edm::EventS
   //get hold of isolated association map
   edm::Handle<reco::RecoEcalCandidateIsolationMap> depMap;
   iEvent.getByToken (isoToken_,depMap);
-  
+
   //get hold of non-isolated association map
   edm::Handle<reco::RecoEcalCandidateIsolationMap> depNonIsoMap;
   if(!doIsolated_) iEvent.getByToken (nonIsoToken_,depNonIsoMap);
-  
+
   // look at all photons, check cuts and add to filter object
   int n = 0;
-  
+
   for (unsigned int i=0; i<recoecalcands.size(); i++) {
-    
+
     ref = recoecalcands[i];
-    reco::RecoEcalCandidateIsolationMap::const_iterator mapi = (*depMap).find( ref );    
-    if (mapi==(*depMap).end() && !doIsolated_) mapi = (*depNonIsoMap).find( ref ); 
-   
+    reco::RecoEcalCandidateIsolationMap::const_iterator mapi = (*depMap).find( ref );
+    if (mapi==(*depMap).end() && !doIsolated_) mapi = (*depNonIsoMap).find( ref );
+
     float vali = mapi->val;
     float energy = ref->superCluster()->energy();
     float EtaSC = ref->eta();
-    if (useEt_) energy = energy * sin (2*atan(exp(-EtaSC)));   
+    if (useEt_) energy = energy * sin (2*atan(exp(-EtaSC)));
     if (energy < 0.) energy=0.; /* first and second order terms assume non-negative energies */
-    
+
     if ( lessThan_ ) {
       if ((fabs(EtaSC) < 1.479 && vali <= thrRegularEB_ + energy*thrOverEEB_ + energy*energy*thrOverE2EB_) || (fabs(EtaSC) >= 1.479 && vali <= thrRegularEE_ + energy*thrOverEEE_ + energy*energy*thrOverE2EE_) ) {
 	  n++;
@@ -133,7 +133,7 @@ HLTEgammaGenericQuadraticFilter::hltFilter(edm::Event& iEvent, const edm::EventS
       }
     }
   }
-  
+
   // filter decision
   bool accept(n>=ncandcut_);
 

--- a/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaGenericQuadraticFilter.cc
@@ -74,7 +74,7 @@ HLTEgammaGenericQuadraticFilter::~HLTEgammaGenericQuadraticFilter(){}
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaGenericQuadraticFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTEgammaGenericQuadraticFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace trigger;
   if (saveTags()) {

--- a/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterPairs.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterPairs.cc
@@ -24,8 +24,9 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include <vector>
+#include <cmath>
 
-#define TWOPI 6.283185308
+#define TWOPI 2*M_PI
 //
 // constructors and destructor
 //
@@ -165,7 +166,7 @@ HLTEgammaL1MatchFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup
   return accept;
 }
 
-bool HLTEgammaL1MatchFilterPairs::CheckL1Matching(edm::Ref<reco::RecoEcalCandidateCollection>ref,std::vector<l1extra::L1EmParticleRef >& l1EGIso,std::vector<l1extra::L1EmParticleRef >& l1EGNonIso){
+bool HLTEgammaL1MatchFilterPairs::CheckL1Matching(edm::Ref<reco::RecoEcalCandidateCollection> ref, std::vector<l1extra::L1EmParticleRef >& l1EGIso, std::vector<l1extra::L1EmParticleRef >& l1EGNonIso) const {
 
   for (unsigned int i=0; i<l1EGIso.size(); i++) {
     //ORCA matching method
@@ -182,7 +183,7 @@ bool HLTEgammaL1MatchFilterPairs::CheckL1Matching(edm::Ref<reco::RecoEcalCandida
 
     float deltaphi=fabs(ref->phi() -l1EGIso[i]->phi());
     if(deltaphi>TWOPI) deltaphi-=TWOPI;
-    if(deltaphi>TWOPI/2.) deltaphi=TWOPI-deltaphi;
+    if(deltaphi>M_PI) deltaphi=TWOPI-deltaphi;
 
     if(ref->eta() < etaBinHigh && ref->eta() > etaBinLow && deltaphi <region_phi_size_/2. )  {return true;}
 
@@ -203,7 +204,7 @@ bool HLTEgammaL1MatchFilterPairs::CheckL1Matching(edm::Ref<reco::RecoEcalCandida
 
     float deltaphi=fabs(ref->phi() - l1EGNonIso[i]->phi());
     if(deltaphi>TWOPI) deltaphi-=TWOPI;
-    if(deltaphi>TWOPI/2.) deltaphi=TWOPI-deltaphi;
+    if(deltaphi>M_PI) deltaphi=TWOPI-deltaphi;
 
     if(ref->eta() < etaBinHigh && ref->eta() > etaBinLow && deltaphi <region_phi_size_/2. )  {return true;}
 	

--- a/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterPairs.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterPairs.cc
@@ -76,7 +76,7 @@ HLTEgammaL1MatchFilterPairs::fillDescriptions(edm::ConfigurationDescriptions& de
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaL1MatchFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTEgammaL1MatchFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
 
   using namespace trigger;

--- a/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterPairs.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterPairs.cc
@@ -30,21 +30,21 @@
 //
 // constructors and destructor
 //
-HLTEgammaL1MatchFilterPairs::HLTEgammaL1MatchFilterPairs(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTEgammaL1MatchFilterPairs::HLTEgammaL1MatchFilterPairs(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
    candIsolatedTag_ = iConfig.getParameter< edm::InputTag > ("candIsolatedTag");
    l1IsolatedTag_ = iConfig.getParameter< edm::InputTag > ("l1IsolatedTag");
    candNonIsolatedTag_ = iConfig.getParameter< edm::InputTag > ("candNonIsolatedTag");
    l1NonIsolatedTag_ = iConfig.getParameter< edm::InputTag > ("l1NonIsolatedTag");
    L1SeedFilterTag_ = iConfig.getParameter< edm::InputTag > ("L1SeedFilterTag");
- 
+
    AlsoNonIsolatedFirst_ = iConfig.getParameter<bool>("AlsoNonIsolatedFirst");
    AlsoNonIsolatedSecond_  = iConfig.getParameter<bool>("AlsoNonIsolatedSecond");
- 
+
    region_eta_size_      = iConfig.getParameter<double> ("region_eta_size");
    region_eta_size_ecap_ = iConfig.getParameter<double> ("region_eta_size_ecap");
    region_phi_size_      = iConfig.getParameter<double> ("region_phi_size");
-   barrel_end_           = iConfig.getParameter<double> ("barrel_end");   
+   barrel_end_           = iConfig.getParameter<double> ("barrel_end");
    endcap_end_           = iConfig.getParameter<double> ("endcap_end");
 
    candIsolatedToken_ = consumes<reco::RecoEcalCandidateCollection>(candIsolatedTag_);
@@ -70,20 +70,20 @@ HLTEgammaL1MatchFilterPairs::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<double>("region_phi_size",1.044);
   desc.add<double>("barrel_end",1.4791);
   desc.add<double>("endcap_end",2.65);
-  descriptions.add("hltEgammaL1MatchFilterPairs",desc);  
+  descriptions.add("hltEgammaL1MatchFilterPairs",desc);
 }
 
 
 
 // ------------ method called to produce the data  ------------
 bool
-HLTEgammaL1MatchFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTEgammaL1MatchFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
 
   using namespace trigger;
   using namespace l1extra;
   std::vector < std::pair< edm::Ref<reco::RecoEcalCandidateCollection>, edm::Ref<reco::RecoEcalCandidateCollection> > > thePairs;
-  
+
   edm::Handle<reco::RecoEcalCandidateCollection> recoIsolecalcands;
   iEvent.getByToken(candIsolatedToken_,recoIsolecalcands);
   edm::Handle<reco::RecoEcalCandidateCollection> recoNonIsolecalcands;
@@ -103,7 +103,7 @@ HLTEgammaL1MatchFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup
 	 }
        }
    }
-  
+
 
   // create pairs <L1NonIso,L1Iso> and optionally <L1NonIso, L1NonIso>
    if (AlsoNonIsolatedFirst_){
@@ -134,9 +134,9 @@ HLTEgammaL1MatchFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup
   edm::Handle<trigger::TriggerFilterObjectWithRefs> L1SeedOutput;
   iEvent.getByToken (L1SeedFilterToken_,L1SeedOutput);
 
-  std::vector<l1extra::L1EmParticleRef > l1EGIso;       
+  std::vector<l1extra::L1EmParticleRef > l1EGIso;
   L1SeedOutput->getObjects(TriggerL1IsoEG, l1EGIso);
-  std::vector<l1extra::L1EmParticleRef > l1EGNonIso;       
+  std::vector<l1extra::L1EmParticleRef > l1EGNonIso;
   L1SeedOutput->getObjects(TriggerL1NoIsoEG, l1EGNonIso);
 
 //   std::cout<<"L1EGIso size: "<<l1EGIso.size()<<std::endl;
@@ -144,25 +144,25 @@ HLTEgammaL1MatchFilterPairs::hltFilter(edm::Event& iEvent, const edm::EventSetup
 //   std::cout<<"L1EGNonIso size: "<<l1EGNonIso.size()<<std::endl;
 //   for (unsigned int i=0; i<l1EGNonIso.size(); i++){std::cout<<"L1EGNonIso Et Eta phi: "<<l1EGNonIso[i]->et()<<" "<<l1EGNonIso[i]->eta()<<" "<<l1EGNonIso[i]->phi()<<std::endl;}
 //   std::cout<<"Lpair vector size: "<<thePairs.size()<<std::endl;
-  
+
   std::vector < std::pair< edm::Ref<reco::RecoEcalCandidateCollection>, edm::Ref<reco::RecoEcalCandidateCollection> > >::iterator  pairsIt;
   for (pairsIt = thePairs.begin(); pairsIt != thePairs.end(); pairsIt++){
 //      edm::Ref<reco::RecoEcalCandidateCollection> r1 = pairsIt->first;
 //      edm::Ref<reco::RecoEcalCandidateCollection> r2 = pairsIt->second;
 //      std::cout<<"1) Et Eta phi: "<<r1->et()<<" "<<r1->eta()<<" "<<r1->phi()<<" 2) Et eta phi: "<<r2->et()<<" "<<r2->eta()<<" "<<r2->phi()<<std::endl;
-    
+
     if ( CheckL1Matching(pairsIt->first,l1EGIso,l1EGNonIso) && CheckL1Matching(pairsIt->second,l1EGIso,l1EGNonIso) ){
       filterproduct.addObject(TriggerCluster, pairsIt->first);
       filterproduct.addObject(TriggerCluster, pairsIt->second);
       n++;
-    } 
+    }
   }
 
 
   //  std::cout<<"#####################################################"<<std::endl;
   // filter decision
   bool accept(n>=1);
-  
+
   return accept;
 }
 

--- a/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterRegional.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterRegional.cc
@@ -27,7 +27,7 @@
 //
 // constructors and destructor
 //
-HLTEgammaL1MatchFilterRegional::HLTEgammaL1MatchFilterRegional(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTEgammaL1MatchFilterRegional::HLTEgammaL1MatchFilterRegional(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
    candIsolatedTag_ = iConfig.getParameter< edm::InputTag > ("candIsolatedTag");
    l1IsolatedTag_ = iConfig.getParameter< edm::InputTag > ("l1IsolatedTag");
@@ -40,8 +40,8 @@ HLTEgammaL1MatchFilterRegional::HLTEgammaL1MatchFilterRegional(const edm::Parame
    region_eta_size_      = iConfig.getParameter<double> ("region_eta_size");
    region_eta_size_ecap_ = iConfig.getParameter<double> ("region_eta_size_ecap");
    region_phi_size_      = iConfig.getParameter<double> ("region_phi_size");
-   barrel_end_           = iConfig.getParameter<double> ("barrel_end");   
-   endcap_end_           = iConfig.getParameter<double> ("endcap_end");   
+   barrel_end_           = iConfig.getParameter<double> ("barrel_end");
+   endcap_end_           = iConfig.getParameter<double> ("endcap_end");
 
    candIsolatedToken_ = consumes<reco::RecoEcalCandidateCollection>(candIsolatedTag_);
    if(!doIsolated_) candNonIsolatedToken_ = consumes<reco::RecoEcalCandidateCollection>(candNonIsolatedTag_);
@@ -66,7 +66,7 @@ HLTEgammaL1MatchFilterRegional::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<double>("region_phi_size",1.044);
   desc.add<double>("barrel_end",1.4791);
   desc.add<double>("endcap_end",2.65);
-  descriptions.add("hltEgammaL1MatchFilterRegional",desc);  
+  descriptions.add("hltEgammaL1MatchFilterRegional",desc);
 }
 
 // ------------ method called to produce the data  ------------
@@ -104,76 +104,76 @@ HLTEgammaL1MatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSe
   edm::Handle<trigger::TriggerFilterObjectWithRefs> L1SeedOutput;
   iEvent.getByToken (L1SeedFilterToken_,L1SeedOutput);
 
-  std::vector<l1extra::L1EmParticleRef > l1EGIso;       
+  std::vector<l1extra::L1EmParticleRef > l1EGIso;
   L1SeedOutput->getObjects(TriggerL1IsoEG, l1EGIso);
-  
-  std::vector<l1extra::L1EmParticleRef > l1EGNonIso;       
+
+  std::vector<l1extra::L1EmParticleRef > l1EGNonIso;
   L1SeedOutput->getObjects(TriggerL1NoIsoEG, l1EGNonIso);
 
-  
+
   for (reco::RecoEcalCandidateCollection::const_iterator recoecalcand= recoIsolecalcands->begin(); recoecalcand!=recoIsolecalcands->end(); recoecalcand++) {
 
-  
+
     if(fabs(recoecalcand->eta()) < endcap_end_){
       //SC should be inside the ECAL fiducial volume
 
       bool matchedSCIso = matchedToL1Cand(l1EGIso,recoecalcand->eta(),recoecalcand->phi());
 
-      //now due to SC cleaning given preference to isolated candiates, 
+      //now due to SC cleaning given preference to isolated candiates,
       //if there is an isolated and nonisolated L1 cand in the same eta/phi bin
       //the corresponding SC will be only in the isolated SC collection
-      //so if we are !doIsolated_, we need to run over the nonisol L1 collection as well 
+      //so if we are !doIsolated_, we need to run over the nonisol L1 collection as well
       bool matchedSCNonIso=false;
       if(!doIsolated_){
 	matchedSCNonIso =  matchedToL1Cand(l1EGNonIso,recoecalcand->eta(),recoecalcand->phi());
       }
-       
+
 
       if(matchedSCIso || matchedSCNonIso) {
 	n++;
 
-	ref = edm::Ref<reco::RecoEcalCandidateCollection>(recoIsolecalcands, distance(recoIsolecalcands->begin(),recoecalcand) );       
+	ref = edm::Ref<reco::RecoEcalCandidateCollection>(recoIsolecalcands, distance(recoIsolecalcands->begin(),recoecalcand) );
 	filterproduct.addObject(TriggerCluster, ref);
       }//end  matched check
 
     }//end endcap fiduical check
-    
+
   }//end loop over all isolated RecoEcalCandidates
-  
-  //if doIsolated_ is false now run over the nonisolated superclusters and non isolated L1 seeds 
+
+  //if doIsolated_ is false now run over the nonisolated superclusters and non isolated L1 seeds
   //however in the case we have a single collection of superclusters containing both iso L1 and non iso L1 seeded superclusters,
   //we specific doIsolated=false to match to isolated superclusters to non isolated seeds in the above loop
   //however we do not have a non isolated collection of superclusters so we have to protect against that
   if(!doIsolated_ && !candNonIsolatedTag_.label().empty()) {
-  
+
     edm::Handle<reco::RecoEcalCandidateCollection> recoNonIsolecalcands;
     iEvent.getByToken(candNonIsolatedToken_,recoNonIsolecalcands);
-    
+
     for (reco::RecoEcalCandidateCollection::const_iterator recoecalcand= recoNonIsolecalcands->begin(); recoecalcand!=recoNonIsolecalcands->end(); recoecalcand++) {
       if(fabs(recoecalcand->eta()) < endcap_end_){
 	bool matchedSCNonIso =  matchedToL1Cand(l1EGNonIso,recoecalcand->eta(),recoecalcand->phi());
 	
 	if(matchedSCNonIso) {
 	  n++;
-	  ref = edm::Ref<reco::RecoEcalCandidateCollection>(recoNonIsolecalcands, distance(recoNonIsolecalcands->begin(),recoecalcand) );       
+	  ref = edm::Ref<reco::RecoEcalCandidateCollection>(recoNonIsolecalcands, distance(recoNonIsolecalcands->begin(),recoecalcand) );
 	  filterproduct.addObject(TriggerCluster, ref);
 	}//end  matched check
 	
       }//end endcap fiduical check
-      
+
     }//end loop over all isolated RecoEcalCandidates
   }//end doIsolatedCheck
-  
+
 
   // filter decision
   bool accept(n>=ncandcut_);
-  
+
   return accept;
 }
 
 
-bool 
-HLTEgammaL1MatchFilterRegional::matchedToL1Cand(const std::vector<l1extra::L1EmParticleRef >& l1Cands,const float scEta,const float scPhi) 
+bool
+HLTEgammaL1MatchFilterRegional::matchedToL1Cand(const std::vector<l1extra::L1EmParticleRef >& l1Cands,const float scEta,const float scPhi) const
 {
   for (unsigned int i=0; i<l1Cands.size(); i++) {
     //ORCA matching method
@@ -187,11 +187,11 @@ HLTEgammaL1MatchFilterRegional::matchedToL1Cand(const std::vector<l1extra::L1EmP
       etaBinLow = l1Cands[i]->eta() - region_eta_size_ecap_/2.;
       etaBinHigh = etaBinLow + region_eta_size_ecap_;
     }
-    
+
     float deltaphi=fabs(scPhi -l1Cands[i]->phi());
     if(deltaphi>TWOPI) deltaphi-=TWOPI;
     if(deltaphi>TWOPI/2.) deltaphi=TWOPI-deltaphi;
-    
+
     if(scEta < etaBinHigh && scEta > etaBinLow && deltaphi <region_phi_size_/2. )  {
       return true;
     }

--- a/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterRegional.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterRegional.cc
@@ -74,7 +74,7 @@ HLTEgammaL1MatchFilterRegional::fillDescriptions(edm::ConfigurationDescriptions&
 //doIsolated=true, only isolated superclusters are allowed to match isolated L1 seeds
 //doIsolated=false, isolated superclusters are allowed to match either iso or non iso L1 seeds, non isolated superclusters are allowed only to match non-iso seeds. If no collection name is given for non-isolated superclusters, assumes the the isolated collection contains all (both iso + non iso) seeded superclusters.
 bool
-HLTEgammaL1MatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTEgammaL1MatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   // std::cout <<"runnr "<<iEvent.id().run()<<" event "<<iEvent.id().event()<<std::endl;
   using namespace trigger;

--- a/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterRegional.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterRegional.cc
@@ -74,7 +74,7 @@ HLTEgammaL1MatchFilterRegional::fillDescriptions(edm::ConfigurationDescriptions&
 //doIsolated=true, only isolated superclusters are allowed to match isolated L1 seeds
 //doIsolated=false, isolated superclusters are allowed to match either iso or non iso L1 seeds, non isolated superclusters are allowed only to match non-iso seeds. If no collection name is given for non-isolated superclusters, assumes the the isolated collection contains all (both iso + non iso) seeded superclusters.
 bool
-HLTEgammaL1MatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTEgammaL1MatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   // std::cout <<"runnr "<<iEvent.id().run()<<" event "<<iEvent.id().event()<<std::endl;
   using namespace trigger;

--- a/HLTrigger/Egamma/src/HLTEgammaTriggerFilterObjectWrapper.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaTriggerFilterObjectWrapper.cc
@@ -22,7 +22,7 @@
 //
 // constructors and destructor
 //
-HLTEgammaTriggerFilterObjectWrapper::HLTEgammaTriggerFilterObjectWrapper(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTEgammaTriggerFilterObjectWrapper::HLTEgammaTriggerFilterObjectWrapper(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
    candIsolatedTag_ = iConfig.getParameter< edm::InputTag > ("candIsolatedTag");
    candNonIsolatedTag_ = iConfig.getParameter< edm::InputTag > ("candNonIsolatedTag");
@@ -38,14 +38,14 @@ HLTEgammaTriggerFilterObjectWrapper::fillDescriptions(edm::ConfigurationDescript
   desc.add<edm::InputTag>("candIsolatedTag",edm::InputTag("hltL1IsoRecoEcalCandidate"));
   desc.add<edm::InputTag>("candNonIsolatedTag",edm::InputTag("hltL1NonIsoRecoEcalCandidate"));
   desc.add<bool>("doIsolated",false);
-  descriptions.add("hltEgammaTriggerFilterObjectWrapper",desc);  
+  descriptions.add("hltEgammaTriggerFilterObjectWrapper",desc);
 }
 
 HLTEgammaTriggerFilterObjectWrapper::~HLTEgammaTriggerFilterObjectWrapper(){}
 
 
 // ------------ method called to produce the data  ------------
-bool HLTEgammaTriggerFilterObjectWrapper::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTEgammaTriggerFilterObjectWrapper::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace trigger;
   using namespace l1extra;
@@ -53,23 +53,23 @@ bool HLTEgammaTriggerFilterObjectWrapper::hltFilter(edm::Event& iEvent, const ed
   // Get the recoEcalCandidates
   edm::Handle<reco::RecoEcalCandidateCollection> recoIsolecalcands;
   iEvent.getByToken(candIsolatedToken_,recoIsolecalcands);
-  
+
   edm::Ref<reco::RecoEcalCandidateCollection> ref;
   // transform the L1Iso_RecoEcalCandidate into the TriggerFilterObjectWithRefs
   for (reco::RecoEcalCandidateCollection::const_iterator recoecalcand= recoIsolecalcands->begin(); recoecalcand!=recoIsolecalcands->end(); recoecalcand++) {
-    ref = edm::Ref<reco::RecoEcalCandidateCollection>(recoIsolecalcands, distance(recoIsolecalcands->begin(),recoecalcand) );       
+    ref = edm::Ref<reco::RecoEcalCandidateCollection>(recoIsolecalcands, distance(recoIsolecalcands->begin(),recoecalcand) );
     filterproduct.addObject(TriggerCluster, ref);
   }
-  
+
   if(!doIsolated_) {
-    // transform the L1NonIso_RecoEcalCandidate into the TriggerFilterObjectWithRefs and add them to the L1Iso ones.  
+    // transform the L1NonIso_RecoEcalCandidate into the TriggerFilterObjectWithRefs and add them to the L1Iso ones.
     edm::Handle<reco::RecoEcalCandidateCollection> recoNonIsolecalcands;
     iEvent.getByToken(candNonIsolatedToken_,recoNonIsolecalcands);
     for (reco::RecoEcalCandidateCollection::const_iterator recoecalcand= recoNonIsolecalcands->begin(); recoecalcand!=recoNonIsolecalcands->end(); recoecalcand++) {
-      ref = edm::Ref<reco::RecoEcalCandidateCollection>(recoNonIsolecalcands, distance(recoNonIsolecalcands->begin(),recoecalcand) );       
+      ref = edm::Ref<reco::RecoEcalCandidateCollection>(recoNonIsolecalcands, distance(recoNonIsolecalcands->begin(),recoecalcand) );
       filterproduct.addObject(TriggerCluster, ref);
     }
   }
-  
-  return true;  
+
+  return true;
  }

--- a/HLTrigger/Egamma/src/HLTEgammaTriggerFilterObjectWrapper.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaTriggerFilterObjectWrapper.cc
@@ -45,7 +45,7 @@ HLTEgammaTriggerFilterObjectWrapper::~HLTEgammaTriggerFilterObjectWrapper(){}
 
 
 // ------------ method called to produce the data  ------------
-bool HLTEgammaTriggerFilterObjectWrapper::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTEgammaTriggerFilterObjectWrapper::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace trigger;
   using namespace l1extra;

--- a/HLTrigger/Egamma/src/HLTElectronEoverpFilterRegional.cc
+++ b/HLTrigger/Egamma/src/HLTElectronEoverpFilterRegional.cc
@@ -53,7 +53,7 @@ HLTElectronEoverpFilterRegional::fillDescriptions(edm::ConfigurationDescriptions
 
 // ------------ method called to produce the data  ------------
 bool
-HLTElectronEoverpFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTElectronEoverpFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
 
   // The filter object

--- a/HLTrigger/Egamma/src/HLTElectronEoverpFilterRegional.cc
+++ b/HLTrigger/Egamma/src/HLTElectronEoverpFilterRegional.cc
@@ -21,7 +21,7 @@
 //
 // constructors and destructor
 //
-HLTElectronEoverpFilterRegional::HLTElectronEoverpFilterRegional(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTElectronEoverpFilterRegional::HLTElectronEoverpFilterRegional(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
    candTag_ = iConfig.getParameter< edm::InputTag > ("candTag");
    electronIsolatedProducer_ = iConfig.getParameter< edm::InputTag > ("electronIsolatedProducer");
@@ -48,12 +48,12 @@ HLTElectronEoverpFilterRegional::fillDescriptions(edm::ConfigurationDescriptions
   desc.add<double>("eoverpendcapcut",2.45);
   desc.add<int>("ncandcut",1);
   desc.add<bool>("doIsolated",true);
-  descriptions.add("hltElectronEoverpFilter",desc);  
+  descriptions.add("hltElectronEoverpFilter",desc);
 }
 
 // ------------ method called to produce the data  ------------
 bool
-HLTElectronEoverpFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTElectronEoverpFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
 
   // The filter object
@@ -80,26 +80,26 @@ HLTElectronEoverpFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventS
 
  // look at all candidates,  check cuts and add to filter object
   int n(0);
-  
-    //loop over all the RecoCandidates from the previous filter, 
-    // associate them with the corresponding Electron object 
+
+    //loop over all the RecoCandidates from the previous filter,
+    // associate them with the corresponding Electron object
     //(the matching is done checking the super clusters)
     // and put into the event a Ref to the Electron objects that passes the
-    // selections  
+    // selections
   for (unsigned int i=0; i<recoecalcands.size(); i++) {
     reco::SuperClusterRef recr2 = recoecalcands[i]->superCluster();
 
     //loop over the electrons to find the matching one
     for(reco::ElectronCollection::const_iterator iElectron = electronIsolatedHandle->begin(); iElectron != electronIsolatedHandle->end(); iElectron++){
-      
+
       reco::ElectronRef electronref(reco::ElectronRef(electronIsolatedHandle,iElectron - electronIsolatedHandle->begin()));
       const reco::SuperClusterRef theClus = electronref->superCluster();
-      
+
       if(&(*recr2) ==  &(*theClus)) {
 
 	float elecEoverp = 0;
 	const math::XYZVector trackMom =  electronref->track()->momentum();
-	if( trackMom.R() != 0) elecEoverp = 
+	if( trackMom.R() != 0) elecEoverp =
 				 electronref->superCluster()->energy()/ trackMom.R();
 
 	if( fabs(electronref->eta()) < 1.5 ){
@@ -120,15 +120,15 @@ HLTElectronEoverpFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventS
     if(!doIsolated_) {
     //loop over the electrons to find the matching one
     for(reco::ElectronCollection::const_iterator iElectron = electronNonIsolatedHandle->begin(); iElectron != electronNonIsolatedHandle->end(); iElectron++){
-      
+
       reco::ElectronRef electronref(reco::ElectronRef(electronNonIsolatedHandle,iElectron - electronNonIsolatedHandle->begin()));
       const reco::SuperClusterRef theClus = electronref->superCluster();
-      
+
       if(&(*recr2) ==  &(*theClus)) {
 
 	float elecEoverp = 0;
 	const math::XYZVector trackMom =  electronref->track()->momentum();
-	if( trackMom.R() != 0) elecEoverp = 
+	if( trackMom.R() != 0) elecEoverp =
 				 electronref->superCluster()->energy()/ trackMom.R();
 
 	if( fabs(electronref->eta()) < 1.5 ){
@@ -150,6 +150,6 @@ HLTElectronEoverpFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventS
 
   // filter decision
   bool accept(n>=ncandcut_);
-  
+
   return accept;
 }

--- a/HLTrigger/Egamma/src/HLTElectronEtFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronEtFilter.cc
@@ -29,11 +29,11 @@ HLTElectronEtFilter::HLTElectronEtFilter(const edm::ParameterSet& iConfig) : HLT
   candTag_ = iConfig.getParameter< edm::InputTag > ("candTag");
   EtEB_ = iConfig.getParameter<double> ("EtCutEB");
   EtEE_ = iConfig.getParameter<double> ("EtCutEE");
-  
+
   ncandcut_  = iConfig.getParameter<int> ("ncandcut");
   doIsolated_ = iConfig.getParameter<bool> ("doIsolated");
 
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand"); 
+  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand");
   L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
 
   candToken_ =  consumes<trigger::TriggerFilterObjectWithRefs>(candTag_);
@@ -50,11 +50,11 @@ HLTElectronEtFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.add<double>("EtCutEE",0.0);
   desc.add<int>("ncandcut",1);
   desc.add<bool>("doIsolated",true);
-  descriptions.add("hltElectronEtFilter",desc);  
+  descriptions.add("hltElectronEtFilter",desc);
 }
 
 // ------------ method called to produce the data  ------------
-bool HLTElectronEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTElectronEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace trigger;
   if (saveTags()) {
@@ -71,25 +71,25 @@ bool HLTElectronEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
   std::vector<edm::Ref<reco::ElectronCollection> > elecands;
   PrevFilterOutput->getObjects(TriggerElectron, elecands);
 
-  
-    
+
+
   // look at all photons, check cuts and add to filter object
   int n = 0;
-  
+
   for (unsigned int i=0; i<elecands.size(); i++) {
-    
+
     ref = elecands[i];
     float Pt = ref->pt();
     float Eta = fabs(ref->eta());
-    
+
     if ( (Eta < 1.479 && Pt > EtEB_) || (Eta >= 1.479 && Pt > EtEE_) ) {
       n++;
       filterproduct.addObject(TriggerElectron, ref);
     }
-    
-  }  
+
+  }
   // filter decision
   bool accept(n>=ncandcut_);
-  
+
   return accept;
 }

--- a/HLTrigger/Egamma/src/HLTElectronEtFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronEtFilter.cc
@@ -54,7 +54,7 @@ HLTElectronEtFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptio
 }
 
 // ------------ method called to produce the data  ------------
-bool HLTElectronEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTElectronEtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace trigger;
   if (saveTags()) {

--- a/HLTrigger/Egamma/src/HLTElectronGenericFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronGenericFilter.cc
@@ -37,8 +37,8 @@ HLTElectronGenericFilter::HLTElectronGenericFilter(const edm::ParameterSet& iCon
   thrTimesPtEE_ = iConfig.getParameter<double> ("thrTimesPtEE");
   ncandcut_  = iConfig.getParameter<int> ("ncandcut");
   doIsolated_ = iConfig.getParameter<bool> ("doIsolated");
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand"); 
-  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand"); 
+  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand");
+  L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
 
   candToken_ =  consumes<trigger::TriggerFilterObjectWithRefs>(candTag_);
   isoToken_ = consumes<reco::ElectronIsolationMap>(isoTag_);
@@ -65,12 +65,12 @@ HLTElectronGenericFilter::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<bool>("doIsolated",true);
   desc.add<edm::InputTag>("L1IsoCand",edm::InputTag("hltPixelMatchElectronsL1Iso"));
   desc.add<edm::InputTag>("L1NonIsoCand",edm::InputTag("hltPixelMatchElectronsL1NonIso"));
-  descriptions.add("hltElectronGenericFilter",desc);  
+  descriptions.add("hltElectronGenericFilter",desc);
 }
 
 // ------------ method called to produce the data  ------------
 bool
-HLTElectronGenericFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTElectronGenericFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace trigger;
 
@@ -88,24 +88,24 @@ HLTElectronGenericFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
   std::vector<edm::Ref<reco::ElectronCollection> > elecands;
   PrevFilterOutput->getObjects(TriggerElectron, elecands);
 
-  
+
   //get hold of isolated association map
   edm::Handle<reco::ElectronIsolationMap> depMap;
   iEvent.getByToken (isoToken_,depMap);
-  
+
   //get hold of non-isolated association map
   edm::Handle<reco::ElectronIsolationMap> depNonIsoMap;
   if(!doIsolated_) iEvent.getByToken (nonIsoToken_,depNonIsoMap);
-  
+
   // look at all photons, check cuts and add to filter object
   int n = 0;
-  
+
   for (unsigned int i=0; i<elecands.size(); i++) {
-    
+
     ref = elecands[i];
-    reco::ElectronIsolationMap::const_iterator mapi = (*depMap).find( ref );    
-    if (mapi==(*depMap).end() && !doIsolated_) mapi = (*depNonIsoMap).find( ref ); 
-   
+    reco::ElectronIsolationMap::const_iterator mapi = (*depMap).find( ref );
+    if (mapi==(*depMap).end() && !doIsolated_) mapi = (*depNonIsoMap).find( ref );
+
     float vali = mapi->val;
     float Pt = ref->pt();
     float Eta = fabs(ref->eta());
@@ -146,10 +146,10 @@ HLTElectronGenericFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
       }
     }
   }
-  
+
   // filter decision
   bool accept(n>=ncandcut_);
-  
+
   return accept;
 }
 

--- a/HLTrigger/Egamma/src/HLTElectronGenericFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronGenericFilter.cc
@@ -70,7 +70,7 @@ HLTElectronGenericFilter::fillDescriptions(edm::ConfigurationDescriptions& descr
 
 // ------------ method called to produce the data  ------------
 bool
-HLTElectronGenericFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTElectronGenericFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace trigger;
 

--- a/HLTrigger/Egamma/src/HLTElectronMissingHitsFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronMissingHitsFilter.cc
@@ -37,32 +37,32 @@ void HLTElectronMissingHitsFilter::fillDescriptions(edm::ConfigurationDescriptio
   desc.add<int>("barrelcut", 0);
   desc.add<int>("endcapcut", 0);
   desc.add<int>("ncandcut", 1);
-  descriptions.add("hltElectronMissingHitsFilter", desc);  
+  descriptions.add("hltElectronMissingHitsFilter", desc);
 }
 
-bool HLTElectronMissingHitsFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+bool HLTElectronMissingHitsFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
 
   using namespace trigger;
 
   if (saveTags())
     filterproduct.addCollectionTag(electronProducer_);
-    
+
   edm::Handle<trigger::TriggerFilterObjectWithRefs> PrevFilterOutput;
   iEvent.getByLabel (candTag_,PrevFilterOutput);
 
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > recoecalcands;
   PrevFilterOutput->getObjects(TriggerCluster, recoecalcands);
-  if(recoecalcands.empty()) 
+  if(recoecalcands.empty())
     PrevFilterOutput->getObjects(TriggerPhoton,recoecalcands);
 
   edm::Handle<reco::ElectronCollection> electronHandle;
   iEvent.getByLabel(electronProducer_, electronHandle);
 
   int n(0);
-  
-  edm::RefToBase<reco::Candidate> candref;   
+
+  edm::RefToBase<reco::Candidate> candref;
   for (unsigned int i=0; i<recoecalcands.size(); i++) {
-    
+
     reco::SuperClusterRef scCand = recoecalcands[i]->superCluster();
     for(reco::ElectronCollection::const_iterator iElectron = electronHandle->begin(); iElectron != electronHandle->end(); iElectron++) {
       reco::ElectronRef electronref(reco::ElectronRef(electronHandle, iElectron - electronHandle->begin()));
@@ -95,6 +95,6 @@ bool HLTElectronMissingHitsFilter::hltFilter(edm::Event& iEvent, const edm::Even
   }
 
   bool accept(n >= ncandcut_);
-  
+
   return accept;
 }

--- a/HLTrigger/Egamma/src/HLTElectronMissingHitsFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronMissingHitsFilter.cc
@@ -40,7 +40,7 @@ void HLTElectronMissingHitsFilter::fillDescriptions(edm::ConfigurationDescriptio
   descriptions.add("hltElectronMissingHitsFilter", desc);  
 }
 
-bool HLTElectronMissingHitsFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+bool HLTElectronMissingHitsFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
 
   using namespace trigger;
 

--- a/HLTrigger/Egamma/src/HLTElectronMuonInvMassFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronMuonInvMassFilter.cc
@@ -49,7 +49,7 @@ HLTElectronMuonInvMassFilter::fillDescriptions(edm::ConfigurationDescriptions& d
 
 // ------------ method called to produce the data  ------------
 bool
-HLTElectronMuonInvMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTElectronMuonInvMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/Egamma/src/HLTElectronMuonInvMassFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronMuonInvMassFilter.cc
@@ -13,7 +13,7 @@
 //
 // constructors and destructor
 //
-HLTElectronMuonInvMassFilter::HLTElectronMuonInvMassFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTElectronMuonInvMassFilter::HLTElectronMuonInvMassFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   eleCandTag_             = iConfig.getParameter< edm::InputTag > ("elePrevCandTag");
   muonCandTag_            = iConfig.getParameter< edm::InputTag > ("muonPrevCandTag");
@@ -21,7 +21,7 @@ HLTElectronMuonInvMassFilter::HLTElectronMuonInvMassFilter(const edm::ParameterS
   upperMassCut_           = iConfig.getParameter<double> ("upperMassCut");
   ncandcut_  = iConfig.getParameter<int> ("ncandcut");
   relaxed_ = iConfig.getUntrackedParameter<bool> ("electronRelaxed",true) ;
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("ElectronL1IsoCand"); 
+  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("ElectronL1IsoCand");
   L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("ElectronL1NonIsoCand");
   MuonCollTag_= iConfig.getParameter< edm::InputTag > ("MuonCand");
   eleCandToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(eleCandTag_);
@@ -44,12 +44,12 @@ HLTElectronMuonInvMassFilter::fillDescriptions(edm::ConfigurationDescriptions& d
   desc.add<edm::InputTag>("ElectronL1IsoCand",edm::InputTag("hltPixelMatchElectronsActivity"));
   desc.add<edm::InputTag>("ElectronL1NonIsoCand",edm::InputTag("hltPixelMatchElectronsActivity"));
   desc.add<edm::InputTag>("MuonCand",edm::InputTag("hltL3MuonCandidates"));
-  descriptions.add("hltElectronMuonInvMassFilter",desc);  
+  descriptions.add("hltElectronMuonInvMassFilter",desc);
 }
 
 // ------------ method called to produce the data  ------------
 bool
-HLTElectronMuonInvMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTElectronMuonInvMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;
@@ -67,7 +67,7 @@ HLTElectronMuonInvMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetu
   }
 
   edm::Handle<trigger::TriggerFilterObjectWithRefs> EleFromPrevFilter;
-  iEvent.getByToken (eleCandToken_,EleFromPrevFilter); 
+  iEvent.getByToken (eleCandToken_,EleFromPrevFilter);
 
   edm::Handle<trigger::TriggerFilterObjectWithRefs> MuonFromPrevFilter;
   iEvent.getByToken (muonCandToken_,MuonFromPrevFilter);
@@ -81,28 +81,28 @@ HLTElectronMuonInvMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetu
   Ref< ElectronCollection > refele;
   vector< Ref< ElectronCollection > > electrons;
   EleFromPrevFilter->getObjects(TriggerElectron, electrons);
-  
+
   vector<RecoChargedCandidateRef> l3muons;
   MuonFromPrevFilter->getObjects(TriggerMuon,l3muons);
-  
+
   for(unsigned int i=0; i<l3muons.size(); i++) {
     TrackRef tk = l3muons[i]->get<TrackRef>();
     //     TrackRef tk = l3muons[i].track();
     double muonEnergy = sqrt(tk->momentum().Mag2()+MuMass2);
-    TLorentzVector pThisMuon(tk->px(), tk->py(), 
+    TLorentzVector pThisMuon(tk->px(), tk->py(),
 			     tk->pz(), muonEnergy );
     pMuon.push_back( pThisMuon );
     muonCharge.push_back( tk->charge() );
   }
-  
+
   for (unsigned int i=0; i<electrons.size(); i++) {
     refele = electrons[i];
-    TLorentzVector pThisEle(refele->px(), refele->py(), 
+    TLorentzVector pThisEle(refele->px(), refele->py(),
 			    refele->pz(), refele->energy() );
     pElectron.push_back( pThisEle );
     eleCharge.push_back( refele->charge() );
   }
-  
+
   int nEleMuPairs = 0;
   for(unsigned int i=0; i<electrons.size(); i++) {
     for(unsigned int j=0; j<l3muons.size(); j++) {

--- a/HLTrigger/Egamma/src/HLTElectronOneOEMinusOneOPFilterRegional.cc
+++ b/HLTrigger/Egamma/src/HLTElectronOneOEMinusOneOPFilterRegional.cc
@@ -22,7 +22,7 @@
 //
 // constructors and destructor
 //
-HLTElectronOneOEMinusOneOPFilterRegional::HLTElectronOneOEMinusOneOPFilterRegional(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTElectronOneOEMinusOneOPFilterRegional::HLTElectronOneOEMinusOneOPFilterRegional(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   candTag_ = iConfig.getParameter< edm::InputTag > ("candTag");
   electronIsolatedProducer_ = iConfig.getParameter< edm::InputTag > ("electronIsolatedProducer");
@@ -47,7 +47,7 @@ HLTElectronOneOEMinusOneOPFilterRegional::fillDescriptions(edm::ConfigurationDes
   desc.add<double>("endcapcut",999.9);
   desc.add<int>("ncandcut",1);
   desc.add<bool>("doIsolated",false);
-  descriptions.add("hltElectronOneOEMinusOneOPFilterRegional",desc);  
+  descriptions.add("hltElectronOneOEMinusOneOPFilterRegional",desc);
 }
 
 HLTElectronOneOEMinusOneOPFilterRegional::~HLTElectronOneOEMinusOneOPFilterRegional(){}
@@ -55,7 +55,7 @@ HLTElectronOneOEMinusOneOPFilterRegional::~HLTElectronOneOEMinusOneOPFilterRegio
 
 // ------------ method called to produce the data  ------------
 bool
-HLTElectronOneOEMinusOneOPFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTElectronOneOEMinusOneOPFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace trigger;
 
@@ -65,7 +65,7 @@ HLTElectronOneOEMinusOneOPFilterRegional::hltFilter(edm::Event& iEvent, const ed
     if (not doIsolated_) filterproduct.addCollectionTag(electronNonIsolatedProducer_);
   }
   //will be a collection of Ref<reco::ElectronCollection> ref;
-    
+
   edm::Handle<trigger::TriggerFilterObjectWithRefs> PrevFilterOutput;
   iEvent.getByToken (candToken_,PrevFilterOutput);
 
@@ -83,27 +83,27 @@ HLTElectronOneOEMinusOneOPFilterRegional::hltFilter(edm::Event& iEvent, const ed
 
  // look at all candidates,  check cuts and add to filter object
   int n(0);
-  
-    //loop over all the RecoCandidates from the previous filter, 
-    // associate them with the corresponding Electron object 
+
+    //loop over all the RecoCandidates from the previous filter,
+    // associate them with the corresponding Electron object
     //(the matching is done checking the super clusters)
     // and put into the event a Ref to the Electron objects that passes the
-    // selections  
- 
-  edm::RefToBase<reco::Candidate> candref;   
+    // selections
+
+  edm::RefToBase<reco::Candidate> candref;
   for (unsigned int i=0; i<recoecalcands.size(); i++) {
-    
+
     reco::SuperClusterRef recr2 = recoecalcands[i]->superCluster();
     //loop over the electrons to find the matching one
     for(reco::ElectronCollection::const_iterator iElectron = electronIsolatedHandle->begin(); iElectron != electronIsolatedHandle->end(); iElectron++){
-      // ElectronRef is a Ref<reco::RecoEcalCandidateCollection>   
+      // ElectronRef is a Ref<reco::RecoEcalCandidateCollection>
       reco::ElectronRef electronref(reco::ElectronRef(electronIsolatedHandle,iElectron - electronIsolatedHandle->begin()));
       const reco::SuperClusterRef theClus = electronref->superCluster();
       if(&(*recr2) ==  &(*theClus)) {
 	
 	float elecEoverp = 0;
 	const math::XYZVector trackMom =  electronref->track()->momentum();
-	if( trackMom.R() != 0) elecEoverp = 
+	if( trackMom.R() != 0) elecEoverp =
 				 fabs((1/electronref->superCluster()->energy()) - (1/trackMom.R()));
 
 	if( fabs(electronref->eta()) < 1.5 ){
@@ -124,16 +124,16 @@ HLTElectronOneOEMinusOneOPFilterRegional::hltFilter(edm::Event& iEvent, const ed
     if(!doIsolated_) {
     //loop over the electrons to find the matching one
     for(reco::ElectronCollection::const_iterator iElectron = electronNonIsolatedHandle->begin(); iElectron != electronNonIsolatedHandle->end(); iElectron++){
-      
+
       reco::ElectronRef electronref(reco::ElectronRef(electronNonIsolatedHandle,iElectron - electronNonIsolatedHandle->begin()));
       const reco::SuperClusterRef theClus = electronref->superCluster();
-      
+
       if(&(*recr2) ==  &(*theClus)) {
 
 	float elecEoverp = 0;
 	const math::XYZVector trackMom =  electronref->track()->momentum();
-	if( trackMom.R() != 0) elecEoverp = 
-				fabs((1/electronref->superCluster()->energy()) - (1/trackMom.R())); 
+	if( trackMom.R() != 0) elecEoverp =
+				fabs((1/electronref->superCluster()->energy()) - (1/trackMom.R()));
 
 	if( fabs(electronref->eta()) < 1.5 ){
 	  if ( elecEoverp < barrelcut_) {
@@ -154,6 +154,6 @@ HLTElectronOneOEMinusOneOPFilterRegional::hltFilter(edm::Event& iEvent, const ed
 
   // filter decision
   bool accept(n>=ncandcut_);
-  
+
   return accept;
 }

--- a/HLTrigger/Egamma/src/HLTElectronOneOEMinusOneOPFilterRegional.cc
+++ b/HLTrigger/Egamma/src/HLTElectronOneOEMinusOneOPFilterRegional.cc
@@ -55,7 +55,7 @@ HLTElectronOneOEMinusOneOPFilterRegional::~HLTElectronOneOEMinusOneOPFilterRegio
 
 // ------------ method called to produce the data  ------------
 bool
-HLTElectronOneOEMinusOneOPFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTElectronOneOEMinusOneOPFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace trigger;
 

--- a/HLTrigger/Egamma/src/HLTElectronPFMTFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronPFMTFilter.cc
@@ -49,7 +49,7 @@ void HLTElectronPFMTFilter::fillDescriptions(edm::ConfigurationDescriptions& des
 
 // ------------ method called to produce the data  ------------
 bool
-    HLTElectronPFMTFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+    HLTElectronPFMTFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/Egamma/src/HLTElectronPFMTFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronPFMTFilter.cc
@@ -49,7 +49,7 @@ void HLTElectronPFMTFilter::fillDescriptions(edm::ConfigurationDescriptions& des
 
 // ------------ method called to produce the data  ------------
 bool
-    HLTElectronPFMTFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+    HLTElectronPFMTFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/Egamma/src/HLTElectronPixelMatchFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronPixelMatchFilter.cc
@@ -30,7 +30,7 @@
 //
 // constructors and destructor
 //
-HLTElectronPixelMatchFilter::HLTElectronPixelMatchFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTElectronPixelMatchFilter::HLTElectronPixelMatchFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   candTag_            = iConfig.getParameter< edm::InputTag > ("candTag");
   L1IsoPixelSeedsTag_  = iConfig.getParameter< edm::InputTag > ("L1IsoPixelSeedsTag");
@@ -38,7 +38,7 @@ HLTElectronPixelMatchFilter::HLTElectronPixelMatchFilter(const edm::ParameterSet
   npixelmatchcut_     = iConfig.getParameter<double> ("npixelmatchcut");
   ncandcut_           = iConfig.getParameter<int> ("ncandcut");
   doIsolated_    = iConfig.getParameter<bool> ("doIsolated");
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand"); 
+  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand");
   L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
 
   candToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(candTag_);
@@ -60,12 +60,12 @@ HLTElectronPixelMatchFilter::fillDescriptions(edm::ConfigurationDescriptions& de
   desc.add<bool>("doIsolated",true);
   desc.add<edm::InputTag>("L1IsoCand",edm::InputTag("hltL1IsoRecoEcalCandidate"));
   desc.add<edm::InputTag>("L1NonIsoCand",edm::InputTag("hltL1NonIsoRecoEcalCandidate"));
-  descriptions.add("hltElectronPixelMatchFilter",desc);  
+  descriptions.add("hltElectronPixelMatchFilter",desc);
 }
 
 // ------------ method called to produce the data  ------------
 bool
-HLTElectronPixelMatchFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTElectronPixelMatchFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   // The filter object
   using namespace trigger;
@@ -83,7 +83,7 @@ HLTElectronPixelMatchFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > recoecalcands;
   PrevFilterOutput->getObjects(TriggerCluster, recoecalcands);
   if(recoecalcands.empty()) PrevFilterOutput->getObjects(TriggerPhoton,recoecalcands);  //we dont know if its type trigger cluster or trigger photon
-  
+
   //get hold of the pixel seed - supercluster association map
   edm::Handle<reco::ElectronSeedCollection> L1IsoSeeds;
   iEvent.getByToken (L1IsoPixelSeedsToken_,L1IsoSeeds);
@@ -92,7 +92,7 @@ HLTElectronPixelMatchFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
   if(!doIsolated_){
     iEvent.getByToken (L1NonIsoPixelSeedsToken_,L1NonIsoSeeds);
   }
-  
+
   // look at all egammas,  check cuts and add to filter object
   int n = 0;
   // std::cout<<"@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@"<<std::endl;
@@ -104,13 +104,13 @@ HLTElectronPixelMatchFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
     // std::cout<<"AA  ref, e, eta, phi"<<&(*recr2)<<" "<<recr2->energy()<<" "<<recr2->eta()<<" "<<recr2->phi()<<std::endl;
     int nmatch = 0;
 
-    for(reco::ElectronSeedCollection::const_iterator it = L1IsoSeeds->begin(); 
+    for(reco::ElectronSeedCollection::const_iterator it = L1IsoSeeds->begin();
 	it != L1IsoSeeds->end(); it++){
 
       edm::RefToBase<reco::CaloCluster> caloCluster = it->caloCluster() ;
       reco::SuperClusterRef scRef = caloCluster.castTo<reco::SuperClusterRef>() ;
       // std::cout<<"BB ref, e, eta, phi"<<&(*scRef)<<" "<<scRef->energy()<<" "<<scRef->eta()<<" "<<scRef->phi()<<std::endl;
-   
+
       if(&(*recr2) ==  &(*scRef)) {
 	nmatch++;
       }
@@ -118,7 +118,7 @@ HLTElectronPixelMatchFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
 
     if(!doIsolated_){
 
-      for(reco::ElectronSeedCollection::const_iterator it = L1NonIsoSeeds->begin(); 
+      for(reco::ElectronSeedCollection::const_iterator it = L1NonIsoSeeds->begin();
 	  it != L1NonIsoSeeds->end(); it++){
 	edm::RefToBase<reco::CaloCluster> caloCluster = it->caloCluster() ;
 	reco::SuperClusterRef scRef = caloCluster.castTo<reco::SuperClusterRef>() ;
@@ -129,17 +129,17 @@ HLTElectronPixelMatchFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
       }
 
     }//end if(!doIsolated_)
-    
+
     if ( nmatch >= npixelmatchcut_) {
       n++;
       filterproduct.addObject(TriggerCluster, ref);
     }
-    
+
   }//end of loop over candidates
-  // std::cout<<"######################################################################"<<std::endl;   
+  // std::cout<<"######################################################################"<<std::endl;
   // filter decision
   bool accept(n>=ncandcut_);
-  
+
   return accept;
 }
 

--- a/HLTrigger/Egamma/src/HLTElectronPixelMatchFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronPixelMatchFilter.cc
@@ -65,7 +65,7 @@ HLTElectronPixelMatchFilter::fillDescriptions(edm::ConfigurationDescriptions& de
 
 // ------------ method called to produce the data  ------------
 bool
-HLTElectronPixelMatchFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTElectronPixelMatchFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   // The filter object
   using namespace trigger;

--- a/HLTrigger/Egamma/src/HLTPMDocaFilter.cc
+++ b/HLTrigger/Egamma/src/HLTPMDocaFilter.cc
@@ -44,7 +44,7 @@ HLTPMDocaFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
 
 // ------------ method called to produce the data  ------------
 bool
-HLTPMDocaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTPMDocaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/Egamma/src/HLTPMDocaFilter.cc
+++ b/HLTrigger/Egamma/src/HLTPMDocaFilter.cc
@@ -1,8 +1,8 @@
 /** \class HLTPMDocaFilter
- * 
- *  Original Author: Jeremy Werner                          
- *  Institution: Princeton University, USA                                                                 *  Contact: Jeremy.Werner@cern.ch 
- *  Date: February 21, 2007     
+ *
+ *  Original Author: Jeremy Werner
+ *  Institution: Princeton University, USA                                                                 *  Contact: Jeremy.Werner@cern.ch
+ *  Date: February 21, 2007
  *
  */
 
@@ -20,7 +20,7 @@
 //
 // constructors and destructor
 //
-HLTPMDocaFilter::HLTPMDocaFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTPMDocaFilter::HLTPMDocaFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   candTag_             = iConfig.getParameter< edm::InputTag > ("candTag");
   docaDiffPerpCutHigh_ = iConfig.getParameter<double> ("docaDiffPerpCutHigh");
@@ -39,12 +39,12 @@ HLTPMDocaFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
   desc.add<double>("docaDiffPerpCutHigh",0.055691);
   desc.add<double>("docaDiffPerpCutLow",0.0);
   desc.add<int>("nZcandcut",1);
-  descriptions.add("hltPMDocaFilter",desc);  
+  descriptions.add("hltPMDocaFilter",desc);
 }
 
 // ------------ method called to produce the data  ------------
 bool
-HLTPMDocaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTPMDocaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;
@@ -56,11 +56,11 @@ HLTPMDocaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, tr
 
   edm::Handle<trigger::TriggerFilterObjectWithRefs> PrevFilterOutput;
   iEvent.getByToken (candToken_,PrevFilterOutput);
-  
+
   std::vector<edm::Ref<reco::ElectronCollection> > electrons;
   PrevFilterOutput->getObjects(TriggerElectron, electrons);
-  
- 
+
+
   int n = 0;
 
   unsigned int size = electrons.size();
@@ -87,11 +87,11 @@ HLTPMDocaFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, tr
 	 }
      }
   }
-  
+
 
   // filter decision
   bool accept(n>=nZcandcut_);
-  
+
   return accept;
 }
 

--- a/HLTrigger/Egamma/src/HLTPMMassFilter.cc
+++ b/HLTrigger/Egamma/src/HLTPMMassFilter.cc
@@ -2,16 +2,18 @@
  *
  * Original Author: Jeremy Werner
  * Institution: Princeton University, USA
- * Contact: Jeremy.Werner@cern.ch 
+ * Contact: Jeremy.Werner@cern.ch
  * Date: February 21, 2007
  */
+
+#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "HLTrigger/Egamma/interface/HLTPMMassFilter.h"
 
 //
 // constructors and destructor
 //
-HLTPMMassFilter::HLTPMMassFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTPMMassFilter::HLTPMMassFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   candTag_            = iConfig.getParameter< edm::InputTag > ("candTag");
   beamSpot_           = iConfig.getParameter< edm::InputTag > ("beamSpot");
@@ -22,7 +24,7 @@ HLTPMMassFilter::HLTPMMassFilter(const edm::ParameterSet& iConfig) : HLTFilter(i
   isElectron1_ = iConfig.getUntrackedParameter<bool> ("isElectron1",true) ;
   isElectron2_ = iConfig.getUntrackedParameter<bool> ("isElectron2",true) ;
   relaxed_ = iConfig.getUntrackedParameter<bool> ("relaxed",true) ;
-  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand"); 
+  L1IsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1IsoCand");
   L1NonIsoCollTag_= iConfig.getParameter< edm::InputTag > ("L1NonIsoCand");
   candToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(candTag_);
   beamSpotToken_ = consumes<reco::BeamSpot>(beamSpot_);
@@ -45,7 +47,7 @@ HLTPMMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
   desc.addUntracked<bool>("relaxed",true);
   desc.add<edm::InputTag>("L1IsoCand",edm::InputTag("hltL1IsoRecoEcalCandidate"));
   desc.add<edm::InputTag>("L1NonIsoCand",edm::InputTag("hltL1IsoRecoEcalCandidate"));
-  descriptions.add("hltPMMassFilter",desc);  
+  descriptions.add("hltPMMassFilter",desc);
 }
 
 // ------------ method called to produce the data  ------------
@@ -62,20 +64,21 @@ HLTPMMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, tr
     filterproduct.addCollectionTag(L1IsoCollTag_);
     if (relaxed_) filterproduct.addCollectionTag(L1NonIsoCollTag_);
   }
-  
+
+  edm::ESHandle<MagneticField> theMagField;
   iSetup.get<IdealMagneticFieldRecord>().get(theMagField);
 
   edm::Handle<trigger::TriggerFilterObjectWithRefs> PrevFilterOutput;
-  iEvent.getByToken (candToken_,PrevFilterOutput); 
+  iEvent.getByToken (candToken_,PrevFilterOutput);
 
   // beam spot
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
   iEvent.getByToken(beamSpotToken_,recoBeamSpotHandle);
-  // gets its position 
+  // gets its position
   const GlobalPoint vertexPos(recoBeamSpotHandle->position().x(),
 			      recoBeamSpotHandle->position().y(),
 			      recoBeamSpotHandle->position().z());
-   
+
   int n = 0;
 
   // REMOVED USAGE OF STATIC ARRAYS
@@ -89,17 +92,17 @@ HLTPMMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, tr
   std::vector<double> etaOrig;
 
   if (isElectron1_ && isElectron2_) {
-    
+
     Ref< ElectronCollection > refele;
-    
+
     vector< Ref< ElectronCollection > > electrons;
     PrevFilterOutput->getObjects(TriggerElectron, electrons);
-    
+
     for (unsigned int i=0; i<electrons.size(); i++) {
-    
+
       refele = electrons[i];
 
-      TLorentzVector pThisEle(refele->px(), refele->py(), 
+      TLorentzVector pThisEle(refele->px(), refele->py(),
 			      refele->pz(), refele->energy() );
       pEleCh1.push_back( pThisEle );
       charge.push_back( refele->charge() );
@@ -115,7 +118,7 @@ HLTPMMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, tr
 	if(fabs(p1Ele.E() - p2Ele.E()) < 0.00001) continue;
 	if(reqOppCharge_ && charge[jj]*charge[ii] > 0) continue;
 	
-	TLorentzVector pTot = p1Ele + p2Ele; 
+	TLorentzVector pTot = p1Ele + p2Ele;
 	double mass = pTot.M();
 	
 	if(mass>=lowerMassCut_ && mass<=upperMassCut_){
@@ -127,29 +130,25 @@ HLTPMMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, tr
 	}
       }
     }
-  
+
   } else {
-    
+
     Ref< RecoEcalCandidateCollection > refsc;
 
     vector< Ref< RecoEcalCandidateCollection > > scs;
     PrevFilterOutput->getObjects(TriggerCluster, scs);
-    
+
     for (unsigned int i=0; i<scs.size(); i++) {
-    
+
       refsc = scs[i];
       const reco::SuperClusterRef sc = refsc->superCluster();
-      TLorentzVector pscPos = this->approxMomAtVtx(theMagField.product(),
-						   vertexPos,
-						   sc,1);
+      TLorentzVector pscPos = approxMomAtVtx(theMagField.product(), vertexPos, sc, 1);
       pEleCh1.push_back( pscPos );
-      
-      TLorentzVector pscEle = this->approxMomAtVtx(theMagField.product(),
-						   vertexPos,
-						   sc,-1);
+
+      TLorentzVector pscEle = approxMomAtVtx(theMagField.product(), vertexPos, sc, -1);
       pEleCh2.push_back( pscEle );
       etaOrig.push_back( sc->eta() );
-      
+
     }
 
     for(unsigned int jj=0;jj<scs.size();jj++){
@@ -161,7 +160,7 @@ HLTPMMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, tr
 	
 	if(fabs(p1Ele.E() - p2Ele.E()) < 0.00001) continue;
 	
-	TLorentzVector pTot = p1Ele + p2Ele; 
+	TLorentzVector pTot = p1Ele + p2Ele;
 	double mass = pTot.M();
 	
 	if(mass>= lowerMassCut_ && mass<=upperMassCut_){
@@ -175,15 +174,15 @@ HLTPMMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, tr
     }
   }
 
-  
+
   // filter decision
-  bool accept(n>=nZcandcut_); 
+  bool accept(n>=nZcandcut_);
   // if (accept) std::cout << "n size = " << n << std::endl;
 
   return accept;
 }
 
-TLorentzVector HLTPMMassFilter::approxMomAtVtx( const MagneticField *magField, const GlobalPoint& xvert, const reco::SuperClusterRef sc, int charge)
+TLorentzVector HLTPMMassFilter::approxMomAtVtx( const MagneticField *magField, const GlobalPoint& xvert, const reco::SuperClusterRef sc, int charge) const
 {
     GlobalPoint xsc(sc->position().x(),
 		    sc->position().y(),
@@ -193,9 +192,9 @@ TLorentzVector HLTPMMassFilter::approxMomAtVtx( const MagneticField *magField, c
     float theApproxMomMod = theFTS.momentum().x()*theFTS.momentum().x() +
                             theFTS.momentum().y()*theFTS.momentum().y() +
                             theFTS.momentum().z()*theFTS.momentum().z();
-    TLorentzVector theApproxMom(theFTS.momentum().x(), 
+    TLorentzVector theApproxMom(theFTS.momentum().x(),
 				theFTS.momentum().y(),
-				theFTS.momentum().z(), 
+				theFTS.momentum().z(),
                                 sqrt(theApproxMomMod + 2.61121E-7));
     return theApproxMom ;
 }

--- a/HLTrigger/Egamma/src/HLTPMMassFilter.cc
+++ b/HLTrigger/Egamma/src/HLTPMMassFilter.cc
@@ -50,7 +50,7 @@ HLTPMMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
 
 // ------------ method called to produce the data  ------------
 bool
-HLTPMMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTPMMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/Egamma/src/HLTPMMassFilter.cc
+++ b/HLTrigger/Egamma/src/HLTPMMassFilter.cc
@@ -52,7 +52,7 @@ HLTPMMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
 
 // ------------ method called to produce the data  ------------
 bool
-HLTPMMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTPMMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/HLTcore/interface/HLTFilter.h
+++ b/HLTrigger/HLTcore/interface/HLTFilter.h
@@ -3,7 +3,7 @@
 
 /** \class HLTFilter
  *
- *  
+ *
  *  This class derives from EDFilter and adds a few HLT specific items.
  *  All HLT filters that wish to save summary objects for the AOD must derive from the HLTFilter class.
  *
@@ -36,7 +36,7 @@ private:
   bool filter(edm::Event & event, const edm::EventSetup & setup) override final;
 
   // declared pure virtual to enforce inheriting classes to implement it
-  virtual bool hltFilter(edm::Event & event, const edm::EventSetup & setup, trigger::TriggerFilterObjectWithRefs & filterobject) const = 0;
+  virtual bool hltFilter(edm::Event & event, const edm::EventSetup & setup, trigger::TriggerFilterObjectWithRefs & filterobject) = 0;
 
 private:
   const bool saveTags_;

--- a/HLTrigger/HLTcore/interface/HLTFilter.h
+++ b/HLTrigger/HLTcore/interface/HLTFilter.h
@@ -33,10 +33,10 @@ public:
   virtual ~HLTFilter();
 
 private:
-  bool filter(edm::Event & event, const edm::EventSetup & setup);
+  bool filter(edm::Event & event, const edm::EventSetup & setup) override final;
 
-  // declared pue virtual to enforce inheriting classes to implement it
-  virtual bool hltFilter(edm::Event & event, const edm::EventSetup & setup, trigger::TriggerFilterObjectWithRefs & filterobject) = 0;
+  // declared pure virtual to enforce inheriting classes to implement it
+  virtual bool hltFilter(edm::Event & event, const edm::EventSetup & setup, trigger::TriggerFilterObjectWithRefs & filterobject) const = 0;
 
 private:
   const bool saveTags_;

--- a/HLTrigger/HLTcore/src/HLTFilter.cc
+++ b/HLTrigger/HLTcore/src/HLTFilter.cc
@@ -1,6 +1,6 @@
 /** \class HLTFilter
  *
- *  
+ *
  *  This class derives from EDFilter and adds a few HLT specific
  *  items. Any and all HLT filters must derive from the HLTFilter
  *  class!
@@ -20,7 +20,7 @@
 HLTFilter::HLTFilter(const edm::ParameterSet & config) :
   EDFilter(),
   saveTags_(config.getParameter<bool>("saveTags"))
-{ 
+{
   // register common HLTFilter products
   produces<trigger::TriggerFilterObjectWithRefs>();
 }
@@ -30,7 +30,7 @@ HLTFilter::makeHLTFilterDescription(edm::ParameterSetDescription& desc) {
   desc.add<bool>("saveTags",false);
 }
 
-HLTFilter::~HLTFilter() 
+HLTFilter::~HLTFilter()
 { }
 
 bool HLTFilter::filter(edm::Event & event, const edm::EventSetup & setup) {

--- a/HLTrigger/HLTfilters/interface/HLTBeamModeFilter.h
+++ b/HLTrigger/HLTfilters/interface/HLTBeamModeFilter.h
@@ -50,7 +50,7 @@ public:
     /// parameter description
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
     /// filter the event
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
 private:
 

--- a/HLTrigger/HLTfilters/interface/HLTBeamModeFilter.h
+++ b/HLTrigger/HLTfilters/interface/HLTBeamModeFilter.h
@@ -50,7 +50,7 @@ public:
     /// parameter description
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
     /// filter the event
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
 private:
 

--- a/HLTrigger/HLTfilters/interface/HLTDoublet.h
+++ b/HLTrigger/HLTfilters/interface/HLTDoublet.h
@@ -38,7 +38,7 @@ class HLTDoublet : public HLTFilter {
       explicit HLTDoublet(const edm::ParameterSet&);
       ~HLTDoublet();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       // configuration

--- a/HLTrigger/HLTfilters/interface/HLTDoublet.h
+++ b/HLTrigger/HLTfilters/interface/HLTDoublet.h
@@ -3,7 +3,7 @@
 
 /** \class HLTDoublet
  *
- *  
+ *
  *  This class is an HLTFilter (-> EDFilter) implementing a basic HLT
  *  trigger for pairs of object, evaluating all pairs with the first
  *  object from collection 1, and the second object from collection 2,
@@ -42,34 +42,30 @@ class HLTDoublet : public HLTFilter {
 
    private:
       // configuration
-      std::vector<edm::InputTag> originTag1_;  // input tag identifying originals 1st product
-      std::vector<edm::InputTag> originTag2_;  // input tag identifying originals 2nd product
-      edm::InputTag inputTag1_;   // input tag identifying filtered 1st product
-      edm::InputTag inputTag2_;   // input tag identifying filtered 2nd product
-      edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken1_;
-      edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken2_;
-      int triggerType1_;
-      int triggerType2_;
-      double min_Dphi_,max_Dphi_; // Delta phi window
-      double min_Deta_,max_Deta_; // Delta eta window
-      double min_Minv_,max_Minv_; // Minv(1,2) window
-      double min_DelR_,max_DelR_; // Delta R window
-      double min_Pt_  ,max_Pt_;   // Pt(1,2) window
-      int    min_N_;              // number of pairs passing cuts required
+      const std::vector<edm::InputTag> originTag1_;     // input tag identifying originals 1st product
+      const std::vector<edm::InputTag> originTag2_;     // input tag identifying originals 2nd product
+      const edm::InputTag inputTag1_;                   // input tag identifying filtered 1st product
+      const edm::InputTag inputTag2_;                   // input tag identifying filtered 2nd product
+      const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken1_;
+      const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken2_;
+      const int    triggerType1_;
+      const int    triggerType2_;
+      const double min_Dphi_,max_Dphi_;                 // Delta phi window
+      const double min_Deta_,max_Deta_;                 // Delta eta window
+      const double min_Minv_,max_Minv_;                 // Minv(1,2) window
+      const double min_DelR_,max_DelR_;                 // Delta R window
+      const double min_Pt_  ,max_Pt_;                   // Pt(1,2) window
+      const int    min_N_;                              // number of pairs passing cuts required
 
       // calculated from configuration in c'tor
-      bool   same_;                      // 1st and 2nd product are one and the same
-      bool   cutdphi_,cutdeta_,cutminv_,cutdelr_,cutpt_; // cuts are on=true or off=false
-
-      std::string label_;         // module label
+      const bool   same_;                                       // 1st and 2nd product are one and the same
+      const bool   cutdphi_,cutdeta_,cutminv_,cutdelr_,cutpt_;  // cuts are on=true or off=false
 
       //
       typedef std::vector<T1> T1Collection;
       typedef edm::Ref<T1Collection> T1Ref;
-      std::vector<T1Ref> coll1_;
       typedef std::vector<T2> T2Collection;
       typedef edm::Ref<T2Collection> T2Ref;
-      std::vector<T2Ref> coll2_;
 
 };
 

--- a/HLTrigger/HLTfilters/interface/HLTDoublet.h
+++ b/HLTrigger/HLTfilters/interface/HLTDoublet.h
@@ -38,7 +38,7 @@ class HLTDoublet : public HLTFilter {
       explicit HLTDoublet(const edm::ParameterSet&);
       ~HLTDoublet();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       // configuration

--- a/HLTrigger/HLTfilters/interface/HLTDoubletDZ.h
+++ b/HLTrigger/HLTfilters/interface/HLTDoubletDZ.h
@@ -27,7 +27,7 @@ class HLTDoubletDZ : public HLTFilter {
       explicit HLTDoubletDZ(const edm::ParameterSet&);
       ~HLTDoubletDZ();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       // configuration

--- a/HLTrigger/HLTfilters/interface/HLTDoubletDZ.h
+++ b/HLTrigger/HLTfilters/interface/HLTDoubletDZ.h
@@ -1,7 +1,7 @@
 #ifndef HLTDoubletDZ_h
 #define HLTDoubletDZ_h
 
-// 
+//
 // Class imlements |dZ|<Max for a pair of two objects
 //
 
@@ -31,29 +31,24 @@ class HLTDoubletDZ : public HLTFilter {
 
    private:
       // configuration
-      std::vector<edm::InputTag> originTag1_;  // input tag identifying originals 1st product
-      std::vector<edm::InputTag> originTag2_;  // input tag identifying originals 2nd product
-      edm::InputTag inputTag1_;   // input tag identifying filtered 1st product
-      edm::InputTag inputTag2_;   // input tag identifying filtered 2nd product
-      edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken1_;
-      edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken2_;
-      int triggerType1_;
-      int triggerType2_;
-      double minDR_;              // minimum dR between two objects to be considered a pair
-      double maxDZ_;              // number of pairs passing cuts required
-      bool   same_;               // 1st and 2nd product are one and the same
-      int    min_N_;              // number of pairs passing cuts required
-      bool   checkSC_;            // make sure SC constituents are different
-
-      std::string label_;         // module label
+      const std::vector<edm::InputTag> originTag1_;  // input tag identifying originals 1st product
+      const std::vector<edm::InputTag> originTag2_;  // input tag identifying originals 2nd product
+      const edm::InputTag inputTag1_;   // input tag identifying filtered 1st product
+      const edm::InputTag inputTag2_;   // input tag identifying filtered 2nd product
+      const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken1_;
+      const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> inputToken2_;
+      const int triggerType1_;
+      const int triggerType2_;
+      const double minDR_;              // minimum dR between two objects to be considered a pair
+      const double maxDZ_;              // number of pairs passing cuts required
+      const int    min_N_;              // number of pairs passing cuts required
+      const bool   checkSC_;            // make sure SC constituents are different
+      const bool   same_;               // 1st and 2nd product are one and the same
 
       typedef std::vector<T1> T1Collection;
       typedef edm::Ref<T1Collection> T1Ref;
-      std::vector<T1Ref> coll1_;
       typedef std::vector<T2> T2Collection;
       typedef edm::Ref<T2Collection> T2Ref;
-      std::vector<T2Ref> coll2_;
-
 
 };
 

--- a/HLTrigger/HLTfilters/interface/HLTDoubletDZ.h
+++ b/HLTrigger/HLTfilters/interface/HLTDoubletDZ.h
@@ -27,7 +27,7 @@ class HLTDoubletDZ : public HLTFilter {
       explicit HLTDoubletDZ(const edm::ParameterSet&);
       ~HLTDoubletDZ();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       // configuration

--- a/HLTrigger/HLTfilters/interface/HLTFiltCand.h
+++ b/HLTrigger/HLTfilters/interface/HLTFiltCand.h
@@ -39,7 +39,7 @@ class HLTFiltCand : public HLTFilter {
       explicit HLTFiltCand(const edm::ParameterSet&);
       ~HLTFiltCand();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       edm::InputTag photTag_;  // input tag identifying product containing photons

--- a/HLTrigger/HLTfilters/interface/HLTFiltCand.h
+++ b/HLTrigger/HLTfilters/interface/HLTFiltCand.h
@@ -3,7 +3,7 @@
 
 /** \class HLTFiltCand
  *
- *  
+ *
  *  This class is an HLTFilter (-> EDFilter) implementing a very basic
  *  HLT trigger acting on candidates, requiring a g/e/m/j tuple above
  *  pt cuts
@@ -39,7 +39,7 @@ class HLTFiltCand : public HLTFilter {
       explicit HLTFiltCand(const edm::ParameterSet&);
       ~HLTFiltCand();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       edm::InputTag photTag_;  // input tag identifying product containing photons

--- a/HLTrigger/HLTfilters/interface/HLTGlobalSums.h
+++ b/HLTrigger/HLTfilters/interface/HLTGlobalSums.h
@@ -3,7 +3,7 @@
 
 /** \class HLTGlobalSums
  *
- *  
+ *
  *  This class is an HLTFilter (-> EDFilter) implementing cuts on
  *  global sums such as the scalar sum of Et (a.k.a. H_T), available
  *  in the T=CaloMET or T=MET object.
@@ -30,7 +30,7 @@ class HLTGlobalSums : public HLTFilter {
       explicit HLTGlobalSums(const edm::ParameterSet&);
       ~HLTGlobalSums();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       // configuration

--- a/HLTrigger/HLTfilters/interface/HLTGlobalSums.h
+++ b/HLTrigger/HLTfilters/interface/HLTGlobalSums.h
@@ -30,7 +30,7 @@ class HLTGlobalSums : public HLTFilter {
       explicit HLTGlobalSums(const edm::ParameterSet&);
       ~HLTGlobalSums();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       // configuration

--- a/HLTrigger/HLTfilters/interface/HLTLevel1GTSeed.h
+++ b/HLTrigger/HLTfilters/interface/HLTLevel1GTSeed.h
@@ -64,7 +64,7 @@ public:
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
     /// filter the event
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
 private:
 
@@ -90,9 +90,9 @@ private:
 
     /// seeding is done via L1 trigger object maps, considering the objects which fired in L1
     bool seedsL1TriggerObjectMaps(
-            edm::Event &, 
+            edm::Event &,
             trigger::TriggerFilterObjectWithRefs &,
-            const L1GlobalTriggerReadoutRecord *, 
+            const L1GlobalTriggerReadoutRecord *,
             const int physicsDaqPartition);
 
     /// seeding is done ignoring if a L1 object fired or not

--- a/HLTrigger/HLTfilters/interface/HLTLevel1GTSeed.h
+++ b/HLTrigger/HLTfilters/interface/HLTLevel1GTSeed.h
@@ -64,7 +64,7 @@ public:
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
     /// filter the event
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
 private:
 

--- a/HLTrigger/HLTfilters/interface/HLTSinglet.h
+++ b/HLTrigger/HLTfilters/interface/HLTSinglet.h
@@ -29,7 +29,7 @@ class HLTSinglet : public HLTFilter {
       explicit HLTSinglet(const edm::ParameterSet&);
       ~HLTSinglet();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       edm::InputTag                     inputTag_;   // input tag identifying product

--- a/HLTrigger/HLTfilters/interface/HLTSinglet.h
+++ b/HLTrigger/HLTfilters/interface/HLTSinglet.h
@@ -3,7 +3,7 @@
 
 /** \class HLTSinglet
  *
- *  
+ *
  *  This class is an HLTFilter (-> EDFilter) implementing a basic HLT
  *  trigger for single objects of the same physics type, cutting on
  *  variables relating to their 4-momentum representation
@@ -32,15 +32,14 @@ class HLTSinglet : public HLTFilter {
       virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
-      edm::InputTag                     inputTag_;   // input tag identifying product
-      edm::EDGetTokenT<std::vector<T> > inputToken_; // token identifying product
-      int    triggerType_ ;     // triggerType configured
-      double min_E_;            // energy threshold in GeV 
-      double min_Pt_;           // pt threshold in GeV 
-      double min_Mass_;         // mass threshold in GeV 
-      double max_Eta_;          // eta range (symmetric)
-      int    min_N_;            // number of objects passing cuts required
-      int    tid_;              // actual triggerType
+      const edm::InputTag                    inputTag_;     // input tag identifying product
+      const edm::EDGetTokenT<std::vector<T>> inputToken_;   // token identifying product
+      const int    triggerType_ ;                           // triggerType configured
+      const int    min_N_;                                  // number of objects passing cuts required
+      const double min_E_;                                  // energy threshold in GeV
+      const double min_Pt_;                                 // pt threshold in GeV
+      const double min_Mass_;                               // mass threshold in GeV
+      const double max_Eta_;                                // eta range (symmetric)
 };
 
 #endif // HLTSinglet_h

--- a/HLTrigger/HLTfilters/interface/HLTSinglet.h
+++ b/HLTrigger/HLTfilters/interface/HLTSinglet.h
@@ -29,7 +29,7 @@ class HLTSinglet : public HLTFilter {
       explicit HLTSinglet(const edm::ParameterSet&);
       ~HLTSinglet();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       const edm::InputTag                    inputTag_;     // input tag identifying product

--- a/HLTrigger/HLTfilters/interface/HLTSmartSinglet.h
+++ b/HLTrigger/HLTfilters/interface/HLTSmartSinglet.h
@@ -34,7 +34,7 @@ class HLTSmartSinglet : public HLTFilter {
       explicit HLTSmartSinglet(const edm::ParameterSet&);
       ~HLTSmartSinglet();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       edm::InputTag                     inputTag_;   // input tag identifying product

--- a/HLTrigger/HLTfilters/interface/HLTSmartSinglet.h
+++ b/HLTrigger/HLTfilters/interface/HLTSmartSinglet.h
@@ -3,7 +3,7 @@
 
 /** \class HLTSmartSinglet
  *
- *  
+ *
  *  This class is an HLTFilter (-> EDFilter) implementing a smart HLT
  *  trigger cut, specified as a string such as "pt>15 && -3<eta<3",
  *  for single objects of the same physics type, allowing to cut on
@@ -34,11 +34,11 @@ class HLTSmartSinglet : public HLTFilter {
       explicit HLTSmartSinglet(const edm::ParameterSet&);
       ~HLTSmartSinglet();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       edm::InputTag                     inputTag_;   // input tag identifying product
-      edm::EDGetTokenT<std::vector<T> > inputToken_; // token identifying product      
+      edm::EDGetTokenT<std::vector<T> > inputToken_; // token identifying product
       int triggerType_;        // triggerType
       std::string   cut_;      // smart cut
       int           min_N_;    // number of objects passing cuts required

--- a/HLTrigger/HLTfilters/interface/HLTSummaryFilter.h
+++ b/HLTrigger/HLTfilters/interface/HLTSummaryFilter.h
@@ -3,7 +3,7 @@
 
 /** \class HLTSummaryFilter
  *
- *  
+ *
  *  This class is an HLTFilter (-> EDFilter) implementing a smart HLT
  *  trigger cut, specified as a string such as "pt>15 && -3<eta<3",
  *  for objects in the TriggerSummaryAOD product, allowing to cut on
@@ -36,7 +36,7 @@ class HLTSummaryFilter : public HLTFilter {
       explicit HLTSummaryFilter(const edm::ParameterSet&);
       ~HLTSummaryFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       edm::InputTag                           summaryTag_;   // input tag identifying TriggerSummaryAOD

--- a/HLTrigger/HLTfilters/interface/HLTSummaryFilter.h
+++ b/HLTrigger/HLTfilters/interface/HLTSummaryFilter.h
@@ -36,7 +36,7 @@ class HLTSummaryFilter : public HLTFilter {
       explicit HLTSummaryFilter(const edm::ParameterSet&);
       ~HLTSummaryFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       edm::InputTag                           summaryTag_;   // input tag identifying TriggerSummaryAOD

--- a/HLTrigger/HLTfilters/interface/TriggerResultsFilter.h
+++ b/HLTrigger/HLTfilters/interface/TriggerResultsFilter.h
@@ -3,12 +3,11 @@
 
 /** \class TriggerResultsFilter
  *
- *  
- *  This class is an HLTFilter (-> EDFilter) implementing filtering on
- *  arbitrary logical combinations of L1 and HLT results.
  *
- *  It has been written as an extension of the HLTHighLevel and HLTHighLevelDev 
- *  filters.
+ *  This class is an EDFilter implementing filtering on arbitrary logical combinations
+ *  of L1 and HLT results.
+ *
+ *  It has been written as an extension of the HLTHighLevel and HLTHighLevelDev filters.
  *
  *
  *  Authors: Martin Grunewald, Andrea Bocci
@@ -42,7 +41,7 @@ public:
   explicit TriggerResultsFilter(const edm::ParameterSet &);
   ~TriggerResultsFilter();
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  virtual bool filter(edm::Event &, const edm::EventSetup &);
+  bool filter(edm::Event &, const edm::EventSetup &) override;
 
 private:
   /// parse the logical expression into functionals

--- a/HLTrigger/HLTfilters/interface/TriggerResultsFilterFromDB.h
+++ b/HLTrigger/HLTfilters/interface/TriggerResultsFilterFromDB.h
@@ -40,7 +40,7 @@ public:
   explicit TriggerResultsFilterFromDB(const edm::ParameterSet &);
   ~TriggerResultsFilterFromDB();
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  virtual bool hltFilter(edm::Event &, const edm::EventSetup &, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event &, const edm::EventSetup &, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
 private:
   /// read the triggerConditions from the database

--- a/HLTrigger/HLTfilters/interface/TriggerResultsFilterFromDB.h
+++ b/HLTrigger/HLTfilters/interface/TriggerResultsFilterFromDB.h
@@ -3,12 +3,12 @@
 
 /** \class TriggerResultsFilterFromDB
  *
- *  
- *  This class is an HLTFilter (-> EDFilter) implementing filtering on
- *  arbitrary logical combinations of L1 and HLT results.
  *
- *  It is a modifed version of TriggerResultsFilter that reads the 
- *  trigger expression from the database.
+ *  This class is an EDFilter implementing filtering on arbitrary logical combinations
+ *  of L1 and HLT results.
+ *
+ *  It is a modifed version of TriggerResultsFilter that reads the trigger expression
+ *  from the database.
  *
  *
  *  Authors: Martin Grunewald, Andrea Bocci
@@ -19,8 +19,8 @@
 #include <string>
 
 #include "FWCore/Framework/interface/ESWatcher.h"
+#include "FWCore/Framework/interface/EDFilter.h"
 #include "CondFormats/DataRecord/interface/AlCaRecoTriggerBitsRcd.h"
-#include "HLTrigger/HLTcore/interface/HLTFilter.h"
 #include "HLTrigger/HLTcore/interface/TriggerExpressionData.h"
 
 // forward declaration
@@ -35,12 +35,12 @@ namespace triggerExpression {
 // class declaration
 //
 
-class TriggerResultsFilterFromDB : public HLTFilter {
+class TriggerResultsFilterFromDB : public edm::EDFilter {
 public:
   explicit TriggerResultsFilterFromDB(const edm::ParameterSet &);
   ~TriggerResultsFilterFromDB();
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  virtual bool hltFilter(edm::Event &, const edm::EventSetup &, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+  bool filter(edm::Event &, const edm::EventSetup &) override;
 
 private:
   /// read the triggerConditions from the database

--- a/HLTrigger/HLTfilters/src/HLTBeamModeFilter.cc
+++ b/HLTrigger/HLTfilters/src/HLTBeamModeFilter.cc
@@ -78,20 +78,20 @@ void HLTBeamModeFilter::fillDescriptions(edm::ConfigurationDescriptions& descrip
   //    #
   //    # InputTag for the L1 Global Trigger EVM readout record
   //    #   gtDigis        GT Emulator
-  //    #   l1GtEvmUnpack  GT EVM Unpacker (default module name) 
-  //    #   gtEvmDigis     GT EVM Unpacker in RawToDigi standard sequence  
+  //    #   l1GtEvmUnpack  GT EVM Unpacker (default module name)
+  //    #   gtEvmDigis     GT EVM Unpacker in RawToDigi standard sequence
   //    #
   //    #   cloned GT unpacker in HLT = gtEvmDigis
   desc.add<edm::InputTag>("L1GtEvmReadoutRecordTag",edm::InputTag("gtEvmDigis"));
   //    #
-  //    # vector of allowed beam modes 
+  //    # vector of allowed beam modes
   //    # default value: 11 (STABLE)
   std::vector<unsigned int> allowedBeamMode(1,11);
   desc.add<std::vector<unsigned int> >("AllowedBeamMode",allowedBeamMode);
   descriptions.add("hltBeamModeFilter", desc);
 }
 
-bool HLTBeamModeFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& evSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+bool HLTBeamModeFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& evSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
 
     // for MC samples, return always true (not even checking validity of L1GlobalTriggerEvmReadoutRecord)
     // eventually, the BST information will be filled also in MC simulation to spare this check

--- a/HLTrigger/HLTfilters/src/HLTBeamModeFilter.cc
+++ b/HLTrigger/HLTfilters/src/HLTBeamModeFilter.cc
@@ -91,7 +91,7 @@ void HLTBeamModeFilter::fillDescriptions(edm::ConfigurationDescriptions& descrip
   descriptions.add("hltBeamModeFilter", desc);
 }
 
-bool HLTBeamModeFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& evSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+bool HLTBeamModeFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& evSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
 
     // for MC samples, return always true (not even checking validity of L1GlobalTriggerEvmReadoutRecord)
     // eventually, the BST information will be filled also in MC simulation to spare this check

--- a/HLTrigger/HLTfilters/src/HLTDoublet.cc
+++ b/HLTrigger/HLTfilters/src/HLTDoublet.cc
@@ -111,7 +111,7 @@ HLTDoublet<T1,T2>::fillDescriptions(edm::ConfigurationDescriptions& descriptions
 // ------------ method called to produce the data  ------------
 template<typename T1, typename T2>
 bool
-HLTDoublet<T1,T2>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTDoublet<T1,T2>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
    using namespace std;
    using namespace edm;

--- a/HLTrigger/HLTfilters/src/HLTDoublet.cc
+++ b/HLTrigger/HLTfilters/src/HLTDoublet.cc
@@ -104,7 +104,7 @@ HLTDoublet<T1,T2>::fillDescriptions(edm::ConfigurationDescriptions& descriptions
 // ------------ method called to produce the data  ------------
 template<typename T1, typename T2>
 bool
-HLTDoublet<T1,T2>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTDoublet<T1,T2>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
    using namespace std;
    using namespace edm;

--- a/HLTrigger/HLTfilters/src/HLTDoublet.cc
+++ b/HLTrigger/HLTfilters/src/HLTDoublet.cc
@@ -25,7 +25,7 @@
 // constructors and destructor
 //
 template<typename T1, typename T2>
-HLTDoublet<T1,T2>::HLTDoublet(const edm::ParameterSet& iConfig) : HLTFilter(iConfig), 
+HLTDoublet<T1,T2>::HLTDoublet(const edm::ParameterSet& iConfig) : HLTFilter(iConfig),
   originTag1_(iConfig.template getParameter<std::vector<edm::InputTag> >("originTag1")),
   originTag2_(iConfig.template getParameter<std::vector<edm::InputTag> >("originTag2")),
   inputTag1_(iConfig.template getParameter<edm::InputTag>("inputTag1")),
@@ -45,21 +45,14 @@ HLTDoublet<T1,T2>::HLTDoublet(const edm::ParameterSet& iConfig) : HLTFilter(iCon
   min_Pt_   (iConfig.template getParameter<double>("MinPt")),
   max_Pt_   (iConfig.template getParameter<double>("MaxPt")),
   min_N_    (iConfig.template getParameter<int>("MinN")),
-  label_    (iConfig.getParameter<std::string>("@module_label")),
-  coll1_(),
-  coll2_()
+  same_     (inputTag1_.encode() == inputTag2_.encode()),    // same collections to be compared?
+  cutdphi_  (min_Dphi_ <= max_Dphi_), // cut active?
+  cutdeta_  (min_Deta_ <= max_Deta_), // cut active?
+  cutminv_  (min_Minv_ <= max_Minv_), // cut active?
+  cutdelr_  (min_DelR_ <= max_DelR_), // cut active?
+  cutpt_    (min_Pt_   <= max_Pt_  )  // cut active?
 {
-
-   // same collections to be compared?
-   same_ = (inputTag1_.encode()==inputTag2_.encode());
-
-   cutdphi_ = (min_Dphi_ <= max_Dphi_); // cut active?
-   cutdeta_ = (min_Deta_ <= max_Deta_); // cut active?
-   cutminv_ = (min_Minv_ <= max_Minv_); // cut active?
-   cutdelr_ = (min_DelR_ <= max_DelR_); // cut active?
-   cutpt_   = (min_Pt_   <= max_Pt_  ); // cut active?
-
-   LogDebug("") << "InputTags and cuts : " 
+   LogDebug("") << "InputTags and cuts : "
 		<< inputTag1_.encode() << " " << inputTag2_.encode()
 		<< triggerType1_ << " " << triggerType2_
 		<< " Dphi [" << min_Dphi_ << " " << max_Dphi_ << "]"
@@ -124,27 +117,28 @@ HLTDoublet<T1,T2>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 
    bool accept(false);
 
-   LogVerbatim("HLTDoublet") << " XXX " << label_ << " 0 " << std::endl;
+   LogVerbatim("HLTDoublet") << " XXX " << moduleLabel() << " 0 " << std::endl;
+
+   std::vector<T1Ref> coll1;
+   std::vector<T2Ref> coll2;
 
    // get hold of pre-filtered object collections
-   Handle<TriggerFilterObjectWithRefs> coll1,coll2;
-   if (iEvent.getByToken(inputToken1_,coll1) && iEvent.getByToken(inputToken2_,coll2)) {
-     coll1_.clear();
-     coll1->getObjects(triggerType1_,coll1_);
-     const size_type n1(coll1_.size());
-     coll2_.clear();
-     coll2->getObjects(triggerType2_,coll2_);
-     const size_type n2(coll2_.size());
+   Handle<TriggerFilterObjectWithRefs> handle1, handle2;
+   if (iEvent.getByToken(inputToken1_,handle1) && iEvent.getByToken(inputToken2_,handle2)) {
+     handle1->getObjects(triggerType1_, coll1);
+     handle2->getObjects(triggerType2_, coll2);
+     const size_type n1(coll1.size());
+     const size_type n2(coll2.size());
 
      if (saveTags()) {
        InputTag tagOld;
        for (unsigned int i=0; i<originTag1_.size(); ++i) {
 	 filterproduct.addCollectionTag(originTag1_[i]);
-	 LogVerbatim("HLTDoublet") << " XXX " << label_ << " 1a/" << i << " " << originTag1_[i].encode() << std::endl;
+	 LogVerbatim("HLTDoublet") << " XXX " << moduleLabel() << " 1a/" << i << " " << originTag1_[i].encode() << std::endl;
        }
        tagOld=InputTag();
        for (size_type i1=0; i1!=n1; ++i1) {
-	 const ProductID pid(coll1_[i1].id());
+	 const ProductID pid(coll1[i1].id());
 	 const string&    label(iEvent.getProvenance(pid).moduleLabel());
 	 const string& instance(iEvent.getProvenance(pid).productInstanceName());
 	 const string&  process(iEvent.getProvenance(pid).processName());
@@ -152,16 +146,16 @@ HLTDoublet<T1,T2>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 	 if (tagOld.encode()!=tagNew.encode()) {
 	   filterproduct.addCollectionTag(tagNew);
 	   tagOld=tagNew;
-	   LogVerbatim("HLTDoublet") << " XXX " << label_ << " 1b " << tagNew.encode() << std::endl;
+	   LogVerbatim("HLTDoublet") << " XXX " << moduleLabel() << " 1b " << tagNew.encode() << std::endl;
 	 }
        }
        for (unsigned int i=0; i<originTag2_.size(); ++i) {
 	 filterproduct.addCollectionTag(originTag2_[i]);
-	 LogVerbatim("HLTDoublet") << " XXX " << label_ << " 2a/" << i << " " << originTag2_[i].encode() << std::endl;
+	 LogVerbatim("HLTDoublet") << " XXX " << moduleLabel() << " 2a/" << i << " " << originTag2_[i].encode() << std::endl;
        }
        tagOld=InputTag();
        for (size_type i2=0; i2!=n2; ++i2) {
-	 const ProductID pid(coll2_[i2].id());
+	 const ProductID pid(coll2[i2].id());
 	 const string&    label(iEvent.getProvenance(pid).moduleLabel());
 	 const string& instance(iEvent.getProvenance(pid).productInstanceName());
 	 const string&  process(iEvent.getProvenance(pid).processName());
@@ -169,7 +163,7 @@ HLTDoublet<T1,T2>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 	 if (tagOld.encode()!=tagNew.encode()) {
 	   filterproduct.addCollectionTag(tagNew);
 	   tagOld=tagNew;
-	   LogVerbatim("HLTDoublet") << " XXX " << label_ << " 2b " << tagNew.encode() << std::endl;
+	   LogVerbatim("HLTDoublet") << " XXX " << moduleLabel() << " 2b " << tagNew.encode() << std::endl;
 	 }
        }
      }
@@ -179,25 +173,25 @@ HLTDoublet<T1,T2>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
      T2Ref r2;
      Particle::LorentzVector p1,p2,p;
      for (unsigned int i1=0; i1!=n1; i1++) {
-       r1=coll1_[i1];
+       r1=coll1[i1];
        p1=r1->p4();
        unsigned int I(0);
        if (same_) {I=i1+1;}
        for (unsigned int i2=I; i2!=n2; i2++) {
-	 r2=coll2_[i2];
+	 r2=coll2[i2];
 	 p2=r2->p4();
 
 	 double Dphi(std::abs(p1.phi()-p2.phi()));
 	 if (Dphi>M_PI) Dphi=2.0*M_PI-Dphi;
-	 
+	
 	 double Deta(std::abs(p1.eta()-p2.eta()));
-	 
+	
 	 p=p1+p2;
 	 double Minv(std::abs(p.mass()));
 	 double Pt(p.pt());
 
 	 double DelR(sqrt(Dphi*Dphi+Deta*Deta));
-	 
+	
 	 if ( ( (!cutdphi_) || ((min_Dphi_<=Dphi) && (Dphi<=max_Dphi_)) ) &&
 	      ( (!cutdeta_) || ((min_Deta_<=Deta) && (Deta<=max_Deta_)) ) &&
 	      ( (!cutminv_) || ((min_Minv_<=Minv) && (Minv<=max_Minv_)) ) &&
@@ -207,7 +201,7 @@ HLTDoublet<T1,T2>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 	   filterproduct.addObject(triggerType1_,r1);
 	   filterproduct.addObject(triggerType2_,r2);
 	 }
-	 
+	
        }
      }
      // filter decision

--- a/HLTrigger/HLTfilters/src/HLTDoubletDZ.cc
+++ b/HLTrigger/HLTfilters/src/HLTDoubletDZ.cc
@@ -67,7 +67,7 @@ HLTDoubletDZ<T1,T2>::fillDescriptions(edm::ConfigurationDescriptions& descriptio
 // ------------ method called to produce the data  ------------
 template<typename T1, typename T2>
 bool
-HLTDoubletDZ<T1,T2>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTDoubletDZ<T1,T2>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
    using namespace std;
    using namespace edm;

--- a/HLTrigger/HLTfilters/src/HLTDoubletDZ.cc
+++ b/HLTrigger/HLTfilters/src/HLTDoubletDZ.cc
@@ -63,7 +63,7 @@ HLTDoubletDZ<T1,T2>::fillDescriptions(edm::ConfigurationDescriptions& descriptio
 // ------------ method called to produce the data  ------------
 template<typename T1, typename T2>
 bool
-HLTDoubletDZ<T1,T2>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTDoubletDZ<T1,T2>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
    using namespace std;
    using namespace edm;

--- a/HLTrigger/HLTfilters/src/HLTDoubletDZ.cc
+++ b/HLTrigger/HLTfilters/src/HLTDoubletDZ.cc
@@ -31,12 +31,8 @@ HLTDoubletDZ<T1,T2>::HLTDoubletDZ(const edm::ParameterSet& iConfig) : HLTFilter(
   maxDZ_ (iConfig.template getParameter<double>("MaxDZ")),
   min_N_    (iConfig.template getParameter<int>("MinN")),
   checkSC_  (iConfig.template getParameter<bool>("checkSC")),
-  label_    (iConfig.getParameter<std::string>("@module_label")),
-  coll1_(),
-  coll2_()
+  same_     (inputTag1_.encode()==inputTag2_.encode())      // same collections to be compared?
 {
-   // same collections to be compared?
-   same_ = (inputTag1_.encode()==inputTag2_.encode());
 }
 
 template<typename T1, typename T2>
@@ -80,27 +76,28 @@ HLTDoubletDZ<T1,T2>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup
 
    bool accept(false);
 
-   LogVerbatim("HLTDoubletDZ") << " XXX " << label_ << " 0 " << std::endl;
+   LogVerbatim("HLTDoubletDZ") << " XXX " << moduleLabel() << " 0 " << std::endl;
+
+   std::vector<T1Ref> coll1;
+   std::vector<T2Ref> coll2;
 
    // get hold of pre-filtered object collections
-   Handle<TriggerFilterObjectWithRefs> coll1,coll2;
-   if (iEvent.getByToken(inputToken1_,coll1) && iEvent.getByToken(inputToken2_,coll2)) {
-     coll1_.clear();
-     coll1->getObjects(triggerType1_,coll1_);
-     const size_type n1(coll1_.size());
-     coll2_.clear();
-     coll2->getObjects(triggerType2_,coll2_);
-     const size_type n2(coll2_.size());
+   Handle<TriggerFilterObjectWithRefs> handle1,handle2;
+   if (iEvent.getByToken(inputToken1_, handle1) and iEvent.getByToken(inputToken2_, handle2)) {
+     handle1->getObjects(triggerType1_, coll1);
+     handle2->getObjects(triggerType2_, coll2);
+     const size_type n1(coll1.size());
+     const size_type n2(coll2.size());
 
      if (saveTags()) {
        InputTag tagOld;
        for (unsigned int i=0; i<originTag1_.size(); ++i) {
 	 filterproduct.addCollectionTag(originTag1_[i]);
-	 LogVerbatim("HLTDoubletDZ") << " XXX " << label_ << " 1a/" << i << " " << originTag1_[i].encode() << std::endl;
+	 LogVerbatim("HLTDoubletDZ") << " XXX " << moduleLabel() << " 1a/" << i << " " << originTag1_[i].encode() << std::endl;
        }
        tagOld=InputTag();
        for (size_type i1=0; i1!=n1; ++i1) {
-	 const ProductID pid(coll1_[i1].id());
+	 const ProductID pid(coll1[i1].id());
 	 const string&    label(iEvent.getProvenance(pid).moduleLabel());
 	 const string& instance(iEvent.getProvenance(pid).productInstanceName());
 	 const string&  process(iEvent.getProvenance(pid).processName());
@@ -108,16 +105,16 @@ HLTDoubletDZ<T1,T2>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup
 	 if (tagOld.encode()!=tagNew.encode()) {
 	   filterproduct.addCollectionTag(tagNew);
 	   tagOld=tagNew;
-           LogVerbatim("HLTDoubletDZ") << " XXX " << label_ << " 1b " << tagNew.encode() << std::endl;
+           LogVerbatim("HLTDoubletDZ") << " XXX " << moduleLabel() << " 1b " << tagNew.encode() << std::endl;
 	 }
        }
        for (unsigned int i=0; i<originTag2_.size(); ++i) {
 	 filterproduct.addCollectionTag(originTag2_[i]);
-	 LogVerbatim("HLTDoubletDZ") << " XXX " << label_ << " 2a/" << originTag2_[i].encode() << std::endl;
+	 LogVerbatim("HLTDoubletDZ") << " XXX " << moduleLabel() << " 2a/" << originTag2_[i].encode() << std::endl;
        }
        tagOld=InputTag();
        for (size_type i2=0; i2!=n2; ++i2) {
-	 const ProductID pid(coll2_[i2].id());
+	 const ProductID pid(coll2[i2].id());
 	 const string&    label(iEvent.getProvenance(pid).moduleLabel());
 	 const string& instance(iEvent.getProvenance(pid).productInstanceName());
 	 const string&  process(iEvent.getProvenance(pid).processName());
@@ -125,7 +122,7 @@ HLTDoubletDZ<T1,T2>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup
 	 if (tagOld.encode()!=tagNew.encode()) {
 	   filterproduct.addCollectionTag(tagNew);
 	   tagOld=tagNew;
-           LogVerbatim("HLTDoubletDZ") << " XXX " << label_ << " 2b " << tagNew.encode() << std::endl;
+           LogVerbatim("HLTDoubletDZ") << " XXX " << moduleLabel() << " 2b " << tagNew.encode() << std::endl;
 	 }
        }
      }
@@ -135,12 +132,12 @@ HLTDoubletDZ<T1,T2>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup
      T2Ref r2;
      Particle::LorentzVector p1,p2,p;
      for (unsigned int i1=0; i1!=n1; i1++) {
-       r1=coll1_[i1];
+       r1=coll1[i1];
        const reco::Candidate& candidate1(*r1);
        unsigned int I(0);
        if (same_) {I=i1+1;}
        for (unsigned int i2=I; i2!=n2; i2++) {
-	 r2=coll2_[i2];
+	 r2=coll2[i2];
 	 if (checkSC_) {
 	   if (r1->superCluster().isNonnull() && r2->superCluster().isNonnull()) {
 	     if (r1->superCluster() == r2->superCluster()) continue;

--- a/HLTrigger/HLTfilters/src/HLTFiltCand.cc
+++ b/HLTrigger/HLTfilters/src/HLTFiltCand.cc
@@ -40,7 +40,7 @@
 //
 // constructors and destructor
 //
- 
+
 HLTFiltCand::HLTFiltCand(const edm::ParameterSet& iConfig) : HLTFilter(iConfig),
   photTag_ (iConfig.getParameter<edm::InputTag>("photTag")),
   elecTag_ (iConfig.getParameter<edm::InputTag>("elecTag")),
@@ -102,7 +102,7 @@ HLTFiltCand::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 
 // ------------ method called to produce the data  ------------
 bool
-HLTFiltCand::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTFiltCand::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
    using namespace std;
    using namespace edm;

--- a/HLTrigger/HLTfilters/src/HLTFiltCand.cc
+++ b/HLTrigger/HLTfilters/src/HLTFiltCand.cc
@@ -102,7 +102,7 @@ HLTFiltCand::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 
 // ------------ method called to produce the data  ------------
 bool
-HLTFiltCand::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTFiltCand::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
    using namespace std;
    using namespace edm;

--- a/HLTrigger/HLTfilters/src/HLTGlobalSums.cc
+++ b/HLTrigger/HLTfilters/src/HLTGlobalSums.cc
@@ -89,7 +89,7 @@ HLTGlobalSums<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
 // ------------ method called to produce the data  ------------
 template<typename T> 
 bool
-HLTGlobalSums<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTGlobalSums<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
    using namespace std;
    using namespace edm;

--- a/HLTrigger/HLTfilters/src/HLTGlobalSums.cc
+++ b/HLTrigger/HLTfilters/src/HLTGlobalSums.cc
@@ -33,7 +33,7 @@ HLTGlobalSums<T>::HLTGlobalSums(const edm::ParameterSet& iConfig) : HLTFilter(iC
   min_N_      (iConfig.template getParameter<int>("MinN")),
   tid_(triggerType_)
 {
-   LogDebug("") << "InputTags and cuts : " 
+   LogDebug("") << "InputTags and cuts : "
 		<< inputTag_.encode() << " "
 		<< triggerType_ << " "
 		<< observable_
@@ -87,9 +87,9 @@ HLTGlobalSums<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
 //
 
 // ------------ method called to produce the data  ------------
-template<typename T> 
+template<typename T>
 bool
-HLTGlobalSums<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTGlobalSums<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
    using namespace std;
    using namespace edm;

--- a/HLTrigger/HLTfilters/src/HLTLevel1GTSeed.cc
+++ b/HLTrigger/HLTfilters/src/HLTLevel1GTSeed.cc
@@ -252,7 +252,7 @@ HLTLevel1GTSeed::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
   descriptions.add("hltLevel1GTSeed", desc);
 }
 
-bool HLTLevel1GTSeed::hltFilter(edm::Event& iEvent, const edm::EventSetup& evSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+bool HLTLevel1GTSeed::hltFilter(edm::Event& iEvent, const edm::EventSetup& evSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
 
     // all HLT filters must create and fill a HLT filter object,
     // recording any reconstructed physics objects satisfying

--- a/HLTrigger/HLTfilters/src/HLTLevel1GTSeed.cc
+++ b/HLTrigger/HLTfilters/src/HLTLevel1GTSeed.cc
@@ -200,12 +200,12 @@ HLTLevel1GTSeed::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
   makeHLTFilterDescription(desc);
 
   // # default: true
-  // #    seeding done via L1 trigger object maps, with objects that fired 
+  // #    seeding done via L1 trigger object maps, with objects that fired
   // #    only objects from the central BxInEvent (L1A) are used
   // # if false:
-  // #    seeding is done ignoring if a L1 object fired or not, 
-  // #    adding all L1EXtra objects corresponding to the object types 
-  // #    used in all conditions from the algorithms in logical expression 
+  // #    seeding is done ignoring if a L1 object fired or not,
+  // #    adding all L1EXtra objects corresponding to the object types
+  // #    used in all conditions from the algorithms in logical expression
   // #    for a given number of BxInEvent
   desc.add<bool>("L1UseL1TriggerObjectMaps",true);
 
@@ -252,7 +252,7 @@ HLTLevel1GTSeed::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
   descriptions.add("hltLevel1GTSeed", desc);
 }
 
-bool HLTLevel1GTSeed::hltFilter(edm::Event& iEvent, const edm::EventSetup& evSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+bool HLTLevel1GTSeed::hltFilter(edm::Event& iEvent, const edm::EventSetup& evSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
 
     // all HLT filters must create and fill a HLT filter object,
     // recording any reconstructed physics objects satisfying

--- a/HLTrigger/HLTfilters/src/HLTSinglet.cc
+++ b/HLTrigger/HLTfilters/src/HLTSinglet.cc
@@ -116,7 +116,7 @@ HLTSinglet<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 // ------------ method called to produce the data  ------------
 template<typename T>
 bool
-HLTSinglet<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTSinglet<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
    using namespace std;
    using namespace edm;

--- a/HLTrigger/HLTfilters/src/HLTSinglet.cc
+++ b/HLTrigger/HLTfilters/src/HLTSinglet.cc
@@ -117,7 +117,7 @@ HLTSinglet<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 // ------------ method called to produce the data  ------------
 template<typename T> 
 bool
-HLTSinglet<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTSinglet<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
    using namespace std;
    using namespace edm;

--- a/HLTrigger/HLTfilters/src/HLTSinglet.cc
+++ b/HLTrigger/HLTfilters/src/HLTSinglet.cc
@@ -73,20 +73,19 @@ int getObjectType(const l1extra::L1JetParticle & candidate) {
 // constructors and destructor
 //
 template<typename T>
-HLTSinglet<T>::HLTSinglet(const edm::ParameterSet& iConfig) : HLTFilter(iConfig), 
+HLTSinglet<T>::HLTSinglet(const edm::ParameterSet& iConfig) : HLTFilter(iConfig),
   inputTag_    (iConfig.template getParameter<edm::InputTag>("inputTag")),
   inputToken_  (consumes<std::vector<T> >(inputTag_)),
   triggerType_ (iConfig.template getParameter<int>("triggerType")),
+  min_N_    (iConfig.template getParameter<int>          ("MinN"    )),
   min_E_    (iConfig.template getParameter<double>       ("MinE"    )),
   min_Pt_   (iConfig.template getParameter<double>       ("MinPt"   )),
   min_Mass_ (iConfig.template getParameter<double>       ("MinMass" )),
-  max_Eta_  (iConfig.template getParameter<double>       ("MaxEta"  )),
-  min_N_    (iConfig.template getParameter<int>          ("MinN"    )),
-  tid_ (triggerType_)
+  max_Eta_  (iConfig.template getParameter<double>       ("MaxEta"  ))
 {
    LogDebug("") << "Input/ptcut/etacut/ncut : "
 		<< inputTag_.encode() << " "
-		<< min_E_ << " " << min_Pt_ << " " << min_Mass_ << " " 
+		<< min_E_ << " " << min_Pt_ << " " << min_Mass_ << " "
 		<< max_Eta_ << " " << min_N_ ;
 }
 
@@ -115,7 +114,7 @@ HLTSinglet<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 //
 
 // ------------ method called to produce the data  ------------
-template<typename T> 
+template<typename T>
 bool
 HLTSinglet<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
@@ -147,14 +146,15 @@ HLTSinglet<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trig
    typename TCollection::const_iterator i ( objects->begin() );
    for (; i!=objects->end(); i++) {
      if ( (i->energy() >= min_E_) &&
-	  (i->pt() >= min_Pt_) && 
-	  (i->mass() >= min_Mass_) && 
+	  (i->pt() >= min_Pt_) &&
+	  (i->mass() >= min_Mass_) &&
 	  ( (max_Eta_ < 0.0) || (std::abs(i->eta()) <= max_Eta_) ) ) {
        n++;
        ref=TRef(objects,distance(objects->begin(),i));
-       tid_=getObjectType<T>(*i);
-       if (tid_==0) tid_=triggerType_;
-       filterproduct.addObject(tid_,ref);
+       int tid = getObjectType<T>(*i);
+       if (tid == 0)
+         tid = triggerType_;
+       filterproduct.addObject(tid, ref);
      }
    }
 

--- a/HLTrigger/HLTfilters/src/HLTSmartSinglet.cc
+++ b/HLTrigger/HLTfilters/src/HLTSmartSinglet.cc
@@ -23,7 +23,7 @@
 // constructors and destructor
 //
 template<typename T>
-HLTSmartSinglet<T>::HLTSmartSinglet(const edm::ParameterSet& iConfig) : HLTFilter(iConfig), 
+HLTSmartSinglet<T>::HLTSmartSinglet(const edm::ParameterSet& iConfig) : HLTFilter(iConfig),
   inputTag_    (iConfig.template getParameter<edm::InputTag>("inputTag")),
   inputToken_  (consumes<std::vector<T> >(inputTag_)),
   triggerType_ (iConfig.template getParameter<int>("triggerType")),
@@ -43,7 +43,7 @@ HLTSmartSinglet<T>::~HLTSmartSinglet()
 {
 }
 
-template<typename T> 
+template<typename T>
 void
 HLTSmartSinglet<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
@@ -60,9 +60,9 @@ HLTSmartSinglet<T>::fillDescriptions(edm::ConfigurationDescriptions& description
 //
 
 // ------------ method called to produce the data  ------------
-template<typename T> 
+template<typename T>
 bool
-HLTSmartSinglet<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTSmartSinglet<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
    using namespace std;
    using namespace edm;

--- a/HLTrigger/HLTfilters/src/HLTSmartSinglet.cc
+++ b/HLTrigger/HLTfilters/src/HLTSmartSinglet.cc
@@ -62,7 +62,7 @@ HLTSmartSinglet<T>::fillDescriptions(edm::ConfigurationDescriptions& description
 // ------------ method called to produce the data  ------------
 template<typename T> 
 bool
-HLTSmartSinglet<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTSmartSinglet<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
    using namespace std;
    using namespace edm;

--- a/HLTrigger/HLTfilters/src/HLTSummaryFilter.cc
+++ b/HLTrigger/HLTfilters/src/HLTSummaryFilter.cc
@@ -58,7 +58,7 @@ HLTSummaryFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
 
 // ------------ method called to produce the data  ------------
 bool
-HLTSummaryFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTSummaryFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
    using namespace std;
    using namespace edm;

--- a/HLTrigger/HLTfilters/src/HLTSummaryFilter.cc
+++ b/HLTrigger/HLTfilters/src/HLTSummaryFilter.cc
@@ -29,7 +29,7 @@ HLTSummaryFilter::HLTSummaryFilter(const edm::ParameterSet& iConfig) : HLTFilter
   edm::LogInfo("HLTSummaryFilter")
      << "Summary/member/cut/ncut : "
      << summaryTag_.encode() << " "
-     << memberTag_.encode() << " " 
+     << memberTag_.encode() << " "
      << cut_<< " " << min_N_ ;
 }
 
@@ -58,7 +58,7 @@ HLTSummaryFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
 
 // ------------ method called to produce the data  ------------
 bool
-HLTSummaryFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTSummaryFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
    using namespace std;
    using namespace edm;
@@ -69,8 +69,8 @@ HLTSummaryFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
    iEvent.getByToken(summaryToken_,summary);
 
    if (!summary.isValid()) {
-     LogError("HLTSummaryFilter") << "Trigger summary product " 
-				  << summaryTag_.encode() 
+     LogError("HLTSummaryFilter") << "Trigger summary product "
+				  << summaryTag_.encode()
 				  << " not found! Filter returns false always";
      return false;
    }
@@ -92,7 +92,7 @@ HLTSummaryFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
        << " Filter objects: " << n << "/" << n1;
      return accept;
    }
-   
+
    // check if we want to cut on all physics objects of a full "L3" collection
    index=summary->collectionIndex(memberTag_);
    if (index<summary->sizeCollections()) {

--- a/HLTrigger/HLTfilters/src/TriggerResultsFilterFromDB.cc
+++ b/HLTrigger/HLTfilters/src/TriggerResultsFilterFromDB.cc
@@ -30,7 +30,7 @@
 //
 // constructors and destructor
 //
-TriggerResultsFilterFromDB::TriggerResultsFilterFromDB(const edm::ParameterSet & config) : HLTFilter(config),
+TriggerResultsFilterFromDB::TriggerResultsFilterFromDB(const edm::ParameterSet & config) :
   m_eventSetupPathsKey(config.getParameter<std::string>("eventSetupPathsKey")),
   m_eventSetupWatcher(),
   m_expression(0),
@@ -46,7 +46,6 @@ TriggerResultsFilterFromDB::~TriggerResultsFilterFromDB()
 void
 TriggerResultsFilterFromDB::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  makeHLTFilterDescription(desc);
   // # HLT results   - set to empty to ignore HLT
   desc.add<edm::InputTag>("hltResults",edm::InputTag("TriggerResults"));
   // # L1 GT results - set to empty to ignore L1T
@@ -99,8 +98,7 @@ void TriggerResultsFilterFromDB::pathsFromSetup(const edm::Event & event, const 
 
   TriggerMap::const_iterator listIter = triggerMap.find(m_eventSetupPathsKey);
   if (listIter == triggerMap.end()) {
-    throw cms::Exception("Configuration") << "TriggerResultsFilterFromDB [instance: " << * moduleLabel() 
-                                          << " - path: " << * pathName(event) 
+    throw cms::Exception("Configuration") << "TriggerResultsFilterFromDB [instance: " << moduleDescription().moduleLabel()
                                           << "]: No triggerList with key " << m_eventSetupPathsKey << " in AlCaRecoTriggerBitsRcd";
   }
 
@@ -109,7 +107,7 @@ void TriggerResultsFilterFromDB::pathsFromSetup(const edm::Event & event, const 
   parse( triggerBits->decompose(listIter->second) );
 }
 
-bool TriggerResultsFilterFromDB::hltFilter(edm::Event & event, const edm::EventSetup & setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool TriggerResultsFilterFromDB::filter(edm::Event & event, const edm::EventSetup & setup)
 {
   // if the IOV has changed, re-read the triggerConditions from the database
   if (m_eventSetupWatcher.check(setup))

--- a/HLTrigger/HLTfilters/src/TriggerResultsFilterFromDB.cc
+++ b/HLTrigger/HLTfilters/src/TriggerResultsFilterFromDB.cc
@@ -109,7 +109,7 @@ void TriggerResultsFilterFromDB::pathsFromSetup(const edm::Event & event, const 
   parse( triggerBits->decompose(listIter->second) );
 }
 
-bool TriggerResultsFilterFromDB::hltFilter(edm::Event & event, const edm::EventSetup & setup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool TriggerResultsFilterFromDB::hltFilter(edm::Event & event, const edm::EventSetup & setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   // if the IOV has changed, re-read the triggerConditions from the database
   if (m_eventSetupWatcher.check(setup))

--- a/HLTrigger/JetMET/interface/HLT2jetGapFilter.h
+++ b/HLTrigger/JetMET/interface/HLT2jetGapFilter.h
@@ -23,7 +23,7 @@ class HLT2jetGapFilter : public HLTFilter {
       explicit HLT2jetGapFilter(const edm::ParameterSet&);
       ~HLT2jetGapFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions); 
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       edm::EDGetTokenT<reco::CaloJetCollection> m_theCaloJetToken;

--- a/HLTrigger/JetMET/interface/HLT2jetGapFilter.h
+++ b/HLTrigger/JetMET/interface/HLT2jetGapFilter.h
@@ -22,8 +22,8 @@ class HLT2jetGapFilter : public HLTFilter {
    public:
       explicit HLT2jetGapFilter(const edm::ParameterSet&);
       ~HLT2jetGapFilter();
-      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions); 
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       edm::EDGetTokenT<reco::CaloJetCollection> m_theCaloJetToken;

--- a/HLTrigger/JetMET/interface/HLTAcoFilter.h
+++ b/HLTrigger/JetMET/interface/HLTAcoFilter.h
@@ -29,7 +29,7 @@ class HLTAcoFilter : public HLTFilter {
       explicit HLTAcoFilter(const edm::ParameterSet&);
       ~HLTAcoFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions); 
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
 

--- a/HLTrigger/JetMET/interface/HLTAcoFilter.h
+++ b/HLTrigger/JetMET/interface/HLTAcoFilter.h
@@ -28,8 +28,8 @@ class HLTAcoFilter : public HLTFilter {
    public:
       explicit HLTAcoFilter(const edm::ParameterSet&);
       ~HLTAcoFilter();
-      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions); 
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
 

--- a/HLTrigger/JetMET/interface/HLTAlphaTFilter.h
+++ b/HLTrigger/JetMET/interface/HLTAlphaTFilter.h
@@ -28,7 +28,7 @@ class HLTAlphaTFilter : public HLTFilter {
       explicit HLTAlphaTFilter(const edm::ParameterSet&);
       ~HLTAlphaTFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       

--- a/HLTrigger/JetMET/interface/HLTAlphaTFilter.h
+++ b/HLTrigger/JetMET/interface/HLTAlphaTFilter.h
@@ -28,10 +28,10 @@ class HLTAlphaTFilter : public HLTFilter {
       explicit HLTAlphaTFilter(const edm::ParameterSet&);
       ~HLTAlphaTFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
-      
+
       edm::EDGetTokenT<std::vector<T>> m_theRecoJetToken;
       edm::EDGetTokenT<std::vector<T>> m_theFastJetToken;
 

--- a/HLTrigger/JetMET/interface/HLTDiJetAveFilter.h
+++ b/HLTrigger/JetMET/interface/HLTDiJetAveFilter.h
@@ -26,7 +26,7 @@ class HLTDiJetAveFilter : public HLTFilter {
       explicit HLTDiJetAveFilter(const edm::ParameterSet&);
       ~HLTDiJetAveFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       edm::EDGetTokenT<std::vector<T>> m_theJetToken;

--- a/HLTrigger/JetMET/interface/HLTDiJetAveFilter.h
+++ b/HLTrigger/JetMET/interface/HLTDiJetAveFilter.h
@@ -26,7 +26,7 @@ class HLTDiJetAveFilter : public HLTFilter {
       explicit HLTDiJetAveFilter(const edm::ParameterSet&);
       ~HLTDiJetAveFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       edm::EDGetTokenT<std::vector<T>> m_theJetToken;

--- a/HLTrigger/JetMET/interface/HLTExclDiJetFilter.h
+++ b/HLTrigger/JetMET/interface/HLTExclDiJetFilter.h
@@ -27,7 +27,7 @@ class HLTExclDiJetFilter : public HLTFilter {
       explicit HLTExclDiJetFilter(const edm::ParameterSet&);
       ~HLTExclDiJetFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       edm::EDGetTokenT<std::vector<T>> m_theJetToken;

--- a/HLTrigger/JetMET/interface/HLTExclDiJetFilter.h
+++ b/HLTrigger/JetMET/interface/HLTExclDiJetFilter.h
@@ -27,7 +27,7 @@ class HLTExclDiJetFilter : public HLTFilter {
       explicit HLTExclDiJetFilter(const edm::ParameterSet&);
       ~HLTExclDiJetFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       edm::EDGetTokenT<std::vector<T>> m_theJetToken;

--- a/HLTrigger/JetMET/interface/HLTFatJetMassFilter.h
+++ b/HLTrigger/JetMET/interface/HLTFatJetMassFilter.h
@@ -27,7 +27,7 @@ class HLTFatJetMassFilter : public HLTFilter {
       explicit HLTFatJetMassFilter(const edm::ParameterSet&);
       ~HLTFatJetMassFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       edm::EDGetTokenT<std::vector<jetType>> m_theJetToken;

--- a/HLTrigger/JetMET/interface/HLTFatJetMassFilter.h
+++ b/HLTrigger/JetMET/interface/HLTFatJetMassFilter.h
@@ -27,7 +27,7 @@ class HLTFatJetMassFilter : public HLTFilter {
       explicit HLTFatJetMassFilter(const edm::ParameterSet&);
       ~HLTFatJetMassFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       edm::EDGetTokenT<std::vector<jetType>> m_theJetToken;

--- a/HLTrigger/JetMET/interface/HLTForwardBackwardJetsFilter.h
+++ b/HLTrigger/JetMET/interface/HLTForwardBackwardJetsFilter.h
@@ -22,7 +22,7 @@ class HLTForwardBackwardJetsFilter : public HLTFilter {
       explicit HLTForwardBackwardJetsFilter(const edm::ParameterSet&);
       ~HLTForwardBackwardJetsFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       edm::EDGetTokenT<std::vector<T>> m_theJetToken;

--- a/HLTrigger/JetMET/interface/HLTForwardBackwardJetsFilter.h
+++ b/HLTrigger/JetMET/interface/HLTForwardBackwardJetsFilter.h
@@ -22,7 +22,7 @@ class HLTForwardBackwardJetsFilter : public HLTFilter {
       explicit HLTForwardBackwardJetsFilter(const edm::ParameterSet&);
       ~HLTForwardBackwardJetsFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       edm::EDGetTokenT<std::vector<T>> m_theJetToken;

--- a/HLTrigger/JetMET/interface/HLTHemiDPhiFilter.h
+++ b/HLTrigger/JetMET/interface/HLTHemiDPhiFilter.h
@@ -21,13 +21,13 @@ class HLTHemiDPhiFilter : public HLTFilter {
       explicit HLTHemiDPhiFilter(const edm::ParameterSet&);
       ~HLTHemiDPhiFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
-      
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+
 
    private:
       edm::EDGetTokenT<std::vector<math::XYZTLorentzVector>> m_theHemiToken;
       static double deltaPhi(double, double); //helper function
-  
+
       edm::InputTag inputTag_; // input tag identifying product
       double min_dphi_;          // minimum dphi value
       bool accept_NJ_;         // accept or reject events with high NJ

--- a/HLTrigger/JetMET/interface/HLTHemiDPhiFilter.h
+++ b/HLTrigger/JetMET/interface/HLTHemiDPhiFilter.h
@@ -21,12 +21,12 @@ class HLTHemiDPhiFilter : public HLTFilter {
       explicit HLTHemiDPhiFilter(const edm::ParameterSet&);
       ~HLTHemiDPhiFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       
 
    private:
       edm::EDGetTokenT<std::vector<math::XYZTLorentzVector>> m_theHemiToken;
-      double deltaPhi(double, double); //helper function
+      static double deltaPhi(double, double); //helper function
   
       edm::InputTag inputTag_; // input tag identifying product
       double min_dphi_;          // minimum dphi value

--- a/HLTrigger/JetMET/interface/HLTHtMhtFilter.h
+++ b/HLTrigger/JetMET/interface/HLTHtMhtFilter.h
@@ -22,7 +22,7 @@ class HLTHtMhtFilter : public HLTFilter {
     explicit HLTHtMhtFilter(const edm::ParameterSet &);
     ~HLTHtMhtFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    virtual bool hltFilter(edm::Event & iEvent, const edm::EventSetup & iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+    virtual bool hltFilter(edm::Event & iEvent, const edm::EventSetup & iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
   private:
     std::vector<edm::EDGetTokenT<std::vector<reco::MET>>> m_theHtToken;

--- a/HLTrigger/JetMET/interface/HLTHtMhtFilter.h
+++ b/HLTrigger/JetMET/interface/HLTHtMhtFilter.h
@@ -22,7 +22,7 @@ class HLTHtMhtFilter : public HLTFilter {
     explicit HLTHtMhtFilter(const edm::ParameterSet &);
     ~HLTHtMhtFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    virtual bool hltFilter(edm::Event & iEvent, const edm::EventSetup & iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct);
+    virtual bool hltFilter(edm::Event & iEvent, const edm::EventSetup & iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
   private:
     std::vector<edm::EDGetTokenT<std::vector<reco::MET>>> m_theHtToken;

--- a/HLTrigger/JetMET/interface/HLTJetCollectionsFilter.h
+++ b/HLTrigger/JetMET/interface/HLTJetCollectionsFilter.h
@@ -23,7 +23,7 @@ class HLTJetCollectionsFilter : public HLTFilter {
       explicit HLTJetCollectionsFilter(const edm::ParameterSet&);
       ~HLTJetCollectionsFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
    private:
       edm::InputTag inputTag_; // input tag identifying jet collections
       edm::InputTag originalTag_; // input tag original jet collection

--- a/HLTrigger/JetMET/interface/HLTJetCollectionsFilter.h
+++ b/HLTrigger/JetMET/interface/HLTJetCollectionsFilter.h
@@ -23,7 +23,7 @@ class HLTJetCollectionsFilter : public HLTFilter {
       explicit HLTJetCollectionsFilter(const edm::ParameterSet&);
       ~HLTJetCollectionsFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
    private:
       edm::InputTag inputTag_; // input tag identifying jet collections
       edm::InputTag originalTag_; // input tag original jet collection

--- a/HLTrigger/JetMET/interface/HLTJetCollectionsVBFFilter.h
+++ b/HLTrigger/JetMET/interface/HLTJetCollectionsVBFFilter.h
@@ -27,7 +27,7 @@ class HLTJetCollectionsVBFFilter : public HLTFilter {
       explicit HLTJetCollectionsVBFFilter(const edm::ParameterSet&);
       ~HLTJetCollectionsVBFFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       edm::EDGetTokenT<std::vector<edm::RefVector<std::vector<T>,T,edm::refhelper::FindUsingAdvance<std::vector<T>,T>>> > m_theJetToken;

--- a/HLTrigger/JetMET/interface/HLTJetCollectionsVBFFilter.h
+++ b/HLTrigger/JetMET/interface/HLTJetCollectionsVBFFilter.h
@@ -27,7 +27,7 @@ class HLTJetCollectionsVBFFilter : public HLTFilter {
       explicit HLTJetCollectionsVBFFilter(const edm::ParameterSet&);
       ~HLTJetCollectionsVBFFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       edm::EDGetTokenT<std::vector<edm::RefVector<std::vector<T>,T,edm::refhelper::FindUsingAdvance<std::vector<T>,T>>> > m_theJetToken;

--- a/HLTrigger/JetMET/interface/HLTJetSortedVBFFilter.h
+++ b/HLTrigger/JetMET/interface/HLTJetSortedVBFFilter.h
@@ -3,7 +3,7 @@
 
 /** \class HLTJetSortedVBFFilter
  *
- *  
+ *
  *  This class is an HLTFilter (-> EDFilter) implementing a
  *  single jet requirement with an Energy threshold (not Et!)
  *  Based on HLTSinglet
@@ -41,19 +41,19 @@ class HLTJetSortedVBFFilter : public HLTFilter {
   explicit HLTJetSortedVBFFilter(const edm::ParameterSet&);
   ~HLTJetSortedVBFFilter();
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&,trigger::TriggerFilterObjectWithRefs& filterproduct) const;
-      
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&,trigger::TriggerFilterObjectWithRefs& filterproduct) override;
+
  private:
   edm::EDGetTokenT<std::vector<T>> m_theJetsToken;
   edm::EDGetTokenT<reco::JetTagCollection> m_theJetTagsToken;
-  edm::InputTag inputJets_; 
-  edm::InputTag inputJetTags_; 
-  double mqq_;           
-  double detaqq_; 
-  double detabb_;        
-  double ptsqq_;          
-  double ptsbb_; 
-  double seta_; 
+  edm::InputTag inputJets_;
+  edm::InputTag inputJetTags_;
+  double mqq_;
+  double detaqq_;
+  double detabb_;
+  double ptsqq_;
+  double ptsbb_;
+  double seta_;
   std::string value_;
   int triggerType_;
 };

--- a/HLTrigger/JetMET/interface/HLTJetSortedVBFFilter.h
+++ b/HLTrigger/JetMET/interface/HLTJetSortedVBFFilter.h
@@ -41,7 +41,7 @@ class HLTJetSortedVBFFilter : public HLTFilter {
   explicit HLTJetSortedVBFFilter(const edm::ParameterSet&);
   ~HLTJetSortedVBFFilter();
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&,trigger::TriggerFilterObjectWithRefs& filterproduct);
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&,trigger::TriggerFilterObjectWithRefs& filterproduct) const;
       
  private:
   edm::EDGetTokenT<std::vector<T>> m_theJetsToken;

--- a/HLTrigger/JetMET/interface/HLTJetVBFFilter.h
+++ b/HLTrigger/JetMET/interface/HLTJetVBFFilter.h
@@ -26,7 +26,7 @@ class HLTJetVBFFilter : public HLTFilter {
       explicit HLTJetVBFFilter(const edm::ParameterSet&);
       ~HLTJetVBFFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       edm::InputTag inputTag_; // input tag identifying jets

--- a/HLTrigger/JetMET/interface/HLTJetVBFFilter.h
+++ b/HLTrigger/JetMET/interface/HLTJetVBFFilter.h
@@ -26,7 +26,7 @@ class HLTJetVBFFilter : public HLTFilter {
       explicit HLTJetVBFFilter(const edm::ParameterSet&);
       ~HLTJetVBFFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       edm::InputTag inputTag_; // input tag identifying jets

--- a/HLTrigger/JetMET/interface/HLTMhtFilter.h
+++ b/HLTrigger/JetMET/interface/HLTMhtFilter.h
@@ -27,7 +27,7 @@ class HLTMhtFilter : public HLTFilter {
       explicit HLTMhtFilter(const edm::ParameterSet&);
       ~HLTMhtFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       edm::EDGetTokenT<reco::METCollection> m_theMhtToken;

--- a/HLTrigger/JetMET/interface/HLTMhtFilter.h
+++ b/HLTrigger/JetMET/interface/HLTMhtFilter.h
@@ -27,7 +27,7 @@ class HLTMhtFilter : public HLTFilter {
       explicit HLTMhtFilter(const edm::ParameterSet&);
       ~HLTMhtFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       edm::EDGetTokenT<reco::METCollection> m_theMhtToken;

--- a/HLTrigger/JetMET/interface/HLTMhtHtFilter.h
+++ b/HLTrigger/JetMET/interface/HLTMhtHtFilter.h
@@ -28,7 +28,7 @@ class HLTMhtHtFilter : public HLTFilter {
       explicit HLTMhtHtFilter(const edm::ParameterSet&);
       ~HLTMhtHtFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       edm::EDGetTokenT<std::vector<T>> m_theObjectToken;

--- a/HLTrigger/JetMET/interface/HLTMhtHtFilter.h
+++ b/HLTrigger/JetMET/interface/HLTMhtHtFilter.h
@@ -28,7 +28,7 @@ class HLTMhtHtFilter : public HLTFilter {
       explicit HLTMhtHtFilter(const edm::ParameterSet&);
       ~HLTMhtHtFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       edm::EDGetTokenT<std::vector<T>> m_theObjectToken;
@@ -50,7 +50,7 @@ class HLTMhtHtFilter : public HLTFilter {
                                                 //----mode = 4 for HT only
                                                 //----mode = 5 for HT and AlphaT cross trigger (ALWAYS uses jet ET, not pT)
       const bool                usePt_;
-      const bool                useTracks_; 
+      const bool                useTracks_;
       int   triggerType_;
 };
 

--- a/HLTrigger/JetMET/interface/HLTMonoJetFilter.h
+++ b/HLTrigger/JetMET/interface/HLTMonoJetFilter.h
@@ -26,7 +26,7 @@ class HLTMonoJetFilter : public HLTFilter {
       explicit HLTMonoJetFilter(const edm::ParameterSet&);
       ~HLTMonoJetFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       edm::InputTag inputJetTag_;   // input tag identifying jets

--- a/HLTrigger/JetMET/interface/HLTMonoJetFilter.h
+++ b/HLTrigger/JetMET/interface/HLTMonoJetFilter.h
@@ -26,7 +26,7 @@ class HLTMonoJetFilter : public HLTFilter {
       explicit HLTMonoJetFilter(const edm::ParameterSet&);
       ~HLTMonoJetFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       edm::InputTag inputJetTag_;   // input tag identifying jets

--- a/HLTrigger/JetMET/interface/HLTNVFilter.h
+++ b/HLTrigger/JetMET/interface/HLTNVFilter.h
@@ -20,7 +20,7 @@ class HLTNVFilter : public HLTFilter {
    public:
       explicit HLTNVFilter(const edm::ParameterSet&);
       ~HLTNVFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/JetMET/interface/HLTNVFilter.h
+++ b/HLTrigger/JetMET/interface/HLTNVFilter.h
@@ -20,7 +20,7 @@ class HLTNVFilter : public HLTFilter {
    public:
       explicit HLTNVFilter(const edm::ParameterSet&);
       ~HLTNVFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/JetMET/interface/HLTPFEnergyFractionsFilter.h
+++ b/HLTrigger/JetMET/interface/HLTPFEnergyFractionsFilter.h
@@ -36,7 +36,7 @@ class HLTPFEnergyFractionsFilter : public HLTFilter {
       explicit HLTPFEnergyFractionsFilter(const edm::ParameterSet&);
       ~HLTPFEnergyFractionsFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       edm::EDGetTokenT<reco::PFJetCollection> m_thePFJetToken;

--- a/HLTrigger/JetMET/interface/HLTPFEnergyFractionsFilter.h
+++ b/HLTrigger/JetMET/interface/HLTPFEnergyFractionsFilter.h
@@ -36,7 +36,7 @@ class HLTPFEnergyFractionsFilter : public HLTFilter {
       explicit HLTPFEnergyFractionsFilter(const edm::ParameterSet&);
       ~HLTPFEnergyFractionsFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       edm::EDGetTokenT<reco::PFJetCollection> m_thePFJetToken;

--- a/HLTrigger/JetMET/interface/HLTPhi2METFilter.h
+++ b/HLTrigger/JetMET/interface/HLTPhi2METFilter.h
@@ -20,7 +20,7 @@ class HLTPhi2METFilter : public HLTFilter {
    public:
       explicit HLTPhi2METFilter(const edm::ParameterSet&);
       ~HLTPhi2METFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/JetMET/interface/HLTPhi2METFilter.h
+++ b/HLTrigger/JetMET/interface/HLTPhi2METFilter.h
@@ -20,7 +20,7 @@ class HLTPhi2METFilter : public HLTFilter {
    public:
       explicit HLTPhi2METFilter(const edm::ParameterSet&);
       ~HLTPhi2METFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/JetMET/interface/HLTRapGapFilter.h
+++ b/HLTrigger/JetMET/interface/HLTRapGapFilter.h
@@ -20,7 +20,7 @@ class HLTRapGapFilter : public HLTFilter {
    public:
       explicit HLTRapGapFilter(const edm::ParameterSet&);
       ~HLTRapGapFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/JetMET/interface/HLTRapGapFilter.h
+++ b/HLTrigger/JetMET/interface/HLTRapGapFilter.h
@@ -20,7 +20,7 @@ class HLTRapGapFilter : public HLTFilter {
    public:
       explicit HLTRapGapFilter(const edm::ParameterSet&);
       ~HLTRapGapFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/JetMET/src/HLT2jetGapFilter.cc
+++ b/HLTrigger/JetMET/src/HLT2jetGapFilter.cc
@@ -18,16 +18,16 @@
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/Utilities/interface/InputTag.h" 
+#include "FWCore/Utilities/interface/InputTag.h"
 
 //
 // constructors and destructor
 //
-HLT2jetGapFilter::HLT2jetGapFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLT2jetGapFilter::HLT2jetGapFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
    inputTag_ = iConfig.getParameter<edm::InputTag> ("inputTag");
    minEt_    = iConfig.getParameter<double> ("minEt");
-   minEta_   = iConfig.getParameter<double> ("minEta"); 
+   minEta_   = iConfig.getParameter<double> ("minEta");
 
    m_theCaloJetToken = consumes<reco::CaloJetCollection>(inputTag_);
 
@@ -47,7 +47,7 @@ HLT2jetGapFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
 
 // ------------ method called to produce the data  ------------
 bool
-HLT2jetGapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLT2jetGapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace trigger;
 
@@ -69,9 +69,9 @@ HLT2jetGapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
     double etajet2=0.;
     int countjets =0;
 
-    for (reco::CaloJetCollection::const_iterator recocalojet = recocalojets->begin(); 
+    for (reco::CaloJetCollection::const_iterator recocalojet = recocalojets->begin();
 	 recocalojet<=(recocalojets->begin()+1); recocalojet++) {
-      
+
       if(countjets==0) {
 	etjet1 = recocalojet->et();
 	etajet1 = recocalojet->eta();
@@ -84,20 +84,20 @@ HLT2jetGapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
     }
 
   if(etjet1>minEt_ && etjet2>minEt_ && (etajet1*etajet2)<0 && std::abs(etajet1)>minEta_ && std::abs(etajet2)>minEta_){
-      for (reco::CaloJetCollection::const_iterator recocalojet = recocalojets->begin(); 
+      for (reco::CaloJetCollection::const_iterator recocalojet = recocalojets->begin();
 	   recocalojet<=(recocalojets->begin()+1); recocalojet++) {
 	reco::CaloJetRef ref(reco::CaloJetRef(recocalojets,distance(recocalojets->begin(),recocalojet)));
 	filterproduct.addObject(TriggerJet,ref);
 	n++;
       }
     }
-    
+
   } // events with two or more jets
-  
-  
-  
+
+
+
   // filter decision
   bool accept(n>=2);
-  
+
   return accept;
 }

--- a/HLTrigger/JetMET/src/HLT2jetGapFilter.cc
+++ b/HLTrigger/JetMET/src/HLT2jetGapFilter.cc
@@ -47,7 +47,7 @@ HLT2jetGapFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
 
 // ------------ method called to produce the data  ------------
 bool
-HLT2jetGapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLT2jetGapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace trigger;
 

--- a/HLTrigger/JetMET/src/HLTAcoFilter.cc
+++ b/HLTrigger/JetMET/src/HLTAcoFilter.cc
@@ -21,20 +21,20 @@
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/Utilities/interface/InputTag.h" 
+#include "FWCore/Utilities/interface/InputTag.h"
 
 
 //
 // constructors and destructor
 //
-HLTAcoFilter::HLTAcoFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTAcoFilter::HLTAcoFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
    inputJetTag_ = iConfig.getParameter< edm::InputTag > ("inputJetTag");
    inputMETTag_ = iConfig.getParameter< edm::InputTag > ("inputMETTag");
    minDPhi_     = iConfig.getParameter<double> ("minDeltaPhi");
    maxDPhi_     = iConfig.getParameter<double> ("maxDeltaPhi");
-   minEtjet1_   = iConfig.getParameter<double> ("minEtJet1"); 
-   minEtjet2_   = iConfig.getParameter<double> ("minEtJet2"); 
+   minEtjet1_   = iConfig.getParameter<double> ("minEtJet1");
+   minEtjet2_   = iConfig.getParameter<double> ("minEtJet2");
    AcoString_   = iConfig.getParameter<std::string> ("Acoplanar");
 
    m_theJetToken = consumes<reco::CaloJetCollection>(inputJetTag_);
@@ -59,7 +59,7 @@ HLTAcoFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 
 // ------------ method called to produce the data  ------------
 bool
-HLTAcoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTAcoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;
@@ -89,8 +89,8 @@ HLTAcoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigg
   double phijet2=0.;
   //double etmiss=0.;
   double phimiss=0.;
-   
-  VRcalomet vrefMET; 
+
+  VRcalomet vrefMET;
   metcal->getObjects(TriggerMET,vrefMET);
   CaloMETRef metRef=vrefMET.at(0);
   //etmiss  = vrefMET.at(0)->et();
@@ -99,12 +99,12 @@ HLTAcoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigg
   CaloJetRef ref1,ref2;
 
   if (JetNum>0) {
-    CaloJetCollection::const_iterator recocalojet = recocalojets->begin(); 
+    CaloJetCollection::const_iterator recocalojet = recocalojets->begin();
 	
     etjet1 = recocalojet->et();
     phijet1 = recocalojet->phi();
     ref1  = CaloJetRef(recocalojets,distance(recocalojets->begin(),recocalojet));
-    
+
     if(JetNum>1) {
       recocalojet++;
       etjet2 = recocalojet->et();
@@ -113,36 +113,36 @@ HLTAcoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigg
     }
     double Dphi= -1.;
     int JetSel = 0;
-    
+
     if (AcoString_ == "Jet2Met") {
       Dphi = std::abs(phimiss-phijet2);
-      if (JetNum>=2 && etjet1>minEtjet1_  && etjet2>minEtjet2_) {JetSel=1;} 
+      if (JetNum>=2 && etjet1>minEtjet1_  && etjet2>minEtjet2_) {JetSel=1;}
     }
     if (AcoString_ == "Jet1Jet2") {
       Dphi = std::abs(phijet1-phijet2);
-      if (JetNum>=2 && etjet1>minEtjet1_  && etjet2>minEtjet2_) {JetSel=1;} 
+      if (JetNum>=2 && etjet1>minEtjet1_  && etjet2>minEtjet2_) {JetSel=1;}
     }
-    if (AcoString_ == "Jet1Met") { 
+    if (AcoString_ == "Jet1Met") {
       Dphi = std::abs(phimiss-phijet1);
-      if (JetNum>=1 && etjet1>minEtjet1_ ) {JetSel=1;} 
+      if (JetNum>=1 && etjet1>minEtjet1_ ) {JetSel=1;}
     }
-    
-      
+
+
     if (Dphi>M_PI) {Dphi=2.0*M_PI-Dphi;}
     if(JetSel>0 && Dphi>=minDPhi_ && Dphi<=maxDPhi_){
-      
+
       if (AcoString_=="Jet2Met" || AcoString_=="Jet1Met")  {filterproduct.addObject(TriggerMET,metRef);}
       if (AcoString_=="Jet1Met" || AcoString_=="Jet1Jet2") {filterproduct.addObject(TriggerJet,ref1);}
       if (AcoString_=="Jet2Met" || AcoString_=="Jet1Jet2") {filterproduct.addObject(TriggerJet,ref2);}
       n++;
     }
-    
+
 
   } // at least one jet
-  
-    
+
+
   // filter decision
   bool accept(n>=1);
-    
+
   return accept;
 }

--- a/HLTrigger/JetMET/src/HLTAcoFilter.cc
+++ b/HLTrigger/JetMET/src/HLTAcoFilter.cc
@@ -59,7 +59,7 @@ HLTAcoFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 
 // ------------ method called to produce the data  ------------
 bool
-HLTAcoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTAcoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/JetMET/src/HLTAlphaTFilter.cc
+++ b/HLTrigger/JetMET/src/HLTAlphaTFilter.cc
@@ -85,7 +85,7 @@ void HLTAlphaTFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descri
 
 // ------------ method called to produce the data  ------------
 template<typename T>
-bool HLTAlphaTFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTAlphaTFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
 
   using namespace std;

--- a/HLTrigger/JetMET/src/HLTAlphaTFilter.cc
+++ b/HLTrigger/JetMET/src/HLTAlphaTFilter.cc
@@ -25,18 +25,18 @@ typedef ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> > LorentzV  ;
 // constructors and destructor
 //
 template<typename T>
-HLTAlphaTFilter<T>::HLTAlphaTFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTAlphaTFilter<T>::HLTAlphaTFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
-  inputJetTag_         = iConfig.getParameter< edm::InputTag > ("inputJetTag"); 
-  inputJetTagFastJet_  = iConfig.getParameter< edm::InputTag > ("inputJetTagFastJet"); 
-  minPtJet_            = iConfig.getParameter<std::vector<double> > ("minPtJet"); 
-  etaJet_              = iConfig.getParameter<std::vector<double> > ("etaJet"); 
-  maxNJets_            = iConfig.getParameter<unsigned int> ("maxNJets"); 
-  minHt_               = iConfig.getParameter<double> ("minHt"); 
+  inputJetTag_         = iConfig.getParameter< edm::InputTag > ("inputJetTag");
+  inputJetTagFastJet_  = iConfig.getParameter< edm::InputTag > ("inputJetTagFastJet");
+  minPtJet_            = iConfig.getParameter<std::vector<double> > ("minPtJet");
+  etaJet_              = iConfig.getParameter<std::vector<double> > ("etaJet");
+  maxNJets_            = iConfig.getParameter<unsigned int> ("maxNJets");
+  minHt_               = iConfig.getParameter<double> ("minHt");
   minAlphaT_           = iConfig.getParameter<double> ("minAlphaT");
   triggerType_         = iConfig.getParameter<int>("triggerType");
   // sanity checks
-  
+
   if (       (minPtJet_.size()    !=  etaJet_.size())
 	     || (  (minPtJet_.size()<1) || (etaJet_.size()<1) )
 	     || ( ((minPtJet_.size()<2) || (etaJet_.size()<2))))
@@ -55,7 +55,7 @@ HLTAlphaTFilter<T>::~HLTAlphaTFilter(){}
 template<typename T>
 void HLTAlphaTFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
-  makeHLTFilterDescription(desc); 
+  makeHLTFilterDescription(desc);
   desc.add<edm::InputTag>("inputJetTag",edm::InputTag("hltMCJetCorJetIcone5HF07"));
   desc.add<edm::InputTag>("inputJetTagFastJet",edm::InputTag("hltMCJetCorJetIcone5HF07"));
 
@@ -85,7 +85,7 @@ void HLTAlphaTFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descri
 
 // ------------ method called to produce the data  ------------
 template<typename T>
-bool HLTAlphaTFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTAlphaTFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
 
   using namespace std;
@@ -97,7 +97,7 @@ bool HLTAlphaTFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iS
   typedef Ref<TCollection> TRef;
 
   // The filter object
-  if (saveTags()) filterproduct.addCollectionTag(inputJetTag_);  
+  if (saveTags()) filterproduct.addCollectionTag(inputJetTag_);
 
   TRef ref;
   // Get the Candidates
@@ -126,7 +126,7 @@ bool HLTAlphaTFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iS
     std::vector<LorentzV> jets;
     typename TCollection::const_iterator ijet     = recojets->begin();
     typename TCollection::const_iterator ijetFast = recojetsFastJet->begin();
-    typename TCollection::const_iterator jjet     = recojets->end(); 
+    typename TCollection::const_iterator jjet     = recojets->end();
 
 
 
@@ -147,9 +147,9 @@ bool HLTAlphaTFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iS
 	    // Add to HT
 	    htFast += ijetFast->et();
 	  }
-	}      
-    
-	// Add to JetVector    
+	}
+
+	// Add to JetVector
 	LorentzV JetLVec(ijet->pt(),ijet->eta(),ijet->phi(),ijet->mass());
 	jets.push_back( JetLVec );
 	double aT = AlphaT(jets).value();

--- a/HLTrigger/JetMET/src/HLTDiJetAveFilter.cc
+++ b/HLTrigger/JetMET/src/HLTDiJetAveFilter.cc
@@ -28,14 +28,14 @@ template<typename T>
 HLTDiJetAveFilter<T>::HLTDiJetAveFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig),
   inputJetTag_ (iConfig.template getParameter< edm::InputTag > ("inputJetTag")),
   minPtAve_    (iConfig.template getParameter<double> ("minPtAve")),
-  minPtJet3_   (iConfig.template getParameter<double> ("minPtJet3")), 
+  minPtJet3_   (iConfig.template getParameter<double> ("minPtJet3")),
   minDphi_     (iConfig.template getParameter<double> ("minDphi")),
   triggerType_ (iConfig.template getParameter<int> ("triggerType"))
 {
   m_theJetToken = consumes<std::vector<T>>(inputJetTag_);
   LogDebug("") << "HLTDiJetAveFilter: Input/minPtAve/minPtJet3/minDphi/triggerType : "
 	       << inputJetTag_.encode() << " "
-	       << minPtAve_ << " " 
+	       << minPtAve_ << " "
 	       << minPtJet3_ << " "
 	       << minDphi_ << " "
 	       << triggerType_;
@@ -60,12 +60,12 @@ HLTDiJetAveFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descripti
 // ------------ method called to produce the data  ------------
 template<typename T>
 bool
-HLTDiJetAveFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTDiJetAveFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;
   using namespace reco;
-  using namespace trigger; 
+  using namespace trigger;
 
   typedef vector<T> TCollection;
   typedef Ref<TCollection> TRef;
@@ -76,7 +76,7 @@ HLTDiJetAveFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetu
   // get hold of collection of objects
   Handle<TCollection> objects;
   iEvent.getByToken (m_theJetToken,objects);
-  
+
   // look at all candidates,  check cuts and add to filter object
   int n(0);
 
@@ -90,7 +90,7 @@ HLTDiJetAveFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetu
     int nmax=1;
     if (objects->size() > 2) nmax=2;
 
-    TRef JetRef1,JetRef2; 
+    TRef JetRef1,JetRef2;
 
     typename TCollection::const_iterator i ( objects->begin() );
     for (; i<=(objects->begin()+nmax); i++) {
@@ -109,22 +109,22 @@ HLTDiJetAveFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetu
       }
       ++countjets;
     }
-    
+
     double PtAve=(ptjet1 + ptjet2) / 2.;
     double Dphi = std::abs(deltaPhi(phijet1,phijet2));
-    
+
     if( PtAve>minPtAve_ && ptjet3<minPtJet3_ && Dphi>minDphi_){
       filterproduct.addObject(triggerType_,JetRef1);
       filterproduct.addObject(triggerType_,JetRef2);
       ++n;
     }
-    
+
   } // events with two or more jets
-  
-  
-  
+
+
+
   // filter decision
   bool accept(n>=1);
-  
+
   return accept;
 }

--- a/HLTrigger/JetMET/src/HLTDiJetAveFilter.cc
+++ b/HLTrigger/JetMET/src/HLTDiJetAveFilter.cc
@@ -60,7 +60,7 @@ HLTDiJetAveFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descripti
 // ------------ method called to produce the data  ------------
 template<typename T>
 bool
-HLTDiJetAveFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTDiJetAveFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/JetMET/src/HLTExclDiJetFilter.cc
+++ b/HLTrigger/JetMET/src/HLTExclDiJetFilter.cc
@@ -25,11 +25,11 @@
 // constructors and destructor
 //
 template<typename T>
-HLTExclDiJetFilter<T>::HLTExclDiJetFilter(const edm::ParameterSet& iConfig) : 
+HLTExclDiJetFilter<T>::HLTExclDiJetFilter(const edm::ParameterSet& iConfig) :
   HLTFilter(iConfig),
   inputJetTag_ (iConfig.template getParameter< edm::InputTag > ("inputJetTag")),
-  minPtJet_    (iConfig.template getParameter<double> ("minPtJet")), 
-  minHFe_      (iConfig.template getParameter<double> ("minHFe")), 
+  minPtJet_    (iConfig.template getParameter<double> ("minPtJet")),
+  minHFe_      (iConfig.template getParameter<double> ("minHFe")),
   HF_OR_       (iConfig.template getParameter<bool> ("HF_OR")),
   triggerType_    (iConfig.template getParameter<int> ("triggerType"))
 {
@@ -37,7 +37,7 @@ HLTExclDiJetFilter<T>::HLTExclDiJetFilter(const edm::ParameterSet& iConfig) :
   m_theCaloTowerCollectionToken = consumes<CaloTowerCollection>(edm::InputTag("hltTowerMakerForAll"));
   LogDebug("") << "HLTExclDiJetFilter: Input/minPtJet/minHFe/HF_OR/triggerType : "
 	       << inputJetTag_.encode() << " "
-	       << minPtJet_ << " " 
+	       << minPtJet_ << " "
 	       << minHFe_ << " "
 	       << HF_OR_ << " "
 	       << triggerType_;
@@ -49,7 +49,7 @@ HLTExclDiJetFilter<T>::~HLTExclDiJetFilter(){}
 template<typename T>
 void
 HLTExclDiJetFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  edm::ParameterSetDescription desc; 
+  edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
   desc.add<edm::InputTag>("inputJetTag",edm::InputTag("hltMCJetCorJetIcone5HF07"));
   desc.add<double>("minPtJet",30.0);
@@ -62,7 +62,7 @@ HLTExclDiJetFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descript
 // ------------ method called to produce the data  ------------
 template<typename T>
 bool
-HLTExclDiJetFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTExclDiJetFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;
@@ -80,15 +80,15 @@ HLTExclDiJetFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 
   // look at all candidates,  check cuts and add to filter object
   int n(0);
-  
-  double ptjet1=0., ptjet2=0.;  
+
+  double ptjet1=0., ptjet2=0.;
   double phijet1=0., phijet2=0.;
-  
+
   if(recojets->size() > 1){
     // events with two or more jets
-    
+
     int countjets =0;
-    
+
     TRef JetRef1,JetRef2;
 
     typename TCollection::const_iterator recojet ( recojets->begin() );
@@ -103,7 +103,7 @@ HLTExclDiJetFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
       //
       if(countjets==1) {
 	ptjet2 = recojet->pt();
-        phijet2 = recojet->phi(); 
+        phijet2 = recojet->phi();
 
 	JetRef2 = TRef(recojets,distance(recojets->begin(),recojet));
       }
@@ -124,7 +124,7 @@ HLTExclDiJetFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
   } // events with two or more jets
 
   // calotowers
-  bool hf_accept=false; 
+  bool hf_accept=false;
 
   if(n>0) {
      double ehfp(0.);
@@ -148,8 +148,8 @@ HLTExclDiJetFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
   } // n>0
 
 
-////////////////////////////////////////////////////////  
-  
+////////////////////////////////////////////////////////
+
 // filter decision
   bool accept(n>0 && hf_accept);
 

--- a/HLTrigger/JetMET/src/HLTExclDiJetFilter.cc
+++ b/HLTrigger/JetMET/src/HLTExclDiJetFilter.cc
@@ -62,7 +62,7 @@ HLTExclDiJetFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descript
 // ------------ method called to produce the data  ------------
 template<typename T>
 bool
-HLTExclDiJetFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTExclDiJetFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/JetMET/src/HLTFatJetMassFilter.cc
+++ b/HLTrigger/JetMET/src/HLTFatJetMassFilter.cc
@@ -72,7 +72,7 @@ HLTFatJetMassFilter<jetType>::fillDescriptions(edm::ConfigurationDescriptions& d
 // ------------ method called to produce the data  ------------
 template<typename jetType>
 bool
-HLTFatJetMassFilter<jetType>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTFatJetMassFilter<jetType>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/JetMET/src/HLTFatJetMassFilter.cc
+++ b/HLTrigger/JetMET/src/HLTFatJetMassFilter.cc
@@ -72,7 +72,7 @@ HLTFatJetMassFilter<jetType>::fillDescriptions(edm::ConfigurationDescriptions& d
 // ------------ method called to produce the data  ------------
 template<typename jetType>
 bool
-HLTFatJetMassFilter<jetType>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTFatJetMassFilter<jetType>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/JetMET/src/HLTForwardBackwardJetsFilter.cc
+++ b/HLTrigger/JetMET/src/HLTForwardBackwardJetsFilter.cc
@@ -69,7 +69,7 @@ HLTForwardBackwardJetsFilter<T>::fillDescriptions(edm::ConfigurationDescriptions
 // ------------ method called to produce the data  ------------
 template<typename T>
 bool
-HLTForwardBackwardJetsFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTForwardBackwardJetsFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/JetMET/src/HLTForwardBackwardJetsFilter.cc
+++ b/HLTrigger/JetMET/src/HLTForwardBackwardJetsFilter.cc
@@ -24,11 +24,11 @@
 // constructors and destructor
 //
 template<typename T>
-HLTForwardBackwardJetsFilter<T>::HLTForwardBackwardJetsFilter(const edm::ParameterSet& iConfig) : 
+HLTForwardBackwardJetsFilter<T>::HLTForwardBackwardJetsFilter(const edm::ParameterSet& iConfig) :
   HLTFilter(iConfig),
   inputTag_ (iConfig.template getParameter< edm::InputTag > ("inputTag")),
   minPt_    (iConfig.template getParameter<double> ("minPt")),
-  minEta_   (iConfig.template getParameter<double> ("minEta")), 
+  minEta_   (iConfig.template getParameter<double> ("minEta")),
   maxEta_   (iConfig.template getParameter<double> ("maxEta")),
   nNeg_     (iConfig.template getParameter<unsigned int>("nNeg")),
   nPos_     (iConfig.template getParameter<unsigned int>("nPos")),
@@ -38,7 +38,7 @@ HLTForwardBackwardJetsFilter<T>::HLTForwardBackwardJetsFilter(const edm::Paramet
   m_theJetToken = consumes<std::vector<T>>(inputTag_);
   LogDebug("") << "HLTForwardBackwardJetsFilter: Input/minPt/minEta/maxEta/triggerType : "
 	       << inputTag_.encode() << " "
-	       << minPt_ << " " 
+	       << minPt_ << " "
 	       << minEta_ << " "
 	       << maxEta_ << " "
 	       << nNeg_ << " "
@@ -69,27 +69,27 @@ HLTForwardBackwardJetsFilter<T>::fillDescriptions(edm::ConfigurationDescriptions
 // ------------ method called to produce the data  ------------
 template<typename T>
 bool
-HLTForwardBackwardJetsFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTForwardBackwardJetsFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;
   using namespace reco;
-  using namespace trigger; 
+  using namespace trigger;
 
   typedef vector<T> TCollection;
   typedef Ref<TCollection> TRef;
-  
+
   // The filter object
   if (saveTags()) filterproduct.addCollectionTag(inputTag_);
 
   // get hold of collection of objects
   Handle<TCollection> objects;
   iEvent.getByToken(m_theJetToken,objects);
-  
+
   // look at all candidates,  check cuts and add to filter object
   unsigned int nPosJets(0);
   unsigned int nNegJets(0);
-  
+
   typename TCollection::const_iterator jet;
   // look for jets satifying pt and eta cuts; first on the plus side, then the minus side
 
@@ -109,13 +109,13 @@ HLTForwardBackwardJetsFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventS
       }
     }
   }
-  
+
   // filter decision
   const bool accept(
 		    ( nNegJets >= nNeg_ ) &&
 		    ( nPosJets >= nPos_ ) &&
 		    ((nNegJets+nPosJets) >= nTot_ )
-		   );  
-  
+		   );
+
   return accept;
 }

--- a/HLTrigger/JetMET/src/HLTHemiDPhiFilter.cc
+++ b/HLTrigger/JetMET/src/HLTHemiDPhiFilter.cc
@@ -53,8 +53,8 @@ HLTHemiDPhiFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions
 //
 
 // ------------ method called to produce the data  ------------
-bool 
-HLTHemiDPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool
+HLTHemiDPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
    using namespace std;
    using namespace edm;
@@ -78,15 +78,15 @@ HLTHemiDPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 
   //***********************************
   // Get the set of hemisphere axes
-   
+
    TLorentzVector j1R(hemispheres->at(0).x(),hemispheres->at(0).y(),hemispheres->at(0).z(),hemispheres->at(0).t());
    TLorentzVector j2R(hemispheres->at(1).x(),hemispheres->at(1).y(),hemispheres->at(1).z(),hemispheres->at(1).t());
 
    // compute the dPhi between them
   double dphi = 50.;
-  dphi = deltaPhi(j1R.Phi(),j2R.Phi()); 
-  
-  // Dphi requirement  
+  dphi = deltaPhi(j1R.Phi(),j2R.Phi());
+
+  // Dphi requirement
 
   if(dphi<=min_dphi_) return true;
 
@@ -96,7 +96,7 @@ HLTHemiDPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 
 
 double HLTHemiDPhiFilter::deltaPhi(double v1, double v2)
-{ 
+{
   // Computes the correctly normalized phi difference
   // v1, v2 = phi of object 1 and 2
   double diff = std::abs(v2 - v1);

--- a/HLTrigger/JetMET/src/HLTHemiDPhiFilter.cc
+++ b/HLTrigger/JetMET/src/HLTHemiDPhiFilter.cc
@@ -54,7 +54,7 @@ HLTHemiDPhiFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions
 
 // ------------ method called to produce the data  ------------
 bool 
-HLTHemiDPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTHemiDPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
    using namespace std;
    using namespace edm;
@@ -96,12 +96,10 @@ HLTHemiDPhiFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 
 
 double HLTHemiDPhiFilter::deltaPhi(double v1, double v2)
-{ // Computes the correctly normalized phi difference
+{ 
+  // Computes the correctly normalized phi difference
   // v1, v2 = phi of object 1 and 2
   double diff = std::abs(v2 - v1);
- double corr = 2*acos(-1.) - diff;
- if (diff < acos(-1.)){ return diff;} else { return corr;} 
- 
+  return (diff < M_PI) ? diff : 2*M_PI - diff;
 }
-
 

--- a/HLTrigger/JetMET/src/HLTHtMhtFilter.cc
+++ b/HLTrigger/JetMET/src/HLTHtMhtFilter.cc
@@ -62,7 +62,7 @@ void HLTHtMhtFilter::fillDescriptions(edm::ConfigurationDescriptions & descripti
 }
 
 
-bool HLTHtMhtFilter::hltFilter(edm::Event & iEvent, const edm::EventSetup & iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+bool HLTHtMhtFilter::hltFilter(edm::Event & iEvent, const edm::EventSetup & iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
 
   // the filter objects to be stored
   std::auto_ptr<reco::METCollection> metobject(new reco::METCollection());

--- a/HLTrigger/JetMET/src/HLTHtMhtFilter.cc
+++ b/HLTrigger/JetMET/src/HLTHtMhtFilter.cc
@@ -62,7 +62,7 @@ void HLTHtMhtFilter::fillDescriptions(edm::ConfigurationDescriptions & descripti
 }
 
 
-bool HLTHtMhtFilter::hltFilter(edm::Event & iEvent, const edm::EventSetup & iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+bool HLTHtMhtFilter::hltFilter(edm::Event & iEvent, const edm::EventSetup & iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
 
   // the filter objects to be stored
   std::auto_ptr<reco::METCollection> metobject(new reco::METCollection());

--- a/HLTrigger/JetMET/src/HLTJetCollectionsFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetCollectionsFilter.cc
@@ -56,7 +56,7 @@ HLTJetCollectionsFilter<jetType>::fillDescriptions(edm::ConfigurationDescription
 // ------------ method called to produce the data  ------------
 template <typename jetType>
 bool
-HLTJetCollectionsFilter<jetType>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTJetCollectionsFilter<jetType>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/JetMET/src/HLTJetCollectionsFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetCollectionsFilter.cc
@@ -56,7 +56,7 @@ HLTJetCollectionsFilter<jetType>::fillDescriptions(edm::ConfigurationDescription
 // ------------ method called to produce the data  ------------
 template <typename jetType>
 bool
-HLTJetCollectionsFilter<jetType>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTJetCollectionsFilter<jetType>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;
@@ -94,7 +94,7 @@ HLTJetCollectionsFilter<jetType>::hltFilter(edm::Event& iEvent, const edm::Event
 
     if (numberOfGoodJets >= minNJets_) {
       accept = true;
-      // keep looping through collections to save all possible jets 
+      // keep looping through collections to save all possible jets
     }
   }
 

--- a/HLTrigger/JetMET/src/HLTJetCollectionsVBFFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetCollectionsVBFFilter.cc
@@ -34,7 +34,7 @@ HLTJetCollectionsVBFFilter<T>::HLTJetCollectionsVBFFilter(const edm::ParameterSe
    originalTag_(iConfig.getParameter< edm::InputTag > ("originalTag")),
    softJetPt_(iConfig.getParameter<double> ("SoftJetPt")),
    hardJetPt_(iConfig.getParameter<double> ("HardJetPt")),
-   minDeltaEta_(iConfig.getParameter<double> ("MinDeltaEta")), 
+   minDeltaEta_(iConfig.getParameter<double> ("MinDeltaEta")),
    thirdJetPt_(iConfig.getParameter<double> ("ThirdJetPt")),
    maxAbsJetEta_(iConfig.getParameter<double> ("MaxAbsJetEta")),
    maxAbsThirdJetEta_(iConfig.getParameter<double> ("MaxAbsThirdJetEta")),
@@ -69,7 +69,7 @@ HLTJetCollectionsVBFFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& 
 // ------------ method called to produce the data  ------------
 template <typename T>
 bool
-HLTJetCollectionsVBFFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTJetCollectionsVBFFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;
@@ -90,9 +90,9 @@ HLTJetCollectionsVBFFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSet
   // filter decision
   bool accept(false);
   std::vector < TRef > goodJetRefs;
-  
+
   for(unsigned int collection = 0; collection < theJetCollections.size(); ++ collection) {
-    
+
     const TRefVector & refVector =  theJetCollections[collection];
     if(refVector.size() < minNJets_) continue;
 
@@ -101,47 +101,47 @@ HLTJetCollectionsVBFFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSet
     // 3rd Jet check decision
     bool goodThirdJet(false);
     if ( minNJets_ < 3 ) goodThirdJet = true;
-    
+
     //empty the good jets collection
     goodJetRefs.clear();
-            
+
     TRef refOne;
     TRef refTwo;
     typename TRefVector::const_iterator jetOne ( refVector.begin() );
     int firstJetIndex=100, secondJetIndex=100, thirdJetIndex=100;
 
-    // Cycle to look for VBF jets 
+    // Cycle to look for VBF jets
     for (; jetOne != refVector.end(); jetOne++) {
       TRef jetOneRef(*jetOne);
-            
+
       if ( thereAreVBFJets ) break;
       if ( jetOneRef->pt() < hardJetPt_ ) break;
       if ( std::abs(jetOneRef->eta()) > maxAbsJetEta_ ) continue;
-      
+
       typename TRefVector::const_iterator jetTwo = jetOne + 1;
-      secondJetIndex = firstJetIndex; 
+      secondJetIndex = firstJetIndex;
       for (; jetTwo != refVector.end(); jetTwo++) {
         TRef jetTwoRef(*jetTwo);
-      
+
         if ( jetTwoRef->pt() < softJetPt_ ) break;
         if ( std::abs(jetTwoRef->eta()) > maxAbsJetEta_ ) continue;
-        
+
         if ( std::abs(jetTwoRef->eta() - jetOneRef->eta()) < minDeltaEta_ ) continue;
-        
+
         thereAreVBFJets = true;
         refOne = TRef(refVector, distance(refVector.begin(), jetOne));
         goodJetRefs.push_back(refOne);
         refTwo = TRef(refVector, distance(refVector.begin(), jetTwo));
         goodJetRefs.push_back(refTwo);
-        
+
         firstJetIndex = (int) (jetOne - refVector.begin());
         secondJetIndex= (int) (jetTwo - refVector.begin());
-        
+
         break;
-        
+
       }
     }// Close looop on VBF
-        
+
     // Look for a third jet, if you've found the previous 2
     if ( minNJets_ > 2 && thereAreVBFJets ) {
       TRef refThree;
@@ -150,9 +150,9 @@ HLTJetCollectionsVBFFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSet
         thirdJetIndex = (int) (jetThree - refVector.begin());
 
         TRef jetThreeRef(*jetThree);
-          
+
         if ( thirdJetIndex == firstJetIndex || thirdJetIndex == secondJetIndex ) continue;
-      
+
         if (jetThreeRef->pt() >= thirdJetPt_ && std::abs(jetThreeRef->eta()) <= maxAbsThirdJetEta_) {
           goodThirdJet = true;
           refThree = TRef(refVector, distance(refVector.begin(), jetThree));

--- a/HLTrigger/JetMET/src/HLTJetCollectionsVBFFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetCollectionsVBFFilter.cc
@@ -69,7 +69,7 @@ HLTJetCollectionsVBFFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& 
 // ------------ method called to produce the data  ------------
 template <typename T>
 bool
-HLTJetCollectionsVBFFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTJetCollectionsVBFFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
@@ -76,7 +76,7 @@ HLTJetSortedVBFFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descr
 // ------------ method called to produce the data  ------------
 template<typename T>
 bool 
-HLTJetSortedVBFFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& setup,trigger::TriggerFilterObjectWithRefs& filterproduct)
+HLTJetSortedVBFFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& setup,trigger::TriggerFilterObjectWithRefs& filterproduct) const
 {
 
    using namespace std;

--- a/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
@@ -75,8 +75,8 @@ HLTJetSortedVBFFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descr
 
 // ------------ method called to produce the data  ------------
 template<typename T>
-bool 
-HLTJetSortedVBFFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& setup,trigger::TriggerFilterObjectWithRefs& filterproduct) const
+bool
+HLTJetSortedVBFFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& setup,trigger::TriggerFilterObjectWithRefs& filterproduct)
 {
 
    using namespace std;
@@ -86,7 +86,7 @@ HLTJetSortedVBFFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& se
 
    typedef vector<T> TCollection;
    typedef Ref<TCollection> TRef;
-     
+
    bool accept(false);
 
    if (saveTags()) filterproduct.addCollectionTag(inputJets_);
@@ -155,8 +155,8 @@ HLTJetSortedVBFFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& se
    double ptsqq_bs   = (q1+q2).Pt();
    double ptsbb_bs   = (b1+b2).Pt();
    double signeta    = q1.Eta()*q2.Eta();
-   
-   if ( 
+
+   if (
 	(mqq_bs     > mqq_    ) &&
 	(deltaetaqq > detaqq_ ) &&
 	(deltaetabb < detabb_ ) &&

--- a/HLTrigger/JetMET/src/HLTJetVBFFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetVBFFilter.cc
@@ -29,9 +29,9 @@ HLTJetVBFFilter<T>::HLTJetVBFFilter(const edm::ParameterSet& iConfig) : HLTFilte
   inputTag_       (iConfig.template getParameter< edm::InputTag > ("inputTag")),
   minPtLow_       (iConfig.template getParameter<double> ("minPtLow")),
   minPtHigh_      (iConfig.template getParameter<double> ("minPtHigh")),
-  etaOpposite_    (iConfig.template getParameter<bool>   ("etaOpposite")), 
-  minDeltaEta_    (iConfig.template getParameter<double> ("minDeltaEta")), 
-  minInvMass_     (iConfig.template getParameter<double> ("minInvMass")), 
+  etaOpposite_    (iConfig.template getParameter<bool>   ("etaOpposite")),
+  minDeltaEta_    (iConfig.template getParameter<double> ("minDeltaEta")),
+  minInvMass_     (iConfig.template getParameter<double> ("minInvMass")),
   maxEta_         (iConfig.template getParameter<double> ("maxEta")),
   leadingJetOnly_ (iConfig.template getParameter<bool>   ("leadingJetOnly")),
   triggerType_    (iConfig.template getParameter<int> ("triggerType"))
@@ -39,7 +39,7 @@ HLTJetVBFFilter<T>::HLTJetVBFFilter(const edm::ParameterSet& iConfig) : HLTFilte
   m_theObjectToken = consumes<std::vector<T>>(inputTag_);
   LogDebug("") << "HLTJetVBFFilter: Input/minPtLow_/minPtHigh_/triggerType : "
 	       << inputTag_.encode() << " "
-	       << minPtLow_  << " " 
+	       << minPtLow_  << " "
 	       << minPtHigh_ << " "
 	       << triggerType_;
 }
@@ -48,7 +48,7 @@ template<typename T>
 HLTJetVBFFilter<T>::~HLTJetVBFFilter(){}
 
 template<typename T>
-void 
+void
 HLTJetVBFFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
@@ -69,8 +69,8 @@ HLTJetVBFFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& description
 //
 template<typename T>
 bool
-HLTJetVBFFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
-{ 
+HLTJetVBFFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+{
   using namespace std;
   using namespace edm;
   using namespace reco;
@@ -85,27 +85,27 @@ HLTJetVBFFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
   // get hold of collection of objects
   Handle<TCollection> objects;
   iEvent.getByToken (m_theObjectToken,objects);
-  
+
   // look at all candidates, check cuts and add to filter object
   int n(0);
-  
+
   // events with two or more jets
   if(objects->size() > 1){
-    
+
     double ejet1   = 0.;
     double pxjet1  = 0.;
     double pyjet1  = 0.;
     double pzjet1  = 0.;
     double ptjet1  = 0.;
     double etajet1 = 0.;
-    
+
     double ejet2   = 0.;
     double pxjet2  = 0.;
     double pyjet2  = 0.;
     double pzjet2  = 0.;
     double ptjet2  = 0.;
     double etajet2 = 0.;
-    
+
     // loop on all jets
     int countJet1(0);
     int countJet2(0);
@@ -115,7 +115,7 @@ HLTJetVBFFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
       if( leadingJetOnly_==true && countJet1>2 ) break;
       //
       if( jet1->pt() < minPtHigh_ ) break; //No need to go to the next jet (lower PT)
-      if( std::abs(jet1->eta()) > maxEta_ ) continue;      
+      if( std::abs(jet1->eta()) > maxEta_ ) continue;
       //
       countJet2 = countJet1-1;
       typename TCollection::const_iterator jet2 ( jet1+1 );
@@ -141,13 +141,13 @@ HLTJetVBFFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
         etajet2 = jet2->eta();
         //
         float deltaetajet = etajet1 - etajet2;
-        float invmassjet = sqrt( (ejet1  + ejet2)  * (ejet1  + ejet2) - 
-      	                         (pxjet1 + pxjet2) * (pxjet1 + pxjet2) - 
-                                 (pyjet1 + pyjet2) * (pyjet1 + pyjet2) - 
+        float invmassjet = sqrt( (ejet1  + ejet2)  * (ejet1  + ejet2) -
+      	                         (pxjet1 + pxjet2) * (pxjet1 + pxjet2) -
+                                 (pyjet1 + pyjet2) * (pyjet1 + pyjet2) -
                                  (pzjet1 + pzjet2) * (pzjet1 + pzjet2) );
-        
+
         // VBF cuts
-        if ( (ptjet1 > minPtHigh_) && 
+        if ( (ptjet1 > minPtHigh_) &&
 	     (ptjet2 > minPtLow_) &&
              ( (etaOpposite_ == true && etajet1*etajet2 < 0) || (etaOpposite_ == false) ) &&
              (std::abs(deltaetajet) > minDeltaEta_) &&
@@ -163,9 +163,9 @@ HLTJetVBFFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
       //if(n>=1) break; //Store all possible pairs
     }// loop on all jets
   }// events with two or more jets
-  
+
   // filter decision
   bool accept(n>=1);
-  
+
   return accept;
 }

--- a/HLTrigger/JetMET/src/HLTJetVBFFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetVBFFilter.cc
@@ -69,7 +69,7 @@ HLTJetVBFFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& description
 //
 template<typename T>
 bool
-HLTJetVBFFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTJetVBFFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 { 
   using namespace std;
   using namespace edm;

--- a/HLTrigger/JetMET/src/HLTMhtFilter.cc
+++ b/HLTrigger/JetMET/src/HLTMhtFilter.cc
@@ -39,7 +39,7 @@ void HLTMhtFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions
 
 // ------------ method called to produce the data  ------------
 bool
-  HLTMhtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+  HLTMhtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/JetMET/src/HLTMhtFilter.cc
+++ b/HLTrigger/JetMET/src/HLTMhtFilter.cc
@@ -39,7 +39,7 @@ void HLTMhtFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions
 
 // ------------ method called to produce the data  ------------
 bool
-  HLTMhtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+  HLTMhtFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/JetMET/src/HLTMhtHtFilter.cc
+++ b/HLTrigger/JetMET/src/HLTMhtHtFilter.cc
@@ -105,7 +105,7 @@ HLTMhtHtFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions
 // ------------ method called to produce the data  ------------
 template<typename T>
 bool
-HLTMhtHtFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTMhtHtFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/JetMET/src/HLTMhtHtFilter.cc
+++ b/HLTrigger/JetMET/src/HLTMhtHtFilter.cc
@@ -27,7 +27,7 @@
 // constructors and destructor
 //
 template<typename T>
-HLTMhtHtFilter<T>::HLTMhtHtFilter(const edm::ParameterSet& iConfig) : 
+HLTMhtHtFilter<T>::HLTMhtHtFilter(const edm::ParameterSet& iConfig) :
   HLTFilter(iConfig),
   inputJetTag_    ( iConfig.template getParameter<edm::InputTag>("inputJetTag") ),
   inputTracksTag_ ( iConfig.template getParameter<edm::InputTag>("inputTracksTag") ),
@@ -53,8 +53,8 @@ HLTMhtHtFilter<T>::HLTMhtHtFilter(const edm::ParameterSet& iConfig) :
   // sanity checks
   if ( (minPtJet_.size() != etaJet_.size())
        or ( (minPtJet_.size()<1) || (etaJet_.size()<1) )
-       or ( ((minPtJet_.size()<2) || (etaJet_.size()<2)) and ( (mode_==1) or (mode_==2) or (mode_ == 5))) 
-       ) 
+       or ( ((minPtJet_.size()<2) || (etaJet_.size()<2)) and ( (mode_==1) or (mode_==2) or (mode_ == 5)))
+       )
     {
       edm::LogError("HLTMhtHtFilter") << "inconsistent module configuration!";
     }
@@ -66,7 +66,7 @@ template<typename T>
 HLTMhtHtFilter<T>::~HLTMhtHtFilter(){}
 
 template<typename T>
-void 
+void
 HLTMhtHtFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
@@ -105,7 +105,7 @@ HLTMhtHtFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions
 // ------------ method called to produce the data  ------------
 template<typename T>
 bool
-HLTMhtHtFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTMhtHtFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;
@@ -117,7 +117,7 @@ HLTMhtHtFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 
   // The filter object
   if (saveTags()) filterproduct.addCollectionTag(inputJetTag_);
-  
+
   // Ref to Candidate object to be recorded in filter object
   TRef ref;
 
@@ -126,7 +126,7 @@ HLTMhtHtFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
   iEvent.getByToken (m_theObjectToken,objects);
   Handle<TrackCollection> tracks;
   if (useTracks_) iEvent.getByToken(m_theTrackToken,tracks);
- 
+
   // look at all candidates,  check cuts and add to filter object
   int n(0), nj(0), flag(0);
   double ht=0.;
@@ -202,7 +202,7 @@ HLTMhtHtFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
     if( mode_==2 && sqrt(mhtx*mhtx + mhty*mhty) + meffSlope_*ht > minMeff_) flag=1;
     if( mode_==3 && sqrt(mhtx*mhtx + mhty*mhty) > minPT12_ && nj>1) flag=1;
     if( mode_==4 && ht > minHt_ && nj >= minNJet_ ) flag=1;
-    
+
     if (flag==1) {
       typename TCollection::const_iterator jet ( objects->begin() );
       for (; jet!=objects->end(); jet++) {
@@ -220,6 +220,6 @@ HLTMhtHtFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 
   // filter decision
   bool accept(n>0);
-  
+
   return accept;
 }

--- a/HLTrigger/JetMET/src/HLTMonoJetFilter.cc
+++ b/HLTrigger/JetMET/src/HLTMonoJetFilter.cc
@@ -59,7 +59,7 @@ HLTMonoJetFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptio
 //
 template<typename T>
 bool
-HLTMonoJetFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTMonoJetFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/JetMET/src/HLTMonoJetFilter.cc
+++ b/HLTrigger/JetMET/src/HLTMonoJetFilter.cc
@@ -59,7 +59,7 @@ HLTMonoJetFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptio
 //
 template<typename T>
 bool
-HLTMonoJetFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTMonoJetFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/JetMET/src/HLTNVFilter.cc
+++ b/HLTrigger/JetMET/src/HLTNVFilter.cc
@@ -50,7 +50,7 @@ void HLTNVFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
 
 // ------------ method called to produce the data  ------------
 bool
-HLTNVFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTNVFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/JetMET/src/HLTNVFilter.cc
+++ b/HLTrigger/JetMET/src/HLTNVFilter.cc
@@ -23,12 +23,12 @@
 //
 // constructors and destructor
 //
-HLTNVFilter::HLTNVFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTNVFilter::HLTNVFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
    inputJetTag_ = iConfig.getParameter< edm::InputTag > ("inputJetTag");
    inputMETTag_ = iConfig.getParameter< edm::InputTag > ("inputMETTag");
    minNV_   = iConfig.getParameter<double> ("minNV");
-   minEtjet1_= iConfig.getParameter<double> ("minEtJet1"); 
+   minEtjet1_= iConfig.getParameter<double> ("minEtJet1");
    minEtjet2_ = iConfig.getParameter<double> ("minEtJet2");
    m_theJetToken = consumes<reco::CaloJetCollection>(inputJetTag_);
    m_theMETToken = consumes<trigger::TriggerFilterObjectWithRefs>(inputMETTag_);
@@ -50,7 +50,7 @@ void HLTNVFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
 
 // ------------ method called to produce the data  ------------
 bool
-HLTNVFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTNVFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;
@@ -79,16 +79,16 @@ HLTNVFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigge
     double etjet2=0.;
     double etmiss=0.;
     int countjets =0;
-   
-    VRcalomet vrefMET; 
+
+    VRcalomet vrefMET;
     metcal->getObjects(TriggerMET,vrefMET);
     CaloMETRef metRef=vrefMET.at(0);
     etmiss=vrefMET.at(0)->et();
 
     CaloJetRef ref1,ref2;
-    for (CaloJetCollection::const_iterator recocalojet = recocalojets->begin(); 
+    for (CaloJetCollection::const_iterator recocalojet = recocalojets->begin();
 	 recocalojet<=(recocalojets->begin()+1); recocalojet++) {
-      
+
       if(countjets==0) {
 	etjet1 = recocalojet->et();
                 ref1  = CaloJetRef(recocalojets,distance(recocalojets->begin(),recocalojet));
@@ -99,7 +99,7 @@ HLTNVFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigge
       }
       countjets++;
     }
-    
+
     double NV = (etmiss*etmiss-(etjet1-etjet2)*(etjet1-etjet2))/(etjet2*etjet2);
     if(etjet1>minEtjet1_  && etjet2>minEtjet2_ && NV>minNV_){
       filterproduct.addObject(TriggerMET,metRef);
@@ -107,13 +107,13 @@ HLTNVFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigge
       filterproduct.addObject(TriggerJet,ref2);
       n++;
     }
-    
+
   } // events with two or more jets
-  
-  
-  
+
+
+
   // filter decision
   bool accept(n>=1);
-  
+
   return accept;
 }

--- a/HLTrigger/JetMET/src/HLTPFEnergyFractionsFilter.cc
+++ b/HLTrigger/JetMET/src/HLTPFEnergyFractionsFilter.cc
@@ -64,7 +64,7 @@ HLTPFEnergyFractionsFilter::fillDescriptions(edm::ConfigurationDescriptions& des
 
 // ------------ method called to produce the data  ------------
 bool
-HLTPFEnergyFractionsFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTPFEnergyFractionsFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/JetMET/src/HLTPFEnergyFractionsFilter.cc
+++ b/HLTrigger/JetMET/src/HLTPFEnergyFractionsFilter.cc
@@ -64,7 +64,7 @@ HLTPFEnergyFractionsFilter::fillDescriptions(edm::ConfigurationDescriptions& des
 
 // ------------ method called to produce the data  ------------
 bool
-HLTPFEnergyFractionsFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTPFEnergyFractionsFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/JetMET/src/HLTPhi2METFilter.cc
+++ b/HLTrigger/JetMET/src/HLTPhi2METFilter.cc
@@ -22,14 +22,14 @@
 //
 // constructors and destructor
 //
-HLTPhi2METFilter::HLTPhi2METFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTPhi2METFilter::HLTPhi2METFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
    inputJetTag_ = iConfig.getParameter< edm::InputTag > ("inputJetTag");
    inputMETTag_ = iConfig.getParameter< edm::InputTag > ("inputMETTag");
    minDPhi_   = iConfig.getParameter<double> ("minDeltaPhi");
    maxDPhi_   = iConfig.getParameter<double> ("maxDeltaPhi");
-   minEtjet1_= iConfig.getParameter<double> ("minEtJet1"); 
-   minEtjet2_= iConfig.getParameter<double> ("minEtJet2"); 
+   minEtjet1_= iConfig.getParameter<double> ("minEtJet1");
+   minEtjet2_= iConfig.getParameter<double> ("minEtJet2");
    m_theJetToken = consumes<reco::CaloJetCollection>(inputJetTag_);
    m_theMETToken = consumes<trigger::TriggerFilterObjectWithRefs>(inputMETTag_);
 }
@@ -48,7 +48,7 @@ void HLTPhi2METFilter::fillDescriptions(edm::ConfigurationDescriptions& descript
 
 // ------------ method called to produce the data  ------------
 bool
-HLTPhi2METFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTPhi2METFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;
@@ -69,7 +69,7 @@ HLTPhi2METFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
   // look at all candidates,  check cuts and add to filter object
   int n(0);
 
-  VRcalomet vrefMET; 
+  VRcalomet vrefMET;
   metcal->getObjects(TriggerMET,vrefMET);
   CaloMETRef metRef=vrefMET.at(0);
   CaloJetRef ref1,ref2;
@@ -83,10 +83,10 @@ HLTPhi2METFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
     // double etmiss  = vrefMET.at(0)->et();
     double phimiss = vrefMET.at(0)->phi();
     int countjets =0;
-   
-    for (CaloJetCollection::const_iterator recocalojet = recocalojets->begin(); 
+
+    for (CaloJetCollection::const_iterator recocalojet = recocalojets->begin();
 	 recocalojet<=(recocalojets->begin()+1); recocalojet++) {
-      
+
       if(countjets==0) {
 	etjet1 = recocalojet->et();
 	ref1  = CaloJetRef(recocalojets,distance(recocalojets->begin(),recocalojet));
@@ -106,13 +106,13 @@ HLTPhi2METFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
 	filterproduct.addObject(TriggerJet,ref2);
 	n++;
     }
-    
+
   } // events with two or more jets
-  
-  
-  
+
+
+
   // filter decision
   bool accept(n>=1);
-  
+
   return accept;
 }

--- a/HLTrigger/JetMET/src/HLTPhi2METFilter.cc
+++ b/HLTrigger/JetMET/src/HLTPhi2METFilter.cc
@@ -48,7 +48,7 @@ void HLTPhi2METFilter::fillDescriptions(edm::ConfigurationDescriptions& descript
 
 // ------------ method called to produce the data  ------------
 bool
-HLTPhi2METFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTPhi2METFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/JetMET/src/HLTRapGapFilter.cc
+++ b/HLTrigger/JetMET/src/HLTRapGapFilter.cc
@@ -45,7 +45,7 @@ void HLTRapGapFilter::fillDescriptions(edm::ConfigurationDescriptions& descripti
 
 // ------------ method called to produce the data  ------------
 bool
-HLTRapGapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTRapGapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace reco;
   using namespace trigger;

--- a/HLTrigger/JetMET/src/HLTRapGapFilter.cc
+++ b/HLTrigger/JetMET/src/HLTRapGapFilter.cc
@@ -22,12 +22,12 @@
 //
 // constructors and destructor
 //
-HLTRapGapFilter::HLTRapGapFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTRapGapFilter::HLTRapGapFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
    inputTag_   = iConfig.getParameter< edm::InputTag > ("inputTag");
    absEtaMin_  = iConfig.getParameter<double> ("minEta");
-   absEtaMax_  = iConfig.getParameter<double> ("maxEta"); 
-   caloThresh_ = iConfig.getParameter<double> ("caloThresh"); 
+   absEtaMax_  = iConfig.getParameter<double> ("maxEta");
+   caloThresh_ = iConfig.getParameter<double> ("caloThresh");
    m_theJetToken = consumes<reco::CaloJetCollection>(inputTag_);
 }
 
@@ -45,7 +45,7 @@ void HLTRapGapFilter::fillDescriptions(edm::ConfigurationDescriptions& descripti
 
 // ------------ method called to produce the data  ------------
 bool
-HLTRapGapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTRapGapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace reco;
   using namespace trigger;
@@ -58,7 +58,7 @@ HLTRapGapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, tr
 
   // look at all candidates,  check cuts and add to filter object
   int n(0);
-  
+
   //std::cout << "Found " << recocalojets->size() << " jets in this event" << std::endl;
 
   if(recocalojets->size() > 1){
@@ -69,16 +69,16 @@ HLTRapGapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, tr
     double sumets=0.;
     int countjets =0;
 
-    for (CaloJetCollection::const_iterator recocalojet = recocalojets->begin(); 
+    for (CaloJetCollection::const_iterator recocalojet = recocalojets->begin();
 	 recocalojet!=(recocalojets->end()); recocalojet++) {
-      
+
       etjet = recocalojet->energy();
       etajet = recocalojet->eta();
-      
+
       if(std::abs(etajet) > absEtaMin_ && std::abs(etajet) < absEtaMax_)
 	{
 	  sumets += etjet;
-	  //std::cout << "Adding jet with eta = " << etajet << ", and e = " 
+	  //std::cout << "Adding jet with eta = " << etajet << ", and e = "
 	  //	    << etjet << std::endl;
 	}
       countjets++;
@@ -87,18 +87,18 @@ HLTRapGapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, tr
     //std::cout << "Sum jet energy = " << sumets << std::endl;
     if(sumets<=caloThresh_){
       //std::cout << "Passed filter!" << std::endl;
-      for (CaloJetCollection::const_iterator recocalojet = recocalojets->begin(); 
+      for (CaloJetCollection::const_iterator recocalojet = recocalojets->begin();
 	   recocalojet!=(recocalojets->end()); recocalojet++) {
 	CaloJetRef ref(CaloJetRef(recocalojets,distance(recocalojets->begin(),recocalojet)));
 	filterproduct.addObject(TriggerJet,ref);
 	n++;
       }
     }
-    
+
   } // events with two or more jets
-  
+
   // filter decision
   bool accept(n>0);
-  
+
   return accept;
 }

--- a/HLTrigger/Muon/interface/HLTDiMuonGlbTrkFilter.h
+++ b/HLTrigger/Muon/interface/HLTDiMuonGlbTrkFilter.h
@@ -14,7 +14,7 @@ class HLTDiMuonGlbTrkFilter : public HLTFilter {
   HLTDiMuonGlbTrkFilter(const edm::ParameterSet&);
   virtual ~HLTDiMuonGlbTrkFilter(){}
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
  private:
   // WARNING: two input collection represent should be aligned and represent

--- a/HLTrigger/Muon/interface/HLTDiMuonGlbTrkFilter.h
+++ b/HLTrigger/Muon/interface/HLTDiMuonGlbTrkFilter.h
@@ -14,7 +14,7 @@ class HLTDiMuonGlbTrkFilter : public HLTFilter {
   HLTDiMuonGlbTrkFilter(const edm::ParameterSet&);
   virtual ~HLTDiMuonGlbTrkFilter(){}
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
  private:
   // WARNING: two input collection represent should be aligned and represent

--- a/HLTrigger/Muon/interface/HLTMuonDimuonL2Filter.h
+++ b/HLTrigger/Muon/interface/HLTMuonDimuonL2Filter.h
@@ -26,7 +26,7 @@ class HLTMuonDimuonL2Filter : public HLTFilter {
       explicit HLTMuonDimuonL2Filter(const edm::ParameterSet&);
       ~HLTMuonDimuonL2Filter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       edm::InputTag                    beamspotTag_ ;

--- a/HLTrigger/Muon/interface/HLTMuonDimuonL2Filter.h
+++ b/HLTrigger/Muon/interface/HLTMuonDimuonL2Filter.h
@@ -3,7 +3,7 @@
 
 /** \class HLTMuonDimuonL2Filter
  *
- *  
+ *
  *  This class is an HLTFilter (-> EDFilter) implementing a muon pair
  *  filter for HLT muons
  *
@@ -26,7 +26,7 @@ class HLTMuonDimuonL2Filter : public HLTFilter {
       explicit HLTMuonDimuonL2Filter(const edm::ParameterSet&);
       ~HLTMuonDimuonL2Filter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       edm::InputTag                    beamspotTag_ ;
@@ -38,7 +38,7 @@ class HLTMuonDimuonL2Filter : public HLTFilter {
       /// input tag of the map from the L2 seed to the sister L2 seeds of cleaned tracks
       edm::InputTag             seedMapTag_;
       edm::EDGetTokenT<SeedMap> seedMapToken_;
-      
+
       bool   fast_Accept_;      // flag to save time: stop processing after identification of the first valid pair
       double max_Eta_;          // Eta cut
       int    min_Nhits_;        // threshold on number of hits on muon

--- a/HLTrigger/Muon/interface/HLTMuonDimuonL3Filter.h
+++ b/HLTrigger/Muon/interface/HLTMuonDimuonL3Filter.h
@@ -25,7 +25,7 @@ class HLTMuonDimuonL3Filter : public HLTFilter {
       explicit HLTMuonDimuonL3Filter(const edm::ParameterSet&);
       ~HLTMuonDimuonL3Filter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       static bool triggeredByLevel2(reco::TrackRef const & track, std::vector<reco::RecoChargedCandidateRef> const & vcands);

--- a/HLTrigger/Muon/interface/HLTMuonDimuonL3Filter.h
+++ b/HLTrigger/Muon/interface/HLTMuonDimuonL3Filter.h
@@ -3,7 +3,7 @@
 
 /** \class HLTMuonDimuonL3Filter
  *
- *  
+ *
  *  This class is an HLTFilter (-> EDFilter) implementing a muon pair
  *  filter for HLT muons
  *
@@ -26,16 +26,17 @@ class HLTMuonDimuonL3Filter : public HLTFilter {
       ~HLTMuonDimuonL3Filter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
       virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
-      bool triggeredByLevel2(const reco::TrackRef& track,std::vector<reco::RecoChargedCandidateRef>& vcands);
 
    private:
+      static bool triggeredByLevel2(reco::TrackRef const & track, std::vector<reco::RecoChargedCandidateRef> const & vcands);
+
       edm::InputTag                    beamspotTag_ ;
       edm::EDGetTokenT<reco::BeamSpot> beamspotToken_ ;
       edm::InputTag                                          candTag_;   // input tag identifying product contains muons
       edm::EDGetTokenT<reco::RecoChargedCandidateCollection> candToken_; // token identifying product contains muons
       edm::InputTag                                          previousCandTag_;   // input tag identifying product contains muons passing the previous level
       edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> previousCandToken_; // tokenidentifying product contains muons passing the previous level
-      
+
       bool   fast_Accept_;      // flag to save time: stop processing after identification of the first valid pair
       double max_Eta_;          // Eta cut
       int    min_Nhits_;        // threshold on number of hits on muon

--- a/HLTrigger/Muon/interface/HLTMuonDimuonL3Filter.h
+++ b/HLTrigger/Muon/interface/HLTMuonDimuonL3Filter.h
@@ -25,7 +25,7 @@ class HLTMuonDimuonL3Filter : public HLTFilter {
       explicit HLTMuonDimuonL3Filter(const edm::ParameterSet&);
       ~HLTMuonDimuonL3Filter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       bool triggeredByLevel2(const reco::TrackRef& track,std::vector<reco::RecoChargedCandidateRef>& vcands);
 
    private:

--- a/HLTrigger/Muon/interface/HLTMuonIsoFilter.h
+++ b/HLTrigger/Muon/interface/HLTMuonIsoFilter.h
@@ -27,7 +27,7 @@ class HLTMuonIsoFilter : public HLTFilter {
       explicit HLTMuonIsoFilter(const edm::ParameterSet&);
       ~HLTMuonIsoFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       bool triggerdByPreviousLevel(const reco::RecoChargedCandidateRef &, const std::vector<reco::RecoChargedCandidateRef> &);
    private:
       edm::InputTag                                          candTag_;   // input tag identifying muon container

--- a/HLTrigger/Muon/interface/HLTMuonIsoFilter.h
+++ b/HLTrigger/Muon/interface/HLTMuonIsoFilter.h
@@ -3,7 +3,7 @@
 
 /** \class HLTMuonIsoFilter
  *
- *  
+ *
  *  This class is an HLTFilter (-> EDFilter) implementing
  *  the isolation filtering for HLT muons
  *
@@ -28,8 +28,10 @@ class HLTMuonIsoFilter : public HLTFilter {
       ~HLTMuonIsoFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
       virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
-      bool triggerdByPreviousLevel(const reco::RecoChargedCandidateRef &, const std::vector<reco::RecoChargedCandidateRef> &);
+
    private:
+      static bool triggerdByPreviousLevel(const reco::RecoChargedCandidateRef &, const std::vector<reco::RecoChargedCandidateRef> &);
+
       edm::InputTag                                          candTag_;   // input tag identifying muon container
       edm::EDGetTokenT<reco::RecoChargedCandidateCollection> candToken_; // token identifying muon container
       edm::InputTag                                          previousCandTag_;   // input tag identifying product contains muons passing the previous level

--- a/HLTrigger/Muon/interface/HLTMuonIsoFilter.h
+++ b/HLTrigger/Muon/interface/HLTMuonIsoFilter.h
@@ -27,7 +27,7 @@ class HLTMuonIsoFilter : public HLTFilter {
       explicit HLTMuonIsoFilter(const edm::ParameterSet&);
       ~HLTMuonIsoFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       static bool triggerdByPreviousLevel(const reco::RecoChargedCandidateRef &, const std::vector<reco::RecoChargedCandidateRef> &);

--- a/HLTrigger/Muon/interface/HLTMuonL1Filter.h
+++ b/HLTrigger/Muon/interface/HLTMuonL1Filter.h
@@ -76,17 +76,11 @@ class HLTMuonL1Filter : public HLTFilter {
     bool excludeSingleSegmentCSC_;
 
     /// checks if the passed L1MuExtraParticle is a single segment CSC
-    bool isSingleSegmentCSC(const l1extra::L1MuonParticleRef & muon, L1CSCTrackCollection const & csctfTracks) const;
+    bool isSingleSegmentCSC(const l1extra::L1MuonParticleRef & muon, L1CSCTrackCollection const & csctfTracks, L1MuTriggerScales const & scales) const;
 
     /// input tag identifying the product containing CSCTF tracks
     edm::InputTag                          csctfTag_;
     edm::EDGetTokenT<L1CSCTrackCollection> csctfToken_;
-
-    /// trigger scales
-    const L1MuTriggerScales *l1MuTriggerScales_;
-
-    /// trigger scales cache ID
-    unsigned long long m_scalesCacheID_ ;
 };
 
 #endif //HLTMuonL1Filter_h

--- a/HLTrigger/Muon/interface/HLTMuonL1Filter.h
+++ b/HLTrigger/Muon/interface/HLTMuonL1Filter.h
@@ -3,8 +3,8 @@
 
 /** \class HLTMuonL1Filter
  *
- *  
- *  This class is an HLTFilter (-> EDFilter) implementing a 
+ *
+ *  This class is an HLTFilter (-> EDFilter) implementing a
  *  filter on L1 GMT input
  *
  *  \author J. Alcaraz
@@ -46,7 +46,7 @@ class HLTMuonL1Filter : public HLTFilter {
     /// max Eta cut
     double maxEta_;
 
-    /// pT threshold 
+    /// pT threshold
     double minPt_;
 
     /// Quality codes:
@@ -64,7 +64,7 @@ class HLTMuonL1Filter : public HLTFilter {
     ///
     /// Quality bit mask:
     ///
-    /// the eight lowest order or least significant bits correspond to the qulity codes above; 
+    /// the eight lowest order or least significant bits correspond to the qulity codes above;
     /// if a bit is 1, that code is accepted, otherwise not;
     /// example: 11101000 accepts qualities 3, 5, 6, 7
     int qualityBitMask_;
@@ -76,14 +76,11 @@ class HLTMuonL1Filter : public HLTFilter {
     bool excludeSingleSegmentCSC_;
 
     /// checks if the passed L1MuExtraParticle is a single segment CSC
-    bool isSingleSegmentCSC(const l1extra::L1MuonParticleRef &);
+    bool isSingleSegmentCSC(const l1extra::L1MuonParticleRef & muon, L1CSCTrackCollection const & csctfTracks) const;
 
     /// input tag identifying the product containing CSCTF tracks
     edm::InputTag                          csctfTag_;
     edm::EDGetTokenT<L1CSCTrackCollection> csctfToken_;
-    
-    /// handle for CSCTFtracks
-    edm::Handle<L1CSCTrackCollection> csctfTracks_;
 
     /// trigger scales
     const L1MuTriggerScales *l1MuTriggerScales_;

--- a/HLTrigger/Muon/interface/HLTMuonL1Filter.h
+++ b/HLTrigger/Muon/interface/HLTMuonL1Filter.h
@@ -32,7 +32,7 @@ class HLTMuonL1Filter : public HLTFilter {
     explicit HLTMuonL1Filter(const edm::ParameterSet&);
     ~HLTMuonL1Filter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
   private:
     /// input tag identifying the product containing muons

--- a/HLTrigger/Muon/interface/HLTMuonL1Filter.h
+++ b/HLTrigger/Muon/interface/HLTMuonL1Filter.h
@@ -32,7 +32,7 @@ class HLTMuonL1Filter : public HLTFilter {
     explicit HLTMuonL1Filter(const edm::ParameterSet&);
     ~HLTMuonL1Filter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
   private:
     /// input tag identifying the product containing muons

--- a/HLTrigger/Muon/interface/HLTMuonL1RegionalFilter.h
+++ b/HLTrigger/Muon/interface/HLTMuonL1RegionalFilter.h
@@ -3,7 +3,7 @@
 
 /** \class HLTMuonL1RegionalFilter
  *
- *  
+ *
  *  This filter cuts on MinPt and Quality in specified eta regions
  *
  *
@@ -22,7 +22,7 @@ class HLTMuonL1RegionalFilter : public HLTFilter {
     explicit HLTMuonL1RegionalFilter(const edm::ParameterSet&);
     ~HLTMuonL1RegionalFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
   private:
     /// input tag identifying the product containing muons
@@ -57,7 +57,7 @@ class HLTMuonL1RegionalFilter : public HLTFilter {
     /// the eight lowest order or least significant bits correspond to the qulity codes above;
     /// if a bit is 1, that code is accepted, otherwise not;
     /// example: 11101000 accepts qualities 3, 5, 6, 7
-    /// 
+    ///
     /// the vector of quality bit masks, one for each eta region
     std::vector<int> qualityBitMasks_;
 

--- a/HLTrigger/Muon/interface/HLTMuonL1RegionalFilter.h
+++ b/HLTrigger/Muon/interface/HLTMuonL1RegionalFilter.h
@@ -22,7 +22,7 @@ class HLTMuonL1RegionalFilter : public HLTFilter {
     explicit HLTMuonL1RegionalFilter(const edm::ParameterSet&);
     ~HLTMuonL1RegionalFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
   private:
     /// input tag identifying the product containing muons

--- a/HLTrigger/Muon/interface/HLTMuonL1toL3TkPreFilter.h
+++ b/HLTrigger/Muon/interface/HLTMuonL1toL3TkPreFilter.h
@@ -3,7 +3,7 @@
 
 /** \class HLTMuonL1toL3TkPreFilter
  *
- *  
+ *
  *  This class is an HLTFilter (-> EDFilter) implementing a first
  *  filtering for HLT muons
  *
@@ -28,7 +28,7 @@ class HLTMuonL1toL3TkPreFilter : public HLTFilter {
       explicit HLTMuonL1toL3TkPreFilter(const edm::ParameterSet&);
       ~HLTMuonL1toL3TkPreFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       bool triggeredAtL1(const l1extra::L1MuonParticleRef & l1mu,std::vector<l1extra::L1MuonParticleRef>& vcands) const;
@@ -44,7 +44,7 @@ class HLTMuonL1toL3TkPreFilter : public HLTFilter {
       int    min_Nhits_;        // threshold on number of hits on muon
       double max_Dr_;           // impact parameter cut
       double max_Dz_;           // dz cut
-      double min_Pt_;           // pt threshold in GeV 
+      double min_Pt_;           // pt threshold in GeV
       double nsigma_Pt_;        // pt uncertainty margin (in number of sigmas)
 };
 

--- a/HLTrigger/Muon/interface/HLTMuonL1toL3TkPreFilter.h
+++ b/HLTrigger/Muon/interface/HLTMuonL1toL3TkPreFilter.h
@@ -28,9 +28,10 @@ class HLTMuonL1toL3TkPreFilter : public HLTFilter {
       explicit HLTMuonL1toL3TkPreFilter(const edm::ParameterSet&);
       ~HLTMuonL1toL3TkPreFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
-      bool triggeredAtL1(const l1extra::L1MuonParticleRef & l1mu,std::vector<l1extra::L1MuonParticleRef>& vcands);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+
    private:
+      bool triggeredAtL1(const l1extra::L1MuonParticleRef & l1mu,std::vector<l1extra::L1MuonParticleRef>& vcands) const;
 
       edm::InputTag                    beamspotTag_ ;
       edm::EDGetTokenT<reco::BeamSpot> beamspotToken_ ;

--- a/HLTrigger/Muon/interface/HLTMuonL2PreFilter.h
+++ b/HLTrigger/Muon/interface/HLTMuonL2PreFilter.h
@@ -26,7 +26,7 @@ class HLTMuonL2PreFilter : public HLTFilter {
     explicit HLTMuonL2PreFilter(const edm::ParameterSet&);
     ~HLTMuonL2PreFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
   private:
     /// input tag of the beam spot

--- a/HLTrigger/Muon/interface/HLTMuonL2PreFilter.h
+++ b/HLTrigger/Muon/interface/HLTMuonL2PreFilter.h
@@ -3,7 +3,7 @@
 
 /** \class HLTMuonL2PreFilter
  *
- *  
+ *
  *  This class is an HLTFilter (-> EDFilter) implementing a first
  *  filtering for HLT muons
  *
@@ -26,7 +26,7 @@ class HLTMuonL2PreFilter : public HLTFilter {
     explicit HLTMuonL2PreFilter(const edm::ParameterSet&);
     ~HLTMuonL2PreFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
   private:
     /// input tag of the beam spot
@@ -51,7 +51,7 @@ class HLTMuonL2PreFilter : public HLTFilter {
     /// maxEta cut
     double maxEta_;
 
-    /// |eta| bins for minNstations cut 
+    /// |eta| bins for minNstations cut
     /// (#bins must match #minNstations cuts and #minNhits cuts)
     std::vector<double> absetaBins_;
 
@@ -66,7 +66,7 @@ class HLTMuonL2PreFilter : public HLTFilter {
 
     /// minimum number of valid chambers
     std::vector<int> minNchambers_;
-    
+
     /// cut on impact parameter wrt to the beam spot
     double maxDr_;
 

--- a/HLTrigger/Muon/interface/HLTMuonL3PreFilter.h
+++ b/HLTrigger/Muon/interface/HLTMuonL3PreFilter.h
@@ -28,9 +28,10 @@ class HLTMuonL3PreFilter : public HLTFilter {
       explicit HLTMuonL3PreFilter(const edm::ParameterSet&);
       ~HLTMuonL3PreFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
-      bool triggeredByLevel2(const reco::TrackRef& track,std::vector<reco::RecoChargedCandidateRef>& vcands);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+
    private:
+      bool triggeredByLevel2(const reco::TrackRef& track,std::vector<reco::RecoChargedCandidateRef>& vcands) const;
 
       edm::InputTag                    beamspotTag_ ;
       edm::EDGetTokenT<reco::BeamSpot> beamspotToken_ ;

--- a/HLTrigger/Muon/interface/HLTMuonL3PreFilter.h
+++ b/HLTrigger/Muon/interface/HLTMuonL3PreFilter.h
@@ -3,7 +3,7 @@
 
 /** \class HLTMuonL3PreFilter
  *
- *  
+ *
  *  This class is an HLTFilter (-> EDFilter) implementing a first
  *  filtering for HLT muons
  *
@@ -28,7 +28,7 @@ class HLTMuonL3PreFilter : public HLTFilter {
       explicit HLTMuonL3PreFilter(const edm::ParameterSet&);
       ~HLTMuonL3PreFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       bool triggeredByLevel2(const reco::TrackRef& track,std::vector<reco::RecoChargedCandidateRef>& vcands) const;
@@ -46,7 +46,7 @@ class HLTMuonL3PreFilter : public HLTFilter {
       double min_Dr_;           // minimum impact parameter cut
       double max_Dz_;           // dz cut
       double min_DxySig_;       // dxy significance cut
-      double min_Pt_;           // pt threshold in GeV 
+      double min_Pt_;           // pt threshold in GeV
       double nsigma_Pt_;        // pt uncertainty margin (in number of sigmas)
       double max_NormalizedChi2_; // cutoff in normalized chi2
       double max_DXYBeamSpot_; // cutoff in dxy from the beamspot
@@ -55,7 +55,7 @@ class HLTMuonL3PreFilter : public HLTFilter {
   double min_TrackPt_; //cutoff in tracker track pt
 
   bool devDebug_;
-  
+
 
 };
 

--- a/HLTrigger/Muon/interface/HLTMuonTrackMassFilter.h
+++ b/HLTrigger/Muon/interface/HLTMuonTrackMassFilter.h
@@ -21,7 +21,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
   bool pairMatched (std::vector<reco::RecoChargedCandidateRef>& prevMuonRefs,
 		    std::vector<reco::RecoChargedCandidateRef>& prevTrackRefs,
 		    const reco::RecoChargedCandidateRef& muonRef,

--- a/HLTrigger/Muon/interface/HLTMuonTrackMassFilter.h
+++ b/HLTrigger/Muon/interface/HLTMuonTrackMassFilter.h
@@ -1,6 +1,6 @@
 #ifndef HLTMuonTrackMassFilter_h_
 #define HLTMuonTrackMassFilter_h_
-/** HLT filter by muon+track mass (taken from two RecoChargedCandidate collections). 
+/** HLT filter by muon+track mass (taken from two RecoChargedCandidate collections).
  *  Tracks are subject to quality and momentum cuts. The match with previous muon
  *  (and possibly track, if run after another mass filter) candidates is checked.
 */
@@ -21,12 +21,12 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
   bool pairMatched (std::vector<reco::RecoChargedCandidateRef>& prevMuonRefs,
 		    std::vector<reco::RecoChargedCandidateRef>& prevTrackRefs,
 		    const reco::RecoChargedCandidateRef& muonRef,
 		    const reco::RecoChargedCandidateRef& trackRef) const;
-      
+
 private:
   edm::InputTag                    beamspotTag_;   ///< beamspot used for quality cuts
   edm::EDGetTokenT<reco::BeamSpot> beamspotToken_; ///< beamspot used for quality cuts

--- a/HLTrigger/Muon/interface/HLTMuonTrimuonL3Filter.h
+++ b/HLTrigger/Muon/interface/HLTMuonTrimuonL3Filter.h
@@ -3,7 +3,7 @@
 
 /** \class HLTMuonTrimuonL3Filter
  *
- *  
+ *
  *  This class is an HLTFilter (-> EDFilter) implementing a muon triplet
  *  filter for HLT muons
  *
@@ -27,16 +27,17 @@ class HLTMuonTrimuonL3Filter : public HLTFilter {
       ~HLTMuonTrimuonL3Filter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
       virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
-      bool triggeredByLevel2(const reco::TrackRef& track,std::vector<reco::RecoChargedCandidateRef>& vcands);
 
    private:
+      static bool triggeredByLevel2(const reco::TrackRef& track, std::vector<reco::RecoChargedCandidateRef>& vcands);
+
       edm::InputTag beamspotTag_ ;
       edm::EDGetTokenT<reco::BeamSpot> beamspotToken_ ;
       edm::InputTag                                          candTag_;   // input tag identifying product contains muons
       edm::EDGetTokenT<reco::RecoChargedCandidateCollection> candToken_; // token identifying product contains muons
       edm::InputTag                                          previousCandTag_;   // input tag identifying product contains muons passing the previous level
       edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> previousCandToken_; // token identifying product contains muons passing the previous level
-      
+
       bool   fast_Accept_;      // flag to save time: stop processing after identification of the first valid triplet
       double max_Eta_;          // Eta cut
       int    min_Nhits_;        // threshold on number of hits on muon

--- a/HLTrigger/Muon/interface/HLTMuonTrimuonL3Filter.h
+++ b/HLTrigger/Muon/interface/HLTMuonTrimuonL3Filter.h
@@ -26,7 +26,7 @@ class HLTMuonTrimuonL3Filter : public HLTFilter {
       explicit HLTMuonTrimuonL3Filter(const edm::ParameterSet&);
       ~HLTMuonTrimuonL3Filter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       static bool triggeredByLevel2(const reco::TrackRef& track, std::vector<reco::RecoChargedCandidateRef>& vcands);

--- a/HLTrigger/Muon/interface/HLTMuonTrimuonL3Filter.h
+++ b/HLTrigger/Muon/interface/HLTMuonTrimuonL3Filter.h
@@ -26,7 +26,7 @@ class HLTMuonTrimuonL3Filter : public HLTFilter {
       explicit HLTMuonTrimuonL3Filter(const edm::ParameterSet&);
       ~HLTMuonTrimuonL3Filter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       bool triggeredByLevel2(const reco::TrackRef& track,std::vector<reco::RecoChargedCandidateRef>& vcands);
 
    private:

--- a/HLTrigger/Muon/src/HLTDiMuonGlbTrkFilter.cc
+++ b/HLTrigger/Muon/src/HLTDiMuonGlbTrkFilter.cc
@@ -62,7 +62,7 @@ HLTDiMuonGlbTrkFilter::fillDescriptions(edm::ConfigurationDescriptions& descript
 }
 
 bool
-HLTDiMuonGlbTrkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTDiMuonGlbTrkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   edm::Handle<reco::MuonCollection> muons;
   iEvent.getByToken(m_muonsToken,muons);
@@ -107,6 +107,6 @@ HLTDiMuonGlbTrkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 
   for ( std::set<unsigned int>::const_iterator itr = mus.begin(); itr != mus.end(); ++itr )
     filterproduct.addObject(trigger::TriggerMuon, reco::RecoChargedCandidateRef(cands,*itr));
-  
+
   return npassed>0;
 }

--- a/HLTrigger/Muon/src/HLTDiMuonGlbTrkFilter.cc
+++ b/HLTrigger/Muon/src/HLTDiMuonGlbTrkFilter.cc
@@ -62,7 +62,7 @@ HLTDiMuonGlbTrkFilter::fillDescriptions(edm::ConfigurationDescriptions& descript
 }
 
 bool
-HLTDiMuonGlbTrkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTDiMuonGlbTrkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   edm::Handle<reco::MuonCollection> muons;
   iEvent.getByToken(m_muonsToken,muons);

--- a/HLTrigger/Muon/src/HLTMuonDimuonL2Filter.cc
+++ b/HLTrigger/Muon/src/HLTMuonDimuonL2Filter.cc
@@ -1,7 +1,7 @@
 /** \class HLTMuonDimuonL2Filter
  *
  * See header file for documentation
- *  
+ *
  *  \author J. Alcaraz, P. Garcia, M.Vander Donckt
  *
  */
@@ -69,7 +69,7 @@ HLTMuonDimuonL2Filter::HLTMuonDimuonL2Filter(const edm::ParameterSet& iConfig): 
 {
 
    LogDebug("HLTMuonDimuonL2Filter")
-      << " CandTag/MinN/MaxEta/MinNhits/MinNstations/MinNchambers/MaxDr/MaxDz/MinPt1/MinPt2/MinInvMass/MaxInvMass/MinAcop/MaxAcop/MinAngle/MaxAngle/MinPtBalance/MaxPtBalance/NSigmaPt : " 
+      << " CandTag/MinN/MaxEta/MinNhits/MinNstations/MinNchambers/MaxDr/MaxDz/MinPt1/MinPt2/MinInvMass/MaxInvMass/MinAcop/MaxAcop/MinAngle/MaxAngle/MinPtBalance/MaxPtBalance/NSigmaPt : "
       << candTag_.encode()
       << " " << fast_Accept_
       << " " << max_Eta_
@@ -129,7 +129,7 @@ HLTMuonDimuonL2Filter::fillDescriptions(edm::ConfigurationDescriptions& descript
 
 // ------------ method called to produce the data  ------------
 bool
-HLTMuonDimuonL2Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTMuonDimuonL2Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
 
    double const MuMass = 0.106;
@@ -169,7 +169,7 @@ HLTMuonDimuonL2Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
             << tk1->charge()*tk1->pt() << ", eta= " << tk1->eta() << ", hits= " << tk1->numberOfValidHits();
       // find the L1 Particle corresponding to the L2 Track
       if (!mapL2ToL1.isTriggeredByL1(tk1)) continue;
- 
+
       if (fabs(tk1->eta())>max_Eta_) continue;
 
       // cut on number of hits
@@ -177,7 +177,7 @@ HLTMuonDimuonL2Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 
       // number of stations
       if (tk1->hitPattern().muonStationsWithAnyHits() < min_Nstations_) continue;
-      
+
       // number of chambers
       if(tk1->hitPattern().dtStationsWithAnyHits() +
 	 tk1->hitPattern().cscStationsWithAnyHits() < min_Nchambers_) continue;
@@ -306,12 +306,12 @@ HLTMuonDimuonL2Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 	      }
 	      if (i1done && i2done) break;
             }
-	    
-            if (!i1done) { 
+	
+            if (!i1done) {
 	      ref1=RecoChargedCandidateRef( Ref<RecoChargedCandidateCollection> (mucands,distance(mucands->begin(), cand1)));
 	      filterproduct.addObject(TriggerMuon,ref1);
             }
-            if (!i2done) { 
+            if (!i2done) {
 	      ref2=RecoChargedCandidateRef( Ref<RecoChargedCandidateCollection> (mucands,distance(mucands->begin(),cand2 )));
 	    filterproduct.addObject(TriggerMuon,ref2);
             }
@@ -324,7 +324,7 @@ HLTMuonDimuonL2Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
    // filter decision
    const bool accept (n >= 1);
 
-   LogDebug("HLTMuonDimuonL2Filter") << " >>>>> Result of HLTMuonDimuonL2Filter is "<< accept << ", number of muon pairs passing thresholds= " << n; 
+   LogDebug("HLTMuonDimuonL2Filter") << " >>>>> Result of HLTMuonDimuonL2Filter is "<< accept << ", number of muon pairs passing thresholds= " << n;
 
    return accept;
 }

--- a/HLTrigger/Muon/src/HLTMuonDimuonL2Filter.cc
+++ b/HLTrigger/Muon/src/HLTMuonDimuonL2Filter.cc
@@ -129,7 +129,7 @@ HLTMuonDimuonL2Filter::fillDescriptions(edm::ConfigurationDescriptions& descript
 
 // ------------ method called to produce the data  ------------
 bool
-HLTMuonDimuonL2Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTMuonDimuonL2Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
 
    double const MuMass = 0.106;

--- a/HLTrigger/Muon/src/HLTMuonDimuonL3Filter.cc
+++ b/HLTrigger/Muon/src/HLTMuonDimuonL3Filter.cc
@@ -138,7 +138,7 @@ HLTMuonDimuonL3Filter::fillDescriptions(edm::ConfigurationDescriptions& descript
 
 // ------------ method called to produce the data  ------------
 bool
-HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
 
    if (min_InvMass_.size() != min_PtPair_.size()) {cout << "ERROR!!! Vector sizes don't match!" << endl; return false;}

--- a/HLTrigger/Muon/src/HLTMuonDimuonL3Filter.cc
+++ b/HLTrigger/Muon/src/HLTMuonDimuonL3Filter.cc
@@ -65,14 +65,14 @@ HLTMuonDimuonL3Filter::HLTMuonDimuonL3Filter(const edm::ParameterSet& iConfig) :
    max_Acop_    (iConfig.getParameter<double> ("MaxAcop")),
    min_PtBalance_ (iConfig.getParameter<double> ("MinPtBalance")),
    max_PtBalance_ (iConfig.getParameter<double> ("MaxPtBalance")),
-   nsigma_Pt_   (iConfig.getParameter<double> ("NSigmaPt")), 
+   nsigma_Pt_   (iConfig.getParameter<double> ("NSigmaPt")),
    max_DCAMuMu_  (iConfig.getParameter<double>("MaxDCAMuMu")),
    max_YPair_   (iConfig.getParameter<double>("MaxRapidityPair")),
    cutCowboys_(iConfig.getParameter<bool>("CutCowboys"))
 {
 
    LogDebug("HLTMuonDimuonL3Filter")
-      << " CandTag/MinN/MaxEta/MinNhits/MaxDr/MaxDz/MinPt1/MinPt2/MinInvMass/MaxInvMass/MinAcop/MaxAcop/MinPtBalance/MaxPtBalance/NSigmaPt/MaxDzMuMu/MaxRapidityPair : " 
+      << " CandTag/MinN/MaxEta/MinNhits/MaxDr/MaxDz/MinPt1/MinPt2/MinInvMass/MaxInvMass/MinAcop/MaxAcop/MinPtBalance/MaxPtBalance/NSigmaPt/MaxDzMuMu/MaxRapidityPair : "
       << candTag_.encode()
       << " " << fast_Accept_
       << " " << max_Eta_
@@ -147,7 +147,7 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
    if (min_InvMass_.size() != min_PtMin_.size()) {cout << "ERROR!!! Vector sizes don't match!" << endl; return false;}
    if (min_InvMass_.size() != max_PtMin_.size()) {cout << "ERROR!!! Vector sizes don't match!" << endl; return false;}
    if (min_InvMass_.size() != max_InvMass_.size()) {cout << "ERROR!!! Vector sizes don't match!" << endl; return false;}
-  
+
    double const MuMass = 0.106;
    double const MuMass2 = MuMass*MuMass;
    // All HLT filters must create and fill an HLT filter object,
@@ -178,7 +178,7 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
    // Needed for DCA calculation
    ESHandle<MagneticField> bFieldHandle;
    iSetup.get<IdealMagneticFieldRecord>().get(bFieldHandle);
-  
+
    // needed to compare to L2
    vector<RecoChargedCandidateRef> vl2cands;
    previousLevelCands->getObjects(TriggerMuon,vl2cands);
@@ -194,7 +194,7 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
    for (; L2toL3s_it1!=L2toL3s_end; ++L2toL3s_it1){
 
      if (!triggeredByLevel2(L2toL3s_it1->first,vl2cands)) continue;
-     
+
      //loop over the L3Tk reconstructed for this L2.
      unsigned int iTk1=0;
      unsigned int maxItk1=L2toL3s_it1->second.size();
@@ -207,17 +207,17 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 					 << tk1->charge()*tk1->pt() << " (" << cand1->charge()*cand1->pt()<< ") " << ", eta= " << tk1->eta() << " (" << cand1->eta() << ") " << ", hits= " << tk1->numberOfValidHits();
 
        if (fabs(cand1->eta())>max_Eta_) continue;
-       
+
        // cut on number of hits
        if (tk1->numberOfValidHits()<min_Nhits_) continue;
-       
+
        //dr cut
        //      if (fabs(tk1->d0())>max_Dr_) continue;
        if (fabs( (- (cand1->vx()-beamSpot.x0()) * cand1->py() + (cand1->vy()-beamSpot.y0()) * cand1->px() ) / cand1->pt() ) >max_Dr_) continue;
-       
+
        //dz cut
        if (fabs((cand1->vz()-beamSpot.z0()) - ((cand1->vx()-beamSpot.x0())*cand1->px()+(cand1->vy()-beamSpot.y0())*cand1->py())/cand1->pt() * cand1->pz()/cand1->pt())>max_Dz_) continue;
-       
+
        // Pt threshold cut
        double pt1 = cand1->pt();
        //       double err1 = tk1->error(0);
@@ -230,27 +230,27 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
        L2toL3s_it2++;
        for (; L2toL3s_it2!=L2toL3s_end; ++L2toL3s_it2){
 	 if (!triggeredByLevel2(L2toL3s_it2->first,vl2cands)) continue;
-	 
+	
 	    //loop over the L3Tk reconstructed for this L2.
 	    unsigned int iTk2=0;
 	    unsigned int maxItk2=L2toL3s_it2->second.size();
 	    for (; iTk2!=maxItk2; iTk2++){
 	      RecoChargedCandidateRef & cand2=L2toL3s_it2->second[iTk2];
 	      TrackRef tk2 = cand2->get<TrackRef>();
-	      
+	
 	      // eta cut
 	      LogDebug("HLTMuonDimuonL3Filter") << " 2nd muon in loop: q*pt= " << tk2->charge()*tk2->pt() << " (" << cand2->charge()*cand2->pt() << ") " << ", eta= " << tk2->eta() << " (" << cand2->eta() << ") " << ", hits= " << tk2->numberOfValidHits() << ", d0= " << tk2->d0() ;
 	      if (fabs(cand2->eta())>max_Eta_) continue;
-	      
+	
 	      // cut on number of hits
 	      if (tk2->numberOfValidHits()<min_Nhits_) continue;
-	      
+	
 	      //dr cut
 	      // if (fabs(tk2->d0())>max_Dr_) continue;
 	      if (fabs( (- (cand2->vx()-beamSpot.x0()) * cand2->py() + (cand2->vy()-beamSpot.y0()) * cand2->px() ) / cand2->pt() ) >max_Dr_) continue;
 
 	      //dz cut
-	      if (fabs((cand2->vz()-beamSpot.z0()) - ((cand2->vx()-beamSpot.x0())*cand2->px()+(cand2->vy()-beamSpot.y0())*cand2->py())/cand2->pt() * cand2->pz()/cand2->pt())>max_Dz_) continue;	      
+	      if (fabs((cand2->vz()-beamSpot.z0()) - ((cand2->vx()-beamSpot.x0())*cand2->px()+(cand2->vy()-beamSpot.y0())*cand2->py())/cand2->pt() * cand2->pz()/cand2->pt())>max_Dz_) continue;	
 
 	      // Pt threshold cut
 	      double pt2 = cand2->pt();
@@ -260,13 +260,13 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 	      // Don't convert to 90% efficiency threshold
 	      LogDebug("HLTMuonDimuonL3Filter") << " ... 2nd muon in loop, pt2= "
 						<< pt2 << ", ptLx2= " << ptLx2;
-	      
+	
 	      if (chargeOpt_<0) {
 		if (cand1->charge()*cand2->charge()>0) continue;
 	      } else if (chargeOpt_>0) {
 		if (cand1->charge()*cand2->charge()<0) continue;
 	      }
-	      
+	
 	      // Acoplanarity
 	      double acop = fabs(cand1->phi()-cand2->phi());
 	      if (acop>M_PI) acop = 2*M_PI - acop;
@@ -286,10 +286,10 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 	      p1 = Particle::LorentzVector(cand1->px(),cand1->py(),cand1->pz(),e1);
 	      p2 = Particle::LorentzVector(cand2->px(),cand2->py(),cand2->pz(),e2);
 	      p = p1+p2;
-	      
+	
 	      double pt12 = p.pt();
 	      LogDebug("HLTMuonDimuonL3Filter") << " ... 1-2 pt12= " << pt12;
-	      
+	
 	      double invmass = abs(p.mass());
 	      // if (invmass>0) invmass = sqrt(invmass); else invmass = 0;
 	      LogDebug("HLTMuonDimuonL3Filter") << " ... 1-2 invmass= " << invmass;
@@ -327,15 +327,15 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 		if (!cApp.status()
 		    || cApp.distance() > max_DCAMuMu_) continue;
 	      }
-              
+
               // Max dimuon |rapidity|
               double rapidity = fabs(p.Rapidity());
               if ( rapidity > max_YPair_) continue;
-              
+
 	      ///
 	      // if cutting on cowboys reject muons that bend towards each other
 	      if(cutCowboys_ && (cand1->charge()*deltaPhi(cand1->phi(), cand2->phi()) > 0.)) continue;
-              
+
 	      // Add this pair
 	      n++;
 	      LogDebug("HLTMuonDimuonL3Filter") << " Track1 passing filter: pt= " << cand1->pt() << ", eta: " << cand1->eta();
@@ -356,14 +356,14 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 		}
 		if (i1done && i2done) break;
 	      }
-	    
-	      if (!i1done) { 
+	
+	      if (!i1done) {
 		filterproduct.addObject(TriggerMuon,cand1);
 	      }
-	      if (!i2done) { 
+	      if (!i2done) {
 		filterproduct.addObject(TriggerMuon,cand2);
 	      }
-	      
+	
 	      //break anyway since a L3 track pair has been found matching the criteria
 	      thisL3Index1isDone=true;
 	      atLeastOnePair=true;
@@ -373,7 +373,7 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
 	    if (atLeastOnePair && fast_Accept_) break;
        }//loop on the second L2
 
-       
+
        //break the loop if fast accept.
        if (atLeastOnePair && fast_Accept_) break;
        if (thisL3Index1isDone) break;
@@ -381,18 +381,18 @@ HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSet
      //break the loop if fast accept.
      if (atLeastOnePair && fast_Accept_) break;
    }//loop on the first L2
-   
+
    // filter decision
    const bool accept (n >= 1);
 
-   LogDebug("HLTMuonDimuonL3Filter") << " >>>>> Result of HLTMuonDimuonL3Filter is "<< accept << ", number of muon pairs passing thresholds= " << n; 
+   LogDebug("HLTMuonDimuonL3Filter") << " >>>>> Result of HLTMuonDimuonL3Filter is "<< accept << ", number of muon pairs passing thresholds= " << n;
 
    return accept;
 }
 
 
 bool
-HLTMuonDimuonL3Filter::triggeredByLevel2(const TrackRef& staTrack,vector<RecoChargedCandidateRef>& vcands)
+HLTMuonDimuonL3Filter::triggeredByLevel2(TrackRef const & staTrack,vector<RecoChargedCandidateRef> const & vcands)
 {
   bool ok=false;
   for (unsigned int i=0; i<vcands.size(); i++) {

--- a/HLTrigger/Muon/src/HLTMuonDimuonL3Filter.cc
+++ b/HLTrigger/Muon/src/HLTMuonDimuonL3Filter.cc
@@ -138,7 +138,7 @@ HLTMuonDimuonL3Filter::fillDescriptions(edm::ConfigurationDescriptions& descript
 
 // ------------ method called to produce the data  ------------
 bool
-HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTMuonDimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
 
    if (min_InvMass_.size() != min_PtPair_.size()) {cout << "ERROR!!! Vector sizes don't match!" << endl; return false;}

--- a/HLTrigger/Muon/src/HLTMuonIsoFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonIsoFilter.cc
@@ -83,7 +83,7 @@ HLTMuonIsoFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
 
 // ------------ method called to produce the data  ------------
 bool
-HLTMuonIsoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTMuonIsoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
    using namespace std;
    using namespace edm;

--- a/HLTrigger/Muon/src/HLTMuonIsoFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonIsoFilter.cc
@@ -34,7 +34,7 @@ HLTMuonIsoFilter::HLTMuonIsoFilter(const edm::ParameterSet& iConfig) : HLTFilter
    previousCandTag_ (iConfig.getParameter<edm::InputTag > ("PreviousCandTag")),
    previousCandToken_ (consumes<trigger::TriggerFilterObjectWithRefs>(previousCandTag_)),
    depTag_  (iConfig.getParameter< std::vector< edm::InputTag > >("DepTag" ) ),
-   depToken_(0), 
+   depToken_(0),
    theDepositIsolator(0),
    min_N_   (iConfig.getParameter<int> ("MinN"))
 {
@@ -46,7 +46,7 @@ HLTMuonIsoFilter::HLTMuonIsoFilter(const edm::ParameterSet& iConfig) : HLTFilter
   decMapToken_ = consumes<edm::ValueMap<bool> >(depTag_.front());
 
    LogDebug("HLTMuonIsoFilter") << " candTag : " << candTag_.encode()
-				<< "\n" << tags 
+				<< "\n" << tags
 				<< "  MinN : " << min_N_;
 
    edm::ParameterSet isolatorPSet = iConfig.getParameter<edm::ParameterSet>("IsolatorPSet");
@@ -56,7 +56,7 @@ HLTMuonIsoFilter::HLTMuonIsoFilter(const edm::ParameterSet& iConfig) : HLTFilter
      std::string type = isolatorPSet.getParameter<std::string>("ComponentName");
      theDepositIsolator = MuonIsolatorFactory::get()->create(type, isolatorPSet);
    }
-   
+
    if (theDepositIsolator) produces<edm::ValueMap<bool> >();
 }
 
@@ -83,7 +83,7 @@ HLTMuonIsoFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
 
 // ------------ method called to produce the data  ------------
 bool
-HLTMuonIsoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTMuonIsoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
    using namespace std;
    using namespace edm;
@@ -95,7 +95,7 @@ HLTMuonIsoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
    // this HLT filter, and place it in the Event.
 
    //the decision map
-   std::auto_ptr<edm::ValueMap<bool> > 
+   std::auto_ptr<edm::ValueMap<bool> >
      isoMap( new edm::ValueMap<bool> ());
 
    // get hold of trks
@@ -106,7 +106,7 @@ HLTMuonIsoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
    iEvent.getByToken(previousCandToken_,previousLevelCands);
    vector<RecoChargedCandidateRef> vcands;
    previousLevelCands->getObjects(TriggerMuon,vcands);
-   
+
    //get hold of energy deposition
    unsigned int nDep=depTag_.size();
    std::vector< Handle<edm::ValueMap<reco::IsoDeposit> > > depMap(nDep);
@@ -127,8 +127,8 @@ HLTMuonIsoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
    unsigned int iMu=0;
    for (; iMu<nMu; iMu++) {
      RecoChargedCandidateRef candref(mucands,iMu);
-     LogDebug("HLTMuonIsoFilter") << "candref isNonnull " << candref.isNonnull(); 
-     
+     LogDebug("HLTMuonIsoFilter") << "candref isNonnull " << candref.isNonnull();
+
      //did this candidate triggered at previous stage.
      if (!triggerdByPreviousLevel(candref,vcands)) continue;
 
@@ -149,13 +149,13 @@ HLTMuonIsoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
        //get the selection
        muonisolation::MuIsoBaseIsolator::Result selection = theDepositIsolator->result( isoContainer, *tk );
        isos[iMu]=selection.valBool;
-       
+
      }else{
        //get the decision from the event
        isos[iMu]=(*decisionMap)[tk];
      }
      LogDebug("HLTMuonIsoFilter") << " Muon with q*pt= " << tk->charge()*tk->pt() << ", eta= " << tk->eta() << "; "<<(isos[iMu]?"Is an isolated muon.":"Is NOT an isolated muon.");
-       
+
      if (!isos[iMu]) continue;
 
      nIsolatedMu++;
@@ -168,7 +168,7 @@ HLTMuonIsoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
    if (theDepositIsolator){
      //put the decision map
      if (nMu!=0){
-       edm::ValueMap<bool> ::Filler isoFiller(*isoMap);     
+       edm::ValueMap<bool> ::Filler isoFiller(*isoMap);
        // get a track ref
 
        TrackRef aRef = mucands->front().get<TrackRef>();
@@ -181,7 +181,7 @@ HLTMuonIsoFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
      iEvent.put(isoMap);
    }
 
-   LogDebug("HLTMuonIsoFilter") << " >>>>> Result of HLTMuonIsoFilter is " << accept << ", number of muons passing isolation cuts= " << nIsolatedMu; 
+   LogDebug("HLTMuonIsoFilter") << " >>>>> Result of HLTMuonIsoFilter is " << accept << ", number of muons passing isolation cuts= " << nIsolatedMu;
 
    return accept;
 }
@@ -196,4 +196,4 @@ bool HLTMuonIsoFilter::triggerdByPreviousLevel(const reco::RecoChargedCandidateR
 
   return ok;
 }
-																						       
+																						

--- a/HLTrigger/Muon/src/HLTMuonL1Filter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL1Filter.cc
@@ -104,7 +104,7 @@ HLTMuonL1Filter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTMuonL1Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const{
+bool HLTMuonL1Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
   using namespace std;
   using namespace edm;
   using namespace trigger;

--- a/HLTrigger/Muon/src/HLTMuonL1Filter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL1Filter.cc
@@ -106,7 +106,7 @@ HLTMuonL1Filter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTMuonL1Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct){
+bool HLTMuonL1Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const{
   using namespace std;
   using namespace edm;
   using namespace trigger;

--- a/HLTrigger/Muon/src/HLTMuonL1RegionalFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL1RegionalFilter.cc
@@ -20,7 +20,7 @@ HLTMuonL1RegionalFilter::HLTMuonL1RegionalFilter(const edm::ParameterSet& iConfi
   using namespace std;
   using namespace edm;
 
-  // read in the eta-range dependent parameters  
+  // read in the eta-range dependent parameters
   const vector<ParameterSet> cuts = iConfig.getParameter<vector<ParameterSet> >("Cuts");
   size_t ranges = cuts.size();
   if(ranges==0){
@@ -153,7 +153,7 @@ HLTMuonL1RegionalFilter::fillDescriptions(edm::ConfigurationDescriptions& descri
   descriptions.add("hltMuonL1RegionalFilter", desc);
 }
 
-bool HLTMuonL1RegionalFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const{
+bool HLTMuonL1RegionalFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
   using namespace std;
   using namespace edm;
   using namespace trigger;
@@ -172,7 +172,7 @@ bool HLTMuonL1RegionalFilter::hltFilter(edm::Event& iEvent, const edm::EventSetu
   iEvent.getByToken(previousCandToken_, previousLevelCands);
   vector<L1MuonParticleRef> prevMuons;
   previousLevelCands->getObjects(TriggerL1Mu, prevMuons);
-   
+
   // look at all mucands,  check cuts and add to filter object
   int n = 0;
   for (size_t i = 0; i < allMuons->size(); i++) {

--- a/HLTrigger/Muon/src/HLTMuonL1RegionalFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL1RegionalFilter.cc
@@ -153,7 +153,7 @@ HLTMuonL1RegionalFilter::fillDescriptions(edm::ConfigurationDescriptions& descri
   descriptions.add("hltMuonL1RegionalFilter", desc);
 }
 
-bool HLTMuonL1RegionalFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct){
+bool HLTMuonL1RegionalFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const{
   using namespace std;
   using namespace edm;
   using namespace trigger;

--- a/HLTrigger/Muon/src/HLTMuonL1toL3TkPreFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL1toL3TkPreFilter.cc
@@ -50,9 +50,9 @@ HLTMuonL1toL3TkPreFilter::HLTMuonL1toL3TkPreFilter(const ParameterSet& iConfig) 
 {
 
    LogDebug("HLTMuonL1toL3TkPreFilter")
-      << " CandTag/MinN/MaxEta/MinNhits/MaxDr/MaxDz/MinPt/NSigmaPt : " 
+      << " CandTag/MinN/MaxEta/MinNhits/MaxDr/MaxDz/MinPt/NSigmaPt : "
       << candTag_.encode()
-      << " " << min_N_ 
+      << " " << min_N_
       << " " << max_Eta_
       << " " << min_Nhits_
       << " " << max_Dr_
@@ -90,7 +90,7 @@ HLTMuonL1toL3TkPreFilter::fillDescriptions(edm::ConfigurationDescriptions& descr
 
 // ------------ method called to produce the data  ------------
 bool
-HLTMuonL1toL3TkPreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTMuonL1toL3TkPreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
 
    // All HLT filters must create and fill an HLT filter object,
@@ -121,21 +121,21 @@ HLTMuonL1toL3TkPreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, tri
    beamSpot = *recoBeamSpotHandle;
 
 
-   //needed to compare to L1 
+   //needed to compare to L1
    vector<l1extra::L1MuonParticleRef> vl1cands;
    previousLevelCands->getObjects(TriggerL1Mu,vl1cands);
 
    std::map<l1extra::L1MuonParticleRef, std::vector<RecoChargedCandidateRef> > ::iterator L1toL3s_it = L1toL3s.begin();
    std::map<l1extra::L1MuonParticleRef, std::vector<RecoChargedCandidateRef> > ::iterator L1toL3s_end = L1toL3s.end();
    for (; L1toL3s_it!=L1toL3s_end; ++L1toL3s_it){
-     
+
      if (!triggeredAtL1(L1toL3s_it->first,vl1cands)) continue;
-     
+
      //loop over the L3Tk reconstructed for this L1.
      unsigned int iTk=0;
      unsigned int maxItk=L1toL3s_it->second.size();
      for (; iTk!=maxItk; iTk++){
-       
+
        RecoChargedCandidateRef & cand=L1toL3s_it->second[iTk];
        TrackRef tk = cand->track();
 
@@ -163,7 +163,7 @@ HLTMuonL1toL3TkPreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, tri
       if (ptLx<min_Pt_) continue;
 
       //one good L3Tk
-      filterproduct.addObject(TriggerMuon,cand);      
+      filterproduct.addObject(TriggerMuon,cand);
       break; // and go on with the next L1 association
      }
 
@@ -175,15 +175,15 @@ HLTMuonL1toL3TkPreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, tri
    for (unsigned int i=0; i<vref.size(); i++ ) {
      TrackRef tk = vref[i]->track();
      LogDebug("HLTMuonL1toL3TkPreFilter")
-       << " Track passing filter: pt= " << tk->pt() << ", eta: " 
+       << " Track passing filter: pt= " << tk->pt() << ", eta: "
        << tk->eta();
    }
-   
+
    // filter decision
    const bool accept ((int)n >= min_N_);
-   
-   LogDebug("HLTMuonL1toL3TkPreFilter") << " >>>>> Result of HLTMuonL1toL3TkPreFilter is " << accept << ", number of muons passing thresholds= " << n; 
-   
+
+   LogDebug("HLTMuonL1toL3TkPreFilter") << " >>>>> Result of HLTMuonL1toL3TkPreFilter is " << accept << ", number of muons passing thresholds= " << n;
+
    return accept;
 }
 

--- a/HLTrigger/Muon/src/HLTMuonL1toL3TkPreFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL1toL3TkPreFilter.cc
@@ -90,7 +90,7 @@ HLTMuonL1toL3TkPreFilter::fillDescriptions(edm::ConfigurationDescriptions& descr
 
 // ------------ method called to produce the data  ------------
 bool
-HLTMuonL1toL3TkPreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTMuonL1toL3TkPreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
 
    // All HLT filters must create and fill an HLT filter object,
@@ -186,8 +186,9 @@ HLTMuonL1toL3TkPreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, tri
    
    return accept;
 }
+
 bool
-HLTMuonL1toL3TkPreFilter::triggeredAtL1(const l1extra::L1MuonParticleRef & l1mu,std::vector<l1extra::L1MuonParticleRef>& vcands)
+HLTMuonL1toL3TkPreFilter::triggeredAtL1(const l1extra::L1MuonParticleRef & l1mu,std::vector<l1extra::L1MuonParticleRef>& vcands) const
 {
   bool ok=false;
 

--- a/HLTrigger/Muon/src/HLTMuonL2PreFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL2PreFilter.cc
@@ -35,7 +35,7 @@ HLTMuonL2PreFilter::HLTMuonL2PreFilter(const edm::ParameterSet& iConfig): HLTFil
   seedMapToken_(consumes<SeedMap>(seedMapTag_)),
   minN_( iConfig.getParameter<int>("MinN") ),
   maxEta_( iConfig.getParameter<double>("MaxEta") ),
-  absetaBins_( iConfig.getParameter<std::vector<double> >("AbsEtaBins") ), 
+  absetaBins_( iConfig.getParameter<std::vector<double> >("AbsEtaBins") ),
   minNstations_( iConfig.getParameter<std::vector<int> >("MinNstations") ),
   minNhits_( iConfig.getParameter<std::vector<int> >("MinNhits") ),
   cutOnChambers_( iConfig.getParameter<bool>("CutOnChambers") ),
@@ -50,10 +50,10 @@ HLTMuonL2PreFilter::HLTMuonL2PreFilter(const edm::ParameterSet& iConfig): HLTFil
   using namespace std;
 
   // check that number of eta bins matches number of nStation cuts
-  if( minNstations_.size()!=absetaBins_.size() || 
-      minNhits_.size()!=absetaBins_.size()     || 
+  if( minNstations_.size()!=absetaBins_.size() ||
+      minNhits_.size()!=absetaBins_.size()     ||
       ( cutOnChambers_ && minNchambers_.size()!=absetaBins_.size() ) ) {
-    throw cms::Exception("Configuration") << "Number of MinNstations, MinNhits, or MinNchambers cuts " 
+    throw cms::Exception("Configuration") << "Number of MinNstations, MinNhits, or MinNchambers cuts "
 					  << "does not match number of eta bins." << endl;
   }
 
@@ -136,7 +136,7 @@ HLTMuonL2PreFilter::fillDescriptions(edm::ConfigurationDescriptions& description
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTMuonL2PreFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTMuonL2PreFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   // All HLT filters must create and fill an HLT filter object,
   // recording any reconstructed physics objects satisfying (or not)
@@ -171,7 +171,7 @@ bool HLTMuonL2PreFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iS
   for(RecoChargedCandidateCollection::const_iterator cand=allMuons->begin(); cand!=allMuons->end(); cand++){
     TrackRef mu = cand->get<TrackRef>();
 
-    // check if this muon passed previous level 
+    // check if this muon passed previous level
     if(!mapL2ToL1.isTriggeredByL1(mu)) continue;
 
     // eta cut
@@ -225,7 +225,7 @@ bool HLTMuonL2PreFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iS
 
   // filter decision
   const bool accept (n >= minN_);
-   
+
   // dump event for debugging
   if(edm::isDebugEnabled()){
     ostringstream ss;

--- a/HLTrigger/Muon/src/HLTMuonL2PreFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL2PreFilter.cc
@@ -136,7 +136,7 @@ HLTMuonL2PreFilter::fillDescriptions(edm::ConfigurationDescriptions& description
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTMuonL2PreFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTMuonL2PreFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   // All HLT filters must create and fill an HLT filter object,
   // recording any reconstructed physics objects satisfying (or not)

--- a/HLTrigger/Muon/src/HLTMuonL3PreFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL3PreFilter.cc
@@ -41,7 +41,7 @@ HLTMuonL3PreFilter::HLTMuonL3PreFilter(const ParameterSet& iConfig) : HLTFilter(
    candTag_   (iConfig.getParameter<InputTag > ("CandTag")),
    candToken_ (consumes<reco::RecoChargedCandidateCollection>(candTag_)),
    previousCandTag_   (iConfig.getParameter<InputTag > ("PreviousCandTag")),
-   previousCandToken_ (consumes<trigger::TriggerFilterObjectWithRefs>(previousCandTag_)), 
+   previousCandToken_ (consumes<trigger::TriggerFilterObjectWithRefs>(previousCandTag_)),
    min_N_     (iConfig.getParameter<int> ("MinN")),
    max_Eta_   (iConfig.getParameter<double> ("MaxEta")),
    min_Nhits_ (iConfig.getParameter<int> ("MinNhits")),
@@ -50,7 +50,7 @@ HLTMuonL3PreFilter::HLTMuonL3PreFilter(const ParameterSet& iConfig) : HLTFilter(
    max_Dz_    (iConfig.getParameter<double> ("MaxDz")),
    min_DxySig_(iConfig.getParameter<double> ("MinDxySig")),
    min_Pt_    (iConfig.getParameter<double> ("MinPt")),
-   nsigma_Pt_  (iConfig.getParameter<double> ("NSigmaPt")), 
+   nsigma_Pt_  (iConfig.getParameter<double> ("NSigmaPt")),
    max_NormalizedChi2_ (iConfig.getParameter<double> ("MaxNormalizedChi2")),
    max_DXYBeamSpot_ (iConfig.getParameter<double> ("MaxDXYBeamSpot")),
    min_NmuonHits_ (iConfig.getParameter<int> ("MinNmuonHits")),
@@ -61,7 +61,7 @@ HLTMuonL3PreFilter::HLTMuonL3PreFilter(const ParameterSet& iConfig) : HLTFilter(
    LogDebug("HLTMuonL3PreFilter")
       << " CandTag/MinN/MaxEta/MinNhits/MaxDr/MinDr/MaxDz/MinDxySig/MinPt/NSigmaPt : "
       << candTag_.encode()
-      << " " << min_N_ 
+      << " " << min_N_
       << " " << max_Eta_
       << " " << min_Nhits_
       << " " << max_Dr_
@@ -107,7 +107,7 @@ HLTMuonL3PreFilter::fillDescriptions(edm::ConfigurationDescriptions& description
 
 // ------------ method called to produce the data  ------------
 bool
-HLTMuonL3PreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTMuonL3PreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
 
    // All HLT filters must create and fill an HLT filter object,
@@ -149,23 +149,23 @@ HLTMuonL3PreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trigger::
    for (; L2toL3s_it!=L2toL3s_end; ++L2toL3s_it){
 
      if (!triggeredByLevel2(L2toL3s_it->first,vl2cands)) continue;
-     
+
      //loop over the L3Tk reconstructed for this L2.
      unsigned int iTk=0;
      unsigned int maxItk=L2toL3s_it->second.size();
      for (; iTk!=maxItk; iTk++){
-       
+
        RecoChargedCandidateRef & cand=L2toL3s_it->second[iTk];
        TrackRef tk = cand->track();
 
        LogDebug("HLTMuonL3PreFilter") << " Muon in loop, q*pt= " << tk->charge()*tk->pt() <<" (" << cand->charge()*cand->pt() << ") " << ", eta= " << tk->eta() << " (" << cand->eta() << ") " << ", hits= " << tk->numberOfValidHits() << ", d0= " << tk->d0() << ", dz= " << tk->dz();
-       
+
        // eta cut
        if (fabs(cand->eta())>max_Eta_) continue;
-       
+
        // cut on number of hits
        if (tk->numberOfValidHits()<min_Nhits_) continue;
-       
+
        //max dr cut
        //if (fabs(tk->d0())>max_Dr_) continue;
        if (fabs( (- (cand->vx()-beamSpot.x0()) * cand->py() + (cand->vy()-beamSpot.y0()) * cand->px() ) / cand->pt() ) >max_Dr_) continue;
@@ -188,7 +188,7 @@ HLTMuonL3PreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trigger::
        //min muon hits cut
        reco::HitPattern trackHits = tk->hitPattern();
        if (trackHits.numberOfValidMuonHits() < min_NmuonHits_ ) continue;
-       
+
        //pt difference cut
        double candPt = cand->pt();
        double trackPt = tk->pt();
@@ -197,7 +197,7 @@ HLTMuonL3PreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trigger::
 
        //track pt cut
        if (trackPt < min_TrackPt_ ) continue;
-       
+
        // Pt threshold cut
        double pt = cand->pt();
        double err0 = tk->error(0);
@@ -206,10 +206,10 @@ HLTMuonL3PreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trigger::
        // convert 50% efficiency threshold to 90% efficiency threshold
        if (abspar0>0) ptLx += nsigma_Pt_*err0/abspar0*pt;
        LogTrace("HLTMuonL3PreFilter") << " ...Muon in loop, trackkRef pt= "
-				      << tk->pt() << ", ptLx= " << ptLx 
+				      << tk->pt() << ", ptLx= " << ptLx
 				      << " cand pT " << cand->pt();
       if (ptLx<min_Pt_) continue;
-      
+
       filterproduct.addObject(TriggerMuon,cand);
       n++;
       break; // and go on with the next L2 association
@@ -224,11 +224,11 @@ HLTMuonL3PreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trigger::
      LogDebug("HLTMuonL3PreFilter")
        << " Track passing filter: trackRef pt= " << tk->pt() << " (" << candref->pt() << ") " << ", eta: " << tk->eta() << " (" << candref->eta() << ") ";
    }
-   
+
    // filter decision
    const bool accept (n >= min_N_);
-   
-   LogDebug("HLTMuonL3PreFilter") << " >>>>> Result of HLTMuonL3PreFilter is " << accept << ", number of muons passing thresholds= " << n; 
+
+   LogDebug("HLTMuonL3PreFilter") << " >>>>> Result of HLTMuonL3PreFilter is " << accept << ", number of muons passing thresholds= " << n;
 
    return accept;
 }

--- a/HLTrigger/Muon/src/HLTMuonL3PreFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL3PreFilter.cc
@@ -107,7 +107,7 @@ HLTMuonL3PreFilter::fillDescriptions(edm::ConfigurationDescriptions& description
 
 // ------------ method called to produce the data  ------------
 bool
-HLTMuonL3PreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTMuonL3PreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
 
    // All HLT filters must create and fill an HLT filter object,
@@ -232,8 +232,9 @@ HLTMuonL3PreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trigger::
 
    return accept;
 }
+
 bool
-HLTMuonL3PreFilter::triggeredByLevel2(const TrackRef& staTrack,vector<RecoChargedCandidateRef>& vcands)
+HLTMuonL3PreFilter::triggeredByLevel2(const TrackRef& staTrack,vector<RecoChargedCandidateRef>& vcands) const
 {
   bool ok=false;
   for (unsigned int i=0; i<vcands.size(); i++) {

--- a/HLTrigger/Muon/src/HLTMuonTrackMassFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonTrackMassFilter.cc
@@ -65,7 +65,7 @@ HLTMuonTrackMassFilter::HLTMuonTrackMassFilter(const edm::ParameterSet& iConfig)
   bool massesValid = minMasses_.size()==maxMasses_.size();
   if ( massesValid ) {
     for ( unsigned int i=0; i<minMasses_.size(); ++i ) {
-      if ( minMasses_[i]<0 || maxMasses_[i]<0 || 
+      if ( minMasses_[i]<0 || maxMasses_[i]<0 ||
 	   minMasses_[i]>maxMasses_[i] )  massesValid = false;
     }
   }
@@ -84,7 +84,7 @@ HLTMuonTrackMassFilter::HLTMuonTrackMassFilter(const edm::ParameterSet& iConfig)
   stream << "  previousCandidates = " << prevCandTag_ << "\n";
   stream << "  saveTags= " << saveTags() << "\n";
   stream << "  mass windows =";
-  for ( size_t i=0; i<minMasses_.size(); ++i )  
+  for ( size_t i=0; i<minMasses_.size(); ++i )
     stream << " (" << minMasses_[i] << "," << maxMasses_[i] << ")";
   stream << "\n";
   stream << "  checkCharge = " << checkCharge_ << "\n";
@@ -136,7 +136,7 @@ HLTMuonTrackMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descrip
 }
 
 bool
-HLTMuonTrackMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTMuonTrackMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   // The filter object
   if (saveTags()) {
@@ -176,8 +176,8 @@ HLTMuonTrackMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
   //
   // access to muons and selection according to configuration
   //   if the previous candidates are taken from a muon+track
-  //   quarkonia filter we rely on the fact that only the muons 
-  //   are flagged as TriggerMuon 
+  //   quarkonia filter we rely on the fact that only the muons
+  //   are flagged as TriggerMuon
   //
   std::vector<reco::RecoChargedCandidateRef> selectedMuonRefs;
   selectedMuonRefs.reserve(muonHandle->size());
@@ -252,7 +252,7 @@ HLTMuonTrackMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 // 	      << muon.track()->dz(beamspot)-track.track()->dz(beamspot) << " "
 // 	      << track.charge()+qMuon << " "
 // 	      << (p4Muon+track.p4()).mass() << "\n";
-      
+
 //       if ( fabs(muon.track()->dz(beamspot)-track.track()->dz(beamspot))>
 // 	   maxDzMuonTrack_ )  continue;
 //       ++nDz;
@@ -260,12 +260,12 @@ HLTMuonTrackMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
       ++nQ;
 
       ///
-      
+
       // DCA between the two muons
-      
+
       reco::TrackRef tk1 = muon.track();
       reco::TrackRef tk2 = track.track();
-      
+
       reco::TransientTrack mu1TT(*tk1, &(*bFieldHandle));
       reco::TransientTrack mu2TT(*tk2, &(*bFieldHandle));
       TrajectoryStateClosestToPoint mu1TS = mu1TT.impactPointTSCP();
@@ -275,7 +275,7 @@ HLTMuonTrackMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
          cApp.calculate(mu1TS.theState(), mu2TS.theState());
          if (!cApp.status() || cApp.distance() > max_DCAMuonTrack_) continue;
       }
-      
+
       ///
       // if cutting on cowboys reject muons that bend towards each other
       if(cutCowboys_ && (qMuon*deltaPhi(p4Muon.phi(), track.phi()) > 0.)) continue;
@@ -303,7 +303,7 @@ HLTMuonTrackMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 
   if ( edm::isDebugEnabled() ) {
     std::ostringstream stream;
-    stream << "Total number of combinations = " 
+    stream << "Total number of combinations = "
 // 	   << selectedMuonRefs.size()*selectedTrackRefs.size() << " , after dz " << nDz
 	   << " , after charge " << nQ << " , after cutCowboy " << nCowboy << " , after mass " << nComb << std::endl;
     stream << "Found " << nComb << " jpsi candidates with # / mass / q / pt / eta" << std::endl;
@@ -319,7 +319,7 @@ HLTMuonTrackMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 	p4Mu = muRefs[i]->p4();
 	p4Tk = tkRefs[i]->p4();
 	p4JPsi = p4Mu + p4Tk;
-	stream << "  " << i << " " 
+	stream << "  " << i << " "
 	       << p4JPsi.M() << " "
 	       << muRefs[i]->charge()+tkRefs[i]->charge() << " "
 	       << p4JPsi.P() << " "
@@ -389,7 +389,7 @@ HLTMuonTrackMassFilter::pairMatched (std::vector<reco::RecoChargedCandidateRef>&
   return false;
 }
 
-				       
+				
 
 
 

--- a/HLTrigger/Muon/src/HLTMuonTrackMassFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonTrackMassFilter.cc
@@ -136,7 +136,7 @@ HLTMuonTrackMassFilter::fillDescriptions(edm::ConfigurationDescriptions& descrip
 }
 
 bool
-HLTMuonTrackMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTMuonTrackMassFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   // The filter object
   if (saveTags()) {

--- a/HLTrigger/Muon/src/HLTMuonTrimuonL3Filter.cc
+++ b/HLTrigger/Muon/src/HLTMuonTrimuonL3Filter.cc
@@ -63,13 +63,13 @@ HLTMuonTrimuonL3Filter::HLTMuonTrimuonL3Filter(const edm::ParameterSet& iConfig)
    max_Acop_    (iConfig.getParameter<double> ("MaxAcop")),
    min_PtBalance_ (iConfig.getParameter<double> ("MinPtBalance")),
    max_PtBalance_ (iConfig.getParameter<double> ("MaxPtBalance")),
-   nsigma_Pt_   (iConfig.getParameter<double> ("NSigmaPt")), 
+   nsigma_Pt_   (iConfig.getParameter<double> ("NSigmaPt")),
    max_DCAMuMu_  (iConfig.getParameter<double>("MaxDCAMuMu")),
    max_YTriplet_   (iConfig.getParameter<double>("MaxRapidityTriplet"))
 {
 
    LogDebug("HLTMuonTrimuonL3Filter")
-      << " CandTag/MinN/MaxEta/MinNhits/MaxDr/MaxDz/MinPt1/MinPt2/MinInvMass/MaxInvMass/MinAcop/MaxAcop/MinPtBalance/MaxPtBalance/NSigmaPt/MaxDzMuMu/MaxRapidityTriplet : " 
+      << " CandTag/MinN/MaxEta/MinNhits/MaxDr/MaxDz/MinPt1/MinPt2/MinInvMass/MaxInvMass/MinAcop/MaxAcop/MinPtBalance/MaxPtBalance/NSigmaPt/MaxDzMuMu/MaxRapidityTriplet : "
       << candTag_.encode()
       << " " << fast_Accept_
       << " " << max_Eta_
@@ -124,7 +124,7 @@ HLTMuonTrimuonL3Filter::fillDescriptions(edm::ConfigurationDescriptions& descrip
 
 // ------------ method called to produce the data  ------------
 bool
-HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
 
    double const MuMass = 0.106;
@@ -157,7 +157,7 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
    // Needed for DCA calculation
    ESHandle<MagneticField> bFieldHandle;
    iSetup.get<IdealMagneticFieldRecord>().get(bFieldHandle);
-  
+
    // needed to compare to L2
    vector<RecoChargedCandidateRef> vl2cands;
    previousLevelCands->getObjects(TriggerMuon,vl2cands);
@@ -173,7 +173,7 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
    for (; L2toL3s_it1!=L2toL3s_end; ++L2toL3s_it1){
 
      if (!triggeredByLevel2(L2toL3s_it1->first,vl2cands)) continue;
-     
+
      //loop over the L3Tk reconstructed for this L2.
      unsigned int iTk1=0;
      unsigned int maxItk1=L2toL3s_it1->second.size();
@@ -186,17 +186,17 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 					 << tk1->charge()*tk1->pt() << " (" << cand1->charge()*cand1->pt()<< ") " << ", eta= " << tk1->eta() << " (" << cand1->eta() << ") " << ", hits= " << tk1->numberOfValidHits();
 
        if (fabs(cand1->eta())>max_Eta_) continue;
-       
+
        // cut on number of hits
        if (tk1->numberOfValidHits()<min_Nhits_) continue;
-       
+
        //dr cut
        //      if (fabs(tk1->d0())>max_Dr_) continue;
        if (fabs( (- (cand1->vx()-beamSpot.x0()) * cand1->py() + (cand1->vy()-beamSpot.y0()) * cand1->px() ) / cand1->pt() ) >max_Dr_) continue;
-       
+
        //dz cut
        if (fabs((cand1->vz()-beamSpot.z0()) - ((cand1->vx()-beamSpot.x0())*cand1->px()+(cand1->vy()-beamSpot.y0())*cand1->py())/cand1->pt() * cand1->pz()/cand1->pt())>max_Dz_) continue;
-       
+
        // Pt threshold cut
        double pt1 = cand1->pt();
        //       double err1 = tk1->error(0);
@@ -209,28 +209,28 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
        L2toL3s_it2++;
        for (; L2toL3s_it2!=L2toL3s_end; ++L2toL3s_it2){
 	 if (!triggeredByLevel2(L2toL3s_it2->first,vl2cands)) continue;
-	 
+	
 	    //loop over the L3Tk reconstructed for this L2.
 	    unsigned int iTk2=0;
 	    unsigned int maxItk2=L2toL3s_it2->second.size();
 	    for (; iTk2!=maxItk2; iTk2++){
 	      RecoChargedCandidateRef & cand2=L2toL3s_it2->second[iTk2];
 	      TrackRef tk2 = cand2->get<TrackRef>();
-	      
+	
 	      // eta cut
 	      LogDebug("HLTMuonTrimuonL3Filter") << " 2nd muon in loop: q*pt= " << tk2->charge()*tk2->pt() << " (" << cand2->charge()*cand2->pt() << ") " << ", eta= " << tk2->eta() << " (" << cand2->eta() << ") " << ", hits= " << tk2->numberOfValidHits() << ", d0= " << tk2->d0() ;
 	      if (fabs(cand2->eta())>max_Eta_) continue;
-	      
+	
 	      // cut on number of hits
 	      if (tk2->numberOfValidHits()<min_Nhits_) continue;
-	      
+	
 	      //dr cut
 	      // if (fabs(tk2->d0())>max_Dr_) continue;
 	      if (fabs( (- (cand2->vx()-beamSpot.x0()) * cand2->py() + (cand2->vy()-beamSpot.y0()) * cand2->px() ) / cand2->pt() ) >max_Dr_) continue;
-	      
+	
 	      //dz cut
-	      if (fabs((cand2->vz()-beamSpot.z0()) - ((cand2->vx()-beamSpot.x0())*cand2->px()+(cand2->vy()-beamSpot.y0())*cand2->py())/cand2->pt() * cand2->pz()/cand2->pt())>max_Dz_) continue;	      
-	      
+	      if (fabs((cand2->vz()-beamSpot.z0()) - ((cand2->vx()-beamSpot.x0())*cand2->px()+(cand2->vy()-beamSpot.y0())*cand2->py())/cand2->pt() * cand2->pz()/cand2->pt())>max_Dz_) continue;	
+	
 	      // Pt threshold cut
 	      double pt2 = cand2->pt();
 	      //	      double err2 = tk2->error(0);
@@ -239,7 +239,7 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 	      // Don't convert to 90% efficiency threshold
 	      LogDebug("HLTMuonTrimuonL3Filter") << " ... 2nd muon in loop, pt2= "
 						 << pt2 << ", ptLx2= " << ptLx2;
-	      
+	
 	      std::map<reco::TrackRef, std::vector<RecoChargedCandidateRef> > ::iterator L2toL3s_it3 = L2toL3s_it2;
 	      L2toL3s_it3++;
 	      for (; L2toL3s_it3!=L2toL3s_end; ++L2toL3s_it3){
@@ -255,19 +255,19 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 		  // eta cut
 		  LogDebug("HLTMuonTrimuonL3Filter") << " 3rd muon in loop: q*pt= "
 						     << tk3->charge()*tk3->pt() << " (" << cand3->charge()*cand3->pt()<< ") " << ", eta= " << tk3->eta() << " (" << cand3->eta() << ") " << ", hits= " << tk3->numberOfValidHits();
-		  
+		
 		  if (fabs(cand3->eta())>max_Eta_) continue;
-		  
+		
 		  // cut on number of hits
 		  if (tk3->numberOfValidHits()<min_Nhits_) continue;
-		  
+		
 		  //dr cut
 		  //      if (fabs(tk1->d0())>max_Dr_) continue;
 		  if (fabs( (- (cand3->vx()-beamSpot.x0()) * cand3->py() + (cand3->vy()-beamSpot.y0()) * cand3->px() ) / cand3->pt() ) >max_Dr_) continue;
-		  
+		
 		  //dz cut
 		  if (fabs((cand3->vz()-beamSpot.z0()) - ((cand3->vx()-beamSpot.x0())*cand3->px()+(cand3->vy()-beamSpot.y0())*cand3->py())/cand3->pt() * cand3->pz()/cand3->pt())>max_Dz_) continue;
-		  
+		
 		  // Pt threshold cut
 		  double pt3 = cand3->pt();
 		  //       double err3 = tk3->error(0);
@@ -276,7 +276,7 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 		  // Don't convert to 90% efficiency threshold
 		  LogDebug("HLTMuonTrimuonL3Filter") << " ... 3rd muon in loop, pt3= "
 						     << pt3 << ", ptLx3= " << ptLx3;
-		  
+		
 		  if (ptLx1>ptLx2 && ptLx1>ptLx3 && ptLx1<min_PtMax_) continue;
 		  else if (ptLx2>ptLx1 && ptLx2>ptLx3 && ptLx2<min_PtMax_) continue;
                   else if (ptLx3<ptLx2 && ptLx3>ptLx1 && ptLx3<min_PtMax_) continue;
@@ -284,11 +284,11 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 		  if (ptLx1<ptLx2 && ptLx1<ptLx3 && ptLx1<min_PtMin_) continue;
 		  else if (ptLx2<ptLx1 && ptLx2<ptLx3 && ptLx2<min_PtMin_) continue;
                   else if (ptLx3<ptLx2 && ptLx3<ptLx1 && ptLx3<min_PtMin_) continue;
-		  
+		
 		  if (chargeOpt_>0) {
 		    if (abs (cand1->charge()+cand2->charge()+cand3->charge()) != chargeOpt_) continue;
 		  }
-		  
+		
 		  // Acoplanarity
 		  double acop = fabs(cand1->phi()-cand2->phi());
 		  if (acop>M_PI) acop = 2*M_PI - acop;
@@ -310,7 +310,7 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 		  LogDebug("HLTMuonTrimuonL3Filter") << " ... 3-2 acop= " << acop;
 		  if (acop<min_Acop_) continue;
 		  if (acop>max_Acop_) continue;
-		  
+		
 		  // Pt balance
 		  double ptbalance = fabs(cand1->pt()-cand2->pt());
 		  if (ptbalance<min_PtBalance_) continue;
@@ -321,7 +321,7 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 		  ptbalance = fabs(cand3->pt()-cand2->pt());
 		  if (ptbalance<min_PtBalance_) continue;
 		  if (ptbalance>max_PtBalance_) continue;
-		  
+		
 		  // Combined trimuon system
 		  e1 = sqrt(cand1->momentum().Mag2()+MuMass2);
 		  e2 = sqrt(cand2->momentum().Mag2()+MuMass2);
@@ -330,21 +330,21 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 		  p2 = Particle::LorentzVector(cand2->px(),cand2->py(),cand2->pz(),e2);
 		  p3 = Particle::LorentzVector(cand3->px(),cand3->py(),cand3->pz(),e3);
 		  p = p1+p2+p3;
-		  
+		
 		  double pt123 = p.pt();
 		  LogDebug("HLTMuonTrimuonL3Filter") << " ... 1-2 pt123= " << pt123;
 		  if (pt123<min_PtTriplet_) continue;
-		  
+		
 		  double invmass = abs(p.mass());
 		  // if (invmass>0) invmass = sqrt(invmass); else invmass = 0;
 		  LogDebug("HLTMuonTrimuonL3Filter") << " ... 1-2 invmass= " << invmass;
 		  if (invmass<min_InvMass_) continue;
 		  if (invmass>max_InvMass_) continue;
-		  
+		
 		  // Delta Z between the two muons
 		  //double DeltaZMuMu = fabs(tk2->dz(beamSpot.position())-tk1->dz(beamSpot.position()));
 		  //if ( DeltaZMuMu > max_DzMuMu_) continue;
-		  
+		
 		  // DCA between the three muons
 		  TransientTrack mu1TT(*tk1, &(*bFieldHandle));
 		  TransientTrack mu2TT(*tk2, &(*bFieldHandle));
@@ -364,18 +364,18 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 		    if (!cApp.status()
 			|| cApp.distance() > max_DCAMuMu_) continue;
 		  }
-		  
+		
 		  // Max dimuon |rapidity|
 		  double rapidity = fabs(p.Rapidity());
 		  if ( rapidity > max_YTriplet_) continue;
-		  
+		
 		  // Add this triplet
 		  n++;
 		  LogDebug("HLTMuonTrimuonL3Filter") << " Track1 passing filter: pt= " << cand1->pt() << ", eta: " << cand1->eta();
 		  LogDebug("HLTMuonTrimuonL3Filter") << " Track2 passing filter: pt= " << cand2->pt() << ", eta: " << cand2->eta();
 		  LogDebug("HLTMuonTrimuonL3Filter") << " Track2 passing filter: pt= " << cand3->pt() << ", eta: " << cand3->eta();
 		  LogDebug("HLTMuonTrimuonL3Filter") << " Invmass= " << invmass;
-		  
+		
 		  bool i1done = false;
 		  bool i2done = false;
 		  bool i3done = false;
@@ -393,17 +393,17 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 		    }
 		    if (i1done && i2done && i3done) break;
 		  }
-		  
-		  if (!i1done) { 
+		
+		  if (!i1done) {
 		    filterproduct.addObject(TriggerMuon,cand1);
 		  }
-		  if (!i2done) { 
+		  if (!i2done) {
 		    filterproduct.addObject(TriggerMuon,cand2);
 		  }
-		  if (!i3done) { 
+		  if (!i3done) {
 		    filterproduct.addObject(TriggerMuon,cand3);
 		  }
-		  
+		
 		  //break anyway since a L3 track triplet has been found matching the criteria
 		  thisL3Index1isDone=true;
 		  atLeastOneTriplet=true;
@@ -416,8 +416,8 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
 	    //break the loop if fast accept.
 	    if (atLeastOneTriplet && fast_Accept_) break;
        }//loop on the second L2
-       
-       
+
+
        //break the loop if fast accept.
        if (atLeastOneTriplet && fast_Accept_) break;
        if (thisL3Index1isDone) break;
@@ -425,12 +425,12 @@ HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSe
      //break the loop if fast accept.
      if (atLeastOneTriplet && fast_Accept_) break;
    }//loop on the first L2
-   
+
    // filter decision
    const bool accept (n >= 1);
-   
-   LogDebug("HLTMuonTrimuonL3Filter") << " >>>>> Result of HLTMuonTrimuonL3Filter is "<< accept << ", number of muon triplets passing thresholds= " << n; 
-   
+
+   LogDebug("HLTMuonTrimuonL3Filter") << " >>>>> Result of HLTMuonTrimuonL3Filter is "<< accept << ", number of muon triplets passing thresholds= " << n;
+
    return accept;
 }
 

--- a/HLTrigger/Muon/src/HLTMuonTrimuonL3Filter.cc
+++ b/HLTrigger/Muon/src/HLTMuonTrimuonL3Filter.cc
@@ -124,7 +124,7 @@ HLTMuonTrimuonL3Filter::fillDescriptions(edm::ConfigurationDescriptions& descrip
 
 // ------------ method called to produce the data  ------------
 bool
-HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTMuonTrimuonL3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
 
    double const MuMass = 0.106;

--- a/HLTrigger/btau/src/HLTDisplacedmumuFilter.cc
+++ b/HLTrigger/btau/src/HLTDisplacedmumuFilter.cc
@@ -38,7 +38,7 @@ HLTDisplacedmumuFilter::HLTDisplacedmumuFilter(const edm::ParameterSet& iConfig)
   fastAccept_ (iConfig.getParameter<bool>("FastAccept")),
   minLxySignificance_ (iConfig.getParameter<double>("MinLxySignificance")),
   maxLxySignificance_ (iConfig.getParameter<double>("MaxLxySignificance")),
-  maxNormalisedChi2_ (iConfig.getParameter<double>("MaxNormalisedChi2")), 
+  maxNormalisedChi2_ (iConfig.getParameter<double>("MaxNormalisedChi2")),
   minVtxProbability_ (iConfig.getParameter<double>("MinVtxProbability")),
   minCosinePointingAngle_ (iConfig.getParameter<double>("MinCosinePointingAngle")),
   DisplacedVertexTag_(iConfig.getParameter<edm::InputTag>("DisplacedVertexTag")),
@@ -78,13 +78,13 @@ void HLTDisplacedmumuFilter::beginJob()
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void HLTDisplacedmumuFilter::endJob() 
+void HLTDisplacedmumuFilter::endJob()
 {
  	
 }
 
 // ------------ method called on each new Event  ------------
-bool HLTDisplacedmumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTDisplacedmumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
 
 
@@ -93,40 +93,40 @@ bool HLTDisplacedmumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
   iEvent.getByToken(beamSpotToken_,recoBeamSpotHandle);
   vertexBeamSpot = *recoBeamSpotHandle;
- 
-  
+
+
   // get displaced vertices
   reco::VertexCollection displacedVertexColl;
   edm::Handle<reco::VertexCollection> displacedVertexCollHandle;
   bool foundVertexColl = iEvent.getByToken(DisplacedVertexToken_, displacedVertexCollHandle);
   if(foundVertexColl) displacedVertexColl = *displacedVertexCollHandle;
-  
- 
+
+
   // get muon collection
   edm::Handle<reco::RecoChargedCandidateCollection> mucands;
   iEvent.getByToken(MuonToken_,mucands);
- 
+
   // All HLT filters must create and fill an HLT filter object,
   // recording any reconstructed physics objects satisfying (or not)
   // this HLT filter, and place it in the Event.
-  
+
 
   // Ref to Candidate object to be recorded in filter object
   reco::RecoChargedCandidateRef ref1;
   reco::RecoChargedCandidateRef ref2;
 
   if (saveTags()) filterproduct.addCollectionTag(MuonTag_);
-  
+
   bool triggered = false;
- 
+
   // loop over vertex collection
   for(reco::VertexCollection::iterator it = displacedVertexColl.begin(); it!= displacedVertexColl.end(); it++){
           reco::Vertex displacedVertex = *it;
-        
+
           // check if the vertex actually consists of exactly two muon tracks, throw exception if not
           if(displacedVertex.tracksSize() != 2)  throw cms::Exception("BadLogic") << "HLTDisplacedmumuFilter: ERROR: the Jpsi vertex must have exactly two muons by definition. It now has n muons = "
         									    << displacedVertex.tracksSize() << std::endl;
-       
+
           float normChi2 = displacedVertex.normalizedChi2();
 	  if (normChi2 > maxNormalisedChi2_) continue;
 
@@ -140,10 +140,10 @@ bool HLTDisplacedmumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
           // the second one
           trackIt++;
           reco::TrackRef vertextkRef2 =  (*trackIt).castTo<reco::TrackRef>();
-          
+
 	  // first find these two tracks in the muon collection
 	  reco::RecoChargedCandidateCollection::const_iterator cand1;
-	  reco::RecoChargedCandidateCollection::const_iterator cand2;	  
+	  reco::RecoChargedCandidateCollection::const_iterator cand2;	
 
 	  int iFoundRefs = 0;
 	  for (reco::RecoChargedCandidateCollection::const_iterator cand=mucands->begin(); cand!=mucands->end(); cand++) {
@@ -151,14 +151,14 @@ bool HLTDisplacedmumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
 	    if(tkRef == vertextkRef1) {cand1 = cand; iFoundRefs++;}
 	    if(tkRef == vertextkRef2) {cand2 = cand; iFoundRefs++;}
 	  }
-	  if(iFoundRefs != 2) throw cms::Exception("BadLogic") << "HLTDisplacedmumuFilter: ERROR: the Jpsi vertex must have exactly two muons by definition."  << std::endl; 
-	  
+	  if(iFoundRefs != 2) throw cms::Exception("BadLogic") << "HLTDisplacedmumuFilter: ERROR: the Jpsi vertex must have exactly two muons by definition."  << std::endl;
+	
           // calculate two-track transverse momentum
           math::XYZVector pperp(cand1->px() + cand2->px(),
         			  cand1->py() + cand2->py(),
         			  0.);
-          
-        
+
+
 	  reco::Vertex::Point vpoint=displacedVertex.position();
 	  //translate to global point, should be improved
 	  GlobalPoint secondaryVertex (vpoint.x(), vpoint.y(), vpoint.z());
@@ -169,32 +169,32 @@ bool HLTDisplacedmumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
 
 	  GlobalPoint displacementFromBeamspot( -1*((vertexBeamSpot.x0() -  secondaryVertex.x()) +  (secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dxdz()),
         					  -1*((vertexBeamSpot.y0() - secondaryVertex.y())+  (secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dydz()), 0);
-        
+
           float lxy = displacementFromBeamspot.perp();
           float lxyerr = sqrt(err.rerr(displacementFromBeamspot));
-        
-        
+
+
           //calculate the angle between the decay length and the mumu momentum
 	  reco::Vertex::Point vperp(displacementFromBeamspot.x(),displacementFromBeamspot.y(),0.);
-         
+
           float cosAlpha = vperp.Dot(pperp)/(vperp.R()*pperp.R());
-        
+
           // check thresholds
           if (cosAlpha < minCosinePointingAngle_) continue;
           if (minLxySignificance_ > 0. && lxy/lxyerr < minLxySignificance_) continue;
-	  if (maxLxySignificance_ > 0. && lxy/lxyerr > maxLxySignificance_) continue; 
+	  if (maxLxySignificance_ > 0. && lxy/lxyerr > maxLxySignificance_) continue;
 	  triggered = true;
- 
+
 	  // now add the muons that passed to the filter object
-	  
+	
 	  ref1=reco::RecoChargedCandidateRef( edm::Ref<reco::RecoChargedCandidateCollection> 	(mucands,distance(mucands->begin(), cand1)));
 	  filterproduct.addObject(trigger::TriggerMuon,ref1);
-	  
+	
 	  ref2=reco::RecoChargedCandidateRef( edm::Ref<reco::RecoChargedCandidateCollection> (mucands,distance(mucands->begin(),cand2 )));
 	  filterproduct.addObject(trigger::TriggerMuon,ref2);
   }
 
-  LogDebug("HLTDisplacedMumuFilter") << " >>>>> Result of HLTDisplacedMumuFilter is "<< triggered <<std::endl; 
+  LogDebug("HLTDisplacedMumuFilter") << " >>>>> Result of HLTDisplacedMumuFilter is "<< triggered <<std::endl;
 
   return triggered;
 }

--- a/HLTrigger/btau/src/HLTDisplacedmumuFilter.cc
+++ b/HLTrigger/btau/src/HLTDisplacedmumuFilter.cc
@@ -84,7 +84,7 @@ void HLTDisplacedmumuFilter::endJob()
 }
 
 // ------------ method called on each new Event  ------------
-bool HLTDisplacedmumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTDisplacedmumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
 
 

--- a/HLTrigger/btau/src/HLTDisplacedmumuFilter.h
+++ b/HLTrigger/btau/src/HLTDisplacedmumuFilter.h
@@ -16,9 +16,9 @@ class HLTDisplacedmumuFilter : public HLTFilter {
     ~HLTDisplacedmumuFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);	
     virtual void beginJob() ;
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
     virtual void endJob() ;
-    
+
   private:
     bool fastAccept_;
     double minLxySignificance_;

--- a/HLTrigger/btau/src/HLTDisplacedmumuFilter.h
+++ b/HLTrigger/btau/src/HLTDisplacedmumuFilter.h
@@ -16,7 +16,7 @@ class HLTDisplacedmumuFilter : public HLTFilter {
     ~HLTDisplacedmumuFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);	
     virtual void beginJob() ;
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
     virtual void endJob() ;
     
   private:

--- a/HLTrigger/btau/src/HLTDisplacedmumumuFilter.cc
+++ b/HLTrigger/btau/src/HLTDisplacedmumumuFilter.cc
@@ -84,7 +84,7 @@ void HLTDisplacedmumumuFilter::endJob()
 }
 
 // ------------ method called on each new Event  ------------
-bool HLTDisplacedmumumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTDisplacedmumumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
 
 

--- a/HLTrigger/btau/src/HLTDisplacedmumumuFilter.cc
+++ b/HLTrigger/btau/src/HLTDisplacedmumumuFilter.cc
@@ -38,7 +38,7 @@ HLTDisplacedmumumuFilter::HLTDisplacedmumumuFilter(const edm::ParameterSet& iCon
   fastAccept_ (iConfig.getParameter<bool>("FastAccept")),
   minLxySignificance_ (iConfig.getParameter<double>("MinLxySignificance")),
   maxLxySignificance_ (iConfig.getParameter<double>("MaxLxySignificance")),
-  maxNormalisedChi2_ (iConfig.getParameter<double>("MaxNormalisedChi2")), 
+  maxNormalisedChi2_ (iConfig.getParameter<double>("MaxNormalisedChi2")),
   minVtxProbability_ (iConfig.getParameter<double>("MinVtxProbability")),
   minCosinePointingAngle_ (iConfig.getParameter<double>("MinCosinePointingAngle")),
   DisplacedVertexTag_(iConfig.getParameter<edm::InputTag>("DisplacedVertexTag")),
@@ -78,13 +78,13 @@ void HLTDisplacedmumumuFilter::beginJob()
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void HLTDisplacedmumumuFilter::endJob() 
+void HLTDisplacedmumumuFilter::endJob()
 {
  	
 }
 
 // ------------ method called on each new Event  ------------
-bool HLTDisplacedmumumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTDisplacedmumumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
 
 
@@ -93,23 +93,23 @@ bool HLTDisplacedmumumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSet
   edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
   iEvent.getByToken(beamSpotToken_,recoBeamSpotHandle);
   vertexBeamSpot = *recoBeamSpotHandle;
- 
-  
+
+
   // get displaced vertices
   reco::VertexCollection displacedVertexColl;
   edm::Handle<reco::VertexCollection> displacedVertexCollHandle;
   bool foundVertexColl = iEvent.getByToken(DisplacedVertexToken_, displacedVertexCollHandle);
   if(foundVertexColl) displacedVertexColl = *displacedVertexCollHandle;
-  
- 
+
+
   // get muon collection
   edm::Handle<reco::RecoChargedCandidateCollection> mucands;
   iEvent.getByToken(MuonToken_,mucands);
- 
+
   // All HLT filters must create and fill an HLT filter object,
   // recording any reconstructed physics objects satisfying (or not)
   // this HLT filter, and place it in the Event.
-  
+
 
   // Ref to Candidate object to be recorded in filter object
   reco::RecoChargedCandidateRef ref1;
@@ -118,17 +118,17 @@ bool HLTDisplacedmumumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSet
 
   if (saveTags()) filterproduct.addCollectionTag(MuonTag_);
 
-  
+
   bool triggered = false;
- 
+
   // loop over vertex collection
   for(reco::VertexCollection::iterator it = displacedVertexColl.begin(); it!= displacedVertexColl.end(); it++){
           reco::Vertex displacedVertex = *it;
-        
+
           // check if the vertex actually consists of exactly two muon tracks, throw exception if not
           if(displacedVertex.tracksSize() != 3)  throw cms::Exception("BadLogic") << "HLTDisplacedmumumuFilter: ERROR: the Jpsi vertex must have exactly three muons by definition. It now has n muons = "
         									    << displacedVertex.tracksSize() << std::endl;
-       
+
           float normChi2 = displacedVertex.normalizedChi2();
 	  if (normChi2 > maxNormalisedChi2_) continue;
 
@@ -145,10 +145,10 @@ bool HLTDisplacedmumumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSet
           // the second one
           trackIt++;
           reco::TrackRef vertextkRef3 =  (*trackIt).castTo<reco::TrackRef>();
-          
+
 	  reco::RecoChargedCandidateCollection::const_iterator cand1;
-	  reco::RecoChargedCandidateCollection::const_iterator cand2;	  
-	  reco::RecoChargedCandidateCollection::const_iterator cand3;	  
+	  reco::RecoChargedCandidateCollection::const_iterator cand2;	
+	  reco::RecoChargedCandidateCollection::const_iterator cand3;	
 
 	  // first find these two tracks in the muon collection
 	  int iFoundRefs = 0;
@@ -158,14 +158,14 @@ bool HLTDisplacedmumumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSet
 	    if(tkRef == vertextkRef2) {cand2 = cand; iFoundRefs++;}
 	    if(tkRef == vertextkRef3) {cand3 = cand; iFoundRefs++;}
 	  }
-	  if(iFoundRefs != 3) throw cms::Exception("BadLogic") << "HLTDisplacedmumumuFilter: ERROR: the Jpsi vertex must have exactly two muons by definition."  << std::endl; 
+	  if(iFoundRefs != 3) throw cms::Exception("BadLogic") << "HLTDisplacedmumumuFilter: ERROR: the Jpsi vertex must have exactly two muons by definition."  << std::endl;
 
           // calculate two-track transverse momentum
           math::XYZVector pperp(cand1->px() + cand2->px() + cand3->px(),
 				cand1->py() + cand2->py() + cand3->py(),
         			  0.);
-          
-        
+
+
 	  reco::Vertex::Point vpoint=displacedVertex.position();
 	  //translate to global point, should be improved
 	  GlobalPoint secondaryVertex (vpoint.x(), vpoint.y(), vpoint.z());
@@ -176,27 +176,27 @@ bool HLTDisplacedmumumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSet
 
 	  GlobalPoint displacementFromBeamspot( -1*((vertexBeamSpot.x0() -  secondaryVertex.x()) +  (secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dxdz()),
         					  -1*((vertexBeamSpot.y0() - secondaryVertex.y())+  (secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dydz()), 0);
-        
+
           float lxy = displacementFromBeamspot.perp();
           float lxyerr = sqrt(err.rerr(displacementFromBeamspot));
-        
-        
+
+
           //calculate the angle between the decay length and the mumumu momentum
 	  reco::Vertex::Point vperp(displacementFromBeamspot.x(),displacementFromBeamspot.y(),0.);
-         
+
           float cosAlpha = vperp.Dot(pperp)/(vperp.R()*pperp.R());
-        
+
           // check thresholds
           if (cosAlpha < minCosinePointingAngle_) continue;
           if (minLxySignificance_ > 0. && lxy/lxyerr < minLxySignificance_) continue;
-	  if (maxLxySignificance_ > 0. && lxy/lxyerr > maxLxySignificance_) continue; 
+	  if (maxLxySignificance_ > 0. && lxy/lxyerr > maxLxySignificance_) continue;
 	  triggered = true;
- 
+
 	  // now add the muons that passed to the filter object
-	  
+	
 	  ref1=reco::RecoChargedCandidateRef( edm::Ref<reco::RecoChargedCandidateCollection> 	(mucands,distance(mucands->begin(), cand1)));
 	  filterproduct.addObject(trigger::TriggerMuon,ref1);
-	  
+	
 	  ref2=reco::RecoChargedCandidateRef( edm::Ref<reco::RecoChargedCandidateCollection> (mucands,distance(mucands->begin(),cand2 )));
 	  filterproduct.addObject(trigger::TriggerMuon,ref2);
 
@@ -204,7 +204,7 @@ bool HLTDisplacedmumumuFilter::hltFilter(edm::Event& iEvent, const edm::EventSet
 	  filterproduct.addObject(trigger::TriggerMuon,ref3);
   }
 
-  LogDebug("HLTDisplacedMumumuFilter") << " >>>>> Result of HLTDisplacedMumumuFilter is "<< triggered <<std::endl; 
+  LogDebug("HLTDisplacedMumumuFilter") << " >>>>> Result of HLTDisplacedMumumuFilter is "<< triggered <<std::endl;
 
   return triggered;
 }

--- a/HLTrigger/btau/src/HLTDisplacedmumumuFilter.h
+++ b/HLTrigger/btau/src/HLTDisplacedmumumuFilter.h
@@ -16,7 +16,7 @@ class HLTDisplacedmumumuFilter : public HLTFilter {
     ~HLTDisplacedmumumuFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
     virtual void beginJob() ;
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
     virtual void endJob() ;
     
   private:

--- a/HLTrigger/btau/src/HLTDisplacedmumumuFilter.h
+++ b/HLTrigger/btau/src/HLTDisplacedmumumuFilter.h
@@ -16,9 +16,9 @@ class HLTDisplacedmumumuFilter : public HLTFilter {
     ~HLTDisplacedmumumuFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
     virtual void beginJob() ;
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
     virtual void endJob() ;
-    
+
   private:
     bool fastAccept_;
     double minLxySignificance_;

--- a/HLTrigger/btau/src/HLTJetPairDzMatchFilter.cc
+++ b/HLTrigger/btau/src/HLTJetPairDzMatchFilter.cc
@@ -52,7 +52,7 @@ template<typename T>
 HLTJetPairDzMatchFilter<T>::~HLTJetPairDzMatchFilter(){}
 
 template<typename T>
-bool HLTJetPairDzMatchFilter<T>::hltFilter(edm::Event& ev, const edm::EventSetup& es, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTJetPairDzMatchFilter<T>::hltFilter(edm::Event& ev, const edm::EventSetup& es, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/btau/src/HLTJetPairDzMatchFilter.cc
+++ b/HLTrigger/btau/src/HLTJetPairDzMatchFilter.cc
@@ -18,7 +18,7 @@
 
 template<typename T>
 HLTJetPairDzMatchFilter<T>::HLTJetPairDzMatchFilter(const edm::ParameterSet& conf) : HLTFilter(conf)
-{ 
+{
   m_jetTag	= conf.getParameter<edm::InputTag>("JetSrc");
   m_jetToken    = consumes<std::vector<T> >(m_jetTag);
   m_jetMinPt	= conf.getParameter<double>("JetMinPt");
@@ -27,15 +27,15 @@ HLTJetPairDzMatchFilter<T>::HLTJetPairDzMatchFilter(const edm::ParameterSet& con
   m_jetMaxDZ	= conf.getParameter<double>("JetMaxDZ");
   m_triggerType = conf.getParameter<int>("TriggerType");
 
-  // set the minimum DR between jets, so that one never has a chance 
+  // set the minimum DR between jets, so that one never has a chance
   // to create a pair out of the same Jet replicated with two
   // different vertices
   if (m_jetMinDR < 0.1) m_jetMinDR = 0.1;
-  
+
 }
 
 template<typename T>
-void 
+void
 HLTJetPairDzMatchFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
@@ -52,12 +52,12 @@ template<typename T>
 HLTJetPairDzMatchFilter<T>::~HLTJetPairDzMatchFilter(){}
 
 template<typename T>
-bool HLTJetPairDzMatchFilter<T>::hltFilter(edm::Event& ev, const edm::EventSetup& es, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTJetPairDzMatchFilter<T>::hltFilter(edm::Event& ev, const edm::EventSetup& es, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;
   using namespace reco;
-  
+
   typedef vector<T> TCollection;
   typedef Ref<TCollection> TRef;
 
@@ -79,9 +79,9 @@ bool HLTJetPairDzMatchFilter<T>::hltFilter(edm::Event& ev, const edm::EventSetup
 
   size_t npairs = 0, nfail_dz = 0;
   if (n_jets > 1) for(size_t j1 = 0; j1 < n_jets; ++j1)
-  { 
+  {
     if ( jets[j1].pt() < m_jetMinPt || std::abs(jets[j1].eta()) > m_jetMaxEta ) continue;
-    
+
     float mindz = 99.f;
     for(size_t j2 = j1+1; j2 < n_jets; ++j2)
     {
@@ -96,7 +96,7 @@ bool HLTJetPairDzMatchFilter<T>::hltFilter(edm::Event& ev, const edm::EventSetup
       if ( dr2 < m_jetMinDR*m_jetMinDR ) {
 	continue;
       }
-      
+
       if (std::abs(dz) < std::abs(mindz)) mindz = dz;
 
       // do not form a pair if dz is too large
@@ -104,20 +104,20 @@ bool HLTJetPairDzMatchFilter<T>::hltFilter(edm::Event& ev, const edm::EventSetup
 	++nfail_dz;
 	continue;
       }
-      
+
       // add references to both jets
       ref = TRef(jetsHandle, j1);
       filterproduct.addObject(m_triggerType, ref);
-      
+
       ref = TRef(jetsHandle, j2);
       filterproduct.addObject(m_triggerType, ref);
 
       ++npairs;
-      
+
     }
 
   }
-  
+
   return npairs>0;
 
 }

--- a/HLTrigger/btau/src/HLTJetPairDzMatchFilter.h
+++ b/HLTrigger/btau/src/HLTJetPairDzMatchFilter.h
@@ -23,7 +23,7 @@ class HLTJetPairDzMatchFilter : public HLTFilter {
     explicit HLTJetPairDzMatchFilter(const edm::ParameterSet&);
     ~HLTJetPairDzMatchFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
     
   private:
 

--- a/HLTrigger/btau/src/HLTJetPairDzMatchFilter.h
+++ b/HLTrigger/btau/src/HLTJetPairDzMatchFilter.h
@@ -8,7 +8,7 @@
 
 /** class HLTJetPairDzMatchFilter
  * an HLT filter which picks up a JetCollection (supposedly, of L2 tau jets)
- * and passes only events with at least one pair of non-overlapping jets with 
+ * and passes only events with at least one pair of non-overlapping jets with
  * vertices within some dz
  */
 namespace edm {
@@ -23,8 +23,8 @@ class HLTJetPairDzMatchFilter : public HLTFilter {
     explicit HLTJetPairDzMatchFilter(const edm::ParameterSet&);
     ~HLTJetPairDzMatchFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
-    
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+
   private:
 
     edm::InputTag                     m_jetTag;
@@ -37,4 +37,4 @@ class HLTJetPairDzMatchFilter : public HLTFilter {
 
 };
 
-#endif 
+#endif

--- a/HLTrigger/btau/src/HLTJetTag.cc
+++ b/HLTrigger/btau/src/HLTJetTag.cc
@@ -1,7 +1,7 @@
 /** \class HLTJetTag
  *
- *  This class is an HLTFilter (a spcialized EDFilter) implementing 
- *  tagged multi-jet trigger for b and tau. 
+ *  This class is an HLTFilter (a spcialized EDFilter) implementing
+ *  tagged multi-jet trigger for b and tau.
  *  It should be run after the normal multi-jet trigger.
  *
  *
@@ -41,7 +41,7 @@ HLTJetTag<T>::HLTJetTag(const edm::ParameterSet & config) : HLTFilter(config),
 {
   m_JetsToken = consumes<std::vector<T> >(m_Jets),
   m_JetTagsToken = consumes<reco::JetTagCollection>(m_JetTags),
-  
+
   edm::LogInfo("") << " (HLTJetTag) trigger cuts: " << std::endl
                    << "\ttype of        jets used: " << m_Jets.encode() << std::endl
                    << "\ttype of tagged jets used: " << m_JetTags.encode() << std::endl
@@ -77,7 +77,7 @@ HLTJetTag<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 // ------------ method called to produce the data  ------------
 template<typename T>
 bool
-HLTJetTag<T>::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTJetTag<T>::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/btau/src/HLTJetTag.cc
+++ b/HLTrigger/btau/src/HLTJetTag.cc
@@ -77,7 +77,7 @@ HLTJetTag<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 // ------------ method called to produce the data  ------------
 template<typename T>
 bool
-HLTJetTag<T>::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTJetTag<T>::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/btau/src/HLTJetTag.h
+++ b/HLTrigger/btau/src/HLTJetTag.h
@@ -3,8 +3,8 @@
 
 /** \class HLTJetTag
  *
- *  This class is an HLTFilter (a spcialized EDFilter) implementing 
- *  tagged multi-jet trigger for b and tau. 
+ *  This class is an HLTFilter (a spcialized EDFilter) implementing
+ *  tagged multi-jet trigger for b and tau.
  *  It should be run after the normal multi-jet trigger.
  *
  *
@@ -35,7 +35,7 @@ class HLTJetTag : public HLTFilter {
     explicit HLTJetTag(const edm::ParameterSet & config);
     ~HLTJetTag();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    virtual bool hltFilter(edm::Event & event, const edm::EventSetup & setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+    virtual bool hltFilter(edm::Event & event, const edm::EventSetup & setup, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
 private:
   edm::InputTag                     m_Jets;      // module label of input JetCollection

--- a/HLTrigger/btau/src/HLTJetTag.h
+++ b/HLTrigger/btau/src/HLTJetTag.h
@@ -35,7 +35,7 @@ class HLTJetTag : public HLTFilter {
     explicit HLTJetTag(const edm::ParameterSet & config);
     ~HLTJetTag();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    virtual bool hltFilter(edm::Event & event, const edm::EventSetup & setup, trigger::TriggerFilterObjectWithRefs & filterproduct);
+    virtual bool hltFilter(edm::Event & event, const edm::EventSetup & setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
 private:
   edm::InputTag                     m_Jets;      // module label of input JetCollection

--- a/HLTrigger/btau/src/HLTmmkFilter.cc
+++ b/HLTrigger/btau/src/HLTmmkFilter.cc
@@ -11,14 +11,14 @@
 
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
- 
+
 #include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
 #include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
-#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h" 
+#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/TrajectoryParametrization/interface/GlobalTrajectoryParameters.h"
 
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
@@ -95,16 +95,16 @@ void HLTmmkFilter::endJob() {
 
 
 // ----------------------------------------------------------------------
-bool HLTmmkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+bool HLTmmkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
 
   const double MuMass(0.106);
   const double MuMass2(MuMass*MuMass);
-  
+
   const double thirdTrackMass2(thirdTrackMass_*thirdTrackMass_);
-  
-  auto_ptr<CandidateCollection> output(new CandidateCollection());    
+
+  auto_ptr<CandidateCollection> output(new CandidateCollection());
   auto_ptr<VertexCollection> vertexCollection(new VertexCollection());
-  
+
   //get the transient track builder:
   edm::ESHandle<TransientTrackBuilder> theB;
   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",theB);
@@ -133,32 +133,32 @@ bool HLTmmkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
   // get track candidates around displaced muons
   Handle<RecoChargedCandidateCollection> trkcands;
   iEvent.getByToken(trkCandToken_,trkcands);
-  
+
   if (saveTags()) {
     filterproduct.addCollectionTag(muCandTag_);
     filterproduct.addCollectionTag(trkCandTag_);
   }
-  
+
   double e1,e2,e3;
   Particle::LorentzVector p,p1,p2,p3;
-  
+
   //TrackRefs to mu cands in trkcand
   vector<TrackRef> trkMuCands;
-  
+
   //Already used mu tracks to avoid double counting candidates
   vector<bool> isUsedCand(trkcands->size(),false);
-  
+
   int counter = 0;
-  
+
   //run algorithm
   for (RecoChargedCandidateCollection::const_iterator mucand1=mucands->begin(), endCand1=mucands->end(); mucand1!=endCand1; ++mucand1) {
-  
+
   	if ( mucands->size()<2) break;
   	if ( trkcands->size()<1) break;
-  
+
   	TrackRef trk1 = mucand1->get<TrackRef>();
 	LogDebug("HLTDisplacedMumukFilter") << " 1st muon: q*pt= " << trk1->charge()*trk1->pt() << ", eta= " << trk1->eta() << ", hits= " << trk1->numberOfValidHits();
-  
+
   	// eta cut
 	if (fabs(trk1->eta()) > maxEta_) continue;
 	
@@ -168,7 +168,7 @@ bool HLTmmkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
   	RecoChargedCandidateCollection::const_iterator mucand2 = mucand1; ++mucand2;
   	
   	for (RecoChargedCandidateCollection::const_iterator endCand2=mucands->end(); mucand2!=endCand2; ++mucand2) {
-  
+
   		TrackRef trk2 = mucand2->get<TrackRef>();
 
 		LogDebug("HLTDisplacedMumukFilter") << " 2nd muon: q*pt= " << trk2->charge()*trk2->pt() << ", eta= " << trk2->eta() << ", hits= " << trk2->numberOfValidHits();
@@ -207,11 +207,11 @@ bool HLTmmkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 
 		//combine muons with all tracks
   		for ( trkcand = trkcands->begin(), endCandTrk=trkcands->end(), isUsedIter = isUsedCand.begin(), endIsUsedCand = isUsedCand.end(); trkcand != endCandTrk && isUsedIter != endIsUsedCand; ++trkcand, ++isUsedIter) {
- 
+
   			TrackRef trk3 = trkcand->get<TrackRef>();
 
 			LogDebug("HLTDisplacedMumukFilter") << " 3rd track: q*pt= " << trk3->charge()*trk3->pt() << ", eta= " << trk3->eta() << ", hits= " << trk3->numberOfValidHits();
- 
+
  			//skip overlapping muon candidates
 			bool skip=false;
  			for (unsigned int itmc=0;itmc<trkMuCands.size();itmc++) if(trk3==trkMuCands.at(itmc)) skip=true;
@@ -298,7 +298,7 @@ bool HLTmmkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 			//Add event
 			++counter;
  			
- 			//Get refs 
+ 			//Get refs
  			bool i1done = false;
 			bool i2done = false;
 			bool i3done = false;
@@ -317,11 +317,11 @@ bool HLTmmkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 				if (i1done && i2done && i3done) break;
 			}
 		
-			if (!i1done) { 
+			if (!i1done) {
 				refMu1=RecoChargedCandidateRef( Ref<RecoChargedCandidateCollection> (mucands,distance(mucands->begin(), mucand1)));
 				filterproduct.addObject(TriggerMuon,refMu1);
 			}
-			if (!i2done) { 
+			if (!i2done) {
 				refMu2=RecoChargedCandidateRef( Ref<RecoChargedCandidateCollection> (mucands,distance(mucands->begin(),mucand2)));
 				filterproduct.addObject(TriggerMuon,refMu2);
 			}
@@ -331,19 +331,19 @@ bool HLTmmkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, 
 			}
  			
  			if (fastAccept_) break;
-  		}  
+  		}
   		
   		trkMuCands.clear();
-  	} 
+  	}
   }
 
   // filter decision
   const bool accept (counter >= 1);
-  
-  LogDebug("HLTDisplacedMumukFilter") << " >>>>> Result of HLTDisplacedMumukFilter is "<< accept << ", number of muon pairs passing thresholds= " << counter; 
-  
+
+  LogDebug("HLTDisplacedMumukFilter") << " >>>>> Result of HLTDisplacedMumukFilter is "<< accept << ", number of muon pairs passing thresholds= " << counter;
+
   iEvent.put(vertexCollection);
-  
+
   return accept;
 }
 
@@ -361,21 +361,21 @@ FreeTrajectoryState HLTmmkFilter::initialFreeState( const reco::Track& tk,
 }
 
 int HLTmmkFilter::overlap(const reco::Candidate &a, const reco::Candidate &b) {
-  
+
   double eps(1.44e-4);
 
   double dpt = a.pt() - b.pt();
   dpt *= dpt;
 
-  double dphi = deltaPhi(a.phi(), b.phi()); 
-  dphi *= dphi; 
+  double dphi = deltaPhi(a.phi(), b.phi());
+  dphi *= dphi;
 
-  double deta = a.eta() - b.eta(); 
-  deta *= deta; 
+  double deta = a.eta() - b.eta();
+  deta *= deta;
 
   if ((dphi + deta) < eps) {
     return 1;
-  } 
+  }
 
   return 0;
 

--- a/HLTrigger/btau/src/HLTmmkFilter.cc
+++ b/HLTrigger/btau/src/HLTmmkFilter.cc
@@ -95,7 +95,7 @@ void HLTmmkFilter::endJob() {
 
 
 // ----------------------------------------------------------------------
-bool HLTmmkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+bool HLTmmkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
 
   const double MuMass(0.106);
   const double MuMass2(MuMass*MuMass);

--- a/HLTrigger/btau/src/HLTmmkFilter.h
+++ b/HLTrigger/btau/src/HLTmmkFilter.h
@@ -3,8 +3,8 @@
 //
 // Package:    HLTstaging
 // Class:      HLTmmkFilter
-// 
-/**\class HLTmmkFilter 
+//
+/**\class HLTmmkFilter
 
  HLT Filter for b to (mumu) + X
 
@@ -31,7 +31,7 @@ namespace edm {
 // ----------------------------------------------------------------------
 
 namespace reco {
-  class Candidate; 
+  class Candidate;
   class Track;
 }
 
@@ -43,20 +43,21 @@ class HLTmmkFilter : public HLTFilter {
  public:
   explicit HLTmmkFilter(const edm::ParameterSet&);
   ~HLTmmkFilter();
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);  
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
  private:
   virtual void beginJob() ;
   virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
   virtual void endJob();
-  virtual int overlap(const reco::Candidate&, const reco::Candidate&);
-  virtual FreeTrajectoryState initialFreeState( const reco::Track&,const MagneticField*);
-  
+
+  static int overlap(const reco::Candidate&, const reco::Candidate&);
+  static FreeTrajectoryState initialFreeState( const reco::Track&,const MagneticField*);
+
   edm::InputTag                                          muCandTag_;
   edm::EDGetTokenT<reco::RecoChargedCandidateCollection> muCandToken_;
-  edm::InputTag                                          trkCandTag_; 
+  edm::InputTag                                          trkCandTag_;
   edm::EDGetTokenT<reco::RecoChargedCandidateCollection> trkCandToken_;
-  
+
   const double thirdTrackMass_;
   const double maxEta_;
   const double minPt_;

--- a/HLTrigger/btau/src/HLTmmkFilter.h
+++ b/HLTrigger/btau/src/HLTmmkFilter.h
@@ -47,7 +47,7 @@ class HLTmmkFilter : public HLTFilter {
 
  private:
   virtual void beginJob() ;
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
   virtual void endJob();
 
   static int overlap(const reco::Candidate&, const reco::Candidate&);

--- a/HLTrigger/btau/src/HLTmmkFilter.h
+++ b/HLTrigger/btau/src/HLTmmkFilter.h
@@ -47,7 +47,7 @@ class HLTmmkFilter : public HLTFilter {
 
  private:
   virtual void beginJob() ;
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
   virtual void endJob();
   virtual int overlap(const reco::Candidate&, const reco::Candidate&);
   virtual FreeTrajectoryState initialFreeState( const reco::Track&,const MagneticField*);

--- a/HLTrigger/btau/src/HLTmmkkFilter.cc
+++ b/HLTrigger/btau/src/HLTmmkkFilter.cc
@@ -97,7 +97,7 @@ void HLTmmkkFilter::endJob() {
 
 
 // ----------------------------------------------------------------------
-bool HLTmmkkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+bool HLTmmkkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
 
   const double MuMass(0.106);
   const double MuMass2(MuMass*MuMass);

--- a/HLTrigger/btau/src/HLTmmkkFilter.cc
+++ b/HLTrigger/btau/src/HLTmmkkFilter.cc
@@ -11,14 +11,14 @@
 
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
- 
+
 #include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
 #include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
-#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h" 
+#include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/TrajectoryParametrization/interface/GlobalTrajectoryParameters.h"
 
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
@@ -97,17 +97,17 @@ void HLTmmkkFilter::endJob() {
 
 
 // ----------------------------------------------------------------------
-bool HLTmmkkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+bool HLTmmkkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
 
   const double MuMass(0.106);
   const double MuMass2(MuMass*MuMass);
-  
+
   const double thirdTrackMass2(thirdTrackMass_*thirdTrackMass_);
   const double fourthTrackMass2(fourthTrackMass_*fourthTrackMass_);
-  
-  auto_ptr<CandidateCollection> output(new CandidateCollection());    
+
+  auto_ptr<CandidateCollection> output(new CandidateCollection());
   auto_ptr<VertexCollection> vertexCollection(new VertexCollection());
-  
+
   //get the transient track builder:
   edm::ESHandle<TransientTrackBuilder> theB;
   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",theB);
@@ -137,32 +137,32 @@ bool HLTmmkkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
   // get track candidates around displaced muons
   Handle<RecoChargedCandidateCollection> trkcands;
   iEvent.getByToken(trkCandToken_,trkcands);
-  
+
   if (saveTags()) {
     filterproduct.addCollectionTag(muCandTag_);
     filterproduct.addCollectionTag(trkCandTag_);
   }
-  
+
   double e1,e2,e3,e4;
   Particle::LorentzVector p,p1,p2,p3,p4;
-  
+
   //TrackRefs to mu cands in trkcand
   vector<TrackRef> trkMuCands;
-  
+
   //Already used mu tracks to avoid double counting candidates
   vector<bool> isUsedCand(trkcands->size(),false);
-  
+
   int counter = 0;
-  
+
   //run algorithm
   for (RecoChargedCandidateCollection::const_iterator mucand1=mucands->begin(), endCand1=mucands->end(); mucand1!=endCand1; ++mucand1) {
-  
+
   	if ( mucands->size()<2) break;
   	if ( trkcands->size()<2) break;
-  
+
   	TrackRef trk1 = mucand1->get<TrackRef>();
 	LogDebug("HLTDisplacedMumukkFilter") << " 1st muon: q*pt= " << trk1->charge()*trk1->pt() << ", eta= " << trk1->eta() << ", hits= " << trk1->numberOfValidHits();
-  
+
   	// eta cut
 	if (fabs(trk1->eta()) > maxEta_) continue;
 	
@@ -172,7 +172,7 @@ bool HLTmmkkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
   	RecoChargedCandidateCollection::const_iterator mucand2 = mucand1; ++mucand2;
   	
   	for (RecoChargedCandidateCollection::const_iterator endCand2=mucands->end(); mucand2!=endCand2; ++mucand2) {
-  
+
   		TrackRef trk2 = mucand2->get<TrackRef>();
 
 		LogDebug("HLTDisplacedMumukkFilter") << " 2nd muon: q*pt= " << trk2->charge()*trk2->pt() << ", eta= " << trk2->eta() << ", hits= " << trk2->numberOfValidHits();
@@ -211,11 +211,11 @@ bool HLTmmkkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
 
 		//combine muons with all tracks
   		for ( trkcand = trkcands->begin(), endCandTrk=trkcands->end(), isUsedIter = isUsedCand.begin(), endIsUsedCand = isUsedCand.end(); trkcand != endCandTrk && isUsedIter != endIsUsedCand; ++trkcand, ++isUsedIter) {
- 
+
   			TrackRef trk3 = trkcand->get<TrackRef>();
 
 			LogDebug("HLTDisplacedMumukkFilter") << " 3rd track: q*pt= " << trk3->charge()*trk3->pt() << ", eta= " << trk3->eta() << ", hits= " << trk3->numberOfValidHits();
- 
+
  			//skip overlapping muon candidates
 			bool skip=false;
  			for (unsigned int itmc=0;itmc<trkMuCands.size();itmc++) if(trk3==trkMuCands.at(itmc)) skip=true;
@@ -242,18 +242,18 @@ bool HLTmmkkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
 
                           LogDebug("HLTDisplacedMumukkFilter") << " 4th track: q*pt= " << trk4->charge()*trk4->pt() << ", eta= " << trk4->eta() << ", hits= " << trk4->numberOfValidHits();
 
-                          //skip overlapping muon candidates                                                                                                       
+                          //skip overlapping muon candidates
 			  bool skip2=false;
 			  for (unsigned int itmc=0;itmc<trkMuCands.size();itmc++) if(trk4==trkMuCands.at(itmc)) skip2=true;
 			  if(skip2) continue;
 
-                          //skip already used tracks                                                                                                               
+                          //skip already used tracks
                           if(*isUsedIter2) continue;
 
-                          // eta cut                                                                                                                               
+                          // eta cut
                           if (fabs(trk4->eta()) > maxEta_) continue;
 
-                          // Pt threshold cut                                                                                                                      
+                          // Pt threshold cut
                           if (trk4->pt() < minPt_) continue;
 
 			  // Combined system
@@ -268,76 +268,76 @@ bool HLTmmkkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
 			  p4 = Particle::LorentzVector(trk4->px(),trk4->py(),trk4->pz(),e4);
 			
 			  p = p1+p2+p3+p4;
-			  
+			
 			  //invariant mass cut
 			  double invmass = abs(p.mass());
-			  
+			
 			  LogDebug("HLTDisplacedMumukkFilter") << " Invmass= " << invmass;
-			  
+			
 			  FreeTrajectoryState InitialFTS = initialFreeState(*trk3, magField);
 			  TrajectoryStateClosestToBeamLine tscb( blsBuilder(InitialFTS, *recoBeamSpotHandle) );
 			  double d0sig = tscb.transverseImpactParameter().significance();
-			  
+			
 			  if (d0sig < minD0Significance_) continue;
-			  
+			
 			  FreeTrajectoryState InitialFTS2 = initialFreeState(*trk4, magField);
 			  TrajectoryStateClosestToBeamLine tscb2( blsBuilder(InitialFTS2, *recoBeamSpotHandle) );
 			  d0sig = tscb2.transverseImpactParameter().value()/tscb2.transverseImpactParameter().significance();
-			  
+			
 			  if (d0sig < minD0Significance_) continue;
 			
 			  if (invmass>maxInvMass_ || invmass<minInvMass_) continue;
-			  
+			
 			  // do the vertex fit
 			  vector<TransientTrack> t_tks;
 			  t_tks.push_back((*theB).build(&trk1));
 			  t_tks.push_back((*theB).build(&trk2));
 			  t_tks.push_back((*theB).build(&trk3));
 			  t_tks.push_back((*theB).build(&trk4));
-			  
+			
 			  if (t_tks.size()!=4) continue;
-			  
+			
 			  KalmanVertexFitter kvf;
 			  TransientVertex tv = kvf.vertex(t_tks);
-			  
+			
 			  if (!tv.isValid()) continue;
-			  
+			
 			  Vertex vertex = tv;
-			  
+			
 			  // get vertex position and error to calculate the decay length significance
 			  GlobalPoint secondaryVertex = tv.position();
 			  GlobalError err = tv.positionError();
-			  
+			
 			  //calculate decay length  significance w.r.t. the beamspot
 			  GlobalPoint displacementFromBeamspot( -1*((vertexBeamSpot.x0() -secondaryVertex.x()) +  (secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dxdz()), -1*((vertexBeamSpot.y0() - secondaryVertex.y())+ (secondaryVertex.z() -vertexBeamSpot.z0()) * vertexBeamSpot.dydz()), 0);
-			  
+			
 			  float lxy = displacementFromBeamspot.perp();
 			  float lxyerr = sqrt(err.rerr(displacementFromBeamspot));
-			  
+			
 			  // get normalizes chi2
 			  float normChi2 = tv.normalisedChiSquared();
-			  
+			
 			  //calculate the angle between the decay length and the mumu momentum
 			  Vertex::Point vperp(displacementFromBeamspot.x(),displacementFromBeamspot.y(),0.);
 			  math::XYZVector pperp(p.x(),p.y(),0.);
-			  
+			
 			  float cosAlpha = vperp.Dot(pperp)/(vperp.R()*pperp.R());
-			  
+			
 			  LogDebug("HLTDisplacedMumukkFilter") << " vertex fit normalised chi2: " << normChi2 << ", Lxy significance: " << lxy/lxyerr << ", cosine pointing angle: " << cosAlpha;
-			  
+			
 			  // put vertex in the event
 			  vertexCollection->push_back(vertex);
-			  
+			
 			  if (normChi2 > maxNormalisedChi2_) continue;
 			  if (lxy/lxyerr < minLxySignificance_) continue;
 			  if(cosAlpha < minCosinePointingAngle_) continue;
-			  
+			
 			  LogDebug("HLTDisplacedMumukkFilter") << " Event passed!";
-			  
+			
 			  //Add event
 			  ++counter;
-			  
-			  //Get refs 
+			
+			  //Get refs
 			  bool i1done = false;
 			  bool i2done = false;
 			  bool i3done = false;
@@ -358,12 +358,12 @@ bool HLTmmkkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
 			    }
 			    if (i1done && i2done && i3done && i4done) break;
 			  }
-			  
-			  if (!i1done) { 
+			
+			  if (!i1done) {
 			    refMu1=RecoChargedCandidateRef( Ref<RecoChargedCandidateCollection> (mucands,distance(mucands->begin(), mucand1)));
 			    filterproduct.addObject(TriggerMuon,refMu1);
 			  }
-			  if (!i2done) { 
+			  if (!i2done) {
 			    refMu2=RecoChargedCandidateRef( Ref<RecoChargedCandidateCollection> (mucands,distance(mucands->begin(),mucand2)));
 			    filterproduct.addObject(TriggerMuon,refMu2);
 			  }
@@ -375,22 +375,22 @@ bool HLTmmkkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
 			    refTrk2=RecoChargedCandidateRef( Ref<RecoChargedCandidateCollection> (trkcands,distance(trkcands->begin(),trkcand)));
 			    filterproduct.addObject(TriggerTrack,refTrk2);
 			  }
-			  
+			
 			  if (fastAccept_) break;
 			}
-  		}  
+  		}
   		
   		trkMuCands.clear();
-  	} 
+  	}
   }
-  
+
   // filter decision
   const bool accept (counter >= 1);
-  
-  LogDebug("HLTDisplacedMumukkFilter") << " >>>>> Result of HLTDisplacedMumukkFilter is "<< accept << ", number of muon pairs passing thresholds= " << counter; 
-  
+
+  LogDebug("HLTDisplacedMumukkFilter") << " >>>>> Result of HLTDisplacedMumukkFilter is "<< accept << ", number of muon pairs passing thresholds= " << counter;
+
   iEvent.put(vertexCollection);
-  
+
   return accept;
 }
 
@@ -408,21 +408,21 @@ FreeTrajectoryState HLTmmkkFilter::initialFreeState( const reco::Track& tk,
 }
 
 int HLTmmkkFilter::overlap(const reco::Candidate &a, const reco::Candidate &b) {
-  
+
   double eps(1.44e-4);
 
   double dpt = a.pt() - b.pt();
   dpt *= dpt;
 
-  double dphi = deltaPhi(a.phi(), b.phi()); 
-  dphi *= dphi; 
+  double dphi = deltaPhi(a.phi(), b.phi());
+  dphi *= dphi;
 
-  double deta = a.eta() - b.eta(); 
-  deta *= deta; 
+  double deta = a.eta() - b.eta();
+  deta *= deta;
 
   if ((dphi + deta) < eps) {
     return 1;
-  } 
+  }
 
   return 0;
 

--- a/HLTrigger/btau/src/HLTmmkkFilter.h
+++ b/HLTrigger/btau/src/HLTmmkkFilter.h
@@ -46,7 +46,7 @@ class HLTmmkkFilter : public HLTFilter {
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
  private:
   virtual void beginJob();
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
   virtual void endJob();
 
   static int overlap(const reco::Candidate&, const reco::Candidate&);

--- a/HLTrigger/btau/src/HLTmmkkFilter.h
+++ b/HLTrigger/btau/src/HLTmmkkFilter.h
@@ -46,7 +46,7 @@ class HLTmmkkFilter : public HLTFilter {
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);  
  private:
   virtual void beginJob() ;
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
   virtual void endJob();
   virtual int overlap(const reco::Candidate&, const reco::Candidate&);
   virtual FreeTrajectoryState initialFreeState( const reco::Track&,const MagneticField*);

--- a/HLTrigger/btau/src/HLTmmkkFilter.h
+++ b/HLTrigger/btau/src/HLTmmkkFilter.h
@@ -3,8 +3,8 @@
 //
 // Package:    HLTstaging
 // Class:      HLTmmkkFilter
-// 
-/**\class HLTmmkkFilter 
+//
+/**\class HLTmmkkFilter
 
  HLT Filter for b to (mumu) + X
 
@@ -31,7 +31,7 @@ namespace edm {
 // ----------------------------------------------------------------------
 
 namespace reco {
-  class Candidate; 
+  class Candidate;
   class Track;
 }
 
@@ -43,19 +43,20 @@ class HLTmmkkFilter : public HLTFilter {
  public:
   explicit HLTmmkkFilter(const edm::ParameterSet&);
   ~HLTmmkkFilter();
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);  
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
  private:
-  virtual void beginJob() ;
+  virtual void beginJob();
   virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
   virtual void endJob();
-  virtual int overlap(const reco::Candidate&, const reco::Candidate&);
-  virtual FreeTrajectoryState initialFreeState( const reco::Track&,const MagneticField*);
-  
+
+  static int overlap(const reco::Candidate&, const reco::Candidate&);
+  static FreeTrajectoryState initialFreeState(const reco::Track &, const MagneticField *);
+
   edm::InputTag                                          muCandTag_;
   edm::EDGetTokenT<reco::RecoChargedCandidateCollection> muCandToken_;
   edm::InputTag                                          trkCandTag_;
   edm::EDGetTokenT<reco::RecoChargedCandidateCollection> trkCandToken_;
-  
+
   const double thirdTrackMass_;
   const double fourthTrackMass_;
   const double maxEta_;

--- a/HLTrigger/special/interface/HLTCSCActivityFilter.h
+++ b/HLTrigger/special/interface/HLTCSCActivityFilter.h
@@ -4,7 +4,7 @@
 //
 // Package:    HLTCSCActivityFilter
 // Class:      HLTCSCActivityFilter
-// 
+//
 /**\class HLTCSCActivityFilter HLTCSCActivityFilter.cc filter/HLTCSCActivityFilter/src/HLTCSCActivityFilter.cc
 
 Description: Filter to select HCAL abort gap events
@@ -45,10 +45,10 @@ class HLTCSCActivityFilter : public HLTFilter {
 public:
   explicit HLTCSCActivityFilter(const edm::ParameterSet&);
   virtual ~HLTCSCActivityFilter();
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);   
-  
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
   edm::EDGetTokenT<CSCStripDigiCollection> m_cscStripDigiToken;
   edm::InputTag m_cscStripDigiTag;

--- a/HLTrigger/special/interface/HLTCSCActivityFilter.h
+++ b/HLTrigger/special/interface/HLTCSCActivityFilter.h
@@ -48,7 +48,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);   
   
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
   edm::EDGetTokenT<CSCStripDigiCollection> m_cscStripDigiToken;
   edm::InputTag m_cscStripDigiTag;

--- a/HLTrigger/special/interface/HLTCSCOverlapFilter.h
+++ b/HLTrigger/special/interface/HLTCSCOverlapFilter.h
@@ -18,7 +18,7 @@ class HLTCSCOverlapFilter : public HLTFilter {
  public:
   explicit HLTCSCOverlapFilter(const edm::ParameterSet&);
   ~HLTCSCOverlapFilter();
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);   
 
  private:

--- a/HLTrigger/special/interface/HLTCSCOverlapFilter.h
+++ b/HLTrigger/special/interface/HLTCSCOverlapFilter.h
@@ -18,8 +18,8 @@ class HLTCSCOverlapFilter : public HLTFilter {
  public:
   explicit HLTCSCOverlapFilter(const edm::ParameterSet&);
   ~HLTCSCOverlapFilter();
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);   
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
  private:
   edm::InputTag m_input;
@@ -31,4 +31,4 @@ class HLTCSCOverlapFilter : public HLTFilter {
   TH1F *m_nhitsNoWindowCut, *m_xdiff, *m_ydiff, *m_pairsWithWindowCut;
 };
 
-#endif 
+#endif

--- a/HLTrigger/special/interface/HLTCSCRing2or3Filter.h
+++ b/HLTrigger/special/interface/HLTCSCRing2or3Filter.h
@@ -18,8 +18,8 @@ class HLTCSCRing2or3Filter : public HLTFilter {
  public:
   explicit HLTCSCRing2or3Filter(const edm::ParameterSet&);
   ~HLTCSCRing2or3Filter();
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);   
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
  private:
   edm::EDGetTokenT<CSCRecHit2DCollection> cscrechitsToken;
@@ -28,4 +28,4 @@ class HLTCSCRing2or3Filter : public HLTFilter {
   double m_xWindow, m_yWindow;
 };
 
-#endif 
+#endif

--- a/HLTrigger/special/interface/HLTCSCRing2or3Filter.h
+++ b/HLTrigger/special/interface/HLTCSCRing2or3Filter.h
@@ -18,7 +18,7 @@ class HLTCSCRing2or3Filter : public HLTFilter {
  public:
   explicit HLTCSCRing2or3Filter(const edm::ParameterSet&);
   ~HLTCSCRing2or3Filter();
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);   
 
  private:

--- a/HLTrigger/special/interface/HLTCountNumberOfObject.h
+++ b/HLTrigger/special/interface/HLTCountNumberOfObject.h
@@ -32,7 +32,7 @@ public:
   {
     srcToken_ = consumes<OColl>(src_);
   }
-  
+
   ~HLTCountNumberOfObject() { }
 
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions)
@@ -44,9 +44,9 @@ public:
       desc.add<int>("MaxN",99999);
       descriptions.add(std::string("hlt")+std::string(typeid(HLTCountNumberOfObject<OColl>).name()),desc);
     }
-  
+
 private:
-  virtual bool hltFilter(edm::Event& iEvent, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+  virtual bool hltFilter(edm::Event& iEvent, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override
   {
     edm::Handle<OColl> oHandle;
     iEvent.getByToken(srcToken_, oHandle);
@@ -58,7 +58,7 @@ private:
 
     return answer;
   }
- 
+
   edm::InputTag src_;
   edm::EDGetTokenT<OColl> srcToken_;
   int minN_,maxN_;

--- a/HLTrigger/special/interface/HLTCountNumberOfObject.h
+++ b/HLTrigger/special/interface/HLTCountNumberOfObject.h
@@ -46,7 +46,7 @@ public:
     }
   
 private:
-  virtual bool hltFilter(edm::Event& iEvent, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct)
+  virtual bool hltFilter(edm::Event& iEvent, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const
   {
     edm::Handle<OColl> oHandle;
     iEvent.getByToken(srcToken_, oHandle);

--- a/HLTrigger/special/interface/HLTDTActivityFilter.h
+++ b/HLTrigger/special/interface/HLTDTActivityFilter.h
@@ -4,7 +4,7 @@
 //
 // Package:    HLTDTActivityFilter
 // Class:      HLTDTActivityFilter
-// 
+//
 
 
 /*
@@ -55,22 +55,22 @@ public:
 
   explicit HLTDTActivityFilter(const edm::ParameterSet&);
   virtual ~HLTDTActivityFilter();
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);   
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
 
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
   virtual bool beginRun(edm::Run& iRun, const edm::EventSetup& iSetup);
 
-  bool hasActivity(const std::bitset<4> &) const;  
+  bool hasActivity(const std::bitset<4> &) const;
   bool matchChamber(const uint32_t &, const L1MuRegionalCand&) const;
-  
+
   enum activityType { DCC=0, DDU=1, RPC=2, DIGI=3 };
-  
+
 
   // ----------member data ---------------------------
 
-  edm::InputTag inputTag_[4]; 
+  edm::InputTag inputTag_[4];
   bool process_[4];
   std::bitset<15> activeSecs_;
 
@@ -91,7 +91,7 @@ private:
   int   maxBX_[3];
   int   minActiveChambs_;
   int   minChambLayers_;
-  
+
   float maxDeltaPhi_;
   float maxDeltaEta_;
 

--- a/HLTrigger/special/interface/HLTDTActivityFilter.h
+++ b/HLTrigger/special/interface/HLTDTActivityFilter.h
@@ -59,11 +59,11 @@ public:
 
 private:
 
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
   virtual bool beginRun(edm::Run& iRun, const edm::EventSetup& iSetup);
 
-  bool hasActivity(const std::bitset<4> &);  
-  bool matchChamber(const uint32_t &, const L1MuRegionalCand&);
+  bool hasActivity(const std::bitset<4> &) const;  
+  bool matchChamber(const uint32_t &, const L1MuRegionalCand&) const;
   
   enum activityType { DCC=0, DDU=1, RPC=2, DIGI=3 };
   

--- a/HLTrigger/special/interface/HLTEcalIsolationFilter.h
+++ b/HLTrigger/special/interface/HLTEcalIsolationFilter.h
@@ -13,14 +13,14 @@ class HLTEcalIsolationFilter : public HLTFilter {
    public:
       explicit HLTEcalIsolationFilter(const edm::ParameterSet&);
       ~HLTEcalIsolationFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:
       edm::InputTag candTag_;
       edm::EDGetTokenT<reco::IsolatedPixelTrackCandidateCollection> candToken_;
-      double maxennearby; 
-      double minen;        
+      double maxennearby;
+      double minen;
       int maxhitout;
       int maxhitin;
       double maxenin;
@@ -29,4 +29,4 @@ class HLTEcalIsolationFilter : public HLTFilter {
 
 };
 
-#endif 
+#endif

--- a/HLTrigger/special/interface/HLTEcalIsolationFilter.h
+++ b/HLTrigger/special/interface/HLTEcalIsolationFilter.h
@@ -13,7 +13,7 @@ class HLTEcalIsolationFilter : public HLTFilter {
    public:
       explicit HLTEcalIsolationFilter(const edm::ParameterSet&);
       ~HLTEcalIsolationFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/special/interface/HLTHcalNZSFilter.h
+++ b/HLTrigger/special/interface/HLTHcalNZSFilter.h
@@ -4,7 +4,7 @@
 //
 // Package:    HLTHcalNZSFilter
 // Class:      HLTHcalNZSFilter
-// 
+//
 /**\class HLTHcalNZSFilter HLTHcalNZSFilter.cc filter/HLTHcalNZSFilter/src/HLTHcalNZSFilter.cc
 
 Description: Filter to select HCAL non-ZS events
@@ -43,12 +43,12 @@ public:
   explicit HLTHcalNZSFilter(const edm::ParameterSet&);
   virtual ~HLTHcalNZSFilter();
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  
+
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
-  
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+
   // ----------member data ---------------------------
-  
+
   edm::EDGetTokenT<FEDRawDataCollection> dataInputToken_;
   edm::InputTag dataInputTag_;
 

--- a/HLTrigger/special/interface/HLTHcalNZSFilter.h
+++ b/HLTrigger/special/interface/HLTHcalNZSFilter.h
@@ -45,16 +45,12 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
   
 private:
-  virtual void beginJob(void);
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
-  virtual void endJob(void);
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
   
   // ----------member data ---------------------------
   
   edm::EDGetTokenT<FEDRawDataCollection> dataInputToken_;
   edm::InputTag dataInputTag_;
-  bool          summary_;
-  int           eventsNZS_; 
 
 };
 

--- a/HLTrigger/special/interface/HLTHcalNoiseFilter.h
+++ b/HLTrigger/special/interface/HLTHcalNoiseFilter.h
@@ -19,7 +19,7 @@ class HLTHcalNoiseFilter : public HLTFilter {
    public:
       explicit HLTHcalNoiseFilter(const edm::ParameterSet&);
       ~HLTHcalNoiseFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/special/interface/HLTHcalNoiseFilter.h
+++ b/HLTrigger/special/interface/HLTHcalNoiseFilter.h
@@ -19,7 +19,7 @@ class HLTHcalNoiseFilter : public HLTFilter {
    public:
       explicit HLTHcalNoiseFilter(const edm::ParameterSet&);
       ~HLTHcalNoiseFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:
@@ -34,8 +34,6 @@ class HLTHcalNoiseFilter : public HLTFilter {
       double MetCut_;
       double JetMinE_;
       double JetHCALminEnergyFraction_;
-      int nAnomalousEvents;
-      int nEvents;
 };
 
 #endif

--- a/HLTrigger/special/interface/HLTHcalPhiSymFilter.h
+++ b/HLTrigger/special/interface/HLTHcalPhiSymFilter.h
@@ -6,7 +6,7 @@
 // Package:    HLTHcalPhiSymFilter
 // Class:      HLTHcalPhiSymFilter
 //
-/**\class HLTHcalPhiSymFilter HLTHcalPhiSymFilter.cc 
+/**\class HLTHcalPhiSymFilter HLTHcalPhiSymFilter.cc
 
  Description: Producer for HcalRecHits to be used for phi-symmetry HCAL calibration . Discard events in which no suitable rechit is available
 
@@ -41,7 +41,7 @@ class HLTHcalPhiSymFilter : public HLTFilter {
       explicit HLTHcalPhiSymFilter(const edm::ParameterSet&);
       ~HLTHcalPhiSymFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event &, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event &, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       // ----------member data ---------------------------

--- a/HLTrigger/special/interface/HLTHcalPhiSymFilter.h
+++ b/HLTrigger/special/interface/HLTHcalPhiSymFilter.h
@@ -41,7 +41,7 @@ class HLTHcalPhiSymFilter : public HLTFilter {
       explicit HLTHcalPhiSymFilter(const edm::ParameterSet&);
       ~HLTHcalPhiSymFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event &, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event &, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       // ----------member data ---------------------------

--- a/HLTrigger/special/interface/HLTPixelAsymmetryFilter.h
+++ b/HLTrigger/special/interface/HLTPixelAsymmetryFilter.h
@@ -8,14 +8,14 @@
 //
 // Filter definition
 //
-// We perform a selection on PIXEL cluster repartition 
+// We perform a selection on PIXEL cluster repartition
 //
 // This filter is primarily used to select Beamgas (aka PKAM) events
-// 
+//
 // An asymmetry parameter, based on the pixel clusters, is computed as follows
-// 
+//
 //  asym1 = fpix-/(fpix- + fpix+) for beam1
-//  asym2 = fpix+/(fpix- + fpix+) for beam2 
+//  asym2 = fpix+/(fpix- + fpix+) for beam2
 //
 // with:
 //
@@ -23,7 +23,7 @@
 //  fpix+ = mean cluster charge in FPIX+
 //  bpix  = mean cluster charge in BarrelPIX
 //
-//  Usually for PKAM events, cluster repartition is quite uniform and asymmetry is around 0.5 
+//  Usually for PKAM events, cluster repartition is quite uniform and asymmetry is around 0.5
 //
 //
 // More details:
@@ -56,11 +56,11 @@ class HLTPixelAsymmetryFilter : public HLTFilter {
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
  private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > inputToken_;
   edm::InputTag inputTag_; // input tag identifying product containing pixel clusters
-  double  min_asym_;       // minimum asymmetry 
+  double  min_asym_;       // minimum asymmetry
   double  max_asym_;       // maximum asymmetry
   double  clus_thresh_;    // minimum charge for a cluster to be selected (in e-)
   double  bmincharge_;     // minimum average charge in the barrel (bpix, in e-)

--- a/HLTrigger/special/interface/HLTPixelAsymmetryFilter.h
+++ b/HLTrigger/special/interface/HLTPixelAsymmetryFilter.h
@@ -56,7 +56,7 @@ class HLTPixelAsymmetryFilter : public HLTFilter {
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
  private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
   edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster> > inputToken_;
   edm::InputTag inputTag_; // input tag identifying product containing pixel clusters

--- a/HLTrigger/special/interface/HLTPixelIsolTrackFilter.h
+++ b/HLTrigger/special/interface/HLTPixelIsolTrackFilter.h
@@ -15,16 +15,16 @@ class HLTPixelIsolTrackFilter : public HLTFilter {
    public:
       explicit HLTPixelIsolTrackFilter(const edm::ParameterSet&);
       ~HLTPixelIsolTrackFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:
       edm::EDGetTokenT<reco::IsolatedPixelTrackCandidateCollection> candToken_;
       edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> hltGTseedToken_;
-      edm::InputTag candTag_; 
+      edm::InputTag candTag_;
       edm::InputTag hltGTseedlabel_;
-      double maxptnearby_;    
-      double minpttrack_;        
+      double maxptnearby_;
+      double minpttrack_;
       double minetatrack_;
       double maxetatrack_;
       bool filterE_;
@@ -34,4 +34,4 @@ class HLTPixelIsolTrackFilter : public HLTFilter {
       double minDeltaPtL1Jet_;
 };
 
-#endif 
+#endif

--- a/HLTrigger/special/interface/HLTPixelIsolTrackFilter.h
+++ b/HLTrigger/special/interface/HLTPixelIsolTrackFilter.h
@@ -15,7 +15,7 @@ class HLTPixelIsolTrackFilter : public HLTFilter {
    public:
       explicit HLTPixelIsolTrackFilter(const edm::ParameterSet&);
       ~HLTPixelIsolTrackFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/special/interface/HLTPixlMBFilt.h
+++ b/HLTrigger/special/interface/HLTPixlMBFilt.h
@@ -3,7 +3,7 @@
 
 /** \class HLTFiltCand
  *
- *  
+ *
  *  This class is an HLTFilter (-> EDFilter) implementing a minimum-bias
  *  HLT trigger acting on candidates, requiring tracks in Pixel det
  *
@@ -30,7 +30,7 @@ class HLTPixlMBFilt : public HLTFilter {
    public:
       explicit HLTPixlMBFilt(const edm::ParameterSet&);
       ~HLTPixlMBFilt();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/special/interface/HLTPixlMBFilt.h
+++ b/HLTrigger/special/interface/HLTPixlMBFilt.h
@@ -30,7 +30,7 @@ class HLTPixlMBFilt : public HLTFilter {
    public:
       explicit HLTPixlMBFilt(const edm::ParameterSet&);
       ~HLTPixlMBFilt();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/special/interface/HLTPixlMBForAlignmentFilter.h
+++ b/HLTrigger/special/interface/HLTPixlMBForAlignmentFilter.h
@@ -3,7 +3,7 @@
 
 /** \class HLTFiltCand
  *
- *  
+ *
  *  This class is an HLTFilter (-> EDFilter) implementing a minimum-bias
  *  HLT trigger acting on candidates, requiring tracks in Pixel det
  *
@@ -30,7 +30,7 @@ class HLTPixlMBForAlignmentFilter : public HLTFilter {
    public:
       explicit HLTPixlMBForAlignmentFilter(const edm::ParameterSet&);
       ~HLTPixlMBForAlignmentFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/special/interface/HLTPixlMBForAlignmentFilter.h
+++ b/HLTrigger/special/interface/HLTPixlMBForAlignmentFilter.h
@@ -30,7 +30,7 @@ class HLTPixlMBForAlignmentFilter : public HLTFilter {
    public:
       explicit HLTPixlMBForAlignmentFilter(const edm::ParameterSet&);
       ~HLTPixlMBForAlignmentFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/special/interface/HLTRPCTrigNoSyncFilter.h
+++ b/HLTrigger/special/interface/HLTRPCTrigNoSyncFilter.h
@@ -59,7 +59,7 @@ class HLTRPCTrigNoSyncFilter : public HLTFilter{
 
    private:
       virtual void beginJob() ;
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       virtual void endJob() ;
       edm::InputTag m_GMTInputTag;
       edm::InputTag rpcRecHitsLabel;

--- a/HLTrigger/special/interface/HLTRPCTrigNoSyncFilter.h
+++ b/HLTrigger/special/interface/HLTRPCTrigNoSyncFilter.h
@@ -59,7 +59,7 @@ class HLTRPCTrigNoSyncFilter : public HLTFilter{
 
    private:
       virtual void beginJob() ;
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       virtual void endJob() ;
       edm::InputTag m_GMTInputTag;
       edm::InputTag rpcRecHitsLabel;

--- a/HLTrigger/special/interface/HLTSingleVertexPixelTrackFilter.h
+++ b/HLTrigger/special/interface/HLTSingleVertexPixelTrackFilter.h
@@ -22,7 +22,7 @@ class HLTSingleVertexPixelTrackFilter : public HLTFilter {
    public:
       explicit HLTSingleVertexPixelTrackFilter(const edm::ParameterSet&);
       ~HLTSingleVertexPixelTrackFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/special/interface/HLTSingleVertexPixelTrackFilter.h
+++ b/HLTrigger/special/interface/HLTSingleVertexPixelTrackFilter.h
@@ -22,7 +22,7 @@ class HLTSingleVertexPixelTrackFilter : public HLTFilter {
    public:
       explicit HLTSingleVertexPixelTrackFilter(const edm::ParameterSet&);
       ~HLTSingleVertexPixelTrackFilter();
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
    private:

--- a/HLTrigger/special/interface/HLTTrackWithHits.h
+++ b/HLTrigger/special/interface/HLTTrackWithHits.h
@@ -36,9 +36,9 @@ public:
   {
     srcToken_ = consumes<reco::TrackCollection>(src_);
   }
-  
+
   ~HLTTrackWithHits() { }
-  
+
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions)
     {
       edm::ParameterSetDescription desc;
@@ -51,9 +51,9 @@ public:
       desc.add<int>("MinPXL",0);
       descriptions.add("hltTrackWithHits",desc);
     }
-  
+
 private:
-  virtual bool hltFilter(edm::Event& iEvent, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+  virtual bool hltFilter(edm::Event& iEvent, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override
   {
     edm::Handle<reco::TrackCollection> oHandle;
     iEvent.getByToken(srcToken_, oHandle);
@@ -66,12 +66,12 @@ private:
       if ( MinFPX_>0 && hits.numberOfValidPixelEndcapHits() >= MinFPX_ ) { ++count; continue; }
       if ( MinPXL_>0 && hits.numberOfValidPixelHits() >= MinPXL_ )       { ++count; continue; }
     }
-      
+
     bool answer=(count>=minN_ && count<=maxN_);
     LogDebug("HLTTrackWithHits")<<module(iEvent)<<" sees: "<<s<<" objects. Only: "<<count<<" satisfy the hit requirement. Filter answer is: "<<(answer?"true":"false")<<std::endl;
     return answer;
   }
- 
+
   edm::InputTag src_;
   edm::EDGetTokenT<reco::TrackCollection> srcToken_;
   int minN_,maxN_,MinBPX_,MinFPX_,MinPXL_;

--- a/HLTrigger/special/interface/HLTTrackWithHits.h
+++ b/HLTrigger/special/interface/HLTTrackWithHits.h
@@ -53,7 +53,7 @@ public:
     }
   
 private:
-  virtual bool hltFilter(edm::Event& iEvent, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct)
+  virtual bool hltFilter(edm::Event& iEvent, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const
   {
     edm::Handle<reco::TrackCollection> oHandle;
     iEvent.getByToken(srcToken_, oHandle);

--- a/HLTrigger/special/interface/HLTTrackerHaloFilter.h
+++ b/HLTrigger/special/interface/HLTTrackerHaloFilter.h
@@ -7,7 +7,7 @@
 //
 // HLTrackerHaloFilter
 //
-// Filter selecting beam halo track candidates by looking at 
+// Filter selecting beam halo track candidates by looking at
 // TEC clusters accumulations
 //
 // This filter is working with events seeded by L1_BeamHalo
@@ -46,7 +46,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
   edm::EDGetTokenT<edm::RefGetter<SiStripCluster> > inputToken_;
   edm::InputTag inputTag_; // input tag identifying product containing pixel clusters
@@ -55,8 +55,8 @@ private:
   int sign_accu_;  // Minimal size for a signal accumulation
   int max_clusT_;  // Maximum number of TEC clusters
   int max_back_;   // Max number of accumulations per side
-  int fastproc_;   // fast unpacking of cluster info, based on DetIds 
- 
+  int fastproc_;   // fast unpacking of cluster info, based on DetIds
+
   static const int m_TEC_cells[];
 };
 

--- a/HLTrigger/special/interface/HLTTrackerHaloFilter.h
+++ b/HLTrigger/special/interface/HLTTrackerHaloFilter.h
@@ -46,7 +46,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
   edm::EDGetTokenT<edm::RefGetter<SiStripCluster> > inputToken_;
   edm::InputTag inputTag_; // input tag identifying product containing pixel clusters
@@ -57,14 +57,7 @@ private:
   int max_back_;   // Max number of accumulations per side
   int fastproc_;   // fast unpacking of cluster info, based on DetIds 
  
-  int SST_clus_MAP_m[5][8][9];
-  int SST_clus_MAP_p[5][8][9];
-  int SST_clus_PROJ_m[5][8];
-  int SST_clus_PROJ_p[5][8];
-
   static const int m_TEC_cells[];
-
-
 };
 
 #endif

--- a/HLTrigger/special/src/HLTCSCAcceptBusyFilter.cc
+++ b/HLTrigger/special/src/HLTCSCAcceptBusyFilter.cc
@@ -2,7 +2,7 @@
 //
 // Package:    HLTCSCAcceptBusyFilter
 // Class:      HLTCSCAcceptBusyFilter
-// 
+//
 /**\class HLTCSCAcceptBusyFilter HLTCSCAcceptBusyFilter.cc Analyzers/HLTCSCAcceptBusyFilter/src/HLTCSCAcceptBusyFilter.cc
 
  Description: [one line class summary]
@@ -50,11 +50,11 @@ public:
   explicit HLTCSCAcceptBusyFilter(const edm::ParameterSet&);
   virtual ~HLTCSCAcceptBusyFilter();
   virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);   
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  bool AcceptManyHitsInChamber(unsigned int maxRecHitsPerChamber, const edm::Handle<CSCRecHit2DCollection>& recHits);
-  
+  bool AcceptManyHitsInChamber(unsigned int maxRecHitsPerChamber, const edm::Handle<CSCRecHit2DCollection>& recHits) const;
+
   // ----------member data ---------------------------
   edm::EDGetTokenT<CSCRecHit2DCollection> cscrechitsToken;
   edm::InputTag cscrechitsTag;
@@ -74,7 +74,7 @@ private:
 //
 // constructors and destructor
 //
-HLTCSCAcceptBusyFilter::HLTCSCAcceptBusyFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTCSCAcceptBusyFilter::HLTCSCAcceptBusyFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
    //now do what ever initialization is needed
    cscrechitsTag        = iConfig.getParameter<edm::InputTag>("cscrechitsTag");
@@ -86,7 +86,7 @@ HLTCSCAcceptBusyFilter::HLTCSCAcceptBusyFilter(const edm::ParameterSet& iConfig)
 
 HLTCSCAcceptBusyFilter::~HLTCSCAcceptBusyFilter()
 {
- 
+
    // do anything here that needs to be done at desctruction time
    // (e.g. close files, deallocate resources etc.)
 
@@ -113,9 +113,9 @@ bool HLTCSCAcceptBusyFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
    using namespace edm;
 
   // Get the RecHits collection :
-  Handle<CSCRecHit2DCollection> recHits; 
-  iEvent.getByToken(cscrechitsToken,recHits);  
-  
+  Handle<CSCRecHit2DCollection> recHits;
+  iEvent.getByToken(cscrechitsToken,recHits);
+
   if(  AcceptManyHitsInChamber(maxRecHitsPerChamber, recHits) ) {
     return (!invert);
   } else {
@@ -126,7 +126,7 @@ bool HLTCSCAcceptBusyFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
 
 
 // ------------ method to find chamber with nMax hits
-bool HLTCSCAcceptBusyFilter::AcceptManyHitsInChamber(unsigned int maxRecHitsPerChamber, const edm::Handle<CSCRecHit2DCollection>& recHits) {
+bool HLTCSCAcceptBusyFilter::AcceptManyHitsInChamber(unsigned int maxRecHitsPerChamber, const edm::Handle<CSCRecHit2DCollection>& recHits) const {
 
   unsigned int maxNRecHitsPerChamber(0);
 

--- a/HLTrigger/special/src/HLTCSCAcceptBusyFilter.cc
+++ b/HLTrigger/special/src/HLTCSCAcceptBusyFilter.cc
@@ -49,7 +49,7 @@ class HLTCSCAcceptBusyFilter : public HLTFilter {
 public:
   explicit HLTCSCAcceptBusyFilter(const edm::ParameterSet&);
   virtual ~HLTCSCAcceptBusyFilter();
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);   
 
 private:
@@ -108,7 +108,7 @@ HLTCSCAcceptBusyFilter::fillDescriptions(edm::ConfigurationDescriptions& descrip
 //
 
 // ------------ method called on each new Event  ------------
-bool HLTCSCAcceptBusyFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+bool HLTCSCAcceptBusyFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
 
    using namespace edm;
 

--- a/HLTrigger/special/src/HLTCSCAcceptBusyFilter.cc
+++ b/HLTrigger/special/src/HLTCSCAcceptBusyFilter.cc
@@ -49,7 +49,7 @@ class HLTCSCAcceptBusyFilter : public HLTFilter {
 public:
   explicit HLTCSCAcceptBusyFilter(const edm::ParameterSet&);
   virtual ~HLTCSCAcceptBusyFilter();
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
@@ -108,7 +108,7 @@ HLTCSCAcceptBusyFilter::fillDescriptions(edm::ConfigurationDescriptions& descrip
 //
 
 // ------------ method called on each new Event  ------------
-bool HLTCSCAcceptBusyFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+bool HLTCSCAcceptBusyFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
 
    using namespace edm;
 

--- a/HLTrigger/special/src/HLTCSCActivityFilter.cc
+++ b/HLTrigger/special/src/HLTCSCActivityFilter.cc
@@ -56,7 +56,7 @@ HLTCSCActivityFilter::fillDescriptions(edm::ConfigurationDescriptions& descripti
 //
 
 // ------------ method called on each new Event  ------------
-bool HLTCSCActivityFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+bool HLTCSCActivityFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
   using namespace edm;
   using namespace std;
   using namespace trigger;

--- a/HLTrigger/special/src/HLTCSCActivityFilter.cc
+++ b/HLTrigger/special/src/HLTCSCActivityFilter.cc
@@ -56,7 +56,7 @@ HLTCSCActivityFilter::fillDescriptions(edm::ConfigurationDescriptions& descripti
 //
 
 // ------------ method called on each new Event  ------------
-bool HLTCSCActivityFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+bool HLTCSCActivityFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
   using namespace edm;
   using namespace std;
   using namespace trigger;

--- a/HLTrigger/special/src/HLTCSCOverlapFilter.cc
+++ b/HLTrigger/special/src/HLTCSCOverlapFilter.cc
@@ -13,7 +13,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-HLTCSCOverlapFilter::HLTCSCOverlapFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTCSCOverlapFilter::HLTCSCOverlapFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
      , m_input(iConfig.getParameter<edm::InputTag>("input"))
      , m_minHits(iConfig.getParameter<unsigned int>("minHits"))
      , m_xWindow(iConfig.getParameter<double>("xWindow"))
@@ -52,7 +52,7 @@ HLTCSCOverlapFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   descriptions.add("hltCSCOverlapFilter",desc);
 }
 
-bool HLTCSCOverlapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+bool HLTCSCOverlapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
    edm::Handle<CSCRecHit2DCollection> hits;
    iEvent.getByToken(cscrechitsToken, hits);
 
@@ -90,11 +90,11 @@ bool HLTCSCOverlapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
 	 CSCDetId chamber_id(chamber_iter->first);
 	 int chamber = chamber_id.chamber();
 	 int next = chamber + 1;
-      
+
 	 // Some rings have 36 chambers, others have 18.  This will still be valid when ME4/2 is added.
 	 if (next == 37  &&  (std::abs(chamber_id.station()) == 1  ||  chamber_id.ring() == 2)) next = 1;
 	 if (next == 19  &&  (std::abs(chamber_id.station()) != 1  &&  chamber_id.ring() == 1)) next = 1;
-      
+
 	 int next_id = CSCDetId(chamber_id.endcap(), chamber_id.station(), chamber_id.ring(), next, 0).rawId();
 
 	 std::map<int, std::vector<const CSCRecHit2D*> >::const_iterator chamber_next = chamber_tohit.find(next_id);
@@ -134,4 +134,4 @@ bool HLTCSCOverlapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
 
    return keep;
 }
-  
+

--- a/HLTrigger/special/src/HLTCSCOverlapFilter.cc
+++ b/HLTrigger/special/src/HLTCSCOverlapFilter.cc
@@ -52,7 +52,7 @@ HLTCSCOverlapFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   descriptions.add("hltCSCOverlapFilter",desc);
 }
 
-bool HLTCSCOverlapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+bool HLTCSCOverlapFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
    edm::Handle<CSCRecHit2DCollection> hits;
    iEvent.getByToken(cscrechitsToken, hits);
 

--- a/HLTrigger/special/src/HLTCSCRing2or3Filter.cc
+++ b/HLTrigger/special/src/HLTCSCRing2or3Filter.cc
@@ -35,7 +35,7 @@ HLTCSCRing2or3Filter::fillDescriptions(edm::ConfigurationDescriptions& descripti
   descriptions.add("hltCSCRing2or3Filter",desc);
 }
 
-bool HLTCSCRing2or3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+bool HLTCSCRing2or3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
    edm::Handle<CSCRecHit2DCollection> hits;
    iEvent.getByToken(cscrechitsToken, hits);
 

--- a/HLTrigger/special/src/HLTCSCRing2or3Filter.cc
+++ b/HLTrigger/special/src/HLTCSCRing2or3Filter.cc
@@ -13,7 +13,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-HLTCSCRing2or3Filter::HLTCSCRing2or3Filter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTCSCRing2or3Filter::HLTCSCRing2or3Filter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
      , m_input(iConfig.getParameter<edm::InputTag>("input"))
      , m_minHits(iConfig.getParameter<unsigned int>("minHits"))
      , m_xWindow(iConfig.getParameter<double>("xWindow"))
@@ -35,7 +35,7 @@ HLTCSCRing2or3Filter::fillDescriptions(edm::ConfigurationDescriptions& descripti
   descriptions.add("hltCSCRing2or3Filter",desc);
 }
 
-bool HLTCSCRing2or3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+bool HLTCSCRing2or3Filter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
    edm::Handle<CSCRecHit2DCollection> hits;
    iEvent.getByToken(cscrechitsToken, hits);
 

--- a/HLTrigger/special/src/HLTCaloTowerFilter.cc
+++ b/HLTrigger/special/src/HLTCaloTowerFilter.cc
@@ -2,7 +2,7 @@
 //
 // Package:    HLTCaloTowerFilter
 // Class:      HLTCaloTowerFilter
-// 
+//
 /**\class HLTCaloTowerFilter HLTCaloTowerFilter.cc Work/HLTCaloTowerFilter/src/HLTCaloTowerFilter.cc
 
  Description: <one line class summary>
@@ -34,15 +34,15 @@ class HLTCaloTowerFilter : public HLTFilter {
 public:
   explicit HLTCaloTowerFilter(const edm::ParameterSet&);
   ~HLTCaloTowerFilter();
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);   
-    
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
   // ----------member data ---------------------------
   edm::EDGetTokenT<CaloTowerCollection> inputToken_;
   edm::InputTag inputTag_;    // input tag identifying product
-  double        min_Pt_;      // pt threshold in GeV 
+  double        min_Pt_;      // pt threshold in GeV
   double        max_Eta_;     // eta range (symmetric)
   unsigned int  min_N_;       // number of objects passing cuts required
 
@@ -84,7 +84,7 @@ HLTCaloTowerFilter::fillDescriptions(edm::ConfigurationDescriptions& description
 
 // ------------ method called on each new Event  ------------
 bool
-HLTCaloTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+HLTCaloTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
   using namespace std;
   using namespace edm;
   using namespace reco;

--- a/HLTrigger/special/src/HLTCaloTowerFilter.cc
+++ b/HLTrigger/special/src/HLTCaloTowerFilter.cc
@@ -37,7 +37,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);   
     
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
 
   // ----------member data ---------------------------
   edm::EDGetTokenT<CaloTowerCollection> inputToken_;
@@ -84,7 +84,7 @@ HLTCaloTowerFilter::fillDescriptions(edm::ConfigurationDescriptions& description
 
 // ------------ method called on each new Event  ------------
 bool
-HLTCaloTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+HLTCaloTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
   using namespace std;
   using namespace edm;
   using namespace reco;

--- a/HLTrigger/special/src/HLTDTActivityFilter.cc
+++ b/HLTrigger/special/src/HLTDTActivityFilter.cc
@@ -144,7 +144,7 @@ bool HLTDTActivityFilter::beginRun(edm::Run& iRun, const edm::EventSetup& iSetup
 }
 
 // ------------ method called on each new Event  ------------
-bool HLTDTActivityFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+bool HLTDTActivityFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
 
   using namespace edm;
   using namespace std;
@@ -280,7 +280,7 @@ bool HLTDTActivityFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
 }
 
 
-bool HLTDTActivityFilter::hasActivity(const std::bitset<4>& actWord) {
+bool HLTDTActivityFilter::hasActivity(const std::bitset<4>& actWord) const {
 
   bool actTPG   = orTPG_   ? actWord[DCC] || actWord[DDU] : actWord[DCC] && actWord[DDU];
   bool actTrig  = orRPC_   ? actWord[RPC] || actTPG : actWord[RPC] && actTPG;
@@ -290,7 +290,7 @@ bool HLTDTActivityFilter::hasActivity(const std::bitset<4>& actWord) {
 
 }
 
-bool HLTDTActivityFilter::matchChamber(const uint32_t& rawId, const L1MuRegionalCand& rpcTrig) {
+bool HLTDTActivityFilter::matchChamber(const uint32_t& rawId, const L1MuRegionalCand& rpcTrig) const {
 
   const GlobalPoint chPos = dtGeom_->chamber(DTChamberId(rawId))->position();
   

--- a/HLTrigger/special/src/HLTDTActivityFilter.cc
+++ b/HLTrigger/special/src/HLTDTActivityFilter.cc
@@ -77,14 +77,14 @@ HLTDTActivityFilter::HLTDTActivityFilter(const edm::ParameterSet& iConfig) : HLT
 
   maxDeltaPhi_  = iConfig.getParameter<double>("maxDeltaPhi");
   maxDeltaEta_  = iConfig.getParameter<double>("maxDeltaEta");
-  
+
 
   activeSecs_.reset();
   vector<int> aSectors = iConfig.getParameter<vector<int> >("activeSectors");
   vector<int>::const_iterator iSec = aSectors.begin();
   vector<int>::const_iterator eSec = aSectors.end();
-  for (;iSec!=eSec;++iSec) 
-    if ((*iSec)>0 && (*iSec<15)) activeSecs_.set((*iSec)); 
+  for (;iSec!=eSec;++iSec)
+    if ((*iSec)>0 && (*iSec<15)) activeSecs_.set((*iSec));
 
   inputDCCToken_  = consumes<L1MuDTChambPhContainer>(inputTag_[DCC]);
   inputDDUToken_  = consumes<DTLocalTriggerCollection>(inputTag_[DDU]);
@@ -112,7 +112,7 @@ HLTDTActivityFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptio
   desc.add<bool>("orTPG",true);
   desc.add<bool>("orRPC",true);
   desc.add<bool>("orDigi",false)->
-    setComment(" # && of trig & digi info");  
+    setComment(" # && of trig & digi info");
   desc.add<int>("minDCCBX",-1);
   desc.add<int>("maxDCCBX",1);
   desc.add<int>("minDDUBX",8);
@@ -144,12 +144,12 @@ bool HLTDTActivityFilter::beginRun(edm::Run& iRun, const edm::EventSetup& iSetup
 }
 
 // ------------ method called on each new Event  ------------
-bool HLTDTActivityFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+bool HLTDTActivityFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
 
   using namespace edm;
   using namespace std;
 
-  activityMap actMap;  
+  activityMap actMap;
 
   if (process_[DCC]) {
 
@@ -158,45 +158,45 @@ bool HLTDTActivityFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
     vector<L1MuDTChambPhDigi>*  phTrigs = l1DTTPGPh->getContainer();
     vector<L1MuDTChambPhDigi>::const_iterator iph  = phTrigs->begin();
     vector<L1MuDTChambPhDigi>::const_iterator iphe = phTrigs->end();
-    
+
     for(; iph !=iphe ; ++iph) {
 
       int qual = iph->code();
       int bx   = iph->bxNum();
       int ch   = iph->stNum();
-      int sec  = iph->scNum() + 1; // DTTF range [0:11] -> DT SC range [1:12] 
+      int sec  = iph->scNum() + 1; // DTTF range [0:11] -> DT SC range [1:12]
       int wh   = iph->whNum();
 
       if (!activeSecs_[sec]) continue;
 
-      if (ch<=maxStation_ && bx>=minBX_[DCC] && bx<=maxBX_[DCC] 
+      if (ch<=maxStation_ && bx>=minBX_[DCC] && bx<=maxBX_[DCC]
 	  && qual>=minQual_ && qual<7) {
 	actMap[DTChamberId(wh,ch,sec).rawId()].set(DCC);	
       }
 
     }
-    
+
   }
 
   if (process_[DDU]) {
-    
+
     Handle<DTLocalTriggerCollection> trigsDDU;
     iEvent.getByToken(inputDDUToken_,trigsDDU);
     DTLocalTriggerCollection::DigiRangeIterator detUnitIt;
-    
+
     for (detUnitIt=trigsDDU->begin();detUnitIt!=trigsDDU->end();++detUnitIt){
 
       int ch  = (*detUnitIt).first.station();
       if (!activeSecs_[(*detUnitIt).first.sector()]) continue;
-      
+
       const DTLocalTriggerCollection::Range& range = (*detUnitIt).second;
 
       for (DTLocalTriggerCollection::const_iterator trigIt = range.first; trigIt!=range.second;++trigIt){	
 	int bx = trigIt->bx();
 	int qual = trigIt->quality();
-	if ( ch<=maxStation_ && bx>=minBX_[DDU] && bx<=maxBX_[DDU] 
+	if ( ch<=maxStation_ && bx>=minBX_[DDU] && bx<=maxBX_[DDU]
 	     && qual>=minQual_ && qual<7) {
-	  actMap[(*detUnitIt).first.rawId()].set(DDU);       
+	  actMap[(*detUnitIt).first.rawId()].set(DDU);
 	}
 
       }
@@ -206,12 +206,12 @@ bool HLTDTActivityFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
   }
 
   if (process_[DIGI]) {
-    
+
     edm::Handle<DTDigiCollection> dtdigis;
     iEvent.getByToken(inputDigiToken_, dtdigis);
     std::map<uint32_t,int> hitMap;
     DTDigiCollection::DigiRangeIterator dtLayerIdIt;
-    
+
     for (dtLayerIdIt=dtdigis->begin(); dtLayerIdIt!=dtdigis->end(); dtLayerIdIt++) {
 
       DTChamberId chId = ((*dtLayerIdIt).first).chamberId();
@@ -231,12 +231,12 @@ bool HLTDTActivityFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
       }
 
     }
-    
+
   }
 
   if (process_[RPC]) {
 
-    edm::Handle<L1MuGMTReadoutCollection> gmtrc; 
+    edm::Handle<L1MuGMTReadoutCollection> gmtrc;
     iEvent.getByToken(inputRPCToken_,gmtrc);
 
     std::vector<L1MuGMTReadoutRecord> gmtrr = gmtrc->getRecords();
@@ -248,7 +248,7 @@ bool HLTDTActivityFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
       std::vector<L1MuRegionalCand> rpcCands = (*recIt).getBrlRPCCands();
       std::vector<L1MuRegionalCand>::const_iterator candIt  = rpcCands.begin();
       std::vector<L1MuRegionalCand>::const_iterator candEnd = rpcCands.end();
-      
+
       for(; candIt!=candEnd; ++candIt) {
 	
 	if (candIt->empty()) continue;
@@ -258,25 +258,25 @@ bool HLTDTActivityFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
 	  activityMap::iterator actMapIt  = actMap.begin();
 	  activityMap::iterator actMapEnd = actMap.end();
 	  for (; actMapIt!= actMapEnd; ++ actMapIt)
-	    if (matchChamber((*actMapIt).first,(*candIt))) 
+	    if (matchChamber((*actMapIt).first,(*candIt)))
 	      (*actMapIt).second.set(RPC);
 	}
       }
     }
 
   }
-  
+
   int nActCh = 0;
   activityMap::const_iterator actMapIt  = actMap.begin();
   activityMap::const_iterator actMapEnd = actMap.end();
 
-  for (; actMapIt!=actMapEnd; ++actMapIt) 
+  for (; actMapIt!=actMapEnd; ++actMapIt)
     hasActivity((*actMapIt).second) && nActCh++ ;
 
   bool result = nActCh>=minActiveChambs_;
 
   return result;
-  
+
 }
 
 
@@ -284,7 +284,7 @@ bool HLTDTActivityFilter::hasActivity(const std::bitset<4>& actWord) const {
 
   bool actTPG   = orTPG_   ? actWord[DCC] || actWord[DDU] : actWord[DCC] && actWord[DDU];
   bool actTrig  = orRPC_   ? actWord[RPC] || actTPG : actWord[RPC] && actTPG;
-  bool result   = orDigi_  ? actWord[DIGI] || actTrig : actWord[DIGI] && actTrig; 
+  bool result   = orDigi_  ? actWord[DIGI] || actTrig : actWord[DIGI] && actTrig;
 
   return result;
 
@@ -293,7 +293,7 @@ bool HLTDTActivityFilter::hasActivity(const std::bitset<4>& actWord) const {
 bool HLTDTActivityFilter::matchChamber(const uint32_t& rawId, const L1MuRegionalCand& rpcTrig) const {
 
   const GlobalPoint chPos = dtGeom_->chamber(DTChamberId(rawId))->position();
-  
+
   float fDeltaPhi = fabs( chPos.phi() - rpcTrig.phiValue() );
   if ( fDeltaPhi>Geom::pi() ) fDeltaPhi = fabs(fDeltaPhi - 2*Geom::pi());
 

--- a/HLTrigger/special/src/HLTEcalIsolationFilter.cc
+++ b/HLTrigger/special/src/HLTEcalIsolationFilter.cc
@@ -10,7 +10,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-HLTEcalIsolationFilter::HLTEcalIsolationFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTEcalIsolationFilter::HLTEcalIsolationFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   candTag_ = iConfig.getParameter<edm::InputTag> ("EcalIsolatedParticleSource");
   maxhitout = iConfig.getParameter<int> ("MaxNhitOuterCone");
@@ -36,7 +36,7 @@ HLTEcalIsolationFilter::fillDescriptions(edm::ConfigurationDescriptions& descrip
   descriptions.add("hltEcalIsolationFilter",desc);
 }
 
-bool HLTEcalIsolationFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTEcalIsolationFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
 
   // Ref to Candidate object to be recorded in filter object
@@ -59,11 +59,11 @@ bool HLTEcalIsolationFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
 	  n++;
 	}
     }
-  
-  
+
+
   bool accept(n>0);
 
   return accept;
 
 }
-	  
+	

--- a/HLTrigger/special/src/HLTEcalIsolationFilter.cc
+++ b/HLTrigger/special/src/HLTEcalIsolationFilter.cc
@@ -36,7 +36,7 @@ HLTEcalIsolationFilter::fillDescriptions(edm::ConfigurationDescriptions& descrip
   descriptions.add("hltEcalIsolationFilter",desc);
 }
 
-bool HLTEcalIsolationFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTEcalIsolationFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
 
   // Ref to Candidate object to be recorded in filter object

--- a/HLTrigger/special/src/HLTEcalTowerFilter.cc
+++ b/HLTrigger/special/src/HLTEcalTowerFilter.cc
@@ -34,7 +34,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual bool hltFilter(edm::Event &, const edm::EventSetup &, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+  virtual bool hltFilter(edm::Event &, const edm::EventSetup &, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
 
   edm::EDGetTokenT<CaloTowerCollection> inputToken_;
   edm::InputTag inputTag_; // input tag identifying product
@@ -82,7 +82,7 @@ HLTEcalTowerFilter::fillDescriptions(edm::ConfigurationDescriptions& description
 
 // ------------ method called to produce the data  ------------
   bool 
-HLTEcalTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTEcalTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/special/src/HLTEcalTowerFilter.cc
+++ b/HLTrigger/special/src/HLTEcalTowerFilter.cc
@@ -1,6 +1,6 @@
 /** \class HLTEcalTowerFilter
  *
- *  
+ *
  *  This class is an HLTFilter (-> EDFilter) implementing a
  *  single CaloTower requirement with an emEnergy threshold (not Et!)
  *
@@ -34,11 +34,11 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual bool hltFilter(edm::Event &, const edm::EventSetup &, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+  virtual bool hltFilter(edm::Event &, const edm::EventSetup &, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
   edm::EDGetTokenT<CaloTowerCollection> inputToken_;
   edm::InputTag inputTag_; // input tag identifying product
-  double min_E_;           // energy threshold in GeV 
+  double min_E_;           // energy threshold in GeV
   double max_Eta_;         // maximum eta
   int min_N_;              // minimum number
 
@@ -81,8 +81,8 @@ HLTEcalTowerFilter::fillDescriptions(edm::ConfigurationDescriptions& description
 //
 
 // ------------ method called to produce the data  ------------
-  bool 
-HLTEcalTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+  bool
+HLTEcalTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/special/src/HLTFEDSizeFilter.cc
+++ b/HLTrigger/special/src/HLTFEDSizeFilter.cc
@@ -2,7 +2,7 @@
 //
 // Package:    HLTFEDSizeFilter
 // Class:      HLTFEDSizeFilter
-// 
+//
 /**\class HLTFEDSizeFilter HLTFEDSizeFilter.cc Work/HLTFEDSizeFilter/src/HLTFEDSizeFilter.cc
 
  Description: <one line class summary>
@@ -42,28 +42,28 @@ public:
     explicit HLTFEDSizeFilter(const edm::ParameterSet&);
     ~HLTFEDSizeFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    
+
 private:
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
-    
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+
     // ----------member data ---------------------------
     edm::EDGetTokenT<FEDRawDataCollection> RawCollectionToken_;
     edm::InputTag RawCollection_;
     unsigned int  threshold_;
     unsigned int  fedStart_, fedStop_ ;
     bool          requireAllFEDs_;
- 
+
 };
 
 //
 // constructors and destructor
 //
-HLTFEDSizeFilter::HLTFEDSizeFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTFEDSizeFilter::HLTFEDSizeFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
     threshold_      = iConfig.getParameter<unsigned int>("threshold");
     RawCollection_  = iConfig.getParameter<edm::InputTag>("rawData");
     // For a list of FEDs by subdetector, see DataFormats/FEDRawData/src/FEDNumbering.cc
-    fedStart_       = iConfig.getParameter<unsigned int>("firstFED"); 
+    fedStart_       = iConfig.getParameter<unsigned int>("firstFED");
     fedStop_        = iConfig.getParameter<unsigned int>("lastFED");
     requireAllFEDs_ = iConfig.getParameter<bool>("requireAllFEDs");
 
@@ -100,7 +100,7 @@ HLTFEDSizeFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
 
 // ------------ method called on each new Event  ------------
 bool
-HLTFEDSizeFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+HLTFEDSizeFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
 
     // get the RAW data collction
     edm::Handle<FEDRawDataCollection> h_raw;

--- a/HLTrigger/special/src/HLTFEDSizeFilter.cc
+++ b/HLTrigger/special/src/HLTFEDSizeFilter.cc
@@ -44,7 +44,7 @@ public:
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
     
 private:
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
     
     // ----------member data ---------------------------
     edm::EDGetTokenT<FEDRawDataCollection> RawCollectionToken_;
@@ -100,7 +100,7 @@ HLTFEDSizeFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
 
 // ------------ method called on each new Event  ------------
 bool
-HLTFEDSizeFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+HLTFEDSizeFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
 
     // get the RAW data collction
     edm::Handle<FEDRawDataCollection> h_raw;

--- a/HLTrigger/special/src/HLTHcalNZSFilter.cc
+++ b/HLTrigger/special/src/HLTHcalNZSFilter.cc
@@ -46,7 +46,6 @@ HLTHcalNZSFilter::HLTHcalNZSFilter(const edm::ParameterSet& iConfig) : HLTFilter
   //now do what ever initialization is needed
 
   dataInputTag_ = iConfig.getParameter<edm::InputTag>("InputTag") ;
-  summary_      = iConfig.getUntrackedParameter<bool>("FilterSummary",false) ;
   dataInputToken_ = consumes<FEDRawDataCollection>(dataInputTag_);
 }
 
@@ -64,7 +63,6 @@ HLTHcalNZSFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
   edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
   desc.add<edm::InputTag>("InputTag",edm::InputTag("source"));
-  desc.addUntracked<bool>("FilterSummary",false);
   descriptions.add("hltHcalNZSFilter",desc);
 }
 
@@ -74,11 +72,11 @@ HLTHcalNZSFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
 
 // ------------ method called on each new Event  ------------
 bool
-HLTHcalNZSFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTHcalNZSFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace edm;
 
-  // MC treatment for this hltFilter(NZS not fully emulated in HTR for MC, trigger::TriggerFilterObjectWithRefs & filterproduct)
+  // MC treatment for this hltFilter(NZS not fully emulated in HTR for MC, trigger::TriggerFilterObjectWithRefs & filterproduct) const
   if (!iEvent.isRealData()) return false;
 
   edm::Handle<FEDRawDataCollection> rawdata;  
@@ -116,7 +114,7 @@ HLTHcalNZSFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
       }
   }
   
-  if ( (nNZSfed == nFEDs) && (nFEDs > 0) ) { eventsNZS_++ ; return true ; }
+  if ( (nNZSfed == nFEDs) && (nFEDs > 0) ) { return true ; }
   else {
       if ( nNZSfed > 0 ) LogWarning("HLTHcalNZSFilter") << "Mixture of ZS(" << nZSfed
                                                         << ") and NZS(" << nNZSfed
@@ -126,15 +124,3 @@ HLTHcalNZSFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, t
 
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void 
-HLTHcalNZSFilter::beginJob(void)
-{
-  eventsNZS_ = 0 ; 
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-HLTHcalNZSFilter::endJob(void) {
-  if ( summary_ ) edm::LogWarning("HLTHcalNZSFilter") << "Kept " << eventsNZS_ << " non-ZS events" ;  
-}

--- a/HLTrigger/special/src/HLTHcalNZSFilter.cc
+++ b/HLTrigger/special/src/HLTHcalNZSFilter.cc
@@ -2,7 +2,7 @@
 //
 // Package:    HLTHcalNZSFilter
 // Class:      HLTHcalNZSFilter
-// 
+//
 /**\class HLTHcalNZSFilter HLTHcalNZSFilter.cc filter/HLTHcalNZSFilter/src/HLTHcalNZSFilter.cc
 
 Description: Filter to select HCAL abort gap events
@@ -41,7 +41,7 @@ Implementation:
 //
 // constructors and destructor
 //
-HLTHcalNZSFilter::HLTHcalNZSFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTHcalNZSFilter::HLTHcalNZSFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   //now do what ever initialization is needed
 
@@ -52,7 +52,7 @@ HLTHcalNZSFilter::HLTHcalNZSFilter(const edm::ParameterSet& iConfig) : HLTFilter
 
 HLTHcalNZSFilter::~HLTHcalNZSFilter()
 {
- 
+
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 
@@ -72,53 +72,53 @@ HLTHcalNZSFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
 
 // ------------ method called on each new Event  ------------
 bool
-HLTHcalNZSFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTHcalNZSFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace edm;
 
-  // MC treatment for this hltFilter(NZS not fully emulated in HTR for MC, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+  // MC treatment for this hltFilter(NZS not fully emulated in HTR for MC, trigger::TriggerFilterObjectWithRefs & filterproduct) override
   if (!iEvent.isRealData()) return false;
 
-  edm::Handle<FEDRawDataCollection> rawdata;  
+  edm::Handle<FEDRawDataCollection> rawdata;
   iEvent.getByToken(dataInputToken_,rawdata);
 
-  int nFEDs = 0 ; int nNZSfed = 0 ; int nZSfed = 0 ; 
+  int nFEDs = 0 ; int nNZSfed = 0 ; int nZSfed = 0 ;
   for (int i=FEDNumbering::MINHCALFEDID; i<=FEDNumbering::MAXHCALFEDID; i++) {
-      const FEDRawData& fedData = rawdata->FEDData(i) ; 
-      if ( fedData.size() < 24 ) continue ; 
+      const FEDRawData& fedData = rawdata->FEDData(i) ;
+      if ( fedData.size() < 24 ) continue ;
       nFEDs++ ;
-      
+
       // Check for Zero-suppression
       HcalHTRData htr;
-      const HcalDCCHeader* dccHeader = (const HcalDCCHeader*)(fedData.data()) ; 
-      int nZS = 0 ; int nUS = 0 ; int nSpigot = 0 ; 
-      for (int spigot=0; spigot<HcalDCCHeader::SPIGOT_COUNT; spigot++) {    
+      const HcalDCCHeader* dccHeader = (const HcalDCCHeader*)(fedData.data()) ;
+      int nZS = 0 ; int nUS = 0 ; int nSpigot = 0 ;
+      for (int spigot=0; spigot<HcalDCCHeader::SPIGOT_COUNT; spigot++) {
           if (!dccHeader->getSpigotPresent(spigot)) continue;
-          
+
           // Load the given decoder with the pointer and length from this spigot.
-          dccHeader->getSpigotData(spigot,htr, fedData.size()); 
+          dccHeader->getSpigotData(spigot,htr, fedData.size());
           if ((htr.getFirmwareFlavor()&0xE0)==0x80) continue ; // This is TTP data
 
-          nSpigot++ ; 
+          nSpigot++ ;
           // check min length, correct wordcount, empty event, or total length if histo event.
-          if ( htr.isUnsuppressed() ) nUS++ ; 
-          else nZS++ ; 
+          if ( htr.isUnsuppressed() ) nUS++ ;
+          else nZS++ ;
       }
 
-      if ( nUS == nSpigot ) nNZSfed++ ; 
+      if ( nUS == nSpigot ) nNZSfed++ ;
       else {
-          nZSfed++ ; 
+          nZSfed++ ;
           if ( nUS > 0 ) LogWarning("HLTHcalNZSFilter") << "Mixture of ZS(" << nZS
                                                         << ") and NZS(" << nUS
                                                         << ") spigots in FED " << i ;
       }
   }
-  
+
   if ( (nNZSfed == nFEDs) && (nFEDs > 0) ) { return true ; }
   else {
       if ( nNZSfed > 0 ) LogWarning("HLTHcalNZSFilter") << "Mixture of ZS(" << nZSfed
                                                         << ") and NZS(" << nNZSfed
-                                                        << ") FEDs in this event" ; 
+                                                        << ") FEDs in this event" ;
       return false ;
   }
 

--- a/HLTrigger/special/src/HLTHcalNoiseFilter.cc
+++ b/HLTrigger/special/src/HLTHcalNoiseFilter.cc
@@ -27,8 +27,6 @@ HLTHcalNoiseFilter::HLTHcalNoiseFilter(const edm::ParameterSet& iConfig) : HLTFi
     JetSourceToken_ = consumes<reco::CaloJetCollection>(JetSource_);
     TowerSourceToken_ = consumes<CaloTowerCollection>(TowerSource_);
   }
-  nAnomalousEvents=0;
-  nEvents=0;
 }
 
 HLTHcalNoiseFilter::~HLTHcalNoiseFilter() { }
@@ -52,7 +50,7 @@ HLTHcalNoiseFilter::fillDescriptions(edm::ConfigurationDescriptions& description
 // member functions
 //
 
-bool HLTHcalNoiseFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTHcalNoiseFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
    using namespace edm;
    using namespace reco;
@@ -83,14 +81,13 @@ bool HLTHcalNoiseFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iS
        TowerContainer.clear();
        JetContainer.clear();
        CaloTower seedTower;
-       nEvents++;
        for(CaloJetCollection::const_iterator calojetIter = calojetHandle->begin();calojetIter != calojetHandle->end();++calojetIter) {
-	 if( ((calojetIter->et())*cosh(calojetIter->eta()) > JetMinE_) && (calojetIter->energyFractionHadronic() > JetHCALminEnergyFraction_) ) {
+	 if( ((calojetIter->et())*cosh(calojetIter->eta()) > JetMinE_) and (calojetIter->energyFractionHadronic() > JetHCALminEnergyFraction_) ) {
 	   JetContainer.push_back(*calojetIter);
 	   double maxTowerE = 0.0;
 	   for(CaloTowerCollection::const_iterator kal = towerHandle->begin(); kal != towerHandle->end(); kal++) {
 	     double dR = deltaR((*calojetIter).eta(),(*calojetIter).phi(),(*kal).eta(),(*kal).phi());
-	     if( (dR < 0.50) && (kal->p() > maxTowerE) ) {
+	     if( (dR < 0.50) and (kal->p() > maxTowerE) ) {
 	       maxTowerE = kal->p();
 	       seedTower = *kal;
 	     }
@@ -100,10 +97,9 @@ bool HLTHcalNoiseFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iS
 	 
        }
        if(JetContainer.size() > 0) {
-	 nAnomalousEvents++;
 	 isAnomalous_BasedOnEnergyFraction = true;
        }
      }
    
-   return ((useMet_&&isAnomalous_BasedOnMET)||(useJet_&&isAnomalous_BasedOnEnergyFraction));
+   return ((useMet_ and isAnomalous_BasedOnMET) or (useJet_ and isAnomalous_BasedOnEnergyFraction));
 }

--- a/HLTrigger/special/src/HLTHcalNoiseFilter.cc
+++ b/HLTrigger/special/src/HLTHcalNoiseFilter.cc
@@ -1,4 +1,4 @@
-// Author:  Alfredo Gurrola 
+// Author:  Alfredo Gurrola
 //(20/11/08 make MET and JET logic independent   /Grigory Safronov)
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -9,7 +9,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
-HLTHcalNoiseFilter::HLTHcalNoiseFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTHcalNoiseFilter::HLTHcalNoiseFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   JetSource_ = iConfig.getParameter<edm::InputTag>("JetSource");
   MetSource_ = iConfig.getParameter<edm::InputTag>("MetSource");
@@ -50,13 +50,13 @@ HLTHcalNoiseFilter::fillDescriptions(edm::ConfigurationDescriptions& description
 // member functions
 //
 
-bool HLTHcalNoiseFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTHcalNoiseFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
    using namespace edm;
    using namespace reco;
 
    bool isAnomalous_BasedOnMET = false;
-   bool isAnomalous_BasedOnEnergyFraction=false; 
+   bool isAnomalous_BasedOnEnergyFraction=false;
 
    if (useMet_)
      {
@@ -64,15 +64,15 @@ bool HLTHcalNoiseFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iS
        iEvent.getByToken(MetSourceToken_, metHandle);
        const CaloMETCollection *metCol = metHandle.product();
        const CaloMET met = metCol->front();
-    
+
        if(met.pt() > MetCut_) isAnomalous_BasedOnMET=true;
      }
-       
+
    if (useJet_)
      {
        Handle<CaloJetCollection> calojetHandle;
        iEvent.getByToken(JetSourceToken_,calojetHandle);
-       
+
        Handle<CaloTowerCollection> towerHandle;
        iEvent.getByToken(TowerSourceToken_, towerHandle);
 
@@ -94,12 +94,12 @@ bool HLTHcalNoiseFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iS
 	   }
 	   TowerContainer.push_back(seedTower);
 	 }
-	 
+	
        }
        if(JetContainer.size() > 0) {
 	 isAnomalous_BasedOnEnergyFraction = true;
        }
      }
-   
+
    return ((useMet_ and isAnomalous_BasedOnMET) or (useJet_ and isAnomalous_BasedOnEnergyFraction));
 }

--- a/HLTrigger/special/src/HLTHcalPhiSymFilter.cc
+++ b/HLTrigger/special/src/HLTHcalPhiSymFilter.cc
@@ -49,7 +49,7 @@ HLTHcalPhiSymFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptio
 
 // ------------ method called to produce the data  ------------
 bool
-HLTHcalPhiSymFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTHcalPhiSymFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   edm::Handle<HBHERecHitCollection> HBHERecHitsH;
   edm::Handle<HORecHitCollection> HORecHitsH;

--- a/HLTrigger/special/src/HLTHcalPhiSymFilter.cc
+++ b/HLTrigger/special/src/HLTHcalPhiSymFilter.cc
@@ -2,7 +2,7 @@
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-HLTHcalPhiSymFilter::HLTHcalPhiSymFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTHcalPhiSymFilter::HLTHcalPhiSymFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   HBHEHits_ = iConfig.getParameter< edm::InputTag > ("HBHEHitCollection");
   HOHits_ = iConfig.getParameter< edm::InputTag > ("HOHitCollection");
@@ -49,22 +49,22 @@ HLTHcalPhiSymFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptio
 
 // ------------ method called to produce the data  ------------
 bool
-HLTHcalPhiSymFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+HLTHcalPhiSymFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   edm::Handle<HBHERecHitCollection> HBHERecHitsH;
   edm::Handle<HORecHitCollection> HORecHitsH;
   edm::Handle<HFRecHitCollection> HFRecHitsH;
-  
+
   iEvent.getByToken(HBHEHitsToken_,HBHERecHitsH);
   iEvent.getByToken(HOHitsToken_,HORecHitsH);
   iEvent.getByToken(HFHitsToken_,HFRecHitsH);
- 
+
   //Create empty output collections
   std::auto_ptr< HBHERecHitCollection > phiSymHBHERecHitCollection( new HBHERecHitCollection );
   std::auto_ptr< HORecHitCollection > phiSymHORecHitCollection( new HORecHitCollection );
   std::auto_ptr< HFRecHitCollection > phiSymHFRecHitCollection( new HFRecHitCollection );
 
-  //Select interesting HBHERecHits 
+  //Select interesting HBHERecHits
   for (HBHERecHitCollection::const_iterator it=HBHERecHitsH->begin(); it!=HBHERecHitsH->end(); it++) {
     if (it->energy()>eCut_HB_&&it->id().subdet()==1) {
         phiSymHBHERecHitCollection->push_back(*it);
@@ -74,7 +74,7 @@ HLTHcalPhiSymFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup
     }
 
   }
-  
+
   //Select interesting HORecHits
   for (HORecHitCollection::const_iterator it=HORecHitsH->begin(); it!=HORecHitsH->end(); it++) {
     if (it->energy()>eCut_HO_&&it->id().subdet()==3) {
@@ -95,6 +95,6 @@ HLTHcalPhiSymFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup
   if (phiSymHBHERecHitCollection->size()>0) iEvent.put( phiSymHBHERecHitCollection, phiSymHBHEHits_);
   if (phiSymHORecHitCollection->size()>0) iEvent.put( phiSymHORecHitCollection, phiSymHOHits_);
   if (phiSymHFRecHitCollection->size()>0) iEvent.put( phiSymHFRecHitCollection, phiSymHFHits_);
-  
+
   return true;
 }

--- a/HLTrigger/special/src/HLTHcalSimpleRecHitFilter.cc
+++ b/HLTrigger/special/src/HLTHcalSimpleRecHitFilter.cc
@@ -45,7 +45,7 @@ public:
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
     // ----------member data ---------------------------
     edm::EDGetTokenT<HFRecHitCollection> HcalRecHitsToken_;
@@ -114,7 +114,7 @@ HLTHcalSimpleRecHitFilter::fillDescriptions(edm::ConfigurationDescriptions& desc
 
 // ------------ method called on each new Event  ------------
 bool
-HLTHcalSimpleRecHitFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+HLTHcalSimpleRecHitFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
     // using namespace edm;
 
     // getting very basic uncalRH

--- a/HLTrigger/special/src/HLTHcalSimpleRecHitFilter.cc
+++ b/HLTrigger/special/src/HLTHcalSimpleRecHitFilter.cc
@@ -45,7 +45,7 @@ public:
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
     
 private:
-    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
     
     // ----------member data ---------------------------
     edm::EDGetTokenT<HFRecHitCollection> HcalRecHitsToken_;
@@ -114,7 +114,7 @@ HLTHcalSimpleRecHitFilter::fillDescriptions(edm::ConfigurationDescriptions& desc
 
 // ------------ method called on each new Event  ------------
 bool
-HLTHcalSimpleRecHitFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+HLTHcalSimpleRecHitFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
     // using namespace edm;
 
     // getting very basic uncalRH

--- a/HLTrigger/special/src/HLTHcalSimpleRecHitFilter.cc
+++ b/HLTrigger/special/src/HLTHcalSimpleRecHitFilter.cc
@@ -2,7 +2,7 @@
 //
 // Package:    HLTHcalSimpleRecHitFilter
 // Class:      HLTHcalSimpleRecHitFilter
-// 
+//
 /**\class HLTHcalSimpleRecHitFilter HLTHcalSimpleRecHitFilter.cc Work/HLTHcalSimpleRecHitFilter/src/HLTHcalSimpleRecHitFilter.cc
 
  Description: <one line class summary>
@@ -43,10 +43,10 @@ public:
     explicit HLTHcalSimpleRecHitFilter(const edm::ParameterSet&);
     ~HLTHcalSimpleRecHitFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    
+
 private:
     virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
-    
+
     // ----------member data ---------------------------
     edm::EDGetTokenT<HFRecHitCollection> HcalRecHitsToken_;
     edm::InputTag HcalRecHitCollection_;
@@ -55,13 +55,13 @@ private:
     int minNHitsPos_;
     bool doCoincidence_;
     std::vector<unsigned int> maskedList_;
-    
+
 };
 
 //
 // constructors and destructor
 //
-HLTHcalSimpleRecHitFilter::HLTHcalSimpleRecHitFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTHcalSimpleRecHitFilter::HLTHcalSimpleRecHitFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
     //now do what ever initialization is needed
     threshold_     = iConfig.getParameter<double>("threshold");
@@ -73,7 +73,7 @@ HLTHcalSimpleRecHitFilter::HLTHcalSimpleRecHitFilter(const edm::ParameterSet& iC
     else
       //worry about possible user menus with the old interface
       if (iConfig.existsAs<std::vector<int> >("maskedChannels")) {
-	std::vector<int> tVec=iConfig.getParameter<std::vector<int> >("maskedChannels"); 
+	std::vector<int> tVec=iConfig.getParameter<std::vector<int> >("maskedChannels");
 	if ( tVec.size() > 0 ) {
 	  edm::LogError("cfg error")  << "masked list of channels missing from HLT menu. Migration from vector of ints to vector of uints needed for this release";
 	  cms::Exception("Invalid/obsolete masked list of channels");
@@ -86,7 +86,7 @@ HLTHcalSimpleRecHitFilter::HLTHcalSimpleRecHitFilter(const edm::ParameterSet& iC
 
 HLTHcalSimpleRecHitFilter::~HLTHcalSimpleRecHitFilter()
 {
- 
+
    // do anything here that needs to be done at desctruction time
    // (e.g. close files, deallocate resources etc.)
 
@@ -124,19 +124,17 @@ HLTHcalSimpleRecHitFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& 
     } catch ( std::exception& ex) {
         edm::LogWarning("HLTHcalSimpleRecHitFilter") << HcalRecHitCollection_ << " not available";
     }
-    
-    bool accept = false ; 
+
+    bool accept = false ;
 
     int nHitsNeg=0, nHitsPos=0;
-    for ( HFRecHitCollection::const_iterator hitItr = crudeHits->begin(); hitItr != crudeHits->end(); ++hitItr ) {     
+    for ( HFRecHitCollection::const_iterator hitItr = crudeHits->begin(); hitItr != crudeHits->end(); ++hitItr ) {
        HFRecHit hit = (*hitItr);
-     
+
        // masking noisy channels
-       std::vector<unsigned int>::iterator result;
-       result = find( maskedList_.begin(), maskedList_.end(), hit.id().rawId());    
-       if  (result != maskedList_.end()) 
-           continue; 
-       
+       if (std::find( maskedList_.begin(), maskedList_.end(), hit.id().rawId() ) != maskedList_.end())
+           continue;
+
        // only count tower above threshold
        if ( hit.energy() < threshold_ ) continue;
 
@@ -148,13 +146,13 @@ HLTHcalSimpleRecHitFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& 
     // Logic
     if (!doCoincidence_) accept = (nHitsNeg>=minNHitsNeg_) || (nHitsPos>=minNHitsPos_);
     else accept = (nHitsNeg>=minNHitsNeg_) && (nHitsPos>=minNHitsPos_);
-//  edm::LogInfo("HcalFilter")  << "at evet: " << iEvent.id().event() 
+//  edm::LogInfo("HcalFilter")  << "at evet: " << iEvent.id().event()
 //    << " and run: " << iEvent.id().run()
 //    << " Total HF hits: " << crudeHits->size() << " Above Threshold - nNeg: " << nHitsNeg << " nPos " << nHitsPos
 //    << " doCoinc: " << doCoincidence_ << " accept: " << accept << std::endl;
 
     // result
-    return accept; 
+    return accept;
 }
 
 //define this as a plug-in

--- a/HLTrigger/special/src/HLTHcalTowerFilter.cc
+++ b/HLTrigger/special/src/HLTHcalTowerFilter.cc
@@ -1,5 +1,5 @@
 /** \class HLTHcalTowerFilter
- *  
+ *
  *  This class is an EDFilter implementing the following requirement:
  *  the number of caltowers with hadEnergy>E_Thr less than N_Thr for HB/HE/HF sperately.
  *
@@ -17,16 +17,16 @@
 //
 // class declaration
 //
-class HLTHcalTowerFilter : public HLTFilter 
+class HLTHcalTowerFilter : public HLTFilter
 {
 public:
   explicit HLTHcalTowerFilter(const edm::ParameterSet &);
   ~HLTHcalTowerFilter();
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  
+
 private:
-  virtual bool hltFilter(edm::Event &, const edm::EventSetup &, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
-  
+  virtual bool hltFilter(edm::Event &, const edm::EventSetup &, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+
   edm::EDGetTokenT<CaloTowerCollection> inputToken_;
   edm::InputTag inputTag_;    // input tag identifying product
   double min_E_HB_;           // energy threshold for HB in GeV
@@ -103,14 +103,14 @@ HLTHcalTowerFilter::fillDescriptions(edm::ConfigurationDescriptions& description
 //
 
 // ------------ method called to produce the data  ------------
-bool 
-HLTHcalTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool
+HLTHcalTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;
   using namespace reco;
   using namespace trigger;
-   
+
   // The filter object
   if (saveTags()) filterproduct.addCollectionTag(inputTag_);
 
@@ -126,13 +126,13 @@ HLTHcalTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, t
   int n_HFP = 0;
   double abseta = 0.0;
   double eta = 0.0;
-  for(CaloTowerCollection::const_iterator i = towers->begin(); i != towers->end(); ++i) 
+  for(CaloTowerCollection::const_iterator i = towers->begin(); i != towers->end(); ++i)
     {
       eta    = i->eta();
       abseta = std::abs(eta);
       if(abseta<1.305)
 	{
-	  if(i->hadEnergy() >= min_E_HB_) 
+	  if(i->hadEnergy() >= min_E_HB_)
 	    {
 	      n_HB++;
 	      //edm::Ref<CaloTowerCollection> ref(towers, std::distance(towers->begin(), i));
@@ -150,7 +150,7 @@ HLTHcalTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, t
 	}
       else
 	{
-	  if(i->hadEnergy() >= min_E_HF_) 
+	  if(i->hadEnergy() >= min_E_HF_)
 	    {
 	      n_HF++;
 	      //edm::Ref<CaloTowerCollection> ref(towers, std::distance(towers->begin(), i));

--- a/HLTrigger/special/src/HLTHcalTowerFilter.cc
+++ b/HLTrigger/special/src/HLTHcalTowerFilter.cc
@@ -25,7 +25,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
   
 private:
-  virtual bool hltFilter(edm::Event &, const edm::EventSetup &, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+  virtual bool hltFilter(edm::Event &, const edm::EventSetup &, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
   
   edm::EDGetTokenT<CaloTowerCollection> inputToken_;
   edm::InputTag inputTag_;    // input tag identifying product
@@ -104,7 +104,7 @@ HLTHcalTowerFilter::fillDescriptions(edm::ConfigurationDescriptions& description
 
 // ------------ method called to produce the data  ------------
 bool 
-HLTHcalTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+HLTHcalTowerFilter::hltFilter(edm::Event& event, const edm::EventSetup& setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/HLTrigger/special/src/HLTPixelActivityFilter.cc
+++ b/HLTrigger/special/src/HLTPixelActivityFilter.cc
@@ -17,7 +17,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
 
   edm::InputTag inputTag_;          // input tag identifying product containing pixel clusters
   unsigned int  min_clusters_;      // minimum number of clusters
@@ -68,7 +68,7 @@ HLTPixelActivityFilter::fillDescriptions(edm::ConfigurationDescriptions& descrip
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTPixelActivityFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTPixelActivityFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   // All HLT filters must create and fill an HLT filter object,
   // recording any reconstructed physics objects satisfying (or not)

--- a/HLTrigger/special/src/HLTPixelActivityFilter.cc
+++ b/HLTrigger/special/src/HLTPixelActivityFilter.cc
@@ -17,7 +17,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
   edm::InputTag inputTag_;          // input tag identifying product containing pixel clusters
   unsigned int  min_clusters_;      // minimum number of clusters
@@ -36,7 +36,7 @@ private:
 //
 // constructors and destructor
 //
- 
+
 HLTPixelActivityFilter::HLTPixelActivityFilter(const edm::ParameterSet& config) : HLTFilter(config),
   inputTag_     (config.getParameter<edm::InputTag>("inputTag")),
   min_clusters_ (config.getParameter<unsigned int>("minClusters")),
@@ -45,7 +45,7 @@ HLTPixelActivityFilter::HLTPixelActivityFilter(const edm::ParameterSet& config) 
   inputToken_ = consumes<edmNew::DetSetVector<SiPixelCluster> >(inputTag_);
   LogDebug("") << "Using the " << inputTag_ << " input collection";
   LogDebug("") << "Requesting at least " << min_clusters_ << " clusters";
-  if(max_clusters_ > 0) 
+  if(max_clusters_ > 0)
     LogDebug("") << "...but no more than " << max_clusters_ << " clusters";
 }
 
@@ -68,7 +68,7 @@ HLTPixelActivityFilter::fillDescriptions(edm::ConfigurationDescriptions& descrip
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTPixelActivityFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTPixelActivityFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   // All HLT filters must create and fill an HLT filter object,
   // recording any reconstructed physics objects satisfying (or not)
@@ -84,7 +84,7 @@ bool HLTPixelActivityFilter::hltFilter(edm::Event& event, const edm::EventSetup&
   unsigned int clusterSize = clusterColl->dataSize();
   LogDebug("") << "Number of clusters accepted: " << clusterSize;
   bool accept = (clusterSize >= min_clusters_);
-  if(max_clusters_ > 0) 
+  if(max_clusters_ > 0)
     accept &= (clusterSize <= max_clusters_);
 
   // return with final filter decision

--- a/HLTrigger/special/src/HLTPixelAsymmetryFilter.cc
+++ b/HLTrigger/special/src/HLTPixelAsymmetryFilter.cc
@@ -49,7 +49,7 @@ HLTPixelAsymmetryFilter::fillDescriptions(edm::ConfigurationDescriptions& descri
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTPixelAsymmetryFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTPixelAsymmetryFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   // All HLT filters must create and fill an HLT filter object,
   // recording any reconstructed physics objects satisfying (or not)

--- a/HLTrigger/special/src/HLTPixelAsymmetryFilter.cc
+++ b/HLTrigger/special/src/HLTPixelAsymmetryFilter.cc
@@ -13,7 +13,7 @@
 //
 // constructors and destructor
 //
- 
+
 HLTPixelAsymmetryFilter::HLTPixelAsymmetryFilter(const edm::ParameterSet& config) : HLTFilter(config),
   inputTag_ (config.getParameter<edm::InputTag>("inputTag")),
   min_asym_ (config.getParameter<double>("MinAsym")),
@@ -37,7 +37,7 @@ HLTPixelAsymmetryFilter::fillDescriptions(edm::ConfigurationDescriptions& descri
   edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
   desc.add<edm::InputTag>("inputTag",edm::InputTag("hltSiPixelClusters"));
-  desc.add<double>("MinAsym",0.);        // minimum asymmetry 
+  desc.add<double>("MinAsym",0.);        // minimum asymmetry
   desc.add<double>("MaxAsym",1.);        // maximum asymmetry
   desc.add<double>("MinCharge",4000.);   // minimum charge for a cluster to be selected (in e-)
   desc.add<double>("MinBarrel",10000.);  // minimum average charge in the barrel (bpix, in e-)
@@ -49,7 +49,7 @@ HLTPixelAsymmetryFilter::fillDescriptions(edm::ConfigurationDescriptions& descri
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTPixelAsymmetryFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTPixelAsymmetryFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   // All HLT filters must create and fill an HLT filter object,
   // recording any reconstructed physics objects satisfying (or not)
@@ -75,7 +75,7 @@ bool HLTPixelAsymmetryFilter::hltFilter(edm::Event& event, const edm::EventSetup
   int n_clus[3]   = {0,0,0};
   double e_clus[3] = {0.,0.,0.};
 
-  for (edmNew::DetSetVector<SiPixelCluster>::const_iterator DSViter=clusterColl->begin(); DSViter!=clusterColl->end();DSViter++ ) 
+  for (edmNew::DetSetVector<SiPixelCluster>::const_iterator DSViter=clusterColl->begin(); DSViter!=clusterColl->end();DSViter++ )
   {
     edmNew::DetSet<SiPixelCluster>::const_iterator begin=DSViter->begin();
     edmNew::DetSet<SiPixelCluster>::const_iterator end  =DSViter->end();
@@ -105,17 +105,17 @@ bool HLTPixelAsymmetryFilter::hltFilter(edm::Event& event, const edm::EventSetup
 
     if (detpos<0) continue;
 
-    for(edmNew::DetSet<SiPixelCluster>::const_iterator iter=begin;iter!=end;++iter) 
+    for(edmNew::DetSet<SiPixelCluster>::const_iterator iter=begin;iter!=end;++iter)
     {
       if (iter->charge()>clus_thresh_ )
       {
 	++n_clus[detpos];
 	e_clus[detpos]+=iter->charge();
-      }    
+      }
     }
   } // End of cluster loop
 
-  for (int i=0;i<3;++i) 
+  for (int i=0;i<3;++i)
   {
     if (n_clus[i])
       e_clus[i] /= n_clus[i];

--- a/HLTrigger/special/src/HLTPixelClusterShapeFilter.cc
+++ b/HLTrigger/special/src/HLTPixelClusterShapeFilter.cc
@@ -35,7 +35,7 @@ private:
     float w;
   };
 
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
   int getContainedHits(const std::vector<VertexHit> &hits, double z0, double &chi) const;
 
 };
@@ -98,7 +98,7 @@ HLTPixelClusterShapeFilter::fillDescriptions(edm::ConfigurationDescriptions& des
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTPixelClusterShapeFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTPixelClusterShapeFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   // All HLT filters must create and fill an HLT filter object,
   // recording any reconstructed physics objects satisfying (or not)

--- a/HLTrigger/special/src/HLTPixelClusterShapeFilter.cc
+++ b/HLTrigger/special/src/HLTPixelClusterShapeFilter.cc
@@ -35,7 +35,7 @@ private:
     float w;
   };
 
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
   int getContainedHits(const std::vector<VertexHit> &hits, double z0, double &chi);
 
 };
@@ -98,7 +98,7 @@ HLTPixelClusterShapeFilter::fillDescriptions(edm::ConfigurationDescriptions& des
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTPixelClusterShapeFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTPixelClusterShapeFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   // All HLT filters must create and fill an HLT filter object,
   // recording any reconstructed physics objects satisfying (or not)

--- a/HLTrigger/special/src/HLTPixelClusterShapeFilter.cc
+++ b/HLTrigger/special/src/HLTPixelClusterShapeFilter.cc
@@ -36,7 +36,7 @@ private:
   };
 
   virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
-  int getContainedHits(const std::vector<VertexHit> &hits, double z0, double &chi);
+  int getContainedHits(const std::vector<VertexHit> &hits, double z0, double &chi) const;
 
 };
 
@@ -60,7 +60,7 @@ private:
 //
 // constructors and destructor
 //
- 
+
 HLTPixelClusterShapeFilter::HLTPixelClusterShapeFilter(const edm::ParameterSet& config) : HLTFilter(config),
   inputTag_     (config.getParameter<edm::InputTag>("inputTag")),
   minZ_         (config.getParameter<double>("minZ")),
@@ -83,8 +83,8 @@ HLTPixelClusterShapeFilter::fillDescriptions(edm::ConfigurationDescriptions& des
   edm::ParameterSetDescription desc;
   makeHLTFilterDescription(desc);
   desc.add<edm::InputTag>("inputTag",edm::InputTag("hltSiPixelRecHits"));
-  desc.add<double>("minZ",-20.0); 
-  desc.add<double>("maxZ",20.05); 
+  desc.add<double>("minZ",-20.0);
+  desc.add<double>("maxZ",20.05);
   desc.add<double>("zStep",0.2);
   std::vector<double> temp; temp.push_back(0.0); temp.push_back(0.0045);
   desc.add<std::vector<double> >("clusterPars",temp);
@@ -122,7 +122,7 @@ bool HLTPixelClusterShapeFilter::hltFilter(edm::Event& event, const edm::EventSe
     // loop over pixel rechits
     int nPxlHits=0;
     std::vector<VertexHit> vhits;
-    for(SiPixelRecHitCollection::DataContainer::const_iterator hit = hits->data().begin(), 
+    for(SiPixelRecHitCollection::DataContainer::const_iterator hit = hits->data().begin(),
           end = hits->data().end(); hit != end; ++hit) {
       if (!hit->isValid())
         continue;
@@ -135,7 +135,7 @@ bool HLTPixelClusterShapeFilter::hltFilter(edm::Event& event, const edm::EventSe
         const PixelTopology *pixTopo = &(pgdu->specificTopology());
         std::vector<SiPixelCluster::Pixel> pixels(hit->cluster()->pixels());
         bool pixelOnEdge = false;
-        for(std::vector<SiPixelCluster::Pixel>::const_iterator pixel = pixels.begin(); 
+        for(std::vector<SiPixelCluster::Pixel>::const_iterator pixel = pixels.begin();
             pixel != pixels.end(); ++pixel) {
           int pixelX = pixel->x;
           int pixelY = pixel->y;
@@ -153,8 +153,8 @@ bool HLTPixelClusterShapeFilter::hltFilter(edm::Event& event, const edm::EventSe
 				   hit->localPosition().z());
       GlobalPoint gpos = pgdu->toGlobal(lpos);
       VertexHit vh;
-      vh.z = gpos.z(); 
-      vh.r = gpos.perp(); 
+      vh.z = gpos.z();
+      vh.r = gpos.perp();
       vh.w = hit->cluster()->sizeY();
       vhits.push_back(vh);
     }
@@ -165,17 +165,17 @@ bool HLTPixelClusterShapeFilter::hltFilter(edm::Event& event, const edm::EventSe
     double chi = 0, chi_max = 1e+9;
     for(double z0 = minZ_; z0 <= maxZ_; z0 += zStep_) {
       nhits = getContainedHits(vhits, z0, chi);
-      if(nhits == 0) 
+      if(nhits == 0)
 	continue;
-      if(nhits > nhits_max) { 
-	chi_max = 1e+9; 
-	nhits_max = nhits; 
+      if(nhits > nhits_max) {
+	chi_max = 1e+9;
+	nhits_max = nhits;
       }
       if(nhits >= nhits_max && chi < chi_max) {
-	chi_max = chi; 
-	zest = z0;   
+	chi_max = chi;
+	zest = z0;
       }
-    } 
+    }
 
     chi = 0;
     int nbest=0, nminus=0, nplus=0;
@@ -196,9 +196,9 @@ bool HLTPixelClusterShapeFilter::hltFilter(edm::Event& event, const edm::EventSe
   for(unsigned int i=0; i < clusterPars_.size(); i++) {
     polyCut += clusterPars_[i]*std::pow((double)nPxlHits,(int)i);
   }
-  if(nPxlHits < nhitsTrunc_) 
+  if(nPxlHits < nhitsTrunc_)
     polyCut=0;             // don't use cut below nhitsTrunc_ pixel hits
-  if(polyCut > clusterTrunc_ && clusterTrunc_ > 0) 
+  if(polyCut > clusterTrunc_ && clusterTrunc_ > 0)
     polyCut=clusterTrunc_; // no cut above clusterTrunc_
 
   if (clusVtxQual < polyCut) accept = false;
@@ -208,7 +208,7 @@ bool HLTPixelClusterShapeFilter::hltFilter(edm::Event& event, const edm::EventSe
   return accept;
 }
 
-int HLTPixelClusterShapeFilter::getContainedHits(const std::vector<VertexHit> &hits, double z0, double &chi)
+int HLTPixelClusterShapeFilter::getContainedHits(const std::vector<VertexHit> &hits, double z0, double &chi) const
 {
   // Calculate number of hits contained in v-shaped window in cluster y-width vs. z-position.
   int n = 0;
@@ -216,7 +216,7 @@ int HLTPixelClusterShapeFilter::getContainedHits(const std::vector<VertexHit> &h
 
   for(std::vector<VertexHit>::const_iterator hit = hits.begin(); hit!= hits.end(); hit++) {
     double p = 2 * fabs(hit->z - z0)/hit->r + 0.5; // FIXME
-    if(fabs(p - hit->w) <= 1.) { 
+    if(fabs(p - hit->w) <= 1.) {
       chi += fabs(p - hit->w);
       n++;
     }

--- a/HLTrigger/special/src/HLTPixelIsolTrackFilter.cc
+++ b/HLTrigger/special/src/HLTPixelIsolTrackFilter.cc
@@ -9,7 +9,7 @@
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
-HLTPixelIsolTrackFilter::HLTPixelIsolTrackFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTPixelIsolTrackFilter::HLTPixelIsolTrackFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   candTag_             = iConfig.getParameter<edm::InputTag> ("candTag");
   hltGTseedlabel_      = iConfig.getParameter<edm::InputTag> ("L1GTSeedLabel");
@@ -47,7 +47,7 @@ HLTPixelIsolTrackFilter::fillDescriptions(edm::ConfigurationDescriptions& descri
   descriptions.add("isolPixelTrackFilter",desc);
 }
 
-bool HLTPixelIsolTrackFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTPixelIsolTrackFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   if (saveTags())
     filterproduct.addCollectionTag(candTag_);
@@ -66,18 +66,18 @@ bool HLTPixelIsolTrackFilter::hltFilter(edm::Event& iEvent, const edm::EventSetu
 
   edm::Handle<trigger::TriggerFilterObjectWithRefs> l1trigobj;
   iEvent.getByToken(hltGTseedToken_, l1trigobj);
-  
+
   std::vector< edm::Ref<l1extra::L1JetParticleCollection> > l1tauobjref;
   std::vector< edm::Ref<l1extra::L1JetParticleCollection> > l1jetobjref;
   std::vector< edm::Ref<l1extra::L1JetParticleCollection> > l1forjetobjref;
-  
+
   l1trigobj->getObjects(trigger::TriggerL1TauJet, l1tauobjref);
   l1trigobj->getObjects(trigger::TriggerL1CenJet, l1jetobjref);
   l1trigobj->getObjects(trigger::TriggerL1ForJet, l1forjetobjref);
-  
+
   for (unsigned int p=0; p<l1tauobjref.size(); p++)
       if (l1tauobjref[p]->pt() > ptTriggered)
-	  ptTriggered = l1tauobjref[p]->pt(); 
+	  ptTriggered = l1tauobjref[p]->pt();
   for (unsigned int p=0; p<l1jetobjref.size(); p++)
       if (l1jetobjref[p]->pt() > ptTriggered)
 	  ptTriggered = l1jetobjref[p]->pt();
@@ -89,10 +89,10 @@ bool HLTPixelIsolTrackFilter::hltFilter(edm::Event& iEvent, const edm::EventSetu
   for (unsigned int i=0; i<recotrackcands->size(); i++)
     {
       candref = edm::Ref<reco::IsolatedPixelTrackCandidateCollection>(recotrackcands, i);
-      
+
       // cut on deltaPT
       if (ptTriggered-candref->pt()<minDeltaPtL1Jet_) continue;
-      
+
       // select on transverse momentum
       if (!filterE_&&(candref->maxPtPxl()<maxptnearby_)&&
 	  (candref->pt()>minpttrack_)&&fabs(candref->track()->eta())<maxetatrack_&&fabs(candref->track()->eta())>minetatrack_)
@@ -111,11 +111,11 @@ bool HLTPixelIsolTrackFilter::hltFilter(edm::Event& iEvent, const edm::EventSetu
       }
 
       // stop looping over tracks if max number is reached
-      if(!dropMultiL2Event_ && n>=nMaxTrackCandidates_) break; 
+      if(!dropMultiL2Event_ && n>=nMaxTrackCandidates_) break;
 
     } // loop over tracks
-  
-  
+
+
   bool accept(n>0);
 
   if( dropMultiL2Event_ && n>nMaxTrackCandidates_ ) accept=false;
@@ -123,4 +123,4 @@ bool HLTPixelIsolTrackFilter::hltFilter(edm::Event& iEvent, const edm::EventSetu
   return accept;
 
 }
-	  
+	

--- a/HLTrigger/special/src/HLTPixelIsolTrackFilter.cc
+++ b/HLTrigger/special/src/HLTPixelIsolTrackFilter.cc
@@ -47,7 +47,7 @@ HLTPixelIsolTrackFilter::fillDescriptions(edm::ConfigurationDescriptions& descri
   descriptions.add("isolPixelTrackFilter",desc);
 }
 
-bool HLTPixelIsolTrackFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTPixelIsolTrackFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   if (saveTags())
     filterproduct.addCollectionTag(candTag_);

--- a/HLTrigger/special/src/HLTPixlMBFilt.cc
+++ b/HLTrigger/special/src/HLTPixlMBFilt.cc
@@ -27,7 +27,7 @@
 //
 // constructors and destructor
 //
- 
+
 HLTPixlMBFilt::HLTPixlMBFilt(const edm::ParameterSet& iConfig) : HLTFilter(iConfig),
     pixlTag_ (iConfig.getParameter<edm::InputTag>("pixlTag")),
     min_Pt_  (iConfig.getParameter<double>("MinPt")),
@@ -61,7 +61,7 @@ HLTPixlMBFilt::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTPixlMBFilt::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTPixlMBFilt::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
    using namespace std;
    using namespace edm;
@@ -93,9 +93,9 @@ bool HLTPixlMBFilt::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
    unsigned int nsame_vtx=0;
    int itrk = -1;
    if (tracks->size() >= min_trks_) {
-     for (ipixl=apixl; ipixl!=epixl; ipixl++){ 
+     for (ipixl=apixl; ipixl!=epixl; ipixl++){
        itrk++;
-       const double& ztrk1 = ipixl->vz();		    
+       const double& ztrk1 = ipixl->vz();		
        const double& etatrk1 = ipixl->momentum().eta();
        const double& phitrk1 = ipixl->momentum().phi();
        nsame_vtx=1;
@@ -111,7 +111,7 @@ bool HLTPixlMBFilt::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup,
          for (jpixl=apixl; jpixl!=epixl; jpixl++) {
 	   jtrk++;
 	   if (jpixl==ipixl) continue;
-           const double& ztrk2 = jpixl->vz();		    
+           const double& ztrk2 = jpixl->vz();		
            const double& etatrk2 = jpixl->momentum().eta();
            const double& phitrk2 = jpixl->momentum().phi();
            double eta_dist=etatrk2-etatrk1;

--- a/HLTrigger/special/src/HLTPixlMBFilt.cc
+++ b/HLTrigger/special/src/HLTPixlMBFilt.cc
@@ -61,7 +61,7 @@ HLTPixlMBFilt::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTPixlMBFilt::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTPixlMBFilt::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
    using namespace std;
    using namespace edm;

--- a/HLTrigger/special/src/HLTPixlMBForAlignmentFilter.cc
+++ b/HLTrigger/special/src/HLTPixlMBForAlignmentFilter.cc
@@ -64,7 +64,7 @@ HLTPixlMBForAlignmentFilter::fillDescriptions(edm::ConfigurationDescriptions& de
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTPixlMBForAlignmentFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTPixlMBForAlignmentFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
    using namespace std;
    using namespace edm;

--- a/HLTrigger/special/src/HLTPixlMBForAlignmentFilter.cc
+++ b/HLTrigger/special/src/HLTPixlMBForAlignmentFilter.cc
@@ -27,7 +27,7 @@
 //
 // constructors and destructor
 //
- 
+
 HLTPixlMBForAlignmentFilter::HLTPixlMBForAlignmentFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig),
     pixlTag_ (iConfig.getParameter<edm::InputTag>("pixlTag")),
     min_Pt_  (iConfig.getParameter<double>("MinPt")),
@@ -64,7 +64,7 @@ HLTPixlMBForAlignmentFilter::fillDescriptions(edm::ConfigurationDescriptions& de
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTPixlMBForAlignmentFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTPixlMBForAlignmentFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
    using namespace std;
    using namespace edm;
@@ -100,8 +100,8 @@ bool HLTPixlMBForAlignmentFilter::hltFilter(edm::Event& iEvent, const edm::Event
      etastore.clear();
      phistore.clear();
      itstore.clear();
-     for (ipixl=apixl; ipixl!=epixl; ipixl++){ 
-       const double& ztrk1 = ipixl->vz();                    
+     for (ipixl=apixl; ipixl!=epixl; ipixl++){
+       const double& ztrk1 = ipixl->vz();
        const double& etatrk1 = ipixl->momentum().eta();
        const double& phitrk1 = ipixl->momentum().phi();
        const double& pttrk1 = ipixl->pt();
@@ -131,7 +131,7 @@ bool HLTPixlMBForAlignmentFilter::hltFilter(edm::Event& iEvent, const edm::Event
        for (unsigned int i=0; i<itstore.size(); i++) {
          int nincone=0;
 //       check isolation wrt ALL tracks, not only those above ptcut
-         for (ipixl=apixl; ipixl!=epixl; ipixl++){ 
+         for (ipixl=apixl; ipixl!=epixl; ipixl++){
            double phidist=std::abs( phistore.at(i) - ipixl->momentum().phi() );
            double etadist=std::abs( etastore.at(i) - ipixl->momentum().eta() );
            double trkdist = sqrt(phidist*phidist + etadist*etadist);
@@ -171,7 +171,7 @@ bool HLTPixlMBForAlignmentFilter::hltFilter(edm::Event& iEvent, const edm::Event
              if (is_separated) itsep.push_back(locisol.at(j));
            }
          }
-         if (itsep.size() >= min_trks_) { 
+         if (itsep.size() >= min_trks_) {
            accept = true;
            break;
          }

--- a/HLTrigger/special/src/HLTRPCTrigNoSyncFilter.cc
+++ b/HLTrigger/special/src/HLTRPCTrigNoSyncFilter.cc
@@ -1,7 +1,7 @@
 // -*- C++ -*-
 //
 // Class:      HLTRPCTrigNoSyncFilter
-// 
+//
 /**\class RPCPathChambFilter HLTRPCTrigNoSyncFilter.cc HLTrigger/special/src/HLTRPCTrigNoSyncFilter.cc
 
  Description: <one line class summary>
@@ -43,14 +43,14 @@ bool bigmag(const RPC4DHit &Point1,const RPC4DHit &Point2){
   else return false;
 }
 
-HLTRPCTrigNoSyncFilter::HLTRPCTrigNoSyncFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig) 
+HLTRPCTrigNoSyncFilter::HLTRPCTrigNoSyncFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
 {
   //now do what ever initialization is needed
   m_GMTInputTag =iConfig.getParameter< edm::InputTag >("GMTInputTag");
   rpcRecHitsLabel = iConfig.getParameter<edm::InputTag>("rpcRecHits");
   m_GMTInputToken = consumes<L1MuGMTReadoutCollection>(m_GMTInputTag);
   rpcRecHitsToken = consumes<RPCRecHitCollection>(rpcRecHitsLabel);
-    
+
 }
 
 
@@ -74,17 +74,17 @@ HLTRPCTrigNoSyncFilter::fillDescriptions(edm::ConfigurationDescriptions& descrip
 //
 
 // ------------ method called on each new Event  ------------
-bool HLTRPCTrigNoSyncFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const{
+bool HLTRPCTrigNoSyncFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
 
   std::vector<RPC4DHit> GlobalRPC4DHits;
   std::vector<RPC4DHit> GlobalRPC4DHitsNoBx0;
 
   edm::Handle<RPCRecHitCollection> rpcRecHits;
-  
+
   //std::cout <<"\t Getting the RPC RecHits"<<std::endl;
 
   iEvent.getByToken(rpcRecHitsToken,rpcRecHits);
-  
+
   if(!rpcRecHits.isValid()){
     //std::cout<<"no valid RPC Collection"<<std::endl;
     //std::cout<<"event skipped"<<std::endl;
@@ -95,7 +95,7 @@ bool HLTRPCTrigNoSyncFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
     //std::cout<<"event skipped"<<std::endl;
     return false;
   }
-  
+
   RPCRecHitCollection::const_iterator recHit;
 
   edm::ESHandle<RPCGeometry> rpcGeo;
@@ -105,14 +105,14 @@ bool HLTRPCTrigNoSyncFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
 
   for (recHit = rpcRecHits->begin(); recHit != rpcRecHits->end(); recHit++){
     RPCDetId rollId = (RPCDetId)(*recHit).rpcId();
-    LocalPoint recHitPos=recHit->localPosition();    
+    LocalPoint recHitPos=recHit->localPosition();
     const RPCRoll* rollasociated = rpcGeo->roll(rollId);
-    const BoundPlane & RPCSurface = rollasociated->surface(); 
+    const BoundPlane & RPCSurface = rollasociated->surface();
     GlobalPoint RecHitInGlobal = RPCSurface.toGlobal(recHitPos);
-    
+
     int BX = recHit->BunchX();
     //std::cout<<"\t \t We have an RPC Rec Hit! bx="<<BX<<" Roll="<<rollId<<" Global Position="<<RecHitInGlobal<<std::endl;
-    
+
     RPC4DHit ThisHit;
     ThisHit.bx =  BX;
     ThisHit.gp = RecHitInGlobal;
@@ -133,12 +133,12 @@ bool HLTRPCTrigNoSyncFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
     //std::cout<<"event skipped"<<std::endl;
     return false;
   }
-   
+
   edm::Handle<L1MuGMTReadoutCollection> gmtrc_handle;
   iEvent.getByToken(m_GMTInputToken,gmtrc_handle);
-  
+
   std::vector<L1MuGMTExtendedCand> gmt_candidates = (*gmtrc_handle).getRecord().getGMTCands();
-  
+
   std::vector<L1MuGMTExtendedCand>::const_iterator candidate;
   //std::cout<<"The number of GMT Candidates in this event is "<<gmt_candidates.size()<<std::endl;
 
@@ -146,21 +146,21 @@ bool HLTRPCTrigNoSyncFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
     //std::cout<<"event skipped no gmt candidates"<<std::endl;
     return false;
   }
-  
+
   for(candidate=gmt_candidates.begin(); candidate!=gmt_candidates.end(); candidate++) {
     int qual = candidate->quality();
     //std::cout<<"quality of this GMT Candidate (should be >5)= "<<qual<<std::endl;
     if(qual < 5) continue;
     float eta=candidate->etaValue();
-    float phi=candidate->phiValue();      
-    
+    float phi=candidate->phiValue();
+
     //std::cout<<" phi="<<phi<<" eta="<<eta<<std::endl;
-    
+
     //Creating container in this etaphi direction;
-    
+
     std::vector<RPC4DHit> PointsForGMT;
-    
-    for(std::vector<RPC4DHit>::iterator Point = GlobalRPC4DHitsNoBx0.begin(); Point!=GlobalRPC4DHitsNoBx0.end(); ++Point){ 
+
+    for(std::vector<RPC4DHit>::iterator Point = GlobalRPC4DHitsNoBx0.begin(); Point!=GlobalRPC4DHitsNoBx0.end(); ++Point){
       float phiP = Point->gp.phi();
       float etaP = Point->gp.eta();
       //std::cout<<"\t \t GMT   phi="<<phi<<" eta="<<eta<<std::endl;
@@ -171,14 +171,14 @@ bool HLTRPCTrigNoSyncFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
 	//std::cout<<"\t \t match!"<<std::endl;
       }
     }
-    
+
     //std::cout<<"\t Points matching this GMT="<<PointsForGMT.size()<<std::endl;
 
     if(PointsForGMT.size()<1){
       //std::cout<<"\t Not enough RPCRecHits not syncrhonized for this GMT!!!"<<std::endl;
       continue;
     }
-      
+
     std::sort(PointsForGMT.begin(), PointsForGMT.end(), bigmag);
 
     //std::cout<<"GMT candidate phi="<<phi<<std::endl;
@@ -189,7 +189,7 @@ bool HLTRPCTrigNoSyncFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
     bool incr = true;
     bool anydifferentzero = true;
     bool anydifferentone = true;
-    
+
     //std::cout<<"\t \t loop on the RPCHit4D!!!"<<std::endl;
     for(std::vector<RPC4DHit>::iterator point = PointsForGMT.begin(); point < PointsForGMT.end(); ++point) {
       //float r=point->gp.mag();
@@ -201,31 +201,31 @@ bool HLTRPCTrigNoSyncFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup
       //std::cout<<"\t \t  r="<<r<<" phi="<<point->gp.phi()<<" eta="<<point->gp.eta()<<" bx="<<point->bx<<" outOfTime"<<outOfTime<<" incr"<<incr<<" anydifferentzero"<<anydifferentzero<<std::endl;
     }
     //std::cout<<"\t \t";
-    
+
     //for(std::vector<RPC4DHit>::iterator point = PointsForGMT.begin(); point < PointsForGMT.end(); ++point) {
       //std::cout<<point->bx;
     //}
     //std::cout<<std::endl;
-    
+
     bool Candidate = (outOfTime&&incr);
-    
-    if(Candidate){ 
+
+    if(Candidate){
       //std::cout<<" Event Passed We found an strange trigger Candidate phi="<<phi<<" eta="<<eta<<std::endl;
       return true;
     }
   }
-  
+
   //std::cout<<"event skipped rechits out of time but not related with a GMT "<<std::endl;
   return false;
 }
 
 // ------------ method called once each job just before starting event loop  ------------
-void 
+void
 HLTRPCTrigNoSyncFilter::beginJob(){
 }
 
 // ------------ method called once each job just after ending the event loop  ------------
-void 
+void
 HLTRPCTrigNoSyncFilter::endJob(){
 }
 

--- a/HLTrigger/special/src/HLTRPCTrigNoSyncFilter.cc
+++ b/HLTrigger/special/src/HLTRPCTrigNoSyncFilter.cc
@@ -74,7 +74,7 @@ HLTRPCTrigNoSyncFilter::fillDescriptions(edm::ConfigurationDescriptions& descrip
 //
 
 // ------------ method called on each new Event  ------------
-bool HLTRPCTrigNoSyncFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct){
+bool HLTRPCTrigNoSyncFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const{
 
   std::vector<RPC4DHit> GlobalRPC4DHits;
   std::vector<RPC4DHit> GlobalRPC4DHitsNoBx0;

--- a/HLTrigger/special/src/HLTSingleVertexPixelTrackFilter.cc
+++ b/HLTrigger/special/src/HLTSingleVertexPixelTrackFilter.cc
@@ -58,7 +58,7 @@ HLTSingleVertexPixelTrackFilter::fillDescriptions(edm::ConfigurationDescriptions
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTSingleVertexPixelTrackFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTSingleVertexPixelTrackFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
    // All HLT filters must create and fill an HLT filter object,
    // recording any reconstructed physics objects satisfying (or not)

--- a/HLTrigger/special/src/HLTSingleVertexPixelTrackFilter.cc
+++ b/HLTrigger/special/src/HLTSingleVertexPixelTrackFilter.cc
@@ -13,13 +13,13 @@
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
 #include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
 #include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h" 
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 // constructors and destructor
 //
- 
+
 HLTSingleVertexPixelTrackFilter::HLTSingleVertexPixelTrackFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig),
     pixelVerticesTag_ (iConfig.getParameter<edm::InputTag>("vertexCollection")),
     pixelTracksTag_ (iConfig.getParameter<edm::InputTag>("trackCollection")),
@@ -58,7 +58,7 @@ HLTSingleVertexPixelTrackFilter::fillDescriptions(edm::ConfigurationDescriptions
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTSingleVertexPixelTrackFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTSingleVertexPixelTrackFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
    // All HLT filters must create and fill an HLT filter object,
    // recording any reconstructed physics objects satisfying (or not)
@@ -70,7 +70,7 @@ bool HLTSingleVertexPixelTrackFilter::hltFilter(edm::Event& iEvent, const edm::E
    edm::Ref<reco::RecoChargedCandidateCollection> candref;
 
    // Specific filter code
-   bool accept = false; 
+   bool accept = false;
 
    int nTrackCandidate = 0;
 
@@ -91,7 +91,7 @@ bool HLTSingleVertexPixelTrackFilter::hltFilter(edm::Event& iEvent, const edm::E
             int ntracksize = verticesItr->tracksSize();
             double vz = verticesItr->z();
             if(fabs(vz) > max_Vz_) continue;
-            if( ntracksize > nmax) 
+            if( ntracksize > nmax)
             {
               vzmax = vz;
               nmax = ntracksize;
@@ -112,7 +112,7 @@ bool HLTSingleVertexPixelTrackFilter::hltFilter(edm::Event& iEvent, const edm::E
             if(fabs(eta) > max_Eta_) continue;
             double pt  = tracksItr->pt();
             if(pt < min_Pt_ || pt > max_Pt_) continue;
-            double vz = tracksItr->vz();   
+            double vz = tracksItr->vz();
             if(fabs(vz-vzmax) > min_sep_) continue;
 
             candref = edm::Ref<reco::RecoChargedCandidateCollection>(trackCollection, icount);
@@ -122,7 +122,7 @@ bool HLTSingleVertexPixelTrackFilter::hltFilter(edm::Event& iEvent, const edm::E
        }
      }
    }
-       
+
    accept = ( nTrackCandidate >= min_trks_ );
 
    return accept;

--- a/HLTrigger/special/src/HLTTrackSeedMultiplicityFilter.cc
+++ b/HLTrigger/special/src/HLTTrackSeedMultiplicityFilter.cc
@@ -17,7 +17,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
   edm::InputTag inputTag_;       // input tag identifying product containing track seeds
   unsigned int  min_seeds_;      // minimum number of track seeds
@@ -35,7 +35,7 @@ private:
 //
 // constructors and destructor
 //
- 
+
 HLTTrackSeedMultiplicityFilter::HLTTrackSeedMultiplicityFilter(const edm::ParameterSet& config) : HLTFilter(config),
   inputTag_  (config.getParameter<edm::InputTag>("inputTag")),
   min_seeds_ (config.getParameter<unsigned int>("minSeeds")),
@@ -44,7 +44,7 @@ HLTTrackSeedMultiplicityFilter::HLTTrackSeedMultiplicityFilter(const edm::Parame
   inputToken_ = consumes<TrajectorySeedCollection>(inputTag_);
   LogDebug("") << "Using the " << inputTag_ << " input collection";
   LogDebug("") << "Requesting at least " << min_seeds_ << " seeds";
-  if(max_seeds_ > 0) 
+  if(max_seeds_ > 0)
     LogDebug("") << "...but no more than " << max_seeds_ << " seeds";
 }
 
@@ -67,7 +67,7 @@ HLTTrackSeedMultiplicityFilter::fillDescriptions(edm::ConfigurationDescriptions&
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTTrackSeedMultiplicityFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTTrackSeedMultiplicityFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   // All HLT filters must create and fill an HLT filter object,
   // recording any reconstructed physics objects satisfying (or not)
@@ -87,7 +87,7 @@ bool HLTTrackSeedMultiplicityFilter::hltFilter(edm::Event& event, const edm::Eve
   {
     //std::cout << "Problem!!" << std::endl;
     rsSeedCollection = seedColl.product();
-  } 
+  }
   else
   {
     return false;
@@ -105,9 +105,9 @@ bool HLTTrackSeedMultiplicityFilter::hltFilter(edm::Event& event, const edm::Eve
 
   bool accept = (seedsize >= min_seeds_);
 
-  if(max_seeds_ > 0) 
+  if(max_seeds_ > 0)
     accept &= (seedsize <= max_seeds_);
-  
+
   // return with final filter decision
   return accept;
 }

--- a/HLTrigger/special/src/HLTTrackSeedMultiplicityFilter.cc
+++ b/HLTrigger/special/src/HLTTrackSeedMultiplicityFilter.cc
@@ -17,7 +17,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+  virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
 
   edm::InputTag inputTag_;       // input tag identifying product containing track seeds
   unsigned int  min_seeds_;      // minimum number of track seeds
@@ -67,7 +67,7 @@ HLTTrackSeedMultiplicityFilter::fillDescriptions(edm::ConfigurationDescriptions&
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTTrackSeedMultiplicityFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTTrackSeedMultiplicityFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   // All HLT filters must create and fill an HLT filter object,
   // recording any reconstructed physics objects satisfying (or not)

--- a/HLTrigger/special/src/HLTTrackerHaloFilter.cc
+++ b/HLTrigger/special/src/HLTTrackerHaloFilter.cc
@@ -53,9 +53,8 @@ HLTTrackerHaloFilter::fillDescriptions(edm::ConfigurationDescriptions& descripti
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTTrackerHaloFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+bool HLTTrackerHaloFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
-
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
   iSetup.get<IdealGeometryRecord>().get(tTopoHandle);
@@ -74,19 +73,11 @@ bool HLTTrackerHaloFilter::hltFilter(edm::Event& event, const edm::EventSetup& i
   
 
   /// First initialize some variables
+  int SST_clus_MAP_m[5][8][9]; memset(SST_clus_MAP_m,  0x00, sizeof(SST_clus_MAP_m));
+  int SST_clus_MAP_p[5][8][9]; memset(SST_clus_MAP_p,  0x00, sizeof(SST_clus_MAP_p));
+  int SST_clus_PROJ_m[5][8];   memset(SST_clus_PROJ_m, 0x00, sizeof(SST_clus_PROJ_m));
+  int SST_clus_PROJ_p[5][8];   memset(SST_clus_PROJ_p, 0x00, sizeof(SST_clus_PROJ_p));
 
-  for (int i=0;i<5;++i)
-  {
-    for (int j=0;j<8;++j)
-    {
-      SST_clus_PROJ_m[i][j]=0;
-      SST_clus_PROJ_p[i][j]=0;
-
-      for (int k=0;k<9;++k) SST_clus_MAP_m[i][j][k]=0;
-      for (int k=0;k<9;++k) SST_clus_MAP_p[i][j][k]=0;
-    }
-  }
-  
   int n_total_clus  = 0;
   int n_total_clusp = 0;
   int n_total_clusm = 0;

--- a/HLTrigger/special/src/HLTTrackerHaloFilter.cc
+++ b/HLTrigger/special/src/HLTTrackerHaloFilter.cc
@@ -17,7 +17,7 @@
 //
 // constructors and destructor
 //
- 
+
 HLTTrackerHaloFilter::HLTTrackerHaloFilter(const edm::ParameterSet& config) : HLTFilter(config),
   inputTag_     (config.getParameter<edm::InputTag>("inputTag")),
   max_clusTp_   (config.getParameter<int>("MaxClustersTECp")),
@@ -53,7 +53,7 @@ HLTTrackerHaloFilter::fillDescriptions(edm::ConfigurationDescriptions& descripti
 //
 
 // ------------ method called to produce the data  ------------
-bool HLTTrackerHaloFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+bool HLTTrackerHaloFilter::hltFilter(edm::Event& event, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHandle;
@@ -63,14 +63,14 @@ bool HLTTrackerHaloFilter::hltFilter(edm::Event& event, const edm::EventSetup& i
   // All HLT filters must create and fill an HLT filter object,
   // recording any reconstructed physics objects satisfying (or not)
   // this HLT filter, and place it in the Event.
-  
+
   // The filter object
   if (saveTags()) filterproduct.addCollectionTag(inputTag_);
-  
+
   // get hold of products from Event
   edm::Handle<edm::RefGetter<SiStripCluster> > refgetter;
   event.getByToken(inputToken_, refgetter);
-  
+
 
   /// First initialize some variables
   int SST_clus_MAP_m[5][8][9]; memset(SST_clus_MAP_m,  0x00, sizeof(SST_clus_MAP_m));
@@ -95,7 +95,7 @@ bool HLTTrackerHaloFilter::hltFilter(edm::Event& event, const edm::EventSetup& i
 
   // Then we loop over tracker cabling regions
 
-  for(;iregion!=refgetter->end();++iregion) 
+  for(;iregion!=refgetter->end();++iregion)
   {
 
     // Don't go further if one of the TEC cluster cut is not passed
@@ -103,8 +103,8 @@ bool HLTTrackerHaloFilter::hltFilter(edm::Event& event, const edm::EventSetup& i
     if (n_total_clusp>max_clusTp_) return false;
     if (n_total_clusm>max_clusTm_) return false;
 
-    ++index;  
-    
+    ++index;
+
     // Some cuts applied if fast processing requested
     //
     // !!!! Will fail if cabling is changing !!!!
@@ -124,13 +124,13 @@ bool HLTTrackerHaloFilter::hltFilter(edm::Event& event, const edm::EventSetup& i
 
     // We are in TEC, so we load the clusters
     edm::RegionIndex<SiStripCluster>::const_iterator iclus = iregion->begin();
-  
-    for(;iclus!=iregion->end();++iclus) 
+
+    for(;iclus!=iregion->end();++iclus)
     {
       if (iclus->geographicalId()%2 == 1) continue;
 
-      // We skip a a part of the clusters, to restore 
-      // some symmetry between rings  
+      // We skip a a part of the clusters, to restore
+      // some symmetry between rings
       if (tTopo->tecRing(iclus->geographicalId())<3 ||tTopo->tecIsStereo(iclus->geographicalId())) continue;
 
       ++n_total_clus;
@@ -138,7 +138,7 @@ bool HLTTrackerHaloFilter::hltFilter(edm::Event& event, const edm::EventSetup& i
       int r_id = tTopo->tecRing(iclus->geographicalId())-3;
       int p_id = tTopo->tecPetalNumber(iclus->geographicalId())-1;
       int w_id = tTopo->tecWheel(iclus->geographicalId())-1;
-    
+
       // Then we do accumulations and cuts 'on the fly'
 
       if (tTopo->tecSide(iclus->geographicalId())==1) // Minus side (BEAM2)
@@ -153,7 +153,7 @@ bool HLTTrackerHaloFilter::hltFilter(edm::Event& event, const edm::EventSetup& i
 	  if (SST_clus_PROJ_m[r_id][p_id]>maxm) maxm = SST_clus_PROJ_m[r_id][p_id];
 	  if (SST_clus_PROJ_m[r_id][p_id]==sign_accu_) ++npeakm;
 
-	  if (npeakm>=max_back_) return false; // Too many accumulations (PKAM) 
+	  if (npeakm>=max_back_) return false; // Too many accumulations (PKAM)
 	}
       }
       else // Plus side (BEAM1)
@@ -168,12 +168,12 @@ bool HLTTrackerHaloFilter::hltFilter(edm::Event& event, const edm::EventSetup& i
 	  if (SST_clus_PROJ_p[r_id][p_id]>maxp) maxp = SST_clus_PROJ_p[r_id][p_id];
 	  if (SST_clus_PROJ_p[r_id][p_id]==sign_accu_) ++npeakp;
 
-	  if (npeakp>=max_back_) return false;  
+	  if (npeakp>=max_back_) return false;
 	}
       }
     } // End of clusters loop
   } // End of regions loop
-  
+
 
   // The final selection is applied here
   // Most of the cuts have already been applied tough
@@ -184,7 +184,7 @@ bool HLTTrackerHaloFilter::hltFilter(edm::Event& event, const edm::EventSetup& i
   if (n_total_clusp<sign_accu_)               return false;
   if (n_total_clusm<sign_accu_)               return false;
   if (maxm<sign_accu_ || maxp<sign_accu_)     return false;
-  if (npeakm>=max_back_ || npeakp>=max_back_) return false;     
+  if (npeakm>=max_back_ || npeakp>=max_back_) return false;
 
   return true;
 }

--- a/HLTrigger/special/src/HLTVertexFilter.cc
+++ b/HLTrigger/special/src/HLTVertexFilter.cc
@@ -2,7 +2,7 @@
 //
 // Package:    HLTVertexFilter
 // Class:      HLTVertexFilter
-// 
+//
 /**\class HLTVertexFilter HLTVertexFilter.cc
 
  Description: HLTFilter to accept events with at least a given number of vertices
@@ -40,10 +40,10 @@ public:
   explicit HLTVertexFilter(const edm::ParameterSet & config);
   ~HLTVertexFilter();
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    
+
 private:
-  virtual 
-  bool hltFilter(edm::Event & event, const edm::EventSetup & setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+  virtual
+  bool hltFilter(edm::Event & event, const edm::EventSetup & setup, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
   edm::EDGetTokenT<reco::VertexCollection> m_inputToken;
   edm::InputTag m_inputTag;     // input vertex collection
@@ -94,7 +94,7 @@ HLTVertexFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
 
 // ------------ method called on each new Event  ------------
 bool
-HLTVertexFilter::hltFilter(edm::Event &  event, edm::EventSetup const & setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
+HLTVertexFilter::hltFilter(edm::Event &  event, edm::EventSetup const & setup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
 
   // get hold of collection of objects
   edm::Handle<reco::VertexCollection> vertices;

--- a/HLTrigger/special/src/HLTVertexFilter.cc
+++ b/HLTrigger/special/src/HLTVertexFilter.cc
@@ -43,7 +43,7 @@ public:
     
 private:
   virtual 
-  bool hltFilter(edm::Event & event, const edm::EventSetup & setup, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
+  bool hltFilter(edm::Event & event, const edm::EventSetup & setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
 
   edm::EDGetTokenT<reco::VertexCollection> m_inputToken;
   edm::InputTag m_inputTag;     // input vertex collection
@@ -94,7 +94,7 @@ HLTVertexFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) 
 
 // ------------ method called on each new Event  ------------
 bool
-HLTVertexFilter::hltFilter(edm::Event &  event, edm::EventSetup const & setup, trigger::TriggerFilterObjectWithRefs & filterproduct) {
+HLTVertexFilter::hltFilter(edm::Event &  event, edm::EventSetup const & setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const {
 
   // get hold of collection of objects
   edm::Handle<reco::VertexCollection> vertices;

--- a/RecoTauTag/HLTProducers/src/HLTPFTauPairLeadTrackDzMatchFilter.cc
+++ b/RecoTauTag/HLTProducers/src/HLTPFTauPairLeadTrackDzMatchFilter.cc
@@ -13,7 +13,7 @@
 
 
 HLTPFTauPairLeadTrackDzMatchFilter::HLTPFTauPairLeadTrackDzMatchFilter(const edm::ParameterSet& conf) : HLTFilter(conf){
- 
+
   tauSrc_	        = conf.getParameter<edm::InputTag>("tauSrc");
   tauMinPt_	        = conf.getParameter<double>("tauMinPt");
   tauMaxEta_	        = conf.getParameter<double>("tauMaxEta");
@@ -21,11 +21,11 @@ HLTPFTauPairLeadTrackDzMatchFilter::HLTPFTauPairLeadTrackDzMatchFilter(const edm
   tauLeadTrackMaxDZ_	= conf.getParameter<double>("tauLeadTrackMaxDZ");
   triggerType_          = conf.getParameter<int>("triggerType");
 
-  // set the minimum DR between taus, so that one never has a chance 
+  // set the minimum DR between taus, so that one never has a chance
   // to create a pair out of the same Tau replicated with two
   // different vertices
   if (tauMinDR_ < 0.1) tauMinDR_ = 0.1;
-  
+
 }
 
 HLTPFTauPairLeadTrackDzMatchFilter::~HLTPFTauPairLeadTrackDzMatchFilter(){}
@@ -44,11 +44,11 @@ void HLTPFTauPairLeadTrackDzMatchFilter::fillDescriptions(edm::ConfigurationDesc
   descriptions.add("hltPFTauPairLeadTrackDzMatchFilter",desc);
 }
 
-bool HLTPFTauPairLeadTrackDzMatchFilter::hltFilter(edm::Event& ev, const edm::EventSetup& es, trigger::TriggerFilterObjectWithRefs& filterproduct) const{
+bool HLTPFTauPairLeadTrackDzMatchFilter::hltFilter(edm::Event& ev, const edm::EventSetup& es, trigger::TriggerFilterObjectWithRefs& filterproduct) {
 
   using namespace std;
   using namespace reco;
-  
+
   // The resuilting filter object to store in the Event
   if(saveTags() ) filterproduct.addCollectionTag(tauSrc_);
 
@@ -63,19 +63,19 @@ bool HLTPFTauPairLeadTrackDzMatchFilter::hltFilter(edm::Event& ev, const edm::Ev
 
   // Combine taus into pairs and check the dz matching
   size_t npairs = 0, nfail_dz = 0;
-  if(n_taus > 1) for(size_t t1 = 0; t1 < n_taus; ++t1) { 
+  if(n_taus > 1) for(size_t t1 = 0; t1 < n_taus; ++t1) {
     if( taus[t1].leadPFChargedHadrCand().isNull() ||
 	taus[t1].leadPFChargedHadrCand()->trackRef().isNull() ||
-        taus[t1].pt() < tauMinPt_ || 
-	std::abs(taus[t1].eta() ) > tauMaxEta_ ) 
+        taus[t1].pt() < tauMinPt_ ||
+	std::abs(taus[t1].eta() ) > tauMaxEta_ )
       continue;
-    
+
     float mindz = 99.f;
     for(size_t t2 = t1+1; t2 < n_taus; ++t2){
       if( taus[t2].leadPFChargedHadrCand().isNull() ||
 	  taus[t2].leadPFChargedHadrCand()->trackRef().isNull() ||
-	  taus[t2].pt() < tauMinPt_ || 
-	  std::abs(taus[t2].eta() ) > tauMaxEta_ ) 
+	  taus[t2].pt() < tauMinPt_ ||
+	  std::abs(taus[t2].eta() ) > tauMaxEta_ )
 	continue;
 
       float dr2 = reco::deltaR2(taus[t1].eta(), taus[t1].phi(),
@@ -87,7 +87,7 @@ bool HLTPFTauPairLeadTrackDzMatchFilter::hltFilter(edm::Event& ev, const edm::Ev
       if ( dr2 < tauMinDR_*tauMinDR_ ) {
 	continue;
       }
-      
+
       if (std::abs(dz) < std::abs(mindz)) mindz = dz;
 
       // do not form a pair if dz is too large
@@ -95,16 +95,16 @@ bool HLTPFTauPairLeadTrackDzMatchFilter::hltFilter(edm::Event& ev, const edm::Ev
 	++nfail_dz;
 	continue;
       }
-      
+
       // add references to both jets
       ref = PFTauRef(tausHandle, t1);
       filterproduct.addObject(triggerType_, ref);
-      
+
       ref = PFTauRef(tausHandle, t2);
       filterproduct.addObject(triggerType_, ref);
 
       ++npairs;
-      
+
     }
 
   }

--- a/RecoTauTag/HLTProducers/src/HLTPFTauPairLeadTrackDzMatchFilter.cc
+++ b/RecoTauTag/HLTProducers/src/HLTPFTauPairLeadTrackDzMatchFilter.cc
@@ -44,7 +44,7 @@ void HLTPFTauPairLeadTrackDzMatchFilter::fillDescriptions(edm::ConfigurationDesc
   descriptions.add("hltPFTauPairLeadTrackDzMatchFilter",desc);
 }
 
-bool HLTPFTauPairLeadTrackDzMatchFilter::hltFilter(edm::Event& ev, const edm::EventSetup& es, trigger::TriggerFilterObjectWithRefs& filterproduct){
+bool HLTPFTauPairLeadTrackDzMatchFilter::hltFilter(edm::Event& ev, const edm::EventSetup& es, trigger::TriggerFilterObjectWithRefs& filterproduct) const{
 
   using namespace std;
   using namespace reco;

--- a/RecoTauTag/HLTProducers/src/HLTPFTauPairLeadTrackDzMatchFilter.h
+++ b/RecoTauTag/HLTProducers/src/HLTPFTauPairLeadTrackDzMatchFilter.h
@@ -10,7 +10,7 @@
 
 /** class HLTPFTauPairLeadTrackDzMatchFilter
  * an HLT filter which picks up a PFTauCollection
- * and passes only events with at least one pair of non-overlapping taus with 
+ * and passes only events with at least one pair of non-overlapping taus with
  * vertices of leading tracks within some dz
  */
 
@@ -21,8 +21,8 @@ class HLTPFTauPairLeadTrackDzMatchFilter : public HLTFilter {
     explicit HLTPFTauPairLeadTrackDzMatchFilter(const edm::ParameterSet& conf);
     ~HLTPFTauPairLeadTrackDzMatchFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-    virtual bool hltFilter(edm::Event& ev, const edm::EventSetup& es, trigger::TriggerFilterObjectWithRefs& filterproduct) const;
-    
+    virtual bool hltFilter(edm::Event& ev, const edm::EventSetup& es, trigger::TriggerFilterObjectWithRefs& filterproduct) override;
+
   private:
 
     edm::InputTag tauSrc_;
@@ -34,4 +34,4 @@ class HLTPFTauPairLeadTrackDzMatchFilter : public HLTFilter {
 
 };
 
-#endif 
+#endif

--- a/RecoTauTag/HLTProducers/src/HLTPFTauPairLeadTrackDzMatchFilter.h
+++ b/RecoTauTag/HLTProducers/src/HLTPFTauPairLeadTrackDzMatchFilter.h
@@ -21,7 +21,7 @@ class HLTPFTauPairLeadTrackDzMatchFilter : public HLTFilter {
     explicit HLTPFTauPairLeadTrackDzMatchFilter(const edm::ParameterSet& conf);
     ~HLTPFTauPairLeadTrackDzMatchFilter();
     static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
-    virtual bool hltFilter(edm::Event& ev, const edm::EventSetup& es, trigger::TriggerFilterObjectWithRefs& filterproduct);
+    virtual bool hltFilter(edm::Event& ev, const edm::EventSetup& es, trigger::TriggerFilterObjectWithRefs& filterproduct) const;
     
   private:
 

--- a/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
+++ b/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
@@ -43,8 +43,8 @@ HLTDeDxFilter::HLTDeDxFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConf
   inputTracksToken_ = consumes<reco::TrackCollection>(iConfig.getParameter< edm::InputTag > ("inputTracksTag"));
   inputdedxToken_   = consumes<edm::ValueMap<reco::DeDxData> >(iConfig.getParameter< edm::InputTag > ("inputDeDxTag"));
 
-  thisModuleTag_ = edm::InputTag(iConfig.getParameter<std::string>("@module_label")); 
- 
+  thisModuleTag_ = edm::InputTag(iConfig.getParameter<std::string>("@module_label"));
+
   //register your products
   produces<reco::RecoChargedCandidateCollection>();
 }
@@ -67,7 +67,7 @@ void HLTDeDxFilter::fillDescriptions(edm::ConfigurationDescriptions& description
 
 // ------------ method called to produce the data  ------------
 bool
-  HLTDeDxFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+  HLTDeDxFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
 {
   using namespace std;
   using namespace edm;
@@ -87,7 +87,7 @@ bool
   edm::Handle<reco::TrackCollection> trackCollectionHandle;
   iEvent.getByToken(inputTracksToken_,trackCollectionHandle);
   reco::TrackCollection trackCollection = *trackCollectionHandle.product();
-  
+
   edm::Handle<edm::ValueMap<reco::DeDxData> > dEdxTrackHandle;
   iEvent.getByToken(inputdedxToken_, dEdxTrackHandle);
   const edm::ValueMap<reco::DeDxData> dEdxTrack = *dEdxTrackHandle.product();
@@ -104,12 +104,12 @@ bool
           Particle::LorentzVector p4(track->px(), track->py(), track->pz(), sqrt(pow(track->p(),2) + pow(dEdxTrack[track].dEdx(),2)));
           Particle::Point vtx(track->vx(),track->vy(), track->vz());
           //SAVE NOH, NOM, NOS INFORMATION AS IF IT WAS THE PDGID OF THE PARTICLE
-          int Hits  = ((dEdxTrack[track].numberOfSaturatedMeasurements()&0xFF)<<16) | ((dEdxTrack[track].numberOfMeasurements()&0xFF)<<8) | (track->found()&0xFF); 
+          int Hits  = ((dEdxTrack[track].numberOfSaturatedMeasurements()&0xFF)<<16) | ((dEdxTrack[track].numberOfMeasurements()&0xFF)<<8) | (track->found()&0xFF);
           RecoChargedCandidate cand(q, p4, vtx, Hits, 0);
           cand.setTrack(track);
           chargedCandidates->push_back(cand);
        }
-       accept=true; 
+       accept=true;
     }
   }
 

--- a/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
+++ b/RecoTracker/DeDx/plugins/HLTDeDxFilter.cc
@@ -67,7 +67,7 @@ void HLTDeDxFilter::fillDescriptions(edm::ConfigurationDescriptions& description
 
 // ------------ method called to produce the data  ------------
 bool
-  HLTDeDxFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct)
+  HLTDeDxFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
 {
   using namespace std;
   using namespace edm;

--- a/RecoTracker/DeDx/plugins/HLTDeDxFilter.h
+++ b/RecoTracker/DeDx/plugins/HLTDeDxFilter.h
@@ -25,11 +25,11 @@ class HLTDeDxFilter : public HLTFilter {
       explicit HLTDeDxFilter(const edm::ParameterSet&);
       ~HLTDeDxFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) override;
 
    private:
       bool saveTags_;              // whether to save this tag
-      double minDEDx_;     
+      double minDEDx_;
       double minPT_;
       double minNOM_;
       double maxETA_;

--- a/RecoTracker/DeDx/plugins/HLTDeDxFilter.h
+++ b/RecoTracker/DeDx/plugins/HLTDeDxFilter.h
@@ -25,7 +25,7 @@ class HLTDeDxFilter : public HLTFilter {
       explicit HLTDeDxFilter(const edm::ParameterSet&);
       ~HLTDeDxFilter();
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct);
+      virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const;
 
    private:
       bool saveTags_;              // whether to save this tag


### PR DESCRIPTION
This is a work-in-progress to convert all HLTFilters into global modules.
As a first step, clean up most of the HLTFilters so that they do not modify their internal state during the call to hltFilter().

The only exception left is HLTLevel1GTSeed, which looks rather complicated to fix, and will be dealt in a subsequent pull request. 
