### PR TITLE
Const fix in CondFormats/ESObjects

### DIFF
--- a/CondFormats/ESObjects/interface/ESCondObjectContainer.h
+++ b/CondFormats/ESObjects/interface/ESCondObjectContainer.h
@@ -3,6 +3,7 @@
 
 #include "DataFormats/EcalDetId/interface/EcalContainer.h"
 #include "DataFormats/EcalDetId/interface/ESDetId.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 template < typename T >
 class ESCondObjectContainer {
@@ -81,34 +82,16 @@ class ESCondObjectContainer {
 
                 inline
                 Item & operator[]( uint32_t rawId ) {
-                        DetId id(rawId);
-                        static Item dummy;
-                        switch (id.subdetId()) {
-                                case EcalPreshower :
-                                        { 
-                                                return es_[rawId];
-                                        }
-                                        break;
-                                default:
-                                        // FIXME (add throw)
-                                        return dummy;
-                        }
+                        if (DetId(rawId).subdetId() == EcalPreshower)
+				return es_[rawId];
+                        throw cms::Exception("TypeNotEcalPreshower");
                 }
                 
                 inline
                 Item const & operator[]( uint32_t rawId ) const {
-                        DetId id(rawId);
-                        static Item dummy;
-                        switch (id.subdetId()) {
-                                case EcalPreshower :
-                                        { 
-                                                return es_[rawId];
-                                        }
-                                        break;
-                                default:
-                                        // FIXME (add throw)
-                                        return dummy;
-                        }
+                        if (DetId(rawId).subdetId() == EcalPreshower)
+				return es_[rawId];
+			throw cms::Exception("TypeNotEcalPreshower");
                 }
                 
         private:

--- a/CondFormats/ESObjects/interface/ESCondObjectContainer.h
+++ b/CondFormats/ESObjects/interface/ESCondObjectContainer.h
@@ -28,30 +28,14 @@ class ESCondObjectContainer {
                 
                 inline
                 void insert( std::pair<uint32_t, Item> const &a ) {
-                        DetId id(a.first);
-                        switch (id.subdetId()) {
-                                case EcalPreshower :
-                                        { 
-                                                es_.insert(a);
-                                        }
-                                        break;
-                                default:
-                                        // FIXME (add throw)
-                                        return;
+                        if (DetId(a.first).subdetId() == EcalPreshower) {
+				es_.insert(a);
                         }
                 }
                 
                 inline
                 const_iterator find( uint32_t rawId ) const {
-                        DetId id(rawId);
-			const_iterator it = es_.end();
-			if(id.subdetId()== EcalPreshower) {
-			  it = es_.find(rawId);
-			  if ( it != es_.end() ) {
-			    return it;
-			  }
-			} 
-			return it;
+			return es_.find(rawId);
                 }
 
                 inline
@@ -82,16 +66,12 @@ class ESCondObjectContainer {
 
                 inline
                 Item & operator[]( uint32_t rawId ) {
-                        if (DetId(rawId).subdetId() == EcalPreshower)
-				return es_[rawId];
-                        throw cms::Exception("TypeNotEcalPreshower");
+			return es_[rawId];
                 }
                 
                 inline
                 Item const & operator[]( uint32_t rawId ) const {
-                        if (DetId(rawId).subdetId() == EcalPreshower)
-				return es_[rawId];
-			throw cms::Exception("TypeNotEcalPreshower");
+			return es_[rawId];
                 }
                 
         private:

--- a/CondFormats/ESObjects/interface/ESPedestals.h
+++ b/CondFormats/ESObjects/interface/ESPedestals.h
@@ -7,7 +7,7 @@
 struct ESPedestal {
         struct Zero { float z1; float z2;};
 
-        static Zero zero;
+        static const Zero zero;
 
         float mean;
         float rms;

--- a/CondFormats/ESObjects/src/ESPedestals.cc
+++ b/CondFormats/ESObjects/src/ESPedestals.cc
@@ -1,3 +1,3 @@
 #include "CondFormats/ESObjects/interface/ESPedestals.h"
 
-ESPedestal::Zero ESPedestal::zero = {0.,0.};
+const ESPedestal::Zero ESPedestal::zero = {0.,0.};


### PR DESCRIPTION
I made both `operator[]` operators to throw if it's not `EcalPreshower`. That resolves two FIXME items and currently passes a short matrix (testing full matrix). If you look into `ESCondObjectContainer` it raises a question. All operations on it checks for `EcalPreshower`, thus maybe design of container is wrong (C++ static type checking is not utilized). Actually both `operator[]` and `find` should never even check for `EcalPreshower`. I assume class contract states that only `EcalPreshower` can be in the container. Check `insert`.

I would suggest to drop checks, because `insert` already guarantees all are  `EcalPreshower`.

I will update after a feedback.

Regarding `struct ESPedestal`. You don't need getter methods, it's a struct, all members are public by default.
