### PR TITLE
Added ModuleDescription access to stream modules

### DIFF
--- a/FWCore/Framework/interface/stream/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerBase.h
@@ -48,6 +48,10 @@ namespace edm {
       static void prevalidate(ConfigurationDescriptions& descriptions);
       static const std::string& baseType();
       
+      // Warning: the returned moduleDescription will be invalid during construction
+      ModuleDescription const& moduleDescription() const {
+        return *moduleDescriptionPtr_;
+      }
     protected:
 
       void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func);
@@ -67,9 +71,12 @@ namespace edm {
       virtual void endRun(edm::Run const&, edm::EventSetup const&) {}
       virtual void endStream(){}
 
+      void setModuleDescriptionPtr(ModuleDescription const* iDesc) {
+        moduleDescriptionPtr_ = iDesc;
+      }
       // ---------- member data --------------------------------
       std::function<void(BranchDescription const&)> callWhenNewProductsRegistered_;
-
+      ModuleDescription const* moduleDescriptionPtr_;
     };
     
   }

--- a/FWCore/Framework/interface/stream/EDFilterBase.h
+++ b/FWCore/Framework/interface/stream/EDFilterBase.h
@@ -51,6 +51,10 @@ namespace edm {
       static void prevalidate(ConfigurationDescriptions& descriptions);
       static const std::string& baseType();
       
+      // Warning: the returned moduleDescription will be invalid during construction
+      ModuleDescription const& moduleDescription() const {
+        return *moduleDescriptionPtr_;
+      }
     private:
       EDFilterBase(const EDFilterBase&) = delete; // stop default
       
@@ -64,10 +68,14 @@ namespace edm {
       virtual void endRun(edm::Run const&, edm::EventSetup const&) {}
       virtual void endStream(){}
 
+      void setModuleDescriptionPtr(ModuleDescription const* iDesc) {
+        moduleDescriptionPtr_ = iDesc;
+      }
       // ---------- member data --------------------------------
 
       std::vector<BranchID> previousParentage_;
       ParentageID previousParentageId_;
+      ModuleDescription const* moduleDescriptionPtr_;
     };
   }
 }

--- a/FWCore/Framework/interface/stream/EDProducerBase.h
+++ b/FWCore/Framework/interface/stream/EDProducerBase.h
@@ -51,6 +51,10 @@ namespace edm {
       static void prevalidate(ConfigurationDescriptions& descriptions);
       static const std::string& baseType();
       
+      // Warning: the returned moduleDescription will be invalid during construction
+      ModuleDescription const& moduleDescription() const {
+        return *moduleDescriptionPtr_;
+      }
     private:
       EDProducerBase(const EDProducerBase&) = delete; // stop default
       
@@ -64,11 +68,13 @@ namespace edm {
       virtual void endRun(edm::Run const&, edm::EventSetup const&) {}
       virtual void endStream(){}
 
+      void setModuleDescriptionPtr(ModuleDescription const* iDesc) {
+        moduleDescriptionPtr_ = iDesc;
+      }
       // ---------- member data --------------------------------
-
       std::vector<BranchID> previousParentage_;
       ParentageID previousParentageId_;
-
+      ModuleDescription const* moduleDescriptionPtr_;
     };
     
   }

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -81,6 +81,7 @@ namespace edm {
       template<typename F> void createStreamModules(F iFunc) {
         for(auto& m: m_streamModules) {
           m = iFunc();
+          m->setModuleDescriptionPtr(&moduleDescription_);
         }
       }
       

--- a/FWCore/Framework/src/stream/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerBase.cc
@@ -34,7 +34,7 @@ using namespace edm::stream;
 //
 // constructors and destructor
 //
-EDAnalyzerBase::EDAnalyzerBase()
+EDAnalyzerBase::EDAnalyzerBase(): moduleDescriptionPtr_(nullptr)
 {
 }
 

--- a/FWCore/Framework/src/stream/EDFilterBase.cc
+++ b/FWCore/Framework/src/stream/EDFilterBase.cc
@@ -31,7 +31,7 @@ using namespace edm::stream;
 //
 // constructors and destructor
 //
-EDFilterBase::EDFilterBase()
+EDFilterBase::EDFilterBase(): moduleDescriptionPtr_(nullptr)
 {
 }
 

--- a/FWCore/Framework/src/stream/EDProducerBase.cc
+++ b/FWCore/Framework/src/stream/EDProducerBase.cc
@@ -31,7 +31,7 @@ using namespace edm::stream;
 //
 // constructors and destructor
 //
-EDProducerBase::EDProducerBase()
+EDProducerBase::EDProducerBase(): moduleDescriptionPtr_(nullptr)
 {
 }
 


### PR DESCRIPTION
When ModuleDescription access was added to the other module types, the stream types were accidentally left out. This makes them uniform with all the other types.
