### PR TITLE
Don't use obsolete signals

### DIFF
--- a/PerfTools/Callgrind/interface/ProfilerService.h
+++ b/PerfTools/Callgrind/interface/ProfilerService.h
@@ -5,6 +5,7 @@
 //FIXME only forward declarations???
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/PathContext.h"
 
 #include <vector>
 #include <string>
@@ -20,7 +21,7 @@ public:
 
   /// Standard Service Constructor
   ProfilerService(edm::ParameterSet const& pset, 
-		  edm::ActivityRegistry  & activity);
+		  edm::ActivityRegistry& activity);
 
   /// Destructor
   ~ProfilerService();
@@ -60,18 +61,18 @@ public:
     fullEvent();
   }
 
-  void beginEventI(const edm::EventID&, const edm::Timestamp&) {
+  void beginEventI(edm::StreamContext const& stream) {
     beginEvent();
   }
 
-  void endEventI(const edm::Event&, const edm::EventSetup&) {
+  void endEventI(edm::StreamContext const& stream) {
     endEvent();
   }
-  void beginPathI(std::string const & path) {
-    beginPath(path);
+  void beginPathI(edm::StreamContext const& stream, edm::PathContext const& path) {
+    beginPath(path.pathName());
   }
-  void endPathI(std::string const & path,  const edm::HLTPathStatus&) {
-    endPath(path);
+  void endPathI(edm::StreamContext const& stream, edm::PathContext const& path, edm::HLTPathStatus const&) {
+    endPath(path.pathName());
   }
 
 private:
@@ -81,8 +82,8 @@ private:
   void beginEvent();
   void endEvent();
   
-  void beginPath(std::string const & path);
-  void endPath(std::string const & path);
+  void beginPath(std::string const& path);
+  void endPath(std::string const& path);
 
   void newEvent();
 

--- a/PerfTools/Callgrind/src/ProfilerService.cc
+++ b/PerfTools/Callgrind/src/ProfilerService.cc
@@ -10,7 +10,7 @@
 #include "valgrind/callgrind.h"
 
 ProfilerService::ProfilerService(edm::ParameterSet const& pset, 
-				 edm::ActivityRegistry  & activity) :
+				 edm::ActivityRegistry& activity) :
   
   m_firstEvent(pset.getUntrackedParameter<int>("firstEvent",0 )),
   m_lastEvent(pset.getUntrackedParameter<int>("lastEvent",std::numeric_limits<int>::max())),
@@ -31,10 +31,10 @@ ProfilerService::ProfilerService(edm::ParameterSet const& pset,
   if (std::find(m_paths.begin(),m_paths.end(),fullEvent) != m_paths.end())
     activity.watchPostSourceEvent(this,&ProfilerService::preSourceI);
   else {
-    activity.watchPreProcessEvent(this,&ProfilerService::beginEventI);
-    activity.watchPostProcessEvent(this,&ProfilerService::endEventI);
-    activity.watchPreProcessPath(this,&ProfilerService::beginPathI);
-    activity.watchPostProcessPath(this,&ProfilerService::endPathI);
+    activity.watchPreEvent(this,&ProfilerService::beginEventI);
+    activity.watchPostEvent(this,&ProfilerService::endEventI);
+    activity.watchPrePathEvent(this,&ProfilerService::beginPathI);
+    activity.watchPostPathEvent(this,&ProfilerService::endPathI);
   }
 }
 
@@ -128,7 +128,7 @@ void  ProfilerService::endEvent() {
   forceStopInstrumentation();
 }
 
-void  ProfilerService::beginPath(std::string const & path) {
+void  ProfilerService::beginPath(std::string const& path) {
   if (!doEvent()) return;
   // assume less than 5-6 path to instrument or to exclude
   if (std::find(m_excludedPaths.begin(),m_excludedPaths.end(),path) != m_excludedPaths.end()) {
@@ -140,7 +140,7 @@ void  ProfilerService::beginPath(std::string const & path) {
   startInstrumentation();
 }
 
-void  ProfilerService::endPath(std::string const & path) {
+void  ProfilerService::endPath(std::string const& path) {
   resumeInstrumentation();
   if (m_activePath==path) {
     stopInstrumentation();


### PR DESCRIPTION
In branch CMSSW_7_0_THREADED_X, the ProfilerService tests in PerfTools/Callgrind were failing because the ProfilerService used obsolete signals.
This pull request replaces the use of each obsolete signal with the use of its replacement.
