### PR TITLE
Implement isArray() and arrayLength()

### DIFF
--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -84,6 +84,7 @@ public:
   long getProperty() const;
   bool isClass() const;
   bool isConst() const;
+  bool isArray() const;
   bool isEnum() const;
   bool isFundamental() const;
   bool isPointer() const;
@@ -98,6 +99,7 @@ public:
   std::string friendlyClassName() const;
   std::string templateName() const;
   size_t size() const;
+  size_t arrayLength() const;
   size_t dataMemberSize() const;
   size_t functionMemberSize() const;
   MemberWithDict dataMemberByName(const std::string&) const;

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -388,6 +388,16 @@ isConst() const
 
 bool
 TypeWithDict::
+isArray() const
+{
+  if (type_ == nullptr) {
+    return false;
+  }
+  return gInterpreter->Type_IsArray(type_);
+}
+
+bool
+TypeWithDict::
 isEnum() const
 {
   if (type_ == nullptr) {
@@ -542,6 +552,16 @@ size() const
     return 0;
   }
   return gInterpreter->Type_Size(type_);
+}
+
+size_t
+TypeWithDict::
+arrayLength() const
+{
+  if (type_ == nullptr) {
+    return 0;
+  }
+  return gInterpreter->Type_ArraySize(type_);
 }
 
 size_t


### PR DESCRIPTION
Add the implementation of two functions needed to replace the use of Reflex in the Conditions code.
Implementation provided by Paul Russo.
