### PR TITLE
Add missing iostream include in TauAnalysis/MCEmbeddingTools

### DIFF
--- a/TauAnalysis/MCEmbeddingTools/plugins/CaloRecHitMixer.h
+++ b/TauAnalysis/MCEmbeddingTools/plugins/CaloRecHitMixer.h
@@ -23,6 +23,7 @@
 #include "DataFormats/CaloRecHit/interface/CaloRecHit.h"
 
 #include <string>
+#include <iostream>
 #include <map>
 
 struct CaloRecHitMixer_mixedRecHitInfoType


### PR DESCRIPTION
The following is needed for ROOT6.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
