### PR TITLE
Don't store bunchspace as it may be updated

### DIFF
--- a/SimGeneral/MixingModule/plugins/Adjuster.h
+++ b/SimGeneral/MixingModule/plugins/Adjuster.h
@@ -20,7 +20,7 @@ namespace edm {
   class AdjusterBase {
   public:
     virtual ~AdjusterBase() {}
-    virtual void doOffset(int bcr, const edm::EventPrincipal&, ModuleCallingContext const*, unsigned int EventNr, int vertexOffset) = 0;
+    virtual void doOffset(int bunchspace, int bcr, const edm::EventPrincipal&, ModuleCallingContext const*, unsigned int EventNr, int vertexOffset) = 0;
     virtual bool checkSignal(edm::Event const& event) = 0;
   };
 
@@ -28,11 +28,11 @@ namespace edm {
   class Adjuster : public AdjusterBase {
 
   public:
-    Adjuster(int bunchsp, InputTag const& tag);
+    Adjuster(InputTag const& tag);
 
     virtual ~Adjuster() {}
 
-    virtual void doOffset(int bcr, const edm::EventPrincipal&, ModuleCallingContext const*, unsigned int EventNr, int vertexOffset);
+    virtual void doOffset(int bunchspace, int bcr, const edm::EventPrincipal&, ModuleCallingContext const*, unsigned int EventNr, int vertexOffset);
 
     virtual bool checkSignal(edm::Event const& event) {
       bool got = false;
@@ -42,7 +42,6 @@ namespace edm {
     }
 
    private:
-    int bunchSpace_;  //in nsec
     InputTag tag_;
   };
 
@@ -58,17 +57,16 @@ namespace edm {
   }
 
   template<typename T>
-  void  Adjuster<T>::doOffset(int bcr, const EventPrincipal &ep, ModuleCallingContext const* mcc, unsigned int eventNr, int vertexOffset) {
+  void  Adjuster<T>::doOffset(int bunchspace, int bcr, const EventPrincipal &ep, ModuleCallingContext const* mcc, unsigned int eventNr, int vertexOffset) {
     boost::shared_ptr<Wrapper<std::vector<T> > const> shPtr = getProductByTag<std::vector<T> >(ep, tag_, mcc);
     if (shPtr) {
       std::vector<T>& product = const_cast<std::vector<T>&>(*shPtr->product());
-      detail::doTheOffset(bunchSpace_, bcr, product, eventNr, vertexOffset);
+      detail::doTheOffset(bunchspace, bcr, product, eventNr, vertexOffset);
     }
   }
 
   template<typename T>
-  Adjuster<T>::Adjuster(int bunchsp, InputTag const& tag) :
-           bunchSpace_(bunchsp), tag_(tag) {
+  Adjuster<T>::Adjuster(InputTag const& tag) : tag_(tag) {
   }
 }
 

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -80,7 +80,7 @@ namespace edm {
             std::string label;
 
             branchesActivate(TypeID(typeid(std::vector<SimTrack>)).friendlyClassName(),std::string(""),tag,label);
-            adjustersObjects_.push_back(new Adjuster<SimTrack>(bunchSpace_, tag));
+            adjustersObjects_.push_back(new Adjuster<SimTrack>(tag));
             bool makeCrossingFrame = pset.getUntrackedParameter<bool>("makeCrossingFrame", false);
             if(makeCrossingFrame) {
               workersObjects_.push_back(new MixingWorker<SimTrack>(minBunch_,maxBunch_,bunchSpace_,std::string(""),label,labelCF,maxNbSources_,tag,tagCF));
@@ -108,7 +108,7 @@ namespace edm {
             std::string label;
 
             branchesActivate(TypeID(typeid(std::vector<SimVertex>)).friendlyClassName(),std::string(""),tag,label);
-            adjustersObjects_.push_back(new Adjuster<SimVertex>(bunchSpace_, tag));
+            adjustersObjects_.push_back(new Adjuster<SimVertex>(tag));
             bool makeCrossingFrame = pset.getUntrackedParameter<bool>("makeCrossingFrame", false);
             if(makeCrossingFrame) {
               workersObjects_.push_back(new MixingWorker<SimVertex>(minBunch_,maxBunch_,bunchSpace_,std::string(""),label,labelCF,maxNbSources_,tag,tagCF));
@@ -146,7 +146,7 @@ namespace edm {
               std::string label;
 
               branchesActivate(TypeID(typeid(std::vector<PCaloHit>)).friendlyClassName(),subdets[ii],tag,label);
-              adjustersObjects_.push_back(new Adjuster<PCaloHit>(bunchSpace_, tag));
+              adjustersObjects_.push_back(new Adjuster<PCaloHit>(tag));
               if(binary_search_all(crossingFrames, tag.instance())) {
                 workersObjects_.push_back(new MixingWorker<PCaloHit>(minBunch_,maxBunch_,bunchSpace_,subdets[ii],label,labelCF,maxNbSources_,tag,tagCF));
                 produces<CrossingFrame<PCaloHit> >(label);
@@ -169,7 +169,7 @@ namespace edm {
               std::string label;
 
               branchesActivate(TypeID(typeid(std::vector<PSimHit>)).friendlyClassName(),subdets[ii],tag,label);
-              adjustersObjects_.push_back(new Adjuster<PSimHit>(bunchSpace_, tag));
+              adjustersObjects_.push_back(new Adjuster<PSimHit>(tag));
               if(binary_search_all(crossingFrames, tag.instance())) {
                 workersObjects_.push_back(new MixingWorker<PSimHit>(minBunch_,maxBunch_,bunchSpace_,subdets[ii],label,labelCF,maxNbSources_,tag,tagCF));
                 produces<CrossingFrame<PSimHit> >(label);
@@ -304,7 +304,7 @@ namespace edm {
     ModuleContextSentry moduleContextSentry(&moduleCallingContext, parentContext);
 
     for (auto const& adjuster : adjusters_) {
-      adjuster->doOffset(bunchCrossing, eventPrincipal, &moduleCallingContext, eventId, vertexOffset);
+      adjuster->doOffset(bunchSpace_, bunchCrossing, eventPrincipal, &moduleCallingContext, eventId, vertexOffset);
     }
     PileUpEventPrincipal pep(eventPrincipal, &moduleCallingContext, bunchCrossing);
     accumulateEvent(pep, setup);


### PR DESCRIPTION
Pull request 1615 (already merged) fixed a problem with multiple time shifting of the same hits in the mixing module.
However, the Adjuster class that implemented this stored the bunchspace.  The Mixing Module allows the bunch space to be updated on run or lumi boundaries.  If this happened, the adjuster would still use the original value.

This simple pull request fixes this by passing in the bunch space as an argument, rather than storing it as a member of the Adjuster class.
