### PR TITLE
getByLabel to getByToken migration for multithread

### DIFF
--- a/HLTrigger/Egamma/interface/HLTElectronMissingHitsFilter.h
+++ b/HLTrigger/Egamma/interface/HLTElectronMissingHitsFilter.h
@@ -23,6 +23,8 @@ class HLTElectronMissingHitsFilter : public HLTFilter {
  private:
       edm::InputTag candTag_;            // input tag for the RecoCandidates from the previous filter
       edm::InputTag electronProducer_;   // input tag for the producer of electrons
+      edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> candToken_;
+      edm::EDGetTokenT<reco::ElectronCollection> electronProducerToken_;
 
       int barrelcut_;      // barrel cut
       int endcapcut_;      // endcap cut

--- a/HLTrigger/Egamma/src/HLTElectronMissingHitsFilter.cc
+++ b/HLTrigger/Egamma/src/HLTElectronMissingHitsFilter.cc
@@ -24,6 +24,8 @@ HLTElectronMissingHitsFilter::HLTElectronMissingHitsFilter(const edm::ParameterS
   barrelcut_ = iConfig.getParameter<int> ("barrelcut");
   endcapcut_ = iConfig.getParameter<int> ("endcapcut");
   ncandcut_  = iConfig.getParameter<int> ("ncandcut");
+  candToken_ = consumes<trigger::TriggerFilterObjectWithRefs>(candTag_);
+  electronProducerToken_ = consumes<reco::ElectronCollection>(electronProducer_);
 }
 
 HLTElectronMissingHitsFilter::~HLTElectronMissingHitsFilter()
@@ -48,7 +50,7 @@ bool HLTElectronMissingHitsFilter::hltFilter(edm::Event& iEvent, const edm::Even
     filterproduct.addCollectionTag(electronProducer_);
 
   edm::Handle<trigger::TriggerFilterObjectWithRefs> PrevFilterOutput;
-  iEvent.getByLabel (candTag_,PrevFilterOutput);
+  iEvent.getByToken (candToken_,PrevFilterOutput);
 
   std::vector<edm::Ref<reco::RecoEcalCandidateCollection> > recoecalcands;
   PrevFilterOutput->getObjects(TriggerCluster, recoecalcands);
@@ -56,7 +58,7 @@ bool HLTElectronMissingHitsFilter::hltFilter(edm::Event& iEvent, const edm::Even
     PrevFilterOutput->getObjects(TriggerPhoton,recoecalcands);
 
   edm::Handle<reco::ElectronCollection> electronHandle;
-  iEvent.getByLabel(electronProducer_, electronHandle);
+  iEvent.getByToken(electronProducerToken_, electronHandle);
 
   int n(0);
 


### PR DESCRIPTION
HLT fix for the migration towards a multithread fwk: in the lately added HLTrigger.Egamma.HLTElectronMissingHitsFilter it was forgotten, apparently. Here fixed.
