### PR TITLE
Import missing Winter13 BTag performance DB from CVS

### DIFF
--- a/RecoBTag/PerformanceDB/python/BTagPerformanceDBWinter13.py
+++ b/RecoBTag/PerformanceDB/python/BTagPerformanceDBWinter13.py
@@ -1,0 +1,5 @@
+from RecoBTag.PerformanceDB.measure.Btag_btagMistagWinter13 import *
+from RecoBTag.PerformanceDB.measure.Btag_btagMuJetsWpNoTtbar import *
+from RecoBTag.PerformanceDB.measure.Btag_btagMuJetsWpTtbar import *
+from RecoBTag.PerformanceDB.measure.Btag_btagTtbarWpWinter13 import *
+from RecoBTag.PerformanceDB.measure.Btag_btagTtbarDiscrimWinter13 import *

--- a/RecoBTag/PerformanceDB/python/PoolBTagPerformanceDBWinter13.py
+++ b/RecoBTag/PerformanceDB/python/PoolBTagPerformanceDBWinter13.py
@@ -1,0 +1,5 @@
+from RecoBTag.PerformanceDB.measure.Pool_btagMistagWinter13 import *
+from RecoBTag.PerformanceDB.measure.Pool_btagMuJetsWpNoTtbar import *
+from RecoBTag.PerformanceDB.measure.Pool_btagMuJetsWpTtbar import *
+from RecoBTag.PerformanceDB.measure.Pool_btagTtbarWpWinter13 import *
+from RecoBTag.PerformanceDB.measure.Pool_btagTtbarDiscrimWinter13 import *

--- a/RecoBTag/PerformanceDB/python/measure/Btag_btagMistagWinter13.py
+++ b/RecoBTag/PerformanceDB/python/measure/Btag_btagMistagWinter13.py
@@ -1,0 +1,105 @@
+import FWCore.ParameterSet.Config as cms
+
+BtagPerformanceESProducer_MISTAGCSVL = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGCSVL'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGCSVL_T'),
+    WorkingPointName = cms.string('MISTAGCSVL_WP')
+)
+
+BtagPerformanceESProducer_MISTAGCSVM = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGCSVM'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGCSVM_T'),
+    WorkingPointName = cms.string('MISTAGCSVM_WP')
+)
+
+BtagPerformanceESProducer_MISTAGCSVT = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGCSVT'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGCSVT_T'),
+    WorkingPointName = cms.string('MISTAGCSVT_WP')
+)
+
+BtagPerformanceESProducer_MISTAGCSVSLV1L = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGCSVSLV1L'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGCSVSLV1L_T'),
+    WorkingPointName = cms.string('MISTAGCSVSLV1L_WP')
+)
+
+BtagPerformanceESProducer_MISTAGCSVSLV1M = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGCSVSLV1M'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGCSVSLV1M_T'),
+    WorkingPointName = cms.string('MISTAGCSVSLV1M_WP')
+)
+
+BtagPerformanceESProducer_MISTAGCSVSLV1T = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGCSVSLV1T'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGCSVSLV1T_T'),
+    WorkingPointName = cms.string('MISTAGCSVSLV1T_WP')
+)
+
+BtagPerformanceESProducer_MISTAGCSVV1L = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGCSVV1L'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGCSVV1L_T'),
+    WorkingPointName = cms.string('MISTAGCSVV1L_WP')
+)
+
+BtagPerformanceESProducer_MISTAGCSVV1M = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGCSVV1M'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGCSVV1M_T'),
+    WorkingPointName = cms.string('MISTAGCSVV1M_WP')
+)
+
+BtagPerformanceESProducer_MISTAGCSVV1T = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGCSVV1T'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGCSVV1T_T'),
+    WorkingPointName = cms.string('MISTAGCSVV1T_WP')
+)
+
+BtagPerformanceESProducer_MISTAGJPL = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGJPL'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGJPL_T'),
+    WorkingPointName = cms.string('MISTAGJPL_WP')
+)
+
+BtagPerformanceESProducer_MISTAGJPM = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGJPM'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGJPM_T'),
+    WorkingPointName = cms.string('MISTAGJPM_WP')
+)
+
+BtagPerformanceESProducer_MISTAGJPT = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGJPT'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGJPT_T'),
+    WorkingPointName = cms.string('MISTAGJPT_WP')
+)
+
+BtagPerformanceESProducer_MISTAGTCHPT = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGTCHPT'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGTCHPT_T'),
+    WorkingPointName = cms.string('MISTAGTCHPT_WP')
+)

--- a/RecoBTag/PerformanceDB/python/measure/Btag_btagMuJetsWpNoTtbar.py
+++ b/RecoBTag/PerformanceDB/python/measure/Btag_btagMuJetsWpNoTtbar.py
@@ -1,0 +1,105 @@
+import FWCore.ParameterSet.Config as cms
+
+BtagPerformanceESProducer_MUJETSWPBTAGNOTTBARCSVL = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGNOTTBARCSVL'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGNOTTBARCSVL_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGNOTTBARCSVL_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGNOTTBARCSVM = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGNOTTBARCSVM'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGNOTTBARCSVM_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGNOTTBARCSVM_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGNOTTBARCSVT = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGNOTTBARCSVT'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGNOTTBARCSVT_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGNOTTBARCSVT_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGNOTTBARCSVV1L = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGNOTTBARCSVV1L'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGNOTTBARCSVV1L_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGNOTTBARCSVV1L_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGNOTTBARCSVV1M = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGNOTTBARCSVV1M'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGNOTTBARCSVV1M_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGNOTTBARCSVV1M_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGNOTTBARCSVV1T = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGNOTTBARCSVV1T'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGNOTTBARCSVV1T_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGNOTTBARCSVV1T_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGNOTTBARCSVSLV1L = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGNOTTBARCSVSLV1L'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGNOTTBARCSVSLV1L_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGNOTTBARCSVSLV1L_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGNOTTBARCSVSLV1M = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGNOTTBARCSVSLV1M'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGNOTTBARCSVSLV1M_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGNOTTBARCSVSLV1M_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGNOTTBARCSVSLV1T = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGNOTTBARCSVSLV1T'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGNOTTBARCSVSLV1T_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGNOTTBARCSVSLV1T_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGNOTTBARJPL = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGNOTTBARJPL'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGNOTTBARJPL_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGNOTTBARJPL_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGNOTTBARJPM = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGNOTTBARJPM'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGNOTTBARJPM_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGNOTTBARJPM_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGNOTTBARJPT = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGNOTTBARJPT'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGNOTTBARJPT_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGNOTTBARJPT_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGNOTTBARTCHPT = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGNOTTBARTCHPT'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGNOTTBARTCHPT_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGNOTTBARTCHPT_WP')
+)

--- a/RecoBTag/PerformanceDB/python/measure/Btag_btagMuJetsWpTtbar.py
+++ b/RecoBTag/PerformanceDB/python/measure/Btag_btagMuJetsWpTtbar.py
@@ -1,0 +1,81 @@
+import FWCore.ParameterSet.Config as cms
+
+BtagPerformanceESProducer_MUJETSWPBTAGTTBARCSVL = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGTTBARCSVL'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGTTBARCSVL_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGTTBARCSVL_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGTTBARCSVM = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGTTBARCSVM'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGTTBARCSVM_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGTTBARCSVM_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGTTBARCSVT = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGTTBARCSVT'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGTTBARCSVT_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGTTBARCSVT_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGTTBARCSVV1L = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGTTBARCSVV1L'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGTTBARCSVV1L_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGTTBARCSVV1L_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGTTBARCSVV1M = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGTTBARCSVV1M'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGTTBARCSVV1M_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGTTBARCSVV1M_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGTTBARCSVV1T = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGTTBARCSVV1T'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGTTBARCSVV1T_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGTTBARCSVV1T_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGTTBARCSVSLV1L = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGTTBARCSVSLV1L'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGTTBARCSVSLV1L_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGTTBARCSVSLV1L_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGTTBARCSVSLV1M = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGTTBARCSVSLV1M'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGTTBARCSVSLV1M_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGTTBARCSVSLV1M_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGTTBARCSVSLV1T = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGTTBARCSVSLV1T'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGTTBARCSVSLV1T_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGTTBARCSVSLV1T_WP')
+)
+
+BtagPerformanceESProducer_MUJETSWPBTAGTTBARTCHPT = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MUJETSWPBTAGTTBARTCHPT'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MUJETSWPBTAGTTBARTCHPT_T'),
+    WorkingPointName = cms.string('MUJETSWPBTAGTTBARTCHPT_WP')
+)

--- a/RecoBTag/PerformanceDB/python/measure/Btag_btagTtbarDiscrimWinter13.py
+++ b/RecoBTag/PerformanceDB/python/measure/Btag_btagTtbarDiscrimWinter13.py
@@ -1,0 +1,25 @@
+import FWCore.ParameterSet.Config as cms
+
+BtagPerformanceESProducer_TTBARDISCRIMBTAGCSV = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('TTBARDISCRIMBTAGCSV'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('TTBARDISCRIMBTAGCSV_T'),
+    WorkingPointName = cms.string('TTBARDISCRIMBTAGCSV_WP')
+)
+
+BtagPerformanceESProducer_TTBARDISCRIMBTAGJP = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('TTBARDISCRIMBTAGJP'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('TTBARDISCRIMBTAGJP_T'),
+    WorkingPointName = cms.string('TTBARDISCRIMBTAGJP_WP')
+)
+
+BtagPerformanceESProducer_TTBARDISCRIMBTAGTCHP = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('TTBARDISCRIMBTAGTCHP'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('TTBARDISCRIMBTAGTCHP_T'),
+    WorkingPointName = cms.string('TTBARDISCRIMBTAGTCHP_WP')
+)

--- a/RecoBTag/PerformanceDB/python/measure/Btag_btagTtbarWpWinter13.py
+++ b/RecoBTag/PerformanceDB/python/measure/Btag_btagTtbarWpWinter13.py
@@ -1,0 +1,57 @@
+import FWCore.ParameterSet.Config as cms
+
+BtagPerformanceESProducer_TTBARWPBTAGCSVL = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('TTBARWPBTAGCSVL'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('TTBARWPBTAGCSVL_T'),
+    WorkingPointName = cms.string('TTBARWPBTAGCSVL_WP')
+)
+
+BtagPerformanceESProducer_TTBARWPBTAGCSVM = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('TTBARWPBTAGCSVM'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('TTBARWPBTAGCSVM_T'),
+    WorkingPointName = cms.string('TTBARWPBTAGCSVM_WP')
+)
+
+BtagPerformanceESProducer_TTBARWPBTAGCSVT = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('TTBARWPBTAGCSVT'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('TTBARWPBTAGCSVT_T'),
+    WorkingPointName = cms.string('TTBARWPBTAGCSVT_WP')
+)
+
+BtagPerformanceESProducer_TTBARWPBTAGJPL = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('TTBARWPBTAGJPL'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('TTBARWPBTAGJPL_T'),
+    WorkingPointName = cms.string('TTBARWPBTAGJPL_WP')
+)
+
+BtagPerformanceESProducer_TTBARWPBTAGJPM = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('TTBARWPBTAGJPM'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('TTBARWPBTAGJPM_T'),
+    WorkingPointName = cms.string('TTBARWPBTAGJPM_WP')
+)
+
+BtagPerformanceESProducer_TTBARWPBTAGJPT = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('TTBARWPBTAGJPT'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('TTBARWPBTAGJPT_T'),
+    WorkingPointName = cms.string('TTBARWPBTAGJPT_WP')
+)
+
+BtagPerformanceESProducer_TTBARWPBTAGTCHPT = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('TTBARWPBTAGTCHPT'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('TTBARWPBTAGTCHPT_T'),
+    WorkingPointName = cms.string('TTBARWPBTAGTCHPT_WP')
+)

--- a/RecoBTag/PerformanceDB/python/measure/Pool_btagMistagWinter13.py
+++ b/RecoBTag/PerformanceDB/python/measure/Pool_btagMistagWinter13.py
@@ -1,0 +1,105 @@
+import FWCore.ParameterSet.Config as cms
+
+BtagPerformanceESProducer_MISTAGCSVL = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGCSVL'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGCSVL_T'),
+    WorkingPointName = cms.string('MISTAGCSVL_WP')
+)
+
+BtagPerformanceESProducer_MISTAGCSVM = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGCSVM'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGCSVM_T'),
+    WorkingPointName = cms.string('MISTAGCSVM_WP')
+)
+
+BtagPerformanceESProducer_MISTAGCSVT = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGCSVT'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGCSVT_T'),
+    WorkingPointName = cms.string('MISTAGCSVT_WP')
+)
+
+BtagPerformanceESProducer_MISTAGCSVSLV1L = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGCSVSLV1L'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGCSVSLV1L_T'),
+    WorkingPointName = cms.string('MISTAGCSVSLV1L_WP')
+)
+
+BtagPerformanceESProducer_MISTAGCSVSLV1M = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGCSVSLV1M'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGCSVSLV1M_T'),
+    WorkingPointName = cms.string('MISTAGCSVSLV1M_WP')
+)
+
+BtagPerformanceESProducer_MISTAGCSVSLV1T = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGCSVSLV1T'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGCSVSLV1T_T'),
+    WorkingPointName = cms.string('MISTAGCSVSLV1T_WP')
+)
+
+BtagPerformanceESProducer_MISTAGCSVV1L = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGCSVV1L'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGCSVV1L_T'),
+    WorkingPointName = cms.string('MISTAGCSVV1L_WP')
+)
+
+BtagPerformanceESProducer_MISTAGCSVV1M = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGCSVV1M'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGCSVV1M_T'),
+    WorkingPointName = cms.string('MISTAGCSVV1M_WP')
+)
+
+BtagPerformanceESProducer_MISTAGCSVV1T = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGCSVV1T'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGCSVV1T_T'),
+    WorkingPointName = cms.string('MISTAGCSVV1T_WP')
+)
+
+BtagPerformanceESProducer_MISTAGJPL = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGJPL'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGJPL_T'),
+    WorkingPointName = cms.string('MISTAGJPL_WP')
+)
+
+BtagPerformanceESProducer_MISTAGJPM = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGJPM'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGJPM_T'),
+    WorkingPointName = cms.string('MISTAGJPM_WP')
+)
+
+BtagPerformanceESProducer_MISTAGJPT = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGJPT'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGJPT_T'),
+    WorkingPointName = cms.string('MISTAGJPT_WP')
+)
+
+BtagPerformanceESProducer_MISTAGTCHPT = cms.ESProducer("BtagPerformanceESProducer",
+# this is what it makes available
+    ComponentName = cms.string('MISTAGTCHPT'),
+# this is where it gets the payload from                                                
+    PayloadName = cms.string('MISTAGTCHPT_T'),
+    WorkingPointName = cms.string('MISTAGTCHPT_WP')
+)

--- a/RecoBTag/PerformanceDB/python/measure/Pool_btagMuJetsWpNoTtbar.py
+++ b/RecoBTag/PerformanceDB/python/measure/Pool_btagMuJetsWpNoTtbar.py
@@ -1,0 +1,142 @@
+import FWCore.ParameterSet.Config as cms
+
+from CondCore.DBCommon.CondDBCommon_cfi import *
+
+PoolDBESSourcebtagMuJetsWpNoTtbar = cms.ESSource("PoolDBESSource",
+                              CondDBCommon,
+                              toGet = cms.VPSet(
+    #
+    # working points
+    #
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGNOTTBARCSVL_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARCSVL_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGNOTTBARCSVL_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARCSVL_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGNOTTBARCSVM_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARCSVM_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGNOTTBARCSVM_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARCSVM_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGNOTTBARCSVT_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARCSVT_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGNOTTBARCSVT_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARCSVT_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGNOTTBARCSVV1L_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARCSVV1L_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGNOTTBARCSVV1L_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARCSVV1L_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGNOTTBARCSVV1M_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARCSVV1M_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGNOTTBARCSVV1M_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARCSVV1M_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGNOTTBARCSVV1T_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARCSVV1T_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGNOTTBARCSVV1T_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARCSVV1T_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGNOTTBARCSVSLV1L_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARCSVSLV1L_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGNOTTBARCSVSLV1L_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARCSVSLV1L_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGNOTTBARCSVSLV1M_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARCSVSLV1M_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGNOTTBARCSVSLV1M_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARCSVSLV1M_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGNOTTBARCSVSLV1T_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARCSVSLV1T_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGNOTTBARCSVSLV1T_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARCSVSLV1T_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGNOTTBARJPL_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARJPL_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGNOTTBARJPL_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARJPL_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGNOTTBARJPM_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARJPM_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGNOTTBARJPM_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARJPM_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGNOTTBARJPT_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARJPT_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGNOTTBARJPT_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARJPT_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGNOTTBARTCHPT_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARTCHPT_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGNOTTBARTCHPT_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGNOTTBARTCHPT_WP')
+    ),
+))
+PoolDBESSourcebtagMuJetsWpNoTtbar.connect = 'frontier://FrontierProd/CMS_COND_PAT_000'

--- a/RecoBTag/PerformanceDB/python/measure/Pool_btagMuJetsWpTtbar.py
+++ b/RecoBTag/PerformanceDB/python/measure/Pool_btagMuJetsWpTtbar.py
@@ -1,0 +1,112 @@
+import FWCore.ParameterSet.Config as cms
+
+from CondCore.DBCommon.CondDBCommon_cfi import *
+
+PoolDBESSourcebtagMuJetsWpTtbar = cms.ESSource("PoolDBESSource",
+                              CondDBCommon,
+                              toGet = cms.VPSet(
+    #
+    # working points
+    #
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGTTBARCSVL_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARCSVL_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGTTBARCSVL_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARCSVL_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGTTBARCSVM_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARCSVM_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGTTBARCSVM_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARCSVM_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGTTBARCSVT_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARCSVT_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGTTBARCSVT_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARCSVT_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGTTBARCSVV1L_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARCSVV1L_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGTTBARCSVV1L_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARCSVV1L_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGTTBARCSVV1M_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARCSVV1M_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGTTBARCSVV1M_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARCSVV1M_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGTTBARCSVV1T_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARCSVV1T_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGTTBARCSVV1T_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARCSVV1T_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGTTBARCSVSLV1L_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARCSVSLV1L_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGTTBARCSVSLV1L_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARCSVSLV1L_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGTTBARCSVSLV1M_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARCSVSLV1M_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGTTBARCSVSLV1M_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARCSVSLV1M_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGTTBARCSVSLV1T_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARCSVSLV1T_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGTTBARCSVSLV1T_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARCSVSLV1T_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_MUJETSWPBTAGTTBARTCHPT_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARTCHPT_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_MUJETSWPBTAGTTBARTCHPT_v10_offline'),
+    label = cms.untracked.string('MUJETSWPBTAGTTBARTCHPT_WP')
+    ),
+))
+PoolDBESSourcebtagMuJetsWpTtbar.connect = 'frontier://FrontierProd/CMS_COND_PAT_000'

--- a/RecoBTag/PerformanceDB/python/measure/Pool_btagTtbarDiscrimWinter13.py
+++ b/RecoBTag/PerformanceDB/python/measure/Pool_btagTtbarDiscrimWinter13.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+from CondCore.DBCommon.CondDBCommon_cfi import *
+
+PoolDBESSourcebtagTtbarDiscrim = cms.ESSource("PoolDBESSource",
+                              CondDBCommon,
+                              toGet = cms.VPSet(
+    #
+    # working points
+    #
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_TTBARDISCRIMBTAGCSV_v10_offline'),
+    label = cms.untracked.string('TTBARDISCRIMBTAGCSV_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_TTBARDISCRIMBTAGCSV_v10_offline'),
+    label = cms.untracked.string('TTBARDISCRIMBTAGCSV_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_TTBARDISCRIMBTAGJP_v10_offline'),
+    label = cms.untracked.string('TTBARDISCRIMBTAGJP_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_TTBARDISCRIMBTAGJP_v10_offline'),
+    label = cms.untracked.string('TTBARDISCRIMBTAGJP_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromBinnedTFormula_TTBARDISCRIMBTAGTCHP_v10_offline'),
+    label = cms.untracked.string('TTBARDISCRIMBTAGTCHP_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_TTBARDISCRIMBTAGTCHP_v10_offline'),
+    label = cms.untracked.string('TTBARDISCRIMBTAGTCHP_WP')
+    ),
+))
+PoolDBESSourcebtagTtbarDiscrim.connect = 'frontier://FrontierProd/CMS_COND_PAT_000'

--- a/RecoBTag/PerformanceDB/python/measure/Pool_btagTtbarWpWinter13.py
+++ b/RecoBTag/PerformanceDB/python/measure/Pool_btagTtbarWpWinter13.py
@@ -1,0 +1,82 @@
+import FWCore.ParameterSet.Config as cms
+
+from CondCore.DBCommon.CondDBCommon_cfi import *
+
+PoolDBESSourcebtagTtbarWp = cms.ESSource("PoolDBESSource",
+                              CondDBCommon,
+                              toGet = cms.VPSet(
+    #
+    # working points
+    #
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromTable_TTBARWPBTAGCSVL_v10_offline'),
+    label = cms.untracked.string('TTBARWPBTAGCSVL_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_TTBARWPBTAGCSVL_v10_offline'),
+    label = cms.untracked.string('TTBARWPBTAGCSVL_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromTable_TTBARWPBTAGCSVM_v10_offline'),
+    label = cms.untracked.string('TTBARWPBTAGCSVM_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_TTBARWPBTAGCSVM_v10_offline'),
+    label = cms.untracked.string('TTBARWPBTAGCSVM_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromTable_TTBARWPBTAGCSVT_v10_offline'),
+    label = cms.untracked.string('TTBARWPBTAGCSVT_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_TTBARWPBTAGCSVT_v10_offline'),
+    label = cms.untracked.string('TTBARWPBTAGCSVT_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromTable_TTBARWPBTAGJPL_v10_offline'),
+    label = cms.untracked.string('TTBARWPBTAGJPL_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_TTBARWPBTAGJPL_v10_offline'),
+    label = cms.untracked.string('TTBARWPBTAGJPL_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromTable_TTBARWPBTAGJPM_v10_offline'),
+    label = cms.untracked.string('TTBARWPBTAGJPM_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_TTBARWPBTAGJPM_v10_offline'),
+    label = cms.untracked.string('TTBARWPBTAGJPM_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromTable_TTBARWPBTAGJPT_v10_offline'),
+    label = cms.untracked.string('TTBARWPBTAGJPT_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_TTBARWPBTAGJPT_v10_offline'),
+    label = cms.untracked.string('TTBARWPBTAGJPT_WP')
+    ),
+    cms.PSet(
+    record = cms.string('PerformancePayloadRecord'),
+    tag = cms.string('PerformancePayloadFromTable_TTBARWPBTAGTCHPT_v10_offline'),
+    label = cms.untracked.string('TTBARWPBTAGTCHPT_T')
+    ),
+    cms.PSet(
+    record = cms.string('PerformanceWPRecord'),
+    tag = cms.string('PerformanceWorkingPoint_TTBARWPBTAGTCHPT_v10_offline'),
+    label = cms.untracked.string('TTBARWPBTAGTCHPT_WP')
+    ),
+))
+PoolDBESSourcebtagTtbarWp.connect = 'frontier://FrontierProd/CMS_COND_PAT_000'


### PR DESCRIPTION
This PR imports missing Winter13 Btag performance db from CVS ( RecoBTag/PerformanceDB, V01-03-21) . PR for 5.3.x and 6.2.x will follow.
