### PR TITLE
fix uninitialized variable

### DIFF
--- a/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
+++ b/SimCalorimetry/HcalSimProducers/src/HcalDigitizer.cc
@@ -111,6 +111,7 @@ HcalDigitizer::HcalDigitizer(const edm::ParameterSet& ps) :
   theHOSiPMHitFilter(HcalOuter),
   theZDCHitFilter(),
   theHitCorrection(0),
+  theTimeSlewSim(0),
   theNoiseGenerator(0),
   theNoiseHitGenerator(0),
   theHBHEDigitizer(0),


### PR DESCRIPTION
time slew object was not initialized (which was fine until a recent config change turned off its creation...)
