### PR TITLE
Fix consumes validation reco track

### DIFF
--- a/Validation/RecoTrack/interface/SiPixelTrackingRecHitsValid.h
+++ b/Validation/RecoTrack/interface/SiPixelTrackingRecHitsValid.h
@@ -33,6 +33,8 @@
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h" 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 //#include "Validation/RecoTrack/interface/TrackLocalAngle.h"
 #include <TROOT.h>
 #include <TTree.h>
@@ -86,8 +88,9 @@ class SiPixelTrackingRecHitsValid : public edm::EDAnalyzer
   DQMStore* dbe_;
   std::string outputFile_;
   std::string debugNtuple_;
-  std::string src_;
   std::string builderName_;
+  edm::EDGetTokenT<SiPixelRecHitCollection> siPixelRecHitCollectionToken_;
+  edm::EDGetTokenT<reco::TrackCollection> recoTrackCollectionToken_;
   bool MTCCtrack_;
 
   bool checkType_; // do we check that the simHit associated with recHit is of the expected particle type ?

--- a/Validation/RecoTrack/interface/SiStripTrackingRecHitsValid.h
+++ b/Validation/RecoTrack/interface/SiStripTrackingRecHitsValid.h
@@ -81,9 +81,10 @@ class SiStripTrackingRecHitsValid : public edm::EDAnalyzer
  private:
 
   edm::ParameterSet conf_;
-
-  DQMStore* dbe_;
   std::string outputFile_;
+  edm::EDGetTokenT< std::vector<Trajectory> > v_TrajectoryToken_;
+  
+  DQMStore* dbe_;
 
   MonitorElement* PullRMSvsTrackwidth;
   MonitorElement* PullRMSvsExpectedwidth;

--- a/Validation/RecoTrack/plugins/SiPixelTrackingRecHitsValid.cc
+++ b/Validation/RecoTrack/plugins/SiPixelTrackingRecHitsValid.cc
@@ -21,7 +21,6 @@
 #include "Geometry/TrackerGeometryBuilder/interface/GluedGeomDet.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
 #include "DataFormats/DetId/interface/DetId.h" 
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
@@ -33,8 +32,6 @@
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
-
-#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 
@@ -120,7 +117,8 @@ SiPixelTrackingRecHitsValid::SiPixelTrackingRecHitsValid(const ParameterSet& ps)
   //Read config file
   MTCCtrack_ = ps.getParameter<bool>("MTCCtrack");
   outputFile_ = ps.getUntrackedParameter<string>("outputFile", "pixeltrackingrechitshisto.root");
-  src_ = ps.getUntrackedParameter<std::string>( "src" );
+  siPixelRecHitCollectionToken_ = consumes<SiPixelRecHitCollection>( edm::InputTag( "siPixelRecHits" ) );
+  recoTrackCollectionToken_ = consumes<reco::TrackCollection>( edm::InputTag( ps.getUntrackedParameter<std::string>( "src" ) ) );
   builderName_ = ps.getParameter<std::string>("TTRHBuilder");   
   checkType_ = ps.getParameter<bool>("checkType");
   genType_ = ps.getParameter<int>("genType");
@@ -1103,7 +1101,7 @@ void SiPixelTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
       // --------------------------------------- all hits -----------------------------------------------------------
       //--- Fetch Pixel RecHits
       edm::Handle<SiPixelRecHitCollection> recHitColl;
-      e.getByLabel( "siPixelRecHits", recHitColl);
+      e.getByToken( siPixelRecHitCollectionToken_, recHitColl );
       
       //cout <<" ----- Found " 
       //   << const_cast<SiPixelRecHitCollection*>(recHitColl.product())->size()
@@ -1189,7 +1187,7 @@ void SiPixelTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
        
       // Get tracks
       edm::Handle<reco::TrackCollection> trackCollection;
-      e.getByLabel(src_, trackCollection);
+      e.getByToken( recoTrackCollectionToken_, trackCollection );
       const reco::TrackCollection *tracks = trackCollection.product();
       reco::TrackCollection::const_iterator tciter;
 

--- a/Validation/RecoTrack/plugins/SiPixelTrackingRecHitsValid.cc
+++ b/Validation/RecoTrack/plugins/SiPixelTrackingRecHitsValid.cc
@@ -44,9 +44,6 @@
 #include <TTree.h>
 #include <TFile.h>
 
-using namespace std;
-using namespace edm;
-
 // End job: write and close the ntuple file
 void SiPixelTrackingRecHitsValid::endJob() 
 {
@@ -112,20 +109,20 @@ void SiPixelTrackingRecHitsValid::beginJob()
   
 }
 
-SiPixelTrackingRecHitsValid::SiPixelTrackingRecHitsValid(const ParameterSet& ps):conf_(ps), dbe_(0), tfile_(0), t_(0)
+SiPixelTrackingRecHitsValid::SiPixelTrackingRecHitsValid(const edm::ParameterSet& ps):conf_(ps), dbe_(0), tfile_(0), t_(0)
 {
   //Read config file
   MTCCtrack_ = ps.getParameter<bool>("MTCCtrack");
-  outputFile_ = ps.getUntrackedParameter<string>("outputFile", "pixeltrackingrechitshisto.root");
+  outputFile_ = ps.getUntrackedParameter<std::string>("outputFile", "pixeltrackingrechitshisto.root");
   siPixelRecHitCollectionToken_ = consumes<SiPixelRecHitCollection>( edm::InputTag( "siPixelRecHits" ) );
   recoTrackCollectionToken_ = consumes<reco::TrackCollection>( edm::InputTag( ps.getUntrackedParameter<std::string>( "src" ) ) );
   builderName_ = ps.getParameter<std::string>("TTRHBuilder");   
   checkType_ = ps.getParameter<bool>("checkType");
   genType_ = ps.getParameter<int>("genType");
-  debugNtuple_=ps.getUntrackedParameter<string>("debugNtuple", "SiPixelTrackingRecHitsValid_Ntuple.root");
+  debugNtuple_=ps.getUntrackedParameter<std::string>("debugNtuple", "SiPixelTrackingRecHitsValid_Ntuple.root");
 
   // Book histograms
-  dbe_ = Service<DQMStore>().operator->();
+  dbe_ = edm::Service<DQMStore>().operator->();
   //dbe_->showDirStructure();
 
   //float math_pi = 3.14159265;
@@ -1160,7 +1157,7 @@ void SiPixelTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 			  mePosxZmPanel2_all_hits->Fill( rechitx );
 			  mePosyZmPanel2_all_hits->Fill( rechity );
 			}
-		      else LogWarning("SiPixelTrackingRecHitsValid") << "..............................................Wrong panel number !"; 
+		      else edm::LogWarning("SiPixelTrackingRecHitsValid") << "..............................................Wrong panel number !"; 
 		    } // if ( side==1 ) 
 		  else if ( side==2 )
 		    {
@@ -1174,12 +1171,12 @@ void SiPixelTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 			   mePosxZpPanel2_all_hits->Fill( rechitx );
 			   mePosyZpPanel2_all_hits->Fill( rechity );
 			 }
-		       else  LogWarning("SiPixelTrackingRecHitsValid")<< "..............................................Wrong panel number !";
+		       else  edm::LogWarning("SiPixelTrackingRecHitsValid")<< "..............................................Wrong panel number !";
 		    } //else if ( side==2 )
-		  else LogWarning("SiPixelTrackingRecHitsValid") << ".......................................................Wrong side !" ;
+		  else edm::LogWarning("SiPixelTrackingRecHitsValid") << ".......................................................Wrong side !" ;
 		  
 		} // else if ( detId.subdetId()==PixelSubdetector::PixelEndcap )
-	      else LogWarning("SiPixelTrackingRecHitsValid") << "Pixel rechit collection but we are not in the pixel detector" << (int)detId.subdetId() ;
+	      else edm::LogWarning("SiPixelTrackingRecHitsValid") << "Pixel rechit collection but we are not in the pixel detector" << (int)detId.subdetId() ;
 	      
 	    }
 	}
@@ -1277,8 +1274,8 @@ void SiPixelTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 			  
 			  int n_assoc_muon = 0;
 
-			  vector<PSimHit>::const_iterator closestit = matched.begin();
-			  for (vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++)
+			  std::vector<PSimHit>::const_iterator closestit = matched.begin();
+			  for (std::vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++)
 			    {
 			      if ( checkType_ )
 				{
@@ -1303,7 +1300,7 @@ void SiPixelTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 				  closestit = m;
 				  found_hit_from_generated_particle = true;
 				}
-			    } // for (vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++)
+			    } // for (std::vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++)
 			  
 			  // This recHit does not have any simHit with the same particleType as the particles generated
 			  // Ignore it as most probably come from delta rays.
@@ -1312,8 +1309,8 @@ void SiPixelTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 			  
 			  if ( n_assoc_muon > 1 )
 			    {
-			      LogWarning("SiPixelTrackingRecHitsValid") << " ----- This is not good: n_assoc_muon = " << n_assoc_muon ;
-			      LogWarning("SiPixelTrackingRecHitsValid") << "evt = " << evt ;
+			      edm::LogWarning("SiPixelTrackingRecHitsValid") << " ----- This is not good: n_assoc_muon = " << n_assoc_muon ;
+			      edm::LogWarning("SiPixelTrackingRecHitsValid") << "evt = " << evt ;
 			    }
 
 			  pidhit = (*closestit).particleType();
@@ -1386,7 +1383,7 @@ void SiPixelTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 				  half = 0;
 				}
 			      else 
-				LogWarning("SiPixelTrackingRecHitsValid") << "-------------------------------------------------- Wrong module size !!!";
+				edm::LogWarning("SiPixelTrackingRecHitsValid") << "-------------------------------------------------- Wrong module size !!!";
 
 			      float tmp1 = theGeomDet->surface().toGlobal(Local3DPoint(0.,0.,0.)).perp();
 			      float tmp2 = theGeomDet->surface().toGlobal(Local3DPoint(0.,0.,1.)).perp();
@@ -1618,7 +1615,7 @@ void SiPixelTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 				      mePullYvsEtaZmPanel2DiskPlaq[disk-1][plaq-1]->Fill( eta, rechitpully );
 
 				    }
-				  else LogWarning("SiPixelTrackingRecHitsValid") << "..............................................Wrong panel number !"; 
+				  else edm::LogWarning("SiPixelTrackingRecHitsValid") << "..............................................Wrong panel number !"; 
 				} // if ( side==1 ) 
 			      else if ( side==2 )
 				{
@@ -1738,12 +1735,12 @@ void SiPixelTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 				      mePullYvsEtaZpPanel2DiskPlaq[disk-1][plaq-1]->Fill( eta, rechitpully );
 
 				    }
-				  else LogWarning("SiPixelTrackingRecHitsValid") << "..............................................Wrong panel number !"; 
+				  else edm::LogWarning("SiPixelTrackingRecHitsValid") << "..............................................Wrong panel number !"; 
 				} //else if ( side==2 )
-			      else LogWarning("SiPixelTrackingRecHitsValid") << ".......................................................Wrong side !" ;
+			      else edm::LogWarning("SiPixelTrackingRecHitsValid") << ".......................................................Wrong side !" ;
 			      
 			    } // else if ( detId.subdetId()==PixelSubdetector::PixelEndcap )
-			  else LogWarning("SiPixelTrackingRecHitsValid") << "Pixel rechit but we are not in the pixel detector" << (int)detId.subdetId() ;
+			  else edm::LogWarning("SiPixelTrackingRecHitsValid") << "Pixel rechit but we are not in the pixel detector" << (int)detId.subdetId() ;
 			  
 			  if(debugNtuple_.size()!=0)t_->Fill();
 

--- a/Validation/RecoTrack/plugins/SiStripTrackingRecHitsValid.cc
+++ b/Validation/RecoTrack/plugins/SiStripTrackingRecHitsValid.cc
@@ -57,6 +57,7 @@ SiStripTrackingRecHitsValid::SiStripTrackingRecHitsValid(const edm::ParameterSet
   outputFile_ = ps.getUntrackedParameter<string>("outputFile", "striptrackingrechitshisto.root");
   //src_ = ps.getUntrackedParameter<std::string>( "src" );
   //builderName_ = ps.getParameter<std::string>("TTRHBuilder");   
+  v_TrajectoryToken_ = consumes< std::vector<Trajectory> >( edm::InputTag( ps.getParameter<std::string>( "trajectoryInput" ) ) );
 
   // Book histograms
   dbe_ = edm::Service<DQMStore>().operator->();
@@ -1259,7 +1260,7 @@ void SiStripTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
   // Mangano's
 
   edm::Handle<vector<Trajectory> > trajCollectionHandle;
-  e.getByLabel(conf_.getParameter<string>("trajectoryInput"),trajCollectionHandle);
+  e.getByToken( v_TrajectoryToken_, trajCollectionHandle );
 
   edm::LogVerbatim("TrajectoryAnalyzer") << "trajColl->size(): " << trajCollectionHandle->size() ;
 

--- a/Validation/RecoTrack/plugins/SiStripTrackingRecHitsValid.cc
+++ b/Validation/RecoTrack/plugins/SiStripTrackingRecHitsValid.cc
@@ -34,8 +34,6 @@
 
 #include "RecoLocalTracker/SiStripRecHitConverter/interface/StripCPE.h"
 
-using namespace std;
-
 // ROOT
 #include "TROOT.h"
 #include "TFile.h"
@@ -54,7 +52,7 @@ SiStripTrackingRecHitsValid::SiStripTrackingRecHitsValid(const edm::ParameterSet
 
   //Read config file
   //MTCCtrack_ = ps.getParameter<bool>("MTCCtrack");
-  outputFile_ = ps.getUntrackedParameter<string>("outputFile", "striptrackingrechitshisto.root");
+  outputFile_ = ps.getUntrackedParameter<std::string>("outputFile", "striptrackingrechitshisto.root");
   //src_ = ps.getUntrackedParameter<std::string>( "src" );
   //builderName_ = ps.getParameter<std::string>("TTRHBuilder");   
   v_TrajectoryToken_ = consumes< std::vector<Trajectory> >( edm::InputTag( ps.getParameter<std::string>( "trajectoryInput" ) ) );
@@ -1259,20 +1257,20 @@ void SiStripTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 
   // Mangano's
 
-  edm::Handle<vector<Trajectory> > trajCollectionHandle;
+  edm::Handle<std::vector<Trajectory> > trajCollectionHandle;
   e.getByToken( v_TrajectoryToken_, trajCollectionHandle );
 
   edm::LogVerbatim("TrajectoryAnalyzer") << "trajColl->size(): " << trajCollectionHandle->size() ;
 
   //cout<<"trajColl->size() = "<<trajCollectionHandle->size()<<endl;
   
-  for(vector<Trajectory>::const_iterator it = trajCollectionHandle->begin(); it!=trajCollectionHandle->end();it++){
+  for(std::vector<Trajectory>::const_iterator it = trajCollectionHandle->begin(); it!=trajCollectionHandle->end();it++){
      
     edm::LogVerbatim("TrajectoryAnalyzer") << "this traj has " << it->foundHits() << " valid hits"  << " , "
 					    << "isValid: " << it->isValid() ;
 
-    vector<TrajectoryMeasurement> tmColl = it->measurements();
-    for(vector<TrajectoryMeasurement>::const_iterator itTraj = tmColl.begin(); itTraj!=tmColl.end(); itTraj++){
+    std::vector<TrajectoryMeasurement> tmColl = it->measurements();
+    for(std::vector<TrajectoryMeasurement>::const_iterator itTraj = tmColl.begin(); itTraj!=tmColl.end(); itTraj++){
       if(! itTraj->updatedState().isValid()) continue;
            
 //        edm::LogVerbatim("TrajectoryAnalyzer") << "tm number: " << (itTraj - tmColl.begin()) + 1<< " , "
@@ -1330,7 +1328,7 @@ void SiStripTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 	  const GluedGeomDet* gluedDet = (const GluedGeomDet*)tracker.idToDet(matchedhit->geographicalId());
 	  const StripGeomDetUnit* partnerstripdet =(StripGeomDetUnit*) gluedDet->stereoDet();
 	  std::pair<LocalPoint,LocalVector> hitPair;
-	  for(vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
+	  for(std::vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
 	    //project simhit;
 	    hitPair= projectHit((*m),partnerstripdet,gluedDet->surface());
 	    distx = fabs(rechitmatchedx - hitPair.first.x());
@@ -1548,7 +1546,7 @@ void SiStripTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 	    if(!matched.empty()){
 	      //		  cout << "\t\t\tmatched  " << matched.size() << endl;
 	      //	      cout<<"associatesimplehit"<<endl;
-	      for(vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
+	      for(std::vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
 		dist = abs((monohit)->localPosition().x() - (*m).localPosition().x());
 		if(dist<mindist){
 		  mindist = dist;
@@ -1657,7 +1655,7 @@ void SiStripTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 	      matched = associate.associateHit(*stereohit);
 	      if(!matched.empty()){
 		//		  cout << "\t\t\tmatched  " << matched.size() << endl;
-		for(vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
+		for(std::vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
 		  dist = abs((stereohit)->localPosition().x() - (*m).localPosition().x());
 		  if(dist<mindist){
 		    mindist = dist;
@@ -1774,7 +1772,7 @@ void SiStripTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 	  matched = associate.associateHit(*hit1d);
 	  if(!matched.empty()){
 	    //		  cout << "\t\t\tmatched  " << matched.size() << endl;
-	    for(vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
+	    for(std::vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
 	      dist = abs((hit1d)->localPosition().x() - (*m).localPosition().x());
 	      if(dist<mindist){
 		mindist = dist;
@@ -1944,7 +1942,7 @@ void SiStripTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 	  matched = associate.associateHit(*hit1d);
 	  if(!matched.empty()){
 	    //		  cout << "\t\t\tmatched  " << matched.size() << endl;
-	    for(vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
+	    for(std::vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
 	      dist = abs((hit1d)->localPosition().x() - (*m).localPosition().x());
 	      if(dist<mindist){
 		mindist = dist;
@@ -2050,7 +2048,7 @@ void SiStripTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 	  matched = associate.associateHit(*hit2d);
 	  if(!matched.empty()){
 	    //		  cout << "\t\t\tmatched  " << matched.size() << endl;
-	    for(vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
+	    for(std::vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
 	      dist = abs((hit2d)->localPosition().x() - (*m).localPosition().x());
 	      if(dist<mindist){
 		mindist = dist;
@@ -2219,7 +2217,7 @@ void SiStripTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 	  matched = associate.associateHit(*hit2d);
 	  if(!matched.empty()){
 	    //		  cout << "\t\t\tmatched  " << matched.size() << endl;
-	    for(vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
+	    for(std::vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
 	      dist = abs((hit2d)->localPosition().x() - (*m).localPosition().x());
 	      if(dist<mindist){
 		mindist = dist;


### PR DESCRIPTION
Fix consumes for package Validation/RecoTrack. The following plugins have been put on hold:
Validation/RecoTrack/plugins/MultiTrackValidator.cc
Validation/RecoTrack/plugins/MultiTrackValidatorGenPs.cc
Validation/RecoTrack/plugins/SiPixelTrackingRecHitsValid.cc
Validation/RecoTrack/plugins/TrackerSeedValidator.cc
along with their base class:
Validation/RecoTrack/interface/MultiTrackValidatorBase.h
Tested with whiteRabbit #3.
