### PR TITLE
thread safety statics work L1Trigger-GlobalTrigger

### DIFF
--- a/L1Trigger/GlobalTrigger/src/L1GtAlgorithmEvaluation.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GtAlgorithmEvaluation.cc
@@ -78,7 +78,7 @@ void L1GtAlgorithmEvaluation::evaluateAlgorithm(const int chipNumber,
 
     // stack containing temporary results
     // FIXME we shall find a better solution than static
-    static  std::stack<bool, std::vector<bool> > resultStack;
+    std::stack<bool, std::vector<bool> > resultStack;
     bool b1, b2;
 
     int opNumber = 0;
@@ -175,8 +175,7 @@ void L1GtAlgorithmEvaluation::evaluateAlgorithm(const int chipNumber,
 
     m_algoResult = resultStack.top();
 
-    // clear resultStack
-    while(!resultStack.empty()) resultStack.pop();
+    // clear resultStack not needed since it is now a function temporary
 
 }
 


### PR DESCRIPTION
L1GtAlgorithmEvaluation::evaluateAlgorithm::returnStack can be made non-static since it is essentially deleted at the end of the function
