### PR TITLE
Made sure all statics are const

### DIFF
--- a/CalibFormats/SiStripObjects/src/SiStripFecCabling.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripFecCabling.cc
@@ -156,8 +156,7 @@ const SiStripModule& SiStripFecCabling::module( const FedChannelConnection& conn
   }
 
   if ( !ss.str().empty() ) { edm::LogWarning(mlCabling_) << ss.str(); }
-  static FedChannelConnection temp;
-  static const SiStripModule module(temp);
+  static const SiStripModule module{FedChannelConnection{}};
   return module;
 }
 
@@ -175,8 +174,7 @@ const SiStripModule& SiStripFecCabling::module( const uint32_t& dcu_id ) const {
       }
     }
   }
-  static const FedChannelConnection temp;
-  static const SiStripModule module(temp);
+  static const SiStripModule module{FedChannelConnection{}};
   return module;
 }
 


### PR DESCRIPTION
The thread-safety checker was complaining that a static was non-const. Turned out that static was never changing and in fact was only used to initialize another const static. It was possible to remove the static and replace it with a temporary which only is used to initialize the const static.
