### PR TITLE
static data member is not thread safe and doesn't need to be static

### DIFF
--- a/TrackingTools/GeomPropagators/interface/SmartPropagator.h
+++ b/TrackingTools/GeomPropagators/interface/SmartPropagator.h
@@ -140,12 +140,12 @@ class SmartPropagator GCC11_FINAL : public Propagator {
 
   private:
     ///build the tracker volume
-  static void initTkVolume(float epsilon);
+    void initTkVolume(float epsilon);
 
     Propagator* theTkProp;
     Propagator* theGenProp;
     const MagneticField* theField;
-    static ReferenceCountingPointer<Cylinder> & theTkVolume();
+    ReferenceCountingPointer<Cylinder> theTkVolume;
 
   protected:
 

--- a/TrackingTools/GeomPropagators/src/SmartPropagator.cc
+++ b/TrackingTools/GeomPropagators/src/SmartPropagator.cc
@@ -31,10 +31,6 @@
 /* ====================================================================== */
 
 /* static member */
-ReferenceCountingPointer<BoundCylinder> & SmartPropagator::theTkVolume() {
-  static ReferenceCountingPointer<BoundCylinder> local=0;
-  return local;
-}
 
 
 
@@ -43,7 +39,7 @@ SmartPropagator::SmartPropagator(const Propagator* aTkProp, const Propagator* aG
                                  PropagationDirection dir, float epsilon) :
   Propagator(dir), theTkProp(aTkProp->clone()), theGenProp(aGenProp->clone()), theField(field) { 
 
-  if (theTkVolume()==0) initTkVolume(epsilon);
+  initTkVolume(epsilon);
 
 }
 
@@ -52,7 +48,7 @@ SmartPropagator::SmartPropagator(const Propagator& aTkProp, const Propagator& aG
                                  PropagationDirection dir, float epsilon) :
   Propagator(dir), theTkProp(aTkProp.clone()), theGenProp(aGenProp.clone()), theField(field) {
 
-  if (theTkVolume()==0) initTkVolume(epsilon);
+  initTkVolume(epsilon);
 
 }
 
@@ -66,7 +62,7 @@ SmartPropagator::SmartPropagator(const SmartPropagator& aProp) :
 
     //SL since it's a copy constructor, then the TkVolume has been already
     //initialized
-    //if (theTkVolume==0) initTkVolume(epsilon);
+    // initTkVolume(epsilon);
 
   }
 
@@ -94,7 +90,7 @@ void SmartPropagator::initTkVolume(float epsilon) {
   Surface::PositionType pos(0,0,0); // centered at the global origin
   Surface::RotationType rot; // unit matrix - barrel cylinder orientation
 
-  theTkVolume() = Cylinder::build(radius, pos, rot, new SimpleCylinderBounds(r_in, r_out, z_min, z_max));
+  theTkVolume = Cylinder::build(radius, pos, rot, new SimpleCylinderBounds(r_in, r_out, z_min, z_max));
 
 }
 


### PR DESCRIPTION
The class SmartPropagator has a non-const static data member that should not be static, for several reasons:
1) it's not thread safe.
2) If the constructor gets called multiple times with different values of the 'epsilon' argument,  the new value will not be used.  This is a bug.  In CMSSW at the moment, it is always called with the same value, but it still is a bug.

This pull request makes the data member non-static.
