### PR TITLE
Made const functions of AssociationVector thread safe

### DIFF
--- a/DataFormats/Candidate/src/classes_def.xml
+++ b/DataFormats/Candidate/src/classes_def.xml
@@ -121,7 +121,6 @@
   </class>
   <class pattern="edm::AssociationVector<*>">
     <field name="transientVector_" transient="true"/>
-    <field name="fixed_" transient="true"/>
   </class>
   <class name="reco::CandRefValueMap" /> 
 

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -241,7 +241,6 @@
 
   <class name="reco::GsfElectronIsoCollection">
     <field name="transientVector_" transient="true"/>
-    <field name="fixed_" transient="true"/>
   </class>
   <class name="reco::GsfElectronIsoCollectionRef"/>
   <class name="reco::GsfElectronIsoCollectionRefProd"/>
@@ -253,7 +252,6 @@
 
   <class name="reco::GsfElectronIsoNumCollection">
     <field name="transientVector_" transient="true"/>
-    <field name="fixed_" transient="true"/>
   </class>
   <class name="reco::GsfElectronIsoNumCollectionRef"/>
   <class name="reco::GsfElectronIsoNumCollectionRefProd"/>

--- a/DataFormats/JetReco/src/classes_def_3.xml
+++ b/DataFormats/JetReco/src/classes_def_3.xml
@@ -42,7 +42,6 @@
   
   <class pattern="edm::AssociationVector<*>">
     <field name="transientVector_" transient="true"/>
-    <field name="fixed_" transient="true"/>
   </class>
 
   <class name="edm::Wrapper<reco::JetFloatAssociation::Container>" />

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -56,7 +56,6 @@
   
   <class name="reco::CaloTauDiscriminatorByIsolationBase">
     <field name="transientVector_" transient="true"/>
-    <field name="fixed_" transient="true"/>
   </class>
   <class name="reco::CaloTauDiscriminatorByIsolation" ClassVersion="10">
    <version ClassVersion="10" checksum="2968502385"/>
@@ -70,7 +69,6 @@
 
   <class name="reco::CaloTauDiscriminatorBase">
     <field name="transientVector_" transient="true"/>
-    <field name="fixed_" transient="true"/>
   </class>
   <class name="reco::CaloTauDiscriminator" ClassVersion="10">
    <version ClassVersion="10" checksum="1989330711"/>

--- a/DataFormats/TauReco/src/classes_def_3.xml
+++ b/DataFormats/TauReco/src/classes_def_3.xml
@@ -1,7 +1,6 @@
 <lcgdict>
   <class name="reco::CaloTauDiscriminatorAgainstElectronBase">
     <field name="transientVector_" transient="true"/>
-    <field name="fixed_" transient="true"/>
   </class>
   <class name="reco::CaloTauDiscriminatorAgainstElectron" ClassVersion="10">
    <version ClassVersion="10" checksum="3692008801"/>
@@ -21,7 +20,6 @@
 
   <class name="reco::PFTauDiscriminatorByIsolationBase">
     <field name="transientVector_" transient="true"/>
-    <field name="fixed_" transient="true"/>
   </class>
   <class name="reco::PFTauDiscriminatorByIsolation" ClassVersion="10">
    <version ClassVersion="10" checksum="1187112623"/>
@@ -41,7 +39,6 @@
 
   <class name="reco::PFTauDiscriminatorBase">
     <field name="transientVector_" transient="true"/>
-    <field name="fixed_" transient="true"/>
   </class>
 
   <class name="reco::PFTauDiscriminator" ClassVersion="10">
@@ -56,7 +53,6 @@
 
   <class name="reco::JetPiZeroAssociationBase">
     <field name="transientVector_" transient="true"/>
-    <field name="fixed_" transient="true"/>
   </class>
 
   <class name="reco::JetPiZeroAssociation" ClassVersion="10">
@@ -74,7 +70,6 @@
 
   <class name="reco::PFTauDecayModeAssociation">
     <field name="transientVector_" transient="true"/>
-    <field name="fixed_" transient="true"/>
   </class>
   <class name="reco::PFTauDecayModeAssociationRef"/>
   <class name="reco::PFTauDecayModeAssociationRefProd"/>

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -55,7 +55,6 @@
  <class name="edm::DetSetVector<edmtest::Unsortable>"/>
  <class pattern="class edm::AssociationVector<edm::RefProd<std::vector<edmtest::Simple> >,std::vector<edmtest::Simple>,edm::Ref<std::vector<edmtest::Simple>,edmtest::Simple,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Simple>,edmtest::Simple> >,unsigned int>">
    <field name="transientVector_" transient="true"/>
-   <field name="fixed_" transient="true"/>
  </class>
  <class name="edm::Wrapper<edmtest::DummyProduct>"/>
  <class name="edm::Wrapper<edmtest::IntProduct>"/>

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -85,7 +85,6 @@
 
   <class pattern="edm::AssociationVector<*>">
     <field name="transientVector_" transient="true"/>
-    <field name="fixed_" transient="true"/>
   </class>
 
      <!--   <class name="reco::DeDxDataCollection"/> -->

--- a/SimDataFormats/JetMatching/src/classes_def.xml
+++ b/SimDataFormats/JetMatching/src/classes_def.xml
@@ -10,7 +10,6 @@
   <class name="std::vector<std::pair<edm::RefToBase<reco::Jet>, reco::JetFlavour> >"/>
   <class name="reco::JetFlavourMatchingCollectionBase">
     <field name="transientVector_" transient="true"/>
-    <field name="fixed_" transient="true"/>
   </class>
   <class name="reco::JetFlavourMatchingCollection" ClassVersion="10">
    <version ClassVersion="10" checksum="344297371"/>
@@ -30,7 +29,6 @@
   <class name="std::vector<std::pair<edm::RefToBase<reco::Jet>, reco::MatchedPartons> >"/>
   <class name="reco::JetMatchedPartonsCollectionBase">
     <field name="transientVector_" transient="true"/>  
-    <field name="fixed_" transient="true"/>
   </class>
   <class name="reco::JetMatchedPartonsCollection" ClassVersion="10">
    <version ClassVersion="10" checksum="1343220703"/>


### PR DESCRIPTION
The AssociationVector uses a cache, transientVector_. The management of that cache is now thread safe if multiple threads call const functions simultaneously.
