### PR TITLE
Add link dependencies on WrappedStdDictionaries

### DIFF
--- a/FWCore/Framework/BuildFile.xml
+++ b/FWCore/Framework/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/Provenance"/>
+<use   name="DataFormats/WrappedStdDictionaries"/>
 <use   name="FWCore/Common"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -151,6 +151,7 @@
   <use   name="DataFormats/Common"/>
   <use   name="DataFormats/Provenance"/>
   <use   name="DataFormats/TestObjects"/>
+  <use   name="DataFormats/WrappedStdDictionaries"/>
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/ParameterSet"/>
   <use   name="FWCore/RootAutoLibraryLoader"/>
@@ -169,6 +170,7 @@
 </bin>
 <bin   name="TestFWCoreFrameworkeventprocessor" file="testRunner.cpp,eventprocessor2_t.cppunit.cc,eventprocessor_t.cppunit.cc">
   <use   name="DataFormats/Provenance"/>
+  <use   name="DataFormats/WrappedStdDictionaries"/>
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/RootAutoLibraryLoader"/>
   <use   name="FWCore/ServiceRegistry"/>
@@ -216,6 +218,7 @@
 </bin>
 <bin   name="TestFWCoreFrameworkGlobalStreamOne" file="TestDriver.cpp">
   <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_global_stream_one.sh"/>
+  <use   name="DataFormats/WrappedStdDictionaries"/>
   <use   name="FWCore/Utilities"/>
 </bin>
 <bin   name="TestFWCoreFrameworkReplace" file="TestDriver.cpp">


### PR DESCRIPTION
Fix four failing framework unit tests in the ROOT 6 branch by explicitly adding a link dependency on DataFormats/WrappedStdDictionaries, so those dictionaries will be loaded.  Automatic loading of missing dictionaries is not working properly.
Autoloading is not normally needed because the dictionary for a class is normally in the same package as the code for the class.   This is not true for DataFormats/StdDictionaries and DataFormats/WrappedStdDictionaries.   StdDictionaries is already always loaded.  This request does the same for WrappedStdDictionaries.
