### PR TITLE
Add missing std qualifier

### DIFF
--- a/Fireworks/Core/src/FWConfigurationManager.cc
+++ b/Fireworks/Core/src/FWConfigurationManager.cc
@@ -207,7 +207,7 @@ class FWXMLConfigParser : public SimpleSAXParser
       };
 
 public:
-   FWXMLConfigParser(istream &f) 
+   FWXMLConfigParser(std::istream &f) 
    : SimpleSAXParser(f),
      m_state(IN_BEGIN_DOCUMENT),
      m_first(0)


### PR DESCRIPTION
A missing std:: qualifier prevents the file Fireworks/Core/src/FWConfigurationManager.cc from compiling.
This trivial pull request against the ROOT6 branch adds the qualifier, allowing the file to compile without error.
Note: The qualifier is not missing in the main 7_0_X branch.
