### PR TITLE
Make static a const in SiStripFecCabling::fecs()

### DIFF
--- a/CalibFormats/SiStripObjects/interface/SiStripFecCabling.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripFecCabling.h
@@ -79,7 +79,7 @@ const std::vector<SiStripFecCrate>& SiStripFecCabling::crates() const { return c
 
 // TEMPORARY method to maintain backward compatibility!
 const std::vector<SiStripFec>& SiStripFecCabling::fecs() const { 
-  static std::vector<SiStripFec> my_fecs;
+  const static std::vector<SiStripFec> my_fecs;
   if ( !crates_.empty() ) { return crates_[0].fecs(); }
   else { return my_fecs; }
 }


### PR DESCRIPTION
I believe here is a problem of pointer/reference. People try to code in C++, but with C in mind. They want to return a const reference, but reference must point to a valid object, there is no such thing as null reference (not allowed by standard). To overcome the issue people started to define dummy statics inside the functions and return a reference to the dummy. It's wrong. The function should return a pointer and callee should return `nullptr` if needed. The caller cannot even handle situation if it gets a reference, it doesn't know if returned reference is valid or not.
