### PR TITLE
Removed need for UpdaterService in MuonDetLayerMeasurements

### DIFF
--- a/RecoMuon/MeasurementDet/interface/MuonDetLayerMeasurements.h
+++ b/RecoMuon/MeasurementDet/interface/MuonDetLayerMeasurements.h
@@ -135,16 +135,12 @@ class MuonDetLayerMeasurements {
   void checkRPCRecHits();
 
   // keeps track of which event the cache holds
-  edm::EventID theDTEventID;
-  edm::EventID theCSCEventID;
-  edm::EventID theRPCEventID;
+  edm::Event::CacheIdentifier_t theDTEventCacheID;
+  edm::Event::CacheIdentifier_t theCSCEventCacheID;
+  edm::Event::CacheIdentifier_t theRPCEventCacheID;
 
   const edm::Event* theEvent;   
 
-  // strings to uniquely identify current process
-  std::string theDTCheckName;
-  std::string theRPCCheckName;
-  std::string theCSCCheckName;
 };
 #endif
 

--- a/RecoMuon/MeasurementDet/src/MuonDetLayerMeasurements.cc
+++ b/RecoMuon/MeasurementDet/src/MuonDetLayerMeasurements.cc
@@ -13,7 +13,7 @@
 #include "TrackingTools/PatternTools/interface/TrajMeasLessEstim.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/Services/interface/UpdaterService.h"
+
 
 
 typedef MuonTransientTrackingRecHit::MuonRecHitPointer MuonRecHitPointer;
@@ -34,21 +34,11 @@ MuonDetLayerMeasurements::MuonDetLayerMeasurements(const edm::InputTag& dtlabel,
   theDTRecHits(),
   theCSCRecHits(),
   theRPCRecHits(),
-  theDTEventID(),
-  theCSCEventID(),
-  theRPCEventID(),
-  theEvent(0){
-  static int procInstance(0);
-  std::ostringstream sDT;
-  sDT<<"MuonDetLayerMeasurements::checkDTRecHits::" << procInstance;
-  theDTCheckName = sDT.str();
-  std::ostringstream sRPC;
-  sRPC<<"MuonDetLayerMeasurements::checkRPCRecHits::" << procInstance;
-  theRPCCheckName = sRPC.str();
-  std::ostringstream sCSC;
-  sCSC<<"MuonDetLayerMeasurements::checkCSCRecHits::" << procInstance;
-  theCSCCheckName = sCSC.str();
-  procInstance++;
+  theDTEventCacheID(0),
+  theCSCEventCacheID(0),
+  theRPCEventCacheID(0),
+  theEvent(0)
+{
 }
 
 MuonDetLayerMeasurements::~MuonDetLayerMeasurements(){}
@@ -127,11 +117,12 @@ MuonRecHitContainer MuonDetLayerMeasurements::recHits(const GeomDet* geomDet,
 void MuonDetLayerMeasurements::checkDTRecHits()
 {
   checkEvent();
-  if (!edm::Service<UpdaterService>()->checkOnce(theDTCheckName)) return;
+  auto const cacheID = theEvent->cacheIdentifier();
+  if (cacheID == theDTEventCacheID) return;
 
   {
-    theDTEventID = theEvent->id();
     theEvent->getByLabel(theDTRecHitLabel, theDTRecHits);
+    theDTEventCacheID = cacheID;
   }
   if(!theDTRecHits.isValid())
   {
@@ -143,11 +134,12 @@ void MuonDetLayerMeasurements::checkDTRecHits()
 void MuonDetLayerMeasurements::checkCSCRecHits()
 {
   checkEvent();
-  if (!edm::Service<UpdaterService>()->checkOnce(theCSCCheckName)) return;
+  auto cacheID = theEvent->cacheIdentifier();
+  if (cacheID == theCSCEventCacheID) return;
 
   {
-    theCSCEventID = theEvent->id();
     theEvent->getByLabel(theCSCRecHitLabel, theCSCRecHits);
+    theCSCEventCacheID = cacheID;
   }
   if(!theCSCRecHits.isValid())
   {
@@ -159,11 +151,12 @@ void MuonDetLayerMeasurements::checkCSCRecHits()
 void MuonDetLayerMeasurements::checkRPCRecHits()
 {
   checkEvent();
-  if (!edm::Service<UpdaterService>()->checkOnce(theRPCCheckName)) return;
+  auto cacheID = theEvent->cacheIdentifier();
+  if (cacheID == theRPCEventCacheID) return;
 
   {
-    theRPCEventID = theEvent->id();
     theEvent->getByLabel(theRPCRecHitLabel, theRPCRecHits);
+    theRPCEventCacheID = cacheID;
   }
   if(!theRPCRecHits.isValid())
   {


### PR DESCRIPTION
The UpdaterService is not thread-safe and therefore must be removed. MuonDetLayerMeasurments was the only user of UpdaterService in production jobs. The use of the UpdaterService was replaced with the new cacheIdentifier() information from the edm::Event. The cacheIdentifier() can be used to quickly check to see if an edm::Event has changed since the last call to a method.
