### PR TITLE
updating the HCAL LMAP code for HO ring 0 changes performed during LS1

### DIFF
--- a/CalibCalorimetry/HcalAlgos/test/maptester_cfg.py
+++ b/CalibCalorimetry/HcalAlgos/test/maptester_cfg.py
@@ -7,8 +7,7 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1) )
 process.GlobalTag.globaltag = "START62_V1::All"
 
-process.source = cms.Source("EmptySource",
-)
+process.source = cms.Source("EmptySource")
 
 process.demo = cms.EDAnalyzer("MapTester",
 #    mapIOV = cms.uint32(1), # HO pre 2009


### PR DESCRIPTION
Updated the HCAL logical map code to account for the changes introduced during LS1 with the swapping of the HO ring-0 interface cards
