### PR TITLE
Fix bookhistograms signature

### DIFF
--- a/DQMServices/Components/src/DQMDcsInfo.cc
+++ b/DQMServices/Components/src/DQMDcsInfo.cc
@@ -32,7 +32,9 @@ DQMDcsInfo::DQMDcsInfo(const edm::ParameterSet& ps)
 DQMDcsInfo::~DQMDcsInfo(){
 }
 
-void DQMDcsInfo::bookHistograms(DQMStore::IBooker & ibooker) {
+void DQMDcsInfo::bookHistograms(DQMStore::IBooker & ibooker,
+                                edm::Run const & /* iRun */,
+                                edm::EventSetup const & /* iSetup */) {
 
   // Fetch GlobalTag information and fill the string/ME.
   ibooker.cd();

--- a/DQMServices/Components/src/DQMDcsInfo.h
+++ b/DQMServices/Components/src/DQMDcsInfo.h
@@ -37,7 +37,7 @@ protected:
 
   /// Analyze
   void analyze(const edm::Event& e, const edm::EventSetup& c);
-  void bookHistograms(DQMStore::IBooker &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void endLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c);
 
 private:

--- a/DQMServices/Components/src/DQMEventInfo.cc
+++ b/DQMServices/Components/src/DQMEventInfo.cc
@@ -45,7 +45,9 @@ DQMEventInfo::DQMEventInfo(const edm::ParameterSet& ps){
 DQMEventInfo::~DQMEventInfo(){
 }
 
-void DQMEventInfo::bookHistograms(DQMStore::IBooker & ibooker)
+void DQMEventInfo::bookHistograms(DQMStore::IBooker & ibooker,
+                                  edm::Run const & /* iRun*/,
+                                  edm::EventSetup const & /* iSetup */)
 {
   ibooker.setCurrentFolder(eventInfoFolder_) ;
 

--- a/DQMServices/Components/src/DQMEventInfo.h
+++ b/DQMServices/Components/src/DQMEventInfo.h
@@ -35,7 +35,7 @@ public:
 
   /// Constructor
   DQMEventInfo(const edm::ParameterSet& ps);
-  
+
   /// Destructor
   virtual ~DQMEventInfo();
 
@@ -43,7 +43,7 @@ protected:
 
   /// Analyze
   void analyze(const edm::Event& e, const edm::EventSetup& c);
-  void bookHistograms(DQMStore::IBooker &) override;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) ;
   void beginLuminosityBlock(const edm::LuminosityBlock& l, const edm::EventSetup& c);
 
@@ -67,7 +67,7 @@ private:
   int64_t pEvent_;
 
   //////////////////////////////////////////////////////////////////
-  ///These MEs are filled with the info from the most recent event 
+  ///These MEs are filled with the info from the most recent event
   ///   by the module
   //////////////////////////////////////////////////////////////////
   MonitorElement * runId_;

--- a/DQMServices/Components/test/DummyBookFillDQMStoreMultiThread.cc
+++ b/DQMServices/Components/test/DummyBookFillDQMStoreMultiThread.cc
@@ -156,7 +156,7 @@ class DummyBookFillDQMStoreMultiThread :  public DQMEDAnalyzer {
   virtual void endLuminosityBlock(edm::LuminosityBlock const&,
                                   edm::EventSetup const&);
 
-  void bookHistograms(DQMStore::IBooker &);
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
   void fillerDispose();
 
   // ----------member data ---------------------------
@@ -195,7 +195,9 @@ void DummyBookFillDQMStoreMultiThread::fillerDispose(void) {
 }
 
 
-void DummyBookFillDQMStoreMultiThread::bookHistograms(DQMStore::IBooker &iBooker) {
+void DummyBookFillDQMStoreMultiThread::bookHistograms(DQMStore::IBooker &iBooker,
+                                                      edm::Run const & /* iRun */,
+                                                      edm::EventSetup const & /* iSetup */) {
   fillerDispose();
 
   std::cout << "Booking" << std::endl;

--- a/DQMServices/Core/interface/DQMEDAnalyzer.h
+++ b/DQMServices/Core/interface/DQMEDAnalyzer.h
@@ -50,7 +50,7 @@ public:
                                               dqmDetails::NoCache*);
   uint32_t streamId() const {return stream_id_;}
   virtual void dqmBeginRun(edm::Run const&, edm::EventSetup const&) {}
-  virtual void bookHistograms(DQMStore::IBooker &) = 0;
+  virtual void bookHistograms(DQMStore::IBooker &i, edm::Run const&, edm::EventSetup const&) = 0;
 
 private:
   uint32_t stream_id_;

--- a/DQMServices/Core/src/DQMEDAnalyzer.cc
+++ b/DQMServices/Core/src/DQMEDAnalyzer.cc
@@ -17,8 +17,8 @@ void DQMEDAnalyzer::beginStream(edm::StreamID id)
 void DQMEDAnalyzer::beginRun(edm::Run const &iRun,
                              edm::EventSetup const &iSetup) {
   DQMStore * store = edm::Service<DQMStore>().operator->();
-  store->bookTransaction([this](DQMStore::IBooker &b) {
-                           this->bookHistograms(b);
+  store->bookTransaction([this, &iRun, &iSetup](DQMStore::IBooker &b) {
+                           this->bookHistograms(b, iRun, iSetup);
                          },
                          iRun.run(),
                          streamId(),

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -323,10 +323,11 @@ MonitorElement * DQMStore::IBooker::book2D(const std::string &name,
 void DQMStore::mergeAndResetMEsRunSummaryCache(uint32_t run,
                                                uint32_t streamId,
                                                uint32_t moduleId) {
-  std::cout << "Merging objects from run: "
-	    << run
-	    << ", stream: " << streamId
-	    << " module: " << moduleId << std::endl;
+  if (verbose_ > 1)
+    std::cout << "Merging objects from run: "
+              << run
+              << ", stream: " << streamId
+              << " module: " << moduleId << std::endl;
   std::string null_str("");
   MonitorElement proto(&null_str, null_str, run, streamId, moduleId);
   std::set<MonitorElement>::const_iterator e = data_.end();
@@ -373,10 +374,11 @@ void DQMStore::mergeAndResetMEsLuminositySummaryCache(uint32_t run,
 						      uint32_t lumi,
 						      uint32_t streamId,
 						      uint32_t moduleId) {
-  std::cout << "Merging objects from run: "
-	    << run << 	" lumi: " << lumi
-	    << ", stream: " << streamId
-	    << " module: " << moduleId << std::endl;
+  if (verbose_ > 1)
+    std::cout << "Merging objects from run: "
+              << run << 	" lumi: " << lumi
+              << ", stream: " << streamId
+              << " module: " << moduleId << std::endl;
   std::string null_str("");
   MonitorElement proto(&null_str, null_str, run, streamId, moduleId);
   std::set<MonitorElement>::const_iterator e = data_.end();

--- a/DQMServices/Core/test/DQMTestMultiThread.cc
+++ b/DQMServices/Core/test/DQMTestMultiThread.cc
@@ -16,7 +16,9 @@ class DQMTestMultiThread
 
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
-  virtual void bookHistograms(DQMStore::IBooker&) override;
+  virtual void bookHistograms(DQMStore::IBooker&,
+                              edm::Run const &,
+                              edm::EventSetup const &) override;
 
   void dumpMe(MonitorElement const&, bool printStat = false);
 
@@ -34,7 +36,9 @@ DQMTestMultiThread::DQMTestMultiThread(const edm::ParameterSet &pset)
       debug_(pset.getUntrackedParameter<bool>("debug", false))
 {}
 
-void DQMTestMultiThread::bookHistograms(DQMStore::IBooker &b) {
+void DQMTestMultiThread::bookHistograms(DQMStore::IBooker &b,
+                                        edm::Run const & /* iRun*/,
+                                        edm::EventSetup const & /* iSetup*/ ) {
   b.setCurrentFolder("");
   b.setCurrentFolder(folder_);
   myHisto = b.book1D("MyHisto",


### PR DESCRIPTION
Pass `edm::Run const &` and `edm::EventSetup const &` to `bookHistograms` method to allow customizations of folders/ME based on stuff coming out of either or both of them. Requested independently by Yutaro and Mia.
