### PR TITLE
Added bounds check on an array index.

### DIFF
--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
@@ -515,7 +515,7 @@ namespace // Unnamed namespace for things only used in this file
 				size_t hepMCGenParticleIndex=(*hHepMCGenParticleIndices)[recoGenParticleIndex];
 
 				// They should be the same size, give or take a fencepost error, so this should never happen - but just in case
-				if( genParticleIndices_.size()<hepMCGenParticleIndex ) genParticleIndices_.resize(hepMCGenParticleIndex);
+				if( genParticleIndices_.size()<=hepMCGenParticleIndex ) genParticleIndices_.resize(hepMCGenParticleIndex+1);
 
 				genParticleIndices_[ hepMCGenParticleIndex ]=recoGenParticleIndex;
 			}
@@ -547,7 +547,7 @@ namespace // Unnamed namespace for things only used in this file
 		if( simTrack.eventId().event()==0 && simTrack.eventId().bunchCrossing()==0 ) // if this is a track in the signal event
 		{
 			int hepMCGenParticleIndex=simTrack.genpartIndex();
-			if( hepMCGenParticleIndex>=0 && hGenParticles_.isValid() )
+			if( hepMCGenParticleIndex>=0 && hepMCGenParticleIndex<static_cast<int>(genParticleIndices_.size()) && hGenParticles_.isValid() )
 			{
 				int recoGenParticleIndex=genParticleIndices_[hepMCGenParticleIndex];
 				reco::GenParticleRef generatorParticleRef( hGenParticles_, recoGenParticleIndex );


### PR DESCRIPTION
Added a bounds check on an array index (line 550).  This only shows up with changes David Dagenhart made on another branch, but should still have the check in the main tree.
Some array indexing was also fixed (line 518), although this line is a safe-guard that I don't expect to ever be invoked anyway (see comment in the line above).  Even so the indexing should be corrected anyway.
