### PR TITLE
Fixed memory problem in PrimaryVertexAnalyzer4PU

### DIFF
--- a/Validation/RecoVertex/interface/PrimaryVertexAnalyzer4PU.h
+++ b/Validation/RecoVertex/interface/PrimaryVertexAnalyzer4PU.h
@@ -178,7 +178,7 @@ private:
 		   std::vector<SimEvent>& simEvt,
 		   const bool selectedOnly=true);
 
-  int* supf(std::vector<SimPart>& simtrks, const reco::TrackCollection & trks);
+  std::vector<int> supf(std::vector<SimPart>& simtrks, const reco::TrackCollection & trks);
   static bool match(const ParameterVector  &a, const ParameterVector &b);
   std::vector<SimPart> getSimTrkParameters( edm::Handle<edm::SimTrackContainer> & simTrks,
 					    edm::Handle<edm::SimVertexContainer> & simVtcs,


### PR DESCRIPTION
PrimaryVertexANalyzer4PU was allocating an array of arrays using new[] but failed to use delete[]. The problem was found by the static analyzer. Rather than fix the fragile delete, I switched to code to use container objects which manage their own memory. This also meant changing a function to return a std::vector<int> rather than an int\* and requiring the caller to remember to delete the item (there wrong delete was being used there anyway).
