### PR TITLE
get rid of last remaining getByLabel calls in HLTrigger/HLTanalyzers

### DIFF
--- a/HLTrigger/HLTanalyzers/interface/EventHeader.h
+++ b/HLTrigger/HLTanalyzers/interface/EventHeader.h
@@ -17,11 +17,10 @@
   */
 class EventHeader {
 public:
-  EventHeader(edm::ConsumesCollector && iC);
-  EventHeader(); 
+  EventHeader();
   ~EventHeader();
 
-  void setup(TTree* tree);
+  void setup(edm::ConsumesCollector && iC, TTree* tree);
 
   /** Analyze the Data */
   void analyze(edm::Event const& iEvent, TTree* tree);

--- a/HLTrigger/HLTanalyzers/interface/HLTBitAnalyzer.h
+++ b/HLTrigger/HLTanalyzers/interface/HLTBitAnalyzer.h
@@ -80,6 +80,6 @@ private:
   std::string _HistName; // Name of histogram file
   double _EtaMin,_EtaMax;
   TFile* m_file; // pointer to Histogram file
-	bool _UseTFileService;
+  bool _UseTFileService;
 
 };

--- a/HLTrigger/HLTanalyzers/interface/HLTHeavyIon.h
+++ b/HLTrigger/HLTanalyzers/interface/HLTHeavyIon.h
@@ -59,7 +59,6 @@ typedef std::vector<std::string> MyStrings;
 class HLTHeavyIon {
 public:
   HLTHeavyIon(edm::ConsumesCollector && iC); 
-  HLTHeavyIon(); 
 
   void setup(const edm::ParameterSet& pSet, TTree* tree);
   void beginRun(const edm::Run& , const edm::EventSetup& );

--- a/HLTrigger/HLTanalyzers/src/EventHeader.cc
+++ b/HLTrigger/HLTanalyzers/src/EventHeader.cc
@@ -39,7 +39,7 @@ void EventHeader::setup(edm::ConsumesCollector && iC, TTree* HltTree) {
   HltTree->Branch("Orbit",     &fOrbit,       "Orbit/I"); 
   HltTree->Branch("AvgInstDelLumi", &fAvgInstDelLumi, "AvgInstDelLumi/D");
 
-  lumi_Token = iC.consumes<LumiSummary>(edm::InputTag("lumiProducer")); 
+  lumi_Token = iC.consumes<LumiSummary,edm::InLumi>(edm::InputTag("lumiProducer")); 
 }
 
 /* **Analyze the event** */

--- a/HLTrigger/HLTanalyzers/src/EventHeader.cc
+++ b/HLTrigger/HLTanalyzers/src/EventHeader.cc
@@ -8,12 +8,6 @@
 
 #include "HLTrigger/HLTanalyzers/interface/EventHeader.h"
 
-
-EventHeader::EventHeader(edm::ConsumesCollector && iC) : EventHeader::EventHeader()
-{
-  lumi_Token = iC.consumes<LumiSummary>(edm::InputTag("lumiProducer")); 
-}
-
 EventHeader::EventHeader() :
   fRun( -1 ),
   fEvent( -1 ),
@@ -22,16 +16,14 @@ EventHeader::EventHeader() :
   fOrbit( -1 ),
   fAvgInstDelLumi( -999. ),
   _Debug( false )
-{
-  //  lumi_Token = consumes<LumiSummary>(edm::InputTag("lumiProducer")); 
-}
+{ }
 
 EventHeader::~EventHeader() {
 
 }
 
 /*  Setup the analysis to put the branch-variables into the tree. */
-void EventHeader::setup(TTree* HltTree) {
+void EventHeader::setup(edm::ConsumesCollector && iC, TTree* HltTree) {
 
   fRun = -1;
   fEvent = -1;
@@ -46,6 +38,8 @@ void EventHeader::setup(TTree* HltTree) {
   HltTree->Branch("Bx",        &fBx,          "Bx/I"); 
   HltTree->Branch("Orbit",     &fOrbit,       "Orbit/I"); 
   HltTree->Branch("AvgInstDelLumi", &fAvgInstDelLumi, "AvgInstDelLumi/D");
+
+  lumi_Token = iC.consumes<LumiSummary>(edm::InputTag("lumiProducer")); 
 }
 
 /* **Analyze the event** */
@@ -62,8 +56,7 @@ void EventHeader::analyze(edm::Event const& iEvent, TTree* HltTree) {
   const edm::LuminosityBlock& iLumi = iEvent.getLuminosityBlock(); 
   edm::Handle<LumiSummary> lumiSummary; 
   try{
-    if (!lumi_Token.isUnitialized() ) iLumi.getByToken(lumi_Token, lumiSummary);
-    else iLumi.getByLabel(edm::InputTag("lumiProducer"), lumiSummary);
+    iLumi.getByToken(lumi_Token, lumiSummary);
     lumiSummary->isValid();
   }
   catch(cms::Exception&){

--- a/HLTrigger/HLTanalyzers/src/HLTAnalyzer.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTAnalyzer.cc
@@ -13,11 +13,7 @@ template <class T>
 static inline
 bool getCollection(const edm::Event & event, std::vector<MissingCollectionInfo> & missing, edm::Handle<T> & handle, const edm::InputTag & name, const edm::EDGetTokenT<T> token, const char * description) 
 {
-  if (token.isUnitialized()) {
-    event.getByLabel(name, handle);
-    std::cout << "*** HLTAnalyzer/getCollection: Token corresponding to label " << name << "is not initialized" << std::endl;
-    }
-  else  event.getByToken(token, handle);
+  event.getByToken(token, handle);
   bool valid = handle.isValid();
   if (not valid) {
     missing.push_back( std::make_pair(description, & name) );
@@ -378,7 +374,7 @@ HLTAnalyzer::HLTAnalyzer(edm::ParameterSet const& conf) {
     hlt_analysis_.setup(conf, HltTree);
     vrt_analysisHLT_.setup(conf, HltTree, "HLT");
     vrt_analysisOffline0_.setup(conf, HltTree, "Offline0");
-    evt_header_.setup(HltTree);
+    evt_header_.setup(consumesCollector(), HltTree);
 }
 
 void HLTAnalyzer::beginRun(const edm::Run& run, const edm::EventSetup& c){ 

--- a/HLTrigger/HLTanalyzers/src/HLTBitAnalyzer.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTBitAnalyzer.cc
@@ -15,11 +15,7 @@ template <class T>
 static inline
 bool getCollection(const edm::Event & event, std::vector<MissingCollectionInfo> & missing, edm::Handle<T> & handle, const edm::InputTag & name, const edm::EDGetTokenT<T> token, const char * description) 
 {
-  if (token.isUnitialized()) {
-    event.getByLabel(name, handle);
-    std::cout << "*** HLTAnalyzer/getCollection: Token corresponding to label " << name << "is not initialized" << std::endl;
-    }
-  else  event.getByToken(token, handle);
+  event.getByToken(token, handle);
   bool valid = handle.isValid();
   if (not valid) {
     missing.push_back( std::make_pair(description, & name) );
@@ -97,7 +93,7 @@ HLTBitAnalyzer::HLTBitAnalyzer(edm::ParameterSet const& conf) {
 
   // Setup the different analysis
   hlt_analysis_.setup(conf, HltTree);
-  evt_header_.setup(HltTree);
+  evt_header_.setup(consumesCollector(), HltTree);
 }
 
 // Boiler-plate "analyze" method declaration for an analyzer module.

--- a/HLTrigger/HLTanalyzers/src/HLTHeavyIon.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTHeavyIon.cc
@@ -18,20 +18,14 @@
 #include "DataFormats/HeavyIonEvent/interface/Centrality.h"
 using namespace std;
 
-HLTHeavyIon::HLTHeavyIon(edm::ConsumesCollector && iC) : HLTHeavyIon::HLTHeavyIon()
-{
-  centralityBin_Token = iC.consumes<int>( centralityBin_Label); 
-}
-
-HLTHeavyIon::HLTHeavyIon() {
-
+HLTHeavyIon::HLTHeavyIon(edm::ConsumesCollector && iC) {
   //set parameter defaults 
   _Monte = false;
   _Debug = false;
   _OR_BXes=false;
   UnpackBxInEvent=1;
   centralityBin_Label = edm::InputTag("centralityBin");
-
+  centralityBin_Token = iC.consumes<int>( centralityBin_Label); 
 }
 
 void
@@ -46,7 +40,6 @@ HLTHeavyIon::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
 
 
 void HLTHeavyIon::beginRun(const edm::Run& run, const edm::EventSetup& c){ 
-
 
   bool changed(true);
   if (hltConfig_.init(run,c,processName_,changed)) {
@@ -169,8 +162,7 @@ void HLTHeavyIon::analyze(const edm::Handle<edm::TriggerResults>                
    }
 
    edm::Handle<int> binHandle;
-   if (!centralityBin_Token.isUnitialized()) iEvent.getByToken(centralityBin_Token,binHandle);
-   else iEvent.getByLabel(centralityBin_Label,binHandle);
+   iEvent.getByToken(centralityBin_Token,binHandle);
    hiBin = *binHandle;
 
   hiNpix = centrality->multiplicityPixel();


### PR DESCRIPTION
Remove the last remaining calls to getByLabel in the HLTrigger/HLTanalyzers package, also in the helper functions and their callers.
