### PR TITLE
do not use sse3 for mic

### DIFF
--- a/DataFormats/Math/interface/SIMDVec.h
+++ b/DataFormats/Math/interface/SIMDVec.h
@@ -1,7 +1,7 @@
 #ifndef DataFormat_Math_SIMDVec_H
 #define DataFormat_Math_SIMDVec_H
 
-#if ( defined(IN_DICTBUILD) || defined(__REFLEX__) || defined(__CINT__) ) || (__BIGGEST_ALIGNMENT__<16)
+#if ( defined(IN_DICTBUILD) || defined(__REFLEX__) || defined(__CINT__) || defined(__MIC__)) || (__BIGGEST_ALIGNMENT__<16)
 #elif (defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ > 7)) || defined(__clang__)
 #define USE_EXTVECT
 #elif (defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ > 4)) 

--- a/DataFormats/Math/interface/SSEVec.h
+++ b/DataFormats/Math/interface/SSEVec.h
@@ -1,7 +1,7 @@
 #ifndef DataFormat_Math_SSEVec_H
 #define DataFormat_Math_SSEVec_H
 
-#if !defined(__arm__)
+#if !defined(__arm__) && !defined(__MIC__)
 #if defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ > 4)
 #include <x86intrin.h>
 #define CMS_USE_SSE

--- a/DataFormats/Math/interface/sse_mathfun.h
+++ b/DataFormats/Math/interface/sse_mathfun.h
@@ -1,7 +1,7 @@
 #ifndef SSE_MATHFUN_H
 #define SSE_MATHFUN_H
 
-#if !defined(__arm__)
+#if !defined(__arm__) && !defined(__MIC__)
 #if (defined(__GNUC__) && (__GNUC__ == 4) && (__GNUC_MINOR__ > 4)) || defined(__clang__)
 #include <x86intrin.h>
 #define CMS_USE_SSE


### PR DESCRIPTION
successfully compiled for slc5/slc6 gcc481.
Full runTheMatrix and addOnTests ran successfully for both slc5/slc6 archs
