### PR TITLE
Classes in DataFormats/L1DTTrackFinder only return const * from const functions

### DIFF
--- a/DQM/DTMonitorModule/src/DTLocalTriggerBaseTask.cc
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerBaseTask.cc
@@ -360,8 +360,8 @@ void DTLocalTriggerBaseTask::bookHistos(int wh) {
 }
 
 
-void DTLocalTriggerBaseTask::runDCCAnalysis( std::vector<L1MuDTChambPhDigi>* phTrigs, 
-					 std::vector<L1MuDTChambThDigi>* thTrigs ){
+void DTLocalTriggerBaseTask::runDCCAnalysis( std::vector<L1MuDTChambPhDigi> const* phTrigs, 
+					     std::vector<L1MuDTChambThDigi> const* thTrigs ){
 
   vector<L1MuDTChambPhDigi>::const_iterator iph  = phTrigs->begin();
   vector<L1MuDTChambPhDigi>::const_iterator iphe = phTrigs->end();

--- a/DQM/DTMonitorModule/src/DTLocalTriggerBaseTask.h
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerBaseTask.h
@@ -73,7 +73,7 @@ class DTLocalTriggerBaseTask: public edm::EDAnalyzer{
  private:
 
   /// Run analysis on DCC data
-  void runDCCAnalysis(std::vector<L1MuDTChambPhDigi>* phTrigs, std::vector<L1MuDTChambThDigi>* thTrigs);
+  void runDCCAnalysis(std::vector<L1MuDTChambPhDigi> const* phTrigs, std::vector<L1MuDTChambThDigi> const* thTrigs);
 
   /// Run analysis on ROS data
   void runDDUAnalysis(edm::Handle<DTLocalTriggerCollection>& trigsDDU);
@@ -82,7 +82,7 @@ class DTLocalTriggerBaseTask: public edm::EDAnalyzer{
   void runDDUvsDCCAnalysis();
 
   /// Get the Top folder (different between Physics and TP and DCC/DDU)
-  std::string& topFolder(std::string type) { return baseFolder[type == "DCC"]; }
+  std::string& topFolder(std::string const& type) { return baseFolder[type == "DCC"]; }
   
   /// Book the histograms
   void bookHistos(const DTChamberId& chamb);

--- a/DQM/DTMonitorModule/src/DTLocalTriggerLutTask.cc
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerLutTask.cc
@@ -167,7 +167,7 @@ void DTLocalTriggerLutTask::analyze(const edm::Event& e, const edm::EventSetup& 
     
   edm::Handle<L1MuDTChambPhContainer> trigHandle;
   e.getByLabel(dccInputTag,trigHandle);
-  vector<L1MuDTChambPhDigi>* trigs = trigHandle->getContainer();
+  vector<L1MuDTChambPhDigi> const* trigs = trigHandle->getContainer();
   searchDccBest(trigs);
 
   Handle<DTRecSegment4DCollection> segments4D;
@@ -250,7 +250,7 @@ void DTLocalTriggerLutTask::analyze(const edm::Event& e, const edm::EventSetup& 
   
 }
 
-void DTLocalTriggerLutTask::searchDccBest( std::vector<L1MuDTChambPhDigi>* trigs ){
+void DTLocalTriggerLutTask::searchDccBest( std::vector<L1MuDTChambPhDigi> const* trigs ){
   
   string histoType ;
   string histoTag ;

--- a/DQM/DTMonitorModule/src/DTLocalTriggerLutTask.h
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerLutTask.h
@@ -57,7 +57,7 @@ class DTLocalTriggerLutTask: public edm::EDAnalyzer{
   void beginRun(const edm::Run& , const edm::EventSetup&);
 
   /// Find best (highest qual) DCC trigger segments
-  void searchDccBest(std::vector<L1MuDTChambPhDigi>* trigs);
+  void searchDccBest(std::vector<L1MuDTChambPhDigi> const* trigs);
   
   /// Analyze
   void analyze(const edm::Event& e, const edm::EventSetup& c);

--- a/DQM/DTMonitorModule/src/DTLocalTriggerSynchTask.cc
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerSynchTask.cc
@@ -128,7 +128,7 @@ void DTLocalTriggerSynchTask::analyze(const edm::Event& event, const edm::EventS
   // Get best DCC triggers
   edm::Handle<L1MuDTChambPhContainer> l1DTTPGPh;
   event.getByLabel(inputTagDCC,l1DTTPGPh);
-  vector<L1MuDTChambPhDigi>*  phTrigs = l1DTTPGPh->getContainer();
+  vector<L1MuDTChambPhDigi> const*  phTrigs = l1DTTPGPh->getContainer();
   
   vector<L1MuDTChambPhDigi>::const_iterator iph  = phTrigs->begin();
   vector<L1MuDTChambPhDigi>::const_iterator iphe = phTrigs->end();

--- a/DQM/DTMonitorModule/src/DTLocalTriggerTask.cc
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerTask.cc
@@ -280,11 +280,11 @@ void DTLocalTriggerTask::analyze(const edm::Event& e, const edm::EventSetup& c){
   if ( useDCC ) {   
     edm::Handle<L1MuDTChambPhContainer> l1DTTPGPh;
     e.getByLabel(dcc_label,l1DTTPGPh);
-    vector<L1MuDTChambPhDigi>*  l1PhTrig = l1DTTPGPh->getContainer();
+    vector<L1MuDTChambPhDigi> const*  l1PhTrig = l1DTTPGPh->getContainer();
 
     edm::Handle<L1MuDTChambThContainer> l1DTTPGTh;
     e.getByLabel(dcc_label,l1DTTPGTh);
-    vector<L1MuDTChambThDigi>*  l1ThTrig = l1DTTPGTh->getContainer();
+    vector<L1MuDTChambThDigi> const*  l1ThTrig = l1DTTPGTh->getContainer();
 
     runDCCAnalysis(l1PhTrig,l1ThTrig);
   }  
@@ -508,8 +508,8 @@ void DTLocalTriggerTask::bookWheelHistos(int wh, string histoTag) {
 
 }
 
-void DTLocalTriggerTask::runDCCAnalysis( std::vector<L1MuDTChambPhDigi>* phTrigs, 
-					 std::vector<L1MuDTChambThDigi>* thTrigs ){
+void DTLocalTriggerTask::runDCCAnalysis( std::vector<L1MuDTChambPhDigi> const* phTrigs, 
+					 std::vector<L1MuDTChambThDigi> const* thTrigs ){
 
   string histoType ;
   string histoTag ;

--- a/DQM/DTMonitorModule/src/DTLocalTriggerTask.h
+++ b/DQM/DTMonitorModule/src/DTLocalTriggerTask.h
@@ -73,7 +73,7 @@ class DTLocalTriggerTask: public edm::EDAnalyzer{
   void setQLabels(MonitorElement* me, short int iaxis);
 
   /// Run analysis on DCC data
-  void runDCCAnalysis(std::vector<L1MuDTChambPhDigi>* phTrigs, std::vector<L1MuDTChambThDigi>* thTrigs);
+  void runDCCAnalysis(std::vector<L1MuDTChambPhDigi> const* phTrigs, std::vector<L1MuDTChambThDigi> const* thTrigs);
 
   /// Run analysis on ROS data
   void runDDUAnalysis(edm::Handle<DTLocalTriggerCollection>& trigsDDU);

--- a/DQM/DTMonitorModule/src/DTTriggerEfficiencyTask.cc
+++ b/DQM/DTMonitorModule/src/DTTriggerEfficiencyTask.cc
@@ -139,7 +139,7 @@ void DTTriggerEfficiencyTask::analyze(const edm::Event& e, const edm::EventSetup
   // Getting best DCC Stuff
   edm::Handle<L1MuDTChambPhContainer> l1DTTPGPh;
   e.getByLabel(inputTagDCC,l1DTTPGPh);
-  vector<L1MuDTChambPhDigi>*  phTrigs = l1DTTPGPh->getContainer();
+  vector<L1MuDTChambPhDigi> const*  phTrigs = l1DTTPGPh->getContainer();
 
   vector<L1MuDTChambPhDigi>::const_iterator iph  = phTrigs->begin();
   vector<L1MuDTChambPhDigi>::const_iterator iphe = phTrigs->end();

--- a/DQM/L1TMonitor/interface/L1TDTTF.h
+++ b/DQM/L1TMonitor/interface/L1TDTTF.h
@@ -55,8 +55,8 @@ class L1TDTTF : public edm::EDAnalyzer {
  private:
 
 
-  void fillMEs( std::vector<L1MuDTTrackCand> * trackContainer,
-		std::vector<L1MuRegionalCand> & gmtDttfCands );
+  void fillMEs( std::vector<L1MuDTTrackCand> const* trackContainer,
+		std::vector<L1MuRegionalCand>& gmtDttfCands );
   void setWheelLabel(MonitorElement *me);
   void setQualLabel(MonitorElement *me, int axis);
   void bookEta( int wh, int & nbins, float & start, float & stop );

--- a/DQM/L1TMonitor/src/L1TDTTF.cc
+++ b/DQM/L1TMonitor/src/L1TDTTF.cc
@@ -634,7 +634,7 @@ void L1TDTTF::analyze(const edm::Event& event,
     return;
   }
 
-  L1MuDTTrackContainer::TrackContainer * trackContainer =
+  L1MuDTTrackContainer::TrackContainer const * trackContainer =
     myL1MuDTTrackContainer->getContainer();
 
   /// dttf counters
@@ -811,8 +811,8 @@ void L1TDTTF::analyze(const edm::Event& event,
 
 
 //--------------------------------------------------------
-void L1TDTTF::fillMEs( std::vector<L1MuDTTrackCand> * trackContainer,
-		       std::vector<L1MuRegionalCand> & gmtDttfCands )
+void L1TDTTF::fillMEs( std::vector<L1MuDTTrackCand> const* trackContainer,
+		       std::vector<L1MuRegionalCand>& gmtDttfCands )
 {
 
   L1MuDTTrackContainer::TrackContainer::const_iterator track

--- a/DQM/L1TMonitor/src/L1TDTTPG.cc
+++ b/DQM/L1TMonitor/src/L1TDTTPG.cc
@@ -334,7 +334,7 @@ void L1TDTTPG::analyze(const Event& e, const EventSetup& c)
 			     << dttpgSource_.label() ;
     return;
   }
-  L1MuDTChambPhContainer::Phi_Container *myPhContainer =  
+  L1MuDTChambPhContainer::Phi_Container const *myPhContainer =  
     myL1MuDTChambPhContainer->getContainer();
 
   edm::Handle<L1MuDTChambThContainer > myL1MuDTChambThContainer;  
@@ -347,7 +347,7 @@ void L1TDTTPG::analyze(const Event& e, const EventSetup& c)
 
     return;
   }
-  L1MuDTChambThContainer::The_Container* myThContainer =  
+  L1MuDTChambThContainer::The_Container const* myThContainer =  
     myL1MuDTChambThContainer->getContainer();
 
   int ndttpgphtrack = 0;
@@ -585,7 +585,7 @@ void L1TDTTPG::analyze(const Event& e, const EventSetup& c)
     return;
   }
 
-  L1MuDTTrackContainer::TrackContainer *t =  myL1MuDTTrackContainer->getContainer();
+  L1MuDTTrackContainer::TrackContainer const * t =  myL1MuDTTrackContainer->getContainer();
 
 
 

--- a/DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhContainer.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1MuDTChambPhContainer.h
@@ -46,15 +46,15 @@ class L1MuDTChambPhContainer {
 
   void setContainer(const Phi_Container& inputSegments);
 
-  Phi_Container* getContainer() const;
+  Phi_Container const* getContainer() const;
 
   bool bxEmpty(int step) const;
 
   int bxSize(int step1, int step2) const;
 
-  L1MuDTChambPhDigi* chPhiSegm1(int wheel, int stat, int sect, int bx) const;
+  L1MuDTChambPhDigi const* chPhiSegm1(int wheel, int stat, int sect, int bx) const;
 
-  L1MuDTChambPhDigi* chPhiSegm2(int wheel, int stat, int sect, int bx) const;
+  L1MuDTChambPhDigi const* chPhiSegm2(int wheel, int stat, int sect, int bx) const;
 
  private:
 

--- a/DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainer.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1MuDTChambThContainer.h
@@ -46,13 +46,13 @@ class L1MuDTChambThContainer {
 
   void setContainer(const The_Container& inputSegments);
 
-  The_Container* getContainer() const;
+  The_Container const* getContainer() const;
 
   bool bxEmpty(int step) const;
 
   int bxSize(int step1, int step2) const;
 
-  L1MuDTChambThDigi* chThetaSegm(int wheel, int stat, int sect, int bx) const;
+  L1MuDTChambThDigi const* chThetaSegm(int wheel, int stat, int sect, int bx) const;
 
  private:
 

--- a/DataFormats/L1DTTrackFinder/interface/L1MuDTTrackContainer.h
+++ b/DataFormats/L1DTTrackFinder/interface/L1MuDTTrackContainer.h
@@ -47,15 +47,15 @@ class L1MuDTTrackContainer {
 
   void setContainer(const TrackContainer& inputTracks);
 
-  TrackContainer* getContainer() const;
+  TrackContainer const* getContainer() const;
 
   bool bxEmpty(int step) const;
 
   int bxSize(int step1, int step2) const;
 
-  L1MuDTTrackCand* dtTrackCand1(int wheel, int sect, int bx) const;
+  L1MuDTTrackCand const* dtTrackCand1(int wheel, int sect, int bx) const;
 
-  L1MuDTTrackCand* dtTrackCand2(int wheel, int sect, int bx) const;
+  L1MuDTTrackCand const* dtTrackCand2(int wheel, int sect, int bx) const;
 
 
  private:

--- a/DataFormats/L1DTTrackFinder/src/L1MuDTChambPhContainer.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1MuDTChambPhContainer.cc
@@ -48,13 +48,8 @@ void L1MuDTChambPhContainer::setContainer(const Phi_Container& inputSegments) {
   phiSegments = inputSegments;
 }
 
-L1MuDTChambPhContainer::Phi_Container* L1MuDTChambPhContainer::getContainer() const {
-
-  Phi_Container* rT=0;
-
-  rT = const_cast<Phi_Container*>(&phiSegments);
-
-  return(rT);
+L1MuDTChambPhContainer::Phi_Container const* L1MuDTChambPhContainer::getContainer() const {
+  return &phiSegments;
 }
 
 bool L1MuDTChambPhContainer::bxEmpty(int step) const {
@@ -86,31 +81,31 @@ int L1MuDTChambPhContainer::bxSize(int step1, int step2) const {
   return(size);
 }
 
-L1MuDTChambPhDigi* L1MuDTChambPhContainer::chPhiSegm1(int wheel, int stat, int sect, int step) const {
+L1MuDTChambPhDigi const* L1MuDTChambPhContainer::chPhiSegm1(int wheel, int stat, int sect, int step) const {
 
-  L1MuDTChambPhDigi* rT=0;
+  L1MuDTChambPhDigi const* rT=0;
 
   for ( Phi_iterator i  = phiSegments.begin();
                      i != phiSegments.end();
                      i++ ) {
     if  (step == i->bxNum() && wheel == i->whNum() && sect == i->scNum()
       && stat == i->stNum() && i->Ts2Tag() == 0)
-      rT = const_cast<L1MuDTChambPhDigi*>(&(*i));
+      rT = &(*i);
   }
 
   return(rT);
 }
 
-L1MuDTChambPhDigi* L1MuDTChambPhContainer::chPhiSegm2(int wheel, int stat, int sect, int step) const {
+L1MuDTChambPhDigi const* L1MuDTChambPhContainer::chPhiSegm2(int wheel, int stat, int sect, int step) const {
 
-  L1MuDTChambPhDigi* rT=0;
+  L1MuDTChambPhDigi const* rT=0;
 
   for ( Phi_iterator i  = phiSegments.begin();
                      i != phiSegments.end();
                      i++ ) {
     if  (step == i->bxNum()-1 && wheel == i->whNum() && sect == i->scNum()
       && stat == i->stNum() && i->Ts2Tag() == 1)
-      rT = const_cast<L1MuDTChambPhDigi*>(&(*i));
+      rT = &(*i);
   }
 
   return(rT);

--- a/DataFormats/L1DTTrackFinder/src/L1MuDTChambThContainer.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1MuDTChambThContainer.cc
@@ -48,13 +48,8 @@ void L1MuDTChambThContainer::setContainer(const The_Container& inputSegments) {
   theSegments = inputSegments;
 }
 
-L1MuDTChambThContainer::The_Container* L1MuDTChambThContainer::getContainer() const {
-
-  The_Container* rT=0;
-
-  rT = const_cast<The_Container*>(&theSegments);
-
-  return(rT);
+L1MuDTChambThContainer::The_Container const* L1MuDTChambThContainer::getContainer() const {
+  return &theSegments;
 }
 
 bool L1MuDTChambThContainer::bxEmpty(int step) const {
@@ -83,16 +78,16 @@ int L1MuDTChambThContainer::bxSize(int step1, int step2) const {
   return(size);
 }
 
-L1MuDTChambThDigi* L1MuDTChambThContainer::chThetaSegm(int wheel, int stat, int sect, int step) const {
+L1MuDTChambThDigi const* L1MuDTChambThContainer::chThetaSegm(int wheel, int stat, int sect, int step) const {
 
-  L1MuDTChambThDigi* rT=0;
+  L1MuDTChambThDigi const* rT=0;
 
   for ( The_iterator i  = theSegments.begin();
                      i != theSegments.end();
                      i++ ) {
     if  (step == i->bxNum() && wheel == i->whNum() && sect == i->scNum()
       && stat == i->stNum() )
-      rT = const_cast<L1MuDTChambThDigi*>(&(*i));
+      rT = &(*i);
   }
 
   return(rT);

--- a/DataFormats/L1DTTrackFinder/src/L1MuDTTrackContainer.cc
+++ b/DataFormats/L1DTTrackFinder/src/L1MuDTTrackContainer.cc
@@ -48,13 +48,8 @@ void L1MuDTTrackContainer::setContainer(const TrackContainer& inputTracks) {
   dtTracks = inputTracks;
 }
 
-L1MuDTTrackContainer::TrackContainer* L1MuDTTrackContainer::getContainer() const {
-
-  TrackContainer* rT=0;
-
-  rT = const_cast<TrackContainer*>(&dtTracks);
-
-  return(rT);
+L1MuDTTrackContainer::TrackContainer const* L1MuDTTrackContainer::getContainer() const {
+  return &dtTracks;
 }
 
 bool L1MuDTTrackContainer::bxEmpty(int step) const {
@@ -84,31 +79,31 @@ int L1MuDTTrackContainer::bxSize(int step1, int step2) const {
   return(size);
 }
 
-L1MuDTTrackCand* L1MuDTTrackContainer::dtTrackCand1(int wheel, int sect, int step) const {
+L1MuDTTrackCand const* L1MuDTTrackContainer::dtTrackCand1(int wheel, int sect, int step) const {
 
-  L1MuDTTrackCand* rT=0;
+  L1MuDTTrackCand const* rT=0;
 
   for ( Trackiterator i  = dtTracks.begin();
                       i != dtTracks.end();
                       i++ ) {
     if  (step == i->bx() && wheel == i->whNum() && sect == i->scNum()
       && i->TrkTag() == 0)
-      rT = const_cast<L1MuDTTrackCand*>(&(*i));
+      rT = &(*i);
   }
 
   return(rT);
 }
 
-L1MuDTTrackCand* L1MuDTTrackContainer::dtTrackCand2(int wheel, int sect, int step) const {
+L1MuDTTrackCand const* L1MuDTTrackContainer::dtTrackCand2(int wheel, int sect, int step) const {
 
-  L1MuDTTrackCand* rT=0;
+  L1MuDTTrackCand const* rT=0;
 
   for ( Trackiterator i  = dtTracks.begin();
                       i != dtTracks.end();
                       i++ ) {
     if  (step == i->bx() && wheel == i->whNum() && sect == i->scNum()
       && i->TrkTag() == 1)
-      rT = const_cast<L1MuDTTrackCand*>(&(*i));
+      rT = &(*i);
   }
 
   return(rT);

--- a/HLTrigger/special/src/HLTDTActivityFilter.cc
+++ b/HLTrigger/special/src/HLTDTActivityFilter.cc
@@ -155,7 +155,7 @@ bool HLTDTActivityFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& i
 
     edm::Handle<L1MuDTChambPhContainer> l1DTTPGPh;
     iEvent.getByToken(inputDCCToken_,l1DTTPGPh);
-    vector<L1MuDTChambPhDigi>*  phTrigs = l1DTTPGPh->getContainer();
+    vector<L1MuDTChambPhDigi> const*  phTrigs = l1DTTPGPh->getContainer();
     vector<L1MuDTChambPhDigi>::const_iterator iph  = phTrigs->begin();
     vector<L1MuDTChambPhDigi>::const_iterator iphe = phTrigs->end();
     

--- a/L1Trigger/CSCTrackFinder/src/CSCTFDTReceiver.cc
+++ b/L1Trigger/CSCTrackFinder/src/CSCTFDTReceiver.cc
@@ -33,7 +33,7 @@ CSCTriggerContainer<csctf::TrackStub> CSCTFDTReceiver::process(const L1MuDTChamb
 	  for(int is = sector; is <= sector+1; ++is)
 	    {
 	      int iss = (is == 12) ? 0 : is;
-	      L1MuDTChambPhDigi* dtts[2];
+	      L1MuDTChambPhDigi const* dtts[2];
 
 	      for(int stub = 0; stub < 2; ++stub)
 		{

--- a/L1Trigger/DTTrackFinder/src/L1MuDTEtaProcessor.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTEtaProcessor.cc
@@ -229,7 +229,7 @@ void L1MuDTEtaProcessor::receiveData(int bx, const edm::Event& e, const edm::Eve
   int sector = m_epid;
   for ( int stat = 1; stat <= 3; stat++ ) {
     for ( int wheel = -2; wheel <= 2; wheel++ ) {
-      L1MuDTChambThDigi* tseta = dttrig->chThetaSegm(wheel,stat,sector,bx);
+      L1MuDTChambThDigi const* tseta = dttrig->chThetaSegm(wheel,stat,sector,bx);
       bitset<7> pos;
       bitset<7> qual;
 

--- a/L1Trigger/DTTrackFinder/src/L1MuDTSectorReceiver.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTSectorReceiver.cc
@@ -107,7 +107,7 @@ void L1MuDTSectorReceiver::receiveDTBXData(int bx, const edm::Event& e, const ed
   edm::Handle<L1MuDTChambPhContainer> dttrig;
   e.getByLabel(L1MuDTTFConfig::getDTDigiInputTag(),dttrig);
 
-  L1MuDTChambPhDigi* ts=0;
+  L1MuDTChambPhDigi const* ts=0;
 
   // const int bx_offset = dttrig->correctBX();
   int bx_offset=0;
@@ -167,7 +167,7 @@ void L1MuDTSectorReceiver::receiveDTBXData(int bx, const edm::Event& e, const ed
           int sh_phi = 12 - L1MuDTTFConfig::getNbitsExtPhi();
           int tolerance = L1MuDTTFConfig::getTSOutOfTimeWindow();
 
-          L1MuDTChambPhDigi* tsPreviousBX_1 = dttrig->chPhiSegm1(wheel,station,sector,bx-1);
+          L1MuDTChambPhDigi const * tsPreviousBX_1 = dttrig->chPhiSegm1(wheel,station,sector,bx-1);
           if ( tsPreviousBX_1 ) {
             int phiBX  = tsPreviousBX_1->phi();
             int qualBX = tsPreviousBX_1->code();
@@ -175,7 +175,7 @@ void L1MuDTSectorReceiver::receiveDTBXData(int bx, const edm::Event& e, const ed
                  qualBX > qual ) skipTS = true;
           }
           
-          L1MuDTChambPhDigi* tsPreviousBX_2 = dttrig->chPhiSegm2(wheel,station,sector,bx-1);
+          L1MuDTChambPhDigi const * tsPreviousBX_2 = dttrig->chPhiSegm2(wheel,station,sector,bx-1);
           if ( tsPreviousBX_2 ) {
             int phiBX  = tsPreviousBX_2->phi();
             int qualBX = tsPreviousBX_2->code();
@@ -183,7 +183,7 @@ void L1MuDTSectorReceiver::receiveDTBXData(int bx, const edm::Event& e, const ed
                  qualBX > qual ) skipTS = true;
           }
      
-          L1MuDTChambPhDigi* tsNextBX_1 = dttrig->chPhiSegm1(wheel,station,sector,bx+1);
+          L1MuDTChambPhDigi const * tsNextBX_1 = dttrig->chPhiSegm1(wheel,station,sector,bx+1);
           if ( tsNextBX_1 ) {
             int phiBX  = tsNextBX_1->phi();
             int qualBX = tsNextBX_1->code();
@@ -191,7 +191,7 @@ void L1MuDTSectorReceiver::receiveDTBXData(int bx, const edm::Event& e, const ed
                  qualBX > qual ) skipTS = true;
           }
 
-          L1MuDTChambPhDigi* tsNextBX_2 = dttrig->chPhiSegm2(wheel,station,sector,bx+1);
+          L1MuDTChambPhDigi const * tsNextBX_2 = dttrig->chPhiSegm2(wheel,station,sector,bx+1);
           if ( tsNextBX_2 ) {
             int phiBX  = tsNextBX_2->phi();
             int qualBX = tsNextBX_2->code();

--- a/L1Trigger/HardwareValidation/plugins/L1EmulBias.h
+++ b/L1Trigger/HardwareValidation/plugins/L1EmulBias.h
@@ -227,7 +227,7 @@ L1EmulBias::ModifyCollection(std::auto_ptr<L1MuDTTrackContainer>& data,
 			   const edm::Handle<L1MuDTTrackContainer> emul) {
   typedef std::vector<L1MuDTTrackCand>  TrackContainer;
   typedef TrackContainer::const_iterator col_cit;
-  TrackContainer* tracks_in = emul->getContainer();
+  TrackContainer const* tracks_in = emul->getContainer();
   TrackContainer tracks;
   for(col_cit it = tracks_in->begin(); it!=tracks_in->end(); it++) {
     L1MuDTTrackCand cand(*it);    
@@ -257,7 +257,7 @@ L1EmulBias::ModifyCollection(std::auto_ptr<L1MuDTChambPhContainer>& data,
 			   const edm::Handle<L1MuDTChambPhContainer> emul) {
   typedef std::vector<L1MuDTChambPhDigi> Phi_Container;
   typedef Phi_Container::const_iterator  col_it;
-  Phi_Container* tracks_in = emul->getContainer(); 
+  Phi_Container const* tracks_in = emul->getContainer(); 
   Phi_Container tracks(tracks_in->size());
   int uqua;
   for(col_it it=tracks_in->begin(); it!=tracks_in->end(); it++) {
@@ -276,7 +276,7 @@ L1EmulBias::ModifyCollection(std::auto_ptr<L1MuDTChambThContainer>& data,
 			   const edm::Handle<L1MuDTChambThContainer> emul) {
   typedef std::vector<L1MuDTChambThDigi> Thi_Container;
   typedef Thi_Container::const_iterator  col_cit;
-  Thi_Container* tracks_in = emul->getContainer(); 
+  Thi_Container const* tracks_in = emul->getContainer(); 
   Thi_Container tracks(tracks_in->size());
   int uos[7],uqa[7];
   for(col_cit it=tracks_in->begin(); it!=tracks_in->end(); it++) {

--- a/L1Trigger/HardwareValidation/src/L1Comparator.cc
+++ b/L1Trigger/HardwareValidation/src/L1Comparator.cc
@@ -316,13 +316,13 @@ L1Comparator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   L1MuRegionalCandCollection dtf_trk_data_v, dtf_trk_emul_v;
   dtf_trk_data_v.clear(); dtf_trk_emul_v.clear();
   if(dtf_trk_data_.isValid()) {
-    L1MuDTTrackCandCollection *dttc = dtf_trk_data_->getContainer();
+    L1MuDTTrackCandCollection const *dttc = dtf_trk_data_->getContainer();
     for(L1MuDTTrackCandCollection::const_iterator  it=dttc->begin(); 
 	it!=dttc->end(); it++)
       dtf_trk_data_v.push_back(L1MuRegionalCand(*it)); 
   }
   if(dtf_trk_emul_.isValid()) {
-    L1MuDTTrackCandCollection *dttc = dtf_trk_emul_->getContainer();
+    L1MuDTTrackCandCollection const *dttc = dtf_trk_emul_->getContainer();
     for(L1MuDTTrackCandCollection::const_iterator  it=dttc->begin(); 
 	it!=dttc->end(); it++)
       dtf_trk_emul_v.push_back(L1MuRegionalCand(*it)); 


### PR DESCRIPTION
The thread-safety checker complained that the Container classes in DataFormats/L1DTTrackFinder
were returning non-const pointers to member data from const member functions. These were
changed to return const pointers. This required changing variable types in calling classes
however it turned out those classes never modified the objects anyway so no algorithmic
changes were neeed.
