### PR TITLE
Save tp memory

### DIFF
--- a/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
@@ -2,12 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
              
 trackingParticles = cms.PSet(
-        maximumPreviousBunchCrossing=cms.uint32(5),
 	accumulatorType = cms.string('TrackingTruthAccumulator'),
 	createUnmergedCollection = cms.bool(False),
 	createMergedBremsstrahlung = cms.bool(True),
 	alwaysAddAncestors = cms.bool(True),
-	maximumPreviousBunchCrossing = cms.uint32(9999),
+	maximumPreviousBunchCrossing = cms.uint32(5),
 	maximumSubsequentBunchCrossing = cms.uint32(9999),
 	simHitCollections = cms.PSet(
 		muon = cms.VInputTag( cms.InputTag('g4SimHits','MuonDTHits'),

--- a/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
+++ b/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py
@@ -1,8 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
+             
 trackingParticles = cms.PSet(
+        maximumPreviousBunchCrossing=cms.uint32(5),
 	accumulatorType = cms.string('TrackingTruthAccumulator'),
-	createUnmergedCollection = cms.bool(True),
+	createUnmergedCollection = cms.bool(False),
 	createMergedBremsstrahlung = cms.bool(True),
 	alwaysAddAncestors = cms.bool(True),
 	maximumPreviousBunchCrossing = cms.uint32(9999),


### PR DESCRIPTION
Saves 400MB for 40pu/25ns by two config changes:

mergedtruth.createUnmergedCollection=cms.bool(False)
mergedtruth.maximumPreviousBunchCrossing=cms.uint32(5)

I did not test the relvals..
