### PR TITLE
Fixed sending DelayedGet signal for getByToken

### DIFF
--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -170,14 +170,6 @@ namespace edm {
     // Try unscheduled production.
     if(phb.onDemand()) {
       if(fillOnDemand) {
-        if(mcc) {
-          preModuleDelayedGetSignal_.emit(*(mcc->getStreamContext()),*mcc);
-        }
-        std::shared_ptr<void> guard(nullptr,[this,mcc](const void*){
-          if(mcc) {
-            postModuleDelayedGetSignal_.emit(*(mcc->getStreamContext()),*mcc);
-          }
-        });
         unscheduledFill(phb.resolvedModuleLabel(),
                         mcc);
       }
@@ -347,6 +339,10 @@ namespace edm {
           << "with a null pointer to the ModuleCalling Context. This should never happen.\n"
           << "Contact a Framework developer";
       }
+      preModuleDelayedGetSignal_.emit(*(mcc->getStreamContext()),*mcc);
+      std::shared_ptr<void> guard(nullptr,[this,mcc](const void*){
+        postModuleDelayedGetSignal_.emit(*(mcc->getStreamContext()),*mcc);
+      });
       unscheduledHandler_->tryToFill(moduleLabel, *const_cast<EventPrincipal*>(this), mcc);
     }
     return true;


### PR DESCRIPTION
The call path taken by getByToken is different than that for getByLabel during an unscheduled call. This caused the DelayedGet signal to not be sent. The DelayedGet signal has now been moved to unscheduledFill since that is used by both call paths.
