### PR TITLE
Do not apply L1 prescales (again) in L1REPACK step

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_GT_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_GT_cff.py
@@ -25,6 +25,8 @@ unpackCastorDigis = EventFilter.CastorRawToDigi.CastorRawToDigi_cfi.castorDigis.
 
 import L1Trigger.GlobalTrigger.gtDigis_cfi
 simGtDigis = L1Trigger.GlobalTrigger.gtDigis_cfi.gtDigis.clone(
+    AlgorithmTriggersUnprescaled= cms.bool(True),
+    TechnicalTriggersUnprescaled= cms.bool(True),
     GmtInputTag                 = cms.InputTag( 'unpackGtDigis' ),
     GctInputTag                 = cms.InputTag( 'unpackGctDigis' ),
     CastorInputTag              = cms.InputTag( 'unpackCastorDigis' ),


### PR DESCRIPTION
Fix for AlCaReco RelVal validation samples.
