### PR TITLE
Fix thread safety issues by removing mutable data members of MuonDetIdAssociator 

### DIFF
--- a/TrackingTools/TrackAssociator/interface/DetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/interface/DetIdAssociator.h
@@ -129,8 +129,8 @@ class DetIdAssociator{
    
    virtual GlobalPoint getPosition(const DetId&) const = 0;
    virtual const unsigned int getNumberOfSubdetectors() const { return 1;}
-   virtual const std::vector<DetId>& getValidDetIds(unsigned int subDetectorIndex) const = 0;
-   virtual std::pair<const_iterator, const_iterator> getDetIdPoints(const DetId&) const = 0;
+   virtual void getValidDetIds(unsigned int subDetectorIndex, std::vector<DetId>&) const = 0;
+   virtual std::pair<const_iterator, const_iterator> getDetIdPoints(const DetId&, std::vector<GlobalPoint>&) const = 0;
    
    virtual bool insideElement(const GlobalPoint&, const DetId&) const = 0;
    virtual bool crossedElement(const GlobalPoint&, 

--- a/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociator.cc
+++ b/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociator.cc
@@ -7,7 +7,8 @@ bool CaloDetIdAssociator::crossedElement(const GlobalPoint& point1,
 					 const SteppingHelixStateInfo* initialState
 					 ) const
 {
-   const std::pair<const_iterator,const_iterator>& points = getDetIdPoints(id);
+   std::vector<GlobalPoint> pointBuffer;
+   const std::pair<const_iterator,const_iterator>& points = getDetIdPoints(id, pointBuffer);
    // fast check
    bool xLess(false), xIn(false), xMore(false);
    bool yLess(false), yIn(false), yMore(false);
@@ -200,14 +201,14 @@ GlobalPoint CaloDetIdAssociator::getPosition(const DetId& id) const {
   return geometry_->getSubdetectorGeometry(id)->getGeometry(id)->getPosition();
 }
    
-const std::vector<DetId>& CaloDetIdAssociator::getValidDetIds(unsigned int subDectorIndex) const 
+void CaloDetIdAssociator::getValidDetIds(unsigned int subDectorIndex, std::vector<DetId>& detIds) const 
 {
   if ( subDectorIndex!=0 ) cms::Exception("FatalError") << "Calo sub-dectors are all handle as one sub-system, but subDetectorIndex is not zero.\n";
-  return geometry_->getValidDetIds(DetId::Calo, 1);
+  detIds = geometry_->getValidDetIds(DetId::Calo, 1);
 }
    
 std::pair<DetIdAssociator::const_iterator, DetIdAssociator::const_iterator> 
-CaloDetIdAssociator::getDetIdPoints(const DetId& id) const 
+CaloDetIdAssociator::getDetIdPoints(const DetId& id, std::vector<GlobalPoint>& points) const 
 {
   const CaloSubdetectorGeometry* subDetGeom = geometry_->getSubdetectorGeometry(id);
   if(! subDetGeom){

--- a/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/CaloDetIdAssociator.h
@@ -38,24 +38,24 @@ class CaloDetIdAssociator: public DetIdAssociator{
    CaloDetIdAssociator(const edm::ParameterSet& pSet)
      :DetIdAssociator(pSet.getParameter<int>("nPhi"),pSet.getParameter<int>("nEta"),pSet.getParameter<double>("etaBinSize")),geometry_(0){};
    
-   virtual void setGeometry(const CaloGeometry* ptr){ geometry_ = ptr; };
+   virtual void setGeometry(const CaloGeometry* ptr) { geometry_ = ptr; };
 
-   virtual void setGeometry(const DetIdAssociatorRecord& iRecord);
+   virtual void setGeometry(const DetIdAssociatorRecord& iRecord) override;
 
-   virtual const GeomDet* getGeomDet(const DetId& id) const { return 0; };
+   virtual const GeomDet* getGeomDet(const DetId& id) const override { return 0; };
 
-   virtual const char* name() const { return "CaloTowers"; }
+   virtual const char* name() const override { return "CaloTowers"; }
 
  protected:
-   virtual void check_setup() const;
+   virtual void check_setup() const override;
    
-   virtual GlobalPoint getPosition(const DetId& id) const;
+   virtual GlobalPoint getPosition(const DetId& id) const override;
    
-   virtual const std::vector<DetId>& getValidDetIds( unsigned int subDetectorIndex ) const;
+   virtual void getValidDetIds( unsigned int subDetectorIndex, std::vector<DetId>& ) const override;
    
-   virtual std::pair<const_iterator, const_iterator> getDetIdPoints(const DetId& id) const;
+   virtual std::pair<const_iterator, const_iterator> getDetIdPoints(const DetId& id, std::vector<GlobalPoint>& points) const override;
 
-   virtual bool insideElement(const GlobalPoint& point, const DetId& id) const {
+   virtual bool insideElement(const GlobalPoint& point, const DetId& id) const override{
       return  geometry_->getSubdetectorGeometry(id)->getGeometry(id)->inside(point);
    };
 
@@ -63,7 +63,7 @@ class CaloDetIdAssociator: public DetIdAssociator{
 			       const GlobalPoint&, 
 			       const DetId& id,
 			       const double tolerance = -1,
-			       const SteppingHelixStateInfo* = 0 ) const;
+			       const SteppingHelixStateInfo* = 0 ) const override;
    const CaloGeometry* geometry_;
    std::vector<GlobalPoint> dummy_;
 };

--- a/TrackingTools/TrackAssociator/plugins/EcalDetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/EcalDetIdAssociator.h
@@ -26,16 +26,16 @@ class EcalDetIdAssociator: public CaloDetIdAssociator{
 
    EcalDetIdAssociator(const edm::ParameterSet& pSet):CaloDetIdAssociator(pSet){};
 
-   virtual const char* name() const { return "ECAL"; }
+   virtual const char* name() const override { return "ECAL"; }
 
  protected:
 
-   virtual const unsigned int getNumberOfSubdetectors() const { return 2;}
-   virtual const std::vector<DetId>& getValidDetIds(unsigned int subDetectorIndex) const {
+   virtual const unsigned int getNumberOfSubdetectors() const override { return 2;}
+   virtual void getValidDetIds(unsigned int subDetectorIndex, std::vector<DetId>& validIds) const {
      if ( subDetectorIndex == 0 )
-       return geometry_->getValidDetIds(DetId::Ecal, EcalBarrel);//EB
+       validIds = geometry_->getValidDetIds(DetId::Ecal, EcalBarrel);//EB
      else
-       return geometry_->getValidDetIds(DetId::Ecal, EcalEndcap);//EE
+       validIds = geometry_->getValidDetIds(DetId::Ecal, EcalEndcap);//EE
    };
 
 };

--- a/TrackingTools/TrackAssociator/plugins/HODetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/HODetIdAssociator.h
@@ -26,15 +26,15 @@ class HODetIdAssociator: public CaloDetIdAssociator{
 
    HODetIdAssociator(const edm::ParameterSet& pSet):CaloDetIdAssociator(pSet){};
 
-   virtual const char* name() const { return "HO"; }
+   virtual const char* name() const override { return "HO"; }
 
  protected:
 
-   const std::vector<DetId>& getValidDetIds(unsigned int subDectorIndex) const
+   void getValidDetIds(unsigned int subDectorIndex, std::vector<DetId>& validIds) const override
      {
        if ( subDectorIndex!=0 ) cms::Exception("FatalError") << 
 	 "HO sub-dectors are all handle as one sub-system, but subDetectorIndex is not zero.\n";
-       return geometry_->getValidDetIds(DetId::Hcal, HcalOuter);
+       validIds = geometry_->getValidDetIds(DetId::Hcal, HcalOuter);
      }
 };
 #endif

--- a/TrackingTools/TrackAssociator/plugins/HcalDetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/HcalDetIdAssociator.h
@@ -26,16 +26,16 @@ class HcalDetIdAssociator: public CaloDetIdAssociator{
 
    HcalDetIdAssociator(const edm::ParameterSet& pSet):CaloDetIdAssociator(pSet){};
    
-   virtual const char* name() const { return "HCAL"; }
+   virtual const char* name() const override { return "HCAL"; }
 
  protected:
 
-   virtual const unsigned int getNumberOfSubdetectors() const { return 2;}
-   virtual const std::vector<DetId>& getValidDetIds(unsigned int subDetectorIndex) const {
+   virtual const unsigned int getNumberOfSubdetectors() const override { return 2;}
+   void getValidDetIds(unsigned int subDetectorIndex, std::vector<DetId>& validIds) const {
      if ( subDetectorIndex == 0 )
-       return geometry_->getValidDetIds(DetId::Hcal, HcalBarrel);//HB
+       validIds = geometry_->getValidDetIds(DetId::Hcal, HcalBarrel);//HB
      else
-       return geometry_->getValidDetIds(DetId::Hcal, HcalEndcap);//HE
+       validIds = geometry_->getValidDetIds(DetId::Hcal, HcalEndcap);//HE
    };
 };
 #endif

--- a/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/MuonDetIdAssociator.h
@@ -38,40 +38,38 @@ class MuonDetIdAssociator: public DetIdAssociator{
    MuonDetIdAssociator(const edm::ParameterSet& pSet)
      :DetIdAssociator(pSet.getParameter<int>("nPhi"),pSet.getParameter<int>("nEta"),pSet.getParameter<double>("etaBinSize")),geometry_(0),cscbadchambers_(0),includeBadChambers_(pSet.getParameter<bool>("includeBadChambers")){};
    
-   virtual void setGeometry(const GlobalTrackingGeometry* ptr){ geometry_ = ptr; }
+   virtual void setGeometry(const GlobalTrackingGeometry* ptr) { geometry_ = ptr; }
 
-   virtual void setGeometry(const DetIdAssociatorRecord& iRecord);
+   virtual void setGeometry(const DetIdAssociatorRecord& iRecord) override;
 
-   virtual void setCSCBadChambers(const CSCBadChambers* ptr){ cscbadchambers_ = ptr; }
+   virtual void setCSCBadChambers(const CSCBadChambers* ptr) { cscbadchambers_ = ptr; }
 
-   virtual void setConditions(const DetIdAssociatorRecord& iRecord){
+   virtual void setConditions(const DetIdAssociatorRecord& iRecord) override{
       edm::ESHandle<CSCBadChambers> cscbadchambersH;
       iRecord.getRecord<CSCBadChambersRcd>().get(cscbadchambersH);
       setCSCBadChambers(cscbadchambersH.product());
    };
 
-   virtual const GeomDet* getGeomDet( const DetId& id ) const;
+   virtual const GeomDet* getGeomDet( const DetId& id ) const override;
 
-   virtual const char* name() const { return "AllMuonDetectors"; }
+   virtual const char* name() const override { return "AllMuonDetectors"; }
 
  protected:
    
-   virtual void check_setup() const;
+   virtual void check_setup() const override;
    
-   virtual GlobalPoint getPosition(const DetId& id) const;
+   virtual GlobalPoint getPosition(const DetId& id) const override;
    
-   virtual const std::vector<DetId>& getValidDetIds(unsigned int) const;
+   virtual void getValidDetIds(unsigned int, std::vector<DetId>&) const override;
    
-   virtual std::pair<const_iterator,const_iterator> getDetIdPoints(const DetId& id) const;
+   virtual std::pair<const_iterator,const_iterator> getDetIdPoints(const DetId& id, std::vector<GlobalPoint>& points) const override;
 
-   virtual bool insideElement(const GlobalPoint& point, const DetId& id) const;
+   virtual bool insideElement(const GlobalPoint& point, const DetId& id) const override;
 
    const GlobalTrackingGeometry* geometry_;
 
    const CSCBadChambers* cscbadchambers_;
    bool includeBadChambers_;
-   mutable std::vector<GlobalPoint> points_;
-   mutable std::vector<DetId> validIds_;
 
 };
 #endif

--- a/TrackingTools/TrackAssociator/plugins/PreshowerDetIdAssociator.h
+++ b/TrackingTools/TrackAssociator/plugins/PreshowerDetIdAssociator.h
@@ -26,12 +26,12 @@ class PreshowerDetIdAssociator: public CaloDetIdAssociator{
 
    PreshowerDetIdAssociator(const edm::ParameterSet& pSet):CaloDetIdAssociator(pSet){};
      
-   virtual const char* name() const { return "Preshower"; }
+   virtual const char* name() const override { return "Preshower"; }
  protected:
 
-   virtual const std::vector<DetId>& getValidDetIds(unsigned int subDetectorIndex) const {
+   virtual void getValidDetIds(unsigned int subDetectorIndex, std::vector<DetId>& validIds) const override {
      if ( subDetectorIndex != 0 ) throw cms::Exception("FatalError") << "Preshower has only one sub-detector for geometry. Abort.";
-     return geometry_->getValidDetIds(DetId::Ecal, EcalPreshower);
+     validIds = geometry_->getValidDetIds(DetId::Ecal, EcalPreshower);
    };
 
 };


### PR DESCRIPTION
The class MuonDetIdAssociator contained two mutable data members, both vectors, that were modified by const member functions of the class.  This is not thread safe.
This pull request removes the mutable data members.  Instead, a vector is passed in to the functions for filling by the functions.  There is no need to store the vectors in the class.
Tested with checkdeps -a and the relval matrix.
