### PR TITLE
material properties in HF: from Copper to Iron

### DIFF
--- a/FastSimulation/CalorimeterProperties/interface/HCALForwardProperties.h
+++ b/FastSimulation/CalorimeterProperties/interface/HCALForwardProperties.h
@@ -27,18 +27,6 @@ class HCALForwardProperties : public HCALProperties
 
   virtual ~HCALForwardProperties() { }
 
-  /// Radiation length in cm
-  inline double radLenIncm()  const { return radiationLengthIncm(); }
-
-  /// Radiation length in cm but static 
-  static inline double radiationLengthIncm() { return 1.43; }
- 
-  /// Radiation length in g/cm^2
-  inline double radLenIngcm2() const { return 12.86; }
-
-  ///Interaction length in cm
-  inline double interactionLength() const { return 15.05; }
-
   double getHcalDepth(double);
 
   double thickness(double eta) const { 

--- a/FastSimulation/CalorimeterProperties/src/Calorimeter.cc
+++ b/FastSimulation/CalorimeterProperties/src/Calorimeter.cc
@@ -48,13 +48,15 @@ Calorimeter::Calorimeter(const edm::ParameterSet& fastCalo):
   PreshowerGeometry_          (NULL)  
 {
   edm::ParameterSet fastDet = fastCalo.getParameter<edm::ParameterSet>("CalorimeterProperties");
+  edm::ParameterSet fastDetHF = fastCalo.getParameter<edm::ParameterSet>("ForwardCalorimeterProperties");
+
   myPreshowerLayer1Properties_  = new PreshowerLayer1Properties(fastDet); 
   myPreshowerLayer2Properties_  = new PreshowerLayer2Properties(fastDet);
   myECALBarrelProperties_       = new ECALBarrelProperties     (fastDet);
   myECALEndcapProperties_       = new ECALEndcapProperties     (fastDet);
   myHCALBarrelProperties_       = new HCALBarrelProperties     (fastDet);
   myHCALEndcapProperties_       = new HCALEndcapProperties     (fastDet);
-  myHCALForwardProperties_      = new HCALForwardProperties    (fastDet);
+  myHCALForwardProperties_      = new HCALForwardProperties    (fastDetHF);
 
 }
 

--- a/FastSimulation/Calorimetry/python/Calorimetry_cff.py
+++ b/FastSimulation/Calorimetry/python/Calorimetry_cff.py
@@ -43,6 +43,27 @@ FamosCalorimetryBlock = cms.PSet(
             GapLossProbability = cms.double(0.9),
             SimulatePreshower = cms.bool(True)
         ),
+        ForwardCalorimeterProperties = cms.PSet(
+            HadronicCalorimeterProperties= cms.PSet(
+                  HCAL_Sampling = cms.double(0.0035),
+                  # Watch out ! The following two values are defined wrt the electron shower simulation
+                  # There are not directly related to the detector properties
+                  HCAL_PiOverE = cms.double(0.2),
+                  # HCAL_PiOverE = cms.double(0.4)
+                  HCALAeff= cms.double(55.845),
+                  HCALZeff= cms.double(26),
+                  HCALrho= cms.double(7.87),
+
+                  HCALradiationLengthIncm= cms.double(1.757),
+                  HCALradLenIngcm2= cms.double(13.84),
+                  HCALmoliereRadius= cms.double(1.719),
+                  HCALcriticalEnergy= cms.double(21E-3),
+                  HCALinteractionLength= cms.double(16.77),
+
+                  HCALetatow=cms.vdouble( 0.000, 0.087, 0.174, 0.261, 0.348, 0.435, 0.522, 0.609, 0.696, 0.783, 0.870,    0.957, 1.044, 1.131, 1.218, 1.305, 1.392, 1.479, 1.566, 1.653, 1.740, 1.830,    1.930, 2.043, 2.172, 2.322, 2.500, 2.650, 2.853, 3.000, 3.139, 3.314, 3.489,    3.664, 3.839, 4.013, 4.191, 4.363, 4.538, 4.716, 4.889, 5.191),
+                  HCALDepthLam=cms.vdouble( 8.930, 9.001, 9.132, 8.912, 8.104, 8.571, 8.852, 9.230, 9.732, 10.29,          10.95, 11.68, 12.49, 12.57, 12.63,  6.449, 5.806, 8.973, 8.934,  8.823,          8.727, 8.641, 8.565, 8.496, 8.436, 8.383, 8.346, 8.307, 8.298,  8.281,          9.442, 9.437, 9.432, 9.429, 9.432, 9.433, 9.430, 9.437, 9.442, 9.446, 9.435)
+                  ),
+        ),
         CalorimeterProperties = cms.PSet(
             # triplet for each p value:  p, k_e(p), k_h(p) ...
             RespCorrP = cms.vdouble(1.0, 1.0, 1.0, 1000.0, 1.0, 1.0),  


### PR DESCRIPTION
So far, the passive material in the entire HCAL was assumed to be Copper, while in reality the passive material in HF is Iron. A specific PSet is added here, for HF, with the Iron properties taken from the PDG 2012.
