### PR TITLE
Bugfix: Set Photon ID/vertex information for PFlow selected photons.

### DIFF
--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -754,6 +754,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 	  reco::PFCandidate::ParticleType particleType = reco::PFCandidate::gamma;
 	  myPFPhoton.setParticleType(particleType);
 	  myPFPhoton.setCharge(0);
+	  myPFPhoton.set_mva_nothing_gamma(1.);  
 	  myPFPhoton.setP4(gedPhoRef->p4());
 	  if(egmLocalDebug) {
 	    cout << " PFAlgo: found a photon with NEW EGamma code " << endl;

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -754,7 +754,9 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 	  reco::PFCandidate::ParticleType particleType = reco::PFCandidate::gamma;
 	  myPFPhoton.setParticleType(particleType);
 	  myPFPhoton.setCharge(0);
-	  myPFPhoton.set_mva_nothing_gamma(1.);  
+	  myPFPhoton.set_mva_nothing_gamma(1.);
+	  math::XYZPoint v(primaryVertex_.x(), primaryVertex_.y(), primaryVertex_.z());
+	  myPFPhoton.setVertex( v  );  
 	  myPFPhoton.setP4(gedPhoRef->p4());
 	  if(egmLocalDebug) {
 	    cout << " PFAlgo: found a photon with NEW EGamma code " << endl;


### PR DESCRIPTION
Set mva value to one as well as primary vertex for photons selected by PFlow.

Shouldn't have an effect on gedPhotons, only changes plots that analyze directly the particleFlow:photons collection.
