### PR TITLE
Fix memory leak in MomentumScaleCalibration.

### DIFF
--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitUtils.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitUtils.cc
@@ -1989,13 +1989,13 @@ std::vector<TGraphErrors*> MuScleFitUtils::fitMass (TH2F* histo) {
 
   // Cleanup
   // -------
-  delete x;
-  delete ym;
-  delete eym;
-  delete yw;
-  delete eyw;
-  delete yc;
-  delete e;
+  delete[] x;
+  delete[] ym;
+  delete[] eym;
+  delete[] yw;
+  delete[] eyw;
+  delete[] yc;
+  delete[] e;
   delete fitFcn;
 
   results.push_back(grM);


### PR DESCRIPTION
As seen in https://cmssdt.cern.ch/SDT/jenkins-artifacts/ib-static-analysis/CMSSW_7_0_X_2013-11-23-0200/slc5_amd64_gcc481/llvm-analysis/report-Lsc9ur.html#EndPath
