### PR TITLE
remove obsolete workarounds

### DIFF
--- a/DataFormats/Provenance/src/classes.h
+++ b/DataFormats/Provenance/src/classes.h
@@ -55,13 +55,6 @@ namespace edm {
   typedef Hash<ModuleDescriptionType> ModuleDescriptionID;
 }
 
-using edm::EntryDescriptionType;      // WORKAROUND for genreflex bug
-using edm::ModuleDescriptionType;     // WORKAROUND for genreflex bug
-using edm::ParameterSetType;          // WORKAROUND for genreflex bug
-using edm::ParentageType;             // WORKAROUND for genreflex bug
-using edm::ProcessConfigurationType;  // WORKAROUND for genreflex bug
-using edm::ProcessHistoryType;        // WORKAROUND for genreflex bug
-
 namespace {
   struct dictionary {
   std::pair<edm::BranchKey, edm::BranchDescription> dummyPairBranch;

--- a/SimDataFormats/GeneratorProducts/src/classes.h
+++ b/SimDataFormats/GeneratorProducts/src/classes.h
@@ -33,8 +33,6 @@
 
 #include "HepMC/GenRanges.h"
 
-typedef unsigned long long size_type;  // WORKAROUND for genreflex bug
-
 namespace {
 	struct dictionary {
 		// HepMC externals used in HepMCProduct


### PR DESCRIPTION
Remove workarounds for ROOT6 genreflex bugs that have been fixed.
