### PR TITLE
edmCheckClassVersion: disable for ROOT6 until ready

### DIFF
--- a/FWCore/Utilities/scripts/edmCheckClassVersion
+++ b/FWCore/Utilities/scripts/edmCheckClassVersion
@@ -231,6 +231,10 @@ if options.generate and not foundRootDoesNotMatchError and not missingDict:
 
     outFile.writelines(out)
 
+# Disable for ROOT6 for now
+import sys
+sys.exit(0)
+
 if (len(foundErrors)>0 and not options.generate) or (options.generate and foundRootDoesNotMatchError) or missingDict:
    import sys
    sys.exit(1)


### PR DESCRIPTION
edmCheckClassVersion must be disabled and return 0 in order to
generate capabilities files in CMSSW.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
