### PR TITLE
Fixing muon double counting bug

### DIFF
--- a/HLTrigger/HLTanalyzers/src/HLTMCtruth.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTMCtruth.cc
@@ -98,7 +98,7 @@ void HLTMCtruth::analyze(const edm::Handle<reco::CandidateView> & mctruth,
 	int pdgid = simTracks->at(j).type();
 	if (abs(pdgid)!=13) continue;
 	double pt = simTracks->at(j).momentum().pt();
-	if (pt<2.5) continue;
+	if (pt<5.0) continue;
 	double eta = simTracks->at(j).momentum().eta();
 	if (abs(eta)>2.5) continue;
 	if (simTracks->at(j).noVertex()) continue;
@@ -164,8 +164,8 @@ void HLTMCtruth::analyze(const edm::Handle<reco::CandidateView> & mctruth,
 
 	// Set-up flags, based on Pythia-generator information, for avoiding double-counting events when
 	// using both pp->{e,mu}X AND QCD samples
- 	if (((mcpid[nmc]==13)||(mcpid[nmc]==-13))&&(mcpt[nmc]>2.5)) {mu3 += 1;} // Flag for muons with pT > 2.5 GeV/c
-	if (((mcpid[nmc]==11)||(mcpid[nmc]==-11))&&(mcpt[nmc]>2.5)) {el3 += 1;} // Flag for electrons with pT > 2.5 GeV/c
+ 	if (((mcpid[nmc]==13)||(mcpid[nmc]==-13))&&(mcpt[nmc]>5.0)) {mu3 += 1;} // Flag for muons with pT > 2.5 GeV/c
+	if (((mcpid[nmc]==11)||(mcpid[nmc]==-11))&&(mcpt[nmc]>5.0)) {el3 += 1;} // Flag for electrons with pT > 2.5 GeV/c
 
 	if (mcpid[nmc]==-5) {mab += 1;} // Flag for bbar
 	if (mcpid[nmc]==5) {mbb += 1;} // Flag for b

--- a/HLTrigger/HLTanalyzers/src/HLTMCtruth.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTMCtruth.cc
@@ -164,7 +164,7 @@ void HLTMCtruth::analyze(const edm::Handle<reco::CandidateView> & mctruth,
 
 	// Set-up flags, based on Pythia-generator information, for avoiding double-counting events when
 	// using both pp->{e,mu}X AND QCD samples
-// 	if (((mcpid[nmc]==13)||(mcpid[nmc]==-13))&&(mcpt[nmc]>2.5)) {mu3 += 1;} // Flag for muons with pT > 2.5 GeV/c
+ 	if (((mcpid[nmc]==13)||(mcpid[nmc]==-13))&&(mcpt[nmc]>2.5)) {mu3 += 1;} // Flag for muons with pT > 2.5 GeV/c
 	if (((mcpid[nmc]==11)||(mcpid[nmc]==-11))&&(mcpt[nmc]>2.5)) {el3 += 1;} // Flag for electrons with pT > 2.5 GeV/c
 
 	if (mcpid[nmc]==-5) {mab += 1;} // Flag for bbar


### PR DESCRIPTION
A bug was fixed. Now a histogram will be made to take care of muon double counting when using MuEnriched samples.
