### PR TITLE
Thread safety fix: avoid mutable

### DIFF
--- a/RecoLuminosity/LumiProducer/interface/DIPLumiSummary.h
+++ b/RecoLuminosity/LumiProducer/interface/DIPLumiSummary.h
@@ -57,11 +57,11 @@ class DIPLumiSummary {
  private :
   unsigned int m_runnum;
   unsigned int m_ls;
-  float m_instlumi;//avg inst lumi in LS
-  float m_dellumi;//integrated luminosity of this ls
-  float m_reclumi;
+  const float m_instlumi;//avg inst lumi in LS
+  const float m_dellumi;//integrated luminosity of this ls
+  const float m_reclumi;
   float m_deadfrac;
-  unsigned short m_cmsalive;  
+  const unsigned short m_cmsalive;  
 }; 
 
 std::ostream& operator<<(std::ostream& s, const DIPLumiSummary& diplumiSummary);

--- a/RecoLuminosity/LumiProducer/interface/DIPLumiSummary.h
+++ b/RecoLuminosity/LumiProducer/interface/DIPLumiSummary.h
@@ -10,7 +10,10 @@ class DIPLumiSummary {
   DIPLumiSummary():m_runnum(0),m_ls(0),m_instlumi(0.0),m_dellumi(0.0),m_reclumi(0.0),m_deadfrac(1.0),m_cmsalive(false){}
   
   /// set default constructor
-  DIPLumiSummary(float instlumi,float dellumi,float reclumi,unsigned short cmsalive):m_instlumi(instlumi),m_dellumi(dellumi),m_reclumi(reclumi),m_deadfrac(1.0),m_cmsalive(cmsalive){}
+  DIPLumiSummary(float instlumi,float dellumi,float reclumi,unsigned short cmsalive):m_instlumi(instlumi),m_dellumi(dellumi),m_reclumi(reclumi),m_deadfrac(1.0),m_cmsalive(cmsalive)
+  {
+    if(m_reclumi>0.0){m_deadfrac=1.0-(m_reclumi/m_dellumi);}
+  }
     
   /// destructor
   ~DIPLumiSummary(){}
@@ -57,7 +60,7 @@ class DIPLumiSummary {
   float m_instlumi;//avg inst lumi in LS
   float m_dellumi;//integrated luminosity of this ls
   float m_reclumi;
-  mutable float m_deadfrac;
+  float m_deadfrac;
   unsigned short m_cmsalive;  
 }; 
 

--- a/RecoLuminosity/LumiProducer/src/DIPLumiSummary.cc
+++ b/RecoLuminosity/LumiProducer/src/DIPLumiSummary.cc
@@ -26,9 +26,6 @@ DIPLumiSummary::intgRecLumiByLS()const{
 }
 float 
 DIPLumiSummary::deadtimefraction() const{
-  if(m_reclumi>0.0){
-    m_deadfrac=1.0-(m_reclumi/m_dellumi);
-  }
   return m_deadfrac;
 }
 int 


### PR DESCRIPTION
Thread safety issue fix by avoiding mutable data member:
  Looks like m_reclumi and m_dellumi are only set in constructor. So we calculate m_deadfrac in constructor too.
