### PR TITLE
Add protection against sqrt(negative value) due to numerical rounding ef...

### DIFF
--- a/RecoJets/JetProducers/src/VirtualJetProducerHelper.cc
+++ b/RecoJets/JetProducers/src/VirtualJetProducerHelper.cc
@@ -1,13 +1,13 @@
 #include "RecoJets/JetProducers/interface/VirtualJetProducerHelper.h"
 
 #include <cmath>
-
+#include <algorithm>
 
 double reco::helper::VirtualJetProducerHelper::intersection(double r12) 
 {
   if (r12 == 0)         return M_PI;
   if (r12 >= 2)         return 0;
-  return 2 * acos(r12/2) - 0.5*r12*sqrt(4 - r12*r12);
+  return 2 * acos(r12/2) - 0.5*r12*sqrt(std::max(0.0 , 4 - r12*r12));
 }
 
 double reco::helper::VirtualJetProducerHelper::intersection(double r12, double r23, double r13) 
@@ -16,7 +16,7 @@ double reco::helper::VirtualJetProducerHelper::intersection(double r12, double r
   const double          r12_2   = r12*r12;
   const double          r13_2   = r13*r13;
   const double          temp    = (r12_2 + r13_2 - r23*r23);
-  const double          T2      = 4*r12_2*r13_2 - temp*temp;
+  const double          T2      = std::max(0.0 , 4*r12_2*r13_2 - temp*temp);
   const double          common  = 0.5*( intersection(r12) + intersection(r13) + intersection(r23) - M_PI + sqrt(T2)/2 );
   return common;
 }
@@ -27,7 +27,7 @@ double reco::helper::VirtualJetProducerHelper::intersection(double r12, double r
   const double          r12_2   = r12*r12;
   const double          r13_2   = r13*r13;
   const double          temp    = (r12_2 + r13_2 - r23*r23);
-  const double          T2	= 4*r12_2*r13_2 - temp*temp;
+  const double          T2	= std::max(0.0 , 4*r12_2*r13_2 - temp*temp);
   const double          common  = 0.5*( a12 + a13 + a23 - M_PI + sqrt(T2)/2 );
   return common;
 }


### PR DESCRIPTION
...fects

Fixes pre9 relval crashes observed here: https://hypernews.cern.ch/HyperNews/CMS/get/relval/2765.html

```
between 1 and 6 percent of the HLTD jobs failed due to this error

An exception of category 'FatalRootError' occurred while
   [0] Processing run: 208307 lumi: 263 event: 412070218
   [1] Running path 'HLT_Ele30_CaloIdVT_TrkIdT_PFNoPUJet100_PFNoPUJet25_v9'
   [2] Calling event method for module HLTPFJetCollectionsForElePlusJets/'hltEle30CaloIdVTTrkIdTCleanAK5PFNoPUJet'
   Additional Info:
      [a] Fatal Root Error: @SUB=TVector3::PseudoRapidity
transvers momentum = 0! return +/- 10e10

```

Essentially, due to numerical rounding, a sqrt of s slightly negative number is taken,
which produces a "nan" which ends up as the jetarea and has knock on effects 
when calculating jet energy corrections updating the jet kinematics and thus the
jet eta.
