### PR TITLE
Allow Services to see how many threads

### DIFF
--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -568,7 +568,8 @@ namespace edm {
 
     service::SystemBounds bounds(preallocations_.numberOfStreams(),
                                  preallocations_.numberOfLuminosityBlocks(),
-                                 preallocations_.numberOfRuns());
+                                 preallocations_.numberOfRuns(),
+                                 preallocations_.numberOfThreads());
     actReg_->preallocateSignal_(bounds);
     //NOTE:  This implementation assumes 'Job' means one call
     // the EventProcessor::run

--- a/FWCore/ServiceRegistry/interface/SystemBounds.h
+++ b/FWCore/ServiceRegistry/interface/SystemBounds.h
@@ -32,15 +32,18 @@ namespace edm {
     public:
       SystemBounds(unsigned int iNStreams,
                    unsigned int iNLumis,
-                   unsigned int iNRuns) :
+                   unsigned int iNRuns,
+                   unsigned int iNThreads) :
       m_nStreams(iNStreams),
       m_nLumis(iNLumis),
-      m_nRuns(iNRuns) {}
+      m_nRuns(iNRuns),
+      m_nThreads(iNThreads){}
       
       // ---------- const member functions ---------------------
       unsigned int maxNumberOfStreams() const {return m_nStreams; }
       unsigned int maxNumberOfConcurrentRuns() const {return m_nRuns;}
       unsigned int maxNumberOfConcurrentLuminosityBlocks() const {return m_nLumis;}
+      unsigned int maxNumberOfThreads() const { return m_nThreads; }
       
     private:
       
@@ -48,6 +51,7 @@ namespace edm {
       unsigned int m_nStreams;
       unsigned int m_nLumis;
       unsigned int m_nRuns;
+      unsigned int m_nThreads;
     };
 
   }


### PR DESCRIPTION
Andrea Bocci requested that a Service be able to know many threads the framework is going to use. This extends SystemBounds to do that.
