### PR TITLE
Add missing std:: qualifiers

### DIFF
--- a/PerfTools/EdmEvent/src/EdmEventSize.cc
+++ b/PerfTools/EdmEvent/src/EdmEventSize.cc
@@ -158,7 +158,7 @@ namespace perftools {
 
   namespace detail {
 
-    void dump(ostream& co, EdmEventSize::BranchRecord const & br) {
+    void dump(std::ostream& co, EdmEventSize::BranchRecord const & br) {
       co << br.name << " " <<  br.uncompr_size <<  " " << br.compr_size << "\n"; 
     }
   }
@@ -203,7 +203,7 @@ namespace perftools {
 	  if ( um > 0 && um < mn ) mn = um;
 	}
 	mn *= 0.8;
-	double mx = max( compressed.GetMaximum(), uncompressed.GetMaximum() );
+	double mx = std::max( compressed.GetMaximum(), uncompressed.GetMaximum() );
 	mx *= 1.2;
 	uncompressed.SetMinimum( mn );
 	uncompressed.SetMaximum( mx );


### PR DESCRIPTION
The package PerfTools/EdmEvent fails to compile against ROOT 6 because of two missing std:: namespace qualifiers.This totally trivial and technical pull request simply adds the qualifiers.
Please bypass signatures if not signed in time for pre8.
