### PR TITLE
Made Conversion thread-safe and smaller in memory and storage

### DIFF
--- a/DataFormats/EgammaCandidates/interface/Conversion.h
+++ b/DataFormats/EgammaCandidates/interface/Conversion.h
@@ -86,16 +86,13 @@ namespace reco {
 		  const reco::Vertex  &  convVtx,
 		  ConversionAlgorithm=undefined);
       
-           
       
-      /// destructor
-      virtual ~Conversion();
       /// returns a clone of the candidate
       Conversion * clone() const;
       /// Pointer to CaloCluster (foe Egamma Conversions it points to  a SuperCluster)
       reco::CaloClusterPtrVector caloCluster() const {return caloCluster_ ;}
       /// vector of track to base references 
-      std::vector<edm::RefToBase<reco::Track> > tracks() const ; 
+      std::vector<edm::RefToBase<reco::Track> > const& tracks() const ; 
       /// returns  the reco conversion vertex
       const reco::Vertex & conversionVertex() const  { return theConversionVertex_ ; }
       /// Bool flagging objects having track size >0
@@ -190,18 +187,14 @@ namespace reco {
       
       /// vector pointer to a/multiple seed CaloCluster(s)
       reco::CaloClusterPtrVector caloCluster_;
-      ///  vector of Track references
-      std::vector<reco::TrackRef>  tracks_;
       /// vector Track RefToBase
-      mutable std::vector<edm::RefToBase<reco::Track> >  trackToBaseRefs_;
+      std::vector<edm::RefToBase<reco::Track> >  trackToBaseRefs_;
       /// position at the ECAl surface of the track extrapolation
       std::vector<math::XYZPointF>  thePositionAtEcal_;
       /// Fitted Kalman conversion vertex
       reco::Vertex theConversionVertex_;
       /// Clusters mathing the tracks (these are not the seeds)
       std::vector<reco::CaloClusterPtr> theMatchingBCs_;
-      /// Distance of min approach of the two tracks
-      float theMinDistOfApproach_;
       /// P_in of tracks
       std::vector<math::XYZPointF> theTrackInnerPosition_;    
       /// P_in of tracks
@@ -212,15 +205,17 @@ namespace reco {
       std::vector<uint8_t> nHitsBeforeVtx_;
       ///signed decay length and uncertainty from nearest hit on track to conversion vertex
       std::vector<Measurement1DFloat> dlClosestHitToVtx_;
-      ///number of shared hits between tracks
-      uint8_t nSharedHits_;
-      /// TMVA output
-      float theMVAout_;
       /// vectors of TMVA outputs from pflow for one leg conversions
       std::vector<float>  theOneLegMVA_;
+      /// Distance of min approach of the two tracks
+      float theMinDistOfApproach_;
+      /// TMVA output
+      float theMVAout_;
+      uint16_t qualityMask_;
+      ///number of shared hits between tracks
+      uint8_t nSharedHits_;
       /// conversion algorithm/provenance
       uint8_t algorithm_;
-      uint16_t qualityMask_;
 
 
   };

--- a/DataFormats/EgammaCandidates/src/Conversion.cc
+++ b/DataFormats/EgammaCandidates/src/Conversion.cc
@@ -19,20 +19,24 @@ Conversion::Conversion(  const reco::CaloClusterPtrVector& sc,
 			 ConversionAlgorithm algo):  
 			 
 
-  caloCluster_(sc), tracks_(tr), 
+  caloCluster_(sc),
+  trackToBaseRefs_(),
   thePositionAtEcal_(trackPositionAtEcal), 
   theConversionVertex_(convVtx), 
   theMatchingBCs_(matchingBC), 
-  theMinDistOfApproach_(DCA),
   theTrackInnerPosition_(innPoint),
   theTrackPin_(trackPin),
   theTrackPout_(trackPout),
-  nSharedHits_(0),  
+  theMinDistOfApproach_(DCA),
   theMVAout_(mva),
-  algorithm_(algo),
-  qualityMask_(0)
+  qualityMask_(0),
+  nSharedHits_(0),  
+  algorithm_(algo)
  { 
-   
+   trackToBaseRefs_.resize(tr.size());
+   for( auto const& track: tr) {
+     trackToBaseRefs_.emplace_back(track);
+   }
  }
 
 
@@ -58,16 +62,16 @@ Conversion::Conversion(  const reco::CaloClusterPtrVector& sc,
   thePositionAtEcal_(trackPositionAtEcal), 
   theConversionVertex_(convVtx), 
   theMatchingBCs_(matchingBC), 
-  theMinDistOfApproach_(DCA),
   theTrackInnerPosition_(innPoint),
   theTrackPin_(trackPin),
   theTrackPout_(trackPout),
   nHitsBeforeVtx_(nHitsBeforeVtx),
   dlClosestHitToVtx_(dlClosestHitToVtx),
-  nSharedHits_(nSharedHits),
+  theMinDistOfApproach_(DCA),
   theMVAout_(mva),
-  algorithm_(algo),
-  qualityMask_(0)
+  qualityMask_(0),
+  nSharedHits_(nSharedHits),
+  algorithm_(algo)
  { 
    
  }
@@ -79,12 +83,17 @@ Conversion::Conversion(  const reco::CaloClusterPtrVector& sc,
 			 const std::vector<reco::TrackRef>& tr, 
 			 const reco::Vertex  & convVtx,
 			 ConversionAlgorithm algo):  
-  caloCluster_(sc), tracks_(tr), 
+  caloCluster_(sc),
+  trackToBaseRefs_(),
   theConversionVertex_(convVtx),
+  qualityMask_(0),
   nSharedHits_(0),
-  algorithm_(algo),
-  qualityMask_(0)
+  algorithm_(algo)
  { 
+   trackToBaseRefs_.resize(tr.size());
+   for( auto const& track: tr) {
+     trackToBaseRefs_.emplace_back(track);
+   }
 
 
   theMinDistOfApproach_ = 9999.;
@@ -108,9 +117,9 @@ Conversion::Conversion(  const reco::CaloClusterPtrVector& sc,
 			 ConversionAlgorithm algo):  
   caloCluster_(sc), trackToBaseRefs_(tr), 
   theConversionVertex_(convVtx), 
+  qualityMask_(0),
   nSharedHits_(0),
-  algorithm_(algo),
-  qualityMask_(0)
+  algorithm_(algo)
  { 
 
 
@@ -149,9 +158,6 @@ Conversion::Conversion() {
 }
 
 
-Conversion::~Conversion() { }
-
-
 std::string const Conversion::algoNames[] = { "undefined","ecalSeeded","trackerOnly","mixed","pflow"};  
 
 Conversion::ConversionAlgorithm Conversion::algoByName(const std::string &name){
@@ -167,17 +173,7 @@ Conversion * Conversion::clone() const {
 }
 
 
-std::vector<edm::RefToBase<reco::Track> >  Conversion::tracks() const { 
-  if (trackToBaseRefs_.size() ==0 ) {
- 
-    for (std::vector<reco::TrackRef>::const_iterator ref=tracks_.begin(); ref!=tracks_.end(); ref++ ) 
-      {
-	edm::RefToBase<reco::Track> tt(*ref);
-	trackToBaseRefs_.push_back(tt);
-	
-      }  
-  }
-
+std::vector<edm::RefToBase<reco::Track> > const&  Conversion::tracks() const { 
   return trackToBaseRefs_;
 }
 
@@ -306,13 +302,12 @@ double  Conversion::EoverPrefittedTracks() const  {
 
 std::vector<double>  Conversion::tracksSigned_d0() const  {
   std::vector<double> result;
-
-  for (unsigned int i=0; i< nTracks(); i++)   
-    result.push_back(tracks()[i]->d0()* tracks()[i]->charge()) ;
-
+  result.reserve(tracks().size());
+  
+  for (auto const& track: tracks()) {
+    result.emplace_back(track->d0()* track->charge()) ;
+  }
   return result;
-
-
 }
 
 double  Conversion::dPhiTracksAtVtx() const  {

--- a/DataFormats/EgammaCandidates/src/Conversion.cc
+++ b/DataFormats/EgammaCandidates/src/Conversion.cc
@@ -33,7 +33,7 @@ Conversion::Conversion(  const reco::CaloClusterPtrVector& sc,
   nSharedHits_(0),  
   algorithm_(algo)
  { 
-   trackToBaseRefs_.resize(tr.size());
+   trackToBaseRefs_.reserve(tr.size());
    for( auto const& track: tr) {
      trackToBaseRefs_.emplace_back(track);
    }
@@ -90,7 +90,7 @@ Conversion::Conversion(  const reco::CaloClusterPtrVector& sc,
   nSharedHits_(0),
   algorithm_(algo)
  { 
-   trackToBaseRefs_.resize(tr.size());
+   trackToBaseRefs_.reserve(tr.size());
    for( auto const& track: tr) {
      trackToBaseRefs_.emplace_back(track);
    }

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -6,9 +6,13 @@
   <class name="reco::Photon" ClassVersion="13">
    <version ClassVersion="13" checksum="2963666409"/>
   </class>
-  <class name="reco::Conversion" ClassVersion="10">
+  <class name="reco::Conversion" ClassVersion="11">
    <version ClassVersion="10" checksum="2140222741"/>
+   <version ClassVersion="11" checksum="598717096"/>
   </class>
+  <ioread sourceClass = "reco::Conversion" version="[1-10]" targetClass="reco::Conversion" source="std::vector<reco::TrackRef> tracks_; std::vector<edm::RefToBase<reco::Track> > trackToBaseRefs_" target="trackToBaseRefs_">
+     <![CDATA[trackToBaseRefs_=onfile.trackToBaseRefs_; if(onfile.tracks_.size()>onfile.trackToBaseRefs_.size()) { for(auto const& t: onfile.tracks_) { trackToBaseRefs_.emplace_back(t);} }]]>
+  </ioread>
   <class name="reco::Electron" ClassVersion="11">
    <version ClassVersion="11" checksum="1178796923"/>
   </class>


### PR DESCRIPTION
Conversion previously stored two copies of tracks, one as Refs and
the other as RefToBase. Only the RefToBase were used internally and
externally. However, the RefToBase were filled from the Ref as needed.
Therefore I dropped the Refs and instead fill the RefToBase from the
Refs in the appropriate constructors. This means the vector of RefToBases
does not have to be mutable and therefore the object is thread-safe.

Added a ROOT I/O rule which allows reading back the old format which
has the Refs in the case where only the Refs were ever filled.

Also changed order of member data so the compiler no longer had to add
padding between the member data.
