### PR TITLE
turn off pixel dataloss

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -14,6 +14,8 @@ from SLHCUpgradeSimulations.Configuration.HCalCustoms import customise_HcalPhase
 from SLHCUpgradeSimulations.Configuration.gemCustoms import customise as customise_gem
 from SLHCUpgradeSimulations.Configuration.fastsimCustoms import customiseDefault as fastCustomiseDefault
 from SLHCUpgradeSimulations.Configuration.fastsimCustoms import customisePhase2 as fastCustomisePhase2
+from SLHCUpgradeSimulations.Configuration.customise_mixing import customise_noPixelDataloss as cNoPixDataloss
+
 
 import SLHCUpgradeSimulations.Configuration.aging as aging
 
@@ -366,3 +368,7 @@ def bsStudyStep2(process):
         ptMin = cms.double(0.3)
         )
     return process
+
+def customise_noPixelDataloss(process):
+    return cNoPixDataloss(process)
+

--- a/SLHCUpgradeSimulations/Configuration/python/customise_mixing.py
+++ b/SLHCUpgradeSimulations/Configuration/python/customise_mixing.py
@@ -38,6 +38,8 @@ def customise_NoCrossing(process):
     return (process)
 
 def customise_pixelMixing_PU(process):
+    if hasattr(process,'noPixelDataloss'):
+        return process #avoid race condition
     if hasattr(process,'mix'): 
         n=0
         if hasattr(process.mix,'input'):
@@ -58,3 +60,16 @@ def customise_NoCrossing_PU(process):
     process=customise_NoCrossing(process)
     return (process)
 
+
+def customise_noPixelDataloss(process):
+    process.noPixelDataloss=cms.untracked.PSet()
+    if hasattr(process,'mix'):
+        process.mix.digitizers.pixel.thePixelColEfficiency_BPix1 = cms.double(1)
+        process.mix.digitizers.pixel.thePixelColEfficiency_BPix2 = cms.double(1)
+        process.mix.digitizers.pixel.thePixelColEfficiency_BPix3 = cms.double(1)
+        process.mix.digitizers.pixel.thePixelColEfficiency_BPix4 = cms.double(1)
+        process.mix.digitizers.pixel.thePixelColEfficiency_FPix1 = cms.double(1)
+        process.mix.digitizers.pixel.thePixelColEfficiency_FPix2 = cms.double(1)
+        process.mix.digitizers.pixel.thePixelColEfficiency_FPix3 = cms.double(1)
+    return process
+    


### PR DESCRIPTION
Modifying the customize functions ( CombinedCustoms + customise_mixing) to allow to remove the pixel inefficiencies at the digi step
