### PR TITLE
Improve FedRawDataInputSource input source

### DIFF
--- a/EventFilter/Utilities/plugins/EvFDaqDirector.h
+++ b/EventFilter/Utilities/plugins/EvFDaqDirector.h
@@ -31,6 +31,7 @@ namespace evf{
       void preBeginRun(edm::RunID const& id, edm::Timestamp const& ts);
       void postEndRun(edm::Run const& run, edm::EventSetup const& es);
       std::string &baseDir(){return base_dir_;}
+      std::string &fuBaseDir(){return run_dir_;}
       std::string &smBaseDir(){return sm_base_dir_;}
       std::string &buBaseDir(){return bu_run_dir_;}
       std::string &buBaseOpenDir(){return bu_run_open_dir_;}
@@ -49,20 +50,22 @@ namespace evf{
       int readBuLock();
       // DEPRECATED
       //int updateFuLock(unsigned int &ls);
-      bool updateFuLock(unsigned int& ls, unsigned int& index, bool& eorSeen);
+      bool updateFuLock(unsigned int& ls, std::string& nextFile, bool& eorSeen);
       void writeLsStatisticsBU(unsigned int, unsigned int, unsigned long long, long long);
       void writeLsStatisticsFU(unsigned int ls, unsigned int events, timeval completion_time){}
       void writeDiskAndThrottleStat(double, int, int);
       void tryInitializeFuLockFile();
+      unsigned int getRunNumber() const { return run_; }
       unsigned int getJumpLS() const { return jumpLS_; }
       unsigned int getJumpIndex() const { return jumpIndex_; }
+      std::string getJumpFilePath() const { return formatRawFilePath(jumpLS_,jumpIndex_); }
       bool getTestModeNoBuilderUnit() { return testModeNoBuilderUnit_;}
       FILE * maybeCreateAndLockFileHeadForStream(unsigned int ls, std::string &stream);
       void unlockAndCloseMergeStream();
-      std::string formatRawFilePath(unsigned int ls, unsigned int index);
-      std::string formatOpenRawFilePath(unsigned int ls, unsigned int index);
-      std::string formatMergeFilePath(unsigned int ls, std::string &stream);
-      std::string formatEndOfLS(unsigned int ls);
+      std::string formatRawFilePath(unsigned int ls, unsigned int index) const;
+      std::string formatOpenRawFilePath(unsigned int ls, unsigned int index) const;
+      std::string formatMergeFilePath(unsigned int ls, std::string &stream) const;
+      std::string formatEndOfLS(unsigned int ls) const;
 
     private:
       bool bulock();
@@ -73,7 +76,7 @@ namespace evf{
       bool mkFuRunDir();
       // This functionality is for emulator running only
       bool createOutputDirectory();
-      bool bumpFile(unsigned int& ls, unsigned int& index);
+      bool bumpFile(unsigned int& ls, unsigned int& index, std::string& nextFile);
       bool findHighestActiveLS(unsigned int& startingLS) const;
       void openFULockfileStream(std::string& fuLockFilePath, bool create);
 

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -40,7 +40,7 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset,
   edm::RawInputSource(pset, desc),
   eventChunkSize_(pset.getUntrackedParameter<unsigned int> ("eventChunkSize",16)),
   getLSFromFilename_(pset.getUntrackedParameter<bool> ("getLSFromFilename", true)),
-  verifyAdler32_(pset.getUntrackedParameter<bool> ("verifyAdler32", false)),
+  verifyAdler32_(pset.getUntrackedParameter<bool> ("verifyAdler32", true)),
   testModeNoBuilderUnit_(edm::Service<evf::EvFDaqDirector>()->getTestModeNoBuilderUnit()),
   runNumber_(edm::Service<evf::EvFDaqDirector>()->getRunNumber()),
   buInputDir_(edm::Service<evf::EvFDaqDirector>()->buBaseDir()),
@@ -340,8 +340,11 @@ bool FedRawDataInputSource::grabNextJsonFile(boost::filesystem::path const& json
 
     if ( testModeNoBuilderUnit_ )
       boost::filesystem::copy(jsonSourcePath,jsonDestPath);
-    else
-      boost::filesystem::rename(jsonSourcePath,jsonDestPath);
+    else {
+      //boost::filesystem::rename(jsonSourcePath,jsonDestPath);
+      boost::filesystem::copy(jsonSourcePath,jsonDestPath);
+      boost::filesystem::remove(jsonSourcePath);
+    }
 
     currentInputJson_ = jsonDestPath; // store location for later deletion.
     boost::filesystem::ifstream ij(jsonDestPath);
@@ -350,7 +353,7 @@ bool FedRawDataInputSource::grabNextJsonFile(boost::filesystem::path const& json
     if(!reader_.parse(ij,deserializeRoot)){
       throw std::runtime_error("Cannot deserialize input JSON file");
     }
-    else{
+    else {
       dp.deserialize(deserializeRoot);
       std::string data = dp.getData()[0];
       currentInputEventCount_=atoi(data.c_str()); //all this is horrible...

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -37,96 +37,57 @@
 FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset,
                                              edm::InputSourceDescription const& desc) :
   edm::RawInputSource(pset, desc),
-  getLSFromFilename_(
-                     pset.getUntrackedParameter<bool> ("getLSFromFilename", true)),
-  testModeNoBuilderUnit_(edm::Service<evf::EvFDaqDirector>()->getTestModeNoBuilderUnit()),
   eventChunkSize_(pset.getUntrackedParameter<unsigned int> ("eventChunkSize",16)),
-  runNumber_(pset.getUntrackedParameter<unsigned int> ("runNumber")),
+  getLSFromFilename_(pset.getUntrackedParameter<bool> ("getLSFromFilename", true)),
+  testModeNoBuilderUnit_(edm::Service<evf::EvFDaqDirector>()->getTestModeNoBuilderUnit()),
+  runNumber_(edm::Service<evf::EvFDaqDirector>()->getRunNumber()),
+  buInputDir_(edm::Service<evf::EvFDaqDirector>()->buBaseDir()),
+  fuOutputDir_(edm::Service<evf::EvFDaqDirector>()->fuBaseDir()),
   daqProvenanceHelper_(edm::TypeID(typeid(FEDRawDataCollection))),
-  formatVersion_(0),
-  fileIndex_(0),
   fileStream_(0),
-  workDirCreated_(false),
   eventID_(),
   lastOpenedLumi_(0),
-  currentDataDir_(""),
   currentInputJson_(""),
   currentInputEventCount_(0),
   eorFileSeen_(false),
-  buffer_left(0),
-  data_buffer(new unsigned char[1024 * 1024 * eventChunkSize_])
-
+  dataBuffer_(new unsigned char[1024 * 1024 * eventChunkSize_]),
+  bufferCursor_(dataBuffer_),
+  bufferLeft_(0)
 {
+  char thishost[256];
   gethostname(thishost, 255); 
   edm::LogInfo("FedRawDataInputSource") << "test mode: "
                                         << testModeNoBuilderUnit_ << ", read-ahead chunk size: " << eventChunkSize_
                                         << " on host " << thishost;
 
   daqProvenanceHelper_.daqInit(productRegistryUpdate(), processHistoryRegistryForUpdate());
-  findAllDirectories();
   setNewRun();
-  setRunAuxiliary(
-                  new edm::RunAuxiliary(runNumber_, edm::Timestamp::beginOfTime(),
+  setRunAuxiliary(new edm::RunAuxiliary(runNumber_, edm::Timestamp::beginOfTime(),
 					edm::Timestamp::invalidTimestamp()));
 }
 
-FedRawDataInputSource::~FedRawDataInputSource() {
-	if (fileStream_)
-		fclose(fileStream_);
-	fileStream_ = 0;
+FedRawDataInputSource::~FedRawDataInputSource()
+{
+  if (fileStream_)
+    fclose(fileStream_);
+  fileStream_ = 0;
 }
 
-void FedRawDataInputSource::findAllDirectories() {
-  
-  std::string rootFUDirectory = edm::Service<evf::EvFDaqDirector>()->baseDir();
-  // is this really necessary ? Should not be as the process start is now *triggered* by the appearence of this directory...
-  boost::filesystem::directory_iterator itEnd;
-  bool foundInFu = false;
-  for (boost::filesystem::directory_iterator it(rootFUDirectory); it
-         != itEnd; ++it) {
-    std::string::size_type pos = std::string::npos;
-    if (boost::filesystem::is_directory(it->path())
-        && std::string::npos != (pos = it->path().string().find("run"))){
-      std::string rnString = it->path().string().substr(pos+3);
-      if(runNumber_ == (unsigned int)atoi(rnString.c_str())) {foundInFu=true; localRunBaseDirectory_=it->path(); break;}
-    }
-  }
-  if(!foundInFu) throw cms::Exception("LogicError") << "Run directory for run " << runNumber_ << " not found on Fu disk " 
-                                                          << rootFUDirectory;
-
-  // store the path to the BU (input) dir
-  buRunDirectory_ = boost::filesystem::path(edm::Service<evf::EvFDaqDirector>()->buBaseDir());
-  //  buRunDirectory_ /= localRunBaseDirectory_.filename();
-  
-  
-  if (!boost::filesystem::exists(buRunDirectory_)) 
-    throw cms::Exception("LogicError") << "Run directory for run " << runNumber_ << " not found on Bu disk " 
-                                       << buRunDirectory_.string();
-  edm::LogInfo("FedRawDataInputSource") << "Getting data from "
-                                        << buRunDirectory_.string();
-
-}
-
-bool FedRawDataInputSource::checkNextEvent() {
-
-  FRDEventHeader_V2 eventHeader;
-
-  if (!getEventHeaderFromBuffer(&eventHeader)) {
+bool FedRawDataInputSource::checkNextEvent()
+{
+  if ( ! cacheNextEvent() ) {
     // run has ended
     resetLuminosityBlockAuxiliary();
     return false;
   }
 
-  assert(eventHeader.version_ > 1);
-  formatVersion_ = eventHeader.version_;
-
   //same lumi, or new lumi detected in file (old mode)
   if (!getLSFromFilename_) {
     //get new lumi from file header
+    const uint32_t lumi = event_->lumi();
     if (!luminosityBlockAuxiliary()
-        || luminosityBlockAuxiliary()->luminosityBlock()
-        != eventHeader.lumi_) {
-      lastOpenedLumi_ = eventHeader.lumi_;
+        || luminosityBlockAuxiliary()->luminosityBlock() != lumi) {
+      lastOpenedLumi_ = lumi;
       resetLuminosityBlockAuxiliary();
       timeval tv;
       gettimeofday(&tv, 0);
@@ -135,7 +96,7 @@ bool FedRawDataInputSource::checkNextEvent() {
                                 + (unsigned long long) tv.tv_usec);
       edm::LuminosityBlockAuxiliary* luminosityBlockAuxiliary =
         new edm::LuminosityBlockAuxiliary(runAuxiliary()->run(),
-                                          eventHeader.lumi_, lsopentime,
+                                          lumi, lsopentime,
                                           edm::Timestamp::invalidTimestamp());
       setLuminosityBlockAuxiliary(luminosityBlockAuxiliary);
     }
@@ -161,13 +122,82 @@ bool FedRawDataInputSource::checkNextEvent() {
     }
   }
 
-  eventID_ = edm::EventID(eventHeader.run_, lastOpenedLumi_,
-                          eventHeader.event_);
+  eventID_ = edm::EventID(event_->run(), lastOpenedLumi_,
+                          event_->event());
 
   setEventCached();
 
   return true;
 
+}
+
+bool FedRawDataInputSource::cacheNextEvent()
+{
+  if ( bufferLeft_ < sizeof(FRDEventHeader_V3) )
+  {
+    if ( !readNextChunkIntoBuffer(sizeof(FRDEventHeader_V3)) ) return false;
+  }
+
+  event_.reset( new FRDEventMsgView(bufferCursor_) );
+
+  assert(event_->version() >= 3);
+
+  const uint32_t msgSize = event_->size();
+
+  if ( bufferLeft_ < msgSize )
+  {
+    if ( !readNextChunkIntoBuffer(msgSize) )
+    {
+      throw cms::Exception("FedRawDataInputSource::cacheNextEvent") <<
+        "Premature end of input file while reading event data";
+    }
+  }
+
+  bufferLeft_ -= msgSize;
+  bufferCursor_ += msgSize;
+
+  return true;
+}
+
+bool FedRawDataInputSource::readNextChunkIntoBuffer(const uint32_t minSize)
+{
+  //this function is called when we reach the end of the buffer (i.e. bytes to read are more than bytes left in buffer)
+  if (eofReached() && !openNextFile())
+    return false; //should only happen when requesting the next event header and the run is over
+  if (bufferLeft_ == 0) { //in the rare case the last byte barely fit
+    uint32_t chunksize = 1024 * 1024 * eventChunkSize_;
+    bufferLeft_ = fread((void*) dataBuffer_, sizeof(unsigned char),
+                        chunksize, fileStream_); //reads a maximum of chunksize bytes from file into buffer
+  } else { //refill the buffer after having moved the bufferLeft_ bytes at the head
+    uint32_t chunksize = 1024 * 1024 * eventChunkSize_ - bufferLeft_;
+    memcpy((void*) dataBuffer_, bufferCursor_, bufferLeft_); //this copy could be avoided
+    bufferLeft_ += fread((void*) (dataBuffer_ + bufferLeft_),
+                         sizeof(unsigned char), chunksize, fileStream_);
+  }
+  bufferCursor_ = dataBuffer_; // reset the cursor at the beginning of the buffer
+  return (bufferLeft_ >= minSize);
+}
+
+bool FedRawDataInputSource::eofReached() const
+{
+  if (fileStream_ == 0)
+    return true;
+
+  int c;
+  c = fgetc(fileStream_);
+  ungetc(c, fileStream_);
+
+  return (c == EOF);
+}
+
+bool FedRawDataInputSource::openNextFile()
+{
+  while (!searchForNextFile() && !eorFileSeen_) {
+    edm::LogInfo("FedRawDataInputSource") << "No file for me... sleep and try again..." << std::endl;
+    usleep(100000);
+  }
+
+  return (fileStream_ != 0 || !eorFileSeen_);
 }
 
 void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal) 
@@ -178,10 +208,9 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal)
   
   edm::EventAuxiliary aux(eventID_, processGUID(), tstamp, true,
                           edm::EventAuxiliary::PhysicsTrigger);
-    makeEvent(eventPrincipal, aux);
+  makeEvent(eventPrincipal, aux);
   
-  edm::WrapperOwningHolder edp(
-                               new edm::Wrapper<FEDRawDataCollection>(rawData),
+  edm::WrapperOwningHolder edp(new edm::Wrapper<FEDRawDataCollection>(rawData),
                                edm::Wrapper<FEDRawDataCollection>::getInterface());
   
   eventPrincipal.put(daqProvenanceHelper_.constBranchDescription_, edp,
@@ -190,45 +219,11 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal)
   return;
 }
 
-bool FedRawDataInputSource::eofReached() const {
-  if (fileStream_ == 0)
-    return true;
-  
-  int c;
-  c = fgetc(fileStream_);
-  ungetc(c, fileStream_);
-  
-  return (c == EOF);
-}
-
-edm::Timestamp FedRawDataInputSource::fillFEDRawDataCollection(std::auto_ptr<FEDRawDataCollection>& rawData) {
+edm::Timestamp FedRawDataInputSource::fillFEDRawDataCollection(std::auto_ptr<FEDRawDataCollection>& rawData) const
+{
   edm::Timestamp tstamp;
-  uint32_t eventSize = 0;
-  uint32_t paddingSize = 0;
-  if (formatVersion_ >= 3) {
-    eventSize = getEventSizeFromBuffer();
-    paddingSize = getPaddingSizeFromBuffer();
-  }
-  uint32_t fedSizes[1024];
-  eventSize += fillFedSizesFromBuffer(fedSizes);
-  
-  /*
-    if (formatVersion_ < 3) {
-    for (unsigned int i = 0; i < 1024; i++)
-    eventSize += fedSizes[i];
-    }
-  */
-
-  unsigned int gtpevmsize = fedSizes[FEDNumbering::MINTriggerGTPFEDID];
-  if (gtpevmsize > 0)
-    evf::evtn::evm_board_setformat(gtpevmsize);
-  
-  //todo put this in a separate function
-  if (buffer_left < eventSize)
-    checkIfBuffered();
-  char* event = (char *) (data_buffer + buffer_cursor);
-  buffer_left -= eventSize;
-  buffer_cursor += eventSize;
+  uint32_t eventSize = event_->eventSize();
+  char* event = (char *) (event_->startAddress() + sizeof(FRDEventHeader_V3));
   
   while (eventSize > 0) {
     eventSize -= sizeof(fedt_t);
@@ -238,127 +233,51 @@ edm::Timestamp FedRawDataInputSource::fillFEDRawDataCollection(std::auto_ptr<FED
     const fedh_t* fedHeader = (fedh_t *) (event + eventSize);
     const uint16_t fedId = FED_SOID_EXTRACT(fedHeader->sourceid);
     if (fedId == FEDNumbering::MINTriggerGTPFEDID) {
-      const uint64_t gpsl = evf::evtn::getgpslow(
-                                                 (unsigned char*) fedHeader);
-      const uint64_t gpsh = evf::evtn::getgpshigh(
-                                                  (unsigned char*) fedHeader);
-      tstamp = edm::Timestamp(
-                              static_cast<edm::TimeValue_t> ((gpsh << 32) + gpsl));
+      evf::evtn::evm_board_setformat(fedSize);
+      const uint64_t gpsl = evf::evtn::getgpslow((unsigned char*) fedHeader);
+      const uint64_t gpsh = evf::evtn::getgpshigh((unsigned char*) fedHeader);
+      tstamp = edm::Timestamp(static_cast<edm::TimeValue_t> ((gpsh << 32) + gpsl));
     }
     FEDRawData& fedData = rawData->FEDData(fedId);
     fedData.resize(fedSize);
     memcpy(fedData.data(), event + eventSize, fedSize);
   }
   assert(eventSize == 0);
-  buffer_left -= paddingSize;
-  buffer_cursor += paddingSize;
-	//	delete event;
+
   return tstamp;
 }
 
-bool FedRawDataInputSource::openNextFile() {
-  // @@EM !!!!!!!!!!!!!!    this function is dead wood
-  createWorkingDirectory();
-  boost::filesystem::path nextFile;
-  //  boost::filesystem::path nextFile = buRunDirectory_;
-
-  //  std::ostringstream fileName;
-  //   fileName << std::setfill('0') << std::setw(16) << fileIndex_++ << "_"
-  //            << thishost << "_" << getpid() << ".raw";
-  //   nextFile /= fileName.str();
-  
-  //   openFile(nextFile);//closes previous file
-
-  while (!searchForNextFile(nextFile) && !eorFileSeen_) {
-    std::cout << "No file for me... sleep and try again..." << std::endl;
-    usleep(100000);
-  }
-
-  return (fileStream_ != 0 || !eorFileSeen_);
-}
-
-void FedRawDataInputSource::openFile(boost::filesystem::path const& nextFile) {
-
-  if (fileStream_) {
-    fclose(fileStream_);
-    fileStream_ = 0;
-    
-    if (!testModeNoBuilderUnit_) {
-      boost::filesystem::remove(openFile_); // won't work in case of forked children
-    } else {
-      renameToNextFree();
-    }
-    
-  }
-
-  const int fileDescriptor = open(nextFile.c_str(), O_RDONLY);
-  if (fileDescriptor != -1) {
-    fileStream_ = fdopen(fileDescriptor, "rb");
-    openFile_ = nextFile;
-  }
-  edm::LogInfo("FedRawDataInputSource") << " tried to open file.. " << nextFile << " fd:"
-            << fileDescriptor;
-}
-
-void FedRawDataInputSource::renameToNextFree()
+bool FedRawDataInputSource::searchForNextFile()
 {
-  boost::filesystem::path fileToRename(openFile_);
-
-  unsigned int jumpLS =
-    edm::Service<evf::EvFDaqDirector>()->getJumpLS();
-  unsigned int jumpIndex =
-    edm::Service<evf::EvFDaqDirector>()->getJumpIndex();
-
-  string path = formatRawFilePath(jumpLS,jumpIndex);
-  edm::LogInfo("FedRawDataInputSource") << "Instead of delete, RENAME: " << openFile_ 
-                                        << " to: " << path;
-  int rc = rename(openFile_.string().c_str(), path.c_str());
-  if (rc != 0) {
-    edm::LogError("FedRawDataInputSource") << "RENAME RAW FAILED!";
-  }
-  
-  edm::LogInfo("FedRawDataInputSource") << "Also rename json: " << openFile_ << " to: " << path;
-  string sourceJson = formatJsnFilePath(jumpLS - 2,jumpIndex);
-  string destJson = formatJsnFilePath(jumpLS,jumpIndex);
-  rc = rename(sourceJson.c_str(), destJson.c_str());
-
-  if (rc != 0) {
-    edm::LogError("FedRawDataInputSource") << "RENAME JSON FAILED!";
-  }
-}
-
-bool FedRawDataInputSource::searchForNextFile(boost::filesystem::path const& nextFile) {
-
-  std::stringstream ss;
-  unsigned int ls = lastOpenedLumi_;
-  unsigned int index;
-  unsigned int initialLS = ls;
-  
   if(currentInputEventCount_!=0){
     throw cms::Exception("RuntimeError") << "Went to search for next file but according to BU more events in " 
                                          << currentInputJson_.string();
   }
   boost::filesystem::remove(currentInputJson_); //the content of this file is now accounted for in the output json
   
+  std::string nextFile;
+  uint32_t ls;
+
   edm::LogInfo("FedRawDataInputSource") << "Asking for next file... to the DaqDirector";
   evf::FastMonitoringService*fms = (evf::FastMonitoringService *) (edm::Service<evf::MicroStateService>().operator->());
   fms->startedLookingForFile();
-  bool fileIsOKToGrab = edm::Service<evf::EvFDaqDirector>()->updateFuLock(ls,index, eorFileSeen_);
+  bool fileIsOKToGrab = edm::Service<evf::EvFDaqDirector>()->updateFuLock(ls,nextFile,eorFileSeen_);
 
   if (fileIsOKToGrab) {
 
-    string path = formatRawFilePath(ls,index);
-    edm::LogInfo("FedRawDataInputSource") << "The director says to grab: " << path;
+    edm::LogInfo("FedRawDataInputSource") << "The director says to grab: " << nextFile;
 
     fms->stoppedLookingForFile();
     edm::LogInfo("FedRawDataInputSource") << "grabbing next file, setting last seen lumi to LS = " << ls;
-    boost::filesystem::path theFileToGrab(path);
-    assert(grabNextFile(theFileToGrab, nextFile));
-    if (getLSFromFilename_)
-      lastOpenedLumi_ = ls;
+
+    boost::filesystem::path sourcePath(nextFile);
+    assert( grabNextJsonFile(sourcePath.replace_extension(".jsn")) );
+    openDataFile(sourcePath);
+
+    if (getLSFromFilename_) lastOpenedLumi_ = ls;
     return true;
       
-  } else if (ls > initialLS && !eorFileSeen_) {
+  } else if (ls > lastOpenedLumi_) {
     // ls was increased, so some EoL jsn files were seen, without new data files
     edm::LogInfo("FedRawDataInputSource") << "EoL jsn file(s) seen! Current LS is: " << ls;
     resetLuminosityBlockAuxiliary();
@@ -392,33 +311,28 @@ bool FedRawDataInputSource::searchForNextFile(boost::filesystem::path const& nex
   }
 }
 
-bool FedRawDataInputSource::grabNextFile(boost::filesystem::path& file,
-                                         boost::filesystem::path const& nextFile) {
+bool FedRawDataInputSource::grabNextJsonFile(boost::filesystem::path const& jsonSourcePath)
+{
   try {
-    // assemble json path on /hlt/data
-    boost::filesystem::path nextFileJson = workingDirectory_;
-    boost::filesystem::path jsonSourcePath(file);
-    boost::filesystem::path jsonDestPath(nextFileJson);
-    boost::filesystem::path jsonExt(".jsn");
-    jsonSourcePath.replace_extension(jsonExt);
-    boost::filesystem::path jsonTempPath(jsonDestPath);
+    // assemble json destination path
+    boost::filesystem::path jsonDestPath(fuOutputDir_);
 
     std::ostringstream fileNameWithPID;
     fileNameWithPID << jsonSourcePath.stem().string() << "_pid"
                     << std::setfill('0') << std::setw(5) << getpid() << ".jsn";
-    boost::filesystem::path filePathWithPID(fileNameWithPID.str());
-    jsonTempPath /= filePathWithPID;
+    const boost::filesystem::path filePathWithPID(fileNameWithPID.str());
+    jsonDestPath /= fileNameWithPID.str();
+
     edm::LogInfo("FedRawDataInputSource") << " JSON rename " << jsonSourcePath << " to "
-                                          << jsonTempPath;
-    //COPY JSON
-    string mvCmd = (testModeNoBuilderUnit_? "cp " : "mv ") 
-      + jsonSourcePath.string() 
-      + " "
-      + jsonTempPath.string();
-    edm::LogInfo("FedRawDataInputSource")<< " Running cmd = " << mvCmd;
-    int rc = system(mvCmd.c_str()); // horrible!!! let's find something better !!!
-    currentInputJson_ = jsonTempPath; // store location for later deletion.
-    boost::filesystem::ifstream ij(jsonTempPath);
+                                          << jsonDestPath;
+
+    if ( testModeNoBuilderUnit_ )
+      boost::filesystem::copy(jsonSourcePath,jsonDestPath);
+    else
+      boost::filesystem::rename(jsonSourcePath,jsonDestPath);
+
+    currentInputJson_ = jsonDestPath; // store location for later deletion.
+    boost::filesystem::ifstream ij(jsonDestPath);
     Json::Value deserializeRoot;
     DataPoint dp;
     if(!reader_.parse(ij,deserializeRoot)){
@@ -430,24 +344,23 @@ bool FedRawDataInputSource::grabNextFile(boost::filesystem::path& file,
       currentInputEventCount_=atoi(data.c_str()); //all this is horrible...
     }
     
-    //std::cout << " return code = " << rc << std::endl;
-    if (rc != 0) {
-      throw std::runtime_error("Cannot copy JSON file, rc is != 0!");
-    }
-    openFile(file);
-    
     return true;
   }
 
-  catch (const boost::filesystem::filesystem_error& ex) {
+  catch (const boost::filesystem::filesystem_error& ex)
+  {
     // Input dir gone?
     edm::LogError("FedRawDataInputSource") << " - grabNextFile BOOST FILESYSTEM ERROR CAUGHT: " << ex.what()
                   << " - Maybe the BU run dir disappeared? Ending process with code 0...";
     _exit(0);
-  } catch (std::runtime_error e) {
+  }
+  catch (std::runtime_error e)
+  {
     // Another process grabbed the file and NFS did not register this
      edm::LogError("FedRawDataInputSource") << " - grabNextFile runtime Exception: " << e.what() << std::endl;
-  } catch (std::exception e) {
+  }
+  catch (std::exception e)
+  {
     // BU run directory disappeared?
     edm::LogError("FedRawDataInputSource") << " - grabNextFileSOME OTHER EXCEPTION OCCURED!!!! ->" << e.what()
                                            << std::endl;
@@ -455,135 +368,52 @@ bool FedRawDataInputSource::grabNextFile(boost::filesystem::path& file,
   return false;
 }
 
-/* this functionality now assumed by the DaqDirector */
+void FedRawDataInputSource::openDataFile(boost::filesystem::path const& nextFile)
+{
+  if (fileStream_) {
+    fclose(fileStream_);
+    fileStream_ = 0;
 
-// bool FedRawDataInputSource::runEnded() const {
-// 	boost::filesystem::path endOfRunMarker = buRunDirectory_;
-// 	endOfRunMarker /= "EndOfRun.jsn";
-// 	return boost::filesystem::exists(endOfRunMarker);
-// }
+    if (!testModeNoBuilderUnit_) {
+      boost::filesystem::remove(openFile_); // won't work in case of forked children
+    } else {
+      renameToNextFree();
+    }
+  }
 
-void FedRawDataInputSource::preForkReleaseResources() {
+  const int fileDescriptor = open(nextFile.c_str(), O_RDONLY);
+  if (fileDescriptor != -1) {
+    fileStream_ = fdopen(fileDescriptor, "rb");
+    openFile_ = nextFile;
+  }
+  edm::LogInfo("FedRawDataInputSource") << " tried to open file.. " << nextFile << " fd:"
+            << fileDescriptor;
 }
 
-void FedRawDataInputSource::postForkReacquireResources(boost::shared_ptr<edm::multicore::MessageReceiverForSource>) {
-  createWorkingDirectory();
+void FedRawDataInputSource::renameToNextFree() const
+{
+  boost::filesystem::path source(openFile_);
+  boost::filesystem::path destination( edm::Service<evf::EvFDaqDirector>()->getJumpFilePath() );
+
+  edm::LogInfo("FedRawDataInputSource") << "Instead of delete, RENAME: " << openFile_
+                                        << " to: " << destination.string();
+  boost::filesystem::rename(source,destination);
+  boost::filesystem::rename(source.replace_extension(".jsn"),destination.replace_extension(".jsn"));
+}
+
+void FedRawDataInputSource::preForkReleaseResources()
+{}
+
+void FedRawDataInputSource::postForkReacquireResources(boost::shared_ptr<edm::multicore::MessageReceiverForSource>)
+{
   InputSource::rewind();
   setRunAuxiliary(
                   new edm::RunAuxiliary(runNumber_, edm::Timestamp::beginOfTime(),
 					edm::Timestamp::invalidTimestamp()));
 }
 
-void FedRawDataInputSource::rewind_() {
-}
-
-void FedRawDataInputSource::createWorkingDirectory() {
-
-  if(workDirCreated_) return;
-  //this function is moot since all processes share the same working directory which is the local run base 
-  workingDirectory_ = localRunBaseDirectory_;
-  // workingDirectory_ /= "open";
-  
-  // 	if (!openDirFound) {
-  // 		boost::filesystem::create_directories(workingDirectory_);
-  // 	}
-
-  workDirCreated_ = true;
-
-  // also create MON directory
-
-  boost::filesystem::path monDirectory = localRunBaseDirectory_;
-  monDirectory /= "mon";
-  
-  bool foundMonDir = false;
-  if (boost::filesystem::is_directory(monDirectory))
-    foundMonDir = true;
-  if (!foundMonDir) {
-    edm::LogInfo("FedRawDataInputSource") << "mon directory not found - creating";
-    boost::filesystem::create_directories(monDirectory);
-  }
-
-}
-
-uint32_t FedRawDataInputSource::getEventSizeFromBuffer() {
-  if (buffer_left < sizeof(uint32_t))
-    checkIfBuffered();
-  uint32_t retval = *(uint32_t*) (data_buffer + buffer_cursor);
-  buffer_left -= sizeof(uint32_t);
-  buffer_cursor += sizeof(uint32_t);
-  return retval;
-}
-
-uint32_t FedRawDataInputSource::getPaddingSizeFromBuffer() {
-  if (buffer_left < sizeof(uint32_t))
-    checkIfBuffered();
-  uint32_t retval = *(uint32_t*) (data_buffer + buffer_cursor);
-  buffer_left -= sizeof(uint32_t);
-  buffer_cursor += sizeof(uint32_t);
-  return retval;
-}
-
-uint32_t FedRawDataInputSource::fillFedSizesFromBuffer(uint32_t *fedSizes) {
-  if (buffer_left < sizeof(uint32_t) * 1024)
-    checkIfBuffered();
-  memcpy((void*) fedSizes, (void*) (data_buffer + buffer_cursor),
-         sizeof(uint32_t) * 1024);
-  uint32_t eventSize = 0;
-  if (formatVersion_ < 3) {
-    for (unsigned int i = 0; i < 1024; i++)
-      eventSize += fedSizes[i];
-  }
-  buffer_left -= sizeof(uint32_t) * 1024;
-  buffer_cursor += sizeof(uint32_t) * 1024;
-  return eventSize;
-}
-
-bool FedRawDataInputSource::getEventHeaderFromBuffer(FRDEventHeader_V2 *eventHeader) {
-  if (buffer_left < sizeof(uint32_t) * 4)
-    if (!checkIfBuffered())
-      return false;
-  memcpy((void*) eventHeader, (void*) (data_buffer + buffer_cursor),
-         sizeof(uint32_t) * 4);
-  assert(eventHeader->version_ > 1);
-  formatVersion_ = eventHeader->version_;
-  buffer_left -= sizeof(uint32_t) * 4;
-  buffer_cursor += sizeof(uint32_t) * 4;
-  return true;
-}
-
-bool FedRawDataInputSource::checkIfBuffered() {
-  //this function is called when we reach the end of the buffer (i.e. bytes to read are more than bytes left in buffer)
-  if (eofReached() && !openNextFile())
-    return false; //should only happen when requesting the next event header and the run is over
-  if (buffer_left == 0) { //in the rare case the last byte barely fit
-    uint32_t chunksize = 1024 * 1024 * eventChunkSize_;
-    buffer_left = fread((void*) data_buffer, sizeof(unsigned char),
-                        chunksize, fileStream_); //reads a maximum of chunksize bytes from file into buffer
-  } else { //refill the buffer after having moved the buffer_left bytes at the head
-    uint32_t chunksize = 1024 * 1024 * eventChunkSize_ - buffer_left;
-    memcpy((void*) data_buffer, data_buffer + buffer_cursor, buffer_left); //this copy could be avoided
-    buffer_left += fread((void*) (data_buffer + buffer_left),
-                         sizeof(unsigned char), chunksize, fileStream_);
-  }
-  buffer_cursor = 0; // reset the cursor at the beginning of the buffer
-  return (buffer_left != 0);
-}
-
-// @@EM !!! can be done a lot better than this 
-std::string FedRawDataInputSource::formatRawFilePath(unsigned int ls, unsigned int index){
-  stringstream ss;
-  ss << buRunDirectory_.string() << "/run" << std::setfill('0') << std::setw(6) << runNumber_
-     << "_ls" << std::setfill('0') << std::setw(4) << ls 
-     << "_index" << std::setfill('0') << std::setw(6) << index << ".raw";
-  return ss.str();
-}
-std::string FedRawDataInputSource::formatJsnFilePath(unsigned int ls, unsigned int index){
-  stringstream ss;
-  ss << buRunDirectory_.string() << "/run" << std::setfill('0') << std::setw(6) << runNumber_
-     << "_ls" << std::setfill('0') << std::setw(4) << ls 
-     << "_index" << std::setfill('0') << std::setw(6) << index << ".jsn";
-  return ss.str();
-}
+void FedRawDataInputSource::rewind_()
+{}
 
 // define this class as an input source
 DEFINE_FWK_INPUT_SOURCE( FedRawDataInputSource);

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.h
@@ -51,6 +51,7 @@ private:
 
   // get LS from filename instead of event header
   const bool getLSFromFilename_;
+  const bool verifyAdler32_;
   const bool testModeNoBuilderUnit_;
   
   const edm::RunNumber_t runNumber_;

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.h
@@ -42,9 +42,9 @@ private:
   bool openNextFile();
   bool searchForNextFile();
   bool grabNextJsonFile(boost::filesystem::path const&);
-  void openDataFile(boost::filesystem::path const&);
+  void openDataFile(std::string const&);
   bool eofReached() const;
-  bool readNextChunkIntoBuffer(const uint32_t minSize);
+  bool readNextChunkIntoBuffer();
   void renameToNextFree() const;
 
   const unsigned int eventChunkSize_; // for buffered read-ahead

--- a/IOPool/Streamer/interface/FRDEventMessage.h
+++ b/IOPool/Streamer/interface/FRDEventMessage.h
@@ -67,6 +67,7 @@ class FRDEventMsgView
   FRDEventMsgView(void* buf);
 
   uint8* startAddress() const { return buf_; }
+  void* payload() const { return payload_; }
   uint32 size() const { return size_; }
 
   uint32 version() const { return version_; }
@@ -80,6 +81,7 @@ class FRDEventMsgView
  private:
 
   uint8* buf_;
+  void* payload_;
   uint32 size_;
   uint32 version_;
   uint32 run_;

--- a/IOPool/Streamer/interface/FRDEventMessage.h
+++ b/IOPool/Streamer/interface/FRDEventMessage.h
@@ -12,6 +12,17 @@
  *
  * 08-Aug-2008 - KAB  - Initial Implementation
  * 06-Oct-2008 - KAB  - Added version number and lumi block number (version #2)
+ * 14-Nov-2013 - RKM  - Added event size, adler32 and padding size (version #3)
+ *
+ * Version 3 Format:
+ *   uint32 - format version number
+ *   uint32 - run number
+ *   uint32 - lumi number
+ *   uint32 - event number
+ *   uint32 - event size
+ *   uint32 - padding size needed to fill memory page size (_SC_PAGE_SIZE)
+ *   uint32 - adler32 checksum of FED data (excluding event header)
+ *   variable size - FED data
  *
  * Version 2 Format:
  *   uint32 - format version number
@@ -23,6 +34,17 @@
  */
 
 #include "IOPool/Streamer/interface/MsgTools.h"
+
+struct FRDEventHeader_V3
+{
+  uint32 version_;
+  uint32 run_;
+  uint32 lumi_;
+  uint32 event_;
+  uint32 eventSize_;
+  uint32 paddingSize_;
+  uint32 adler32_;
+};
 
 struct FRDEventHeader_V2
 {
@@ -45,17 +67,27 @@ class FRDEventMsgView
   FRDEventMsgView(void* buf);
 
   uint8* startAddress() const { return buf_; }
-  uint32 size() const { return event_len_; }
+  uint32 size() const { return size_; }
 
-  uint32 version() const;
-  uint32 run() const;
-  uint32 lumi() const;
-  uint32 event() const;
+  uint32 version() const { return version_; }
+  uint32 run() const { return run_; }
+  uint32 lumi() const { return lumi_; }
+  uint32 event() const { return event_; }
+  uint32 eventSize() const { return eventSize_; }
+  uint32 paddingSize() const { return paddingSize_; }
+  uint32 adler32() const { return adler32_; }
 
  private:
 
   uint8* buf_;
-  uint32 event_len_;
+  uint32 size_;
+  uint32 version_;
+  uint32 run_;
+  uint32 lumi_;
+  uint32 event_;
+  uint32 eventSize_;
+  uint32 paddingSize_;
+  uint32 adler32_;
 };
 
 #endif

--- a/IOPool/Streamer/src/FRDEventMessage.cc
+++ b/IOPool/Streamer/src/FRDEventMessage.cc
@@ -25,6 +25,7 @@
  */
 FRDEventMsgView::FRDEventMsgView(void* buf)
   : buf_((uint8*)buf),
+    payload_(0),
     size_(0),
     version_(0),
     run_(0),
@@ -92,4 +93,6 @@ FRDEventMsgView::FRDEventMsgView(void* buf)
           ++bufPtr;
       }
   }
+
+  payload_ = (void*)bufPtr;
 }

--- a/IOPool/Streamer/src/FRDEventMessage.cc
+++ b/IOPool/Streamer/src/FRDEventMessage.cc
@@ -23,84 +23,73 @@
 /**
  * Constructor for the FRD event message viewer.
  */
-FRDEventMsgView::FRDEventMsgView(void* buf): buf_((uint8*)buf)
+FRDEventMsgView::FRDEventMsgView(void* buf)
+  : buf_((uint8*)buf),
+    size_(0),
+    version_(0),
+    run_(0),
+    lumi_(0),
+    event_(0),
+    eventSize_(0),
+    paddingSize_(0),
+    adler32_(0)
 {
   uint32* bufPtr = static_cast<uint32*>(buf);
-  uint32 versionNumber = *bufPtr;
+  version_ = *bufPtr;
   // if the version number is rather large, then we assume that the true
   // version number is one.  (In version one of the format, there was
   // no version number in the data, and the run number appeared first.)
-  if (versionNumber >= 32) {
-      versionNumber = 1;
+  if (version_ >= 32) {
+      version_ = 1;
   }
 
-  // for now, all we need to do here is calculate the full event size
-  event_len_ = 0;
-  if (versionNumber >= 2) {
-      event_len_ += sizeof(uint32);  // version number
+  size_ = 0;
+
+  // version number
+  if (version_ >= 2) {
+      size_ += sizeof(uint32);
       ++bufPtr;
   }
-  event_len_ += sizeof(uint32);  // run number
+
+  // run number
+  run_ = *bufPtr;
+  size_ += sizeof(uint32);
   ++bufPtr;
-  if (versionNumber >= 2) {
-      event_len_ += sizeof(uint32);  // lumi number
+
+  // lumi number
+  if (version_ >= 2) {
+      lumi_ = *bufPtr;
+      size_ += sizeof(uint32);
       ++bufPtr;
   }
-  event_len_ += sizeof(uint32);  // event number
+
+  // event number
+  event_ = *bufPtr;
+  size_ += sizeof(uint32);
   ++bufPtr;
-  for (int idx = 0; idx < 1024; idx++) {
-    event_len_ += sizeof(uint32);  // FED N size
-    event_len_ += *bufPtr;         // FED N data
-    ++bufPtr;
-  }
-}
 
-uint32 FRDEventMsgView::version() const
-{
-  FRDEventHeader_V2* hdr = (FRDEventHeader_V2*) buf_;
-  uint32 version = hdr->version_;
-  if (version >= 32) {  // value looks like run number, so assume version 1
-      return 1;
-  }
-  else {  // version 2 and above
-      return hdr->version_;
-  }
-}
+  if (version_ >= 3) {
+      // event size
+      eventSize_ = *bufPtr;
+      size_ += sizeof(uint32) + eventSize_;
+      ++bufPtr;
 
-uint32 FRDEventMsgView::run() const
-{
-  FRDEventHeader_V2* hdr = (FRDEventHeader_V2*) buf_;
-  uint32 version = hdr->version_;
-  if (version >= 32) {  // value looks like run number, so assume version 1
-      FRDEventHeader_V1* hdrV1 = (FRDEventHeader_V1*) buf_;
-      return hdrV1->run_;
-  }
-  else {  // version 2 and above
-      return hdr->run_;
-  }
-}
+      // padding size
+      paddingSize_ = *bufPtr;
+      size_ += sizeof(uint32) + paddingSize_;
+      ++bufPtr;
 
-uint32 FRDEventMsgView::lumi() const
-{
-  FRDEventHeader_V2* hdr = (FRDEventHeader_V2*) buf_;
-  uint32 version = hdr->version_;
-  if (version >= 32) {  // value looks like run number, so assume version 1
-      return 1;
+      // adler32
+      adler32_ = *bufPtr;
+      size_ += sizeof(uint32);
+      ++bufPtr;
   }
-  else {  // version 2 and above
-      return hdr->lumi_;
-  }
-}
-
-uint32 FRDEventMsgView::event() const
-{
-  FRDEventHeader_V2* hdr = (FRDEventHeader_V2*) buf_;
-  uint32 version = hdr->version_;
-  if (version >= 32) {  // value looks like run number, so assume version 1
-      FRDEventHeader_V1* hdrV1 = (FRDEventHeader_V1*) buf_;
-      return hdrV1->event_;
-  }
-  else {  // version 2 and above
-      return hdr->event_;
+  else {
+      for (int idx = 0; idx < 1024; idx++) {
+          size_ += sizeof(uint32);  // FED N size
+          size_ += *bufPtr;         // FED N data
+          eventSize_ += *bufPtr;
+          ++bufPtr;
+      }
   }
 }


### PR DESCRIPTION
Define version 3 of FRDEventMessage to be used for the exchange of raw data from the BU to the FUs on file-based filter farm. Adapt and cleanup the FedRawDataInputSource used to read the data back. This includes minor changes to the EvFDaqDirector.
