### PR TITLE
Protect against applying the offset more than once

### DIFF
--- a/SimGeneral/MixingModule/interface/PileUpEventPrincipal.h
+++ b/SimGeneral/MixingModule/interface/PileUpEventPrincipal.h
@@ -28,8 +28,7 @@ public:
 
   bool
   addLabel(edm::TypeID const& type, std::string const& label) const {
-    return true;
-    //return labels_.insert(std::make_pair(type, label)).second;
+    return labels_.insert(std::make_pair(type, label)).second;
   }
 
   edm::EventPrincipal const& principal() {


### PR DESCRIPTION
This pull request fixes a bug by preventing the digi accumulators, used by the mixing module, from applying the out-of -time offsets more than once to the same hits.
Note:  This does not fix the more general problem where a digi accumulator and a crossing frame each apply the offset once to the same hit, resulting in a double offset.
Tested with checkdeps -a and the relvals.
