### PR TITLE
Use thread safe collection for static in L1MuGMTReadoutCollection

### DIFF
--- a/DataFormats/L1GlobalMuonTrigger/BuildFile.xml
+++ b/DataFormats/L1GlobalMuonTrigger/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="rootrflx"/>
+<use   name="tbb"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTReadoutCollection.h
+++ b/DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTReadoutCollection.h
@@ -56,11 +56,7 @@ class L1MuGMTReadoutCollection {
     for (iter=m_Records.begin(); iter!=m_Records.end(); iter++) {
       if ((*iter).getBxCounter() == bx) return (*iter);
     }
-    // if bx not found return empty readout record
-    static std::map<int, L1MuGMTReadoutRecord> empty_record_cache;
-    if (empty_record_cache.find(bx) == empty_record_cache.end())
-      empty_record_cache.insert( std::make_pair(bx, L1MuGMTReadoutRecord(bx)) );
-    return empty_record_cache[bx];
+    return getDefaultFor(bx);
   };
 
   // add record
@@ -69,6 +65,7 @@ class L1MuGMTReadoutCollection {
   };
 
  private:
+  static L1MuGMTReadoutRecord const& getDefaultFor(int bx);
 
   std::vector<L1MuGMTReadoutRecord> m_Records;
 

--- a/DataFormats/L1GlobalMuonTrigger/src/L1MuGMTReadoutCollection.cc
+++ b/DataFormats/L1GlobalMuonTrigger/src/L1MuGMTReadoutCollection.cc
@@ -1,0 +1,30 @@
+// -*- C++ -*-
+//
+// Package:     DataFormats/L1GlobalMuonTrigger
+// Class  :     L1MuGMTReadoutCollection
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Mon, 04 Nov 2013 17:08:29 GMT
+//
+
+// system include files
+#include "tbb/concurrent_unordered_map.h"
+
+// user include files
+#include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTReadoutCollection.h"
+
+static tbb::concurrent_unordered_map<int, L1MuGMTReadoutRecord> s_empty_record_cache;
+
+L1MuGMTReadoutRecord const&
+L1MuGMTReadoutCollection::getDefaultFor(int bx) {
+  // if bx not found return empty readout record
+  auto itFound = s_empty_record_cache.find(bx); 
+  if ( itFound == s_empty_record_cache.end()) {
+    auto foundPair = s_empty_record_cache.insert( std::make_pair(bx, L1MuGMTReadoutRecord(bx)) );
+    itFound = foundPair.first;
+  }
+  return itFound->second;
+}


### PR DESCRIPTION
L1MuGMTReadoutCollection::getRecord returns a const reference to a
dummy item if the requested item is not in its main collection. Prevously
this was done by using a static std::map to hold any requested missing
items. To make this thread safe we changed to a tbb::concurrent_unordered_map.
