### PR TITLE
5_3_X Hide FullFramework proxy builder from add colleciton dialog in cmsShow

### DIFF
--- a/Fireworks/Core/src/FWLiteJobMetadataManager.cc
+++ b/Fireworks/Core/src/FWLiteJobMetadataManager.cc
@@ -102,7 +102,10 @@ FWLiteJobMetadataManager::doUpdate(FWJobMetadataUpdateRequest *request)
          /* if(!infos[ii].representsSubPart() && minProx != infos[ii].proximity()) {
             continue;
             } */
-         purposes.insert(infos[ii].purpose());
+          // AMT: this is a simple workaround to hide FF proxybuilder
+          //      the proper solution is implemented in CMSSW_7_0_X
+          if (infos[ii].purpose() != "TracksFF")
+             purposes.insert(infos[ii].purpose());
       }
       
       if (purposes.empty())

--- a/Fireworks/Muons/plugins/FWDTSegmentProxyBuilder.cc
+++ b/Fireworks/Muons/plugins/FWDTSegmentProxyBuilder.cc
@@ -1,3 +1,4 @@
+
 // -*- C++ -*-
 //
 // Package:     Muons
@@ -8,11 +9,11 @@
 //
 // Original Author:
 //         Created:  Sun Jan  6 23:57:00 EST 2008
-// $Id: FWDTSegmentProxyBuilder.cc,v 1.14 2010/11/11 20:25:28 amraktad Exp $
 //
 
 #include "TEveGeoNode.h"
 #include "TEveStraightLineSet.h"
+#include "TEvePointSet.h"
 #include "TGeoArb8.h"
 
 #include "Fireworks/Core/interface/FWSimpleProxyBuilderTemplate.h"
@@ -20,7 +21,10 @@
 #include "Fireworks/Core/interface/FWGeometry.h"
 #include "Fireworks/Core/interface/fwLog.h"
 
+#include "DataFormats/MuonDetId/interface/DTChamberId.h"
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
+
+#include <vector>
 
 class FWDTSegmentProxyBuilder : public FWSimpleProxyBuilderTemplate<DTRecSegment4D>
 {
@@ -28,18 +32,20 @@ public:
    FWDTSegmentProxyBuilder( void ) {}
    virtual ~FWDTSegmentProxyBuilder( void ) {}
 
+  virtual bool haveSingleProduct() const { return false; }
+
    REGISTER_PROXYBUILDER_METHODS();
 
 private:
    FWDTSegmentProxyBuilder( const FWDTSegmentProxyBuilder& );
    const FWDTSegmentProxyBuilder& operator=( const FWDTSegmentProxyBuilder& );
 
-   void build( const DTRecSegment4D& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext* );
+   void buildViewType( const DTRecSegment4D& iData, unsigned int iIndex, TEveElement& oItemHolder, FWViewType::EType type, const FWViewContext* );
 };
 
 void
-FWDTSegmentProxyBuilder::build( const DTRecSegment4D& iData,           
-				unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext* )
+FWDTSegmentProxyBuilder::buildViewType( const DTRecSegment4D& iData,           
+				unsigned int iIndex, TEveElement& oItemHolder, FWViewType::EType type, const FWViewContext* )
 {
   unsigned int rawid = iData.chamberId().rawId();
   const FWGeometry *geom = item()->getGeom();
@@ -69,6 +75,14 @@ FWDTSegmentProxyBuilder::build( const DTRecSegment4D& iData,
       double localDirectionIn[3]  = {  dir.x(),  dir.y(),  dir.z() };
       double localDirectionOut[3] = { -dir.x(), -dir.y(), -dir.z() };
 
+      // In RhoZ view, draw segments at the middle of the chamber, otherwise they won't align with 1D rechits, 
+      // for which only one coordinate is known.
+      if (type == FWViewType::kRhoZ) { 
+	localPosition[0]=0;
+	localDirectionIn[0]=0;
+	localDirectionOut[0]=0;
+      }
+
       Double_t distIn = box->DistFromInside( localPosition, localDirectionIn );
       Double_t distOut = box->DistFromInside( localPosition, localDirectionOut );
       LocalVector vIn = unit * distIn;
@@ -90,6 +104,37 @@ FWDTSegmentProxyBuilder::build( const DTRecSegment4D& iData,
 
       segmentSet->AddLine( globalSegmentInnerPoint[0], globalSegmentInnerPoint[1], globalSegmentInnerPoint[2],
 			   globalSegmentOuterPoint[0], globalSegmentOuterPoint[1], globalSegmentOuterPoint[2] );
+
+      
+      // Draw hits included in the segment
+      TEvePointSet* pointSet = new TEvePointSet;
+      // FIXME: This should be set elsewhere.
+      pointSet->SetMarkerSize(1.5);
+      setupAddElement( pointSet, &oItemHolder );
+
+      std::vector<DTRecHit1D> recHits;
+      const DTChamberRecSegment2D* phiSeg = iData.phiSegment();      
+      const DTSLRecSegment2D* zSeg = iData.zSegment();
+      if (type == FWViewType::kRhoPhi && phiSeg) {
+	recHits = phiSeg->specificRecHits();
+      }
+      if (type == FWViewType::kRhoZ && zSeg) {
+	recHits = zSeg->specificRecHits();
+      }
+
+      for (std::vector<DTRecHit1D>::const_iterator rh=recHits.begin(); rh!=recHits.end(); ++rh){
+	DTLayerId layerId = (*rh).wireId().layerId();
+	LocalPoint hpos = (*rh).localPosition();
+	float hitLocalPos[3]= {hpos.x(), hpos.y(), hpos.z()};
+	if (layerId.superLayer()==2 && type == FWViewType::kRhoZ) {
+	  // In RhoZ view, draw theta SL hits at the middle of the chamber, otherwise they won't align with 1D rechits, 
+	  // for which only one coordinate is known.
+	  hitLocalPos[1]=0;
+	}
+	float hitGlobalPoint[3];
+	geom->localToGlobal(layerId, hitLocalPos, hitGlobalPoint);
+	pointSet->SetNextPoint(hitGlobalPoint[0], hitGlobalPoint[1], hitGlobalPoint[2]);
+      }
     }
   }
 }

--- a/Fireworks/SimData/plugins/FWPSimHitProxyBuilder.cc
+++ b/Fireworks/SimData/plugins/FWPSimHitProxyBuilder.cc
@@ -11,6 +11,7 @@
 #include "Fireworks/Core/interface/FWGeometry.h"
 #include "Fireworks/Core/interface/fwLog.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
+#include <DataFormats/MuonDetId/interface/DTWireId.h>
 
 #include "TEvePointSet.h"
 
@@ -20,6 +21,8 @@ public:
    FWPSimHitProxyBuilder( void ) {} 
    virtual ~FWPSimHitProxyBuilder( void ) {}
 
+   virtual bool haveSingleProduct() const { return false; }
+
    REGISTER_PROXYBUILDER_METHODS();
 
 private:
@@ -28,11 +31,11 @@ private:
    // Disable default assignment operator
    const FWPSimHitProxyBuilder& operator=( const FWPSimHitProxyBuilder& );
 
-   void build( const PSimHit& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext* );
+   void buildViewType( const PSimHit& iData, unsigned int iIndex, TEveElement& oItemHolder, FWViewType::EType type, const FWViewContext* );
 };
 
 void
-FWPSimHitProxyBuilder::build( const PSimHit& iData, unsigned int iIndex, TEveElement& oItemHolder, const FWViewContext* )
+FWPSimHitProxyBuilder::buildViewType( const PSimHit& iData, unsigned int iIndex, TEveElement& oItemHolder, FWViewType::EType type, const FWViewContext* )
 {
    TEvePointSet* pointSet = new TEvePointSet;
    setupAddElement( pointSet, &oItemHolder );
@@ -48,6 +51,26 @@ FWPSimHitProxyBuilder::build( const PSimHit& iData, unsigned int iIndex, TEveEle
    
    float local[3] = { iData.localPosition().x(), iData.localPosition().y(), iData.localPosition().z() };
    float global[3];
+
+   // Specialized for DT simhits
+   DetId id(rawid);
+   if (id.det()==DetId::Muon && id.subdetId()==1) {   
+     DTWireId wId(rawid);
+     rawid = wId.layerId().rawId(); // DT simhits are in the RF of the DTLayer, but their ID is the id of the wire!
+     if (abs(iData.particleType())!=13){
+       pointSet->SetMarkerStyle(26); // Draw non-muon simhits (e.g. delta rays) with a different marker
+     } 
+     if (type == FWViewType::kRhoZ) { // 
+       // In RhoZ view, draw hits at the middle of the layer in the global Z coordinate, 
+       // otherwise they won't align with 1D rechits, for which only one coordinate is known.
+       if (wId.superLayer()==2) {
+	 local[1]=0;
+       } else {
+	 local[0]=0;
+       }
+     }
+   }
+
    geom->localToGlobal( rawid, local, global );
    pointSet->SetNextPoint( global[0], global[1], global[2] );
 }

--- a/Fireworks/SimData/plugins/FWTrackingParticleProxyBuilder.cc
+++ b/Fireworks/SimData/plugins/FWTrackingParticleProxyBuilder.cc
@@ -55,8 +55,7 @@ FWTrackingParticleProxyBuilder::build( const TrackingParticle& iData, unsigned i
    TEvePointSet* pointSet = new TEvePointSet;
    setupAddElement( pointSet, track );
    pointSet->SetMarkerSize(item()->getConfig()->value<long>("Point Size"));
-#warning "This file has been modified just to get it to compile without any regard as to whether it still functions as intended"
-#ifdef REMOVED_JUST_TO_GET_IT_TO_COMPILE__THIS_CODE_NEEDS_TO_BE_CHECKED
+
    const FWGeometry *geom = item()->getGeom();
    const std::vector<PSimHit>& hits = iData.trackPSimHit();
 
@@ -95,7 +94,6 @@ FWTrackingParticleProxyBuilder::build( const TrackingParticle& iData, unsigned i
 	 track->AddPathMark( TEvePathMark( TEvePathMark::kDecay, TEveVector( global[0], global[1], global[2] ),
 					   TEveVector( globalDir[0], globalDir[1], globalDir[2] )));
    }
-#endif
    
    track->MakeTrack();
    setupAddElement( track, &oItemHolder );


### PR DESCRIPTION
Fireworks/Core
As simple workaround to hide FF proxybuilder in cmsShow. Proper solution implemented in 7_0_X.

Note: This pull request is on top of pending https://github.com/cms-sw/cmssw/pull/1250.
