### PR TITLE
freeTrajectoryState() should return const pointer

### DIFF
--- a/DQM/DTMonitorModule/src/DTChamberEfficiency.cc
+++ b/DQM/DTMonitorModule/src/DTChamberEfficiency.cc
@@ -208,7 +208,7 @@ void DTChamberEfficiency::analyze(const Event & event,
       const DetLayer *initialLayer = theService->detLayerGeometry()->idToLayer(id);
 
       TrajectoryStateOnSurface init_fs = trans_track.innermostMeasurementState();
-      FreeTrajectoryState *init_fs_free = init_fs.freeState();
+      const FreeTrajectoryState *init_fs_free = init_fs.freeState();
 
       //get the list of compatible layers
       vector<const DetLayer*> layer_list = compatibleLayers(initialLayer,*init_fs_free,alongMomentum);

--- a/RecoBTag/BTagTools/src/SignedDecayLength3D.cc
+++ b/RecoBTag/BTagTools/src/SignedDecayLength3D.cc
@@ -24,7 +24,7 @@ pair<bool,Measurement1D> SignedDecayLength3D::apply(const TransientTrack & trans
 
   //TrajectoryStateOnSurface TSOS = (aRecTrack).impactPointStateOnSurface();
   TrajectoryStateOnSurface TSOS = transientTrack.impactPointState();
-  FreeTrajectoryState * FTS = TSOS.freeTrajectoryState();
+  const FreeTrajectoryState * FTS = TSOS.freeTrajectoryState();
 
   TrajectoryStateOnSurface theTSOS = closestApproachToJet(*FTS, vertex, direction,transientTrack.field());
   theIsValid= theTSOS.isValid();

--- a/RecoBTag/BTagTools/src/SignedImpactParameter3D.cc
+++ b/RecoBTag/BTagTools/src/SignedImpactParameter3D.cc
@@ -29,7 +29,7 @@ pair<bool,Measurement1D> SignedImpactParameter3D::apply(const TransientTrack & t
     return pair<bool,Measurement1D>(theIsValid,Measurement1D(0.,0.)) ;
    }
   
-  FreeTrajectoryState * FTS = TSOS.freeTrajectoryState();
+  const FreeTrajectoryState * FTS = TSOS.freeTrajectoryState();
 
   GlobalVector JetDirection(direction);
   
@@ -120,7 +120,7 @@ pair<double,Measurement1D> SignedImpactParameter3D::distanceWithJetAxis(const Tr
     return pair<double,Measurement1D> (theDistanceAlongJetAxis,Measurement1D(theDistanceToJetAxis,theLDist_err));
   }
   
-  FreeTrajectoryState * FTS = TSOS.freeTrajectoryState();
+  const FreeTrajectoryState * FTS = TSOS.freeTrajectoryState();
 
   GlobalVector jetDirection(direction);
 

--- a/RecoBTag/BTagTools/src/SignedTransverseImpactParameter.cc
+++ b/RecoBTag/BTagTools/src/SignedTransverseImpactParameter.cc
@@ -23,7 +23,7 @@ pair<bool,Measurement1D> SignedTransverseImpactParameter::apply(const TransientT
 
   TrajectoryStateOnSurface stateOnSurface = track.impactPointState();
 
-  FreeTrajectoryState * FTS =  stateOnSurface.freeState(); //aRecTrack.stateAtFirstPoint().freeTrajectoryState());
+  const FreeTrajectoryState * FTS =  stateOnSurface.freeState(); //aRecTrack.stateAtFirstPoint().freeTrajectoryState());
 
   GlobalPoint vertexPosition(vertex.x(),vertex.y(),vertex.z());
  

--- a/RecoEgamma/EgammaPhotonAlgos/interface/InOutConversionSeedFinder.h
+++ b/RecoEgamma/EgammaPhotonAlgos/interface/InOutConversionSeedFinder.h
@@ -64,7 +64,7 @@ class InOutConversionSeedFinder : public ConversionSeedFinder {
 
   edm::ParameterSet conf_;
   virtual void fillClusterSeeds(  ) const ;
-  void startSeed(FreeTrajectoryState * fts, const TrajectoryStateOnSurface & stateAtPreviousLayer, int charge, int layer) const ;
+  void startSeed(const FreeTrajectoryState * fts, const TrajectoryStateOnSurface & stateAtPreviousLayer, int charge, int layer) const ;
   virtual void findSeeds(const TrajectoryStateOnSurface & startingState,
 			 float signedpt, unsigned int startingLayer) const ;
   

--- a/RecoEgamma/EgammaPhotonAlgos/src/InOutConversionSeedFinder.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/InOutConversionSeedFinder.cc
@@ -205,7 +205,7 @@ void InOutConversionSeedFinder::fillClusterSeeds() const {
     }
     
     //PropagatorWithMaterial reversePropagator(oppositeToMomentum, 0.000511, &(*theMF_) );
-    FreeTrajectoryState * fts = myPointer->updatedState().freeTrajectoryState();
+    const FreeTrajectoryState * fts = myPointer->updatedState().freeTrajectoryState();
     
    //std::cout << " InOutConversionSeedFinder::fillClusterSeeds First FTS charge " << fts->charge() << " Position " << fts->position() << " momentum " << fts->momentum() << " R " << sqrt(fts->position().x()*fts->position().x() + fts->position().y()* fts->position().y() ) << " Z " << fts->position().z() << " phi " << fts->position().phi() << " fts parameters " << fts->parameters() << "\n";
     
@@ -310,7 +310,7 @@ void InOutConversionSeedFinder::fillClusterSeeds() const {
 
 
 
-void InOutConversionSeedFinder::startSeed( FreeTrajectoryState * fts, const TrajectoryStateOnSurface & stateAtPreviousLayer, int charge, int ilayer  )  const {
+void InOutConversionSeedFinder::startSeed( const FreeTrajectoryState * fts, const TrajectoryStateOnSurface & stateAtPreviousLayer, int charge, int ilayer  )  const {
   
   //std::cout << "InOutConversionSeedFinder::startSeed ilayer " << ilayer <<  "\n";
   // Get a list of basic clusters that are consistent with a track 

--- a/RecoMuon/CosmicMuonProducer/src/CosmicMuonTrajectoryBuilder.cc
+++ b/RecoMuon/CosmicMuonProducer/src/CosmicMuonTrajectoryBuilder.cc
@@ -474,7 +474,7 @@ void CosmicMuonTrajectoryBuilder::build(const TrajectoryStateOnSurface& ts,
 
   if ( !ts.isValid() ) return;
 
-  FreeTrajectoryState* fts = ts.freeState();
+  const FreeTrajectoryState* fts = ts.freeState();
   if ( !fts ) return;
 
   vector<const DetLayer*> navLayers;

--- a/RecoMuon/StandAloneTrackFinder/interface/StandAloneMuonFilter.h
+++ b/RecoMuon/StandAloneTrackFinder/interface/StandAloneMuonFilter.h
@@ -123,7 +123,7 @@ private:
  
   /// Set the rigth Navigation
   std::vector<const DetLayer*> compatibleLayers(const DetLayer *initialLayer,
-						FreeTrajectoryState& fts,
+						const FreeTrajectoryState& fts,
 						PropagationDirection propDir);
 
   bool update(const DetLayer * layer, 

--- a/RecoMuon/StandAloneTrackFinder/src/StandAloneMuonFilter.cc
+++ b/RecoMuon/StandAloneTrackFinder/src/StandAloneMuonFilter.cc
@@ -164,7 +164,7 @@ void StandAloneMuonFilter::incrementCompatibleChamberCounters(const DetLayer *la
 
 
 vector<const DetLayer*> StandAloneMuonFilter::compatibleLayers(const DetLayer *initialLayer,
-								 FreeTrajectoryState& fts,
+								 const FreeTrajectoryState& fts,
 								 PropagationDirection propDir){
   vector<const DetLayer*> detLayers;
 

--- a/RecoTracker/SpecialSeedGenerators/src/CtfSpecialSeedGenerator.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CtfSpecialSeedGenerator.cc
@@ -275,7 +275,7 @@ bool CtfSpecialSeedGenerator::postCheck(const TrajectorySeed& seed){
         TrajectoryStateOnSurface theTSOS = trajectoryStateTransform::transientState(pstate,
 								      &(theTracker->idToDet(DetId(pstate.detId()))->surface()),
 								      &(*theMagfield));	
-	FreeTrajectoryState* state = theTSOS.freeState();	
+	const FreeTrajectoryState* state = theTSOS.freeState();	
 	StraightLinePlaneCrossing planeCrossingLower( Basic3DVector<float>(state->position()), 
 						      Basic3DVector<float>(state->momentum()),
 						      alongMomentum);

--- a/RecoTracker/TkNavigation/src/SimpleNavigableLayer.cc
+++ b/RecoTracker/TkNavigation/src/SimpleNavigableLayer.cc
@@ -44,7 +44,7 @@ TrajectoryStateOnSurface SimpleNavigableLayer::crossingState(const FreeTrajector
   propState = propagator(dir).propagate( dest, detLayer()->surface());
   if ( !propState.isValid()) return TrajectoryStateOnSurface();
   
-  FreeTrajectoryState & dest2 = *propState.freeState();
+  const FreeTrajectoryState & dest2 = *propState.freeState();
   GlobalPoint finalPoint = dest2.position();
   LogDebug("SimpleNavigableLayer")<<"second propagation("<< dir <<") to: \n"
 				  <<dest2;

--- a/RecoTracker/TkNavigation/src/StartingLayerFinder.cc
+++ b/RecoTracker/TkNavigation/src/StartingLayerFinder.cc
@@ -136,7 +136,7 @@ StartingLayerFinder::startingLayers(const TrajectorySeed& aSeed) const {
 							      thePropagator->magneticField());
 
 
-  FreeTrajectoryState* fts=tsos.freeTrajectoryState();
+  const FreeTrajectoryState* fts=tsos.freeTrajectoryState();
   
   return startingLayers(*fts, dr, dz);
 }

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
@@ -147,8 +147,8 @@ TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj, T& track,
   // Therefore the lastMeasurement is the inner one (for LHC-like tracks)
   if(traj->firstMeasurement().updatedState().isValid() &&
      traj->lastMeasurement().updatedState().isValid()){
-    FreeTrajectoryState*  outerState = traj->firstMeasurement().updatedState().freeState();    
-    FreeTrajectoryState*  innerState = traj->lastMeasurement().updatedState().freeState(); 
+    const FreeTrajectoryState*  outerState = traj->firstMeasurement().updatedState().freeState();    
+    const FreeTrajectoryState*  innerState = traj->lastMeasurement().updatedState().freeState(); 
     TrajectoryStateOnSurface outerTSOS = traj->firstMeasurement().updatedState();
     TrajectoryStateOnSurface innerTSOS = traj->lastMeasurement().updatedState();
     const DetLayer* outerLayer = traj->firstMeasurement().layer();

--- a/RecoVertex/KinematicFitPrimitives/test/KinematicState_t.cpp
+++ b/RecoVertex/KinematicFitPrimitives/test/KinematicState_t.cpp
@@ -56,7 +56,7 @@ int main() {
   cout << "ts curv err\n" << ts.curvilinearError().matrix() << std::endl;					   
   cout << "ts cart err\n" << ts.cartesianError().matrix() << std::endl;					   
 
-  FreeTrajectoryState* fts = ts.freeTrajectoryState();
+  const FreeTrajectoryState* fts = ts.freeTrajectoryState();
   assert(fts);
 
   KinematicState ks(*fts,0.151,0.01);

--- a/TrackingTools/TrajectoryState/interface/BasicTrajectoryState.h
+++ b/TrackingTools/TrajectoryState/interface/BasicTrajectoryState.h
@@ -206,7 +206,7 @@ public:
 
 
 
-  FreeTrajectoryState* freeTrajectoryState(bool withErrors=true) const {
+  FreeTrajectoryState const* freeTrajectoryState(bool withErrors=true) const {
     if unlikely(!isValid()) notValid();
     if(withErrors && hasError()) { // this is the right thing
       checkCurvilinError();

--- a/TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h
+++ b/TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h
@@ -128,11 +128,11 @@ public:
     return data().hasError();
   }
 
-  FreeTrajectoryState* freeState(bool withErrors = true) const {
+  FreeTrajectoryState const* freeState(bool withErrors = true) const {
     return data().freeTrajectoryState();
   }
 
-  FreeTrajectoryState* freeTrajectoryState(bool withErrors = true) const {
+  FreeTrajectoryState const* freeTrajectoryState(bool withErrors = true) const {
     return freeState();
   }
 

--- a/Validation/RecoMuon/src/HTrack.cc
+++ b/Validation/RecoMuon/src/HTrack.cc
@@ -130,7 +130,7 @@ void HTrack::Fill(TrajectoryStateOnSurface &tsos){
   Fill(*tsos.freeState());
 }
 
-void HTrack::Fill(FreeTrajectoryState &fts){
+void HTrack::Fill(const FreeTrajectoryState &fts){
   
   hVariables->Fill(fts.momentum().mag(),
 		   fts.momentum().perp(),
@@ -154,7 +154,7 @@ void HTrack::computeResolutionAndPull(TrajectoryStateOnSurface& tsos, SimTrack& 
 }
 
 
-void HTrack::computeResolutionAndPull(FreeTrajectoryState& fts, SimTrack& simTrack){
+void HTrack::computeResolutionAndPull(const FreeTrajectoryState& fts, SimTrack& simTrack){
   
 
   // Global Resolution
@@ -252,7 +252,7 @@ void HTrack::computeResolutionAndPull(FreeTrajectoryState& fts, SimTrack& simTra
   }
 }
 
-void HTrack::computeResolution(FreeTrajectoryState &fts,
+void HTrack::computeResolution(const FreeTrajectoryState &fts,
 			       SimTrack& simTrack,
 			       HResolution* hReso){
 
@@ -268,7 +268,7 @@ void HTrack::computeResolution(FreeTrajectoryState &fts,
 	      fts.charge()+simTrack.type()/abs(simTrack.type())); // FIXME
 }
 
-void HTrack::computeTDRResolution(FreeTrajectoryState &fts,
+void HTrack::computeTDRResolution(const FreeTrajectoryState &fts,
 				  SimTrack& simTrack,
 				  HResolution* hReso){
 
@@ -285,7 +285,7 @@ void HTrack::computeTDRResolution(FreeTrajectoryState &fts,
 	      resolution(fts.charge()/fts.momentum().perp(),simCharge/sqrt(simTrack.momentum().Perp2())));
 }
 
-void HTrack::computePull(FreeTrajectoryState &fts,
+void HTrack::computePull(const FreeTrajectoryState &fts,
 			 SimTrack& simTrack,
 			 HResolution* hReso){
 

--- a/Validation/RecoMuon/src/HTrack.h
+++ b/Validation/RecoMuon/src/HTrack.h
@@ -19,15 +19,15 @@ class HTrack{
   
   double resolution(double rec,double sim);
   
-  void computeResolution(FreeTrajectoryState& fts,
+  void computeResolution(const FreeTrajectoryState& fts,
 			 SimTrack &simTracks,
 			 HResolution* hReso);
   
-  void computeTDRResolution(FreeTrajectoryState& fts,
+  void computeTDRResolution(const FreeTrajectoryState& fts,
 			    SimTrack &simTracks,
 			    HResolution* hReso);
   
-  void computePull(FreeTrajectoryState& fts,
+  void computePull(const FreeTrajectoryState& fts,
 		   SimTrack &simTracks,
 		   HResolution* hReso); 
 
@@ -35,11 +35,11 @@ class HTrack{
   void computeResolutionAndPull(TrajectoryStateOnSurface &vtx,
 				SimTrack &simTrack);
 
-  void computeResolutionAndPull(FreeTrajectoryState& fts, 
+  void computeResolutionAndPull(const FreeTrajectoryState& fts, 
 				SimTrack& simTrack);
   
   void Fill(TrajectoryStateOnSurface &);
-  void Fill(FreeTrajectoryState &);
+  void Fill(const FreeTrajectoryState &);
   void FillDeltaR(double);
 
   double computeEfficiency(HTrackVariables *sim);


### PR DESCRIPTION
freeTrajectoryState() is a const member function of TrajectoryStateOnSurface that returns a non-const pointer to a data member of the class.  The pointer is never used to modify the member.
This pull request (for thread safety) changes the function to return a pointer to const, and propagates the const qualifier through other packages so that everything compiles.
Tested with checkdeps -a and the relval matrix.
