### PR TITLE
Added cacheIdentifier to Run, Lumi and Event

### DIFF
--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -85,6 +85,16 @@ namespace edm {
 
     RunNumber_t
     run() const {return id().run();}
+    
+    /**If you are caching data from the Event, you should also keep
+     this number.  If this number changes then you know that
+     the data you have cached is invalid.
+     The value of '0' will never be returned so you can use that to
+     denote that you have not yet checked the value.
+     */
+    typedef unsigned long CacheIdentifier_t;
+    CacheIdentifier_t
+    cacheIdentifier() const;
 
     template<typename PROD>
     bool

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -57,6 +57,16 @@ namespace edm {
      */
     LuminosityBlockIndex index() const;
     
+    /**If you are caching data from the LuminosityBlock, you should also keep
+     this number.  If this number changes then you know that
+     the data you have cached is invalid.
+     The value of '0' will never be returned so you can use that to
+     denote that you have not yet checked the value.
+     */
+    typedef unsigned long CacheIdentifier_t;
+    CacheIdentifier_t
+    cacheIdentifier() const;
+    
     //Used in conjunction with EDGetToken
     void setConsumer(EDConsumerBase const* iConsumer);
     template <typename PROD>

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -165,6 +165,10 @@ namespace edm {
     void getAllProvenance(std::vector<Provenance const*>& provenances) const;
 
     BranchType const& branchType() const {return branchType_;}
+    
+    //This will never return 0 so you can use 0 to mean unset
+    typedef unsigned long CacheIdentifier_t;
+    CacheIdentifier_t cacheIdentifier() const {return cacheIdentifier_;}
 
     DelayedReader* reader() const {return reader_;}
 
@@ -269,6 +273,8 @@ namespace edm {
     // input ProcessHistory, the following pointer should be null.
     // The Principal does not own this object.
     HistoryAppender* historyAppender_;
+    
+    CacheIdentifier_t cacheIdentifier_;
 
   };
 

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -63,6 +63,17 @@ namespace edm {
      */
     RunIndex index() const;
 
+    /**If you are caching data from the Run, you should also keep
+     this number.  If this number changes then you know that
+     the data you have cached is invalid.
+     The value of '0' will never be returned so you can use that to
+     denote that you have not yet checked the value.
+     */
+    typedef unsigned long CacheIdentifier_t;
+    CacheIdentifier_t
+    cacheIdentifier() const;
+
+    
     template <typename PROD>
     bool
     getByLabel(std::string const& label, Handle<PROD>& result) const;

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -31,6 +31,11 @@ namespace edm {
     for_all(putProducts_, principal_get_adapter_detail::deleter());
   }
 
+  Event::CacheIdentifier_t
+  Event::cacheIdentifier() const {
+    return eventPrincipal().cacheIdentifier();
+  }
+
   void
   Event::setConsumer(EDConsumerBase const* iConsumer) {
     provRecorder_.setConsumer(iConsumer);

--- a/FWCore/Framework/src/LuminosityBlock.cc
+++ b/FWCore/Framework/src/LuminosityBlock.cc
@@ -27,6 +27,9 @@ namespace edm {
     return luminosityBlockPrincipal().index();
   }
 
+  LuminosityBlock::CacheIdentifier_t
+  LuminosityBlock::cacheIdentifier() const {return luminosityBlockPrincipal().cacheIdentifier();}
+
   
   LuminosityBlockPrincipal&
   LuminosityBlock::luminosityBlockPrincipal() {

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -26,6 +26,7 @@
 #include <sstream>
 #include <stdexcept>
 #include <typeinfo>
+#include <atomic>
 
 namespace edm {
 
@@ -121,7 +122,12 @@ namespace edm {
     }
 }
 
-
+  //0 means unset
+  static std::atomic<Principal::CacheIdentifier_t> s_nextIdentifier{1};
+  static inline Principal::CacheIdentifier_t nextIdentifier() {
+    return s_nextIdentifier.fetch_add(1,std::memory_order_acq_rel);
+  }
+  
   Principal::Principal(boost::shared_ptr<ProductRegistry const> reg,
                        boost::shared_ptr<ProductHolderIndexHelper const> productLookup,
                        ProcessConfiguration const& pc,
@@ -139,7 +145,7 @@ namespace edm {
     productPtrs_(),
     branchType_(bt),
     historyAppender_(historyAppender),
-    cacheIdentifier_(1) //0 means unset
+    cacheIdentifier_(nextIdentifier())
   {
 
     //Now that these have been set, we can create the list of Branches we need.
@@ -328,7 +334,7 @@ namespace edm {
                            ProcessHistoryRegistry const& processHistoryRegistry,
                            DelayedReader* reader) {
     //increment identifier here since clearPrincipal isn't called for Run/Lumi
-    ++cacheIdentifier_;
+    cacheIdentifier_=nextIdentifier();
     if(reader) {
       reader_ = reader;
     }

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -138,7 +138,9 @@ namespace edm {
     reader_(),
     productPtrs_(),
     branchType_(bt),
-    historyAppender_(historyAppender) {
+    historyAppender_(historyAppender),
+    cacheIdentifier_(1) //0 means unset
+  {
 
     //Now that these have been set, we can create the list of Branches we need.
     std::string const source("source");
@@ -325,6 +327,8 @@ namespace edm {
   Principal::fillPrincipal(ProcessHistoryID const& hist,
                            ProcessHistoryRegistry const& processHistoryRegistry,
                            DelayedReader* reader) {
+    //increment identifier here since clearPrincipal isn't called for Run/Lumi
+    ++cacheIdentifier_;
     if(reader) {
       reader_ = reader;
     }

--- a/FWCore/Framework/src/Run.cc
+++ b/FWCore/Framework/src/Run.cc
@@ -20,6 +20,9 @@ namespace edm {
     for_all(putProducts_, principal_get_adapter_detail::deleter());
   }
 
+  Run::CacheIdentifier_t
+  Run::cacheIdentifier() const {return runPrincipal().cacheIdentifier();}
+
   RunIndex Run::index() const { return runPrincipal().index();}
   
   RunPrincipal&


### PR DESCRIPTION
Added a cacheIdentifier in order to make it easier to identify when an item cached from a Principal has changed. This has been used by the EventSetup system from the beginning.
