### PR TITLE
Added reset method to AtomicPtrCache

### DIFF
--- a/DataFormats/Common/interface/AtomicPtrCache.h
+++ b/DataFormats/Common/interface/AtomicPtrCache.h
@@ -71,6 +71,9 @@ namespace edm {
     
     T* load();
     
+    ///unsets the value and deletes the memory
+    void reset();
+    
   private:
     
     // ---------- member data --------------------------------
@@ -107,7 +110,7 @@ namespace edm {
         m_data.store( new T{*ptr}, std::memory_order_release);
       }
     } else {
-      delete m_data.exchange(nullptr);
+      delete m_data.exchange(nullptr, std::memory_order_acq_rel);
     }
     return *this;
   }
@@ -136,6 +139,9 @@ namespace edm {
     }
     return retValue;
   }
+
+  template<typename T>
+  inline void AtomicPtrCache<T>::reset() { delete m_data.exchange(nullptr,std::memory_order_acq_rel);}
 
 #endif
 }

--- a/DataFormats/Common/test/atomicptrcache_t.cppunit.cc
+++ b/DataFormats/Common/test/atomicptrcache_t.cppunit.cc
@@ -33,6 +33,9 @@ testAtomicPtrCache::check()
     cache.set(std::move(p));
     CPPUNIT_ASSERT(true == cache.isSet());
     CPPUNIT_ASSERT(cache->size() == values.size());
+    
+    cache.reset();
+    CPPUNIT_ASSERT(false == cache.isSet());
   }
   
   {


### PR DESCRIPTION
After using AtomicPtrCache in real code, we found that a dedicated reset() method makes the code cleaner. Previously one had to create a temporary empty AtomicPtrCache and assign it to the old variable in order to reset.
