### PR TITLE
cmsRun returns non-zero if caught unix signal

### DIFF
--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -335,7 +335,10 @@ int main(int argc, char* argv[]) {
       context = "Calling EventProcessor::runToCompletion (which does almost everything after beginJob and before endJob)";
       proc.on();
       bool onlineStateTransitions = false;
-      proc->runToCompletion(onlineStateTransitions);
+      edm::EventProcessor::StatusCode status = proc->runToCompletion(onlineStateTransitions);
+      if (status == edm::EventProcessor::epSignal) {
+        returnCode = edm::errors::CaughtSignal;
+      }
       proc.off();
 
       context = "Calling endJob";

--- a/FWCore/Utilities/interface/EDMException.h
+++ b/FWCore/Utilities/interface/EDMException.h
@@ -64,7 +64,9 @@ namespace edm {
       
        ExceededResourceVSize = 8030,
        ExceededResourceRSS = 8031,
-       ExceededResourceTime = 8032
+       ExceededResourceTime = 8032,
+      
+       CaughtSignal = 9000
     };
 
   }


### PR DESCRIPTION
If any of the signals cmsRun catches (SIGINT and SIGUSR2) are caught, cmsRun now returns a non zero value. This was requested by data ops.
Backported from CMSSW_7_0_X.
