### PR TITLE
fixed crash at exit

### DIFF
--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -162,7 +162,7 @@ RunManager::RunManager(edm::ParameterSet const & p)
 
 RunManager::~RunManager() 
 { 
-    if (m_kernel!=0) delete m_kernel; 
+  //   if (m_kernel!=0) delete m_kernel; 
 }
 
 void RunManager::initG4(const edm::EventSetup & es)


### PR DESCRIPTION
Fixed crash at destruction of Simulation objects. Not needed for the main branch.
