### PR TITLE
removal of statics from FastSimulation/Event/interface/FBaseSimEvent.icc

### DIFF
--- a/FastSimulation/Event/interface/FBaseSimEvent.icc
+++ b/FastSimulation/Event/interface/FBaseSimEvent.icc
@@ -2,17 +2,26 @@
 #include "FastSimulation/Event/interface/FSimVertex.h"
 #include "FastSimDataFormats/NuclearInteractions/interface/FSimVertexType.h"
 
-static FSimTrack oTrack;
 inline FSimTrack& FBaseSimEvent::track(int i) const { 
-  return (i>=0 && i<(int)nTracks()) ? (*theSimTracks)[i] : oTrack; }
+  if (i < 0 || i>=(int)nTracks()){
+    throw cms::Exception("FastSim") << "Index for FSimTracks out of range, please contact FastSim developers"<< std::endl;
+  }
+  return (*theSimTracks)[i];
+}
 
-static FSimVertex oVertex;
 inline FSimVertex& FBaseSimEvent::vertex(int i) const { 
-  return (i>=0 && i<(int)nVertices()) ? (*theSimVertices)[i] : oVertex; }
+  if (i < 0 || i>=(int)nVertices()){
+    throw cms::Exception("FastSim") << "Index for FSimVertex out of range, please contact FastSim developers"<< std::endl;
+  }
+  return (*theSimVertices)[i];
+}
 
-static FSimVertexType oVertexType;
-inline FSimVertexType& FBaseSimEvent::vertexType(int i) const { 
-  return (i>=0 && i<(int)nVertices()) ? (*theFSimVerticesType)[i] : oVertexType; }
+inline FSimVertexType& FBaseSimEvent::vertexType(int i) const {
+  if (i < 0 || i >=(int)nVertices()){
+    throw cms::Exception("FastSim") << "Index for FSimVertexType out of range, please contact FastSim developers"<< std::endl;
+  }
+  return (*theFSimVerticesType)[i]; 
+}
 
 inline const SimTrack& FBaseSimEvent::embdTrack(int i) const { 
   return (*theSimTracks)[i].simTrack(); }

--- a/FastSimulation/Event/interface/FSimTrack.icc
+++ b/FastSimulation/Event/interface/FSimTrack.icc
@@ -3,33 +3,61 @@
 
 inline const FSimVertex& FSimTrack::vertex() const{ return mom_->vertex(vertIndex()); }
 
-inline const FSimVertex& FSimTrack::endVertex() const { return mom_->vertex(endv_); }
-
-inline const FSimTrack& FSimTrack::mother() const{ return vertex().parent(); }
-
-inline const FSimTrack& FSimTrack::daughter(int i) const { 
-  return abs(type()) != 11 && abs(type()) != 13 ? endVertex().daughter(i) : mom_->track(daugh_[i]); 
+inline const FSimVertex& FSimTrack::endVertex() const {
+  if(endv_ < 0)
+    throw cms::Exception("FastSim") << "FSimTrack::endVertex() called for FSimTrack w/o end vertex, please contact FastSim developers" << std::endl;
+  return mom_->vertex(endv_); 
 }
 
-inline int FSimTrack::nDaughters() const { 
-  return abs(type()) != 11 && abs(type()) != 13 ? endVertex().nDaughters() : daugh_.size(); 
+inline const FSimTrack& FSimTrack::mother() const{ 
+  if(noMother()){
+    throw cms::Exception("FastSim") << "FSimTrack::mother() called for FSimTrack w/o mother, please contact FastSim developers" << std::endl;    
+  }
+  return vertex().parent(); 
 }
 
-inline const std::vector<int>& FSimTrack::daughters() const { 
-  return abs(type()) != 11 ? endVertex().daughters() : daugh_; 
+inline const FSimTrack& FSimTrack::daughter(int i) const {
+  if(i < 0 || i >= nDaughters())
+    throw cms::Exception("FastSim") << "FSimTrack::daughter(int index) index out of range, please contact FastSim developers" << std::endl;        
+  if(abs(type()) == 11 || abs(type()) == 13)
+    return mom_->track(daugh_[i]);
+  else
+    return endVertex().daughter(i);
+}
+
+inline int FSimTrack::nDaughters() const {
+  if(abs(type()) == 11 || abs(type()) == 13)
+    return daugh_.size();
+  else{
+    if(noEndVertex())
+      return 0;
+    else 
+      return endVertex().nDaughters(); 
+  }
+}
+
+inline const std::vector<int>& FSimTrack::daughters() const {
+  if(abs(type()) == 11)
+    return daugh_;
+  else{
+    if(noEndVertex())
+      throw cms::Exception("FastSim") << "FSimTrack::daughter(int index) called for FSimTrack w/o end vertex, please contact FastSim developers" << std::endl;
+    return endVertex().daughters();
+  }	
 }
 
 inline bool FSimTrack::noEndVertex() const { 
 
+  // The particle either has no end vertex index
+  if(endv_ < 0)
+     return true;
+
+  // or it's an electron/muon that has just Brem'ed, but continues its way
+  // ... but not those intermediate e/mu PYTHIA entries with prompt Brem
   bool bremOutOfPipe = true;
   if( (mom_->vertex(endv_)).position().Perp2() < 1.0 )  bremOutOfPipe = false;
-
   return 
-    // The particle either has no end vertex index
-    endv_ == -1 || 
-    // or it's an electron/muon that has just Brem'ed, but continues its way
-    // ... but not those intermediate e/mu PYTHIA entries with prompt Brem
-    ( (abs(type())==11 || abs(type())==13) && 
+      ( (abs(type())==11 || abs(type())==13) && 
       bremOutOfPipe &&
       endVertex().nDaughters()>0 && 
       endVertex().daughter(endVertex().nDaughters()-1).type()==22); 

--- a/FastSimulation/Event/src/FSimEvent.cc
+++ b/FastSimulation/Event/src/FSimEvent.cc
@@ -73,7 +73,7 @@ FSimEvent::load(edm::SimTrackContainer & c, edm::SimTrackContainer & m) const
 	 fabs(t.momentum().eta()) < 3.0 &&
 	 track(i).noEndVertex() ) {
       // Actually save the muon mother (and the attached muon) in case
-      if ( track(i).mother().closestDaughterId() == (int)i ) {
+      if ( !track(i).noMother() && track(i).mother().closestDaughterId() == (int)i ) {
 	const SimTrack& T = embdTrack(track(i).mother().id());
 	m.push_back(T);
       } 

--- a/FastSimulation/TrajectoryManager/src/TrajectoryManager.cc
+++ b/FastSimulation/TrajectoryManager/src/TrajectoryManager.cc
@@ -679,7 +679,7 @@ TrajectoryManager::makeSinglePSimHit( const GeomDetUnit& det,
   // daughter to the mother's track. The same applies to a charged particle decay into
   // another charged particle.
   int localTkID = tkID;
-  if ( mySimEvent->track(tkID).mother().closestDaughterId() == tkID )
+  if ( !mySimEvent->track(tkID).noMother() && mySimEvent->track(tkID).mother().closestDaughterId() == tkID )
     localTkID = mySimEvent->track(tkID).mother().id();
 
   // FIXME: fix the track ID and the particle ID


### PR DESCRIPTION
this pull request replaces https://github.com/cms-sw/cmssw/pull/1368

I removed the definition of static FSimTrack, FSimVertex and FSimVertexType.
These statics used to be returned by functions track(int i), vertex(int i), vertexType(int i) in case the index i was out of range.
Now instead an error is thrown.
To avoid indices out of range, a number of changes were made
- interface/FSimTrack.icc

The function FSimTrack::noEndVertex() now first of all checks if FSimTrack has an end vertex
(index of end vertex >= 0)
associated and returns false if this is not the case.

FSimtrack::nDaughters() returns 0 if the thrack has no daughter

To ease future debugging, errors are thrown when
- FSimTrack::mother() is called for tracks w/o mother
- FSimTrack::endVertex() is called for tracks w/o mother
- FSimTrack::daugther(int i) is called with i out of range
- FSimTrack::daughters() is called for track w/o end vertex
- src/FSimEvent.cc

The function FSimEvent::load(edm::SimTrackContainer & c, edm::SimTrackContainer & m)
now verifies wether a track has a mother (index mother >= 0)
before evaluating the properties of the mother.
- FastSimulation/TrajectoryManager/src/TrajectoryManager.cc

avoided the call of FSimTrack::mother() for tracks w/o mother

*\* Tests:
runTheMatrix.py -l 5.1,401.0
