### PR TITLE
add a StreamContext to the Pre/PostSource signals

### DIFF
--- a/DQMServices/Core/src/DQMService.cc
+++ b/DQMServices/Core/src/DQMService.cc
@@ -34,6 +34,10 @@ static void
 restrictDQMAccessM(const edm::ModuleDescription &)
 { restrictDQMAccess(); }
 
+static void
+restrictDQMAccessS(edm::StreamID)
+{ restrictDQMAccess(); }
+
 /// Release access to the DQM core.
 static void
 releaseDQMAccess(void)
@@ -41,6 +45,10 @@ releaseDQMAccess(void)
 
 static void
 releaseDQMAccessM(const edm::ModuleDescription &)
+{ releaseDQMAccess(); }
+
+static void
+releaseDQMAccessS(edm::StreamID)
 { releaseDQMAccess(); }
 
 // -------------------------------------------------------------------
@@ -53,8 +61,8 @@ DQMService::DQMService(const edm::ParameterSet &pset, edm::ActivityRegistry &ar)
 {
   ar.watchPreSourceConstruction(&restrictDQMAccessM);
   ar.watchPostSourceConstruction(&releaseDQMAccessM);
-  ar.watchPreSource(&restrictDQMAccess);
-  ar.watchPostSource(&releaseDQMAccess);
+  ar.watchPreSourceEvent(&restrictDQMAccessS);
+  ar.watchPostSourceEvent(&releaseDQMAccessS);
   ar.watchPreModule(&restrictDQMAccessM);
   ar.watchPostModule(&releaseDQMAccessM);
   ar.watchPostProcessEvent(this, &DQMService::flush);

--- a/DataFormats/GeometrySurface/plugins/BlockWipedAllocatorService.cc
+++ b/DataFormats/GeometrySurface/plugins/BlockWipedAllocatorService.cc
@@ -50,7 +50,6 @@ public:
 
     blockWipedPool(&pool);
     if (m_useAlloc) BlockWipedPoolAllocated::usePool();
-    iAR.watchPreSource(this,&BlockWipedAllocatorService::preSource);
     iAR.watchPreProcessEvent(this,&BlockWipedAllocatorService::preEventProcessing);
     iAR.watchPostEndJob(this,&BlockWipedAllocatorService::postEndJob);
     iAR.watchPreModule(this,&BlockWipedAllocatorService::preModule);
@@ -59,11 +58,6 @@ public:
 
   // wipe the workspace before each event
   void preEventProcessing(const edm::EventID&, const edm::Timestamp&) { wiper();}
-
-  // nope event-principal deleted in source
-  void preSource() {
-   // wiper();
-  }
 
   void dump() {
     if (m_silent) return;

--- a/EventFilter/Utilities/interface/MicroStateServiceClassic.h
+++ b/EventFilter/Utilities/interface/MicroStateServiceClassic.h
@@ -37,9 +37,8 @@ namespace evf{
       void preEventProcessing(const edm::EventID&, const edm::Timestamp&);
       void postEventProcessing(const edm::Event&, const edm::EventSetup&);
       
-      void preSource();
-      void postSource();
-      
+      void preSourceEvent(edm::StreamID);
+      void postSourceEvent(edm::StreamID);
       
       void preModule(const edm::ModuleDescription&);
       void postModule(const edm::ModuleDescription&);

--- a/EventFilter/Utilities/plugins/FastMonitoringService.cc
+++ b/EventFilter/Utilities/plugins/FastMonitoringService.cc
@@ -44,8 +44,8 @@ namespace evf{
     reg.watchPreProcessPath(this,&FastMonitoringService::preProcessPath);
     reg.watchPreProcessEvent(this,&FastMonitoringService::preEventProcessing);
     reg.watchPostProcessEvent(this,&FastMonitoringService::postEventProcessing);
-    reg.watchPreSource(this,&FastMonitoringService::preSource);
-    reg.watchPostSource(this,&FastMonitoringService::postSource);
+    reg.watchPreSourceEvent(this,&FastMonitoringService::preSourceEvent);
+    reg.watchPostSourceEvent(this,&FastMonitoringService::postSourceEvent);
   
     reg.watchPreModule(this,&FastMonitoringService::preModule);
     reg.watchPostModule(this,&FastMonitoringService::postModule);
@@ -246,13 +246,14 @@ namespace evf{
     fmt_.m_data.processedJ_.value()++;
     fmt_.monlock_.unlock();
   }
-  void FastMonitoringService::preSource()
+
+  void FastMonitoringService::preSourceEvent(edm::StreamID)
   {
     //    boost::mutex::scoped_lock sl(lock_);
     fmt_.m_data.microstate_ = &reservedMicroStateNames[mIdle];
   }
 
-  void FastMonitoringService::postSource()
+  void FastMonitoringService::postSourceEvent(edm::StreamID)
   {
     //    boost::mutex::scoped_lock sl(lock_);
     fmt_.m_data.microstate_ = &reservedMicroStateNames[mFwkOvh];

--- a/EventFilter/Utilities/plugins/FastMonitoringService.h
+++ b/EventFilter/Utilities/plugins/FastMonitoringService.h
@@ -118,8 +118,8 @@ namespace evf{
       void preEventProcessing(const edm::EventID&, const edm::Timestamp&);
       void postEventProcessing(const edm::Event&, const edm::EventSetup&);
       
-      void preSource();
-      void postSource();
+      void preSourceEvent(edm::StreamID);
+      void postSourceEvent(edm::StreamID);
       
       void preModule(const edm::ModuleDescription&);
       void postModule(const edm::ModuleDescription&);

--- a/EventFilter/Utilities/src/MicroStateServiceClassic.cc
+++ b/EventFilter/Utilities/src/MicroStateServiceClassic.cc
@@ -15,8 +15,8 @@ namespace evf{
   
     reg.watchPreProcessEvent(this,&MicroStateServiceClassic::preEventProcessing);
     reg.watchPostProcessEvent(this,&MicroStateServiceClassic::postEventProcessing);
-    reg.watchPreSource(this,&MicroStateServiceClassic::preSource);
-    reg.watchPostSource(this,&MicroStateServiceClassic::postSource);
+    reg.watchPreSourceEvent(this,&MicroStateServiceClassic::preSourceEvent);
+    reg.watchPostSourceEvent(this,&MicroStateServiceClassic::postSourceEvent);
   
     reg.watchPreModule(this,&MicroStateServiceClassic::preModule);
     reg.watchPostModule(this,&MicroStateServiceClassic::postModule);
@@ -53,13 +53,14 @@ namespace evf{
     boost::mutex::scoped_lock sl(lock_);
     microstate2_ = &input;
   }
-  void MicroStateServiceClassic::preSource()
+
+  void MicroStateServiceClassic::preSourceEvent(edm::StreamID)
   {
     boost::mutex::scoped_lock sl(lock_);
     microstate2_ = &input;
   }
 
-  void MicroStateServiceClassic::postSource()
+  void MicroStateServiceClassic::postSourceEvent(edm::StreamID)
   {
     boost::mutex::scoped_lock sl(lock_);
     microstate2_ = &fwkovh;

--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -109,10 +109,10 @@ namespace edm {
     ItemType nextItemType();
 
     /// Read next event
-    void readEvent(EventPrincipal& ep, StreamContext *);
+    void readEvent(EventPrincipal& ep, StreamContext &);
 
     /// Read a specific event
-    bool readEvent(EventPrincipal& ep, EventID const&, StreamContext *);
+    bool readEvent(EventPrincipal& ep, EventID const&, StreamContext &);
 
     /// Read next luminosity block Auxilary
     boost::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary();
@@ -279,9 +279,15 @@ namespace edm {
 
     class EventSourceSentry {
     public:
-      explicit EventSourceSentry(InputSource const& source);
+      EventSourceSentry(InputSource const& source, StreamContext & sc);
+      ~EventSourceSentry();
+
+      EventSourceSentry(EventSourceSentry const&) = delete; // Disallow copying and moving
+      EventSourceSentry& operator=(EventSourceSentry const&) = delete; // Disallow copying and moving
+
     private:
-      SourceSentry sentry_;
+      InputSource const& source_;
+      StreamContext & sc_;
     };
 
     class LumiSourceSentry {
@@ -386,7 +392,7 @@ namespace edm {
     virtual void readRun_(RunPrincipal& runPrincipal);
     virtual void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal);
     virtual void readEvent_(EventPrincipal& eventPrincipal) = 0;
-    virtual bool readIt(EventID const&, EventPrincipal& eventPrincipal);
+    virtual bool readIt(EventID const& id, EventPrincipal& eventPrincipal, StreamContext& streamContext);
     virtual std::unique_ptr<FileBlock> readFile_();
     virtual void closeFile_() {}
     virtual bool goToEvent_(EventID const& eventID);

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -1809,7 +1809,7 @@ namespace edm {
     //TODO this will have to become per stream
     auto& event = principalCache_.eventPrincipal(iStreamIndex);
     StreamContext streamContext(event.streamID(), &processContext_);
-    input_->readEvent(event, &streamContext);
+    input_->readEvent(event, streamContext);
     FDEBUG(1) << "\treadEvent\n";
   }
   void EventProcessor::processEvent(unsigned int iStreamIndex) {

--- a/FWCore/Integration/test/ThrowingSource.cc
+++ b/FWCore/Integration/test/ThrowingSource.cc
@@ -130,7 +130,6 @@ namespace edm {
   ThrowingSource::readEvent_(EventPrincipal& eventPrincipal) {
     if (whenToThrow_ == kReadEvent) throw cms::Exception("TestThrow") << "ThrowingSource::readEvent_";
     assert(eventCached() || processingMode() != RunsLumisAndEvents);
-    EventSourceSentry sentry(*this);
     EventAuxiliary aux(eventID(), processGUID(), Timestamp(presentTime()), false, EventAuxiliary::Undefined);
     eventPrincipal.fillEventPrincipal(aux, processHistoryRegistry());
   }

--- a/FWCore/MessageService/interface/MessageLogger.h
+++ b/FWCore/MessageService/interface/MessageLogger.h
@@ -64,12 +64,14 @@ private:
   void  postEndJob();
   void  jobFailure();
   
-  void  preSource  ();
-  void  postSource ();
+  void  preSourceEvent  ( StreamID );
+  void  postSourceEvent ( StreamID );
+  void  preSourceRunLumi  ();
+  void  postSourceRunLumi ();
   
-  void  preFile       ( std::string const &, bool );
+  void  preFile       ( std::string const&, bool );
   void  preFileClose  ( std::string const&, bool );
-  void  postFile      ( std::string const &, bool );
+  void  postFile      ( std::string const&, bool );
   
   void  preModuleConstruction ( ModuleDescription const & );
   void  postModuleConstruction( ModuleDescription const & );

--- a/FWCore/MessageService/src/MessageLogger.cc
+++ b/FWCore/MessageService/src/MessageLogger.cc
@@ -257,13 +257,13 @@ namespace edm {
       iRegistry.watchPreModuleEvent(this,&MessageLogger::preModuleEvent);
       iRegistry.watchPostModuleEvent(this,&MessageLogger::postModuleEvent);
       
-      iRegistry.watchPreSource(this,&MessageLogger::preSource);
-      iRegistry.watchPostSource(this,&MessageLogger::postSource);
+      iRegistry.watchPreSourceEvent(this,&MessageLogger::preSourceEvent);
+      iRegistry.watchPostSourceEvent(this,&MessageLogger::postSourceEvent);
       // change log 14:
-      iRegistry.watchPreSourceRun(this,&MessageLogger::preSource);
-      iRegistry.watchPostSourceRun(this,&MessageLogger::postSource);
-      iRegistry.watchPreSourceLumi(this,&MessageLogger::preSource);
-      iRegistry.watchPostSourceLumi(this,&MessageLogger::postSource);
+      iRegistry.watchPreSourceRun(this,&MessageLogger::preSourceRunLumi);
+      iRegistry.watchPostSourceRun(this,&MessageLogger::postSourceRunLumi);
+      iRegistry.watchPreSourceLumi(this,&MessageLogger::preSourceRunLumi);
+      iRegistry.watchPostSourceLumi(this,&MessageLogger::postSourceRunLumi);
       iRegistry.watchPreOpenFile(this,&MessageLogger::preFile);
       iRegistry.watchPostOpenFile(this,&MessageLogger::postFile);
       iRegistry.watchPreCloseFile(this,&MessageLogger::preFileClose);
@@ -676,12 +676,13 @@ namespace edm {
       MessageDrop::instance()->setSinglet("AfterBeginJob");     // Change Log 17
     }
     
-    void
-    MessageLogger::preSource()
-    {
-      establish("source");
-    }
-    void MessageLogger::postSource()
+    void MessageLogger::preSourceEvent(StreamID)
+    { establish("source"); }
+    void MessageLogger::postSourceEvent(StreamID)
+    { unEstablish("AfterSource"); }
+    void MessageLogger::preSourceRunLumi()
+    { establish("source"); }
+    void MessageLogger::postSourceRunLumi()
     { unEstablish("AfterSource"); }
     
     void MessageLogger::preFile( std::string const &, bool )

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -31,6 +31,7 @@ unscheduled execution. The tests are in FWCore/Integration/test:
 // system include files
 //#include "boost/signal.hpp"
 #include "FWCore/Utilities/interface/Signal.h"
+#include "FWCore/Utilities/interface/StreamID.h"
 #include "boost/bind.hpp"
 #include "boost/mem_fn.hpp"
 #include "boost/utility.hpp"
@@ -102,20 +103,20 @@ namespace edm {
       AR_WATCH_USING_METHOD_0(watchJobFailure)
       
       /// signal is emitted before the source starts creating an Event
-      typedef signalslot::Signal<void()> PreSource;
-      PreSource preSourceSignal_;
-      void watchPreSource(PreSource::slot_type const& iSlot) {
+      typedef signalslot::Signal<void(StreamID)> PreSourceEvent;
+      PreSourceEvent preSourceSignal_;
+      void watchPreSourceEvent(PreSourceEvent::slot_type const& iSlot) {
         preSourceSignal_.connect(iSlot);
       }
-      AR_WATCH_USING_METHOD_0(watchPreSource)
+      AR_WATCH_USING_METHOD_1(watchPreSourceEvent)
 
       /// signal is emitted after the source starts creating an Event
-      typedef signalslot::Signal<void()> PostSource;
-      PostSource postSourceSignal_;
-      void watchPostSource(PostSource::slot_type const& iSlot) {
+      typedef signalslot::Signal<void(StreamID)> PostSourceEvent;
+      PostSourceEvent postSourceSignal_;
+      void watchPostSourceEvent(PostSourceEvent::slot_type const& iSlot) {
          postSourceSignal_.connect_front(iSlot);
       }
-      AR_WATCH_USING_METHOD_0(watchPostSource)
+      AR_WATCH_USING_METHOD_1(watchPostSourceEvent)
         
       /// signal is emitted before the source starts creating a Lumi
       typedef signalslot::Signal<void()> PreSourceLumi;

--- a/FWCore/Services/src/Memory.cc
+++ b/FWCore/Services/src/Memory.cc
@@ -143,7 +143,7 @@ namespace edm {
       if(!oncePerEventMode_) { // default, prints on increases
         iReg.watchPreSourceConstruction(this, &SimpleMemoryCheck::preSourceConstruction);
         iReg.watchPostSourceConstruction(this, &SimpleMemoryCheck::postSourceConstruction);
-        iReg.watchPostSource(this, &SimpleMemoryCheck::postSource);
+        iReg.watchPostSourceEvent(this, &SimpleMemoryCheck::postSourceEvent);
         iReg.watchPostModuleConstruction(this, &SimpleMemoryCheck::postModuleConstruction);
         iReg.watchPostModuleBeginJob(this, &SimpleMemoryCheck::postModuleBeginJob);
         iReg.watchPostEvent(this, &SimpleMemoryCheck::postEvent);
@@ -267,7 +267,7 @@ namespace edm {
       }
     }
 
-    void SimpleMemoryCheck::postSource() {
+    void SimpleMemoryCheck::postSourceEvent(StreamID sid) {
       bool expected = false;
       if(measurementUnderway_.compare_exchange_strong(expected,true,std::memory_order_acq_rel) ) {
         std::shared_ptr<void> guard(nullptr,[this](void const*) {

--- a/FWCore/Services/src/Memory.h
+++ b/FWCore/Services/src/Memory.h
@@ -62,7 +62,7 @@ namespace edm {
 
       void preSourceConstruction(const ModuleDescription&);
       void postSourceConstruction(const ModuleDescription&);
-      void postSource();
+      void postSourceEvent(StreamID);
 
       void postBeginJob();
       

--- a/FWCore/Services/src/Tracer.cc
+++ b/FWCore/Services/src/Tracer.cc
@@ -47,8 +47,8 @@ Tracer::Tracer(ParameterSet const& iPS, ActivityRegistry&iRegistry) :
   iRegistry.watchPostBeginJob(this, &Tracer::postBeginJob);
   iRegistry.watchPostEndJob(this, &Tracer::postEndJob);
 
-  iRegistry.watchPreSource(this, &Tracer::preSource);
-  iRegistry.watchPostSource(this, &Tracer::postSource);
+  iRegistry.watchPreSourceEvent(this, &Tracer::preSourceEvent);
+  iRegistry.watchPostSourceEvent(this, &Tracer::postSourceEvent);
 
   iRegistry.watchPreSourceLumi(this, &Tracer::preSourceLumi);
   iRegistry.watchPostSourceLumi(this, &Tracer::postSourceLumi);
@@ -164,12 +164,12 @@ Tracer::postEndJob() {
 }
 
 void
-Tracer::preSource() {
+Tracer::preSourceEvent(StreamID sid) {
   LogAbsolute("Tracer") << indention_ << indention_ << " starting: source event";
 }
 
 void
-Tracer::postSource() {
+Tracer::postSourceEvent(StreamID sid) {
   LogAbsolute("Tracer") << indention_ << indention_ << " finished: source event";
 }
 
@@ -179,7 +179,7 @@ Tracer::preSourceLumi() {
 }
 
 void
-Tracer::postSourceLumi () {
+Tracer::postSourceLumi() {
   LogAbsolute("Tracer") << indention_ << indention_ << " finished: source lumi";
 }
 
@@ -189,7 +189,7 @@ Tracer::preSourceRun() {
 }
 
 void
-Tracer::postSourceRun () {
+Tracer::postSourceRun() {
   LogAbsolute("Tracer") << indention_ << indention_ << " finished: source run";
 }
 

--- a/FWCore/Services/src/Tracer.h
+++ b/FWCore/Services/src/Tracer.h
@@ -53,8 +53,8 @@ namespace edm {
          void postBeginJob();
          void postEndJob();
          
-         void preSource();
-         void postSource();
+         void preSourceEvent(StreamID);
+         void postSourceEvent(StreamID);
 
          void preSourceLumi();
          void postSourceLumi();

--- a/FWCore/Sources/src/ProducerSourceBase.cc
+++ b/FWCore/Sources/src/ProducerSourceBase.cc
@@ -59,7 +59,6 @@ namespace edm {
   void
   ProducerSourceBase::readEvent_(EventPrincipal& eventPrincipal) {
     assert(eventCached() || processingMode() != RunsLumisAndEvents);
-    EventSourceSentry sentry(*this);
     EventAuxiliary aux(eventID_, processGUID(), Timestamp(presentTime_), isRealData_, eType_);
     eventPrincipal.fillEventPrincipal(aux, processHistoryRegistry());
     Event e(eventPrincipal, moduleDescription(), nullptr);

--- a/FWCore/Sources/src/RawInputSource.cc
+++ b/FWCore/Sources/src/RawInputSource.cc
@@ -51,7 +51,6 @@ namespace edm {
 
   void
   RawInputSource::makeEvent(EventPrincipal& eventPrincipal, EventAuxiliary const& eventAuxiliary) {
-    EventSourceSentry sentry(*this);
     eventPrincipal.fillEventPrincipal(eventAuxiliary, processHistoryRegistry());
   }
 

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.cc
@@ -144,7 +144,6 @@ bool LHESource::setRunAndEventInfo(edm::EventID&, edm::TimeValue_t&)
 void
 LHESource::readEvent_(edm::EventPrincipal& eventPrincipal) {
 	assert(eventCached() || processingMode() != RunsLumisAndEvents);
-	EventSourceSentry sentry(*this);
 	edm::EventAuxiliary aux(eventID(), processGUID(), edm::Timestamp(presentTime()), false);
 	aux.setProcessHistoryID(phid_);
 	eventPrincipal.fillEventPrincipal(aux, processHistoryRegistryForUpdate());

--- a/HLTrigger/Timer/interface/FastTimerService.h
+++ b/HLTrigger/Timer/interface/FastTimerService.h
@@ -111,8 +111,8 @@ public:
 
   /* FIXME not yet implemented
   // try to assess the overhead which may not be included in the source, paths and event timers
-  double queryPreSourceOverhead() const;    // time spent after the previous event's postProcessEvent and this event's preSource
-  double queryPreEventOverhead() const;     // time spent after this event's postSource and preProcessEvent
+  double queryPreSourceOverhead() const;    // time spent after the previous event's postProcessEvent and this event's preSourceEvent
+  double queryPreEventOverhead() const;     // time spent after this event's postSourceEvent and preProcessEvent
   double queryPreEndPathsOverhead() const;  // time spent after the last path's postProcessPath and the first endpath's preProcessPath
   */
 
@@ -125,8 +125,8 @@ private:
   void preModuleBeginJob( edm::ModuleDescription const & );
   void preProcessEvent( edm::EventID const &, edm::Timestamp const & );
   void postProcessEvent( edm::Event const &, edm::EventSetup const & );
-  void preSource();
-  void postSource();
+  void preSourceEvent(  edm::StreamID );
+  void postSourceEvent( edm::StreamID );
   void prePathBeginRun( std::string const & );
   void preProcessPath(  std::string const & );
   void postProcessPath( std::string const &, edm::HLTPathStatus const & );

--- a/HLTrigger/Timer/src/FastTimerService.cc
+++ b/HLTrigger/Timer/src/FastTimerService.cc
@@ -207,8 +207,8 @@ FastTimerService::FastTimerService(const edm::ParameterSet & config, edm::Activi
   registry.watchPrePathBeginRun(   this, & FastTimerService::prePathBeginRun) ;
   registry.watchPreProcessEvent(   this, & FastTimerService::preProcessEvent );
   registry.watchPostProcessEvent(  this, & FastTimerService::postProcessEvent );
-  registry.watchPreSource(         this, & FastTimerService::preSource );
-  registry.watchPostSource(        this, & FastTimerService::postSource );
+  registry.watchPreSourceEvent(    this, & FastTimerService::preSourceEvent );
+  registry.watchPostSourceEvent(   this, & FastTimerService::postSourceEvent );
   // watch per-path events
   registry.watchPreProcessPath(    this, & FastTimerService::preProcessPath );
   registry.watchPostProcessPath(   this, & FastTimerService::postProcessPath );
@@ -1018,7 +1018,7 @@ void FastTimerService::postProcessEvent(edm::Event const & event, edm::EventSetu
   m_is_first_event = false;
 }
 
-void FastTimerService::preSource() {
+void FastTimerService::preSourceEvent(edm::StreamID sid) {
   //edm::LogImportant("FastTimerService") << __func__ << "()";
 
   start(m_timer_source);
@@ -1035,7 +1035,7 @@ void FastTimerService::preSource() {
   ++m_summary_events;
 }
 
-void FastTimerService::postSource() {
+void FastTimerService::postSourceEvent(edm::StreamID sid) {
   //edm::LogImportant("FastTimerService") << __func__ << "()";
 
   stop(m_timer_source);

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -192,7 +192,6 @@ namespace edm {
 
   void
   PoolSource::readEvent_(EventPrincipal& eventPrincipal) {
-    EventSourceSentry sentry{*this};
     primaryFileSequence_->readEvent(eventPrincipal);
     if(secondaryFileSequence_ && !branchIDsToReplace_[InEvent].empty()) {
       bool found = secondaryFileSequence_->skipToItem(eventPrincipal.run(),
@@ -214,9 +213,10 @@ namespace edm {
   }
 
   bool
-  PoolSource::readIt(EventID const& id, EventPrincipal& eventPrincipal) {
+  PoolSource::readIt(EventID const& id, EventPrincipal& eventPrincipal, StreamContext& streamContext) {
     bool found = primaryFileSequence_->skipToItem(id.run(), id.luminosityBlock(), id.event());
     if(!found) return false;
+    EventSourceSentry sentry(*this, streamContext);
     readEvent_(eventPrincipal);
     return true;
   }

--- a/IOPool/Input/src/PoolSource.h
+++ b/IOPool/Input/src/PoolSource.h
@@ -45,7 +45,7 @@ namespace edm {
     virtual void closeFile_();
     virtual void endJob();
     virtual ItemType getNextItemType();
-    virtual bool readIt(EventID const& id, EventPrincipal& eventPrincipal);
+    virtual bool readIt(EventID const& id, EventPrincipal& eventPrincipal, StreamContext& streamContext) override;
     virtual void skip(int offset);
     virtual bool goToEvent_(EventID const& eventID);
     virtual void rewind_();

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -194,7 +194,6 @@ namespace edm {
          << eventView.eventLength() << " "
          << eventView.eventData()
          << std::endl;
-    EventSourceSentry sentry(*this);
     // uncompress if we need to
     // 78 was a dummy value (for no uncompressed) - should be 0 for uncompressed
     // need to get rid of this when 090 MTCC streamers are gotten rid of

--- a/PerfTools/Callgrind/interface/ProfilerService.h
+++ b/PerfTools/Callgrind/interface/ProfilerService.h
@@ -56,7 +56,7 @@ public:
 
   // ---- Service Interface: to  be called only by the Framework ----
   
-  void preSourceI() {
+  void preSourceI(edm::StreamID) {
     fullEvent();
   }
 

--- a/PerfTools/Callgrind/src/ProfilerService.cc
+++ b/PerfTools/Callgrind/src/ProfilerService.cc
@@ -29,7 +29,7 @@ ProfilerService::ProfilerService(edm::ParameterSet const& pset,
   // either FullEvent or selected path
   static std::string const fullEvent("FullEvent");
   if (std::find(m_paths.begin(),m_paths.end(),fullEvent) != m_paths.end())
-    activity.watchPostSource(this,&ProfilerService::preSourceI);
+    activity.watchPostSourceEvent(this,&ProfilerService::preSourceI);
   else {
     activity.watchPreProcessEvent(this,&ProfilerService::beginEventI);
     activity.watchPostProcessEvent(this,&ProfilerService::endEventI);


### PR DESCRIPTION
- fill the StreamContext in the Eventprocessor before reading the Event
- pass the StreamContext to the Pre/PostSource signals
- drop the EventSourceProxy, and call the Pre/PostSource signals explicitly from the InputSource
- adapt all services to the change in the signals
