### PR TITLE
Threaded Random Number Interface for OscarProducer

### DIFF
--- a/FWCore/Concurrency/interface/SharedResourceNames.h
+++ b/FWCore/Concurrency/interface/SharedResourceNames.h
@@ -1,0 +1,28 @@
+#ifndef FWCore_Concurrency_SharedResourceNames_h
+#define FWCore_Concurrency_SharedResourceNames_h
+//
+// Package: Concurrency
+// Class : ShareResourceNames
+//
+/**\class edm::SharedResourceNames
+
+Description: Contains the names of external shared resources.
+
+*/
+//
+// Original Author: W. David Dagenhart
+// Created: 19 November 2013
+//
+
+#include <string>
+
+namespace edm {
+  class SharedResourceNames {
+  public:
+    // GEANT 4.9.X needs to be declared a shared resource
+    // In the future, 4.10.X and later might not need to be
+    static const std::string kGEANT;
+    static const std::string kCLHEPRandomEngine;
+  };
+}
+#endif

--- a/FWCore/Concurrency/src/SharedResourceNames.cc
+++ b/FWCore/Concurrency/src/SharedResourceNames.cc
@@ -1,0 +1,4 @@
+#include "FWCore/Concurrency/interface/SharedResourceNames.h"
+
+const std::string edm::SharedResourceNames::kGEANT = "GEANT";
+const std::string edm::SharedResourceNames::kCLHEPRandomEngine = "CLHEPRandomEngine";

--- a/SimG4Core/Application/interface/OscarProducer.h
+++ b/SimG4Core/Application/interface/OscarProducer.h
@@ -1,9 +1,8 @@
 #ifndef SimG4Core_OscarProducer_H
 #define SimG4Core_OscarProducer_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
-// #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -13,11 +12,9 @@
 
 #include "SimG4Core/Application/interface/CustomUIsession.h"
 
-namespace CLHEP {
-    class HepRandomEngine;
-}
+#include <memory>
 
-class OscarProducer : public edm::EDProducer
+class OscarProducer : public edm::one::EDProducer<edm::one::SharedResources, edm::one::WatchRuns>
 {
 public:
     typedef std::vector<boost::shared_ptr<SimProducer> > Producers;
@@ -25,16 +22,12 @@ public:
     explicit OscarProducer(edm::ParameterSet const & p);
     virtual ~OscarProducer();
     virtual void beginRun(const edm::Run & r,const edm::EventSetup& c) override;
-    virtual void beginJob();
-    virtual void endJob();
+    virtual void endRun(const edm::Run & r,const edm::EventSetup& c) override { }
     virtual void produce(edm::Event & e, const edm::EventSetup& c) override;
 protected:
-    RunManager*   m_runManager;
+    std::unique_ptr<RunManager> m_runManager;
     Producers     m_producers;
-    CustomUIsession* m_UIsession;
-
-private:
-    CLHEP::HepRandomEngine*  m_engine;
+    std::unique_ptr<CustomUIsession> m_UIsession;
 };
 
 #endif

--- a/SimG4Core/Application/interface/OscarProducer.h
+++ b/SimG4Core/Application/interface/OscarProducer.h
@@ -24,7 +24,7 @@ public:
     virtual void beginRun(const edm::Run & r,const edm::EventSetup& c) override;
     virtual void endRun(const edm::Run & r,const edm::EventSetup& c) override { }
     virtual void produce(edm::Event & e, const edm::EventSetup& c) override;
-protected:
+private:
     std::unique_ptr<RunManager> m_runManager;
     Producers     m_producers;
     std::unique_ptr<CustomUIsession> m_UIsession;

--- a/SimG4Core/Application/plugins/BuildFile.xml
+++ b/SimG4Core/Application/plugins/BuildFile.xml
@@ -1,3 +1,4 @@
+<use   name="FWCore/Concurrency"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="SimDataFormats/CaloHit"/>

--- a/SimG4Core/HelpfulWatchers/src/BeginOfTrackCounter.h
+++ b/SimG4Core/HelpfulWatchers/src/BeginOfTrackCounter.h
@@ -28,6 +28,10 @@
 #include "SimG4Core/Notification/interface/BeginOfTrack.h"
 
 // forward declarations
+namespace edm {
+   class ParameterSet;
+}
+
 namespace simwatcher {
    class BeginOfTrackCounter : public SimProducer,
       public Observer<const BeginOfTrack*>

--- a/SimG4Core/Watcher/interface/SimProducer.h
+++ b/SimG4Core/Watcher/interface/SimProducer.h
@@ -19,6 +19,7 @@
 //
 
 // system include files
+#include <algorithm>
 #include <string>
 #include <vector>
 #include "boost/bind.hpp"
@@ -26,7 +27,12 @@
 
 // user include files
 #include "SimG4Core/Watcher/interface/SimWatcher.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/ProducerBase.h"
+
+namespace edm {
+   class Event;
+   class EventSetup;
+}
 
 // forward declarations
 namespace simproducer {
@@ -40,7 +46,7 @@ namespace simproducer {
 	 const std::string& instanceName() const {
 	    return m_instanceName; }
 
-	 virtual void registerProduct(edm::EDProducer*) const = 0;
+	 virtual void registerProduct(edm::ProducerBase*) const = 0;
       private:
 	 std::string m_instanceName;
    };
@@ -51,7 +57,7 @@ namespace simproducer {
 	 ProductInfo(const std::string& iInstanceName) :
 	    ProductInfoBase(iInstanceName) {}
 
-	 void registerProduct(edm::EDProducer* iProd) const {
+         void registerProduct(edm::ProducerBase* iProd) const {
 	    (*iProd). template produces<T>(this->instanceName());
 	 }
    };
@@ -71,7 +77,7 @@ class SimProducer : public SimWatcher
       // ---------- member functions ---------------------------
       virtual void produce(edm::Event&, const edm::EventSetup&) = 0;
       
-      void registerProducts(edm::EDProducer& iProd) {
+      void registerProducts(edm::ProducerBase& iProd) {
 	 std::for_each(m_info.begin(), m_info.end(),
 		       boost::bind(&simproducer::ProductInfoBase::registerProduct,_1, &iProd));
       }

--- a/Validation/EcalHits/interface/EcalSimHitsValidProducer.h
+++ b/Validation/EcalHits/interface/EcalSimHitsValidProducer.h
@@ -18,6 +18,10 @@ class G4Step;
 class EndOfEvent;
 class PEcalValidInfo;
 
+namespace edm {
+    class ParameterSet;
+}
+
 class EcalSimHitsValidProducer : public SimProducer,
                          public Observer<const BeginOfEvent*>,
                          public Observer<const G4Step*>,

--- a/Validation/Geometry/interface/MaterialBudgetAction.h
+++ b/Validation/Geometry/interface/MaterialBudgetAction.h
@@ -26,6 +26,10 @@ class EndOfEvent;
 class G4StepPoint;
 class G4VTouchable;
 
+namespace edm {
+  class ParameterSet;
+}
+
 class MaterialBudgetAction : public SimProducer, 
 			     public Observer<const BeginOfRun*>,
 			     public Observer<const BeginOfTrack*>,

--- a/Validation/HcalHits/interface/SimG4HcalValidation.h
+++ b/Validation/HcalHits/interface/SimG4HcalValidation.h
@@ -27,6 +27,10 @@ class BeginOfRun;
 class BeginOfEvent;
 class EndOfEvent;
 
+namespace edm {
+  class ParameterSet;
+}
+
 class SimG4HcalValidation : public SimProducer,
 			    public Observer<const BeginOfJob *>, 
 			    public Observer<const BeginOfRun *>, 


### PR DESCRIPTION
Modify OscarProducer to use the new interface for
the random number service that requires a StreamID
argument to the getEngine function. Modify the module
to be a "One" type module with shared resources
declared for GEANT and the CLHEPRandomEngine.
It is also "watching" runs. Note that with this
change it will now seg fault if any random numbers
were generated in the constructor or beginRun.
SimProducer is fixed to deal with the changed module
type. We are presuming the static code checking would
reveal any other threading problems related to making
this a "One" type module. This is for GEANT 4.9.X.
We will need to revisit this when we move to 4.10.X,
which will be the multithreaded GEANT.

The only changes in Validation are the addition of
a missing forward declaration revealed by the other
changes.
