### PR TITLE
Xeon Phi: disable SSEVec compilation for mic

### DIFF
--- a/DataFormats/Math/src/SSEVec.cc
+++ b/DataFormats/Math/src/SSEVec.cc
@@ -1,4 +1,4 @@
-#if !defined(__arm__)
+#if !defined(__arm__) && !defined(__MIC__) 
 #include "DataFormats/Math/interface/SSEVec.h"
 #include "DataFormats/Math/interface/SSERot.h"
 using namespace mathSSE;

--- a/DataFormats/Math/test/SSEVec_t.cpp
+++ b/DataFormats/Math/test/SSEVec_t.cpp
@@ -1,4 +1,4 @@
-#if !defined(__arm__)
+#if !defined(__arm__) && !defined(__MIC__)
 #include "DataFormats/Math/interface/SSEVec.h"
 
 #include<cmath>


### PR DESCRIPTION
Just like arm, disabled the SSEVec compilation for mic. This touches only a .cc file in src and a .ccp file in test directory.
