### PR TITLE
Dictionary (classes*h) must have unique namespace or/and struct name

### DIFF
--- a/Alignment/LaserAlignment/src/classes.h
+++ b/Alignment/LaserAlignment/src/classes.h
@@ -1,7 +1,7 @@
 #include "Alignment/LaserAlignment/interface/TsosVectorCollection.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace {
+namespace Alignment_LaserAlignment {
   struct dictionary {
     TsosVectorCollection tsosesColl;
     edm::Wrapper<TsosVectorCollection> tsosesWrappedColl;

--- a/AnalysisDataFormats/EWK/src/classes.h
+++ b/AnalysisDataFormats/EWK/src/classes.h
@@ -20,7 +20,7 @@
 #include <map>
 
 
-namespace {
+namespace AnalysisDataFormats_EWK {
   struct dictionary {
      std::vector<reco::WMuNuCandidate> v1;
      edm::Wrapper<std::vector<reco::WMuNuCandidate> > c1;

--- a/AnalysisDataFormats/Egamma/src/classes.h
+++ b/AnalysisDataFormats/Egamma/src/classes.h
@@ -3,10 +3,8 @@
 #include "AnalysisDataFormats/Egamma/interface/ElectronIDAssociation.h"
 #include "DataFormats/Common/interface/RefToBase.h"
 
-namespace
-{
-   struct dictionary
-   {
+namespace AnalysisDataFormats_Egamma {
+   struct dictionary {
       reco::ElectronIDCollection c1;
       edm::Wrapper<reco::ElectronIDCollection> w1;
       edm::Ref<reco::ElectronIDCollection> r1;

--- a/AnalysisDataFormats/SUSYBSMObjects/src/classes.h
+++ b/AnalysisDataFormats/SUSYBSMObjects/src/classes.h
@@ -4,8 +4,7 @@
 #include "AnalysisDataFormats/SUSYBSMObjects/interface/HSCPDeDxInfo.h"
 #include "AnalysisDataFormats/SUSYBSMObjects/interface/MuonSegment.h"
 
-namespace {
- namespace {
+namespace AnalysisDataFormats_SUSYBSMObjects {
   susybsm::HSCParticle pa;
 /*  susybsm::DriftTubeTOF dtitof;
 
@@ -66,7 +65,4 @@ namespace {
   edm::Wrapper<susybsm::HSCPDeDxInfo> hscpDEDXW;
   edm::Wrapper<susybsm::HSCPDeDxInfoCollection> hscpDEDXcW;
   edm::Wrapper<susybsm::HSCPDeDxInfoValueMap> hscpDEDXvmW;
-
-  
- }
 }

--- a/AnalysisDataFormats/TopObjects/src/classes.h
+++ b/AnalysisDataFormats/TopObjects/src/classes.h
@@ -15,7 +15,7 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "TString.h"
 
-namespace {
+namespace AnalysisDataFormats_TopObjects {
   struct dictionary {
     TtGenEvent ttgen;
     StGenEvent stgen;

--- a/AnalysisDataFormats/TrackInfo/src/classes.h
+++ b/AnalysisDataFormats/TrackInfo/src/classes.h
@@ -9,7 +9,7 @@
 #include <vector>
 
 
-namespace {
+namespace AnalysisDataFormats_TrackInfo {
   struct dictionary {
 
     reco::TrackingStateInfo                 tsi;

--- a/CondCore/ORA/test/classes.h
+++ b/CondCore/ORA/test/classes.h
@@ -1416,16 +1416,18 @@ class SH {
 
 }  // namespace testORA
 
-namespace {
-  std::vector<double>::iterator dummy1;
-  std::vector<int>::iterator dummy2;
-  std::vector<int16_t>::iterator dummy3;
-  std::vector<short>::iterator dummy4;
-  std::vector<float>::iterator dummy5;
-  std::vector<testORA::Entry>::iterator dummy6;
-  std::vector<testORA::SiStripNoises::DetRegistry>::iterator dummy7;
-  std::vector<std::vector<double> >::iterator dummy8;
-  std::pair<size_t,testORA::SM> dummy9;
+namespace CondCore_ORA {
+  struct dictionary {
+    std::vector<double>::iterator dummy1;
+    std::vector<int>::iterator dummy2;
+    std::vector<int16_t>::iterator dummy3;
+    std::vector<short>::iterator dummy4;
+    std::vector<float>::iterator dummy5;
+    std::vector<testORA::Entry>::iterator dummy6;
+    std::vector<testORA::SiStripNoises::DetRegistry>::iterator dummy7;
+    std::vector<std::vector<double> >::iterator dummy8;
+    std::pair<size_t,testORA::SM> dummy9;
+  };
 }
 
 #endif

--- a/CondCore/RegressionTest/test/classes.h
+++ b/CondCore/RegressionTest/test/classes.h
@@ -1,6 +1,6 @@
 
 #include "CondCore/RegressionTest/interface/RegressionTestPayload.h"
-namespace {
+namespace CondCore_RegressionTest {
 	struct dictionary {
 	  std::vector<double>::iterator dummy1;
 	  std::vector<int>::iterator dummy2;

--- a/CondCore/Utilities/src/classes.h
+++ b/CondCore/Utilities/src/classes.h
@@ -1,7 +1,7 @@
 #include "CondCore/Utilities/interface/CondBasicIter.h"
 #include <iostream>
 
-namespace {
+namespace CondCore_Utilities {
   struct dictionary {
   };
 }

--- a/CondFormats/BTauObjects/src/classes.h
+++ b/CondFormats/BTauObjects/src/classes.h
@@ -6,7 +6,7 @@
 #include "CondFormats/BTauObjects/interface/CombinedTauTagCalibration.h"
 
 
-namespace {
+namespace CondFormats_BTauObjects {
   struct dictionary {
     std::vector<float> b1;
 

--- a/CondFormats/CSCObjects/src/classes.h
+++ b/CondFormats/CSCObjects/src/classes.h
@@ -22,7 +22,7 @@
 #include "CondFormats/CSCObjects/interface/CSCDBGasGainCorrection.h"
 
 
-namespace {
+namespace CondFormats_CSCObjects {
   struct dictionary {
 
     std::vector<CSCPedestals::Item>   pedcontainer1;

--- a/CondFormats/Calibration/src/classes.h
+++ b/CondFormats/Calibration/src/classes.h
@@ -15,7 +15,7 @@
 #include "CondFormats/Calibration/interface/Conf.h"
 #include "CondFormats/Calibration/interface/big.h"
 
-namespace {
+namespace CondFormats_Calibration {
   struct dictionary {
     fixedArray<unsigned short,2097> d;
     std::map<std::string, Algo> e;

--- a/CondFormats/CastorObjects/src/classes.h
+++ b/CondFormats/CastorObjects/src/classes.h
@@ -13,7 +13,7 @@
 #include "CondFormats/CastorObjects/interface/CastorSaturationCorr.h"
 #include "CondFormats/CastorObjects/interface/CastorSaturationCorrs.h"
 
-namespace {
+namespace CondFormats_CastorObjects {
   struct dictionary {
     CastorPedestals mypeds;
     std::vector<CastorPedestal> mypedsVec;

--- a/CondFormats/Common/src/classes.h
+++ b/CondFormats/Common/src/classes.h
@@ -12,14 +12,10 @@
 
 #include <vector>
 
-namespace {
-  namespace {
-    struct dictionaries {
-    };
-
-    struct Dummy {
-         std::map<unsigned long long,unsigned long long> dummyForTests;
-         std::map<unsigned long long,unsigned long long>::value_type dummyForTest2;
+namespace CondFormats_Common {
+    struct dictionary {
+      std::map<unsigned long long,unsigned long long> dummyForTests;
+      std::map<unsigned long long,unsigned long long>::value_type dummyForTest2;
 
       DropBoxMetadata::Parameters aparam;
       std::pair<std::string, DropBoxMetadata::Parameters> apair1;
@@ -27,10 +23,6 @@ namespace {
 
       std::map<std::string, DropBoxMetadata::Parameters> amap1;
       std::map<const std::basic_string<char>, DropBoxMetadata::Parameters> amap2;
-
     };
-
-  }
-
 }
 

--- a/CondFormats/DQMObjects/src/classes.h
+++ b/CondFormats/DQMObjects/src/classes.h
@@ -2,7 +2,7 @@
 #include "CondFormats/DQMObjects/interface/HDQMSummary.h"
 
 
-namespace {
+namespace CondFormats_DQMObjects {
   struct dictionary { 
   
   std::vector<std::string>::iterator tmp30;

--- a/CondFormats/DTObjects/src/classes.h
+++ b/CondFormats/DTObjects/src/classes.h
@@ -27,7 +27,7 @@
 #include "CondFormats/DTObjects/interface/DTKeyedConfig.h"
 #include "CondFormats/DTObjects/interface/DTTPGParameters.h"
 
-namespace {
+namespace CondFormats_DTObjects {
   struct dictionary {
 //    std::pair<           DTT0Id,           DTT0Data>          t0Pair;
     std::pair<        DTTtrigId,        DTTtrigData>       tTrigPair;
@@ -79,7 +79,7 @@ namespace {
 
 /*
 // wrapper declarations
-namespace {
+namespace CondFormats_DTObjects {
    struct wrappers {
       pool::Ptr<DTReadOutMapping >          pMap;
       cond::DataWrapper<DTReadOutMapping > dwMap;

--- a/CondFormats/ESObjects/src/classes.h
+++ b/CondFormats/ESObjects/src/classes.h
@@ -20,7 +20,7 @@
 #include "CondFormats/ESObjects/interface/ESRecHitRatioCuts.h"
 #include "CondFormats/ESObjects/interface/ESTimeSampleWeights.h"
 
-namespace{
+namespace CondFormats_ESObjects {
   struct dictionary {
 
     ESCondObjectContainer<ESPedestal> ESPedestalsMap;

--- a/CondFormats/EcalObjects/src/classes.h
+++ b/CondFormats/EcalObjects/src/classes.h
@@ -62,7 +62,7 @@
 
 
 
-namespace{
+namespace CondFormats_EcalObjects {
   struct dictionary {
     
     std::vector<EcalChannelStatusCode> v_ecalChannelStatusCode;

--- a/CondFormats/EgammaObjects/src/classes.h
+++ b/CondFormats/EgammaObjects/src/classes.h
@@ -6,7 +6,7 @@
 #include "CondFormats/EgammaObjects/interface/GBRTree2D.h"
 #include "CondFormats/EgammaObjects/interface/GBRForest2D.h"
 
-namespace {
+namespace CondFormats_EgammaObjects {
   struct dictionary {
     ElectronLikelihoodCategoryData a;
  

--- a/CondFormats/HIObjects/src/classes.h
+++ b/CondFormats/HIObjects/src/classes.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 
-namespace {  
+namespace CondFormats_HIObjects {
   struct dictionary{
     std::vector<CentralityTable::CBin> dummy;
     std::vector<RPFlatParams::EP> yummy;

--- a/CondFormats/HcalObjects/src/classes.h
+++ b/CondFormats/HcalObjects/src/classes.h
@@ -2,7 +2,7 @@
 
 #include "CondFormats/HcalObjects/interface/AllObjects.h"
 
-namespace {
+namespace CondFormats_HcalObjects {
   struct dictionary {
 
     HcalPedestals mypeds();

--- a/CondFormats/JetMETObjects/src/classes.h
+++ b/CondFormats/JetMETObjects/src/classes.h
@@ -7,14 +7,18 @@
 #include "CondFormats/JetMETObjects/interface/FFTJetCorrectorParameters.h"
 
 #include <vector>
- 
-JetCorrectorParameters corr;
-JetCorrectorParameters::Definitions def;
-JetCorrectorParameters::Record record;
-std::vector<JetCorrectorParameters> corrv;
-std::vector<JetCorrectorParameters::Record> recordv;
-JetCorrectorParametersCollection coll;
-JetCorrectorParametersCollection::pair_type pair_type;
-JetCorrectorParametersCollection::collection_type colltype;
-std::vector<JetCorrectorParametersCollection> collv;
-FFTJetCorrectorParameters fftcorr;
+
+namespace CondFormats_JetMETObjects {
+  struct dictionary {
+    JetCorrectorParameters corr;
+    JetCorrectorParameters::Definitions def;
+    JetCorrectorParameters::Record record;
+    std::vector<JetCorrectorParameters> corrv;
+    std::vector<JetCorrectorParameters::Record> recordv;
+    JetCorrectorParametersCollection coll;
+    JetCorrectorParametersCollection::pair_type pair_type;
+    JetCorrectorParametersCollection::collection_type colltype;
+    std::vector<JetCorrectorParametersCollection> collv;
+    FFTJetCorrectorParameters fftcorr;
+  };
+}

--- a/CondFormats/L1TObjects/src/classes.h
+++ b/CondFormats/L1TObjects/src/classes.h
@@ -44,7 +44,7 @@
 #include "CondFormats/L1TObjects/interface/L1RPCHsbConfig.h"
 
 
-namespace {
+namespace CondFormats_L1TObjects {
   struct dictionary {
     std::vector<L1MuDTExtLut::LUT> dummy3 ;
     std::vector<L1GtMuonTemplate> dummy4 ;

--- a/CondFormats/Luminosity/src/classes.h
+++ b/CondFormats/Luminosity/src/classes.h
@@ -1,6 +1,9 @@
 #include "CondFormats/Luminosity/interface/LumiSectionData.h"
-namespace {
+
+namespace CondFormats_Luminosity {
+  struct dictionary {
     std::vector<lumi::BunchCrossingInfo>::iterator tmp1;
     std::vector<lumi::HLTInfo>::iterator tmp2;
     std::vector<lumi::TriggerInfo>::iterator tmp3;
+  };
 }

--- a/CondFormats/OptAlignObjects/src/classes.h
+++ b/CondFormats/OptAlignObjects/src/classes.h
@@ -32,7 +32,7 @@
 //template std::vector< PXsensors::Item >::const_iterator;
 //template edm::Wrapper<OpticalAlignments>;
 
-namespace{
+namespace CondFormats_OptAlignObjects {
   struct dictionary {
     std::vector<OpticalAlignInfo> optaligninfovec;
     std::vector<MBAChBenchCalPlateData> mbacalvec;

--- a/CondFormats/PhysicsToolsObjects/src/classes.h
+++ b/CondFormats/PhysicsToolsObjects/src/classes.h
@@ -14,7 +14,7 @@
 #include "CondFormats/PhysicsToolsObjects/interface/PhysicsTFormulaPayload.h"
 
 
-namespace { // anonymous
+namespace CondFormats_PhysicsToolsObjects { // anonymous
 struct dictionary {
 
 #ifdef STD_DICTIONARIES_STUFF_MISSING

--- a/CondFormats/RPCObjects/src/classes.h
+++ b/CondFormats/RPCObjects/src/classes.h
@@ -32,7 +32,7 @@
 #include "CondFormats/RPCObjects/interface/RPCObGasMix.h"
 #include "CondFormats/RPCObjects/interface/RPCObGasHum.h"
 
-namespace{
+namespace CondFormats_RPCObjects {
   struct dictionary {
     std::vector<ChamberStripSpec> theStrips;
  

--- a/CondFormats/RecoMuonObjects/src/classes.h
+++ b/CondFormats/RecoMuonObjects/src/classes.h
@@ -1,6 +1,6 @@
 #include "CondFormats/RecoMuonObjects/interface/MuScleFitDBobject.h"
 
-namespace {
+namespace CondFormats_RecoMuonObjects {
   struct dictionary {
     // std::vector<PhysicsTools::Calibration::HistogramD2D> a;
     MuScleFitDBobject e;

--- a/CondFormats/RunInfo/src/classes.h
+++ b/CondFormats/RunInfo/src/classes.h
@@ -4,7 +4,7 @@
 #include "CondFormats/RunInfo/interface/L1TriggerScaler.h"
 #include "CondFormats/RunInfo/interface/MixingModuleConfig.h"
 #include "CondFormats/RunInfo/interface/FillInfo.h"
-namespace {
+namespace CondFormats_RunInfo {
   struct dictionary {
     std::vector<runinfo_test::RunNumber::Item>::iterator tmp0;
     std::vector<L1TriggerScaler::Lumi>::iterator tmp1;

--- a/CondFormats/SiPixelObjects/src/classes.h
+++ b/CondFormats/SiPixelObjects/src/classes.h
@@ -16,7 +16,7 @@ template class PixelDCSObject<bool>;
 template class PixelDCSObject<float>;
 template class PixelDCSObject<CaenChannel>;
 
-namespace {
+namespace CondFormats_SiPixelObjects {
   struct dictionary {
     std::map<SiPixelFedCablingMap::Key, sipixelobjects::PixelROC> theMap; 
     std::pair<const SiPixelFedCablingMap::Key, sipixelobjects::PixelROC> theMapValueT; 

--- a/CondFormats/SiStripObjects/src/classes.h
+++ b/CondFormats/SiStripObjects/src/classes.h
@@ -14,7 +14,7 @@
 #include "CondFormats/SiStripObjects/interface/SiStripSummary.h"
 #include "CondFormats/SiStripObjects/interface/SiStripConfObject.h"
 
-namespace {
+namespace CondFormats_SiStripObjects {
   struct dictionary {
     std::vector< std::vector<FedChannelConnection> > tmp1;
   

--- a/CondTools/Utilities/test/classes.h
+++ b/CondTools/Utilities/test/classes.h
@@ -14,7 +14,7 @@
 
 #include <iostream>
 
-namespace {
+namespace CondTools_Utilities {
   struct dictionary {
 
     CondCachedIter<Pedestals> dummy0;

--- a/DPGAnalysis/SiStripTools/src/classes.h
+++ b/DPGAnalysis/SiStripTools/src/classes.h
@@ -8,7 +8,7 @@
 
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace { 
+namespace DPGAnalysis_SiStripTools {
   struct dictionary {
     TinyEventCollection dummycoll;
     SingleSiStripDigiMultiplicity dummy1;

--- a/DQM/SiPixelHistoricInfoClient/interface/classes.h
+++ b/DQM/SiPixelHistoricInfoClient/interface/classes.h
@@ -2,7 +2,7 @@
 
 #include "DQM/SiPixelHistoricInfoClient/interface/HDQMInspectorConfigSiPixel.h"
 
-namespace {
+namespace DQM_SiPixelHistoricInfoClient {
   struct dictionary {
     HDQMInspectorConfigSiPixel RealDummyDum;
   };

--- a/DQM/SiStripHistoricInfoClient/interface/classes.h
+++ b/DQM/SiStripHistoricInfoClient/interface/classes.h
@@ -3,7 +3,7 @@
 #include "DQM/SiStripHistoricInfoClient/interface/HDQMInspectorConfigSiStrip.h"
 #include "DQM/SiStripHistoricInfoClient/interface/HDQMInspectorConfigTracking.h"
 
-namespace {
+namespace DQM_SiStripHistoricInfoClient {
   struct dictionary {
     HDQMInspectorConfigSiStrip dummy1;
     HDQMInspectorConfigTracking dummy2;

--- a/DQMServices/Diagnostic/interface/classes.h
+++ b/DQMServices/Diagnostic/interface/classes.h
@@ -9,7 +9,7 @@
 // #include "DQMServices/Diagnostic/test/HDQMGraphAnalysis.h"
 
 
-namespace {
+namespace DQMServices_Diagnostic {
   struct dictionary {
     CondCachedIter<HDQMSummary> dummy13;
 

--- a/DataFormats/Alignment/src/classes.h
+++ b/DataFormats/Alignment/src/classes.h
@@ -8,7 +8,7 @@
 #include "DataFormats/Alignment/interface/TkFittedLasBeam.h"
 
 
-namespace {
+namespace DataFormats_Alignment {
   struct dictionary {
     //////////////////////////////////////////////
     // for LAS interface to track-based alignment

--- a/DataFormats/BTauReco/src/classes.h
+++ b/DataFormats/BTauReco/src/classes.h
@@ -46,7 +46,7 @@ namespace reco {
     typedef TauMassTagInfo::ClusterTrackAssociationCollection::ref_type     TauMassTagInfo_ClusterTrackAssociationRefType;
 }
 
-namespace {
+namespace DataFormats_BTauReco {
   struct dictionary {
 
     reco::SecondaryVertexTagInfo::TrackData                             sv_td;

--- a/DataFormats/BeamSpot/src/classes.h
+++ b/DataFormats/BeamSpot/src/classes.h
@@ -7,7 +7,7 @@
 #include "Math/CylindricalEta3D.h" 
 #include "DataFormats/Math/interface/Vector.h" 
 
-namespace {
+namespace DataFormats_BeamSpot {
   struct dictionary {
     reco::BeamSpot b;
     edm::Wrapper<reco::BeamSpot> b_w;

--- a/DataFormats/CLHEP/src/classes.h
+++ b/DataFormats/CLHEP/src/classes.h
@@ -5,7 +5,7 @@
 #include "CLHEP/Vector/LorentzVector.h"
 #include "CLHEP/Vector/ThreeVector.h"
 
-namespace {
+namespace DataFormats_CLHEP {
   struct dictionary {
     std::vector<CLHEP::HepLorentzVector> dummy0;
   };

--- a/DataFormats/CSCDigi/src/classes.h
+++ b/DataFormats/CSCDigi/src/classes.h
@@ -34,7 +34,7 @@
 #include <vector>
 #include <map>
 
-namespace{
+namespace DataFormats_CSCDigi {
   struct dictionary {
 
   CSCWireDigi cWD_;

--- a/DataFormats/CSCRecHit/src/classes.h
+++ b/DataFormats/CSCRecHit/src/classes.h
@@ -7,7 +7,7 @@
 #include <DataFormats/Common/interface/Wrapper.h>
 #include <vector>
 
-namespace{ 
+namespace DataFormats_CSCRecHit {
   struct dictionary {
     std::map<CSCDetId,std::pair<unsigned int,unsigned int> > dummycscdetid1;  
     std::map<CSCDetId,std::pair<unsigned long,unsigned long> > dummycscdetid2;  

--- a/DataFormats/CaloRecHit/src/classes.h
+++ b/DataFormats/CaloRecHit/src/classes.h
@@ -6,7 +6,7 @@
 #include "DataFormats/CaloRecHit/interface/CaloCluster.h"
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
 
-namespace {
+namespace DataFormats_CaloRecHit {
   struct dictionary {
     // FIXME: The following 2 entries are found already in DataFormats/EgammaReco with the typedef 'reco::BasicCluster'
 //     std::vector<reco::CaloCluster> v11;

--- a/DataFormats/CaloTowers/src/classes.h
+++ b/DataFormats/CaloTowers/src/classes.h
@@ -13,7 +13,7 @@
 #include "DataFormats/Common/interface/FwdPtr.h"
 
 
-namespace {
+namespace DataFormats_CaloTowers {
   struct dictionary {
     std::vector<CaloTower> v1;
     CaloTowerCollection c1;

--- a/DataFormats/Candidate/src/classes.h
+++ b/DataFormats/Candidate/src/classes.h
@@ -39,7 +39,7 @@ namespace reco {
    typedef edm::AssociationMap<edm::OneToManyWithQualityGeneric<CandidateView,CandidateView,bool> > CandViewCandViewAssociation;
 }
 
-namespace {
+namespace DataFormats_Candidate {
   struct dictionary {
     std::vector<reco::Candidate *> v1;
     reco::CandidateCollection o1;

--- a/DataFormats/CastorReco/src/classes.h
+++ b/DataFormats/CastorReco/src/classes.h
@@ -5,7 +5,7 @@
 #include "DataFormats/CastorReco/interface/CastorEgamma.h"
 #include "DataFormats/CastorReco/interface/CastorJet.h"
 
-namespace { 
+namespace DataFormats_CastorReco {
   struct dictionary {
     std::vector<reco::CastorTower> v11;
     reco::CastorTowerCollection v1;

--- a/DataFormats/Common/src/classes.h
+++ b/DataFormats/Common/src/classes.h
@@ -29,7 +29,7 @@
 
 #include <vector>
 
-namespace {
+namespace DataFormats_Common {
   struct dictionary {
     edm::Wrapper<edm::DataFrameContainer> dummywdfc;
     edm::Wrapper<edm::HLTPathStatus> dummyx16;

--- a/DataFormats/DTDigi/src/classes.h
+++ b/DataFormats/DTDigi/src/classes.h
@@ -6,7 +6,7 @@
 #include <vector>
 #include <map>
 
-namespace{ 
+namespace DataFormats_DTDigi {
   struct dictionary {
 
   DTDigi d;

--- a/DataFormats/DTRecHit/src/classes.h
+++ b/DataFormats/DTRecHit/src/classes.h
@@ -13,7 +13,7 @@
 #include <vector>
 #include <map>
 
-namespace{
+namespace DataFormats_DTRecHit {
   struct dictionary {
     std::map<DTLayerId,std::pair<unsigned int,unsigned int> > dummydtlayerid1;
     std::map<DTLayerId,std::pair<unsigned long,unsigned long> > dummydtlayerid2;

--- a/DataFormats/DetId/src/classes.h
+++ b/DataFormats/DetId/src/classes.h
@@ -6,7 +6,7 @@
 #include "DataFormats/DetId/interface/DetIdCollection.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace {
+namespace DataFormats_DetId {
   struct dictionary {
     std::vector<DetId> dummy;
     edm::EDCollection<DetId> vDI_;

--- a/DataFormats/EcalDetId/src/classes.h
+++ b/DataFormats/EcalDetId/src/classes.h
@@ -10,7 +10,7 @@
 #include "DataFormats/EcalDetId/interface/EcalDetIdCollections.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace {
+namespace DataFormats_EcalDetId {
   struct dictionary {
     edm::EDCollection<EBDetId> vEBDI_;
     edm::EDCollection<EEDetId> vEEDI_;

--- a/DataFormats/EcalDigi/src/classes.h
+++ b/DataFormats/EcalDigi/src/classes.h
@@ -1,7 +1,7 @@
 #include "DataFormats/EcalDigi/interface/EcalDigiCollections.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace {
+namespace DataFormats_EcalDigi {
   struct dictionary {
     std::vector<EcalMGPASample> vMGPA_;
     std::vector<EcalFEMSample> vFEM_;

--- a/DataFormats/EcalRawData/src/classes.h
+++ b/DataFormats/EcalRawData/src/classes.h
@@ -10,7 +10,7 @@
 
 #include <DataFormats/Common/interface/Wrapper.h>
 
-namespace {
+namespace DataFormats_EcalRawData {
   struct dictionary {
     EcalDCCHeaderBlock ERDC_;
     EcalDCCHeaderBlock::EcalDCCEventSettings ERDCSet_;

--- a/DataFormats/EcalRecHit/src/classes.h
+++ b/DataFormats/EcalRecHit/src/classes.h
@@ -8,7 +8,7 @@
 #include "DataFormats/Common/interface/Holder.h"
 #include <vector>
 
-namespace {
+namespace DataFormats_EcalRecHit {
   struct dictionary {
     EcalUncalibratedRecHit _ahit;
     std::vector<EcalUncalibratedRecHit> _hitVect;
@@ -50,7 +50,7 @@ namespace {
 #include "DataFormats/EcalRecHit/interface/EcalRecHitComparison.h"
 #include "boost/cstdint.hpp" 
 
-namespace {
+namespace DataFormats_EcalRecHit {
   struct dictionary2 {
     edm::Wrapper< EcalRecHit > dummy01;
     edm::Wrapper< std::vector<EcalRecHit>  > dummy11;

--- a/DataFormats/EgammaCandidates/src/classes.h
+++ b/DataFormats/EgammaCandidates/src/classes.h
@@ -44,7 +44,7 @@
 #include <boost/cstdint.hpp>
 
 
-namespace {
+namespace DataFormats_EgammaCandidates {
 
   struct dictionary {
 

--- a/DataFormats/EgammaReco/src/classes.h
+++ b/DataFormats/EgammaReco/src/classes.h
@@ -19,7 +19,7 @@
 #include "DataFormats/EgammaReco/interface/BasicClusterShapeAssociation.h"
 #include "DataFormats/EgammaReco/interface/HFEMClusterShapeAssociation.h"
 
-namespace {
+namespace DataFormats_EgammaReco {
   struct dictionary {
 
 	edm::RefToBase<reco::CaloCluster> refToBaseCaloCluster ;

--- a/DataFormats/EgammaTrackReco/src/classes.h
+++ b/DataFormats/EgammaTrackReco/src/classes.h
@@ -25,7 +25,7 @@
 
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace {
+namespace DataFormats_EgammaTrackReco {
   struct dictionary {
 
     reco::TrackCandidateSuperClusterAssociationCollection v5;

--- a/DataFormats/FEDRawData/src/classes.h
+++ b/DataFormats/FEDRawData/src/classes.h
@@ -4,7 +4,7 @@
 #include <DataFormats/Common/interface/Wrapper.h>
 #include <DataFormats/Common/interface/RefProd.h>
 
- namespace{ 
+namespace DataFormats_FEDRawData {
    struct dictionary {
      FEDRawData              a1; 
      std::vector<FEDRawData> a2;

--- a/DataFormats/FP420Cluster/src/classes.h
+++ b/DataFormats/FP420Cluster/src/classes.h
@@ -12,7 +12,7 @@
 
 #include "DataFormats/FP420Cluster/interface/ClusterFP420.h"
 #include "DataFormats/FP420Cluster/interface/ClusterCollectionFP420.h"
-namespace {
+namespace DataFormats_FP420Cluster {
   struct dictionary {
     edm::Wrapper<ClusterFP420 > zc0;
     edm::Wrapper<std::vector<ClusterFP420> > zc1;
@@ -28,7 +28,7 @@ namespace {
 
 #include "DataFormats/FP420Cluster/interface/TrackFP420.h"
 #include "DataFormats/FP420Cluster/interface/TrackCollectionFP420.h"
-namespace {
+namespace DataFormats_FP420Cluster {
   struct dictionary2 {
     edm::Wrapper<TrackFP420 > zt0;
     edm::Wrapper<std::vector<TrackFP420> > zt1;
@@ -44,7 +44,7 @@ namespace {
 
 #include "DataFormats/FP420Cluster/interface/RecoFP420.h"
 #include "DataFormats/FP420Cluster/interface/RecoCollectionFP420.h"
-namespace {
+namespace DataFormats_FP420Cluster {
   struct dictionary3 {
     edm::Wrapper<RecoFP420 > zr0;
     edm::Wrapper<std::vector<RecoFP420> > zr1;

--- a/DataFormats/FP420Digi/src/classes.h
+++ b/DataFormats/FP420Digi/src/classes.h
@@ -10,7 +10,7 @@
 #include <vector>
 #include <string>
 
-namespace {
+namespace DataFormats_FP420Digi {
   struct dictionary {
     edm::Wrapper<HDigiFP420 > zs0;
     edm::Wrapper<std::vector<HDigiFP420> > zs1;

--- a/DataFormats/GEMDigi/src/classes.h
+++ b/DataFormats/GEMDigi/src/classes.h
@@ -7,7 +7,7 @@
 #include <DataFormats/Common/interface/Wrapper.h>
 #include <vector>
 
-namespace{ 
+namespace DataFormats_GEMDigi {
   struct dictionary {
     
     GEMDigi g;

--- a/DataFormats/GEMRecHit/src/classes.h
+++ b/DataFormats/GEMRecHit/src/classes.h
@@ -2,7 +2,7 @@
 #include "DataFormats/GEMRecHit/interface/GEMRecHitCollection.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace { 
+namespace DataFormats_GEMRecHit {
   struct dictionary {
     std::pair<unsigned int, unsigned int> dummyrpc1;
     std::pair<unsigned long, unsigned long> dummyrpc2;

--- a/DataFormats/GeometryCommonDetAlgo/src/classes.h
+++ b/DataFormats/GeometryCommonDetAlgo/src/classes.h
@@ -3,7 +3,7 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace {
+namespace DataFormats_GeometryCommonDetAlgo {
   struct dictionary {
     Measurement1D m;
     Measurement1DFloat f;

--- a/DataFormats/GeometryVector/src/classes.h
+++ b/DataFormats/GeometryVector/src/classes.h
@@ -15,7 +15,7 @@
 #include "DataFormats/GeometryVector/interface/Vector2DBase.h"
 #include "DataFormats/GeometryVector/interface/Vector3DBase.h"
 
-namespace {
+namespace DataFormats_GeometryVector {
   struct dictionary {
     Vector2DBase<float,MeasurementTag> dummy7;
     Vector3DBase<float,MeasurementTag> dummy6;

--- a/DataFormats/GsfTrackReco/src/classes.h
+++ b/DataFormats/GsfTrackReco/src/classes.h
@@ -14,7 +14,7 @@
 #include "DataFormats/Common/interface/Holder.h"
 #include <vector>
 
-namespace {
+namespace DataFormats_GsfTrackReco {
   struct dictionary {
     reco::GsfTrackExtraCollection v4;
     edm::Wrapper<reco::GsfTrackExtraCollection> c4;

--- a/DataFormats/HLTReco/src/classes.h
+++ b/DataFormats/HLTReco/src/classes.h
@@ -13,7 +13,7 @@
 #include "DataFormats/Common/interface/Ref.h"
 
 
-namespace {
+namespace DataFormats_HLTReco {
   struct dictionary {
 
     edm::EventTime                                et0;

--- a/DataFormats/HcalCalibObjects/src/classes.h
+++ b/DataFormats/HcalCalibObjects/src/classes.h
@@ -4,7 +4,7 @@
 // #include "DataFormats/HOCalibHit/interface/HOCalibVariableCollection.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace {
+namespace DataFormats_HcalCalibObjects {
   struct dictionary {
    HEDarkening                                  hed;       
    HFRecalibration                              hfr;       

--- a/DataFormats/HcalDetId/src/classes.h
+++ b/DataFormats/HcalDetId/src/classes.h
@@ -12,7 +12,7 @@
 #include "DataFormats/HcalDetId/interface/CastorElectronicsId.h"
 #include <vector>
 
-namespace { 
+namespace DataFormats_HcalDetId {
   struct dictionary {
     std::vector<HcalElectronicsId> eids;
     std::vector<HcalFrontEndId> feids;

--- a/DataFormats/HcalDigi/src/classes.h
+++ b/DataFormats/HcalDigi/src/classes.h
@@ -12,7 +12,7 @@
 #include "DataFormats/HcalDigi/interface/HcalTTPDigi.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace {
+namespace DataFormats_HcalDigi {
   struct dictionary {
     std::vector<HcalQIESample> vQIE_;
     std::vector<HcalUpgradeQIESample> vUQIE_;

--- a/DataFormats/HcalIsolatedTrack/src/classes.h
+++ b/DataFormats/HcalIsolatedTrack/src/classes.h
@@ -1,7 +1,7 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h"
 #include "DataFormats/HcalIsolatedTrack/interface/EcalIsolatedParticleCandidate.h"
-namespace {
+namespace DataFormats_HcalIsolatedTrack {
   struct dictionary {
     edm::Wrapper<std::map< int, std::pair<double,double> > > w2;
  

--- a/DataFormats/HcalRecHit/src/classes.h
+++ b/DataFormats/HcalRecHit/src/classes.h
@@ -17,7 +17,7 @@
 #include "DataFormats/Common/interface/Holder.h"
 #include "DataFormats/Common/interface/RefToBase.h"
 
-namespace {
+namespace DataFormats_HcalRecHit {
   struct dictionary {
     std::vector<HBHERecHit> vHBHE_;
     std::vector<HORecHit> vHO_;

--- a/DataFormats/HeavyIonEvent/src/classes.h
+++ b/DataFormats/HeavyIonEvent/src/classes.h
@@ -3,7 +3,7 @@
 #include "DataFormats/HeavyIonEvent/interface/HeavyIon.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace { 
+namespace DataFormats_HeavyIonEvent {
   struct dictionary {
 
     reco::EvtPlane dummy1;

--- a/DataFormats/HepMCCandidate/src/classes.h
+++ b/DataFormats/HepMCCandidate/src/classes.h
@@ -10,7 +10,7 @@
 #include "DataFormats/HepMCCandidate/interface/FlavorHistoryEvent.h"
 #include <vector>
 
-namespace {
+namespace DataFormats_HepMCCandidate {
   struct dictionary {
     reco::CompositeRefCandidateT<reco::GenParticleRefVector> v1;
     edm::Wrapper<reco::GenParticleCollection> w2;

--- a/DataFormats/Histograms/src/classes.h
+++ b/DataFormats/Histograms/src/classes.h
@@ -21,7 +21,7 @@
 #include "TString.h"
 #include <stdint.h>
 
-namespace {
+namespace DataFormats_Histograms {
   struct dictionary {
     edm::Wrapper<TH1C> dummy1C;
     edm::Wrapper<TH1D> dummy1D;

--- a/DataFormats/JetReco/src/classes_1.h
+++ b/DataFormats/JetReco/src/classes_1.h
@@ -23,7 +23,7 @@
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "DataFormats/Common/interface/Ptr.h"
 
-namespace {
+namespace DataFormats_JetReco {
   struct dictionary1 {
     reco::CaloJetCollection o1;
     reco::CaloJetRef r1;

--- a/DataFormats/JetReco/src/classes_2.h
+++ b/DataFormats/JetReco/src/classes_2.h
@@ -52,7 +52,7 @@
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "DataFormats/Common/interface/Ptr.h"
 
-namespace {
+namespace DataFormats_JetReco {
   struct dictionary2 {
     reco::FFTBasicJet jet_fft_3;
     reco::FFTBasicJetCollection o2_fft_3;

--- a/DataFormats/JetReco/src/classes_3.h
+++ b/DataFormats/JetReco/src/classes_3.h
@@ -38,7 +38,7 @@
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "DataFormats/Common/interface/Ptr.h"
 
-namespace {
+namespace DataFormats_JetReco {
   struct dictionary3 {
     reco::TrackJetCollection o6;
     reco::TrackJetRef r6;

--- a/DataFormats/JetReco/src/classes_4.h
+++ b/DataFormats/JetReco/src/classes_4.h
@@ -38,7 +38,7 @@
 
 #include "DataFormats/JetReco/interface/CATopJetTagInfo.h"
 
-namespace {
+namespace DataFormats_JetReco {
   struct dictionary4 {
     // jet id stuff
     reco::JetID jid;

--- a/DataFormats/L1CSCTrackFinder/src/classes.h
+++ b/DataFormats/L1CSCTrackFinder/src/classes.h
@@ -6,7 +6,7 @@
 #include <DataFormats/L1CSCTrackFinder/interface/CSCTriggerContainer.h>
 #include <DataFormats/Common/interface/Wrapper.h>
 
-namespace {
+namespace DataFormats_L1CSCTrackFinder {
   struct dictionary {
       csc::L1Track cL1TRK;
       csc::L1TrackId cL1TRKID;

--- a/DataFormats/L1CaloTrigger/src/classes.h
+++ b/DataFormats/L1CaloTrigger/src/classes.h
@@ -3,7 +3,7 @@
 #include "DataFormats/L1CaloTrigger/interface/L1CaloCollections.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace {
+namespace DataFormats_L1CaloTrigger {
   struct dictionary {
     L1CaloEmCollection em;
     L1CaloRegionCollection rgn;

--- a/DataFormats/L1DTTrackFinder/src/classes.h
+++ b/DataFormats/L1DTTrackFinder/src/classes.h
@@ -6,7 +6,7 @@
 #include <DataFormats/L1DTTrackFinder/interface/L1MuDTTrackContainer.h>
 #include <DataFormats/Common/interface/Wrapper.h>
 
-namespace{ 
+namespace DataFormats_L1DTTrackFinder {
   struct dictionary {
     L1MuDTChambPhDigi ph_S;
     L1MuDTChambThDigi th_S;

--- a/DataFormats/L1GlobalCaloTrigger/src/classes.h
+++ b/DataFormats/L1GlobalCaloTrigger/src/classes.h
@@ -6,7 +6,7 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefProd.h"
 
-namespace {
+namespace DataFormats_L1GlobalCaloTrigger {
   struct dictionary {
     // internal collections
     L1GctInternEmCandCollection internEmColl;

--- a/DataFormats/L1GlobalMuonTrigger/src/classes.h
+++ b/DataFormats/L1GlobalMuonTrigger/src/classes.h
@@ -5,7 +5,7 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefProd.h"
 
-namespace { 
+namespace DataFormats_L1GlobalMuonTrigger {
 struct dictionary {
   // L1MuRegionalTriggers -> GMT
   std::vector<L1MuRegionalCand> dummy0;

--- a/DataFormats/L1GlobalTrigger/src/classes.h
+++ b/DataFormats/L1GlobalTrigger/src/classes.h
@@ -22,7 +22,7 @@
 #include <vector>
 #include <map>
 
-namespace { struct dictionary {
+namespace DataFormats_L1GlobalTrigger { struct dictionary {
     // dictionary for L1GtfeWord
     L1GtfeWord dummy20;
     edm::Wrapper<L1GtfeWord> dummy21;

--- a/DataFormats/L1Trigger/src/classes.h
+++ b/DataFormats/L1Trigger/src/classes.h
@@ -23,7 +23,7 @@
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RefProd.h"
 
-namespace {
+namespace DataFormats_L1Trigger {
   struct dictionary {
 
      l1extra::L1EmParticleCollection emColl ;

--- a/DataFormats/LTCDigi/src/classes.h
+++ b/DataFormats/LTCDigi/src/classes.h
@@ -1,7 +1,7 @@
 #include "DataFormats/LTCDigi/interface/LTCDigi.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace {
+namespace DataFormats_LTCDigi {
   struct dictionary {
     LTCDigiCollection dummy0;
     edm::Wrapper<LTCDigiCollection> dummy1;

--- a/DataFormats/Luminosity/src/classes.h
+++ b/DataFormats/Luminosity/src/classes.h
@@ -4,7 +4,7 @@
 #include "DataFormats/Luminosity/interface/LumiSummary.h"
 #include "DataFormats/Luminosity/interface/LumiDetails.h"
 
-namespace {
+namespace DataFormats_Luminosity {
    struct dictionary {
       edm::Wrapper<LumiSummaryRunHeader> lumisummaryrunheaderobj;
       edm::Wrapper<LumiSummary> lumisummaryobj;

--- a/DataFormats/METObjects/src/classes.h
+++ b/DataFormats/METObjects/src/classes.h
@@ -7,7 +7,7 @@
 #include "DataFormats/METObjects/interface/TowerMETCollection.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace {
+namespace DataFormats_METObjects {
   struct dictionary {
     edm::Wrapper<BaseMETv0> dummy1;
     edm::Wrapper<METv0> dummy2;

--- a/DataFormats/METReco/src/classes.h
+++ b/DataFormats/METReco/src/classes.h
@@ -38,7 +38,7 @@
 #include "DataFormats/METReco/interface/BoundaryInformation.h"
 
 #include <vector>
-namespace {
+namespace DataFormats_METReco {
   struct dictionary {
     edm::Wrapper<reco::MET> dummy1;
     edm::Wrapper<reco::METCollection> dummy2;

--- a/DataFormats/Math/src/classes.h
+++ b/DataFormats/Math/src/classes.h
@@ -14,7 +14,7 @@
 #include "DataFormats/Common/interface/RefVector.h"
 #include <vector>
 
-namespace {
+namespace DataFormats_Math {
   struct dictionary {
     math::XYZVector v1;
     math::XYZVectorD vd1;

--- a/DataFormats/MuonReco/src/classes.h
+++ b/DataFormats/MuonReco/src/classes.h
@@ -28,7 +28,7 @@
 #include <vector>
 #include <map>
 
-namespace {
+namespace DataFormats_MuonReco {
   struct dictionary {
     std::vector<reco::Muon> v1;
     edm::Wrapper<std::vector<reco::Muon> > c1;

--- a/DataFormats/MuonSeed/src/classes.h
+++ b/DataFormats/MuonSeed/src/classes.h
@@ -8,7 +8,7 @@
 #include "DataFormats/Common/interface/AssociationMap.h"
 #include "DataFormats/Common/interface/OneToMany.h"
 
-namespace {
+namespace DataFormats_MuonSeed {
   struct dictionary {
     std::vector<L2MuonTrajectorySeed> v1;
     L2MuonTrajectorySeedCollection c1;

--- a/DataFormats/ParticleFlowCandidate/src/classes.h
+++ b/DataFormats/ParticleFlowCandidate/src/classes.h
@@ -31,7 +31,7 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 
 
-namespace {
+namespace DataFormats_ParticleFlowCandidate {
   struct dictionary {
 
     reco::PFCandidateRef c_r;

--- a/DataFormats/ParticleFlowReco/src/classes_1.h
+++ b/DataFormats/ParticleFlowReco/src/classes_1.h
@@ -63,7 +63,7 @@
 
 #include <map>
 
-namespace {
+namespace DataFormats_ParticleFlowReco {
   struct dictionary1 {
 
     /* NuclearInteraction stuffs  */

--- a/DataFormats/ParticleFlowReco/src/classes_2.h
+++ b/DataFormats/ParticleFlowReco/src/classes_2.h
@@ -63,7 +63,7 @@
 
 #include <map>
 
-namespace {
+namespace DataFormats_ParticleFlowReco {
   struct dictionary2 {
 
     std::vector<reco::PFCluster>                         dummy1;

--- a/DataFormats/PatCandidates/src/classes_objects.h
+++ b/DataFormats/PatCandidates/src/classes_objects.h
@@ -17,7 +17,7 @@
 #include "DataFormats/PatCandidates/interface/Hemisphere.h"
 #include "DataFormats/PatCandidates/interface/Conversion.h"
 
-namespace {
+namespace DataFormats_PatCandidates {
   struct dictionaryobjects {
 
   /*   PAT Object Collection Iterators   */

--- a/DataFormats/PatCandidates/src/classes_other.h
+++ b/DataFormats/PatCandidates/src/classes_other.h
@@ -17,7 +17,7 @@
 
 #include "DataFormats/PatCandidates/interface/CandKinResolution.h"
 
-namespace {
+namespace DataFormats_PatCandidates {
   struct dictionaryother {
 
   std::pair<std::string, std::vector<float> > jcfcf;

--- a/DataFormats/PatCandidates/src/classes_trigger.h
+++ b/DataFormats/PatCandidates/src/classes_trigger.h
@@ -8,7 +8,7 @@
 #include <iterator>
 #include <vector>
 
-namespace {
+namespace DataFormats_PatCandidates {
   struct dictionarytrigger {
 
   pat::TriggerObjectCollection v_p_to;

--- a/DataFormats/PatCandidates/src/classes_user.h
+++ b/DataFormats/PatCandidates/src/classes_user.h
@@ -10,7 +10,7 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
-namespace {
+namespace DataFormats_PatCandidates {
   struct dictionaryuser {
 
   /*   UserData: Core   */

--- a/DataFormats/Provenance/src/classes.h
+++ b/DataFormats/Provenance/src/classes.h
@@ -55,7 +55,7 @@ namespace edm {
   typedef Hash<ModuleDescriptionType> ModuleDescriptionID;
 }
 
-namespace {
+namespace DataFormats_Provenance {
   struct dictionary {
   std::pair<edm::BranchKey, edm::BranchDescription> dummyPairBranch;
   std::map<edm::ParameterSetID, edm::ParameterSetBlob> dummyMapParam;

--- a/DataFormats/RPCDigi/src/classes.h
+++ b/DataFormats/RPCDigi/src/classes.h
@@ -8,7 +8,7 @@
 #include <vector>
 #include <map>
 
-namespace{ 
+namespace DataFormats_RPCDigi {
   struct dictionary {
     
     RPCDigi d;

--- a/DataFormats/RPCRecHit/src/classes.h
+++ b/DataFormats/RPCRecHit/src/classes.h
@@ -2,7 +2,7 @@
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace { 
+namespace DataFormats_RPCRecHit {
   struct dictionary {
     std::pair<unsigned int, unsigned int> dummyrpc1;
     std::pair<unsigned long, unsigned long> dummyrpc2;

--- a/DataFormats/RecoCandidate/src/classes.h
+++ b/DataFormats/RecoCandidate/src/classes.h
@@ -38,7 +38,7 @@
 #include "DataFormats/RecoCandidate/interface/IsoDepositFwd.h"
 
 
-namespace {
+namespace DataFormats_RecoCandidate {
 
   struct dictionary {
     reco::RecoChargedCandidateCollection v1;

--- a/DataFormats/Scalers/src/classes.h
+++ b/DataFormats/Scalers/src/classes.h
@@ -14,10 +14,8 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefProd.h"
 
-namespace 
-{
-  struct dictionary 
-  {
+namespace DataFormats_Scalers {
+  struct dictionary {
     L1AcceptBunchCrossing l1AcceptBunchCrossing;
     L1TriggerScalers l1TriggerScalers;
     L1TriggerRates l1TriggerRates;

--- a/DataFormats/SiPixelCluster/src/classes.h
+++ b/DataFormats/SiPixelCluster/src/classes.h
@@ -5,7 +5,7 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/ContainerMask.h"
 
-namespace {
+namespace DataFormats_SiPixelCluster {
   struct dictionary {
     std::vector<SiPixelCluster> v1;
     edm::DetSet<SiPixelCluster> ds1;

--- a/DataFormats/SiPixelDigi/src/classes.h
+++ b/DataFormats/SiPixelDigi/src/classes.h
@@ -11,7 +11,7 @@
 #include "boost/cstdint.hpp"
 #include <vector>
 
-namespace {
+namespace DataFormats_SiPixelDigi {
   struct dictionary {
     SiPixelCalibDigi::datacontainer calibdatacontainer;
     SiPixelCalibDigi calibdigiitself;

--- a/DataFormats/SiPixelRawData/src/classes.h
+++ b/DataFormats/SiPixelRawData/src/classes.h
@@ -6,7 +6,7 @@
 #include "DataFormats/Common/interface/DetSetVector.h"
 #include <vector>
 
-namespace {
+namespace DataFormats_SiPixelRawData {
   struct dictionary {
     std::vector<SiPixelRawDataError> err0;
     std::map<int, std::vector<SiPixelRawDataError> > err1;

--- a/DataFormats/SiStripCluster/src/classes.h
+++ b/DataFormats/SiStripCluster/src/classes.h
@@ -7,7 +7,7 @@
 #include <map>
 #include "DataFormats/Common/interface/LazyGetter.h"
 
-namespace {
+namespace DataFormats_SiStripCluster {
   struct dictionary {
     edm::Wrapper<SiStripClusterCollection> siStripClusterCollectionWrapper;
   };
@@ -18,7 +18,7 @@ namespace {
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/Common/interface/ContainerMask.h"
-namespace {
+namespace DataFormats_SiStripCluster {
   struct dictionary2 {
     edm::Wrapper< SiStripCluster > dummy0;
     edm::Wrapper< std::vector<SiStripCluster>  > dummy1;
@@ -47,7 +47,7 @@ namespace {
 
 #include "boost/cstdint.hpp" 
 #include "DataFormats/Common/interface/RefGetter.h"
-namespace {
+namespace DataFormats_SiStripCluster {
   struct dictionary3 {
 
     edm::Wrapper< edm::RegionIndex<SiStripCluster> > dummy7;

--- a/DataFormats/SiStripCommon/src/classes.h
+++ b/DataFormats/SiStripCommon/src/classes.h
@@ -9,7 +9,7 @@
 #include "DataFormats/SiStripCommon/interface/SiStripFedKey.h"
 #include "DataFormats/SiStripCommon/interface/SiStripDetKey.h"
 #include "DataFormats/SiStripCommon/interface/SiStripNullKey.h"
-namespace { 
+namespace DataFormats_SiStripCommon {
   struct dictionary1 { 
     // edm::Wrapper< SiStripFecKey > fec;
     // edm::Wrapper< SiStripFedKey > fed;
@@ -19,7 +19,7 @@ namespace {
 }
 
 #include "DataFormats/SiStripCommon/interface/SiStripEventSummary.h"
-namespace {
+namespace DataFormats_SiStripCommon {
   struct dictionary2 {
     edm::Wrapper< sistrip::RunType > run_type; 
     edm::Wrapper< sistrip::ApvReadoutMode > apv_mode; 

--- a/DataFormats/SiStripDigi/src/classes.h
+++ b/DataFormats/SiStripDigi/src/classes.h
@@ -9,7 +9,7 @@
 #include <vector>
 
 #include "DataFormats/SiStripDigi/interface/SiStripDigi.h"
-namespace {
+namespace DataFormats_SiStripDigi {
   struct dictionary1 {
     edm::Wrapper<SiStripDigi > zs0;
     edm::Wrapper<std::vector<SiStripDigi> > zs1;
@@ -22,7 +22,7 @@ namespace {
 
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
 #include "boost/cstdint.hpp" 
-namespace {
+namespace DataFormats_SiStripDigi {
   struct dictionary2 {
     edm::Wrapper<SiStripRawDigi > raw0;
     edm::Wrapper<std::vector<SiStripRawDigi> > raw1;
@@ -34,7 +34,7 @@ namespace {
 }
 
 #include "DataFormats/SiStripDigi/interface/SiStripProcessedRawDigi.h"
-namespace {
+namespace DataFormats_SiStripDigi {
   struct dictionary3 {
     edm::Wrapper<SiStripProcessedRawDigi > praw0;
     edm::Wrapper<std::vector<SiStripProcessedRawDigi> > praw1;

--- a/DataFormats/StdDictionaries/src/classes_map.h
+++ b/DataFormats/StdDictionaries/src/classes_map.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-namespace {
+namespace DataFormats_StdDictionaries {
   struct dictionarymap {
   std::map<int,int> dummywm4;
   std::map<int,std::pair<double,double> > dummymipdd;

--- a/DataFormats/StdDictionaries/src/classes_others.h
+++ b/DataFormats/StdDictionaries/src/classes_others.h
@@ -7,7 +7,7 @@
 #include <vector>
 #include <functional>
 
-namespace {
+namespace DataFormats_StdDictionaries {
   struct dictionaryothers {
   std::allocator<char> achar;
   std::allocator<double> adouble;

--- a/DataFormats/StdDictionaries/src/classes_pair.h
+++ b/DataFormats/StdDictionaries/src/classes_pair.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-namespace {
+namespace DataFormats_StdDictionaries {
   struct dictionarypair {
   std::pair<const int,int> newDummy00;
   std::pair<const int,std::pair<double,double> > newDummy01;

--- a/DataFormats/StdDictionaries/src/classes_vector.h
+++ b/DataFormats/StdDictionaries/src/classes_vector.h
@@ -6,7 +6,7 @@
 #include <string>
 #include <vector>
 
-namespace {
+namespace DataFormats_StdDictionaries {
   struct dictionaryvector {
   std::vector<bool> dummy13;
   std::vector<char*> dummy6p;

--- a/DataFormats/Streamer/src/classes.h
+++ b/DataFormats/Streamer/src/classes.h
@@ -1,7 +1,7 @@
 #include "DataFormats/Streamer/interface/StreamedProducts.h"
 
 #include <vector>
-namespace {
+namespace DataFormats_Streamer {
   struct dictionary {
   };
 }

--- a/DataFormats/TauReco/src/classes_1.h
+++ b/DataFormats/TauReco/src/classes_1.h
@@ -27,7 +27,7 @@
 #include <vector>
 #include <map>
 
-namespace {
+namespace DataFormats_TauReco {
   struct dictionary1 {
     reco::L2TauIsolationInfo                                    l2iI;
     reco::L2TauInfoAssociation                                  l2ts;

--- a/DataFormats/TauReco/src/classes_2.h
+++ b/DataFormats/TauReco/src/classes_2.h
@@ -27,7 +27,7 @@
 #include <vector>
 #include <map>
 
-namespace {
+namespace DataFormats_TauReco {
   struct dictionary2 {
 
     std::vector<reco::PFTau>                                    pft_v;

--- a/DataFormats/TauReco/src/classes_3.h
+++ b/DataFormats/TauReco/src/classes_3.h
@@ -27,7 +27,7 @@
 #include <vector>
 #include <map>
 
-namespace {
+namespace DataFormats_TauReco {
   struct dictionary4 {
 
     reco::CaloTauDiscriminatorAgainstElectronBase               calotde_b;

--- a/DataFormats/TauReco/src/classes_hlt.h
+++ b/DataFormats/TauReco/src/classes_hlt.h
@@ -20,7 +20,7 @@
 #include <vector>
 #include <map>
 
-namespace {
+namespace DataFormats_TauReco {
   struct dictionaryhlt {
     //Needed only in HLT-Open
     std::vector<reco::HLTTau>                                  ht_v;

--- a/DataFormats/TestObjects/src/classes.h
+++ b/DataFormats/TestObjects/src/classes.h
@@ -19,7 +19,7 @@
 #include "DataFormats/Common/interface/Holder.h"
 #include "DataFormats/Common/interface/RefToBaseProd.h"
 
-namespace {
+namespace DataFormats_TestObjects {
 struct dictionary {
   edm::Wrapper<edmtest::DummyProduct> dummyw12;
   edm::Wrapper<edmtest::IntProduct> dummyw13;

--- a/DataFormats/TrackCandidate/src/classes.h
+++ b/DataFormats/TrackCandidate/src/classes.h
@@ -6,7 +6,7 @@
 #include "DataFormats/TrackCandidate/interface/TrackCandidateSeedAssociation.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace {
+namespace DataFormats_TrackCandidate {
   struct dictionary {
     TrackCandidate tc;
     TrackCandidateCollection coll;

--- a/DataFormats/TrackReco/src/classes.h
+++ b/DataFormats/TrackReco/src/classes.h
@@ -30,7 +30,7 @@
 
 #include <vector>
 
-namespace {
+namespace DataFormats_TrackReco {
   struct dictionary {
     reco::TrackExtraCollection v3;
     edm::Wrapper<reco::TrackExtraCollection> c3;

--- a/DataFormats/TrackerCommon/src/classes.h
+++ b/DataFormats/TrackerCommon/src/classes.h
@@ -2,7 +2,7 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include <vector>
 
-namespace { class dictionary {
+namespace DataFormats_TrackerCommon { class dictionary {
     ClusterSummary dummy0;
     edm::Wrapper<ClusterSummary> dummy1;
 };}

--- a/DataFormats/TrackerRecHit2D/src/classes.h
+++ b/DataFormats/TrackerRecHit2D/src/classes.h
@@ -29,7 +29,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiTrackerMultiRecHit.h"
 #include <vector>
 
-namespace {
+namespace DataFormats_TrackerRecHit2D {
   struct dictionary {
     ProjectedSiStripRecHit2D projHit;   
     SiStripRecHit2D a1;

--- a/DataFormats/TrackingRecHit/src/classes.h
+++ b/DataFormats/TrackingRecHit/src/classes.h
@@ -7,7 +7,7 @@
 #include "DataFormats/TrackingRecHit/interface/RecSegment.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace {
+namespace DataFormats_TrackingRecHit {
   struct dictionary {
     AlgebraicSymMatrix as;
 

--- a/DataFormats/TrackingSeed/src/classes.h
+++ b/DataFormats/TrackingSeed/src/classes.h
@@ -5,7 +5,7 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include <vector>
 
-namespace {
+namespace DataFormats_TrackingSeed {
   struct dictionary {
     edm::Wrapper<TrackingSeedCollection> trackingSeedCollectionWrapper;
   };

--- a/DataFormats/TrajectorySeed/src/classes.h
+++ b/DataFormats/TrajectorySeed/src/classes.h
@@ -7,7 +7,7 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefToBase.h"
 
-namespace {
+namespace DataFormats_TrajectorySeed {
   struct dictionary {
     std::vector<TrajectorySeed> v1;
     TrajectorySeedCollection c1;

--- a/DataFormats/TrajectoryState/src/classes.h
+++ b/DataFormats/TrajectoryState/src/classes.h
@@ -1,6 +1,6 @@
 #include "DataFormats/TrajectoryState/interface/PTrajectoryStateOnDet.h"
 
-namespace {
+namespace DataFormats_TrajectoryState {
   struct dictionary {
     PTrajectoryStateOnDet v1;
     LocalTrajectoryParameters p1;

--- a/DataFormats/V0Candidate/src/classes.h
+++ b/DataFormats/V0Candidate/src/classes.h
@@ -1,6 +1,6 @@
 #include "DataFormats/V0Candidate/interface/V0Candidate.h"
 
-namespace {
+namespace DataFormats_V0Candidate {
   struct dictionary {
     std::vector<reco::V0Candidate> v01;
     edm::Wrapper<std::vector<reco::V0Candidate> > wv01;

--- a/DataFormats/VZero/src/classes.h
+++ b/DataFormats/VZero/src/classes.h
@@ -2,7 +2,7 @@
 #include "DataFormats/VZero/interface/VZero.h"
 #include <vector>
 
-namespace {
+namespace DataFormats_VZero {
   struct dictionary {
     reco::VZeroCollection v9;
     edm::Wrapper<reco::VZeroCollection> c9;

--- a/DataFormats/VertexReco/src/classes.h
+++ b/DataFormats/VertexReco/src/classes.h
@@ -17,7 +17,7 @@
 #include <vector>
 #include <utility>
 
-namespace {
+namespace DataFormats_VertexReco {
   struct dictionary {
     reco::Vertex rv1;
     std::vector<reco::Vertex> v1;

--- a/DataFormats/WrappedStdDictionaries/src/classes.h
+++ b/DataFormats/WrappedStdDictionaries/src/classes.h
@@ -7,7 +7,7 @@
 #include <set>
 #include <string>
 
-namespace {
+namespace DataFormats_WrappedStdDictionaries {
   struct dictionary {
   edm::Wrapper<std::vector<unsigned long> > dummy1;
   edm::Wrapper<std::vector<unsigned int> > dummy2;

--- a/FWCore/MessageLogger/src/classes.h
+++ b/FWCore/MessageLogger/src/classes.h
@@ -1,7 +1,7 @@
 #include <vector>
 #include "FWCore/MessageLogger/interface/ErrorSummaryEntry.h"
 
-namespace {
+namespace FWCore_MessageLogger {
   struct dictionary {
     std::vector<edm::ErrorSummaryEntry> w_v_es;
   };

--- a/FWCore/Skeletons/scripts/mkTemplates/DataPkg/classes.h
+++ b/FWCore/Skeletons/scripts/mkTemplates/DataPkg/classes.h
@@ -4,7 +4,7 @@
 #include "__subsys__/__pkgname__/interface/YOUR_CLASS_GOES_HERE.h"
 #include <vector>
 
-namespace {
+namespace FWCore_Skeletons {
    struct __subsys_____class__ {
       //add 'dummy' Wrapper variable for each class type you put into the Event
       edm::Wrapper<YOUR_CLASS_GOES_HERE> dummy1;

--- a/FWCore/Skeletons/scripts/mkTemplates/TSelector/classes.h
+++ b/FWCore/Skeletons/scripts/mkTemplates/TSelector/classes.h
@@ -1,6 +1,6 @@
 #include "__subsys__/__class__/src/__class__.h"
 
-namespace {
+namespace FWCore_Skeletons {
   struct dictionary {
   };
 }

--- a/FastSimDataFormats/External/src/classes.h
+++ b/FastSimDataFormats/External/src/classes.h
@@ -2,7 +2,7 @@
 #include "FastSimDataFormats/External/interface/FastTrackerClusterCollection.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace { 
+namespace FastSimDataFormats_External {
   struct dictionary { // dummy is a dummy
     
     FastL1BitInfoCollection dummy01;

--- a/FastSimDataFormats/NuclearInteractions/src/classes.h
+++ b/FastSimDataFormats/NuclearInteractions/src/classes.h
@@ -14,7 +14,7 @@
 #include <DataFormats/Common/interface/ClonePolicy.h>
 
 
-namespace { 
+namespace FastSimDataFormats_NuclearInteractions {
   struct dictionary {
     
     FSimVertexType                                        dummy0;

--- a/FastSimDataFormats/PileUpEvents/src/classes.h
+++ b/FastSimDataFormats/PileUpEvents/src/classes.h
@@ -1,6 +1,6 @@
 #include "FastSimDataFormats/PileUpEvents/interface/PUEvent.h"
 
-namespace { 
+namespace FastSimDataFormats_PileUpEvents {
   struct dictionary {
 
 

--- a/Fireworks/Core/src/classes.h
+++ b/Fireworks/Core/src/classes.h
@@ -31,7 +31,7 @@
 #include "Fireworks/Core/interface/FWTSelectorToEventList.h"
 #include "Fireworks/Core/src/FWEveDigitSetScalableMarker.h"
 #include "Fireworks/Core/src/FW3DViewDistanceMeasureTool.h"
-namespace {
+namespace Fireworks_Core {
    struct Fireworks_Core {
       //add 'dummy' Wrapper variable for each class type you put into the Event
       //FWDisplayEvent de;

--- a/PhysicsTools/FWLite/src/classes.h
+++ b/PhysicsTools/FWLite/src/classes.h
@@ -14,7 +14,7 @@ namespace reco { namespace parser {
 } }
 
 
-namespace {
+namespace PhysicsTools_FWLite {
  struct dictionary {
     // all these are templates, so we need to instantiate them
     reco::parser::ExpressionPtr eptr;

--- a/PhysicsTools/IsolationUtils/src/classes.h
+++ b/PhysicsTools/IsolationUtils/src/classes.h
@@ -3,7 +3,7 @@
 
 typedef PtIsolationAlgo<reco::Candidate,reco::CandidateCollection> CandPtIsolationAlgo;
 
-namespace {
+namespace PhysicsTools_IsolationUtils {
   struct dictionary {
     CandPtIsolationAlgo iso1;
   };

--- a/PhysicsTools/MVAComputer/src/classes.h
+++ b/PhysicsTools/MVAComputer/src/classes.h
@@ -6,7 +6,7 @@
 #include "PhysicsTools/MVAComputer/interface/TreeReader.h"
 
 #ifdef __GCCXML__
-namespace { // anonymous
+namespace PhysicsTools_MVAComputer { // anonymous
 struct dictionary {
 
 std::vector<PhysicsTools::Variable::Value> vv;

--- a/PhysicsTools/MVATrainer/src/classes.h
+++ b/PhysicsTools/MVATrainer/src/classes.h
@@ -1,7 +1,7 @@
 #include "PhysicsTools/MVATrainer/interface/MVATrainer.h"
 #include "PhysicsTools/MVATrainer/interface/TreeTrainer.h"
 
-namespace { // anonymous
+namespace PhysicsTools_MVATrainer { // anonymous
   struct dictionary {
 
   };

--- a/PhysicsTools/ParallelAnalysis/src/classes.h
+++ b/PhysicsTools/ParallelAnalysis/src/classes.h
@@ -1,6 +1,6 @@
 #include "PhysicsTools/ParallelAnalysis/interface/TrackTSelector.h"
 
-namespace {
+namespace PhysicsTools_ParallelAnalysis {
   struct dictionary {
   };
 }

--- a/PhysicsTools/PatUtils/src/classes.h
+++ b/PhysicsTools/PatUtils/src/classes.h
@@ -1,5 +1,5 @@
 #include "PhysicsTools/PatUtils/interface/PATDiObjectProxy.h"
 
-namespace { struct dictionary  {  // apparenlty better than namespace { namespace {
+namespace PhysicsTools_PatUtils { struct dictionary { // apparenlty better than echo namespace PhysicsTools_PatUtils { echo namespace PhysicsTools_PatUtils {
     pat::DiObjectProxy patDiObjectProxy; 
 }; }

--- a/PhysicsTools/SelectorUtils/src/classes.h
+++ b/PhysicsTools/SelectorUtils/src/classes.h
@@ -12,7 +12,7 @@
 #include "PhysicsTools/SelectorUtils/interface/RunLumiSelector.h"
 
 
-namespace {
+namespace PhysicsTools_SelectorUtils {
   struct dictionary {
 
     pat::strbitset strbitset;

--- a/PhysicsTools/TagAndProbe/src/classes.h
+++ b/PhysicsTools/TagAndProbe/src/classes.h
@@ -1,3 +1,0 @@
-namespace tagandprobe {
-  struct dummy{};
-}

--- a/PhysicsTools/TagAndProbe/src/classes_def.xml
+++ b/PhysicsTools/TagAndProbe/src/classes_def.xml
@@ -1,3 +1,0 @@
-<lcgdict>
-   <class name="tagandprobe::dummy"/>
-</lcgdict>

--- a/PhysicsTools/Utilities/src/classes.h
+++ b/PhysicsTools/Utilities/src/classes.h
@@ -6,7 +6,7 @@
 #include "PhysicsTools/Utilities/interface/Lumi3DReWeighting.h"
 
 
-namespace {
+namespace PhysicsTools_Utilities {
   struct dictionary {
 
     reweight::PoissonMeanShifter a;

--- a/RecoParticleFlow/PFRootEvent/src/classes.h
+++ b/RecoParticleFlow/PFRootEvent/src/classes.h
@@ -17,7 +17,7 @@
  
  
  
-namespace {
+namespace RecoParticleFlow_PFRootEvent {
   struct dictionary {
 /*      GPFRecHit dummy1; */
 /*      std::vector<std::vector<GPFRecHit> > dummy2; */

--- a/RecoParticleFlow/PFRootEvent/template/src/classes.h
+++ b/RecoParticleFlow/PFRootEvent/template/src/classes.h
@@ -1,6 +1,6 @@
 #include "RecoParticleFlow/MyPFRootEvent/interface/MyPFRootEventManager.h"
 
-namespace { 
+namespace RecoParticleFlow_PFRootEvent {
   struct dictionary {
 
   };

--- a/RecoTracker/MeasurementDet/src/classes.h
+++ b/RecoTracker/MeasurementDet/src/classes.h
@@ -1,7 +1,7 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 
-namespace { struct dictionary {
+namespace RecoTracker_MeasurementDet { struct dictionary {
   MeasurementTrackerEvent dummy;
   edm::Wrapper<MeasurementTrackerEvent> dummy1;
 };}

--- a/RecoTracker/TkSeedGenerator/src/classes.h
+++ b/RecoTracker/TkSeedGenerator/src/classes.h
@@ -1,5 +1,5 @@
 #include "RecoTracker/TkSeedGenerator/interface/ClusterChecker.h"
-namespace {
+namespace RecoTracker_TkSeedGenerator {
     struct dictionary {
         reco::utils::ClusterTotals totals;
     };

--- a/SimDataFormats/CaloHit/src/classes.h
+++ b/SimDataFormats/CaloHit/src/classes.h
@@ -4,7 +4,7 @@
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace {
+namespace SimDataFormats_CaloHit {
   struct dictionary {
     HFShowerLibraryEventInfo                             rv1;
     edm::Wrapper<HFShowerLibraryEventInfo>               p1;

--- a/SimDataFormats/CaloTest/src/classes.h
+++ b/SimDataFormats/CaloTest/src/classes.h
@@ -1,7 +1,7 @@
 #include "SimDataFormats/CaloTest/interface/HcalTestHistoClass.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace {
+namespace SimDataFormats_CaloTest {
   struct dictionary {
     HcalTestHistoClass theHcalTestHistoClass;
   };

--- a/SimDataFormats/CrossingFrame/src/classes.h
+++ b/SimDataFormats/CrossingFrame/src/classes.h
@@ -12,7 +12,7 @@
 #include <map>
 #include <string>
 
-namespace {
+namespace SimDataFormats_CrossingFrame {
   struct dictionary {
  	CrossingFrame<PSimHit> dummy0;
 	

--- a/SimDataFormats/DigiSimLinks/src/classes.h
+++ b/SimDataFormats/DigiSimLinks/src/classes.h
@@ -4,7 +4,7 @@
 #include <vector>
 #include <map>
 
-namespace{ 
+namespace SimDataFormats_DigiSimLinks {
   struct dictionary {
 
   DTDigiSimLink dummy0;

--- a/SimDataFormats/EcalTestBeam/src/classes.h
+++ b/SimDataFormats/EcalTestBeam/src/classes.h
@@ -4,7 +4,7 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include <vector>
 
-namespace {
+namespace SimDataFormats_EcalTestBeam {
   struct dictionary {
     PEcalTBInfo                 theInfo;
     edm::Wrapper<PEcalTBInfo>   theEcalTBInfo;

--- a/SimDataFormats/EncodedEventId/src/classes.h
+++ b/SimDataFormats/EncodedEventId/src/classes.h
@@ -2,7 +2,7 @@
 #include <boost/cstdint.hpp> 
 #include <vector>
 
-namespace {
+namespace SimDataFormats_EncodedEventId {
   struct dictionary {
     std::vector<EncodedEventId> dummy;
   };

--- a/SimDataFormats/Forward/src/classes.h
+++ b/SimDataFormats/Forward/src/classes.h
@@ -4,7 +4,7 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include <vector>
 
-namespace {
+namespace SimDataFormats_Forward {
   struct dictionary {
     TotemTestHistoClass                   theTotemTestHisto;
     edm::Wrapper<TotemTestHistoClass>     theTotemTestHistoClass;

--- a/SimDataFormats/GeneratorProducts/src/classes.h
+++ b/SimDataFormats/GeneratorProducts/src/classes.h
@@ -18,7 +18,7 @@
 
 #include <HepMC/GenRanges.h>
 
-namespace {
+namespace SimDataFormats_GeneratorProducts {
 	struct dictionary {
 		// HepMC externals used in HepMCProduct
 

--- a/SimDataFormats/HcalTestBeam/src/classes.h
+++ b/SimDataFormats/HcalTestBeam/src/classes.h
@@ -4,7 +4,7 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include <vector>
 
-namespace {
+namespace SimDataFormats_HcalTestBeam {
   struct dictionary {
     PHcalTB04Info                    theInfo4;
     edm::Wrapper<PHcalTB04Info>      theTB04Info;

--- a/SimDataFormats/HiGenData/src/classes.h
+++ b/SimDataFormats/HiGenData/src/classes.h
@@ -1,7 +1,7 @@
 #include "SimDataFormats/HiGenData/interface/GenHIEvent.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace { 
+namespace SimDataFormats_HiGenData {
   struct dictionary {
     edm::GenHIEvent dummy0;
     edm::Wrapper<edm::GenHIEvent> dummy1;

--- a/SimDataFormats/JetMatching/src/classes.h
+++ b/SimDataFormats/JetMatching/src/classes.h
@@ -7,7 +7,7 @@
 #include "SimDataFormats/JetMatching/interface/MatchedPartons.h"
 #include "SimDataFormats/JetMatching/interface/JetMatchedPartons.h"
 
-namespace {
+namespace SimDataFormats_JetMatching {
   struct dictionary {
     reco::JetFlavour                                 jf;
     reco::JetFlavour::Leptons                        jflep;

--- a/SimDataFormats/PileupSummaryInfo/src/classes.h
+++ b/SimDataFormats/PileupSummaryInfo/src/classes.h
@@ -3,7 +3,7 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include <vector>
 
-namespace { 
+namespace SimDataFormats_PileupSummaryInfo {
   struct dictionary {
     PileupSummaryInfo dummy0;
     std::vector<PileupSummaryInfo> dummy1;

--- a/SimDataFormats/RPCDigiSimLink/src/classes.h
+++ b/SimDataFormats/RPCDigiSimLink/src/classes.h
@@ -12,7 +12,7 @@
 
 #include "SimDataFormats/RPCDigiSimLink/interface/RPCDigiSimLink.h"
 
-namespace {
+namespace SimDataFormats_RPCDigiSimLink {
   struct dictionary {
     edm::Wrapper<RPCDigiSimLink> RPCDigiSimLinkWrapper;
     edm::Wrapper< std::vector<RPCDigiSimLink>  > RPCDigiSimLinkVector;

--- a/SimDataFormats/RandomEngine/src/classes.h
+++ b/SimDataFormats/RandomEngine/src/classes.h
@@ -4,7 +4,7 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include <vector>
 
-namespace { 
+namespace SimDataFormats_RandomEngine {
   struct dictionary {
     edm::Wrapper<std::vector<RandomEngineState> > dummy1;
     edm::Wrapper<edm::RandomEngineStates> dummy2;

--- a/SimDataFormats/Track/src/classes.h
+++ b/SimDataFormats/Track/src/classes.h
@@ -5,7 +5,7 @@
 
 #include <vector>
  
-namespace {
+namespace SimDataFormats_Track {
   struct dictionary {
     SimTrack dummy22;
     edm::SimTrackContainer dummy222;

--- a/SimDataFormats/TrackerDigiSimLink/src/classes.h
+++ b/SimDataFormats/TrackerDigiSimLink/src/classes.h
@@ -9,7 +9,7 @@
 #include "SimDataFormats/TrackerDigiSimLink/interface/StripDigiSimLink.h"
 #include "SimDataFormats/TrackerDigiSimLink/interface/StripCompactDigiSimLinks.h"
 
-namespace {
+namespace SimDataFormats_TrackerDigiSimLink {
   struct dictionary {
    edm::Wrapper<PixelDigiSimLink> PixelLink1;
     edm::Wrapper< std::vector<PixelDigiSimLink>  > PixelLink2;

--- a/SimDataFormats/TrackingAnalysis/src/classes.h
+++ b/SimDataFormats/TrackingAnalysis/src/classes.h
@@ -6,10 +6,8 @@
 #include "DataFormats/Common/interface/AssociationMapHelpers.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace
-{
-struct dictionary
-{
+namespace SimDataFormats_TrackingAnalysis {
+  struct dictionary {
     TrackingParticle dummy10;
     TrackingParticleContainer dummy11;
     TrackingParticleCollection c1;

--- a/SimDataFormats/TrackingHit/src/classes.h
+++ b/SimDataFormats/TrackingHit/src/classes.h
@@ -2,7 +2,7 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace {
+namespace SimDataFormats_TrackingHit {
   struct dictionary {
     PSimHit dummy444;
     edm::PSimHitContainer sdummy777;

--- a/SimDataFormats/ValidationFormats/src/classes.h
+++ b/SimDataFormats/ValidationFormats/src/classes.h
@@ -7,7 +7,7 @@
 #include "SimDataFormats/ValidationFormats/interface/MaterialAccountingDetector.h"
 #include "SimDataFormats/ValidationFormats/interface/MaterialAccountingTrack.h"
 
-namespace {
+namespace SimDataFormats_ValidationFormats {
   struct dictionary {
     std::vector<PGlobalSimHit::Vtx>                         dummy1;
     std::vector<PGlobalSimHit::Trk>                         dummy2;

--- a/SimDataFormats/Vertex/src/classes.h
+++ b/SimDataFormats/Vertex/src/classes.h
@@ -5,7 +5,7 @@
 
 #include <vector>
  
-namespace {
+namespace SimDataFormats_Vertex {
   struct dictionary {
     SimVertex dummy33;
     std::vector<SimVertex> dummy333;

--- a/SimGeneral/TrackingAnalysis/src/classes.h
+++ b/SimGeneral/TrackingAnalysis/src/classes.h
@@ -3,7 +3,7 @@
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
-namespace {
+namespace SimGeneral_TrackingAnalysis {
   struct dictionary {
     std::pair<TrackingParticleRef, TrackPSimHitRef> dummy13;
     edm::Wrapper<std::pair<TrackingParticleRef, TrackPSimHitRef> > dummy14;

--- a/SimTracker/TrackHistory/src/classes.h
+++ b/SimTracker/TrackHistory/src/classes.h
@@ -6,16 +6,13 @@
 #include "SimTracker/TrackHistory/interface/VertexCategories.h"
 
 
-namespace
-{
-struct dictionary
-{
+namespace SimTracker_TrackHistory {
+  struct dictionary {
     // Dictionaires for Track and Vertex categories
 
     std::vector<TrackCategories> dummy01;
     std::vector<VertexCategories> dummy02;
     edm::Wrapper<std::vector<TrackCategories> > dummy03;
     edm::Wrapper<std::vector<VertexCategories> > dummy04;
-};
+  };
 }
-

--- a/SimTracker/TrackerHitAssociation/src/classes.h
+++ b/SimTracker/TrackerHitAssociation/src/classes.h
@@ -6,7 +6,7 @@
 #include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
 
 #include "DataFormats/Common/interface/AssociationMap.h"
-namespace {
+namespace SimTracker_TrackerHitAssociation {
   struct dictionary {
     edm::AssociationMap<edm::OneToMany<std::vector<SimTrack>, std::vector<OmniClusterRef>, unsigned int > > dummy01;
     edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<SimTrack>, std::vector<OmniClusterRef>, unsigned int > > > dummy02;

--- a/TBDataFormats/EcalTBObjects/src/classes.h
+++ b/TBDataFormats/EcalTBObjects/src/classes.h
@@ -5,7 +5,7 @@
 #include "TBDataFormats/EcalTBObjects/interface/EcalTBHodoscopeRecInfo.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace {
+namespace TBDataFormats_EcalTBObjects {
   struct dictionary {
     std::vector<EcalTBTDCSample> vTDC_;
     std::vector<EcalTBHodoscopePlaneRawHits> vHplaneRawHits_;

--- a/TBDataFormats/HcalTBObjects/src/classes.h
+++ b/TBDataFormats/HcalTBObjects/src/classes.h
@@ -6,7 +6,7 @@
 #include "TBDataFormats/HcalTBObjects/interface/HcalTBParticleId.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
-namespace {
+namespace TBDataFormats_HcalTBObjects {
   struct dictionary {
 
     edm::Wrapper<HcalTBTriggerData>   theTriggerData_;

--- a/TrackingTools/GsfTracking/src/classes.h
+++ b/TrackingTools/GsfTracking/src/classes.h
@@ -7,7 +7,7 @@
 #include "TrackingTools/GsfTracking/interface/GsfTrackConstraintAssociation.h"
 #include <vector>
 
-namespace {
+namespace TrackingTools_GsfTracking {
   struct dictionary {
 
     TrajGsfTrackAssociationCollection ttam;

--- a/TrackingTools/PatternTools/src/classes.h
+++ b/TrackingTools/PatternTools/src/classes.h
@@ -25,7 +25,7 @@
 #include "TrackingTools/PatternTools/interface/TrackConstraintAssociation.h"
 #include <vector>
 
-namespace {
+namespace TrackingTools_PatternTools {
   struct dictionary {
     std::vector<Trajectory> kk;
     edm::Wrapper<std::vector<Trajectory> > trajCollWrapper;

--- a/TrackingTools/TrajectoryState/src/classes.h
+++ b/TrackingTools/TrajectoryState/src/classes.h
@@ -29,7 +29,7 @@ typedef edm::Ref<TrackParamConstraintAssociationCollection> TrackParamConstraint
 typedef edm::RefProd<TrackParamConstraintAssociationCollection> TrackParamConstraintAssociationRefProd;
 typedef edm::RefVector<TrackParamConstraintAssociationCollection> TrackParamConstraintAssociationRefVector;
 
-namespace {
+namespace TrackingTools_TrajectoryState {
   struct dictionary {
     std::vector<TrackParamConstraint> jjj2;
     edm::Wrapper<std::vector<TrackParamConstraint> > jjj3;

--- a/Validation/RecoParticleFlow/src/classes.h
+++ b/Validation/RecoParticleFlow/src/classes.h
@@ -1,9 +1,3 @@
 #include "Validation/RecoParticleFlow/interface/TH2Analyzer.h"
 #include "Validation/RecoParticleFlow/interface/NicePlot.h"
 #include "Validation/RecoParticleFlow/interface/Comparator.h"
-
-namespace {
-  namespace {
-      
-  }
-}


### PR DESCRIPTION
The patch does minor cleanups and create unique namespaces based
on package name.

The change is needed for ROOT6 as classes*h files becomes a payload
embedded into ROOT6 dictionary, which is executed in an interpreter
(Cling) during dictionary loading procedure.

Very minimal misc. cleanups were done in some cases. Should not change
checksum, it's a technical change. Tested on CMSSW_7_0_ROOT6_X_2013-11-22-0200
only currently. Resolves 10 001 errors on ROOT6 build.

Please, review.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
