### PR TITLE
FastTimerService - multithreading fixes part1

### DIFF
--- a/HLTrigger/Timer/interface/FastTimer.h
+++ b/HLTrigger/Timer/interface/FastTimer.h
@@ -1,0 +1,37 @@
+#ifndef FastTimer_h
+#define FastTimer_h
+
+// C++ headers
+#include <chrono>
+
+class FastTimer {
+public:
+  typedef std::chrono::high_resolution_clock Clock;
+  typedef std::chrono::nanoseconds           Duration;
+  enum class Status {
+    kStopped,
+    kRunning
+  };
+
+  FastTimer();
+
+  void start();
+  void stop();
+  void reset();
+
+  Duration value() const;
+  Duration untilNow() const;
+  Status status() const;
+  Clock::time_point const & getStartTime() const;
+  Clock::time_point const & getStopTime() const;
+  void setStartTime(Clock::time_point const &);
+  void setStopTime(Clock::time_point const &);
+
+private:
+  Duration          m_duration;
+  Clock::time_point m_start;
+  Clock::time_point m_stop;
+  Status            m_status;
+};
+
+#endif // ! FastTimer_h

--- a/HLTrigger/Timer/interface/FastTimerService.h
+++ b/HLTrigger/Timer/interface/FastTimerService.h
@@ -190,7 +190,7 @@ private:
     double                      summary_postmodules;
     double                      summary_overhead;
     double                      summary_total;
-    uint32_t                    last_run;
+    uint32_t                    last_run;           // index of the last module run in this path
     uint32_t                    index;              // index of the Path or EndPath in the "schedule"
     bool                        accept;             // flag indicating if the path acepted the event
     TH1F *                      dqm_active;         // see time_active

--- a/HLTrigger/Timer/interface/FastTimerService.h
+++ b/HLTrigger/Timer/interface/FastTimerService.h
@@ -272,8 +272,8 @@ private:
     }
   };
 
-  template <typename T> class PathMap   : public std::unordered_map<std::string, T> {};
-  template <typename T> class ModuleMap : public std::unordered_map<edm::ModuleDescription const *, T> {};
+  template <typename T> using PathMap   = std::unordered_map<std::string, T>;
+  template <typename T> using ModuleMap = std::unordered_map<edm::ModuleDescription const *, T>;
 
   // timer configuration
   const clockid_t                               m_timer_id;             // the default is to use CLOCK_THREAD_CPUTIME_ID, unless useRealTimeClock is set, which will use CLOCK_REALTIME

--- a/HLTrigger/Timer/interface/FastTimerService.h
+++ b/HLTrigger/Timer/interface/FastTimerService.h
@@ -97,6 +97,7 @@ public:
   double queryModuleTimeByLabel(const std::string &) const;
   double queryModuleTimeByType(const std::string &) const;
   double queryPathActiveTime(const std::string &) const;
+  double queryPathExclusiveTime(const std::string &) const;
   double queryPathTotalTime(const std::string &) const;
 
   // query the time spent in the current event's
@@ -146,7 +147,7 @@ private:
     double                      summary_active;
     TH1F *                      dqm_active;
     bool                        has_just_run;       // flag set to check if a module was active inside a particular path, or not
-    bool                        is_exclusive;       // flag set to check if a module has been run only once
+    bool                        is_exclusive;       // flag set to check if a module was schedules to run exactly once
 
   public:
     ModuleInfo() :
@@ -175,6 +176,7 @@ private:
   struct PathInfo {
     std::vector<ModuleInfo *>   modules;            // list of all modules contributing to the path (duplicate modules stored as null pointers)
     double                      time_active;        // per-event timer: time actually spent in this path
+    double                      time_exclusive;     // per-event timer: time actually spent in this path, in modules that are not run on any other paths
     double                      time_premodules;    // per-event timer: time spent between "begin path" and the first "begin module"
     double                      time_intermodules;  // per-event timer: time spent between modules
     double                      time_postmodules;   // per-event timer: time spent between the last "end module" and "end path"
@@ -203,6 +205,7 @@ private:
     PathInfo() :
       modules(),
       time_active(0.),
+      time_exclusive(0.),
       time_premodules(0.),
       time_intermodules(0.),
       time_postmodules(0.),
@@ -236,6 +239,7 @@ private:
     void reset() {
       modules.clear();
       time_active = 0.;
+      time_exclusive = 0.;
       time_premodules = 0.;
       time_intermodules = 0.;
       time_postmodules = 0.;

--- a/HLTrigger/Timer/plugins/FastTimerFilter.cc
+++ b/HLTrigger/Timer/plugins/FastTimerFilter.cc
@@ -4,7 +4,7 @@
 
 // CMSSW headers
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
@@ -15,7 +15,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "HLTrigger/Timer/interface/FastTimerService.h"
 
-class FastTimerFilter : public edm::EDFilter {
+class FastTimerFilter : public edm::global::EDFilter<> {
 public:
   explicit FastTimerFilter(edm::ParameterSet const &);
   ~FastTimerFilter();
@@ -23,11 +23,11 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  double m_time_limit_event;
-  double m_time_limit_path;
-  double m_time_limit_allpaths;
+  const double m_time_limit_event;
+  const double m_time_limit_path;
+  const double m_time_limit_allpaths;
 
-  bool filter(edm::Event & event, const edm::EventSetup & setup) override;
+  bool filter(edm::StreamID sid, edm::Event & event, const edm::EventSetup & setup) const override;
 };
 
 FastTimerFilter::FastTimerFilter(edm::ParameterSet const & config) :
@@ -42,17 +42,17 @@ FastTimerFilter::~FastTimerFilter()
 }
 
 bool
-FastTimerFilter::filter(edm::Event & event, edm::EventSetup const & setup) 
+FastTimerFilter::filter(edm::StreamID sid, edm::Event & event, edm::EventSetup const & setup) const
 {
   if (not edm::Service<FastTimerService>().isAvailable())
     return false;
 
   FastTimerService const & fts = * edm::Service<FastTimerService>();
-  if (m_time_limit_allpaths > 0. and fts.queryPathsTime()   > m_time_limit_allpaths)
+  if (m_time_limit_allpaths > 0. and fts.queryPathsTime(sid)   > m_time_limit_allpaths)
     return true;
-  if (m_time_limit_event    > 0. and fts.currentEventTime() > m_time_limit_event)
+  if (m_time_limit_event    > 0. and fts.currentEventTime(sid) > m_time_limit_event)
     return true;
-  if (m_time_limit_path     > 0. and fts.currentPathTime()  > m_time_limit_path)
+  if (m_time_limit_path     > 0. and fts.currentPathTime(sid)  > m_time_limit_path)
     return true;
 
   return false;

--- a/HLTrigger/Timer/src/FastTimer.cc
+++ b/HLTrigger/Timer/src/FastTimer.cc
@@ -1,0 +1,71 @@
+// C++ headers
+#include <chrono>
+#include <iostream>     // cerr
+
+#include "HLTrigger/Timer/interface/FastTimer.h"
+
+FastTimer::FastTimer() :
+  m_duration(Duration::zero()),
+  m_start(),
+  m_stop(),
+  m_status(Status::kStopped)
+{ }
+
+// start the timer - only if it was not running
+void FastTimer::start() {
+  if (m_status == Status::kStopped) {
+    m_start    = Clock::now();
+  //m_stop     = Clock::time_point();   // FIXME re-enable this once there is a better way to fill the interpath data
+    m_status   = Status::kRunning;
+  } else {
+    std::cerr << "attempting to start an already running timer" << std::endl;
+  }
+}
+
+// stop the timer - only if it was running
+void FastTimer::stop() {
+  if (m_status == Status::kRunning) {
+    m_stop     = Clock::now();
+    m_duration += std::chrono::duration_cast<Duration>(m_stop - m_start);
+    m_status   = Status::kStopped;
+  }
+}
+
+// reset the timer
+void FastTimer::reset() {
+  m_duration = Duration::zero();
+  m_start    = Clock::time_point();
+  m_stop     = Clock::time_point();
+  m_status   = Status::kStopped;
+}
+
+// read the accumulated time
+FastTimer::Duration FastTimer::value() const {
+  return m_duration;
+}
+
+// if the timer is stopped, read the accumulate time
+// if the timer is running, also add the time up to "now" 
+FastTimer::Duration FastTimer::untilNow() const {
+  return m_duration + ( (m_status == Status::kRunning) ? std::chrono::duration_cast<Duration>(Clock::now() - m_start) : Duration::zero() );
+}
+
+FastTimer::Status FastTimer::status() const {
+  return m_status;
+}
+
+FastTimer::Clock::time_point const & FastTimer::getStartTime() const {
+  return m_start;
+}
+
+FastTimer::Clock::time_point const & FastTimer::getStopTime() const {
+  return m_stop;
+}
+
+void FastTimer::setStartTime(FastTimer::Clock::time_point const & time) {
+  m_start = time;
+}
+
+void FastTimer::setStopTime(FastTimer::Clock::time_point const & time) {
+  m_stop = time;
+}

--- a/HLTrigger/Timer/src/FastTimerService.cc
+++ b/HLTrigger/Timer/src/FastTimerService.cc
@@ -243,11 +243,11 @@ void FastTimerService::preGlobalBeginRun( edm::GlobalContext const & )
     for (unsigned int sid = 0; sid < m_concurrent_streams; ++sid) {
       auto & stream = m_stream[sid];
       // FIXME remove when using threadsafe DQM
-      std::string spath = (boost::format("stream %02d") % sid).str();
+      std::string spath = (m_concurrent_streams > 1) ? (boost::format("/stream %02d") % sid).str() : std::string();
 
       // event summary plots
       if (m_enable_dqm_summary) {
-        m_dqms->setCurrentFolder((m_dqm_path + '/' + spath));
+        m_dqms->setCurrentFolder((m_dqm_path + spath));
         stream.dqm.event         = m_dqms->book1D("event",        "Event processing time",         eventbins,  0., m_dqm_eventtime_range)->getTH1F();
         stream.dqm.event         ->StatOverflows(true);
         stream.dqm.event         ->SetXTitle("processing time [ms]");
@@ -275,7 +275,7 @@ void FastTimerService::preGlobalBeginRun( edm::GlobalContext const & )
       if (m_enable_dqm_summary and m_enable_dqm_bynproc) {
         TH1F * plot;
         for (unsigned int n : m_supported_processes) {
-          m_dqms->setCurrentFolder( (boost::format("%s/Running %d processes") % (m_dqm_path + '/' + spath) % n).str() );
+          m_dqms->setCurrentFolder( (boost::format("%s/Running %d processes") % (m_dqm_path + spath) % n).str() );
           plot = m_dqms->book1D("event",        "Event processing time",       eventbins,  0., m_dqm_eventtime_range)->getTH1F();
           plot->StatOverflows(true);
           plot->SetXTitle("processing time [ms]");
@@ -308,7 +308,7 @@ void FastTimerService::preGlobalBeginRun( edm::GlobalContext const & )
       }
 
       // plots by path
-      m_dqms->setCurrentFolder((m_dqm_path + '/' + spath));
+      m_dqms->setCurrentFolder((m_dqm_path + spath));
       stream.dqm_paths_active_time     = m_dqms->bookProfile("paths_active_time",    "Additional time spent in each path", size, -0.5, size-0.5, pathbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
       stream.dqm_paths_active_time     ->StatOverflows(true);
       stream.dqm_paths_active_time     ->SetYTitle("processing time [ms]");
@@ -339,7 +339,7 @@ void FastTimerService::preGlobalBeginRun( edm::GlobalContext const & )
 
       // per-lumisection plots
       if (m_enable_dqm_byls) {
-        m_dqms->setCurrentFolder((m_dqm_path + '/' + spath));
+        m_dqms->setCurrentFolder((m_dqm_path + spath));
         stream.dqm_byls.event        = m_dqms->bookProfile("event_byls",        "Event processing time, by LumiSection",       m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
         stream.dqm_byls.event        ->StatOverflows(true);
         stream.dqm_byls.event        ->SetXTitle("lumisection");
@@ -374,7 +374,7 @@ void FastTimerService::preGlobalBeginRun( edm::GlobalContext const & )
       if (m_enable_dqm_byls and m_enable_dqm_bynproc) {
         TProfile * plot;
         for (unsigned int n : m_supported_processes) {
-          m_dqms->setCurrentFolder( (boost::format("%s/Running %d processes") % (m_dqm_path + '/' + spath) % n).str() );
+          m_dqms->setCurrentFolder( (boost::format("%s/Running %d processes") % (m_dqm_path + spath) % n).str() );
           plot = m_dqms->bookProfile("event_byls",        "Event processing time, by LumiSection",    m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
           plot->StatOverflows(true);
           plot->SetXTitle("lumisection");
@@ -415,7 +415,7 @@ void FastTimerService::preGlobalBeginRun( edm::GlobalContext const & )
 
       // plots vs. instantaneous luminosity
       if (m_enable_dqm_byluminosity) {
-        m_dqms->setCurrentFolder((m_dqm_path + '/' + spath));
+        m_dqms->setCurrentFolder((m_dqm_path + spath));
         stream.dqm_byluminosity.event        = m_dqms->bookProfile("event_byluminosity",        "Event processing time vs. instantaneous luminosity",        lumibins, 0., m_dqm_luminosity_range, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
         stream.dqm_byluminosity.event        ->StatOverflows(true);
         stream.dqm_byluminosity.event        ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
@@ -450,7 +450,7 @@ void FastTimerService::preGlobalBeginRun( edm::GlobalContext const & )
       if (m_enable_dqm_byluminosity and m_enable_dqm_bynproc) {
         TProfile * plot;
         for (unsigned int n : m_supported_processes) {
-          m_dqms->setCurrentFolder( (boost::format("%s/Running %d processes") % (m_dqm_path + '/' + spath) % n).str() );
+          m_dqms->setCurrentFolder( (boost::format("%s/Running %d processes") % (m_dqm_path + spath) % n).str() );
           plot = m_dqms->bookProfile("event_byluminosity",        "Event processing time vs. instantaneous luminosity",       lumibins, 0., m_dqm_luminosity_range, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
           plot->StatOverflows(true);
           plot->SetYTitle("processing time [ms]");
@@ -491,7 +491,7 @@ void FastTimerService::preGlobalBeginRun( edm::GlobalContext const & )
 
       // per-path and per-module accounting
       if (m_enable_timing_paths) {
-        m_dqms->setCurrentFolder(((m_dqm_path + '/' + spath) + "/Paths"));
+        m_dqms->setCurrentFolder(((m_dqm_path + spath) + "/Paths"));
         for (auto & keyval: stream.paths) {
           std::string const & pathname = keyval.first;
           PathInfo          & pathinfo = keyval.second;
@@ -573,7 +573,7 @@ void FastTimerService::preGlobalBeginRun( edm::GlobalContext const & )
       }
 
       if (m_enable_dqm_bymodule) {
-        m_dqms->setCurrentFolder(((m_dqm_path + '/' + spath) + "/Modules"));
+        m_dqms->setCurrentFolder(((m_dqm_path + spath) + "/Modules"));
         for (auto & keyval: stream.modules) {
           std::string const & label  = keyval.first;
           ModuleInfo        & module = keyval.second;
@@ -584,7 +584,7 @@ void FastTimerService::preGlobalBeginRun( edm::GlobalContext const & )
       }
 
       if (m_enable_dqm_bymoduletype) {
-        m_dqms->setCurrentFolder(((m_dqm_path + '/' + spath) + "/ModuleTypes"));
+        m_dqms->setCurrentFolder(((m_dqm_path + spath) + "/ModuleTypes"));
         for (auto & keyval: stream.moduletypes) {
           std::string const & label  = keyval.first;
           ModuleInfo        & module = keyval.second;
@@ -803,7 +803,7 @@ void FastTimerService::preEvent(edm::StreamContext const & sc) {
   start(m_timer_event);
 
   // account the time spent after the source
-  m_event[sid].postsource = delta(m_timer_source.second, m_timer_event.first);
+  m_event[sid].postsource = delta(m_timer_source.getStopTime(), m_timer_event.getStartTime());
 
   // clear the event counters
   m_event[sid].event        = 0;
@@ -832,7 +832,7 @@ void FastTimerService::preEvent(edm::StreamContext const & sc) {
 
   // copy the start event timestamp as the end of the previous path
   // used by the inter-path overhead measurement
-  m_timer_path.second = m_timer_event.first;
+  m_timer_path.setStopTime( m_timer_event.getStartTime() );
 }
 
 void FastTimerService::postEvent(edm::StreamContext const & sc) {
@@ -844,7 +844,7 @@ void FastTimerService::postEvent(edm::StreamContext const & sc) {
   m_event[sid].event = delta(m_timer_event);
 
   // the last part of inter-path overhead is the time between the end of the last (end)path and the end of the event processing
-  double interpaths = delta(m_timer_path.second, m_timer_event.second);
+  double interpaths = delta(m_timer_path.getStopTime(), m_timer_event.getStopTime());
   m_event[sid].interpaths += interpaths;
   m_event[sid].paths_interpaths[m_stream[sid].paths.size()] = interpaths;
 
@@ -986,7 +986,7 @@ void FastTimerService::preSourceEvent(edm::StreamID sid) {
   start(m_timer_source);
 
   // account the time spent before the source
-  m_event[sid].presource = (m_is_first_event) ? 0. : delta(m_timer_event.second, m_timer_source.first);
+  m_event[sid].presource = (m_is_first_event) ? 0. : delta(m_timer_event.getStopTime(), m_timer_source.getStartTime());
 
   // clear the event counters
   m_event[sid].source = 0.;
@@ -1022,15 +1022,15 @@ void FastTimerService::prePathEvent(edm::StreamContext const & sc, edm::PathCont
 
   if (path == m_first_path) {
     // this is the first path, start the "all paths" counter
-    m_timer_paths.first = m_timer_path.first;
+    m_timer_paths.setStartTime( m_timer_path.getStartTime() );
   } else if (path == m_first_endpath) {
     // this is the first endpath, start the "all paths" counter
-    m_timer_endpaths.first = m_timer_path.first;
+    m_timer_endpaths.setStartTime(m_timer_path.getStartTime());
   }
 
   // measure the inter-path overhead as the time elapsed since the end of preiovus path
   // (or the beginning of the event, if this is the first path - see preEvent)
-  double interpaths = delta(m_timer_path.second,  m_timer_path.first);
+  double interpaths = delta(m_timer_path.getStopTime(), m_timer_path.getStartTime());
   m_event[sid].interpaths += interpaths;
   m_event[sid].paths_interpaths[stream.current_path->index] = interpaths;
 }
@@ -1093,8 +1093,8 @@ void FastTimerService::postPathEvent(edm::StreamContext const & sc, edm::PathCon
         overhead = active;
       } else {
         // extract overhead information
-        pre      = delta(m_timer_path.first,    m_timer_first_module);
-        post     = delta(m_timer_module.second, m_timer_path.second);
+        pre      = delta(m_timer_path.getStartTime(),  m_timer_first_module);
+        post     = delta(m_timer_module.getStopTime(), m_timer_path.getStopTime());
         inter    = active - pre - current - post;
         // take care of numeric precision and rounding errors - the timer is less precise than nanosecond resolution
         if (std::abs(inter) < 1e-9)
@@ -1122,11 +1122,11 @@ void FastTimerService::postPathEvent(edm::StreamContext const & sc, edm::PathCon
 
   if (path == m_last_path) {
     // this is the last path, stop and account the "all paths" counter
-    m_timer_paths.second = m_timer_path.second;
+    m_timer_paths.setStopTime(m_timer_path.getStopTime());
     m_event[sid].all_paths = delta(m_timer_paths);
   } else if (path == m_last_endpath) {
     // this is the last endpath, stop and account the "all endpaths" counter
-    m_timer_endpaths.second = m_timer_path.second;
+    m_timer_endpaths.setStopTime(m_timer_path.getStopTime());
     m_event[sid].all_endpaths = delta(m_timer_endpaths);
   }
 
@@ -1143,7 +1143,7 @@ void FastTimerService::preModuleEvent(edm::StreamContext const &, edm::ModuleCal
     m_is_first_module = false;
 
     // measure the time spent between the beginning of the path and the execution of the first module
-    m_timer_first_module = m_timer_module.first;
+    m_timer_first_module = m_timer_module.getStartTime();
   }
 }
 
@@ -1250,23 +1250,17 @@ void FastTimerService::fillPathMap(std::string const & name, std::vector<std::st
 
 // return the time spent since the last preModuleEvent() event
 double FastTimerService::currentModuleTime(edm::StreamID) const {
-  struct timespec now;
-  gettime(now);
-  return delta(m_timer_module.first, now);
+  return std::chrono::duration_cast<std::chrono::duration<double>>(m_timer_module.untilNow()).count();
 }
 
 // return the time spent since the last prePathEvent() event
 double FastTimerService::currentPathTime(edm::StreamID) const {
-  struct timespec now;
-  gettime(now);
-  return delta(m_timer_path.first, now);
+  return std::chrono::duration_cast<std::chrono::duration<double>>(m_timer_path.untilNow()).count();
 }
 
 // return the time spent since the last preEvent() event
 double FastTimerService::currentEventTime(edm::StreamID) const {
-  struct timespec now;
-  gettime(now);
-  return delta(m_timer_event.first, now);
+  return std::chrono::duration_cast<std::chrono::duration<double>>(m_timer_event.untilNow()).count();
 }
 
 // query the time spent in a module (available after the module has run)

--- a/HLTrigger/Timer/src/FastTimerService.cc
+++ b/HLTrigger/Timer/src/FastTimerService.cc
@@ -77,10 +77,7 @@ FastTimerService::FastTimerService(const edm::ParameterSet & config, edm::Activi
   m_enable_dqm_bymoduletype(     config.getUntrackedParameter<bool>(     "enableDQMbyModuleType"    ) ),
   m_enable_dqm_summary(          config.getUntrackedParameter<bool>(     "enableDQMSummary"         ) ),
   m_enable_dqm_byluminosity(     config.getUntrackedParameter<bool>(     "enableDQMbyLuminosity"    ) ),   
-  m_enable_dqm_byls(             config.existsAs<bool>("enableDQMbyLumiSection", false) ? 
-                                    config.getUntrackedParameter<bool>("enableDQMbyLumiSection") : 
-                                    ( edm::LogWarning("Configuration") << "enableDQMbyLumi is deprecated, please use enableDQMbyLumiSection instead", config.getUntrackedParameter<bool>("enableDQMbyLumi") ) 
-                                 ),
+  m_enable_dqm_byls(             config.getUntrackedParameter<bool>(     "enableDQMbyLumiSection"   ) ),   
   m_enable_dqm_bynproc(          config.getUntrackedParameter<bool>(     "enableDQMbyProcesses"     ) ),
   m_nproc_enabled(               false ),
   m_dqm_eventtime_range(         config.getUntrackedParameter<double>(   "dqmTimeRange"             ) ),            // ms
@@ -1450,10 +1447,7 @@ void FastTimerService::fillDescriptions(edm::ConfigurationDescriptions & descrip
   desc.addUntracked<bool>(   "enableDQMbyModuleType",    false);
   desc.addUntracked<bool>(   "enableDQMSummary",         false);
   desc.addUntracked<bool>(   "enableDQMbyLuminosity",    false);
-  desc.addNode(
-    edm::ParameterDescription<bool>(   "enableDQMbyLumiSection", false, false) or
-    edm::ParameterDescription<bool>(   "enableDQMbyLumi",        false, false)
-  );
+  desc.addUntracked<bool>(   "enableDQMbyLumiSection",   false);
   desc.addUntracked<bool>(   "enableDQMbyProcesses",     false);
   desc.addUntracked<double>( "dqmTimeRange",             1000. );   // ms
   desc.addUntracked<double>( "dqmTimeResolution",           5. );   // ms

--- a/HLTrigger/Timer/src/FastTimerService.cc
+++ b/HLTrigger/Timer/src/FastTimerService.cc
@@ -28,7 +28,11 @@ typedef int clockid_t;
 
 // CMSSW headers
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
+#include "FWCore/ServiceRegistry/interface/PathContext.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ServiceRegistry/interface/StreamContext.h"
+#include "FWCore/ServiceRegistry/interface/SystemBounds.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -36,6 +40,7 @@ typedef int clockid_t;
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/StreamID.h"
 #include "DataFormats/Common/interface/HLTPathStatus.h"
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
@@ -76,10 +81,13 @@ FastTimerService::FastTimerService(const edm::ParameterSet & config, edm::Activi
   m_enable_dqm_bymodule(         config.getUntrackedParameter<bool>(     "enableDQMbyModule"        ) ),
   m_enable_dqm_bymoduletype(     config.getUntrackedParameter<bool>(     "enableDQMbyModuleType"    ) ),
   m_enable_dqm_summary(          config.getUntrackedParameter<bool>(     "enableDQMSummary"         ) ),
-  m_enable_dqm_byluminosity(     config.getUntrackedParameter<bool>(     "enableDQMbyLuminosity"    ) ),   
-  m_enable_dqm_byls(             config.getUntrackedParameter<bool>(     "enableDQMbyLumiSection"   ) ),   
+  m_enable_dqm_byluminosity(     config.getUntrackedParameter<bool>(     "enableDQMbyLuminosity"    ) ),
+  m_enable_dqm_byls(             config.getUntrackedParameter<bool>(     "enableDQMbyLumiSection"   ) ),
   m_enable_dqm_bynproc(          config.getUntrackedParameter<bool>(     "enableDQMbyProcesses"     ) ),
   m_nproc_enabled(               false ),
+  m_concurrent_runs(             0 ),
+  m_concurrent_streams(          0 ),
+  m_concurrent_threads(          0 ),
   m_dqm_eventtime_range(         config.getUntrackedParameter<double>(   "dqmTimeRange"             ) ),            // ms
   m_dqm_eventtime_resolution(    config.getUntrackedParameter<double>(   "dqmTimeResolution"        ) ),            // ms
   m_dqm_pathtime_range(          config.getUntrackedParameter<double>(   "dqmPathTimeRange"         ) ),            // ms
@@ -93,128 +101,59 @@ FastTimerService::FastTimerService(const edm::ParameterSet & config, edm::Activi
   m_luminosity_label(            config.getUntrackedParameter<edm::InputTag>("luminosityProduct") ),                // SCAL unpacker
   m_supported_processes(         config.getUntrackedParameter<std::vector<unsigned int> >("supportedProcesses") ),  // 8, 24, 32
   // caching
-  m_first_path(0),          // these are initialized at prePathBeginRun(),
-  m_last_path(0),           // to make sure we cache the correct pointers
-  m_first_endpath(0),
-  m_last_endpath(0),
+  m_first_path(),
+  m_last_path(),
+  m_first_endpath(),
+  m_last_endpath(),
   m_is_first_module(false),
   m_is_first_event(true),
   // per-event accounting
-  m_event(0.),
-  m_presource(0.),
-  m_source(0.),
-  m_postsource(0.),
-  m_all_paths(0.),
-  m_all_endpaths(0.),
-  m_interpaths(0.),
-  m_paths_interpaths(),
-  // per-job summary
-  m_summary_events(0),
-  m_summary_event(0.),
-  m_summary_presource(0.),
-  m_summary_source(0.),
-  m_summary_postsource(0.),
-  m_summary_all_paths(0.),
-  m_summary_all_endpaths(0.),
-  m_summary_interpaths(0.),
-  m_summary_paths_interpaths(),
-  // DQM - these are initialized at preBeginRun(), to make sure the DQM service has been loaded
-  m_dqms(0),
-  // event summary plots
-  m_dqm_event(0),
-  m_dqm_presource (0),
-  m_dqm_source(0),
-  m_dqm_postsource (0),
-  m_dqm_all_paths(0),
-  m_dqm_all_endpaths(0),
-  m_dqm_interpaths(0),
-  // event summary plots - summed over nodes with the same number of processes
-  m_dqm_nproc_event(0),
-  m_dqm_nproc_source(0),
-  m_dqm_nproc_all_paths(0),
-  m_dqm_nproc_all_endpaths(0),
-  m_dqm_nproc_interpaths(0),
-  // plots by path
-  m_dqm_paths_active_time(0),
-  m_dqm_paths_total_time(0),
-  m_dqm_paths_exclusive_time(0),
-  m_dqm_paths_interpaths(0),
-  // plots per lumisection
-  m_dqm_byls_event(0),
-  m_dqm_byls_presource(0),
-  m_dqm_byls_source(0),
-  m_dqm_byls_postsource(0),
-  m_dqm_byls_all_paths(0),
-  m_dqm_byls_all_endpaths(0),
-  m_dqm_byls_interpaths(0),
-  // plots per lumisection - summed over nodes with the same number of processes
-  m_dqm_nproc_byls_event(0),
-  m_dqm_nproc_byls_presource(0),
-  m_dqm_nproc_byls_source(0),
-  m_dqm_nproc_byls_postsource(0),
-  m_dqm_nproc_byls_all_paths(0),
-  m_dqm_nproc_byls_all_endpaths(0),
-  m_dqm_nproc_byls_interpaths(0),
-  // plots vs. instantaneous luminosity
-  m_dqm_byluminosity_event(0),
-  m_dqm_byluminosity_presource(0),
-  m_dqm_byluminosity_source(0),
-  m_dqm_byluminosity_postsource(0),
-  m_dqm_byluminosity_all_paths(0),
-  m_dqm_byluminosity_all_endpaths(0),
-  m_dqm_byluminosity_interpaths(0),
-  // plots vs. instantaneous luminosity - summed over nodes with the same number of processes
-  m_dqm_nproc_byluminosity_event(0),
-  m_dqm_nproc_byluminosity_presource(0),
-  m_dqm_nproc_byluminosity_source(0),
-  m_dqm_nproc_byluminosity_postsource(0),
-  m_dqm_nproc_byluminosity_all_paths(0),
-  m_dqm_nproc_byluminosity_all_endpaths(0),
-  m_dqm_nproc_byluminosity_interpaths(0),
-  // per-path and per-module accounting
-  m_current_path(0),
-  m_paths(),
-  m_modules(),
-  m_moduletypes(),
-  m_fast_modules(),
-  m_fast_moduletypes()
+  m_event(),
+  // per-run and per-job summaries
+  m_run_summary(),
+  m_job_summary(),
+  // DQM - these are initialized at preGlobalBeginRun(), to make sure the DQM service has been loaded
+  m_stream()
 {
   // enable timers if required by DQM plots
-  m_enable_timing_paths     = m_enable_timing_paths         or 
-                              m_enable_dqm_bypath_active    or 
-                              m_enable_dqm_bypath_total     or 
-                              m_enable_dqm_bypath_overhead  or 
-                              m_enable_dqm_bypath_details   or 
-                              m_enable_dqm_bypath_counters  or 
+  m_enable_timing_paths     = m_enable_timing_paths         or
+                              m_enable_dqm_bypath_active    or
+                              m_enable_dqm_bypath_total     or
+                              m_enable_dqm_bypath_overhead  or
+                              m_enable_dqm_bypath_details   or
+                              m_enable_dqm_bypath_counters  or
                               m_enable_dqm_bypath_exclusive;
 
-  m_enable_timing_modules   = m_enable_timing_modules       or 
-                              m_enable_dqm_bymodule         or 
-                              m_enable_dqm_bymoduletype     or 
-                              m_enable_dqm_bypath_total     or 
-                              m_enable_dqm_bypath_overhead  or 
-                              m_enable_dqm_bypath_details   or 
-                              m_enable_dqm_bypath_counters  or 
+  m_enable_timing_modules   = m_enable_timing_modules       or
+                              m_enable_dqm_bymodule         or
+                              m_enable_dqm_bymoduletype     or
+                              m_enable_dqm_bypath_total     or
+                              m_enable_dqm_bypath_overhead  or
+                              m_enable_dqm_bypath_details   or
+                              m_enable_dqm_bypath_counters  or
                               m_enable_dqm_bypath_exclusive;
 
-  m_enable_timing_exclusive = m_enable_timing_exclusive     or 
+  m_enable_timing_exclusive = m_enable_timing_exclusive     or
                               m_enable_dqm_bypath_exclusive;
 
+  registry.watchPreallocate(       this, & FastTimerService::preallocate );
   registry.watchPreModuleBeginJob( this, & FastTimerService::preModuleBeginJob );
-  registry.watchPreBeginRun(       this, & FastTimerService::preBeginRun );
+  registry.watchPreGlobalBeginRun( this, & FastTimerService::preGlobalBeginRun );
   registry.watchPostEndJob(        this, & FastTimerService::postEndJob );
-  registry.watchPrePathBeginRun(   this, & FastTimerService::prePathBeginRun) ;
-  registry.watchPreProcessEvent(   this, & FastTimerService::preProcessEvent );
-  registry.watchPostProcessEvent(  this, & FastTimerService::postProcessEvent );
+  registry.watchPostGlobalEndRun(  this, & FastTimerService::postGlobalEndRun );
   registry.watchPreSourceEvent(    this, & FastTimerService::preSourceEvent );
   registry.watchPostSourceEvent(   this, & FastTimerService::postSourceEvent );
+  registry.watchPreEvent(          this, & FastTimerService::preEvent );
+  registry.watchPostEvent(         this, & FastTimerService::postEvent );
   // watch per-path events
-  registry.watchPreProcessPath(    this, & FastTimerService::preProcessPath );
-  registry.watchPostProcessPath(   this, & FastTimerService::postProcessPath );
+  registry.watchPrePathEvent(      this, & FastTimerService::prePathEvent );
+  registry.watchPostPathEvent(     this, & FastTimerService::postPathEvent );
   // watch per-module events if enabled
   if (m_enable_timing_modules) {
-    registry.watchPreModule(         this, & FastTimerService::preModule );
-    registry.watchPostModule(        this, & FastTimerService::postModule );
+    registry.watchPreModuleEvent(            this, & FastTimerService::preModuleEvent );
+    registry.watchPostModuleEvent(           this, & FastTimerService::postModuleEvent );
+    registry.watchPreModuleEventDelayedGet(  this, & FastTimerService::preModuleEventDelayedGet );
+    registry.watchPostModuleEventDelayedGet( this, & FastTimerService::postModuleEventDelayedGet );
   }
 
 #if defined(__APPLE__) || defined (__MACH__)
@@ -229,7 +168,7 @@ FastTimerService::~FastTimerService()
 #endif // defined(__APPLE__) || defined(__MACH__)
 }
 
-void FastTimerService::preBeginRun( edm::RunID const &, edm::Timestamp const & )
+void FastTimerService::preGlobalBeginRun( edm::GlobalContext const & )
 {
   // check if the process is bound to a single CPU.
   // otherwise, the results of the CLOCK_THREAD_CPUTIME_ID timer might be inaccurate
@@ -245,19 +184,38 @@ void FastTimerService::preBeginRun( edm::RunID const &, edm::Timestamp const & )
 #endif
 
   edm::service::TriggerNamesService & tns = * edm::Service<edm::service::TriggerNamesService>();
+
+  // cache the names of the first and last path and endpath
+  if (not m_skip_first_path and not tns.getTrigPaths().empty()) {
+    m_first_path = tns.getTrigPaths().front();
+    m_last_path  = tns.getTrigPaths().back();
+  } else if (m_skip_first_path and tns.getTrigPaths().size() > 1) {
+    m_first_path = tns.getTrigPaths().at(1);
+    m_last_path  = tns.getTrigPaths().back();
+  }
+  if (not tns.getEndPaths().empty()) {
+    m_first_endpath = tns.getEndPaths().front();
+    m_last_endpath  = tns.getEndPaths().back();
+  }
+
   uint32_t size_p = tns.getTrigPaths().size();
   uint32_t size_e = tns.getEndPaths().size();
   uint32_t size = size_p + size_e;
   for (uint32_t i = 0; i < size_p; ++i) {
     std::string const & label = tns.getTrigPath(i);
-    m_paths[label].index = i;
+    for (auto & stream: m_stream)
+      stream.paths[label].index = i;
   }
   for (uint32_t i = 0; i < size_e; ++i) {
     std::string const & label = tns.getEndPath(i);
-    m_paths[label].index = size_p + i;
+    for (auto & stream: m_stream)
+      stream.paths[label].index = size_p + i;
   }
-  m_paths_interpaths.assign(size + 1, 0);
-  m_summary_paths_interpaths.assign(size + 1, 0);
+  for (auto & timing: m_event)
+    timing.paths_interpaths.assign(size + 1, 0);
+  for (auto & timing: m_run_summary)
+    timing.paths_interpaths.assign(size + 1, 0);
+  m_job_summary.paths_interpaths.assign(size + 1, 0);
 
   // associate to each path all the modules it contains
   for (uint32_t i = 0; i < tns.getTrigPaths().size(); ++i)
@@ -265,612 +223,595 @@ void FastTimerService::preBeginRun( edm::RunID const &, edm::Timestamp const & )
   for (uint32_t i = 0; i < tns.getEndPaths().size(); ++i)
     fillPathMap( tns.getEndPath(i), tns.getEndPathModules(i) );
 
-  if (m_enable_dqm)
-    // load the DQM store
-    m_dqms = edm::Service<DQMStore>().operator->();
 
-  if (m_dqms) {
-    // book MonitorElement's
+  if (m_enable_dqm) {
+    // load the DQM store
+    DQMStore * m_dqms = edm::Service<DQMStore>().operator->();
+
+    if (m_dqms == nullptr) {
+      // the DQMStore is not available, disable all DQM plots
+      m_enable_dqm = false;
+      return;
+    }
+
     int eventbins  = (int) std::ceil(m_dqm_eventtime_range  / m_dqm_eventtime_resolution);
     int pathbins   = (int) std::ceil(m_dqm_pathtime_range   / m_dqm_pathtime_resolution);
     int modulebins = (int) std::ceil(m_dqm_moduletime_range / m_dqm_moduletime_resolution);
     int lumibins   = (int) std::ceil(m_dqm_luminosity_range / m_dqm_luminosity_resolution);
 
-    // event summary plots
-    if (m_enable_dqm_summary) {
-      m_dqms->setCurrentFolder(m_dqm_path);
-      m_dqm_event         = m_dqms->book1D("event",        "Event processing time",         eventbins,  0., m_dqm_eventtime_range)->getTH1F();
-      m_dqm_event         ->StatOverflows(true);
-      m_dqm_event         ->SetXTitle("processing time [ms]");
-      m_dqm_presource     = m_dqms->book1D("presource",    "Pre-Source processing time",    modulebins, 0., m_dqm_moduletime_range)->getTH1F();
-      m_dqm_presource     ->StatOverflows(true);
-      m_dqm_presource     ->SetXTitle("processing time [ms]");
-      m_dqm_source        = m_dqms->book1D("source",       "Source processing time",        modulebins, 0., m_dqm_moduletime_range)->getTH1F();
-      m_dqm_source        ->StatOverflows(true);
-      m_dqm_source        ->SetXTitle("processing time [ms]");
-      m_dqm_postsource    = m_dqms->book1D("postsource",   "Post-Source processing time",   modulebins, 0., m_dqm_moduletime_range)->getTH1F();
-      m_dqm_postsource    ->StatOverflows(true);
-      m_dqm_postsource    ->SetXTitle("processing time [ms]");
-      m_dqm_all_paths     = m_dqms->book1D("all_paths",    "Paths processing time",         eventbins,  0., m_dqm_eventtime_range)->getTH1F();
-      m_dqm_all_paths     ->StatOverflows(true);
-      m_dqm_all_paths     ->SetXTitle("processing time [ms]");
-      m_dqm_all_endpaths  = m_dqms->book1D("all_endpaths", "EndPaths processing time",      pathbins,   0., m_dqm_pathtime_range)->getTH1F();
-      m_dqm_all_endpaths  ->StatOverflows(true);
-      m_dqm_all_endpaths  ->SetXTitle("processing time [ms]");
-      m_dqm_interpaths    = m_dqms->book1D("interpaths",   "Time spent between paths",      pathbins,   0., m_dqm_eventtime_range)->getTH1F();
-      m_dqm_interpaths    ->StatOverflows(true);
-      m_dqm_interpaths    ->SetXTitle("processing time [ms]");
-    }
+    // book MonitorElement's for each stream
+    for (unsigned int sid = 0; sid < m_concurrent_streams; ++sid) {
+      auto & stream = m_stream[sid];
+      // FIXME remove when using threadsafe DQM
+      std::string spath = (boost::format("stream %02d") % sid).str();
 
-    // event summary plots - summed over nodes with the same number of processes
-    if (m_enable_dqm_summary and m_enable_dqm_bynproc) {
-      TH1F * plot;
-      for (int n : m_supported_processes) {
-        m_dqms->setCurrentFolder( (boost::format("%s/Running %d processes") % m_dqm_path % n).str() );
-        plot = m_dqms->book1D("event",        "Event processing time",       eventbins,  0., m_dqm_eventtime_range)->getTH1F();
-        plot->StatOverflows(true);
-        plot->SetXTitle("processing time [ms]");
-        plot = m_dqms->book1D("presource",    "Pre-Source processing time",  modulebins, 0., m_dqm_moduletime_range)->getTH1F();
-        plot->StatOverflows(true);
-        plot->SetXTitle("processing time [ms]");
-        plot = m_dqms->book1D("source",       "Source processing time",      modulebins, 0., m_dqm_moduletime_range)->getTH1F();
-        plot->StatOverflows(true);
-        plot->SetXTitle("processing time [ms]");
-        plot = m_dqms->book1D("postsource",   "Post-Source processing time", modulebins, 0., m_dqm_moduletime_range)->getTH1F();
-        plot->StatOverflows(true);
-        plot->SetXTitle("processing time [ms]");
-        plot = m_dqms->book1D("all_paths",    "Paths processing time",       eventbins,  0., m_dqm_eventtime_range)->getTH1F();
-        plot->StatOverflows(true);
-        plot->SetXTitle("processing time [ms]");
-        plot = m_dqms->book1D("all_endpaths", "EndPaths processing time",    pathbins,   0., m_dqm_pathtime_range)->getTH1F();
-        plot->StatOverflows(true);
-        plot->SetXTitle("processing time [ms]");
-        plot = m_dqms->book1D("interpaths",   "Time spent between paths",    pathbins,   0., m_dqm_eventtime_range)->getTH1F();
-        plot->StatOverflows(true);
-        plot->SetXTitle("processing time [ms]");
+      // event summary plots
+      if (m_enable_dqm_summary) {
+        m_dqms->setCurrentFolder((m_dqm_path + '/' + spath));
+        stream.dqm.event         = m_dqms->book1D("event",        "Event processing time",         eventbins,  0., m_dqm_eventtime_range)->getTH1F();
+        stream.dqm.event         ->StatOverflows(true);
+        stream.dqm.event         ->SetXTitle("processing time [ms]");
+        stream.dqm.presource     = m_dqms->book1D("presource",    "Pre-Source processing time",    modulebins, 0., m_dqm_moduletime_range)->getTH1F();
+        stream.dqm.presource     ->StatOverflows(true);
+        stream.dqm.presource     ->SetXTitle("processing time [ms]");
+        stream.dqm.source        = m_dqms->book1D("source",       "Source processing time",        modulebins, 0., m_dqm_moduletime_range)->getTH1F();
+        stream.dqm.source        ->StatOverflows(true);
+        stream.dqm.source        ->SetXTitle("processing time [ms]");
+        stream.dqm.postsource    = m_dqms->book1D("postsource",   "Post-Source processing time",   modulebins, 0., m_dqm_moduletime_range)->getTH1F();
+        stream.dqm.postsource    ->StatOverflows(true);
+        stream.dqm.postsource    ->SetXTitle("processing time [ms]");
+        stream.dqm.all_paths     = m_dqms->book1D("all_paths",    "Paths processing time",         eventbins,  0., m_dqm_eventtime_range)->getTH1F();
+        stream.dqm.all_paths     ->StatOverflows(true);
+        stream.dqm.all_paths     ->SetXTitle("processing time [ms]");
+        stream.dqm.all_endpaths  = m_dqms->book1D("all_endpaths", "EndPaths processing time",      pathbins,   0., m_dqm_pathtime_range)->getTH1F();
+        stream.dqm.all_endpaths  ->StatOverflows(true);
+        stream.dqm.all_endpaths  ->SetXTitle("processing time [ms]");
+        stream.dqm.interpaths    = m_dqms->book1D("interpaths",   "Time spent between paths",      pathbins,   0., m_dqm_eventtime_range)->getTH1F();
+        stream.dqm.interpaths    ->StatOverflows(true);
+        stream.dqm.interpaths    ->SetXTitle("processing time [ms]");
       }
-    }
 
-    // plots by path
-    m_dqms->setCurrentFolder(m_dqm_path);
-    m_dqm_paths_active_time     = m_dqms->bookProfile("paths_active_time",    "Additional time spent in each path", size, -0.5, size-0.5, pathbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-    m_dqm_paths_active_time     ->StatOverflows(true);
-    m_dqm_paths_active_time     ->SetYTitle("processing time [ms]");
-    m_dqm_paths_total_time      = m_dqms->bookProfile("paths_total_time",     "Total time spent in each path",      size, -0.5, size-0.5, pathbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-    m_dqm_paths_total_time      ->StatOverflows(true);
-    m_dqm_paths_total_time      ->SetYTitle("processing time [ms]");
-    m_dqm_paths_exclusive_time  = m_dqms->bookProfile("paths_exclusive_time", "Exclusive time spent in each path",  size, -0.5, size-0.5, pathbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-    m_dqm_paths_exclusive_time  ->StatOverflows(true);
-    m_dqm_paths_exclusive_time  ->SetYTitle("processing time [ms]");
-    m_dqm_paths_interpaths      = m_dqms->bookProfile("paths_interpaths",     "Time spent between each path",       size, -0.5, size-0.5, pathbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-    m_dqm_paths_interpaths      ->StatOverflows(true);
-    m_dqm_paths_interpaths      ->SetYTitle("processing time [ms]");
-
-    for (uint32_t i = 0; i < size_p; ++i) {
-      std::string const & label = tns.getTrigPath(i);
-      m_dqm_paths_active_time    ->GetXaxis()->SetBinLabel(i + 1, label.c_str());
-      m_dqm_paths_total_time     ->GetXaxis()->SetBinLabel(i + 1, label.c_str());
-      m_dqm_paths_exclusive_time ->GetXaxis()->SetBinLabel(i + 1, label.c_str());
-      m_dqm_paths_interpaths     ->GetXaxis()->SetBinLabel(i + 1, label.c_str());
-    }
-    for (uint32_t i = 0; i < size_e; ++i) {
-      std::string const & label = tns.getEndPath(i);
-      m_dqm_paths_active_time    ->GetXaxis()->SetBinLabel(i + size_p + 1, label.c_str());
-      m_dqm_paths_total_time     ->GetXaxis()->SetBinLabel(i + size_p + 1, label.c_str());
-      m_dqm_paths_exclusive_time ->GetXaxis()->SetBinLabel(i + size_p + 1, label.c_str());
-      m_dqm_paths_interpaths     ->GetXaxis()->SetBinLabel(i + size_p + 1, label.c_str());
-    }
-
-    // per-lumisection plots
-    if (m_enable_dqm_byls) {
-      m_dqms->setCurrentFolder(m_dqm_path);
-      m_dqm_byls_event        = m_dqms->bookProfile("event_byls",        "Event processing time, by LumiSection",       m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-      m_dqm_byls_event        ->StatOverflows(true);
-      m_dqm_byls_event        ->SetXTitle("lumisection");
-      m_dqm_byls_event        ->SetYTitle("processing time [ms]");
-      m_dqm_byls_presource    = m_dqms->bookProfile("presource_byls",    "Pre-Source processing time, by LumiSection",  m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-      m_dqm_byls_presource    ->StatOverflows(true);
-      m_dqm_byls_presource    ->SetXTitle("lumisection");
-      m_dqm_byls_presource    ->SetYTitle("processing time [ms]");
-      m_dqm_byls_source       = m_dqms->bookProfile("source_byls",       "Source processing time, by LumiSection",      m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-      m_dqm_byls_source       ->StatOverflows(true);
-      m_dqm_byls_source       ->SetXTitle("lumisection");
-      m_dqm_byls_source       ->SetYTitle("processing time [ms]");
-      m_dqm_byls_postsource   = m_dqms->bookProfile("postsource_byls",   "Post-Source processing time, by LumiSection", m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-      m_dqm_byls_postsource   ->StatOverflows(true);
-      m_dqm_byls_postsource   ->SetXTitle("lumisection");
-      m_dqm_byls_postsource   ->SetYTitle("processing time [ms]");
-      m_dqm_byls_all_paths    = m_dqms->bookProfile("all_paths_byls",    "Paths processing time, by LumiSection",       m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-      m_dqm_byls_all_paths    ->StatOverflows(true);
-      m_dqm_byls_all_paths    ->SetXTitle("lumisection");
-      m_dqm_byls_all_paths    ->SetYTitle("processing time [ms]");
-      m_dqm_byls_all_endpaths = m_dqms->bookProfile("all_endpaths_byls", "EndPaths processing time, by LumiSection",    m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-      m_dqm_byls_all_endpaths ->StatOverflows(true);
-      m_dqm_byls_all_endpaths ->SetXTitle("lumisection");
-      m_dqm_byls_all_endpaths ->SetYTitle("processing time [ms]");
-      m_dqm_byls_interpaths   = m_dqms->bookProfile("interpaths_byls",   "Time spent between paths, by LumiSection",    m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-      m_dqm_byls_interpaths   ->StatOverflows(true);
-      m_dqm_byls_interpaths   ->SetXTitle("lumisection");
-      m_dqm_byls_interpaths   ->SetYTitle("processing time [ms]");
-    }
-
-    // per-lumisection plots
-    if (m_enable_dqm_byls and m_enable_dqm_bynproc) {
-      TProfile * plot;
-      for (int n : m_supported_processes) {
-        m_dqms->setCurrentFolder( (boost::format("%s/Running %d processes") % m_dqm_path % n).str() );
-        plot = m_dqms->bookProfile("event_byls",        "Event processing time, by LumiSection",    m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-        plot->StatOverflows(true);
-        plot->SetXTitle("lumisection");
-        plot->SetYTitle("processing time [ms]");
-        plot = m_dqms->bookProfile("presource_byls",    "Pre-Source processing time, by LumiSection",   m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-        plot->StatOverflows(true);
-        plot->SetXTitle("lumisection");
-        plot->SetYTitle("processing time [ms]");
-        plot = m_dqms->bookProfile("source_byls",       "Source processing time, by LumiSection",   m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-        plot->StatOverflows(true);
-        plot->SetXTitle("lumisection");
-        plot->SetYTitle("processing time [ms]");
-        plot = m_dqms->bookProfile("postsource_byls",   "Post-Source processing time, by LumiSection",   m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-        plot->StatOverflows(true);
-        plot->SetXTitle("lumisection");
-        plot->SetYTitle("processing time [ms]");
-        plot = m_dqms->bookProfile("all_paths_byls",    "Paths processing time, by LumiSection",    m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-        plot->StatOverflows(true);
-        plot->SetXTitle("lumisection");
-        plot->SetYTitle("processing time [ms]");
-        plot = m_dqms->bookProfile("all_endpaths_byls", "EndPaths processing time, by LumiSection", m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-        plot->StatOverflows(true);
-        plot->SetXTitle("lumisection");
-        plot->SetYTitle("processing time [ms]");
-        plot = m_dqms->bookProfile("interpaths_byls",   "Time spent between paths, by LumiSection", m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-        plot->StatOverflows(true);
-        plot->SetXTitle("lumisection");
-        plot->SetYTitle("processing time [ms]");
+      // event summary plots - summed over nodes with the same number of processes
+      if (m_enable_dqm_summary and m_enable_dqm_bynproc) {
+        TH1F * plot;
+        for (unsigned int n : m_supported_processes) {
+          m_dqms->setCurrentFolder( (boost::format("%s/Running %d processes") % (m_dqm_path + '/' + spath) % n).str() );
+          plot = m_dqms->book1D("event",        "Event processing time",       eventbins,  0., m_dqm_eventtime_range)->getTH1F();
+          plot->StatOverflows(true);
+          plot->SetXTitle("processing time [ms]");
+          if (m_concurrent_threads == n) stream.dqm_nproc.event = plot;
+          plot = m_dqms->book1D("presource",    "Pre-Source processing time",  modulebins, 0., m_dqm_moduletime_range)->getTH1F();
+          plot->StatOverflows(true);
+          plot->SetXTitle("processing time [ms]");
+          if (m_concurrent_threads == n) stream.dqm_nproc.presource = plot;
+          plot = m_dqms->book1D("source",       "Source processing time",      modulebins, 0., m_dqm_moduletime_range)->getTH1F();
+          plot->StatOverflows(true);
+          plot->SetXTitle("processing time [ms]");
+          if (m_concurrent_threads == n) stream.dqm_nproc.source = plot;
+          plot = m_dqms->book1D("postsource",   "Post-Source processing time", modulebins, 0., m_dqm_moduletime_range)->getTH1F();
+          plot->StatOverflows(true);
+          plot->SetXTitle("processing time [ms]");
+          if (m_concurrent_threads == n) stream.dqm_nproc.postsource = plot;
+          plot = m_dqms->book1D("all_paths",    "Paths processing time",       eventbins,  0., m_dqm_eventtime_range)->getTH1F();
+          plot->StatOverflows(true);
+          plot->SetXTitle("processing time [ms]");
+          if (m_concurrent_threads == n) stream.dqm_nproc.all_paths = plot;
+          plot = m_dqms->book1D("all_endpaths", "EndPaths processing time",    pathbins,   0., m_dqm_pathtime_range)->getTH1F();
+          plot->StatOverflows(true);
+          plot->SetXTitle("processing time [ms]");
+          if (m_concurrent_threads == n) stream.dqm_nproc.all_endpaths = plot;
+          plot = m_dqms->book1D("interpaths",   "Time spent between paths",    pathbins,   0., m_dqm_eventtime_range)->getTH1F();
+          plot->StatOverflows(true);
+          plot->SetXTitle("processing time [ms]");
+          if (m_concurrent_threads == n) stream.dqm_nproc.interpaths = plot;
+        }
       }
-    }
 
-    // plots vs. instantaneous luminosity
-    if (m_enable_dqm_byluminosity) {
-      m_dqms->setCurrentFolder(m_dqm_path);
-      m_dqm_byluminosity_event        = m_dqms->bookProfile("event_byluminosity",        "Event processing time vs. instantaneous luminosity",        lumibins, 0., m_dqm_luminosity_range, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-      m_dqm_byluminosity_event        ->StatOverflows(true);
-      m_dqm_byluminosity_event        ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
-      m_dqm_byluminosity_event        ->SetYTitle("processing time [ms]");
-      m_dqm_byluminosity_presource    = m_dqms->bookProfile("presource_byluminosity",    "Pre-Source processing time vs. instantaneous luminosity",   lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-      m_dqm_byluminosity_presource    ->StatOverflows(true);
-      m_dqm_byluminosity_presource    ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
-      m_dqm_byluminosity_presource    ->SetYTitle("processing time [ms]");
-      m_dqm_byluminosity_source       = m_dqms->bookProfile("source_byluminosity",       "Source processing time vs. instantaneous luminosity",       lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-      m_dqm_byluminosity_source       ->StatOverflows(true);
-      m_dqm_byluminosity_source       ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
-      m_dqm_byluminosity_source       ->SetYTitle("processing time [ms]");
-      m_dqm_byluminosity_postsource   = m_dqms->bookProfile("postsource_byluminosity",   "Post-Source processing time vs. instantaneous luminosity",  lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-      m_dqm_byluminosity_postsource   ->StatOverflows(true);
-      m_dqm_byluminosity_postsource   ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
-      m_dqm_byluminosity_postsource   ->SetYTitle("processing time [ms]");
-      m_dqm_byluminosity_all_paths    = m_dqms->bookProfile("all_paths_byluminosity",    "Paths processing time vs. instantaneous luminosity",        lumibins, 0., m_dqm_luminosity_range, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-      m_dqm_byluminosity_all_paths    ->StatOverflows(true);
-      m_dqm_byluminosity_all_paths    ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
-      m_dqm_byluminosity_all_paths    ->SetYTitle("processing time [ms]");
-      m_dqm_byluminosity_all_endpaths = m_dqms->bookProfile("all_endpaths_byluminosity", "EndPaths processing time vs. instantaneous luminosity",     lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-      m_dqm_byluminosity_all_endpaths ->StatOverflows(true);
-      m_dqm_byluminosity_all_endpaths ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
-      m_dqm_byluminosity_all_endpaths ->SetYTitle("processing time [ms]");
-      m_dqm_byluminosity_interpaths   = m_dqms->bookProfile("interpaths_byluminosity",   "Time spent between paths vs. instantaneous luminosity",     lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-      m_dqm_byluminosity_interpaths   ->StatOverflows(true);
-      m_dqm_byluminosity_interpaths   ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
-      m_dqm_byluminosity_interpaths   ->SetYTitle("processing time [ms]");
-    }
+      // plots by path
+      m_dqms->setCurrentFolder((m_dqm_path + '/' + spath));
+      stream.dqm_paths_active_time     = m_dqms->bookProfile("paths_active_time",    "Additional time spent in each path", size, -0.5, size-0.5, pathbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+      stream.dqm_paths_active_time     ->StatOverflows(true);
+      stream.dqm_paths_active_time     ->SetYTitle("processing time [ms]");
+      stream.dqm_paths_total_time      = m_dqms->bookProfile("paths_total_time",     "Total time spent in each path",      size, -0.5, size-0.5, pathbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+      stream.dqm_paths_total_time      ->StatOverflows(true);
+      stream.dqm_paths_total_time      ->SetYTitle("processing time [ms]");
+      stream.dqm_paths_exclusive_time  = m_dqms->bookProfile("paths_exclusive_time", "Exclusive time spent in each path",  size, -0.5, size-0.5, pathbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+      stream.dqm_paths_exclusive_time  ->StatOverflows(true);
+      stream.dqm_paths_exclusive_time  ->SetYTitle("processing time [ms]");
+      stream.dqm_paths_interpaths      = m_dqms->bookProfile("paths_interpaths",     "Time spent between each path",       size, -0.5, size-0.5, pathbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+      stream.dqm_paths_interpaths      ->StatOverflows(true);
+      stream.dqm_paths_interpaths      ->SetYTitle("processing time [ms]");
 
-    // plots vs. instantaneous luminosity
-    if (m_enable_dqm_byluminosity and m_enable_dqm_bynproc) {
-      TProfile * plot;
-      for (int n : m_supported_processes) {
-        m_dqms->setCurrentFolder( (boost::format("%s/Running %d processes") % m_dqm_path % n).str() );
-        plot = m_dqms->bookProfile("event_byluminosity",        "Event processing time vs. instantaneous luminosity",       lumibins, 0., m_dqm_luminosity_range, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-        plot->StatOverflows(true);
-        plot->SetYTitle("processing time [ms]");
-        plot->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
-        plot = m_dqms->bookProfile("presource_byluminosity",    "Pre-Source processing time vs. instantaneous luminosity",  lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-        plot->StatOverflows(true);
-        plot->SetYTitle("processing time [ms]");
-        plot->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
-        plot = m_dqms->bookProfile("source_byluminosity",       "Source processing time vs. instantaneous luminosity",      lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-        plot->StatOverflows(true);
-        plot->SetYTitle("processing time [ms]");
-        plot->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
-        plot = m_dqms->bookProfile("postsource_byluminosity",   "Post-Source processing time vs. instantaneous luminosity", lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-        plot->StatOverflows(true);
-        plot->SetYTitle("processing time [ms]");
-        plot->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
-        plot = m_dqms->bookProfile("all_paths_byluminosity",    "Paths processing time vs. instantaneous luminosity",       lumibins, 0., m_dqm_luminosity_range, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-        plot->StatOverflows(true);
-        plot->SetYTitle("processing time [ms]");
-        plot->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
-        plot = m_dqms->bookProfile("all_endpaths_byluminosity", "EndPaths processing time vs. instantaneous luminosity",    lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-        plot->StatOverflows(true);
-        plot->SetYTitle("processing time [ms]");
-        plot->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
-        plot = m_dqms->bookProfile("interpaths_byluminosity",   "Time spent between paths vs. instantaneous luminosity",    lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-        plot->StatOverflows(true);
-        plot->SetYTitle("processing time [ms]");
-        plot->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
+      for (uint32_t i = 0; i < size_p; ++i) {
+        std::string const & label = tns.getTrigPath(i);
+        stream.dqm_paths_active_time    ->GetXaxis()->SetBinLabel(i + 1, label.c_str());
+        stream.dqm_paths_total_time     ->GetXaxis()->SetBinLabel(i + 1, label.c_str());
+        stream.dqm_paths_exclusive_time ->GetXaxis()->SetBinLabel(i + 1, label.c_str());
+        stream.dqm_paths_interpaths     ->GetXaxis()->SetBinLabel(i + 1, label.c_str());
       }
-    }
+      for (uint32_t i = 0; i < size_e; ++i) {
+        std::string const & label = tns.getEndPath(i);
+        stream.dqm_paths_active_time    ->GetXaxis()->SetBinLabel(i + size_p + 1, label.c_str());
+        stream.dqm_paths_total_time     ->GetXaxis()->SetBinLabel(i + size_p + 1, label.c_str());
+        stream.dqm_paths_exclusive_time ->GetXaxis()->SetBinLabel(i + size_p + 1, label.c_str());
+        stream.dqm_paths_interpaths     ->GetXaxis()->SetBinLabel(i + size_p + 1, label.c_str());
+      }
 
-    // per-path and per-module accounting
-    if (m_enable_timing_paths) {
-      m_dqms->setCurrentFolder((m_dqm_path + "/Paths"));
-      for (auto & keyval: m_paths) {
-        std::string const & pathname = keyval.first;
-        PathInfo          & pathinfo = keyval.second;
+      // per-lumisection plots
+      if (m_enable_dqm_byls) {
+        m_dqms->setCurrentFolder((m_dqm_path + '/' + spath));
+        stream.dqm_byls.event        = m_dqms->bookProfile("event_byls",        "Event processing time, by LumiSection",       m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+        stream.dqm_byls.event        ->StatOverflows(true);
+        stream.dqm_byls.event        ->SetXTitle("lumisection");
+        stream.dqm_byls.event        ->SetYTitle("processing time [ms]");
+        stream.dqm_byls.presource    = m_dqms->bookProfile("presource_byls",    "Pre-Source processing time, by LumiSection",  m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+        stream.dqm_byls.presource    ->StatOverflows(true);
+        stream.dqm_byls.presource    ->SetXTitle("lumisection");
+        stream.dqm_byls.presource    ->SetYTitle("processing time [ms]");
+        stream.dqm_byls.source       = m_dqms->bookProfile("source_byls",       "Source processing time, by LumiSection",      m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+        stream.dqm_byls.source       ->StatOverflows(true);
+        stream.dqm_byls.source       ->SetXTitle("lumisection");
+        stream.dqm_byls.source       ->SetYTitle("processing time [ms]");
+        stream.dqm_byls.postsource   = m_dqms->bookProfile("postsource_byls",   "Post-Source processing time, by LumiSection", m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+        stream.dqm_byls.postsource   ->StatOverflows(true);
+        stream.dqm_byls.postsource   ->SetXTitle("lumisection");
+        stream.dqm_byls.postsource   ->SetYTitle("processing time [ms]");
+        stream.dqm_byls.all_paths    = m_dqms->bookProfile("all_paths_byls",    "Paths processing time, by LumiSection",       m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+        stream.dqm_byls.all_paths    ->StatOverflows(true);
+        stream.dqm_byls.all_paths    ->SetXTitle("lumisection");
+        stream.dqm_byls.all_paths    ->SetYTitle("processing time [ms]");
+        stream.dqm_byls.all_endpaths = m_dqms->bookProfile("all_endpaths_byls", "EndPaths processing time, by LumiSection",    m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+        stream.dqm_byls.all_endpaths ->StatOverflows(true);
+        stream.dqm_byls.all_endpaths ->SetXTitle("lumisection");
+        stream.dqm_byls.all_endpaths ->SetYTitle("processing time [ms]");
+        stream.dqm_byls.interpaths   = m_dqms->bookProfile("interpaths_byls",   "Time spent between paths, by LumiSection",    m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+        stream.dqm_byls.interpaths   ->StatOverflows(true);
+        stream.dqm_byls.interpaths   ->SetXTitle("lumisection");
+        stream.dqm_byls.interpaths   ->SetYTitle("processing time [ms]");
+      }
 
-        if (m_enable_dqm_bypath_active) {
-          pathinfo.dqm_active       = m_dqms->book1D(pathname + "_active",       pathname + " active time",            pathbins, 0., m_dqm_pathtime_range)->getTH1F();
-          pathinfo.dqm_active       ->StatOverflows(true);
-          pathinfo.dqm_active       ->SetXTitle("processing time [ms]");
+      // per-lumisection plots
+      if (m_enable_dqm_byls and m_enable_dqm_bynproc) {
+        TProfile * plot;
+        for (unsigned int n : m_supported_processes) {
+          m_dqms->setCurrentFolder( (boost::format("%s/Running %d processes") % (m_dqm_path + '/' + spath) % n).str() );
+          plot = m_dqms->bookProfile("event_byls",        "Event processing time, by LumiSection",    m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+          plot->StatOverflows(true);
+          plot->SetXTitle("lumisection");
+          plot->SetYTitle("processing time [ms]");
+          if (m_concurrent_threads == n) stream.dqm_nproc_byls.event = plot;
+          plot = m_dqms->bookProfile("presource_byls",    "Pre-Source processing time, by LumiSection",   m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+          plot->StatOverflows(true);
+          plot->SetXTitle("lumisection");
+          plot->SetYTitle("processing time [ms]");
+          if (m_concurrent_threads == n) stream.dqm_nproc_byls.presource = plot;
+          plot = m_dqms->bookProfile("source_byls",       "Source processing time, by LumiSection",   m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+          plot->StatOverflows(true);
+          plot->SetXTitle("lumisection");
+          plot->SetYTitle("processing time [ms]");
+          if (m_concurrent_threads == n) stream.dqm_nproc_byls.source = plot;
+          plot = m_dqms->bookProfile("postsource_byls",   "Post-Source processing time, by LumiSection",   m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+          plot->StatOverflows(true);
+          plot->SetXTitle("lumisection");
+          plot->SetYTitle("processing time [ms]");
+          if (m_concurrent_threads == n) stream.dqm_nproc_byls.postsource = plot;
+          plot = m_dqms->bookProfile("all_paths_byls",    "Paths processing time, by LumiSection",    m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+          plot->StatOverflows(true);
+          plot->SetXTitle("lumisection");
+          plot->SetYTitle("processing time [ms]");
+          if (m_concurrent_threads == n) stream.dqm_nproc_byls.all_paths = plot;
+          plot = m_dqms->bookProfile("all_endpaths_byls", "EndPaths processing time, by LumiSection", m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+          plot->StatOverflows(true);
+          plot->SetXTitle("lumisection");
+          plot->SetYTitle("processing time [ms]");
+          if (m_concurrent_threads == n) stream.dqm_nproc_byls.all_endpaths = plot;
+          plot = m_dqms->bookProfile("interpaths_byls",   "Time spent between paths, by LumiSection", m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+          plot->StatOverflows(true);
+          plot->SetXTitle("lumisection");
+          plot->SetYTitle("processing time [ms]");
+          if (m_concurrent_threads == n) stream.dqm_nproc_byls.interpaths = plot;
         }
+      }
 
-        if (m_enable_dqm_bypath_total) {
-          pathinfo.dqm_total        = m_dqms->book1D(pathname + "_total",        pathname + " total time",             pathbins, 0., m_dqm_pathtime_range)->getTH1F();
-          pathinfo.dqm_total        ->StatOverflows(true);
-          pathinfo.dqm_total        ->SetXTitle("processing time [ms]");
+      // plots vs. instantaneous luminosity
+      if (m_enable_dqm_byluminosity) {
+        m_dqms->setCurrentFolder((m_dqm_path + '/' + spath));
+        stream.dqm_byluminosity.event        = m_dqms->bookProfile("event_byluminosity",        "Event processing time vs. instantaneous luminosity",        lumibins, 0., m_dqm_luminosity_range, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+        stream.dqm_byluminosity.event        ->StatOverflows(true);
+        stream.dqm_byluminosity.event        ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
+        stream.dqm_byluminosity.event        ->SetYTitle("processing time [ms]");
+        stream.dqm_byluminosity.presource    = m_dqms->bookProfile("presource_byluminosity",    "Pre-Source processing time vs. instantaneous luminosity",   lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+        stream.dqm_byluminosity.presource    ->StatOverflows(true);
+        stream.dqm_byluminosity.presource    ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
+        stream.dqm_byluminosity.presource    ->SetYTitle("processing time [ms]");
+        stream.dqm_byluminosity.source       = m_dqms->bookProfile("source_byluminosity",       "Source processing time vs. instantaneous luminosity",       lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+        stream.dqm_byluminosity.source       ->StatOverflows(true);
+        stream.dqm_byluminosity.source       ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
+        stream.dqm_byluminosity.source       ->SetYTitle("processing time [ms]");
+        stream.dqm_byluminosity.postsource   = m_dqms->bookProfile("postsource_byluminosity",   "Post-Source processing time vs. instantaneous luminosity",  lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+        stream.dqm_byluminosity.postsource   ->StatOverflows(true);
+        stream.dqm_byluminosity.postsource   ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
+        stream.dqm_byluminosity.postsource   ->SetYTitle("processing time [ms]");
+        stream.dqm_byluminosity.all_paths    = m_dqms->bookProfile("all_paths_byluminosity",    "Paths processing time vs. instantaneous luminosity",        lumibins, 0., m_dqm_luminosity_range, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+        stream.dqm_byluminosity.all_paths    ->StatOverflows(true);
+        stream.dqm_byluminosity.all_paths    ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
+        stream.dqm_byluminosity.all_paths    ->SetYTitle("processing time [ms]");
+        stream.dqm_byluminosity.all_endpaths = m_dqms->bookProfile("all_endpaths_byluminosity", "EndPaths processing time vs. instantaneous luminosity",     lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+        stream.dqm_byluminosity.all_endpaths ->StatOverflows(true);
+        stream.dqm_byluminosity.all_endpaths ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
+        stream.dqm_byluminosity.all_endpaths ->SetYTitle("processing time [ms]");
+        stream.dqm_byluminosity.interpaths   = m_dqms->bookProfile("interpaths_byluminosity",   "Time spent between paths vs. instantaneous luminosity",     lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+        stream.dqm_byluminosity.interpaths   ->StatOverflows(true);
+        stream.dqm_byluminosity.interpaths   ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
+        stream.dqm_byluminosity.interpaths   ->SetYTitle("processing time [ms]");
+      }
+
+      // plots vs. instantaneous luminosity
+      if (m_enable_dqm_byluminosity and m_enable_dqm_bynproc) {
+        TProfile * plot;
+        for (unsigned int n : m_supported_processes) {
+          m_dqms->setCurrentFolder( (boost::format("%s/Running %d processes") % (m_dqm_path + '/' + spath) % n).str() );
+          plot = m_dqms->bookProfile("event_byluminosity",        "Event processing time vs. instantaneous luminosity",       lumibins, 0., m_dqm_luminosity_range, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+          plot->StatOverflows(true);
+          plot->SetYTitle("processing time [ms]");
+          plot->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
+          if (m_concurrent_threads == n) stream.dqm_nproc_byluminosity.event = plot;
+          plot = m_dqms->bookProfile("presource_byluminosity",    "Pre-Source processing time vs. instantaneous luminosity",  lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+          plot->StatOverflows(true);
+          plot->SetYTitle("processing time [ms]");
+          plot->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
+          if (m_concurrent_threads == n) stream.dqm_nproc_byluminosity.presource = plot;
+          plot = m_dqms->bookProfile("source_byluminosity",       "Source processing time vs. instantaneous luminosity",      lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+          plot->StatOverflows(true);
+          plot->SetYTitle("processing time [ms]");
+          plot->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
+          if (m_concurrent_threads == n) stream.dqm_nproc_byluminosity.source = plot;
+          plot = m_dqms->bookProfile("postsource_byluminosity",   "Post-Source processing time vs. instantaneous luminosity", lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+          plot->StatOverflows(true);
+          plot->SetYTitle("processing time [ms]");
+          plot->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
+          if (m_concurrent_threads == n) stream.dqm_nproc_byluminosity.postsource = plot;
+          plot = m_dqms->bookProfile("all_paths_byluminosity",    "Paths processing time vs. instantaneous luminosity",       lumibins, 0., m_dqm_luminosity_range, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+          plot->StatOverflows(true);
+          plot->SetYTitle("processing time [ms]");
+          plot->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
+          if (m_concurrent_threads == n) stream.dqm_nproc_byluminosity.all_paths = plot;
+          plot = m_dqms->bookProfile("all_endpaths_byluminosity", "EndPaths processing time vs. instantaneous luminosity",    lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+          plot->StatOverflows(true);
+          plot->SetYTitle("processing time [ms]");
+          plot->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
+          if (m_concurrent_threads == n) stream.dqm_nproc_byluminosity.all_endpaths = plot;
+          plot = m_dqms->bookProfile("interpaths_byluminosity",   "Time spent between paths vs. instantaneous luminosity",    lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+          plot->StatOverflows(true);
+          plot->SetYTitle("processing time [ms]");
+          plot->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
+          if (m_concurrent_threads == n) stream.dqm_nproc_byluminosity.interpaths = plot;
         }
+      }
 
-        if (m_enable_dqm_bypath_overhead) {
-          pathinfo.dqm_premodules   = m_dqms->book1D(pathname + "_premodules",   pathname + " pre-modules overhead",   modulebins, 0., m_dqm_moduletime_range)->getTH1F();
-          pathinfo.dqm_premodules   ->StatOverflows(true);
-          pathinfo.dqm_premodules   ->SetXTitle("processing time [ms]");
-          pathinfo.dqm_intermodules = m_dqms->book1D(pathname + "_intermodules", pathname + " inter-modules overhead", modulebins, 0., m_dqm_moduletime_range)->getTH1F();
-          pathinfo.dqm_intermodules ->StatOverflows(true);
-          pathinfo.dqm_intermodules ->SetXTitle("processing time [ms]");
-          pathinfo.dqm_postmodules  = m_dqms->book1D(pathname + "_postmodules",  pathname + " post-modules overhead",  modulebins, 0., m_dqm_moduletime_range)->getTH1F();
-          pathinfo.dqm_postmodules  ->StatOverflows(true);
-          pathinfo.dqm_postmodules  ->SetXTitle("processing time [ms]");
-          pathinfo.dqm_overhead     = m_dqms->book1D(pathname + "_overhead",     pathname + " overhead time",          modulebins, 0., m_dqm_moduletime_range)->getTH1F();
-          pathinfo.dqm_overhead     ->StatOverflows(true);
-          pathinfo.dqm_overhead     ->SetXTitle("processing time [ms]");
-        }
+      // per-path and per-module accounting
+      if (m_enable_timing_paths) {
+        m_dqms->setCurrentFolder(((m_dqm_path + '/' + spath) + "/Paths"));
+        for (auto & keyval: stream.paths) {
+          std::string const & pathname = keyval.first;
+          PathInfo          & pathinfo = keyval.second;
 
-        if (m_enable_dqm_bypath_details or m_enable_dqm_bypath_counters) {
-          // book histograms for modules-in-paths statistics
+          if (m_enable_dqm_bypath_active) {
+            pathinfo.dqm_active       = m_dqms->book1D(pathname + "_active",       pathname + " active time",            pathbins, 0., m_dqm_pathtime_range)->getTH1F();
+            pathinfo.dqm_active       ->StatOverflows(true);
+            pathinfo.dqm_active       ->SetXTitle("processing time [ms]");
+          }
 
-          // find histograms X-axis labels
-          uint32_t id;
-          std::vector<std::string> const & modules = ((id = tns.findTrigPath(pathname)) != tns.getTrigPaths().size()) ? tns.getTrigPathModules(id) :
-                                                     ((id = tns.findEndPath(pathname))  != tns.getEndPaths().size())  ? tns.getEndPathModules(id)  :
-                                                     std::vector<std::string>();
+          if (m_enable_dqm_bypath_total) {
+            pathinfo.dqm_total        = m_dqms->book1D(pathname + "_total",        pathname + " total time",             pathbins, 0., m_dqm_pathtime_range)->getTH1F();
+            pathinfo.dqm_total        ->StatOverflows(true);
+            pathinfo.dqm_total        ->SetXTitle("processing time [ms]");
+          }
 
-          static std::vector<std::string> dup;
-          if (modules.size() > dup.size())
-            fill_dups(dup, modules.size());
+          if (m_enable_dqm_bypath_overhead) {
+            pathinfo.dqm_premodules   = m_dqms->book1D(pathname + "_premodules",   pathname + " pre-modules overhead",   modulebins, 0., m_dqm_moduletime_range)->getTH1F();
+            pathinfo.dqm_premodules   ->StatOverflows(true);
+            pathinfo.dqm_premodules   ->SetXTitle("processing time [ms]");
+            pathinfo.dqm_intermodules = m_dqms->book1D(pathname + "_intermodules", pathname + " inter-modules overhead", modulebins, 0., m_dqm_moduletime_range)->getTH1F();
+            pathinfo.dqm_intermodules ->StatOverflows(true);
+            pathinfo.dqm_intermodules ->SetXTitle("processing time [ms]");
+            pathinfo.dqm_postmodules  = m_dqms->book1D(pathname + "_postmodules",  pathname + " post-modules overhead",  modulebins, 0., m_dqm_moduletime_range)->getTH1F();
+            pathinfo.dqm_postmodules  ->StatOverflows(true);
+            pathinfo.dqm_postmodules  ->SetXTitle("processing time [ms]");
+            pathinfo.dqm_overhead     = m_dqms->book1D(pathname + "_overhead",     pathname + " overhead time",          modulebins, 0., m_dqm_moduletime_range)->getTH1F();
+            pathinfo.dqm_overhead     ->StatOverflows(true);
+            pathinfo.dqm_overhead     ->SetXTitle("processing time [ms]");
+          }
 
-          std::vector<const char *> labels(modules.size(), nullptr);
-          for (uint32_t i = 0; i < modules.size(); ++i)
-            labels[i] = (pathinfo.modules[i]) ? modules[i].c_str() : dup[i].c_str();
-          
-          // book counter histograms
-          if (m_enable_dqm_bypath_counters) {
-            pathinfo.dqm_module_counter = m_dqms->book1D(pathname + "_module_counter", pathname + " module counter", modules.size(), -0.5, modules.size() - 0.5)->getTH1F();
-            // find module labels
-            for (uint32_t i = 0; i < modules.size(); ++i) {
-              pathinfo.dqm_module_counter->GetXaxis()->SetBinLabel( i+1, labels[i] );
+          if (m_enable_dqm_bypath_details or m_enable_dqm_bypath_counters) {
+            // book histograms for modules-in-paths statistics
+
+            // find histograms X-axis labels
+            uint32_t id;
+            std::vector<std::string> const & modules = ((id = tns.findTrigPath(pathname)) != tns.getTrigPaths().size()) ? tns.getTrigPathModules(id) :
+                                                       ((id = tns.findEndPath(pathname))  != tns.getEndPaths().size())  ? tns.getEndPathModules(id)  :
+                                                       std::vector<std::string>();
+
+            static std::vector<std::string> dup;
+            if (modules.size() > dup.size())
+              fill_dups(dup, modules.size());
+
+            std::vector<const char *> labels(modules.size(), nullptr);
+            for (uint32_t i = 0; i < modules.size(); ++i)
+              labels[i] = (pathinfo.modules[i]) ? modules[i].c_str() : dup[i].c_str();
+
+            // book counter histograms
+            if (m_enable_dqm_bypath_counters) {
+              pathinfo.dqm_module_counter = m_dqms->book1D(pathname + "_module_counter", pathname + " module counter", modules.size(), -0.5, modules.size() - 0.5)->getTH1F();
+              // find module labels
+              for (uint32_t i = 0; i < modules.size(); ++i) {
+                pathinfo.dqm_module_counter->GetXaxis()->SetBinLabel( i+1, labels[i] );
+              }
+            }
+            // book detailed timing histograms
+            if (m_enable_dqm_bypath_details) {
+              pathinfo.dqm_module_active  = m_dqms->book1D(pathname + "_module_active",  pathname + " module active",  modules.size(), -0.5, modules.size() - 0.5)->getTH1F();
+              pathinfo.dqm_module_active  ->SetYTitle("cumulative processing time [ms]");
+              pathinfo.dqm_module_total   = m_dqms->book1D(pathname + "_module_total",   pathname + " module total",   modules.size(), -0.5, modules.size() - 0.5)->getTH1F();
+              pathinfo.dqm_module_total   ->SetYTitle("cumulative processing time [ms]");
+              // find module labels
+              for (uint32_t i = 0; i < modules.size(); ++i) {
+                pathinfo.dqm_module_active ->GetXaxis()->SetBinLabel( i+1, labels[i] );
+                pathinfo.dqm_module_total  ->GetXaxis()->SetBinLabel( i+1, labels[i] );
+              }
             }
           }
-          // book detailed timing histograms
-          if (m_enable_dqm_bypath_details) {
-            pathinfo.dqm_module_active  = m_dqms->book1D(pathname + "_module_active",  pathname + " module active",  modules.size(), -0.5, modules.size() - 0.5)->getTH1F();
-            pathinfo.dqm_module_active  ->SetYTitle("cumulative processing time [ms]");
-            pathinfo.dqm_module_total   = m_dqms->book1D(pathname + "_module_total",   pathname + " module total",   modules.size(), -0.5, modules.size() - 0.5)->getTH1F();
-            pathinfo.dqm_module_total   ->SetYTitle("cumulative processing time [ms]");
-            // find module labels
-            for (uint32_t i = 0; i < modules.size(); ++i) {
-              pathinfo.dqm_module_active ->GetXaxis()->SetBinLabel( i+1, labels[i] );
-              pathinfo.dqm_module_total  ->GetXaxis()->SetBinLabel( i+1, labels[i] );
-            }
+
+          // book exclusive path time histograms
+          if (m_enable_dqm_bypath_exclusive) {
+            pathinfo.dqm_exclusive = m_dqms->book1D(pathname + "_exclusive", pathname + " exclusive time", pathbins, 0., m_dqm_pathtime_range)->getTH1F();
+            pathinfo.dqm_exclusive ->StatOverflows(true);
+            pathinfo.dqm_exclusive ->SetXTitle("processing time [ms]");
           }
+
         }
+      }
 
-        // book exclusive path time histograms
-        if (m_enable_dqm_bypath_exclusive) {
-          pathinfo.dqm_exclusive = m_dqms->book1D(pathname + "_exclusive", pathname + " exclusive time", pathbins, 0., m_dqm_pathtime_range)->getTH1F();
-          pathinfo.dqm_exclusive ->StatOverflows(true);
-          pathinfo.dqm_exclusive ->SetXTitle("processing time [ms]");
+      if (m_enable_dqm_bymodule) {
+        m_dqms->setCurrentFolder(((m_dqm_path + '/' + spath) + "/Modules"));
+        for (auto & keyval: stream.modules) {
+          std::string const & label  = keyval.first;
+          ModuleInfo        & module = keyval.second;
+          module.dqm_active = m_dqms->book1D(label, label, modulebins, 0., m_dqm_moduletime_range)->getTH1F();
+          module.dqm_active->StatOverflows(true);
+          module.dqm_active->SetXTitle("processing time [ms]");
         }
-
       }
-    }
-   
-    if (m_enable_dqm_bymodule) {
-      m_dqms->setCurrentFolder((m_dqm_path + "/Modules"));
-      for (auto & keyval: m_modules) {
-        std::string const & label  = keyval.first;
-        ModuleInfo        & module = keyval.second;
-        module.dqm_active = m_dqms->book1D(label, label, modulebins, 0., m_dqm_moduletime_range)->getTH1F();
-        module.dqm_active->StatOverflows(true);
-        module.dqm_active->SetXTitle("processing time [ms]");
-      }
-    }
 
-    if (m_enable_dqm_bymoduletype) {
-      m_dqms->setCurrentFolder((m_dqm_path + "/ModuleTypes"));
-      for (auto & keyval: m_moduletypes) {
-        std::string const & label  = keyval.first;
-        ModuleInfo        & module = keyval.second;
-        module.dqm_active = m_dqms->book1D(label, label, modulebins, 0., m_dqm_moduletime_range)->getTH1F();
-        module.dqm_active->StatOverflows(true);
-        module.dqm_active->SetXTitle("processing time [ms]");
+      if (m_enable_dqm_bymoduletype) {
+        m_dqms->setCurrentFolder(((m_dqm_path + '/' + spath) + "/ModuleTypes"));
+        for (auto & keyval: stream.moduletypes) {
+          std::string const & label  = keyval.first;
+          ModuleInfo        & module = keyval.second;
+          module.dqm_active = m_dqms->book1D(label, label, modulebins, 0., m_dqm_moduletime_range)->getTH1F();
+          module.dqm_active->StatOverflows(true);
+          module.dqm_active->SetXTitle("processing time [ms]");
+        }
       }
-    }
 
+    }
   }
 }
 
-void FastTimerService::setNumberOfProcesses(unsigned int procs) {
-  // the service is not configured to support plots by number of processes
-  if (not m_enable_dqm or not m_enable_dqm_bynproc)
-    return;
 
-  // the DQM store has not been configured yet
-  if (not m_dqms)
-    return;
+void
+FastTimerService::preallocate(edm::service::SystemBounds const& bounds)
+{
+  m_concurrent_runs    = bounds.maxNumberOfConcurrentRuns();
+  m_concurrent_streams = bounds.maxNumberOfStreams();
+  m_concurrent_threads = bounds.maxNumberOfThreads();
 
-  // check if the service is configured to support this number of processes
-  if (std::find(m_supported_processes.begin(), m_supported_processes.end(), procs) == m_supported_processes.end()) {
-    m_nproc_enabled = false;
-    // event summary plots - summed over nodes with the same number of processes
-    m_dqm_nproc_event                     = 0;
-    m_dqm_nproc_presource                 = 0;
-    m_dqm_nproc_source                    = 0;
-    m_dqm_nproc_postsource                = 0;
-    m_dqm_nproc_all_paths                 = 0;
-    m_dqm_nproc_all_endpaths              = 0;
-    m_dqm_nproc_interpaths                = 0;
-    // plots per lumisection - summed over nodes with the same number of processes
-    m_dqm_nproc_byls_event                = 0;
-    m_dqm_nproc_byls_presource            = 0;
-    m_dqm_nproc_byls_source               = 0;
-    m_dqm_nproc_byls_postsource           = 0;
-    m_dqm_nproc_byls_all_paths            = 0;
-    m_dqm_nproc_byls_all_endpaths         = 0;
-    m_dqm_nproc_byls_interpaths           = 0;
-    // plots vs. instantaneous luminosity - summed over nodes with the same number of processes
-    m_dqm_nproc_byluminosity_event        = 0;
-    m_dqm_nproc_byluminosity_presource    = 0;
-    m_dqm_nproc_byluminosity_source       = 0;
-    m_dqm_nproc_byluminosity_postsource   = 0;
-    m_dqm_nproc_byluminosity_all_paths    = 0;
-    m_dqm_nproc_byluminosity_all_endpaths = 0;
-    m_dqm_nproc_byluminosity_interpaths   = 0;
-  } else {
+  m_event.resize(m_concurrent_streams);
+  m_run_summary.resize(m_concurrent_runs);
+  m_stream.resize(m_concurrent_streams);
+
+  if (m_enable_dqm_bynproc and std::find(m_supported_processes.begin(), m_supported_processes.end(), m_concurrent_threads) != m_supported_processes.end())
     m_nproc_enabled = true;
-    // event summary plots - summed over nodes with the same number of processes
-    m_dqm_nproc_event                     = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "event"                    ).str() )->getTH1F();
-    m_dqm_nproc_presource                 = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "presource"                ).str() )->getTH1F();
-    m_dqm_nproc_source                    = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "source"                   ).str() )->getTH1F();
-    m_dqm_nproc_postsource                = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "postsource"               ).str() )->getTH1F();
-    m_dqm_nproc_all_paths                 = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "all_paths"                ).str() )->getTH1F();
-    m_dqm_nproc_all_endpaths              = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "all_endpaths"             ).str() )->getTH1F();
-    m_dqm_nproc_interpaths                = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "interpaths"               ).str() )->getTH1F();
-    // plots per lumisection - summed over nodes with the same number of processes
-    m_dqm_nproc_byls_event                = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "event_byls"               ).str() )->getTProfile();
-    m_dqm_nproc_byls_presource            = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "presource_byls"           ).str() )->getTProfile();
-    m_dqm_nproc_byls_source               = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "source_byls"              ).str() )->getTProfile();
-    m_dqm_nproc_byls_postsource           = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "postsource_byls"          ).str() )->getTProfile();
-    m_dqm_nproc_byls_all_paths            = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "all_paths_byls"           ).str() )->getTProfile();
-    m_dqm_nproc_byls_all_endpaths         = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "all_endpaths_byls"        ).str() )->getTProfile();
-    m_dqm_nproc_byls_interpaths           = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "interpaths_byls"          ).str() )->getTProfile();
-    // plots vs. instantaneous luminosity - summed over nodes with the same number of processes
-    m_dqm_nproc_byluminosity_event        = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "event_byluminosity"       ).str() )->getTProfile();
-    m_dqm_nproc_byluminosity_presource    = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "presource_byluminosity"   ).str() )->getTProfile();
-    m_dqm_nproc_byluminosity_source       = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "source_byluminosity"      ).str() )->getTProfile();
-    m_dqm_nproc_byluminosity_postsource   = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "postsource_byluminosity"  ).str() )->getTProfile();
-    m_dqm_nproc_byluminosity_all_paths    = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "all_paths_byluminosity"   ).str() )->getTProfile();
-    m_dqm_nproc_byluminosity_all_endpaths = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "all_endpaths_byluminosity").str() )->getTProfile();
-    m_dqm_nproc_byluminosity_interpaths   = m_dqms->get( (boost::format("%s/Running %d processes/%s") % m_dqm_path % procs % "interpaths_byluminosity"  ).str() )->getTProfile();
-  }
 }
 
-void FastTimerService::postEndJob() {
+
+void
+FastTimerService::postEndJob()
+{
+  /*
   if (m_enable_timing_summary) {
-    // print a timing sumary for the whle job
+    // print a timing sumary for the run
     edm::service::TriggerNamesService & tns = * edm::Service<edm::service::TriggerNamesService>();
 
     std::ostringstream out;
     out << std::fixed << std::setprecision(6);
     out << "FastReport " << (m_timer_id == CLOCK_REALTIME ? "(real time) " : "(CPU time)  ") << '\n';
-    out << "FastReport              " << std::right << std::setw(10) << m_summary_presource    / (double) m_summary_events << "  Pre-Source"    << '\n';
-    out << "FastReport              " << std::right << std::setw(10) << m_summary_source       / (double) m_summary_events << "  Source"        << '\n';
-    out << "FastReport              " << std::right << std::setw(10) << m_summary_postsource   / (double) m_summary_events << "  Post-Source"   << '\n';
-    out << "FastReport              " << std::right << std::setw(10) << m_summary_event        / (double) m_summary_events << "  Event"         << '\n';
-    out << "FastReport              " << std::right << std::setw(10) << m_summary_all_paths    / (double) m_summary_events << "  all Paths"     << '\n';
-    out << "FastReport              " << std::right << std::setw(10) << m_summary_all_endpaths / (double) m_summary_events << "  all EndPaths"  << '\n';
-    out << "FastReport              " << std::right << std::setw(10) << m_summary_interpaths   / (double) m_summary_events << "  between paths" << '\n';
+    out << "FastReport              " << std::right << std::setw(10) << m_job_summary.presource    / (double) m_job_summary.count << "  Pre-Source"    << '\n';
+    out << "FastReport              " << std::right << std::setw(10) << m_job_summary.source       / (double) m_job_summary.count << "  Source"        << '\n';
+    out << "FastReport              " << std::right << std::setw(10) << m_job_summary.postsource   / (double) m_job_summary.count << "  Post-Source"   << '\n';
+    out << "FastReport              " << std::right << std::setw(10) << m_job_summary.event        / (double) m_job_summary.count << "  Event"         << '\n';
+    out << "FastReport              " << std::right << std::setw(10) << m_job_summary.all_paths    / (double) m_job_summary.count << "  all Paths"     << '\n';
+    out << "FastReport              " << std::right << std::setw(10) << m_job_summary.all_endpaths / (double) m_job_summary.count << "  all EndPaths"  << '\n';
+    out << "FastReport              " << std::right << std::setw(10) << m_job_summary.interpaths   / (double) m_job_summary.count << "  between paths" << '\n';
     if (m_enable_timing_modules) {
       double modules_total = 0.;
-      for (auto & keyval: m_modules)
+      for (auto & keyval: m_stream.modules)
         modules_total += keyval.second.summary_active;
-      out << "FastReport              " << std::right << std::setw(10) << modules_total / (double) m_summary_events << "  all Modules"   << '\n';
+      out << "FastReport              " << std::right << std::setw(10) << modules_total / (double) m_job_summary.count << "  all Modules"   << '\n';
     }
     out << '\n';
     if (m_enable_timing_paths and not m_enable_timing_modules) {
       out << "FastReport " << (m_timer_id == CLOCK_REALTIME ? "(real time) " : "(CPU time)  ")    << "     Active Path" << '\n';
       for (auto const & name: tns.getTrigPaths())
         out << "FastReport              "
-            << std::right << std::setw(10) << m_paths[name].summary_active / (double) m_summary_events << "  "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_active / (double) m_job_summary.count << "  "
             << name << '\n';
       out << '\n';
       out << "FastReport " << (m_timer_id == CLOCK_REALTIME ? "(real time) " : "(CPU time)  ")    << "     Active EndPath" << '\n';
       for (auto const & name: tns.getEndPaths())
         out << "FastReport              "
-            << std::right << std::setw(10) << m_paths[name].summary_active / (double) m_summary_events << "  "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_active / (double) m_job_summary.count << "  "
             << name << '\n';
     } else if (m_enable_timing_paths and m_enable_timing_modules) {
       out << "FastReport " << (m_timer_id == CLOCK_REALTIME ? "(real time) " : "(CPU time)  ")    << "     Active       Pre-     Inter-  Post-mods   Overhead      Total  Path" << '\n';
       for (auto const & name: tns.getTrigPaths()) {
         out << "FastReport              "
-            << std::right << std::setw(10) << m_paths[name].summary_active        / (double) m_summary_events << " "
-            << std::right << std::setw(10) << m_paths[name].summary_premodules    / (double) m_summary_events << " "
-            << std::right << std::setw(10) << m_paths[name].summary_intermodules  / (double) m_summary_events << " "
-            << std::right << std::setw(10) << m_paths[name].summary_postmodules   / (double) m_summary_events << " "
-            << std::right << std::setw(10) << m_paths[name].summary_overhead      / (double) m_summary_events << " "
-            << std::right << std::setw(10) << m_paths[name].summary_total         / (double) m_summary_events << "  "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_active        / (double) m_job_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_premodules    / (double) m_job_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_intermodules  / (double) m_job_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_postmodules   / (double) m_job_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_overhead      / (double) m_job_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_total         / (double) m_job_summary.count << "  "
             << name << '\n';
       }
       out << '\n';
       out << "FastReport " << (m_timer_id == CLOCK_REALTIME ? "(real time) " : "(CPU time)  ")    << "     Active       Pre-     Inter-  Post-mods   Overhead      Total  EndPath" << '\n';
       for (auto const & name: tns.getEndPaths()) {
         out << "FastReport              "
-            << std::right << std::setw(10) << m_paths[name].summary_active        / (double) m_summary_events << " "
-            << std::right << std::setw(10) << m_paths[name].summary_premodules    / (double) m_summary_events << " "
-            << std::right << std::setw(10) << m_paths[name].summary_intermodules  / (double) m_summary_events << " "
-            << std::right << std::setw(10) << m_paths[name].summary_postmodules   / (double) m_summary_events << " "
-            << std::right << std::setw(10) << m_paths[name].summary_overhead      / (double) m_summary_events << " "
-            << std::right << std::setw(10) << m_paths[name].summary_total         / (double) m_summary_events << "  "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_active        / (double) m_job_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_premodules    / (double) m_job_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_intermodules  / (double) m_job_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_postmodules   / (double) m_job_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_overhead      / (double) m_job_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_total         / (double) m_job_summary.count << "  "
             << name << '\n';
       }
     }
     out << '\n';
     if (m_enable_timing_modules) {
       out << "FastReport " << (m_timer_id == CLOCK_REALTIME ? "(real time) " : "(CPU time)  ")    << "     Active  Module" << '\n';
-      for (auto & keyval: m_modules) {
+      for (auto & keyval: m_stream.modules) {
         std::string const & label  = keyval.first;
         ModuleInfo  const & module = keyval.second;
-        out << "FastReport              " << std::right << std::setw(10) << module.summary_active  / (double) m_summary_events << "  " << label << '\n';
+        out << "FastReport              " << std::right << std::setw(10) << module.summary_active  / (double) m_job_summary.count << "  " << label << '\n';
       }
       out << "FastReport " << (m_timer_id == CLOCK_REALTIME ? "(real time) " : "(CPU time)  ")    << "     Active  Module" << '\n';
       out << '\n';
       out << "FastReport " << (m_timer_id == CLOCK_REALTIME ? "(real time) " : "(CPU time)  ")    << "     Active  Module" << '\n';
-      for (auto & keyval: m_moduletypes) {
+      for (auto & keyval: m_stream.moduletypes) {
         std::string const & label  = keyval.first;
         ModuleInfo  const & module = keyval.second;
-        out << "FastReport              " << std::right << std::setw(10) << module.summary_active  / (double) m_summary_events << "  " << label << '\n';
+        out << "FastReport              " << std::right << std::setw(10) << module.summary_active  / (double) m_job_summary.count << "  " << label << '\n';
       }
       out << "FastReport " << (m_timer_id == CLOCK_REALTIME ? "(real time) " : "(CPU time)  ")    << "     Active  Module" << '\n';
     }
     out << '\n';
     edm::LogVerbatim("FastReport") << out.str();
   }
-
-  // needed for the DAQ when reconfiguring between runs
-  reset();
+  */
 }
 
-void FastTimerService::reset() {
-  // transient dqm configuration
-  m_nproc_enabled = false;
-  // caching
-  m_first_path = 0;          // these are initialized at prePathBeginRun(),
-  m_last_path = 0;           // to make sure we cache the correct pointers
-  m_first_endpath = 0;
-  m_last_endpath = 0;
-  m_is_first_module = false;
-  m_is_first_event = true;
-  // per-event accounting
-  m_event = 0.;
-  m_presource = 0.;
-  m_source = 0.;
-  m_postsource = 0.;
-  m_all_paths = 0.;
-  m_all_endpaths = 0.;
-  m_interpaths = 0.;
-  m_paths_interpaths.clear();
-  // per-job summary
-  m_summary_events = 0;
-  m_summary_event = 0.;
-  m_summary_presource = 0.;
-  m_summary_source = 0.;
-  m_summary_postsource = 0.;
-  m_summary_all_paths = 0.;
-  m_summary_all_endpaths = 0.;
-  m_summary_interpaths = 0.;
-  m_summary_paths_interpaths.clear();
-  // DQM - the DAQ destroys and re-creates the DQM and DQMStore services at each reconfigure, so we don't need to clean them up
-  m_dqms = 0;
-  // event summary plots
-  m_dqm_event = 0;
-  m_dqm_presource  = 0;
-  m_dqm_source = 0;
-  m_dqm_postsource  = 0;
-  m_dqm_all_paths = 0;
-  m_dqm_all_endpaths = 0;
-  m_dqm_interpaths = 0;
-  // event summary plots - summed over nodes with the same number of processes
-  m_dqm_nproc_event = 0;
-  m_dqm_nproc_presource = 0;
-  m_dqm_nproc_source = 0;
-  m_dqm_nproc_postsource = 0;
-  m_dqm_nproc_all_paths = 0;
-  m_dqm_nproc_all_endpaths = 0;
-  m_dqm_nproc_interpaths = 0;
-  // plots by path
-  m_dqm_paths_active_time = 0;
-  m_dqm_paths_total_time = 0;
-  m_dqm_paths_exclusive_time = 0;
-  m_dqm_paths_interpaths = 0;
-  // plots per lumisection
-  m_dqm_byls_event = 0;
-  m_dqm_byls_presource = 0;
-  m_dqm_byls_source = 0;
-  m_dqm_byls_postsource = 0;
-  m_dqm_byls_all_paths = 0;
-  m_dqm_byls_all_endpaths = 0;
-  m_dqm_byls_interpaths = 0;
-  // plots per lumisection - summed over nodes with the same number of processes
-  m_dqm_nproc_byls_event = 0;
-  m_dqm_nproc_byls_presource = 0;
-  m_dqm_nproc_byls_source = 0;
-  m_dqm_nproc_byls_postsource = 0;
-  m_dqm_nproc_byls_all_paths = 0;
-  m_dqm_nproc_byls_all_endpaths = 0;
-  m_dqm_nproc_byls_interpaths = 0;
-  // plots vs. instantaneous luminosity
-  m_dqm_byluminosity_event = 0;
-  m_dqm_byluminosity_presource = 0;
-  m_dqm_byluminosity_source = 0;
-  m_dqm_byluminosity_postsource = 0;
-  m_dqm_byluminosity_all_paths = 0;
-  m_dqm_byluminosity_all_endpaths = 0;
-  m_dqm_byluminosity_interpaths = 0;
-  // plots vs. instantaneous luminosity - summed over nodes with the same number of processes
-  m_dqm_nproc_byluminosity_event = 0;
-  m_dqm_nproc_byluminosity_presource = 0;
-  m_dqm_nproc_byluminosity_source = 0;
-  m_dqm_nproc_byluminosity_postsource = 0;
-  m_dqm_nproc_byluminosity_all_paths = 0;
-  m_dqm_nproc_byluminosity_all_endpaths = 0;
-  m_dqm_nproc_byluminosity_interpaths = 0;
-  // per-path and per-module accounting
-  m_current_path = 0;
-  m_paths.clear();          // this should destroy all PathInfo objects and reset the associated plots
-  m_modules.clear();        // this should destroy all ModuleInfo objects and reset the associated plots
-  m_moduletypes.clear();    // this should destroy all ModuleInfo objects and reset the associated plots
-  m_fast_modules.clear();
-  m_fast_moduletypes.clear();
+
+void
+FastTimerService::postGlobalEndRun(edm::GlobalContext const &)
+{
+  /*
+  if (m_enable_timing_summary) {
+    // print a timing sumary for the run
+    edm::service::TriggerNamesService & tns = * edm::Service<edm::service::TriggerNamesService>();
+
+    std::ostringstream out;
+    out << std::fixed << std::setprecision(6);
+    out << "FastReport " << (m_timer_id == CLOCK_REALTIME ? "(real time) " : "(CPU time)  ") << '\n';
+    out << "FastReport              " << std::right << std::setw(10) << m_run_summary.presource    / (double) m_run_summary.count << "  Pre-Source"    << '\n';
+    out << "FastReport              " << std::right << std::setw(10) << m_run_summary.source       / (double) m_run_summary.count << "  Source"        << '\n';
+    out << "FastReport              " << std::right << std::setw(10) << m_run_summary.postsource   / (double) m_run_summary.count << "  Post-Source"   << '\n';
+    out << "FastReport              " << std::right << std::setw(10) << m_run_summary.event        / (double) m_run_summary.count << "  Event"         << '\n';
+    out << "FastReport              " << std::right << std::setw(10) << m_run_summary.all_paths    / (double) m_run_summary.count << "  all Paths"     << '\n';
+    out << "FastReport              " << std::right << std::setw(10) << m_run_summary.all_endpaths / (double) m_run_summary.count << "  all EndPaths"  << '\n';
+    out << "FastReport              " << std::right << std::setw(10) << m_run_summary.interpaths   / (double) m_run_summary.count << "  between paths" << '\n';
+    if (m_enable_timing_modules) {
+      double modules_total = 0.;
+      for (auto & keyval: m_stream.modules)
+        modules_total += keyval.second.summary_active;
+      out << "FastReport              " << std::right << std::setw(10) << modules_total / (double) m_run_summary.count << "  all Modules"   << '\n';
+    }
+    out << '\n';
+    if (m_enable_timing_paths and not m_enable_timing_modules) {
+      out << "FastReport " << (m_timer_id == CLOCK_REALTIME ? "(real time) " : "(CPU time)  ")    << "     Active Path" << '\n';
+      for (auto const & name: tns.getTrigPaths())
+        out << "FastReport              "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_active / (double) m_run_summary.count << "  "
+            << name << '\n';
+      out << '\n';
+      out << "FastReport " << (m_timer_id == CLOCK_REALTIME ? "(real time) " : "(CPU time)  ")    << "     Active EndPath" << '\n';
+      for (auto const & name: tns.getEndPaths())
+        out << "FastReport              "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_active / (double) m_run_summary.count << "  "
+            << name << '\n';
+    } else if (m_enable_timing_paths and m_enable_timing_modules) {
+      out << "FastReport " << (m_timer_id == CLOCK_REALTIME ? "(real time) " : "(CPU time)  ")    << "     Active       Pre-     Inter-  Post-mods   Overhead      Total  Path" << '\n';
+      for (auto const & name: tns.getTrigPaths()) {
+        out << "FastReport              "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_active        / (double) m_run_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_premodules    / (double) m_run_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_intermodules  / (double) m_run_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_postmodules   / (double) m_run_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_overhead      / (double) m_run_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_total         / (double) m_run_summary.count << "  "
+            << name << '\n';
+      }
+      out << '\n';
+      out << "FastReport " << (m_timer_id == CLOCK_REALTIME ? "(real time) " : "(CPU time)  ")    << "     Active       Pre-     Inter-  Post-mods   Overhead      Total  EndPath" << '\n';
+      for (auto const & name: tns.getEndPaths()) {
+        out << "FastReport              "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_active        / (double) m_run_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_premodules    / (double) m_run_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_intermodules  / (double) m_run_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_postmodules   / (double) m_run_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_overhead      / (double) m_run_summary.count << " "
+            << std::right << std::setw(10) << m_stream.paths[name].summary_total         / (double) m_run_summary.count << "  "
+            << name << '\n';
+      }
+    }
+    out << '\n';
+    if (m_enable_timing_modules) {
+      out << "FastReport " << (m_timer_id == CLOCK_REALTIME ? "(real time) " : "(CPU time)  ")    << "     Active  Module" << '\n';
+      for (auto & keyval: m_stream.modules) {
+        std::string const & label  = keyval.first;
+        ModuleInfo  const & module = keyval.second;
+        out << "FastReport              " << std::right << std::setw(10) << module.summary_active  / (double) m_run_summary.count << "  " << label << '\n';
+      }
+      out << "FastReport " << (m_timer_id == CLOCK_REALTIME ? "(real time) " : "(CPU time)  ")    << "     Active  Module" << '\n';
+      out << '\n';
+      out << "FastReport " << (m_timer_id == CLOCK_REALTIME ? "(real time) " : "(CPU time)  ")    << "     Active  Module" << '\n';
+      for (auto & keyval: m_stream.moduletypes) {
+        std::string const & label  = keyval.first;
+        ModuleInfo  const & module = keyval.second;
+        out << "FastReport              " << std::right << std::setw(10) << module.summary_active  / (double) m_run_summary.count << "  " << label << '\n';
+      }
+      out << "FastReport " << (m_timer_id == CLOCK_REALTIME ? "(real time) " : "(CPU time)  ")    << "     Active  Module" << '\n';
+    }
+    out << '\n';
+    edm::LogVerbatim("FastReport") << out.str();
+  }
+  */
 }
 
 void FastTimerService::preModuleBeginJob(edm::ModuleDescription const & module) {
   // allocate a counter for each module and module type
-  m_fast_modules[& module]     = & m_modules[module.moduleLabel()];;
-  m_fast_moduletypes[& module] = & m_moduletypes[module.moduleName()];
+  for (auto & stream: m_stream) {
+    stream.fast_modules[& module]     = & stream.modules[module.moduleLabel()];;
+    stream.fast_moduletypes[& module] = & stream.moduletypes[module.moduleName()];
+  }
 }
 
-void FastTimerService::preProcessEvent(edm::EventID const & id, edm::Timestamp const & stamp) {
+void FastTimerService::preEvent(edm::StreamContext const & sc) {
+  unsigned int sid = sc.streamID().value();
+
   // new event, reset the per-event counter
   start(m_timer_event);
 
   // account the time spent after the source
-  m_postsource = delta(m_timer_source.second, m_timer_event.first);
-  m_summary_postsource += m_postsource;
+  m_event[sid].postsource = delta(m_timer_source.second, m_timer_event.first);
 
   // clear the event counters
-  m_event        = 0;
-  m_all_paths    = 0;
-  m_all_endpaths = 0;
-  m_interpaths   = 0;
-  m_paths_interpaths.assign(m_paths.size() + 1, 0);
-  for (auto & keyval : m_paths) {
+  m_event[sid].event        = 0;
+  m_event[sid].all_paths    = 0;
+  m_event[sid].all_endpaths = 0;
+  m_event[sid].interpaths   = 0;
+  m_event[sid].paths_interpaths.assign(m_stream[sid].paths.size() + 1, 0);
+  for (auto & keyval : m_stream[sid].paths) {
     keyval.second.time_active       = 0.;
     keyval.second.time_exclusive    = 0.;
     keyval.second.time_premodules   = 0.;
@@ -878,12 +819,12 @@ void FastTimerService::preProcessEvent(edm::EventID const & id, edm::Timestamp c
     keyval.second.time_postmodules  = 0.;
     keyval.second.time_total        = 0.;
   }
-  for (auto & keyval : m_modules) {
+  for (auto & keyval : m_stream[sid].modules) {
     keyval.second.time_active       = 0.;
     keyval.second.run_in_path       = nullptr;
     keyval.second.counter           = 0;
   }
-  for (auto & keyval : m_moduletypes) {
+  for (auto & keyval : m_stream[sid].moduletypes) {
     keyval.second.time_active       = 0.;
     keyval.second.run_in_path       = nullptr;
     keyval.second.counter           = 0;
@@ -894,24 +835,27 @@ void FastTimerService::preProcessEvent(edm::EventID const & id, edm::Timestamp c
   m_timer_path.second = m_timer_event.first;
 }
 
-void FastTimerService::postProcessEvent(edm::Event const & event, edm::EventSetup const & setup) {
+void FastTimerService::postEvent(edm::StreamContext const & sc) {
+  unsigned int sid = sc.streamID();
+  unsigned int rid = sc.runIndex();
+
   // stop the per-event timer, and account event time
   stop(m_timer_event);
-  m_event = delta(m_timer_event);
-  m_summary_event += m_event;
+  m_event[sid].event = delta(m_timer_event);
 
   // the last part of inter-path overhead is the time between the end of the last (end)path and the end of the event processing
   double interpaths = delta(m_timer_path.second, m_timer_event.second);
-  m_interpaths += interpaths;
-  m_paths_interpaths[m_paths.size()] = interpaths;
+  m_event[sid].interpaths += interpaths;
+  m_event[sid].paths_interpaths[m_stream[sid].paths.size()] = interpaths;
 
-  m_summary_interpaths += m_interpaths;
-  for (unsigned int i = 0; i <= m_paths.size(); ++i)
-    m_summary_paths_interpaths[i] += m_paths_interpaths[i];
+  // keep track of the total number of events and add this event's time to the per-run and per-job summary
+  m_event[sid].count = 1;
+  m_run_summary[rid] += m_event[sid];
+  m_job_summary += m_event[sid];
 
   // elaborate "exclusive" modules
   if (m_enable_timing_exclusive) {
-    for (auto & keyval: m_paths) {
+    for (auto & keyval: m_stream[sid].paths) {
       PathInfo & pathinfo = keyval.second;
       pathinfo.time_exclusive = pathinfo.time_overhead;
 
@@ -930,24 +874,24 @@ void FastTimerService::postProcessEvent(edm::Event const & event, edm::EventSetu
   m_is_first_event = false;
 
   // fill the DQM plots from the internal buffers
-  if (m_dqms == nullptr)
+  if (not m_enable_dqm)
     return;
 
   // fill plots for per-event time by path
   if (m_enable_timing_paths) {
 
-    for (auto & keyval: m_paths) {
+    for (auto & keyval: m_stream[sid].paths) {
       PathInfo & pathinfo = keyval.second;
 
-      m_dqm_paths_active_time->Fill(pathinfo.index, pathinfo.time_active * 1000.);
+      m_stream[sid].dqm_paths_active_time->Fill(pathinfo.index, pathinfo.time_active * 1000.);
       if (m_enable_dqm_bypath_active)
         pathinfo.dqm_active      ->Fill(pathinfo.time_active          * 1000.);
 
-      m_dqm_paths_exclusive_time->Fill(pathinfo.index, pathinfo.time_exclusive * 1000.);
+      m_stream[sid].dqm_paths_exclusive_time->Fill(pathinfo.index, pathinfo.time_exclusive * 1000.);
       if (m_enable_dqm_bypath_exclusive)
         pathinfo.dqm_exclusive   ->Fill(pathinfo.time_exclusive       * 1000.);
 
-      m_dqm_paths_total_time->Fill(pathinfo.index, pathinfo.time_total * 1000.);
+      m_stream[sid].dqm_paths_total_time->Fill(pathinfo.index, pathinfo.time_total * 1000.);
       if (m_enable_dqm_bypath_total)
         pathinfo.dqm_total       ->Fill(pathinfo.time_total           * 1000.);
 
@@ -963,6 +907,9 @@ void FastTimerService::postProcessEvent(edm::Event const & event, edm::EventSetu
       if (m_enable_dqm_bypath_details) {
         for (uint32_t i = 0; i <= pathinfo.last_run; ++i) {
           ModuleInfo * module = pathinfo.modules[i];
+          // skip duplicate modules
+          if (module == nullptr)
+            continue;
           // fill the total time for all non-duplicate modules
           pathinfo.dqm_module_total->Fill(i, module->time_active * 1000.);
           // fill the active time only for module that have actually run in this path
@@ -986,7 +933,7 @@ void FastTimerService::postProcessEvent(edm::Event const & event, edm::EventSetu
 
   // fill plots for per-event time by module
   if (m_enable_dqm_bymodule) {
-    for (auto & keyval : m_modules) {
+    for (auto & keyval : m_stream[sid].modules) {
       ModuleInfo & module = keyval.second;
       module.dqm_active->Fill(module.time_active * 1000.);
     }
@@ -994,80 +941,43 @@ void FastTimerService::postProcessEvent(edm::Event const & event, edm::EventSetu
 
   // fill plots for per-event time by module type
   if (m_enable_dqm_bymoduletype) {
-    for (auto & keyval : m_moduletypes) {
+    for (auto & keyval : m_stream[sid].moduletypes) {
       ModuleInfo & module = keyval.second;
       module.dqm_active->Fill(module.time_active * 1000.);
     }
   }
 
   // fill the interpath overhead plot
-  for (unsigned int i = 0; i <= m_paths.size(); ++i)
-    m_dqm_paths_interpaths->Fill(i, m_paths_interpaths[i] * 1000.);
-  
-  if (m_enable_dqm_summary) {
-    m_dqm_event         ->Fill(m_event          * 1000.);
-    m_dqm_presource     ->Fill(m_presource      * 1000.);
-    m_dqm_source        ->Fill(m_source         * 1000.);
-    m_dqm_postsource    ->Fill(m_postsource     * 1000.);
-    m_dqm_all_paths     ->Fill(m_all_paths      * 1000.);
-    m_dqm_all_endpaths  ->Fill(m_all_endpaths   * 1000.);
-    m_dqm_interpaths    ->Fill(m_interpaths     * 1000.);
+  for (unsigned int i = 0; i <= m_stream[sid].paths.size(); ++i)
+    m_stream[sid].dqm_paths_interpaths->Fill(i, m_event[sid].paths_interpaths[i] * 1000.);
 
-    if (m_nproc_enabled) {
-      m_dqm_nproc_event         ->Fill(m_event          * 1000.);
-      m_dqm_nproc_presource     ->Fill(m_presource      * 1000.);
-      m_dqm_nproc_source        ->Fill(m_source         * 1000.);
-      m_dqm_nproc_postsource    ->Fill(m_postsource     * 1000.);
-      m_dqm_nproc_all_paths     ->Fill(m_all_paths      * 1000.);
-      m_dqm_nproc_all_endpaths  ->Fill(m_all_endpaths   * 1000.);
-      m_dqm_nproc_interpaths    ->Fill(m_interpaths     * 1000.);
-    }
+  if (m_enable_dqm_summary) {
+    m_stream[sid].dqm.fill(m_event[sid]);
+
+    if (m_nproc_enabled)
+      m_stream[sid].dqm_nproc.fill(m_event[sid]);
   }
 
   if (m_enable_dqm_byls) {
-    unsigned int ls = event.getLuminosityBlock().luminosityBlock();
-    m_dqm_byls_event        ->Fill(ls, m_event        * 1000.);
-    m_dqm_byls_presource    ->Fill(ls, m_presource    * 1000.);
-    m_dqm_byls_source       ->Fill(ls, m_source       * 1000.);
-    m_dqm_byls_postsource   ->Fill(ls, m_postsource   * 1000.);
-    m_dqm_byls_all_paths    ->Fill(ls, m_all_paths    * 1000.);
-    m_dqm_byls_all_endpaths ->Fill(ls, m_all_endpaths * 1000.);
-    m_dqm_byls_interpaths   ->Fill(ls, m_interpaths   * 1000.);
-    
-    if (m_nproc_enabled) {
-      m_dqm_nproc_byls_event        ->Fill(ls, m_event        * 1000.);
-      m_dqm_nproc_byls_presource    ->Fill(ls, m_presource    * 1000.);
-      m_dqm_nproc_byls_source       ->Fill(ls, m_source       * 1000.);
-      m_dqm_nproc_byls_postsource   ->Fill(ls, m_postsource   * 1000.);
-      m_dqm_nproc_byls_all_paths    ->Fill(ls, m_all_paths    * 1000.);
-      m_dqm_nproc_byls_all_endpaths ->Fill(ls, m_all_endpaths * 1000.);
-      m_dqm_nproc_byls_interpaths   ->Fill(ls, m_interpaths   * 1000.);
-    }
+    unsigned int ls = sc.eventID().luminosityBlock();
+    m_stream[sid].dqm_byls.fill(ls, m_event[sid] );
+
+    if (m_nproc_enabled)
+      m_stream[sid].dqm_nproc_byls.fill(ls, m_event[sid]);
   }
 
   if (m_enable_dqm_byluminosity) {
     float luminosity = 0.;
+    /*
+     * FIXME - find an alternative approach, the new signals do not pass the actual Event here
     edm::Handle<LumiScalersCollection> h_luminosity;
     if (event.getByLabel(m_luminosity_label, h_luminosity) and not h_luminosity->empty())
       luminosity = h_luminosity->front().instantLumi();   // in units of 1e30 cm-2s-1
+    */
+    m_stream[sid].dqm_byluminosity.fill(luminosity, m_event[sid]);
 
-    m_dqm_byluminosity_event        ->Fill(luminosity, m_event        * 1000.);
-    m_dqm_byluminosity_presource    ->Fill(luminosity, m_presource    * 1000.);
-    m_dqm_byluminosity_source       ->Fill(luminosity, m_source       * 1000.);
-    m_dqm_byluminosity_postsource   ->Fill(luminosity, m_postsource   * 1000.);
-    m_dqm_byluminosity_all_paths    ->Fill(luminosity, m_all_paths    * 1000.);
-    m_dqm_byluminosity_all_endpaths ->Fill(luminosity, m_all_endpaths * 1000.);
-    m_dqm_byluminosity_interpaths   ->Fill(luminosity, m_interpaths   * 1000.);
-    
-    if (m_nproc_enabled) {
-      m_dqm_nproc_byluminosity_event        ->Fill(luminosity, m_event        * 1000.);
-      m_dqm_nproc_byluminosity_presource    ->Fill(luminosity, m_presource    * 1000.);
-      m_dqm_nproc_byluminosity_source       ->Fill(luminosity, m_source       * 1000.);
-      m_dqm_nproc_byluminosity_postsource   ->Fill(luminosity, m_postsource   * 1000.);
-      m_dqm_nproc_byluminosity_all_paths    ->Fill(luminosity, m_all_paths    * 1000.);
-      m_dqm_nproc_byluminosity_all_endpaths ->Fill(luminosity, m_all_endpaths * 1000.);
-      m_dqm_nproc_byluminosity_interpaths   ->Fill(luminosity, m_interpaths   * 1000.);
-    }
+    if (m_nproc_enabled)
+      m_stream[sid].dqm_nproc_byluminosity.fill(luminosity, m_event[sid]);
   }
 
 }
@@ -1076,78 +986,61 @@ void FastTimerService::preSourceEvent(edm::StreamID sid) {
   start(m_timer_source);
 
   // account the time spent before the source
-  m_presource = (m_is_first_event) ? 0. : delta(m_timer_event.second, m_timer_source.first);
-  m_summary_presource += m_presource;
+  m_event[sid].presource = (m_is_first_event) ? 0. : delta(m_timer_event.second, m_timer_source.first);
 
   // clear the event counters
-  m_source = 0.;
-  m_postsource = 0.;
-
-  // keep track of the total number of events
-  ++m_summary_events;
+  m_event[sid].source = 0.;
+  m_event[sid].postsource = 0.;
 }
 
 void FastTimerService::postSourceEvent(edm::StreamID sid) {
   stop(m_timer_source);
-  m_source = delta(m_timer_source);
-  m_summary_source += m_source;
+
+  m_event[sid].source = delta(m_timer_source);
 }
 
-void FastTimerService::prePathBeginRun(std::string const & path ) {
-  // cache the pointers to the names of the first and last path and endpath
-  edm::service::TriggerNamesService & tns = * edm::Service<edm::service::TriggerNamesService>();
-  if (not m_skip_first_path and not tns.getTrigPaths().empty()) {
-    if (path == tns.getTrigPaths().front())
-      m_first_path = & path;
-    if (path == tns.getTrigPaths().back())
-      m_last_path = & path;
-  }
-  else if (m_skip_first_path and tns.getTrigPaths().size() > 1) {
-    if (path == tns.getTrigPaths().at(1))
-      m_first_path = & path;
-    if (path == tns.getTrigPaths().back())
-      m_last_path = & path;
-  }
-  if (not tns.getEndPaths().empty()) {
-    if (path == tns.getEndPaths().front())
-      m_first_endpath = & path;
-    if (path == tns.getEndPaths().back())
-      m_last_endpath = & path;
-  }
-}
 
-void FastTimerService::preProcessPath(std::string const & path ) {
+void FastTimerService::prePathEvent(edm::StreamContext const & sc, edm::PathContext const & pc) {
+  std::string const & path = pc.pathName();
+  unsigned int sid = sc.streamID();
+  auto & stream = m_stream[sid];
+
   // prepare to measure the time spent between the beginning of the path and the execution of the first module
   m_is_first_module = true;
 
-  PathMap<PathInfo>::iterator keyval = m_paths.find(path);
-  if (keyval != m_paths.end()) {
-    m_current_path = & keyval->second;
+  PathMap<PathInfo>::iterator keyval = stream.paths.find(path);
+  if (keyval != stream.paths.end()) {
+    stream.current_path = & keyval->second;
   } else {
     // should never get here
-    m_current_path = 0;
-    edm::LogError("FastTimerService") << "FastTimerService::preProcessPath: unexpected path " << path;
+    stream.current_path = 0;
+    edm::LogError("FastTimerService") << "FastTimerService::prePathEvent: unexpected path " << path;
   }
 
   // time each (end)path
   start(m_timer_path);
 
-  if (& path == m_first_path) {
+  if (path == m_first_path) {
     // this is the first path, start the "all paths" counter
     m_timer_paths.first = m_timer_path.first;
-  } else if (& path == m_first_endpath) {
+  } else if (path == m_first_endpath) {
     // this is the first endpath, start the "all paths" counter
     m_timer_endpaths.first = m_timer_path.first;
   }
 
   // measure the inter-path overhead as the time elapsed since the end of preiovus path
-  // (or the beginning of the event, if this is the first path - see preProcessEvent)
+  // (or the beginning of the event, if this is the first path - see preEvent)
   double interpaths = delta(m_timer_path.second,  m_timer_path.first);
-  m_interpaths += interpaths;
-  m_paths_interpaths[m_current_path->index] = interpaths;
+  m_event[sid].interpaths += interpaths;
+  m_event[sid].paths_interpaths[stream.current_path->index] = interpaths;
 }
 
-void FastTimerService::postProcessPath(std::string const & path, edm::HLTPathStatus const & status) {
+
+void FastTimerService::postPathEvent(edm::StreamContext const & sc, edm::PathContext const & pc, edm::HLTPathStatus const & status) {
+  std::string const & path = pc.pathName();
+  unsigned int        sid = sc.streamID().value();
+  auto &              stream = m_stream[sid];
+
   // time each (end)path
   stop(m_timer_path);
 
@@ -1156,7 +1049,7 @@ void FastTimerService::postProcessPath(std::string const & path, edm::HLTPathSta
   // if enabled, account each (end)path
   if (m_enable_timing_paths) {
 
-    PathInfo & pathinfo = * m_current_path;
+    PathInfo & pathinfo = * stream.current_path;
     pathinfo.time_active = active;
     pathinfo.summary_active += active;
 
@@ -1227,21 +1120,19 @@ void FastTimerService::postProcessPath(std::string const & path, edm::HLTPathSta
     }
   }
 
-  if (& path == m_last_path) {
+  if (path == m_last_path) {
     // this is the last path, stop and account the "all paths" counter
     m_timer_paths.second = m_timer_path.second;
-    m_all_paths = delta(m_timer_paths);
-    m_summary_all_paths += m_all_paths;
-  } else if (& path == m_last_endpath) {
+    m_event[sid].all_paths = delta(m_timer_paths);
+  } else if (path == m_last_endpath) {
     // this is the last endpath, stop and account the "all endpaths" counter
     m_timer_endpaths.second = m_timer_path.second;
-    m_all_endpaths = delta(m_timer_endpaths);
-    m_summary_all_endpaths += m_all_endpaths;
+    m_event[sid].all_endpaths = delta(m_timer_endpaths);
   }
 
 }
 
-void FastTimerService::preModule(edm::ModuleDescription const & module) {
+void FastTimerService::preModuleEvent(edm::StreamContext const &, edm::ModuleCallingContext const &) {
   // this is ever called only if m_enable_timing_modules = true
   assert(m_enable_timing_modules);
 
@@ -1253,10 +1144,14 @@ void FastTimerService::preModule(edm::ModuleDescription const & module) {
 
     // measure the time spent between the beginning of the path and the execution of the first module
     m_timer_first_module = m_timer_module.first;
-  } 
+  }
 }
 
-void FastTimerService::postModule(edm::ModuleDescription const & module) {
+void FastTimerService::postModuleEvent(edm::StreamContext const & sc, edm::ModuleCallingContext const & mcc) {
+  edm::ModuleDescription const * md = mcc.moduleDescription();
+  unsigned int sid = sc.streamID().value();
+  auto & stream = m_stream[sid];
+
   // this is ever called only if m_enable_timing_modules = true
   assert(m_enable_timing_modules);
 
@@ -1264,23 +1159,26 @@ void FastTimerService::postModule(edm::ModuleDescription const & module) {
   stop(m_timer_module);
 
   { // if-scope
-    ModuleMap<ModuleInfo*>::iterator keyval = m_fast_modules.find(& module);
-    if (keyval != m_fast_modules.end()) {
+    ModuleMap<ModuleInfo*>::iterator keyval = stream.fast_modules.find(md);
+    if (keyval != stream.fast_modules.end()) {
       double time = delta(m_timer_module);
       ModuleInfo & module = * keyval->second;
-      module.run_in_path     = m_current_path;
+      module.run_in_path     = stream.current_path;
       module.time_active     = time;
       module.summary_active += time;
       // plots are filled post event processing
     } else {
       // should never get here
-      edm::LogError("FastTimerService") << "FastTimerService::postModule: unexpected module " << module.moduleLabel();
+      if (md == nullptr)
+        edm::LogError("FastTimerService") << "FastTimerService::postModuleEvent: invalid module";
+      else
+        edm::LogError("FastTimerService") << "FastTimerService::postModuleEvent: unexpected module " << md->moduleLabel();
     }
   }
 
   { // if-scope
-    ModuleMap<ModuleInfo*>::iterator keyval = m_fast_moduletypes.find(& module);
-    if (keyval != m_fast_moduletypes.end()) {
+    ModuleMap<ModuleInfo*>::iterator keyval = stream.fast_moduletypes.find(md);
+    if (keyval != stream.fast_moduletypes.end()) {
       double time = delta(m_timer_module);
       ModuleInfo & module = * keyval->second;
       // module.run_in_path is not meaningful here
@@ -1289,32 +1187,58 @@ void FastTimerService::postModule(edm::ModuleDescription const & module) {
       // plots are filled post event processing
     } else {
       // should never get here
-      edm::LogError("FastTimerService") << "FastTimerService::postModule: unexpected module " << module.moduleLabel();
+      if (md == nullptr)
+        edm::LogError("FastTimerService") << "FastTimerService::postModuleEvent: invalid module";
+      else
+        edm::LogError("FastTimerService") << "FastTimerService::postModuleEvent: unexpected module " << md->moduleLabel();
     }
   }
 
 }
 
+void FastTimerService::preModuleEventDelayedGet(edm::StreamContext const &, edm::ModuleCallingContext const &) {
+  // this is ever called only if m_enable_timing_modules = true
+  assert(m_enable_timing_modules);
+
+  // XXX
+  // check if the signal has interrupted a module or not
+  //  - if it is, pause the time for that module, and prepare timing a new module
+  //  - otherwise, ignore it
+}
+
+void FastTimerService::postModuleEventDelayedGet(edm::StreamContext const &, edm::ModuleCallingContext const &) {
+  // this is ever called only if m_enable_timing_modules = true
+  assert(m_enable_timing_modules);
+
+  // XXX
+  // check if the signal has interrupted a module or not
+  //  - if it is, reasume the timing for the original module
+  //  - otherwise, ignore it
+}
+
 // associate to a path all the modules it contains
 void FastTimerService::fillPathMap(std::string const & name, std::vector<std::string> const & modules) {
-  std::vector<ModuleInfo *> & pathmap = m_paths[name].modules;
-  pathmap.clear();
-  pathmap.reserve( modules.size() );
-  std::unordered_set<ModuleInfo const *> pool;        // keep track of inserted modules
-  for (auto const & module: modules) {
-    // fix the name of negated or ignored modules
-    std::string const & label = (module[0] == '!' or module[0] == '-') ? module.substr(1) : module;
+  for (auto & stream: m_stream) {
 
-    auto const & it = m_modules.find(label);
-    if (it == m_modules.end()) {
-      // no matching module was found
-      pathmap.push_back( 0 );
-    } else if (pool.insert(& it->second).second) {
-      // new module
-      pathmap.push_back(& it->second);
-    } else {
-      // duplicate module
-      pathmap.push_back( 0 );
+    std::vector<ModuleInfo *> & pathmap = stream.paths[name].modules;
+    pathmap.clear();
+    pathmap.reserve( modules.size() );
+    std::unordered_set<ModuleInfo const *> pool;        // keep track of inserted modules
+    for (auto const & module: modules) {
+      // fix the name of negated or ignored modules
+      std::string const & label = (module[0] == '!' or module[0] == '-') ? module.substr(1) : module;
+
+      auto const & it = stream.modules.find(label);
+      if (it == stream.modules.end()) {
+        // no matching module was found
+        pathmap.push_back( 0 );
+      } else if (pool.insert(& it->second).second) {
+        // new module
+        pathmap.push_back(& it->second);
+      } else {
+        // duplicate module
+        pathmap.push_back( 0 );
+      }
     }
 
   }
@@ -1324,31 +1248,31 @@ void FastTimerService::fillPathMap(std::string const & name, std::vector<std::st
 // query the current module/path/event
 // Note: these functions incur in a "per-call timer overhead" (see above), currently of the order of 340ns
 
-// return the time spent since the last preModule() event
-double FastTimerService::currentModuleTime() const {
+// return the time spent since the last preModuleEvent() event
+double FastTimerService::currentModuleTime(edm::StreamID) const {
   struct timespec now;
   gettime(now);
   return delta(m_timer_module.first, now);
 }
 
-// return the time spent since the last preProcessPath() event
-double FastTimerService::currentPathTime() const {
+// return the time spent since the last prePathEvent() event
+double FastTimerService::currentPathTime(edm::StreamID) const {
   struct timespec now;
   gettime(now);
   return delta(m_timer_path.first, now);
 }
 
-// return the time spent since the last preProcessEvent() event
-double FastTimerService::currentEventTime() const {
+// return the time spent since the last preEvent() event
+double FastTimerService::currentEventTime(edm::StreamID) const {
   struct timespec now;
   gettime(now);
   return delta(m_timer_event.first, now);
 }
 
 // query the time spent in a module (available after the module has run)
-double FastTimerService::queryModuleTime(const edm::ModuleDescription & module) const {
-  ModuleMap<ModuleInfo *>::const_iterator keyval = m_fast_modules.find(& module);
-  if (keyval != m_fast_modules.end()) {
+double FastTimerService::queryModuleTime(edm::StreamID sid, const edm::ModuleDescription & module) const {
+  ModuleMap<ModuleInfo *>::const_iterator keyval = m_stream[sid].fast_modules.find(& module);
+  if (keyval != m_stream[sid].fast_modules.end()) {
     return keyval->second->time_active;
   } else {
     edm::LogError("FastTimerService") << "FastTimerService::queryModuleTime: unexpected module " << module.moduleLabel();
@@ -1357,9 +1281,9 @@ double FastTimerService::queryModuleTime(const edm::ModuleDescription & module) 
 }
 
 // query the time spent in a module (available after the module has run
-double FastTimerService::queryModuleTimeByLabel(const std::string & label) const {
-  auto const & keyval = m_modules.find(label);
-  if (keyval != m_modules.end()) {
+double FastTimerService::queryModuleTimeByLabel(edm::StreamID sid, const std::string & label) const {
+  auto const & keyval = m_stream[sid].modules.find(label);
+  if (keyval != m_stream[sid].modules.end()) {
     return keyval->second.time_active;
   } else {
     // module not found
@@ -1369,9 +1293,9 @@ double FastTimerService::queryModuleTimeByLabel(const std::string & label) const
 }
 
 // query the time spent in a module (available after the module has run
-double FastTimerService::queryModuleTimeByType(const std::string & type) const {
-  auto const & keyval = m_moduletypes.find(type);
-  if (keyval != m_moduletypes.end()) {
+double FastTimerService::queryModuleTimeByType(edm::StreamID sid, const std::string & type) const {
+  auto const & keyval = m_stream[sid].moduletypes.find(type);
+  if (keyval != m_stream[sid].moduletypes.end()) {
     return keyval->second.time_active;
   } else {
     // module not found
@@ -1381,9 +1305,9 @@ double FastTimerService::queryModuleTimeByType(const std::string & type) const {
 }
 
 // query the time spent in a path (available after the path has run)
-double FastTimerService::queryPathActiveTime(const std::string & path) const {
-  PathMap<PathInfo>::const_iterator keyval = m_paths.find(path);
-  if (keyval != m_paths.end()) {
+double FastTimerService::queryPathActiveTime(edm::StreamID sid, const std::string & path) const {
+  PathMap<PathInfo>::const_iterator keyval = m_stream[sid].paths.find(path);
+  if (keyval != m_stream[sid].paths.end()) {
     return keyval->second.time_active;
   } else {
     edm::LogError("FastTimerService") << "FastTimerService::queryPathActiveTime: unexpected path " << path;
@@ -1392,9 +1316,9 @@ double FastTimerService::queryPathActiveTime(const std::string & path) const {
 }
 
 // query the time spent in a path (available after the path has run)
-double FastTimerService::queryPathExclusiveTime(const std::string & path) const {
-  PathMap<PathInfo>::const_iterator keyval = m_paths.find(path);
-  if (keyval != m_paths.end()) {
+double FastTimerService::queryPathExclusiveTime(edm::StreamID sid, const std::string & path) const {
+  PathMap<PathInfo>::const_iterator keyval = m_stream[sid].paths.find(path);
+  if (keyval != m_stream[sid].paths.end()) {
     return keyval->second.time_exclusive;
   } else {
     edm::LogError("FastTimerService") << "FastTimerService::queryPathExclusiveTime: unexpected path " << path;
@@ -1403,9 +1327,9 @@ double FastTimerService::queryPathExclusiveTime(const std::string & path) const 
 }
 
 // query the total time spent in a path (available after the path has run)
-double FastTimerService::queryPathTotalTime(const std::string & path) const {
-  PathMap<PathInfo>::const_iterator keyval = m_paths.find(path);
-  if (keyval != m_paths.end()) {
+double FastTimerService::queryPathTotalTime(edm::StreamID sid, const std::string & path) const {
+  PathMap<PathInfo>::const_iterator keyval = m_stream[sid].paths.find(path);
+  if (keyval != m_stream[sid].paths.end()) {
     return keyval->second.time_total;
   } else {
     edm::LogError("FastTimerService") << "FastTimerService::queryPathTotalTime: unexpected path " << path;
@@ -1414,23 +1338,23 @@ double FastTimerService::queryPathTotalTime(const std::string & path) const {
 }
 
 // query the time spent in the current event's source (available during event processing)
-double FastTimerService::querySourceTime() const {
-  return m_source;
+double FastTimerService::querySourceTime(edm::StreamID sid) const {
+  return m_event[sid].source;
 }
 
 // query the time spent in the current event's paths (available during endpaths)
-double FastTimerService::queryPathsTime() const {
-  return m_all_paths;
+double FastTimerService::queryPathsTime(edm::StreamID sid) const {
+  return m_event[sid].all_paths;
 }
 
 // query the time spent in the current event's endpaths (available after all endpaths have run)
-double FastTimerService::queryEndPathsTime() const {
-  return m_all_endpaths;
+double FastTimerService::queryEndPathsTime(edm::StreamID sid) const {
+  return m_event[sid].all_endpaths;
 }
 
 // query the time spent processing the current event (available after the event has been processed)
-double FastTimerService::queryEventTime() const {
-  return m_event;
+double FastTimerService::queryEventTime(edm::StreamID sid) const {
+  return m_event[sid].event;
 }
 
 // describe the module's configuration
@@ -1441,7 +1365,7 @@ void FastTimerService::fillDescriptions(edm::ConfigurationDescriptions & descrip
   desc.addUntracked<bool>(   "enableTimingModules",      true);
   desc.addUntracked<bool>(   "enableTimingExclusive",    false);
   desc.addUntracked<bool>(   "enableTimingSummary",      false);
-  desc.addUntracked<bool>(   "skipFirstPath",            false), 
+  desc.addUntracked<bool>(   "skipFirstPath",            false),
   desc.addUntracked<bool>(   "enableDQM",                true);
   desc.addUntracked<bool>(   "enableDQMbyPathActive",    false);
   desc.addUntracked<bool>(   "enableDQMbyPathTotal",     true);

--- a/HLTrigger/Timer/src/FastTimerService.cc
+++ b/HLTrigger/Timer/src/FastTimerService.cc
@@ -231,8 +231,6 @@ FastTimerService::~FastTimerService()
 
 void FastTimerService::preBeginRun( edm::RunID const &, edm::Timestamp const & )
 {
-  //edm::LogImportant("FastTimerService") << __func__ << "()";
-
   // check if the process is bound to a single CPU.
   // otherwise, the results of the CLOCK_THREAD_CPUTIME_ID timer might be inaccurate
 #ifdef __linux
@@ -675,8 +673,6 @@ void FastTimerService::setNumberOfProcesses(unsigned int procs) {
 }
 
 void FastTimerService::postEndJob() {
-  //edm::LogImportant("FastTimerService") << __func__ << "()";
-
   if (m_enable_timing_summary) {
     // print a timing sumary for the whle job
     edm::service::TriggerNamesService & tns = * edm::Service<edm::service::TriggerNamesService>();
@@ -855,17 +851,12 @@ void FastTimerService::reset() {
 }
 
 void FastTimerService::preModuleBeginJob(edm::ModuleDescription const & module) {
-  //edm::LogImportant("FastTimerService") << __func__ << "(" << & module << ")";
-  //edm::LogImportant("FastTimerService") << "module type " << module.moduleName() << " label " << module.moduleLabel() << " @ " << & module;
-
   // allocate a counter for each module and module type
   m_fast_modules[& module]     = & m_modules[module.moduleLabel()];;
   m_fast_moduletypes[& module] = & m_moduletypes[module.moduleName()];
 }
 
 void FastTimerService::preProcessEvent(edm::EventID const & id, edm::Timestamp const & stamp) {
-  //edm::LogImportant("FastTimerService") << __func__ << "(...)";
-
   // new event, reset the per-event counter
   start(m_timer_event);
 
@@ -904,8 +895,6 @@ void FastTimerService::preProcessEvent(edm::EventID const & id, edm::Timestamp c
 }
 
 void FastTimerService::postProcessEvent(edm::Event const & event, edm::EventSetup const & setup) {
-  //edm::LogImportant("FastTimerService") << __func__ << "(...)";
-
   // stop the per-event timer, and account event time
   stop(m_timer_event);
   m_event = delta(m_timer_event);
@@ -1084,8 +1073,6 @@ void FastTimerService::postProcessEvent(edm::Event const & event, edm::EventSetu
 }
 
 void FastTimerService::preSourceEvent(edm::StreamID sid) {
-  //edm::LogImportant("FastTimerService") << __func__ << "()";
-
   start(m_timer_source);
 
   // account the time spent before the source
@@ -1101,16 +1088,12 @@ void FastTimerService::preSourceEvent(edm::StreamID sid) {
 }
 
 void FastTimerService::postSourceEvent(edm::StreamID sid) {
-  //edm::LogImportant("FastTimerService") << __func__ << "()";
-
   stop(m_timer_source);
   m_source = delta(m_timer_source);
   m_summary_source += m_source;
 }
 
 void FastTimerService::prePathBeginRun(std::string const & path ) {
-  //edm::LogImportant("FastTimerService") << __func__ << "(" << path << ")";
-
   // cache the pointers to the names of the first and last path and endpath
   edm::service::TriggerNamesService & tns = * edm::Service<edm::service::TriggerNamesService>();
   if (not m_skip_first_path and not tns.getTrigPaths().empty()) {
@@ -1134,8 +1117,6 @@ void FastTimerService::prePathBeginRun(std::string const & path ) {
 }
 
 void FastTimerService::preProcessPath(std::string const & path ) {
-  //edm::LogImportant("FastTimerService") << __func__ << "(" << path << ")";
-
   // prepare to measure the time spent between the beginning of the path and the execution of the first module
   m_is_first_module = true;
 
@@ -1167,8 +1148,6 @@ void FastTimerService::preProcessPath(std::string const & path ) {
 }
 
 void FastTimerService::postProcessPath(std::string const & path, edm::HLTPathStatus const & status) {
-  //edm::LogImportant("FastTimerService") << __func__ << "(" << path << ", ...)";
-
   // time each (end)path
   stop(m_timer_path);
 
@@ -1263,8 +1242,6 @@ void FastTimerService::postProcessPath(std::string const & path, edm::HLTPathSta
 }
 
 void FastTimerService::preModule(edm::ModuleDescription const & module) {
-  //edm::LogImportant("FastTimerService") << __func__ << "(" << & module << ")";
-
   // this is ever called only if m_enable_timing_modules = true
   assert(m_enable_timing_modules);
 
@@ -1280,8 +1257,6 @@ void FastTimerService::preModule(edm::ModuleDescription const & module) {
 }
 
 void FastTimerService::postModule(edm::ModuleDescription const & module) {
-  //edm::LogImportant("FastTimerService") << __func__ << "(" << & module << ")";
-
   // this is ever called only if m_enable_timing_modules = true
   assert(m_enable_timing_modules);
 


### PR DESCRIPTION
Migrate the FastTimerService to the new signals, even though it is not fully thread-safe yet.
Also
- convert FastTimerFilter to a global module
- migrate the FTS to the C++11 std::chono interface for timers 
