### PR TITLE
Remove mutable keyword by removing const declaration from unused functio...

### DIFF
--- a/SimDataFormats/HiGenData/interface/GenHIEvent.h
+++ b/SimDataFormats/HiGenData/interface/GenHIEvent.h
@@ -64,14 +64,14 @@ namespace edm {
       double EtMR() const {return EtMR_;}
       int NchargedPtCut() const {return nChargedPtCut_;}
       int NchargedPtCutMR() const {return nChargedPtCutMR_;}
-      void setGenParticles(const reco::GenParticleCollection*) const;
+      void setGenParticles(const reco::GenParticleCollection*);
       const std::vector<reco::GenParticleRef>    getSubEvent(unsigned int sub_id) const;
 
       int           getNsubs() const {return subevents_.size();}
 
    private:
 
-      mutable SubEventCollection subevents_;
+      SubEventCollection subevents_;
       int sel_;
 
       double b_;

--- a/SimDataFormats/HiGenData/src/GenHIEvent.cc
+++ b/SimDataFormats/HiGenData/src/GenHIEvent.cc
@@ -2,7 +2,7 @@
 #include "SimDataFormats/HiGenData/interface/GenHIEvent.h"
 using namespace edm;
 
-void GenHIEvent::setGenParticles(const reco::GenParticleCollection* input) const {
+void GenHIEvent::setGenParticles(const reco::GenParticleCollection* input) {
   subevents_.reserve(nhard_);
   for(int i = 0; i < nhard_; ++i){
     std::vector<reco::GenParticleRef> refs;


### PR DESCRIPTION
Eliminate static analyzer warning about thread safety by removing the mutable keyword from a data member of
GenHIEvent and removing the const qualifier from the declaration of the function that modifies it.
The function in question was added three years ago and is never called anywhere in CMSSW, so this is clearly harmless.
