### PR TITLE
Fix unit tests for Random Numbers. This is for the threaded

### DIFF
--- a/IOMC/RandomEngine/test/testRandomService.sh
+++ b/IOMC/RandomEngine/test/testRandomService.sh
@@ -12,7 +12,6 @@ pushd ${LOCAL_TMP_DIR}
   echo "=============================================="
   cmsRun ${LOCAL_TEST_DIR}/${test}1_cfg.py > testRandomService1Dump.txt || die "cmsRun ${LOCAL_TEST_DIR}/${test}1_cfg.py" $?
   diff ${LOCAL_TEST_DIR}/unit_test_outputs/testRandomService1Dump.txt  testRandomService1Dump.txt || die "comparing testRandomService1Dump.txt" $?
-  mv ${test}.txt ${test}1.txt
   mv testRandomService_0_t1.txt testRandomService1_0_t1.txt
   mv testRandomService_0_t2.txt testRandomService1_0_t2.txt
   mv testRandomService_0_t3.txt testRandomService1_0_t3.txt

--- a/IOMC/RandomEngine/test/unit_test_outputs/testMultiStreamDump.txt
+++ b/IOMC/RandomEngine/test/unit_test_outputs/testMultiStreamDump.txt
@@ -16,8 +16,8 @@ RandomNumberGeneratorService dump
     childIndex_ = 0
     eventSeedOffset_ = 0
     verbose_ = 1
-    restoreStateTag_ = InputTag:  label = , instance = 
-    restoreStateBeginLumiTag_ = InputTag:  label = , instance = beginLumi
+    restoreStateTag_ = InputTag:  label = , instance = , process = @skipCurrentProcess
+    restoreStateBeginLumiTag_ = InputTag:  label = , instance = beginLumi, process = @skipCurrentProcess
 
     streamEngines_
         Stream 0

--- a/IOMC/RandomEngine/test/unit_test_outputs/testRandomService1Dump.txt
+++ b/IOMC/RandomEngine/test/unit_test_outputs/testRandomService1Dump.txt
@@ -18,8 +18,8 @@ RandomNumberGeneratorService dump
     childIndex_ = 0
     eventSeedOffset_ = 0
     verbose_ = 1
-    restoreStateTag_ = InputTag:  label = , instance = 
-    restoreStateBeginLumiTag_ = InputTag:  label = , instance = beginLumi
+    restoreStateTag_ = InputTag:  label = , instance = , process = @skipCurrentProcess
+    restoreStateBeginLumiTag_ = InputTag:  label = , instance = beginLumi, process = @skipCurrentProcess
 
     streamEngines_
         Stream 0


### PR DESCRIPTION
branch only. Affects unit tests only. Reference files needed
updating plus minor cleanup. The change that caused this problem
was cleanly merged from the 7_0_X branch, but I did not notice
the unit test reference files needed to be different on the
threaded branch. One conflicted and the other did not exist
in 7_0_X.
