### PR TITLE
Thread safety fix for PolyFit2DParametrizedMagneticField.cc

### DIFF
--- a/MagneticField/ParametrizedEngine/plugins/BFit.cc
+++ b/MagneticField/ParametrizedEngine/plugins/BFit.cc
@@ -137,7 +137,7 @@ void BFit::SetField(double B)
 
 //_______________________________________________________________________________
 void BFit::GetField(double r,   double z,   double phi,
-                    double &Br, double &Bz, double &Bphi)
+                    double &Br, double &Bz, double &Bphi) const
 {
 //Get field components in the point (r,z,phi). Always return Bphi=0. 
 //Parameters phi and Bphi introduced in order to keep interface

--- a/MagneticField/ParametrizedEngine/plugins/BFit.h
+++ b/MagneticField/ParametrizedEngine/plugins/BFit.h
@@ -43,7 +43,7 @@ public:
    
    void SetField(double B);
    void GetField(double r,   double z,   double phi,
-                 double &Br, double &Bz, double &Bphi);
+                 double &Br, double &Bz, double &Bphi) const;
 };
 }
 

--- a/MagneticField/ParametrizedEngine/plugins/rz_poly.cc
+++ b/MagneticField/ParametrizedEngine/plugins/rz_poly.cc
@@ -243,7 +243,7 @@ rz_poly& rz_poly::operator*=(double *C)
 }
 
 //_______________________________________________________________________________
-double rz_poly::GetSVal(double r, double z, double *C)
+double rz_poly::GetSVal(double r, double z, const double *C) const
 {
 //Return value of a polynomial, ignoring terms, that are switched off
 

--- a/MagneticField/ParametrizedEngine/plugins/rz_poly.h
+++ b/MagneticField/ParametrizedEngine/plugins/rz_poly.h
@@ -52,13 +52,13 @@ public:
    rz_poly& operator*=(double  C);
    rz_poly& operator*=(double *C);
    
-   double  GetSVal(double r, double z, double *C);
+   double  GetSVal(double r, double z, const double *C) const;
    double *GetVVal(double r, double z, double *rez_out = 0);
    
-   int GetMaxRPow() {return max_nr-1;}
-   int GetMaxZPow() {return max_nz-1;}
-   int GetLength()  {return (int)data.size();}
-   int GetNActive() {return n_active;}
+   int GetMaxRPow() const {return max_nr-1;}
+   int GetMaxZPow() const {return max_nz-1;}
+   int GetLength()  const {return (int)data.size();}
+   int GetNActive() const {return n_active;}
    
    double *Expand(double *C);
    


### PR DESCRIPTION
made couple of functions consts to avoid thread-safety issue Non-const member function could modify member data object.
