### PR TITLE
Declare more framework non-const statics const or atomic

### DIFF
--- a/FWCore/Framework/interface/ComponentFactory.h
+++ b/FWCore/Framework/interface/ComponentFactory.h
@@ -111,7 +111,7 @@ template<typename T>
       }
    
       // ---------- static member functions --------------------
-      static ComponentFactory<T>* get();
+      static ComponentFactory<T> const* get();
 
       // ---------- member functions ---------------------------
 
@@ -129,9 +129,9 @@ template<typename T>
 }
 #define COMPONENTFACTORY_GET(_type_) \
 EDM_REGISTER_PLUGINFACTORY(edmplugin::PluginFactory<edm::eventsetup::ComponentMakerBase<_type_>* ()>,_type_::name()); \
-static edm::eventsetup::ComponentFactory<_type_> s_dummyfactory; \
+static edm::eventsetup::ComponentFactory<_type_> const s_dummyfactory; \
 namespace edm { namespace eventsetup { \
-template<> edm::eventsetup::ComponentFactory<_type_>* edm::eventsetup::ComponentFactory<_type_>::get() \
+template<> edm::eventsetup::ComponentFactory<_type_> const* edm::eventsetup::ComponentFactory<_type_>::get() \
 { return &s_dummyfactory; } \
   } } \
 typedef int componentfactory_get_needs_semicolon

--- a/FWCore/PluginManager/interface/ProblemTracker.h
+++ b/FWCore/PluginManager/interface/ProblemTracker.h
@@ -13,6 +13,8 @@ occur, good state information can be printed.
 
 **/
 
+#include <atomic>
+
 namespace edm
 {
   class ProblemTracker
@@ -25,7 +27,7 @@ namespace edm
     ~ProblemTracker();
     ProblemTracker(const ProblemTracker&);
 
-    static bool dead_;
+    static std::atomic<bool> dead_;
   };
 
   class AssertHandler

--- a/FWCore/PluginManager/interface/ProblemTracker.h
+++ b/FWCore/PluginManager/interface/ProblemTracker.h
@@ -13,8 +13,6 @@ occur, good state information can be printed.
 
 **/
 
-#include <atomic>
-
 namespace edm
 {
   class ProblemTracker
@@ -26,8 +24,6 @@ namespace edm
     ProblemTracker();
     ~ProblemTracker();
     ProblemTracker(const ProblemTracker&);
-
-    static std::atomic<bool> dead_;
   };
 
   class AssertHandler

--- a/FWCore/PluginManager/src/ProblemTracker.cc
+++ b/FWCore/PluginManager/src/ProblemTracker.cc
@@ -11,7 +11,7 @@ namespace edm
 
   // -----------------------------------------------
 
-  bool ProblemTracker::dead_ = true;
+  std::atomic<bool> ProblemTracker::dead_{true};
   //edmplugin::DebugAids::AssertHook ProblemTracker::old_assert_hook_ = 0;
 
   ProblemTracker::ProblemTracker()

--- a/FWCore/PluginManager/src/ProblemTracker.cc
+++ b/FWCore/PluginManager/src/ProblemTracker.cc
@@ -11,12 +11,10 @@ namespace edm
 
   // -----------------------------------------------
 
-  std::atomic<bool> ProblemTracker::dead_{true};
   //edmplugin::DebugAids::AssertHook ProblemTracker::old_assert_hook_ = 0;
 
   ProblemTracker::ProblemTracker()
   {
-    dead_ = false;
     //old_assert_hook_ = edmplugin::DebugAids::failHook(&failure);
     if(not edmplugin::PluginManager::isAvailable()) {
       edmplugin::PluginManager::Config config(edmplugin::standard::config());
@@ -28,7 +26,6 @@ namespace edm
   ProblemTracker::~ProblemTracker()
   {
     // since this is a singleton, we will not restore the old handle
-    dead_ = true;
   }
 
   ProblemTracker const* ProblemTracker::instance()

--- a/FWCore/Services/src/VertexTracker.cc
+++ b/FWCore/Services/src/VertexTracker.cc
@@ -2,7 +2,7 @@
 
 #include <ostream>
 
-unsigned int VertexTracker::next_id_ = 0;
+std::atomic<unsigned int> VertexTracker::next_id_{0};
 
 std::ostream& 
 operator<<(std::ostream& ost, const VertexTracker& vt)

--- a/FWCore/Services/src/VertexTracker.h
+++ b/FWCore/Services/src/VertexTracker.h
@@ -1,6 +1,7 @@
 #ifndef FWCore_Services_Vertex_Tracker_h
 #define FWCore_Services_Vertex_Tracker_h
 
+#include <atomic>
 #include <iosfwd>
 #include <string>
 
@@ -99,7 +100,7 @@ struct VertexTracker
   mutable float        percent_leaf_;
   mutable float        percent_path_;
 
-  static unsigned int next_id_;
+  static std::atomic<unsigned int> next_id_;
 };
 
 std::ostream&


### PR DESCRIPTION
This pull request is for thread safety in the framework.  Some more non const statics that are never modified are declared const, snd some that are modified are declared std::atomic. One that is never read is removed.
Tested with checkdeps -a and the relval matrix.
