### PR TITLE
Added CallOnceNoWait and CallNTimesNoWait

### DIFF
--- a/FWCore/Utilities/interface/CallNTimesNoWait.h
+++ b/FWCore/Utilities/interface/CallNTimesNoWait.h
@@ -1,0 +1,61 @@
+#ifndef FWCore_Utilities_CallNTimesNoWait_h
+#define FWCore_Utilities_CallNTimesNoWait_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Utilities
+// Class  :     CallNTimesNoWait
+// 
+/**\class edm::CallNTimesNoWait CallNTimesNoWait.h "CallNTimesNoWait.h"
+
+ Description: Thread safe way to do something N times
+
+ Usage:
+    This class allows one to safely do a 'non-side-effect' operation N times in a job.
+ An example use would be
+ \code
+    void myFunc( int iValue) {
+      static CallNTimesNoWait message{2};
+      message([&]() { edm::LogInfo("IWantToKnow")<<"called with "<<iValue; } );
+ \endcode
+ The important thing to remember, is there is no guarantee that the operation being run
+ finishes before a thread which doesn't get to run the operation reaches the code following
+ the call. Therefore it is useful to suppress messages but should not be used to do something
+ like filling a container with values since the filling is not guaranteed to complete before
+ another thread skips the call.
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Fri, 15 Nov 2013 14:29:41 GMT
+//
+
+// system include files
+#include<atomic>
+
+// user include files
+
+// forward declarations
+namespace edm {
+  class CallNTimesNoWait
+  {
+    
+  public:
+    CallNTimesNoWait( unsigned short iNTimes ): m_ntimes(static_cast<int>(iNTimes)-1), m_done(false){}
+    
+    template <typename T>
+    void operator()(T iCall) {
+      if(not m_done.load(std::memory_order_acquire) ) {
+        if(m_ntimes.fetch_sub(1,std::memory_order_acquire)<0) {
+          m_done.store(true,std::memory_order_acquire);
+          return;
+        };
+        iCall();
+      }
+    }
+    
+	private:
+    std::atomic<int> m_ntimes;
+    std::atomic<bool> m_done;
+  };
+}
+
+#endif

--- a/FWCore/Utilities/interface/CallNTimesNoWait.h
+++ b/FWCore/Utilities/interface/CallNTimesNoWait.h
@@ -44,8 +44,8 @@ namespace edm {
     template <typename T>
     void operator()(T iCall) {
       if(not m_done.load(std::memory_order_acquire) ) {
-        if(m_ntimes.fetch_sub(1,std::memory_order_acquire)<0) {
-          m_done.store(true,std::memory_order_acquire);
+        if(m_ntimes.fetch_sub(1,std::memory_order_acq_rel)<0) {
+          m_done.store(true,std::memory_order_release);
           return;
         };
         iCall();

--- a/FWCore/Utilities/interface/CallOnceNoWait.h
+++ b/FWCore/Utilities/interface/CallOnceNoWait.h
@@ -1,0 +1,59 @@
+#ifndef FWCore_Utilities_CallOnceNoWait_h
+#define FWCore_Utilities_CallOnceNoWait_h
+// -*- C++ -*-
+//
+// Package:     FWCore/Utilities
+// Class  :     CallOnceNoWait
+// 
+/**\class edm::CallOnceNoWait CallOnceNoWait.h "FWCore/Utilities/interface/CallOnceNoWait.h"
+
+ Description: Thread safe way to do something 1 time
+
+ Usage:
+ This class allows one to safely do a 'non-side-effect' operation 1 time in a job.
+ An example use would be
+ \code
+ void myFunc( int iValue) {
+ static CallOnceNoWait message;
+ message([&]() { edm::LogInfo("IWantToKnow")<<"called with "<<iValue; } );
+ \endcode
+ The important thing to remember, is there is no guarantee that the operation being run
+ finishes before a thread which doesn't get to run the operation reaches the code following
+ the call. Therefore it is useful to suppress messages but should not be used to do something
+ like filling a container with values since the filling is not guaranteed to complete before
+ another thread skips the call.
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Fri, 15 Nov 2013 14:29:51 GMT
+//
+
+// system include files
+#include <atomic>
+
+// user include files
+
+// forward declarations
+
+namespace edm {
+  class CallOnceNoWait
+  {
+  public:
+    CallOnceNoWait() : m_called(false) {}
+    
+    template <typename T>
+    void operator()(T iCall) {
+      bool expected = false;
+      if(m_called.compare_exchange_strong(expected, true, std::memory_order_acq_rel)) {
+        iCall();
+      }
+    }
+    
+  private:
+    std::atomic<bool> m_called;
+  };
+}
+
+
+#endif

--- a/FWCore/Utilities/test/BuildFile.xml
+++ b/FWCore/Utilities/test/BuildFile.xml
@@ -35,7 +35,7 @@
 <bin   file="MallocOpts_t.cpp">
   <use   name="cppunit"/>
 </bin>
-<bin   name="testFWCoreUtilities" file="typeidbase_t.cppunit.cpp,typeid_t.cppunit.cpp,cputimer_t.cppunit.cpp,extensioncord_t.cppunit.cpp,friendlyname_t.cppunit.cpp,signal_t.cppunit.cpp,soatuple_t.cppunit.cpp,transform.cppunit.cpp">
+<bin   name="testFWCoreUtilities" file="typeidbase_t.cppunit.cpp,typeid_t.cppunit.cpp,cputimer_t.cppunit.cpp,extensioncord_t.cppunit.cpp,friendlyname_t.cppunit.cpp,signal_t.cppunit.cpp,soatuple_t.cppunit.cpp,transform.cppunit.cpp,callxnowait_t.cppunit.cpp">
   <use   name="cppunit"/>
 </bin>
 

--- a/FWCore/Utilities/test/callxnowait_t.cppunit.cpp
+++ b/FWCore/Utilities/test/callxnowait_t.cppunit.cpp
@@ -1,0 +1,124 @@
+/*----------------------------------------------------------------------
+
+Test program for edm::TypeID class.
+Changed by Viji on 29-06-2005
+
+ ----------------------------------------------------------------------*/
+
+#include <cassert>
+#include <cppunit/extensions/HelperMacros.h>
+#include "FWCore/Utilities/interface/CallOnceNoWait.h"
+#include "FWCore/Utilities/interface/CallNTimesNoWait.h"
+
+#include <thread>
+
+class testCallXNoWait: public CppUnit::TestFixture
+{
+  CPPUNIT_TEST_SUITE(testCallXNoWait);
+  
+  CPPUNIT_TEST(onceTest);
+  CPPUNIT_TEST(nTimesTest);
+  CPPUNIT_TEST(onceThreadedTest);
+  CPPUNIT_TEST(nTimesThreadedTest);
+  
+  CPPUNIT_TEST_SUITE_END();
+public:
+  void setUp(){}
+  void tearDown(){}
+  
+  void onceTest();
+  void nTimesTest();
+  
+  void onceThreadedTest();
+  void nTimesThreadedTest();
+};
+
+///registration of the test so that the runner can find it
+CPPUNIT_TEST_SUITE_REGISTRATION(testCallXNoWait);
+
+void testCallXNoWait::onceTest()
+{
+
+  edm::CallOnceNoWait guard;
+  
+  unsigned int iCount=0;
+  
+  guard([&iCount](){ ++iCount; });
+  
+  CPPUNIT_ASSERT(iCount == 1);
+
+  guard([&iCount](){ ++iCount; });
+  CPPUNIT_ASSERT(iCount == 1);
+
+}
+
+void testCallXNoWait::nTimesTest()
+{
+  edm::CallNTimesNoWait guard{3};
+  
+  unsigned int iCount=0;
+  
+  for(unsigned int i=0; i<6; ++i) {
+    guard([&iCount](){ ++iCount; });
+    if(i<3) {
+      CPPUNIT_ASSERT(iCount == i+1);
+    } else {
+      CPPUNIT_ASSERT(iCount == 3);
+    }
+  }
+}
+
+
+void testCallXNoWait::onceThreadedTest()
+{
+  
+  edm::CallOnceNoWait guard;
+  
+  unsigned int iCount=0;
+  
+  std::vector<std::thread> threads;
+  
+  std::atomic<bool> start{false};
+
+  for(unsigned int i=0; i<4; ++i) {
+    threads.emplace_back([&guard,&iCount,&start](){
+      while(not start) {}
+      guard([&iCount](){ ++iCount; });
+    });
+  }
+  CPPUNIT_ASSERT(iCount == 0);
+  
+  start = true;
+  for(auto& t : threads) {
+    t.join();
+  }
+  CPPUNIT_ASSERT(iCount == 1);
+}
+
+
+void testCallXNoWait::nTimesThreadedTest()
+{
+  const unsigned short kMaxTimes=3;
+  edm::CallNTimesNoWait guard(kMaxTimes);
+  
+  unsigned int iCount=0;
+  
+  std::vector<std::thread> threads;
+  
+  std::atomic<bool> start{false};
+  
+  for(unsigned int i=0; i<2*kMaxTimes; ++i) {
+    threads.emplace_back([&guard,&iCount,&start](){
+      while(not start) {}
+      guard([&iCount](){ ++iCount; });
+    });
+  }
+  CPPUNIT_ASSERT(iCount == 0);
+  
+  start = true;
+  for(auto& t : threads) {
+    t.join();
+  }
+  CPPUNIT_ASSERT(iCount == kMaxTimes);
+}
+


### PR DESCRIPTION
These classes make it easier to do a non-important operation once or n times per job. This pattern is primarily used by people who want to limit the number of messages sent to the MessageLogger.
