### PR TITLE
Fixes needed after RelVal input removal at CERN.

### DIFF
--- a/PhysicsTools/PatAlgos/python/patInputFiles_cff.py
+++ b/PhysicsTools/PatAlgos/python/patInputFiles_cff.py
@@ -2,16 +2,16 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
 
 filesRelValProdTTbarAODSIM = cms.untracked.vstring(
-    pickRelValInputFiles( cmsswVersion  = 'CMSSW_6_2_0_pre5'
+    pickRelValInputFiles( cmsswVersion  = 'CMSSW_6_2_0_pre8'
                         , relVal        = 'RelValProdTTbar'
-                        , globalTag     = 'PRE_ST61_V1'
+                        , globalTag     = 'PRE_ST62_V8'
                         , dataTier      = 'AODSIM'
                         , maxVersions   = 1
                         , numberOfFiles = 1
                         )
     )
 filesRelValProdTTbarGENSIMRECO = cms.untracked.vstring(
-    pickRelValInputFiles( cmsswVersion  = 'CMSSW_6_2_0_pre5'
+    pickRelValInputFiles( cmsswVersion  = 'CMSSW_6_2_0_pre5' # event content in 620pre8 broken
                         , relVal        = 'RelValProdTTbar'
                         , globalTag     = 'PRE_ST61_V1'
                         , dataTier      = 'GEN-SIM-RECO'
@@ -20,7 +20,7 @@ filesRelValProdTTbarGENSIMRECO = cms.untracked.vstring(
                         )
     )
 filesRelValTTbarPileUpGENSIMRECO = cms.untracked.vstring(
-    pickRelValInputFiles( cmsswVersion  = 'CMSSW_6_2_0_pre5'
+    pickRelValInputFiles( cmsswVersion  = 'CMSSW_6_2_0_pre5' # event content in 620pre8 broken
                         , relVal        = 'RelValTTbar'
                         , globalTag     = 'PU_PRE_ST61_V1'
                         , dataTier      = 'GEN-SIM-RECO'
@@ -29,15 +29,24 @@ filesRelValTTbarPileUpGENSIMRECO = cms.untracked.vstring(
                         )
     )
 filesSingleMuRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_6_2_0_pre4'
-                        #, relVal        = 'SingleMu'
-                        #, dataTier      = 'RECO'
-                        #, globalTag     = 'PRE_61_V1_RelVal_mu2012D'
-                        #, maxVersions   = 1
-                        #, numberOfFiles = 1
-                        #)
+    pickRelValInputFiles( cmsswVersion  = 'CMSSW_6_2_0_pre8'
+                        , relVal        = 'SingleMu'
+                        , dataTier      = 'RECO'
+                        , globalTag     = 'PRE_62_V8_RelVal_mu2012D'
+                        , maxVersions   = 1
+                        , numberOfFiles = 1
+                        )
     # only one block available at CERN
     # FIXME: need to fix DBS query in 'pickRelValInputFiles' to identify them properly
     # ==> query for file requiring dataset AND site does not work in DBS :-(
-       '/store/relval/CMSSW_6_2_0_pre4/SingleMu/RECO/PRE_61_V1_RelVal_mu2012D-v1/00000/2A8716C9-3492-E211-8E04-0025905938A4.root',
+       #'/store/relval/CMSSW_6_2_0_pre8/SingleMu/RECO/PRE_62_V8_RelVal_mu2012B-v1/00000/029F8FA5-D7E0-E211-BCCF-001E67398430.root',
+       #'/store/relval/CMSSW_6_2_0_pre8/SingleMu/RECO/PRE_62_V8_RelVal_mu2012B-v1/00000/1A9A0FE7-D5E0-E211-9868-003048F01164.root',
+       #'/store/relval/CMSSW_6_2_0_pre8/SingleMu/RECO/PRE_62_V8_RelVal_mu2012B-v1/00000/4E0F44F0-D5E0-E211-9A0A-003048CF6780.root',
+       #'/store/relval/CMSSW_6_2_0_pre8/SingleMu/RECO/PRE_62_V8_RelVal_mu2012B-v1/00000/6E43C4C0-DBE0-E211-B452-003048D37366.root',
+       #'/store/relval/CMSSW_6_2_0_pre8/SingleMu/RECO/PRE_62_V8_RelVal_mu2012B-v1/00000/A426EC8A-DAE0-E211-BE58-D8D385FF4A94.root',
+       #'/store/relval/CMSSW_6_2_0_pre8/SingleMu/RECO/PRE_62_V8_RelVal_mu2012B-v1/00000/A45F6ADF-D8E0-E211-948B-003048FE9D54.root',
+       #'/store/relval/CMSSW_6_2_0_pre8/SingleMu/RECO/PRE_62_V8_RelVal_mu2012B-v1/00000/CE1D92A1-D9E0-E211-B7F0-C860001BD934.root',
+       #'/store/relval/CMSSW_6_2_0_pre8/SingleMu/RECO/PRE_62_V8_RelVal_mu2012B-v1/00000/D61C12DD-E9E0-E211-8A9E-5404A63886D2.root',
+       #'/store/relval/CMSSW_6_2_0_pre8/SingleMu/RECO/PRE_62_V8_RelVal_mu2012B-v1/00000/E4F44285-DFE0-E211-BEA9-0025B3203918.root',
+       #'/store/relval/CMSSW_6_2_0_pre8/SingleMu/RECO/PRE_62_V8_RelVal_mu2012B-v1/00000/F848CDC3-D6E0-E211-BA88-003048F009C4.root'
     )

--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
@@ -36,19 +36,13 @@ patJets = cms.EDProducer("PATJetProducer",
     addBTagInfo          = cms.bool(True),   ## master switch
     addDiscriminators    = cms.bool(True),   ## addition btag discriminators
     discriminatorSources = cms.VInputTag(
-        cms.InputTag("combinedSecondaryVertexBJetTags"),
-        cms.InputTag("combinedSecondaryVertexMVABJetTags"),
         cms.InputTag("jetBProbabilityBJetTags"),
         cms.InputTag("jetProbabilityBJetTags"),
+        cms.InputTag("trackCountingHighPurBJetTags"),
+        cms.InputTag("trackCountingHighEffBJetTags"),
         cms.InputTag("simpleSecondaryVertexHighEffBJetTags"),
         cms.InputTag("simpleSecondaryVertexHighPurBJetTags"),
-        cms.InputTag("softElectronByPtBJetTags"),
-        cms.InputTag("softElectronByIP3dBJetTags"),
-        cms.InputTag("softMuonBJetTags"),
-        cms.InputTag("softMuonByPtBJetTags"),
-        cms.InputTag("softMuonByIP3dBJetTags"),
-        cms.InputTag("trackCountingHighEffBJetTags"),
-        cms.InputTag("trackCountingHighPurBJetTags"),
+        cms.InputTag("combinedSecondaryVertexBJetTags")
     ),
     # clone tag infos ATTENTION: these take lots of space!
     # usually the discriminators from the default algos

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -131,6 +131,7 @@ class AddJetCollection(ConfigToolBase):
         for x in ["ak", "kt", "sc", "ic"]:
             if jetSource.getModuleLabel().lower().find(x)>-1:
                 _algo=jetSource.getModuleLabel()[jetSource.getModuleLabel().lower().find(x):jetSource.getModuleLabel().lower().find(x)+3]
+                break
 	#print _algo
         ## add new patJets to process (keep instance for later further modifications)
         from PhysicsTools.PatAlgos.producersLayer1.jetProducer_cfi import patJets

--- a/PhysicsTools/PatAlgos/test/patTuple_addDecayInFlight_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addDecayInFlight_cfg.py
@@ -2,8 +2,8 @@
 from PhysicsTools.PatAlgos.patTemplate_cfg import *
 
 # load the PAT config
-process.load("PhysicsTools.PatAlgos.patSequences_cff")
-
+process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
+process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 
 ## add inFlightMuons
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
@@ -16,20 +16,12 @@ process.inFlightMuons = cms.EDProducer("PATGenCandsFromSimTracksProducer",
         writeAncestors = cms.bool(True),             ## save also the intermediate GEANT ancestors of the muons
         genParticles   = cms.InputTag("genParticles"),
 )
+process.out.outputCommands.append('keep *_inFlightMuons_*_*')
+
 ## prepare several clones of match associations for status 1, 3 and in flight muons (status -1)
 process.muMatch3 = process.muonMatch.clone(mcStatus = cms.vint32( 3))
 process.muMatch1 = process.muonMatch.clone(mcStatus = cms.vint32( 1))
 process.muMatchF = process.muonMatch.clone(mcStatus = cms.vint32(-1),matched = cms.InputTag("inFlightMuons"))
-
-## add the new matches to the default sequence
-process.patDefaultSequence.replace(process.muonMatch,
-                                   process.muMatch1 +
-                                   process.muMatch3 +
-                                   process.muMatchF
-                                   )
-
-## embed the new matches to the patMuon (they are then accessible via
-## genMuon(int idx))
 process.patMuons.genParticleMatch = cms.VInputTag(
     cms.InputTag("muMatch3"),
     cms.InputTag("muMatch1"),
@@ -39,15 +31,11 @@ process.patMuons.genParticleMatch = cms.VInputTag(
 ## dump event content
 process.content = cms.EDAnalyzer("EventContentAnalyzer")
 
-## add the in flight muons to the output
-process.out.outputCommands.append('keep *_inFlightMuons_*_*')
-
-## let it run
+process.options.allowUnscheduled = cms.untracked.bool(True)
+#process.Tracer = cms.Service("Tracer")
 process.p = cms.Path(
-    #process.content +
-    process.inFlightMuons +
-    process.patDefaultSequence
-)
+    process.selectedPatCandidates
+    )
 
 ## ------------------------------------------------------
 #  In addition you usually want to change the following

--- a/PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
@@ -31,15 +31,15 @@ from PhysicsTools.PatAlgos.tools.jetTools import switchJetCollection
 #                 jetIdLabel   = "ak5"
 #                 )
 
-## uncomment the following lines to add ak7CaloJets to your PAT output
+## uncomment the following lines to add ak5PFJetsCHS to your PAT output
 addJetCollection(
    process,
-   labelName = 'AK7Calo',
-   jetSource = cms.InputTag('ak7CaloJets'),
-   jetCorrections = ('AK7Calo', cms.vstring(['L1Offset', 'L2Relative', 'L3Absolute']), 'Type-2'),
+   labelName = 'AK5PFCHS',
+   jetSource = cms.InputTag('ak5PFJetsCHS'),
+   jetCorrections = ('AK5PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2')
    )
-process.patJetsAK7Calo.addJetID=True
-process.patJetsAK7Calo.jetIDMap="ak7JetID"
+process.patJetsAK5PFCHS.addJetID=True
+process.patJetsAK5PFCHS.jetIDMap="ak5JetID"
 
 ## uncomment the following lines to add kt6CaloJets to your PAT output
 postfixAK5Calo = 'Copy'
@@ -104,8 +104,8 @@ switchJetCollection(
 #
 #   process.GlobalTag.globaltag =  ...    ##  (according to https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideFrontierConditions)
 #                                         ##
-from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarGENSIMRECO
-process.source.fileNames = filesRelValProdTTbarGENSIMRECO
+from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarAODSIM
+process.source.fileNames = filesRelValProdTTbarAODSIM
 #                                         ##
 process.maxEvents.input = 10
 #                                         ##


### PR DESCRIPTION
The fixes originally apply to 70X and are sync'ed here, which includes an update of available b-tags.
PhysicsTools/PatAlgos/test/patTuple_addDecayInFlight_cfg.py has been forgotten to be migrated to unscheduled processing.
