### PR TITLE
fix beam spot in ParametersDefinerFoTP

### DIFF
--- a/SimTracker/TrackAssociation/interface/ParametersDefinerForTP.h
+++ b/SimTracker/TrackAssociation/interface/ParametersDefinerForTP.h
@@ -18,6 +18,7 @@ class ParametersDefinerForTP {
 
  public:
   ParametersDefinerForTP(){};
+  ParametersDefinerForTP(const edm::ParameterSet& iConfig);
   virtual ~ParametersDefinerForTP() {};
 
     typedef int Charge; ///< electric charge type
@@ -47,6 +48,8 @@ class ParametersDefinerForTP {
   }
 
   virtual void initEvent(edm::Handle<SimHitTPAssociationProducer::SimHitTPAssociationList> simHitsTPAssocToSet) const { }
+
+  edm::InputTag beamSpotInputTag_;
 
 };
 

--- a/SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.cc
+++ b/SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.cc
@@ -17,6 +17,7 @@
 
 
 ParametersDefinerForTPESProducer::ParametersDefinerForTPESProducer(const edm::ParameterSet& iConfig)
+  : pset_(iConfig)
 {
   //the following line is needed to tell the framework what
   // data is being produced
@@ -45,7 +46,7 @@ ParametersDefinerForTPESProducer::~ParametersDefinerForTPESProducer()
 ParametersDefinerForTPESProducer::ReturnType
 ParametersDefinerForTPESProducer::produce(const TrackAssociatorRecord& iRecord)
 {
-  ReturnType parametersDefiner_ (new ParametersDefinerForTP());
+  ReturnType parametersDefiner_ (new ParametersDefinerForTP(pset_));
   return parametersDefiner_ ;
 }
 

--- a/SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h
+++ b/SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h
@@ -19,6 +19,8 @@ class  ParametersDefinerForTPESProducer: public edm::ESProducer{
   virtual ~ParametersDefinerForTPESProducer(); 
   boost::shared_ptr<ParametersDefinerForTP> produce(const TrackAssociatorRecord &);
 
+  edm::ParameterSet pset_;
+
 };
 
 

--- a/SimTracker/TrackAssociation/python/LhcParametersDefinerForTP_cfi.py
+++ b/SimTracker/TrackAssociation/python/LhcParametersDefinerForTP_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 LhcParametersDefinerForTP = cms.ESProducer("ParametersDefinerForTPESProducer",
-ComponentName = cms.string('LhcParametersDefinerForTP')
+   ComponentName = cms.string('LhcParametersDefinerForTP'),
+   beamSpot      = cms.untracked.InputTag('offlineBeamSpot')                                        
 )

--- a/SimTracker/TrackAssociation/src/ParametersDefinerForTP.cc
+++ b/SimTracker/TrackAssociation/src/ParametersDefinerForTP.cc
@@ -11,6 +11,13 @@
 #include <FWCore/Framework/interface/ESHandle.h>
 class TrajectoryStateClosestToBeamLineBuilder;
 
+
+ParametersDefinerForTP::ParametersDefinerForTP(const edm::ParameterSet& iConfig)
+  : beamSpotInputTag_ ( iConfig.getUntrackedParameter<edm::InputTag>("beamSpot", edm::InputTag("offlineBeamSpot")) )
+{
+}
+
+
 TrackingParticle::Vector
 ParametersDefinerForTP::momentum(const edm::Event& iEvent, const edm::EventSetup& iSetup,
 	const Charge charge, const Point & vtx, const LorentzVector& lv) const {
@@ -22,7 +29,7 @@ ParametersDefinerForTP::momentum(const edm::Event& iEvent, const edm::EventSetup
   iSetup.get<IdealMagneticFieldRecord>().get(theMF);
   
   edm::Handle<reco::BeamSpot> bs;
-  iEvent.getByLabel(InputTag("offlineBeamSpot"),bs);
+  iEvent.getByLabel(beamSpotInputTag_,bs);
 
   TrackingParticle::Vector momentum(0, 0, 0); 
 
@@ -49,7 +56,7 @@ TrackingParticle::Point ParametersDefinerForTP::vertex(const edm::Event& iEvent,
   iSetup.get<IdealMagneticFieldRecord>().get(theMF);
   
   edm::Handle<reco::BeamSpot> bs;
-  iEvent.getByLabel(InputTag("offlineBeamSpot"),bs);
+  iEvent.getByLabel(beamSpotInputTag_,bs);
 
   TrackingParticle::Point vertex(0, 0, 0);
   


### PR DESCRIPTION
add beamSpot parameter in the ParametersDefinerForTP
in order to avoid hard coded definition
