### PR TITLE
Const function must return const ptr for thread safety

### DIFF
--- a/Alignment/KalmanAlignmentAlgorithm/interface/KalmanAlignmentSetup.h
+++ b/Alignment/KalmanAlignmentAlgorithm/interface/KalmanAlignmentSetup.h
@@ -70,13 +70,13 @@ private:
 
   std::string theId;
 
-  TrajectoryFitter* theFitter;
+  const TrajectoryFitter* theFitter;
   Propagator* thePropagator;
   std::vector< SubDetId > theTrackingSubDetIds;
   unsigned int theMinTrackingHits;
   SortingDirection theSortingDir;
 
-  TrajectoryFitter* theExternalFitter;
+  const TrajectoryFitter* theExternalFitter;
   Propagator* theExternalPropagator;
   std::vector< SubDetId > theExternalTrackingSubDetIds;
   unsigned int theMinExternalHits;

--- a/TrackingTools/TrackFitters/interface/KFSplittingFitter.h
+++ b/TrackingTools/TrackFitters/interface/KFSplittingFitter.h
@@ -34,7 +34,7 @@ public:
 		    const MeasurementEstimator* aEstimator) : 
     fitter(aPropagator, aUpdator, aEstimator) {}
 
-  virtual KFSplittingFitter* clone() const {
+  virtual const KFSplittingFitter* clone() const {
     return new KFSplittingFitter(fitter.propagator(),fitter.updator(),fitter.estimator());
   }
   

--- a/TrackingTools/TrackFitters/interface/TrajectoryFitter.h
+++ b/TrackingTools/TrackFitters/interface/TrajectoryFitter.h
@@ -23,7 +23,7 @@ public:
   typedef Trajectory::RecHitContainer      RecHitContainer;
 
   virtual ~TrajectoryFitter() {}
-  virtual TrajectoryFitter* clone() const = 0;
+  virtual const TrajectoryFitter* clone() const = 0;
 
   // new interface return one trajectory: if fit fails trajectory is invalid...
   virtual Trajectory fitOne(const Trajectory& traj, fitType type=standard) const=0;


### PR DESCRIPTION
clone() is a const member function of TrackFitter that returns a non-const pointer through which a non-const data member of the invoking object can be accessed.  This is because the function, under certain conditions, does a shallow copy (It is poorly named).  The pointer is never used to modify any member.
This pull request (for thread safety) changes the function to return a pointer to const, and propagates the const qualifier through another package so that everything compiles.
