### PR TITLE
remove HLT references

### DIFF
--- a/DQMOffline/Muon/src/MuonAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonAnalyzer.cc
@@ -15,7 +15,7 @@
 #include "DQMOffline/Muon/src/SegmentTrackAnalyzer.h"
 #include "DQMOffline/Muon/src/MuonKinVsEtaAnalyzer.h"
 #include "DQMOffline/Muon/src/DiMuonHistograms.h"
-#include "DQMOffline/Muon/src/MuonRecoOneHLT.h"
+//#include "DQMOffline/Muon/src/MuonRecoOneHLT.h"
 #include "DQMOffline/Muon/src/EfficiencyAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -60,7 +60,7 @@ MuonAnalyzer::MuonAnalyzer(const edm::ParameterSet& pSet) {
   theMuonSegmentsAnalyzerFlag   = parameters.getUntrackedParameter<bool>("DoTrackSegmentsAnalysis",true);
   theMuonKinVsEtaAnalyzerFlag   = parameters.getUntrackedParameter<bool>("DoMuonKinVsEtaAnalysis" ,true);
   theDiMuonHistogramsFlag       = parameters.getUntrackedParameter<bool>("DoDiMuonHistograms"     ,true);
-  theMuonRecoOneHLTAnalyzerFlag = parameters.getUntrackedParameter<bool>("DoMuonRecoOneHLT"       ,true);
+  //  theMuonRecoOneHLTAnalyzerFlag = parameters.getUntrackedParameter<bool>("DoMuonRecoOneHLT"       ,true);
   theEfficiencyAnalyzerFlag     = parameters.getUntrackedParameter<bool>("DoEfficiencyAnalysis"   ,true);
   
   // If the previous are defined... create the analyzer class 
@@ -84,8 +84,8 @@ MuonAnalyzer::MuonAnalyzer(const edm::ParameterSet& pSet) {
     trackStaMuAnalysisParameters.addParameter<edm::InputTag>("MuTrackCollection",theStaMuTrackCollectionLabel);
     theStaMuonSegmentsAnalyzer = new SegmentTrackAnalyzer(trackStaMuAnalysisParameters, theService);
   }
-  if (theMuonRecoOneHLTAnalyzerFlag)
-    theMuonRecoOneHLTAnalyzer = new MuonRecoOneHLT(parameters.getParameter<ParameterSet>("muonRecoOneHLTAnalysis"),theService);
+  //  if (theMuonRecoOneHLTAnalyzerFlag)
+  //    theMuonRecoOneHLTAnalyzer = new MuonRecoOneHLT(parameters.getParameter<ParameterSet>("muonRecoOneHLTAnalysis"),theService);
   if(theEfficiencyAnalyzerFlag)
     theEfficiencyAnalyzer = new EfficiencyAnalyzer(parameters.getParameter<ParameterSet>("efficiencyAnalysis"), theService);
 }
@@ -102,11 +102,11 @@ MuonAnalyzer::~MuonAnalyzer() {
   }
   if(theMuonKinVsEtaAnalyzerFlag)   delete theMuonKinVsEtaAnalyzer;
   if(theDiMuonHistogramsFlag)       delete theDiMuonHistograms;
-  if(theMuonRecoOneHLTAnalyzerFlag) delete theMuonRecoOneHLTAnalyzer;
+  //  if(theMuonRecoOneHLTAnalyzerFlag) delete theMuonRecoOneHLTAnalyzer;
   if(theEfficiencyAnalyzerFlag)     delete theEfficiencyAnalyzer;
 }
 void MuonAnalyzer::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup){
-  if (theMuonRecoOneHLTAnalyzerFlag) theMuonRecoOneHLTAnalyzer->beginRun(iRun,iSetup);
+  //  if (theMuonRecoOneHLTAnalyzerFlag) theMuonRecoOneHLTAnalyzer->beginRun(iRun,iSetup);
 }
 void MuonAnalyzer::beginJob(void) {
   metname = "muonAnalyzer";
@@ -121,7 +121,7 @@ void MuonAnalyzer::beginJob(void) {
   if(theMuonSegmentsAnalyzerFlag)   theStaMuonSegmentsAnalyzer->beginJob(theDbe);
   if(theMuonKinVsEtaAnalyzerFlag)   theMuonKinVsEtaAnalyzer->beginJob(theDbe);
   if(theDiMuonHistogramsFlag)       theDiMuonHistograms->beginJob(theDbe);
-  if(theMuonRecoOneHLTAnalyzerFlag) theMuonRecoOneHLTAnalyzer->beginJob(theDbe);
+  //  if(theMuonRecoOneHLTAnalyzerFlag) theMuonRecoOneHLTAnalyzer->beginJob(theDbe);
   if(theEfficiencyAnalyzerFlag)     theEfficiencyAnalyzer->beginJob(theDbe); 
 }
 void MuonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
@@ -155,10 +155,10 @@ void MuonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
       //	theMuonRecoOneHLTAnalyzer->analyze(iEvent, iSetup, *triggerResults);
       //      }
     }
-    if(theMuonRecoOneHLTAnalyzerFlag) {
-      LogTrace(metname)<<"[MuonAnalyzer] Call to the muon reco One HLT analyzer";
-      theMuonRecoOneHLTAnalyzer->analyze(iEvent, iSetup, *triggerResults);
-    }
+    //    if(theMuonRecoOneHLTAnalyzerFlag) {
+    //      LogTrace(metname)<<"[MuonAnalyzer] Call to the muon reco One HLT analyzer";
+    //      theMuonRecoOneHLTAnalyzer->analyze(iEvent, iSetup, *triggerResults);
+    //    }
     if (theEfficiencyAnalyzerFlag){
       LogTrace(metname)<<"[MuonAnalyzer] Call to the efficiency analyzer";
       theEfficiencyAnalyzer->analyze(iEvent,iSetup);

--- a/DQMOffline/Muon/src/MuonAnalyzer.h
+++ b/DQMOffline/Muon/src/MuonAnalyzer.h
@@ -18,10 +18,10 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/Common/interface/TriggerResults.h"
-#include "DataFormats/HLTReco/interface/TriggerEvent.h"
-#include "DataFormats/HLTReco/interface/TriggerObject.h"
-#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
-#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+//#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+//#include "DataFormats/HLTReco/interface/TriggerObject.h"
+//#include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
+//#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 //
 #include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
 
@@ -34,7 +34,7 @@ class MuonKinVsEtaAnalyzer;
 class DiMuonHistograms;
 class DQMStore;
 class MuonServiceProxy;
-class MuonRecoOneHLT;
+//class MuonRecoOneHLT;
 class EfficiencyAnalyzer;
 
 class MuonAnalyzer : public edm::EDAnalyzer {
@@ -80,7 +80,7 @@ class MuonAnalyzer : public edm::EDAnalyzer {
   bool theMuonKinVsEtaAnalyzerFlag;
   bool theMuonSegmentsAnalyzerFlag;
   bool theDiMuonHistogramsFlag;
-  bool theMuonRecoOneHLTAnalyzerFlag;
+  //  bool theMuonRecoOneHLTAnalyzerFlag;
   bool theEfficiencyAnalyzerFlag;
  
   // Define Analysis Modules
@@ -91,7 +91,7 @@ class MuonAnalyzer : public edm::EDAnalyzer {
   SegmentTrackAnalyzer*      theGlbMuonSegmentsAnalyzer;
   SegmentTrackAnalyzer*      theStaMuonSegmentsAnalyzer;
   DiMuonHistograms*          theDiMuonHistograms;
-  MuonRecoOneHLT*            theMuonRecoOneHLTAnalyzer;
+  //  MuonRecoOneHLT*            theMuonRecoOneHLTAnalyzer;
   EfficiencyAnalyzer*        theEfficiencyAnalyzer; 
 };
 #endif  


### PR DESCRIPTION
Removing HLT references from MuonAnalyzer to being able to run DQMOffline package on the SLHC releases. 
