### PR TITLE
Fill mutable in L1ParticleMap in a thread-safe way

### DIFF
--- a/DataFormats/L1Trigger/interface/L1ParticleMap.h
+++ b/DataFormats/L1Trigger/interface/L1ParticleMap.h
@@ -100,7 +100,9 @@
 
 // system include files
 #include <string>
-
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+#include <atomic>
+#endif
 // user include files
 #include "DataFormats/L1Trigger/interface/L1EmParticleFwd.h" 
 #include "DataFormats/L1Trigger/interface/L1JetParticleFwd.h" 
@@ -281,9 +283,12 @@ namespace l1extra {
 	    const L1IndexComboVector& indexCombos =
 	       L1IndexComboVector()
 	    ) ;
+	 L1ParticleMap( const L1ParticleMap&);
+	 L1ParticleMap& operator=(const L1ParticleMap&);
 
 	 virtual ~L1ParticleMap();
 
+	 void swap(L1ParticleMap&);
 	 // ---------- const member functions ---------------------
 	 L1TriggerType triggerType() const
 	 { return triggerType_ ; }
@@ -359,13 +364,18 @@ namespace l1extra {
 
 	 // const L1ParticleMap& operator=(const L1ParticleMap&); // stop default
 
+	 void setIndexCombos() const;
 	 // ---------- member data --------------------------------
 
 	 // Index into trigger menu.
 	 L1TriggerType triggerType_ ;
 
 	 bool triggerDecision_ ;
-
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+	 mutable std::atomic<char> indexCombosState_;
+#else
+	 mutable char indexCombosState_;
+#endif
 	 // Vector of length numOfObjects() that gives the
 	 // type of each trigger object.
 	 L1ObjectTypeVector objectTypes_ ;
@@ -389,10 +399,10 @@ namespace l1extra {
 	 //
 	 // This data member is mutable because if #particles = 1, then this
 	 // vector is empty and is filled on request.
-	 mutable L1IndexComboVector indexCombos_ ;
+	 mutable L1IndexComboVector indexCombos_ ; //CMS thread safe via indexCombosState_
 
 	 // Static array of trigger names.
-	 static std::string triggerNames_[ kNumOfL1TriggerTypes ] ;
+	 static const std::string triggerNames_[ kNumOfL1TriggerTypes ] ;
    };
 
 }

--- a/DataFormats/L1Trigger/src/L1ParticleMap.cc
+++ b/DataFormats/L1Trigger/src/L1ParticleMap.cc
@@ -17,6 +17,7 @@
 #include "DataFormats/L1Trigger/interface/L1EmParticle.h"  
 #include "DataFormats/L1Trigger/interface/L1JetParticle.h"  
 #include "DataFormats/L1Trigger/interface/L1MuonParticle.h"  
+#include "FWCore/Concurrency/interface/hardware_pause.h"
 
 using namespace l1extra ;
 
@@ -30,7 +31,7 @@ using namespace l1extra ;
 
 // EG = isolated OR non-isolated
 // Jet = central OR forward OR tau
-std::string
+const std::string
 L1ParticleMap::triggerNames_[ kNumOfL1TriggerTypes ] = {
    "L1_SingleMu3",
    "L1_SingleMu5",
@@ -157,6 +158,14 @@ L1ParticleMap::triggerNames_[ kNumOfL1TriggerTypes ] = {
    "L1_ZeroBias"
 } ;
 
+namespace {
+  enum IndexComboStates {
+    kUnset,
+    kSetting,
+    kSet
+  };
+}
+
 //
 // constructors and destructor
 //
@@ -175,6 +184,7 @@ L1ParticleMap::L1ParticleMap(
    const L1IndexComboVector& indexCombos )
    : triggerType_( triggerType ),
      triggerDecision_( triggerDecision ),
+     indexCombosState_{indexCombos.size()>0? kSet:kUnset},
      objectTypes_( objectTypes ),
      emParticles_( emParticles ),
      jetParticles_( jetParticles ),
@@ -184,10 +194,23 @@ L1ParticleMap::L1ParticleMap(
 {
 }
 
-// L1ParticleMap::L1ParticleMap(const L1ParticleMap& rhs)
-// {
-//    // do actual copying here;
-// }
+L1ParticleMap::L1ParticleMap(const L1ParticleMap& rhs):
+  triggerType_(rhs.triggerType_),
+  triggerDecision_(rhs.triggerDecision_),
+  indexCombosState_(kUnset),
+  objectTypes_(rhs.objectTypes_),
+  emParticles_(rhs.emParticles_),
+  jetParticles_(rhs.jetParticles_),
+  muonParticles_(rhs.muonParticles_),
+  etMissParticle_(rhs.etMissParticle_),
+  indexCombos_()
+{
+    // do actual copying here;
+  if(rhs.indexCombosState_.load(std::memory_order_acquire) == kSet) {
+    indexCombos_=rhs.indexCombos_;
+    indexCombosState_.store(kSet,std::memory_order_release);
+  }
+}
 
 L1ParticleMap::~L1ParticleMap()
 {
@@ -196,18 +219,30 @@ L1ParticleMap::~L1ParticleMap()
 //
 // assignment operators
 //
-// const L1ParticleMap& L1ParticleMap::operator=(const L1ParticleMap& rhs)
-// {
-//   //An exception safe implementation is
-//   L1ParticleMap temp(rhs);
-//   swap(rhs);
-//
-//   return *this;
-// }
+L1ParticleMap& L1ParticleMap::operator=(const L1ParticleMap& rhs)
+{
+   //An exception safe implementation is
+   L1ParticleMap temp(rhs);
+   swap(temp);
+
+   return *this;
+}
 
 //
 // member functions
 //
+void
+L1ParticleMap::swap( L1ParticleMap& rhs) {
+  std::swap(triggerType_,rhs.triggerType_);
+  std::swap(triggerDecision_,rhs.triggerDecision_);
+  indexCombosState_.store(rhs.indexCombosState_.exchange(indexCombosState_.load(std::memory_order_acquire),std::memory_order_acq_rel),std::memory_order_release);
+  std::swap(objectTypes_,rhs.objectTypes_);
+  std::swap(emParticles_,rhs.emParticles_);
+  std::swap(jetParticles_,rhs.jetParticles_);
+  std::swap(muonParticles_,rhs.muonParticles_);
+  std::swap(etMissParticle_,rhs.etMissParticle_);
+  std::swap(indexCombos_,rhs.indexCombos_);
+}
 
 //
 // const member functions
@@ -216,74 +251,96 @@ L1ParticleMap::~L1ParticleMap()
 const L1ParticleMap::L1IndexComboVector&
 L1ParticleMap::indexCombos() const
 {
-   if( indexCombos_.size() == 0 )
-   {
-      // Determine the number of non-global objects.  There should be 0 or 1.
-      int numNonGlobal = 0 ;
-      L1ObjectType nonGlobalType = kNumOfL1ObjectTypes ;
-      int nonGlobalIndex = -1 ;
-      for( int i = 0 ; i < numOfObjects() ; ++i )
-      {
-	 if( !objectTypeIsGlobal( objectTypes_[ i ] ) )
-	 {
-	    ++numNonGlobal ;
-	    nonGlobalType = objectTypes_[ i ] ;
-	    nonGlobalIndex = i ;
-	 }
-      }
-
-      if( numNonGlobal == 0 )
-      {
-	 // Dummy entry for each object type.
-	 L1IndexCombo tmpCombo ;
-
-	 for( int i = 0 ; i < numOfObjects() ; ++i )
-	 {
-	    tmpCombo.push_back( 0 ) ;
-	 }
-
-	 indexCombos_.push_back( tmpCombo ) ;
-      }
-      else if( numNonGlobal == 1 )
-      {
-	 int nParticles = 0 ;
-
-	 if( nonGlobalType == kEM )
-	 {
-	    nParticles = emParticles_.size() ;
-	 }
-	 else if( nonGlobalType == kJet )
-	 {
-	    nParticles = jetParticles_.size() ;
-	 }
-	 else if( nonGlobalType == kMuon )
-	 {
-	    nParticles = muonParticles_.size() ;
-	 }
-
-	 for( int i = 0 ; i < nParticles ; ++i )
-	 {
-	    L1IndexCombo tmpCombo ;
-
-	    for( int j = 0 ; j < numOfObjects() ; ++j )
-	    {
-	       if( j == nonGlobalIndex )
-	       {		  
-		  tmpCombo.push_back( i ) ;
-	       }
-	       else
-	       {
-		  tmpCombo.push_back( 0 ) ;
-	       }
-	    }
-
-	    indexCombos_.push_back( tmpCombo ) ;
-	 }
-      }
+   if(kSet != indexCombosState_.load(std::memory_order_acquire)) {
+      setIndexCombos();
    }
-
    return indexCombos_ ;
 }
+
+void
+L1ParticleMap::setIndexCombos() const {
+  // Determine the number of non-global objects.  There should be 0 or 1.
+  int numNonGlobal = 0 ;
+  L1ObjectType nonGlobalType = kNumOfL1ObjectTypes ;
+  int nonGlobalIndex = -1 ;
+
+  L1IndexComboVector tempIndexCombos;
+  for( int i = 0 ; i < numOfObjects() ; ++i )
+  {
+    if( !objectTypeIsGlobal( objectTypes_[ i ] ) )
+    {
+      ++numNonGlobal ;
+      nonGlobalType = objectTypes_[ i ] ;
+      nonGlobalIndex = i ;
+    }
+  }
+  
+  if( numNonGlobal == 0 )
+  {
+    // Dummy entry for each object type.
+    L1IndexCombo tmpCombo ;
+    tmpCombo.reserve(numOfObjects());
+    for( int i = 0 ; i < numOfObjects() ; ++i )
+    {
+      tmpCombo.push_back( 0 ) ;
+    }
+
+    tempIndexCombos.push_back( tmpCombo ) ;
+  }
+  else if( numNonGlobal == 1 )
+  {
+    int nParticles = 0 ;
+
+    if( nonGlobalType == kEM )
+    {
+      nParticles = emParticles_.size() ;
+    }
+    else if( nonGlobalType == kJet )
+    {
+      nParticles = jetParticles_.size() ;
+    }
+    else if( nonGlobalType == kMuon )
+    {
+      nParticles = muonParticles_.size() ;
+    }
+
+    tempIndexCombos.reserve(nParticles);
+    for( int i = 0 ; i < nParticles ; ++i )
+    {
+      L1IndexCombo tmpCombo ;
+      tmpCombo.reserve(numOfObjects());
+      for( int j = 0 ; j < numOfObjects() ; ++j )
+      {
+	if( j == nonGlobalIndex )
+	{		  
+	  tmpCombo.push_back( i ) ;
+	}
+	else
+	{
+	  tmpCombo.push_back( 0 ) ;
+	}
+      }
+
+      tempIndexCombos.push_back( tmpCombo ) ;
+    }
+  }
+  char expected = kUnset;
+  if(indexCombosState_.compare_exchange_strong(expected,kSetting,std::memory_order_acq_rel)) {
+    //If this was read from an old file, it is possible that indexCombos_ is already set.
+    // This is the only safe place to check since we know no other thread can be attempting 
+    // to change this value.
+    if(indexCombos_.empty()) {
+      indexCombos_.swap(tempIndexCombos);
+    }
+    indexCombosState_.store(kSet, std::memory_order_release);
+  } else {
+    //have to wait
+    while(kSet != indexCombosState_.load(std::memory_order_acquire)) {
+      hardware_pause();
+    }
+  }
+}
+
 
 const reco::LeafCandidate*
 L1ParticleMap::candidateInCombo( int aIndexInCombo,

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -12,6 +12,7 @@
    <version ClassVersion="10" checksum="256436604"/>
   </class>
   <class name="l1extra::L1ParticleMap" ClassVersion="10">
+   <field name="indexCombosState_" transient="true"/>
    <version ClassVersion="10" checksum="72905536"/>
   </class>
   <class name="l1extra::L1HFRings" ClassVersion="10">


### PR DESCRIPTION
L1ParticleMap delays filling indexCombos_ until requested. This
could have been changed to being done in the constructor. However,
any data already stored may or may not have had indexCombos_ updated
(since indexCombos_ is stored) and therefore we still must do a
delayed fill. This is made thread safe via the use of a std::atomic
which keeps track of the state of indexCombos_. The new std::atomic
is declared transient and placed next to bool member data in order
to avoid extra padding by the compiler.
