### PR TITLE
filter out safe class name when reported as type with 'class ' prepended...

### DIFF
--- a/Utilities/StaticAnalyzers/src/ClassChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ClassChecker.cpp
@@ -313,7 +313,7 @@ void WalkAST::VisitDeclRefExpr( clang::DeclRefExpr * DRE) {
 void WalkAST::ReportDeclRef( const clang::DeclRefExpr * DRE) {
 
  if (const clang::VarDecl * D = llvm::dyn_cast<clang::VarDecl>(DRE->getDecl())) {
-	clang::QualType t =  D->getType();  
+	clang::QualType t =  D->getType();
 	const clang::Stmt * PS = ParentStmt(DRE);
  	CmsException m_exception;
   	clang::LangOptions LangOpts;
@@ -323,6 +323,7 @@ void WalkAST::ReportDeclRef( const clang::DeclRefExpr * DRE) {
 
   	clang::ento::PathDiagnosticLocation CELoc = clang::ento::PathDiagnosticLocation::createBegin(DRE, BR.getSourceManager(),AC);
 	if (!m_exception.reportClass( CELoc, BR ) ) return;
+	if ( support::isSafeClassName( t.getAsString() ) ) return;
         if ( D->hasAttr<CMSThreadGuardAttr>() || D->hasAttr<CMSThreadSafeAttr>()) return;
 	if ( D->isStaticLocal() && D->getTSCSpec() != clang::ThreadStorageClassSpecifier::TSCS_thread_local && ! support::isConst( t ) )
 	{

--- a/Utilities/StaticAnalyzers/src/CmsSupport.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsSupport.cpp
@@ -86,9 +86,15 @@ bool support::isSafeClassName(const std::string &name) {
   std::string mutex = "std::mutex";
   std::string rmutex = "std::recursive_mutex";
   std::string btsp = "boost::thread_specific_ptr<";
+  std::string catomic = "class std::atomic<";
+  std::string cmutex = "class std::mutex";
+  std::string crmutex = "class std::recursive_mutex";
+  std::string cbtsp = "class boost::thread_specific_ptr<";
   
-  if ( name.substr(0,atomic.length()) == atomic || name.substr(0,mutex.length()) == mutex
-	|| name.substr(0,rmutex.length()) == rmutex || name.substr(0,btsp.length()) == btsp )
+  
+  if ( name.substr(0,atomic.length()) == atomic || name.substr(0,catomic.length()) == atomic || name.substr(0,mutex.length()) == mutex 
+	|| name.substr(0,cmutex.length()) == mutex || name.substr(0,rmutex.length()) == rmutex || name.substr(0,crmutex.length()) == rmutex 
+	|| name.substr(0,btsp.length()) == btsp || name.substr(0,cbtsp.length()) == btsp ) 
 	return true;	
   return false;
 }


### PR DESCRIPTION
This fixes false report for non-const static local for file TrackingTools/GsfTools/src/GsfPropagatorAdapter.cc
