### PR TITLE
Fix PFClusterProducer For ConfDB

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterProducer.cc
@@ -224,7 +224,11 @@ PFClusterProducer::PFClusterProducer(const edm::ParameterSet& iConfig)
     threshPFClusterES_ = iConfig.getParameter<double>("thresh_Preshower");
     applyCrackCorrections_ = 
       iConfig.getParameter<bool>("applyCrackCorrections");
-    produces<reco::PFCluster::EEtoPSAssociation>();
+    if (inputTagPFClustersPS_.label().empty()) {
+      produces_eeps = false;
+    } else {
+      produces<reco::PFCluster::EEtoPSAssociation>();
+    }
   }
 
   //inputTagClusterCollectionName_ =  iConfig.getParameter<string>("PFClusterCollectionName");    


### PR DESCRIPTION
ConfDB uses static templates with always all parameters. Hence a plugin should not behave differently if a
parameter is present in the py config or not. This fix replaces that logic by checking the value of the added
InputTag: if it is empty, the old behaviour (as was without this parameter present) is obtained.
