### PR TITLE
Pixel digi

### DIFF
--- a/Geometry/CommonTopologies/interface/PixelTopology.h
+++ b/Geometry/CommonTopologies/interface/PixelTopology.h
@@ -41,8 +41,8 @@ class PixelTopology : public Topology {
 
   virtual bool isItBigPixelInX(const int ixbin) const = 0;
   virtual bool isItBigPixelInY(const int iybin) const = 0;
-  virtual bool containsBigPixelInX(const int& ixmin, const int& ixmax) const = 0;
-  virtual bool containsBigPixelInY(const int& iymin, const int& iymax) const = 0;
+  virtual bool containsBigPixelInX(int ixmin, int ixmax) const = 0;
+  virtual bool containsBigPixelInY(int iymin, int iymax) const = 0;
 
   virtual bool isItEdgePixelInX (int ixbin) const = 0;
   virtual bool isItEdgePixelInY (int iybin) const = 0;

--- a/Geometry/TrackerGeometryBuilder/interface/ProxyPixelTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/ProxyPixelTopology.h
@@ -78,10 +78,10 @@ public:
   virtual bool isItBigPixelInY(const int iybin) const {
     return specificTopology().isItBigPixelInY(iybin);
   }
-  virtual bool containsBigPixelInX(const int& ixmin, const int& ixmax) const {
+  virtual bool containsBigPixelInX(int ixmin, int ixmax) const {
     return specificTopology().containsBigPixelInX(ixmin, ixmax);
   }
-  virtual bool containsBigPixelInY(const int& iymin, const int& iymax) const {
+  virtual bool containsBigPixelInY(int iymin, int iymax) const {
     return specificTopology().containsBigPixelInY(iymin, iymax);
   }
 

--- a/Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h
+++ b/Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h
@@ -122,14 +122,14 @@ public:
   // Return the BIG pixel information for a given pixel
   //
   virtual bool isItBigPixelInX( const int ixbin ) const {
-    return (( m_upgradeGeometry )?(false):(( ixbin == 79 ) || ( ixbin == 80 )));
+    return (( m_upgradeGeometry )?(false):(( ixbin == 79 ) | ( ixbin == 80 )));
   } 
+
   virtual bool isItBigPixelInY( const int iybin ) const {
-      if( m_upgradeGeometry ) return false;
-      else
-      {
+      if unlikely( m_upgradeGeometry ) return false;
+      else {
 	int iybin0 = iybin%52;
- 	return(( iybin0 == 0 ) || ( iybin0 == 51 ));
+ 	return(( iybin0 == 0 ) | ( iybin0 == 51 ));
 	// constexpr int bigYIndeces[]{0,51,52,103,104,155,156,207,208,259,260,311,312,363,364,415,416,511};
 	// return *std::lower_bound(std::begin(bigYIndeces),std::end(bigYIndeces),iybin) == iybin;
      }
@@ -138,21 +138,27 @@ public:
   //-------------------------------------------------------------
   // Return BIG pixel flag in a given pixel range
   //
-  bool containsBigPixelInX( const int& ixmin, const int& ixmax ) const;
-  bool containsBigPixelInY( const int& iymin, const int& iymax ) const;
+  bool containsBigPixelInX(int ixmin, int ixmax ) const {
+    return m_upgradeGeometry ? false :( (ixmin<=80) & (ixmax>=79) );
+  }
+  bool containsBigPixelInY(int iymin, int iymax ) const {
+    return  m_upgradeGeometry ? false :
+      ( isItBigPixelInY( iymin ) || isItBigPixelInY( iymax ) ||  (iymin/52) != (iymax/52) )
+      ;  
+  }
 
 
   //-------------------------------------------------------------
   // Check whether the pixel is at the edge of the module
   //
   bool isItEdgePixelInX (int ixbin) const {
-    return ( (ixbin == 0) || (ixbin == (m_nrows-1)) );
+    return ( (ixbin == 0) | (ixbin == (m_nrows-1)) );
   } 
   bool isItEdgePixelInY (int iybin) const {
-    return ( (iybin == 0) || (iybin == (m_ncols-1)) );
+    return ( (iybin == 0) | (iybin == (m_ncols-1)) );
   } 
   bool isItEdgePixel (int ixbin, int iybin) const {
-    return ( isItEdgePixelInX( ixbin ) || isItEdgePixelInY( iybin ) );
+    return ( isItEdgePixelInX( ixbin ) | isItEdgePixelInY( iybin ) );
   } 
 
   //------------------------------------------------------------------

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -78,8 +78,8 @@ public:
       computeAnglesFromDetPosition(cl);
       
       // localPosition( cl, det ) must be called before localError( cl, det ) !!!
-      LocalPoint lp = localPosition( cl, det );
-      LocalError le = localError( cl, det );        
+      LocalPoint lp = localPosition( cl);
+      LocalError le = localError( cl);        
       
       return std::make_pair( lp, le );
     }
@@ -96,23 +96,23 @@ public:
     computeAnglesFromTrajectory(cl, ltp);
     
     // localPosition( cl, det ) must be called before localError( cl, det ) !!!
-    LocalPoint lp = localPosition( cl, det ); 
-    LocalError le = localError( cl, det );        
+    LocalPoint lp = localPosition( cl); 
+    LocalError le = localError( cl);        
     
     return std::make_pair( lp, le );
   } 
   
   
   
-  
+private:
   //--------------------------------------------------------------------------
   // This is where the action happens.
   //--------------------------------------------------------------------------
-  virtual LocalPoint localPosition(const SiPixelCluster& cl, const GeomDetUnit & det) const;  // = 0, take out dk 8/06
-  virtual LocalError localError   (const SiPixelCluster& cl, const GeomDetUnit & det) const = 0;
+  virtual LocalPoint localPosition(const SiPixelCluster& cl) const = 0;
+  virtual LocalError localError   (const SiPixelCluster& cl) const = 0;
   
   
-  
+public:  
   //--------------------------------------------------------------------------
   //--- Accessors of other auxiliary quantities
   inline float probabilityX()  const { return probabilityX_ ;  }
@@ -253,16 +253,6 @@ public:
   mutable Topology::LocalTrackPred loc_trk_pred_;
 
   mutable LocalTrajectoryParameters loc_traj_param_;
-  
-  //---------------------------------------------------------------------------
-  //  Methods.
-  //---------------------------------------------------------------------------
-  void       setTheDet( const GeomDetUnit & det, const SiPixelCluster & cluster ) const ;
-
-  MeasurementPoint measurementPosition( const SiPixelCluster& cluster, 
-					const GeomDetUnit & det) const;
-  MeasurementError measurementError   ( const SiPixelCluster&, 
-					const GeomDetUnit & det) const ;
 
   //---------------------------------------------------------------------------
   //  Geometrical services to subclasses.
@@ -275,6 +265,8 @@ private:
 				    const LocalTrajectoryParameters & ltp) const;
 
 protected:
+  void  setTheDet( const GeomDetUnit & det, const SiPixelCluster & cluster ) const ;
+
   LocalVector driftDirection       ( GlobalVector bfield ) const ; //wrong sign
   LocalVector driftDirection       ( LocalVector bfield ) const ; //wrong sign
   LocalVector driftDirectionCorrect( GlobalVector bfield ) const ;
@@ -292,10 +284,6 @@ protected:
   float lorentzShiftX() const;
   float lorentzShiftY() const;
  
-  //--- Position in X and Y
-  virtual float xpos( const SiPixelCluster& ) const = 0;
-  virtual float ypos( const SiPixelCluster& ) const = 0;
-  
   
   LocalVector const & getDrift() const {return  driftDirection_ ;}
  

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -95,27 +95,6 @@ public:
     return std::make_pair( lp, le );
   } 
   
-  //--------------------------------------------------------------------------
-  // The third one, with the user-supplied alpha and beta
-  //--------------------------------------------------------------------------
-  LocalValues localParameters( const SiPixelCluster & cl,
-			       const GeomDetUnit    & det, 
-			       float alpha, float beta) const 
-  {
-    nRecHitsTotal_++ ;
-    alpha_ = alpha;
-    beta_  = beta;
-    double HalfPi = 0.5*TMath::Pi();
-    cotalpha_ = tan(HalfPi - alpha_);
-    cotbeta_  = tan(HalfPi - beta_ );
-      setTheDet( det, cl );
-      
-      // localPosition( cl, det ) must be called before localError( cl, det ) !!!
-      LocalPoint lp = localPosition( cl, det ); 
-      LocalError le = localError( cl, det );        
-      
-      return std::make_pair( lp, le );
-  }
   
   
   void computeAnglesFromDetPosition(const SiPixelCluster & cl, 
@@ -207,12 +186,9 @@ public:
   mutable float theSign;
 
   //--- Cluster-level quantities (may need more)
-  mutable float alpha_;
-  mutable float beta_;
-
-  // G.Giurgiu (12/13/06)-----
   mutable float cotalpha_;
   mutable float cotbeta_;
+  mutable bool  zneg;
 
   // G.Giurgiu (05/14/08) track local coordinates
   mutable float trk_lp_x;
@@ -250,10 +226,10 @@ public:
   // be computed *incorrectly* (i.e. there's a bug) we add new variables
   // so that we can study the effect of the bug.
   mutable LocalVector driftDirection_;  // drift direction cached // &&&
-  mutable double lorentzShiftX_;   // a FULL shift, not 1/2 like theLShiftX!
-  mutable double lorentzShiftY_;   // a FULL shift, not 1/2 like theLShiftY!
-  mutable double lorentzShiftInCmX_;   // a FULL shift, in cm
-  mutable double lorentzShiftInCmY_;   // a FULL shift, in cm
+  mutable float lorentzShiftX_;   // a FULL shift, not 1/2 like theLShiftX!
+  mutable float lorentzShiftY_;   // a FULL shift, not 1/2 like theLShiftY!
+  mutable float lorentzShiftInCmX_;   // a FULL shift, in cm
+  mutable float lorentzShiftInCmY_;   // a FULL shift, in cm
 
 
   //--- Global quantities

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -304,9 +304,9 @@ protected:
   Param const & param() const;
  
  private:
-  typedef  std::unordered_map< unsigned int, Param> Params;
+  using Params=std::vector<Param>;
   
-  mutable Params m_Params;
+  mutable Params m_Params=Params(1440);
   
 
 

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -59,6 +59,13 @@ public:
 	       const SiPixelLorentzAngle * lorentzAngle = 0, const SiPixelCPEGenericErrorParm * genErrorParm = 0, 
 	       const SiPixelTemplateDBObject * templateDBobject = 0);
   
+
+ //--------------------------------------------------------------------------
+  // Allow the magnetic field to be set/updated later.
+  //--------------------------------------------------------------------------
+  inline void setMagField(const MagneticField *mag) const { magfield_ = mag; }
+ 
+
   //--------------------------------------------------------------------------
   // Obtain the angles from the position of the DetUnit.
   // LocalValues is typedef for pair<LocalPoint,LocalError> 
@@ -68,7 +75,7 @@ public:
     {
       nRecHitsTotal_++ ;
       setTheDet( det, cl );
-      computeAnglesFromDetPosition(cl, det);
+      computeAnglesFromDetPosition(cl);
       
       // localPosition( cl, det ) must be called before localError( cl, det ) !!!
       LocalPoint lp = localPosition( cl, det );
@@ -86,7 +93,7 @@ public:
   {
     nRecHitsTotal_++ ;
     setTheDet( det, cl );
-    computeAnglesFromTrajectory(cl, det, ltp);
+    computeAnglesFromTrajectory(cl, ltp);
     
     // localPosition( cl, det ) must be called before localError( cl, det ) !!!
     LocalPoint lp = localPosition( cl, det ); 
@@ -97,13 +104,6 @@ public:
   
   
   
-  void computeAnglesFromDetPosition(const SiPixelCluster & cl, 
-				    const GeomDetUnit    & det ) const;
-  
-  //--------------------------------------------------------------------------
-  // Allow the magnetic field to be set/updated later.
-  //--------------------------------------------------------------------------
-  inline void setMagField(const MagneticField *mag) const { magfield_ = mag; }
   
   //--------------------------------------------------------------------------
   // This is where the action happens.
@@ -171,6 +171,7 @@ public:
   mutable Param const * theParam;
 
   mutable GeomDetType::SubDetector thePart;
+  mutable  Local3DPoint theOrigin;
   //mutable EtaCorrection theEtaFunc;
   mutable float theThickness;
   mutable float thePitchX;
@@ -266,10 +267,14 @@ public:
   //---------------------------------------------------------------------------
   //  Geometrical services to subclasses.
   //---------------------------------------------------------------------------
+private:
+  void computeAnglesFromDetPosition(const SiPixelCluster & cl ) const;
+  
 
-  void computeAnglesFromTrajectory (const SiPixelCluster & cl,
-				    const GeomDetUnit    & det, 
+  void computeAnglesFromTrajectory (const SiPixelCluster & cl, 
 				    const LocalTrajectoryParameters & ltp) const;
+
+protected:
   LocalVector driftDirection       ( GlobalVector bfield ) const ; //wrong sign
   LocalVector driftDirection       ( LocalVector bfield ) const ; //wrong sign
   LocalVector driftDirectionCorrect( GlobalVector bfield ) const ;

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
@@ -67,22 +67,22 @@ private:
   //--------------------------------------------------------------------
   //  Methods.
   //------------------------------------------------------------------
-  double
-    generic_position_formula( int size,                //!< Size of this projection.
-			      double Q_f,              //!< Charge in the first pixel.
-			      double Q_l,              //!< Charge in the last pixel.
-			      double upper_edge_first_pix, //!< As the name says.
-			      double lower_edge_last_pix,  //!< As the name says.
-			      double half_lorentz_shift,   //!< L-shift at half thickness
-			      double cot_angle,            //!< cot of alpha_ or beta_
-			      double pitch,            //!< thePitchX or thePitchY
-			      bool first_is_big,       //!< true if the first is big
-			      bool last_is_big,        //!< true if the last is big
-			      double eff_charge_cut_low, //!< Use edge if > W_eff (in pix) &&&
-			      double eff_charge_cut_high,//!< Use edge if < W_eff (in pix) &&&
-			      double size_cut           //!< Use edge when size == cuts
-			      ) const;
-
+  float
+  generic_position_formula( int size,                //!< Size of this projection.
+			    float Q_f,              //!< Charge in the first pixel.
+			    float Q_l,              //!< Charge in the last pixel.
+			    float upper_edge_first_pix, //!< As the name says.
+			    float lower_edge_last_pix,  //!< As the name says.
+			    float half_lorentz_shift,   //!< L-shift at half thickness
+			    float cot_angle,            //!< cot of alpha_ or beta_
+			    float pitch,            //!< thePitchX or thePitchY
+			    bool first_is_big,       //!< true if the first is big
+			    bool last_is_big,        //!< true if the last is big
+			    float eff_charge_cut_low, //!< Use edge if > W_eff (in pix) &&&
+			    float eff_charge_cut_high,//!< Use edge if < W_eff (in pix) &&&
+			    float size_cut           //!< Use edge when size == cuts
+			    ) const;
+  
   void
     collect_edge_charges(const SiPixelCluster& cluster,  //!< input, the cluster
 			 float & Q_f_X,              //!< output, Q first  in X 
@@ -97,12 +97,12 @@ private:
   float err2Y(bool&, int&) const;
 
   //--- Cuts made externally settable
-  double the_eff_charge_cut_lowX;
-  double the_eff_charge_cut_lowY;
-  double the_eff_charge_cut_highX;
-  double the_eff_charge_cut_highY;
-  double the_size_cutX;
-  double the_size_cutY;
+  float the_eff_charge_cut_lowX;
+  float the_eff_charge_cut_lowY;
+  float the_eff_charge_cut_highX;
+  float the_eff_charge_cut_highY;
+  float the_size_cutX;
+  float the_size_cutY;
 
   bool inflate_errors;
   bool inflate_all_errors_no_trk_angle;
@@ -114,8 +114,8 @@ private:
   bool IrradiationBiasCorrection_;
   bool isUpgrade_;
 
-  double EdgeClusterErrorX_;
-  double EdgeClusterErrorY_;
+  float EdgeClusterErrorX_;
+  float EdgeClusterErrorY_;
 
   std::vector<float> xerr_barrel_l1_,yerr_barrel_l1_,xerr_barrel_ln_;
   std::vector<float> yerr_barrel_ln_,xerr_endcap_,yerr_endcap_;

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
@@ -58,12 +58,12 @@ class PixelCPEGeneric : public PixelCPEBase
   PixelCPEGeneric(edm::ParameterSet const& conf, const MagneticField *, const SiPixelLorentzAngle *, const SiPixelCPEGenericErrorParm *, const SiPixelTemplateDBObject *);
   ~PixelCPEGeneric() {;}
 
-  LocalPoint localPosition (const SiPixelCluster& cluster, const GeomDetUnit & det) const; 
-  
-  // However, we do need to implement localError().
-  LocalError localError   (const SiPixelCluster& cl, const GeomDetUnit & det) const;
+
  
- private:
+private:
+  LocalPoint localPosition (const SiPixelCluster& cluster) const; 
+  LocalError localError   (const SiPixelCluster& cl) const;
+
   //--------------------------------------------------------------------
   //  Methods.
   //------------------------------------------------------------------
@@ -152,11 +152,6 @@ class PixelCPEGeneric : public PixelCPEBase
   mutable float dx2   ; // CPE Generic x-bias for single double-pixel cluster
 
 	 
- protected:
-  //--- These functions are no longer needed, yet they are declared 
-  //--- pure virtual in the base class.
-  float xpos( const SiPixelCluster& ) const { return -999000.0; }  // &&& should abort
-  float ypos( const SiPixelCluster& ) const { return -999000.0; }  // &&& should abort
 
 };
 

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h
@@ -87,10 +87,8 @@ class PixelCPEGeneric : public PixelCPEBase
     collect_edge_charges(const SiPixelCluster& cluster,  //!< input, the cluster
 			 float & Q_f_X,              //!< output, Q first  in X 
 			 float & Q_l_X,              //!< output, Q last   in X
-			 float & Q_m_X,              //!< output, Q middle in X
 			 float & Q_f_Y,              //!< output, Q first  in Y 
-			 float & Q_l_Y,              //!< output, Q last   in Y
-			 float & Q_m_Y               //!< output, Q middle in Y
+			 float & Q_l_Y               //!< output, Q last   in Y
 			 ) const;
   
   
@@ -131,27 +129,27 @@ class PixelCPEGeneric : public PixelCPEBase
   mutable SiPixelTemplate templ_;
   mutable int templID_; 
 
-	// The truncation value pix_maximum is an angle-dependent cutoff on the
-	// individual pixel signals. It should be applied to all pixels in the
-	// cluster [signal_i = fminf(signal_i, pixmax)] before the column and row
-	// sums are made. Morris
-	mutable float pixmx;
-
-	// These are errors predicted by PIXELAV
-	mutable float sigmay; // CPE Generic y-error for multi-pixel cluster
-	mutable float sigmax; // CPE Generic x-error for multi-pixel cluster
-	mutable float sy1   ; // CPE Generic y-error for single single-pixel
-	mutable float sy2   ; // CPE Generic y-error for single double-pixel cluster
-	mutable float sx1   ; // CPE Generic x-error for single single-pixel cluster
-	mutable float sx2   ; // CPE Generic x-error for single double-pixel cluster
-
-	// These are irradiation bias corrections
-	mutable float deltay; // CPE Generic y-bias for multi-pixel cluster
-	mutable float deltax; // CPE Generic x-bias for multi-pixel cluster
-	mutable float dy1   ; // CPE Generic y-bias for single single-pixel cluster
-	mutable float dy2   ; // CPE Generic y-bias for single double-pixel cluster
-	mutable float dx1   ; // CPE Generic x-bias for single single-pixel cluster
-	mutable float dx2   ; // CPE Generic x-bias for single double-pixel cluster
+  // The truncation value pix_maximum is an angle-dependent cutoff on the
+  // individual pixel signals. It should be applied to all pixels in the
+  // cluster [signal_i = fminf(signal_i, pixmax)] before the column and row
+  // sums are made. Morris
+  mutable float pixmx;
+  
+  // These are errors predicted by PIXELAV
+  mutable float sigmay; // CPE Generic y-error for multi-pixel cluster
+  mutable float sigmax; // CPE Generic x-error for multi-pixel cluster
+  mutable float sy1   ; // CPE Generic y-error for single single-pixel
+  mutable float sy2   ; // CPE Generic y-error for single double-pixel cluster
+  mutable float sx1   ; // CPE Generic x-error for single single-pixel cluster
+  mutable float sx2   ; // CPE Generic x-error for single double-pixel cluster
+  
+  // These are irradiation bias corrections
+  mutable float deltay; // CPE Generic y-bias for multi-pixel cluster
+  mutable float deltax; // CPE Generic x-bias for multi-pixel cluster
+  mutable float dy1   ; // CPE Generic y-bias for single single-pixel cluster
+  mutable float dy2   ; // CPE Generic y-bias for single double-pixel cluster
+  mutable float dx1   ; // CPE Generic x-bias for single single-pixel cluster
+  mutable float dx2   ; // CPE Generic x-bias for single double-pixel cluster
 
 	 
  protected:

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateReco.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateReco.h
@@ -38,19 +38,15 @@ class PixelCPETemplateReco : public PixelCPEBase
   PixelCPETemplateReco(edm::ParameterSet const& conf, const MagneticField *, const SiPixelLorentzAngle *, const SiPixelTemplateDBObject *);
   ~PixelCPETemplateReco();
 
+
+private:
   // We only need to implement measurementPosition, since localPosition() from
   // PixelCPEBase will call it and do the transformation
   // Gavril : put it back
-  LocalPoint localPosition (const SiPixelCluster& cluster, const GeomDetUnit & det) const; 
+  LocalPoint localPosition (const SiPixelCluster& cluster) const; 
   
   // However, we do need to implement localError().
-  LocalError localError   (const SiPixelCluster& cl, const GeomDetUnit & det) const;
-
- protected:
-  //--- These functions are no longer needed, yet they are declared 
-  //--- pure virtual in the base class.
-  float xpos( const SiPixelCluster& ) const { return -999000.0; }  // &&& should abort
-  float ypos( const SiPixelCluster& ) const { return -999000.0; }  // &&& should abort
+  LocalError localError   (const SiPixelCluster& cl) const;
 
  private:
   // Template storage

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelRecHitConverter.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelRecHitConverter.h
@@ -32,8 +32,8 @@
 //---------------------------------------------------------------------------
 
 //--- Base class for CPEs:
-#include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
-//&&& #include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h"
+
+#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h"
 
 //--- Geometry + DataFormats
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
@@ -94,13 +94,11 @@ namespace cms
   private:
     edm::ParameterSet conf_;
     // TO DO: maybe allow a map of pointers?
-    std::string cpeName_;                   // what the user said s/he wanted
-    const PixelClusterParameterEstimator * cpe_;  // what we got (for now, one ptr to base class)
-    //&&& PixelCPEBase * cpe_;                    // what we got (for now, one ptr to base class)
-    bool ready_;                            // needed CPE's valid => good to go!
+    std::string cpeName_="None";                   // what the user said s/he wanted
+    /// const PixelClusterParameterEstimator * cpe_;  // what we got (for now, one ptr to base class)
+    PixelCPEBase const * cpe_=nullptr;                    // What we got (for now, one ptr to base class)
     edm::InputTag src_;
     edm::EDGetTokenT<edmNew::DetSetVector<SiPixelCluster>> tPixelCluster;
-    int   theVerboseLevel;              // algorithm's verbosity
     bool m_newCont; // save also in emdNew::DetSetVector
   };
 }

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
@@ -281,8 +281,8 @@ class SiPixelTemplate {
 //           float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2, float& lorywidth, float& lorxwidth);
 	
 // Overload for backward compatibility. 
-	int qbin(int id, float cotalpha, float cotbeta, float locBz, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax, 
-			 float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2);
+  int qbin(int id, float cotalpha, float cotbeta, float locBz, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax, 
+	   float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2);
 	
 // Overload to use for cluster splitting 
 	int qbin(int id, float cotalpha, float cotbeta, float qclus);

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
@@ -277,8 +277,8 @@ class SiPixelTemplate {
   float xflcorr(int binq, float qflx);
   
 // Interpolate input beta angle to estimate the average charge. return qbin flag for input cluster charge, and estimate y/x errors and biases for the Generic Algorithm. 
-  int qbin(int id, float cotalpha, float cotbeta, float locBz, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax, 
-           float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2, float& lorywidth, float& lorxwidth);
+//  int qbin(int id, float cotalpha, float cotbeta, float locBz, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax, 
+//           float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2, float& lorywidth, float& lorxwidth);
 	
 // Overload for backward compatibility. 
 	int qbin(int id, float cotalpha, float cotbeta, float locBz, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax, 

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelTemplate.h
@@ -105,6 +105,11 @@ struct SiPixelTemplateEntry { //!< Basic template entry corresponding to a singl
   float sxtwo;             //!< rms for one double-pixel x-clusters 
   float qmin;              //!< minimum cluster charge for valid hit (keeps 99.9% of simulated hits) 
   float qmin2;             //!< tighter minimum cluster charge for valid hit (keeps 99.8% of simulated hits)
+  float yavggen[4];        //!< generic algorithm: average y-bias of reconstruction binned in 4 charge bins 
+  float yrmsgen[4];        //!< generic algorithm: average y-rms of reconstruction binned in 4 charge bins 
+  float xavggen[4];        //!< generic algorithm: average x-bias of reconstruction binned in 4 charge bins 
+  float xrmsgen[4];        //!< generic algorithm: average x-rms of reconstruction binned in 4 charge bins 
+
   float clsleny;           //!< cluster y-length in pixels at signal height symax/2
   float clslenx;           //!< cluster x-length in pixels at signal height sxmax/2
   float mpvvav;            //!< most probable charge in Vavilov distribution (not actually for larger kappa)
@@ -143,12 +148,8 @@ struct SiPixelTemplateEntry { //!< Basic template entry corresponding to a singl
   float xrmsc2m[4];        //!< 1st pass chi2 min search: average x-rms of reconstruction binned in 4 charge bins 
   float chi2xavgc2m[4];    //!< 1st pass chi2 min search: average x chi^2 in 4 charge bins (merged clusters) 
   float chi2xminc2m[4];    //!< 1st pass chi2 min search: minimum of x chi^2 in 4 charge bins (merged clusters) 
-  float yavggen[4];        //!< generic algorithm: average y-bias of reconstruction binned in 4 charge bins 
-  float yrmsgen[4];        //!< generic algorithm: average y-rms of reconstruction binned in 4 charge bins 
   float ygx0gen[4];        //!< generic algorithm: average y0 from Gaussian fit binned in 4 charge bins 
   float ygsiggen[4];       //!< generic algorithm: average sigma_y from Gaussian fit binned in 4 charge bins 
-  float xavggen[4];        //!< generic algorithm: average x-bias of reconstruction binned in 4 charge bins 
-  float xrmsgen[4];        //!< generic algorithm: average x-rms of reconstruction binned in 4 charge bins 
   float xgx0gen[4];        //!< generic algorithm: average x0 from Gaussian fit binned in 4 charge bins 
   float xgsiggen[4];       //!< generic algorithm: average sigma_x from Gaussian fit binned in 4 charge bins 
   float qbfrac[3];         //!< fraction of sample in qbin = 0-2 (>=3 is the complement)
@@ -165,21 +166,22 @@ struct SiPixelTemplateEntry { //!< Basic template entry corresponding to a singl
 
 
 struct SiPixelTemplateHeader {           //!< template header structure 
-  char title[80];         //!< template title 
   int ID;                 //!< template ID number 
-  int templ_version;      //!< Version number of the template to ensure code compatibility 
-  float Bfield;           //!< Bfield in Tesla
   int NTy;                //!< number of Template y entries 
   int NTyx;               //!< number of Template y-slices of x entries 
   int NTxx;               //!< number of Template x-entries in each slice
   int Dtype;              //!< detector type (0=BPix, 1=FPix)
+  float qscale;           //!< Charge scaling to match cmssw and pixelav
+  float lorywidth;        //!< estimate of y-lorentz width from single pixel offset
+  float lorxwidth;        //!< estimate of x-lorentz width from single pixel offset
   float Vbias;            //!< detector bias potential in Volts 
   float temperature;      //!< detector temperature in deg K 
   float fluence;          //!< radiation fluence in n_eq/cm^2 
-  float qscale;           //!< Charge scaling to match cmssw and pixelav
   float s50;              //!< 1/2 of the readout threshold in ADC units
-  float lorywidth;        //!< estimate of y-lorentz width from single pixel offset
-  float lorxwidth;        //!< estimate of x-lorentz width from single pixel offset
+  char title[80];         //!< template title 
+  int templ_version;      //!< Version number of the template to ensure code compatibility 
+  float Bfield;           //!< Bfield in Tesla
+
   float xsize;            //!< pixel size (for future use in upgraded geometry)
   float ysize;            //!< pixel size (for future use in upgraded geometry)
   float zsize;            //!< pixel size (for future use in upgraded geometry)
@@ -189,6 +191,9 @@ struct SiPixelTemplateHeader {           //!< template header structure
 
 struct SiPixelTemplateStore { //!< template storage structure 
   SiPixelTemplateHeader head;
+  float cotbetaY[60];
+  float cotbetaX[5];
+  float cotalphaX[29];
 #ifndef SI_PIXEL_TEMPLATE_USE_BOOST 
   SiPixelTemplateEntry enty[60];     //!< 60 Barrel y templates spanning cluster lengths from 0px to +18px [28 entries for fpix]
   SiPixelTemplateEntry entx[5][29];  //!< 29 Barrel x templates spanning cluster lengths from -6px (-1.125Rad) to +6px (+1.125Rad) in each of 5 slices [3x29 for fpix]
@@ -228,6 +233,9 @@ class SiPixelTemplate {
   bool pushfile(const SiPixelTemplateDBObject& dbobject);     // load the private store with info from db
 #endif
   
+  // initialize the rest;
+  void postInit();
+
 	
 // Interpolate input alpha and beta angles to produce a working template for each individual hit. 
   bool interpolate(int id, float cotalpha, float cotbeta, float locBz);

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
@@ -150,10 +150,10 @@ namespace cms
       } //  <-- End loop on Clusters
 	
 
-      // LogDebug("SiPixelRecHitConverter")
+      //  LogDebug("SiPixelRecHitConverter")
       std::cout << "SiPixelRecHitConverterVI "
-	<< " Found " << recHitsOnDetUnit.size() << " RecHits on " << detid //;
-	<< std::endl;
+		<< " Found " << recHitsOnDetUnit.size() << " RecHits on " << detid //;
+		<< std::endl;
       
       
     } //    <-- End loop on DetUnits

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
@@ -146,14 +146,14 @@ namespace cms
 	recHitsOnDetUnit.push_back(hit);
 	// =============================
 
-	//std::cout << "SiPixelRecHitConverterVI " << numberOfClusters << ' '<< lp << " " << le << std::endl;
+	std::cout << "SiPixelRecHitConverterVI " << numberOfClusters << ' '<< lp << " " << le << std::endl;
       } //  <-- End loop on Clusters
 	
 
       //  LogDebug("SiPixelRecHitConverter")
-      //std::cout << "SiPixelRecHitConverterVI "
-	//	<< " Found " << recHitsOnDetUnit.size() << " RecHits on " << detid //;
-	//	<< std::endl;
+      std::cout << "SiPixelRecHitConverterVI "
+		<< " Found " << recHitsOnDetUnit.size() << " RecHits on " << detid //;
+		<< std::endl;
       
       
     } //    <-- End loop on DetUnits

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
@@ -146,14 +146,14 @@ namespace cms
 	recHitsOnDetUnit.push_back(hit);
 	// =============================
 
-	std::cout << "SiPixelRecHitConverterVI " << numberOfClusters << ' '<< lp << " " << le << std::endl;
+	// std::cout << "SiPixelRecHitConverterVI " << numberOfClusters << ' '<< lp << " " << le << std::endl;
       } //  <-- End loop on Clusters
 	
 
       //  LogDebug("SiPixelRecHitConverter")
-      std::cout << "SiPixelRecHitConverterVI "
-		<< " Found " << recHitsOnDetUnit.size() << " RecHits on " << detid //;
-		<< std::endl;
+      //std::cout << "SiPixelRecHitConverterVI "
+	//	<< " Found " << recHitsOnDetUnit.size() << " RecHits on " << detid //;
+	//	<< std::endl;
       
       
     } //    <-- End loop on DetUnits

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
@@ -146,14 +146,14 @@ namespace cms
 	recHitsOnDetUnit.push_back(hit);
 	// =============================
 
-	std::cout << "SiPixelRecHitConverterVI " << numberOfClusters << ' '<< lp << " " << le << std::endl;
+	//std::cout << "SiPixelRecHitConverterVI " << numberOfClusters << ' '<< lp << " " << le << std::endl;
       } //  <-- End loop on Clusters
 	
 
       //  LogDebug("SiPixelRecHitConverter")
-      std::cout << "SiPixelRecHitConverterVI "
-		<< " Found " << recHitsOnDetUnit.size() << " RecHits on " << detid //;
-		<< std::endl;
+      //std::cout << "SiPixelRecHitConverterVI "
+	//	<< " Found " << recHitsOnDetUnit.size() << " RecHits on " << detid //;
+	//	<< std::endl;
       
       
     } //    <-- End loop on DetUnits

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
@@ -145,17 +145,25 @@ namespace cms
 	// Now save it =================
 	recHitsOnDetUnit.push_back(hit);
 	// =============================
+
+	std::cout << "SiPixelRecHitConverterVI " << numberOfClusters << ' '<< lp << " " << le << std::endl;
       } //  <-- End loop on Clusters
 	
-      LogDebug("SiPixelRecHitConverter") << " Found " 
-					 << recHitsOnDetUnit.size() << " RecHits on " << detid;	
+
+      // LogDebug("SiPixelRecHitConverter")
+      std::cout << "SiPixelRecHitConverterVI "
+	<< " Found " << recHitsOnDetUnit.size() << " RecHits on " << detid //;
+	<< std::endl;
       
       
     } //    <-- End loop on DetUnits
     
-    LogDebug ("SiPixelRecHitConverter") 
+    //    LogDebug ("SiPixelRecHitConverter") 
+      std::cout << "SiPixelRecHitConverterVI "
       << cpeName_ << " converted " << numberOfClusters 
       << " SiPixelClusters into SiPixelRecHits, in " 
-      << numberOfDetUnits << " DetUnits."; 	
+      << numberOfDetUnits << " DetUnits." //; 
+      << std::endl;
+	
   }
 }  // end of namespace cms

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
@@ -159,11 +159,11 @@ namespace cms
     } //    <-- End loop on DetUnits
     
     //    LogDebug ("SiPixelRecHitConverter") 
-      std::cout << "SiPixelRecHitConverterVI "
-      << cpeName_ << " converted " << numberOfClusters 
-      << " SiPixelClusters into SiPixelRecHits, in " 
-      << numberOfDetUnits << " DetUnits." //; 
-      << std::endl;
+    //  std::cout << "SiPixelRecHitConverterVI "
+    //  << cpeName_ << " converted " << numberOfClusters 
+    //  << " SiPixelClusters into SiPixelRecHits, in " 
+    //  << numberOfDetUnits << " DetUnits." //; 
+    //  << std::endl;
 	
   }
 }  // end of namespace cms

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
@@ -11,9 +11,6 @@
 
 // Our own stuff
 #include "RecoLocalTracker/SiPixelRecHits/interface/SiPixelRecHitConverter.h"
-#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPETemplateReco.h"
-#include "RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGeneric.h"
-
 // Geometry
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
@@ -23,9 +20,6 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/DetSet2RangeMap.h"
 
-// Framework Already defined in the *.h file
-//#include "DataFormats/Common/interface/Handle.h"
-//#include "FWCore/Framework/interface/ESHandle.h"
 
 // STL
 #include <vector>
@@ -48,16 +42,11 @@ namespace cms
   SiPixelRecHitConverter::SiPixelRecHitConverter(edm::ParameterSet const& conf) 
     : 
     conf_(conf),
-    cpeName_("None"),     // bogus
-    cpe_(0),              // the default, in case we fail to make one
-    ready_(false),        // since we obviously aren't
     src_( conf.getParameter<edm::InputTag>( "src" ) ),
-    theVerboseLevel(conf.getUntrackedParameter<int>("VerboseLevel",0))
-  {
-    tPixelCluster = consumes< edmNew::DetSetVector<SiPixelCluster> >( src_);
+    tPixelCluster(consumes< edmNew::DetSetVector<SiPixelCluster> >( src_)) {
     //--- Declare to the EDM what kind of collections we will be making.
     produces<SiPixelRecHitCollection>();
-   
+    
   }
   
   // Destructor
@@ -87,18 +76,14 @@ namespace cms
     edm::ESHandle<TrackerGeometry> geom;
     es.get<TrackerDigiGeometryRecord>().get( geom );
 
-		// Step B: create empty output collection
+    // Step B: create empty output collection
     std::auto_ptr<SiPixelRecHitCollectionNew> output(new SiPixelRecHitCollectionNew);
-
+    
     // Step B*: create CPE
     edm::ESHandle<PixelClusterParameterEstimator> hCPE;
     std::string cpeName_ = conf_.getParameter<std::string>("CPE");
     es.get<TkPixelCPERecord>().get(cpeName_,hCPE);
-    const PixelClusterParameterEstimator &cpe(*hCPE);
-    cpe_ = &cpe;
-    
-    if(cpe_) ready_ = true;
-    
+    cpe_ = dynamic_cast< const PixelCPEBase* >(&(*hCPE));
     
     // Step C: Iterate over DetIds and invoke the strip CPE algorithm
     // on each DetUnit
@@ -117,9 +102,8 @@ namespace cms
   //---------------------------------------------------------------------------
   void SiPixelRecHitConverter::run(edm::Handle<edmNew::DetSetVector<SiPixelCluster> >  inputhandle,
 				   SiPixelRecHitCollectionNew &output,
-				   edm::ESHandle<TrackerGeometry> & geom) 
-  {
-    if ( ! ready_ ) 
+				   edm::ESHandle<TrackerGeometry> & geom) {
+    if ( ! cpe_ ) 
       {
 	edm::LogError("SiPixelRecHitConverter") << " at least one CPE is not ready -- can't run!";
 	// TO DO: throw an exception here?  The user may want to know...
@@ -134,60 +118,42 @@ namespace cms
     
     edmNew::DetSetVector<SiPixelCluster>::const_iterator DSViter=input.begin();
     
-    for ( ; DSViter != input.end() ; DSViter++) 
-      {
-	numberOfDetUnits++;
-	unsigned int detid = DSViter->detId();
-	DetId detIdObject( detid );  
-	const GeomDetUnit * genericDet = geom->idToDetUnit( detIdObject );
-	const PixelGeomDetUnit * pixDet = dynamic_cast<const PixelGeomDetUnit*>(genericDet);
-	assert(pixDet); 
-	SiPixelRecHitCollectionNew::FastFiller recHitsOnDetUnit(output,detid);
+    for ( ; DSViter != input.end() ; DSViter++) {
+      numberOfDetUnits++;
+      unsigned int detid = DSViter->detId();
+      DetId detIdObject( detid );  
+      const GeomDetUnit * genericDet = geom->idToDetUnit( detIdObject );
+      const PixelGeomDetUnit * pixDet = dynamic_cast<const PixelGeomDetUnit*>(genericDet);
+      assert(pixDet); 
+      SiPixelRecHitCollectionNew::FastFiller recHitsOnDetUnit(output,detid);
+      
+      edmNew::DetSet<SiPixelCluster>::const_iterator clustIt = DSViter->begin(), clustEnd = DSViter->end();
+      
+      for ( ; clustIt != clustEnd; clustIt++) {
+	numberOfClusters++;
+	std::pair<LocalPoint, LocalError> lv = cpe_->localParameters( *clustIt, *genericDet );
+	LocalPoint lp( lv.first );
+	LocalError le( lv.second );
+	// Create a persistent edm::Ref to the cluster
+	edm::Ref< edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster > cluster = edmNew::makeRefTo( inputhandle, clustIt);
+	// Make a RecHit and add it to the DetSet
+	// old : recHitsOnDetUnit.push_back( new SiPixelRecHit( lp, le, detIdObject, &*clustIt) );
+	SiPixelRecHit hit( lp, le, detIdObject, cluster);
+	// Copy the extra stuff;
+	hit.setRawQualityWord( cpe_->rawQualityWord() );
+	// 
+	// Now save it =================
+	recHitsOnDetUnit.push_back(hit);
+	// =============================
+      } //  <-- End loop on Clusters
 	
-	edmNew::DetSet<SiPixelCluster>::const_iterator clustIt = DSViter->begin(), clustEnd = DSViter->end();
-	
-	for ( ; clustIt != clustEnd; clustIt++) 
-	  {
-	    numberOfClusters++;
-	    std::pair<LocalPoint, LocalError> lv = cpe_->localParameters( *clustIt, *genericDet );
-	    LocalPoint lp( lv.first );
-	    LocalError le( lv.second );
-	    // Create a persistent edm::Ref to the cluster
-	    edm::Ref< edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster > cluster = edmNew::makeRefTo( inputhandle, clustIt);
-	    // Make a RecHit and add it to the DetSet
-	    // old : recHitsOnDetUnit.push_back( new SiPixelRecHit( lp, le, detIdObject, &*clustIt) );
-	    SiPixelRecHit hit( lp, le, detIdObject, cluster);
-	    // Copy the extra stuff; unfortunately, only the derivatives of PixelCPEBase
-	    // are capable of doing that.  So until we get rid of CPEFromDetPosition
-	    // we'll have to dynamic_cast :(
-	    // &&& This cast can be moved to the setupCPE, so that it's done once per job.
-	    const PixelCPEBase * cpeBase 
-	      = dynamic_cast< const PixelCPEBase* >( cpe_ );
-	    if (cpeBase) 
-	      {
-		hit.setRawQualityWord( cpeBase->rawQualityWord() );
-		// hit.setProbabilityX( cpeBase->probabilityX() );
-		// hit.setProbabilityY( cpeBase->probabilityY() );
-		// hit.setQBin( cpeBase->qBin() );
-		// hit.setCotAlphaFromCluster( cpeBase->cotAlphaFromCluster() );
-		// hit.setCotBetaFromCluster ( cpeBase->cotBetaFromCluster()  );
-	      }
-	    // 
-	    // Now save it =================
-	    recHitsOnDetUnit.push_back(hit);
-	    // =============================
-	  } //  <-- End loop on Clusters
-	
-	if ( recHitsOnDetUnit.size()>0 ) 
-	  {
-	    if (theVerboseLevel > 2) 
-	      LogDebug("SiPixelRecHitConverter") << " Found " 
-						 << recHitsOnDetUnit.size() << " RecHits on " << detid;	
-	  }
-	
-      } //    <-- End loop on DetUnits
+      LogDebug("SiPixelRecHitConverter") << " Found " 
+					 << recHitsOnDetUnit.size() << " RecHits on " << detid;	
+      
+      
+    } //    <-- End loop on DetUnits
     
-    if ( theVerboseLevel > 2 ) LogDebug ("SiPixelRecHitConverter") 
+    LogDebug ("SiPixelRecHitConverter") 
       << cpeName_ << " converted " << numberOfClusters 
       << " SiPixelClusters into SiPixelRecHits, in " 
       << numberOfDetUnits << " DetUnits."; 	

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -153,10 +153,8 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const & conf,
 //! into the local frame (in centimeters).  
 //-----------------------------------------------------------------------------
 LocalPoint
-PixelCPEGeneric::localPosition(const SiPixelCluster& cluster, 
-			       const GeomDetUnit & det) const 
+PixelCPEGeneric::localPosition(const SiPixelCluster& cluster) const 
 {
-  setTheDet( det, cluster );  //!< Initialize this det unit
   computeLorentzShifts();  //!< correctly compute lorentz shifts in X and Y
   if ( UseErrorsFromTemplates_ )
     {
@@ -548,12 +546,8 @@ collect_edge_charges(const SiPixelCluster& cluster,  //!< input, the cluster
 //  Hit error in the local frame
 //-------------------------------------------------------------------------
 LocalError 
-PixelCPEGeneric::localError( const SiPixelCluster& cluster, 
-			     const GeomDetUnit & det) const 
+PixelCPEGeneric::localError( const SiPixelCluster& cluster) const 
 {
-  setTheDet( det, cluster );
-
-
    
   // Default errors are the maximum error used for edge clusters.
   /*
@@ -598,7 +592,7 @@ PixelCPEGeneric::localError( const SiPixelCluster& cluster,
       
       if ( thePart == GeomDetEnumerators::PixelBarrel ) 
 	{
-	  DetId id = (det.geographicalId());
+	  DetId id = (theDet->geographicalId());
 	  int layer=PXBDetId(id).layer();
 	  if ( layer==1 ) {
 	    if ( !edgex )

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -379,24 +379,24 @@ PixelCPEGeneric::localPosition(const SiPixelCluster& cluster) const
 //!  are passed by the caller.  The only class variable used by this method
 //!  is the theThickness, since that's common for both X and Y.
 //-----------------------------------------------------------------------------
-double
+float
 PixelCPEGeneric::    
 generic_position_formula( int size,                //!< Size of this projection.
-			  double Q_f,              //!< Charge in the first pixel.
-			  double Q_l,              //!< Charge in the last pixel.
-			  double upper_edge_first_pix, //!< As the name says.
-			  double lower_edge_last_pix,  //!< As the name says.
-			  double half_lorentz_shift,   //!< L-shift at half thickness
-			  double cot_angle,        //!< cot of alpha_ or beta_
-			  double pitch,            //!< thePitchX or thePitchY
+			  float Q_f,              //!< Charge in the first pixel.
+			  float Q_l,              //!< Charge in the last pixel.
+			  float upper_edge_first_pix, //!< As the name says.
+			  float lower_edge_last_pix,  //!< As the name says.
+			  float half_lorentz_shift,   //!< L-shift at half thickness
+			  float cot_angle,        //!< cot of alpha_ or beta_
+			  float pitch,            //!< thePitchX or thePitchY
 			  bool first_is_big,       //!< true if the first is big
 			  bool last_is_big,        //!< true if the last is big
-			  double eff_charge_cut_low, //!< Use edge if > W_eff  &&&
-			  double eff_charge_cut_high,//!< Use edge if < W_eff  &&&
-			  double size_cut         //!< Use edge when size == cuts
+			  float eff_charge_cut_low, //!< Use edge if > W_eff  &&&
+			  float eff_charge_cut_high,//!< Use edge if < W_eff  &&&
+			  float size_cut         //!< Use edge when size == cuts
 			 ) const
 {
-  double geom_center = 0.5 * ( upper_edge_first_pix + lower_edge_last_pix );
+  float geom_center = 0.5f * ( upper_edge_first_pix + lower_edge_last_pix );
 
   //--- The case of only one pixel in this projection is separate.  Note that
   //--- here first_pix == last_pix, so the average of the two is still the
@@ -413,26 +413,23 @@ generic_position_formula( int size,                //!< Size of this projection.
 
   //--- Width of the clusters minus the edge (first and last) pixels.
   //--- In the note, they are denoted x_F and x_L (and y_F and y_L)
-  double W_inner      = lower_edge_last_pix - upper_edge_first_pix;  // in cm
+  float W_inner      = lower_edge_last_pix - upper_edge_first_pix;  // in cm
 
 
   //--- Predicted charge width from geometry
-  double W_pred = 
+  float W_pred = 
     theThickness * cot_angle                     // geometric correction (in cm)
-    - 2 * half_lorentz_shift;                    // (in cm) &&& check fpix!  
+    - 2.f * half_lorentz_shift;                    // (in cm) &&& check fpix!  
   
 
   //--- Total length of the two edge pixels (first+last)
-  double sum_of_edge = 0.0;
-  if (first_is_big) sum_of_edge += 2.0;
-  else              sum_of_edge += 1.0;
-  
-  if (last_is_big)  sum_of_edge += 2.0;
-  else              sum_of_edge += 1.0;
+  float sum_of_edge = 2.0f;
+  if (first_is_big) sum_of_edge += 1.0f;
+  if (last_is_big)  sum_of_edge += 1.0f;
   
 
   //--- The `effective' charge width -- particle's path in first and last pixels only
-  double W_eff = fabs( W_pred ) - W_inner;
+  float W_eff = std::abs( W_pred ) - W_inner;
 
 
   //--- If the observed charge width is inconsistent with the expectations
@@ -441,22 +438,23 @@ generic_position_formula( int size,                //!< Size of this projection.
   //--- length of the edge pixels.
   //
   //  bool usedEdgeAlgo = false;
-  if (( W_eff/pitch < eff_charge_cut_low ) ||
-      ( W_eff/pitch > eff_charge_cut_high ) || (size >= size_cut)) 
+  if ( (size >= size_cut) || (
+       ( W_eff/pitch < eff_charge_cut_low ) |
+       ( W_eff/pitch > eff_charge_cut_high ) ) ) 
     {
-      W_eff = pitch * 0.5 * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
+      W_eff = pitch * 0.5f * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
       //  usedEdgeAlgo = true;
       nRecHitsUsedEdge_++;
     }
 
   
   //--- Finally, compute the position in this projection
-  double Qdiff = Q_l - Q_f;
-  double Qsum  = Q_l + Q_f;
+  float Qdiff = Q_l - Q_f;
+  float Qsum  = Q_l + Q_f;
 
-	//--- Temporary fix for clusters with both first and last pixel with charge = 0
-	if(Qsum==0) Qsum=1.0;
-  double hit_pos = geom_center + 0.5*(Qdiff/Qsum) * W_eff + half_lorentz_shift;
+  //--- Temporary fix for clusters with both first and last pixel with charge = 0
+  if(Qsum==0) Qsum=1.0f;
+  float hit_pos = geom_center + 0.5f*(Qdiff/Qsum) * W_eff + half_lorentz_shift;
 
  #ifdef EDM_ML_DEBUG
   //--- Debugging output

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -254,6 +254,7 @@ PixelCPEGeneric::localPosition(const SiPixelCluster& cluster) const
       local_LLcorn_URpix = theTopol->localPosition(meas_LLcorn_URpix);
     }
 
+ #ifdef EDM_ML_DEBUG
   if (theVerboseLevel > 20) {
     cout  
       << "\n\t >>> cluster.x = " << cluster.x()
@@ -268,6 +269,7 @@ PixelCPEGeneric::localPosition(const SiPixelCluster& cluster) const
       << "," << meas_LLcorn_URpix.y() 
       << endl;
   }
+#endif
 
   //--- &&& Note that the cuts below should not be hardcoded (like in Orca and
   //--- &&& CPEFromDetPosition/PixelCPEInitial), but rather be
@@ -275,8 +277,11 @@ PixelCPEGeneric::localPosition(const SiPixelCluster& cluster) const
 
 
   //--- Position, including the half lorentz shift
+
+ #ifdef EDM_ML_DEBUG
   if (theVerboseLevel > 20) 
     cout << "\t >>> Generic:: processing X" << endl;
+#endif
 
   float xPos = 
     generic_position_formula( cluster.sizeX(),
@@ -292,8 +297,11 @@ PixelCPEGeneric::localPosition(const SiPixelCluster& cluster) const
                               the_size_cutX);           // cut for eff charge width &&&
 
 
+ #ifdef EDM_ML_DEBUG
   if (theVerboseLevel > 20) 
     cout << "\t >>> Generic:: processing Y" << endl;
+#endif
+
   float yPos = 
     generic_position_formula( cluster.sizeY(),
 			      Q_f_Y, Q_l_Y, 
@@ -432,12 +440,12 @@ generic_position_formula( int size,                //!< Size of this projection.
   //--- it with an *average* effective charge width, which is the average
   //--- length of the edge pixels.
   //
-  bool usedEdgeAlgo = false;
+  //  bool usedEdgeAlgo = false;
   if (( W_eff/pitch < eff_charge_cut_low ) ||
       ( W_eff/pitch > eff_charge_cut_high ) || (size >= size_cut)) 
     {
       W_eff = pitch * 0.5 * sum_of_edge;  // ave. length of edge pixels (first+last) (cm)
-      usedEdgeAlgo = true;
+      //  usedEdgeAlgo = true;
       nRecHitsUsedEdge_++;
     }
 
@@ -450,6 +458,7 @@ generic_position_formula( int size,                //!< Size of this projection.
 	if(Qsum==0) Qsum=1.0;
   double hit_pos = geom_center + 0.5*(Qdiff/Qsum) * W_eff + half_lorentz_shift;
 
+ #ifdef EDM_ML_DEBUG
   //--- Debugging output
   if (theVerboseLevel > 20) {
     if ( thePart == GeomDetEnumerators::PixelBarrel ) {
@@ -479,7 +488,7 @@ generic_position_formula( int size,                //!< Size of this projection.
       cout << "\n\t >>> Used angle information." ;
     cout << endl;
   }
-
+#endif
 
   return hit_pos;
 }
@@ -584,7 +593,7 @@ PixelCPEGeneric::localError( const SiPixelCluster& cluster) const
   // Find if cluster contains double (big) pixels. 
   bool bigInX = theRecTopol->containsBigPixelInX( minPixelRow, maxPixelRow ); 	 
   bool bigInY = theRecTopol->containsBigPixelInY( minPixelCol, maxPixelCol );
-  if (  isUpgrade_ ||(!with_track_angle && DoCosmics_) )
+  if unlikely(  isUpgrade_ ||(!with_track_angle && DoCosmics_) )
     {
       //cout << "Track angles are not known and we are processing cosmics." << endl; 
       //cout << "Default angle estimation which assumes track from PV (0,0,0) does not work." << endl;

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -18,7 +18,12 @@
 #include <iostream>
 using namespace std;
 
-const double HALF_PI = 1.57079632679489656;
+namespace {
+  constexpr float HALF_PI = 1.57079632679489656;
+  constexpr float PI = 2*HALF_PI;
+
+}
+
 
 //-----------------------------------------------------------------------------
 //!  The constructor.
@@ -728,9 +733,14 @@ PixelCPEGeneric::localError( const SiPixelCluster& cluster,
 	    } 
 	  else 
 	    { 	 
+
+	      auto alpha = HALF_PI - std::atan(cotalpha_);
+	      auto beta = HALF_PI - std::atan(cotbeta_); 
+	      if (zneg) { beta -=PI; alpha -=PI;}
+
 	      pair<float,float> errPair = 	 
 		genErrorsFromDB_->getError( genErrorParm_, thePart, sizex, sizey, 	 
-					    alpha_, beta_, bigInX, bigInY ); 
+					    alpha, beta, bigInX, bigInY ); 
 	      if ( !edgex ) 
 		xerr = errPair.first; 	 
 	      if ( !edgey ) 

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPETemplateReco.cc
@@ -111,10 +111,8 @@ PixelCPETemplateReco::~PixelCPETemplateReco()
 //  The main call to the template code.
 //------------------------------------------------------------------
 LocalPoint
-PixelCPETemplateReco::localPosition(const SiPixelCluster& cluster, const GeomDetUnit & det) const 
+PixelCPETemplateReco::localPosition(const SiPixelCluster& cluster) const 
 {
-  setTheDet( det, cluster );
-  
   bool fpix;  //  barrel(false) or forward(true)
   if ( thePart == GeomDetEnumerators::PixelBarrel )   
     fpix = false;    // no, it's not forward -- it's barrel
@@ -466,8 +464,7 @@ PixelCPETemplateReco::localPosition(const SiPixelCluster& cluster, const GeomDet
 //  localError() relies on localPosition() being called FIRST!!!
 //------------------------------------------------------------------
 LocalError  
-PixelCPETemplateReco::localError( const SiPixelCluster& cluster, 
-				  const GeomDetUnit& det ) const 
+PixelCPETemplateReco::localError( const SiPixelCluster& cluster) const 
 {
   //cout << endl;
   //cout << "Set PixelCPETemplate errors .............................................." << endl;
@@ -495,9 +492,7 @@ PixelCPETemplateReco::localError( const SiPixelCluster& cluster,
       // If errors are not split at the cluster splitting level, set the errors here
 
       //cout  << "Errors are not split at the cluster splitting level, set the errors here : " << endl; 
-  
-      setTheDet( det, cluster );
-      
+       
       int maxPixelCol = cluster.maxPixelCol();
       int maxPixelRow = cluster.maxPixelRow();
       int minPixelCol = cluster.minPixelCol();

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
@@ -70,10 +70,8 @@
 //
 //
 
-//#include <stdlib.h> 
-//#include <stdio.h>
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-//#include <cmath.h>
+#include <cmath>
 #else
 #include <math.h>
 #endif
@@ -481,7 +479,8 @@ bool SiPixelTemplate::pushfile(int filenum)
 		// Add this template to the store
 		
 		thePixelTemp_.push_back(theCurrentTemp);
-		
+
+		postInit();		
 		return true;
 		
 	} else {
@@ -497,6 +496,7 @@ bool SiPixelTemplate::pushfile(int filenum)
 
 
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
+
 
 //**************************************************************** 
 //! This routine initializes the global template structures from an
@@ -515,6 +515,7 @@ bool SiPixelTemplate::pushfile(const SiPixelTemplateDBObject& dbobject)
 	
 	// We must create a new object because dbobject must be a const and our stream must not be
 	SiPixelTemplateDBObject db = dbobject;
+	//	SiPixelTemplateDBObject & db = const_cast<SiPixelTemplateDBObject&>(dbobject);
 	
 	// Create a local template storage entry
 	SiPixelTemplateStore theCurrentTemp;
@@ -859,11 +860,40 @@ bool SiPixelTemplate::pushfile(const SiPixelTemplateDBObject& dbobject)
 		thePixelTemp_.push_back(theCurrentTemp);
 		
 	}
+	postInit();
 	return true;
 	
 } // TempInit 
 
 #endif
+
+
+void SiPixelTemplate::postInit() {
+
+  std::cout << "SiPixelTemplate size " << thePixelTemp_.size() << std::endl;
+#ifndef SI_PIXEL_TEMPLATE_USE_BOOST 
+  std::cout <<"uses C arrays" << std::endl;
+#endif
+
+  int i=0;
+  for (auto & templ : thePixelTemp_) {
+    std::cout << i <<':' << templ.head.ID << ' ' << templ.head.NTy <<','<< templ.head.NTyx <<','<< templ.head.NTxx << std::endl;
+    for ( auto iy=1; iy<templ.head.NTy; ++iy  ) { auto & ent = templ.enty[iy]; std::cout << ent.cotbeta <<',' << ent.cotbeta-templ.enty[iy-1].cotbeta << ' '; }
+    std::cout << std::endl;
+    for ( auto ix=1; ix<templ.head.NTxx; ++ix  ){ auto & ent = templ.entx[0][ix]; std::cout << ent.cotalpha <<','<< ent.cotalpha-templ.entx[0][ix-1].cotalpha << ' ';}
+      std::cout << std::endl;
+    ++i;
+  }
+
+  for (auto & templ : thePixelTemp_) {
+    for ( auto iy=0; iy<templ.head.NTy; ++iy ) templ.cotbetaY[iy]=templ.enty[iy].cotbeta;
+    for ( auto iy=0; iy<templ.head.NTyx; ++iy )  templ.cotbetaX[iy]= templ.entx[iy][0].cotbeta;
+    for ( auto ix=0; ix<templ.head.NTxx; ++ix ) templ.cotalphaX[ix]=templ.entx[0][ix].cotalpha;
+  }
+
+}
+
+
 
 
 // ************************************************************************************************************ 
@@ -2152,247 +2182,215 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
 {
     // Interpolate for a new set of track angles 
     
-    // Local variables 
-    int i, binq;
-	int ilow, ihigh, iylow, iyhigh, Ny, Nxx, Nyx, index;
-	float yratio, yxratio, xxratio;
-	float acotb, qscale, qavg, qmin, qmin2, fq, qtotal, qcorrect, cotb, cotalpha0;
-	float yavggen[4], yrmsgen[4], xavggen[4], xrmsgen[4];
-	bool flip_y;
-	
 
 // Find the index corresponding to id
 
-       index = -1;
-       for(i=0; i<(int)thePixelTemp_.size(); ++i) {
-	
-	      if(id == thePixelTemp_[i].head.ID) {
-	   
-	         index = i;
-		     break;
-          }
-	    }
+   int index = -1;
+    for( int i=0; i<(int)thePixelTemp_.size(); ++i) {      
+      if(id == thePixelTemp_[i].head.ID) {
+	index = i;
+	break;
+      }
+    }
 	 
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-	   if(index < 0 || index >= (int)thePixelTemp_.size()) {
-	      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::qbin can't find needed template ID = " << id << std::endl;
-	   }
+    if(index < 0 || index >= (int)thePixelTemp_.size()) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::qbin can't find needed template ID = " << id << std::endl;
+    }
 #else
-	   assert(index >= 0 && index < (int)thePixelTemp_.size());
+    assert(index >= 0 && index < (int)thePixelTemp_.size());
 #endif
 	 
-//		
+    //	
 
-// Interpolate the absolute value of cot(beta)     
+
+    auto const & templ = thePixelTemp_[index];	
     
-    acotb = fabs((double)cotbeta);
+    // Interpolate the absolute value of cot(beta)     
+    
+    auto acotb = std::abs(cotbeta);
+    
+    //	qcorrect corrects the cot(alpha)=0 cluster charge for non-zero cot(alpha)	
 	
-//	qcorrect corrects the cot(alpha)=0 cluster charge for non-zero cot(alpha)	
+    auto cotalpha0 =  thePixelTemp_[index].enty[0].cotalpha;
+    auto qcorrect=std::sqrt((1.f+cotbeta*cotbeta+cotalpha*cotalpha)/(1.f+cotbeta*cotbeta+cotalpha0*cotalpha0));
+    
+    // for some cosmics, the ususal gymnastics are incorrect   
+    
+    float cotb; bool flip_y;
+    if(thePixelTemp_[index].head.Dtype == 0) {
+      cotb = acotb;
+      flip_y = false;
+      if(cotbeta < 0.f) {flip_y = true;}
+    } else {
+      if(locBz < 0.f) {
+	cotb = cotbeta;
+	flip_y = false;
+      } else {
+	cotb = -cotbeta;
+	flip_y = true;
+      }	
+    }
+    
+    // Copy the charge scaling factor to the private variable     
+    
+    auto qscale = thePixelTemp_[index].head.qscale;
 
-	//	qcorrect corrects the cot(alpha)=0 cluster charge for non-zero cot(alpha)	
-	
-	cotalpha0 =  thePixelTemp_[index].enty[0].cotalpha;
-	qcorrect=std::sqrt((1.f+cotbeta*cotbeta+cotalpha*cotalpha)/(1.f+cotbeta*cotbeta+cotalpha0*cotalpha0));
-				
-	// for some cosmics, the ususal gymnastics are incorrect   
-	
-	if(thePixelTemp_[index].head.Dtype == 0) {
-		cotb = acotb;
-		flip_y = false;
-		if(cotbeta < 0.f) {flip_y = true;}
-	} else {
-	    if(locBz < 0.f) {
-			cotb = cotbeta;
-			flip_y = false;
-		} else {
-			cotb = -cotbeta;
-			flip_y = true;
-		}	
-	}
-	
-	// Copy the charge scaling factor to the private variable     
-		
-	   qscale = thePixelTemp_[index].head.qscale;
-		
-       Ny = thePixelTemp_[index].head.NTy;
-       Nyx = thePixelTemp_[index].head.NTyx;
-       Nxx = thePixelTemp_[index].head.NTxx;
-		
+
+
+    lorywidth = thePixelTemp_[index].head.lorywidth;
+    if(locBz > 0.f) {lorywidth = -lorywidth;}
+    lorxwidth = thePixelTemp_[index].head.lorxwidth;
+
+
+    
+    auto Ny = thePixelTemp_[index].head.NTy;
+    auto Nyx = thePixelTemp_[index].head.NTyx;
+    auto Nxx = thePixelTemp_[index].head.NTxx;
+    
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-		if(Ny < 2 || Nyx < 1 || Nxx < 2) {
-			throw cms::Exception("DataCorrupt") << "template ID = " << id_current_ << "has too few entries: Ny/Nyx/Nxx = " << Ny << "/" << Nyx << "/" << Nxx << std::endl;
-		}
+    if(Ny < 2 || Nyx < 1 || Nxx < 2) {
+      throw cms::Exception("DataCorrupt") << "template ID = " << id_current_ << "has too few entries: Ny/Nyx/Nxx = " << Ny << "/" << Nyx << "/" << Nxx << std::endl;
+    }
 #else
-		assert(Ny > 1 && Nyx > 0 && Nxx > 1);
+    assert(Ny > 1 && Nyx > 0 && Nxx > 1);
 #endif
-        
+    
 // next, loop over all y-angle entries   
-
-	   ilow = 0;
-	   yratio = 0.f;
-
-	   if(cotb >= thePixelTemp_[index].enty[Ny-1].cotbeta) {
-	
-	       ilow = Ny-2;
-		   yratio = 1.f;
-		
-	   } else {
-	   
-	      if(cotb >= thePixelTemp_[index].enty[0].cotbeta) {
-
-             for (i=0; i<Ny-1; ++i) { 
     
-                if( thePixelTemp_[index].enty[i].cotbeta <= cotb && cotb < thePixelTemp_[index].enty[i+1].cotbeta) {
-		  
-	               ilow = i;
-		           yratio = (cotb - thePixelTemp_[index].enty[i].cotbeta)/(thePixelTemp_[index].enty[i+1].cotbeta - thePixelTemp_[index].enty[i].cotbeta);
-		           break;			 
-		        }
-	         }
-		  } 
-	   }
-	
-	   ihigh=ilow + 1;
-			  
-// Interpolate/store all y-related quantities (flip displacements when flip_y)
+    auto ilow = 0;
+    auto ihigh = 0;
+    auto yratio = 0.f;
+      
+    {
+      auto j = std::lower_bound(templ.cotbetaY,templ.cotbetaY+Ny,cotb);
+      if (j==templ.cotbetaY+Ny) { --j;  yratio = 1.f; }
+      else if (j==templ.cotbetaY) { ++j; yratio = 0.f;}
+      else { yratio = (cotb - (*(j-1)) )/( (*j) - (*(j-1)) ) ; }
+      
+      ihigh = j-templ.cotbetaY;
+      ilow = ihigh=1;
+    }
 
-	   qavg = (1.f - yratio)*thePixelTemp_[index].enty[ilow].qavg + yratio*thePixelTemp_[index].enty[ihigh].qavg;
-	   qavg *= qcorrect;
-	   dy1 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].dyone + yratio*thePixelTemp_[index].enty[ihigh].dyone;
-	   if(flip_y) {dy1 = -dy1;}
-	   sy1 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].syone + yratio*thePixelTemp_[index].enty[ihigh].syone;
-	   dy2 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].dytwo + yratio*thePixelTemp_[index].enty[ihigh].dytwo;
-	   if(flip_y) {dy2 = -dy2;}
-	   sy2 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].sytwo + yratio*thePixelTemp_[index].enty[ihigh].sytwo;
-	   qmin = (1.f - yratio)*thePixelTemp_[index].enty[ilow].qmin + yratio*thePixelTemp_[index].enty[ihigh].qmin;
-	   qmin *= qcorrect;
-	   qmin2 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].qmin2 + yratio*thePixelTemp_[index].enty[ihigh].qmin2;
-	   qmin2 *= qcorrect;
-	   for(i=0; i<4; ++i) {
-	      yavggen[i]=(1.f - yratio)*thePixelTemp_[index].enty[ilow].yavggen[i] + yratio*thePixelTemp_[index].enty[ihigh].yavggen[i];
-	      if(flip_y) {yavggen[i] = -yavggen[i];}
-	      yrmsgen[i]=(1.f - yratio)*thePixelTemp_[index].enty[ilow].yrmsgen[i] + yratio*thePixelTemp_[index].enty[ihigh].yrmsgen[i];
-	   }
-	   
-	
-// next, loop over all x-angle entries, first, find relevant y-slices   
-	
-	   iylow = 0;
-	   yxratio = 0.f;
 
-	   if(acotb >= thePixelTemp_[index].entx[Nyx-1][0].cotbeta) {
-	
-	       iylow = Nyx-2;
-		   yxratio = 1.f;
-		
-	   } else if(acotb >= thePixelTemp_[index].entx[0][0].cotbeta) {
 
-          for (i=0; i<Nyx-1; ++i) { 
+    // Interpolate/store all y-related quantities (flip displacements when flip_y)
     
-             if( thePixelTemp_[index].entx[i][0].cotbeta <= acotb && acotb < thePixelTemp_[index].entx[i+1][0].cotbeta) {
-		  
-	            iylow = i;
-		        yxratio = (acotb - thePixelTemp_[index].entx[i][0].cotbeta)/(thePixelTemp_[index].entx[i+1][0].cotbeta - thePixelTemp_[index].entx[i][0].cotbeta);
-		        break;			 
-		     }
-	      }
-	   }
-	
-	   iyhigh=iylow + 1;
+    dy1 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].dyone + yratio*thePixelTemp_[index].enty[ihigh].dyone;
+    if(flip_y) {dy1 = -dy1;}
+    sy1 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].syone + yratio*thePixelTemp_[index].enty[ihigh].syone;
+    dy2 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].dytwo + yratio*thePixelTemp_[index].enty[ihigh].dytwo;
+    if(flip_y) {dy2 = -dy2;}
+    sy2 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].sytwo + yratio*thePixelTemp_[index].enty[ihigh].sytwo;
+ 
+    auto qavg = (1.f - yratio)*thePixelTemp_[index].enty[ilow].qavg + yratio*thePixelTemp_[index].enty[ihigh].qavg;
+    qavg *= qcorrect;
+    auto qmin = (1.f - yratio)*thePixelTemp_[index].enty[ilow].qmin + yratio*thePixelTemp_[index].enty[ihigh].qmin;
+    qmin *= qcorrect;
+    auto qmin2 = (1.f - yratio)*thePixelTemp_[index].enty[ilow].qmin2 + yratio*thePixelTemp_[index].enty[ihigh].qmin2;
+    qmin2 *= qcorrect;
 
-	   ilow = 0;
-	   xxratio = 0.f;
 
-	   if(cotalpha >= thePixelTemp_[index].entx[0][Nxx-1].cotalpha) {
-	
-	       ilow = Nxx-2;
-		   xxratio = 1.f;
-		
-	   } else {
-	   
-	      if(cotalpha >= thePixelTemp_[index].entx[0][0].cotalpha) {
-
-             for (i=0; i<Nxx-1; ++i) { 
-    
-                if( thePixelTemp_[index].entx[0][i].cotalpha <= cotalpha && cotalpha < thePixelTemp_[index].entx[0][i+1].cotalpha) {
-		  
-	               ilow = i;
-		           xxratio = (cotalpha - thePixelTemp_[index].entx[0][i].cotalpha)/(thePixelTemp_[index].entx[0][i+1].cotalpha - thePixelTemp_[index].entx[0][i].cotalpha);
-		           break;
-			    }
-		     }
-		  } 
-	   }
-	
-	   ihigh=ilow + 1;
-			  
-	   dx1 = (1.f - xxratio)*thePixelTemp_[index].entx[0][ilow].dxone + xxratio*thePixelTemp_[index].entx[0][ihigh].dxone;
-	   sx1 = (1.f - xxratio)*thePixelTemp_[index].entx[0][ilow].sxone + xxratio*thePixelTemp_[index].entx[0][ihigh].sxone;
-	   dx2 = (1.f - xxratio)*thePixelTemp_[index].entx[0][ilow].dxtwo + xxratio*thePixelTemp_[index].entx[0][ihigh].dxtwo;
-	   sx2 = (1.f - xxratio)*thePixelTemp_[index].entx[0][ilow].sxtwo + xxratio*thePixelTemp_[index].entx[0][ihigh].sxtwo;
-	   		  
-// pixmax is the maximum allowed pixel charge (used for truncation)
-
-	   pixmx=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index].entx[iylow][ilow].pixmax + xxratio*thePixelTemp_[index].entx[iylow][ihigh].pixmax)
-			  +yxratio*((1.f - xxratio)*thePixelTemp_[index].entx[iyhigh][ilow].pixmax + xxratio*thePixelTemp_[index].entx[iyhigh][ihigh].pixmax);
-			  
-	   for(i=0; i<4; ++i) {
-				  
-	      xavggen[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index].entx[iylow][ilow].xavggen[i] + xxratio*thePixelTemp_[index].entx[iylow][ihigh].xavggen[i])
-		          +yxratio*((1.f - xxratio)*thePixelTemp_[index].entx[iyhigh][ilow].xavggen[i] + xxratio*thePixelTemp_[index].entx[iyhigh][ihigh].xavggen[i]);
-		  
-	      xrmsgen[i]=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index].entx[iylow][ilow].xrmsgen[i] + xxratio*thePixelTemp_[index].entx[iylow][ihigh].xrmsgen[i])
-		          +yxratio*((1.f - xxratio)*thePixelTemp_[index].entx[iyhigh][ilow].xrmsgen[i] + xxratio*thePixelTemp_[index].entx[iyhigh][ihigh].xrmsgen[i]);		  
-	   }
-	   
-		lorywidth = thePixelTemp_[index].head.lorywidth;
-	    if(locBz > 0.f) {lorywidth = -lorywidth;}
-		lorxwidth = thePixelTemp_[index].head.lorxwidth;
-		
-	
-	
 #ifndef SI_PIXEL_TEMPLATE_STANDALONE
-	if(qavg <= 0.f || qmin <= 0.f) {
-		throw cms::Exception("DataCorrupt") << "SiPixelTemplate::qbin, qavg or qmin <= 0," 
-		<< " Probably someone called the generic pixel reconstruction with an illegal trajectory state" << std::endl;
-	}
+    if(qavg <= 0.f || qmin <= 0.f) {
+      throw cms::Exception("DataCorrupt") << "SiPixelTemplate::qbin, qavg or qmin <= 0," 
+					  << " Probably someone called the generic pixel reconstruction with an illegal trajectory state" << std::endl;
+    }
 #else
-	assert(qavg > 0.f && qmin > 0.f);
+    assert(qavg > 0.f && qmin > 0.f);
 #endif
-	
-//  Scale the input charge to account for differences between pixelav and CMSSW simulation or data	
-	
-	qtotal = qscale*qclus;
-	
-// uncertainty and final corrections depend upon total charge bin 	   
-	   
-	fq = qtotal/qavg;
-	if(fq > 1.5f) {
-	   binq=0;
+    
+    //  Scale the input charge to account for differences between pixelav and CMSSW simulation or data	
+    
+    auto qtotal = qscale*qclus;
+    
+    // uncertainty and final corrections depend upon total charge bin 	   
+    
+    auto fq = qtotal/qavg;
+    int  binq;
+    if(fq > 1.5f) {
+      binq=0;
+    } else {
+      if(fq > 1.0f) {
+	binq=1;
+      } else {
+	if(fq > 0.85f) {
+	  binq=2;
 	} else {
-	   if(fq > 1.0f) {
-	      binq=1;
-	   } else {
-		  if(fq > 0.85f) {
-			 binq=2;
-		  } else {
-			 binq=3;
-		  }
-	   }
+	  binq=3;
 	}
-	
-//  Take the errors and bias from the correct charge bin
-	
-	sigmay = yrmsgen[binq]; deltay = yavggen[binq];
-	
-	sigmax = xrmsgen[binq]; deltax = xavggen[binq];
-	
-// If the charge is too small (then flag it)
-	
-	if(qtotal < 0.95f*qmin) {binq = 5;} else {if(qtotal < 0.95f*qmin2) {binq = 4;}}
+      }
+    }
+
+    auto yavggen =(1.f - yratio)*thePixelTemp_[index].enty[ilow].yavggen[binq] + yratio*thePixelTemp_[index].enty[ihigh].yavggen[binq];
+    if(flip_y) {yavggen = -yavggen;}
+    auto yrmsgen =(1.f - yratio)*thePixelTemp_[index].enty[ilow].yrmsgen[binq] + yratio*thePixelTemp_[index].enty[ihigh].yrmsgen[binq];
+    
+    
+// next, loop over all x-angle entries, first, find relevant y-slices   
+    
+    auto iylow = 0;
+    auto iyhigh = 0;
+    auto yxratio = 0.f;
+       
+
+    {
+      auto j = std::lower_bound(templ.cotbetaX,templ.cotbetaX+Nyx,acotb);
+      if (j==templ.cotbetaX+Nyx) { --j;  yxratio = 1.f; }
+      else if (j==templ.cotbetaX) { ++j; yxratio = 0.f;}
+      else { yxratio = (acotb - (*(j-1)) )/( (*j) - (*(j-1)) ) ; }
+      
+      iyhigh = j-templ.cotbetaX;
+      iylow = iyhigh -1;
+    }
+
+
+
+    ilow = ihigh = 0;
+    auto xxratio = 0.f;  
+
+    {
+      auto j = std::lower_bound(templ.cotalphaX,templ.cotalphaX+Nxx,cotalpha);
+      if (j==templ.cotalphaX+Nxx) { --j;  xxratio = 1.f; }
+      else if (j==templ.cotalphaX) { ++j; xxratio = 0.f;}
+      else { xxratio = (cotalpha - (*(j-1)) )/( (*j) - (*(j-1)) ) ; }
+
+      ihigh = j-templ.cotalphaX;
+      ilow = ihigh=1; 
+    }
+    
+
+
+    dx1 = (1.f - xxratio)*thePixelTemp_[index].entx[0][ilow].dxone + xxratio*thePixelTemp_[index].entx[0][ihigh].dxone;
+    sx1 = (1.f - xxratio)*thePixelTemp_[index].entx[0][ilow].sxone + xxratio*thePixelTemp_[index].entx[0][ihigh].sxone;
+    dx2 = (1.f - xxratio)*thePixelTemp_[index].entx[0][ilow].dxtwo + xxratio*thePixelTemp_[index].entx[0][ihigh].dxtwo;
+    sx2 = (1.f - xxratio)*thePixelTemp_[index].entx[0][ilow].sxtwo + xxratio*thePixelTemp_[index].entx[0][ihigh].sxtwo;
+    
+    // pixmax is the maximum allowed pixel charge (used for truncation)
+    
+    pixmx=(1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index].entx[iylow][ilow].pixmax + xxratio*thePixelTemp_[index].entx[iylow][ihigh].pixmax)
+      +yxratio*((1.f - xxratio)*thePixelTemp_[index].entx[iyhigh][ilow].pixmax + xxratio*thePixelTemp_[index].entx[iyhigh][ihigh].pixmax);
+    
+    auto xavggen = (1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index].entx[iylow][ilow].xavggen[binq] + xxratio*thePixelTemp_[index].entx[iylow][ihigh].xavggen[binq])
+      +yxratio*((1.f - xxratio)*thePixelTemp_[index].entx[iyhigh][ilow].xavggen[binq] + xxratio*thePixelTemp_[index].entx[iyhigh][ihigh].xavggen[binq]);
+    
+    auto xrmsgen = (1.f - yxratio)*((1.f - xxratio)*thePixelTemp_[index].entx[iylow][ilow].xrmsgen[binq] + xxratio*thePixelTemp_[index].entx[iylow][ihigh].xrmsgen[binq])
+      +yxratio*((1.f - xxratio)*thePixelTemp_[index].entx[iyhigh][ilow].xrmsgen[binq] + xxratio*thePixelTemp_[index].entx[iyhigh][ihigh].xrmsgen[binq]);		  
+    
 		
+    
+    //  Take the errors and bias from the correct charge bin
+	
+    sigmay = yrmsgen; deltay = yavggen;
+    
+    sigmax = xrmsgen; deltax = xavggen;
+    
+    // If the charge is too small (then flag it)
+    
+    if(qtotal < 0.95f*qmin) {binq = 5;} else {if(qtotal < 0.95f*qmin2) {binq = 4;}}
+    
     return binq;
-  
+    
 } // qbin
 
 // ************************************************************************************************************ 

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
@@ -2177,7 +2177,7 @@ void SiPixelTemplate::xtemp3d(int i, int j, std::vector<float>& xtemplate)
 //! \param lorxwidth - (output) the estimated x Lorentz width
 // ************************************************************************************************************ 
 int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax, 
-                          float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2, float& lorywidth, float& lorxwidth)
+                          float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2) // float& lorywidth, float& lorxwidth)
 		 
 {
     // Interpolate for a new set of track angles 
@@ -2237,11 +2237,11 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
     auto qscale = thePixelTemp_[index].head.qscale;
 
 
-
+     /*
     lorywidth = thePixelTemp_[index].head.lorywidth;
     if(locBz > 0.f) {lorywidth = -lorywidth;}
     lorxwidth = thePixelTemp_[index].head.lorxwidth;
-
+    */
 
     
     auto Ny = thePixelTemp_[index].head.NTy;
@@ -2256,7 +2256,7 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
     assert(Ny > 1 && Nyx > 0 && Nxx > 1);
 #endif
     
-// next, loop over all y-angle entries   
+    // next, loop over all y-angle entries   
     
     auto ilow = 0;
     auto ihigh = 0;
@@ -2269,7 +2269,7 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
       else { yratio = (cotb - (*(j-1)) )/( (*j) - (*(j-1)) ) ; }
       
       ihigh = j-templ.cotbetaY;
-      ilow = ihigh=1;
+      ilow = ihigh-1;
     }
 
 
@@ -2356,7 +2356,7 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
       else { xxratio = (cotalpha - (*(j-1)) )/( (*j) - (*(j-1)) ) ; }
 
       ihigh = j-templ.cotalphaX;
-      ilow = ihigh=1; 
+      ilow = ihigh-1; 
     }
     
 
@@ -2416,6 +2416,7 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
 //! \param sx2 - (output) the estimated x-error for 1 double-pixel clusters in microns
 //! \param dx2 - (output) the estimated x-bias for 1 double-pixel clusters in microns
 // ************************************************************************************************************ 
+/*
 int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, float qclus, float& pixmx, float& sigmay, float& deltay, float& sigmax, float& deltax, 
                           float& sy1, float& dy1, float& sy2, float& dy2, float& sx1, float& dx1, float& sx2, float& dx2)
 
@@ -2425,6 +2426,7 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float locBz, fl
 								 sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2, lorywidth, lorxwidth);
 	
 } // qbin
+*/
 
 // ************************************************************************************************************ 
 //! Interpolate beta/alpha angles to produce an expected average charge. Return int (0-4) describing the charge 
@@ -2439,11 +2441,11 @@ int SiPixelTemplate::qbin(int id, float cotalpha, float cotbeta, float qclus)
 	// Interpolate for a new set of track angles 
 	
 	// Local variables 
-	float pixmx, sigmay, deltay, sigmax, deltax, sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2, locBz, lorywidth, lorxwidth;
+	float pixmx, sigmay, deltay, sigmax, deltax, sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2, locBz; //  lorywidth, lorxwidth;
 	locBz = -1.f;
 	if(cotbeta < 0.f) {locBz = -locBz;}
 	return SiPixelTemplate::qbin(id, cotalpha, cotbeta, locBz, qclus, pixmx, sigmay, deltay, sigmax, deltax, 
-										  sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2, lorywidth, lorxwidth);
+										  sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2); // , lorywidth, lorxwidth);
 	
 } // qbin
 
@@ -2459,12 +2461,12 @@ int SiPixelTemplate::qbin(int id, float cotbeta, float qclus)
 // Interpolate for a new set of track angles 
 				
 // Local variables 
-	float pixmx, sigmay, deltay, sigmax, deltax, sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2, locBz, lorywidth, lorxwidth;
+	float pixmx, sigmay, deltay, sigmax, deltax, sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2, locBz; //, lorywidth, lorxwidth;
 	const float cotalpha = 0.f;
 	locBz = -1.f;
 	if(cotbeta < 0.f) {locBz = -locBz;}
 	return SiPixelTemplate::qbin(id, cotalpha, cotbeta, locBz, qclus, pixmx, sigmay, deltay, sigmax, deltax, 
-								sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2, lorywidth, lorxwidth);
+								sy1, dy1, sy2, dy2, sx1, dx1, sx2, dx2); // , lorywidth, lorxwidth);
 				
 } // qbin
 				

--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplate.cc
@@ -869,7 +869,7 @@ bool SiPixelTemplate::pushfile(const SiPixelTemplateDBObject& dbobject)
 
 
 void SiPixelTemplate::postInit() {
-
+  /*
   std::cout << "SiPixelTemplate size " << thePixelTemp_.size() << std::endl;
 #ifndef SI_PIXEL_TEMPLATE_USE_BOOST 
   std::cout <<"uses C arrays" << std::endl;
@@ -884,6 +884,7 @@ void SiPixelTemplate::postInit() {
       std::cout << std::endl;
     ++i;
   }
+  */
 
   for (auto & templ : thePixelTemp_) {
     for ( auto iy=0; iy<templ.head.NTy; ++iy ) templ.cotbetaY[iy]=templ.enty[iy].cotbeta;


### PR DESCRIPTION
cleanup and improvements in computational performance mostly connected to cluster 2 rechit for pixel.
Fixed also a couple of longstanding bugs. It affects the cluster error (mostly in local x) for about 1% of the clusters.

next would be to test a faster version of SiPixelTemplate::qbin that does not interpolate

p.s.
why things such as
RecoHI/HiCentralityAlgos or /DQM/Physics, SUSYBSMAnalysis/HSCP or DQMOffline/JetMET
depend on details of the PixelTopology remains a mistery to me
