### PR TITLE
Use concurrent unordered map for parameter set registry

### DIFF
--- a/DataFormats/Provenance/src/Provenance.cc
+++ b/DataFormats/Provenance/src/Provenance.cc
@@ -6,6 +6,7 @@
 #include "FWCore/ParameterSet/interface/Registry.h"
 
 #include <algorithm>
+#include <cassert>
 
 /*----------------------------------------------------------------------
 

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -549,10 +549,7 @@ namespace edm {
     looper_.reset();
     actReg_.reset();
 
-    pset::Registry* psetRegistry = pset::Registry::instance();
-    psetRegistry->dataForUpdate().clear();
-    psetRegistry->extraForUpdate().setID(ParameterSetID());
-
+    pset::Registry::instance()->clear();
     ParentageRegistry::instance()->clear();
   }
 

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -396,7 +396,7 @@ namespace edm {
                        outputModulePathPositions);
     processEDAliases(proc_pset, processConfiguration->processName(), preg);
     proc_pset.registerIt();
-    pset::Registry::instance()->extraForUpdate().setID(proc_pset.id());
+    pset::setID(proc_pset.id());
     processConfiguration->setParameterSetID(proc_pset.id());
     processConfiguration->setProcessConfigurationID();
 

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -396,7 +396,7 @@ namespace edm {
                        outputModulePathPositions);
     processEDAliases(proc_pset, processConfiguration->processName(), preg);
     proc_pset.registerIt();
-    pset::setID(proc_pset.id());
+    pset::setProcessParameterSetID(proc_pset.id());
     processConfiguration->setParameterSetID(proc_pset.id());
     processConfiguration->setProcessConfigurationID();
 

--- a/FWCore/ParameterSet/BuildFile.xml
+++ b/FWCore/ParameterSet/BuildFile.xml
@@ -2,6 +2,7 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/Utilities"/>
+<use   name="tbb"/>
 <use   name="boost"/>
 <use   name="boost_filesystem"/>
 <export>

--- a/FWCore/ParameterSet/interface/Registry.h
+++ b/FWCore/ParameterSet/interface/Registry.h
@@ -8,45 +8,96 @@
 // A Registry is used to keep track of the persistent form of all
 // ParameterSets used a given program, so that they may be retrieved by
 // ParameterSetID, and so they may be written to persistent storage.
+// Note that this registry is *not* directly persistable. The contents
+// are persisted, but not the container.
 // ----------------------------------------------------------------------
 
+#include <iosfwd>
 #include <map>
+#include "tbb/concurrent_unordered_map.h"
 
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 #include "DataFormats/Provenance/interface/ParameterSetBlob.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/ThreadSafeRegistry.h"
 
 namespace edm {
   namespace pset {
 
-    class ProcessParameterSetIDCache {
+    class Registry {
     public:
-      ProcessParameterSetIDCache() : id_() { }
-      ParameterSetID id() const { return id_; }
-      void setID(ParameterSetID const& id) { id_ = id; }
-    private:
-      ParameterSetID id_;      
-    };
+      typedef edm::ParameterSetID key_type;
+      typedef edm::ParameterSet   value_type;
 
-    typedef detail::ThreadSafeRegistry<ParameterSetID,
-    					ParameterSet,
-					ProcessParameterSetIDCache>
-                                        Registry;
+      static Registry* instance();
+
+      /// Retrieve the value_type object with the given key.
+      /// If we return 'true', then 'result' carries the
+      /// value_type object.
+      /// If we return 'false, no matching key was found, and
+      /// the value of 'result' is undefined.
+      bool getMapped(key_type const& k, value_type& result) const;
+
+      /** Retrieve a pointer to the value_type object with the given key.
+       If there is no object associated with the given key 0 is returned.
+       */
+      value_type const* getMapped(key_type const& k) const;
+
+      /// Insert the given value_type object into the
+      /// registry. If there was already a value_type object
+      /// with the same key, we don't change it. This should be OK,
+      /// since it should have the same contents if the key is the
+      /// same.  Return 'true' if we really added the new
+      /// value_type object, and 'false' if the
+      /// value_type object was already present.
+      bool insertMapped(value_type const& v);
+
+      ///Not thread safe
+      void clear();
+
+      struct key_hash {
+        std::size_t operator()(key_type const& iKey) const{
+          return iKey.smallHash();
+        }
+      };
+      typedef tbb::concurrent_unordered_map<key_type,value_type,key_hash> map_type;
+      typedef map_type::const_iterator const_iterator;
+
+      const_iterator begin() const {
+        return m_map.begin();
+      }
+
+      const_iterator end() const {
+        return m_map.end();
+      }
+
+      bool empty() const {
+        return m_map.empty();
+      }
+
+      size_t size() const {
+        return m_map.size();
+      }
+
+      /// Fill the given map with the persistent form of each
+      /// ParameterSet in the registry.
+      typedef std::map<ParameterSetID, ParameterSetBlob> regmap_type;
+      void fillMap(regmap_type& fillme) const;
+
+      void print(std::ostream& os) const;
+
+    private:
+      map_type m_map;
+    };
 
     /// Associated free functions.
 
-    /// Return the ParameterSetID of the top-level ParameterSet stored
-    /// in the given Registry. Note the the returned ParameterSetID may
-    /// be invalid; this will happen if the Registry has not yet been
-    /// filled.
-    ParameterSetID getProcessParameterSetID(Registry const& reg);
+    /// Save the ParameterSetID of the top-level ParameterSet.
+    void setID(ParameterSetID const& id);
 
-    /// Fill the given map with the persistent form of each
-    /// ParameterSet in the given registry.
-    typedef std::map<ParameterSetID, ParameterSetBlob> regmap_type;
-    void fillMap(Registry const& reg, regmap_type& fillme);
-
+    /// Return the ParameterSetID of the top-level ParameterSet.
+    /// Note the the returned ParameterSetID may be invalid;
+    /// this will happen if the Registry has not yet been filled.
+    ParameterSetID const& getProcessParameterSetID();
   }  // namespace pset
 
   ParameterSet const& getProcessParameterSet();

--- a/FWCore/ParameterSet/interface/Registry.h
+++ b/FWCore/ParameterSet/interface/Registry.h
@@ -92,7 +92,7 @@ namespace edm {
     /// Associated free functions.
 
     /// Save the ParameterSetID of the top-level ParameterSet.
-    void setID(ParameterSetID const& id);
+    void setProcessParameterSetID(ParameterSetID const& id);
 
     /// Return the ParameterSetID of the top-level ParameterSet.
     /// Note the the returned ParameterSetID may be invalid;

--- a/FWCore/ParameterSet/src/Registry.cc
+++ b/FWCore/ParameterSet/src/Registry.cc
@@ -1,50 +1,104 @@
 // ----------------------------------------------------------------------
 // ----------------------------------------------------------------------
 
+#include <ostream>
+
 #include "FWCore/ParameterSet/interface/Registry.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
-
 namespace edm {
   namespace pset {
-    ParameterSetID
-    getProcessParameterSetID(Registry const& reg) {
-      ParameterSetID const& psetID = reg.extra().id();
-      if (!psetID.isValid()) {
+    static ParameterSetID s_ProcessParameterSetID; 
+
+    Registry*
+    Registry::instance() {
+      static Registry s_reg;
+      return &s_reg;
+    }
+    
+    bool
+    Registry::getMapped(key_type const& k, value_type& result) const {
+      auto it = m_map.find(k);
+      bool found = it != m_map.end();
+      if(found) {
+        result = it->second;
+      }
+      return found;
+    }
+    
+    Registry::value_type const*
+    Registry::getMapped(key_type const& k) const {
+      auto it = m_map.find(k);
+      bool found = it != m_map.end();
+      return found? &(it->second) : static_cast<value_type const*>(nullptr);
+    }
+  
+    bool
+    Registry::insertMapped(value_type const& v) {
+      return m_map.insert(std::make_pair(v.id(),v)).second;
+    }
+    
+    void
+    Registry::clear() {
+      m_map.clear();
+    }
+
+    void
+    Registry::fillMap(regmap_type& fillme) const {
+      fillme.clear();
+      // Note: The tracked part is in the registry.
+      for (auto const& item : m_map) {
+        fillme[item.first].pset() = item.second.toString();
+      }
+    }
+
+    void
+    Registry::print(std::ostream& os) const {
+      os << "Registry with " << size() << " entries\n";
+      for(auto const& item : *this) {
+        os << item.first << " " << item.second << '\n';
+      }
+    }
+
+    ParameterSetID const&
+    getProcessParameterSetID() {
+      if (!s_ProcessParameterSetID.isValid()) {
         throw edm::Exception(errors::LogicError)
           << "Illegal attempt to access the process top level parameter set ID\n"
           << "before that parameter set has been frozen and registered.\n"
           << "The parameter set can be changed during module validation,\n"
-	  << "which occurs concurrently with module construction.\n"
+          << "which occurs concurrently with module construction.\n"
           << "It is illegal to access the parameter set before it is frozen.\n";
       }
-      return psetID;
+      return s_ProcessParameterSetID;
     }
 
-    void fillMap(Registry const& reg, regmap_type& fillme) {
-      fillme.clear();
-      // Note: The tracked part is in the registry.
-      for (auto const& item : reg) {
-	fillme[item.first].pset() = item.second.toString();
-      }
+    void setID(ParameterSetID const& id) {
+      pset::s_ProcessParameterSetID = id;
     }
+
   } // namespace pset
 
   ParameterSet const& getProcessParameterSet() {
-    pset::Registry const& reg = *pset::Registry::instance();
-    ParameterSetID id = pset::getProcessParameterSetID(reg);
 
+    if (!pset::s_ProcessParameterSetID.isValid()) {
+      throw edm::Exception(errors::LogicError)
+        << "Illegal attempt to access the process top level parameter set ID\n"
+        << "before that parameter set has been frozen and registered.\n"
+        << "The parameter set can be changed during module validation,\n"
+        << "which occurs concurrently with module construction.\n"
+        << "It is illegal to access the parameter set before it is frozen.\n";
+    }
+
+    pset::Registry const& reg = *pset::Registry::instance();
     ParameterSet const* result;
-    if (nullptr == (result = reg.getMapped(id))) {
+    if (nullptr == (result = reg.getMapped(pset::s_ProcessParameterSetID))) {
       throw edm::Exception(errors::EventCorruption, "Unknown ParameterSetID")
-	<< "Unable to find the ParameterSet for id: "
-	<< id
-	<< ";\nthis was supposed to be the process ParameterSet\n";
+        << "Unable to find the ParameterSet for id: "
+        << pset::s_ProcessParameterSetID
+        << ";\nthis was supposed to be the process ParameterSet\n";
     }
     return *result;
   }
 
 } // namespace edm
-
-#include "FWCore/Utilities/interface/ThreadSafeRegistry.icc"
-DEFINE_THREAD_SAFE_REGISTRY_INSTANCE(edm::pset::Registry)

--- a/FWCore/ParameterSet/src/Registry.cc
+++ b/FWCore/ParameterSet/src/Registry.cc
@@ -73,7 +73,7 @@ namespace edm {
       return s_ProcessParameterSetID;
     }
 
-    void setID(ParameterSetID const& id) {
+    void setProcessParameterSetID(ParameterSetID const& id) {
       pset::s_ProcessParameterSetID = id;
     }
 

--- a/IOPool/Streamer/src/StreamSerializer.cc
+++ b/IOPool/Streamer/src/StreamSerializer.cc
@@ -60,7 +60,7 @@ namespace edm {
     sd.setBranchIDLists(branchIDLists);
     SendJobHeader::ParameterSetMap psetMap;
 
-    pset::fillMap(*pset::Registry::instance(), psetMap);
+    pset::Registry::instance()->fillMap(psetMap);
     sd.setParameterSetMap(psetMap);
 
     data_buffer.rootbuf_.Reset();

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -16,6 +16,7 @@
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 
 #include <string>
+#include <sys/time.h>
 #include <unistd.h>
 #include "zlib.h"
 
@@ -151,8 +152,7 @@ namespace edm {
     uint32 run = 1;
 
     //Get the Process PSet ID
-    pset::Registry const& reg = *pset::Registry::instance();
-    ParameterSetID toplevel = pset::getProcessParameterSetID(reg);
+    ParameterSetID toplevel = pset::getProcessParameterSetID();
 
     //In case we need to print it
     //  cms::Digest dig(toplevel.compactForm());


### PR DESCRIPTION
For thread safety, use tbb::concurrent_unordered_map for the parameter set registry.
