### PR TITLE
bugfixes for PFEG: mustache conversions, GSF-SC associations, muons, mva-e-pi filling

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -210,6 +210,8 @@ class GsfElectronAlgo {
     void removeNotPreselectedElectrons() ;
     void removeAmbiguousElectrons() ;
     void copyElectrons( reco::GsfElectronCollection & ) ;
+    void setMVAInputs(const std::map<reco::GsfTrackRef,reco::GsfElectron::MvaInput> & mvaInputs)  ;
+    void setMVAOutputs(const std::map<reco::GsfTrackRef,reco::GsfElectron::MvaOutput> & mvaOutputs) ;
     void endEvent() ;
 
   private :
@@ -230,6 +232,7 @@ class GsfElectronAlgo {
     void setPflowPreselectionFlag( reco::GsfElectron * ele ) ;
     bool isPreselected( reco::GsfElectron * ele ) ;
     void calculateShowerShape( const reco::SuperClusterRef &, bool pflow, reco::GsfElectron::ShowerShape & ) ;
+
 
     // associations
     const reco::SuperClusterRef getTrSuperCluster( const reco::GsfTrackRef & trackRef ) ;

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -1115,6 +1115,32 @@ void GsfElectronAlgo::setPflowPreselectionFlag( GsfElectron * ele )
 //   { LogTrace("GsfElectronAlgo") << "Mva criteria are satisfied" ; }
  }
 
+void GsfElectronAlgo::setMVAInputs(const std::map<reco::GsfTrackRef,reco::GsfElectron::MvaInput> & mvaInputs) 
+{
+  GsfElectronPtrCollection::iterator el ;
+  for
+    ( el = eventData_->electrons->begin() ;
+      el != eventData_->electrons->end() ;
+      el++ )
+    {
+      std::map<reco::GsfTrackRef,reco::GsfElectron::MvaInput>::const_iterator itcheck=mvaInputs.find((*el)->gsfTrack());
+      (*el)->setMvaInput(itcheck->second);
+    }
+}
+
+void GsfElectronAlgo::setMVAOutputs(const std::map<reco::GsfTrackRef,reco::GsfElectron::MvaOutput> & mvaOutputs)
+{
+  GsfElectronPtrCollection::iterator el ;
+  for
+    ( el = eventData_->electrons->begin() ;
+      el != eventData_->electrons->end() ;
+      el++ )
+    {
+      std::map<reco::GsfTrackRef,reco::GsfElectron::MvaOutput>::const_iterator itcheck=mvaOutputs.find((*el)->gsfTrack());
+      (*el)->setMvaOutput(itcheck->second);
+    }
+}
+
 void GsfElectronAlgo::createElectron()
  {
   // eventually check ctf track

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.cc
@@ -46,6 +46,8 @@ void GEDGsfElectronProducer::produce( edm::Event & event, const edm::EventSetup 
   beginEvent(event,setup) ;
   matchWithPFCandidates(event);
   algo_->completeElectrons() ;
+  algo_->setMVAOutputs(gsfMVAOutputMap_);
+  algo_->setMVAInputs(gsfMVAInputMap_);
   fillEvent(event) ;
 
   // ValueMap

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.cc
@@ -13,14 +13,14 @@
 
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
-#include "DataFormats/EgammaReco/interface/ElectronSeed.h"
+
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
-#include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
-#include "DataFormats/TrackingRecHit/interface/TrackingRecHitFwd.h"
+
+
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
-
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateEGammaExtra.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateEGammaExtraFwd.h"
 #include "RecoParticleFlow/PFProducer/interface/GsfElectronEqual.h"
 
 #include <iostream>
@@ -44,13 +44,14 @@ GEDGsfElectronProducer::~GEDGsfElectronProducer()
 void GEDGsfElectronProducer::produce( edm::Event & event, const edm::EventSetup & setup )
  {
   beginEvent(event,setup) ;
+  matchWithPFCandidates(event);
   algo_->completeElectrons() ;
   fillEvent(event) ;
 
   // ValueMap
   std::auto_ptr<edm::ValueMap<reco::GsfElectronRef> > valMap_p(new edm::ValueMap<reco::GsfElectronRef>);
   edm::ValueMap<reco::GsfElectronRef>::Filler valMapFiller(*valMap_p);
-  matchWithPFCandidates(event,valMapFiller);
+  fillGsfElectronValueMap(event,valMapFiller);
   valMapFiller.fill();
   event.put(valMap_p,outputValueMapLabel_);  
   // Done with the ValueMap
@@ -58,7 +59,7 @@ void GEDGsfElectronProducer::produce( edm::Event & event, const edm::EventSetup 
   endEvent() ;
  }
 
-void GEDGsfElectronProducer::matchWithPFCandidates(edm::Event & event, edm::ValueMap<reco::GsfElectronRef>::Filler & filler)
+void GEDGsfElectronProducer::fillGsfElectronValueMap(edm::Event & event, edm::ValueMap<reco::GsfElectronRef>::Filler & filler)
 {
   // Read the collection of PFCandidates
   edm::Handle<reco::PFCandidateCollection> pfCandidates;
@@ -92,3 +93,46 @@ void GEDGsfElectronProducer::matchWithPFCandidates(edm::Event & event, edm::Valu
   filler.insert(pfCandidates,values.begin(),values.end());
 }
 
+
+// Something more clever has to be found. The collections are small, so the timing is not 
+// an issue here; but it is clearly suboptimal
+
+void GEDGsfElectronProducer::matchWithPFCandidates(edm::Event & event)
+{
+  gsfMVAInputMap_.clear();
+  gsfMVAOutputMap_.clear();
+
+  // Read the collection of PFCandidates
+  edm::Handle<reco::PFCandidateCollection> pfCandidates;
+  
+  bool found = event.getByToken(egmPFCandidateCollection_, pfCandidates);
+  if(!found) {
+    edm::LogError("GEDGsfElectronProducer")
+       <<" cannot get PFCandidates! ";
+  }
+
+  //Loop over the collection of PFFCandidates
+  reco::PFCandidateCollection::const_iterator it = pfCandidates->begin();
+  reco::PFCandidateCollection::const_iterator itend = pfCandidates->end() ;
+  
+  for ( ; it != itend ; ++it) {
+    reco::GsfElectronRef myRef;
+    // First check that the GsfTrack is non null
+    if( it->gsfTrackRef().isNonnull()) {
+
+      reco::GsfElectron::MvaOutput myMvaOutput;
+      myMvaOutput.mva = it->mva_e_pi();
+      // at the moment, undefined
+      myMvaOutput.status = 0;
+      gsfMVAOutputMap_[it->gsfTrackRef()] = myMvaOutput;
+
+      reco::GsfElectron::MvaInput myMvaInput;
+      myMvaInput.earlyBrem = it->egammaExtraRef()->mvaVariable(reco::PFCandidateEGammaExtra::MVA_FirstBrem);
+      myMvaInput.lateBrem = it->egammaExtraRef()->mvaVariable(reco::PFCandidateEGammaExtra::MVA_LateBrem);
+      myMvaInput.deltaEta = it->egammaExtraRef()->mvaVariable(reco::PFCandidateEGammaExtra::MVA_DeltaEtaTrackCluster);
+      myMvaInput.sigmaEtaEta = it->egammaExtraRef()->sigmaEtaEta();
+      myMvaInput.hadEnergy = it->egammaExtraRef()->hadEnergy();
+      gsfMVAInputMap_[it->gsfTrackRef()] = myMvaInput;
+    }
+  }
+}

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.h
@@ -4,6 +4,7 @@
 
 #include "GsfElectronBaseProducer.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include <map>
 
 class GEDGsfElectronProducer : public GsfElectronBaseProducer
  {
@@ -18,9 +19,12 @@ class GEDGsfElectronProducer : public GsfElectronBaseProducer
  private:
     edm::EDGetTokenT<reco::PFCandidateCollection> egmPFCandidateCollection_;
     std::string outputValueMapLabel_;
+    std::map<reco::GsfTrackRef,reco::GsfElectron::MvaInput> gsfMVAInputMap_;
+    std::map<reco::GsfTrackRef,reco::GsfElectron::MvaOutput> gsfMVAOutputMap_;
 
  private:
-    void matchWithPFCandidates(edm::Event & event, edm::ValueMap<reco::GsfElectronRef>::Filler & filler);
+    void fillGsfElectronValueMap(edm::Event & event, edm::ValueMap<reco::GsfElectronRef>::Filler & filler);
+    void matchWithPFCandidates(edm::Event & event);
 
  } ;
 

--- a/RecoEgamma/EgammaPhotonProducers/python/conversionTrackSequence_cff.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/conversionTrackSequence_cff.py
@@ -135,7 +135,7 @@ inOutOutInMustacheConversionTrackMerger.TrackProducer1 = cms.InputTag('inOutMust
 inOutOutInMustacheConversionTrackMerger.TrackProducer2 = cms.InputTag('outInMustacheConversionTrackProducer')
 
 generalInOutOutInMustacheConversionTrackMerger = generalInOutOutInConversionTrackMerger.clone()
-generalInOutOutInMustacheConversionTrackMerger.TrackProducer1 = cms.InputTag('inOutOutInConversionTrackMerger')
+generalInOutOutInMustacheConversionTrackMerger.TrackProducer1 = cms.InputTag('inOutOutInMustacheConversionTrackMerger')
 
 gsfGeneralInOutOutInMustacheConversionTrackMerger = gsfGeneralInOutOutInConversionTrackMerger.clone()
 gsfGeneralInOutOutInMustacheConversionTrackMerger.TrackProducer1 = cms.InputTag('generalInOutOutInMustacheConversionTrackMerger')

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -1141,16 +1141,20 @@ void PFEGammaAlgo::EarlyConversion(
 }
 
 bool PFEGammaAlgo::isAMuon(const reco::PFBlockElement& pfbe) {
-  NotCloserToOther<reco::PFBlockElement::GSF,reco::PFBlockElement::TRACK>
-    getTrackPartner(_currentblock,_currentlinks,&pfbe);
   switch( pfbe.type() ) {
   case reco::PFBlockElement::GSF:    
     {
-      auto& tracks = _splayedblock[reco::PFBlockElement::TRACK];
-      auto notmatched = 
-	std::partition(tracks.begin(),tracks.end(),getTrackPartner);
-      for( auto tk = tracks.begin(); tk != notmatched; ++tk ) {
-	if( PFMuonAlgo::isMuon(*(tk->first)) ) return true;
+      auto& elements = _currentblock->elements();
+      std::multimap<double,unsigned> tks;
+      _currentblock->associatedElements(pfbe.index(),
+					_currentlinks,
+					tks,
+					reco::PFBlockElement::TRACK,
+					reco::PFBlock::LINKTEST_ALL);      
+      for( const auto& tk : tks ) {
+	if( PFMuonAlgo::isMuon(elements[tk.second]) ) {
+	  return true;
+	}
       }
     }
     break;


### PR DESCRIPTION
Fix the following bugs:
- not checking to merge refineable objects through association by brem tangents (allows tracker driven gsf tracks to pull in super clusters with no associated gsf track)
- fix a bug when in GED mode where the wrong super cluster would get associated to an ECAL driven electron, this was coming from a null seed det ID in the seed PFClusters, which seems like a somewhat deeper bug.
- correctly put the mustache-driven conversions into the conversion sequence. No noticeable changes to e/gamma objects.
- correctly veto ID'd muons from becoming seeds for e/gamma objects
- Fill the electron ID mva value for gedGsfElectrons, should show up in DQM now.

The cluster/linking related fixes improve low-side (i.e. below 0.5) tails in the E_reco/E_true distribution for refined superclusters coming from electrons.

The muon fix should significantly reduce the rate of high pT muons becoming electrons.
