### PR TITLE
FSimTrack::daughters() returns empty vector if no endvertex is present

### DIFF
--- a/FastSimulation/Event/interface/FSimTrack.icc
+++ b/FastSimulation/Event/interface/FSimTrack.icc
@@ -1,6 +1,5 @@
 #include "FastSimulation/Event/interface/FBaseSimEvent.h"
 #include "FastSimulation/Event/interface/FSimVertex.h"
-#include "assert.h"
 
 inline const FSimVertex& FSimTrack::vertex() const{ return mom_->vertex(vertIndex()); }
 

--- a/FastSimulation/Event/interface/FSimTrack.icc
+++ b/FastSimulation/Event/interface/FSimTrack.icc
@@ -1,5 +1,6 @@
 #include "FastSimulation/Event/interface/FBaseSimEvent.h"
 #include "FastSimulation/Event/interface/FSimVertex.h"
+#include "assert.h"
 
 inline const FSimVertex& FSimTrack::vertex() const{ return mom_->vertex(vertIndex()); }
 
@@ -37,13 +38,14 @@ inline int FSimTrack::nDaughters() const {
 }
 
 inline const std::vector<int>& FSimTrack::daughters() const {
-  if(abs(type()) == 11)
+  if(abs(type()) == 11 || noEndVertex() )
     return daugh_;
   else{
-    if(noEndVertex())
-      throw cms::Exception("FastSim") << "FSimTrack::daughter(int index) called for FSimTrack w/o end vertex, please contact FastSim developers" << std::endl;
+    //if(noEndVertex()){
+      //throw cms::Exception("FastSim") << "FSimTrack::daughters() called for FSimTrack w/o end vertex, please contact FastSim developers" << std::endl;
+    //}
     return endVertex().daughters();
-  }	
+  }
 }
 
 inline bool FSimTrack::noEndVertex() const { 


### PR DESCRIPTION
PFSimParticleProducer depends on this behaviour
