### PR TITLE
Fix consumes validation reco tau

### DIFF
--- a/Validation/RecoTau/plugins/CollectionFromZLegProducer.cc
+++ b/Validation/RecoTau/plugins/CollectionFromZLegProducer.cc
@@ -30,8 +30,8 @@ public:
 
 private:  
   // member data
-  edm::InputTag      		  srcTheZ_	    ;
-  std::string        		  OutputCollection_ ;
+  edm::EDGetTokenT< std::vector<reco::CompositeCandidate> >   v_RecoCompositeCandidateToken_;
+  std::string                                                 OutputCollection_ ;
   
 };
 
@@ -43,7 +43,7 @@ private:
 
 //______________________________________________________________________________
 CollectionFromZLegProducer::CollectionFromZLegProducer(const edm::ParameterSet& iConfig)
-  : srcTheZ_(iConfig.getParameter<edm::InputTag>("ZCandidateCollection"))
+  : v_RecoCompositeCandidateToken_( consumes< std::vector<reco::CompositeCandidate> >( iConfig.getParameter<edm::InputTag>( "ZCandidateCollection" ) ) )
 {
   produces<std::vector<reco::CompositeCandidate> >("theTagLeg"  );
   produces<std::vector<reco::CompositeCandidate> >("theProbeLeg");
@@ -66,7 +66,7 @@ void CollectionFromZLegProducer::produce(edm::Event& iEvent,const edm::EventSetu
   std::auto_ptr<std::vector<reco::CompositeCandidate> > theProbeLeg(new std::vector<reco::CompositeCandidate>) ;	     
   
   edm::Handle< std::vector<reco::CompositeCandidate> > theZHandle;
-  iEvent.getByLabel(srcTheZ_,theZHandle);
+  iEvent.getByToken( v_RecoCompositeCandidateToken_,theZHandle );
   
   // this is specific for our 'tag and probe'
   

--- a/Validation/RecoTau/plugins/ElectronFromPVSelector.cc
+++ b/Validation/RecoTau/plugins/ElectronFromPVSelector.cc
@@ -41,10 +41,10 @@ public:
 
 private:  
   // member data
-  edm::InputTag     srcPart_ ;  
-  edm::InputTag     srcPV_   ;  
-  double            max_dxy_ ;
-  double            max_dz_  ;
+  double                                               max_dxy_               ;
+  double                                               max_dz_                ;
+  edm::EDGetTokenT< std::vector<reco::Vertex> >        v_recoVertexToken_     ;
+  edm::EDGetTokenT< std::vector<reco::GsfElectron> >   v_recoGsfElectronToken_;
 };
 
 
@@ -55,10 +55,10 @@ private:
 
 //______________________________________________________________________________
 GsfElectronFromPVSelector::GsfElectronFromPVSelector(const edm::ParameterSet& iConfig)
-  : srcPart_(iConfig.getParameter<edm::InputTag>("srcElectron"))
-  , srcPV_  (iConfig.getParameter<edm::InputTag>("srcVertex"))
-  , max_dxy_(iConfig.getParameter<double>("max_dxy"))
-  , max_dz_ (iConfig.getParameter<double>("max_dz"))
+  : max_dxy_               ( iConfig.getParameter<double>( "max_dxy" ) )
+  , max_dz_                ( iConfig.getParameter<double>( "max_dz" ) )
+  , v_recoVertexToken_     ( consumes< std::vector<reco::Vertex> >( iConfig.getParameter<edm::InputTag>( "srcVertex" ) ) )
+  , v_recoGsfElectronToken_( consumes< std::vector<reco::GsfElectron> >( iConfig.getParameter<edm::InputTag>( "srcElectron" ) ) )
 {
   produces<std::vector<reco::GsfElectron> >();
 }
@@ -77,10 +77,10 @@ void GsfElectronFromPVSelector::produce(edm::Event& iEvent,const edm::EventSetup
   std::auto_ptr<std::vector<reco::GsfElectron> > goodGsfElectrons(new std::vector<reco::GsfElectron >);
   
   edm::Handle< std::vector<reco::Vertex> > VertexHandle;
-  iEvent.getByLabel(srcPV_,VertexHandle);
+  iEvent.getByToken( v_recoVertexToken_, VertexHandle );
 
   edm::Handle< std::vector<reco::GsfElectron> > GsfElectronHandle;
-  iEvent.getByLabel(srcPart_,GsfElectronHandle);
+  iEvent.getByToken( v_recoGsfElectronToken_, GsfElectronHandle );
   
   if( (VertexHandle->size() == 0) || (GsfElectronHandle->size() == 0) ) 
   {

--- a/Validation/RecoTau/plugins/IsoTracks.cc
+++ b/Validation/RecoTau/plugins/IsoTracks.cc
@@ -31,9 +31,9 @@ public:
 
 private:  
   // member data
-  edm::InputTag  src_        ;
-  double         coneRadius_ ;
-  double         threshold_  ;
+  double                                         coneRadius_      ;
+  double                                         threshold_       ;
+  edm::EDGetTokenT< std::vector<reco::Track> >   v_recoTrackToken_;
 
 };
 
@@ -44,9 +44,9 @@ private:
 
 //______________________________________________________________________________
 IsoTracks::IsoTracks(const edm::ParameterSet& iConfig)
-  : src_       (iConfig.getParameter<edm::InputTag>("src"))
-  , coneRadius_(iConfig.getParameter<double>("radius"))
-  , threshold_ (iConfig.getParameter<double>("SumPtFraction"))
+  : coneRadius_      ( iConfig.getParameter<double>( "radius" ) )
+  , threshold_       ( iConfig.getParameter<double>( "SumPtFraction" ) )
+  , v_recoTrackToken_( consumes< std::vector<reco::Track> >( iConfig.getParameter<edm::InputTag>( "src" ) ) )
 {
   produces<std::vector<reco::Track> >();
 }
@@ -65,7 +65,7 @@ void IsoTracks::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
   std::auto_ptr<std::vector<reco::Track> > IsoTracks(new std::vector<reco::Track >);
   
   edm::Handle< std::vector<reco::Track> > dirtyTracks;
-  iEvent.getByLabel(src_,dirtyTracks);
+  iEvent.getByToken( v_recoTrackToken_, dirtyTracks );
   
   if( dirtyTracks->size() == 0 ) 
   {

--- a/Validation/RecoTau/plugins/MuonFromPVSelector.cc
+++ b/Validation/RecoTau/plugins/MuonFromPVSelector.cc
@@ -35,10 +35,10 @@ public:
 
 private:  
   // member data
-  edm::InputTag     srcPart_ ;  
-  edm::InputTag     srcPV_   ;
-  double            max_dxy_ ;
-  double            max_dz_  ;
+  double                                          max_dxy_           ;
+  double                                          max_dz_            ;
+  edm::EDGetTokenT< std::vector<reco::Vertex> >   v_recoVertexToken_ ;
+  edm::EDGetTokenT< std::vector<reco::Muon> >     v_recoMuonToken_   ;
 };
 
 
@@ -49,10 +49,10 @@ private:
 
 //______________________________________________________________________________
 MuonFromPVSelector::MuonFromPVSelector(const edm::ParameterSet& iConfig)
-  : srcPart_(iConfig.getParameter<edm::InputTag>("srcMuon"))
-  , srcPV_  (iConfig.getParameter<edm::InputTag>("srcVertex"))
-  , max_dxy_(iConfig.getParameter<double>("max_dxy"))
-  , max_dz_ (iConfig.getParameter<double>("max_dz"))
+  : max_dxy_          ( iConfig.getParameter<double>( "max_dxy" ) )
+  , max_dz_           ( iConfig.getParameter<double>( "max_dz" ) )
+  , v_recoVertexToken_( consumes< std::vector<reco::Vertex> >( iConfig.getParameter<edm::InputTag>( "srcVertex" ) ) )
+  , v_recoMuonToken_  ( consumes< std::vector<reco::Muon> >( iConfig.getParameter<edm::InputTag>( "srcMuon" ) ) )
 {
   produces<std::vector<reco::Muon> >();
 }
@@ -71,10 +71,10 @@ void MuonFromPVSelector::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
   std::auto_ptr<std::vector<reco::Muon> > goodMuons(new std::vector<reco::Muon >);
   
   edm::Handle< std::vector<reco::Vertex> > VertexHandle;
-  iEvent.getByLabel(srcPV_,VertexHandle);
+  iEvent.getByToken( v_recoVertexToken_, VertexHandle );
 
   edm::Handle< std::vector<reco::Muon> > MuonHandle;
-  iEvent.getByLabel(srcPart_,MuonHandle);
+  iEvent.getByToken( v_recoMuonToken_, MuonHandle );
   
   if( (VertexHandle->size() == 0) || (MuonHandle->size() == 0) ) 
   {

--- a/Validation/RecoTau/plugins/Selectors.cc
+++ b/Validation/RecoTau/plugins/Selectors.cc
@@ -63,7 +63,6 @@ private:
   virtual bool filter(edm::Event&, const edm::EventSetup&) override;
   virtual void endJob() override ;
       
-  edm::InputTag src_, eidsrc_;
   edm::EDGetTokenT<reco::GsfElectronCollection> recoGsfElectronCollectionToken_;
   edm::EDGetTokenT< edm::ValueMap<float> > edmValueMapFloatToken_;
   int eid_; 
@@ -86,16 +85,14 @@ bool
 ElectronIdFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
   //cout << "NonVertexingLeptonFilter:: entering filter" << endl;
-  using namespace reco;
-  using namespace std;
   
-  edm::Handle<GsfElectronCollection> electrons;
+  edm::Handle<reco::GsfElectronCollection> electrons;
   iEvent.getByToken( recoGsfElectronCollectionToken_, electrons );
   
   edm::Handle<edm::ValueMap<float> > eIDValueMap;
   iEvent.getByToken( edmValueMapFloatToken_, eIDValueMap );
   const edm::ValueMap<float> & eIDmap = * eIDValueMap;
-  GsfElectronCollection *product = new GsfElectronCollection();
+  reco::GsfElectronCollection *product = new reco::GsfElectronCollection();
 
   // Loop over electrons
   for (unsigned int i = 0; i < electrons->size(); i++){
@@ -105,7 +102,7 @@ ElectronIdFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
   }
 
   //cout << "Putting in the event" << endl;
-  std::auto_ptr<GsfElectronCollection> collection(product);
+  std::auto_ptr<reco::GsfElectronCollection> collection(product);
   iEvent.put(collection);
   return true;
 }

--- a/Validation/RecoTau/plugins/Selectors.cc
+++ b/Validation/RecoTau/plugins/Selectors.cc
@@ -64,14 +64,16 @@ private:
   virtual void endJob() override ;
       
   edm::InputTag src_, eidsrc_;
+  edm::EDGetTokenT<reco::GsfElectronCollection> recoGsfElectronCollectionToken_;
+  edm::EDGetTokenT< edm::ValueMap<float> > edmValueMapFloatToken_;
   int eid_; 
   // ----------member data ---------------------------
 };
 
-ElectronIdFilter::ElectronIdFilter(const edm::ParameterSet& iConfig):
-  src_(iConfig.getParameter<edm::InputTag>("src")),
-  eidsrc_(iConfig.getParameter<edm::InputTag>("eidsrc")),
-  eid_(iConfig.getParameter<int>("eid"))
+ElectronIdFilter::ElectronIdFilter(const edm::ParameterSet& iConfig)
+  : recoGsfElectronCollectionToken_( consumes<reco::GsfElectronCollection>( iConfig.getParameter<edm::InputTag>( "src" ) ) )
+  , edmValueMapFloatToken_( consumes< edm::ValueMap<float> >( iConfig.getParameter<edm::InputTag>( "eidsrc" ) ) )
+  , eid_( iConfig.getParameter<int>( "eid" ) )
 {
   produces< reco::GsfElectronCollection >();
 }
@@ -88,10 +90,10 @@ ElectronIdFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
   using namespace std;
   
   edm::Handle<GsfElectronCollection> electrons;
-  iEvent.getByLabel(src_,electrons);
+  iEvent.getByToken( recoGsfElectronCollectionToken_, electrons );
   
   edm::Handle<edm::ValueMap<float> > eIDValueMap;
-  iEvent.getByLabel(eidsrc_, eIDValueMap);
+  iEvent.getByToken( edmValueMapFloatToken_, eIDValueMap );
   const edm::ValueMap<float> & eIDmap = * eIDValueMap;
   GsfElectronCollection *product = new GsfElectronCollection();
 

--- a/Validation/RecoTau/plugins/TrackFromPVSelector.cc
+++ b/Validation/RecoTau/plugins/TrackFromPVSelector.cc
@@ -35,10 +35,10 @@ public:
 
 private:  
   // member data
-  edm::InputTag     srcPart_ ;  
-  edm::InputTag     srcPV_   ;
-  double            max_dxy_ ;
-  double            max_dz_  ;
+  double                                          max_dxy_           ;
+  double                                          max_dz_            ;
+  edm::EDGetTokenT< std::vector<reco::Vertex> >   v_recoVertexToken_ ;
+  edm::EDGetTokenT< std::vector<reco::Track> >    v_recoTrackToken_  ;
 };
 
 
@@ -49,10 +49,10 @@ private:
 
 //______________________________________________________________________________
 TrackFromPVSelector::TrackFromPVSelector(const edm::ParameterSet& iConfig)
-  : srcPart_(iConfig.getParameter<edm::InputTag>("srcTrack"))
-  , srcPV_  (iConfig.getParameter<edm::InputTag>("srcVertex"))
-  , max_dxy_(iConfig.getParameter<double>("max_dxy"))
-  , max_dz_ (iConfig.getParameter<double>("max_dz"))
+  : max_dxy_          ( iConfig.getParameter<double>( "max_dxy" ) )
+  , max_dz_           ( iConfig.getParameter<double>( "max_dz" ) )
+  , v_recoVertexToken_( consumes< std::vector<reco::Vertex> >( iConfig.getParameter<edm::InputTag>( "srcVertex" ) ) )
+  , v_recoTrackToken_ ( consumes< std::vector<reco::Track> >( iConfig.getParameter<edm::InputTag>( "srcTrack" ) ) )
 {
   produces<std::vector<reco::Track> >();
 }
@@ -71,10 +71,10 @@ void TrackFromPVSelector::produce(edm::Event& iEvent,const edm::EventSetup& iSet
   std::auto_ptr<std::vector<reco::Track> > goodTracks(new std::vector<reco::Track >);
   
   edm::Handle< std::vector<reco::Vertex> > VertexHandle;
-  iEvent.getByLabel(srcPV_,VertexHandle);
+  iEvent.getByToken( v_recoVertexToken_, VertexHandle );
 
   edm::Handle< std::vector<reco::Track> > TrackHandle;
-  iEvent.getByLabel(srcPart_,TrackHandle);
+  iEvent.getByToken( v_recoTrackToken_, TrackHandle );
   
   if( (VertexHandle->size() == 0) || (TrackHandle->size() == 0) ) 
   {


### PR DESCRIPTION
Consumes fix for Validation/RecoTau package.
The following plugins in the RecoTau package:
Validation/RecoTau/plugins/ObjectViewCleaner.cc
Validation/RecoTau/plugins/PVSorterBySumP.cc
Validation/RecoTau/plugins/ZllArbitrator.cc
have been put on hold.
