### PR TITLE
A few fixes for Tracking stuffs: do not delete at endRun what is created in the constructor

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstruction.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstruction.cc
@@ -68,7 +68,6 @@ void PixelTrackReconstruction::halt()
   delete theFitter; theFitter=0;
   delete theCleaner; theCleaner=0;
   delete theGenerator; theGenerator=0;
-  //  delete theRegionProducer; theRegionProducer=0;
   delete theMerger_; theMerger_=0;
 }
 

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstruction.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstruction.cc
@@ -58,6 +58,7 @@ PixelTrackReconstruction::PixelTrackReconstruction(const ParameterSet& cfg,
   
 PixelTrackReconstruction::~PixelTrackReconstruction() 
 {
+  delete theRegionProducer; theRegionProducer=0;
   halt();
 }
 
@@ -67,7 +68,7 @@ void PixelTrackReconstruction::halt()
   delete theFitter; theFitter=0;
   delete theCleaner; theCleaner=0;
   delete theGenerator; theGenerator=0;
-  delete theRegionProducer; theRegionProducer=0;
+  //  delete theRegionProducer; theRegionProducer=0;
   delete theMerger_; theMerger_=0;
 }
 

--- a/RecoTracker/ConversionSeedGenerators/interface/PhotonConversionTrajectorySeedProducerFromQuadrupletsAlgo.h
+++ b/RecoTracker/ConversionSeedGenerators/interface/PhotonConversionTrajectorySeedProducerFromQuadrupletsAlgo.h
@@ -32,7 +32,7 @@ class PhotonConversionTrajectorySeedProducerFromQuadrupletsAlgo{
  public:
   PhotonConversionTrajectorySeedProducerFromQuadrupletsAlgo(const edm::ParameterSet &,
 	edm::ConsumesCollector && iC);
-  ~PhotonConversionTrajectorySeedProducerFromQuadrupletsAlgo(){};
+  ~PhotonConversionTrajectorySeedProducerFromQuadrupletsAlgo();
 
   void init();
   void clear();

--- a/RecoTracker/ConversionSeedGenerators/interface/PhotonConversionTrajectorySeedProducerFromSingleLegAlgo.h
+++ b/RecoTracker/ConversionSeedGenerators/interface/PhotonConversionTrajectorySeedProducerFromSingleLegAlgo.h
@@ -37,7 +37,7 @@ class PhotonConversionTrajectorySeedProducerFromSingleLegAlgo{
   
   PhotonConversionTrajectorySeedProducerFromSingleLegAlgo(const edm::ParameterSet &,
 	edm::ConsumesCollector && iC);
-  ~PhotonConversionTrajectorySeedProducerFromSingleLegAlgo(){};
+  ~PhotonConversionTrajectorySeedProducerFromSingleLegAlgo();
 
   void init();
   void clear();

--- a/RecoTracker/ConversionSeedGenerators/src/PhotonConversionTrajectorySeedProducerFromQuadrupletsAlgo.cc
+++ b/RecoTracker/ConversionSeedGenerators/src/PhotonConversionTrajectorySeedProducerFromQuadrupletsAlgo.cc
@@ -37,14 +37,17 @@ PhotonConversionTrajectorySeedProducerFromQuadrupletsAlgo(const edm::ParameterSe
   init();  
 }
      
+PhotonConversionTrajectorySeedProducerFromQuadrupletsAlgo::~PhotonConversionTrajectorySeedProducerFromQuadrupletsAlgo() {
+  if(theRegionProducer!=NULL)
+    delete theRegionProducer;
+}
+
 void PhotonConversionTrajectorySeedProducerFromQuadrupletsAlgo::
 clear(){
   if(theHitsGenerator!=NULL)
     delete theHitsGenerator;
   if(theSeedCreator!=NULL)
     delete theSeedCreator;
-  if(theRegionProducer!=NULL)
-    delete theRegionProducer;
 }
 
 void PhotonConversionTrajectorySeedProducerFromQuadrupletsAlgo::

--- a/RecoTracker/ConversionSeedGenerators/src/PhotonConversionTrajectorySeedProducerFromSingleLegAlgo.cc
+++ b/RecoTracker/ConversionSeedGenerators/src/PhotonConversionTrajectorySeedProducerFromSingleLegAlgo.cc
@@ -36,14 +36,17 @@ PhotonConversionTrajectorySeedProducerFromSingleLegAlgo(const edm::ParameterSet 
   init();  
 }
      
+PhotonConversionTrajectorySeedProducerFromSingleLegAlgo::~PhotonConversionTrajectorySeedProducerFromSingleLegAlgo() {
+  if(theRegionProducer!=NULL)
+    delete theRegionProducer;
+}
+
 void PhotonConversionTrajectorySeedProducerFromSingleLegAlgo::
 clear(){
   if(theHitsGenerator!=NULL)
     delete theHitsGenerator;
   if(theSeedCreator!=NULL)
     delete theSeedCreator;
-  if(theRegionProducer!=NULL)
-    delete theRegionProducer;
 }
 
 void PhotonConversionTrajectorySeedProducerFromSingleLegAlgo::

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromRegionHitsEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromRegionHitsEDProducer.cc
@@ -53,10 +53,10 @@ SeedGeneratorFromRegionHitsEDProducer::SeedGeneratorFromRegionHitsEDProducer(
 
 SeedGeneratorFromRegionHitsEDProducer::~SeedGeneratorFromRegionHitsEDProducer()
 {
+  delete theRegionProducer;
 }
 
 void SeedGeneratorFromRegionHitsEDProducer::endRun(edm::Run const&run, const edm::EventSetup& es) {
-  delete theRegionProducer;
   delete theGenerator;
 }
 
@@ -80,7 +80,6 @@ void SeedGeneratorFromRegionHitsEDProducer::beginRun(edm::Run const&run, const e
   SeedCreator * aCreator = SeedCreatorFactory::get()->create( creatorName, creatorPSet);
 
   theGenerator = new SeedGeneratorFromRegionHits(hitsGenerator, aComparitor, aCreator); 
- 
 }
 
 void SeedGeneratorFromRegionHitsEDProducer::produce(edm::Event& ev, const edm::EventSetup& es)


### PR DESCRIPTION
In the modifications meant to port to multi-threaded fwk a few tracking related classes in PR #1628 (later become #1634) the creation of some objects was moved from begin run to the class constructor.
I verified that there were a few cases in which those objects were still destructed at the endRun, thus resulting in a series of segmentation violations reported, e.g., by the first three workflows in https://cmssdt.cern.ch/SDT/cgi-bin//showMatrixTestLogs.py/slc6_amd64_gcc481/www/sat/7.0-sat-02/CMSSW_7_0_X_2013-12-07-0200/pyRelValMatrixLogs/run/
This Pull Request fixes those cases. The wkfs 4.34, 4.6 and 144.6, as well as all those in the short matrix run now without crashing
Please Reco guys: check that what is in this PR still satisfy your wishes (and sign it if so)
