### PR TITLE
Add missing link dependency of TrackingTools/TrajectoryState on MagneticField/Engine

### DIFF
--- a/TrackingTools/TrajectoryState/BuildFile.xml
+++ b/TrackingTools/TrajectoryState/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="DataFormats/TrackReco"/>
 <use   name="DataFormats/TrajectoryState"/>
 <use   name="DataFormats/BeamSpot"/>
+<use   name="MagneticField/Engine"/>
 <use   name="TrackingTools/AnalyticalJacobians"/>
 <use   name="TrackingTools/TrajectoryParametrization"/>
 


### PR DESCRIPTION
The missing link dependency of TrackingTools/TrajectoryState on MagneticField/Engine prevents  TrackingTools/TrajectoryState and 69 other packages dependent on it from linking.

This trivial technical pull request adds the link dependency.

The problem was introduced when an in-line function in MagneticField/Engine was rewritten to be out of line.
This fix will be queued separately to CMSSW_7_0_X, but I didn't want to wait for it to get into the ROOT6 branch.
