### PR TITLE
edm::Handle holds functor for exception construction

### DIFF
--- a/DataFormats/Common/interface/ConvertHandle.h
+++ b/DataFormats/Common/interface/ConvertHandle.h
@@ -1,6 +1,7 @@
 #ifndef DataFormats_Common_ConvertHandle_h
 #define DataFormats_Common_ConvertHandle_h
 
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include "DataFormats/Common/interface/BasicHandle.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/Wrapper.h"
@@ -16,11 +17,11 @@ namespace edm {
 
   // Convert from handle-to-void to handle-to-T
   template<typename T>
-  void convert_handle(BasicHandle const& bh,
+  void convert_handle(BasicHandle && bh,
 		      Handle<T>& result) {
     if(bh.failedToGet()) {
-      Handle<T> h(bh.whyFailed());
-      h.swap(result);
+      Handle<T> h(std::move(bh.whyFailedFactory()));
+      result = std::move(h);
       return;
     }
     void const* basicWrapper = bh.wrapper();
@@ -36,5 +37,15 @@ namespace edm {
     h.swap(result);
   }
 }
+#else
+namespace edm {
+  class BasicHandle;
+  template<typename T> class Handle;
+  
+  template<typename T>
+  void convert_handle(BasicHandle & bh,
+                      Handle<T>& result);
+}
+#endif
 
 #endif

--- a/DataFormats/Common/interface/Handle.h
+++ b/DataFormats/Common/interface/Handle.h
@@ -24,7 +24,7 @@ If failedToGet() returns false but isValid() is also false then no attempt
   to get data has occurred
 
 ----------------------------------------------------------------------*/
-
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
 #include <typeinfo>
 
 #include "DataFormats/Common/interface/HandleBase.h"
@@ -41,8 +41,11 @@ namespace edm {
 
     Handle(T const* prod, Provenance const* prov);
     
-    Handle(boost::shared_ptr<cms::Exception> const&);
-
+    Handle(std::function<std::shared_ptr<cms::Exception>()> &&);
+    Handle(Handle const&) = default;
+    
+    Handle& operator=(Handle&&) = default;
+    
     ~Handle();
 
     T const* product() const;
@@ -61,8 +64,8 @@ namespace edm {
   }
 
   template <class T>
-    Handle<T>::Handle(boost::shared_ptr<cms::Exception> const& iWhyFailed) :
-    HandleBase(iWhyFailed)
+  Handle<T>::Handle(std::function<std::shared_ptr<cms::Exception>()> && iWhyFailed) :
+  HandleBase(std::move(iWhyFailed))
   { }
  
 
@@ -87,5 +90,9 @@ namespace edm {
     return *product();
   }
 }
-
+#else
+namespace edm {
+  template<typename T> class Handle;
+}
+#endif
 #endif

--- a/DataFormats/Common/interface/RefProd.h
+++ b/DataFormats/Common/interface/RefProd.h
@@ -56,11 +56,14 @@ namespace edm {
     RefProd() : product_() {}
 
     /// General purpose constructor from handle.
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     explicit RefProd(Handle<C> const& handle) :
     product_(handle.id(), handle.product(), 0, false) {
       checkTypeAtCompileTime(handle.product());
     }
-
+#else
+    explicit RefProd(Handle<C> const& handle);
+#endif
     /// General purpose constructor from orphan handle.
     explicit RefProd(OrphanHandle<C> const& handle) :
     product_(handle.id(), handle.product(), 0, false) {

--- a/DataFormats/Common/src/HandleBase.cc
+++ b/DataFormats/Common/src/HandleBase.cc
@@ -5,16 +5,16 @@
 namespace edm {
   void const*
   HandleBase::productStorage() const {
-    if (whyFailed_) {
-      throw *whyFailed_;
+    if (whyFailedFactory_) {
+      throw *whyFailedFactory_();
     }
     return product_;
   }
 
   ProductID
   HandleBase::id() const {
-    if (whyFailed_) {
-      throw *whyFailed_;
+    if (whyFailedFactory_) {
+      throw *whyFailedFactory_();
     }
     return prov_->productID();
   }

--- a/DataFormats/FWLite/src/EventBase.cc
+++ b/DataFormats/FWLite/src/EventBase.cc
@@ -44,15 +44,17 @@ namespace fwlite
                  edp);
       if(!edp.isValid() || !edp.isPresent()) {
          edm::TypeID productType(iWrapperInfo);
-         boost::shared_ptr<cms::Exception> whyFailed(new edm::Exception(edm::errors::ProductNotFound));
-         *whyFailed
-         << "getByLabel: Found zero products matching all criteria\n"
-         << "Looking for type: " << productType << "\n"
-         << "Looking for module label: " << iTag.label() << "\n"
-         << "Looking for productInstanceName: " << iTag.instance() << "\n"
-         << (iTag.process().empty() ? "" : "Looking for process: ") << iTag.process() << "\n"
-         << "The data is registered in the file but is not available for this event\n";
-         edm::BasicHandle failed(whyFailed);
+        edm::BasicHandle failed([=]()->std::shared_ptr<cms::Exception>{
+          std::shared_ptr<cms::Exception> whyFailed(new edm::Exception(edm::errors::ProductNotFound));
+          *whyFailed
+          << "getByLabel: Found zero products matching all criteria\n"
+          << "Looking for type: " << productType << "\n"
+          << "Looking for module label: " << iTag.label() << "\n"
+          << "Looking for productInstanceName: " << iTag.instance() << "\n"
+          << (iTag.process().empty() ? "" : "Looking for process: ") << iTag.process() << "\n"
+          << "The data is registered in the file but is not available for this event\n";
+          return whyFailed;
+        });
          return failed;
       }
 

--- a/DataFormats/FWLite/src/LuminosityBlockBase.cc
+++ b/DataFormats/FWLite/src/LuminosityBlockBase.cc
@@ -49,15 +49,17 @@ namespace fwlite
                  edp);
       if(!edp.isValid() || !edp.isPresent()) {
          edm::TypeID productType(iWrapperInfo);
-         boost::shared_ptr<cms::Exception> whyFailed(new edm::Exception(edm::errors::ProductNotFound));
-         *whyFailed
-         << "getByLabel: Found zero products matching all criteria\n"
-         << "Looking for type: " << productType << "\n"
-         << "Looking for module label: " << iTag.label() << "\n"
-         << "Looking for productInstanceName: " << iTag.instance() << "\n"
-         << (iTag.process().empty() ? "" : "Looking for process: ") << iTag.process() << "\n";
 
-         edm::BasicHandle failed(whyFailed);
+        edm::BasicHandle failed([=]()->std::shared_ptr<cms::Exception> {
+          std::shared_ptr<cms::Exception> whyFailed(new edm::Exception(edm::errors::ProductNotFound));
+          *whyFailed
+          << "getByLabel: Found zero products matching all criteria\n"
+          << "Looking for type: " << productType << "\n"
+          << "Looking for module label: " << iTag.label() << "\n"
+          << "Looking for productInstanceName: " << iTag.instance() << "\n"
+          << (iTag.process().empty() ? "" : "Looking for process: ") << iTag.process() << "\n";
+          return whyFailed;
+        });
          return failed;
       }
       edm::BasicHandle value(edp, &s_prov);

--- a/DataFormats/FWLite/src/RunBase.cc
+++ b/DataFormats/FWLite/src/RunBase.cc
@@ -49,15 +49,17 @@ namespace fwlite
                  edp);
       if(!edp.isValid() || !edp.isPresent()) {
          edm::TypeID productType(iWrapperInfo);
-         boost::shared_ptr<cms::Exception> whyFailed(new edm::Exception(edm::errors::ProductNotFound));
-         *whyFailed
-         << "getByLabel: Found zero products matching all criteria\n"
-         << "Looking for type: " << productType << "\n"
-         << "Looking for module label: " << iTag.label() << "\n"
-         << "Looking for productInstanceName: " << iTag.instance() << "\n"
-         << (iTag.process().empty() ? "" : "Looking for process: ") << iTag.process() << "\n";
 
-         edm::BasicHandle failed(whyFailed);
+        edm::BasicHandle failed([=]()->std::shared_ptr<cms::Exception> {
+          std::shared_ptr<cms::Exception> whyFailed(new edm::Exception(edm::errors::ProductNotFound));
+          *whyFailed
+          << "getByLabel: Found zero products matching all criteria\n"
+          << "Looking for type: " << productType << "\n"
+          << "Looking for module label: " << iTag.label() << "\n"
+          << "Looking for productInstanceName: " << iTag.instance() << "\n"
+          << (iTag.process().empty() ? "" : "Looking for process: ") << iTag.process() << "\n";
+          return whyFailed;
+        });
          return failed;
       }
       edm::BasicHandle value(edp, &s_prov);

--- a/FWCore/Common/interface/EventBase.h
+++ b/FWCore/Common/interface/EventBase.h
@@ -81,18 +81,20 @@ namespace edm {
 
    };
 
+#if !defined(__REFLEX__)
    template<typename T>
    bool
    EventBase::getByLabel(InputTag const& tag, Handle<T>& result) const {
       result.clear();
       BasicHandle bh = this->getByLabelImpl(typeid(edm::Wrapper<T>), typeid(T), tag);
-      convert_handle(bh, result);  // throws on conversion error
-      if (bh.failedToGet()) {
+     convert_handle(std::move(bh), result);  // throws on conversion error
+      if (result.failedToGet()) {
          return false;
       }
       return true;
    }
-
+#endif
+  
 }
 #endif /*!defined(__CINT__) && !defined(__MAKECINT__)*/
 

--- a/FWCore/Common/interface/LuminosityBlockBase.h
+++ b/FWCore/Common/interface/LuminosityBlockBase.h
@@ -212,18 +212,19 @@ namespace edm {
     return provRecorder_.getManyByType(results);
   }
 */
+#if !defined(__REFLEX__)
    template<class T>
    bool
    LuminosityBlockBase::getByLabel(const InputTag& tag, Handle<T>& result) const {
       result.clear();
       BasicHandle bh = this->getByLabelImpl(typeid(Wrapper<T>), typeid(T), tag);
-      convert_handle(bh, result);  // throws on conversion error
-      if (bh.failedToGet()) {
+      convert_handle(std::move(bh), result);  // throws on conversion error
+      if (result.failedToGet()) {
          return false;
       }
       return true;
    }
-
+#endif
 
 }
 #endif /*!defined(__CINT__) && !defined(__MAKECINT__)*/

--- a/FWCore/Common/interface/RunBase.h
+++ b/FWCore/Common/interface/RunBase.h
@@ -57,18 +57,19 @@ namespace edm {
 
   };
 
+#if !defined(__REFLEX__)
    template<typename T>
    bool
    RunBase::getByLabel(InputTag const& tag, Handle<T>& result) const {
       result.clear();
       BasicHandle bh = this->getByLabelImpl(typeid(Wrapper<T>), typeid(T), tag);
-      convert_handle(bh, result);  // throws on conversion error
-      if (bh.failedToGet()) {
+      convert_handle(std::move(bh), result);  // throws on conversion error
+      if (result.failedToGet()) {
          return false;
       }
       return true;
    }
-
+#endif
 
 }
 #endif /*!defined(__CINT__) && !defined(__MAKECINT__)*/

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -308,8 +308,8 @@ namespace edm {
   Event::get(ProductID const& oid, Handle<PROD>& result) const {
     result.clear();
     BasicHandle bh = this->getByProductID_(oid);
-    convert_handle(bh, result);  // throws on conversion error
-    if(bh.failedToGet()) {
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if(result.failedToGet()) {
       return false;
     }
     addToGotBranchIDs(*bh.provenance());
@@ -387,8 +387,8 @@ namespace edm {
   Event::getByLabel(InputTag const& tag, Handle<PROD>& result) const {
     result.clear();
     BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), tag, moduleCallingContext_);
-    convert_handle(bh, result);  // throws on conversion error
-    if (bh.failedToGet()) {
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if (result.failedToGet()) {
       return false;
     }
     addToGotBranchIDs(*result.provenance());
@@ -402,8 +402,8 @@ namespace edm {
                     Handle<PROD>& result) const {
     result.clear();
     BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), label, productInstanceName, emptyString_, moduleCallingContext_);
-    convert_handle(bh, result);  // throws on conversion error
-    if (bh.failedToGet()) {
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if (result.failedToGet()) {
       return false;
     }
     addToGotBranchIDs(*result.provenance());
@@ -431,8 +431,8 @@ namespace edm {
   Event::getByToken(EDGetToken token, Handle<PROD>& result) const {
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
-    convert_handle(bh, result);  // throws on conversion error
-    if (bh.failedToGet()) {
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if (result.failedToGet()) {
       return false;
     }
     addToGotBranchIDs(*result.provenance());
@@ -444,8 +444,8 @@ namespace edm {
   Event::getByToken(EDGetTokenT<PROD> token, Handle<PROD>& result) const {
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
-    convert_handle(bh, result);  // throws on conversion error
-    if (bh.failedToGet()) {
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if (result.failedToGet()) {
       return false;
     }
     addToGotBranchIDs(*result.provenance());
@@ -459,7 +459,7 @@ namespace edm {
     result.clear();
     BasicHandle bh = provRecorder_.getMatchingSequenceByLabel_(TypeID(typeid(ELEMENT)), tag, moduleCallingContext_);
     if(bh.failedToGet()) {
-      Handle<View<ELEMENT> > h(bh.whyFailed());
+      Handle<View<ELEMENT> > h(std::move(bh.whyFailedFactory()));
       h.swap(result);
       return false;
     }
@@ -475,7 +475,7 @@ namespace edm {
     result.clear();
     BasicHandle bh = provRecorder_.getMatchingSequenceByLabel_(TypeID(typeid(ELEMENT)), moduleLabel, productInstanceName, emptyString_, moduleCallingContext_);
     if(bh.failedToGet()) {
-      Handle<View<ELEMENT> > h(bh.whyFailed());
+      Handle<View<ELEMENT> > h(std::move(bh.whyFailedFactory()));
       h.swap(result);
       return false;
     }
@@ -495,7 +495,7 @@ namespace edm {
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)),ELEMENT_TYPE, token, moduleCallingContext_);
     if(bh.failedToGet()) {
-      Handle<View<ELEMENT> > h(bh.whyFailed());
+      Handle<View<ELEMENT> > h(bh.whyFailedFactory());
       h.swap(result);
       return false;
     }
@@ -509,7 +509,7 @@ namespace edm {
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)),ELEMENT_TYPE, token, moduleCallingContext_);
     if(bh.failedToGet()) {
-      Handle<View<ELEMENT> > h(bh.whyFailed());
+      Handle<View<ELEMENT> > h(std::move(bh.whyFailedFactory()));
       h.swap(result);
       return false;
     }

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -495,7 +495,7 @@ namespace edm {
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(ELEMENT)),ELEMENT_TYPE, token, moduleCallingContext_);
     if(bh.failedToGet()) {
-      Handle<View<ELEMENT> > h(bh.whyFailedFactory());
+      Handle<View<ELEMENT> > h(std::move(bh.whyFailedFactory()));
       h.swap(result);
       return false;
     }

--- a/FWCore/Framework/interface/GenericHandle.h
+++ b/FWCore/Framework/interface/GenericHandle.h
@@ -33,6 +33,7 @@
 
 // system include files
 #include <string>
+#include <functional>
 
 // forward declarations
 namespace edm {
@@ -66,7 +67,7 @@ public:
    type_(h.type_),
    prod_(h.prod_),
    prov_(h.prov_),
-   whyFailed_(h.whyFailed_) {
+   whyFailedFactory_(h.whyFailedFactory_) {
    }
    
    Handle(ObjectWithDict const& prod, Provenance const* prov, ProductID const&):
@@ -85,7 +86,7 @@ public:
       swap(type_, other.type_);
       std::swap(prod_, other.prod_);
       swap(prov_, other.prov_);
-      swap(whyFailed_, other.whyFailed_);
+      swap(whyFailedFactory_, other.whyFailedFactory_);
    }
    
    
@@ -100,11 +101,11 @@ public:
    }
 
    bool failedToGet() const {
-     return 0 != whyFailed_.get();
+     return bool(whyFailedFactory_);
    }
    ObjectWithDict const* product() const { 
-     if(this->failedToGet()) { 
-       whyFailed_->raise();
+     if(this->failedToGet()) {
+       whyFailedFactory_()->raise();
      } 
      return &prod_;
    }
@@ -116,23 +117,23 @@ public:
    
    ProductID id() const {return prov_->productID();}
 
-   void clear() { prov_ = 0; whyFailed_.reset();}
+   void clear() { prov_ = 0; whyFailedFactory_=nullptr;}
       
-   void setWhyFailed(boost::shared_ptr<cms::Exception> const& iWhyFailed) {
-    whyFailed_=iWhyFailed;
+  void setWhyFailedFactory(std::function<std::shared_ptr<cms::Exception>()> const& iWhyFailed) {
+    whyFailedFactory_=iWhyFailed;
   }
 private:
    TypeWithDict type_;
    ObjectWithDict prod_;
    Provenance const* prov_;    
-   boost::shared_ptr<cms::Exception> whyFailed_;
+  std::function<std::shared_ptr<cms::Exception>()> whyFailedFactory_;
 
 };
 
 typedef Handle<GenericObject> GenericHandle;
 
 ///specialize this function for GenericHandle
-void convert_handle(BasicHandle const& orig,
+void convert_handle(BasicHandle && orig,
                     Handle<GenericObject>& result);
 
 

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -204,8 +204,8 @@ namespace edm {
     }
     result.clear();
     BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), label, productInstanceName, emptyString_, moduleCallingContext_);
-    convert_handle(bh, result);  // throws on conversion error
-    if (bh.failedToGet()) {
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if (result.failedToGet()) {
       return false;
     }
     return true;
@@ -220,8 +220,8 @@ namespace edm {
     }
     result.clear();
     BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), tag, moduleCallingContext_);
-    convert_handle(bh, result);  // throws on conversion error
-    if (bh.failedToGet()) {
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if (result.failedToGet()) {
       return false;
     }
     return true;
@@ -235,8 +235,8 @@ namespace edm {
     }
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
-    convert_handle(bh, result);  // throws on conversion error
-    if (bh.failedToGet()) {
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if (result.failedToGet()) {
       return false;
     }
     return true;
@@ -250,8 +250,8 @@ namespace edm {
     }
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
-    convert_handle(bh, result);  // throws on conversion error
-    if (bh.failedToGet()) {
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if (result.failedToGet()) {
       return false;
     }
     return true;

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -334,12 +334,12 @@ namespace edm {
     // for this function, since it is *not* to be used by EDProducers?
     std::vector<Handle<PROD> > products;
 
-    typename BasicHandleVec::const_iterator it = bhv.begin();
-    typename BasicHandleVec::const_iterator end = bhv.end();
+    typename BasicHandleVec::iterator it = bhv.begin();
+    typename BasicHandleVec::iterator end = bhv.end();
 
     while (it != end) {
       Handle<PROD> result;
-      convert_handle(*it, result);  // throws on conversion error
+      convert_handle(std::move(*it), result);  // throws on conversion error
       products.push_back(result);
       ++it;
     }

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -211,8 +211,8 @@ namespace edm {
     }
     result.clear();
     BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), label, productInstanceName, emptyString_, moduleCallingContext_);
-    convert_handle(bh, result);  // throws on conversion error
-    if (bh.failedToGet()) {
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if (result.failedToGet()) {
       return false;
     }
     return true;
@@ -227,8 +227,8 @@ namespace edm {
     }
     result.clear();
     BasicHandle bh = provRecorder_.getByLabel_(TypeID(typeid(PROD)), tag, moduleCallingContext_);
-    convert_handle(bh, result);  // throws on conversion error
-    if (bh.failedToGet()) {
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if (result.failedToGet()) {
       return false;
     }
     return true;
@@ -242,8 +242,8 @@ namespace edm {
     }
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
-    convert_handle(bh, result);  // throws on conversion error
-    if (bh.failedToGet()) {
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if (result.failedToGet()) {
       return false;
     }
     return true;
@@ -257,8 +257,8 @@ namespace edm {
     }
     result.clear();
     BasicHandle bh = provRecorder_.getByToken_(TypeID(typeid(PROD)),PRODUCT_TYPE, token, moduleCallingContext_);
-    convert_handle(bh, result);  // throws on conversion error
-    if (bh.failedToGet()) {
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if (result.failedToGet()) {
       return false;
     }
     return true;

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -254,10 +254,12 @@ namespace edm {
     BranchID bid = pidToBid(pid);
     ConstProductPtr const phb = getProductHolder(bid, true, false, nullptr);
     if(phb == nullptr) {
-      boost::shared_ptr<cms::Exception> whyFailed(new Exception(errors::ProductNotFound, "InvalidID"));
-      *whyFailed
+      return BasicHandle([pid]()->std::shared_ptr<cms::Exception> {
+        std::shared_ptr<cms::Exception> whyFailed(new Exception(errors::ProductNotFound, "InvalidID"));
+        *whyFailed
         << "get by product ID: no product with given id: " << pid << "\n";
-      return BasicHandle(whyFailed);
+        return whyFailed;
+      });
     }
 
     // Was this already deleted?
@@ -267,11 +269,13 @@ namespace edm {
     // Check for case where we tried on demand production and
     // it failed to produce the object
     if(phb->onDemand()) {
-      boost::shared_ptr<cms::Exception> whyFailed(new Exception(errors::ProductNotFound, "InvalidID"));
-      *whyFailed
+      return BasicHandle([pid]()->std::shared_ptr<cms::Exception> {
+        std::shared_ptr<cms::Exception> whyFailed(new Exception(errors::ProductNotFound, "InvalidID"));
+        *whyFailed
         << "get by product ID: no product with given id: " << pid << "\n"
         << "onDemand production failed to produce it.\n";
-      return BasicHandle(whyFailed);
+        return whyFailed;
+      });
     }
     return BasicHandle(phb->productData());
   }

--- a/FWCore/Framework/src/GenericHandle.cc
+++ b/FWCore/Framework/src/GenericHandle.cc
@@ -16,11 +16,11 @@
 #include "FWCore/Framework/interface/GenericHandle.h"
 
 namespace edm {
-void convert_handle(BasicHandle const& orig,
+void convert_handle(BasicHandle && orig,
                     Handle<GenericObject>& result)
 {
   if(orig.failedToGet()) {
-    result.setWhyFailed(orig.whyFailed());
+    result.setWhyFailedFactory(orig.whyFailedFactory());
     return;
   }
   WrapperHolder originalWrap = orig.wrapperHolder();
@@ -53,8 +53,8 @@ edm::Event::getByLabel<GenericObject>(std::string const& label,
                                       Handle<GenericObject>& result) const
 {
   BasicHandle bh = provRecorder_.getByLabel_(TypeID(result.type().typeInfo()), label, productInstanceName, std::string(), moduleCallingContext_);
-  convert_handle(bh, result);  // throws on conversion error
-  if(!bh.failedToGet()) {
+  convert_handle(std::move(bh), result);  // throws on conversion error
+  if(!result.failedToGet()) {
     addToGotBranchIDs(*bh.provenance());
     return true;
   }
@@ -70,8 +70,8 @@ edm::Event::getByLabel<GenericObject>(edm::InputTag const& tag,
     return this->getByLabel(tag.label(), tag.instance(), result);
   } else {
     BasicHandle bh = provRecorder_.getByLabel_(TypeID(result.type().typeInfo()), tag.label(), tag.instance(),tag.process(), moduleCallingContext_);
-    convert_handle(bh, result);  // throws on conversion error
-    if(!bh.failedToGet()) {
+    convert_handle(std::move(bh), result);  // throws on conversion error
+    if(!result.failedToGet()) {
       addToGotBranchIDs(*bh.provenance());
       return true;
     }

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -56,10 +56,10 @@ namespace edm {
   }
 
   static
-  boost::shared_ptr<cms::Exception>
+  std::shared_ptr<cms::Exception>
   makeNotFoundException(char const* where, KindOfType kindOfType,
                         TypeID const& productType, std::string const& label, std::string const& instance, std::string const& process) {
-    boost::shared_ptr<cms::Exception> exception(new Exception(errors::ProductNotFound));
+    std::shared_ptr<cms::Exception> exception(new Exception(errors::ProductNotFound));
     if (kindOfType == PRODUCT_TYPE) {
       *exception << "Principal::" << where << ": Found zero products matching all criteria\nLooking for type: " << productType << "\n"
                  << "Looking for module label: " << label << "\n" << "Looking for productInstanceName: " << instance << "\n"
@@ -100,7 +100,7 @@ namespace edm {
   static
   void
   throwNotFoundException(char const* where, TypeID const& productType, InputTag const& tag) {
-    boost::shared_ptr<cms::Exception> exception = makeNotFoundException(where, PRODUCT_TYPE, productType, tag.label(), tag.instance(), tag.process());
+    auto exception = makeNotFoundException(where, PRODUCT_TYPE, productType, tag.label(), tag.instance(), tag.process());
     throw *exception;
   }
 
@@ -464,9 +464,9 @@ namespace edm {
 
     ProductData const* result = findProductByLabel(kindOfType, typeID, inputTag, consumer, mcc);
     if(result == 0) {
-      boost::shared_ptr<cms::Exception> whyFailed =
-        makeNotFoundException("getByLabel", kindOfType, typeID, inputTag.label(), inputTag.instance(), inputTag.process());
-      return BasicHandle(whyFailed);
+      return BasicHandle([=]()->std::shared_ptr<cms::Exception> {
+        return makeNotFoundException("getByLabel", kindOfType, typeID, inputTag.label(), inputTag.instance(), inputTag.process());
+      });
     }
     return BasicHandle(*result);
   }
@@ -482,9 +482,9 @@ namespace edm {
 
     ProductData const* result = findProductByLabel(kindOfType, typeID, label, instance, process,consumer, mcc);
     if(result == 0) {
-      boost::shared_ptr<cms::Exception> whyFailed =
-        makeNotFoundException("getByLabel", kindOfType, typeID, label, instance, process);
-      return BasicHandle(whyFailed);
+      return BasicHandle([=]()->std::shared_ptr<cms::Exception> {
+        return makeNotFoundException("getByLabel", kindOfType, typeID, label, instance, process);
+      });
     }
     return BasicHandle(*result);
   }

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -108,17 +108,21 @@ namespace edm {
                                               EDGetToken token) const {
     EDConsumerBase::Labels labels;
     consumer_->labelsForToken(token,labels);
-    boost::shared_ptr<cms::Exception> exception(new Exception(errors::ProductNotFound));
-    if (kindOfType == PRODUCT_TYPE) {
-      *exception << "Principal::getByToken: Found zero products matching all criteria\nLooking for type: " << productType << "\n"
-      << "Looking for module label: " << labels.module << "\n" << "Looking for productInstanceName: " << labels.productInstance << "\n"
-      << (0==labels.process[0] ? "" : "Looking for process: ") << labels.process << "\n";
-    } else {
-      *exception << "Principal::getByToken: Found zero products matching all criteria\nLooking for a container with elements of type: " << productType << "\n"
-      << "Looking for module label: " << labels.module << "\n" << "Looking for productInstanceName: " << labels.productInstance << "\n"
-      << (0==labels.process[0] ? "" : "Looking for process: ") << labels.process << "\n";
-    }
-    return BasicHandle(exception);
+    //no need to copy memory since the exception will no occur after the
+    // const char* have been deleted
+    return BasicHandle([labels,kindOfType,productType]()->std::shared_ptr<cms::Exception> {
+      std::shared_ptr<cms::Exception> exception(new Exception(errors::ProductNotFound));
+      if (kindOfType == PRODUCT_TYPE) {
+        *exception << "Principal::getByToken: Found zero products matching all criteria\nLooking for type: " << productType << "\n"
+        << "Looking for module label: " << labels.module << "\n" << "Looking for productInstanceName: " << labels.productInstance << "\n"
+        << (0==labels.process[0] ? "" : "Looking for process: ") << labels.process << "\n";
+      } else {
+        *exception << "Principal::getByToken: Found zero products matching all criteria\nLooking for a container with elements of type: " << productType << "\n"
+        << "Looking for module label: " << labels.module << "\n" << "Looking for productInstanceName: " << labels.productInstance << "\n"
+        << (0==labels.process[0] ? "" : "Looking for process: ") << labels.process << "\n";
+      }
+      return exception;
+    });
   }
 
   void

--- a/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
+++ b/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
@@ -121,7 +121,7 @@ namespace edm
                                         inputTag_,
                                         nullptr,
                                         mcc);
-      convert_handle(h,product_);
+      convert_handle(std::move(h),product_);
     }
     
     typedef detail::NamedEventSelector NES;

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -579,7 +579,7 @@ void testEvent::getByLabel() {
   }
 
   BasicHandle bh = principal_->getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)), "modMulti", "int1", "LATE",nullptr, nullptr);
-  convert_handle(bh, h);
+  convert_handle(std::move(bh), h);
   CPPUNIT_ASSERT(h->value == 100);
   BasicHandle bh2(principal_->getByLabel(PRODUCT_TYPE, TypeID(typeid(edmtest::IntProduct)), "modMulti", "int1", "nomatch",nullptr, nullptr));
   CPPUNIT_ASSERT(!bh2.isValid());

--- a/Fireworks/Core/src/FWGenericHandle.h
+++ b/Fireworks/Core/src/FWGenericHandle.h
@@ -127,14 +127,14 @@ public:
 
    void clear() { prov_ = 0; whyFailed_.reset();}
       
-   void setWhyFailed(boost::shared_ptr<cms::Exception> const& iWhyFailed) {
+   void setWhyFailed(std::shared_ptr<cms::Exception> const& iWhyFailed) {
     whyFailed_=iWhyFailed;
   }
 private:
    edm::TypeWithDict type_;
    edm::ObjectWithDict prod_;
    Provenance const* prov_;    
-   boost::shared_ptr<cms::Exception> whyFailed_;
+   std::shared_ptr<cms::Exception> whyFailed_;
 };
 
 typedef Handle<FWGenericObject> FWGenericHandle;

--- a/HLTrigger/HLTcore/src/TriggerExpressionData.cc
+++ b/HLTrigger/HLTcore/src/TriggerExpressionData.cc
@@ -24,7 +24,7 @@ const T * get(const edm::Event & event, const edm::InputTag & tag) {
   edm::Handle<T> handle;
   event.getByLabel(tag, handle);
   if (not handle.isValid()) {
-    boost::shared_ptr<cms::Exception> const & error = handle.whyFailed();
+    auto const & error = handle.whyFailed();
     edm::LogWarning(error->category()) << error->what();
     return 0;
   } else {
@@ -38,7 +38,7 @@ const T * get(const edm::Event & event, const edm::EDGetTokenT<T> & token) {
   edm::Handle<T> handle;
   event.getByToken(token, handle);
   if (not handle.isValid()) {
-    boost::shared_ptr<cms::Exception> const & error = handle.whyFailed();
+    auto const & error = handle.whyFailed();
     edm::LogWarning(error->category()) << error->what();
     return 0;
   } else {

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -109,7 +109,7 @@ namespace edm {
                                                     nullptr);
     assert(bhandle.isValid());
     Handle<edmtest::IntProduct> handle;
-    convert_handle<edmtest::IntProduct>(bhandle, handle);
+    convert_handle<edmtest::IntProduct>(std::move(bhandle), handle);
     assert(static_cast<EventNumber_t>(handle->value) == en);
 
     // Check that primary source products are retrieved from the same event as the EventAuxiliary

--- a/IOPool/Streamer/interface/FRDEventOutputModule.h
+++ b/IOPool/Streamer/interface/FRDEventOutputModule.h
@@ -71,7 +71,7 @@ void FRDEventOutputModule<Consumer>::write(edm::EventPrincipal const& e, edm::Mo
                                     emptyString,
                                     nullptr,
                                     mcc);
-  convert_handle(h, fedBuffers);
+  convert_handle(std::move(h), fedBuffers);
 
   // determine the expected size of the FRDEvent
   int expectedSize = (4 + 1024) * sizeof(uint32);


### PR DESCRIPTION
HLT Profiling done by Vincenzo Innocente showed that a large fraction of the time was being spent in setting up exception objects when non-existent data was requested. This was a waste of time since code was always checking the validity of the edm::Handle and therefore the exceptions were never thrown. 

This code has the edm::Handle hold a functor which can create the exception if that exception is actually going to be used. igprof measurements have shown this to be faster than constructing the exception.
