### PR TITLE
70X Crossing Frame customisation name adjustment

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1649,7 +1649,7 @@ class ConfigBuilder(object):
 		    self.executeAndRemember("process.mix.playback = True")
 		    self.executeAndRemember("process.mix.digitizers = cms.PSet()")
                     self.executeAndRemember("for a in process.aliases: delattr(process, a)")
-                    self._options.customisation_file+=",SimGeneral/MixingModule/fullMixCustomize_cff.customize"
+                    self._options.customisation_file+=",SimGeneral/MixingModule/fullMixCustomize_cff.setCrossingFrameOn"
 
 	    if hasattr(self.process,"genstepfilter") and len(self.process.genstepfilter.triggerConditions):
 		    #will get in the schedule, smoothly

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -404,7 +404,7 @@ ecalHcal={
     '--datatier':'GEN-SIM-DIGI-RAW-RECO',
     #'--geometry':'ECALHCAL',
     '--eventcontent':'FEVTDEBUG',
-    '--customise':'Validation/Configuration/ECALHCAL.customise,SimGeneral/MixingModule/fullMixCustomize_cff.customize',
+    '--customise':'Validation/Configuration/ECALHCAL.customise,SimGeneral/MixingModule/fullMixCustomize_cff.setCrossingFrameOn',
     '--beamspot':'NoSmear'}
 
 steps['SingleElectronE120EHCAL']=merge([{'cfg':'SingleElectronE120EHCAL_cfi'},ecalHcal,Kby(25,250),step1Defaults])

--- a/SimGeneral/MixingModule/python/fullMixCustomize_cff.py
+++ b/SimGeneral/MixingModule/python/fullMixCustomize_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-def customize(process):
+def setCrossingFrameOn(process):
 
     process.mix.mixObjects.mixCH.crossingFrames = cms.untracked.vstring(
         'CaloHitsTk', 


### PR DESCRIPTION
change customization name for CrossingFrame activation function to setCrossingFrameOn in order to avoid interferences with other functions
