### PR TITLE
Veelken/veelken 7 0 x boosted taus

### DIFF
--- a/DataFormats/JetReco/src/classes_2.h
+++ b/DataFormats/JetReco/src/classes_2.h
@@ -48,6 +48,10 @@
 #include "DataFormats/Common/interface/RefHolder.h"
 #include "DataFormats/Common/interface/Holder.h"
 #include "DataFormats/Common/interface/Association.h"
+#include "DataFormats/Common/interface/AssociationMap.h"
+
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "DataFormats/Common/interface/Ptr.h"
@@ -149,6 +153,13 @@ namespace {
     // Pile-up summary
     reco::FFTJetPileupSummary r_fft_psumary;
     edm::Wrapper<reco::FFTJetPileupSummary> wr_r_fft_psumary;
+    
+    // jet -> PFCandidate associations, needed for boosted tau reconstruction
+    edm::AssociationMap<edm::OneToMany<std::vector<reco::PFJet>,std::vector<reco::PFCandidate>,unsigned int> > jetPFCandidateAssociation_o;
+    edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<reco::PFJet>,std::vector<reco::PFCandidate>,unsigned int> > > jetPFCandidateAssociation_w;
+    edm::helpers::KeyVal<edm::RefProd<std::vector<reco::PFJet> >,edm::RefProd<std::vector<reco::PFCandidate> > > jetPFCandidateAssociation_kv;
+    edm::helpers::KeyVal<edm::Ref<std::vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFJet>,reco::PFJet> >,edm::RefVector<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > jetPFCandidateAssociation_kv2;
+    std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFJet>,reco::PFJet> >,edm::RefVector<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > > jetPFCandidateAssociation_mkv;
   };
 }
 #endif

--- a/DataFormats/JetReco/src/classes_def_2.xml
+++ b/DataFormats/JetReco/src/classes_def_2.xml
@@ -96,4 +96,11 @@
     <version ClassVersion="10" checksum="987073443"/>
    </class>
    <class name="edm::Wrapper<reco::FFTJetPileupSummary>" />
+
+   <class name="edm::AssociationMap<edm::OneToMany<std::vector<reco::PFJet>,std::vector<reco::PFCandidate>,unsigned int> >"/>
+   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<reco::PFJet>,std::vector<reco::PFCandidate>,unsigned int> > >"/>
+   <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::PFJet> >,edm::RefProd<std::vector<reco::PFCandidate> > >"/>
+   <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFJet>,reco::PFJet> >,edm::RefVector<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > >"/>
+   <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::PFJet>,reco::PFJet,edm::refhelper::FindUsingAdvance<std::vector<reco::PFJet>,reco::PFJet> >,edm::RefVector<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > >"/>
+
 </lcgdict>

--- a/RecoJets/JetAlgorithms/interface/CMSBoostedTauSeedingAlgorithm.h
+++ b/RecoJets/JetAlgorithms/interface/CMSBoostedTauSeedingAlgorithm.h
@@ -1,0 +1,134 @@
+// CMSBoostedTau Package
+// Questions/Comments? 
+//    for physics : Christian.Veelken@cern.ch
+//    for implementation : Salvatore.Rappoccio@cern.ch
+//
+// $Id$
+//
+//----------------------------------------------------------------------
+// This file is part of FastJet contrib.
+//
+// It is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 2 of the License, or (at
+// your option) any later version.
+//
+// It is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+// License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this code. If not, see <http://www.gnu.org/licenses/>.
+//----------------------------------------------------------------------
+
+#ifndef __FASTJET_CONTRIB_CMSBOOSTEDTAUSEEDINGALGORITHM_HH__
+#define __FASTJET_CONTRIB_CMSBOOSTEDTAUSEEDINGALGORITHM_HH__
+
+#include <fastjet/internal/base.hh>
+#include <fastjet/tools/Transformer.hh>
+#include <fastjet/CompositeJetStructure.hh>
+
+#include <fastjet/ClusterSequence.hh>
+#include <fastjet/Error.hh>
+#include <fastjet/JetDefinition.hh>
+//#include "fastjet/FunctionOfPseudoJet.hh"
+
+#include <map>
+#include <sstream>
+#include <string>
+
+FASTJET_BEGIN_NAMESPACE      // defined in fastjet/internal/base.hh
+
+namespace contrib{
+
+  class CMSBoostedTauSeedingAlgorithmStructure;
+
+  //------------------------------------------------------------------------
+  /// \class CMSBoostedTauSeedingAlgorithm
+  /// This class implements the CMS boosted tau algorithm
+  ///
+  class CMSBoostedTauSeedingAlgorithm : public Transformer {
+
+  public:
+    // constructors
+    CMSBoostedTauSeedingAlgorithm(double ptMin, double muMin, double muMax, double yMin, double yMax, double dRMin, double dRMax, int maxDepth, int verbosity = 0);
+
+    // destructor
+    virtual ~CMSBoostedTauSeedingAlgorithm(){}
+
+    // standard usage
+    virtual std::string description() const;
+
+    virtual PseudoJet result(const PseudoJet & jet) const;
+
+    // the type of the associated structure
+    typedef CMSBoostedTauSeedingAlgorithmStructure StructureType;
+
+  protected:
+    void dumpSubJetStructure(const fastjet::PseudoJet& jet, int depth, int maxDepth, const std::string& depth_and_idx_string) const;
+    std::pair<PseudoJet, PseudoJet> findSubjets(const PseudoJet& jet, int depth, bool& subjetsFound) const;
+
+  private: 
+    double ptMin_;  ///< minimum sub-jet pt
+    double muMin_;  ///< the min value of the mass-drop parameter
+    double muMax_;  ///< the max value of the mass-drop parameter
+    double yMin_;   ///< the min value of the asymmetry parameter
+    double yMax_;   ///< the max value of the asymmetry parameter    
+    double dRMin_;  ///< the min value of the dR parameter
+    double dRMax_;  ///< the max value of the dR parameter
+    int maxDepth_;  ///< the max depth for descending into clustering sequence
+
+    int verbosity_; ///< flag to enable/disable debug output
+  };
+
+
+  //------------------------------------------------------------------------
+  /// @ingroup tools_taggers
+  /// \class CMSBoostedTauSeedingAlgorithmStructure
+  /// the structure returned by the CMSBoostedTauSeedingAlgorithm transformer.
+  ///
+  /// See the CMSBoostedTauSeedingAlgorithm class description for the details of what
+  /// is inside this structure
+  ///
+  class CMSBoostedTauSeedingAlgorithmStructure : public CompositeJetStructure {
+  public:
+    /// ctor with initialisation
+    ///  \param pieces  the pieces of the created jet
+    ///  \param rec     the recombiner from the underlying cluster sequence
+    CMSBoostedTauSeedingAlgorithmStructure(const PseudoJet& result_jet, const JetDefinition::Recombiner* rec = 0) 
+      : CompositeJetStructure(result_jet.pieces(), rec), 
+        _mu(0.0), _y(0.0), _dR(0.0), _pt(0.0) 
+    {}
+
+    /// returns the mass-drop ratio, pieces[0].m()/jet.m()
+    inline double mu() const { return _mu; }
+
+    /// returns the value of y = (squared kt distance) / (squared mass) for the
+    /// splitting that triggered the mass-drop condition
+    inline double y() const { return _y; }
+
+    /// returns the value of dR
+    inline double dR() const { return _dR; }
+
+    /// returns the value of pt
+    inline double pt() const { return _pt; }
+
+    // /// returns the original jet (before tagging)
+    //const PseudoJet& original() const { return _original_jet; }
+
+  protected:
+    double _mu;              ///< the value of the mass-drop parameter
+    double _y;               ///< the value of the asymmetry parameter
+    double _dR;              ///< the value of the dR parameter
+    double _pt;              ///< the value of the pt parameter
+    // allow the tagger to set these
+    friend class CMSBoostedTauSeedingAlgorithm;
+  };
+
+
+} // namespace contrib
+
+FASTJET_END_NAMESPACE
+
+#endif  // __FASTJET_CONTRIB_CMSBOOSTEDTAUSEEDINGALGORITHM_HH__

--- a/RecoJets/JetAlgorithms/interface/CMSBoostedTauSeedingAlgorithm.h
+++ b/RecoJets/JetAlgorithms/interface/CMSBoostedTauSeedingAlgorithm.h
@@ -1,9 +1,14 @@
+#ifndef __RecoJets_JetAlgorithms_CMSBoostedTauSeedingAlgorithm_h__
+#define __RecoJets_JetAlgorithms_CMSBoostedTauSeedingAlgorithm_h__
+
 // CMSBoostedTau Package
+//
+// Find subjets corresponding to decay products of tau lepton pair
+// and produce data-formats neccessary to seed tau reconstruction.
+//
 // Questions/Comments? 
 //    for physics : Christian.Veelken@cern.ch
 //    for implementation : Salvatore.Rappoccio@cern.ch
-//
-// $Id$
 //
 //----------------------------------------------------------------------
 // This file is part of FastJet contrib.
@@ -21,9 +26,6 @@
 // You should have received a copy of the GNU General Public License
 // along with this code. If not, see <http://www.gnu.org/licenses/>.
 //----------------------------------------------------------------------
-
-#ifndef __FASTJET_CONTRIB_CMSBOOSTEDTAUSEEDINGALGORITHM_HH__
-#define __FASTJET_CONTRIB_CMSBOOSTEDTAUSEEDINGALGORITHM_HH__
 
 #include <fastjet/internal/base.hh>
 #include <fastjet/tools/Transformer.hh>

--- a/RecoJets/JetAlgorithms/src/CMSBoostedTauSeedingAlgorithm.cc
+++ b/RecoJets/JetAlgorithms/src/CMSBoostedTauSeedingAlgorithm.cc
@@ -1,0 +1,187 @@
+// CMSBoostedTauSeedingAlgorithm Package
+//
+//----------------------------------------------------------------------
+// This file is part of FastJet contrib.
+//
+// It is free software; you can redistribute it and/or modify it under
+// the terms of the GNU General Public License as published by the
+// Free Software Foundation; either version 2 of the License, or (at
+// your option) any later version.
+//
+// It is distributed in the hope that it will be useful, but WITHOUT
+// ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+// or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public
+// License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this code. If not, see <http://www.gnu.org/licenses/>.
+//----------------------------------------------------------------------
+
+#include "RecoJets/JetAlgorithms/interface/CMSBoostedTauSeedingAlgorithm.h"
+
+FASTJET_BEGIN_NAMESPACE      // defined in fastjet/internal/base.hh
+
+namespace contrib{
+
+
+  /////////////////////////////
+  // constructor
+  CMSBoostedTauSeedingAlgorithm::CMSBoostedTauSeedingAlgorithm(double iminPt, 			       
+							       double iminMassDrop, double imaxMassDrop,
+							       double iminY, double imaxY,
+							       double iminDeltaR, double imaxDeltaR,
+							       int maxDepth, 
+							       int verbosity) 
+    : ptMin_(iminPt), 
+      muMin_(iminMassDrop), muMax_(imaxMassDrop), 
+      yMin_(iminY), yMax_(imaxY), 
+      dRMin_(iminDeltaR), dRMax_(imaxDeltaR),
+      maxDepth_(maxDepth),
+      verbosity_(verbosity)
+  {}
+
+  /////////////////////////////
+  // description
+  std::string CMSBoostedTauSeedingAlgorithm::description() const {
+    std::ostringstream oss;
+    oss << "CMSBoostedTauSeedingAlgorithm algorithm";
+    return oss.str();
+  }
+
+
+  /////////////////////////////
+  void CMSBoostedTauSeedingAlgorithm::dumpSubJetStructure(const fastjet::PseudoJet& jet, int depth, int maxDepth, const std::string& depth_and_idx_string) const
+  {
+    if ( maxDepth != -1 && depth > maxDepth ) return;
+    fastjet::PseudoJet subjet1, subjet2; 
+    bool hasSubjets = jet.has_parents(subjet1, subjet2);
+    if ( !hasSubjets ) return;
+    std::string depth_and_idx_string_subjet1 = depth_and_idx_string;
+    if ( depth_and_idx_string_subjet1.length() > 0 ) depth_and_idx_string_subjet1.append(".");
+    depth_and_idx_string_subjet1.append("0");
+    for ( int iSpace = 0; iSpace < depth; ++iSpace ) {
+      std::cout << " ";
+    }
+    std::cout << " jetConstituent #" << depth_and_idx_string_subjet1 << " (depth = " << depth << "): Pt = " << subjet1.pt() << "," 
+	      << " eta = " << subjet1.eta() << ", phi = " << subjet1.phi() << ", mass = " << subjet1.m() 
+	      << " (constituents = " << subjet1.constituents().size() << ")" << std::endl;
+    dumpSubJetStructure(subjet1, depth + 1, maxDepth, depth_and_idx_string_subjet1);
+    std::string depth_and_idx_string_subjet2 = depth_and_idx_string;
+    if ( depth_and_idx_string_subjet2.length() > 0 ) depth_and_idx_string_subjet2.append(".");
+    depth_and_idx_string_subjet2.append("1");
+    for ( int iSpace = 0; iSpace < depth; ++iSpace ) {
+      std::cout << " ";
+    }
+    std::cout << " jetConstituent #" << depth_and_idx_string_subjet2 << " (depth = " << depth << "): Pt = " << subjet2.pt() << "," 
+	      << " eta = " << subjet2.eta() << ", phi = " << subjet2.phi() << ", mass = " << subjet2.m() 
+	      << " (constituents = " << subjet2.constituents().size() << ")" << std::endl;
+    dumpSubJetStructure(subjet2, depth + 1, maxDepth, depth_and_idx_string_subjet2);
+    for ( int iSpace = 0; iSpace < depth; ++iSpace ) {
+      std::cout << " ";
+    }
+    double dR = subjet1.delta_R(subjet2);
+    std::cout << " (mass-drop @ " << depth_and_idx_string << " = " << std::max(subjet1.m(), subjet2.m())/jet.m() << ", dR = " << dR << ")" << std::endl;
+  }
+
+  std::pair<PseudoJet, PseudoJet> CMSBoostedTauSeedingAlgorithm::findSubjets(const PseudoJet& jet, int depth, bool& subjetsFound) const 
+  {
+    if ( verbosity_ >= 2 ) {
+      std::cout << "<CMSBoostedTauSeedingAlgorithm::findSubjets>:" << std::endl;
+      std::cout << " jet: Pt = " << jet.pt() << ", eta = " << jet.eta() << ", phi = " << jet.phi() << ", mass = " << jet.m() << std::endl;
+    }
+
+    PseudoJet subjet1, subjet2;
+    bool hasSubjets = jet.has_parents(subjet1, subjet2);
+    if ( hasSubjets && (maxDepth_ == -1 || depth <= maxDepth_) ) {
+      // make subjet1 the more massive jet
+      if ( subjet1.m2() < subjet2.m2() ) {
+	std::swap(subjet1, subjet2);
+      }
+      double dR = subjet1.delta_R(subjet2);
+      double kT = subjet1.kt_distance(subjet2);
+      double mu = ( jet.m() > 0. ) ? 
+	sqrt(std::max(subjet1.m2(), subjet2.m2())/jet.m2()) : -1.;
+      // check if subjets pass selection required for seeding boosted tau reconstruction
+      if ( subjet1.pt() > ptMin_ && subjet2.pt() > ptMin_ && dR > dRMin_ && dR < dRMax_ && mu > muMin_ && mu < muMax_ && kT < (yMax_*jet.m2()) && kT > (yMin_*jet.m2()) ) {
+	subjetsFound = true;
+	return std::make_pair(subjet1, subjet2); 
+      } else if ( subjet1.pt() > ptMin_ ) {
+	return findSubjets(subjet1, depth + 1, subjetsFound);
+      } else if ( subjet2.pt() > ptMin_ ) {
+	return findSubjets(subjet2, depth + 1, subjetsFound);
+      } 
+    }
+    subjetsFound = false;
+    PseudoJet dummy_subjet1, dummy_subjet2;
+    return std::make_pair(dummy_subjet1, dummy_subjet2); 
+  }
+
+  PseudoJet CMSBoostedTauSeedingAlgorithm::result(const PseudoJet& jet) const 
+  {
+    if ( verbosity_ >= 1 ) {
+      std::cout << "<CMSBoostedTauSeedingAlgorithm::findSubjets>:" << std::endl;
+      std::cout << " jet: Pt = " << jet.pt() << ", eta = " << jet.eta() << ", phi = " << jet.phi() << ", mass = " << jet.m() << std::endl;
+    }
+
+    if ( verbosity_ >= 2 ) {
+      dumpSubJetStructure(jet, 0, maxDepth_, "");
+    }
+
+    bool subjetsFound = false;
+    std::pair<PseudoJet, PseudoJet> subjets = findSubjets(jet, 0, subjetsFound);
+    if ( subjetsFound ) {
+      // fill structure for returning result
+      PseudoJet subjet1 = subjets.first;
+      PseudoJet subjet2 = subjets.second;
+      if ( verbosity_ >= 1 ) {
+	std::cout << "before recombination:" << std::endl;
+	std::cout << " subjet #1: Pt = " << subjet1.pt() << ", eta = " << subjet1.eta() << ", phi = " << subjet1.phi() << ", mass = " << subjet1.m() << std::endl;
+	std::cout << " subjet #2: Pt = " << subjet2.pt() << ", eta = " << subjet2.eta() << ", phi = " << subjet2.phi() << ", mass = " << subjet2.m() << std::endl;
+      }
+
+      const JetDefinition::Recombiner* rec = jet.associated_cluster_sequence()->jet_def().recombiner();
+      PseudoJet result_local = join(subjet1, subjet2, *rec);
+      if ( verbosity_ >= 1 ) {
+	std::cout << "after recombination:" << std::endl;
+	std::vector<fastjet::PseudoJet> subjets = result_local.pieces();
+	int idx_subjet = 0;
+	for ( std::vector<fastjet::PseudoJet>::const_iterator subjet = subjets.begin();
+	      subjet != subjets.end(); ++subjet ) {
+	  std::cout << " subjet #" << idx_subjet << ": Pt = " << subjet->pt() << ", eta = " << subjet->eta() << ", phi = " << subjet->phi() << ", mass = " << subjet->m() 
+		    << " (#constituents = " << subjet->constituents().size() << ")" << std::endl;
+	  std::vector<fastjet::PseudoJet> constituents = subjet->constituents();
+	  int idx_constituent = 0;
+	  for ( std::vector<fastjet::PseudoJet>::const_iterator constituent = constituents.begin();
+		constituent != constituents.end(); ++constituent ) {
+	    if ( constituent->pt() < 1.e-3 ) continue; // CV: skip ghosts
+	    std::cout << "  constituent #" << idx_constituent << ": Pt = " << constituent->pt() << ", eta = " << constituent->eta() << ", phi = " << constituent->phi() << "," 
+		      << " mass = " << constituent->m() << std::endl;
+	    ++idx_constituent;
+	  }
+	  ++idx_subjet;
+	}
+      }
+
+      CMSBoostedTauSeedingAlgorithmStructure* s = new CMSBoostedTauSeedingAlgorithmStructure(result_local);
+      //s->_original_jet = jet;
+      s->_mu = ( jet.m2() > 0. ) ? sqrt(std::max(subjet1.m2(), subjet2.m2())/jet.m2()) : 0.;
+      s->_y  = ( jet.m2() > 0. ) ? subjet1.kt_distance(subjet2)/jet.m2() : 0.;
+      s->_dR = subjet1.delta_R(subjet2);
+      s->_pt = subjet2.pt();
+            
+      result_local.set_structure_shared_ptr(SharedPtr<PseudoJetStructureBase>(s));
+
+      return result_local;
+    } else {
+      // no subjets for seeding boosted tau reconstruction found, return an empty PseudoJet
+      if ( verbosity_  >= 1 ) {
+	std::cout << "No subjets found." << std::endl;
+      }
+      return PseudoJet();
+    }
+  }
+
+
+} // namespace contrib
+ 
+FASTJET_END_NAMESPACE

--- a/RecoJets/JetProducers/plugins/BoostedTauSeedsProducer.cc
+++ b/RecoJets/JetProducers/plugins/BoostedTauSeedsProducer.cc
@@ -1,0 +1,286 @@
+
+/* =============================================================================
+ *       Filename:  BoostedTauSeedsProducer.cc
+ *
+ *    Description:  Take the two subjets found by CMSBoostedTauSeedingAlgorithm
+ *                  and add the data-formats for 
+ *                 o seeding the reconstruction of hadronic taus (PFJets, collection of PFCandidates not within subjet)
+ *                 o computation of electron and muon isolation Pt-sums, excluding the particles in the other subjet (collection of PFCandidates within subjet, used to define "Vetos")
+ *
+ *        Created:  10/22/2013 16:05:00
+ *
+ *         Authors:  Christian Veelken (LLR)
+ *
+ * =============================================================================
+ */
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DataFormats/JetReco/interface/Jet.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/JetReco/interface/PFJetCollection.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/Common/interface/AssociationMap.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefProd.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include <boost/foreach.hpp>
+
+#include <TMath.h>
+
+#include <string>
+#include <iostream>
+#include <iomanip>
+
+class BoostedTauSeedsProducer : public edm::EDProducer 
+{
+ public:
+  explicit BoostedTauSeedsProducer(const edm::ParameterSet&);
+  ~BoostedTauSeedsProducer() {}
+  virtual void produce(edm::Event&, const edm::EventSetup&);
+
+ private:
+  typedef edm::AssociationMap<edm::OneToMany<std::vector<reco::PFJet>, std::vector<reco::PFCandidate>, unsigned int> > JetToPFCandidateAssociation;
+
+  std::string moduleLabel_;
+
+  edm::InputTag srcSubjets_;
+  edm::InputTag srcPFCandidates_;
+
+  int verbosity_;
+};
+
+BoostedTauSeedsProducer::BoostedTauSeedsProducer(const edm::ParameterSet& cfg)
+  : moduleLabel_(cfg.getParameter<std::string>("@module_label"))
+{
+  srcSubjets_ = cfg.getParameter<edm::InputTag>("subjetSrc");
+  srcPFCandidates_ = cfg.getParameter<edm::InputTag>("pfCandidateSrc");
+
+  verbosity_ = ( cfg.exists("verbosity") ) ?
+    cfg.getParameter<int>("verbosity") : 0;
+
+  produces<reco::PFJetCollection>();
+  produces<JetToPFCandidateAssociation>("pfCandAssocMapForIsolation");
+  produces<JetToPFCandidateAssociation>("pfCandAssocMapForIsoDepositVetos");
+}
+
+namespace
+{
+  reco::PFJet convertToPFJet(const reco::Jet& jet, const reco::Jet::Constituents& jetConstituents)
+  {    
+    // CV: code for filling pfJetSpecific objects taken from
+    //        RecoParticleFlow/PFRootEvent/src/JetMaker.cc
+    double chargedHadronEnergy = 0.;
+    double neutralHadronEnergy = 0.;
+    double chargedEmEnergy     = 0.;
+    double neutralEmEnergy     = 0.;
+    double chargedMuEnergy     = 0.;
+    int    chargedMultiplicity = 0;
+    int    neutralMultiplicity = 0;
+    int    muonMultiplicity    = 0;
+    for ( reco::Jet::Constituents::const_iterator jetConstituent = jetConstituents.begin();
+	  jetConstituent != jetConstituents.end(); ++jetConstituent ) {
+      const reco::PFCandidate* pfCandidate = dynamic_cast<const reco::PFCandidate*>(jetConstituent->get());
+      if ( pfCandidate ) {
+	switch ( pfCandidate->particleId() ) {
+	case reco::PFCandidate::h :          // charged hadron
+	  chargedHadronEnergy += pfCandidate->energy();
+	  ++chargedMultiplicity;
+	  break;           
+	case reco::PFCandidate::e :          // electron 
+	  chargedEmEnergy += pfCandidate->energy(); 
+	  ++chargedMultiplicity;
+	  break;
+	case reco::PFCandidate::mu :         // muon
+	  chargedMuEnergy += pfCandidate->energy();
+	  ++chargedMultiplicity;
+	  ++muonMultiplicity;
+	  break;
+	case reco::PFCandidate::gamma :     // photon
+	case reco::PFCandidate::egamma_HF : // electromagnetic in HF
+	  neutralEmEnergy += pfCandidate->energy();
+	  ++neutralMultiplicity;
+	  break;
+	case reco::PFCandidate::h0 :        // neutral hadron
+	case reco::PFCandidate::h_HF :      // hadron in HF
+	  neutralHadronEnergy += pfCandidate->energy();
+	  ++neutralMultiplicity;
+	  break;
+	default:
+	  edm::LogWarning("convertToPFJet") 
+	    << "PFCandidate: Pt = " << pfCandidate->pt() << ", eta = " << pfCandidate->eta() << ", phi = " << pfCandidate->phi() 
+	    << " has invalid particleID = " << pfCandidate->particleId() << " !!" << std::endl;
+	  break;
+	}
+      } else {
+	edm::LogWarning("convertToPFJet") 
+	  << "Jet constituent: Pt = " << pfCandidate->pt() << ", eta = " << pfCandidate->eta() << ", phi = " << pfCandidate->phi() 
+	  << " is not of type PFCandidate !!" << std::endl;
+      }
+    }
+    reco::PFJet::Specific pfJetSpecific;
+    pfJetSpecific.mChargedHadronEnergy = chargedHadronEnergy;
+    pfJetSpecific.mNeutralHadronEnergy = neutralHadronEnergy;
+    pfJetSpecific.mChargedEmEnergy     = chargedEmEnergy;
+    pfJetSpecific.mChargedMuEnergy     = chargedMuEnergy;
+    pfJetSpecific.mNeutralEmEnergy     = neutralEmEnergy;
+    pfJetSpecific.mChargedMultiplicity = chargedMultiplicity;
+    pfJetSpecific.mNeutralMultiplicity = neutralMultiplicity;
+    pfJetSpecific.mMuonMultiplicity    = muonMultiplicity;
+
+    reco::PFJet pfJet(jet.p4(), jet.vertex(), pfJetSpecific, jetConstituents);
+    pfJet.setJetArea(jet.jetArea());
+
+    return pfJet;
+  }
+
+  void getJetConstituents(const reco::Jet& jet, reco::Jet::Constituents& jet_and_subjetConstituents)
+  {
+    reco::Jet::Constituents jetConstituents = jet.getJetConstituents();
+    for ( reco::Jet::Constituents::const_iterator jetConstituent = jetConstituents.begin();
+	  jetConstituent != jetConstituents.end(); ++jetConstituent ) {
+      const reco::Jet* subjet = dynamic_cast<const reco::Jet*>(jetConstituent->get());
+      if ( subjet ) {
+	getJetConstituents(*subjet, jet_and_subjetConstituents);
+      } else { 
+	jet_and_subjetConstituents.push_back(*jetConstituent);
+      }
+    }
+  }
+
+  std::vector<reco::PFCandidateRef> getPFCandidates_exclJetConstituents(const edm::Handle<reco::PFCandidateCollection>& pfCandidates, const reco::Jet::Constituents& jetConstituents, double dRmatch, bool invert)
+  {
+    std::vector<reco::PFCandidateRef> pfCandidates_exclJetConstituents;
+    size_t numPFCandidates = pfCandidates->size();
+    for ( size_t pfCandidateIdx = 0; pfCandidateIdx < numPFCandidates; ++pfCandidateIdx ) {
+      reco::PFCandidateRef pfCandidate(pfCandidates, pfCandidateIdx);
+      bool isJetConstituent = false;
+      for ( reco::Jet::Constituents::const_iterator jetConstituent = jetConstituents.begin();
+	    jetConstituent != jetConstituents.end(); ++jetConstituent ) {
+	double dR = deltaR(pfCandidate->p4(), (*jetConstituent)->p4());
+	if ( dR < dRmatch ) {
+	  isJetConstituent = true;
+	  break;
+	}
+      }
+      if ( !(isJetConstituent^invert) ) {
+	pfCandidates_exclJetConstituents.push_back(pfCandidate);
+      }
+    }
+    return pfCandidates_exclJetConstituents;
+  }
+
+  void printJetConstituents(const std::string& label, const reco::Jet::Constituents& jetConstituents)
+  {
+    std::cout << "#" << label << " = " << jetConstituents.size() << ":" << std::endl;
+    int idx = 0;
+    for ( reco::Jet::Constituents::const_iterator jetConstituent = jetConstituents.begin();
+	  jetConstituent != jetConstituents.end(); ++jetConstituent ) {
+      std::cout << " jetConstituent #" << idx << ": Pt = " << (*jetConstituent)->pt() << ", eta = " << (*jetConstituent)->eta() << ", phi = " << (*jetConstituent)->phi() << std::endl;
+      ++idx;
+    }
+  }
+}
+
+void BoostedTauSeedsProducer::produce(edm::Event& evt, const edm::EventSetup& es)
+{
+  if ( verbosity_ >= 1 ) {
+    std::cout << "<BoostedTauSeedsProducer::produce (moduleLabel = " << moduleLabel_ << ")>:" << std::endl;
+  }
+
+  typedef edm::View<reco::Jet> JetView;
+  edm::Handle<JetView> subjets;
+  evt.getByLabel(srcSubjets_, subjets);
+  if ( verbosity_ >= 1 ) {
+    std::cout << "#subjets = " << subjets->size() << std::endl;
+  }
+  assert((subjets->size() % 2) == 0); // CV: ensure that subjets come in pairs
+
+  edm::Handle<reco::PFCandidateCollection> pfCandidates;
+  evt.getByLabel(srcPFCandidates_, pfCandidates);
+  if ( verbosity_ >= 1 ) {
+    std::cout << "#pfCandidates = " << pfCandidates->size() << std::endl;
+  }
+  
+  std::auto_ptr<reco::PFJetCollection> selectedSubjets(new reco::PFJetCollection());
+  edm::RefProd<reco::PFJetCollection> selectedSubjetRefProd = evt.getRefBeforePut<reco::PFJetCollection>();
+
+  std::auto_ptr<JetToPFCandidateAssociation> selectedSubjetPFCandidateAssociationForIsolation(new JetToPFCandidateAssociation());
+  std::auto_ptr<JetToPFCandidateAssociation> selectedSubjetPFCandidateAssociationForIsoDepositVetos(new JetToPFCandidateAssociation());
+
+  for ( size_t idx = 0; idx < (subjets->size() / 2); ++idx ) {
+    const reco::Jet* subjet1 = &subjets->at(2*idx);
+    const reco::Jet* subjet2 = &subjets->at(2*idx + 1);
+    assert(subjet1 && subjet2);
+    if ( verbosity_ >= 1 ) {
+      std::cout << "processing jet #" << idx << ":" << std::endl;
+      std::cout << " subjet1: Pt = " << subjet1->pt() << ", eta = " << subjet1->eta() << ", phi = " << subjet1->phi() << ", mass = " << subjet1->mass() 
+		<< " (area = " << subjet1->jetArea() << ")" << std::endl;
+      std::cout << " subjet2: Pt = " << subjet2->pt() << ", eta = " << subjet2->eta() << ", phi = " << subjet2->phi() << ", mass = " << subjet2->mass() 
+		<< " (area = " << subjet2->jetArea() << ")" << std::endl;
+    }
+
+    // find PFCandidate constituents of each subjet
+    reco::Jet::Constituents subjetConstituents1;
+    getJetConstituents(*subjet1, subjetConstituents1);    
+    reco::Jet::Constituents subjetConstituents2;
+    getJetConstituents(*subjet2, subjetConstituents2);
+    if ( verbosity_ >= 1 ) {
+      printJetConstituents("subjetConstituents1", subjetConstituents1);
+      printJetConstituents("subjetConstituents2", subjetConstituents2);
+    }
+
+    selectedSubjets->push_back(convertToPFJet(*subjet1, subjetConstituents1));
+    edm::Ref<reco::PFJetCollection> subjetRef1(selectedSubjetRefProd, selectedSubjets->size() - 1);
+    selectedSubjets->push_back(convertToPFJet(*subjet2, subjetConstituents2));
+    edm::Ref<reco::PFJetCollection> subjetRef2(selectedSubjetRefProd, selectedSubjets->size() - 1);
+        
+    // find all PFCandidates that are not constituents of the **other** subjet
+    std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet1 = getPFCandidates_exclJetConstituents(pfCandidates, subjetConstituents2, 1.e-4, false);
+    std::vector<reco::PFCandidateRef> pfCandidatesNotInSubjet2 = getPFCandidates_exclJetConstituents(pfCandidates, subjetConstituents1, 1.e-4, false);
+    if ( verbosity_ >= 1 ) {
+      std::cout << "#pfCandidatesNotInSubjet1 = " << pfCandidatesNotInSubjet1.size() << std::endl;
+      std::cout << "#pfCandidatesNotInSubjet2 = " << pfCandidatesNotInSubjet2.size() << std::endl;
+    }
+
+    // build JetToPFCandidateAssociation 
+    // (key = subjet, value = collection of PFCandidates that are not constituents of subjet)
+    BOOST_FOREACH( const reco::PFCandidateRef& pfCandidate, pfCandidatesNotInSubjet1 ) {
+      selectedSubjetPFCandidateAssociationForIsolation->insert(subjetRef1, pfCandidate);
+    }
+    BOOST_FOREACH( const reco::PFCandidateRef& pfCandidate, pfCandidatesNotInSubjet2 ) {
+      selectedSubjetPFCandidateAssociationForIsolation->insert(subjetRef2, pfCandidate);
+    }
+
+    // find all PFCandidates that are constituents of the **other** subjet
+    std::vector<reco::PFCandidateRef> pfCandidatesInSubjet1 = getPFCandidates_exclJetConstituents(pfCandidates, subjetConstituents2, 1.e-4, true);
+    std::vector<reco::PFCandidateRef> pfCandidatesInSubjet2 = getPFCandidates_exclJetConstituents(pfCandidates, subjetConstituents1, 1.e-4, true);
+    if ( verbosity_ >= 1 ) {
+      std::cout << "#pfCandidatesInSubjet1 = " << pfCandidatesInSubjet1.size() << std::endl;
+      std::cout << "#pfCandidatesInSubjet2 = " << pfCandidatesInSubjet2.size() << std::endl;
+    }
+
+    BOOST_FOREACH( const reco::PFCandidateRef& pfCandidate, pfCandidatesInSubjet1 ) {
+      selectedSubjetPFCandidateAssociationForIsoDepositVetos->insert(subjetRef1, pfCandidate);
+    }
+    BOOST_FOREACH( const reco::PFCandidateRef& pfCandidate, pfCandidatesInSubjet2 ) {
+      selectedSubjetPFCandidateAssociationForIsoDepositVetos->insert(subjetRef2, pfCandidate);
+    }
+  }
+
+  evt.put(selectedSubjets);
+  evt.put(selectedSubjetPFCandidateAssociationForIsolation, "pfCandAssocMapForIsolation");
+  evt.put(selectedSubjetPFCandidateAssociationForIsoDepositVetos, "pfCandAssocMapForIsoDepositVetos");
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(BoostedTauSeedsProducer);

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -62,6 +62,7 @@ FastjetJetProducer::FastjetJetProducer(const edm::ParameterSet& iConfig)
     useFiltering_(false),
     useTrimming_(false),
     usePruning_(false),
+    useCMSBoostedTauSeedingAlgorithm_(false),
     muCut_(-1.0),
     yCut_(-1.0),
     rFilt_(-1.0),
@@ -125,7 +126,6 @@ FastjetJetProducer::FastjetJetProducer(const edm::ParameterSet& iConfig)
     dRMax_ = -1.0;
     maxDepth_ = -1;
     useExplicitGhosts_ = true;
-
 
     if ( iConfig.exists("useMassDropTagger") ) {
       useMassDropTagger_ = true;
@@ -351,10 +351,9 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
     fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceVoronoiArea( fjInputs_, *fjJetDefinition_ , fastjet::VoronoiAreaSpec(voronoiRfact_) ) );
   }
 
-  if ( !useTrimming_ && !useFiltering_ && !usePruning_ ) {
+  if ( !(useMassDropTagger_ || useCMSBoostedTauSeedingAlgorithm_ || useTrimming_ || useFiltering_ || usePruning_) ) {
     fjJets_ = fastjet::sorted_by_pt(fjClusterSeq_->inclusive_jets(jetPtMin_));
-  }
-  else {
+  } else {
     fjJets_.clear();
     std::vector<fastjet::PseudoJet> tempJets = fastjet::sorted_by_pt(fjClusterSeq_->inclusive_jets(jetPtMin_));
 
@@ -382,8 +381,6 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
       transformers.push_back(&pruner);
     }
 
-
-
     for ( std::vector<fastjet::PseudoJet>::const_iterator ijet = tempJets.begin(),
 	    ijetEnd = tempJets.end(); ijet != ijetEnd; ++ijet ) {
 
@@ -393,13 +390,13 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
 	      itransfEnd = transformers.end(); itransf != itransfEnd; ++itransf ) {
 	if ( transformedJet != 0 ) {
 	  transformedJet = (**itransf)(transformedJet);
-	}
-	else {
+	} else {
 	  passed=false;
 	}
       }
-      if ( passed ) 
+      if ( passed ) {
 	fjJets_.push_back( transformedJet );
+      }
     }
   }
 

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.h
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.h
@@ -42,6 +42,7 @@ protected:
   bool useFiltering_;         /// Jet filtering technique
   bool useTrimming_;          /// Jet trimming technique
   bool usePruning_;           /// Jet pruning technique
+  bool useCMSBoostedTauSeedingAlgorithm_; /// algorithm for seeding reconstruction of boosted Taus (similar to mass-drop tagging)
   double muCut_;              /// for mass-drop tagging, m0/mjet (m0 = mass of highest mass subjet)
   double yCut_;               /// for mass-drop tagging, symmetry cut: min(pt1^2,pt2^2) * dR(1,2) / mjet > ycut
   double rFilt_;              /// for filtering, trimming: dR scale of sub-clustering
@@ -49,7 +50,14 @@ protected:
   double trimPtFracMin_;      /// for trimming: constituent minimum pt fraction of full jet
   double zCut_;               /// for pruning: constituent minimum pt fraction of parent cluster
   double RcutFactor_;         /// for pruning: constituent dR * pt/2m < rcut_factor
-
+  double subjetPtMin_;        /// for CMSBoostedTauSeedingAlgorithm : subjet pt min
+  double muMin_;              /// for CMSBoostedTauSeedingAlgorithm : min mass-drop
+  double muMax_;              /// for CMSBoostedTauSeedingAlgorithm : max mass-drop
+  double yMin_;               /// for CMSBoostedTauSeedingAlgorithm : min asymmetry
+  double yMax_;               /// for CMSBoostedTauSeedingAlgorithm : max asymmetry
+  double dRMin_;              /// for CMSBoostedTauSeedingAlgorithm : min dR
+  double dRMax_;              /// for CMSBoostedTauSeedingAlgorithm : max dR
+  int    maxDepth_;           /// for CMSBoostedTauSeedingAlgorithm : max depth for descending into clustering sequence
     
 };
 

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -137,6 +137,7 @@ VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig)
   , nExclude_(0)
   , jetCollInstanceName_ ("")
   , writeCompound_ ( false )
+  , verbosity_(0)
 {
   anomalousTowerDef_ = std::auto_ptr<AnomalousTower>(new AnomalousTower(iConfig));
 
@@ -273,8 +274,11 @@ VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig)
     useDeterministicSeed_ = iConfig.getParameter<bool>("useDeterministicSeed");
     minSeed_ =              iConfig.getParameter<unsigned int>("minSeed");
   }
-
-
+  
+  if ( iConfig.exists("verbosity" ) ) {
+    verbosity_ = iConfig.getParameter<int>("verbosity");
+  }
+  
   produces<std::vector<double> >("rhos");
   produces<std::vector<double> >("sigmas");
   produces<double>("rho");
@@ -678,6 +682,9 @@ void VirtualJetProducer::writeJets( edm::Event & iEvent, edm::EventSetup const& 
 template< class T>
 void VirtualJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSetup const& iSetup)
 {
+  if ( verbosity_ >= 1 ) { 
+    std::cout << "<VirtualJetProducer::writeCompoundJets (moduleLabel = " << moduleLabel_ << ")>:" << std::endl;
+  }
 
   // get a list of output jets
   std::auto_ptr<reco::BasicJetCollection>  jetCollection( new reco::BasicJetCollection() );
@@ -724,6 +731,19 @@ void VirtualJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSetu
     for (; itSubJet != itSubJetEnd; ++itSubJet ){
 
       fastjet::PseudoJet const & subjet = *itSubJet;      
+      if ( verbosity_ >= 1 ) {
+	std::cout << "subjet #" << (itSubJet - itSubJetBegin) << ": Pt = " << subjet.pt() << ", eta = " << subjet.eta() << ", phi = " << subjet.phi() << ", mass = " << subjet.m() 
+		  << " (#constituents = " << subjet.constituents().size() << ")" << std::endl;
+	std::vector<fastjet::PseudoJet> subjet_constituents = subjet.constituents();
+	int idx_constituent = 0;
+	for ( std::vector<fastjet::PseudoJet>::const_iterator constituent = subjet_constituents.begin();
+	      constituent != subjet_constituents.end(); ++constituent ) {
+	  if ( constituent->pt() < 1.e-3 ) continue; // CV: skip ghosts
+	  std::cout << "  constituent #" << idx_constituent << ": Pt = " << constituent->pt() << ", eta = " << constituent->eta() << ", phi = " << constituent->phi() << "," 
+		    << " mass = " << constituent->m() << std::endl;
+	  ++idx_constituent;
+	}
+      }
 
       math::XYZTLorentzVector p4Subjet(subjet.px(), subjet.py(), subjet.pz(), subjet.e() );
       reco::Particle::Point point(0,0,0);

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -34,8 +34,6 @@
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 
-//#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-
 #include "fastjet/SISConePlugin.hh"
 #include "fastjet/CMSIterativeConePlugin.hh"
 #include "fastjet/ATLASConePlugin.hh"
@@ -338,6 +336,7 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
   
   // get inputs and convert them to the fastjet format (fastjet::PeudoJet)
   edm::Handle<reco::CandidateView> inputsHandle;
+  
   edm::Handle< std::vector<edm::FwdPtr<reco::PFCandidate> > > pfinputsHandleAsFwdPtr; 
   
   bool isView = iEvent.getByLabel(src_,inputsHandle);
@@ -543,7 +542,6 @@ void VirtualJetProducer::output(edm::Event & iEvent, edm::EventSetup const& iSet
       break;
     };
   }
-  
 }
 
 template< typename T >
@@ -624,7 +622,6 @@ void VirtualJetProducer::writeJets( edm::Event & iEvent, edm::EventSetup const& 
     std::vector<CandidatePtr> constituents =
       getConstituents(fjConstituents);
 
-
     // calcuate the jet area
     double jetArea=0.0;
     if ( doAreaFastjet_ && fjJet.has_area() ) {
@@ -672,11 +669,7 @@ void VirtualJetProducer::writeJets( edm::Event & iEvent, edm::EventSetup const& 
   }
   // put the jets in the collection
   iEvent.put(jets,jetCollInstanceName_);
-  
-
 }
-
-
 
 /// function template to write out the outputs
 template< class T>
@@ -700,7 +693,6 @@ void VirtualJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSetu
   // this is the hardjet areas
   std::vector<double> area_hardJets;
 
-
   // Loop over the hard jets
   std::vector<fastjet::PseudoJet>::const_iterator it = fjJets_.begin(),
     iEnd = fjJets_.end(),
@@ -721,11 +713,10 @@ void VirtualJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSetu
     std::vector<fastjet::PseudoJet> constituents;
     if ( it->has_pieces() ) {
       constituents = it->pieces();
-    } else {
-      constituents=it->constituents();
+    } else if ( it->has_constituents() ) {
+      constituents = it->constituents();
     }
 
-    
     std::vector<fastjet::PseudoJet>::const_iterator itSubJetBegin = constituents.begin(),
       itSubJet = itSubJetBegin, itSubJetEnd = constituents.end();
     for (; itSubJet != itSubJetEnd; ++itSubJet ){
@@ -740,6 +731,20 @@ void VirtualJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSetu
 	      constituent != subjet_constituents.end(); ++constituent ) {
 	  if ( constituent->pt() < 1.e-3 ) continue; // CV: skip ghosts
 	  std::cout << "  constituent #" << idx_constituent << ": Pt = " << constituent->pt() << ", eta = " << constituent->eta() << ", phi = " << constituent->phi() << "," 
+		    << " mass = " << constituent->m() << std::endl;
+	  ++idx_constituent;
+	}
+      }
+
+      if ( verbosity_ >= 1 ) {
+	std::cout << "subjet #" << (itSubJet - itSubJetBegin) << ": Pt = " << subjet.pt() << ", eta = " << subjet.eta() << ", phi = " << subjet.phi() << ", mass = " << subjet.m() 
+		  << " (#constituents = " << subjet.constituents().size() << ")" << std::endl;
+	std::vector<fastjet::PseudoJet> subjet_constituents = subjet.constituents();
+	int idx_constituent = 0;
+	for ( std::vector<fastjet::PseudoJet>::const_iterator constituent = subjet_constituents.begin();
+	      constituent != subjet_constituents.end(); ++constituent ) {
+	  if ( constituent->pt() < 1.e-3 ) continue; // CV: skip ghosts
+	  std::cout << " constituent #" << idx_constituent << ": Pt = " << constituent->pt() << ", eta = " << constituent->eta() << ", phi = " << constituent->phi() << "," 
 		    << " mass = " << constituent->m() << std::endl;
 	  ++idx_constituent;
 	}
@@ -767,12 +772,11 @@ void VirtualJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSetu
       }
       jet.setJetArea( subjetArea );
       subjetCollection->push_back( jet );
-
     }
   }
+
   // put subjets into event record
   subjetHandleAfterPut = iEvent.put( subjetCollection, jetCollInstanceName_ );
-  
   
   // Now create the hard jets with ptr's to the subjets as constituents
   std::vector<math::XYZTLorentzVector>::const_iterator ip4 = p4_hardJets.begin(),
@@ -794,8 +798,7 @@ void VirtualJetProducer::writeCompoundJets(  edm::Event & iEvent, edm::EventSetu
     toput.setJetArea( area_hardJets[ip4 - ip4Begin] );
     jetCollection->push_back( toput );
   }
-  
+
   // put hard jets into event record
   iEvent.put( jetCollection);
-
 }

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -198,6 +198,8 @@ protected:
   bool                            useDeterministicSeed_; // If desired, use a deterministic seed to fastjet
   unsigned int                    minSeed_;              // minimum seed to use, useful for MC generation
 
+  int                   verbosity_;                 // flag to enable/disable debug output
+
 private:
   std::auto_ptr<AnomalousTower>   anomalousTowerDef_;  // anomalous tower definition
 };

--- a/RecoJets/JetProducers/python/CMSBoostedTauSeedingParameters_cfi.py
+++ b/RecoJets/JetProducers/python/CMSBoostedTauSeedingParameters_cfi.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+# Cambridge-Aachen top jet producer parameters
+# $Id
+CMSBoostedTauSeedingParameters = cms.PSet(
+    useCMSBoostedTauSeedingAlgorithm = cms.bool(True),
+    subjetPtMin = cms.double(10.0), # minimum subjet pt
+    muMin = cms.double(0.0),        # minimum mass drop
+    muMax = cms.double(0.667),      # maximum mass drop
+    yMin = cms.double(-1.e+6),      # minimum asymmetry
+    yMax = cms.double(+1.e+6),      # maximum asymmetry
+    dRMin = cms.double(0.0),        # minimum delta R between subjets
+    dRMax = cms.double(0.8),        # maximum delta R between subjets
+    maxDepth = cms.int32(4)         # maximum depth for descending into clustering sequence
+)
+


### PR DESCRIPTION
added jet substructure tools for seeding boosted tau reconstruction
(forward-port from 5_3_X)

includes improvements and minor bug-fixes
    - added protection that subjet has no constituents to VirtualJetProducer.cc
    - run CMSBoostedTauSeedingAlgorithm regardless of pruning/filtering being used in addition
    - added protection against pathological cases to BoostedTauSeedsProducer.cc
    - minor bug-fix: added missing initialization of useCMSBoostedTauSeedingAlgorithm_ flag
    (forward-port of commits
       https://github.com/veelken/cmssw/commit/985ac7ac45ac2b64021f0efb098c770b74247ed7
       https://github.com/veelken/cmssw/commit/6c99ae25a7cffe5f75e05d9a8d774171811540b7
     from CMSSW_5_3_X branch)
    - switch to getByToken and consumes interface
    - updated include guard and removed cvs specific labels from CMSBoostedTauSeedingAlgorithm.h
