### PR TITLE
Adapt to ROOT6 change in ROOT API

### DIFF
--- a/DQM/SiStripCommissioningAnalysis/src/SiStripPulseShape.cc
+++ b/DQM/SiStripCommissioningAnalysis/src/SiStripPulseShape.cc
@@ -19,7 +19,7 @@ double fdeconv(double *x, double *par)
 double fpeak_convoluted(double *x, double *par)
     {
      TF1 f("peak_convoluted",fpeak,0,200,4);
-     return f.Integral(x[0]-par[4]/2.,x[0]+par[4]/2.,par,1.)/(par[4]);
+     return f.IntegralError(x[0]-par[4]/2.,x[0]+par[4]/2.,par,0,1.)/(par[4]);
     } 
 
 double fdeconv_convoluted(double *x, double *par)


### PR DESCRIPTION
Adapt to a change in the ROOT API between ROOT 5 and ROOT 6.  Without this change, the package does not compile against ROOT 6.
