### PR TITLE
flag function declarations in extern "C" blocks ending with _ 

### DIFF
--- a/Utilities/StaticAnalyzers/src/FunctionChecker.h
+++ b/Utilities/StaticAnalyzers/src/FunctionChecker.h
@@ -10,6 +10,7 @@
 namespace clangcms {
 
 class FunctionChecker : public clang::ento::Checker< clang::ento::check::ASTDecl<clang::CXXMethodDecl>,
+						clang::ento::check::ASTDecl<clang::FunctionDecl>, 
 						clang::ento::check::ASTDecl<clang::FunctionTemplateDecl> > 
 {
   mutable clang::OwningPtr< clang::ento::BugType> BT;
@@ -19,7 +20,8 @@ public:
 
   void checkASTDecl(const clang::CXXMethodDecl *CMD, clang::ento::AnalysisManager& mgr,
                     clang::ento::BugReporter &BR) const ;
-
+ void checkASTDecl(const clang::FunctionDecl *FD, clang::ento::AnalysisManager& mgr,
+                    clang::ento::BugReporter &BR) const ;
   void checkASTDecl(const clang::FunctionTemplateDecl *TD, clang::ento::AnalysisManager& mgr,
                     clang::ento::BugReporter &BR) const ;
 


### PR DESCRIPTION
Since these are most likely fortran functions that access COMMONBLOCK variables they should be flagged and then checked if they appear in the call stack of top level functions.
