### PR TITLE
New KeyList; Solved name clash in OSX for time::MAX/MIN

### DIFF
--- a/CondCore/CondDB/interface/KeyList.h
+++ b/CondCore/CondDB/interface/KeyList.h
@@ -28,8 +28,10 @@ namespace cond {
     public:
       
       explicit KeyList( Session& session );
+
+      void init( const std::string& tag );
       
-      void load(const std::string& tag, const std::vector<unsigned long long>& keys);
+      void load( const std::vector<unsigned long long>& keys );
       
       template<typename T> 
       T const * get(size_t n) const {
@@ -51,9 +53,11 @@ namespace cond {
       int size() const { return m_objects.size();}
 
     private:
-      // the full collection of keyed object
+      // the tag of the full key collection
+      std::string m_tag;
+      // the db session
       Session m_session;
-      // the current set
+      // the key selection
       mutable std::map<size_t,std::pair<std::string,cond::Binary> > m_data;
       std::vector<boost::shared_ptr<void> > m_objects;
       

--- a/CondCore/CondDB/interface/KeyListProxy.h
+++ b/CondCore/CondDB/interface/KeyListProxy.h
@@ -1,0 +1,63 @@
+#ifndef CondCore_CondDB_KeyListProxy_h
+#define CondCore_CondDB_KeyListProxy_h
+
+#include "CondCore/CondDB/interface/PayloadProxy.h"
+#include "CondCore/CondDB/interface/KeyList.h"
+#include <vector>
+#include <string>
+
+namespace cond {
+
+  using KeyList = cond::ora_wrapper::KeyList;
+
+  namespace db {
+    template<> class PayloadProxy<cond::KeyList> : public PayloadProxy<std::vector<cond::Time_t> > {
+    public:
+      typedef std::vector<cond::Time_t> DataT;
+      typedef PayloadProxy<DataT> super;
+
+    
+      PayloadProxy( Session& session, const char * source=0 ) :
+	super( session ),
+	m_keyList( session ) {
+	if( source ) m_name = source;
+      }
+
+      //PayloadProxy( Session& session, const std::string& tag ) :
+      //	  super( session, tag ),
+      //	  m_keyList( session ) {
+      //	m_keyList.load( super::operator()() );
+	//m_name = source;
+      //}
+    
+      virtual ~PayloadProxy(){}
+
+      // dereference (does not load)
+      const cond::KeyList & operator()() const {
+	return me; 
+      }
+        
+      virtual void invalidateCache() {
+	super::invalidateCache();
+      }
+
+      virtual void loadMore(CondGetter const & getter){
+      	me.init(getter.getTag(m_name));
+      }
+
+
+    protected:
+      virtual bool loadPayload() {
+	bool ok = super::loadPayload();
+	me.load(super::operator()());
+	return ok;
+      }
+
+  private:
+
+    std::string m_name;
+    KeyList m_keyList;
+
+  };
+}
+#endif

--- a/CondCore/CondDB/interface/KeyListProxy.h
+++ b/CondCore/CondDB/interface/KeyListProxy.h
@@ -23,13 +23,6 @@ namespace cond {
 	if( source ) m_name = source;
       }
 
-      //PayloadProxy( Session& session, const std::string& tag ) :
-      //	  super( session, tag ),
-      //	  m_keyList( session ) {
-      //	m_keyList.load( super::operator()() );
-	//m_name = source;
-      //}
-    
       virtual ~PayloadProxy(){}
 
       // dereference (does not load)

--- a/CondCore/CondDB/interface/PayloadProxy.h
+++ b/CondCore/CondDB/interface/PayloadProxy.h
@@ -19,7 +19,8 @@ namespace cond {
     class CondGetter {
     public:
       virtual ~CondGetter(){}
-      virtual IOVProxy get(std::string name) const=0;
+      //virtual IOVProxy get(std::string name) const=0;
+      virtual std::string getTag(std::string name) const=0;
       
     };
     
@@ -74,11 +75,11 @@ namespace cond {
     class PayloadProxy : public BasePayloadProxy {
     public:
       
-      explicit PayloadProxy( Session& session ) :
+      PayloadProxy( Session& session, const char * source=0 ) :
 	BasePayloadProxy( session ) {}
       
-      PayloadProxy( Session& session, const std::string& tag ) :
-	BasePayloadProxy(session, tag ) {}
+      //PayloadProxy( Session& session, const std::string& tag ) :
+      //	BasePayloadProxy(session, tag ) {}
       
       virtual ~PayloadProxy(){}
       

--- a/CondCore/CondDB/interface/PayloadProxy.h
+++ b/CondCore/CondDB/interface/PayloadProxy.h
@@ -3,8 +3,6 @@
 
 #include "CondCore/CondDB/interface/ORAWrapper.h"
 #include "CondCore/CondDB/interface/Time.h"
-//#include "CondCore/CondDB/interface/IOVProxy.h"
-//#include "CondCore/CondDB/interface/Session.h"
 
 namespace cond {
 
@@ -19,7 +17,6 @@ namespace cond {
     class CondGetter {
     public:
       virtual ~CondGetter(){}
-      //virtual IOVProxy get(std::string name) const=0;
       virtual std::string getTag(std::string name) const=0;
       
     };
@@ -54,8 +51,6 @@ namespace cond {
       
       virtual void loadMore(CondGetter const &){}
       
-      // reload the iov return true if size has changed
-      
     private:
       virtual void loadPayload() = 0;   
       
@@ -77,9 +72,6 @@ namespace cond {
       
       PayloadProxy( Session& session, const char * source=0 ) :
 	BasePayloadProxy( session ) {}
-      
-      //PayloadProxy( Session& session, const std::string& tag ) :
-      //	BasePayloadProxy(session, tag ) {}
       
       virtual ~PayloadProxy(){}
       

--- a/CondCore/CondDB/interface/Time.h
+++ b/CondCore/CondDB/interface/Time.h
@@ -15,9 +15,9 @@ namespace cond {
     // Time_t
     typedef cond::Time_t Time_t;
 
-    const Time_t MAX(std::numeric_limits<Time_t>::max());
+    const Time_t MAX_VAL(std::numeric_limits<Time_t>::max());
 
-    const Time_t MIN(0);
+    const Time_t MIN_VAL(0);
   
     typedef cond::UnpackedTime UnpackedTime;
 

--- a/CondCore/CondDB/src/GTEditor.cc
+++ b/CondCore/CondDB/src/GTEditor.cc
@@ -19,7 +19,7 @@ namespace cond {
       }
       // GT data
       std::string name;
-      cond::Time_t validity = cond::time::MAX;
+      cond::Time_t validity = cond::time::MAX_VAL;
       std::string description;
       std::string release;
       boost::posix_time::ptime snapshotTime;
@@ -68,7 +68,7 @@ namespace cond {
     }
     
     cond::Time_t GTEditor::validity() const {
-      return m_data.get()? m_data->validity : cond::time::MIN;
+      return m_data.get()? m_data->validity : cond::time::MIN_VAL;
     }
     
     void GTEditor::setValidity( cond::Time_t validity ){

--- a/CondCore/CondDB/src/GTProxy.cc
+++ b/CondCore/CondDB/src/GTProxy.cc
@@ -117,7 +117,7 @@ namespace cond {
     }
     
     cond::Time_t GTProxy::validity() const {
-      return m_data.get() ? m_data->validity : cond::time::MIN;
+      return m_data.get() ? m_data->validity : cond::time::MIN_VAL;
     }
     
     boost::posix_time::ptime GTProxy::snapshotTime() const {

--- a/CondCore/CondDB/src/IOVEditor.cc
+++ b/CondCore/CondDB/src/IOVEditor.cc
@@ -23,8 +23,8 @@ namespace cond {
       std::string payloadType;
       cond::SynchronizationType synchronizationType; 
       std::string description;
-      cond::Time_t endOfValidity = cond::time::MAX;
-      cond::Time_t lastValidatedTime = cond::time::MIN; 
+      cond::Time_t endOfValidity = cond::time::MAX_VAL;
+      cond::Time_t lastValidatedTime = cond::time::MIN_VAL; 
       bool change = false;
       bool exists = false;
       // buffer for the iov sequence
@@ -95,7 +95,7 @@ namespace cond {
     }
     
     cond::Time_t IOVEditor::endOfValidity() const {
-      return m_data.get() ? m_data->endOfValidity : cond::time::MIN;
+      return m_data.get() ? m_data->endOfValidity : cond::time::MIN_VAL;
     }
     
     void IOVEditor::setEndOfValidity( cond::Time_t time ){
@@ -117,7 +117,7 @@ namespace cond {
     }
     
     cond::Time_t IOVEditor::lastValidatedTime() const {
-      return m_data.get() ? m_data->lastValidatedTime : cond::time::MIN;
+      return m_data.get() ? m_data->lastValidatedTime : cond::time::MIN_VAL;
     }
     
     void IOVEditor::setLastValidatedTime(cond::Time_t time ){

--- a/CondCore/CondDB/src/IOVProxy.cc
+++ b/CondCore/CondDB/src/IOVProxy.cc
@@ -22,8 +22,8 @@ namespace cond {
       cond::Time_t endOfValidity;
       cond::Time_t lastValidatedTime;
       // iov data
-      cond::Time_t lowerGroup = cond::time::MAX;
-      cond::Time_t higherGroup = cond::time::MIN;
+      cond::Time_t lowerGroup = cond::time::MAX_VAL;
+      cond::Time_t higherGroup = cond::time::MIN_VAL;
       std::vector<cond::Time_t> sinceGroups;
       IOVProxy::IOVContainer iovSequence;
       size_t numberOfQueries = 0;
@@ -63,7 +63,7 @@ namespace cond {
       next++;
       
       // for the till, the next element has to be verified!
-      retVal.till = cond::time::MAX;
+      retVal.till = cond::time::MAX_VAL;
       if( next != m_end ){
 	
 	// the till has to be calculated according to the time type ( because of the packing for some types ) 
@@ -131,8 +131,8 @@ namespace cond {
 	
 	// load the full iov sequence in this case!
 	IOV::selectLast( m_data->tag, m_data->iovSequence, *m_session );
-	m_data->lowerGroup = cond::time::MIN;
-	m_data->higherGroup = cond::time::MAX;
+	m_data->lowerGroup = cond::time::MIN_VAL;
+	m_data->higherGroup = cond::time::MAX_VAL;
       } else {
 	IOV::selectGroups( m_data->tag, m_data->sinceGroups, *m_session );
       }
@@ -144,8 +144,8 @@ namespace cond {
     
     void IOVProxy::reset(){
       if( m_data.get() ){
-	m_data->lowerGroup = cond::time::MAX;
-	m_data->higherGroup = cond::time::MIN;
+	m_data->lowerGroup = cond::time::MAX_VAL;
+	m_data->higherGroup = cond::time::MIN_VAL;
 	m_data->sinceGroups.clear();
 	m_data->iovSequence.clear();
 	m_data->numberOfQueries = 0;
@@ -165,11 +165,11 @@ namespace cond {
     }
     
     cond::Time_t IOVProxy::endOfValidity() const {
-      return m_data.get() ? m_data->endOfValidity : cond::time::MIN;
+      return m_data.get() ? m_data->endOfValidity : cond::time::MIN_VAL;
     }
     
     cond::Time_t IOVProxy::lastValidatedTime() const {
-      return m_data.get() ? m_data->lastValidatedTime : cond::time::MIN;
+      return m_data.get() ? m_data->lastValidatedTime : cond::time::MIN_VAL;
     }
     
     void IOVProxy::checkSession( const std::string& ctx ){
@@ -221,7 +221,7 @@ namespace cond {
       // first check the available iov cache:
       // case 0 empty cache ( the first request )
       
-      if( m_data->lowerGroup==cond::time::MAX ||
+      if( m_data->lowerGroup==cond::time::MAX_VAL ||
 	  // case 1 : target outside
 	  time < m_data->lowerGroup || time>= m_data->higherGroup ){
 	
@@ -241,7 +241,7 @@ namespace cond {
 	}
 	// the upper group will be also extended to the next (covering in total up to three groups )
 	iGHigh++;
-	cond::Time_t highG = cond::time::MAX;
+	cond::Time_t highG = cond::time::MAX_VAL;
 	if( iGHigh != m_data->sinceGroups.end() ) {
 	  iGHigh++;
 	  if( iGHigh != m_data->sinceGroups.end() ) highG = *iGHigh;
@@ -273,7 +273,7 @@ namespace cond {
     }
     
     std::pair<cond::Time_t,cond::Time_t> IOVProxy::loadedGroup() const {
-      return m_data.get()? std::make_pair( m_data->lowerGroup, m_data->higherGroup ): std::make_pair( cond::time::MAX, cond::time::MIN );
+      return m_data.get()? std::make_pair( m_data->lowerGroup, m_data->higherGroup ): std::make_pair( cond::time::MAX_VAL, cond::time::MIN_VAL );
     }
     
   }

--- a/CondCore/CondDB/src/IOVSchema.cc
+++ b/CondCore/CondDB/src/IOVSchema.cc
@@ -135,7 +135,7 @@ namespace cond {
       Query< SINCE, PAYLOAD_HASH > q( session.coralSchema() );
       q.addCondition<TAG_NAME>( tag );
       if( lowerSinceGroup > 0 ) q.addCondition<SINCE>( lowerSinceGroup, ">=" );
-      if( upperSinceGroup < cond::time::MAX ) q.addCondition<SINCE>( upperSinceGroup, "<" );
+      if( upperSinceGroup < cond::time::MAX_VAL ) q.addCondition<SINCE>( upperSinceGroup, "<" );
       q.addOrderClause<SINCE>();
       q.addOrderClause<INSERTION_TIME>( false );
       size_t initialSize = iovs.size();
@@ -154,7 +154,7 @@ namespace cond {
       Query< SINCE, PAYLOAD_HASH > q( session.coralSchema() );
       q.addCondition<TAG_NAME>( tag );
       if( lowerSinceGroup > 0 ) q.addCondition<SINCE>( lowerSinceGroup, ">=" );
-      if( upperSinceGroup < cond::time::MAX ) q.addCondition<SINCE>( upperSinceGroup, "<" );
+      if( upperSinceGroup < cond::time::MAX_VAL ) q.addCondition<SINCE>( upperSinceGroup, "<" );
       q.addCondition<INSERTION_TIME>( snapshotTime,"<=" );
       q.addOrderClause<SINCE>();
       q.addOrderClause<INSERTION_TIME>( false );
@@ -187,7 +187,7 @@ cond::Time_t targetGroup,
   Query< SINCE, PAYLOAD_HASH > q1( session.coralSchema() );
   q1.addCondition<TAG_NAME>( tag );
   if( lowerSinceGroup > 0 ) q1.addCondition<SINCE>( lowerSinceGroup, ">=" );
-  if( upperSinceGroup < cond::time::MAX ) q1.addCondition<SINCE>( upperSinceGroup, "<=" );
+  if( upperSinceGroup < cond::time::MAX_VAL ) q1.addCondition<SINCE>( upperSinceGroup, "<=" );
   q1.addOrderClause<SINCE>();
   q1.addOrderClause<INSERTION_TIME>( false );
   size_t initialSize = iovs.size();
@@ -219,7 +219,7 @@ size_t IOV::selectSnapshotByGroup( const std::string& tag,
   Query< SINCE, PAYLOAD_HASH > q1( session.coralSchema() );
   q1.addCondition<TAG_NAME>( tag );
   if( lowerSinceGroup > 0 ) q1.addCondition<SINCE>( lowerSinceGroup, ">=" );
-  if( upperSinceGroup < cond::time::MAX ) q1.addCondition<SINCE>( upperSinceGroup, "<=" );
+  if( upperSinceGroup < cond::time::MAX_VAL ) q1.addCondition<SINCE>( upperSinceGroup, "<=" );
   q1.addCondition<INSERTION_TIME>( snapshotUpperTime,"<=" );
   q1.addOrderClause<SINCE>();
   q1.addOrderClause<INSERTION_TIME>( false );

--- a/CondCore/CondDB/src/KeyList.cc
+++ b/CondCore/CondDB/src/KeyList.cc
@@ -6,14 +6,21 @@ namespace cond {
   namespace persistency {
 
     KeyList::KeyList( Session& session ):
+      m_tag(""),
       m_session( session ),
       m_data(),
       m_objects(){
     }
 
-    void KeyList::load(const std::string& tag, const std::vector<unsigned long long>& keys){
+    void KeyList::init( const std::string& tag ){
+      m_tag = tag;
+      m_data.clear();
+      m_objects.clear();
+    }
+
+    void KeyList::load( const std::vector<unsigned long long>& keys ){
       m_session.transaction().start( true );
-      IOVProxy proxy = m_session.readIov( tag );
+      IOVProxy proxy = m_session.readIov( m_tag );
       m_data.clear();
       m_objects.resize(keys.size());
       for (size_t i=0; i<keys.size(); ++i) {

--- a/CondCore/CondDB/src/ORAWrapper.cc
+++ b/CondCore/CondDB/src/ORAWrapper.cc
@@ -640,7 +640,7 @@ namespace cond {
     
     cond::Time_t GTProxy::validity() const {
       if( m_oraData.get() ){
-	return cond::time::MAX;
+	return cond::time::MAX_VAL;
       } else {
 	return m_impl.validity();
       }

--- a/CondCore/CondDB/src/ORAWrapper.cc
+++ b/CondCore/CondDB/src/ORAWrapper.cc
@@ -789,6 +789,46 @@ namespace cond {
     bool Session::isOra() const {
       return m_switch.isOra();
     }
+
+    Switch& Session::details() {
+      return m_switch;
+    }
+
+    KeyList::KeyList( Session& session ):
+      m_tag(""),
+      m_session( session ),
+      m_data(),
+      m_objects(){
+    }
+
+    void KeyList::init( const std::string& tag ){
+      m_tag = tag;
+      m_data.clear();
+      m_objects.clear();
+    }
+
+    void KeyList::load( const std::vector<unsigned long long>& keys ){
+      m_session.transaction().start( true );
+      IOVProxy proxy = m_session.readIov( m_tag );
+      m_data.clear();
+      m_objects.resize(keys.size());
+      for (size_t i=0; i<keys.size(); ++i) {
+	m_objects[i].reset();
+	if (keys[i]!=0) {
+	  auto p = proxy.find(keys[i]);
+	  if ( p!= proxy.end()) {
+	    if( !m_session.isOra() ){
+	      auto item = m_data.insert( std::make_pair( i, std::make_pair("",cond::Binary()) ) );
+	      if( ! m_session.details().impl.fetchPayloadData( (*p).payloadId, item.first->second.first, item.first->second.second ) )
+		throwException("The Iov contains a broken payload reference.","KeyList::load");    
+	    } else {
+	      m_oraData.insert( std::make_pair( i, m_session.details().oraCurrent.getObject( (*p).payloadId ) ) );
+	    }
+	  } 
+	}
+      }
+      m_session.transaction().commit();
+    }
     
   }
 }

--- a/CondCore/CondDB/src/Types.cc
+++ b/CondCore/CondDB/src/Types.cc
@@ -8,13 +8,13 @@
 namespace cond {
 
   void Iov_t::clear(){
-    since = time::MAX;
-    till = time::MIN;
+    since = time::MAX_VAL;
+    till = time::MIN_VAL;
     payloadId.clear();
   }
 
   bool Iov_t::isValid() const {
-    return since != time::MAX && till != time::MIN && !payloadId.empty();
+    return since != time::MAX_VAL && till != time::MIN_VAL && !payloadId.empty();
   }
 
   bool Iov_t::isValidFor( Time_t target ) const {
@@ -25,8 +25,8 @@ namespace cond {
     tag.clear();
     payloadType.clear();
     timeType = invalid;
-    endOfValidity = time::MIN;
-    lastValidatedTime = time::MIN;
+    endOfValidity = time::MIN_VAL;
+    lastValidatedTime = time::MIN_VAL;
   }
 
   static auto s_synchronizationTypeMap = { enumPair( "Offline",OFFLINE ),

--- a/CondCore/ORA/interface/Object.h
+++ b/CondCore/ORA/interface/Object.h
@@ -3,6 +3,7 @@
 
 //
 #include <typeinfo>
+#include <boost/shared_ptr.hpp>
 // externals
 #include "Reflex/Type.h"
 
@@ -22,6 +23,7 @@ namespace ora {
     std::string typeName() const;
     void* cast( const std::type_info& asType ) const;
     template <typename T> T* cast() const;
+    boost::shared_ptr<void> makeShared() const;
     void destruct();
     private:
     void* m_ptr;

--- a/CondCore/ORA/src/Object.cc
+++ b/CondCore/ORA/src/Object.cc
@@ -60,6 +60,10 @@ void* ora::Object::cast( const std::type_info& typeInfo ) const{
   return ClassUtils::upCast( m_type, m_ptr, castType );
 }
 
+boost::shared_ptr<void> ora::Object::makeShared() const {
+  return boost::shared_ptr<void>( m_ptr, RflxDeleter( m_type ) );
+}
+
 void ora::Object::destruct() {
   if( ! m_type ){
     throwException( "Object input class has not been found in the dictionary.",

--- a/CondCore/ORA/test/classes.cc
+++ b/CondCore/ORA/test/classes.cc
@@ -1,0 +1,1 @@
+#include "classes.h"


### PR DESCRIPTION
Introduced new KeyList implementation with the associated PayloadProxy. Fixes for ORAWrapper.
Renamed time::MAX and time::MIN to avoid name clash in OSX
