### PR TITLE
Changes non-const statics in PFCluster to avoid static analyzer warnings

### DIFF
--- a/DataFormats/ParticleFlowReco/interface/PFCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFCluster.h
@@ -96,9 +96,7 @@ namespace reco {
     
     friend    std::ostream& operator<<(std::ostream& out, 
 				       const PFCluster& cluster);
-    /// counter
-    static unsigned     instanceCounter_;
-    
+
     /// \todo move to PFClusterTools
     static void setDepthCorParameters(int mode, 
 				      double a, double b, 
@@ -130,8 +128,7 @@ namespace reco {
     
     /// dummy vertex access
     math::XYZPoint const & vertex() const { 
-      static math::XYZPoint dummyVtx(0,0,0);
-      return dummyVtx;      
+      return dummyVtx_;      
     }
     double vx() const { return vertex().x(); }
     double vy() const { return vertex().y(); }
@@ -161,7 +158,8 @@ namespace reco {
     /// \todo move to PFClusterTools
     static double depthCorBp_;
     
-    
+    static const math::XYZPoint dummyVtx_;
+
     /// color (transient)
     int                 color_;
     

--- a/DataFormats/ParticleFlowReco/src/PFCluster.cc
+++ b/DataFormats/ParticleFlowReco/src/PFCluster.cc
@@ -11,7 +11,7 @@ double PFCluster::depthCorB_ = 7.3;
 double PFCluster::depthCorAp_ = 0.89;
 double PFCluster::depthCorBp_ = 4.0;
 
-unsigned PFCluster::instanceCounter_ = 0;
+const math::XYZPoint PFCluster::dummyVtx_(0,0,0);
 
 PFCluster::PFCluster(PFLayer::Layer layer, double energy,
                      double x, double y, double z ) : 


### PR DESCRIPTION
The static analyzer flagged several non-const statics in this class as potential threaded problems. We removed instanceCounter_ since it was never used and moved the dummyVtx function static used as a return value to be a const
class static. The statics associated with setDepthCorParameters and getDepthCorParameters were left as is but they were reported to the appropriate L2s.
