### PR TITLE
Move *Archive and *serialize out of cond::persistency

### DIFF
--- a/CondCore/CondDB/interface/Serialization.h
+++ b/CondCore/CondDB/interface/Serialization.h
@@ -27,7 +27,6 @@
 class TBufferFile;
 
 namespace cond {
-namespace persistency {
 
   // Archives for the streaming based on ROOT.
 
@@ -102,6 +101,5 @@ namespace persistency {
     return payload;
   }
 
-}
 }
 #endif

--- a/CondCore/CondDB/src/Serialization.cc
+++ b/CondCore/CondDB/src/Serialization.cc
@@ -10,7 +10,6 @@
 #include "Cintex/Cintex.h"
 
 namespace cond {
-namespace persistency {
 
   struct CintexIntializer {
     static bool init;
@@ -37,13 +36,12 @@ namespace persistency {
     return rc;
   }
 }
-}
 
-cond::persistency::RootOutputArchive::RootOutputArchive( std::ostream& dest ):
+cond::RootOutputArchive::RootOutputArchive( std::ostream& dest ):
   m_buffer( dest ){
 } 
 
-void cond::persistency::RootOutputArchive::write( const std::type_info& sourceType, const void* sourceInstance){
+void cond::RootOutputArchive::write( const std::type_info& sourceType, const void* sourceInstance){
   TClass* r_class = lookUpDictionary( sourceType );
   if (!r_class) throwException( "No ROOT class registered for \"" + demangledName(sourceType)+"\"", "RootOutputArchive::write");
   TBufferFile buffer(TBufferFile::kWrite);
@@ -53,17 +51,17 @@ void cond::persistency::RootOutputArchive::write( const std::type_info& sourceTy
   m_buffer.write( static_cast<const char*>(buffer.Buffer()), buffer.Length() ); 
 }
 
-cond::persistency::RootInputArchive::RootInputArchive( std::istream& source ):
+cond::RootInputArchive::RootInputArchive( std::istream& source ):
   m_buffer( std::istreambuf_iterator<char>(source), std::istreambuf_iterator<char>()),
   m_streamer( new TBufferFile( TBufferFile::kRead, m_buffer.size(), const_cast<char*>(m_buffer.c_str()), kFALSE ) ){
   m_streamer->InitMap();
 }
 
-cond::persistency::RootInputArchive::~RootInputArchive(){
+cond::RootInputArchive::~RootInputArchive(){
   delete m_streamer;
 }
 
-void cond::persistency::RootInputArchive::read( const std::type_info& destinationType, void* destinationInstance){
+void cond::RootInputArchive::read( const std::type_info& destinationType, void* destinationInstance){
   TClass* r_class = lookUpDictionary( destinationType );
   if (!r_class) throwException( "No ROOT class registered for \"" + demangledName(destinationType) +"\"","RootInputArchive::read");
   m_streamer->StreamObject(destinationInstance, r_class);   


### PR DESCRIPTION
This fixes the BOOSTIO branch by synchronizing back with
the official branch. Later on we can reinclude this change
from the official branch if needed.
