### PR TITLE
7_0_X remove obsolete version.txt file in Fireworks/Core

### DIFF
--- a/Fireworks/Core/data/version.txt
+++ b/Fireworks/Core/data/version.txt
@@ -1,4 +1,0 @@
-5.2-1
-DataFormats: CMSSW_5_2_5
-patched DataFormats/FWLite V01-15-00
-patched FWCore/FWLite V00-26-00 

--- a/Fireworks/Core/standalone_build/make_tarball.sh
+++ b/Fireworks/Core/standalone_build/make_tarball.sh
@@ -100,10 +100,11 @@ getCmssw()
 
    while read p; do
        echo "get libs from $p"
-       x=`basename $p`
-       cp -a $CMSSW_RELEASE_BASE/lib/*/*${x}* ${tard}/lib/
+       x=`dirname $p`
+       y=`basename $p`
+       cp -a $CMSSW_RELEASE_BASE/lib/*/*${x}*${y}* ${tard}/lib/
        #if [ -f "$file" ]
-	   cp -f $CMSSW_BASE/lib/*/*${x}* ${tard}/lib/ 2>/dev/null
+	   cp -f $CMSSW_BASE/lib/*/*${x}*${y}* ${tard}/lib/ 2>/dev/null
        #fi
     done < fwlite_build_set.file
 
@@ -202,7 +203,7 @@ while [ $# -gt 0 ]; do
     -t)  doTar=on;;
     -v)  verbose=on;
    esac
-   tard=${PWD}/$1
+   tard=$1
    shift
 done
 

--- a/Fireworks/Core/standalone_build/make_tarball.sh
+++ b/Fireworks/Core/standalone_build/make_tarball.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+   dwnCmd="wget --no-check-certificate"
+   if [ `uname` = "Darwin" ]; then
+      # compatibility problem on 10.5
+      dwnCmd="curl -k -O"
+   fi
+
 getExternals()
 {
     mkdir  ${tard}/external
@@ -46,7 +52,7 @@ getExternals()
         ever=`grep $i $HOME/extlist |  perl -ne 'if ($_ =~ /$ENV{i}\/(.*)\/lib\/(.*)/ ) {print "$1\n"; last;}'`
         echo "copy $i $ever"
         if [ -z "$ever" ]; then
-            echo "!!!!!!!! can't get externals fro $i"
+            echo "warning can't get externals for $i"
 	fi
         # echo "cp -a $ext/$i/$ever/lib/* === ${extdl}"
         cp -a $ext/$i/$ever/lib/* ${extdl}
@@ -90,7 +96,7 @@ getCmssw()
    # cms libraries
    mkdir -p ${tard}/lib
    
-   wget --no-check-certificate  https://raw.github.com/cms-sw/cmsdist/IB/CMSSW_7_0_X/stable/fwlite_build_set.file
+   $dwnCmd  https://raw.github.com/cms-sw/cmsdist/IB/CMSSW_7_0_X/stable/fwlite_build_set.file
 
    while read p; do
        echo "get libs from $p"
@@ -117,21 +123,21 @@ getSources()
    echo "getting sources."
    # binary 
    mkdir ${tard}/libexec
-   cp $CMSSW_BASE/bin/*/cmsShow.exe ${tard}/libexec
-   cp $CMSSW_BASE/bin/*/cmsShowSendReport ${tard}/libexec
+   cp $CMSSW_RELEASE_BASE/bin/*/cmsShow.exe ${tard}/libexec
+   cp $CMSSW_RELEASE_BASE/bin/*/cmsShowSendReport ${tard}/libexec
    
    # src
    srcDir="${tard}/src/Fireworks/Core"
    mkdir -p $srcDir
-   cp -a  $CMSSW_BASE/src/Fireworks/Core/macros $srcDir
-   cp -a  $CMSSW_BASE/src/Fireworks/Core/icons $srcDir
-   cp -a  $CMSSW_BASE/src/Fireworks/Core/data $srcDir
+   cp -a  $CMSSW_RELEASE_BASE/src/Fireworks/Core/macros $srcDir
+   cp -a  $CMSSW_RELEASE_BASE/src/Fireworks/Core/icons $srcDir
+   cp -a  $CMSSW_RELEASE_BASE/src/Fireworks/Core/data $srcDir
 
    cv=`perl -e 'if ($ENV{CMSSW_VERSION} =~ /CMSSW_(\d+)_(\d+)_/) {print "${1}.${2}";}'`
    echo $cv > $srcDir/data/version.txt
    echo "DataFormats: $CMSSW_VERSION" >> $srcDir/data/version.txt
    cat $srcDir/data/version.txt
-   cp -a  $CMSSW_BASE/src/Fireworks/Core/scripts $srcDir
+   cp -a  $CMSSW_RELEASE_BASE/src/Fireworks/Core/scripts $srcDir
    
    cd  $tard
    ln -s  src/Fireworks/Core/macros/default.fwc .
@@ -152,11 +158,6 @@ getDataFiles()
 {
    # sample files
    cd $tard
-   dwnCmd="wget"
-   if [ `uname` = "Darwin" ]; then
-      # compatibility problem on 10.5
-      dwnCmd="curl -O"
-   fi
    cd ${tard}
    name=`perl -e '($ver, $a, $b, $c) = split('_', $ENV{CMSSW_VERSION}); print  "data", $a, $b, ".root"  '`
    $dwnCmd http://amraktad.web.cern.ch/amraktad/mail/scratch0/data/$name
@@ -206,6 +207,14 @@ while [ $# -gt 0 ]; do
 done
 
 
+if [[ "$tard" = /* ]]
+then
+   : # Absolute path
+else
+   : tard=$PWD/$tard
+fi
+
+echo "dirpath = $tard"
 
 if [ "X$verbose" = Xon ] ; then
    set -xv


### PR DESCRIPTION
Remove obsolete File.
Improvements in make-tarball script.
