### PR TITLE
Fix some thread safety issues in TrackingTools/GeomPropagators

### DIFF
--- a/TrackingTools/GeomPropagators/interface/BeamHaloPropagator.h
+++ b/TrackingTools/GeomPropagators/interface/BeamHaloPropagator.h
@@ -27,7 +27,7 @@ class BeamHaloPropagator GCC11_FINAL : public Propagator {
 
     /* Constructor */ 
     ///Defines which propagator is used inside endcap and in barrel
-    BeamHaloPropagator(Propagator* aEndCapTkProp, Propagator* aCrossTkProp, const MagneticField* field,
+    BeamHaloPropagator(const Propagator* aEndCapTkProp, const Propagator* aCrossTkProp, const MagneticField* field,
 		       PropagationDirection dir = alongMomentum);
 
     ///Defines which propagator is used inside endcap and in barrel
@@ -117,17 +117,17 @@ class BeamHaloPropagator GCC11_FINAL : public Propagator {
       bool crossingTk(const FreeTrajectoryState& fts, const Plane& plane)  const ;
 
     ///return the propagator used in endcaps
-    Propagator* getEndCapTkPropagator() const ;
+    const Propagator* getEndCapTkPropagator() const ;
     ///return the propagator used to cross the tracker
-    Propagator* getCrossTkPropagator() const ;
+    const Propagator* getCrossTkPropagator() const ;
     ///return the magneticField
     virtual const MagneticField* magneticField() const {return theField;}
 
   private:
     void directionCheck(PropagationDirection dir)const;
 
-    mutable Propagator* theEndCapTkProp;
-    mutable Propagator* theCrossTkProp;
+    Propagator* theEndCapTkProp;
+    Propagator* theCrossTkProp;
     const MagneticField* theField;
     
   protected:

--- a/TrackingTools/GeomPropagators/interface/SmartPropagator.h
+++ b/TrackingTools/GeomPropagators/interface/SmartPropagator.h
@@ -38,7 +38,7 @@ class SmartPropagator GCC11_FINAL : public Propagator {
 
     /* Constructor */ 
     ///Defines which propagator is used inside Tk and which outside
-    SmartPropagator(Propagator* aTkProp, Propagator* aGenProp, const MagneticField* field,
+    SmartPropagator(const Propagator* aTkProp, const Propagator* aGenProp, const MagneticField* field,
         PropagationDirection dir = alongMomentum, float epsilon = 5) ;
 
     ///Defines which propagator is used inside Tk and which outside
@@ -132,9 +132,9 @@ class SmartPropagator GCC11_FINAL : public Propagator {
     bool insideTkVol(const Plane& plane)  const ;
 
     ///return the propagator used inside tracker
-    Propagator* getTkPropagator() const ;
+    const Propagator* getTkPropagator() const ;
     ///return the propagator used outside tracker
-    Propagator* getGenPropagator() const ;
+    const Propagator* getGenPropagator() const ;
     ///return the magneticField
     virtual const MagneticField* magneticField() const {return theField;}
 
@@ -142,8 +142,8 @@ class SmartPropagator GCC11_FINAL : public Propagator {
     ///build the tracker volume
   static void initTkVolume(float epsilon);
 
-    mutable Propagator* theTkProp;
-    mutable Propagator* theGenProp;
+    Propagator* theTkProp;
+    Propagator* theGenProp;
     const MagneticField* theField;
     static ReferenceCountingPointer<Cylinder> & theTkVolume();
 

--- a/TrackingTools/GeomPropagators/src/BeamHaloPropagator.cc
+++ b/TrackingTools/GeomPropagators/src/BeamHaloPropagator.cc
@@ -50,7 +50,7 @@ void BeamHaloPropagator::directionCheck(PropagationDirection dir)const {
   
 }
 
-BeamHaloPropagator::BeamHaloPropagator(Propagator* aEndCapTkProp, Propagator* aCrossTkProp, const MagneticField* field,
+BeamHaloPropagator::BeamHaloPropagator(const Propagator* aEndCapTkProp, const Propagator* aCrossTkProp, const MagneticField* field,
                                  PropagationDirection dir) :
   Propagator(dir), theEndCapTkProp(aEndCapTkProp->clone()), theCrossTkProp(aCrossTkProp->clone()), theField(field) { 
   directionCheck(dir);
@@ -122,12 +122,12 @@ BeamHaloPropagator::propagateWithPath(const FreeTrajectoryState& fts,
 {  return getCrossTkPropagator()->propagateWithPath(fts, cylinder);}
 
 
-Propagator* BeamHaloPropagator::getEndCapTkPropagator() const {
+const Propagator* BeamHaloPropagator::getEndCapTkPropagator() const {
   LogDebug("BeamHaloPropagator")<<"using the EndCap propagator";
   return theEndCapTkProp;}
 
 
-Propagator* BeamHaloPropagator::getCrossTkPropagator() const {
+const Propagator* BeamHaloPropagator::getCrossTkPropagator() const {
   LogDebug("BeamHaloPropagator")<<"using the Crossing propagator";
   return theCrossTkProp;}
 

--- a/TrackingTools/GeomPropagators/src/SmartPropagator.cc
+++ b/TrackingTools/GeomPropagators/src/SmartPropagator.cc
@@ -39,7 +39,7 @@ ReferenceCountingPointer<BoundCylinder> & SmartPropagator::theTkVolume() {
 
 
 /* Constructor */ 
-SmartPropagator::SmartPropagator(Propagator* aTkProp, Propagator* aGenProp, const MagneticField* field,
+SmartPropagator::SmartPropagator(const Propagator* aTkProp, const Propagator* aGenProp, const MagneticField* field,
                                  PropagationDirection dir, float epsilon) :
   Propagator(dir), theTkProp(aTkProp->clone()), theGenProp(aGenProp->clone()), theField(field) { 
 
@@ -193,14 +193,14 @@ bool SmartPropagator::insideTkVol( const Plane& plane)  const {
 }
 
 
-Propagator* SmartPropagator::getTkPropagator() const {
+const Propagator* SmartPropagator::getTkPropagator() const {
 
   return theTkProp;
 
 }
 
 
-Propagator* SmartPropagator::getGenPropagator() const {
+const Propagator* SmartPropagator::getGenPropagator() const {
 
   return theGenProp;
 


### PR DESCRIPTION
This pull request fixes some, but not all, of the thread safety issues in TrackingTools/GeomPropagators that were found by the static analyzer.
Four const member functions that returned a non-const pointer to a data member of the class were modified to return a const pointer instead.
Four data members each had an unnecessary mutable qualifier that was simply removed.
Tested with checkdeps -a and the relval matrix.
