### PR TITLE
Use [[cms::thread_safe]] and [[cms::thread_guard()]] attributes to filter out false positives

### DIFF
--- a/Utilities/StaticAnalyzers/src/ClassChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ClassChecker.cpp
@@ -16,6 +16,7 @@
 //
 //
 #include <clang/AST/Decl.h>
+#include <clang/AST/Attr.h>
 #include <clang/AST/DeclTemplate.h>
 #include <clang/AST/DeclCXX.h>
 #include <clang/AST/StmtVisitor.h>
@@ -322,7 +323,7 @@ void WalkAST::ReportDeclRef( const clang::DeclRefExpr * DRE) {
 
   	clang::ento::PathDiagnosticLocation CELoc = clang::ento::PathDiagnosticLocation::createBegin(DRE, BR.getSourceManager(),AC);
 	if (!m_exception.reportClass( CELoc, BR ) ) return;
-
+        if ( D->hasAttr<CMSThreadGuardAttr>() || D->hasAttr<CMSThreadSafeAttr>()) return;
 	if ( D->isStaticLocal() && D->getTSCSpec() != clang::ThreadStorageClassSpecifier::TSCS_thread_local && ! support::isConst( t ) )
 	{
 		std::string buf;
@@ -682,6 +683,7 @@ void ClassChecker::checkASTDecl(const clang::CXXRecordDecl *RD, clang::ento::Ana
 		if ( !llvm::isa<clang::CXXMethodDecl>((*I)) ) continue;
 		if (!(*I)->isConst()) continue;
 		clang::CXXMethodDecl * MD = llvm::cast<clang::CXXMethodDecl>((*I)->getMostRecentDecl());
+		if ( MD->hasAttr<CMSThreadGuardAttr>() || MD->hasAttr<CMSThreadSafeAttr>()) continue;
 //        	llvm::errs() << "\n\nmethod "<<MD->getQualifiedNameAsString()<<"\n\n";
 //		for (clang::CXXMethodDecl::method_iterator J = MD->begin_overridden_methods(), F = MD->end_overridden_methods(); J != F; ++J) {
 //			llvm::errs()<<"\n\n overwritten method "<<(*J)->getQualifiedNameAsString()<<"\n\n";

--- a/Utilities/StaticAnalyzers/src/CmsException.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsException.cpp
@@ -6,33 +6,16 @@
 
 
 #include "CmsException.h"
+#include "CmsSupport.h"
 
 namespace clangcms {
 
 bool CmsException::reportGeneral( clang::ento::PathDiagnosticLocation const& path,
 				clang::ento::BugReporter & BR ) const
 {
-	  clang::SourceLocation SL = path.asLocation();
-	  if ( SL.isMacroID() ) {return false;}	
-
-      const clang::SourceManager &SM = BR.getSourceManager();
-	  clang::PresumedLoc PL = SM.getPresumedLoc(SL);
-
-	  llvm::StringRef FN = llvm::StringRef((PL.getFilename()));
-	  size_t found = 0;
-	  found += FN.count("xr.cc");
-	  found += FN.count("xi.cc");
-	  found += FN.count("LinkDef.cc");
-	  found += FN.count("/external/");
-	  found += FN.count("/lcg/");
-	  found += FN.count("/cms/cmssw/"); 
-	  found += FN.count("/test/"); 
-//	  found += FN.count("/FWCore/"); 
-	  if ( found!=0 )  {return false;}
-
-	  if (SM.isInSystemHeader(SL) || SM.isInExternCSystemHeader(SL)) {return false;}
- 	  return true;
-
+  const char *sfile=BR.getSourceManager().getPresumedLoc(path.asDecl()->getLocation()).getFilename();
+  if ((!sfile) || (!support::isCmsLocalFile(sfile))) return false;
+  return true;
 }
 
 bool CmsException::reportConstCast( const clang::ento::BugReport &R,

--- a/Utilities/StaticAnalyzers/src/CmsException.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsException.cpp
@@ -13,7 +13,7 @@ namespace clangcms {
 bool CmsException::reportGeneral( clang::ento::PathDiagnosticLocation const& path,
 				clang::ento::BugReporter & BR ) const
 {
-  const char *sfile=BR.getSourceManager().getPresumedLoc(path.asDecl()->getLocation()).getFilename();
+  const char *sfile=BR.getSourceManager().getPresumedLoc(path.asLocation()).getFilename();
   if ((!sfile) || (!support::isCmsLocalFile(sfile))) return false;
   return true;
 }

--- a/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <clang/AST/Attr.h>
 #include "ConstCastAwayChecker.h"
 #include "CmsSupport.h" 
 

--- a/Utilities/StaticAnalyzers/src/ConstCastChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ConstCastChecker.cpp
@@ -5,7 +5,12 @@
 //===----------------------------------------------------------------------===//
 
 
+#include <clang/AST/Attr.h>
 #include "ConstCastChecker.h"
+
+using namespace clang;
+using namespace ento;
+using namespace llvm;
 
 namespace clangcms {
 

--- a/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
@@ -128,7 +128,7 @@ void FWalker::ReportDeclRef ( const clang::DeclRefExpr * DRE) {
 
 void FunctionChecker::checkASTDecl(const CXXMethodDecl *MD, AnalysisManager& mgr,
                     BugReporter &BR) const {
-
+	if ( MD->hasAttr<CMSThreadGuardAttr>() || MD->hasAttr<CMSThreadSafeAttr>()) return;
  	const char *sfile=BR.getSourceManager().getPresumedLoc(MD->getLocation()).getFilename();
  	if (!support::isCmsLocalFile(sfile)) return;
 	std::string fname(sfile);
@@ -141,7 +141,7 @@ void FunctionChecker::checkASTDecl(const CXXMethodDecl *MD, AnalysisManager& mgr
 
 void FunctionChecker::checkASTDecl(const FunctionDecl *FD, AnalysisManager& mgr,
                     BugReporter &BR) const {
-
+	if ( FD->hasAttr<CMSThreadGuardAttr>() || FD->hasAttr<CMSThreadSafeAttr>()) return;
         if (FD-> isInExternCContext()) {
                 std::string buf;
                 std::string dname = FD->getQualifiedNameAsString();
@@ -164,6 +164,7 @@ void FunctionChecker::checkASTDecl(const FunctionTemplateDecl *TD, AnalysisManag
 	for (FunctionTemplateDecl::spec_iterator I = const_cast<clang::FunctionTemplateDecl *>(TD)->spec_begin(), 
 			E = const_cast<clang::FunctionTemplateDecl *>(TD)->spec_end(); I != E; ++I) 
 		{
+			if ( I->hasAttr<CMSThreadGuardAttr>() || I->hasAttr<CMSThreadSafeAttr>()) continue;
 			if (I->doesThisDeclarationHaveABody()) {
 				FWalker walker(BR, mgr.getAnalysisDeclContext(*I));
 				walker.Visit(I->getBody());

--- a/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
@@ -128,7 +128,7 @@ void FWalker::ReportDeclRef ( const clang::DeclRefExpr * DRE) {
 
 void FunctionChecker::checkASTDecl(const CXXMethodDecl *MD, AnalysisManager& mgr,
                     BugReporter &BR) const {
-	if ( MD->hasAttr<CMSThreadGuardAttr>() || MD->hasAttr<CMSThreadSafeAttr>()) return;
+	if ( MD->hasAttr<CMSThreadSafeAttr>()) return;
  	const char *sfile=BR.getSourceManager().getPresumedLoc(MD->getLocation()).getFilename();
  	if (!support::isCmsLocalFile(sfile)) return;
 	std::string fname(sfile);
@@ -141,7 +141,7 @@ void FunctionChecker::checkASTDecl(const CXXMethodDecl *MD, AnalysisManager& mgr
 
 void FunctionChecker::checkASTDecl(const FunctionDecl *FD, AnalysisManager& mgr,
                     BugReporter &BR) const {
-	if ( FD->hasAttr<CMSThreadGuardAttr>() || FD->hasAttr<CMSThreadSafeAttr>()) return;
+	if ( FD->hasAttr<CMSThreadSafeAttr>()) return;
         if (FD-> isInExternCContext()) {
                 std::string buf;
                 std::string dname = FD->getQualifiedNameAsString();
@@ -157,6 +157,7 @@ void FunctionChecker::checkASTDecl(const FunctionDecl *FD, AnalysisManager& mgr,
 void FunctionChecker::checkASTDecl(const FunctionTemplateDecl *TD, AnalysisManager& mgr,
                     BugReporter &BR) const {
 
+	if ( TD->hasAttr<CMSThreadSafeAttr>()) return;
  	const char *sfile=BR.getSourceManager().getPresumedLoc(TD->getLocation ()).getFilename();
    	if (!support::isCmsLocalFile(sfile)) return;
 	std::string fname(sfile);
@@ -164,7 +165,6 @@ void FunctionChecker::checkASTDecl(const FunctionTemplateDecl *TD, AnalysisManag
 	for (FunctionTemplateDecl::spec_iterator I = const_cast<clang::FunctionTemplateDecl *>(TD)->spec_begin(), 
 			E = const_cast<clang::FunctionTemplateDecl *>(TD)->spec_end(); I != E; ++I) 
 		{
-			if ( I->hasAttr<CMSThreadGuardAttr>() || I->hasAttr<CMSThreadSafeAttr>()) continue;
 			if (I->doesThisDeclarationHaveABody()) {
 				FWalker walker(BR, mgr.getAnalysisDeclContext(*I));
 				walker.Visit(I->getBody());

--- a/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
@@ -1,4 +1,5 @@
 #include <clang/AST/DeclCXX.h>
+#include <clang/AST/Attr.h>
 #include <clang/AST/Decl.h>
 #include <clang/AST/DeclTemplate.h>
 #include <clang/AST/StmtVisitor.h>
@@ -63,7 +64,7 @@ void FWalker::ReportDeclRef ( const clang::DeclRefExpr * DRE) {
   
 
   if (const clang::VarDecl * D = llvm::dyn_cast<clang::VarDecl>(DRE->getDecl())) {
-
+	if ( D->hasAttr<CMSThreadGuardAttr>() || D->hasAttr<CMSThreadSafeAttr>()) return;
 	if ( support::isSafeClassName( D->getCanonicalDecl()->getQualifiedNameAsString() ) ) return;
 
  	const char *sfile=BR.getSourceManager().getPresumedLoc(D->getLocation()).getFilename();

--- a/Utilities/StaticAnalyzers/src/GlobalStaticChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/GlobalStaticChecker.cpp
@@ -23,7 +23,6 @@ void GlobalStaticChecker::checkASTDecl(const clang::VarDecl *D,
 			  !support::isConst( t ) )
 	{
 	    clang::ento::PathDiagnosticLocation DLoc = clang::ento::PathDiagnosticLocation::createBegin(D, BR.getSourceManager());
-    	    clang::QualType t =  D->getType();
 
 	    if ( ! m_exception.reportGlobalStaticForType( t, DLoc, BR ) )
 		   return;

--- a/Utilities/StaticAnalyzers/src/GlobalStaticChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/GlobalStaticChecker.cpp
@@ -6,7 +6,11 @@
 
 #include "GlobalStaticChecker.h"
 
+#include <clang/AST/Attr.h>
 #include "CmsSupport.h"
+using namespace clang;
+using namespace ento;
+using namespace llvm;
 
 namespace clangcms
 {
@@ -15,7 +19,7 @@ void GlobalStaticChecker::checkASTDecl(const clang::VarDecl *D,
                     clang::ento::AnalysisManager &Mgr,
                     clang::ento::BugReporter &BR) const
 {
-
+	if ( D->hasAttr<CMSThreadGuardAttr>() || D->hasAttr<CMSThreadSafeAttr>()) return;
 	clang::QualType t =  D->getType();
 	if ( D->hasGlobalStorage() &&
 			  !D->isStaticDataMember() &&

--- a/Utilities/StaticAnalyzers/src/MutableMemberChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/MutableMemberChecker.cpp
@@ -5,13 +5,17 @@
 //===----------------------------------------------------------------------===//
 
 #include "MutableMemberChecker.h"
+#include <clang/AST/Attr.h>
 using namespace clang;
+using namespace ento;
+using namespace llvm;
 namespace clangcms {
 
 void MutableMemberChecker::checkASTDecl(const clang::FieldDecl *D,
                     clang::ento::AnalysisManager &Mgr,
                     clang::ento::BugReporter &BR) const
 {
+        if ( D->hasAttr<CMSThreadGuardAttr>() || D->hasAttr<CMSThreadSafeAttr>()) return;
 	if ( D->isMutable() &&
 			 D->getDeclContext()->isRecord() )
 	{

--- a/Utilities/StaticAnalyzers/src/StaticLocalChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/StaticLocalChecker.cpp
@@ -8,6 +8,10 @@
 
 #include "CmsSupport.h"
 #include <iostream>
+#include <clang/AST/Attr.h>
+using namespace clang;
+using namespace ento;
+using namespace llvm;
 
 namespace clangcms {
 
@@ -17,7 +21,7 @@ void StaticLocalChecker::checkASTDecl(const clang::VarDecl *D,
                     clang::ento::BugReporter &BR) const
 {
 	clang::QualType t =  D->getType();
-
+        if ( D->hasAttr<CMSThreadGuardAttr>() || D->hasAttr<CMSThreadSafeAttr>()) return;
 	if ( ( (D->isStaticLocal() || D->isStaticDataMember() )  && D->getTSCSpec() != clang::ThreadStorageClassSpecifier::TSCS_thread_local) && ! support::isConst( t ) )
 	{
 	    clang::ento::PathDiagnosticLocation DLoc = clang::ento::PathDiagnosticLocation::createBegin(D, BR.getSourceManager());

--- a/Utilities/StaticAnalyzers/test/Makefile
+++ b/Utilities/StaticAnalyzers/test/Makefile
@@ -19,10 +19,10 @@ global_static_edm.o: global_static_edm.cpp
 	$(CXX) global_static_edm.cpp
 
 static_local.o: static_local.cpp
-	$(CXX) static_local.cpp
+	$(CXX) -Wno-attributes -std=c++11 static_local.cpp
 
 class_checker.o: class_checker.cpp
-	$(CXX) -std=c++11 class_checker.cpp	
+	$(CXX) -Wno-attributes -std=c++11 class_checker.cpp	
 
 func_checker.o: func_checker.cpp
-	$(CXX) func_checker.cpp
+	$(CXX) -Wno-attributes -std=c++11 func_checker.cpp

--- a/Utilities/StaticAnalyzers/test/Makefile
+++ b/Utilities/StaticAnalyzers/test/Makefile
@@ -19,10 +19,10 @@ global_static_edm.o: global_static_edm.cpp
 	$(CXX) global_static_edm.cpp
 
 static_local.o: static_local.cpp
-	$(CXX) -Wno-attributes -std=c++11 static_local.cpp
+	$(CXX) -Wno-attributes -std=c++11 $(CURDIR)/static_local.cpp
 
 class_checker.o: class_checker.cpp
-	$(CXX) -Wno-attributes -std=c++11 class_checker.cpp	
+	$(CXX) -Wno-attributes -std=c++11 $(CURDIR)/class_checker.cpp	
 
 func_checker.o: func_checker.cpp
-	$(CXX) -Wno-attributes -std=c++11 func_checker.cpp
+	$(CXX) -Wno-attributes -std=c++11 $(CURDIR)/func_checker.cpp

--- a/Utilities/StaticAnalyzers/test/class_checker.cpp
+++ b/Utilities/StaticAnalyzers/test/class_checker.cpp
@@ -6,7 +6,7 @@ static int const* g_ptr_staticConst = &g_staticConst;
 
 
 // results in a warning by GlobalStaticChecker
-static int g_static;
+[[cms::thread_safe]] static int g_static;
 static int * g_ptr_static = &g_static;
 
 class ClassTest {
@@ -71,7 +71,7 @@ int const & constRefAccess() const { return RVar_; } //OK ?
 
 class Bar
 {
-static int si_;
+[[cms::thread_safe]] static int si_;
 static void const modifyStatic(int &x) {si_=x;}
 private:
 Bar(): ci_{0},ipc_{&i_},icp_{&i_},ir_{i_},icr_{ci_} {}
@@ -152,7 +152,7 @@ void method3() const
 // must not produce a warning
 	int const& ira = (int const&)(icr_);
 // will produce a warning by StaticLocalChecker
-        static int evilStaticLocal = 0;
+        [[cms::thread_safe]] static int evilStaticLocal = 0;
 	static int & intRef = evilStaticLocal;
 	static int * intPtr = & evilStaticLocal;
 // no warnings here

--- a/Utilities/StaticAnalyzers/test/func_checker.cpp
+++ b/Utilities/StaticAnalyzers/test/func_checker.cpp
@@ -1,12 +1,11 @@
 #include "func_checker.h"
-static int global_static = 23;
-
+[[cms::thread_guard("dummy")]] static int global_static = 23;
 class Bar {
 public:
 Bar() {}
-static int member_static;
-void bar() {
-	static int local_static;
+[[cms::thread_guard("dummy2")]] static int member_static;
+void  bar()  {
+	/*[[cms::thread_safe]]*/ static int local_static;
 	member_static = global_static;
 	local_static = global_static; 
 	member_static = external_int;
@@ -19,6 +18,4 @@ int main()
 {
 return 0;
 }
-
-
 

--- a/Utilities/StaticAnalyzers/test/func_checker.h
+++ b/Utilities/StaticAnalyzers/test/func_checker.h
@@ -1,1 +1,1 @@
-extern int external_int;
+[[cms::thread_safe]] extern int external_int;

--- a/Utilities/StaticAnalyzers/test/static_local.cpp
+++ b/Utilities/StaticAnalyzers/test/static_local.cpp
@@ -1,13 +1,11 @@
 
-#include <string>
-
 class Foo
 {
 public:
     void bar()
     {
         // will produce a warning by StaticLocalChecker
-        static int evilStaticLocal = 0;
+        	[[cms::thread_safe]] static int evilStaticLocal = 0;
 		static int & intRef = evilStaticLocal;
 		static int * intPtr = & evilStaticLocal;
 


### PR DESCRIPTION
This is dependent on clang 3.3 having the custom attribute parsing patch.
