### PR TITLE
Add missing iostream includes

### DIFF
--- a/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
+++ b/FWCore/TFWLiteSelector/src/TFWLiteSelectorBasic.cc
@@ -52,6 +52,11 @@
 #include "TFile.h"
 #include "TTree.h"
 
+#include <iostream>
+#include <memory>
+#include <string>
+#include <vector>
+
 namespace edm {
   namespace root {
     class FWLiteDelayedReader : public DelayedReader {

--- a/IOPool/Streamer/src/StreamSerializer.cc
+++ b/IOPool/Streamer/src/StreamSerializer.cc
@@ -25,7 +25,8 @@
 #include "zlib.h"
 #include <algorithm>
 #include <cstdlib>
-#include <list>
+#include <iostream>
+#include <vector>
 
 namespace edm {
 

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -15,9 +15,12 @@
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 
+#include <iostream>
+#include <memory>
 #include <string>
 #include <sys/time.h>
 #include <unistd.h>
+#include <vector>
 #include "zlib.h"
 
 namespace {

--- a/L1Trigger/GlobalTrigger/src/CompareToObjectMapRecord.cc
+++ b/L1Trigger/GlobalTrigger/src/CompareToObjectMapRecord.cc
@@ -16,6 +16,7 @@
 #include "L1Trigger/GlobalTrigger/interface/CompareToObjectMapRecord.h"
 
 #include <algorithm>
+#include <iostream>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Three packages no longer compile against ROOT6 due to missing includes of "iostream".  This trivial pull request adds these missing includes, as well as other missing includes of system headers in those four files that were being modified anyway.
Please merge as soon as convenient.
