### PR TITLE
Add const to constexpr non-static member function in SiPixelCluster.h

### DIFF
--- a/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
+++ b/DataFormats/SiPixelCluster/interface/SiPixelCluster.h
@@ -62,7 +62,7 @@ public:
     constexpr PixelPos(int row, int col) : row_(row) , col_(col) {}
     constexpr int row() const { return row_;}
     constexpr int col() const { return col_;}
-    constexpr PixelPos operator+( const Shift& shift) {
+    constexpr PixelPos operator+( const Shift& shift) const {
       return PixelPos( row() + shift.dx(), col() + shift.dy());
     }
   private:


### PR DESCRIPTION
In C++14 rule 'constexpr implies const' for non-static member functions is no more.
Explicitly add 'const' modifier to keep behavior identical between C++11 and C++14.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
