### PR TITLE
Make static plugin maker instances const

### DIFF
--- a/FWCore/PluginManager/interface/PluginFactory.h
+++ b/FWCore/PluginManager/interface/PluginFactory.h
@@ -99,5 +99,5 @@ namespace edmplugin {\
 #define EDM_PLUGIN_SYM2(x,y) x ## y
 
 #define DEFINE_EDM_PLUGIN(factory,type,name) \
-[[cms::thread_safe]] static factory::PMaker<type> EDM_PLUGIN_SYM(s_maker , __LINE__ ) (name)
+static const factory::PMaker<type> EDM_PLUGIN_SYM(s_maker , __LINE__ ) (name)
 


### PR DESCRIPTION
The maker classes used by the plugin system only have const interfaces so it is safe to make all the static instance of these classes const. This shows the intent better and allows the static analyzer to better understand what is happening.
