### PR TITLE
clang FunctionChecker  -- filter out safe non-const global vars 

### DIFF
--- a/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
@@ -85,10 +85,7 @@ void FWalker::ReportDeclRef ( const clang::DeclRefExpr * DRE) {
 
 	if ( (D->isStaticLocal() && D->getTSCSpec() != clang::ThreadStorageClassSpecifier::TSCS_thread_local ) && ! clangcms::support::isConst( t ) )
 	{
-            std::string vname = D->getCanonicalDecl()->getQualifiedNameAsString();
-	    unsigned found = vname.find_last_of("::");
-	    std::string cname = vname.substr(0,found);
-	    if ( support::isSafeClassName( vname ) ) return;
+	    if ( support::isSafeClassName( t.getAsString() ) ) return;
 		std::string buf;
 	    	llvm::raw_string_ostream os(buf);
 	   	os << "function '"<<dname << "' accesses or modifies non-const static local variable '" << D->getNameAsString() << "'.\n";

--- a/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
@@ -63,6 +63,13 @@ void FWalker::ReportDeclRef ( const clang::DeclRefExpr * DRE) {
   
 
   if (const clang::VarDecl * D = llvm::dyn_cast<clang::VarDecl>(DRE->getDecl())) {
+
+ 	const char *sfile=BR.getSourceManager().getPresumedLoc(D->getLocation()).getFilename();
+	std::string fname(sfile);
+	if ( fname.find("stdio.h") != std::string::npos 
+		|| fname.find("iostream") != std::string::npos 
+		|| fname.find("placeholders.hpp") != std::string::npos) return;	
+
 	clang::QualType t =  D->getType();  
 	const Decl * PD = AC->getDecl();
 	std::string dname =""; 

--- a/Utilities/StaticAnalyzers/src/StaticLocalChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/StaticLocalChecker.cpp
@@ -24,11 +24,7 @@ void StaticLocalChecker::checkASTDecl(const clang::VarDecl *D,
 
 	    if ( ! m_exception.reportGlobalStaticForType( t, DLoc, BR ) )
 			return;
-	    std::string vname = D->getCanonicalDecl()->getQualifiedNameAsString();
-	    unsigned found = vname.find_last_of("::");
-	    std::string cname = vname.substr(0,found);
-//	    if ( ! support::isDataClass( cname) ) return;
-	    if ( support::isSafeClassName( vname ) ) return;
+	    if ( support::isSafeClassName( t.getAsString() ) ) return;
 
 	    std::string buf;
 	    llvm::raw_string_ostream os(buf);


### PR DESCRIPTION
from stdio.h iostream and placeholders.hpp
