### PR TITLE
Thread safety fix: Const function returns pointer or reference to non-const object

### DIFF
--- a/JetMETCorrections/FFTJetObjects/interface/FFTJetDict.h
+++ b/JetMETCorrections/FFTJetObjects/interface/FFTJetDict.h
@@ -17,12 +17,13 @@ template <class Key, class T,
           class Allocator = std::allocator<std::pair<const Key,T> > >
 struct FFTJetDict : public std::map<Key,T,Compare,Allocator>
 {
-    inline T& operator[](const Key&) const;
+    inline T& operator[](const Key&);
+    inline const T& operator[](const Key&) const;
 };
 
 template<class Key,class T,class Compare,class Allocator>
 T& FFTJetDict<Key,T,Compare,Allocator>::
-operator[](const Key& key) const
+operator[](const Key& key)
 {
     typename FFTJetDict<Key,T,Compare,Allocator>::const_iterator it = 
         this->find(key);
@@ -32,4 +33,15 @@ operator[](const Key& key) const
     return const_cast<T&>(it->second);
 }
 
+template<class Key,class T,class Compare,class Allocator>
+const T& FFTJetDict<Key,T,Compare,Allocator>::
+operator[](const Key& key) const
+{
+    typename FFTJetDict<Key,T,Compare,Allocator>::const_iterator it = 
+        this->find(key);
+    if (it == std::map<Key,T,Compare,Allocator>::end())
+        throw cms::Exception("KeyNotFound")
+            << "FFTJetDict: key \"" << key << "\" not found\n";
+    return it->second;
+}
 #endif // JetMETCorrections_FFTJetObjects_FFTJetDict_h


### PR DESCRIPTION
Added new "const T& operator() const" and remove the constness of "T& operator()"
