### PR TITLE
interface/FBaseSimEvent.icc

### DIFF
--- a/FastSimulation/Event/interface/FBaseSimEvent.icc
+++ b/FastSimulation/Event/interface/FBaseSimEvent.icc
@@ -2,17 +2,26 @@
 #include "FastSimulation/Event/interface/FSimVertex.h"
 #include "FastSimDataFormats/NuclearInteractions/interface/FSimVertexType.h"
 
-static FSimTrack oTrack;
 inline FSimTrack& FBaseSimEvent::track(int i) const { 
-  return (i>=0 && i<(int)nTracks()) ? (*theSimTracks)[i] : oTrack; }
+  if (i < 0 || i>=(int)nTracks()){
+    throw cms::Exception("FastSim") << "Index for FSimTracks out of range, please contact FastSim developers"<< std::endl;
+  }
+  return (*theSimTracks)[i];
+}
 
-static FSimVertex oVertex;
 inline FSimVertex& FBaseSimEvent::vertex(int i) const { 
-  return (i>=0 && i<(int)nVertices()) ? (*theSimVertices)[i] : oVertex; }
+  if (i < 0 || i>=(int)nVertices()){
+    throw cms::Exception("FastSim") << "Index for FSimVertex out of range, please contact FastSim developers"<< std::endl;
+  }
+  return (*theSimVertices)[i];
+}
 
-static FSimVertexType oVertexType;
-inline FSimVertexType& FBaseSimEvent::vertexType(int i) const { 
-  return (i>=0 && i<(int)nVertices()) ? (*theFSimVerticesType)[i] : oVertexType; }
+inline FSimVertexType& FBaseSimEvent::vertexType(int i) const {
+  if (i < 0 || i >=(int)nVertices()){
+    throw cms::Exception("FastSim") << "Index for FSimVertexType out of range, please contact FastSim developers"<< std::endl;
+  }
+  return (*theFSimVerticesType)[i]; 
+}
 
 inline const SimTrack& FBaseSimEvent::embdTrack(int i) const { 
   return (*theSimTracks)[i].simTrack(); }

--- a/FastSimulation/Event/interface/FSimTrack.icc
+++ b/FastSimulation/Event/interface/FSimTrack.icc
@@ -21,15 +21,16 @@ inline const std::vector<int>& FSimTrack::daughters() const {
 
 inline bool FSimTrack::noEndVertex() const { 
 
+  // The particle either has no end vertex index
+  if(endv_ < 0)
+     return true;
+
+  // or it's an electron/muon that has just Brem'ed, but continues its way
+  // ... but not those intermediate e/mu PYTHIA entries with prompt Brem
   bool bremOutOfPipe = true;
   if( (mom_->vertex(endv_)).position().Perp2() < 1.0 )  bremOutOfPipe = false;
-
   return 
-    // The particle either has no end vertex index
-    endv_ == -1 || 
-    // or it's an electron/muon that has just Brem'ed, but continues its way
-    // ... but not those intermediate e/mu PYTHIA entries with prompt Brem
-    ( (abs(type())==11 || abs(type())==13) && 
+      ( (abs(type())==11 || abs(type())==13) && 
       bremOutOfPipe &&
       endVertex().nDaughters()>0 && 
       endVertex().daughter(endVertex().nDaughters()-1).type()==22); 

--- a/FastSimulation/Event/src/FSimEvent.cc
+++ b/FastSimulation/Event/src/FSimEvent.cc
@@ -73,7 +73,7 @@ FSimEvent::load(edm::SimTrackContainer & c, edm::SimTrackContainer & m) const
 	 fabs(t.momentum().eta()) < 3.0 &&
 	 track(i).noEndVertex() ) {
       // Actually save the muon mother (and the attached muon) in case
-      if ( track(i).mother().closestDaughterId() == (int)i ) {
+      if ( !track(i).noMother() && track(i).mother().closestDaughterId() == (int)i ) {
 	const SimTrack& T = embdTrack(track(i).mother().id());
 	m.push_back(T);
       } 


### PR DESCRIPTION
I removed the definition of static FSimTrack, FSimVertex and FSimVertexType.
These statics used to be returned by functions track(int i), vertex(int i), vertexType(int i) in case the index i was out of range.
Now instead an error is thrown.
To avoid indices out of range, the following changes were made:

interface/FSimTrack.icc

The function FSimTrack::noEndVertex() now first of all checks if FSimTrack has an end vertex
(index of end vertex >= 0)
associated and returns false if this is not the case.

src/FSimEvent.cc

The function FSimEvent::load(edm::SimTrackContainer & c, edm::SimTrackContainer & m)
now verifies wether a track has a mother (index mother >= 0)
before evaluating the properties of the mother.

Tests:
generated 1000 ttbar events, didn't crash
