### PR TITLE
Updated GTs with the new ZS thresholds for HO

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -1,22 +1,22 @@
 autoCond = { 
     # GlobalTag for MC production with perfectly aligned and calibrated detector
-    'mc'                :   'MC_70_V1::All',
+    'mc'                :   'MC_70_V2::All',
     # GlobalTag for MC production with realistic alignment and calibrations
-    'startup'           :   'START70_V2::All',
+    'startup'           :   'START70_V3::All',
     # GlobalTag for MC production of Heavy Ions events with realistic alignment and calibrations
-    'starthi'           :   'STARTHI70_V1::All',
+    'starthi'           :   'STARTHI70_V3::All',
     # GlobalTag for MC production of p-Pb events with realistic alignment and calibrations
-    'startpa'           :   'STARTHI70_V2::All',
+    'startpa'           :   'STARTHI70_V4::All',
     # GlobalTag for data reprocessing: this should always be the GR_R tag
-    'com10'             :   'PRE_62_V8::All',
+    'com10'             :   'GR_R_62_V2::All',
     # GlobalTag for running HLT on recent data: this should be the GR_P (prompt reco) global tag until a compatible GR_H tag is available, 
     # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
-    'hltonline'         :   'PRE_P62_V8::All',
+    'hltonline'         :   'PRE_P62_V9::All',
     # GlobalTag for POSTLS1 upgrade studies:
-    'upgradePLS1'       :   'POSTLS162_V1::All',
-    'upgrade2017'       :   'DES17_70_V1::All', # placeholder (GT not meant for 62X)
-    'upgrade2019'       :   'DES19_70_V1::All', # placeholder (GT not meant for 62X)
-    'upgradePLS3'       :   'POSTLS261_V2::All' # placeholder (GT not meant for 62X)
+    'upgradePLS1'       :   'POSTLS162_V3::All',
+    'upgrade2017'       :   'DES17_70_V2::All', # placeholder (GT not meant for 62X)
+    'upgrade2019'       :   'DES19_70_V2::All', # placeholder (GT not meant for 62X)
+    'upgradePLS3'       :   'POSTLS262_V1::All' # placeholder (GT not meant for 62X)
 }
 
 aliases = {


### PR DESCRIPTION
Updates all global tags to include the new ZS thresholds for HO (for SiPM).

The 'com10' global tag has been updated to GR_R_62_V2 which includes the changes in GR_R_62_V1 documented here:
https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFrontierConditions#Global_tags_for_collision_da_AN1
The GR_R_62_V1 was not included in autoCond. For this reason, and for this specific GT, several tags are updated with respect to the previous PRE_62_V8 in addition to the new ZS thresholds.
