### PR TITLE
Thread safety fix for MagneticField/Engine:  Member data modified in const function

### DIFF
--- a/MagneticField/Engine/interface/MagneticField.h
+++ b/MagneticField/Engine/interface/MagneticField.h
@@ -12,11 +12,13 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "FWCore/Utilities/interface/Visibility.h"
 #include "FWCore/Utilities/interface/Likely.h"
+#include <atomic>
 
 class MagneticField
 {
  public:
   MagneticField();
+  MagneticField(const MagneticField& orig);
   virtual ~MagneticField();
 
   /// Derived classes can implement cloning without ownership of the 
@@ -25,7 +27,6 @@ class MagneticField
     return 0;
   }
   
-
   /// Field value ad specified global point, in Tesla
   virtual GlobalVector inTesla (const GlobalPoint& gp) const = 0;
 
@@ -52,18 +53,14 @@ class MagneticField
   }
   
   /// The nominal field value for this map in kGauss
-  int nominalValue() const {
-    if unlikely(!nominalValueCompiuted) { 
-      theNominalValue = computeNominalValue();
-      nominalValueCompiuted=true;
-    }
-    return theNominalValue;
-  }
+  int nominalValue() const;
+
 private:
   //nominal field value 
   virtual int computeNominalValue() const;
-  mutable bool nominalValueCompiuted;
+  mutable std::atomic<char> nominalValueCompiuted;
   mutable int theNominalValue;
+  enum FooStates {kUnset, kSetting, kSet};
 };
 
 #endif

--- a/MagneticField/Engine/src/MagneticField.cc
+++ b/MagneticField/Engine/src/MagneticField.cc
@@ -5,11 +5,35 @@
 
 #include "MagneticField/Engine/interface/MagneticField.h"
 
-MagneticField::MagneticField() : nominalValueCompiuted(false){}
+MagneticField::MagneticField() { nominalValueCompiuted.store(kUnset, std::memory_order_release); }
+
+MagneticField::MagneticField(const MagneticField& orig) : theNominalValue (orig.theNominalValue)
+{ nominalValueCompiuted.store(orig.nominalValueCompiuted.load(std::memory_order_acquire), std::memory_order_release); }
 
 MagneticField::~MagneticField(){}
 
-
 int MagneticField::computeNominalValue() const {
   return int((inTesla(GlobalPoint(0.f,0.f,0.f))).z() * 10.f + 0.5f);
+}
+
+int MagneticField::nominalValue() const {
+  if(kSet==nominalValueCompiuted.load(std::memory_order_acquire)) return theNominalValue;
+
+  //need to make one
+  int tmp = computeNominalValue();
+
+  //Try to cache
+  char expected = kUnset;
+  if(nominalValueCompiuted.compare_exchange_strong(expected, kSetting) ) {
+    //it is our job to set the value
+    std::swap(theNominalValue,tmp);
+
+    //this must be after the swap
+    nominalValueCompiuted.store(kSet, std::memory_order_release);
+    return theNominalValue;
+  }
+  //another thread beat us to trying to set theNominalValue
+  // since we don't know when the other thread will finish
+  // we just return tmp
+  return tmp;
 }

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -23,6 +23,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h"
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
 
 #include <algorithm>
 #include <iostream>

--- a/TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h
+++ b/TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h
@@ -20,8 +20,8 @@
 
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/MaterialEffects/interface/MaterialEffectsUpdator.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
 
+class MagneticField;
 class PropagatorWithMaterial GCC11_FINAL : public Propagator {
   
 public:

--- a/TrackingTools/TrajectoryParametrization/interface/GlobalTrajectoryParameters.h
+++ b/TrackingTools/TrajectoryParametrization/interface/GlobalTrajectoryParameters.h
@@ -6,11 +6,7 @@
 #include "DataFormats/TrajectoryState/interface/TrackCharge.h"
 #include "DataFormats/Math/interface/AlgebraicROOTObjects.h"
 
-// Can move the second constructor to .cc, too ... or make all 
-// functions inline?
-// class MagneticField;
-#include "MagneticField/Engine/interface/MagneticField.h"
-
+class MagneticField;
 /** Class providing access to a set of relevant parameters of a trajectory
  *  in the global, Cartesian frame. The basic data members used to calculate
  *  these parameters are the charge and global position and momentum.
@@ -31,13 +27,7 @@ public:
   GlobalTrajectoryParameters(const GlobalPoint& aX,
                              const GlobalVector& aP,
                              TrackCharge aCharge, 
-			     const MagneticField* fieldProvider) :
-    theField(fieldProvider),
-    theX(aX), theP(aP),     
-    theCharge(aCharge)
-  {
-    cachedMagneticField = theField ? theField->inTesla(theX) : GlobalVector(0, 0, 0);
-  } // we must initialize cache to non-NAN to avoid FPE
+			     const MagneticField* fieldProvider);
 
   /** Constructing class from global position, direction (unit length) 
    *  and transverse curvature. The fourth int argument is dummy, 

--- a/TrackingTools/TrajectoryParametrization/src/GlobalTrajectoryParameters.cc
+++ b/TrackingTools/TrajectoryParametrization/src/GlobalTrajectoryParameters.cc
@@ -16,6 +16,17 @@ GlobalTrajectoryParameters::GlobalTrajectoryParameters(const GlobalPoint& aX,
   theCharge = qbpi > 0.f ? 1 : -1;
 }
 
+GlobalTrajectoryParameters::GlobalTrajectoryParameters(const GlobalPoint& aX,
+                             const GlobalVector& aP,
+                             TrackCharge aCharge, 
+                            const MagneticField* fieldProvider) :
+  theField(fieldProvider),
+  theX(aX), theP(aP),     
+  theCharge(aCharge)
+{
+    cachedMagneticField = theField ? theField->inTesla(theX) : GlobalVector(0, 0, 0);
+} // we must initialize cache to non-NAN to avoid FPE
+
 GlobalVector GlobalTrajectoryParameters::magneticFieldInInverseGeV( const GlobalPoint& x) const
 {
   return 2.99792458e-3f * theField->inTesla(x);

--- a/TrackingTools/TrajectoryState/BuildFile.xml
+++ b/TrackingTools/TrajectoryState/BuildFile.xml
@@ -6,6 +6,7 @@
 <use   name="DataFormats/BeamSpot"/>
 <use   name="TrackingTools/AnalyticalJacobians"/>
 <use   name="TrackingTools/TrajectoryParametrization"/>
+<use   name="MagneticField/Engine"/>
 <use   name="rootrflx"/>
 <use   name="vdt"/>
 <export>

--- a/TrackingTools/TrajectoryState/interface/BasicTrajectoryState.h
+++ b/TrackingTools/TrajectoryState/interface/BasicTrajectoryState.h
@@ -30,11 +30,7 @@
 /// vvv DEBUG
 // #include <iostream>
 
-//class MagneticField;
-#include "MagneticField/Engine/interface/MagneticField.h"
-
-
-
+class MagneticField;
 class TrajectoryStateOnSurface;
 
 

--- a/TrackingTools/TrajectoryState/src/BasicTrajectoryState.cc
+++ b/TrackingTools/TrajectoryState/src/BasicTrajectoryState.cc
@@ -3,7 +3,7 @@
 #include "TrackingTools/AnalyticalJacobians/interface/JacobianCurvilinearToLocal.h"
 #include "TrackingTools/AnalyticalJacobians/interface/JacobianLocalToCartesian.h"
 #include "TrackingTools/AnalyticalJacobians/interface/JacobianCartesianToLocal.h"
-
+#include "MagneticField/Engine/interface/MagneticField.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 


### PR DESCRIPTION
use of atomic to avoid 
- Member data modified in const function

Static analyzer will still report it as mutable member are still needed.
