### PR TITLE
Removed use of obsolete LockService

### DIFF
--- a/DQM/TrigXMonitor/python/hlt_scaler_cfg.py
+++ b/DQM/TrigXMonitor/python/hlt_scaler_cfg.py
@@ -71,10 +71,6 @@ process.load("DQM.TrigXMonitor.run58738")
 # )
 process.ModuleWebRegistry = cms.Service("ModuleWebRegistry")
 
-process.LockService = cms.Service("LockService",
-    labels = cms.untracked.vstring('source')
-)
-
 process.MessageLogger = cms.Service("MessageLogger",
     detailedInfo = cms.untracked.PSet(
         threshold = cms.untracked.string('INFO')

--- a/DQM/TrigXMonitorClient/python/test/hlt_scalerclient_cfg.py
+++ b/DQM/TrigXMonitorClient/python/test/hlt_scalerclient_cfg.py
@@ -89,10 +89,6 @@ process.maxEvents = cms.untracked.PSet(
 )
 process.ModuleWebRegistry = cms.Service("ModuleWebRegistry")
 
-process.LockService = cms.Service("LockService",
-    labels = cms.untracked.vstring('source')
-)
-
 process.MessageLogger = cms.Service("MessageLogger",
    #debugModules = cms.untracked.vstring('l1s', 'hlts', 'hltsClient', 'main_input'),
    debugModules = cms.untracked.vstring('hltsClient', 'hlts', 'main_input'),

--- a/DQM/TrigXMonitorClient/python/test/l1t_scalerclient_cfg.py
+++ b/DQM/TrigXMonitorClient/python/test/l1t_scalerclient_cfg.py
@@ -63,10 +63,6 @@ process.maxEvents = cms.untracked.PSet(
 )
 process.ModuleWebRegistry = cms.Service("ModuleWebRegistry")
 
-process.LockService = cms.Service("LockService",
-    labels = cms.untracked.vstring('source')
-)
-
 process.MessageLogger = cms.Service("MessageLogger",
 #  debugModules = cms.untracked.vstring('l1tsClient', 'l1ts', 'main_input'),
   debugModules = cms.untracked.vstring('*'),

--- a/SimTracker/SiPixelDigitizer/test/DQM_Pixel_digi.py
+++ b/SimTracker/SiPixelDigitizer/test/DQM_Pixel_digi.py
@@ -15,9 +15,6 @@ process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring('rfio:/castor/cern.ch/user/v/vesna/testDigis.root')
 )
 
-process.LockService = cms.Service("LockService",
-    labels = cms.untracked.vstring('source')
-)
 process.MessageLogger = cms.Service("MessageLogger",
     debugModules = cms.untracked.vstring('siPixelDigis'),
     cout = cms.untracked.PSet(


### PR DESCRIPTION
The LockService is no longer needed for the DQM so this removes the last
references to that service.
