### PR TITLE
Fixes needed after RelVal input removal at CERN.

### DIFF
--- a/PhysicsTools/PatAlgos/python/patInputFiles_cff.py
+++ b/PhysicsTools/PatAlgos/python/patInputFiles_cff.py
@@ -2,29 +2,29 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
 
 filesRelValProdTTbarAODSIM = cms.untracked.vstring(
-    pickRelValInputFiles( cmsswVersion  = 'CMSSW_6_2_0'
+    pickRelValInputFiles( cmsswVersion  = 'CMSSW_6_2_0_pre8'
                         , relVal        = 'RelValProdTTbar'
                         , globalTag     = 'PRE_ST62_V8'
                         , dataTier      = 'AODSIM'
-                        , maxVersions   = 3
+                        , maxVersions   = 1
                         , numberOfFiles = 1
                         )
     )
 filesRelValProdTTbarGENSIMRECO = cms.untracked.vstring(
-    pickRelValInputFiles( cmsswVersion  = 'CMSSW_6_2_0'
+    pickRelValInputFiles( cmsswVersion  = 'CMSSW_6_2_0_pre5' # event content in 620pre8 broken
                         , relVal        = 'RelValProdTTbar'
-                        , globalTag     = 'PRE_ST62_V8'
+                        , globalTag     = 'PRE_ST61_V1'
                         , dataTier      = 'GEN-SIM-RECO'
-                        , maxVersions   = 3
+                        , maxVersions   = 1
                         , numberOfFiles = 1
                         )
     )
 filesRelValTTbarPileUpGENSIMRECO = cms.untracked.vstring(
-    pickRelValInputFiles( cmsswVersion  = 'CMSSW_6_2_0'
+    pickRelValInputFiles( cmsswVersion  = 'CMSSW_6_2_0_pre5' # event content in 620pre8 broken
                         , relVal        = 'RelValTTbar'
-                        , globalTag     = 'PU_PRE_ST62_V8'
+                        , globalTag     = 'PU_PRE_ST61_V1'
                         , dataTier      = 'GEN-SIM-RECO'
-                        , maxVersions   = 2
+                        , maxVersions   = 1
                         , numberOfFiles = 1
                         )
     )

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -131,6 +131,7 @@ class AddJetCollection(ConfigToolBase):
         for x in ["ak", "kt", "sc", "ic"]:
             if jetSource.getModuleLabel().lower().find(x)>-1:
                 _algo=jetSource.getModuleLabel()[jetSource.getModuleLabel().lower().find(x):jetSource.getModuleLabel().lower().find(x)+3]
+                break
 	#print _algo
         ## add new patJets to process (keep instance for later further modifications)
         from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cfi import patJets

--- a/PhysicsTools/PatAlgos/test/patTuple_addDecayInFlight_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addDecayInFlight_cfg.py
@@ -2,8 +2,8 @@
 from PhysicsTools.PatAlgos.patTemplate_cfg import *
 
 # load the PAT config
-process.load("PhysicsTools.PatAlgos.patSequences_cff")
-
+process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
+process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 
 ## add inFlightMuons
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
@@ -16,20 +16,12 @@ process.inFlightMuons = cms.EDProducer("PATGenCandsFromSimTracksProducer",
         writeAncestors = cms.bool(True),             ## save also the intermediate GEANT ancestors of the muons
         genParticles   = cms.InputTag("genParticles"),
 )
+process.out.outputCommands.append('keep *_inFlightMuons_*_*')
+
 ## prepare several clones of match associations for status 1, 3 and in flight muons (status -1)
 process.muMatch3 = process.muonMatch.clone(mcStatus = cms.vint32( 3))
 process.muMatch1 = process.muonMatch.clone(mcStatus = cms.vint32( 1))
 process.muMatchF = process.muonMatch.clone(mcStatus = cms.vint32(-1),matched = cms.InputTag("inFlightMuons"))
-
-## add the new matches to the default sequence
-process.patDefaultSequence.replace(process.muonMatch,
-                                   process.muMatch1 +
-                                   process.muMatch3 +
-                                   process.muMatchF
-                                   )
-
-## embed the new matches to the patMuon (they are then accessible via
-## genMuon(int idx))
 process.patMuons.genParticleMatch = cms.VInputTag(
     cms.InputTag("muMatch3"),
     cms.InputTag("muMatch1"),
@@ -39,15 +31,11 @@ process.patMuons.genParticleMatch = cms.VInputTag(
 ## dump event content
 process.content = cms.EDAnalyzer("EventContentAnalyzer")
 
-## add the in flight muons to the output
-process.out.outputCommands.append('keep *_inFlightMuons_*_*')
-
-## let it run
+process.options.allowUnscheduled = cms.untracked.bool(True)
+#process.Tracer = cms.Service("Tracer")
 process.p = cms.Path(
-    #process.content +
-    process.inFlightMuons +
-    process.patDefaultSequence
-)
+    process.selectedPatCandidates
+    )
 
 ## ------------------------------------------------------
 #  In addition you usually want to change the following

--- a/PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
@@ -31,15 +31,15 @@ from PhysicsTools.PatAlgos.tools.jetTools import switchJetCollection
                 #jetIdLabel   = "ak5"
                 #)
 
-## uncomment the following lines to add ak7CaloJets to your PAT output
-#addJetCollection(
-   #process,
-   #labelName = 'AK7Calo',
-   #jetSource = cms.InputTag('ak7CaloJets'),
-   #jetCorrections = ('AK7Calo', cms.vstring(['L1Offset', 'L2Relative', 'L3Absolute']), 'Type-2'),
-   #)
-#process.patJetsAK7Calo.addJetID=True
-#process.patJetsAK7Calo.jetIDMap="ak7JetID"
+## uncomment the following lines to add ak5PFJetsCHS to your PAT output
+addJetCollection(
+   process,
+   labelName = 'AK5PFCHS',
+   jetSource = cms.InputTag('ak5PFJetsCHS'),
+   jetCorrections = ('AK5PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2')
+   )
+process.patJetsAK5PFCHS.addJetID=True
+process.patJetsAK5PFCHS.jetIDMap="ak5JetID"
 
 ## uncomment the following lines to add kt6CaloJets to your PAT output
 postfixAK5Calo = 'Copy'
@@ -104,8 +104,8 @@ switchJetCollection(
 #
 #   process.GlobalTag.globaltag =  ...    ##  (according to https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideFrontierConditions)
 #                                         ##
-from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarGENSIMRECO
-process.source.fileNames = filesRelValProdTTbarGENSIMRECO
+from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarAODSIM
+process.source.fileNames = filesRelValProdTTbarAODSIM
 #                                         ##
 process.maxEvents.input = 10
 #                                         ##


### PR DESCRIPTION
The fixes became necessary after CMSSW_6_2_0 RelVals have been removed from CERN, but CMSSW_6_2_0_pre8 RelVals have been kept with their broken RECO event content due to the GEN-SIM production.
PhysicsTools/PatAlgos/test/patTuple_addDecayInFlight_cfg.py has been forgotten to be migrated to unscheduled processing.
