### PR TITLE
Global modules need per thread provenance

### DIFF
--- a/FWCore/Framework/interface/global/EDFilterBase.h
+++ b/FWCore/Framework/interface/global/EDFilterBase.h
@@ -19,6 +19,7 @@
 //
 
 // system include files
+#include <memory>
 
 // user include files
 #include "FWCore/Framework/interface/ProducerBase.h"
@@ -139,8 +140,8 @@ namespace edm {
         moduleDescription_ = md;
       }
       ModuleDescription moduleDescription_;
-      std::vector<BranchID> previousParentage_; //Per stream in the future?
-      ParentageID previousParentageId_;
+      std::unique_ptr<std::vector<BranchID>[]> previousParentages_; //Per stream in the future?
+      std::unique_ptr<ParentageID[]> previousParentageIds_;
     };
 
   }

--- a/FWCore/Framework/interface/global/EDProducerBase.h
+++ b/FWCore/Framework/interface/global/EDProducerBase.h
@@ -19,6 +19,7 @@
 //
 
 // system include files
+#include <memory>
 
 // user include files
 #include "FWCore/Framework/interface/ProducerBase.h"
@@ -33,6 +34,7 @@ namespace edm {
   class ModuleCallingContext;
   class PreallocationConfiguration;
   class StreamID;
+  class GlobalSchedule;
   
   namespace maker {
     template<typename T> class ModuleHolderT;
@@ -47,6 +49,8 @@ namespace edm {
       template <typename T> friend class edm::maker::ModuleHolderT;
       template <typename T> friend class edm::WorkerT;
       typedef EDProducerBase ModuleType;
+      
+      friend class edm::GlobalSchedule;
 
       EDProducerBase();
       virtual ~EDProducerBase();
@@ -139,8 +143,8 @@ namespace edm {
         moduleDescription_ = md;
       }
       ModuleDescription moduleDescription_;
-      std::vector<BranchID> previousParentage_; //Per stream in the future?
-      ParentageID previousParentageId_;
+      std::unique_ptr<std::vector<BranchID>[]> previousParentages_;
+      std::unique_ptr<ParentageID[]> previousParentageIds_;
     };
 
   }

--- a/FWCore/Framework/src/GlobalSchedule.cc
+++ b/FWCore/Framework/src/GlobalSchedule.cc
@@ -46,6 +46,7 @@ namespace edm {
     }
     if(inserter) {
       results_inserter_.reset(new edm::WorkerT<TriggerResultInserter::ModuleType>(inserter, inserter->moduleDescription(), &actions));
+      inserter->doPreallocate(prealloc);
       results_inserter_->setActivityRegistry(actReg_);
       addToAllWorkers(results_inserter_.get());
     }

--- a/FWCore/Framework/src/global/EDFilterBase.cc
+++ b/FWCore/Framework/src/global/EDFilterBase.cc
@@ -39,8 +39,8 @@ namespace edm {
     EDFilterBase::EDFilterBase():
     ProducerBase(),
     moduleDescription_(),
-    previousParentage_(),
-    previousParentageId_() { }
+    previousParentages_(),
+    previousParentageIds_() { }
     
     EDFilterBase::~EDFilterBase()
     {
@@ -52,13 +52,17 @@ namespace edm {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       bool returnValue = this->filter(e.streamID(), e, c);
-      commit_(e,&previousParentage_, &previousParentageId_);
+      const auto streamIndex =e.streamID().value();
+      commit_(e,&previousParentages_[streamIndex], &previousParentageIds_[streamIndex]);
       return returnValue;
     }
     
     void
     EDFilterBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
-      preallocStreams(iPrealloc.numberOfStreams());
+      const auto nStreams =iPrealloc.numberOfStreams();
+      previousParentages_.reset(new std::vector<BranchID>[nStreams]);
+      previousParentageIds_.reset(new ParentageID[nStreams]);
+      preallocStreams(nStreams);
     }
 
     void

--- a/FWCore/Framework/src/global/EDProducerBase.cc
+++ b/FWCore/Framework/src/global/EDProducerBase.cc
@@ -39,8 +39,8 @@ namespace edm {
     EDProducerBase::EDProducerBase():
     ProducerBase(),
     moduleDescription_(),
-    previousParentage_(),
-    previousParentageId_() { }
+    previousParentages_(),
+    previousParentageIds_() { }
     
     EDProducerBase::~EDProducerBase()
     {
@@ -52,13 +52,17 @@ namespace edm {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       this->produce(e.streamID(), e, c);
-      commit_(e,&previousParentage_, &previousParentageId_);
+      const auto streamIndex = e.streamID().value();
+      commit_(e,&previousParentages_[streamIndex], &previousParentageIds_[streamIndex]);
       return true;
     }
 
     void
     EDProducerBase::doPreallocate(PreallocationConfiguration const& iPrealloc) {
-      preallocStreams(iPrealloc.numberOfStreams());
+      auto const nStreams = iPrealloc.numberOfStreams();
+      previousParentages_.reset(new std::vector<BranchID>[nStreams]);
+      previousParentageIds_.reset( new ParentageID[nStreams]);
+      preallocStreams(nStreams);
     }
     
     void


### PR DESCRIPTION
The global module had a bug where all streams were using the same data structures to record their provenance. Now we set aside space for each Stream to have its own provenance information.
As part of this change, the TriggerResultsInserter, which is a global module which is handled in a special way by the framework, needs its doPreallocate method called.
