### PR TITLE
Add TypeWithDict::finalType()

### DIFF
--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -109,6 +109,7 @@ public:
   //FunctionWithDict functionMemberByName(const std::string& name, const TypeWithDict& signature, int mods, TypeMemberQuery memberQuery) const;
   TypeWithDict nestedType(char const*) const;
   TypeWithDict nestedType(const std::string&) const;
+  TypeWithDict finalType() const;
   TypeWithDict toType() const;
   void print(std::ostream& os) const;
   bool hasBase(const std::string&) const;

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -662,6 +662,26 @@ functionMemberByName(const string& member) const
 
 TypeWithDict
 TypeWithDict::
+finalType() const
+{
+  TypeWithDict ret;
+  if (type_ == nullptr) {
+    return ret;
+  }
+  TType* ty = gInterpreter->Type_FinalType(type_);
+  if (ty == nullptr) {
+    return ret;
+  }
+  const std::type_info* ti = gInterpreter->Type_TypeInfo(ty);
+  if (ti == nullptr) {
+    return ret;
+  }
+  ret = TypeWithDict(*ti);
+  return ret;
+}
+
+TypeWithDict
+TypeWithDict::
 toType() const
 {
   TypeWithDict ret;


### PR DESCRIPTION
Add function TypeWithDict::finalType(), which is needed by the conditions code for ROOT 6.
