### PR TITLE
Properly set type info in TypeWithDict ctor

### DIFF
--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -199,6 +199,7 @@ TypeWithDict(TClass* cl, long property /*= 0L*/)
   , dataType_(nullptr)
   , property_((long) kIsClass | property)
 {
+  ti_ = cl->GetTypeInfo();
   type_ = gInterpreter->Type_Factory(*cl->GetTypeInfo());
 }
 


### PR DESCRIPTION
Fixed a failure of three framework unit tests in the ROOT 6 branch due to the failure to properly initialize the ti_ (type_info) data member of TypeWithDict in the constructor from a TClass pointer.

There are 37 other framework unit tests also failing. Fixes for many of those should be coming soon.
