### PR TITLE
Adding gen fragment for RS KK gluon with m = 3 TeV for B2G DQM

### DIFF
--- a/Configuration/Generator/python/RSKKGluon_m3000GeV_13TeV_cff.py
+++ b/Configuration/Generator/python/RSKKGluon_m3000GeV_13TeV_cff.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+source = cms.Source("EmptySource")
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+                                                      crossSection = cms.untracked.double(1.0),
+                                                      pythiaPylistVerbosity = cms.untracked.int32(0),
+                                                      filterEfficiency = cms.untracked.double(1.0),
+                                                      pythiaHepMCVerbosity = cms.untracked.bool(False),
+                                                      comEnergy = cms.double(13000.0),
+                                                      maxEventsToPrint = cms.untracked.int32(0),
+                                                      PythiaParameters = cms.PSet(
+                processParameters = cms.vstring(
+                    'ExtraDimensionsG*:qqbar2KKgluon* = on',
+                                                'ExtraDimensionsG*:KKintMode = 2',
+                                                'ExtraDimensionsG*:KKgqR = -0.2',
+                                                'ExtraDimensionsG*:KKgqL = -0.2',
+                                                'ExtraDimensionsG*:KKgbR = -0.2',
+                                                'ExtraDimensionsG*:KKgbL = 1.0',
+                                                'ExtraDimensionsG*:KKgtR = 5.0',
+                                                'ExtraDimensionsG*:KKgtL = 1.0',
+                                                '5100021:m0 = 3000',
+                                                'Tune:pp 5',
+                                                'Tune:ee 3'),
+                                    parameterSets = cms.vstring('processParameters')
+                                )
+                                                  )
+
+ProductionFilterSequence = cms.Sequence(generator)


### PR DESCRIPTION
As per request of Vitaliano, adding a gen fragment for creating a new RelVal for an RS KK gluon with m = 3 TeV for the B2G DQM efforts. 
