### PR TITLE
Remove or replace two mutable data members from SteppingHelixPropagator

### DIFF
--- a/TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h
+++ b/TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h
@@ -270,9 +270,6 @@ class SteppingHelixPropagator GCC11_FINAL : public Propagator {
 
   StateInfo invalidState_;
 
-  mutable AlgebraicMatrix55 covCurvRot_;
-  mutable AlgebraicMatrix55 dCCurvTransform_;
-
   const MagneticField* field_;
   const VolumeBasedMagneticField* vbField_;
   const AlgebraicSymMatrix55 unit55_;


### PR DESCRIPTION
The class SteppingHelixPropagator has four mutable data members, all of which pose thread safety issues.
This pull request removes or replaces two of them.  One that was unused was removed. The other was easily replaced by a variable on the stack.
The two remaining mutable data members are more difficult to replace, and will be left alone for now.
Tested with checkdeps -a and the relval matrix.
