### PR TITLE
Fixes for thread safety

### DIFF
--- a/FWCore/Framework/src/IOVSyncValue.cc
+++ b/FWCore/Framework/src/IOVSyncValue.cc
@@ -90,7 +90,7 @@ IOVSyncValue::throwInvalidComparison() const {
 //
 const IOVSyncValue&
 IOVSyncValue::invalidIOVSyncValue() {
-   static IOVSyncValue s_invalid;
+   static const IOVSyncValue s_invalid;
    return s_invalid;
 }
 const IOVSyncValue&

--- a/FWCore/Framework/src/TriggerNamesService.cc
+++ b/FWCore/Framework/src/TriggerNamesService.cc
@@ -37,7 +37,7 @@ namespace edm {
       loadPosMap(end_pos_,end_names_);
 
       const unsigned int n(trignames_.size());
-      for(unsigned int i=0;i!=n;++i) {
+      for(unsigned int i = 0; i != n; ++i) {
         modulenames_.push_back(pset.getParameter<Strings>(trignames_[i]));
       }
       for(unsigned int i = 0; i != end_names_.size(); ++i) {
@@ -52,15 +52,15 @@ namespace edm {
 
       // Get the parameter set containing the trigger names from the parameter set registry
       // using the ID from TriggerResults as the key used to find it.
-      ParameterSet const* pset=0;
-      pset::Registry* psetRegistry = pset::Registry::instance();
-      if (0 != (pset=psetRegistry->getMapped(triggerResults.parameterSetID()))) {
+      ParameterSet const* pset = nullptr;
+      pset::Registry const* psetRegistry = pset::Registry::instance();
+      if (nullptr != (pset = psetRegistry->getMapped(triggerResults.parameterSetID()))) {
 
         // Check to make sure the parameter set contains
         // a Strings parameter named "trigger_paths".
         // We do not want to throw an exception if it is not there
         // for reasons of backward compatibility
-        Strings const & psetNames = pset->getParameterNamesForType<Strings>();
+        Strings const& psetNames = pset->getParameterNamesForType<Strings>();
         std::string name("@trigger_paths");
 	if (search_all(psetNames, name)) {
           // It is there, get it

--- a/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
@@ -44,7 +44,7 @@ struct Cache {
   public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
+    static std::atomic<unsigned int> cvalue_;
    
     static std::unique_ptr<Cache> initializeGlobalCache(edm::ParameterSet const& p) {
       ++m_count;
@@ -84,9 +84,9 @@ struct Cache {
   public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbr;
-    static bool ger;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbr;
+    static std::atomic<bool> ger;
     bool br;
     bool er;
 
@@ -158,11 +158,11 @@ struct Cache {
   public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbl;
-    static bool gel;
-    static bool bl;
-    static bool el;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbl;
+    static std::atomic<bool> gel;
+    static std::atomic<bool> bl;
+    static std::atomic<bool> el;
 
     LumiIntAnalyzer(edm::ParameterSet const&p){
       trans_= p.getParameter<int>("transitions");
@@ -232,15 +232,15 @@ struct Cache {
   public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbr;
-    static bool ger;
-    static bool gbrs;
-    static bool gers;
-    static bool brs;
-    static bool ers;
-    static bool br;
-    static bool er;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbr;
+    static std::atomic<bool> ger;
+    static std::atomic<bool> gbrs;
+    static std::atomic<bool> gers;
+    static std::atomic<bool> brs;
+    static std::atomic<bool> ers;
+    static std::atomic<bool> br;
+    static std::atomic<bool> er;
 
     RunSummaryIntAnalyzer(edm::ParameterSet const&p){
       trans_= p.getParameter<int>("transitions");
@@ -336,15 +336,15 @@ struct Cache {
   public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbl;
-    static bool gel;
-    static bool gbls;
-    static bool gels;
-    static bool bls;
-    static bool els;
-    static bool bl;
-    static bool el;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbl;
+    static std::atomic<bool> gel;
+    static std::atomic<bool> gbls;
+    static std::atomic<bool> gels;
+    static std::atomic<bool> bls;
+    static std::atomic<bool> els;
+    static std::atomic<bool> bl;
+    static std::atomic<bool> el;
 
     LumiSummaryIntAnalyzer(edm::ParameterSet const&p){
       trans_= p.getParameter<int>("transitions");
@@ -449,33 +449,33 @@ std::atomic<unsigned int> edmtest::stream::RunIntAnalyzer::m_count{0};
 std::atomic<unsigned int> edmtest::stream::LumiIntAnalyzer::m_count{0};
 std::atomic<unsigned int> edmtest::stream::RunSummaryIntAnalyzer::m_count{0};
 std::atomic<unsigned int> edmtest::stream::LumiSummaryIntAnalyzer::m_count{0};
-unsigned int edmtest::stream::GlobalIntAnalyzer::cvalue_ = 0;
-unsigned int edmtest::stream::RunIntAnalyzer::cvalue_ = 0;
-unsigned int edmtest::stream::LumiIntAnalyzer::cvalue_ = 0;
-unsigned int edmtest::stream::RunSummaryIntAnalyzer::cvalue_ = 0;
-unsigned int edmtest::stream::LumiSummaryIntAnalyzer::cvalue_ = 0;
-bool edmtest::stream::RunIntAnalyzer::gbr=false;
-bool edmtest::stream::RunIntAnalyzer::ger=false;
-bool edmtest::stream::LumiIntAnalyzer::gbl=false;
-bool edmtest::stream::LumiIntAnalyzer::gel=false;
-bool edmtest::stream::LumiIntAnalyzer::bl=false;
-bool edmtest::stream::LumiIntAnalyzer::el=false;
-bool edmtest::stream::RunSummaryIntAnalyzer::gbr=false;
-bool edmtest::stream::RunSummaryIntAnalyzer::ger=false;
-bool edmtest::stream::RunSummaryIntAnalyzer::gbrs=false;
-bool edmtest::stream::RunSummaryIntAnalyzer::gers=false;
-bool edmtest::stream::RunSummaryIntAnalyzer::brs=false;
-bool edmtest::stream::RunSummaryIntAnalyzer::ers=false;
-bool edmtest::stream::RunSummaryIntAnalyzer::br=false;
-bool edmtest::stream::RunSummaryIntAnalyzer::er=false;
-bool edmtest::stream::LumiSummaryIntAnalyzer::gbl=false;
-bool edmtest::stream::LumiSummaryIntAnalyzer::gel=false;
-bool edmtest::stream::LumiSummaryIntAnalyzer::gbls=false;
-bool edmtest::stream::LumiSummaryIntAnalyzer::gels=false;
-bool edmtest::stream::LumiSummaryIntAnalyzer::bls=false;
-bool edmtest::stream::LumiSummaryIntAnalyzer::els=false;
-bool edmtest::stream::LumiSummaryIntAnalyzer::bl=false;
-bool edmtest::stream::LumiSummaryIntAnalyzer::el=false;
+std::atomic<unsigned int> edmtest::stream::GlobalIntAnalyzer::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::RunIntAnalyzer::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::LumiIntAnalyzer::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::RunSummaryIntAnalyzer::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::LumiSummaryIntAnalyzer::cvalue_{0};
+std::atomic<bool> edmtest::stream::RunIntAnalyzer::gbr{false};
+std::atomic<bool> edmtest::stream::RunIntAnalyzer::ger{false};
+std::atomic<bool> edmtest::stream::LumiIntAnalyzer::gbl{false};
+std::atomic<bool> edmtest::stream::LumiIntAnalyzer::gel{false};
+std::atomic<bool> edmtest::stream::LumiIntAnalyzer::bl{false};
+std::atomic<bool> edmtest::stream::LumiIntAnalyzer::el{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntAnalyzer::gbr{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntAnalyzer::ger{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntAnalyzer::gbrs{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntAnalyzer::gers{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntAnalyzer::brs{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntAnalyzer::ers{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntAnalyzer::br{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntAnalyzer::er{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntAnalyzer::gbl{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntAnalyzer::gel{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntAnalyzer::gbls{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntAnalyzer::gels{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntAnalyzer::bls{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntAnalyzer::els{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntAnalyzer::bl{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntAnalyzer::el{false};
 DEFINE_FWK_MODULE(edmtest::stream::GlobalIntAnalyzer);
 DEFINE_FWK_MODULE(edmtest::stream::RunIntAnalyzer);
 DEFINE_FWK_MODULE(edmtest::stream::LumiIntAnalyzer);

--- a/FWCore/Framework/test/stubs/TestStreamFilters.cc
+++ b/FWCore/Framework/test/stubs/TestStreamFilters.cc
@@ -44,7 +44,7 @@ struct Cache {
   public:
     static std::atomic<unsigned int> m_count; 
     unsigned int trans_;
-    static unsigned int cvalue_;
+    static std::atomic<unsigned int> cvalue_;
     
     static std::unique_ptr<Cache> initializeGlobalCache(edm::ParameterSet const&) {
       ++m_count;
@@ -86,9 +86,9 @@ struct Cache {
   public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbr;
-    static bool ger;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbr;
+    static std::atomic<bool> ger;
     bool br;
     bool er;
 
@@ -144,11 +144,11 @@ struct Cache {
   public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbl;
-    static bool gel;
-    static bool bl;
-    static bool el;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbl;
+    static std::atomic<bool> gel;
+    static std::atomic<bool> bl;
+    static std::atomic<bool> el;
 
     LumiIntFilter(edm::ParameterSet const&p){
       trans_= p.getParameter<int>("transitions");
@@ -214,15 +214,15 @@ struct Cache {
   public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbr;
-    static bool ger;
-    static bool gbrs;
-    static bool gers;
-    static bool brs;
-    static bool ers;
-    static bool br;
-    static bool er;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbr;
+    static std::atomic<bool> ger;
+    static std::atomic<bool> gbrs;
+    static std::atomic<bool> gers;
+    static std::atomic<bool> brs;
+    static std::atomic<bool> ers;
+    static std::atomic<bool> br;
+    static std::atomic<bool> er;
 
     RunSummaryIntFilter(edm::ParameterSet const&p){
       trans_= p.getParameter<int>("transitions");
@@ -320,15 +320,15 @@ struct Cache {
   public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbl;
-    static bool gel;
-    static bool gbls;
-    static bool gels;
-    static bool bls;
-    static bool els;
-    static bool bl;
-    static bool el;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbl;
+    static std::atomic<bool> gel;
+    static std::atomic<bool> gbls;
+    static std::atomic<bool> gels;
+    static std::atomic<bool> bls;
+    static std::atomic<bool> els;
+    static std::atomic<bool> bl;
+    static std::atomic<bool> el;
 
     LumiSummaryIntFilter(edm::ParameterSet const&p) {
       trans_= p.getParameter<int>("transitions");
@@ -431,9 +431,9 @@ struct Cache {
     public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbr;
-    static bool ger;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbr;
+    static std::atomic<bool> ger;
 
     TestBeginRunFilter(edm::ParameterSet const&p){
       trans_= p.getParameter<int>("transitions");
@@ -487,9 +487,9 @@ struct Cache {
     public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbr;
-    static bool ger;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbr;
+    static std::atomic<bool> ger;
 
   static std::shared_ptr<Cache> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&, GlobalCache const*) {
      ++m_count;
@@ -546,9 +546,9 @@ struct Cache {
     public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbl;
-    static bool gel;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbl;
+    static std::atomic<bool> gel;
  
     TestBeginLumiBlockFilter(edm::ParameterSet const&p){
       trans_= p.getParameter<int>("transitions");
@@ -604,9 +604,9 @@ struct Cache {
     public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbl;
-    static bool gel;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbl;
+    static std::atomic<bool> gel;
  
     TestEndLumiBlockFilter(edm::ParameterSet const&p){
       trans_= p.getParameter<int>("transitions");
@@ -669,45 +669,45 @@ std::atomic<unsigned int> edmtest::stream::TestBeginRunFilter::m_count{0};
 std::atomic<unsigned int> edmtest::stream::TestEndRunFilter::m_count{0};
 std::atomic<unsigned int> edmtest::stream::TestBeginLumiBlockFilter::m_count{0};
 std::atomic<unsigned int> edmtest::stream::TestEndLumiBlockFilter::m_count{0};
-unsigned int edmtest::stream::GlobalIntFilter::cvalue_ = 0;
-unsigned int edmtest::stream::RunIntFilter::cvalue_ = 0;
-unsigned int edmtest::stream::LumiIntFilter::cvalue_ = 0;
-unsigned int edmtest::stream::RunSummaryIntFilter::cvalue_ = 0;
-unsigned int edmtest::stream::LumiSummaryIntFilter::cvalue_ = 0;
-unsigned int edmtest::stream::TestBeginRunFilter::cvalue_ = 0;
-unsigned int edmtest::stream::TestEndRunFilter::cvalue_ = 0;
-unsigned int edmtest::stream::TestBeginLumiBlockFilter::cvalue_ = 0;
-unsigned int edmtest::stream::TestEndLumiBlockFilter::cvalue_ = 0;
-bool edmtest::stream::RunIntFilter::gbr=false;
-bool edmtest::stream::RunIntFilter::ger=false;
-bool edmtest::stream::LumiIntFilter::gbl=false;
-bool edmtest::stream::LumiIntFilter::gel=false;
-bool edmtest::stream::LumiIntFilter::bl=false;
-bool edmtest::stream::LumiIntFilter::el=false;
-bool edmtest::stream::RunSummaryIntFilter::gbr=false;
-bool edmtest::stream::RunSummaryIntFilter::ger=false;
-bool edmtest::stream::RunSummaryIntFilter::gbrs=false;
-bool edmtest::stream::RunSummaryIntFilter::gers=false;
-bool edmtest::stream::RunSummaryIntFilter::brs=false;
-bool edmtest::stream::RunSummaryIntFilter::ers=false;
-bool edmtest::stream::RunSummaryIntFilter::br=false;
-bool edmtest::stream::RunSummaryIntFilter::er=false;
-bool edmtest::stream::LumiSummaryIntFilter::gbl=false;
-bool edmtest::stream::LumiSummaryIntFilter::gel=false;
-bool edmtest::stream::LumiSummaryIntFilter::gbls=false;
-bool edmtest::stream::LumiSummaryIntFilter::gels=false;
-bool edmtest::stream::LumiSummaryIntFilter::bls=false;
-bool edmtest::stream::LumiSummaryIntFilter::els=false;
-bool edmtest::stream::LumiSummaryIntFilter::bl=false;
-bool edmtest::stream::LumiSummaryIntFilter::el=false;
-bool edmtest::stream::TestBeginRunFilter::gbr=false;
-bool edmtest::stream::TestBeginRunFilter::ger=false;
-bool edmtest::stream::TestEndRunFilter::gbr=false;
-bool edmtest::stream::TestEndRunFilter::ger=false;
-bool edmtest::stream::TestBeginLumiBlockFilter::gbl=false;
-bool edmtest::stream::TestBeginLumiBlockFilter::gel=false;
-bool edmtest::stream::TestEndLumiBlockFilter::gbl=false;
-bool edmtest::stream::TestEndLumiBlockFilter::gel=false;
+std::atomic<unsigned int> edmtest::stream::GlobalIntFilter::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::RunIntFilter::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::LumiIntFilter::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::RunSummaryIntFilter::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::LumiSummaryIntFilter::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::TestBeginRunFilter::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::TestEndRunFilter::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::TestBeginLumiBlockFilter::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::TestEndLumiBlockFilter::cvalue_{0};
+std::atomic<bool> edmtest::stream::RunIntFilter::gbr{false};
+std::atomic<bool> edmtest::stream::RunIntFilter::ger{false};
+std::atomic<bool> edmtest::stream::LumiIntFilter::gbl{false};
+std::atomic<bool> edmtest::stream::LumiIntFilter::gel{false};
+std::atomic<bool> edmtest::stream::LumiIntFilter::bl{false};
+std::atomic<bool> edmtest::stream::LumiIntFilter::el{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntFilter::gbr{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntFilter::ger{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntFilter::gbrs{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntFilter::gers{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntFilter::brs{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntFilter::ers{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntFilter::br{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntFilter::er{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntFilter::gbl{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntFilter::gel{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntFilter::gbls{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntFilter::gels{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntFilter::bls{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntFilter::els{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntFilter::bl{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntFilter::el{false};
+std::atomic<bool> edmtest::stream::TestBeginRunFilter::gbr{false};
+std::atomic<bool> edmtest::stream::TestBeginRunFilter::ger{false};
+std::atomic<bool> edmtest::stream::TestEndRunFilter::gbr{false};
+std::atomic<bool> edmtest::stream::TestEndRunFilter::ger{false};
+std::atomic<bool> edmtest::stream::TestBeginLumiBlockFilter::gbl{false};
+std::atomic<bool> edmtest::stream::TestBeginLumiBlockFilter::gel{false};
+std::atomic<bool> edmtest::stream::TestEndLumiBlockFilter::gbl{false};
+std::atomic<bool> edmtest::stream::TestEndLumiBlockFilter::gel{false};
 DEFINE_FWK_MODULE(edmtest::stream::GlobalIntFilter);
 DEFINE_FWK_MODULE(edmtest::stream::RunIntFilter);
 DEFINE_FWK_MODULE(edmtest::stream::LumiIntFilter);

--- a/FWCore/Framework/test/stubs/TestStreamProducers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamProducers.cc
@@ -50,7 +50,7 @@ struct UnsafeCache {
   public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
+    static std::atomic<unsigned int> cvalue_;
 
     static std::unique_ptr<Cache> initializeGlobalCache(edm::ParameterSet const&) {
       ++m_count;
@@ -91,9 +91,9 @@ struct UnsafeCache {
   public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbr;
-    static bool ger;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbr;
+    static std::atomic<bool> ger;
     bool br;
     bool er;
 
@@ -165,11 +165,11 @@ struct UnsafeCache {
   public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbl;
-    static bool gel;
-    static bool bl;
-    static bool el;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbl;
+    static std::atomic<bool> gel;
+    static std::atomic<bool> bl;
+    static std::atomic<bool> el;
 
 
     LumiIntProducer(edm::ParameterSet const&p) {
@@ -240,15 +240,15 @@ struct UnsafeCache {
   public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbr;
-    static bool ger;
-    static bool gbrs;
-    static bool gers;
-    static bool brs;
-    static bool ers;
-    static bool br;
-    static bool er;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbr;
+    static std::atomic<bool> ger;
+    static std::atomic<bool> gbrs;
+    static std::atomic<bool> gers;
+    static std::atomic<bool> brs;
+    static std::atomic<bool> ers;
+    static std::atomic<bool> br;
+    static std::atomic<bool> er;
 
     RunSummaryIntProducer(edm::ParameterSet const&p){
       trans_= p.getParameter<int>("transitions");
@@ -344,15 +344,15 @@ struct UnsafeCache {
   public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbl;
-    static bool gel;
-    static bool gbls;
-    static bool gels;
-    static bool bls;
-    static bool els;
-    static bool bl;
-    static bool el;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbl;
+    static std::atomic<bool> gel;
+    static std::atomic<bool> gbls;
+    static std::atomic<bool> gels;
+    static std::atomic<bool> bls;
+    static std::atomic<bool> els;
+    static std::atomic<bool> bl;
+    static std::atomic<bool> el;
 
     LumiSummaryIntProducer(edm::ParameterSet const&p){
       trans_= p.getParameter<int>("transitions");
@@ -453,10 +453,10 @@ struct UnsafeCache {
     public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbr;
-    static bool ger;
-    static bool gbrp;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbr;
+    static std::atomic<bool> ger;
+    static std::atomic<bool> gbrp;
  
     TestBeginRunProducer(edm::ParameterSet const&p) {
       trans_= p.getParameter<int>("transitions");
@@ -509,10 +509,10 @@ struct UnsafeCache {
     public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbr;
-    static bool ger;
-    static bool p;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbr;
+    static std::atomic<bool> ger;
+    static std::atomic<bool> p;
 
     static std::shared_ptr<bool> globalBeginRun(edm::Run const& iRun, edm::EventSetup const&, GlobalCache const*) {
       gbr=true;
@@ -566,10 +566,10 @@ struct UnsafeCache {
     public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbl;
-    static bool gel;
-    static bool gblp;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbl;
+    static std::atomic<bool> gel;
+    static std::atomic<bool> gblp;
  
     TestBeginLumiBlockProducer(edm::ParameterSet const&p){
       trans_= p.getParameter<int>("transitions");
@@ -622,10 +622,10 @@ struct UnsafeCache {
     public:
     static std::atomic<unsigned int> m_count;
     unsigned int trans_;
-    static unsigned int cvalue_;
-    static bool gbl;
-    static bool gel;
-    static bool p;
+    static std::atomic<unsigned int> cvalue_;
+    static std::atomic<bool> gbl;
+    static std::atomic<bool> gel;
+    static std::atomic<bool> p;
  
     TestEndLumiBlockProducer(edm::ParameterSet const&p){
       trans_= p.getParameter<int>("transitions");
@@ -682,49 +682,49 @@ std::atomic<unsigned int> edmtest::stream::TestBeginRunProducer::m_count{0};
 std::atomic<unsigned int> edmtest::stream::TestEndRunProducer::m_count{0};
 std::atomic<unsigned int> edmtest::stream::TestBeginLumiBlockProducer::m_count{0};
 std::atomic<unsigned int> edmtest::stream::TestEndLumiBlockProducer::m_count{0};
-unsigned int edmtest::stream::GlobalIntProducer::cvalue_ = 0;
-unsigned int edmtest::stream::RunIntProducer::cvalue_ = 0;
-unsigned int edmtest::stream::LumiIntProducer::cvalue_ = 0;
-unsigned int edmtest::stream::RunSummaryIntProducer::cvalue_ = 0;
-unsigned int edmtest::stream::LumiSummaryIntProducer::cvalue_ = 0;
-unsigned int edmtest::stream::TestBeginRunProducer::cvalue_ = 0;
-unsigned int edmtest::stream::TestEndRunProducer::cvalue_ = 0;
-unsigned int edmtest::stream::TestBeginLumiBlockProducer::cvalue_ = 0;
-unsigned int edmtest::stream::TestEndLumiBlockProducer::cvalue_ = 0;
-bool edmtest::stream::RunIntProducer::gbr=false;
-bool edmtest::stream::RunIntProducer::ger=false;
-bool edmtest::stream::LumiIntProducer::gbl=false;
-bool edmtest::stream::LumiIntProducer::gel=false;
-bool edmtest::stream::LumiIntProducer::bl=false;
-bool edmtest::stream::LumiIntProducer::el=false;
-bool edmtest::stream::RunSummaryIntProducer::gbr=false;
-bool edmtest::stream::RunSummaryIntProducer::ger=false;
-bool edmtest::stream::RunSummaryIntProducer::gbrs=false;
-bool edmtest::stream::RunSummaryIntProducer::gers=false;
-bool edmtest::stream::RunSummaryIntProducer::brs=false;
-bool edmtest::stream::RunSummaryIntProducer::ers=false;
-bool edmtest::stream::RunSummaryIntProducer::br=false;
-bool edmtest::stream::RunSummaryIntProducer::er=false;
-bool edmtest::stream::LumiSummaryIntProducer::gbl=false;
-bool edmtest::stream::LumiSummaryIntProducer::gel=false;
-bool edmtest::stream::LumiSummaryIntProducer::gbls=false;
-bool edmtest::stream::LumiSummaryIntProducer::gels=false;
-bool edmtest::stream::LumiSummaryIntProducer::bls=false;
-bool edmtest::stream::LumiSummaryIntProducer::els=false;
-bool edmtest::stream::LumiSummaryIntProducer::bl=false;
-bool edmtest::stream::LumiSummaryIntProducer::el=false;
-bool edmtest::stream::TestBeginRunProducer::gbr=false;
-bool edmtest::stream::TestBeginRunProducer::gbrp=false;
-bool edmtest::stream::TestBeginRunProducer::ger=false;
-bool edmtest::stream::TestEndRunProducer::gbr=false;
-bool edmtest::stream::TestEndRunProducer::ger=false;
-bool edmtest::stream::TestEndRunProducer::p=false;
-bool edmtest::stream::TestBeginLumiBlockProducer::gbl=false;
-bool edmtest::stream::TestBeginLumiBlockProducer::gblp=false;
-bool edmtest::stream::TestBeginLumiBlockProducer::gel=false;
-bool edmtest::stream::TestEndLumiBlockProducer::gbl=false;
-bool edmtest::stream::TestEndLumiBlockProducer::gel=false;
-bool edmtest::stream::TestEndLumiBlockProducer::p=false;
+std::atomic<unsigned int> edmtest::stream::GlobalIntProducer::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::RunIntProducer::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::LumiIntProducer::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::RunSummaryIntProducer::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::LumiSummaryIntProducer::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::TestBeginRunProducer::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::TestEndRunProducer::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::TestBeginLumiBlockProducer::cvalue_{0};
+std::atomic<unsigned int> edmtest::stream::TestEndLumiBlockProducer::cvalue_{0};
+std::atomic<bool> edmtest::stream::RunIntProducer::gbr{false};
+std::atomic<bool> edmtest::stream::RunIntProducer::ger{false};
+std::atomic<bool> edmtest::stream::LumiIntProducer::gbl{false};
+std::atomic<bool> edmtest::stream::LumiIntProducer::gel{false};
+std::atomic<bool> edmtest::stream::LumiIntProducer::bl{false};
+std::atomic<bool> edmtest::stream::LumiIntProducer::el{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntProducer::gbr{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntProducer::ger{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntProducer::gbrs{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntProducer::gers{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntProducer::brs{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntProducer::ers{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntProducer::br{false};
+std::atomic<bool> edmtest::stream::RunSummaryIntProducer::er{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntProducer::gbl{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntProducer::gel{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntProducer::gbls{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntProducer::gels{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntProducer::bls{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntProducer::els{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntProducer::bl{false};
+std::atomic<bool> edmtest::stream::LumiSummaryIntProducer::el{false};
+std::atomic<bool> edmtest::stream::TestBeginRunProducer::gbr{false};
+std::atomic<bool> edmtest::stream::TestBeginRunProducer::gbrp{false};
+std::atomic<bool> edmtest::stream::TestBeginRunProducer::ger{false};
+std::atomic<bool> edmtest::stream::TestEndRunProducer::gbr{false};
+std::atomic<bool> edmtest::stream::TestEndRunProducer::ger{false};
+std::atomic<bool> edmtest::stream::TestEndRunProducer::p{false};
+std::atomic<bool> edmtest::stream::TestBeginLumiBlockProducer::gbl{false};
+std::atomic<bool> edmtest::stream::TestBeginLumiBlockProducer::gblp{false};
+std::atomic<bool> edmtest::stream::TestBeginLumiBlockProducer::gel{false};
+std::atomic<bool> edmtest::stream::TestEndLumiBlockProducer::gbl{false};
+std::atomic<bool> edmtest::stream::TestEndLumiBlockProducer::gel{false};
+std::atomic<bool> edmtest::stream::TestEndLumiBlockProducer::p{false};
 DEFINE_FWK_MODULE(edmtest::stream::GlobalIntProducer);
 DEFINE_FWK_MODULE(edmtest::stream::RunIntProducer);
 DEFINE_FWK_MODULE(edmtest::stream::LumiIntProducer);

--- a/FWCore/ParameterSet/interface/IllegalParameters.h
+++ b/FWCore/ParameterSet/interface/IllegalParameters.h
@@ -1,3 +1,7 @@
+#ifndef FWCore_PArameterSet_IllegalParameters_h
+#define FWCore_PArameterSet_IllegalParameters_h
+
+#include <atomic>
 
 namespace edm {
 
@@ -7,7 +11,7 @@ namespace edm {
 
   class IllegalParameters {
   private:
-    static bool throwAnException_;
+    static std::atomic<bool> throwAnException_;
     static bool throwAnException() { return throwAnException_; }
     static void setThrowAnException(bool v) { throwAnException_ = v; }
 
@@ -16,3 +20,5 @@ namespace edm {
     friend class ParameterSetDescription;
   };
 }
+
+#endif

--- a/FWCore/ParameterSet/src/IllegalParameters.cc
+++ b/FWCore/ParameterSet/src/IllegalParameters.cc
@@ -1,4 +1,4 @@
 
 #include "FWCore/ParameterSet/interface/IllegalParameters.h"
 
-bool edm::IllegalParameters::throwAnException_ = true;
+std::atomic<bool> edm::IllegalParameters::throwAnException_{true};

--- a/FWCore/ServiceRegistry/test/serviceregistry_t.cppunit.cpp
+++ b/FWCore/ServiceRegistry/test/serviceregistry_t.cppunit.cpp
@@ -19,6 +19,8 @@
 
 #include "boost/thread/thread.hpp"
 
+#include <atomic>
+
 class testServiceRegistry: public CppUnit::TestFixture
 {
    CPPUNIT_TEST_SUITE(testServiceRegistry);
@@ -239,9 +241,9 @@ namespace {
          isUnique_ = (otherRegistry_ != &(edm::ServiceRegistry::instance()));
       }
       void* otherRegistry_;
-      static bool isUnique_;
+      static std::atomic<bool> isUnique_;
    };
-   bool UniqueRegistry::isUnique_ = false;
+   std::atomic<bool> UniqueRegistry::isUnique_{false};
 
    struct PassServices {
       PassServices(edm::ServiceToken iToken,

--- a/FWCore/Services/src/ProfParse.cc
+++ b/FWCore/Services/src/ProfParse.cc
@@ -1,5 +1,6 @@
 
 #include <algorithm>
+#include <atomic>
 #include <fstream>
 #include <iostream>
 #include <map>
@@ -38,10 +39,10 @@ struct PathTracker
   void setID() const { id_=next_id_++; }
   void incTotal() const { ++total_; }
 
-  static unsigned int next_id_;
+  static std::atomic<unsigned int> next_id_;
 };
 
-unsigned int PathTracker::next_id_ = 0;
+std::atomic<unsigned int> PathTracker::next_id_{0U};
 
 bool PathTracker::operator<(const PathTracker& a) const
 {

--- a/FWCore/Services/src/Sym.cc
+++ b/FWCore/Services/src/Sym.cc
@@ -10,4 +10,4 @@ operator<<(std::ostream& ost,const Sym& s)
   return ost;
 }
 
-int Sym::next_id_ = 1000000;
+std::atomic<int> Sym::next_id_{1000000};

--- a/FWCore/Services/src/Sym.h
+++ b/FWCore/Services/src/Sym.h
@@ -1,6 +1,7 @@
 #ifndef FWCore_Services_Sym_h
 #define FWCore_Services_Sym_h
 
+#include <atomic>
 #include <iosfwd>
 #include <string>
 
@@ -35,7 +36,7 @@ struct Sym {
   int          id_;
   address_type addr_;
 
-  static int next_id_;
+  static std::atomic<int> next_id_;
 
   bool
   operator<(address_type b) const

--- a/FWCore/Sources/interface/VectorInputSourceFactory.h
+++ b/FWCore/Sources/interface/VectorInputSourceFactory.h
@@ -18,7 +18,7 @@ namespace edm {
   public:
     ~VectorInputSourceFactory();
 
-    static VectorInputSourceFactory* get();
+    static VectorInputSourceFactory const* get();
 
     std::unique_ptr<VectorInputSource>
       makeVectorInputSource(ParameterSet const&,
@@ -26,7 +26,7 @@ namespace edm {
 
   private:
     VectorInputSourceFactory();
-    static VectorInputSourceFactory singleInstance_;
+    static VectorInputSourceFactory const singleInstance_;
   };
 }
 #endif

--- a/FWCore/Sources/src/VectorInputSourceFactory.cc
+++ b/FWCore/Sources/src/VectorInputSourceFactory.cc
@@ -10,18 +10,15 @@ EDM_REGISTER_PLUGINFACTORY(edm::VectorInputSourcePluginFactory,"CMS EDM Framewor
 
 namespace edm {
 
-  VectorInputSourceFactory::~VectorInputSourceFactory()
-  {
+  VectorInputSourceFactory::~VectorInputSourceFactory() {
   }
 
-  VectorInputSourceFactory::VectorInputSourceFactory()
-  {
+  VectorInputSourceFactory::VectorInputSourceFactory() {
   }
 
-  VectorInputSourceFactory VectorInputSourceFactory::singleInstance_;
+  VectorInputSourceFactory const VectorInputSourceFactory::singleInstance_;
 
-  VectorInputSourceFactory* VectorInputSourceFactory::get()
-  {
+  VectorInputSourceFactory const* VectorInputSourceFactory::get() {
     // will not work with plugin factories
     //static InputSourceFactory f;
     //return &f;
@@ -31,22 +28,19 @@ namespace edm {
 
   std::unique_ptr<VectorInputSource>
   VectorInputSourceFactory::makeVectorInputSource(ParameterSet const& conf,
-					InputSourceDescription const& desc) const
-    
-  {
+					InputSourceDescription const& desc) const {
     std::string modtype = conf.getParameter<std::string>("@module_type");
     FDEBUG(1) << "VectorInputSourceFactory: module_type = " << modtype << std::endl;
     std::unique_ptr<VectorInputSource> wm(VectorInputSourcePluginFactory::get()->create(modtype,conf,desc));
 
-    if(wm.get()==0)
-      {
+    if(wm.get() == nullptr) {
 	throw edm::Exception(errors::Configuration,"NoSourceModule")
 	  << "VectorInputSource Factory:\n"
 	  << "Cannot find source type from ParameterSet: "
 	  << modtype << "\n"
 	  << "Perhaps your source type is misspelled or is not an EDM Plugin?\n"
 	  << "Try running EdmPluginDump to obtain a list of available Plugins.";
-      }
+    }
 
     FDEBUG(1) << "VectorInputSourceFactory: created input source "
 	      << modtype

--- a/FWCore/Utilities/test/atomic_value_ptr_t.cpp
+++ b/FWCore/Utilities/test/atomic_value_ptr_t.cpp
@@ -2,13 +2,14 @@
 
 #include <memory>
 #include <cassert>
+#include <atomic>
 
 class simple
 {
   int i;
  public:
-  static int count;
-  static int count1;
+  static std::atomic<int> count;
+  static std::atomic<int> count1;
   simple() : i(0) { ++count; ++count1; }
   explicit simple(int j) : i(j) { ++count; ++count1; }
   simple(simple const& s) : i(s.i) { ++count; ++count1; }
@@ -22,8 +23,8 @@ class simple
   }
 };
 
-int simple::count = 0;
-int simple::count1 = 0;
+std::atomic<int> simple::count{0};
+std::atomic<int> simple::count1{0};
 
 
 int main()
@@ -35,7 +36,7 @@ int main()
     edm::atomic_value_ptr<simple> b(a);
     assert(simple::count == 2);
     
-    assert(*a==*b);
+    assert(*a == *b);
     assert(a->isSame(*b) == false);
   } // a and b destroyed
   assert(simple::count == 0);
@@ -43,13 +44,13 @@ int main()
   {
     std::auto_ptr<simple> c(new simple(11));
     std::auto_ptr<simple> d(new simple(11));
-    assert(c.get() != 0);
-    assert(d.get() != 0);
+    assert(c.get() != nullptr);
+    assert(d.get() != nullptr);
     simple* pc = c.get();
     simple* pd = d.get();
 
     edm::atomic_value_ptr<simple> e(c);
-    assert(c.get() == 0);
+    assert(c.get() == nullptr);
     assert(*d == *e);
     assert(e.operator->() == pc);
 
@@ -60,7 +61,7 @@ int main()
     else {
     }
     f = d;
-    assert(d.get() == 0);
+    assert(d.get() == nullptr);
     assert(*e == *f);
     assert(f.operator->() == pd);
     if (f) {

--- a/FWCore/Utilities/test/value_ptr_t.cpp
+++ b/FWCore/Utilities/test/value_ptr_t.cpp
@@ -2,13 +2,14 @@
 
 #include <memory>
 #include <cassert>
+#include <atomic>
 
 class simple
 {
   int i;
  public:
-  static int count;
-  static int count1;
+  static std::atomic<int> count;
+  static std::atomic<int> count1;
   simple() : i(0) { ++count; ++count1; }
   explicit simple(int j) : i(j) { ++count; ++count1; }
   simple(simple const& s) : i(s.i) { ++count; ++count1; }
@@ -22,8 +23,8 @@ class simple
   }
 };
 
-int simple::count = 0;
-int simple::count1 = 0;
+std::atomic<int> simple::count{0};
+std::atomic<int> simple::count1{0};
 
 
 int main()
@@ -43,13 +44,13 @@ int main()
   {
     std::auto_ptr<simple> c(new simple(11));
     std::auto_ptr<simple> d(new simple(11));
-    assert(c.get() != 0);
-    assert(d.get() != 0);
+    assert(c.get() != nullptr);
+    assert(d.get() != nullptr);
     simple* pc = c.get();
     simple* pd = d.get();
 
     edm::value_ptr<simple> e(c);
-    assert(c.get() == 0);
+    assert(c.get() == nullptr);
     assert(*d == *e);
     assert(e.operator->() == pc);
 
@@ -60,7 +61,7 @@ int main()
     else {
     }
     f = d;
-    assert(d.get() == 0);
+    assert(d.get() == nullptr);
     assert(*e == *f);
     assert(f.operator->() == pd);
     if (f) {


### PR DESCRIPTION
In the framework, fix some non-const statics.
If one is never modified, declare it const.
If one is modified, and is of a built  in type, make it std::atomic.
In one case, an integer counter was changed to a bool because it was only checked for zero or non-zero.
In some cases, 0 was changed to nullptr.
Also, some minor formatting changes for consistency.
Thested with checkdeps -a and the relval matrix.
