### PR TITLE
Various fixes for thread safety for RecoMuonL3TrackFinder

### DIFF
--- a/RecoMuon/L3TrackFinder/interface/MuonRoadTrajectoryBuilder.h
+++ b/RecoMuon/L3TrackFinder/interface/MuonRoadTrajectoryBuilder.h
@@ -104,20 +104,19 @@ class MuonRoadTrajectoryBuilder :public TrajectoryBuilder {
    ////internal method that use how grown trajectory builder
    void makeTrajectories_0(const TrajectorySeed & seed, std::vector<Trajectory> & result) const ;
    ////internal method to grow trajectories on one tracker layer
-   int GatherHits(const TrajectoryStateOnSurface & step,const DetLayer * thislayer, TrajectoryCollectionFPair & Trajectories) const ;
+   int GatherHits(const TrajectoryStateOnSurface & step,const DetLayer * thislayer, TrajectoryCollectionFPair & Trajectories,
+                  bool & firstLayer, unsigned int theNumberOfHitPerModule) const;
    ////internal method not yet implemented
    void makeTrajectories_1(const TrajectorySeed & seed, std::vector<Trajectory> & result) const ;
 	  
    ////check and reduce the trajectory according to number of trajectories found
-   bool checkStep(TrajectoryCollection & collection) const ;
+   bool checkStep(TrajectoryCollection & collection, unsigned int& theNumberOfHitPerModule) const ;
    ////check an remove trajectories subset of each other. keeping the longest
    void checkDuplicate(TrajectoryCollection & collection) const ;
 	      
    Trajectory smooth(Trajectory &) const ;
    void cleanTrajectory(Trajectory & traj) const ;
 	      
-   //only global scope variable
-   mutable bool theFirstlayer;
    //algorithm options
    //limit the total number of possible trajectories taken into account for a single seed
    unsigned int theMaxTrajectories;
@@ -128,7 +127,6 @@ class MuonRoadTrajectoryBuilder :public TrajectoryBuilder {
    ////the number of trajectory is more than theMaxTrajectoriesThreshold[0]. and so on ...
    bool theDynamicMaxNumberOfHitPerModule;
    unsigned int theNumberOfHitPerModuleDefault;
-   mutable unsigned int theNumberOfHitPerModule;
    std::vector<unsigned int> theMaxTrajectoriesThreshold;
    std::vector<unsigned int> theNumberOfHitPerModuleThreshold;
   


### PR DESCRIPTION
Fixes for thread safety issues with class MuonRoadTrajectoryBuilder in package RecoMuon/L3TrackFinder.
1) Both mutable data members were removed and replaced with variables on the stack, passed to member functions as arguments as needed.
2) Two non-const reverse iterators that should have been const reverse iterators were made const.
3) A reference that should have been a const reference was made const.

tested with checkdeps -a and the relval matrix.
