### PR TITLE
Fixed typo in operator* which was never called before

### DIFF
--- a/DataFormats/Common/interface/AtomicPtrCache.h
+++ b/DataFormats/Common/interface/AtomicPtrCache.h
@@ -67,7 +67,7 @@ namespace edm {
     
     // ---------- member functions ---------------------------
     T* operator->() { return load();}
-    T& operator*() {return load();}
+    T& operator*() {return *load();}
     
     T* load();
     

--- a/DataFormats/Common/test/atomicptrcache_t.cppunit.cc
+++ b/DataFormats/Common/test/atomicptrcache_t.cppunit.cc
@@ -33,6 +33,18 @@ testAtomicPtrCache::check()
     cache.set(std::move(p));
     CPPUNIT_ASSERT(true == cache.isSet());
     CPPUNIT_ASSERT(cache->size() == values.size());
+    CPPUNIT_ASSERT((*cache).size() == values.size());
+    CPPUNIT_ASSERT(cache.load()->size() == values.size());
+
+    {
+      //test const functions
+      const AtomicPtrCache<Vec> & constCache = cache;
+
+      CPPUNIT_ASSERT(true == constCache.isSet());
+      CPPUNIT_ASSERT(constCache->size() == values.size());
+      CPPUNIT_ASSERT((*constCache).size() == values.size());
+      CPPUNIT_ASSERT(constCache.load()->size() == values.size());
+    }
     
     cache.reset();
     CPPUNIT_ASSERT(false == cache.isSet());


### PR DESCRIPTION
The non-const version of operator\* was missing a ‘*’ and was not caught since it had not been called.
Updated the unit test so it tests all the functions, both const and non-const.
