### PR TITLE
1-line HO-only fix for Run I data

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
@@ -145,7 +145,7 @@ namespace HcalSimpleRecAlgoImpl {
       HcalDetId cell(digi.id());
       int ieta  = cell.ieta();
       int iphi  = cell.iphi();
-      ampl *= eCorr(ieta,iphi,ampl);
+      if( cell.subdet() == HcalBarrel) ampl *= eCorr(ieta,iphi,ampl);
     }
 
     // Correction for a leak to pre-sample


### PR DESCRIPTION
Small bugfix: removal of unnecessary HO energy  corrections applied to 5+5 ch. (HO ring0 in action in Run I) 
Specifically for Run I re-processing!
