### PR TITLE
Muon dqm fix missing histos

### DIFF
--- a/DQMOffline/Muon/interface/MuonPFAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonPFAnalyzer.h
@@ -82,10 +82,10 @@ private:
 				       edm::Handle<reco::BeamSpot> &beamSpot );
 
 
-  edm::InputTag theGenLabel;
-  edm::InputTag theRecoLabel;
-  edm::InputTag theVertexLabel;
-  edm::InputTag theBeamSpotLabel;
+  edm::EDGetTokenT<reco::GenParticleCollection> theGenLabel_;
+  edm::EDGetTokenT<reco::MuonCollection>        theRecoLabel_;
+  edm::EDGetTokenT<reco::VertexCollection>      theVertexLabel_;
+  edm::EDGetTokenT<reco::BeamSpot>              theBeamSpotLabel_;
 
   std::vector<std::string> theMuonKinds;
 

--- a/DQMOffline/Muon/python/muonAnalyzer_cff.py
+++ b/DQMOffline/Muon/python/muonAnalyzer_cff.py
@@ -8,6 +8,7 @@ from DQMOffline.Muon.muonRecoAnalyzer_cfi import *
 from DQMOffline.Muon.muonEnergyDepositAnalyzer_cfi import *
 from DQMOffline.Muon.segmentTrackAnalyzer_cfi import *
 from DQMOffline.Muon.muonSeedsAnalyzer_cfi import *
+from DQMOffline.Muon.muonPFAnalyzer_cfi import *
 
 muonAnalyzer = cms.Sequence(muonEnergyDepositAnalyzer*
                             muonSeedsAnalyzer*
@@ -17,4 +18,15 @@ muonAnalyzer = cms.Sequence(muonEnergyDepositAnalyzer*
                             muonKinVsEtaAnalyzer*
                             diMuonHistos*
                             muonEfficiencyAnalyzer*
+                            muonPFsequence*
                             muonRecoOneHLT)
+
+muonAnalyzer_noHLT = cms.Sequence(muonEnergyDepositAnalyzer*
+                                  muonSeedsAnalyzer*
+                                  muonRecoAnalyzer*
+                                  glbMuonSegmentAnalyzer*
+                                  staMuonSegmentAnalyzer*
+                                  muonKinVsEtaAnalyzer*
+                                  diMuonHistos*
+                                  muonEfficiencyAnalyzer*
+                                  muonPFsequence)

--- a/DQMOffline/Muon/python/muonMonitors_cff.py
+++ b/DQMOffline/Muon/python/muonMonitors_cff.py
@@ -20,9 +20,13 @@ dqmInfoMuons = cms.EDAnalyzer("DQMEventInfo",
 
 muonTrackAnalyzers = cms.Sequence(MonitorTrackSTAMuons*MonitorTrackGLBMuons)
 
-#muonMonitors = cms.Sequence(muonTrackAnalyzers*dtSegmentsMonitor*cscMonitor*muonAnalyzer*muonIdDQM*dqmInfoMuons*muIsoDQM_seq)
-muonMonitors = cms.Sequence(muonTrackAnalyzers*dtSegmentsMonitor*muonAnalyzer*muonIdDQM*dqmInfoMuons*muIsoDQM_seq)
-
+muonMonitors = cms.Sequence(muonTrackAnalyzers*
+                            dtSegmentsMonitor*
+##                            cscMonitor*
+                            muonAnalyzer*
+                            muonIdDQM*
+                            dqmInfoMuons*
+                            muIsoDQM_seq)
 
 muonMonitorsAndQualityTests = cms.Sequence(muonMonitors*muonQualityTests)
 

--- a/DQMOffline/Muon/python/muonMonitors_cff.py
+++ b/DQMOffline/Muon/python/muonMonitors_cff.py
@@ -22,7 +22,7 @@ muonTrackAnalyzers = cms.Sequence(MonitorTrackSTAMuons*MonitorTrackGLBMuons)
 
 muonMonitors = cms.Sequence(muonTrackAnalyzers*
                             dtSegmentsMonitor*
-##                            cscMonitor*
+                            cscMonitor*
                             muonAnalyzer*
                             muonIdDQM*
                             dqmInfoMuons*

--- a/DQMOffline/Muon/python/muonPFAnalyzer_cfi.py
+++ b/DQMOffline/Muon/python/muonPFAnalyzer_cfi.py
@@ -1,19 +1,18 @@
 import FWCore.ParameterSet.Config as cms
 
-
 muonPFsequence = cms.EDAnalyzer("MuonPFAnalyzer",
-    inputTagMuonReco     = cms.InputTag("muons"),
-    inputTagGenParticles = cms.InputTag("genParticles"),
-    inputTagVertex       = cms.InputTag("offlinePrimaryVertices"),
-    inputTagBeamSpot     = cms.InputTag("offlineBeamSpot"),
- 
-    runOnMC = cms.bool(False),
-    folder = cms.string("Muons/MuonPFAnalyzer/"),
-
-    recoGenDeltaR   = cms.double(0.1),
-    relCombIsoCut   = cms.double(0.15),
-    highPtThreshold = cms.double(200.)
-    )
+                                inputTagMuonReco     = cms.InputTag("muons"),
+                                inputTagGenParticles = cms.InputTag("genParticles"),
+                                inputTagVertex       = cms.InputTag("offlinePrimaryVertices"),
+                                inputTagBeamSpot     = cms.InputTag("offlineBeamSpot"),
+                                
+                                runOnMC = cms.bool(False),
+                                folder = cms.string("Muons/MuonPFAnalyzer/"),
+                                
+                                recoGenDeltaR   = cms.double(0.1),
+                                relCombIsoCut   = cms.double(0.15),
+                                highPtThreshold = cms.double(200.)
+                                )
 
 
 

--- a/DQMOffline/Muon/python/muonQualityTests_cff.py
+++ b/DQMOffline/Muon/python/muonQualityTests_cff.py
@@ -27,8 +27,23 @@ muonClientsQualityTests = cms.EDAnalyzer("QualityTester",
     qtList = cms.untracked.FileInPath('DQMOffline/Muon/data/QualityTests2.xml')
 )
 
-cosmicMuonQualityTests = cms.Sequence(ClientTrackEfficiencyTkTracks*ClientTrackEfficiencySTACosmicMuons*muonSourcesQualityTests*muTrackResidualsTest*muRecoTest*muonClientsQualityTests*muonComp2RefQualityTests*muonComp2RefKolmoQualityTests*muonCosmicTestSummary)
+cosmicMuonQualityTests = cms.Sequence(ClientTrackEfficiencyTkTracks*
+                                      ClientTrackEfficiencySTACosmicMuons*
+                                      muonSourcesQualityTests*
+                                      muTrackResidualsTest*
+                                      muRecoTest*
+                                      muonClientsQualityTests*
+                                      muonComp2RefQualityTests*
+                                      muonComp2RefKolmoQualityTests*
+                                      muonCosmicTestSummary)
 
-muonQualityTests = cms.Sequence(muonSourcesQualityTests*muTrackResidualsTest*effPlotter*muRecoTest*muonClientsQualityTests*muonComp2RefQualityTests*muonComp2RefKolmoQualityTests*muonTestSummary)
+muonQualityTests = cms.Sequence(muonSourcesQualityTests*
+                                muTrackResidualsTest*
+                                effPlotter*
+                                muRecoTest*
+                                muonClientsQualityTests*
+                                muonComp2RefQualityTests*
+                                muonComp2RefKolmoQualityTests*
+                                muonTestSummary)
 
 

--- a/DQMOffline/Muon/python/muonRecoTest_cfi.py
+++ b/DQMOffline/Muon/python/muonRecoTest_cfi.py
@@ -1,17 +1,17 @@
 import FWCore.ParameterSet.Config as cms
 
 muRecoTest = cms.EDAnalyzer("MuonRecoTest",
-    phiMin = cms.double(-3.2),
-    # number of luminosity block to analyse
-    diagnosticPrescale = cms.untracked.int32(1),
-    etaMin = cms.double(-3.0),
-    efficiencyTestName = cms.untracked.string('EfficiencyInRange'),
-    # histo binning
-    etaBin = cms.int32(100),
-    phiBin = cms.int32(100),
-    etaMax = cms.double(3.0),
-    phiMax = cms.double(3.2)
-)
+                            phiMin = cms.double(-3.2),
+                            # number of luminosity block to analyse
+                            diagnosticPrescale = cms.untracked.int32(1),
+                            etaMin = cms.double(-3.0),
+                            efficiencyTestName = cms.untracked.string('EfficiencyInRange'),
+                            # histo binning
+                            etaBin = cms.int32(100),
+                            phiBin = cms.int32(100),
+                            etaMax = cms.double(3.0),
+                            phiMax = cms.double(3.2)
+                            )
 
 
 

--- a/DQMOffline/Muon/src/DTSegmentsTask.cc
+++ b/DQMOffline/Muon/src/DTSegmentsTask.cc
@@ -31,8 +31,6 @@ DTSegmentsTask::DTSegmentsTask(const edm::ParameterSet& pset) {
 
   // Get the DQM needed services
   theDbe = edm::Service<DQMStore>().operator->();
-  theDbe->setVerbose(1);
-  theDbe->setCurrentFolder("Muons/DTSegmentsMonitor");
   
   parameters = pset;
   
@@ -50,6 +48,10 @@ void DTSegmentsTask::beginJob(void){
 
 void DTSegmentsTask::beginRun(const edm::Run& irun, const edm::EventSetup& isetup){
   
+  theDbe->setVerbose(1);
+  theDbe->cd();
+  theDbe->setCurrentFolder("Muons/DTSegmentsMonitor");
+
   // histos for phi segments
   phiHistos.push_back(theDbe->book2D("phiSegments_numHitsVsWheel", "phiSegments_numHitsVsWheel", 5, -2.5, 2.5, 20, 0, 20));
   phiHistos[0]->setBinLabel(1,"W-2",1);

--- a/DQMOffline/Muon/src/DiMuonHistograms.cc
+++ b/DQMOffline/Muon/src/DiMuonHistograms.cc
@@ -35,7 +35,6 @@ DiMuonHistograms::DiMuonHistograms(const edm::ParameterSet& pSet){
   parameters = pSet;
 
   theDbe = edm::Service<DQMStore>().operator->();
-  theDbe->setCurrentFolder("Muons/DiMuonHistograms");  
   
   // declare consumes:
   theMuonCollectionLabel_ = consumes<reco::MuonCollection>  (parameters.getParameter<edm::InputTag>("MuonCollection"));
@@ -54,6 +53,9 @@ void DiMuonHistograms::beginJob(){
 void DiMuonHistograms::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
   LogTrace(metname)<<"[DiMuonHistograms] beginRun()";
   
+  theDbe->cd();
+  theDbe->setCurrentFolder("Muons/DiMuonHistograms");  
+
   etaBin = parameters.getParameter<int>("etaBin");
   etaBBin = parameters.getParameter<int>("etaBBin");
   etaEBin = parameters.getParameter<int>("etaEBin");

--- a/DQMOffline/Muon/src/EfficiencyAnalyzer.cc
+++ b/DQMOffline/Muon/src/EfficiencyAnalyzer.cc
@@ -31,7 +31,6 @@ EfficiencyAnalyzer::EfficiencyAnalyzer(const edm::ParameterSet& pSet){
   
   theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
   theDbe = edm::Service<DQMStore>().operator->();
-  theDbe->setCurrentFolder("Muons/EfficiencyAnalyzer");  
 
   // DATA 
   theMuonCollectionLabel_  = consumes<reco::MuonCollection>  (parameters.getParameter<edm::InputTag>("MuonCollection"));
@@ -52,6 +51,9 @@ void EfficiencyAnalyzer::beginJob(){
 
 void EfficiencyAnalyzer::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup){ 
   metname = "EfficiencyAnalyzer";
+  
+  theDbe->cd();
+  theDbe->setCurrentFolder("Muons/EfficiencyAnalyzer");  
 
   //Vertex requirements
   doPVCheck_ = parameters.getParameter<bool>("doPrimaryVertexCheck");
@@ -74,14 +76,14 @@ void EfficiencyAnalyzer::beginRun(const edm::Run& iRun, const edm::EventSetup& i
 
   test_TightMu_Minv  = theDbe->book1D("test_TightMu_Minv"  ,"Minv",50,70,110);
 
-  h_allProbes_pt = theDbe->book1D("allProbes_pt","All Probes Pt", ptBin_, ptMin_, ptMax_);
-  h_allProbes_EB_pt = theDbe->book1D("allProbes_EB_pt","Barrel: all Probes Pt", ptBin_, ptMin_, ptMax_);
-  h_allProbes_EE_pt = theDbe->book1D("allProbes_EE_pt","Endcap: all Probes Pt", ptBin_, ptMin_, ptMax_);
-  h_allProbes_eta = theDbe->book1D("allProbes_eta","All Probes Eta", etaBin_, etaMin_, etaMax_);
+  h_allProbes_pt     = theDbe->book1D("allProbes_pt","All Probes Pt",              ptBin_, ptMin_, ptMax_);
+  h_allProbes_EB_pt  = theDbe->book1D("allProbes_EB_pt","Barrel: all Probes Pt",   ptBin_, ptMin_, ptMax_);
+  h_allProbes_EE_pt  = theDbe->book1D("allProbes_EE_pt","Endcap: all Probes Pt",   ptBin_, ptMin_, ptMax_);
+  h_allProbes_eta    = theDbe->book1D("allProbes_eta","All Probes Eta",            etaBin_, etaMin_, etaMax_);
   h_allProbes_hp_eta = theDbe->book1D("allProbes_hp_eta","High Pt all Probes Eta", etaBin_, etaMin_, etaMax_);
-  h_allProbes_phi = theDbe->book1D("allProbes_phi","All Probes Phi", phiBin_, phiMin_, phiMax_);
-
-  h_allProbes_TightMu_pt = theDbe->book1D("allProbes_TightMu_pt","All TightMu Probes Pt", ptBin_, ptMin_, ptMax_);
+  h_allProbes_phi    = theDbe->book1D("allProbes_phi","All Probes Phi",            phiBin_, phiMin_, phiMax_);
+  
+  h_allProbes_TightMu_pt    = theDbe->book1D("allProbes_TightMu_pt","All TightMu Probes Pt", ptBin_, ptMin_, ptMax_);
   h_allProbes_EB_TightMu_pt = theDbe->book1D("allProbes_EB_TightMu_pt","Barrel: all TightMu Probes Pt", ptBin_, ptMin_, ptMax_);
   h_allProbes_EE_TightMu_pt = theDbe->book1D("allProbes_EE_TightMu_pt","Endcap: all TightMu Probes Pt", ptBin_, ptMin_, ptMax_);
   h_allProbes_TightMu_nVtx = theDbe->book1D("allProbes_TightMu_nVtx","All Probes (TightMu) nVtx", vtxBin_, vtxMin_, vtxMax_);

--- a/DQMOffline/Muon/src/MuonEnergyDepositAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonEnergyDepositAnalyzer.cc
@@ -24,6 +24,8 @@ using namespace edm;
 MuonEnergyDepositAnalyzer::MuonEnergyDepositAnalyzer(const edm::ParameterSet& pSet){
   parameters = pSet;
 
+  theDbe = edm::Service<DQMStore>().operator->();
+  
   // the services
   theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
 
@@ -37,14 +39,14 @@ MuonEnergyDepositAnalyzer::~MuonEnergyDepositAnalyzer() {
 
 
 void MuonEnergyDepositAnalyzer::beginJob(){
-  metname = "muEnergyDepositAnalyzer";
-  
-  theDbe = edm::Service<DQMStore>().operator->();
-  theDbe->setCurrentFolder("Muons/MuonEnergyDepositAnalyzer");
-
+  metname = "muEnergyDepositAnalyzer";  
 }
+
 void MuonEnergyDepositAnalyzer::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup){
   std::string AlgoName = parameters.getParameter<std::string>("AlgoName");
+
+  theDbe->cd();
+  theDbe->setCurrentFolder("Muons/MuonEnergyDepositAnalyzer");
   
   LogTrace(metname)<<"[MuonEnergyDepositAnalyzer] Parameters initialization";
   LogTrace(metname)<<"[MuonEnergyDepositAnalyzer] Run, Event" << iRun << " , "<< iSetup; 

--- a/DQMOffline/Muon/src/MuonIdDQM.cc
+++ b/DQMOffline/Muon/src/MuonIdDQM.cc
@@ -12,7 +12,6 @@ MuonIdDQM::MuonIdDQM(const edm::ParameterSet& iConfig){
   
   dbe_ = 0;
   dbe_ = edm::Service<DQMStore>().operator->();
-  dbe_->setCurrentFolder(baseFolder_);
 }
 
 MuonIdDQM::~MuonIdDQM() {}
@@ -24,7 +23,12 @@ void MuonIdDQM::beginRun(const edm::Run& irun, const edm::EventSetup& isetup){
 
    char name[100], title[200];
 
+   dbe_->cd();
+   dbe_->setCurrentFolder(baseFolder_);
    // trackerMuon == 0; globalMuon == 1; trackerMuon && !globalMuon == 2; globalMuon && !trackerMuon == 3
+   
+   hSegmentIsAssociatedBool = dbe_->book1D("hSegmentIsAssociatedBool", "Segment Is Associated Boolean", 2, -0.5, 1.5);
+   
    for (unsigned int i = 0; i < 4; i++) {
       if ((i == 0 && ! useTrackerMuons_) || (i == 1 && ! useGlobalMuons_)) continue;
       if ((i == 2 && ! useTrackerMuonsNotGlobalMuons_) || (i == 3 && ! useGlobalMuonsNotTrackerMuons_)) continue;
@@ -39,7 +43,7 @@ void MuonIdDQM::beginRun(const edm::Run& irun, const edm::EventSetup& isetup){
 
       // by station
       for(int station = 0; station < 4; ++station)
-      {
+	{
          sprintf(name, "hDT%iNumSegments", station+1);
          sprintf(title, "DT Station %i Number of Segments (No Arbitration)", station+1);
          hDTNumSegments[i][station] = dbe_->book1D(name, title, 11, -0.5, 10.5);
@@ -116,7 +120,6 @@ void MuonIdDQM::beginRun(const edm::Run& irun, const edm::EventSetup& isetup){
       }// station
    }
 
-   hSegmentIsAssociatedBool = dbe_->book1D("hSegmentIsAssociatedBool", "Segment Is Associated Boolean", 2, -0.5, 1.5);
 }
 
 void MuonIdDQM::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {

--- a/DQMOffline/Muon/src/MuonKinVsEtaAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonKinVsEtaAnalyzer.cc
@@ -25,7 +25,6 @@ MuonKinVsEtaAnalyzer::MuonKinVsEtaAnalyzer(const edm::ParameterSet& pSet) {
   // the services
   theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
   theDbe = edm::Service<DQMStore>().operator->();
-  theDbe->setCurrentFolder("Muons/MuonKinVsEtaAnalyzer");
 
   theMuonCollectionLabel_  = consumes<reco::MuonCollection>(parameters.getParameter<InputTag>("MuonCollection"));
   theVertexLabel_          = consumes<reco::VertexCollection>(parameters.getParameter<edm::InputTag>("VertexLabel"));
@@ -41,7 +40,9 @@ void MuonKinVsEtaAnalyzer::beginJob(){
 
 void MuonKinVsEtaAnalyzer::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup){
   metname = "muonKinVsEta";                                                                                                   
-  
+  theDbe->cd();
+  theDbe->setCurrentFolder("Muons/MuonKinVsEtaAnalyzer");
+
   etaBin = parameters.getParameter<int>("etaBin");
   etaMin = parameters.getParameter<double>("etaMin");
   etaMax = parameters.getParameter<double>("etaMax");

--- a/DQMOffline/Muon/src/MuonPFAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonPFAnalyzer.cc
@@ -40,23 +40,20 @@ using namespace std;
 using namespace reco;
 
 
-MuonPFAnalyzer::MuonPFAnalyzer(const ParameterSet& pSet)
-			       
-{
-
-  LogTrace("MuonPFAnalyzer") << 
-    "[MuonPFAnalyzer] Initializing configuration from parameterset.\n";
-
-  theGenLabel      = pSet.getParameter<InputTag>("inputTagGenParticles");  
-  theRecoLabel     = pSet.getParameter<InputTag>("inputTagMuonReco");  
-  theBeamSpotLabel = pSet.getParameter<InputTag>("inputTagBeamSpot");  
-  theVertexLabel   = pSet.getParameter<InputTag>("inputTagVertex");  
+MuonPFAnalyzer::MuonPFAnalyzer(const ParameterSet& pSet){
+  
+  LogTrace("MuonPFAnalyzer") << "[MuonPFAnalyzer] Initializing configuration from parameterset.\n";
+  
+  theGenLabel_      = consumes<GenParticleCollection>(pSet.getParameter<InputTag>("inputTagGenParticles"));  
+  theRecoLabel_     = consumes<MuonCollection>       (pSet.getParameter<InputTag>("inputTagMuonReco"));  
+  theVertexLabel_   = consumes<VertexCollection>     (pSet.getParameter<InputTag>("inputTagVertex"));  
+  theBeamSpotLabel_ = consumes<BeamSpot>             (pSet.getParameter<InputTag>("inputTagBeamSpot"));  
   
   theHighPtTh   = pSet.getParameter<double>("highPtThreshold");
   theRecoGenR   = pSet.getParameter<double>("recoGenDeltaR");
   theIsoCut     = pSet.getParameter<double>("relCombIsoCut");
   theRunOnMC    = pSet.getParameter<bool>("runOnMC");
-
+  
   theFolder = pSet.getParameter<string>("folder");
   
   theMuonKinds.push_back("");          // all TUNEP/PF muons
@@ -111,16 +108,16 @@ void MuonPFAnalyzer::analyze(const Event& event,
 {
   
   Handle<reco::MuonCollection> muons;
-  event.getByLabel(theRecoLabel, muons);
+  event.getByToken(theRecoLabel_, muons);
 
   Handle<GenParticleCollection> genMuons;
-  event.getByLabel(theGenLabel, genMuons);
+  event.getByToken(theGenLabel_, genMuons);
 
   Handle<BeamSpot> beamSpot;
-  event.getByLabel(theBeamSpotLabel, beamSpot);
+  event.getByToken(theBeamSpotLabel_, beamSpot);
 
   Handle<VertexCollection> vertex;
-  event.getByLabel(theVertexLabel, vertex);
+  event.getByToken(theVertexLabel_, vertex);
 
   const Vertex primaryVertex = getPrimaryVertex(vertex, beamSpot);
 

--- a/DQMOffline/Muon/src/MuonRecoAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonRecoAnalyzer.cc
@@ -23,7 +23,6 @@ MuonRecoAnalyzer::MuonRecoAnalyzer(const edm::ParameterSet& pSet) {
   // the services:
   theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
   theDbe = edm::Service<DQMStore>().operator->();
-  theDbe->setCurrentFolder("Muons/MuonRecoAnalyzer");
   
   theMuonCollectionLabel_ = consumes<reco::MuonCollection>(parameters.getParameter<InputTag>("MuonCollection"));
 }
@@ -42,6 +41,9 @@ void MuonRecoAnalyzer::beginJob(){
 }
 void MuonRecoAnalyzer::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup){
   
+  theDbe->cd();
+  theDbe->setCurrentFolder("Muons/MuonRecoAnalyzer");
+    
   muReco = theDbe->book1D("muReco", "muon reconstructed tracks", 6, 1, 7);
   muReco->setBinLabel(1,"glb+tk+sta");
   muReco->setBinLabel(2,"glb+sta");

--- a/DQMOffline/Muon/src/MuonRecoOneHLT.cc
+++ b/DQMOffline/Muon/src/MuonRecoOneHLT.cc
@@ -20,8 +20,8 @@ MuonRecoOneHLT::MuonRecoOneHLT(const edm::ParameterSet& pSet) { //, MuonServiceP
 
   ParameterSet muonparms   = parameters.getParameter<edm::ParameterSet>("SingleMuonTrigger");
   ParameterSet dimuonparms = parameters.getParameter<edm::ParameterSet>("DoubleMuonTrigger");
-  _SingleMuonEventFlag     = new GenericTriggerEventFlag( muonparms); //, consumesCollector() );
-  _DoubleMuonEventFlag     = new GenericTriggerEventFlag( dimuonparms); //, consumesCollector() );
+  _SingleMuonEventFlag     = new GenericTriggerEventFlag( muonparms, consumesCollector() );
+  _DoubleMuonEventFlag     = new GenericTriggerEventFlag( dimuonparms, consumesCollector() );
 
   // Trigger Expresions in case de connection to the DB fails
   singlemuonExpr_          = muonparms.getParameter<std::vector<std::string> >("hltPaths");

--- a/DQMOffline/Muon/src/MuonRecoOneHLT.cc
+++ b/DQMOffline/Muon/src/MuonRecoOneHLT.cc
@@ -17,12 +17,11 @@ MuonRecoOneHLT::MuonRecoOneHLT(const edm::ParameterSet& pSet) { //, MuonServiceP
   theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
 
   dbe = edm::Service<DQMStore>().operator->();
-  dbe->setCurrentFolder("Muons/MuonRecoOneHLT");
 
   ParameterSet muonparms   = parameters.getParameter<edm::ParameterSet>("SingleMuonTrigger");
   ParameterSet dimuonparms = parameters.getParameter<edm::ParameterSet>("DoubleMuonTrigger");
-  _SingleMuonEventFlag     = new GenericTriggerEventFlag( muonparms, consumesCollector() );
-  _DoubleMuonEventFlag     = new GenericTriggerEventFlag( dimuonparms, consumesCollector() );
+  _SingleMuonEventFlag     = new GenericTriggerEventFlag( muonparms); //, consumesCollector() );
+  _DoubleMuonEventFlag     = new GenericTriggerEventFlag( dimuonparms); //, consumesCollector() );
 
   // Trigger Expresions in case de connection to the DB fails
   singlemuonExpr_          = muonparms.getParameter<std::vector<std::string> >("hltPaths");
@@ -51,6 +50,9 @@ void MuonRecoOneHLT::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetu
   cout << "[MuonRecoOneHLT]  beginRun " << endl;
   cout << "[MuonRecoOneHLT]  Is MuonEventFlag On? "<< _SingleMuonEventFlag->on() << endl;
 #endif
+  
+  dbe->cd();
+  dbe->setCurrentFolder("Muons/MuonRecoOneHLT");
 
   muReco = dbe->book1D("Muon_Reco", "Muon Reconstructed Tracks", 6, 1, 7);
   muReco->setBinLabel(1,"glb+tk+sta");

--- a/DQMOffline/Muon/src/MuonSeedsAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonSeedsAnalyzer.cc
@@ -39,7 +39,6 @@ MuonSeedsAnalyzer::MuonSeedsAnalyzer(const edm::ParameterSet& pSet) {
 
   theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
   theDbe = edm::Service<DQMStore>().operator->();
-  theDbe->setCurrentFolder("Muons/MuonSeedsAnalyzer");
 
 
   theSeedsCollectionLabel_ = consumes<TrajectorySeedCollection>(parameters.getParameter<InputTag>("SeedCollection"));
@@ -58,6 +57,9 @@ void MuonSeedsAnalyzer::beginJob(){
 }
 
 void MuonSeedsAnalyzer::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup){
+
+  theDbe->cd();
+  theDbe->setCurrentFolder("Muons/MuonSeedsAnalyzer");
   
   seedHitBin = parameters.getParameter<int>("RecHitBin");
   seedHitMin = parameters.getParameter<double>("RecHitMin");

--- a/DQMOffline/Muon/src/MuonTestSummary.cc
+++ b/DQMOffline/Muon/src/MuonTestSummary.cc
@@ -28,6 +28,7 @@ using namespace std;
 MuonTestSummary::MuonTestSummary(const edm::ParameterSet& ps){
 
   dbe = Service<DQMStore>().operator->();
+  dbe->cd();
   dbe->setCurrentFolder("Muons/TestSummary"); 
 
   // parameter initialization for kinematics test
@@ -76,12 +77,17 @@ void MuonTestSummary::beginJob(void){
 
   metname = "muonTestSummary";
   LogTrace(metname)<<"[MuonTestSummary] beginJob: Histo booking";
+  dbe->cd();
+  dbe->setCurrentFolder("Muons/TestSummary"); 
 
   // book the summary histos
 }
 void MuonTestSummary::beginRun(Run const& run, EventSetup const& eSetup) {
 
   LogTrace(metname)<<"[MuonTestSummary]: beginRun";
+  
+  dbe->cd();
+  dbe->setCurrentFolder("Muons/TestSummary"); 
 
   // kinematics test report
   kinematicsSummaryMap = dbe->book2D("kinematicsSummaryMap","Kinematics test summary",5,1,6,3,1,4);

--- a/DQMOffline/Muon/src/SegmentTrackAnalyzer.cc
+++ b/DQMOffline/Muon/src/SegmentTrackAnalyzer.cc
@@ -30,7 +30,6 @@ SegmentTrackAnalyzer::SegmentTrackAnalyzer(const edm::ParameterSet& pSet) {
   // MuonService
   theService = new MuonServiceProxy(parameters.getParameter<ParameterSet>("ServiceParameters"));
   theDbe = edm::Service<DQMStore>().operator->();
-  theDbe->setCurrentFolder("Muons/SegmentTrackAnalyzer");
   
   // Read Data:
   theMuTrackCollectionLabel_ = consumes<reco::TrackCollection>(parameters.getParameter<edm::InputTag>("MuTrackCollection"));
@@ -49,6 +48,9 @@ void SegmentTrackAnalyzer::beginJob() {
 }
 void SegmentTrackAnalyzer::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup){
   metname = "segmTrackAnalyzer";
+  
+  theDbe->cd();
+  theDbe->setCurrentFolder("Muons/SegmentTrackAnalyzer");
   
   string trackCollection = parameters.getParameter<edm::InputTag>("MuTrackCollection").label() + parameters.getParameter<edm::InputTag>("MuTrackCollection").instance();
 


### PR DESCRIPTION
We were missing lots of histograms due to not calling correctly SetCurrentFolder on the DQMStore.
Added muonAnalyzer_noHLT sequence for allowing running without any trigger configuration (this will need to be backported to 62X_SLHX)
Put back CSC into the sequence as well as MuonPFAnalyzer.
Added getByToken and consumes declaration into MuonPFAnalyzer (was skipped in the previous pull request) 
