### PR TITLE
switch to PFJet and PFMet as default for standard sequence and add b-tagging sequence for new soft lepton b-tag development and remove obsolete soft lepton tags

### DIFF
--- a/EgammaAnalysis/ElectronTools/interface/EGammaMvaEleEstimator.h
+++ b/EgammaAnalysis/ElectronTools/interface/EGammaMvaEleEstimator.h
@@ -81,6 +81,12 @@ class EGammaMvaEleEstimator{
     Double_t mvaValue(const pat::Electron& ele, 
 		      double rho,
 		      bool printDebug = kFALSE);
+
+    // for kTrig, kNonTrig and kTrigNoIP algorithm
+    Double_t mvaValue(const pat::Electron& ele,
+		      const reco::Vertex& vertex,
+		      double rho,
+		      bool printDebug = kFALSE);
     
     Double_t isoMvaValue(const reco::GsfElectron& ele, 
                          const reco::Vertex& vertex, 

--- a/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaMvaEleEstimator.cc
@@ -1207,9 +1207,131 @@ Double_t EGammaMvaEleEstimator::mvaValue(const reco::GsfElectron& ele,
   return mva;
 }
 
+// for kTrig, kNonTrig and kTrigNoIP algorithm
+Double_t EGammaMvaEleEstimator::mvaValue(const pat::Electron& ele,
+                                         const reco::Vertex& vertex,
+                                         double rho,
+                                         bool printDebug) {
 
-// for kTrigNoIP or kNonTrig algorithm only.
-// code for kTrig still to be implemented
+  if (!fisInitialized) {
+    std::cout << "Error: EGammaMvaEleEstimator not properly initialized.\n";
+    return -9999;
+  }
+
+  bool validKF= false;
+  reco::TrackRef myTrackRef = ele.closestCtfTrackRef();
+  validKF = (myTrackRef.isAvailable());
+  validKF = (myTrackRef.isNonnull());
+
+  // Pure tracking variables
+  fMVAVar_fbrem           =  ele.fbrem();
+  fMVAVar_kfchi2          =  (validKF) ? myTrackRef->normalizedChi2() : 0 ;
+  fMVAVar_kfhits          =  (validKF) ? myTrackRef->hitPattern().trackerLayersWithMeasurement() : -1. ;
+  fMVAVar_gsfchi2         =  ele.gsfTrack()->normalizedChi2();
+
+
+  // Geometrical matchings
+  fMVAVar_deta            =  ele.deltaEtaSuperClusterTrackAtVtx();
+  fMVAVar_dphi            =  ele.deltaPhiSuperClusterTrackAtVtx();
+  fMVAVar_detacalo        =  ele.deltaEtaSeedClusterTrackAtCalo();
+
+  // Pure ECAL -> shower shapes
+  fMVAVar_see             =  ele.sigmaIetaIeta();    //EleSigmaIEtaIEta
+
+  fMVAVar_spp             =  ele.sigmaIphiIphi();
+
+  fMVAVar_etawidth        =  ele.superCluster()->etaWidth();
+  fMVAVar_phiwidth        =  ele.superCluster()->phiWidth();
+  fMVAVar_OneMinusE1x5E5x5       =  (ele.e5x5()) !=0. ? 1.-(ele.e1x5()/ele.e5x5()) : -1. ;
+  fMVAVar_R9              =  ele.r9();
+
+  // Energy matching
+  fMVAVar_HoE             =  ele.hadronicOverEm();
+  fMVAVar_EoP             =  ele.eSuperClusterOverP();
+
+  // unify this in the future?
+  if( fMVAType == kTrig || fMVAType == kNonTrig){
+    fMVAVar_IoEmIoP         =  (1.0/ele.ecalEnergy()) - (1.0 / ele.p());  // in the future to be changed with ele.gsfTrack()->p()
+  }else{
+    fMVAVar_IoEmIoP         =  (1.0/ele.superCluster()->energy()) - (1.0 / ele.gsfTrack()->p());  // in the future to be changed with ele.gsfTrack()->p()
+  }
+  fMVAVar_eleEoPout       =  ele.eEleClusterOverPout();
+  fMVAVar_rho             =  rho;
+  fMVAVar_PreShowerOverRaw=  ele.superCluster()->preshowerEnergy() / ele.superCluster()->rawEnergy();
+
+  // for triggering electrons get the impact parameteres
+  if(fMVAType == kTrig) {
+    //d0
+    if (ele.gsfTrack().isNonnull()) {
+      fMVAVar_d0 = (-1.0)*ele.gsfTrack()->dxy(vertex.position());
+    } else if (ele.closestCtfTrackRef().isNonnull()) {
+      fMVAVar_d0 = (-1.0)*ele.closestCtfTrackRef()->dxy(vertex.position());
+    } else {
+      fMVAVar_d0 = -9999.0;
+    }
+
+    //default values for IP3D
+    fMVAVar_ip3d = -999.0;
+    fMVAVar_ip3dSig = 0.0;
+    if (ele.gsfTrack().isNonnull()) {
+      const double gsfsign   = ( (-ele.gsfTrack()->dxy(vertex.position()))   >=0 ) ? 1. : -1.;
+
+      std::cout << "Warning : if usePV = false when pat-electrons were produced, dB() was calculated with respect to beamspot while original mva uses primary vertex" << std::endl;
+      double ip3d = gsfsign*ele.dB();
+      double ip3derr = ele.edB();
+      fMVAVar_ip3d = ip3d;
+      fMVAVar_ip3dSig = ip3d/ip3derr;
+    }
+  }
+
+  // Spectators
+  fMVAVar_eta             =  ele.superCluster()->eta();
+  fMVAVar_pt              =  ele.pt();
+
+  // evaluate
+  bindVariables();
+  Double_t mva = -9999;
+  if (fUseBinnedVersion) {
+    mva = fTMVAReader[GetMVABin(fMVAVar_eta,fMVAVar_pt)]->EvaluateMVA(fMethodname);
+  } else {
+    mva = fTMVAReader[0]->EvaluateMVA(fMethodname);
+  }
+
+  if(printDebug) {
+    cout << " *** Inside the class fMethodname " << fMethodname << " fMVAType " << fMVAType << endl;
+    cout << " fbrem " <<  fMVAVar_fbrem
+         << " kfchi2 " << fMVAVar_kfchi2
+         << " mykfhits " << fMVAVar_kfhits
+         << " gsfchi2 " << fMVAVar_gsfchi2
+         << " deta " <<  fMVAVar_deta
+         << " dphi " << fMVAVar_dphi
+         << " detacalo " << fMVAVar_detacalo
+      // << " dphicalo " << fMVAVar_dphicalo  
+         << " see " << fMVAVar_see
+         << " spp " << fMVAVar_spp
+         << " etawidth " << fMVAVar_etawidth
+         << " phiwidth " << fMVAVar_phiwidth
+         << " e1x5e5x5 " << fMVAVar_OneMinusE1x5E5x5
+         << " R9 " << fMVAVar_R9
+      // << " mynbrems " << fMVAVar_nbrems  
+         << " HoE " << fMVAVar_HoE
+         << " EoP " << fMVAVar_EoP
+         << " IoEmIoP " << fMVAVar_IoEmIoP
+         << " eleEoPout " << fMVAVar_eleEoPout
+         << " rho " << fMVAVar_rho
+      // << " EoPout " << fMVAVar_EoPout  
+         << " d0 " << fMVAVar_d0
+         << " ip3d " << fMVAVar_ip3d
+         << " eta " << fMVAVar_eta
+         << " pt " << fMVAVar_pt << endl;
+    cout << " ### MVA " << mva << endl;
+  }
+
+  return mva;
+}
+   
+
+// for kTrigNoIP algorithm only.
 Double_t EGammaMvaEleEstimator::mvaValue(const pat::Electron& ele, 
 					 double rho,
 					 bool printDebug) {
@@ -1219,8 +1341,8 @@ Double_t EGammaMvaEleEstimator::mvaValue(const pat::Electron& ele,
     return -9999;
   }
 
-  if ( (fMVAType != EGammaMvaEleEstimator::kTrigNoIP) && (fMVAType != EGammaMvaEleEstimator::kNonTrig )) {
-    std::cout << "Error: This method should be called for kTrig or kNonTrig MVA only" << endl;
+  if ( (fMVAType != EGammaMvaEleEstimator::kTrigNoIP) ) {
+    std::cout << "Error: This method should be called for kTrigNoIP mva only" << endl;
     return -9999;
   }
   

--- a/PhysicsTools/PatAlgos/python/mcMatchLayer0/jetFlavourId_cff.py
+++ b/PhysicsTools/PatAlgos/python/mcMatchLayer0/jetFlavourId_cff.py
@@ -6,7 +6,7 @@ patJetPartons = cms.EDProducer("PartonSelector",
 )
 
 patJetPartonAssociation = cms.EDProducer("JetPartonMatcher",
-    jets    = cms.InputTag("ak5CaloJets"),
+    jets    = cms.InputTag("ak5PFJets"),
     partons = cms.InputTag("patJetPartons"),
     coneSizeToAssociate = cms.double(0.3),
 )

--- a/PhysicsTools/PatAlgos/python/mcMatchLayer0/jetMatch_cfi.py
+++ b/PhysicsTools/PatAlgos/python/mcMatchLayer0/jetMatch_cfi.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 # Example for a configuration of the MC match
 #
 patJetPartonMatch = cms.EDProducer("MCMatcher",        # cut on deltaR, deltaPt/Pt; pick best by deltaR
-    src         = cms.InputTag("ak5CaloJets"),       # RECO objects to match
+    src         = cms.InputTag("ak5PFJets"),       # RECO objects to match
     matched     = cms.InputTag("genParticles"),      # mc-truth particle collection
     mcPdgId     = cms.vint32(1, 2, 3, 4, 5, 21),     # one or more PDG ID (quarks except top; gluons)
     mcStatus    = cms.vint32(3),                     # PYTHIA status code (3 = hard scattering)
@@ -16,7 +16,7 @@ patJetPartonMatch = cms.EDProducer("MCMatcher",        # cut on deltaR, deltaPt/
 )
 
 patJetGenJetMatch = cms.EDProducer("GenJetMatcher",    # cut on deltaR, deltaPt/Pt; pick best by deltaR
-    src         = cms.InputTag("ak5CaloJets"),       # RECO jets (any View<Jet> is ok)
+    src         = cms.InputTag("ak5PFJets"),       # RECO jets (any View<Jet> is ok)
     matched     = cms.InputTag("ak5GenJets"),        # GEN jets  (must be GenJetCollection)
     mcPdgId     = cms.vint32(),                      # n/a
     mcStatus    = cms.vint32(),                      # n/a

--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cff.py
@@ -6,6 +6,14 @@ from PhysicsTools.PatAlgos.recoLayer0.jetMETCorrections_cff import *
 from PhysicsTools.PatAlgos.recoLayer0.bTagging_cff import *
 #from PhysicsTools.PatAlgos.recoLayer0.jetID_cff import *
 
+# b tagging 
+jetSource = 'ak5PFJets'
+from RecoJets.JetAssociationProducers.ak5JTA_cff import *
+ak5JetTracksAssociatorAtVertex.jets = jetSource
+from RecoBTag.Configuration.RecoBTag_cff import * # btagging sequence
+softPFMuonsTagInfos.jets = jetSource
+softPFElectronsTagInfos.jets = jetSource
+
 # add PAT specifics
 from PhysicsTools.PatAlgos.mcMatchLayer0.jetFlavourId_cff import *
 from PhysicsTools.PatAlgos.mcMatchLayer0.jetMatch_cfi import *
@@ -15,6 +23,8 @@ from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cfi import *
 
 makePatJets = cms.Sequence(
     # reco pre-production
+    ak5JetTracksAssociatorAtVertex *
+    btagging * 
     patJetCorrections *
     patJetCharge *
    #secondaryVertexNegativeTagInfos *

--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 patJets = cms.EDProducer("PATJetProducer",
     # input
-    jetSource = cms.InputTag("ak5CaloJets"),
+    jetSource = cms.InputTag("ak5PFJets"),
                                
     # add user data
     userData = cms.PSet(
@@ -45,11 +45,8 @@ patJets = cms.EDProducer("PATJetProducer",
         cms.InputTag("jetProbabilityBJetTags"),
         cms.InputTag("simpleSecondaryVertexHighEffBJetTags"),
         cms.InputTag("simpleSecondaryVertexHighPurBJetTags"),
-        cms.InputTag("softElectronByPtBJetTags"),                
-        cms.InputTag("softElectronByIP3dBJetTags"),
-        cms.InputTag("softMuonBJetTags"),
-        cms.InputTag("softMuonByPtBJetTags"),                
-        cms.InputTag("softMuonByIP3dBJetTags"),
+        cms.InputTag("softPFMuonBJetTags"),                
+        cms.InputTag("softPFElectronBJetTags"),                
         cms.InputTag("trackCountingHighEffBJetTags"),
         cms.InputTag("trackCountingHighPurBJetTags"),
     ),

--- a/PhysicsTools/PatAlgos/python/producersLayer1/metProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/metProducer_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 patMETs = cms.EDProducer("PATMETProducer",
     # input 
-    metSource  = cms.InputTag("caloType1CorrectedMet"),
+    metSource  = cms.InputTag("pfType1CorrectedMet"),
 
     # add user data
     userData = cms.PSet(
@@ -28,7 +28,7 @@ patMETs = cms.EDProducer("PATMETProducer",
     ),
 
     # muon correction
-    addMuonCorrections = cms.bool(True),
+    addMuonCorrections = cms.bool(False),
     muonSource         = cms.InputTag("muons"),
 
     # mc matching configurables

--- a/PhysicsTools/PatAlgos/python/recoLayer0/jetCorrFactors_cfi.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/jetCorrFactors_cfi.py
@@ -5,9 +5,9 @@ patJetCorrFactors = cms.EDProducer("JetCorrFactorsProducer",
     ## the use of emf in the JEC is not yet implemented
     emf = cms.bool(False),
     ## input collection of jets
-    src = cms.InputTag("ak5CaloJets"),
+    src = cms.InputTag("ak5PFJets"),
     ## payload postfix for testing
-    payload = cms.string('AK5Calo'),
+    payload = cms.string('AK5PF'),
     ## correction levels
     levels = cms.vstring(
         ## tags for the individual jet corrections; when

--- a/PhysicsTools/PatAlgos/test/patTuple_metUncertainties_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_metUncertainties_cfg.py
@@ -1,0 +1,41 @@
+## import skeleton process
+from PhysicsTools.PatAlgos.patTemplate_cfg import *
+process.load("PhysicsTools.PatUtils.patPFMETCorrections_cff")
+
+from PhysicsTools.PatAlgos.tools.jetTools import switchJetCollection
+switchJetCollection(process,cms.InputTag('ak5PFJets'),
+                 doBTagging   = False,
+                 jetCorrLabel = ('AK5PF', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute'])),
+                 doType1MET   = False
+                 )
+
+## let it run
+process.p = cms.Path(
+  process.type0PFMEtCorrection
+* process.patPFMETtype0Corr
+* process.patDefaultSequence
+)
+
+# apply type I/type I + II PFMEt corrections to pat::MET object
+# and estimate systematic uncertainties on MET
+from PhysicsTools.PatUtils.tools.metUncertaintyTools import runMEtUncertainties
+runMEtUncertainties(process)
+
+## ------------------------------------------------------
+#  In addition you usually want to change the following
+#  parameters:
+## ------------------------------------------------------
+#
+#   process.GlobalTag.globaltag =  ...    ##  (according to https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideFrontierConditions)
+#                                         ##
+## switch to RECO input
+from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarAODSIM
+process.source.fileNames = filesRelValProdTTbarAODSIM
+#                                         ##
+process.maxEvents.input = 10
+#                                         ##
+#   process.out.outputCommands = [ ... ]  ##  (e.g. taken from PhysicsTools/PatAlgos/python/patEventContent_cff.py)
+#                                         ##
+process.out.fileName = 'patTuple_metUncertainties.root'
+#                                         ##
+#   process.options.wantSummary = False   ##  (to suppress the long output at the end of the job)

--- a/PhysicsTools/PatAlgos/test/runtests.sh
+++ b/PhysicsTools/PatAlgos/test/runtests.sh
@@ -30,6 +30,8 @@ cmsRun ${LOCAL_TEST_DIR}/patTuple_topSelection_cfg.py || die 'Failure using patT
 
 cmsRun ${LOCAL_TEST_DIR}/patTuple_userData_cfg.py || die 'Failure using patTuple_userData_cfg.py' $?
 
+cmsRun ${LOCAL_TEST_DIR}/patTuple_metUncertainties_cfg.py || die 'Failure using patTuple_metUncertainties_cfg.py' $?
+
 # Not needed in IBs
 # cmsRun ${LOCAL_TEST_DIR}/patTuple_factorisedTaginfo_cfg.py || die 'Failure using patTuple_factorisedTaginfo_cfg.py' $?
 # cmsRun ${LOCAL_TEST_DIR}/patTuple_onlyElectrons_cfg.py || die 'Failure using patTuple_onlyElectrons_cfg.py' $?

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -159,7 +159,7 @@ class SmearedJetProducerT : public edm::EDProducer
 
     edm::FileInPath inputFileName = cfg.getParameter<edm::FileInPath>("inputFileName");
     std::string lutName = cfg.getParameter<std::string>("lutName");
-    if ( !inputFileName.isLocal() ) 
+    if (inputFileName.location() == edm::FileInPath::Unknown)
       throw cms::Exception("JetMETsmearInputProducer") 
         << " Failed to find File = " << inputFileName << " !!\n";
 

--- a/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
+++ b/PhysicsTools/PatUtils/interface/SmearedJetProducerT.h
@@ -11,9 +11,7 @@
  * 
  * \author Christian Veelken, LLR
  *
- * \version $Revision: 1.9 $
  *
- * $Id: SmearedJetProducerT.h,v 1.9 2012/08/31 09:58:44 veelken Exp $
  *
  */
 


### PR DESCRIPTION
switch to PFJet and PFMet as default for standard sequence and add b-tagging sequence for new soft lepton b-tag development and remove obsolete soft lepton tags
