### PR TITLE
Use unscoped name for enums

### DIFF
--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -161,7 +161,7 @@ TypeWithDict(const type_info& ti, long property /*= 0L*/)
         abort();
       }
       TObject* tobj =
-        Tycl.class_->GetListOfEnums()->FindObject(name().c_str());
+        Tycl.class_->GetListOfEnums()->FindObject(unscopedName().c_str());
       if (tobj == nullptr) {
         // FIXME: Replace this with an exception!
         fprintf(stderr, "TypeWithDict(const type_info&, long): "
@@ -256,7 +256,7 @@ TypeWithDict(TType* ttype, long property /*= 0L*/)
         abort();
       }
       TObject* tobj =
-        Tycl.class_->GetListOfEnums()->FindObject(name().c_str());
+        Tycl.class_->GetListOfEnums()->FindObject(unscopedName().c_str());
       if (tobj == nullptr) {
         // FIXME: Replace this with an exception!
         fprintf(stderr, "TypeWithDict(TType*, long): "


### PR DESCRIPTION
Fixed a failing framework unit test in the ROOT6 branch.  ROOT stores enum names without scoping qualifiers, so unscoped names must be used to find enum members of classes.
