### PR TITLE
Updated HCAL validation for SLHC

### DIFF
--- a/Validation/CaloTowers/test/macros/InputRelVal_Medium_SLHC.txt
+++ b/Validation/CaloTowers/test/macros/InputRelVal_Medium_SLHC.txt
@@ -1,0 +1,323 @@
+
+HcalDigiTask_occupancy_vs_ieta_depth1_HB	1	HcalDigiTask_occupancy_vs_ieta_depth1_HB.gif	1	-20	20	0	-1	1D	noStat	noChi2	NoLog	41	42	HcalDigiTask_occupancy_vs_ieta_depth1_HB
+HcalDigiTask_occupancy_vs_ieta_depth2_HB	1	HcalDigiTask_occupancy_vs_ieta_depth2_HB.gif	1	-20	20	0	-1	1D	noStat	noChi2	NoLog	41	42	HcalDigiTask_occupancy_vs_ieta_depth2_HB
+HcalDigiTask_occupancy_vs_ieta_depth3_HB        1       HcalDigiTask_occupancy_vs_ieta_depth3_HB.gif    1       -20     20      0       -1      1D      noStat  noChi2  NoLog   41      42      HcalDigiTask_occupancy_vs_ieta_depth3_HB
+HcalDigiTask_occupancy_vs_ieta_depth4_HB        1       HcalDigiTask_occupancy_vs_ieta_depth4_HB.gif    1       -20     20      0       -1      1D      noStat  noChi2  NoLog   41      42      HcalDigiTask_occupancy_vs_ieta_depth4_HB
+HcalDigiTask_occupancy_vs_ieta_depth5_HB        1       HcalDigiTask_occupancy_vs_ieta_depth5_HB.gif    1       -20     20      0       -1      1D      noStat  noChi2  NoLog   41      42      HcalDigiTask_occupancy_vs_ieta_depth5_HB
+HcalDigiTask_occupancy_vs_ieta_depth6_HB        1       HcalDigiTask_occupancy_vs_ieta_depth6_HB.gif    1       -20     20      0       -1      1D      noStat  noChi2  NoLog   41      42      HcalDigiTask_occupancy_vs_ieta_depth6_HB
+HcalDigiTask_occupancy_vs_ieta_depth7_HB        1       HcalDigiTask_occupancy_vs_ieta_depth7_HB.gif    1       -20     20      0       -1      1D      noStat  noChi2  NoLog   41      42      HcalDigiTask_occupancy_vs_ieta_depth7_HB
+
+
+HcalDigiTask_occupancy_vs_ieta_depth1_HE	1	HcalDigiTask_occupancy_vs_ieta_depth1_HE.gif	1	-30	30	0	-1	1D	noStat	noChi2	NoLog	41	42	HcalDigiTask_occupancy_vs_ieta_depth1_HE
+HcalDigiTask_occupancy_vs_ieta_depth2_HE	1	HcalDigiTask_occupancy_vs_ieta_depth2_HE.gif	1	-30	30	0	-1	1D	noStat	noChi2	NoLog	41	42	HcalDigiTask_occupancy_vs_ieta_depth2_HE
+HcalDigiTask_occupancy_vs_ieta_depth3_HE	1	HcalDigiTask_occupancy_vs_ieta_depth3_HE.gif	1	-30	30	0	-1	1D	noStat	noChi2	NoLog	41	42	HcalDigiTask_occupancy_vs_ieta_depth3_HE
+HcalDigiTask_occupancy_vs_ieta_depth4_HE        1       HcalDigiTask_occupancy_vs_ieta_depth4_HE.gif    1       -30     30      0       -1      1D      noStat  noChi2  NoLog   41      42      HcalDigiTask_occupancy_vs_ieta_depth4_HE
+HcalDigiTask_occupancy_vs_ieta_depth5_HE        1       HcalDigiTask_occupancy_vs_ieta_depth5_HE.gif    1       -30     30      0       -1      1D      noStat  noChi2  NoLog   41      42      HcalDigiTask_occupancy_vs_ieta_depth5_HE
+HcalDigiTask_occupancy_vs_ieta_depth6_HE        1       HcalDigiTask_occupancy_vs_ieta_depth6_HE.gif    1       -30     30      0       -1      1D      noStat  noChi2  NoLog   41      42      HcalDigiTask_occupancy_vs_ieta_depth6_HE
+HcalDigiTask_occupancy_vs_ieta_depth7_HE        1       HcalDigiTask_occupancy_vs_ieta_depth7_HE.gif    1       -30     30      0       -1      1D      noStat  noChi2  NoLog   41      42      HcalDigiTask_occupancy_vs_ieta_depth7_HE
+
+HcalDigiTask_occupancy_vs_ieta_depth1_HF	1	HcalDigiTask_occupancy_vs_ieta_depth1_HF.gif	1	-42	42	0	-1	1D	noStat	noChi2	NoLog	41	42	HcalDigiTask_occupancy_vs_ieta_depth1_HF
+HcalDigiTask_occupancy_vs_ieta_depth2_HF	1	HcalDigiTask_occupancy_vs_ieta_depth2_HF.gif	1	-42	42	0	-1	1D	noStat	noChi2	NoLog	41	42	HcalDigiTask_occupancy_vs_ieta_depth2_HF
+HcalDigiTask_occupancy_vs_ieta_depth4_HO	1	HcalDigiTask_occupancy_vs_ieta_depth4_HO.gif	1	-20	20	0	-1	1D	noStat	noChi2	NoLog	41	42	HcalDigiTask_occupancy_vs_ieta_depth4_HO
+
+
+
+HcalDigiTask_bin_5_frac_HB	1	HcalDigiTask_bin_5_frac_HB.gif	1	-0.1	1.0	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_bin_5_frac_HB
+HcalDigiTask_bin_5_frac_HE	1	HcalDigiTask_bin_5_frac_HE.gif	1	-0.1	1.0	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_bin_5_frac_HE
+HcalDigiTask_bin_5_frac_HF	1	HcalDigiTask_bin_3_frac_HF.gif	1	-1.0	2.0	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_bin_3_frac_HF
+HcalDigiTask_bin_6_7_frac_HB	1	HcalDigiTask_bin_6_7_frac_HB.gif	1	-0.1	1.0	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_bin_6_7_frac_HB
+HcalDigiTask_bin_6_7_frac_HE	1	HcalDigiTask_bin_6_7_frac_HE.gif	1	-0.1	1.0	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_bin_6_7_frac_HE
+HcalDigiTask_bin_6_7_frac_HF	1	HcalDigiTask_bin_4_5_frac_HF.gif	1	-1.0	2.0	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_bin_4_5_frac_HF
+
+
+
+HcalDigiTask_signal_amplitude_HB	1	HcalDigiTask_signal_amplitude_HB.gif    1 	-10	2000	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_signal_amplitude_HB
+HcalDigiTask_signal_amplitude_depth1_HB	1	HcalDigiTask_signal_amplitude_depth1_HB.gif    1 	-10	2000	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_signal_amplitude_depth1_HB
+HcalDigiTask_signal_amplitude_depth2_HB	1	HcalDigiTask_signal_amplitude_depth2_HB.gif    1 	-10	2000	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_signal_amplitude_depth2_HB
+HcalDigiTask_signal_amplitude_HE	1	HcalDigiTask_signal_amplitude_HE.gif    1 	-10	2000	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_signal_amplitude_HE
+HcalDigiTask_signal_amplitude_depth1_HE	1	HcalDigiTask_signal_amplitude_depth1_HE.gif    1 	-10	2000	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_signal_amplitude_depth1_HE
+HcalDigiTask_signal_amplitude_depth2_HE	1	HcalDigiTask_signal_amplitude_depth2_HE.gif    1 	-10	2000	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_signal_amplitude_depth2_HE
+HcalDigiTask_signal_amplitude_depth3_HE	1	HcalDigiTask_signal_amplitude_depth3_HE.gif    1 	-10	2000	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_signal_amplitude_depth3_HE
+HcalDigiTask_signal_amplitude_HF	1	HcalDigiTask_signal_amplitude_HF.gif    1 	-10	4000	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_signal_amplitude_HF
+HcalDigiTask_signal_amplitude_depth1_HF	1	HcalDigiTask_signal_amplitude_depth1_HF.gif    1 	-10	4000	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_signal_amplitude_depth1_HF
+HcalDigiTask_signal_amplitude_depth2_HF	1	HcalDigiTask_signal_amplitude_depth2_HF.gif    1 	-10	4000	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_signal_amplitude_depth2_HF
+HcalDigiTask_signal_amplitude_HO	1	HcalDigiTask_signal_amplitude_HO.gif    1	-10	1000	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_signal_amplitude_HO
+
+
+
+HcalDigiTask_number_of_amplitudes_above_10fC_HB	1	HcalDigiTask_number_of_amplitudes_above_10fC_HB.gif	5	-10	100	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_number_of_amplitudes_above_10fC_HB
+HcalDigiTask_number_of_amplitudes_above_10fC_HE	1	HcalDigiTask_number_of_amplitudes_above_10fC_HE.gif	5	-10	100	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_number_of_amplitudes_above_10fC_HE
+HcalDigiTask_number_of_amplitudes_above_10fC_HF	1	HcalDigiTask_number_of_amplitudes_above_10fC_HF.gif	5	-10	500	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_number_of_amplitudes_above_10fC_HF
+HcalDigiTask_number_of_amplitudes_above_10fC_HO	1	HcalDigiTask_number_of_amplitudes_above_10fC_HO.gif	1	-1	100	0	-1	1D	Statrv	Chi2	Log	2	1	HcalDigiTask_number_of_amplitudes_above_10fC_HO
+
+
+
+HcalDigiTask_amplitude_vs_simhits_HB	0	HcalDigiTask_amplitude_vs_simhits_HB.gif	1	0	0.8	0	650	TM	Statrv	noChi2	NoLog	41	42	HcalDigiTask_amplitude_vs_simhits_HB
+HcalDigiTask_amplitude_vs_simhits_profile_HB	
+HcalDigiTask_amplitude_vs_simhits_depth1_HB	0	HcalDigiTask_amplitude_vs_simhits_depth1_HB.gif	1	0	0.8	0	600	TM	Statrv	noChi2	NoLog	41	42	HcalDigiTask_amplitude_vs_simhits_depth1_HB
+HcalDigiTask_amplitude_vs_simhits_profile_depth1_HB
+HcalDigiTask_amplitude_vs_simhits_depth2_HB	0	HcalDigiTask_amplitude_vs_simhits_depth2_HB.gif	1	0	0.4	0	300	TM	Statrv	noChi2	NoLog	41	42	HcalDigiTask_amplitude_vs_simhits_depth2_HB
+HcalDigiTask_amplitude_vs_simhits_profile_depth2_HB
+HcalDigiTask_amplitude_vs_simhits_HE	0	HcalDigiTask_amplitude_vs_simhits_HE.gif	1	0	0.6	0	450	TM	Statrv	noChi2	NoLog	41	42	HcalDigiTask_amplitude_vs_simhits_HE
+HcalDigiTask_amplitude_vs_simhits_profile_HE
+HcalDigiTask_amplitude_vs_simhits_depth1_HE	0	HcalDigiTask_amplitude_vs_simhits_depth1_HE.gif	1	0	0.6	0	450	TM	Statrv	noChi2	NoLog	41	42	HcalDigiTask_amplitude_vs_simhits_depth1_HE
+HcalDigiTask_amplitude_vs_simhits_profile_depth1_HE
+HcalDigiTask_amplitude_vs_simhits_depth2_HE	0	HcalDigiTask_amplitude_vs_simhits_depth2_HE.gif	1	0	0.5	0	450	TM	Statrv	noChi2	NoLog	41	42	HcalDigiTask_amplitude_vs_simhits_depth2_HE
+HcalDigiTask_amplitude_vs_simhits_profile_depth2_HE
+HcalDigiTask_amplitude_vs_simhits_depth3_HE	0	HcalDigiTask_amplitude_vs_simhits_depth3_HE.gif	1	0	0.4	0	450	TM	Statrv	noChi2	NoLog	41	42	HcalDigiTask_amplitude_vs_simhits_depth3_HE
+HcalDigiTask_amplitude_vs_simhits_profile_depth3_HE
+HcalDigiTask_amplitude_vs_simhits_HF	0	HcalDigiTask_amplitude_vs_simhits_HF.gif	1	0	20	0	450	TM	Statrv	noChi2	NoLog	41	42	HcalDigiTask_amplitude_vs_simhits_HF
+HcalDigiTask_amplitude_vs_simhits_profile_HF
+HcalDigiTask_amplitude_vs_simhits_depth1_HF	0	HcalDigiTask_amplitude_vs_simhits_depth1_HF.gif	1	0	20	0	450	TM	Statrv	noChi2	NoLog	41	42	HcalDigiTask_amplitude_vs_simhits_depth1_HF
+HcalDigiTask_amplitude_vs_simhits_profile_depth1_HF
+HcalDigiTask_amplitude_vs_simhits_depth2_HF	0	HcalDigiTask_amplitude_vs_simhits_depth2_HF.gif	1	0	20	0	450	TM	Statrv	noChi2	NoLog	41	42	HcalDigiTask_amplitude_vs_simhits_depth2_HF
+HcalDigiTask_amplitude_vs_simhits_profile_depth2_HF
+HcalDigiTask_amplitude_vs_simhits_HO	0	HcalDigiTask_amplitude_vs_simhits_HO.gif	1	0	0.2	0	250	TM	Statrv	noChi2	NoLog	41	42	HcalDigiTask_amplitude_vs_simhits_HO
+HcalDigiTask_amplitude_vs_simhits_profile_HO
+
+
+
+HcalDigiTask_ratio_amplitude_vs_simhits_HB	0	HcalDigiTask_ratio_amplitude_vs_simhits_HB.gif	10	-50	2000	0	-1	1D	Statrv	Chi2	Log	1	2	HcalDigiTask_ratio_amplitude_vs_simhits_HB
+HcalDigiTask_ratio_amplitude_vs_simhits_depth1_HB	0	HcalDigiTask_ratio_amplitude_vs_simhits_depth1_HB.gif	10	-50	2000	0	-1	1D	Statrv	Chi2	Log	1	2	HcalDigiTask_ratio_amplitude_vs_simhits_depth1_HB
+HcalDigiTask_ratio_amplitude_vs_simhits_depth2_HB	0	HcalDigiTask_ratio_amplitude_vs_simhits_depth2_HB.gif	10	-50	2000	0	-1	1D	Statrv	Chi2	Log	1	2	HcalDigiTask_ratio_amplitude_vs_simhits_depth2_HB
+HcalDigiTask_ratio_amplitude_vs_simhits_HE	0	HcalDigiTask_ratio_amplitude_vs_simhits_HE.gif	20	0	3000	0	-1	1D	Statrv	Chi2	Log	1	2	HcalDigiTask_ratio_amplitude_vs_simhits_HE
+HcalDigiTask_ratio_amplitude_vs_simhits_depth1_HE	0	HcalDigiTask_ratio_amplitude_vs_simhits_depth1_HE.gif	20	0	3000	0	-1	1D	Statrv	Chi2	Log	1	2	HcalDigiTask_ratio_amplitude_vs_simhits_depth1_HE
+HcalDigiTask_ratio_amplitude_vs_simhits_depth2_HE	0	HcalDigiTask_ratio_amplitude_vs_simhits_depth2_HE.gif	20	0	3000	0	-1	1D	Statrv	Chi2	Log	1	2	HcalDigiTask_ratio_amplitude_vs_simhits_depth2_HE
+HcalDigiTask_ratio_amplitude_vs_simhits_depth3_HE	0	HcalDigiTask_ratio_amplitude_vs_simhits_depth3_HE.gif	20	0	3000	0	-1	1D	Statrv	Chi2	Log	1	2	HcalDigiTask_ratio_amplitude_vs_simhits_depth3_HE
+HcalDigiTask_ratio_amplitude_vs_simhits_HF	0	HcalDigiTask_ratio_amplitude_vs_simhits_HF.gif	1	-2	100	0	-1	1D	Statrv	Chi2	Log	1	2	HcalDigiTask_ratio_amplitude_vs_simhits_HF
+HcalDigiTask_ratio_amplitude_vs_simhits_depth1_HF	0	HcalDigiTask_ratio_amplitude_vs_simhits_depth1_HF.gif	1	-2	100	0	-1	1D	Statrv	Chi2	Log	1	2	HcalDigiTask_ratio_amplitude_vs_simhits_depth1_HF
+HcalDigiTask_ratio_amplitude_vs_simhits_depth2_HF	0	HcalDigiTask_ratio_amplitude_vs_simhits_depth2_HF.gif	1	-2	100	0	-1	1D	Statrv	Chi2	Log	1	2	HcalDigiTask_ratio_amplitude_vs_simhits_depth2_HF
+HcalDigiTask_ratio_amplitude_vs_simhits_HO	0	HcalDigiTask_ratio_amplitude_vs_simhits_HO.gif	10	0	2000	0	-1	1D	Statrv	Chi2	Log	1	2	HcalDigiTask_ratio_amplitude_vs_simhits_HO
+
+
+
+HcalDigiTask_Ndigis_HB	1	HcalDigiTask_Ndigis_HB.gif	5	0	600	0	-1	1D	Statrv	Chi2	Log	1	2	HcalDigiTask_Ndigis_HB
+HcalDigiTask_Ndigis_HE	1	HcalDigiTask_Ndigis_HE.gif	5	0	600	0	-1	1D	Statrv	Chi2	Log	1	2	HcalDigiTask_Ndigis_HE
+HcalDigiTask_Ndigis_HF	1	HcalDigiTask_Ndigis_HF.gif	5	0	600	0	-1	1D	Statrv	Chi2	Log	1	2	HcalDigiTask_Ndigis_HF
+HcalDigiTask_Ndigis_HO	1	HcalDigiTask_Ndigis_HO.gif	5	0	600	0	-1	1D	Statrv	Chi2	Log	1	2	HcalDigiTask_Ndigis_HO
+
+
+
+
+HcalDigiTask_signal_amplitude_vs_bin_all_depths_HB	1	HcalDigiTask_signal_amplitude_vs_bin_all_depths_HB.gif	1	0	10	0	1000	2D	noStat	noChi2	Log	2	1	HcalDigiTask_signal_amplitude_vs_bin_all_depths_HB
+HcalDigiTask_signal_amplitude_vs_bin_all_depths_HE	1	HcalDigiTask_signal_amplitude_vs_bin_all_depths_HE.gif	1	0	10	0	1000	2D	noStat	noChi2	Log	2	1	HcalDigiTask_signal_amplitude_vs_bin_all_depths_HE
+HcalDigiTask_signal_amplitude_vs_bin_all_depths_HF	1	HcalDigiTask_signal_amplitude_vs_bin_all_depths_HF.gif	1	0	10	0	4000	2D	noStat	noChi2	Log	2	1	HcalDigiTask_signal_amplitude_vs_bin_all_depths_HF
+HcalDigiTask_signal_amplitude_vs_bin_all_depths_HO	1	HcalDigiTask_signal_amplitude_vs_bin_all_depths_HO.gif	1	0	10	0	500	2D	noStat	noChi2	Log	2	1	HcalDigiTask_signal_amplitude_vs_bin_all_depths_HO
+
+
+
+
+
+                            number_of_bad_cells_Ecal_EB   1      Ecal_EB_CaloTowers_numBadCells.gif     1       0       26      0       -1      1D    noStat  noChi2    Log     2       1              bad cells number EB
+                            number_of_bad_cells_Ecal_EE   1      Ecal_EE_CaloTowers_numBadCells.gif     1       0       26      0       -1      1D    noStat  noChi2    Log     2       1              bad cells number EE
+                            number_of_bad_cells_Hcal_HB   1      Hcal_HB_CaloTowers_numBadCells.gif     1       0       5       0       -1      1D    noStat  noChi2    Log     2       1              bad cells number HB
+                            number_of_bad_cells_Hcal_HE   1      Hcal_HE_CaloTowers_numBadCells.gif     1       0       5       0       -1      1D    noStat  noChi2    Log     2       1              bad cells number HE
+                            number_of_bad_cells_Hcal_HF   1      Hcal_HF_CaloTowers_numBadCells.gif     1       0       5       0       -1      1D    noStat  noChi2    Log     2       1              bad cells number HF
+                      number_of_recovered_cells_Ecal_EB   1      Ecal_EB_CaloTowers_numRcvCells.gif     1       0       26      0       -1      1D    noStat  noChi2    Log     2       1              recovered cells number EB
+                      number_of_recovered_cells_Ecal_EE   1      Ecal_EE_CaloTowers_numRcvCells.gif     1       0       26      0       -1      1D    noStat  noChi2    Log     2       1              recovered cells number EE
+                      number_of_recovered_cells_Hcal_HB   1      Hcal_HB_CaloTowers_numRcvCells.gif     1       0       5       0       -1      1D    noStat  noChi2    Log     2       1              recovered cells number HB
+                      number_of_recovered_cells_Hcal_HE   1      Hcal_HE_CaloTowers_numRcvCells.gif     1       0       5       0       -1      1D    noStat  noChi2    Log     2       1              recovered cells number HE
+                      number_of_recovered_cells_Hcal_HF   1      Hcal_HF_CaloTowers_numRcvCells.gif     1       0       5       0       -1      1D    noStat  noChi2    Log     2       1              recovered cells number HF
+                    number_of_problematic_cells_Ecal_EB   1      Ecal_EB_CaloTowers_numPrbCells.gif     1       0       26      0       -1      1D    noStat  noChi2    Log     2       1              problematic cells number EB
+                    number_of_problematic_cells_Ecal_EE   1      Ecal_EE_CaloTowers_numPrbCells.gif     1       0       26      0       -1      1D    noStat  noChi2    Log     2       1              problematic cells number EE
+                    number_of_problematic_cells_Hcal_HB   1      Hcal_HB_CaloTowers_numPrbCells.gif     1       0       5       0       -1      1D    noStat  noChi2    Log     2       1              problematic cells number HB
+                    number_of_problematic_cells_Hcal_HE   1      Hcal_HE_CaloTowers_numPrbCells.gif     1       0       5       0       -1      1D    noStat  noChi2    Log     2       1              problematic cells number HE
+                    number_of_problematic_cells_Hcal_HF   1      Hcal_HF_CaloTowers_numPrbCells.gif     1       0       5       0       -1      1D    noStat  noChi2    Log     2       1              problematic cells number HF
+                                  CaloTowersTask_MET_HB   1	           HB_CaloTowers_MET_HB.gif	8	0	800	0	-1	1D	Stat	Chi2	Log	2	1	       HB Calo MET (GeV)
+                                  CaloTowersTask_SET_HB   1	           HB_CaloTowers_SET_HB.gif	20	0	2200	0	-1	1D	Stat	Chi2	Log	2	1	       Barrel CaloTowers SET (GeV)	
+                          CaloTowersTask_energy_ECAL_HB   1	HB_CaloTowers_Energy_in_ECAL_HB.gif	10	0	1500	0	-1	1D	Stat	Chi2	Log	2	1	       HB CaloTowers ECAL energy (GeV)
+                          CaloTowersTask_energy_HCAL_HB   1	HB_CaloTowers_Energy_in_HCAL_HB.gif	10	0	2000	0	-1	1D	Stat	Chi2	Log	2	1	       HB CaloTowers HCAL energy (GeV)
+            CaloTowersTask_energy_HcalPlusEcalPlusHO_HB   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                         CaloTowersTask_energy_OUTER_HB   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+    CaloTowersTask_energy_of_ECAL_component_of_tower_HB   0 	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+    CaloTowersTask_energy_of_HCAL_component_of_tower_HB   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                           CaloTowersTask_map_energy_HB   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                      CaloTowersTask_map_energy_ECAL_HB   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                      CaloTowersTask_map_energy_HCAL_HB   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+               CaloTowersTask_number_of_fired_towers_HB   1	       HB_CaloTowers_Ntowers_HB.gif	2	0	500	0	-1	1D	Stat	Chi2	NoLog	2	1	       HB CaloTowers number
+                              CaloTowersTask_phi_MET_HB   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+           CaloTowersTask_sum_of_energy_HCAL_vs_ECAL_HB   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                            CaloTowersTask_EM_Timing_HB   1	     HB_CaloTowers_EM_Timing_HB.gif	2	0	-1	0	-1	1D	Stat	Chi2	Log	2	1	       HB CaloTowers EM Timing
+                           CaloTowersTask_HAD_Timing_HB   1	    HB_CaloTowers_HAD_Timing_HB.gif	2	0	-1	0	-1	1D	Stat	Chi2	Log	2	1	       HB CaloTowers HAD Timing
+                     CaloTowersTask_EM_Energy_Timing_HB   1   HB_CaloTowers_EM_Energy_Timing_HB.gif	1	0	800	0	-1	TM	noStat	noChi2	NoLog	53	42	       HB CaloTowers EM Timing vs Energy
+             CaloTowersTask_EM_Energy_Timing_profile_HB
+                    CaloTowersTask_HAD_Energy_Timing_HB   1  HB_CaloTowers_HAD_Energy_Timing_HB.gif	1	0	600	0	-1	TM	noStat	noChi2	NoLog	53	42	       HB CaloTowers HAD Timing vs Energy
+            CaloTowersTask_HAD_Energy_Timing_profile_HB
+                                  CaloTowersTask_MET_HE   1	           HE_CaloTowers_MET_HE.gif	5	0	700	0	-1	1D	Stat	Chi2	Log	2	1	       HE Calo MET (GeV)
+                                  CaloTowersTask_SET_HE   1	           HE_CaloTowers_SET_HE.gif	20	0	1000	0	-1	1D	Stat	Chi2	Log	2	1	       Endcap CaloTowers SET (GeV)
+                          CaloTowersTask_energy_ECAL_HE   1	HE_CaloTowers_Energy_in_ECAL_HE.gif	5	0	-1	0	-1	1D	Stat	Chi2	Log	2	1	       HE CaloTowers ECAL energy (GeV)
+                          CaloTowersTask_energy_HCAL_HE   1	HE_CaloTowers_Energy_in_HCAL_HE.gif	5	0	-1	0	-1	1D	Stat	Chi2	Log	2	1	       HE CaloTowers HCAL energy (GeV)
+            CaloTowersTask_energy_HcalPlusEcalPlusHO_HE   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                         CaloTowersTask_energy_OUTER_HE   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+    CaloTowersTask_energy_of_ECAL_component_of_tower_HE   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+    CaloTowersTask_energy_of_HCAL_component_of_tower_HE   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                           CaloTowersTask_map_energy_HE   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                      CaloTowersTask_map_energy_ECAL_HE   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                      CaloTowersTask_map_energy_HCAL_HE   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+               CaloTowersTask_number_of_fired_towers_HE   1	       HE_CaloTowers_Ntowers_HE.gif	2	0	500	0	-1	1D	Stat	Chi2	NoLog	2	1	       HE CaloTowers number
+                              CaloTowersTask_phi_MET_HE   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+           CaloTowersTask_sum_of_energy_HCAL_vs_ECAL_HE   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                            CaloTowersTask_EM_Timing_HE   1	     HE_CaloTowers_EM_Timing_HE.gif	2	0	-1	0	-1	1D	Stat	Chi2	Log	2	1	       HE CaloTowers EM Timing
+                           CaloTowersTask_HAD_Timing_HE   1	    HE_CaloTowers_HAD_Timing_HE.gif	2	0	-1	0	-1	1D	Stat	Chi2	Log	2	1	       HE CaloTowers HAD Timing
+                     CaloTowersTask_EM_Energy_Timing_HE   1   HE_CaloTowers_EM_Energy_Timing_HE.gif	1	0	1500	0	-1	TM	noStat	noChi2	NoLog	53	42	       HE CaloTowers EM Timing vs Energy
+             CaloTowersTask_EM_Energy_Timing_profile_HE
+                    CaloTowersTask_HAD_Energy_Timing_HE   1  HE_CaloTowers_HAD_Energy_Timing_HE.gif	1	0	1500	0	-1	TM	noStat	noChi2	NoLog	53	42	       HE CaloTowers HAD Timing vs Energy
+            CaloTowersTask_HAD_Energy_Timing_profile_HE
+                                  CaloTowersTask_MET_HF   1	           HF_CaloTowers_MET_HF.gif	2	0	200	0	-1	1D	Stat	Chi2	Log	2	1	       HF Calo MET (GeV)
+                                  CaloTowersTask_SET_HF   1	           HF_CaloTowers_SET_HF.gif	2	0	-1	0	-1	1D	Stat	Chi2	Log	2	1	       Forward CaloTowers SET (GeV)
+                          CaloTowersTask_energy_ECAL_HF   1	HF_CaloTowers_Energy_in_ECAL_HF.gif	5	0	-1	0	-1	1D	Stat	Chi2	Log	2	1	       HF CaloTowers ECAL energy (GeV)
+                          CaloTowersTask_energy_HCAL_HF   1	HF_CaloTowers_Energy_in_HCAL_HF.gif	5	0	-1	0	-1	1D	Stat	Chi2	Log	2	1	       HF CaloTowers HCAL energy (GeV)
+            CaloTowersTask_energy_HcalPlusEcalPlusHO_HF   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                         CaloTowersTask_energy_OUTER_HF   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+    CaloTowersTask_energy_of_ECAL_component_of_tower_HF   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+    CaloTowersTask_energy_of_HCAL_component_of_tower_HF   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                           CaloTowersTask_map_energy_HF   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                      CaloTowersTask_map_energy_ECAL_HF   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                      CaloTowersTask_map_energy_HCAL_HF   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+               CaloTowersTask_number_of_fired_towers_HF   1	       HF_CaloTowers_Ntowers_HF.gif	2	0	500	0	-1	1D	Stat	Chi2	NoLog	2	1	       HF CaloTowers number
+                              CaloTowersTask_phi_MET_HF   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+           CaloTowersTask_sum_of_energy_HCAL_vs_ECAL_HF   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                            CaloTowersTask_EM_Timing_HF   1	     HF_CaloTowers_EM_Timing_HF.gif	2	0	-1	0	-1	1D	Stat	Chi2	Log	2	1	       HF CaloTowers EM Timing
+                           CaloTowersTask_HAD_Timing_HF   1	    HF_CaloTowers_HAD_Timing_HF.gif	2	0	-1	0	-1	1D	Stat	Chi2	Log	2	1	       HF CaloTowers HAD Timing
+                     CaloTowersTask_EM_Energy_Timing_HF   1   HF_CaloTowers_EM_Energy_Timing_HF.gif	1	0	-1	0	-1	TM	noStat	noChi2	NoLog	53	42	       HF CaloTowers EM Timing vs Energy
+             CaloTowersTask_EM_Energy_Timing_profile_HF
+                    CaloTowersTask_HAD_Energy_Timing_HF   1  HF_CaloTowers_HAD_Energy_Timing_HF.gif	1	0	-1	0	-1	TM	noStat	noChi2	NoLog	53	42	       HF CaloTowers HAD Timing vs Energy
+            CaloTowersTask_HAD_Energy_Timing_profile_HF
+                       CaloTowersTask_occupancy_vs_ieta   1        CaloTowers_occupancy_vs_ieta.gif	1	0	-1	0	-1	1D	noStat	noChi2	NoLog	41	42	       CaloTowers Occupancy vs. iEta
+                    HcalRecHitTask_RecHit_StatusWord_HB   1	                  HB_StatusWord.gif	1	0	-1	1E-8	-1	1D	NoStat	noChi2	Log	41	42	       HB status word
+                    HcalRecHitTask_RecHit_StatusWord_HE   1	                  HE_StatusWord.gif	1	0	-1	1E-8	-1	1D	NoStat	noChi2	Log	41	42	       HE status word
+                    HcalRecHitTask_RecHit_StatusWord_HF   1	                  HF_StatusWord.gif	1	0	-1	1E-8	-1	1D	NoStat	noChi2	Log	41	42	       HF status word
+                    HcalRecHitTask_RecHit_StatusWord_HO   1	                  HO_StatusWord.gif	1	0	-1	0	-1	1D	NoStat	noChi2	noLog	41	42	       HO status word
+                HcalRecHitTask_RecHit_Aux_StatusWord_HB   1                   HB_Aux_StatusWord.gif     1       0       -1      1E-8    -1      1D      NoStat  noChi2  Log     41      42             HB Aux status word
+                HcalRecHitTask_RecHit_Aux_StatusWord_HE   1                   HE_Aux_StatusWord.gif     1       0       -1      1E-8    -1      1D      NoStat  noChi2  Log     41      42             HE Aux status word
+                HcalRecHitTask_RecHit_Aux_StatusWord_HF   1                   HF_Aux_StatusWord.gif     1       0       -1      1E-8    -1      1D      NoStat  noChi2  Log     41      42             HF Aux status word
+                HcalRecHitTask_RecHit_Aux_StatusWord_HO   1                   HO_Aux_StatusWord.gif     1       0       -1      0       -1      1D      NoStat  noChi2  noLog   41      42             HO Aux status word
+                    HcalRecHitTask_energy_of_rechits_HB   1	              RecHits_energy_HB.gif	10	0	600	0	-1	1D	Statrv	Chi2	Log	2	1		HB RecHits energy (GeV)
+                    HcalRecHitTask_energy_of_rechits_HE   1	              RecHits_energy_HE.gif	10	0	-1	0	-1	1D	Statrv	Chi2	Log	2	1		HE RecHits energy (GeV)
+                    HcalRecHitTask_energy_of_rechits_HF   1	              RecHits_energy_HF.gif	10	0	-1	0	-1	1D	Statrv	Chi2	Log	2	1		HF RecHits energy (GeV)
+                    HcalRecHitTask_energy_of_rechits_HO   1	              RecHits_energy_HO.gif	1	0	60	0	-1	1D	Statrv	Chi2	Log	2	1		HO RecHits energy (GeV)
+                               HcalRecHitTask_timing_HB   1	              RecHits_timing_HB.gif	1	0	-1	0	-1	1D	Statrv	Chi2	Log	2	1		HB RecHits timing
+                               HcalRecHitTask_timing_HE   1	              RecHits_timing_HE.gif	1	0	-1	0	-1	1D	Statrv	Chi2	Log	2	1		HE RecHits timing
+                               HcalRecHitTask_timing_HF   1	              RecHits_timing_HF.gif	1	0	-1	0	-1	1D	Statrv	Chi2	Log	2	1		HF RecHits timing
+                               HcalRecHitTask_timing_HO   1	              RecHits_timing_HO.gif	1	0	-1	0	-1	1D	Statrv	Chi2	Log	2	1		HO RecHits timing
+                     HcalRecHitTask_timing_vs_energy_HB   1	            HB_Timing_vs_Energy.gif	1	0	500	0	-1	TM	NoStat	noChi2	noLog	53	42	      HB Timing vs. Energy
+             HcalRecHitTask_timing_vs_energy_profile_HB
+              HcalRecHitTask_timing_vs_energy_HB_depth1   0	notDrawn.gif	1	-1	-1	-1	-1	1D	Stat	Chi2	Log	2	1	notDrawn
+              HcalRecHitTask_timing_vs_energy_HB_depth2   0     notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                     HcalRecHitTask_timing_vs_energy_HE   1	            HE_Timing_vs_Energy.gif	1	0	500	0	-1	TM	NoStat	noChi2	noLog	53	42	      HE Timing vs. Energy
+             HcalRecHitTask_timing_vs_energy_profile_HE
+              HcalRecHitTask_timing_vs_energy_HE_depth1   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+              HcalRecHitTask_timing_vs_energy_HE_depth2   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                     HcalRecHitTask_timing_vs_energy_HF   1	            HF_Timing_vs_Energy.gif	1	0	-1	0	-1	TM	NoStat	noChi2	noLog	53	42	      HF Timing vs. Energy
+             HcalRecHitTask_timing_vs_energy_profile_HF
+                    HcalRecHitTask_timing_vs_energy_HFL   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                    HcalRecHitTask_timing_vs_energy_HFS   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                     HcalRecHitTask_timing_vs_energy_HO   1	            HO_Timing_vs_Energy.gif	1	0	30	0	-1	TM	NoStat	noChi2	noLog	53	42	      HO Timing vs. Energy
+             HcalRecHitTask_timing_vs_energy_profile_HO
+                                                   N_HB   1	                           N_HB.gif	10	0	1200	0	-1	1D	Statrv	Chi2	NoLog	2	1		Number of HB RecHits
+                                                   N_HE   1	                           N_HE.gif	10	0	500	0	-1	1D	Statrv	Chi2	NoLog	2	1		Number of HE RecHits
+                                                   N_HF   1	                           N_HF.gif	10	0	600	0	-1	1D	Statrv	Chi2	NoLog	2	1		Number of HF RecHits
+                                                   N_HO   1	                           N_HO.gif	10	0	600	0	-1	1D	Statrv	Chi2	NoLog	2	1		Number of HO RecHits
+                        HcalRecHitTask_severityLevel_HB   1                    severityLevel_HB.gif     1       0       25      0       -1      1D    noStat  noChi2    Log     2       1                 severityLevel HB
+                        HcalRecHitTask_severityLevel_HE   1                    severityLevel_HE.gif     1       0       25      0       -1      1D    noStat  noChi2    Log     2       1                 severityLevel HE
+                        HcalRecHitTask_severityLevel_HF   1                    severityLevel_HF.gif     1       0       25      0       -1      1D    noStat  noChi2    Log     2       1                 severityLevel HF
+                        HcalRecHitTask_severityLevel_HO   1                    severityLevel_HO.gif     1       0       25      0       -1      1D    noStat  noChi2    Log     2       1                 severityLevel HO
+                                            RMS_seq_HB1   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                            RMS_seq_HB2   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                            RMS_seq_HE1   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                            RMS_seq_HE2   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                            RMS_seq_HE3   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                            RMS_seq_HF1   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                            RMS_seq_HF2   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                             RMS_seq_HO   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                        RMS_vs_ieta_HB1   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                        RMS_vs_ieta_HB2   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                        RMS_vs_ieta_HE1   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                        RMS_vs_ieta_HE2   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                        RMS_vs_ieta_HE3   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                        RMS_vs_ieta_HF1   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                        RMS_vs_ieta_HF2   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                         RMS_vs_ieta_HO   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                          emean_seq_HB1   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                          emean_seq_HB2   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                          emean_seq_HE1   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                          emean_seq_HE2   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                          emean_seq_HE3   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                          emean_seq_HF1   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                          emean_seq_HF2   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                           emean_seq_HO   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                      emean_vs_ieta_HB1   1	              emean_vs_ieta_HB1.gif	1	0	-1	0	-1	PR	noStat	noChi2	NoLog	41	42		Mean energy vs ieta (GeV) HB depth1
+                                      emean_vs_ieta_HB2   1	              emean_vs_ieta_HB2.gif	1	0	-1	0	-1	PR	noStat	noChi2	NoLog	41	42		Mean energy vs ieta (GeV) HB depth2
+                                      emean_vs_ieta_HB3   1                   emean_vs_ieta_HB3.gif     1       0       -1      0       -1      PR      noStat  noChi2  NoLog   41      42              Mean energy vs ieta (GeV) HB depth3
+                                      emean_vs_ieta_HB4   1                   emean_vs_ieta_HB4.gif     1       0       -1      0       -1      PR      noStat  noChi2  NoLog   41      42              Mean energy vs ieta (GeV) HB depth4
+                                      emean_vs_ieta_HB5   1                   emean_vs_ieta_HB5.gif     1       0       -1      0       -1      PR      noStat  noChi2  NoLog   41      42              Mean energy vs ieta (GeV) HB depth5
+                                      emean_vs_ieta_HB6   1                   emean_vs_ieta_HB6.gif     1       0       -1      0       -1      PR      noStat  noChi2  NoLog   41      42              Mean energy vs ieta (GeV) HB depth6
+                                      emean_vs_ieta_HB7   1                   emean_vs_ieta_HB7.gif     1       0       -1      0       -1      PR      noStat  noChi2  NoLog   41      42              Mean energy vs ieta (GeV) HB depth7
+                                      emean_vs_ieta_HE1   1	              emean_vs_ieta_HE1.gif	1	0	-1	0	-1	PR	noStat	noChi2	NoLog	41	42		Mean energy vs ieta (GeV) HE depth1
+                                      emean_vs_ieta_HE2   1	              emean_vs_ieta_HE2.gif	1	0	-1	0	-1	PR	noStat	noChi2	NoLog	41	42		Mean energy vs ieta (GeV) HE depth2
+                                      emean_vs_ieta_HE3   1	              emean_vs_ieta_HE3.gif	1	0	-1	0	-1	PR	noStat	noChi2	NoLog	41	42		Mean energy vs ieta (GeV) HE depth3
+                                      emean_vs_ieta_HE4   1                   emean_vs_ieta_HE4.gif     1       0       -1      0       -1      PR      noStat  noChi2  NoLog   41      42              Mean energy vs ieta (GeV) HE depth4
+                                      emean_vs_ieta_HE5   1                   emean_vs_ieta_HE5.gif     1       0       -1      0       -1      PR      noStat  noChi2  NoLog   41      42              Mean energy vs ieta (GeV) HE depth5
+                                      emean_vs_ieta_HE6   1                   emean_vs_ieta_HE6.gif     1       0       -1      0       -1      PR      noStat  noChi2  NoLog   41      42              Mean energy vs ieta (GeV) HE depth6
+                                      emean_vs_ieta_HE7   1                   emean_vs_ieta_HE7.gif     1       0       -1      0       -1      PR      noStat  noChi2  NoLog   41      42              Mean energy vs ieta (GeV) HE depth7
+
+
+                                      emean_vs_ieta_HF1   1	              emean_vs_ieta_HF1.gif	1	0	-1	0	-1	PR	noStat	noChi2	NoLog	41	42		Mean energy vs ieta (GeV) HF depth1
+                                      emean_vs_ieta_HF2   1	              emean_vs_ieta_HF2.gif	1	0	-1	0	-1	PR	noStat	noChi2	NoLog	41	42		Mean energy vs ieta (GeV) HF depth2
+                                       emean_vs_ieta_HO   1	               emean_vs_ieta_HO.gif	1	0	-1	0	-1	PR	noStat	noChi2	NoLog	41	42		Mean energy vs ieta (GeV) HO 
+                                               map_ecal   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                   occ_sequential1D_HB1   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                   occ_sequential1D_HB2   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                   occ_sequential1D_HE1   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                   occ_sequential1D_HE2   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                   occ_sequential1D_HE3   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                   occ_sequential1D_HF1   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                   occ_sequential1D_HF2   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                    occ_sequential1D_HO   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                      occupancy_map_HB1   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                      occupancy_map_HB2   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                      occupancy_map_HE1   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                      occupancy_map_HE2   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                      occupancy_map_HE3   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                      occupancy_map_HF1   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                      occupancy_map_HF2   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                       occupancy_map_HO   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                  occupancy_vs_ieta_HB1   1	          occupancy_vs_ieta_HB1.gif	1	0	-1	0	-1	1D	noStat	noChi2	NoLog	41	42		HB depth 1: occupancy vs ieta
+                                  occupancy_vs_ieta_HB2   1	          occupancy_vs_ieta_HB2.gif	1	0	-1	0	-1	1D	noStat	noChi2	NoLog	41	42		HB depth 2: occupancy vs ieta
+                                  occupancy_vs_ieta_HB3   1               occupancy_vs_ieta_HB3.gif     1       0       -1      0       -1      1D      noStat  noChi2  NoLog   41      42              HB depth 3: occupancy vs ieta
+                                  occupancy_vs_ieta_HB4   1               occupancy_vs_ieta_HB4.gif     1       0       -1      0       -1      1D      noStat  noChi2  NoLog   41      42              HB depth 4: occupancy vs ieta
+                                  occupancy_vs_ieta_HB5   1               occupancy_vs_ieta_HB5.gif     1       0       -1      0       -1      1D      noStat  noChi2  NoLog   41      42              HB depth 5: occupancy vs ieta
+                                  occupancy_vs_ieta_HB6   1               occupancy_vs_ieta_HB6.gif     1       0       -1      0       -1      1D      noStat  noChi2  NoLog   41      42              HB depth 6: occupancy vs ieta
+                                  occupancy_vs_ieta_HB7   1               occupancy_vs_ieta_HB7.gif     1       0       -1      0       -1      1D      noStat  noChi2  NoLog   41      42              HB depth 7: occupancy vs ieta
+
+
+
+                                  occupancy_vs_ieta_HE1   1	          occupancy_vs_ieta_HE1.gif	1	0	-1	0	-1	1D	noStat	noChi2	NoLog	41	42		HE depth 1: occupancy vs ieta
+                                  occupancy_vs_ieta_HE2   1	          occupancy_vs_ieta_HE2.gif	1	0	-1	0	-1	1D	noStat	noChi2	NoLog	41	42		HE depth 2: occupancy vs ieta
+                                  occupancy_vs_ieta_HE3   1	          occupancy_vs_ieta_HE3.gif	1	0	-1	0	-1	1D	noStat	noChi2	NoLog	41	42		HE depth 3: occupancy vs ieta
+                                  occupancy_vs_ieta_HE4   1               occupancy_vs_ieta_HE4.gif     1       0       -1      0       -1      1D      noStat  noChi2  NoLog   41      42              HE depth 4: occupancy vs ieta
+                                  occupancy_vs_ieta_HE5   1               occupancy_vs_ieta_HE5.gif     1       0       -1      0       -1      1D      noStat  noChi2  NoLog   41      42              HE depth 5: occupancy vs ieta
+                                  occupancy_vs_ieta_HE6   1               occupancy_vs_ieta_HE6.gif     1       0       -1      0       -1      1D      noStat  noChi2  NoLog   41      42              HE depth 6: occupancy vs ieta
+                                  occupancy_vs_ieta_HE7   1               occupancy_vs_ieta_HE7.gif     1       0       -1      0       -1      1D      noStat  noChi2  NoLog   41      42              HE depth 7: occupancy vs ieta
+
+
+                                  occupancy_vs_ieta_HF1   1	          occupancy_vs_ieta_HF1.gif	1	0	-1	0	-1	1D	noStat	noChi2	NoLog	41	42		HF depth 1: occupancy vs ieta
+                                  occupancy_vs_ieta_HF2   1	          occupancy_vs_ieta_HF2.gif	1	0	-1	0	-1	1D	noStat	noChi2	NoLog	41	42		HF depth 2: occupancy vs ieta
+                                   occupancy_vs_ieta_HO   1	           occupancy_vs_ieta_HO.gif	1	0	-1	0	-1	1D	noStat	noChi2	NoLog	41	42		HO: occupancy vs ieta
+                                            emap_depth1   1                    emap_depth1.gif          1      -42      42      0       72      2D      noStat  noChi2  NoLog    2       1                 eta-phi RecHits Emap depth1
+                                            emap_depth1   1                    emap_depth1-1.gif        1      -29      29      0       72      2D      noStat  noChi2  NoLog    2       1                 eta-phi RecHits Emap depth1 (HB/HE)
+                                            emap_depth2   1                    emap_depth2.gif          1      -42      42      0       72      2D      noStat  noChi2  NoLog    2       1                 eta-phi RecHits Emap depth2
+                                            emap_depth3   1                    emap_depth3.gif          1      -42      42      0       72      2D      noStat  noChi2  NoLog    2       1                 eta-phi RecHits Emap depth3
+                                            emap_depth4   1                    emap_depth4.gif          1      -42      42      0       72      2D      noStat  noChi2  NoLog    2       1                 eta-phi RecHits Emap depth4 
+                                            emap_depth5   1                    emap_depth5.gif          1      -42      42      0       72      2D      noStat  noChi2  NoLog    2       1                 eta-phi RecHits Emap depth5
+                                            emap_depth6   1                    emap_depth6.gif          1      -42      42      0       72      2D      noStat  noChi2  NoLog    2       1                 eta-phi RecHits Emap depth6
+                                            emap_depth7   1                    emap_depth7.gif          1      -42      42      0       72      2D      noStat  noChi2  NoLog    2       1                 eta-phi RecHits Emap depth7
+
+                         
+
+                                        hLumiBlockCount   0	notDrawn.gif    1       -1      -1      -1      -1      1D      Stat    Chi2    Log     2       1       notDrawn
+                                             hRBXEnergy   1	                     RBX_energy.gif	1	0	500	0	-1	1D	Statrv	Chi2	NoLog	2	1	      RBX energy (GeV)
+                                        hRBXEnergyType1   1	               RBX_energy_type1.gif	1	0	400	0	-1	1D	Statrv	Chi2	NoLog	2	1	      RBX energy type 1 (GeV)
+                                        hRBXEnergyType2   1	               RBX_energy_type2.gif	4	0	1200	0	-1	1D	Statrv	Chi2	NoLog	2	1	      RBX energy type 2 (GeV)
+                                        hRBXEnergyType3   1	               RBX_energy_type3.gif	4	0	1200	0	-1	1D	Statrv	Chi2	NoLog	2	1	      RBX energy type 3 (GeV)
+                                              hRBXNHits   1	                      RBX_Nhits.gif	1	0	40	0	-1	1D	Statrv	Chi2	NoLog	2	1	      RBX number of hits

--- a/Validation/CaloTowers/test/macros/RelValMacro.C
+++ b/Validation/CaloTowers/test/macros/RelValMacro.C
@@ -42,12 +42,12 @@ void RelValMacro(TString ref_vers = "218", TString val_vers = "218", TString rfn
     //HcalDigis
     //Please note 22 MC histograms are taken OUT of here
     //Add 11 for HD_nProfID and 11 for HD_nHist1 and 22 for HD_nHistTot
-    const int HD_nHistTot = 43 + 11 + 4 + 1; 
+    const int HD_nHistTot = 43 + 11 + 4 + 1 + 9 ; 
 //    const int HD_nHistTot = 43 + 11 + 4 + 11 + 1;
-    const int HD_nHist1 = 8 + 5 + 11 + 4 + 4 + 1;
+    const int HD_nHist1 = 8 + 5 + 11 + 4 + 4 + 1 + 9 ;
 //    const int HD_nHist1 = 8 + 5 + 11 + 4 + 11 + 4 + 1;
-    const int HD_nHist2 = 11;
-    const int HD_nHist2D = 4;
+    const int HD_nHist2 = 11 ;
+    const int HD_nHist2D = 4 ;
     const int HD_nProfInd = 0;
 //    const int HD_nProfInd = 11;
 
@@ -58,11 +58,11 @@ void RelValMacro(TString ref_vers = "218", TString val_vers = "218", TString rfn
     const int CT_nProf = 6;
 
     //RecHits
-    const int RH_nHistTot = 87 + 4 + 4 + 5;
-    const int RH_nHist1 = 24 + 4 + 4;
+    const int RH_nHistTot = 87 + 4 + 4 + 5 + 9 + 9 + 3;
+    const int RH_nHist1 = 24 + 4 + 4 + 9;
     const int RH_nHist2 = 4;
-    const int RH_nHist2D = 5;
-    const int RH_nProfInd = 12;
+    const int RH_nHist2D = 5 + 3;
+    const int RH_nProfInd = 12 + 9;
 
     //RBX Noise
     const int RBX_nHistTot = 6;

--- a/Validation/CaloTowers/test/macros/RunRVMacros_SLHC.csh
+++ b/Validation/CaloTowers/test/macros/RunRVMacros_SLHC.csh
@@ -1,0 +1,141 @@
+#!/bin/tcsh
+
+#Check to see if the CMS environment is set up
+if ($?CMSSW_BASE != 1) then
+    echo "CMS environment not set up"
+#    exit
+endif
+
+#Check for correct number of arguments
+if ($#argv<2) then
+    echo "Script needs 2 input variable"
+#    exit
+endif
+
+set NEW_VERS=$1
+set OLD_VERS=$2
+
+# Two bit value with the first corresponding to whether the validation version is centrally
+# harvested (1) or not (0) and the second to whether the reference version is harvested. Thus:
+# 00: both are privately produced
+# 01: reference version is harvested, validation version is private
+# 10: validation version is harvested, reference version is private
+# 11: both versions are harvested
+# Any other value is the same as 0
+set harvest=11
+
+#Check if base directory already exists
+if (-d ${NEW_VERS}_vs_${OLD_VERS}_RelVal) then
+    echo "Directory already exists"
+    exit
+endif
+
+#Create base directory and top directories
+mkdir ${NEW_VERS}_vs_${OLD_VERS}_RelVal
+cd ${NEW_VERS}_vs_${OLD_VERS}_RelVal
+
+cp ../html_indices/TopLevelRelVal.html index.html
+
+
+#TTbar
+mkdir TTbar
+mkdir TTbar/CaloTowers
+mkdir TTbar/RecHits
+mkdir TTbar/RBX
+mkdir TTbar/HcalDigis
+
+cp ../html_indices/RelVal_HcalDigis_SLHC.html TTbar/HcalDigis/index.html
+cat ../html_indices/RelVal_RecHits_SLHC.html | sed -e s/DATA_SAMPLE/TTbar/ > TTbar/RecHits/index.html
+cp ../html_indices/RelVal_CaloTowers.html TTbar/CaloTowers/index.html
+cp ../html_indices/RBX.html               TTbar/RBX/index.html
+
+#cp -r TTbar TTbarStartup
+#mv    TTbar TTbarMC
+
+#QCD
+mkdir QCD
+mkdir QCD/CaloTowers
+mkdir QCD/RecHits
+mkdir QCD/RBX
+mkdir QCD/HcalDigis
+
+cp ../html_indices/RelVal_HcalDigis_SLHC.html QCD/HcalDigis/index.html
+cat ../html_indices/RelVal_RecHits_SLHC.html | sed -e s/DATA_SAMPLE/QCD_80_120/ > QCD/RecHits/index.html
+cp ../html_indices/RelVal_CaloTowers.html QCD/CaloTowers/index.html
+cp ../html_indices/RBX.html               QCD/RBX/index.html
+
+#cp -r QCD QCDStartup
+#mv    QCD QCDMC
+
+#High Pt QCD
+mkdir HighPtQCD
+mkdir HighPtQCD/CaloTowers
+mkdir HighPtQCD/RecHits
+mkdir HighPtQCD/RBX
+mkdir HighPtQCD/HcalDigis
+
+cp ../html_indices/RelVal_HcalDigis_SLHC.html HighPtQCD/HcalDigis/index.html
+cat ../html_indices/RelVal_RecHits_SLHC.html | sed -e s/DATA_SAMPLE/QCD_3000_3500/ > HighPtQCD/RecHits/index.html
+cp ../html_indices/RelVal_CaloTowers.html HighPtQCD/CaloTowers/index.html
+cp ../html_indices/RBX.html               HighPtQCD/RBX/index.html
+
+#MinBias
+mkdir MinBias
+mkdir MinBias/CaloTowers
+mkdir MinBias/RecHits
+mkdir MinBias/RBX
+mkdir MinBias/HcalDigis
+
+cp ../html_indices/RelVal_HcalDigis_SLHC.html MinBias/HcalDigis/index.html
+cat ../html_indices/RelVal_RecHits_SLHC.html | sed -e s/DATA_SAMPLE/MinBias/ > MinBias/RecHits/index.html
+cp ../html_indices/RelVal_CaloTowers.html MinBias/CaloTowers/index.html
+cp ../html_indices/RBX.html               MinBias/RBX/index.html
+
+
+#Single Pions
+
+mkdir SinglePi50_ECAL+HCAL_Scan
+
+cp ../html_indices/SinglePiScan.html       SinglePi50_ECAL+HCAL_Scan/index.html
+
+cd ../
+
+
+#Process Startup TTbar
+root -b -q 'RelValMacro.C("'${OLD_VERS}'","'${NEW_VERS}'","'HcalRecHitValidationRelVal_TTbar_${OLD_VERS}.root'","'HcalRecHitValidationRelVal_TTbar_${NEW_VERS}.root'","InputRelVal_Medium_SLHC.txt",'${harvest}')'
+
+mv *HcalDigi*.gif   ${NEW_VERS}_vs_${OLD_VERS}_RelVal/TTbar/HcalDigis/
+mv *CaloTowers*.gif ${NEW_VERS}_vs_${OLD_VERS}_RelVal/TTbar/CaloTowers/
+mv RBX*gif          ${NEW_VERS}_vs_${OLD_VERS}_RelVal/TTbar/RBX/
+mv *gif             ${NEW_VERS}_vs_${OLD_VERS}_RelVal/TTbar/RecHits/
+
+
+#Process Startup QCD
+root -b -q 'RelValMacro.C("'${OLD_VERS}_QCD'","'${NEW_VERS}_QCD'","'HcalRecHitValidationRelVal_QCD80_120_${OLD_VERS}.root'","'HcalRecHitValidationRelVal_QCD80_120_${NEW_VERS}.root'","InputRelVal_Medium_SLHC.txt",'${harvest}')'
+
+mv *HcalDigi*.gif   ${NEW_VERS}_vs_${OLD_VERS}_RelVal/QCD/HcalDigis/
+mv *CaloTowers*.gif ${NEW_VERS}_vs_${OLD_VERS}_RelVal/QCD/CaloTowers/
+mv RBX*gif          ${NEW_VERS}_vs_${OLD_VERS}_RelVal/QCD/RBX/
+mv *gif             ${NEW_VERS}_vs_${OLD_VERS}_RelVal/QCD/RecHits/
+
+#Process Startup HighPtQCD
+root -b -q 'RelValMacro.C("'${OLD_VERS}_Startup'","'${NEW_VERS}_Startup'","'HcalRecHitValidationRelVal_HighPtQCD_Startup_${OLD_VERS}.root'","'HcalRecHitValidationRelVal_HighPtQCD_Startup_${NEW_VERS}.root'","InputRelVal_Medium_SLHC.txt",'${harvest}')'
+
+mv *HcalDigi*.gif   ${NEW_VERS}_vs_${OLD_VERS}_RelVal/HighPtQCD/HcalDigis/
+mv *CaloTowers*.gif ${NEW_VERS}_vs_${OLD_VERS}_RelVal/HighPtQCD/CaloTowers/
+mv RBX*gif          ${NEW_VERS}_vs_${OLD_VERS}_RelVal/HighPtQCD/RBX/
+mv *gif             ${NEW_VERS}_vs_${OLD_VERS}_RelVal/HighPtQCD/RecHits/
+
+#Process Startup MinBias
+root -b -q 'RelValMacro.C("'${OLD_VERS}_Startup'","'${NEW_VERS}_Startup'","'HcalRecHitValidationRelVal_MinBias_Startup_${OLD_VERS}.root'","'HcalRecHitValidationRelVal_MinBias_Startup_${NEW_VERS}.root'","InputRelVal_Medium_SLHC.txt",'${harvest}')'
+
+mv *HcalDigi*.gif   ${NEW_VERS}_vs_${OLD_VERS}_RelVal/MinBias/HcalDigis/
+mv *CaloTowers*.gif ${NEW_VERS}_vs_${OLD_VERS}_RelVal/MinBias/CaloTowers/
+mv RBX*gif          ${NEW_VERS}_vs_${OLD_VERS}_RelVal/MinBias/RBX/
+mv *gif             ${NEW_VERS}_vs_${OLD_VERS}_RelVal/MinBias/RecHits/
+
+#Process single pions
+#root -b -q 'SinglePi.C("'${OLD_VERS}'","'${NEW_VERS}'")'
+mv *gif                 ${NEW_VERS}_vs_${OLD_VERS}_RelVal/SinglePi50_ECAL+HCAL_Scan
+
+exit

--- a/Validation/CaloTowers/test/macros/html_indices/RelVal_HcalDigis_SLHC.html
+++ b/Validation/CaloTowers/test/macros/html_indices/RelVal_HcalDigis_SLHC.html
@@ -1,0 +1,108 @@
+<p><p><font color="#aa0000"> >>> click on thumbnail to get a full-size plot </font>
+
+
+<hr><h2><CENTER>	Occupancy	</CENTER></h2>
+<A HREF= "	HcalDigiTask_occupancy_vs_ieta_depth1_HB.gif	"> <img src="	HcalDigiTask_occupancy_vs_ieta_depth1_HB.gif	" width="45%">  </A>
+<A HREF= "	HcalDigiTask_occupancy_vs_ieta_depth2_HB.gif	"> <img src="	HcalDigiTask_occupancy_vs_ieta_depth2_HB.gif	" width="45%">  </A>
+<A HREF= "      HcalDigiTask_occupancy_vs_ieta_depth3_HB.gif    "> <img src="   HcalDigiTask_occupancy_vs_ieta_depth3_HB.gif    " width="45%">  </A>
+<A HREF= "      HcalDigiTask_occupancy_vs_ieta_depth4_HB.gif    "> <img src="   HcalDigiTask_occupancy_vs_ieta_depth4_HB.gif    " width="45%">  </A>
+<A HREF= "      HcalDigiTask_occupancy_vs_ieta_depth5_HB.gif    "> <img src="   HcalDigiTask_occupancy_vs_ieta_depth5_HB.gif    " width="45%">  </A>
+<A HREF= "      HcalDigiTask_occupancy_vs_ieta_depth6_HB.gif    "> <img src="   HcalDigiTask_occupancy_vs_ieta_depth6_HB.gif    " width="45%">  </A>
+<A HREF= "      HcalDigiTask_occupancy_vs_ieta_depth7_HB.gif    "> <img src="   HcalDigiTask_occupancy_vs_ieta_depth7_HB.gif    " width="45%">  </A>
+
+
+<A HREF= "	HcalDigiTask_occupancy_vs_ieta_depth1_HE.gif	"> <img src="	HcalDigiTask_occupancy_vs_ieta_depth1_HE.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_occupancy_vs_ieta_depth2_HE.gif	"> <img src="	HcalDigiTask_occupancy_vs_ieta_depth2_HE.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_occupancy_vs_ieta_depth3_HE.gif	"> <img src="	HcalDigiTask_occupancy_vs_ieta_depth3_HE.gif	" width="30%">  </A>
+<A HREF= "      HcalDigiTask_occupancy_vs_ieta_depth4_HE.gif    "> <img src="   HcalDigiTask_occupancy_vs_ieta_depth4_HE.gif    " width="30%">  </A>
+<A HREF= "      HcalDigiTask_occupancy_vs_ieta_depth5_HE.gif    "> <img src="   HcalDigiTask_occupancy_vs_ieta_depth5_HE.gif    " width="30%">  </A>
+<A HREF= "      HcalDigiTask_occupancy_vs_ieta_depth6_HE.gif    "> <img src="   HcalDigiTask_occupancy_vs_ieta_depth6_HE.gif    " width="30%">  </A>
+<A HREF= "      HcalDigiTask_occupancy_vs_ieta_depth7_HE.gif    "> <img src="   HcalDigiTask_occupancy_vs_ieta_depth7_HE.gif    " width="30%">  </A>
+
+<A HREF= "	HcalDigiTask_occupancy_vs_ieta_depth1_HF.gif	"> <img src="	HcalDigiTask_occupancy_vs_ieta_depth1_HF.gif	" width="45%">  </A>
+<A HREF= "	HcalDigiTask_occupancy_vs_ieta_depth2_HF.gif	"> <img src="	HcalDigiTask_occupancy_vs_ieta_depth2_HF.gif	" width="45%">  </A>
+<A HREF= "	HcalDigiTask_occupancy_vs_ieta_depth4_HO.gif	"> <img src="	HcalDigiTask_occupancy_vs_ieta_depth4_HO.gif	" width="45%">  </A>
+
+
+<hr><h2><CENTER>	Fraction of Signal in SOI and subequent TS' Over Amplitude if Ampl. is Big	</CENTER></h2>
+<A HREF= "	HcalDigiTask_bin_5_frac_HB.gif	"> <img src="	HcalDigiTask_bin_5_frac_HB.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_bin_5_frac_HE.gif	"> <img src="	HcalDigiTask_bin_5_frac_HE.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_bin_3_frac_HF.gif	"> <img src="	HcalDigiTask_bin_3_frac_HF.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_bin_6_7_frac_HB.gif	"> <img src="	HcalDigiTask_bin_6_7_frac_HB.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_bin_6_7_frac_HE.gif	"> <img src="	HcalDigiTask_bin_6_7_frac_HE.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_bin_4_5_frac_HF.gif	"> <img src="	HcalDigiTask_bin_4_5_frac_HF.gif	" width="30%">  </A>
+
+
+<hr><h2><CENTER>        Signal Amplitude </CENTER></h2>
+<A HREF= "	HcalDigiTask_signal_amplitude_HB.gif	"> <img src="	HcalDigiTask_signal_amplitude_HB.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_signal_amplitude_depth1_HB.gif	"> <img src="	HcalDigiTask_signal_amplitude_depth1_HB.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_signal_amplitude_depth2_HB.gif	"> <img src="	HcalDigiTask_signal_amplitude_depth2_HB.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_signal_amplitude_HE.gif	"> <img src="	HcalDigiTask_signal_amplitude_HE.gif	" width="45%">  </A>
+<A HREF= "	HcalDigiTask_signal_amplitude_depth1_HE.gif	"> <img src="	HcalDigiTask_signal_amplitude_depth1_HE.gif	" width="45%">  </A>
+<A HREF= "	HcalDigiTask_signal_amplitude_depth2_HE.gif	"> <img src="	HcalDigiTask_signal_amplitude_depth2_HE.gif	" width="45%">  </A>
+<A HREF= "	HcalDigiTask_signal_amplitude_depth3_HE.gif	"> <img src="	HcalDigiTask_signal_amplitude_depth3_HE.gif	" width="45%">  </A>
+<A HREF= "	HcalDigiTask_signal_amplitude_HF.gif	"> <img src="	HcalDigiTask_signal_amplitude_HF.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_signal_amplitude_depth1_HF.gif	"> <img src="	HcalDigiTask_signal_amplitude_depth1_HF.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_signal_amplitude_depth2_HF.gif	"> <img src="	HcalDigiTask_signal_amplitude_depth2_HF.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_signal_amplitude_HO.gif	"> <img src="	HcalDigiTask_signal_amplitude_HO.gif	" width="45%">  </A>
+
+
+<hr><h2><CENTER>	Number Of Amplitudes	</CENTER></h2>
+<A HREF= "	HcalDigiTask_number_of_amplitudes_above_10fC_HB.gif	"> <img src="	HcalDigiTask_number_of_amplitudes_above_10fC_HB.gif	" width="45%">  </A>
+<A HREF= "	HcalDigiTask_number_of_amplitudes_above_10fC_HE.gif	"> <img src="	HcalDigiTask_number_of_amplitudes_above_10fC_HE.gif	" width="45%">  </A>
+<A HREF= "	HcalDigiTask_number_of_amplitudes_above_10fC_HF.gif	"> <img src="	HcalDigiTask_number_of_amplitudes_above_10fC_HF.gif	" width="45%">  </A>
+<A HREF= "	HcalDigiTask_number_of_amplitudes_above_10fC_HO.gif	"> <img src="	HcalDigiTask_number_of_amplitudes_above_10fC_HO.gif	" width="45%">  </A>
+
+<!--
+<hr><h2><CENTER>	Amplitudes Versus Simhits	</CENTER></h2>
+<A HREF= "	HcalDigiTask_amplitude_vs_simhits_HB.gif	"> <img src="	HcalDigiTask_amplitude_vs_simhits_HB.gif	" width="30%">  </A>
+
+<A HREF= "	HcalDigiTask_amplitude_vs_simhits_depth1_HB.gif	"> <img src="	HcalDigiTask_amplitude_vs_simhits_depth1_HB.gif	" width="30%">  </A>
+
+<A HREF= "	HcalDigiTask_amplitude_vs_simhits_depth2_HB.gif	"> <img src="	HcalDigiTask_amplitude_vs_simhits_depth2_HB.gif	" width="30%">  </A>
+
+<A HREF= "	HcalDigiTask_amplitude_vs_simhits_HE.gif	"> <img src="	HcalDigiTask_amplitude_vs_simhits_HE.gif	" width="45%">  </A>
+
+<A HREF= "	HcalDigiTask_amplitude_vs_simhits_depth1_HE.gif	"> <img src="	HcalDigiTask_amplitude_vs_simhits_depth1_HE.gif	" width="45%">  </A>
+
+<A HREF= "	HcalDigiTask_amplitude_vs_simhits_depth2_HE.gif	"> <img src="	HcalDigiTask_amplitude_vs_simhits_depth2_HE.gif	" width="45%">  </A>
+
+<A HREF= "	HcalDigiTask_amplitude_vs_simhits_depth3_HE.gif	"> <img src="	HcalDigiTask_amplitude_vs_simhits_depth3_HE.gif	" width="45%">  </A>
+
+<A HREF= "	HcalDigiTask_amplitude_vs_simhits_HF.gif	"> <img src="	HcalDigiTask_amplitude_vs_simhits_HF.gif	" width="30%">  </A>
+
+<A HREF= "	HcalDigiTask_amplitude_vs_simhits_depth1_HF.gif	"> <img src="	HcalDigiTask_amplitude_vs_simhits_depth1_HF.gif	" width="30%">  </A>
+
+<A HREF= "	HcalDigiTask_amplitude_vs_simhits_depth2_HF.gif	"> <img src="	HcalDigiTask_amplitude_vs_simhits_depth2_HF.gif	" width="30%">  </A>
+
+<A HREF= "	HcalDigiTask_amplitude_vs_simhits_HO.gif	"> <img src="	HcalDigiTask_amplitude_vs_simhits_HO.gif	" width="45%">  </A>
+
+
+
+<hr><h2><CENTER>	Amplitude Ratio Versus Simhits	</CENTER></h2>
+<A HREF= "	HcalDigiTask_ratio_amplitude_vs_simhits_HB.gif	"> <img src="	HcalDigiTask_ratio_amplitude_vs_simhits_HB.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_ratio_amplitude_vs_simhits_depth1_HB.gif	"> <img src="	HcalDigiTask_ratio_amplitude_vs_simhits_depth1_HB.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_ratio_amplitude_vs_simhits_depth2_HB.gif	"> <img src="	HcalDigiTask_ratio_amplitude_vs_simhits_depth2_HB.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_ratio_amplitude_vs_simhits_HE.gif	"> <img src="	HcalDigiTask_ratio_amplitude_vs_simhits_HE.gif	" width="45%">  </A>
+<A HREF= "	HcalDigiTask_ratio_amplitude_vs_simhits_depth1_HE.gif	"> <img src="	HcalDigiTask_ratio_amplitude_vs_simhits_depth1_HE.gif	" width="45%">  </A>
+<A HREF= "	HcalDigiTask_ratio_amplitude_vs_simhits_depth2_HE.gif	"> <img src="	HcalDigiTask_ratio_amplitude_vs_simhits_depth2_HE.gif	" width="45%">  </A>
+<A HREF= "	HcalDigiTask_ratio_amplitude_vs_simhits_depth3_HE.gif	"> <img src="	HcalDigiTask_ratio_amplitude_vs_simhits_depth3_HE.gif	" width="45%">  </A>
+<A HREF= "	HcalDigiTask_ratio_amplitude_vs_simhits_HF.gif	"> <img src="	HcalDigiTask_ratio_amplitude_vs_simhits_HF.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_ratio_amplitude_vs_simhits_depth1_HF.gif	"> <img src="	HcalDigiTask_ratio_amplitude_vs_simhits_depth1_HF.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_ratio_amplitude_vs_simhits_depth2_HF.gif	"> <img src="	HcalDigiTask_ratio_amplitude_vs_simhits_depth2_HF.gif	" width="30%">  </A>
+<A HREF= "	HcalDigiTask_ratio_amplitude_vs_simhits_HO.gif	"> <img src="	HcalDigiTask_ratio_amplitude_vs_simhits_HO.gif	" width="45%">  </A>
+-->
+
+<hr><h2><CENTER>	Number Of Digis	</CENTER></h2>
+<A HREF= "	HcalDigiTask_Ndigis_HB.gif	"> <img src="	HcalDigiTask_Ndigis_HB.gif	" width="45%">  </A>
+<A HREF= "	HcalDigiTask_Ndigis_HE.gif	"> <img src="	HcalDigiTask_Ndigis_HE.gif	" width="45%">  </A>
+<A HREF= "	HcalDigiTask_Ndigis_HF.gif	"> <img src="	HcalDigiTask_Ndigis_HF.gif	" width="45%">  </A>
+<A HREF= "	HcalDigiTask_Ndigis_HO.gif	"> <img src="	HcalDigiTask_Ndigis_HO.gif	" width="45%">  </A>
+
+
+<hr><h2><CENTER>	Amplitudes Versus TS'	</CENTER></h2>
+<A HREF= "	ref_HcalDigiTask_signal_amplitude_vs_bin_all_depths_HB.gif	"> <img src="	ref_HcalDigiTask_signal_amplitude_vs_bin_all_depths_HB.gif	" width="45%">  </A>		<A HREF= "	val_HcalDigiTask_signal_amplitude_vs_bin_all_depths_HB.gif	"> <img src="	val_HcalDigiTask_signal_amplitude_vs_bin_all_depths_HB.gif	" width="45%">  </A>
+<A HREF= "	ref_HcalDigiTask_signal_amplitude_vs_bin_all_depths_HE.gif	"> <img src="	ref_HcalDigiTask_signal_amplitude_vs_bin_all_depths_HE.gif	" width="45%">  </A>		<A HREF= "	val_HcalDigiTask_signal_amplitude_vs_bin_all_depths_HE.gif	"> <img src="	val_HcalDigiTask_signal_amplitude_vs_bin_all_depths_HE.gif	" width="45%">  </A>
+<A HREF= "	ref_HcalDigiTask_signal_amplitude_vs_bin_all_depths_HF.gif	"> <img src="	ref_HcalDigiTask_signal_amplitude_vs_bin_all_depths_HF.gif	" width="45%">  </A>		<A HREF= "	val_HcalDigiTask_signal_amplitude_vs_bin_all_depths_HF.gif	"> <img src="	val_HcalDigiTask_signal_amplitude_vs_bin_all_depths_HF.gif	" width="45%">  </A>
+<A HREF= "	ref_HcalDigiTask_signal_amplitude_vs_bin_all_depths_HO.gif	"> <img src="	ref_HcalDigiTask_signal_amplitude_vs_bin_all_depths_HO.gif	" width="45%">  </A>		<A HREF= "	val_HcalDigiTask_signal_amplitude_vs_bin_all_depths_HO.gif	"> <img src="	val_HcalDigiTask_signal_amplitude_vs_bin_all_depths_HO.gif	" width="45%">  </A>
+

--- a/Validation/CaloTowers/test/macros/html_indices/RelVal_RecHits_SLHC.html
+++ b/Validation/CaloTowers/test/macros/html_indices/RelVal_RecHits_SLHC.html
@@ -1,0 +1,257 @@
+<h4> RelVal DATA_SAMPLE samples
+<br></h4>
+
+<font color="#aa0000"> >>> click on thumbnail to get a full-size plot </font>
+
+<hr>
+<p>
+Mean reconstructed energy as a function of ieta (ring) 
+<br>
+<br>
+<A HREF= "emean_vs_ieta_HB1.gif">
+<img src="emean_vs_ieta_HB1.gif" width=49%> </A>
+<A HREF= "emean_vs_ieta_HB2.gif">
+<img src="emean_vs_ieta_HB2.gif" width=49%> </A>
+<A HREF= "emean_vs_ieta_HB3.gif">
+<img src="emean_vs_ieta_HB3.gif" width=49%> </A>
+<A HREF= "emean_vs_ieta_HB4.gif">
+<img src="emean_vs_ieta_HB4.gif" width=49%> </A>
+<A HREF= "emean_vs_ieta_HB5.gif">
+<img src="emean_vs_ieta_HB5.gif" width=49%> </A>
+<A HREF= "emean_vs_ieta_HB6.gif">
+<img src="emean_vs_ieta_HB6.gif" width=49%> </A>
+<A HREF= "emean_vs_ieta_HB7.gif">
+<img src="emean_vs_ieta_HB7.gif" width=49%> </A>
+<br>
+<A HREF= "emean_vs_ieta_HE1.gif">
+<img src="emean_vs_ieta_HE1.gif" width=32%> </A>
+<A HREF= "emean_vs_ieta_HE2.gif">
+<img src="emean_vs_ieta_HE2.gif" width=32%> </A>
+<A HREF= "emean_vs_ieta_HE3.gif">
+<img src="emean_vs_ieta_HE3.gif" width=32%> </A>
+<A HREF= "emean_vs_ieta_HE4.gif">
+<img src="emean_vs_ieta_HE4.gif" width=32%> </A>
+<A HREF= "emean_vs_ieta_HE5.gif">
+<img src="emean_vs_ieta_HE5.gif" width=32%> </A>
+<A HREF= "emean_vs_ieta_HE6.gif">
+<img src="emean_vs_ieta_HE6.gif" width=32%> </A>
+<A HREF= "emean_vs_ieta_HE7.gif">
+<img src="emean_vs_ieta_HE7.gif" width=32%> </A>
+<br>
+<A HREF= "emean_vs_ieta_HO.gif">
+<img src="emean_vs_ieta_HO.gif"       width=32%> </A>
+<A HREF= "emean_vs_ieta_HF1.gif">
+<img src="emean_vs_ieta_HF1.gif" width=32%> </A>
+<A HREF= "emean_vs_ieta_HF2.gif">
+<img src="emean_vs_ieta_HF2.gif" width=32%> </A>
+<br>
+
+
+<hr>
+<p>
+RecHits energy distribution in each subdetector
+<br>
+<br>
+<A HREF= "RecHits_energy_HB.gif">
+<img src="RecHits_energy_HB.gif" width=49%> </A>
+<A HREF= "RecHits_energy_HE.gif">
+<img src="RecHits_energy_HE.gif" width=49%> </A>
+<br>
+<A HREF= "RecHits_energy_HO.gif">
+<img src="RecHits_energy_HO.gif" width=49%> </A>
+<A HREF= "RecHits_energy_HF.gif">
+<img src="RecHits_energy_HF.gif" width=49%> </A>
+<br>
+
+<hr>
+<p>
+Number of RecHits in each subdetector (with default ZeroSuppression)
+<br>
+<br>
+<A HREF= "N_HB.gif">
+<img src="N_HB.gif" width=49%> </A>
+<A HREF= "N_HE.gif">
+<img src="N_HE.gif" width=49%> </A>
+<br>
+<A HREF= "N_HO.gif">
+<img src="N_HO.gif" width=49%> </A>
+<A HREF= "N_HF.gif">
+<img src="N_HF.gif" width=49%> </A>
+<br>
+
+
+<hr>
+<p>
+RecHits Timing as a function of energy in each subdetector
+<br>
+<br>
+<A HREF= "HB_Timing_vs_Energy.gif">
+<img src="HB_Timing_vs_Energy.gif" width=49%> </A>
+<A HREF= "HE_Timing_vs_Energy.gif">
+<img src="HE_Timing_vs_Energy.gif" width=49%> </A>
+<br>
+<A HREF= "HO_Timing_vs_Energy.gif">
+<img src="HO_Timing_vs_Energy.gif" width=49%> </A>
+<A HREF= "HF_Timing_vs_Energy.gif">
+<img src="HF_Timing_vs_Energy.gif" width=49%> </A>
+<br>
+
+<hr>
+<p>
+RecHits timing distribution in each subdetector
+<br>
+<br>
+<A HREF= "RecHits_timing_HB.gif">
+<img src="RecHits_timing_HB.gif" width=49%> </A>
+<A HREF= "RecHits_timing_HE.gif">
+<img src="RecHits_timing_HE.gif" width=49%> </A>
+<br>
+<A HREF= "RecHits_timing_HO.gif">
+<img src="RecHits_timing_HO.gif" width=49%> </A>
+<A HREF= "RecHits_timing_HF.gif">
+<img src="RecHits_timing_HF.gif" width=49%> </A>
+<br>
+
+
+<hr>
+<p>
+Occupancy as a function of ieta
+<br>
+<br>
+<A HREF= "occupancy_vs_ieta_HB1.gif">
+<img src="occupancy_vs_ieta_HB1.gif" width=49%> </A>
+<A HREF= "occupancy_vs_ieta_HB2.gif">
+<img src="occupancy_vs_ieta_HB2.gif" width=49%> </A>
+<A HREF= "occupancy_vs_ieta_HB3.gif">
+<img src="occupancy_vs_ieta_HB3.gif" width=49%> </A>
+<A HREF= "occupancy_vs_ieta_HB4.gif">
+<img src="occupancy_vs_ieta_HB4.gif" width=49%> </A>
+<A HREF= "occupancy_vs_ieta_HB5.gif">
+<img src="occupancy_vs_ieta_HB5.gif" width=49%> </A>
+<A HREF= "occupancy_vs_ieta_HB6.gif">
+<img src="occupancy_vs_ieta_HB6.gif" width=49%> </A>
+<A HREF= "occupancy_vs_ieta_HB7.gif">
+<img src="occupancy_vs_ieta_HB7.gif" width=49%> </A>
+<br>
+<A HREF= "occupancy_vs_ieta_HE1.gif">
+<img src="occupancy_vs_ieta_HE1.gif" width=32%> </A>
+<A HREF= "occupancy_vs_ieta_HE2.gif">
+<img src="occupancy_vs_ieta_HE2.gif" width=32%> </A>
+<A HREF= "occupancy_vs_ieta_HE3.gif">
+<img src="occupancy_vs_ieta_HE3.gif" width=32%> </A>
+<A HREF= "occupancy_vs_ieta_HE4.gif">
+<img src="occupancy_vs_ieta_HE4.gif" width=32%> </A>
+<A HREF= "occupancy_vs_ieta_HE5.gif">
+<img src="occupancy_vs_ieta_HE5.gif" width=32%> </A>
+<A HREF= "occupancy_vs_ieta_HE6.gif">
+<img src="occupancy_vs_ieta_HE6.gif" width=32%> </A>
+<A HREF= "occupancy_vs_ieta_HE7.gif">
+<img src="occupancy_vs_ieta_HE7.gif" width=32%> </A>
+<br>
+<A HREF= "occupancy_vs_ieta_HO.gif">
+<img src="occupancy_vs_ieta_HO.gif"  width=32%> </A>
+<A HREF= "occupancy_vs_ieta_HF1.gif">
+<img src="occupancy_vs_ieta_HF1.gif" width=32%> </A>
+<A HREF= "occupancy_vs_ieta_HF2.gif">
+<img src="occupancy_vs_ieta_HF2.gif" width=32%> </A>
+<br>
+
+<hr>
+<p>
+HCAL Status Word in each subdetector
+<br>
+<br>
+<A HREF= "HB_StatusWord.gif">
+<img src="HB_StatusWord.gif" width=49%> </A>
+<A HREF= "HE_StatusWord.gif">
+<img src="HE_StatusWord.gif" width=49%> </A>
+<br>
+<A HREF= "HF_StatusWord.gif">
+<img src="HF_StatusWord.gif" width=49%> </A>
+<A HREF= "HO_StatusWord.gif">
+<img src="HO_StatusWord.gif" width=49%> </A>
+<br>
+<hr>
+
+<hr>
+<p>
+HCAL Aux Status Word in each subdetector
+<br>
+<br>
+<A HREF= "HB_Aux_StatusWord.gif">
+<img src="HB_Aux_StatusWord.gif" width=49%> </A>
+<A HREF= "HE_Aux_StatusWord.gif">
+<img src="HE_Aux_StatusWord.gif" width=49%> </A>
+<br>
+<A HREF= "HF_Aux_StatusWord.gif">
+<img src="HF_Aux_StatusWord.gif" width=49%> </A>
+<A HREF= "HO_Aux_StatusWord.gif">
+<img src="HO_Aux_StatusWord.gif" width=49%> </A>
+<br>
+<hr>
+
+<hr>
+<p>
+HCAL Severity Level in each subdetector
+<br>
+<br>
+<A HREF= "severityLevel_HB.gif">
+<img src="severityLevel_HB.gif" width=49%> </A>
+<A HREF= "severityLevel_HE.gif">
+<img src="severityLevel_HE.gif" width=49%> </A>
+<br>
+<A HREF= "severityLevel_HF.gif">
+<img src="severityLevel_HF.gif" width=49%> </A>
+<A HREF= "severityLevel_HO.gif">
+<img src="severityLevel_HO.gif" width=49%> </A>
+<br>
+
+<hr>
+<p>
+HCAL <E> of RecHits in ieta-iphi maps for each depth
+<br>
+<br>
+<A HREF= "ref_emap_depth1.gif">
+<img src="ref_emap_depth1.gif" width=49%> </A>
+<A HREF= "val_emap_depth1.gif">
+<img src="val_emap_depth1.gif" width=49%> </A>
+<br>
+<A HREF= "ref_emap_depth1-1.gif">
+<img src="ref_emap_depth1-1.gif" width=49%> </A>
+<A HREF= "val_emap_depth1-1.gif">
+<img src="val_emap_depth1-1.gif" width=49%> </A>
+<br>
+<A HREF= "ref_emap_depth2.gif">
+<img src="ref_emap_depth2.gif" width=49%> </A>
+<A HREF= "val_emap_depth2.gif">
+<img src="val_emap_depth2.gif" width=49%> </A>
+<br>
+<A HREF= "ref_emap_depth3.gif">
+<img src="ref_emap_depth3.gif" width=49%> </A>
+<A HREF= "val_emap_depth3.gif">
+<img src="val_emap_depth3.gif" width=49%> </A>
+<br>
+<A HREF= "ref_emap_depth4.gif">
+<img src="ref_emap_depth4.gif" width=49%> </A>
+<A HREF= "val_emap_depth4.gif">
+<img src="val_emap_depth4.gif" width=49%> </A>
+<br>
+<A HREF= "ref_emap_depth5.gif">
+<img src="ref_emap_depth5.gif" width=49%> </A>
+<A HREF= "val_emap_depth5.gif">
+<img src="val_emap_depth5.gif" width=49%> </A>
+<br>
+<A HREF= "ref_emap_depth6.gif">
+<img src="ref_emap_depth6.gif" width=49%> </A>
+<A HREF= "val_emap_depth6.gif">
+<img src="val_emap_depth6.gif" width=49%> </A>
+<br>
+<A HREF= "ref_emap_depth7.gif">
+<img src="ref_emap_depth7.gif" width=49%> </A>
+<A HREF= "val_emap_depth7.gif">
+<img src="val_emap_depth7.gif" width=49%> </A>
+
+
+<br>
+<hr>
+

--- a/Validation/HcalDigis/interface/HcalDigisClient.h
+++ b/Validation/HcalDigis/interface/HcalDigisClient.h
@@ -61,6 +61,8 @@ private:
         double max;
     };
 
+    bool doslhc_;
+
     virtual void runClient();
     int HcalDigisEndjob(const std::vector<MonitorElement*> &hcalMEs, std::string subdet_);
 

--- a/Validation/HcalDigis/interface/HcalDigisValidation.h
+++ b/Validation/HcalDigis/interface/HcalDigisValidation.h
@@ -107,6 +107,7 @@ private:
     std::string mode_;
     std::string mc_;
     int noise_;
+    bool doSLHC_;
 
     edm::ESHandle<CaloGeometry> geometry;
     edm::ESHandle<HcalDbService> conditions;

--- a/Validation/HcalDigis/src/HcalDigisClient.cc
+++ b/Validation/HcalDigis/src/HcalDigisClient.cc
@@ -37,6 +37,9 @@ HcalDigisClient::HcalDigisClient(const edm::ParameterSet& iConfig) {
     booking("HE");
     booking("HO");
     booking("HF");
+    // false for regular rel val and true for SLHC rel val
+    doslhc_  = false;
+
 }
 
 void HcalDigisClient::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -50,7 +53,10 @@ void HcalDigisClient::booking(std::string subdetopt) {
     std::string strtmp;
     HistLim ietaLim(82, -41., 41.);
 
-    for (int depth = 1; depth <= 4; depth++) {
+   int n_depth = 4;
+   if (doslhc_){n_depth = 7;} 
+  
+    for (int depth = 1; depth <= n_depth; depth++) {
         strtmp = "HcalDigiTask_occupancy_vs_ieta_depth" + str(depth) + "_" + subdetopt;
         book1D(strtmp, ietaLim);
     }
@@ -93,7 +99,9 @@ int HcalDigisClient::HcalDigisEndjob(const std::vector<MonitorElement*> &hcalMEs
     MonitorElement * ieta_iphi_occupancy_map2(0);
     MonitorElement * ieta_iphi_occupancy_map3(0);
     MonitorElement * ieta_iphi_occupancy_map4(0);
-
+    MonitorElement * ieta_iphi_occupancy_map5(0);
+    MonitorElement * ieta_iphi_occupancy_map6(0);
+    MonitorElement * ieta_iphi_occupancy_map7(0);
 
     std::cout << " Number of histos " <<     hcalMEs.size() << std::endl;
 
@@ -108,18 +116,45 @@ int HcalDigisClient::HcalDigisEndjob(const std::vector<MonitorElement*> &hcalMEs
          if (hcalMEs[ih]->getName() == strtmp) ieta_iphi_occupancy_map3 = hcalMEs[ih];
          strtmp = "HcalDigiTask_ieta_iphi_occupancy_map_depth4_" + subdet_;
          if (hcalMEs[ih]->getName() == strtmp) ieta_iphi_occupancy_map4 = hcalMEs[ih];
-
+        
+         if (doslhc_){
+            strtmp = "HcalDigiTask_ieta_iphi_occupancy_map_depth5_" + subdet_;
+            if (hcalMEs[ih]->getName() == strtmp) ieta_iphi_occupancy_map5 = hcalMEs[ih];
+            strtmp = "HcalDigiTask_ieta_iphi_occupancy_map_depth6_" + subdet_;
+            if (hcalMEs[ih]->getName() == strtmp) ieta_iphi_occupancy_map6 = hcalMEs[ih];
+            strtmp = "HcalDigiTask_ieta_iphi_occupancy_map_depth7_" + subdet_;
+            if (hcalMEs[ih]->getName() == strtmp) ieta_iphi_occupancy_map7 = hcalMEs[ih];
+         }
     }//
 
-    if (nevtot                   == 0 ||
-	ieta_iphi_occupancy_map1 == 0 ||
-	ieta_iphi_occupancy_map2 == 0 ||
-	ieta_iphi_occupancy_map3 == 0 ||
-	ieta_iphi_occupancy_map4 == 0   
-	) {
-      edm::LogError("HcalDigisClient") << "No nevtot or maps histo found..."; 
-      return 0;
+
+    if (doslhc_ == false){
+       if (nevtot                   == 0 ||
+           ieta_iphi_occupancy_map1 == 0 ||
+           ieta_iphi_occupancy_map2 == 0 ||
+           ieta_iphi_occupancy_map3 == 0 ||
+           ieta_iphi_occupancy_map4 == 0  
+           ) {
+         edm::LogError("HcalDigisClient") << "No nevtot or maps histo found..."; 
+         return 0;
+       }
     }
+    else {
+       if (nevtot                   == 0 ||
+           ieta_iphi_occupancy_map1 == 0 ||
+           ieta_iphi_occupancy_map2 == 0 ||
+           ieta_iphi_occupancy_map3 == 0 ||
+           ieta_iphi_occupancy_map4 == 0 ||
+           ieta_iphi_occupancy_map5 == 0 ||
+           ieta_iphi_occupancy_map6 == 0 ||
+           ieta_iphi_occupancy_map7 == 0
+           ) {
+         edm::LogError("HcalDigisClient") << "No nevtot or maps histo found...";
+         return 0;
+        }
+   }
+
+
 
     int ev = nevtot->getEntries();
     if(ev <= 0) {
@@ -131,7 +166,7 @@ int HcalDigisClient::HcalDigisEndjob(const std::vector<MonitorElement*> &hcalMEs
 
     int nx = ieta_iphi_occupancy_map1->getNbinsX();
     int ny = ieta_iphi_occupancy_map1->getNbinsY();
-    float sumphi_1, sumphi_2, sumphi_3, sumphi_4;
+    float sumphi_1, sumphi_2, sumphi_3, sumphi_4, sumphi_5, sumphi_6, sumphi_7;
     float phi_factor;
     float cnorm;
     
@@ -140,6 +175,9 @@ int HcalDigisClient::HcalDigisEndjob(const std::vector<MonitorElement*> &hcalMEs
         sumphi_2 = 0.;
         sumphi_3 = 0.;
         sumphi_4 = 0.;
+        sumphi_5 = 0.;
+        sumphi_6 = 0.;
+        sumphi_7 = 0.;
 
         for (int j = 1; j <= ny; j++) {
 
@@ -164,6 +202,21 @@ int HcalDigisClient::HcalDigisEndjob(const std::vector<MonitorElement*> &hcalMEs
              cnorm = ieta_iphi_occupancy_map4->getBinContent(i, j) / fev; 
              ieta_iphi_occupancy_map4->setBinContent(i, j, cnorm);
              sumphi_4 += ieta_iphi_occupancy_map4->getBinContent(i, j);
+
+             if (doslhc_){
+                strtmp = "HcalDigiTask_ieta_iphi_occupancy_map_depth5_" + subdet_;
+                cnorm = ieta_iphi_occupancy_map5->getBinContent(i, j) / fev;
+                ieta_iphi_occupancy_map5->setBinContent(i, j, cnorm);
+                sumphi_5 += ieta_iphi_occupancy_map5->getBinContent(i, j);
+                strtmp = "HcalDigiTask_ieta_iphi_occupancy_map_depth6_" + subdet_;
+                cnorm = ieta_iphi_occupancy_map6->getBinContent(i, j) / fev;
+                ieta_iphi_occupancy_map6->setBinContent(i, j, cnorm);
+                sumphi_6 += ieta_iphi_occupancy_map6->getBinContent(i, j);
+                strtmp = "HcalDigiTask_ieta_iphi_occupancy_map_depth7_" + subdet_;
+                cnorm = ieta_iphi_occupancy_map7->getBinContent(i, j) / fev;
+                ieta_iphi_occupancy_map7->setBinContent(i, j, cnorm);
+                sumphi_7 += ieta_iphi_occupancy_map7->getBinContent(i, j);
+             }
 
         }    
 
@@ -198,6 +251,18 @@ int HcalDigisClient::HcalDigisEndjob(const std::vector<MonitorElement*> &hcalMEs
         cnorm = sumphi_4 / phi_factor;
         strtmp = "HcalDigiTask_occupancy_vs_ieta_depth4_" + subdet_;
         fill1D(strtmp, deta, cnorm);
+
+        if (doslhc_){
+           cnorm = sumphi_5 / phi_factor;
+           strtmp = "HcalDigiTask_occupancy_vs_ieta_depth5_" + subdet_;
+           fill1D(strtmp, deta, cnorm);
+           cnorm = sumphi_6 / phi_factor;
+           strtmp = "HcalDigiTask_occupancy_vs_ieta_depth6_" + subdet_;
+           fill1D(strtmp, deta, cnorm);
+           cnorm = sumphi_7 / phi_factor;
+           strtmp = "HcalDigiTask_occupancy_vs_ieta_depth7_" + subdet_;
+           fill1D(strtmp, deta, cnorm);
+        }
 
     } // end of i-loop
 

--- a/Validation/HcalDigis/src/HcalDigisValidation.cc
+++ b/Validation/HcalDigis/src/HcalDigisValidation.cc
@@ -30,6 +30,9 @@ HcalDigisValidation::HcalDigisValidation(const edm::ParameterSet& iConfig) {
     mc_ = iConfig.getUntrackedParameter<std::string > ("mc", "no");
     mode_ = iConfig.getUntrackedParameter<std::string > ("mode", "multi");
     dirName_ = iConfig.getUntrackedParameter<std::string > ("dirName", "HcalDigisV/HcalDigiTask");
+ 
+    // false for regular rel val and true for SLHC rel val 
+    doSLHC_ = false;
 
     dbe_ = edm::Service<DQMStore > ().operator->();
     msm_ = new std::map<std::string, MonitorElement*>();
@@ -121,6 +124,16 @@ void HcalDigisValidation::booking(const std::string bsubdet, int bnoise, int bmc
         sprintf(histo, "HcalDigiTask_ieta_iphi_occupancy_map_depth4_%s", sub);
         book2D(histo, ietaLim, iphiLim);
 
+        if (doSLHC_){
+           sprintf(histo, "HcalDigiTask_ieta_iphi_occupancy_map_depth5_%s", sub);
+           book2D(histo, ietaLim, iphiLim);
+           sprintf(histo, "HcalDigiTask_ieta_iphi_occupancy_map_depth6_%s", sub);
+           book2D(histo, ietaLim, iphiLim);
+           sprintf(histo, "HcalDigiTask_ieta_iphi_occupancy_map_depth7_%s", sub);
+           book2D(histo, ietaLim, iphiLim);        
+        }
+
+
         // occupancies vs ieta
         sprintf(histo, "HcalDigiTask_occupancy_vs_ieta_depth1_%s", sub);
         book1D(histo, ietaLim);
@@ -133,6 +146,15 @@ void HcalDigisValidation::booking(const std::string bsubdet, int bnoise, int bmc
 
         sprintf(histo, "HcalDigiTask_occupancy_vs_ieta_depth4_%s", sub);
         book1D(histo, ietaLim);
+
+        if (doSLHC_){
+           sprintf(histo, "HcalDigiTask_occupancy_vs_ieta_depth5_%s", sub);
+           book1D(histo, ietaLim);
+           sprintf(histo, "HcalDigiTask_occupancy_vs_ieta_depth6_%s", sub);
+           book1D(histo, ietaLim);
+           sprintf(histo, "HcalDigiTask_occupancy_vs_ieta_depth7_%s", sub);
+           book1D(histo, ietaLim);
+        }
 
 
         // maps of sum of amplitudes (sum lin.digis(4,5,6,7) - ped) all depths
@@ -162,6 +184,7 @@ void HcalDigisValidation::booking(const std::string bsubdet, int bnoise, int bmc
         sprintf(histo, "HcalDigiTask_ADC0_adc_depth4_%s", sub);
         book1D(histo, pedestal);
 
+
         sprintf(histo, "HcalDigiTask_ADC0_fC_depth1_%s", sub);
         book1D(histo, pedestalfC);
         sprintf(histo, "HcalDigiTask_ADC0_fC_depth2_%s", sub);
@@ -170,6 +193,7 @@ void HcalDigisValidation::booking(const std::string bsubdet, int bnoise, int bmc
         book1D(histo, pedestalfC);
         sprintf(histo, "HcalDigiTask_ADC0_fC_depth4_%s", sub);
         book1D(histo, pedestalfC);
+
 
         sprintf(histo, "HcalDigiTask_signal_amplitude_%s", sub);
         book1D(histo, digiAmp);
@@ -181,6 +205,15 @@ void HcalDigisValidation::booking(const std::string bsubdet, int bnoise, int bmc
         book1D(histo, digiAmp);
         sprintf(histo, "HcalDigiTask_signal_amplitude_depth4_%s", sub);
         book1D(histo, digiAmp);
+
+        if (doSLHC_){
+           sprintf(histo, "HcalDigiTask_signal_amplitude_depth5_%s", sub);
+           book1D(histo, digiAmp);
+           sprintf(histo, "HcalDigiTask_signal_amplitude_depth6_%s", sub);
+           book1D(histo, digiAmp);
+           sprintf(histo, "HcalDigiTask_signal_amplitude_depth7_%s", sub);
+           book1D(histo, digiAmp);
+        }
 
         sprintf(histo, "HcalDigiTask_signal_amplitude_vs_bin_all_depths_%s", sub);
         book2D(histo, nbin, digiAmp);
@@ -213,6 +246,7 @@ void HcalDigisValidation::booking(const std::string bsubdet, int bnoise, int bmc
             sprintf(histo, "HcalDigiTask_amplitude_vs_simhits_depth4_%s", sub);
             book2D(histo, sime, digiAmp);
 
+
             sprintf(histo, "HcalDigiTask_amplitude_vs_simhits_profile_%s", sub);
             bookPf(histo, sime, digiAmp);
             sprintf(histo, "HcalDigiTask_amplitude_vs_simhits_profile_depth1_%s", sub);
@@ -224,6 +258,7 @@ void HcalDigisValidation::booking(const std::string bsubdet, int bnoise, int bmc
             sprintf(histo, "HcalDigiTask_amplitude_vs_simhits_profile_depth4_%s", sub);
             bookPf(histo, sime, digiAmp);
 
+
             sprintf(histo, "HcalDigiTask_ratio_amplitude_vs_simhits_%s", sub);
             book1D(histo, ratio);
             sprintf(histo, "HcalDigiTask_ratio_amplitude_vs_simhits_depth1_%s", sub);
@@ -234,6 +269,8 @@ void HcalDigisValidation::booking(const std::string bsubdet, int bnoise, int bmc
             book1D(histo, ratio);
             sprintf(histo, "HcalDigiTask_ratio_amplitude_vs_simhits_depth4_%s", sub);
             book1D(histo, ratio);
+
+
         }//mc only
 
     } else { // noise only
@@ -499,6 +536,9 @@ template<class Digi> void HcalDigisValidation::reco(const edm::Event& iEvent, co
     double ampl2_c = 0.;
     double ampl3_c = 0.;
     double ampl4_c = 0.;
+    double ampl5_c = 0.;
+    double ampl6_c = 0.;
+    double ampl7_c = 0.;
     double ampl_c = 0.;
 
     // is set to 1 if "seed" SimHit is found
@@ -576,7 +616,9 @@ template<class Digi> void HcalDigisValidation::reco(const edm::Event& iEvent, co
         double ampl2 = 0.;
         double ampl3 = 0.;
         double ampl4 = 0.;
-
+        double ampl5 = 0.;
+        double ampl6 = 0.;
+        double ampl7 = 0.;
 
         // Gains, pedestals (once !) and only for "noise" case
         if (((nevent1 == 1 && isubdet == 1) ||
@@ -665,6 +707,9 @@ template<class Digi> void HcalDigisValidation::reco(const edm::Event& iEvent, co
                     if (depth == 2) ampl2 += val;
                     if (depth == 3) ampl3 += val;
                     if (depth == 4) ampl4 += val;
+                    if (depth == 5) ampl5 += val;
+                    if (depth == 6) ampl6 += val;
+                    if (depth == 7) ampl7 += val;
 
                     if (closen == 1) {
                         ampl_c += val;
@@ -672,6 +717,9 @@ template<class Digi> void HcalDigisValidation::reco(const edm::Event& iEvent, co
                         if (depth == 2) ampl2_c += val;
                         if (depth == 3) ampl3_c += val;
                         if (depth == 4) ampl4_c += val;
+                        if (depth == 5) ampl5_c += val;
+                        if (depth == 6) ampl6_c += val;
+                        if (depth == 7) ampl7_c += val;
                     }
                 }
 
@@ -682,12 +730,18 @@ template<class Digi> void HcalDigisValidation::reco(const edm::Event& iEvent, co
                     if (depth == 2) ampl2 += val;
                     if (depth == 3) ampl3 += val;
                     if (depth == 4) ampl4 += val;
+                    if (depth == 5) ampl5 += val;
+                    if (depth == 6) ampl6 += val;
+                    if (depth == 7) ampl7 += val;
                     if (closen == 1) {
                         ampl_c += val;
                         if (depth == 1) ampl1_c += val;
                         if (depth == 2) ampl2_c += val;
                         if (depth == 3) ampl3_c += val;
                         if (depth == 4) ampl4_c += val;
+                        if (depth == 5) ampl5_c += val;
+                        if (depth == 6) ampl6_c += val;
+                        if (depth == 7) ampl7_c += val; 
 
                     }
                 }
@@ -847,7 +901,7 @@ void HcalDigisValidation::eval_occupancy() {
     float fev = float (nevtot);
         std::cout << "*** nevtot " <<  nevtot << std::endl;
 
-    float sumphi_1, sumphi_2, sumphi_3, sumphi_4;
+    float sumphi_1, sumphi_2, sumphi_3, sumphi_4, sumphi_5, sumphi_6, sumphi_7;
     float phi_factor;
 
     for (int i = 1; i <= nx; i++) {
@@ -855,6 +909,9 @@ void HcalDigisValidation::eval_occupancy() {
         sumphi_2 = 0.;
         sumphi_3 = 0.;
         sumphi_4 = 0.;
+        sumphi_5 = 0.;
+        sumphi_6 = 0.;
+        sumphi_7 = 0.;
 
         for (int j = 1; j <= ny; j++) {
 
@@ -879,6 +936,21 @@ void HcalDigisValidation::eval_occupancy() {
             cnorm = monitor(strtmp)->getBinContent(i, j) / fev;
             monitor(strtmp)->setBinContent(i, j, cnorm);
             sumphi_4 += monitor(strtmp)->getBinContent(i, j);
+
+            if (doSLHC_){
+               strtmp = "HcalDigiTask_ieta_iphi_occupancy_map_depth5_" + subdet_;
+               cnorm = monitor(strtmp)->getBinContent(i, j) / fev;
+               monitor(strtmp)->setBinContent(i, j, cnorm);
+               sumphi_5 += monitor(strtmp)->getBinContent(i, j);
+               strtmp = "HcalDigiTask_ieta_iphi_occupancy_map_depth6_" + subdet_;
+               cnorm = monitor(strtmp)->getBinContent(i, j) / fev;
+               monitor(strtmp)->setBinContent(i, j, cnorm);
+               sumphi_6 += monitor(strtmp)->getBinContent(i, j);
+               strtmp = "HcalDigiTask_ieta_iphi_occupancy_map_depth7_" + subdet_;
+               cnorm = monitor(strtmp)->getBinContent(i, j) / fev;
+               monitor(strtmp)->setBinContent(i, j, cnorm);
+               sumphi_7 += monitor(strtmp)->getBinContent(i, j);
+            }
 
         }
 
@@ -914,6 +986,18 @@ void HcalDigisValidation::eval_occupancy() {
         cnorm = sumphi_4 / phi_factor;
         strtmp = "HcalDigiTask_occupancy_vs_ieta_depth4_" + subdet_;
         fill1D(strtmp, deta, cnorm);
+
+        if (doSLHC_){
+           cnorm = sumphi_5 / phi_factor;
+           strtmp = "HcalDigiTask_occupancy_vs_ieta_depth5_" + subdet_;
+           fill1D(strtmp, deta, cnorm);
+           cnorm = sumphi_6 / phi_factor;
+           strtmp = "HcalDigiTask_occupancy_vs_ieta_depth6_" + subdet_;
+           fill1D(strtmp, deta, cnorm);
+           cnorm = sumphi_7 / phi_factor;
+           strtmp = "HcalDigiTask_occupancy_vs_ieta_depth7_" + subdet_;
+           fill1D(strtmp, deta, cnorm);
+        }
 
     } // end of i-loop
 

--- a/Validation/HcalRecHits/interface/HcalRecHitsClient.h
+++ b/Validation/HcalRecHits/interface/HcalRecHitsClient.h
@@ -43,6 +43,7 @@ class HcalRecHitsClient : public edm::EDAnalyzer {
 
   bool verbose_;
   bool debug_;
+  bool doslhc_;
 
   std::string dirName_;
   std::string dirNameJet_;

--- a/Validation/HcalRecHits/interface/HcalRecHitsValidation.h
+++ b/Validation/HcalRecHits/interface/HcalRecHitsValidation.h
@@ -79,6 +79,7 @@ class HcalRecHitsValidation : public edm::EDAnalyzer {
   std::string mc_;
   bool        famos_;
   bool        useAllHistos_;
+  bool        doSLHC_;
 
   //RecHit Collection input tags
   edm::InputTag theHBHERecHitCollectionLabel;
@@ -157,66 +158,147 @@ class HcalRecHitsValidation : public edm::EDAnalyzer {
   MonitorElement* emap_depth2;
   MonitorElement* emap_depth3;
   MonitorElement* emap_depth4;
+  MonitorElement* emap_depth5;
+  MonitorElement* emap_depth6;
+  MonitorElement* emap_depth7;
 
   MonitorElement* emean_vs_ieta_HB1;
   MonitorElement* emean_vs_ieta_HB2;
+  MonitorElement* emean_vs_ieta_HB3;
+  MonitorElement* emean_vs_ieta_HB4;
+  MonitorElement* emean_vs_ieta_HB5;
+  MonitorElement* emean_vs_ieta_HB6;
+  MonitorElement* emean_vs_ieta_HB7;
+
   MonitorElement* emean_vs_ieta_HE1;
   MonitorElement* emean_vs_ieta_HE2;
   MonitorElement* emean_vs_ieta_HE3;
+  MonitorElement* emean_vs_ieta_HE4;
+  MonitorElement* emean_vs_ieta_HE5;
+  MonitorElement* emean_vs_ieta_HE6;
+  MonitorElement* emean_vs_ieta_HE7;
+
   MonitorElement* emean_vs_ieta_HO;
   MonitorElement* emean_vs_ieta_HF1;
   MonitorElement* emean_vs_ieta_HF2;
 
   MonitorElement* RMS_vs_ieta_HB1;
   MonitorElement* RMS_vs_ieta_HB2;
+  MonitorElement* RMS_vs_ieta_HB3;
+  MonitorElement* RMS_vs_ieta_HB4;
+  MonitorElement* RMS_vs_ieta_HB5;
+  MonitorElement* RMS_vs_ieta_HB6;
+  MonitorElement* RMS_vs_ieta_HB7;
+
   MonitorElement* RMS_vs_ieta_HE1;
   MonitorElement* RMS_vs_ieta_HE2;
   MonitorElement* RMS_vs_ieta_HE3;
+  MonitorElement* RMS_vs_ieta_HE4;
+  MonitorElement* RMS_vs_ieta_HE5;
+  MonitorElement* RMS_vs_ieta_HE6;
+  MonitorElement* RMS_vs_ieta_HE7;
+
   MonitorElement* RMS_vs_ieta_HO;
   MonitorElement* RMS_vs_ieta_HF1;
   MonitorElement* RMS_vs_ieta_HF2;
 
   MonitorElement* emean_seqHB1;
   MonitorElement* emean_seqHB2;
+  MonitorElement* emean_seqHB3;
+  MonitorElement* emean_seqHB4;
+  MonitorElement* emean_seqHB5;
+  MonitorElement* emean_seqHB6;
+  MonitorElement* emean_seqHB7;
+
   MonitorElement* emean_seqHE1;
   MonitorElement* emean_seqHE2;
   MonitorElement* emean_seqHE3;
+  MonitorElement* emean_seqHE4;
+  MonitorElement* emean_seqHE5;
+  MonitorElement* emean_seqHE6;
+  MonitorElement* emean_seqHE7;
+
   MonitorElement* emean_seqHO;
   MonitorElement* emean_seqHF1;
   MonitorElement* emean_seqHF2;
 
   MonitorElement* RMS_seq_HB1;
   MonitorElement* RMS_seq_HB2;
+  MonitorElement* RMS_seq_HB3;
+  MonitorElement* RMS_seq_HB4;
+  MonitorElement* RMS_seq_HB5;
+  MonitorElement* RMS_seq_HB6;
+  MonitorElement* RMS_seq_HB7;
+
   MonitorElement* RMS_seq_HE1;
   MonitorElement* RMS_seq_HE2;
   MonitorElement* RMS_seq_HE3;
+  MonitorElement* RMS_seq_HE4;
+  MonitorElement* RMS_seq_HE5;
+  MonitorElement* RMS_seq_HE6;
+  MonitorElement* RMS_seq_HE7;
+
   MonitorElement* RMS_seq_HO;
   MonitorElement* RMS_seq_HF1;
   MonitorElement* RMS_seq_HF2;
 
   MonitorElement* occupancy_map_HB1;
   MonitorElement* occupancy_map_HB2;
+  MonitorElement* occupancy_map_HB3;
+  MonitorElement* occupancy_map_HB4;
+  MonitorElement* occupancy_map_HB5;
+  MonitorElement* occupancy_map_HB6;
+  MonitorElement* occupancy_map_HB7;
+
   MonitorElement* occupancy_map_HE1;
   MonitorElement* occupancy_map_HE2;
   MonitorElement* occupancy_map_HE3;
+  MonitorElement* occupancy_map_HE4;
+  MonitorElement* occupancy_map_HE5;
+  MonitorElement* occupancy_map_HE6;
+  MonitorElement* occupancy_map_HE7;
+
   MonitorElement* occupancy_map_HO;
   MonitorElement* occupancy_map_HF1;
   MonitorElement* occupancy_map_HF2;
 
   MonitorElement* occupancy_vs_ieta_HB1;
   MonitorElement* occupancy_vs_ieta_HB2;
+  MonitorElement* occupancy_vs_ieta_HB3;
+  MonitorElement* occupancy_vs_ieta_HB4;
+  MonitorElement* occupancy_vs_ieta_HB5;
+  MonitorElement* occupancy_vs_ieta_HB6;
+  MonitorElement* occupancy_vs_ieta_HB7;
+
   MonitorElement* occupancy_vs_ieta_HE1;
   MonitorElement* occupancy_vs_ieta_HE2;
   MonitorElement* occupancy_vs_ieta_HE3;
+  MonitorElement* occupancy_vs_ieta_HE4;
+  MonitorElement* occupancy_vs_ieta_HE5;
+  MonitorElement* occupancy_vs_ieta_HE6;
+  MonitorElement* occupancy_vs_ieta_HE7;
+
   MonitorElement* occupancy_vs_ieta_HO;
   MonitorElement* occupancy_vs_ieta_HF1;
   MonitorElement* occupancy_vs_ieta_HF2;
 
   MonitorElement* occupancy_seqHB1;
   MonitorElement* occupancy_seqHB2;
+  MonitorElement* occupancy_seqHB3;
+  MonitorElement* occupancy_seqHB4;
+  MonitorElement* occupancy_seqHB5;
+  MonitorElement* occupancy_seqHB6;
+  MonitorElement* occupancy_seqHB7;
+
   MonitorElement* occupancy_seqHE1;
   MonitorElement* occupancy_seqHE2;
   MonitorElement* occupancy_seqHE3;
+  MonitorElement* occupancy_seqHE4;
+  MonitorElement* occupancy_seqHE5;
+  MonitorElement* occupancy_seqHE6;
+  MonitorElement* occupancy_seqHE7;
+
+
   MonitorElement* occupancy_seqHO;
   MonitorElement* occupancy_seqHF1;
   MonitorElement* occupancy_seqHF2;
@@ -227,12 +309,19 @@ class HcalRecHitsValidation : public edm::EDAnalyzer {
   MonitorElement* map_econe_depth2;
   MonitorElement* map_econe_depth3;
   MonitorElement* map_econe_depth4;
+  MonitorElement* map_econe_depth5;
+  MonitorElement* map_econe_depth6;
+  MonitorElement* map_econe_depth7;
+
  
   // for single monoenergetic particles - cone collection profile vs ieta.
   MonitorElement* meEnConeEtaProfile_depth1;
   MonitorElement* meEnConeEtaProfile_depth2;
   MonitorElement* meEnConeEtaProfile_depth3;
   MonitorElement* meEnConeEtaProfile_depth4;
+  MonitorElement* meEnConeEtaProfile_depth5;
+  MonitorElement* meEnConeEtaProfile_depth6;
+  MonitorElement* meEnConeEtaProfile_depth7;
   MonitorElement* meEnConeEtaProfile;
   MonitorElement* meEnConeEtaProfile_E;
   MonitorElement* meEnConeEtaProfile_EH;
@@ -277,6 +366,12 @@ class HcalRecHitsValidation : public edm::EDAnalyzer {
   MonitorElement* meTE_High_HB;
   MonitorElement* meTE_HB1;
   MonitorElement* meTE_HB2;
+  MonitorElement* meTE_HB3;
+  MonitorElement* meTE_HB4;
+  MonitorElement* meTE_HB5;
+  MonitorElement* meTE_HB6;
+  MonitorElement* meTE_HB7;
+
   MonitorElement* meTEprofileHB_Low;
   MonitorElement* meTEprofileHB;
   MonitorElement* meTEprofileHB_High;
@@ -285,6 +380,12 @@ class HcalRecHitsValidation : public edm::EDAnalyzer {
   MonitorElement* meTE_HE;
   MonitorElement* meTE_HE1;
   MonitorElement* meTE_HE2;
+  MonitorElement* meTE_HE3;
+  MonitorElement* meTE_HE4;
+  MonitorElement* meTE_HE5;
+  MonitorElement* meTE_HE6;
+  MonitorElement* meTE_HE7;
+
   MonitorElement* meTEprofileHE_Low;
   MonitorElement* meTEprofileHE;
 

--- a/Validation/HcalRecHits/src/HcalRecHitsClient.cc
+++ b/Validation/HcalRecHits/src/HcalRecHitsClient.cc
@@ -24,6 +24,8 @@ HcalRecHitsClient::HcalRecHitsClient(const edm::ParameterSet& iConfig):conf_(iCo
  
   debug_ = false;
   verbose_ = false;
+  // false for regular relval and true for SLHC relval
+  doslhc_  = false;
 
   dirName_=iConfig.getParameter<std::string>("DQMDirName");
   if(dbe_) dbe_->setCurrentFolder(dirName_);
@@ -116,39 +118,39 @@ int HcalRecHitsClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &hca
    MonitorElement* ZS_HB1=0, *ZS_seqHB1=0, *ZS_HB2=0, *ZS_seqHB2=0; 
    MonitorElement* ZS_HF1=0, *ZS_seqHF1=0, *ZS_HF2=0, *ZS_seqHF2=0; 
    MonitorElement* ZS_HE1=0, *ZS_seqHE1=0, *ZS_HE2=0, *ZS_seqHE2=0, *ZS_HE3=0, *ZS_seqHE3=0;
-   MonitorElement* map_depth1 =0, *map_depth2 =0, *map_depth3 =0, *map_depth4 =0;
+   MonitorElement* map_depth1 =0, *map_depth2 =0, *map_depth3 =0, *map_depth4 =0, *map_depth5 =0, *map_depth6 =0, *map_depth7 =0;
 // others 
    MonitorElement* Nhf=0;
-   MonitorElement* emap_depth1 =0, *emap_depth2 =0, *emap_depth3 =0, *emap_depth4 =0; 
-   MonitorElement* occupancy_seqHB1 =0, *occupancy_seqHB2 =0; 
-   MonitorElement* occupancy_seqHE1 =0, *occupancy_seqHE2 =0, *occupancy_seqHE3 =0;
+   MonitorElement* emap_depth1 =0, *emap_depth2 =0, *emap_depth3 =0, *emap_depth4 =0, *emap_depth5 =0, *emap_depth6 =0, *emap_depth7 =0; 
+   MonitorElement* occupancy_seqHB1 =0, *occupancy_seqHB2 =0, *occupancy_seqHB3 =0, *occupancy_seqHB4 =0, *occupancy_seqHB5 =0, *occupancy_seqHB6 =0, *occupancy_seqHB7 =0; 
+   MonitorElement* occupancy_seqHE1 =0, *occupancy_seqHE2 =0, *occupancy_seqHE3 =0, *occupancy_seqHE4 =0, *occupancy_seqHE5 =0, *occupancy_seqHE6 =0, *occupancy_seqHE7 =0;
    MonitorElement* occupancy_seqHF1 =0, *occupancy_seqHF2 =0; 
    MonitorElement* occupancy_seqHO =0;
-   MonitorElement* emean_seqHB1 =0, *emean_seqHB2 =0; 
-   MonitorElement* emean_seqHE1 =0, *emean_seqHE2 =0, *emean_seqHE3 =0;
+   MonitorElement* emean_seqHB1 =0, *emean_seqHB2 =0, *emean_seqHB3 =0, *emean_seqHB4 =0, *emean_seqHB5 =0, *emean_seqHB6 =0, *emean_seqHB7 =0; 
+   MonitorElement* emean_seqHE1 =0, *emean_seqHE2 =0, *emean_seqHE3 =0, *emean_seqHE4 =0, *emean_seqHE5 =0, *emean_seqHE6 =0, *emean_seqHE7 =0;
    MonitorElement* emean_seqHF1 =0, *emean_seqHF2 =0; 
    MonitorElement* emean_seqHO =0;
 
-   MonitorElement* RMS_seq_HB1 =0, *RMS_seq_HB2 =0; 
-   MonitorElement* RMS_seq_HE1 =0, *RMS_seq_HE2 =0, *RMS_seq_HE3 =0;
+   MonitorElement* RMS_seq_HB1 =0, *RMS_seq_HB2 =0, *RMS_seq_HB3 =0, *RMS_seq_HB4 =0, *RMS_seq_HB5 =0, *RMS_seq_HB6 =0, *RMS_seq_HB7 =0; 
+   MonitorElement* RMS_seq_HE1 =0, *RMS_seq_HE2 =0, *RMS_seq_HE3 =0, *RMS_seq_HE4 =0, *RMS_seq_HE5 =0, *RMS_seq_HE6 =0, *RMS_seq_HE7 =0;
    MonitorElement* RMS_seq_HF1 =0, *RMS_seq_HF2 =0; 
    MonitorElement* RMS_seq_HO =0;
 
    MonitorElement *occupancy_map_HO =0;
-   MonitorElement* occupancy_map_HB1 =0, *occupancy_map_HB2 =0;
+   MonitorElement* occupancy_map_HB1 =0, *occupancy_map_HB2 =0, *occupancy_map_HB3 =0, *occupancy_map_HB4 =0, *occupancy_map_HB5 =0, *occupancy_map_HB6 =0, *occupancy_map_HB7 =0;
    MonitorElement* occupancy_map_HF1 =0, *occupancy_map_HF2 =0;
-   MonitorElement* occupancy_map_HE1 =0, *occupancy_map_HE2 =0, *occupancy_map_HE3 =0;
+   MonitorElement* occupancy_map_HE1 =0, *occupancy_map_HE2 =0, *occupancy_map_HE3 =0, *occupancy_map_HE4 =0, *occupancy_map_HE5 =0, *occupancy_map_HE6 =0, *occupancy_map_HE7 =0;
 
-   MonitorElement* emean_vs_ieta_HB1 =0, *emean_vs_ieta_HB2 =0; 
-   MonitorElement* emean_vs_ieta_HE1 =0, *emean_vs_ieta_HE2 =0/*, *emean_vs_ieta_HE3 =0*/;
+   MonitorElement* emean_vs_ieta_HB1 =0, *emean_vs_ieta_HB2 =0, *emean_vs_ieta_HB3 =0, *emean_vs_ieta_HB4 =0, *emean_vs_ieta_HB5 =0, *emean_vs_ieta_HB6 =0, *emean_vs_ieta_HB7 =0; 
+   MonitorElement* emean_vs_ieta_HE1 =0, *emean_vs_ieta_HE2 =0, *emean_vs_ieta_HE3 =0, *emean_vs_ieta_HE4 =0, *emean_vs_ieta_HE5 =0, *emean_vs_ieta_HE6 =0, *emean_vs_ieta_HE7 =0;
    //MonitorElement* emean_vs_ieta_HF1 =0, *emean_vs_ieta_HF2 =0; 
    //MonitorElement* emean_vs_ieta_HO =0;
-   MonitorElement* RMS_vs_ieta_HB1 =0, *RMS_vs_ieta_HB2 =0; 
-   MonitorElement* RMS_vs_ieta_HE1 =0, *RMS_vs_ieta_HE2 =0, *RMS_vs_ieta_HE3 =0;
+   MonitorElement* RMS_vs_ieta_HB1 =0, *RMS_vs_ieta_HB2 =0, *RMS_vs_ieta_HB3 =0, *RMS_vs_ieta_HB4 =0, *RMS_vs_ieta_HB5 =0, *RMS_vs_ieta_HB6 =0, *RMS_vs_ieta_HB7 =0; 
+   MonitorElement* RMS_vs_ieta_HE1 =0, *RMS_vs_ieta_HE2 =0, *RMS_vs_ieta_HE3 =0, *RMS_vs_ieta_HE4 =0, *RMS_vs_ieta_HE5 =0, *RMS_vs_ieta_HE6 =0, *RMS_vs_ieta_HE7 =0;
    MonitorElement* RMS_vs_ieta_HF1 =0, *RMS_vs_ieta_HF2 =0; 
    MonitorElement* RMS_vs_ieta_HO =0;
-   MonitorElement* occupancy_vs_ieta_HB1 =0, *occupancy_vs_ieta_HB2 =0; 
-   MonitorElement* occupancy_vs_ieta_HE1 =0, *occupancy_vs_ieta_HE2 =0, *occupancy_vs_ieta_HE3 =0;
+   MonitorElement* occupancy_vs_ieta_HB1 =0, *occupancy_vs_ieta_HB2 =0, *occupancy_vs_ieta_HB3 =0, *occupancy_vs_ieta_HB4 =0, *occupancy_vs_ieta_HB5 =0, *occupancy_vs_ieta_HB6 =0, *occupancy_vs_ieta_HB7 =0; 
+   MonitorElement* occupancy_vs_ieta_HE1 =0, *occupancy_vs_ieta_HE2 =0, *occupancy_vs_ieta_HE3 =0, *occupancy_vs_ieta_HE4 =0, *occupancy_vs_ieta_HE5 =0, *occupancy_vs_ieta_HE6 =0, *occupancy_vs_ieta_HE7 =0;
    MonitorElement* occupancy_vs_ieta_HF1 =0, *occupancy_vs_ieta_HF2 =0; 
    MonitorElement* occupancy_vs_ieta_HO =0;
 
@@ -189,60 +191,137 @@ int HcalRecHitsClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &hca
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "emap_depth2") ==0  ){ emap_depth2= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "emap_depth3") ==0  ){ emap_depth3= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "emap_depth4") ==0  ){ emap_depth4= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emap_depth5") ==0  ){ emap_depth5= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emap_depth6") ==0  ){ emap_depth6= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emap_depth7") ==0  ){ emap_depth7= hcalMEs[ih]; }
+
 
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occ_sequential1D_HB1") ==0  ){ occupancy_seqHB1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occ_sequential1D_HB2") ==0  ){ occupancy_seqHB2= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occ_sequential1D_HB3") ==0  ){ occupancy_seqHB3= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occ_sequential1D_HB4") ==0  ){ occupancy_seqHB4= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occ_sequential1D_HB5") ==0  ){ occupancy_seqHB5= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occ_sequential1D_HB6") ==0  ){ occupancy_seqHB6= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occ_sequential1D_HB7") ==0  ){ occupancy_seqHB7= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occ_sequential1D_HE1") ==0  ){ occupancy_seqHE1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occ_sequential1D_HE2") ==0  ){ occupancy_seqHE2= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occ_sequential1D_HE3") ==0  ){ occupancy_seqHE3= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occ_sequential1D_HE4") ==0  ){ occupancy_seqHE4= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occ_sequential1D_HE5") ==0  ){ occupancy_seqHE5= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occ_sequential1D_HE6") ==0  ){ occupancy_seqHE6= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occ_sequential1D_HE7") ==0  ){ occupancy_seqHE7= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occ_sequential1D_HF1") ==0  ){ occupancy_seqHF1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occ_sequential1D_HF2") ==0  ){ occupancy_seqHF2= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occ_sequential1D_HO") ==0  ){ occupancy_seqHO= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_seq_HB1") ==0  ){ emean_seqHB1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_seq_HB2") ==0  ){ emean_seqHB2= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_seq_HB3") ==0  ){ emean_seqHB3= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_seq_HB4") ==0  ){ emean_seqHB4= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_seq_HB5") ==0  ){ emean_seqHB5= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_seq_HB6") ==0  ){ emean_seqHB6= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_seq_HB7") ==0  ){ emean_seqHB7= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_seq_HE1") ==0  ){ emean_seqHE1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_seq_HE2") ==0  ){ emean_seqHE2= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_seq_HE3") ==0  ){ emean_seqHE3= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_seq_HE4") ==0  ){ emean_seqHE4= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_seq_HE5") ==0  ){ emean_seqHE5= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_seq_HE6") ==0  ){ emean_seqHE6= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_seq_HE7") ==0  ){ emean_seqHE7= hcalMEs[ih]; }
+
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_seq_HF1") ==0  ){ emean_seqHF1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_seq_HF2") ==0  ){ emean_seqHF2= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_seq_HO") ==0  ){ emean_seqHO= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_seq_HB1") ==0  ){ RMS_seq_HB1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_seq_HB2") ==0  ){ RMS_seq_HB2= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_seq_HB3") ==0  ){ RMS_seq_HB3= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_seq_HB4") ==0  ){ RMS_seq_HB4= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_seq_HB5") ==0  ){ RMS_seq_HB5= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_seq_HB6") ==0  ){ RMS_seq_HB6= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_seq_HB7") ==0  ){ RMS_seq_HB7= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_seq_HE1") ==0  ){ RMS_seq_HE1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_seq_HE2") ==0  ){ RMS_seq_HE2= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_seq_HE3") ==0  ){ RMS_seq_HE3= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_seq_HE4") ==0  ){ RMS_seq_HE4= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_seq_HE5") ==0  ){ RMS_seq_HE5= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_seq_HE6") ==0  ){ RMS_seq_HE6= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_seq_HE7") ==0  ){ RMS_seq_HE7= hcalMEs[ih]; }
+
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_seq_HF1") ==0  ){ RMS_seq_HF1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_seq_HF2") ==0  ){ RMS_seq_HF2= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_seq_HO") ==0  ){ RMS_seq_HO= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_map_HB1") ==0  ){ occupancy_map_HB1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_map_HB2") ==0  ){ occupancy_map_HB2= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_map_HB3") ==0  ){ occupancy_map_HB3= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_map_HB4") ==0  ){ occupancy_map_HB4= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_map_HB5") ==0  ){ occupancy_map_HB5= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_map_HB6") ==0  ){ occupancy_map_HB6= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_map_HB7") ==0  ){ occupancy_map_HB7= hcalMEs[ih]; }
+
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_map_HE1") ==0  ){ occupancy_map_HE1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_map_HE2") ==0  ){ occupancy_map_HE2= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_map_HE3") ==0  ){ occupancy_map_HE3= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_map_HE4") ==0  ){ occupancy_map_HE4= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_map_HE5") ==0  ){ occupancy_map_HE5= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_map_HE6") ==0  ){ occupancy_map_HE6= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_map_HE7") ==0  ){ occupancy_map_HE7= hcalMEs[ih]; }
+
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_map_HF1") ==0  ){ occupancy_map_HF1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_map_HF2") ==0  ){ occupancy_map_HF2= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_map_HO") ==0  ){ occupancy_map_HO= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_vs_ieta_HB1") ==0  ){ emean_vs_ieta_HB1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_vs_ieta_HB2") ==0  ){ emean_vs_ieta_HB2= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_vs_ieta_HB3") ==0  ){ emean_vs_ieta_HB3= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_vs_ieta_HB4") ==0  ){ emean_vs_ieta_HB4= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_vs_ieta_HB5") ==0  ){ emean_vs_ieta_HB5= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_vs_ieta_HB6") ==0  ){ emean_vs_ieta_HB6= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_vs_ieta_HB7") ==0  ){ emean_vs_ieta_HB7= hcalMEs[ih]; }      
+
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_vs_ieta_HE1") ==0  ){ emean_vs_ieta_HE1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_vs_ieta_HE2") ==0  ){ emean_vs_ieta_HE2= hcalMEs[ih]; }
-      //else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_vs_ieta_HE3") ==0  ){ emean_vs_ieta_HE3= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_vs_ieta_HE3") ==0  ){ emean_vs_ieta_HE3= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_vs_ieta_HE4") ==0  ){ emean_vs_ieta_HE4= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_vs_ieta_HE5") ==0  ){ emean_vs_ieta_HE5= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_vs_ieta_HE6") ==0  ){ emean_vs_ieta_HE6= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_vs_ieta_HE7") ==0  ){ emean_vs_ieta_HE7= hcalMEs[ih]; }     
+
       //else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_vs_ieta_HF1") ==0  ){ emean_vs_ieta_HF1= hcalMEs[ih]; }
       //else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_vs_ieta_HF2") ==0  ){ emean_vs_ieta_HF2= hcalMEs[ih]; }
       //else if( strcmp(hcalMEs[ih]->getName().c_str(), "emean_vs_ieta_HO") ==0  ){ emean_vs_ieta_HO= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_vs_ieta_HB1") ==0  ){ RMS_vs_ieta_HB1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_vs_ieta_HB2") ==0  ){ RMS_vs_ieta_HB2= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_vs_ieta_HB3") ==0  ){ RMS_vs_ieta_HB3= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_vs_ieta_HB4") ==0  ){ RMS_vs_ieta_HB4= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_vs_ieta_HB5") ==0  ){ RMS_vs_ieta_HB5= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_vs_ieta_HB6") ==0  ){ RMS_vs_ieta_HB6= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_vs_ieta_HB7") ==0  ){ RMS_vs_ieta_HB7= hcalMEs[ih]; }
+
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_vs_ieta_HE1") ==0  ){ RMS_vs_ieta_HE1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_vs_ieta_HE2") ==0  ){ RMS_vs_ieta_HE2= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_vs_ieta_HE3") ==0  ){ RMS_vs_ieta_HE3= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_vs_ieta_HE4") ==0  ){ RMS_vs_ieta_HE4= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_vs_ieta_HE5") ==0  ){ RMS_vs_ieta_HE5= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_vs_ieta_HE6") ==0  ){ RMS_vs_ieta_HE6= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_vs_ieta_HE7") ==0  ){ RMS_vs_ieta_HE7= hcalMEs[ih]; }
+
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_vs_ieta_HF1") ==0  ){ RMS_vs_ieta_HF1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_vs_ieta_HF2") ==0  ){ RMS_vs_ieta_HF2= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "RMS_vs_ieta_HO") ==0  ){ RMS_vs_ieta_HO= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_vs_ieta_HB1") ==0  ){ occupancy_vs_ieta_HB1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_vs_ieta_HB2") ==0  ){ occupancy_vs_ieta_HB2= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_vs_ieta_HB3") ==0  ){ occupancy_vs_ieta_HB3= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_vs_ieta_HB4") ==0  ){ occupancy_vs_ieta_HB4= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_vs_ieta_HB5") ==0  ){ occupancy_vs_ieta_HB5= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_vs_ieta_HB6") ==0  ){ occupancy_vs_ieta_HB6= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_vs_ieta_HB7") ==0  ){ occupancy_vs_ieta_HB7= hcalMEs[ih]; }
+
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_vs_ieta_HE1") ==0  ){ occupancy_vs_ieta_HE1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_vs_ieta_HE2") ==0  ){ occupancy_vs_ieta_HE2= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_vs_ieta_HE3") ==0  ){ occupancy_vs_ieta_HE3= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_vs_ieta_HE4") ==0  ){ occupancy_vs_ieta_HE4= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_vs_ieta_HE5") ==0  ){ occupancy_vs_ieta_HE5= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_vs_ieta_HE6") ==0  ){ occupancy_vs_ieta_HE6= hcalMEs[ih]; }
+      else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_vs_ieta_HE7") ==0  ){ occupancy_vs_ieta_HE7= hcalMEs[ih]; }
+
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_vs_ieta_HF1") ==0  ){ occupancy_vs_ieta_HF1= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_vs_ieta_HF2") ==0  ){ occupancy_vs_ieta_HF2= hcalMEs[ih]; }
       else if( strcmp(hcalMEs[ih]->getName().c_str(), "occupancy_vs_ieta_HO") ==0  ){ occupancy_vs_ieta_HO= hcalMEs[ih]; }
@@ -324,8 +403,12 @@ int HcalRecHitsClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &hca
 	        ZS_HF2->Fill(e);
 	        ZS_seqHF2->Fill(double(index),e);
 	     }
+
+          
+            unsigned int n_depth = 4;
+            if (doslhc_){n_depth = 7;}
 	
-	     for (unsigned int i3 = 0;  i3 < 4;  i3++) {  // depth
+	     for (unsigned int i3 = 0;  i3 < n_depth;  i3++) {  // depth
 	        double emin = 100000.;
 	        for (unsigned int i4 = 0;  i4 < 4;  i4++) {  // subdet
 	           /*
@@ -352,6 +435,15 @@ int HcalRecHitsClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &hca
 	           map_depth3->Fill(double(ieta),double(i2),emin);
                 if( i3 == 3 && emin < 10000.) 
 	           map_depth4->Fill(double(ieta),double(i2),emin);
+               if (doslhc_){ 
+                  if( i3 == 4 && emin < 10000.)
+                     map_depth5->Fill(double(ieta),double(i2),emin);
+                  if( i3 == 5 && emin < 10000.)
+                     map_depth6->Fill(double(ieta),double(i2),emin);
+                  if( i3 == 6 && emin < 10000.)
+                    map_depth7->Fill(double(ieta),double(i2),emin);
+                }
+
 	    }
          }
       } 
@@ -369,7 +461,7 @@ int HcalRecHitsClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &hca
       float fev = float (nevtot);
       //    std::cout << "*** nevtot " <<  nevtot << std::endl; 
 
-      float sumphi_hb1, sumphi_hb2, sumphi_he1, sumphi_he2, sumphi_he3,
+      float sumphi_hb1, sumphi_hb2, sumphi_hb3, sumphi_hb4, sumphi_hb5, sumphi_hb6, sumphi_hb7, sumphi_he1, sumphi_he2, sumphi_he3, sumphi_he4, sumphi_he5, sumphi_he6, sumphi_he7,
             sumphi_ho, sumphi_hf1, sumphi_hf2;
       /*
       if(nx != 82 || ny != 72) 
@@ -390,6 +482,15 @@ int HcalRecHitsClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &hca
             emap_depth3->setBinContent(i,j,cnorm);
 	    cnorm = emap_depth4->getBinContent(i,j) / fev;
             emap_depth4->setBinContent(i,j,cnorm);
+ 
+            if (doslhc_){
+               cnorm = emap_depth5->getBinContent(i,j) / fev;
+               emap_depth5->setBinContent(i,j,cnorm);
+               cnorm = emap_depth6->getBinContent(i,j) / fev;
+               emap_depth6->setBinContent(i,j,cnorm);
+               cnorm = emap_depth7->getBinContent(i,j) / fev;
+               emap_depth7->setBinContent(i,j,cnorm);
+         }
 	}
       }
 
@@ -397,9 +498,18 @@ int HcalRecHitsClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &hca
       for (int i = 1; i <= nx; i++) {
          sumphi_hb1 = 0.;
          sumphi_hb2 = 0.;
+         sumphi_hb3 = 0.;
+         sumphi_hb4 = 0.;
+         sumphi_hb5 = 0.;
+         sumphi_hb6 = 0.;
+         sumphi_hb7 = 0.;
          sumphi_he1 = 0.;
          sumphi_he2 = 0.;
          sumphi_he3 = 0.;
+         sumphi_he4 = 0.;
+         sumphi_he5 = 0.;
+         sumphi_he6 = 0.;
+         sumphi_he7 = 0.;
          sumphi_ho  = 0.; 
          sumphi_hf1 = 0.;
          sumphi_hf2 = 0.;
@@ -414,16 +524,40 @@ int HcalRecHitsClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &hca
 	
 	    cnorm = occupancy_map_HB2->getBinContent(i,j) / fev;   
 	    occupancy_map_HB2->setBinContent(i,j,cnorm);
+
+            if (doslhc_){
+               cnorm = occupancy_map_HB3->getBinContent(i,j) / fev;
+               occupancy_map_HB3->setBinContent(i,j,cnorm);
+               cnorm = occupancy_map_HB4->getBinContent(i,j) / fev;
+               occupancy_map_HB4->setBinContent(i,j,cnorm);
+               cnorm = occupancy_map_HB5->getBinContent(i,j) / fev;
+               occupancy_map_HB5->setBinContent(i,j,cnorm);
+               cnorm = occupancy_map_HB6->getBinContent(i,j) / fev;
+               occupancy_map_HB6->setBinContent(i,j,cnorm);
+               cnorm = occupancy_map_HB7->getBinContent(i,j) / fev;
+               occupancy_map_HB7->setBinContent(i,j,cnorm);
+            }
 	
 	    cnorm = occupancy_map_HE1->getBinContent(i,j) / fev;   
 	    occupancy_map_HE1->setBinContent(i,j,cnorm);
 	
 	    cnorm = occupancy_map_HE2->getBinContent(i,j) / fev;   
 	    occupancy_map_HE2->setBinContent(i,j,cnorm);
+
+            cnorm = occupancy_map_HE3->getBinContent(i,j) / fev;
+            occupancy_map_HE3->setBinContent(i,j,cnorm);
 	
-	    cnorm = occupancy_map_HE3->getBinContent(i,j) / fev;   
-	    occupancy_map_HE3->setBinContent(i,j,cnorm);
-	
+            if (doslhc_){
+	       cnorm = occupancy_map_HE4->getBinContent(i,j) / fev;   
+	       occupancy_map_HE4->setBinContent(i,j,cnorm);
+               cnorm = occupancy_map_HE5->getBinContent(i,j) / fev;
+               occupancy_map_HE5->setBinContent(i,j,cnorm);
+               cnorm = occupancy_map_HE6->getBinContent(i,j) / fev;
+               occupancy_map_HE6->setBinContent(i,j,cnorm);
+               cnorm = occupancy_map_HE7->getBinContent(i,j) / fev;
+               occupancy_map_HE7->setBinContent(i,j,cnorm);
+            }
+
 	    cnorm = occupancy_map_HO->getBinContent(i,j) / fev;   
 	    occupancy_map_HO->setBinContent(i,j,cnorm);
 	
@@ -435,9 +569,26 @@ int HcalRecHitsClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &hca
 
 	    sumphi_hb1 += occupancy_map_HB1->getBinContent(i,j);
 	    sumphi_hb2 += occupancy_map_HB2->getBinContent(i,j);
+           
+            if (doslhc_){
+               sumphi_hb3 += occupancy_map_HB3->getBinContent(i,j);
+               sumphi_hb4 += occupancy_map_HB4->getBinContent(i,j);
+               sumphi_hb5 += occupancy_map_HB5->getBinContent(i,j);
+               sumphi_hb6 += occupancy_map_HB6->getBinContent(i,j);
+               sumphi_hb7 += occupancy_map_HB7->getBinContent(i,j);
+            }
+
 	    sumphi_he1 += occupancy_map_HE1->getBinContent(i,j);
 	    sumphi_he2 += occupancy_map_HE2->getBinContent(i,j);
 	    sumphi_he3 += occupancy_map_HE3->getBinContent(i,j);
+      
+            if (doslhc_){
+               sumphi_he4 += occupancy_map_HE4->getBinContent(i,j);
+               sumphi_he5 += occupancy_map_HE5->getBinContent(i,j);
+               sumphi_he6 += occupancy_map_HE6->getBinContent(i,j);
+               sumphi_he7 += occupancy_map_HE7->getBinContent(i,j);
+            }
+
 	    sumphi_ho  += occupancy_map_HO->getBinContent(i,j);
 	    sumphi_hf1 += occupancy_map_HF1->getBinContent(i,j);
 	    sumphi_hf2 += occupancy_map_HF2->getBinContent(i,j);
@@ -446,9 +597,20 @@ int HcalRecHitsClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &hca
             if(useAllHistos){
               occupancy_seqHB1->Fill(double(index),cnorm);
 	      occupancy_seqHB2->Fill(double(index),cnorm);
+              occupancy_seqHB3->Fill(double(index),cnorm);
+              occupancy_seqHB4->Fill(double(index),cnorm);
+              occupancy_seqHB5->Fill(double(index),cnorm);
+              occupancy_seqHB6->Fill(double(index),cnorm);
+              occupancy_seqHB7->Fill(double(index),cnorm);
+     
 	      occupancy_seqHE1->Fill(double(index),cnorm);
 	      occupancy_seqHE2->Fill(double(index),cnorm);
 	      occupancy_seqHE3->Fill(double(index),cnorm);
+              occupancy_seqHE4->Fill(double(index),cnorm);
+              occupancy_seqHE5->Fill(double(index),cnorm);
+              occupancy_seqHE6->Fill(double(index),cnorm);
+              occupancy_seqHE7->Fill(double(index),cnorm);
+
 	      occupancy_seqHO->Fill(double(index),cnorm);
 	      occupancy_seqHF1->Fill(double(index),cnorm);
 	      occupancy_seqHF2->Fill(double(index),cnorm); 
@@ -478,12 +640,38 @@ int HcalRecHitsClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &hca
          occupancy_vs_ieta_HB1->Fill(float(ieta), cnorm);
          cnorm = sumphi_hb2 / phi_factor;
          occupancy_vs_ieta_HB2->Fill(float(ieta), cnorm);
+
+         if (doslhc_){
+            cnorm = sumphi_hb3 / phi_factor;
+            occupancy_vs_ieta_HB3->Fill(float(ieta), cnorm);
+            cnorm = sumphi_hb4 / phi_factor;
+            occupancy_vs_ieta_HB4->Fill(float(ieta), cnorm);
+            cnorm = sumphi_hb5 / phi_factor;
+            occupancy_vs_ieta_HB5->Fill(float(ieta), cnorm);
+            cnorm = sumphi_hb6 / phi_factor;
+            occupancy_vs_ieta_HB6->Fill(float(ieta), cnorm);
+            cnorm = sumphi_hb7 / phi_factor;
+            occupancy_vs_ieta_HB7->Fill(float(ieta), cnorm);
+         }
+
          cnorm = sumphi_he1 / phi_factor;
          occupancy_vs_ieta_HE1->Fill(float(ieta), cnorm);
          cnorm = sumphi_he2 / phi_factor;
          occupancy_vs_ieta_HE2->Fill(float(ieta), cnorm);
          cnorm = sumphi_he3 / phi_factor;
          occupancy_vs_ieta_HE3->Fill(float(ieta), cnorm);
+
+         if (doslhc_){
+            cnorm = sumphi_he4 / phi_factor;
+            occupancy_vs_ieta_HE4->Fill(float(ieta), cnorm);
+            cnorm = sumphi_he5 / phi_factor;
+            occupancy_vs_ieta_HE5->Fill(float(ieta), cnorm);
+            cnorm = sumphi_he6 / phi_factor;
+            occupancy_vs_ieta_HE6->Fill(float(ieta), cnorm);
+            cnorm = sumphi_he7 / phi_factor;
+            occupancy_vs_ieta_HE7->Fill(float(ieta), cnorm);
+         }
+
          cnorm = sumphi_ho / phi_factor;
          occupancy_vs_ieta_HO->Fill(float(ieta), cnorm);
          cnorm = sumphi_hf1 / phi_factor;
@@ -497,12 +685,35 @@ int HcalRecHitsClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &hca
 	    RMS_vs_ieta_HB1->Fill(ieta,cnorm);
 	    cnorm = emean_vs_ieta_HB2->getBinError(i);
 	    RMS_vs_ieta_HB2->Fill(ieta,cnorm);
+
+            cnorm = emean_vs_ieta_HB3->getBinError(i);
+            RMS_vs_ieta_HB3->Fill(ieta,cnorm);
+            cnorm = emean_vs_ieta_HB4->getBinError(i);
+            RMS_vs_ieta_HB4->Fill(ieta,cnorm);
+            cnorm = emean_vs_ieta_HB5->getBinError(i);
+            RMS_vs_ieta_HB5->Fill(ieta,cnorm);
+            cnorm = emean_vs_ieta_HB6->getBinError(i);
+            RMS_vs_ieta_HB6->Fill(ieta,cnorm);
+            cnorm = emean_vs_ieta_HB7->getBinError(i);
+            RMS_vs_ieta_HB7->Fill(ieta,cnorm);
+
 	    cnorm = emean_vs_ieta_HE1->getBinError(i);
 	    RMS_vs_ieta_HE1->Fill(ieta,cnorm);
 	    cnorm = emean_vs_ieta_HE2->getBinError(i);
 	    RMS_vs_ieta_HE2->Fill(ieta,cnorm);
-	    cnorm = emean_vs_ieta_HE1->getBinError(i);
+	    cnorm = emean_vs_ieta_HE3->getBinError(i);
 	    RMS_vs_ieta_HE3->Fill(ieta,cnorm);
+
+            cnorm = emean_vs_ieta_HE4->getBinError(i);
+            RMS_vs_ieta_HE4->Fill(ieta,cnorm);
+            cnorm = emean_vs_ieta_HE5->getBinError(i);
+            RMS_vs_ieta_HE5->Fill(ieta,cnorm);
+            cnorm = emean_vs_ieta_HE6->getBinError(i);
+            RMS_vs_ieta_HE6->Fill(ieta,cnorm);
+            cnorm = emean_vs_ieta_HE7->getBinError(i);
+            RMS_vs_ieta_HE7->Fill(ieta,cnorm);
+
+
 	    cnorm = emean_vs_ieta_HB1->getBinError(i);
 	    RMS_vs_ieta_HO->Fill(ieta,cnorm);
 	    cnorm = emean_vs_ieta_HB1->getBinError(i);
@@ -521,6 +732,18 @@ int HcalRecHitsClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &hca
 	    RMS_seq_HB1->setBinContent(ibin, cnorm);
 	    cnorm = emean_seqHB2->getBinError(ibin);
 	    RMS_seq_HB2->setBinContent(ibin, cnorm);
+            cnorm = emean_seqHB3->getBinError(ibin);
+            RMS_seq_HB3->setBinContent(ibin, cnorm);
+            cnorm = emean_seqHB4->getBinError(ibin);
+            RMS_seq_HB4->setBinContent(ibin, cnorm);
+            cnorm = emean_seqHB5->getBinError(ibin);
+            RMS_seq_HB5->setBinContent(ibin, cnorm);
+            cnorm = emean_seqHB6->getBinError(ibin);
+            RMS_seq_HB6->setBinContent(ibin, cnorm);
+            cnorm = emean_seqHB7->getBinError(ibin);
+            RMS_seq_HB7->setBinContent(ibin, cnorm);
+
+
 	    cnorm = emean_seqHO->getBinError(ibin);
 	    RMS_seq_HO->setBinContent(ibin, cnorm);
          }
@@ -532,6 +755,16 @@ int HcalRecHitsClient::HcalRecHitsEndjob(const std::vector<MonitorElement*> &hca
 	    RMS_seq_HE2->setBinContent(ibin, cnorm);
 	    cnorm = emean_seqHE3->getBinError(ibin);
 	    RMS_seq_HE3->setBinContent(ibin, cnorm);
+            cnorm = emean_seqHE4->getBinError(ibin);
+            RMS_seq_HE4->setBinContent(ibin, cnorm);
+            cnorm = emean_seqHE5->getBinError(ibin);
+            RMS_seq_HE5->setBinContent(ibin, cnorm);
+            cnorm = emean_seqHE6->getBinError(ibin);
+            RMS_seq_HE6->setBinContent(ibin, cnorm);
+            cnorm = emean_seqHE7->getBinError(ibin);
+            RMS_seq_HE7->setBinContent(ibin, cnorm);
+
+
          }
          nx = emean_seqHF1->getNbinsX();    
          for(int ibin = 1; ibin <= nx; ibin++ ){

--- a/Validation/HcalRecHits/src/HcalRecHitsValidation.cc
+++ b/Validation/HcalRecHits/src/HcalRecHitsValidation.cc
@@ -28,6 +28,9 @@ HcalRecHitsValidation::HcalRecHitsValidation(edm::ParameterSet const& conf) {
   famos_        = conf.getUntrackedParameter<bool>("Famos", false);
   useAllHistos_ = conf.getUntrackedParameter<bool>("useAllHistos", false);
 
+  // false for regular relval and true for SLHC relval
+  doSLHC_ = conf.getUntrackedParameter<bool>("doSLHC", false);
+
   //Collections
   theHBHERecHitCollectionLabel = conf.getUntrackedParameter<edm::InputTag>("HBHERecHitCollectionLabel");
   theHFRecHitCollectionLabel   = conf.getUntrackedParameter<edm::InputTag>("HFRecHitCollectionLabel");
@@ -157,6 +160,16 @@ HcalRecHitsValidation::HcalRecHitsValidation(edm::ParameterSet const& conf) {
       sprintf  (histo, "emap_depth4" );
       emap_depth4 = dbe_->book2D(histo, histo, 84, -42., 42., 72, 0., 72.);
       
+    if (doSLHC_){
+       sprintf  (histo, "emap_depth5" );
+       emap_depth5 = dbe_->book2D(histo, histo, 84, -42., 42., 72, 0., 72.);
+       sprintf  (histo, "emap_depth6" );
+       emap_depth6 = dbe_->book2D(histo, histo, 84, -42., 42., 72, 0., 72.);
+       sprintf  (histo, "emap_depth7" );
+       emap_depth7 = dbe_->book2D(histo, histo, 84, -42., 42., 72, 0., 72.);
+    }
+
+      
       if (useAllHistos_){
 	
 	if (ecalselector_ == "yes") {
@@ -170,12 +183,38 @@ HcalRecHitsValidation::HcalRecHitsValidation(edm::ParameterSet const& conf) {
       emean_vs_ieta_HB1 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2010, -10., 2000., "s");
       sprintf  (histo, "emean_vs_ieta_HB2" );
       emean_vs_ieta_HB2 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2010, -10., 2000., "s");
+      
+      if (doSLHC_){
+         sprintf  (histo, "emean_vs_ieta_HB3" );
+         emean_vs_ieta_HB3 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2010, -10., 2000., "s");
+         sprintf  (histo, "emean_vs_ieta_HB4" );
+         emean_vs_ieta_HB4 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2010, -10., 2000., "s");
+         sprintf  (histo, "emean_vs_ieta_HB5" );
+         emean_vs_ieta_HB5 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2010, -10., 2000., "s");
+         sprintf  (histo, "emean_vs_ieta_HB6" );
+         emean_vs_ieta_HB6 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2010, -10., 2000., "s");
+         sprintf  (histo, "emean_vs_ieta_HB7" );
+         emean_vs_ieta_HB7 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2010, -10., 2000., "s");
+      }
+
       sprintf  (histo, "emean_vs_ieta_HE1" );
       emean_vs_ieta_HE1 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2010, -10. ,2000., "s" );
       sprintf  (histo, "emean_vs_ieta_HE2" );
       emean_vs_ieta_HE2 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2010, -10., 2000., "s");
       sprintf  (histo, "emean_vs_ieta_HE3" );
       emean_vs_ieta_HE3 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2010, -10., 2000., "s" );
+
+      if (doSLHC_){
+        sprintf  (histo, "emean_vs_ieta_HE4" );
+        emean_vs_ieta_HE4 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2010, -10., 2000., "s" );
+        sprintf  (histo, "emean_vs_ieta_HE5" );
+        emean_vs_ieta_HE5 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2010, -10., 2000., "s" );
+        sprintf  (histo, "emean_vs_ieta_HE6" );
+        emean_vs_ieta_HE6 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2010, -10., 2000., "s" );
+        sprintf  (histo, "emean_vs_ieta_HE7" );
+        emean_vs_ieta_HE7 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2010, -10., 2000., "s" );
+      }
+
       sprintf  (histo, "emean_vs_ieta_HO" );
       emean_vs_ieta_HO = dbe_->bookProfile(histo, histo, 82, -41., 41., 2010, -10., 2000., "s" );
       sprintf  (histo, "emean_vs_ieta_HF1" );
@@ -188,12 +227,32 @@ HcalRecHitsValidation::HcalRecHitsValidation(edm::ParameterSet const& conf) {
 	RMS_vs_ieta_HB1 = dbe_->book1D(histo, histo, 82, -41., 41.);
 	sprintf  (histo, "RMS_vs_ieta_HB2" );
 	RMS_vs_ieta_HB2 = dbe_->book1D(histo, histo, 82, -41., 41.);
+        sprintf  (histo, "RMS_vs_ieta_HB3" );
+        RMS_vs_ieta_HB3 = dbe_->book1D(histo, histo, 82, -41., 41.);
+        sprintf  (histo, "RMS_vs_ieta_HB4" );
+        RMS_vs_ieta_HB4 = dbe_->book1D(histo, histo, 82, -41., 41.);
+        sprintf  (histo, "RMS_vs_ieta_HB5" );
+        RMS_vs_ieta_HB5 = dbe_->book1D(histo, histo, 82, -41., 41.);
+        sprintf  (histo, "RMS_vs_ieta_HB6" );
+        RMS_vs_ieta_HB6 = dbe_->book1D(histo, histo, 82, -41., 41.);
+        sprintf  (histo, "RMS_vs_ieta_HB7" );
+        RMS_vs_ieta_HB7 = dbe_->book1D(histo, histo, 82, -41., 41.);
+
 	sprintf  (histo, "RMS_vs_ieta_HE1" );
 	RMS_vs_ieta_HE1 = dbe_->book1D(histo, histo, 82, -41., 41.);
 	sprintf  (histo, "RMS_vs_ieta_HE2" );
 	RMS_vs_ieta_HE2 = dbe_->book1D(histo, histo, 82, -41., 41.);
 	sprintf  (histo, "RMS_vs_ieta_HE3" );
 	RMS_vs_ieta_HE3 = dbe_->book1D(histo, histo, 82, -41., 41.);
+        sprintf  (histo, "RMS_vs_ieta_HE4" );
+        RMS_vs_ieta_HE4 = dbe_->book1D(histo, histo, 82, -41., 41.);
+        sprintf  (histo, "RMS_vs_ieta_HE5" );
+        RMS_vs_ieta_HE5 = dbe_->book1D(histo, histo, 82, -41., 41.);
+        sprintf  (histo, "RMS_vs_ieta_HE6" );
+        RMS_vs_ieta_HE6 = dbe_->book1D(histo, histo, 82, -41., 41.);
+        sprintf  (histo, "RMS_vs_ieta_HE7" );
+        RMS_vs_ieta_HE7 = dbe_->book1D(histo, histo, 82, -41., 41.);
+
 	sprintf  (histo, "RMS_vs_ieta_HO" );
 	RMS_vs_ieta_HO = dbe_->book1D(histo, histo, 82, -41., 41.);
 	sprintf  (histo, "RMS_vs_ieta_HF1" );
@@ -206,13 +265,34 @@ HcalRecHitsValidation::HcalRecHitsValidation(edm::ParameterSet const& conf) {
 	emean_seqHB1 = dbe_->bookProfile(histo, histo, 2400, -1200., 1200.,  2010, -10., 2000., "s" );
 	sprintf  (histo, "emean_seq_HB2" );
 	emean_seqHB2 = dbe_->bookProfile(histo, histo, 2400, -1200., 1200.,  2010, -10., 2000., "s" );
-	sprintf  (histo, "emean_seq_HE1" );
+        sprintf  (histo, "emean_seq_HB3" );
+        emean_seqHB3 = dbe_->bookProfile(histo, histo, 2400, -1200., 1200.,  2010, -10., 2000., "s" );
+        sprintf  (histo, "emean_seq_HB4" );
+        emean_seqHB4 = dbe_->bookProfile(histo, histo, 2400, -1200., 1200.,  2010, -10., 2000., "s" );
+        sprintf  (histo, "emean_seq_HB5" );
+        emean_seqHB5 = dbe_->bookProfile(histo, histo, 2400, -1200., 1200.,  2010, -10., 2000., "s" );
+        sprintf  (histo, "emean_seq_HB6" );
+        emean_seqHB6 = dbe_->bookProfile(histo, histo, 2400, -1200., 1200.,  2010, -10., 2000., "s" );
+        sprintf  (histo, "emean_seq_HB7" );
+        emean_seqHB7 = dbe_->bookProfile(histo, histo, 2400, -1200., 1200.,  2010, -10., 2000., "s" );
+	
+        sprintf  (histo, "emean_seq_HE1" );
 	emean_seqHE1 = dbe_->bookProfile(histo, histo, 4400, -2200., 2200.,  2010, -10., 2000., "s" );
 	sprintf  (histo, "emean_seq_HE2" );
 	emean_seqHE2 = dbe_->bookProfile(histo, histo, 4400, -2200., 2200.,  2010, -10., 2000., "s" );
 	sprintf  (histo, "emean_seq_HE3" );
 	emean_seqHE3 = dbe_->bookProfile(histo, histo, 4400, -2200., 2200.,  2010, -10., 2000., "s" );
-	sprintf  (histo, "emean_seq_HO" );
+        sprintf  (histo, "emean_seq_HE4" );
+        emean_seqHE4 = dbe_->bookProfile(histo, histo, 4400, -2200., 2200.,  2010, -10., 2000., "s" );
+        sprintf  (histo, "emean_seq_HE5" );
+        emean_seqHE5 = dbe_->bookProfile(histo, histo, 4400, -2200., 2200.,  2010, -10., 2000., "s" );
+        sprintf  (histo, "emean_seq_HE6" );
+        emean_seqHE6 = dbe_->bookProfile(histo, histo, 4400, -2200., 2200.,  2010, -10., 2000., "s" );
+        sprintf  (histo, "emean_seq_HE7" );
+        emean_seqHE7 = dbe_->bookProfile(histo, histo, 4400, -2200., 2200.,  2010, -10., 2000., "s" );
+
+	
+        sprintf  (histo, "emean_seq_HO" );
 	emean_seqHO = dbe_->bookProfile(histo, histo,  2400, -1200., 1200.,  2010, -10., 2000., "s" );
 	sprintf  (histo, "emean_seq_HF1" );
 	emean_seqHF1 = dbe_->bookProfile(histo, histo, 6000, -3000., 3000.,  2010, -10., 2000., "s" );
@@ -223,12 +303,33 @@ HcalRecHitsValidation::HcalRecHitsValidation(edm::ParameterSet const& conf) {
 	RMS_seq_HB1 = dbe_->book1D(histo, histo, 2400, -1200., 1200.);
 	sprintf  (histo, "RMS_seq_HB2" );
 	RMS_seq_HB2 = dbe_->book1D(histo, histo, 2400, -1200., 1200.);
+        sprintf  (histo, "RMS_seq_HB3" );
+        RMS_seq_HB3 = dbe_->book1D(histo, histo, 2400, -1200., 1200.);
+        sprintf  (histo, "RMS_seq_HB4" );
+        RMS_seq_HB4 = dbe_->book1D(histo, histo, 2400, -1200., 1200.);
+        sprintf  (histo, "RMS_seq_HB5" );
+        RMS_seq_HB5 = dbe_->book1D(histo, histo, 2400, -1200., 1200.);
+        sprintf  (histo, "RMS_seq_HB6" );
+        RMS_seq_HB6 = dbe_->book1D(histo, histo, 2400, -1200., 1200.);
+        sprintf  (histo, "RMS_seq_HB7" );
+        RMS_seq_HB7 = dbe_->book1D(histo, histo, 2400, -1200., 1200.);
+
+
 	sprintf  (histo, "RMS_seq_HE1" );
 	RMS_seq_HE1 = dbe_->book1D(histo, histo, 4400, -2200., 2200.);
 	sprintf  (histo, "RMS_seq_HE2" );
 	RMS_seq_HE2 = dbe_->book1D(histo, histo, 4400, -2200., 2200.);
 	sprintf  (histo, "RMS_seq_HE3" );
 	RMS_seq_HE3 = dbe_->book1D(histo, histo, 4400, -2200., 2200.);
+        sprintf  (histo, "RMS_seq_HE4" );
+        RMS_seq_HE4 = dbe_->book1D(histo, histo, 4400, -2200., 2200.);
+        sprintf  (histo, "RMS_seq_HE5" );
+        RMS_seq_HE5 = dbe_->book1D(histo, histo, 4400, -2200., 2200.);
+        sprintf  (histo, "RMS_seq_HE6" );
+        RMS_seq_HE6 = dbe_->book1D(histo, histo, 4400, -2200., 2200.);
+        sprintf  (histo, "RMS_seq_HE7" );
+        RMS_seq_HE7 = dbe_->book1D(histo, histo, 4400, -2200., 2200.);
+
 	sprintf  (histo, "RMS_seq_HO" );
 	RMS_seq_HO = dbe_->book1D(histo, histo, 2400, -1200., 1200.);
 	sprintf  (histo, "RMS_seq_HF1" );
@@ -243,12 +344,38 @@ HcalRecHitsValidation::HcalRecHitsValidation(edm::ParameterSet const& conf) {
       occupancy_map_HB1 = dbe_->book2D(histo, histo, 82, -41., 41., 72, 0., 72.);
       sprintf  (histo, "occupancy_map_HB2" );
       occupancy_map_HB2 = dbe_->book2D(histo, histo, 82, -41., 41., 72, 0., 72.);
+
+      if (doSLHC_){
+         sprintf  (histo, "occupancy_map_HB3" );
+         occupancy_map_HB3 = dbe_->book2D(histo, histo, 82, -41., 41., 72, 0., 72.);
+         sprintf  (histo, "occupancy_map_HB4" );
+         occupancy_map_HB4 = dbe_->book2D(histo, histo, 82, -41., 41., 72, 0., 72.);
+         sprintf  (histo, "occupancy_map_HB5" );
+         occupancy_map_HB5 = dbe_->book2D(histo, histo, 82, -41., 41., 72, 0., 72.);
+         sprintf  (histo, "occupancy_map_HB6" );
+         occupancy_map_HB6 = dbe_->book2D(histo, histo, 82, -41., 41., 72, 0., 72.);
+         sprintf  (histo, "occupancy_map_HB7" );
+         occupancy_map_HB7 = dbe_->book2D(histo, histo, 82, -41., 41., 72, 0., 72.);
+      }
+
       sprintf  (histo, "occupancy_map_HE1" );
       occupancy_map_HE1 = dbe_->book2D(histo, histo, 82, -41., 41., 72, 0., 72.);
       sprintf  (histo, "occupancy_map_HE2" );
       occupancy_map_HE2 = dbe_->book2D(histo, histo, 82, -41., 41., 72, 0., 72.);      
       sprintf  (histo, "occupancy_map_HE3" );
       occupancy_map_HE3 = dbe_->book2D(histo, histo, 82, -41., 41., 72, 0., 72.);
+   
+      if (doSLHC_){
+         sprintf  (histo, "occupancy_map_HE4" );
+         occupancy_map_HE4 = dbe_->book2D(histo, histo, 82, -41., 41., 72, 0., 72.);
+         sprintf  (histo, "occupancy_map_HE5" );
+         occupancy_map_HE5 = dbe_->book2D(histo, histo, 82, -41., 41., 72, 0., 72.);
+         sprintf  (histo, "occupancy_map_HE6" );
+         occupancy_map_HE6 = dbe_->book2D(histo, histo, 82, -41., 41., 72, 0., 72.);
+         sprintf  (histo, "occupancy_map_HE7" );
+         occupancy_map_HE7 = dbe_->book2D(histo, histo, 82, -41., 41., 72, 0., 72.);
+      }
+
       sprintf  (histo, "occupancy_map_HO" );
       occupancy_map_HO = dbe_->book2D(histo, histo, 82, -41., 41., 72, 0., 72.);      
       sprintf  (histo, "occupancy_map_HF1" );
@@ -261,12 +388,39 @@ HcalRecHitsValidation::HcalRecHitsValidation(edm::ParameterSet const& conf) {
       occupancy_vs_ieta_HB1 = dbe_->book1D(histo, histo, 82, -41., 41.);
       sprintf  (histo, "occupancy_vs_ieta_HB2" );
       occupancy_vs_ieta_HB2 = dbe_->book1D(histo, histo, 82, -41., 41.);
+
+      if (doSLHC_){
+         sprintf  (histo, "occupancy_vs_ieta_HB3" );
+         occupancy_vs_ieta_HB3 = dbe_->book1D(histo, histo, 82, -41., 41.);
+         sprintf  (histo, "occupancy_vs_ieta_HB4" );
+         occupancy_vs_ieta_HB4 = dbe_->book1D(histo, histo, 82, -41., 41.);
+         sprintf  (histo, "occupancy_vs_ieta_HB5" );
+         occupancy_vs_ieta_HB5 = dbe_->book1D(histo, histo, 82, -41., 41.);
+         sprintf  (histo, "occupancy_vs_ieta_HB6" );
+         occupancy_vs_ieta_HB6 = dbe_->book1D(histo, histo, 82, -41., 41.);
+         sprintf  (histo, "occupancy_vs_ieta_HB7" );
+         occupancy_vs_ieta_HB7 = dbe_->book1D(histo, histo, 82, -41., 41.);
+      }
+
+
       sprintf  (histo, "occupancy_vs_ieta_HE1" );
       occupancy_vs_ieta_HE1 = dbe_->book1D(histo, histo, 82, -41., 41.);
       sprintf  (histo, "occupancy_vs_ieta_HE2" );
       occupancy_vs_ieta_HE2 = dbe_->book1D(histo, histo, 82, -41., 41.);
       sprintf  (histo, "occupancy_vs_ieta_HE3" );
       occupancy_vs_ieta_HE3 = dbe_->book1D(histo, histo, 82, -41., 41.);
+ 
+      if (doSLHC_){
+         sprintf  (histo, "occupancy_vs_ieta_HE4" );
+         occupancy_vs_ieta_HE4 = dbe_->book1D(histo, histo, 82, -41., 41.);
+         sprintf  (histo, "occupancy_vs_ieta_HE5" );
+         occupancy_vs_ieta_HE5 = dbe_->book1D(histo, histo, 82, -41., 41.);
+         sprintf  (histo, "occupancy_vs_ieta_HE6" );
+         occupancy_vs_ieta_HE6 = dbe_->book1D(histo, histo, 82, -41., 41.);
+         sprintf  (histo, "occupancy_vs_ieta_HE7" );
+         occupancy_vs_ieta_HE7 = dbe_->book1D(histo, histo, 82, -41., 41.);
+      }
+
       sprintf  (histo, "occupancy_vs_ieta_HO" );
       occupancy_vs_ieta_HO = dbe_->book1D(histo, histo, 82, -41., 41.);
       sprintf  (histo, "occupancy_vs_ieta_HF1" );
@@ -338,6 +492,15 @@ HcalRecHitsValidation::HcalRecHitsValidation(edm::ParameterSet const& conf) {
 	sprintf  (histo, "map_econe_depth4" );
 	map_econe_depth4 =
 	  dbe_->book2D(histo, histo, 520, -5.2, 5.2, 72, -3.1415926536, 3.1415926536);
+        sprintf  (histo, "map_econe_depth5" );
+        map_econe_depth5 =
+          dbe_->book2D(histo, histo, 520, -5.2, 5.2, 72, -3.1415926536, 3.1415926536);
+        sprintf  (histo, "map_econe_depth6" );
+        map_econe_depth6 =
+          dbe_->book2D(histo, histo, 520, -5.2, 5.2, 72, -3.1415926536, 3.1415926536);
+        sprintf  (histo, "map_econe_depth7" );
+        map_econe_depth7 =
+          dbe_->book2D(histo, histo, 520, -5.2, 5.2, 72, -3.1415926536, 3.1415926536);
       }
     }  // end-of (subdet_ =! 6)
 
@@ -370,7 +533,17 @@ HcalRecHitsValidation::HcalRecHitsValidation(edm::ParameterSet const& conf) {
 	meEnConeEtaProfile_depth3 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2100, -100., 2000.);  
 	
 	sprintf (histo, "HcalRecHitTask_En_rechits_cone_profile_vs_ieta_depth4");
-	meEnConeEtaProfile_depth4 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2100, -100., 2000.);  
+	meEnConeEtaProfile_depth4 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2100, -100., 2000.); 
+
+        sprintf (histo, "HcalRecHitTask_En_rechits_cone_profile_vs_ieta_depth5");
+        meEnConeEtaProfile_depth5 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2100, -100., 2000.);
+
+        sprintf (histo, "HcalRecHitTask_En_rechits_cone_profile_vs_ieta_depth6");
+        meEnConeEtaProfile_depth6 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2100, -100., 2000.);
+
+        sprintf (histo, "HcalRecHitTask_En_rechits_cone_profile_vs_ieta_depth7");
+        meEnConeEtaProfile_depth7 = dbe_->bookProfile(histo, histo, 82, -41., 41., 2100, -100., 2000.);
+ 
 	
       }
       
@@ -475,6 +648,18 @@ HcalRecHitsValidation::HcalRecHitsValidation(edm::ParameterSet const& conf) {
 	
 	sprintf (histo, "HcalRecHitTask_timing_vs_energy_HB_depth2" ) ;
 	meTE_HB2 = dbe_->book2D(histo, histo, 3000, -5., 2995.,  70, -48., 92.);
+ 
+        sprintf (histo, "HcalRecHitTask_timing_vs_energy_HB_depth3" ) ;
+        meTE_HB3 = dbe_->book2D(histo, histo, 3000, -5., 2995.,  70, -48., 92.);
+        sprintf (histo, "HcalRecHitTask_timing_vs_energy_HB_depth4" ) ;
+        meTE_HB4 = dbe_->book2D(histo, histo, 3000, -5., 2995.,  70, -48., 92.);
+        sprintf (histo, "HcalRecHitTask_timing_vs_energy_HB_depth5" ) ;
+        meTE_HB5 = dbe_->book2D(histo, histo, 3000, -5., 2995.,  70, -48., 92.);
+        sprintf (histo, "HcalRecHitTask_timing_vs_energy_HB_depth6" ) ;
+        meTE_HB6 = dbe_->book2D(histo, histo, 3000, -5., 2995.,  70, -48., 92.);
+        sprintf (histo, "HcalRecHitTask_timing_vs_energy_HB_depth7" ) ;
+        meTE_HB7 = dbe_->book2D(histo, histo, 3000, -5., 2995.,  70, -48., 92.);
+
 	
 	if(imc != 0) {
 	  sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_HB");
@@ -551,6 +736,18 @@ HcalRecHitsValidation::HcalRecHitsValidation(edm::ParameterSet const& conf) {
 	
 	sprintf (histo, "HcalRecHitTask_timing_vs_energy_HE_depth2" ) ;
 	meTE_HE2 = dbe_->book2D(histo, histo, 1000, -5., 995.,  70, -48., 92.);
+
+        sprintf (histo, "HcalRecHitTask_timing_vs_energy_HE_depth3" ) ;
+        meTE_HE3 = dbe_->book2D(histo, histo, 1000, -5., 995.,  70, -48., 92.);
+        sprintf (histo, "HcalRecHitTask_timing_vs_energy_HE_depth4" ) ;
+        meTE_HE4 = dbe_->book2D(histo, histo, 1000, -5., 995.,  70, -48., 92.);
+        sprintf (histo, "HcalRecHitTask_timing_vs_energy_HE_depth5" ) ;
+        meTE_HE5 = dbe_->book2D(histo, histo, 1000, -5., 995.,  70, -48., 92.);
+        sprintf (histo, "HcalRecHitTask_timing_vs_energy_HE_depth6" ) ;
+        meTE_HE6 = dbe_->book2D(histo, histo, 1000, -5., 995.,  70, -48., 92.);
+        sprintf (histo, "HcalRecHitTask_timing_vs_energy_HE_depth7" ) ;
+        meTE_HE7 = dbe_->book2D(histo, histo, 1000, -5., 995.,  70, -48., 92.);
+
 	
 	if(imc != 0) {
 	  sprintf (histo, "HcalRecHitTask_energy_rechits_vs_simhits_HE");
@@ -736,6 +933,10 @@ void HcalRecHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
   double ehcal_coneMC_2 = 0.;
   double ehcal_coneMC_3 = 0.;
   double ehcal_coneMC_4 = 0.;
+  double ehcal_coneMC_5 = 0.;
+  double ehcal_coneMC_6 = 0.;
+  double ehcal_coneMC_7 = 0.;
+
 
   // Cone size for serach of the hottest HCAL cell around MC
   double searchR = 1.0; 
@@ -896,9 +1097,18 @@ void HcalRecHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
   
   int nhb1 = 0;
   int nhb2 = 0;
+  int nhb3 = 0;
+  int nhb4 = 0;
+  int nhb5 = 0;
+  int nhb6 = 0;
+  int nhb7 = 0;
   int nhe1 = 0;
   int nhe2 = 0;
   int nhe3 = 0;
+  int nhe4 = 0;
+  int nhe5 = 0;
+  int nhe6 = 0;
+  int nhe7 = 0;
   int nho  = 0;
   int nhf1 = 0;
   int nhf2 = 0;  
@@ -927,9 +1137,20 @@ void HcalRecHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
     
     if( sub == 1 && depth == 1)  nhb1++;
     if( sub == 1 && depth == 2)  nhb2++;
+    if( sub == 1 && depth == 3)  nhb3++;
+    if( sub == 1 && depth == 4)  nhb4++;
+    if( sub == 1 && depth == 5)  nhb5++;
+    if( sub == 1 && depth == 6)  nhb6++;
+    if( sub == 1 && depth == 7)  nhb7++;
+
     if( sub == 2 && depth == 1)  nhe1++;
     if( sub == 2 && depth == 2)  nhe2++;
     if( sub == 2 && depth == 3)  nhe3++;
+    if( sub == 2 && depth == 4)  nhe4++;
+    if( sub == 2 && depth == 5)  nhe5++;
+    if( sub == 2 && depth == 6)  nhe6++;
+    if( sub == 2 && depth == 7)  nhe7++;
+
     if( sub == 3 && depth == 4)  nho++;
     if( sub == 4 && depth == 1)  nhf1++;
     if( sub == 4 && depth == 2)  nhf2++;
@@ -977,7 +1198,13 @@ void HcalRecHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
 
       if( depth == 3) emap_depth3->Fill(double(ieta), double(iphi), en);
       if( depth == 4) emap_depth4->Fill(double(ieta), double(iphi), en);
-      
+    
+      if (doSLHC_){
+      if( depth == 5) emap_depth5->Fill(double(ieta), double(iphi), en);
+      if( depth == 6) emap_depth6->Fill(double(ieta), double(iphi), en);
+      if( depth == 7) emap_depth7->Fill(double(ieta), double(iphi), en);     
+      } 
+
       if (depth == 1 && sub == 1 ) {
 	emean_vs_ieta_HB1->Fill(double(ieta), en);
 	occupancy_map_HB1->Fill(double(ieta), double(iphi));          
@@ -992,6 +1219,45 @@ void HcalRecHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
 	  emean_seqHB2->Fill(double(index), en);
 	}
       }
+
+      if (doSLHC_){
+         if (depth == 3  && sub == 1) {
+           emean_vs_ieta_HB3->Fill(double(ieta), en);
+           occupancy_map_HB3->Fill(double(ieta), double(iphi));
+           if(useAllHistos_){
+             emean_seqHB3->Fill(double(index), en);
+           }
+         }
+         if (depth == 4  && sub == 1) {
+           emean_vs_ieta_HB4->Fill(double(ieta), en);
+           occupancy_map_HB4->Fill(double(ieta), double(iphi));
+           if(useAllHistos_){
+             emean_seqHB4->Fill(double(index), en);
+           }
+         }
+         if (depth == 5  && sub == 1) {
+           emean_vs_ieta_HB5->Fill(double(ieta), en);
+           occupancy_map_HB5->Fill(double(ieta), double(iphi));
+           if(useAllHistos_){
+             emean_seqHB5->Fill(double(index), en);
+           }
+         }
+         if (depth == 6  && sub == 1) {
+           emean_vs_ieta_HB6->Fill(double(ieta), en);
+           occupancy_map_HB6->Fill(double(ieta), double(iphi));
+           if(useAllHistos_){
+             emean_seqHB6->Fill(double(index), en);
+           }
+         }
+         if (depth == 7  && sub == 1) {
+           emean_vs_ieta_HB7->Fill(double(ieta), en);
+           occupancy_map_HB7->Fill(double(ieta), double(iphi));
+           if(useAllHistos_){
+             emean_seqHB7->Fill(double(index), en);
+           }
+         }
+     }
+
       if (depth == 1 && sub == 2) {
 	emean_vs_ieta_HE1->Fill(double(ieta), en);
 	occupancy_map_HE1->Fill(double(ieta), double(iphi));   
@@ -1013,7 +1279,37 @@ void HcalRecHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
 	  emean_seqHE3->Fill(double(index), en);
 	}
       }
-      if (depth == 4 ) {
+       if (doSLHC_){
+          if (depth == 4 && sub == 2) {
+           emean_vs_ieta_HE4->Fill(double(ieta), en);
+           occupancy_map_HE4->Fill(double(ieta), double(iphi));
+           if(useAllHistos_){
+             emean_seqHE4->Fill(double(index), en);
+           }
+         }
+          if (depth == 5 && sub == 2) {
+           emean_vs_ieta_HE5->Fill(double(ieta), en);
+           occupancy_map_HE5->Fill(double(ieta), double(iphi));
+           if(useAllHistos_){
+             emean_seqHE5->Fill(double(index), en);
+           }
+         }
+          if (depth == 6 && sub == 2) {
+           emean_vs_ieta_HE6->Fill(double(ieta), en);
+           occupancy_map_HE6->Fill(double(ieta), double(iphi));
+           if(useAllHistos_){
+             emean_seqHE6->Fill(double(index), en);
+           }
+         }
+          if (depth == 7 && sub == 2) {
+           emean_vs_ieta_HE7->Fill(double(ieta), en);
+           occupancy_map_HE7->Fill(double(ieta), double(iphi));
+           if(useAllHistos_){
+             emean_seqHE7->Fill(double(index), en);
+           }
+         }
+     }
+      if (depth == 4 && sub == 3) {
 	emean_vs_ieta_HO->Fill(double(ieta), en);
 	occupancy_map_HO->Fill(double(ieta), double(iphi));          
 	if(useAllHistos_){
@@ -1041,7 +1337,10 @@ void HcalRecHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
       if (depth == 1) ehcal_coneMC_1 += en; 
       if (depth == 2) ehcal_coneMC_2 += en; 
       if (depth == 3) ehcal_coneMC_3 += en; 
-      if (depth == 4) ehcal_coneMC_4 += en; 
+      if (depth == 4) ehcal_coneMC_4 += en;
+      if (depth == 5) ehcal_coneMC_5 += en;
+      if (depth == 6) ehcal_coneMC_6 += en;
+      if (depth == 7) ehcal_coneMC_7 += en; 
     }
     
     //32-bit status word  
@@ -1099,6 +1398,10 @@ void HcalRecHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
       map_econe_depth2->Fill(eta_MC, phi_MC, ehcal_coneMC_2);
       map_econe_depth3->Fill(eta_MC, phi_MC, ehcal_coneMC_3);
       map_econe_depth4->Fill(eta_MC, phi_MC, ehcal_coneMC_4);
+      map_econe_depth5->Fill(eta_MC, phi_MC, ehcal_coneMC_5);
+      map_econe_depth6->Fill(eta_MC, phi_MC, ehcal_coneMC_6);
+      map_econe_depth7->Fill(eta_MC, phi_MC, ehcal_coneMC_7);     
+
     }
   }
 
@@ -1143,17 +1446,29 @@ void HcalRecHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
     double HcalCone_d2 = 0.;
     double HcalCone_d3 = 0.;
     double HcalCone_d4 = 0.;
+    double HcalCone_d5 = 0.;
+    double HcalCone_d6 = 0.;
+    double HcalCone_d7 = 0.;
+
     double HcalCone    = 0.;
 
     int ietaMax1  =  9999;
     int ietaMax2  =  9999;
     int ietaMax3  =  9999;
     int ietaMax4  =  9999;
+    int ietaMax5  =  9999;
+    int ietaMax6  =  9999;
+    int ietaMax7  =  9999;
+
     int ietaMax   =  9999;
     double enMax1 = -9999.;
     double enMax2 = -9999.;
     double enMax3 = -9999.;
     double enMax4 = -9999.;
+    double enMax5 = -9999.;
+    double enMax6 = -9999.;
+    double enMax7 = -9999.;
+
     //    double enMax  = -9999.;
     double etaMax =  9999.;
 
@@ -1228,7 +1543,28 @@ void HcalRecHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
 	    ietaMax4 = ieta;
 	  }
 	}
-
+        if(depth == 5) {
+          HcalCone_d5 += en;
+          if(enMax5 < en) {
+            enMax5   = en;
+            ietaMax5 = ieta;
+          }
+        }
+        if(depth == 6) {
+          HcalCone_d6 += en;
+          if(enMax6 < en) {
+            enMax6   = en;
+            ietaMax6 = ieta;
+          }
+        }
+        if(depth == 7) {
+          HcalCone_d7 += en;
+          if(enMax7 < en) {
+            enMax7   = en;
+            ietaMax7 = ieta;
+          }
+        }
+     
 	if(depth != 4) {
 	  HcalCone += en;
 	}
@@ -1267,7 +1603,12 @@ void HcalRecHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
 
 	if (useAllHistos_){
 	  if      (depth == 1) meTE_HB1->Fill( en, t);
-	  else if (depth == 2) meTE_HB2->Fill( en, t);
+          if      (depth == 2) meTE_HB2->Fill( en, t);
+          if      (depth == 3) meTE_HB3->Fill( en, t);
+          if      (depth == 4) meTE_HB4->Fill( en, t);
+          if      (depth == 5) meTE_HB5->Fill( en, t);
+          if      (depth == 6) meTE_HB6->Fill( en, t);
+	  else if (depth == 7) meTE_HB7->Fill( en, t);
 	}
       }     
       if(sub == 2 && (subdet_ == 2 || subdet_ == 5)) {  
@@ -1281,7 +1622,12 @@ void HcalRecHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
 
 	if (useAllHistos_){
 	  if      (depth == 1) meTE_HE1->Fill( en, t);
-	  else if (depth == 2) meTE_HE2->Fill( en, t);
+          if      (depth == 2) meTE_HE2->Fill( en, t);
+          if      (depth == 3) meTE_HE3->Fill( en, t);
+          if      (depth == 4) meTE_HE4->Fill( en, t);
+          if      (depth == 5) meTE_HE5->Fill( en, t);
+          if      (depth == 6) meTE_HE6->Fill( en, t);
+	  else if (depth == 7) meTE_HE7->Fill( en, t);
 	}
       }
       if(sub == 4 && (subdet_ == 4 || subdet_ == 5)) {  
@@ -1316,6 +1662,10 @@ void HcalRecHitsValidation::analyze(edm::Event const& ev, edm::EventSetup const&
 	meEnConeEtaProfile_depth2->Fill(double(ietaMax2), HcalCone_d2);
 	meEnConeEtaProfile_depth3->Fill(double(ietaMax3), HcalCone_d3);
 	meEnConeEtaProfile_depth4->Fill(double(ietaMax4), HcalCone_d4);
+        meEnConeEtaProfile_depth5->Fill(double(ietaMax5), HcalCone_d5);
+        meEnConeEtaProfile_depth6->Fill(double(ietaMax6), HcalCone_d6);
+        meEnConeEtaProfile_depth7->Fill(double(ietaMax7), HcalCone_d7);
+
       }
       meEnConeEtaProfile       ->Fill(double(ietaMax),  HcalCone);   // 
       meEnConeEtaProfile_E     ->Fill(double(ietaMax), eEcalCone);   


### PR DESCRIPTION
By default "regular" (non-SLHC) mode is set.

SLHC mode requires the following customization:
src/SLHCUpgradeSimulations/Configuration/python/HCalCustoms.py

def customise_Validation(process):
    process.validation_step.remove(process.AllHcalDigisValidation)
    process.validation_step.remove(process.RecHitsValidation)
    process.validation_step.remove(process.globalhitsanalyze)
    return process
-> 
def customise_Validation(process):
    process.AllHcalDigisValidation.doSLHC = True
    process.RecHitsValidation.doSLHC = True
    process.validation_step.remove(process.globalhitsanalyze)
    return process
