### PR TITLE
Remove mutable from track association

### DIFF
--- a/SimTracker/TrackAssociation/interface/CosmicParametersDefinerForTP.h
+++ b/SimTracker/TrackAssociation/interface/CosmicParametersDefinerForTP.h
@@ -16,8 +16,8 @@ class CosmicParametersDefinerForTP : public ParametersDefinerForTP {
   CosmicParametersDefinerForTP(){};
   virtual ~CosmicParametersDefinerForTP() {};
 
-  virtual TrackingParticle::Vector momentum(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticleRef tpr) const;
-  virtual TrackingParticle::Point vertex(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticleRef tpr) const;
+  virtual TrackingParticle::Vector momentum(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticleRef& tpr) const override;
+  virtual TrackingParticle::Point vertex(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticleRef& tpr) const override;
 
   virtual TrackingParticle::Vector momentum(const edm::Event& iEvent, const edm::EventSetup& iSetup, 
 	const Charge ch, const Point & vertex, const LorentzVector& lv) const {

--- a/SimTracker/TrackAssociation/interface/ParametersDefinerForTP.h
+++ b/SimTracker/TrackAssociation/interface/ParametersDefinerForTP.h
@@ -27,7 +27,7 @@ class ParametersDefinerForTP {
   virtual TrackingParticle::Vector momentum(const edm::Event& iEvent, const edm::EventSetup& iSetup, 
 	const Charge ch, const Point & vtx, const LorentzVector& lv) const;
 
-  virtual TrackingParticle::Vector momentum(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticleRef tpr) const{
+  virtual TrackingParticle::Vector momentum(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticleRef& tpr) const{
     return momentum(iEvent, iSetup, tpr->charge(),tpr->vertex(),tpr->p4());
   }
 

--- a/SimTracker/TrackAssociation/interface/QuickTrackAssociatorByHits.h
+++ b/SimTracker/TrackAssociation/interface/QuickTrackAssociatorByHits.h
@@ -63,33 +63,39 @@ public:
 	~QuickTrackAssociatorByHits();
 	QuickTrackAssociatorByHits( const QuickTrackAssociatorByHits& otherAssociator );
 	QuickTrackAssociatorByHits& operator=( const QuickTrackAssociatorByHits& otherAssociator );
+        virtual
 	reco::RecoToSimCollection associateRecoToSim( edm::Handle<edm::View<reco::Track> >& trackCollectionHandle,
 	                                              edm::Handle<TrackingParticleCollection>& trackingParticleCollectionHandle,
 	                                              const edm::Event* pEvent=0,
-	                                              const edm::EventSetup* pSetup=0 ) const;
+	                                              const edm::EventSetup* pSetup=0 ) const override;
+        virtual
 	reco::SimToRecoCollection associateSimToReco( edm::Handle<edm::View<reco::Track> >& trackCollectionHandle,
 	                                              edm::Handle<TrackingParticleCollection>& trackingParticleCollectionHandle,
 	                                              const edm::Event* pEvent=0,
-	                                              const edm::EventSetup* pSetup=0 ) const;
+	                                              const edm::EventSetup* pSetup=0 ) const override;
+        virtual
 	reco::RecoToSimCollection associateRecoToSim( const edm::RefToBaseVector<reco::Track>& trackCollection,
 												  const edm::RefVector<TrackingParticleCollection>& trackingParticleCollection,
 												  const edm::Event* pEvent=0,
-												  const edm::EventSetup* pSetup=0 ) const;
+												  const edm::EventSetup* pSetup=0 ) const override;
+        virtual
 	reco::SimToRecoCollection associateSimToReco( const edm::RefToBaseVector<reco::Track>& trackCollection,
 												  const edm::RefVector<TrackingParticleCollection>& trackingParticleCollection,
 												  const edm::Event* pEvent=0,
-												  const edm::EventSetup* pSetup=0 ) const;
+												  const edm::EventSetup* pSetup=0 ) const override;
 
 	//seed
+        virtual
 	reco::RecoToSimCollectionSeed associateRecoToSim(edm::Handle<edm::View<TrajectorySeed> >&,
 							 edm::Handle<TrackingParticleCollection>&,
 							 const edm::Event * event ,
-							 const edm::EventSetup * setup ) const;
+							 const edm::EventSetup * setup ) const override;
 	
+        virtual
 	reco::SimToRecoCollectionSeed associateSimToReco(edm::Handle<edm::View<TrajectorySeed> >&,
 							 edm::Handle<TrackingParticleCollection>&,
 							 const edm::Event * event ,
-							 const edm::EventSetup * setup ) const;
+							 const edm::EventSetup * setup ) const override;
 
         void prepareCluster2TPMap(const edm::Event* pEvent) const;
 

--- a/SimTracker/TrackAssociation/interface/TrackAssociatorByChi2.h
+++ b/SimTracker/TrackAssociation/interface/TrackAssociatorByChi2.h
@@ -100,29 +100,33 @@ class TrackAssociatorByChi2 : public TrackAssociatorBase {
 									       float,// charge
 									       const reco::BeamSpot&) const;//beam spot
   /// Association Reco To Sim with Collections
+  virtual
   reco::RecoToSimCollection associateRecoToSim(const edm::RefToBaseVector<reco::Track>&,
 					       const edm::RefVector<TrackingParticleCollection>&,
 					       const edm::Event * event = 0,
-                                               const edm::EventSetup * setup = 0 ) const ;
+                                               const edm::EventSetup * setup = 0 ) const override;
   /// Association Sim To Reco with Collections
+  virtual
   reco::SimToRecoCollection associateSimToReco(const edm::RefToBaseVector<reco::Track>&,
 					       const edm::RefVector<TrackingParticleCollection>&,
 					       const edm::Event * event = 0,
-                                               const edm::EventSetup * setup = 0 ) const ;
+                                               const edm::EventSetup * setup = 0 ) const override;
   
   /// compare reco to sim the handle of reco::Track and TrackingParticle collections
+  virtual
   reco::RecoToSimCollection associateRecoToSim(edm::Handle<edm::View<reco::Track> >& tCH, 
 					       edm::Handle<TrackingParticleCollection>& tPCH, 
 					       const edm::Event * event = 0,
-                                               const edm::EventSetup * setup = 0) const {
+                                               const edm::EventSetup * setup = 0) const override {
     return TrackAssociatorBase::associateRecoToSim(tCH,tPCH,event,setup);
   }
   
   /// compare reco to sim the handle of reco::Track and TrackingParticle collections
+  virtual
   reco::SimToRecoCollection associateSimToReco(edm::Handle<edm::View<reco::Track> >& tCH, 
 					       edm::Handle<TrackingParticleCollection>& tPCH,
 					       const edm::Event * event = 0,
-                                               const edm::EventSetup * setup = 0) const {
+                                               const edm::EventSetup * setup = 0) const override {
     return TrackAssociatorBase::associateSimToReco(tCH,tPCH,event,setup);
   }  
 

--- a/SimTracker/TrackAssociation/interface/TrackAssociatorByHits.h
+++ b/SimTracker/TrackAssociation/interface/TrackAssociatorByHits.h
@@ -30,42 +30,48 @@ class TrackAssociatorByHits : public TrackAssociatorBase {
   /* Associate SimTracks to RecoTracks By Hits */
  
   /// Association Reco To Sim with Collections
+  virtual
   reco::RecoToSimCollection associateRecoToSim(const edm::RefToBaseVector<reco::Track>&,
 					       const edm::RefVector<TrackingParticleCollection>&,
 					       const edm::Event * event ,
-                                               const edm::EventSetup * setup  ) const ;
+                                               const edm::EventSetup * setup  ) const override;
   /// Association Sim To Reco with Collections
+  virtual
   reco::SimToRecoCollection associateSimToReco(const edm::RefToBaseVector<reco::Track>&,
 					       const edm::RefVector<TrackingParticleCollection>&,
 					       const edm::Event * event ,
-                                               const edm::EventSetup * setup  ) const ;
+                                               const edm::EventSetup * setup  ) const override;
   
   /// compare reco to sim the handle of reco::Track and TrackingParticle collections
+  virtual
   reco::RecoToSimCollection associateRecoToSim(edm::Handle<edm::View<reco::Track> >& tCH, 
 					       edm::Handle<TrackingParticleCollection>& tPCH, 
 					       const edm::Event * event ,
-                                               const edm::EventSetup * setup ) const {
+                                               const edm::EventSetup * setup ) const override {
     return TrackAssociatorBase::associateRecoToSim(tCH,tPCH,event,setup);
   }
   
   /// compare reco to sim the handle of reco::Track and TrackingParticle collections
+  virtual
   reco::SimToRecoCollection associateSimToReco(edm::Handle<edm::View<reco::Track> >& tCH, 
 					       edm::Handle<TrackingParticleCollection>& tPCH,
 					       const edm::Event * event ,
-                                               const edm::EventSetup * setup ) const {
+                                               const edm::EventSetup * setup ) const override {
     return TrackAssociatorBase::associateSimToReco(tCH,tPCH,event,setup);
   }  
 
   //seed
+  virtual
   reco::RecoToSimCollectionSeed associateRecoToSim(edm::Handle<edm::View<TrajectorySeed> >&, 
 						   edm::Handle<TrackingParticleCollection>&, 
 						   const edm::Event * event ,
-                                                   const edm::EventSetup * setup ) const;
+                                                   const edm::EventSetup * setup ) const override;
   
+  virtual
   reco::SimToRecoCollectionSeed associateSimToReco(edm::Handle<edm::View<TrajectorySeed> >&, 
 						   edm::Handle<TrackingParticleCollection>&, 
 						   const edm::Event * event ,
-                                                   const edm::EventSetup * setup ) const;
+                                                   const edm::EventSetup * setup ) const override;
   template<typename iter>
   void getMatchedIds(std::vector<SimHitIdpr>&, 
 		     std::vector<SimHitIdpr>&, 

--- a/SimTracker/TrackAssociation/interface/TrackAssociatorByPosition.h
+++ b/SimTracker/TrackAssociation/interface/TrackAssociatorByPosition.h
@@ -60,16 +60,18 @@ class TrackAssociatorByPosition : public TrackAssociatorBase {
 
 
   /// compare reco to sim the handle of reco::Track and TrackingParticle collections
+  virtual
   reco::RecoToSimCollection associateRecoToSim(const edm::RefToBaseVector<reco::Track>&,
 					       const edm::RefVector<TrackingParticleCollection>&,
 					       const edm::Event * event = 0,
-                                               const edm::EventSetup * setup = 0 ) const ;
+                                               const edm::EventSetup * setup = 0 ) const override;
 
   /// compare reco to sim the handle of reco::Track and TrackingParticle collections
+  virtual
   reco::SimToRecoCollection associateSimToReco(const edm::RefToBaseVector<reco::Track>&,
 					       const edm::RefVector<TrackingParticleCollection>&,
 					       const edm::Event * event = 0,
-                                               const edm::EventSetup * setup = 0 ) const ;
+                                               const edm::EventSetup * setup = 0 ) const override;
 
   double quality(const TrajectoryStateOnSurface&, const TrajectoryStateOnSurface &)const;
 
@@ -85,8 +87,7 @@ class TrackAssociatorByPosition : public TrackAssociatorBase {
   bool theConsiderAllSimHits;
   
   FreeTrajectoryState getState(const reco::Track &) const;
-  TrajectoryStateOnSurface getState(const TrackingParticleRef)const;
-  mutable edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;
+  TrajectoryStateOnSurface getState(const TrackingParticleRef&, const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc)const;
   edm::InputTag _simHitTpMapTag;
 };
 

--- a/SimTracker/TrackAssociation/src/CosmicParametersDefinerForTP.cc
+++ b/SimTracker/TrackAssociation/src/CosmicParametersDefinerForTP.cc
@@ -20,7 +20,7 @@ class TrajectoryStateClosestToBeamLineBuilder;
 
 
 TrackingParticle::Vector
- CosmicParametersDefinerForTP::momentum(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticleRef tpr) const{
+ CosmicParametersDefinerForTP::momentum(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticleRef& tpr) const{
   // to add a new implementation for cosmic. For the moment, it is just as for the base class:
   using namespace edm;
   using namespace std;
@@ -86,7 +86,7 @@ TrackingParticle::Vector
   return momentum;
 }
 
-TrackingParticle::Point CosmicParametersDefinerForTP::vertex(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticleRef tpr) const{
+TrackingParticle::Point CosmicParametersDefinerForTP::vertex(const edm::Event& iEvent, const edm::EventSetup& iSetup, const TrackingParticleRef& tpr) const{
   
   using namespace edm;
   using namespace std;

--- a/SimTracker/TrackAssociation/src/QuickTrackAssociatorByHits.cc
+++ b/SimTracker/TrackAssociation/src/QuickTrackAssociatorByHits.cc
@@ -15,7 +15,7 @@
 #include "DataFormats/Math/interface/deltaR.h"
 
 QuickTrackAssociatorByHits::QuickTrackAssociatorByHits( const edm::ParameterSet& config )
-	: pHitAssociator_(NULL), pEventForWhichAssociatorIsValid_(NULL),
+	: pHitAssociator_(nullptr), pEventForWhichAssociatorIsValid_(nullptr),
 	  absoluteNumberOfHits_( config.getParameter<bool>( "AbsoluteNumberOfHits" ) ),
 	  qualitySimToReco_( config.getParameter<double>( "Quality_SimToReco" ) ),
 	  puritySimToReco_( config.getParameter<double>( "Purity_SimToReco" ) ),
@@ -91,7 +91,7 @@ QuickTrackAssociatorByHits::QuickTrackAssociatorByHits( const QuickTrackAssociat
 	// Actually, need to check the other hit associator isn't null or the pointer dereference would
 	// probably cause a segmentation fault.
 	if( otherAssociator.pHitAssociator_ ) pHitAssociator_=new TrackerHitAssociator(*otherAssociator.pHitAssociator_);
-	else pHitAssociator_=NULL;
+	else pHitAssociator_=nullptr;
 }
 
 QuickTrackAssociatorByHits& QuickTrackAssociatorByHits::operator=( const QuickTrackAssociatorByHits& otherAssociator )
@@ -104,7 +104,7 @@ QuickTrackAssociatorByHits& QuickTrackAssociatorByHits::operator=( const QuickTr
 	// can be shallow copied from the other associator.
 	//
 	if( otherAssociator.pHitAssociator_ ) pHitAssociator_=new TrackerHitAssociator(*otherAssociator.pHitAssociator_);
-	else pHitAssociator_=NULL;
+	else pHitAssociator_=nullptr;
 	pEventForWhichAssociatorIsValid_=otherAssociator.pEventForWhichAssociatorIsValid_;
 	hitAssociatorParameters_=otherAssociator.hitAssociatorParameters_;
 	absoluteNumberOfHits_=otherAssociator.absoluteNumberOfHits_;
@@ -135,10 +135,10 @@ reco::RecoToSimCollection QuickTrackAssociatorByHits::associateRecoToSim( edm::H
 
 	pTrackCollectionHandle_=&trackCollectionHandle;
 	pTrackingParticleCollectionHandle_=&trackingParticleCollectionHandle;
-	pTrackCollection_=NULL;
-	pTrackingParticleCollection_=NULL;
+	pTrackCollection_=nullptr;
+	pTrackingParticleCollection_=nullptr;
 
-	// This method checks which collection type is set to NULL, and uses the other one.
+	// This method checks which collection type is set to null, and uses the other one.
 	return associateRecoToSimImplementation();
 }
 
@@ -154,10 +154,10 @@ reco::SimToRecoCollection QuickTrackAssociatorByHits::associateSimToReco( edm::H
 
 	pTrackCollectionHandle_=&trackCollectionHandle;
 	pTrackingParticleCollectionHandle_=&trackingParticleCollectionHandle;
-	pTrackCollection_=NULL;
-	pTrackingParticleCollection_=NULL;
+	pTrackCollection_=nullptr;
+	pTrackingParticleCollection_=nullptr;
 
-	// This method checks which collection type is set to NULL, and uses the other one.
+	// This method checks which collection type is set to null, and uses the other one.
 	return associateSimToRecoImplementation();
 }
 
@@ -172,12 +172,12 @@ reco::RecoToSimCollection QuickTrackAssociatorByHits::associateRecoToSim(const e
   if (useClusterTPAssociation_) prepareCluster2TPMap(pEvent);
   else initialiseHitAssociator( pEvent );
 
-  pTrackCollectionHandle_=NULL;
-  pTrackingParticleCollectionHandle_=NULL;
+  pTrackCollectionHandle_=nullptr;
+  pTrackingParticleCollectionHandle_=nullptr;
   pTrackCollection_=&trackCollection;
   pTrackingParticleCollection_=&trackingParticleCollection;
 
-  // This method checks which collection type is set to NULL, and uses the other one.
+  // This method checks which collection type is set to null, and uses the other one.
   return associateRecoToSimImplementation();
 }
 
@@ -191,12 +191,12 @@ reco::SimToRecoCollection QuickTrackAssociatorByHits::associateSimToReco(const e
   if (useClusterTPAssociation_) prepareCluster2TPMap(pEvent);
   else initialiseHitAssociator( pEvent );
 
-  pTrackCollectionHandle_=NULL;
-  pTrackingParticleCollectionHandle_=NULL;
+  pTrackCollectionHandle_=nullptr;
+  pTrackingParticleCollectionHandle_=nullptr;
   pTrackCollection_=&trackCollection;
   pTrackingParticleCollection_=&trackingParticleCollection;
 
-  // This method checks which collection type is set to NULL, and uses the other one.
+  // This method checks which collection type is set to null, and uses the other one.
   return associateSimToRecoImplementation();
 }
 
@@ -592,7 +592,7 @@ void QuickTrackAssociatorByHits::initialiseHitAssociator( const edm::Event* pEve
 	// event). I was doing this by recording the event pointer and checking it hasn't changed
 	// but this doesn't appear to work. Until I find a way of uniquely identifying an event
 	// I'll just create it anew each time.
-//	if( pEventForWhichAssociatorIsValid_==pEvent && pEventForWhichAssociatorIsValid_!=NULL ) return; // Already set up so no need to do anything
+//	if( pEventForWhichAssociatorIsValid_==pEvent && pEventForWhichAssociatorIsValid_!=null ) return; // Already set up so no need to do anything
 
 	// Free up the previous instantiation
 	delete pHitAssociator_;
@@ -614,10 +614,10 @@ QuickTrackAssociatorByHits::associateRecoToSim(edm::Handle<edm::View<TrajectoryS
                                       << pSeedCollectionHandle_->size()<<" #TPs="<<trackingParticleCollectionHandle->size();
 
   initialiseHitAssociator( pEvent );
-  pTrackCollectionHandle_=NULL;
+  pTrackCollectionHandle_=nullptr;
   pTrackingParticleCollectionHandle_=&trackingParticleCollectionHandle;
-  pTrackCollection_=NULL;
-  pTrackingParticleCollection_=NULL;
+  pTrackCollection_=nullptr;
+  pTrackingParticleCollection_=nullptr;
 
   reco::RecoToSimCollectionSeed  returnValue;
 
@@ -675,10 +675,10 @@ QuickTrackAssociatorByHits::associateSimToReco(edm::Handle<edm::View<TrajectoryS
                                       <<pSeedCollectionHandle_->size()<<" #TPs="<<trackingParticleCollectionHandle->size();
 
   initialiseHitAssociator( pEvent );
-  pTrackCollectionHandle_=NULL;
+  pTrackCollectionHandle_=nullptr;
   pTrackingParticleCollectionHandle_=&trackingParticleCollectionHandle;
-  pTrackCollection_=NULL;
-  pTrackingParticleCollection_=NULL;
+  pTrackCollection_=nullptr;
+  pTrackingParticleCollection_=nullptr;
 
   reco::SimToRecoCollectionSeed  returnValue;
 

--- a/SimTracker/TrackAssociation/src/TrackAssociatorByPosition.cc
+++ b/SimTracker/TrackAssociation/src/TrackAssociatorByPosition.cc
@@ -10,11 +10,12 @@
 using namespace edm;
 using namespace reco;
 
-TrajectoryStateOnSurface TrackAssociatorByPosition::getState(const TrackingParticleRef st)const{
+
+TrajectoryStateOnSurface TrackAssociatorByPosition::getState(const TrackingParticleRef& st, const SimHitTPAssociationProducer::SimHitTPAssociationList& simHitsTPAssoc)const{
 
   std::pair<TrackingParticleRef, TrackPSimHitRef> clusterTPpairWithDummyTP(st,TrackPSimHitRef());//SimHit is dummy: for simHitTPAssociationListGreater 
 	                                                                                         // sorting only the cluster is needed
-  auto range = std::equal_range(simHitsTPAssoc->begin(), simHitsTPAssoc->end(), 
+  auto range = std::equal_range(simHitsTPAssoc.begin(), simHitsTPAssoc.end(),
 				clusterTPpairWithDummyTP, SimHitTPAssociationProducer::simHitTPAssociationListGreater);
 
   //  TrackingParticle* simtrack = const_cast<TrackingParticle*>(&st);
@@ -116,6 +117,8 @@ RecoToSimCollection TrackAssociatorByPosition::associateRecoToSim(const edm::Ref
   const double dQmin_default=1542543;
   double dQmin=dQmin_default;
 
+  edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;
+
   //warning: make sure the TP collection used in the map is the same used in the associator!
   e->getByLabel(_simHitTpMapTag,simHitsTPAssoc);
 
@@ -127,7 +130,7 @@ RecoToSimCollection TrackAssociatorByPosition::associateRecoToSim(const edm::Ref
     //    for each tracking particle, find a state position and the plane to propagate the track to.
     for (unsigned int TPi=0;TPi!=tPCH.size();++TPi) {
       //get a state in the muon system 
-      TrajectoryStateOnSurface simReferenceState = getState((tPCH)[TPi]);
+      TrajectoryStateOnSurface simReferenceState = getState((tPCH)[TPi],*simHitsTPAssoc);
       if (!simReferenceState.isValid()) continue;
 
       //propagate the TRACK to the surface
@@ -168,12 +171,14 @@ SimToRecoCollection TrackAssociatorByPosition::associateSimToReco(const edm::Ref
   const double dQmin_default=1542543;
   double dQmin=dQmin_default;
 
+  edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssoc;
+
   //warning: make sure the TP collection used in the map is the same used in the associator!
   e->getByLabel(_simHitTpMapTag,simHitsTPAssoc);
 
   for (unsigned int TPi=0;TPi!=tPCH.size();++TPi){
     //get a state in the muon system
-    TrajectoryStateOnSurface simReferenceState= getState((tPCH)[TPi]);
+    TrajectoryStateOnSurface simReferenceState= getState((tPCH)[TPi],*simHitsTPAssoc);
       
     if (!simReferenceState.isValid()) continue; 
     bool atLeastOne=false;


### PR DESCRIPTION
Classes in the package SimTracker/TrackAssociation contain eight mutable data members that cause thread safety issues.  This pull request removes one of them, and replaces it with a variable on the stack.  The other seven mutable data members are more difficult to deal with, and will be done later.
This pull request also adds "virtual" and "override" keywords to the declarations of virtual functions that override virtual functions in a base class.
This pull request also fixes a problem where "const TrackingParticleRef" was used as an argument type.
The argument should have been passed by const reference, e. g. "const TrackingParticleRef&". There was one place where the argument was passed by reference in the base class but by value in the derived class, so the derived class function did not override the base class function it was supposed to override.  I believe that this bug affected only validation, as the function was only called from there.

Tested with checkdeps -a and the relval matrix.
