### PR TITLE
Remove duplicate dictionary in DataFormats/TauReco

### DIFF
--- a/DataFormats/TauReco/src/classes_def_3.xml
+++ b/DataFormats/TauReco/src/classes_def_3.xml
@@ -1,7 +1,10 @@
 <lcgdict>
+  <!-- Duplicate of CaloTauDiscriminatorByIsolationBase
+  causes duplicate definition link error in ROOT6
   <class name="reco::CaloTauDiscriminatorAgainstElectronBase">
     <field name="transientVector_" transient="true"/>
   </class>
+  -->
   <class name="reco::CaloTauDiscriminatorAgainstElectron" ClassVersion="10">
    <version ClassVersion="10" checksum="3692008801"/>
     <!-- <field name="transientVector_" transient="true"/> -->


### PR DESCRIPTION
In DataFormats/TauReco, the original classes_def.xml file defining dictionaries was previously split into four smaller files to speed up building.  However, two of the files contained a specification of a typedef that resolved to the same class.  In ROOT6, this causes a duplicate definition linking error.  The fix is to comment out one of the dictionary specifications with an explanation that it is a duplicate.  This resolves the link error.
