### PR TITLE
Pixel cluster

### DIFF
--- a/CalibTracker/SiPixelESProducers/BuildFile.xml
+++ b/CalibTracker/SiPixelESProducers/BuildFile.xml
@@ -3,6 +3,8 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="CondFormats/SiPixelObjects"/>
+<use   name="DataFormats/Common"/>
+<use   name="DataFormats/SiPixelDigi"/>
 <use   name="CalibTracker/Records"/>
 <use   name="MagneticField/VolumeBasedEngine"/>
 <use   name="boost"/>

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTService.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationForHLTService.h
@@ -18,12 +18,15 @@
 #include "CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLT.h" 
 #include "CondFormats/DataRecord/interface/SiPixelGainCalibrationForHLTRcd.h"
 
-class SiPixelGainCalibrationForHLTService : public SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationForHLT,SiPixelGainCalibrationForHLTRcd>
+class SiPixelGainCalibrationForHLTService final : public SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationForHLT,SiPixelGainCalibrationForHLTRcd>
 {
 
  public:
   explicit SiPixelGainCalibrationForHLTService(const edm::ParameterSet& conf) : SiPixelGainCalibrationServicePayloadGetter<SiPixelGainCalibrationForHLT,SiPixelGainCalibrationForHLTRcd>(conf){};
   ~SiPixelGainCalibrationForHLTService(){};
+
+  void calibrate(uint32_t detID, DigiIterator b, DigiIterator e, float conversionFactor, float offset, int * electron);
+
 
   // column granularity
   float   getPedestal  ( const uint32_t& detID,const int& col, const int& row);

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h
@@ -238,6 +238,7 @@ float SiPixelGainCalibrationServicePayloadGetter<thePayloadObject,theDBRecordTyp
         std::pair<const typename thePayloadObject::Range, const int> rangeAndNCols = ped->getRangeAndNCols(detID);
 	old_range = rangeAndNCols.first;
 	old_cols  = rangeAndNCols.second;
+	oldColumnIndexGain_ = -1;
       } 
       else if (col == oldColumnIndexPed_ && inTheSameAveragedDataBlock) // same DetID, same column, same data block
       {
@@ -274,6 +275,7 @@ float SiPixelGainCalibrationServicePayloadGetter<thePayloadObject,theDBRecordTyp
       std::pair<const typename thePayloadObject::Range, const int> rangeAndNCols = ped->getRangeAndNCols(detID);
       old_range = rangeAndNCols.first;
       old_cols  = rangeAndNCols.second;
+      oldColumnIndexPed_ = -1;
     }
     else if (col == oldColumnIndexGain_ && inTheSameAveragedDataBlock) // same DetID, same column
     {

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h
@@ -197,6 +197,7 @@ float SiPixelGainCalibrationServicePayloadGetter<thePayloadObject,theDBRecordTyp
         std::pair<const typename thePayloadObject::Range, const int> rangeAndNCols = ped->getRangeAndNCols(detID);
 	old_range = rangeAndNCols.first;
 	old_cols  = rangeAndNCols.second;
+	oldColumnIndexGain_ = -1;
       }
       //std::cout<<" Pedestal "<<ped->getPed(col, row, old_range, old_cols)<<std::endl;
       return  ped->getPed(col, row, old_range, old_cols, isDead, isNoisy);
@@ -216,6 +217,7 @@ float SiPixelGainCalibrationServicePayloadGetter<thePayloadObject,theDBRecordTyp
       std::pair<const typename thePayloadObject::Range, const int> rangeAndNCols = ped->getRangeAndNCols(detID);
       old_range = rangeAndNCols.first;
       old_cols  = rangeAndNCols.second;
+      return oldColumnValuePed_;
     }
     return ped->getGain(col, row, old_range, old_cols, isDead, isNoisy);
   } else throw cms::Exception("NullPointer")

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h
@@ -147,6 +147,7 @@ template<class thePayloadObject, class theDBRecordType>
 void SiPixelGainCalibrationServicePayloadGetter<thePayloadObject,theDBRecordType>::setESObjects( const edm::EventSetup& es ) {
 
     es.get<theDBRecordType>().get(ped);
+    ped->initialize();
     numberOfRowsAveragedOver_ = ped->getNumberOfRowsToAverageOver();
     ESetupInit_ = true;
 

--- a/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h
+++ b/CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationServiceBase.h
@@ -14,32 +14,42 @@
 // ************************************************************************
 // ************************************************************************
 
+#include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/SiPixelDigi/interface/PixelDigi.h"
+
 // Framework
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include <iostream>
-#include <utility>
 
 // Abstract base class provides common interface to different payload getters 
 class SiPixelGainCalibrationServiceBase {
    public:
-      SiPixelGainCalibrationServiceBase(){};
-      virtual ~SiPixelGainCalibrationServiceBase(){};
-      virtual float getGain      ( const uint32_t& detID , const int& col , const int& row)=0;
-      virtual float getPedestal  ( const uint32_t& detID , const int& col , const int& row)=0;
-      virtual bool  isDead       ( const uint32_t& detID , const int& col , const int& row)=0;
-      virtual bool  isDeadColumn ( const uint32_t& detID , const int& col , const int& row)=0;
-      virtual bool  isNoisy       ( const uint32_t& detID , const int& col , const int& row)=0;
-      virtual bool  isNoisyColumn ( const uint32_t& detID , const int& col , const int& row)=0;
-      virtual void  setESObjects(const edm::EventSetup& es )=0;
-      virtual std::vector<uint32_t> getDetIds()=0;
-      virtual double getGainLow()=0;
-      virtual double getGainHigh()=0;
-      virtual double getPedLow()=0;
-      virtual double getPedHigh()=0;
+
+  typedef edm::DetSet<PixelDigi>::const_iterator    DigiIterator;
+
+
+  SiPixelGainCalibrationServiceBase(){};
+  virtual ~SiPixelGainCalibrationServiceBase(){};
+  
+  // default inplementation from PixelThresholdClusterizer 
+  virtual void calibrate(uint32_t detID, DigiIterator b, DigiIterator e, float conversionFactor, float offset, int * electron);
+  
+  virtual float getGain      ( const uint32_t& detID , const int& col , const int& row)=0;
+  virtual float getPedestal  ( const uint32_t& detID , const int& col , const int& row)=0;
+  virtual bool  isDead       ( const uint32_t& detID , const int& col , const int& row)=0;
+  virtual bool  isDeadColumn ( const uint32_t& detID , const int& col , const int& row)=0;
+  virtual bool  isNoisy       ( const uint32_t& detID , const int& col , const int& row)=0;
+  virtual bool  isNoisyColumn ( const uint32_t& detID , const int& col , const int& row)=0;
+  virtual void  setESObjects(const edm::EventSetup& es )=0;
+  virtual std::vector<uint32_t> getDetIds()=0;
+  virtual double getGainLow()=0;
+  virtual double getGainHigh()=0;
+  virtual double getPedLow()=0;
+  virtual double getPedHigh()=0;
+
 };
 
 
@@ -80,7 +90,6 @@ class SiPixelGainCalibrationServicePayloadGetter : public SiPixelGainCalibration
 
   void    throwExepctionForBadRead(std::string payload, const uint32_t& detID, const int& col, const int& row, double value = -1) const;
 
- private:
 
   edm::ParameterSet conf_;
   bool ESetupInit_;

--- a/CalibTracker/SiPixelESProducers/src/SiPixelGainCalibrationService.cc
+++ b/CalibTracker/SiPixelESProducers/src/SiPixelGainCalibrationService.cc
@@ -16,6 +16,28 @@
 
 #include "CalibTracker/SiPixelESProducers/interface/SiPixelGainCalibrationService.h"
 
+
+
+void SiPixelGainCalibrationServiceBase::calibrate(uint32_t detID, DigiIterator b, DigiIterator e, float conversionFactor, float offset, int * electron) {
+  int i=0;
+  for(DigiIterator di = b; di != e; ++di)  {
+    int row = di->row();
+    int col = di->column();
+    
+    if ( isDead(detID,col,row) || isNoisy(detID,col,row) ) electron[i++] =0;
+    else {
+      float DBgain     = getGain(detID, col, row);
+      float DBpedestal = getPedestal(detID, col, row) * DBgain;
+      float vcal = di->adc() * DBgain  - DBpedestal;
+      //    float vcal = (di->adc()  - DBpedestal) * DBgain;
+      electron[i++] = int( vcal * conversionFactor + offset); 
+    }
+  }
+  assert(i==(e-b));
+}
+
+
+
 float SiPixelGainCalibrationService::getPedestal( const uint32_t& detID,const int& col, const int& row)
 {
    bool isDead = false;

--- a/CondFormats/SiPixelObjects/interface/SiPixelGainCalibration.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelGainCalibration.h
@@ -54,7 +54,9 @@ class SiPixelGainCalibration {
   // Constructors
   SiPixelGainCalibration();
   SiPixelGainCalibration(float minPed, float maxPed, float minGain, float maxGain);
-  virtual ~SiPixelGainCalibration(){};
+  ~SiPixelGainCalibration(){}
+
+  void initialize() const{}
 
   bool  put(const uint32_t& detID,Range input, const int& nCols);
   const Range getRange(const uint32_t& detID) const;

--- a/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLT.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLT.h
@@ -53,7 +53,9 @@ class SiPixelGainCalibrationForHLT {
   // Constructors
   SiPixelGainCalibrationForHLT();
   SiPixelGainCalibrationForHLT(float minPed, float maxPed, float minGain, float maxGain);
-  virtual ~SiPixelGainCalibrationForHLT(){};
+  ~SiPixelGainCalibrationForHLT(){}
+
+  void initialize() const;
 
   bool  put(const uint32_t& detID,Range input, const int& nCols);
   const Range getRange(const uint32_t& detID) const;
@@ -62,10 +64,10 @@ class SiPixelGainCalibrationForHLT {
   const std::pair<const Range, const int> getRangeAndNCols(const uint32_t& detID) const;
 
   unsigned int getNumberOfRowsToAverageOver() const { return numberOfRowsToAverageOver_; }
-  double getGainLow() const { return minGain_; }
-  double getGainHigh() const { return maxGain_; }
-  double getPedLow() const { return minPed_; }
-  double getPedHigh() const { return maxPed_; }
+  float getGainLow() const { return minGain_; }
+  float getGainHigh() const { return maxGain_; }
+  float getPedLow() const { return minPed_; }
+  float getPedHigh() const { return maxPed_; }
 
   // Set and get public methods
   void  setData(float ped, float gain, std::vector<char>& vped, bool thisColumnIsDead = false, bool thisColumnIsNoisy = false);
@@ -82,12 +84,14 @@ class SiPixelGainCalibrationForHLT {
 
   float   encodeGain(const float& gain);
   float   encodePed (const float& ped);
-  float   decodeGain(unsigned int gain) const;
-  float   decodePed (unsigned int ped) const;
+  float   decodeGain(unsigned int gain) const {return gain*gainPrecision + minGain_;}
+  float   decodePed (unsigned int ped) const { return ped*pedPrecision + minPed_;}
 
   std::vector<char> v_pedestals; //@@@ blob streaming doesn't work with uint16_t and with classes
   std::vector<DetRegistry> indexes;
   float  minPed_, maxPed_, minGain_, maxGain_;
+
+  mutable float pedPrecision, gainPrecision;
 
   unsigned int numberOfRowsToAverageOver_;   //THIS WILL BE HARDCODED TO 80 (all rows in a ROC) DON'T CHANGE UNLESS YOU KNOW WHAT YOU ARE DOING! 
   unsigned int nBinsToUseForEncoding_;

--- a/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLT.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationForHLT.h
@@ -72,6 +72,9 @@ class SiPixelGainCalibrationForHLT {
   void  setDeadColumn(const int& nRows, std::vector<char>& vped)  { setData(0, 0 /*dummy values, not used*/, vped, true, false); }
   void  setNoisyColumn(const int& nRows, std::vector<char>& vped) { setData(0, 0 /*dummy values, not used*/, vped, false, true); }
 
+
+  std::pair<float,float> getPedAndGain(const int& col, const int& row, const Range& range, const int& nCols, bool& isDeadColumn, bool& isNoisyColumn ) const;
+
   float getPed   (const int& col, const int& row, const Range& range, const int& nCols, bool& isDeadColumn, bool& isNoisyColumn ) const;
   float getGain  (const int& col, const int& row, const Range& range, const int& nCols, bool& isDeadColumn, bool& isNoisyColumn ) const;
 

--- a/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationOffline.h
+++ b/CondFormats/SiPixelObjects/interface/SiPixelGainCalibrationOffline.h
@@ -52,7 +52,10 @@ class SiPixelGainCalibrationOffline {
   // Constructors
   SiPixelGainCalibrationOffline();
   SiPixelGainCalibrationOffline(float minPed, float maxPed, float minGain, float maxGain);
-  virtual ~SiPixelGainCalibrationOffline(){};
+  ~SiPixelGainCalibrationOffline(){}
+
+  void initialize() const{}
+
 
   bool  put(const uint32_t& detID,Range input, const int& nCols);
   const Range getRange(const uint32_t& detID) const;

--- a/CondFormats/SiPixelObjects/src/SiPixelGainCalibrationForHLT.cc
+++ b/CondFormats/SiPixelObjects/src/SiPixelGainCalibrationForHLT.cc
@@ -16,6 +16,7 @@ SiPixelGainCalibrationForHLT::SiPixelGainCalibrationForHLT() :
   deadFlag_(255),
   noisyFlag_(254)
 {
+  initialize();
    if (deadFlag_ > 0xFF)
       throw cms::Exception("GainCalibration Payload configuration error")
          << "[SiPixelGainCalibrationHLT::SiPixelGainCalibrationHLT] Dead flag was set to " << deadFlag_ << ", and it must be set less than or equal to 255";
@@ -31,9 +32,17 @@ SiPixelGainCalibrationForHLT::SiPixelGainCalibrationForHLT(float minPed, float m
   deadFlag_(255),
   noisyFlag_(254)
 {
+  initialize();
    if (deadFlag_ > 0xFF)
       throw cms::Exception("GainCalibration Payload configuration error")
          << "[SiPixelGainCalibrationHLT::SiPixelGainCalibrationHLT] Dead flag was set to " << deadFlag_ << ", and it must be set less than or equal to 255";
+}
+
+
+void SiPixelGainCalibrationForHLT::initialize() const {
+  pedPrecision  = (maxPed_-minPed_)/static_cast<float>(nBinsToUseForEncoding_);
+  gainPrecision = (maxGain_-minGain_)/static_cast<float>(nBinsToUseForEncoding_);
+
 }
 
 bool SiPixelGainCalibrationForHLT::put(const uint32_t& DetId, Range input, const int& nCols) {
@@ -130,24 +139,27 @@ std::pair<float,float> SiPixelGainCalibrationForHLT::getPedAndGain(const int& co
   unsigned int lengthOfAveragedDataInEachColumn = 2;  // we always only have two values per column averaged block 
   unsigned int numberOfDataBlocksToSkip = row / numberOfRowsToAverageOver_;
 
-  const DecodingStructure & s = (const DecodingStructure & ) *(range.first+col*lengthOfColumnData + lengthOfAveragedDataInEachColumn*numberOfDataBlocksToSkip);
+  const DecodingStructure & s = (const DecodingStructure & ) *(range.first + col*lengthOfColumnData + lengthOfAveragedDataInEachColumn*numberOfDataBlocksToSkip);
 
-  if ((s.ped & 0xFF) == deadFlag_)
-     isDeadColumn = true;
-  else if ((s.ped & 0xFF) == noisyFlag_)
-     isNoisyColumn = true;
+  isDeadColumn = (s.ped & 0xFF) == deadFlag_;
+  isNoisyColumn = (s.ped & 0xFF) == noisyFlag_;
 
+  /*
   int maxRow = (lengthOfColumnData/lengthOfAveragedDataInEachColumn)*numberOfRowsToAverageOver_ - 1;
   if (col >= nCols || row > maxRow){
     throw cms::Exception("CorruptedData")
       << "[SiPixelGainCalibrationForHLT::getPed] Pixel out of range: col " << col << " row: " << row;
   }  
+  */
+
   return std::make_pair(decodePed(s.ped & 0xFF),decodeGain(s.gain & 0xFF));
 
 
 }
+
+
 float SiPixelGainCalibrationForHLT::getPed(const int& col, const int& row, const Range& range, const int& nCols, bool& isDeadColumn, bool& isNoisyColumn) const {
-   // TODO MERGE THIS FUNCTION WITH GET GAIN, then provide wrappers
+   // TODO MERGE THIS FUNCTION WITH GET GAIN, then provide wrappers  ( VI done, see above)
 
   // determine what averaged data block we are in (there should be 1 or 2 of these depending on if plaquette is 1 by X or 2 by X
   unsigned int lengthOfColumnData  = (range.second-range.first)/nCols;
@@ -198,7 +210,7 @@ float SiPixelGainCalibrationForHLT::encodeGain( const float& gain ) {
     throw cms::Exception("InsertFailure")
       << "[SiPixelGainCalibrationForHLT::encodeGain] Trying to encode gain (" << gain << ") out of range [" << minGain_ << "," << maxGain_ << "]\n";
   } else {
-    double precision   = (maxGain_-minGain_)/static_cast<float>(nBinsToUseForEncoding_);
+    float precision   = (maxGain_-minGain_)/static_cast<float>(nBinsToUseForEncoding_);
     float  encodedGain = (float)((gain-minGain_)/precision);
     return encodedGain;
   }
@@ -211,27 +223,10 @@ float SiPixelGainCalibrationForHLT::encodePed( const float& ped ) {
     throw cms::Exception("InsertFailure")
       << "[SiPixelGainCalibrationForHLT::encodePed] Trying to encode pedestal (" << ped << ") out of range [" << minPed_ << "," << maxPed_ << "]\n";
   } else {
-    double precision   = (maxPed_-minPed_)/static_cast<float>(nBinsToUseForEncoding_);
+    float precision   = (maxPed_-minPed_)/static_cast<float>(nBinsToUseForEncoding_);
     float  encodedPed = (float)((ped-minPed_)/precision);
     return encodedPed;
   }
 
 }
-
-float SiPixelGainCalibrationForHLT::decodePed( unsigned int ped ) const {
-
-  double precision = (maxPed_-minPed_)/static_cast<float>(nBinsToUseForEncoding_);
-  float decodedPed = (float)(ped*precision + minPed_);
-  return decodedPed;
-
-}
-
-float SiPixelGainCalibrationForHLT::decodeGain( unsigned int gain ) const {
-
-  double precision = (maxGain_-minGain_)/static_cast<float>(nBinsToUseForEncoding_);
-  float decodedGain = (float)(gain*precision + minGain_);
-  return decodedGain;
-
-}
-
 

--- a/CondFormats/SiPixelObjects/src/classes_def.xml
+++ b/CondFormats/SiPixelObjects/src/classes_def.xml
@@ -28,6 +28,8 @@
 
   <class name="SiPixelGainCalibrationForHLT" class_version="0">
      <field name="v_pedestals" mapping="blob"/>
+     <field name="pedPrecision" transient="true"/>
+     <field name="gainPrecision" transient="true"/>
   </class>
   <class name="SiPixelGainCalibrationForHLT::DetRegistry"/>
   <class name="std::vector<SiPixelGainCalibrationForHLT::DetRegistry>"/>

--- a/DataFormats/Common/interface/DetSetNew.h
+++ b/DataFormats/Common/interface/DetSetNew.h
@@ -1,6 +1,8 @@
 #ifndef DataFormats_Common_DetSetNew_h
 #define DataFormats_Common_DetSetNew_h
 
+#include "FWCore/Utilities/interface/GCC11Compatibility.h"
+
 namespace edmNew {
   //  FIXME move it elsewhere....
   typedef unsigned int det_id_type;

--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -11,6 +11,7 @@
 #include <boost/iterator/counting_iterator.hpp>
 #include <boost/any.hpp>
 #include "boost/shared_ptr.hpp"
+#include "FWCore/Utilities/interface/GCC11Compatibility.h"
 
 
 #include<vector>
@@ -161,6 +162,14 @@ namespace edmNew {
 	v.m_data.push_back(d);
 	item.size++;
       }
+#ifndef CMS_NOCXX11
+      void push_back(data_type && d) {
+        v.m_data.push_back(std::move(d));
+        item.size++;
+      }
+
+#endif
+
       data_type & back() { return v.m_data.back();}
       
     private:

--- a/DataFormats/SiPixelDetId/src/PixelChannelIdentifier.cc
+++ b/DataFormats/SiPixelDetId/src/PixelChannelIdentifier.cc
@@ -2,39 +2,6 @@
 //
 #include "DataFormats/SiPixelDetId/interface/PixelChannelIdentifier.h"
 
-#include <iostream>
-#include <algorithm>
-
-
-PixelChannelIdentifier::Packing::Packing(const int row_w, const int column_w, 
-			    const int time_w, const int adc_w) :
-  row_width(row_w), column_width(column_w), adc_width(adc_w) 
-{
-  // Constructor: pre-computes masks and shifts from field widths
-  // Order of fields (from right to left) is
-  // row, column, time, adc count.
-
-  if ( row_w+column_w+time_w+adc_w != 32) {
-    std::cout << std::endl << "Warning in PixelDigi::Packing constructor:" 
-	 << "sum of field widths != 32" << std::endl;
-  }
-  // Fields are counted from right to left!
-
-  row_shift     = 0;
-  column_shift  = row_shift + row_w;
-  time_shift    = column_shift + column_w;
-  adc_shift     = time_shift + time_w;
-  
-  row_mask     = ~(~0 << row_w);
-  column_mask  = ~(~0 << column_w);
-  time_mask    = ~(~0 << time_w);
-  adc_mask     = ~(~0 << adc_w);
-
-  max_row = row_mask;
-  max_column = column_mask;
-  max_adc = adc_mask;
-
-}
 
 /*
 // Extract from CMSIM manual (version Thu Jul 31 16:38:50 MET DST 1997)
@@ -63,4 +30,4 @@ PixelChannelIdentifier::Packing::Packing(const int row_w, const int column_w,
 */
 
 // Initialization of static data members - DEFINES DIGI PACKING !
-PixelChannelIdentifier::Packing PixelChannelIdentifier::thePacking( 8, 9, 4, 11); // row, col, time, adc
+const PixelChannelIdentifier::Packing PixelChannelIdentifier::thePacking( 8, 9, 4, 11); // row, col, time, adc

--- a/DataFormats/SiPixelDigi/interface/PixelDigi.h
+++ b/DataFormats/SiPixelDigi/interface/PixelDigi.h
@@ -55,8 +55,13 @@ public:
 };  
 
 // Comparison operators
+
+//inline bool operator<( const PixelDigi& one, const PixelDigi& other) {
+//  return one.channel() < other.channel();
+//}
+
 inline bool operator<( const PixelDigi& one, const PixelDigi& other) {
-  return one.channel() < other.channel();
+  return (one.packedData()&PixelChannelIdentifier::thePacking.rowcol_mask) < (other.packedData()&PixelChannelIdentifier::thePacking.rowcol_mask);
 }
 
 #include<iostream>

--- a/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelArrayBuffer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelArrayBuffer.h
@@ -92,19 +92,10 @@ bool SiPixelArrayBuffer::inside(int row, int col) const
 }
 
 
-int SiPixelArrayBuffer::operator()(int row, int col) const 
-{
-  if (inside(row,col))  return pixel_vec[index(row,col)];
-  else  return 0;
-}
+int SiPixelArrayBuffer::operator()(int row, int col) const  { return pixel_vec[index(row,col)];}
 
 
-int SiPixelArrayBuffer::operator()(const SiPixelCluster::PixelPos& pix) const 
-{
-  if (inside( pix.row(), pix.col())) return pixel_vec[index(pix)];
-  else return 0;
-}
-
+int SiPixelArrayBuffer::operator()(const SiPixelCluster::PixelPos& pix) const {return pixel_vec[index(pix)];}
 
 // unchecked!
 void SiPixelArrayBuffer::set_adc( int row, int col, int adc) 

--- a/RecoLocalTracker/SiPixelClusterizer/src/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/src/PixelThresholdClusterizer.cc
@@ -151,7 +151,7 @@ void PixelThresholdClusterizer::clusterizeDetUnit( const edm::DetSet<PixelDigi> 
 	  // (TO DO: one is signed, other unsigned, gcc warns...)
 	  if ( cluster.charge() >= theClusterThreshold) 
 	    {
-	      //	cout << "putting in this cluster " << i << " " << cluster.charge() << " " << cluster.amplitudes().size() << endl;
+	      // std::cout << "putting in this cluster " << i << " " << cluster.charge() << " " << cluster.pixelADC().size() << endl;
 	      output.push_back( std::move(cluster) );
 	    }
 	}
@@ -189,7 +189,7 @@ void PixelThresholdClusterizer::copy_to_buffer( DigiIterator begin, DigiIterator
 {
   static int ic=0;
   if (ic==0) {
-    std::cout << (doMissCalibrate ? "VI from db" : "VI linear") << std::endl;
+    // std::cout << (doMissCalibrate ? "VI from db" : "VI linear") << std::endl;
   }
   ic++;
   int electron[end-begin];

--- a/RecoLocalTracker/SiPixelClusterizer/src/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/src/PixelThresholdClusterizer.cc
@@ -358,18 +358,20 @@ PixelThresholdClusterizer::make_cluster( const SiPixelCluster::PixelPos& pix,
   //The only difference between dead/noisy pixels and standard ones is that for dead/noisy pixels,
   //We consider the charge of the pixel to always be zero.
 
+  /*  this is not possible as dead and noisy pixel cannot make it into a seed...
   if ( doMissCalibrate &&
        (theSiPixelGainCalibrationService_->isDead(detid_,pix.col(),pix.row()) || 
 	theSiPixelGainCalibrationService_->isNoisy(detid_,pix.col(),pix.row())) )
     {
+      std::cout << "IMPOSSIBLE" << std::endl;
       seed_adc = 0;
       theBuffer.set_adc(pix, 1);
     }
-  else
-    {
-      seed_adc = theBuffer(pix.row(), pix.col());
-      theBuffer.set_adc( pix, 1);
-    }
+  else {
+  */
+  seed_adc = theBuffer(pix.row(), pix.col());
+  theBuffer.set_adc( pix, 1);
+      //  }
   
   AccretionCluster acluster;
   acluster.add(pix, seed_adc);

--- a/RecoLocalTracker/SiPixelClusterizer/src/PixelThresholdClusterizer.cc
+++ b/RecoLocalTracker/SiPixelClusterizer/src/PixelThresholdClusterizer.cc
@@ -218,14 +218,18 @@ void PixelThresholdClusterizer::copy_to_buffer( DigiIterator begin, DigiIterator
   }
 
   int i=0;
+#ifdef PIXELREGRESSION
   static int eqD=0;
+#endif
   for(DigiIterator di = begin; di != end; ++di) {
     int row = di->row();
     int col = di->column();
     int adc = electron[i++];
+#ifdef PIXELREGRESSION
     int adcOld = calibrate(di->adc(),col,row);
     //assert(adc==adcOld);
     if (adc!=adcOld) std::cout << "VI " << eqD  <<' '<< ic  <<' '<< end-begin <<' '<< i <<' '<< di->adc() <<' ' << adc <<' '<< adcOld << std::endl; else ++eqD;
+#endif
     if ( adc >= thePixelThreshold) {
       theBuffer.set_adc( row, col, adc);
       if ( adc >= theSeedThreshold) theSeeds.push_back( SiPixelCluster::PixelPos(row,col) );

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
@@ -110,9 +110,13 @@ SiStripRecHitMatcher::match( const SiStripRecHit2D *monoRH,
 
 namespace {
   // FIXME for c++0X
-  inline void pb(std::vector<SiStripMatchedRecHit2D*> & v, SiStripMatchedRecHit2D* h) {
+  inline void pb1(std::vector<SiStripMatchedRecHit2D*> & v, SiStripMatchedRecHit2D* h) {
     v.push_back(h);
   }
+  inline void pb2(SiStripRecHitMatcher::CollectorMatched & v, const SiStripMatchedRecHit2D & h) {
+    v.push_back(h);
+  }
+
 }
 
 void
@@ -121,7 +125,7 @@ SiStripRecHitMatcher::match( const SiStripRecHit2D *monoRH,
 			     std::vector<SiStripMatchedRecHit2D*> & collector, 
 			     const GluedGeomDet* gluedDet,
 			     LocalVector trackdirection) const {
-  Collector result(boost::bind(&pb,boost::ref(collector),
+  Collector result(boost::bind(&pb1,boost::ref(collector),
 			     boost::bind(&SiStripMatchedRecHit2D::clone,_1)));
   match(monoRH,begin,end,result,gluedDet,trackdirection);
 }
@@ -154,7 +158,7 @@ SiStripRecHitMatcher::match( const SiStripRecHit2D *monoRH,
 			     const GluedGeomDet* gluedDet,
 			     LocalVector trackdirection) const {
 
-  Collector result(boost::bind(&CollectorMatched::push_back,boost::ref(collector),_1));
+  Collector result(boost::bind(pb2,boost::ref(collector),_1));
   match(monoRH,begin,end,result,gluedDet,trackdirection);
   
 }


### PR DESCRIPTION
Factor 2 speedup in SiPixelClusterProducer for HLT

1) small bug fixed in SiPixelGainCalibrationServiceBase
fixed for HLT and Offline
~0.01% of pixel were wrongly calibrated

improvements in
1) edmNew::DetSetVector (push_back(&&)
2) PixelDigi (faster and more useful sorting)
3) SiPixelGainCalibrationForHLT and SiPixelGainCalibrationForHLTService (added a getPedAndGain and a calibrate loop)
these improvements should be ported also Offline (for the time being a backward compatible implementation added)
and
4) PixelThresholdClusterizer use all the above + some cleanup

No regression observed

once also Sim and Reco are migrated a full cleanup of the interface would be useful...
I do not plan to work on that in the short term
