### PR TITLE
Remove unused typedef reco::electronephltseed_iterator

### DIFF
--- a/DataFormats/EgammaReco/interface/ElectronSeedFwd.h
+++ b/DataFormats/EgammaReco/interface/ElectronSeedFwd.h
@@ -16,8 +16,6 @@ namespace reco {
   typedef edm::RefProd<ElectronSeedCollection> ElectronSeedRefProd;
   /// vector of objects in the same collection of ElectronSeed objects
   typedef edm::RefVector<ElectronSeedCollection> ElectronSeedRefVector;
-  /// iterator over a vector of reference to ElectronSeed objects
-  typedef ElectronSeedRefVector::iterator electronephltseed_iterator;
 }
 
 #endif

--- a/DataFormats/ParticleFlowReco/interface/ConvBremSeedFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/ConvBremSeedFwd.h
@@ -15,8 +15,6 @@ namespace reco {
   typedef edm::RefProd<ConvBremSeedCollection> ConvBremSeedRefProd;
   /// vector of objects in the same collection of ConvBremSeed objects
   typedef edm::RefVector<ConvBremSeedCollection> ConvBremSeedRefVector;
-  /// iterator over a vector of reference to ConvBremSeed objects
-  typedef ConvBremSeedRefVector::iterator electronephltseed_iterator;
 }
 
 #endif


### PR DESCRIPTION
Typdef `electronephltseed_iterator' is defined twice in`reco' namespace
in DataFormats/EgammaReco and DataFormats/ParticleFlowReco. This cannot
be loaded into a single translation unit, othwerwise it triggers typedef
redefinition with different type error.

Git grep shows that these typedefs are not used in CMSSW code.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
