### PR TITLE
Fix header guard define in CalibCompare.h

### DIFF
--- a/RecoParticleFlow/PFClusterTools/interface/CalibCompare.h
+++ b/RecoParticleFlow/PFClusterTools/interface/CalibCompare.h
@@ -1,5 +1,5 @@
 #ifndef CALIBCOMPARE_H_
-#define CALIBCOMAPRE_H_
+#define CALIBCOMPARE_H_
 
 #include "DataFormats/ParticleFlowReco/interface/Calibratable.h"
 #include "RecoParticleFlow/PFClusterTools/interface/Calibrator.h"


### PR DESCRIPTION
Purely a technical change. A typo was found while defining a header guard.
