### PR TITLE
Fix automatic dictionary loading

### DIFF
--- a/FWCore/Framework/BuildFile.xml
+++ b/FWCore/Framework/BuildFile.xml
@@ -1,6 +1,5 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/Provenance"/>
-<use   name="DataFormats/WrappedStdDictionaries"/>
 <use   name="FWCore/Common"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>

--- a/FWCore/Framework/src/ProductRegistryHelper.cc
+++ b/FWCore/Framework/src/ProductRegistryHelper.cc
@@ -8,7 +8,9 @@
 #include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/Utilities/interface/DictionaryTools.h"
+#include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"
+#include "TClass.h"
 
 namespace edm {
   ProductRegistryHelper::~ProductRegistryHelper() { }
@@ -25,11 +27,27 @@ namespace edm {
                                        bool iIsListener) {
     std::string const& prefix = dictionaryPlugInPrefix();
     for(TypeLabelList::const_iterator p = iBegin; p != iEnd; ++p) {
-      TypeWithDict type(p->typeID_.typeInfo());
-      if(!type.hasDictionary()) {
-        //attempt to load
+      // This should load the dictionary if not already loaded.
+      TClass::GetClass(p->typeID_.typeInfo());
+      if(!hasDictionary(p->typeID_.typeInfo())) {
+        // a second attempt to load
         edmplugin::PluginCapabilities::get()->tryToLoad(prefix + p->typeID_.userClassName());
       }
+      if(!hasDictionary(p->typeID_.typeInfo())) {
+        throw Exception(errors::DictionaryNotFound)
+           << "No data dictionary found for class:\n\n"
+           <<  p->typeID_.className()
+           << "\nMost likely the dictionary was never generated,\n"
+           << "but it may be that it was generated in the wrong package.\n"
+           << "Please add (or move) the specification\n"
+           << "<class name=\"whatever\"/>\n"
+           << "to the appropriate classes_def.xml file.\n"
+           << "If the class is a template instance, you may need\n"
+           << "to define a dummy variable of this type in classes.h.\n"
+           << "Also, if this class has any transient members,\n"
+           << "you need to specify them in classes_def.xml.";
+      }
+      TypeWithDict type(p->typeID_.typeInfo());
       BranchDescription pdesc(p->branchType_,
                               iDesc.moduleLabel(),
                               iDesc.processName(),

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -151,7 +151,6 @@
   <use   name="DataFormats/Common"/>
   <use   name="DataFormats/Provenance"/>
   <use   name="DataFormats/TestObjects"/>
-  <use   name="DataFormats/WrappedStdDictionaries"/>
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/ParameterSet"/>
   <use   name="FWCore/RootAutoLibraryLoader"/>
@@ -170,7 +169,6 @@
 </bin>
 <bin   name="TestFWCoreFrameworkeventprocessor" file="testRunner.cpp,eventprocessor2_t.cppunit.cc,eventprocessor_t.cppunit.cc">
   <use   name="DataFormats/Provenance"/>
-  <use   name="DataFormats/WrappedStdDictionaries"/>
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/RootAutoLibraryLoader"/>
   <use   name="FWCore/ServiceRegistry"/>
@@ -192,7 +190,6 @@
   <use   name="DataFormats/Common"/>
   <use   name="DataFormats/Provenance"/>
   <use   name="DataFormats/TestObjects"/>
-  <use   name="DataFormats/WrappedStdDictionaries"/>
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/ParameterSet"/>
   <use   name="FWCore/RootAutoLibraryLoader"/>
@@ -218,7 +215,6 @@
 </bin>
 <bin   name="TestFWCoreFrameworkGlobalStreamOne" file="TestDriver.cpp">
   <flags   TEST_RUNNER_ARGS=" /bin/bash FWCore/Framework/test run_global_stream_one.sh"/>
-  <use   name="DataFormats/WrappedStdDictionaries"/>
   <use   name="FWCore/Utilities"/>
 </bin>
 <bin   name="TestFWCoreFrameworkReplace" file="TestDriver.cpp">

--- a/FWCore/RootAutoLibraryLoader/src/RootAutoLibraryLoader.cc
+++ b/FWCore/RootAutoLibraryLoader/src/RootAutoLibraryLoader.cc
@@ -18,12 +18,12 @@
 #include "FWCore/RootAutoLibraryLoader/src/stdNamespaceAdder.h"
 #include "FWCore/Utilities/interface/DictionaryTools.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/TypeDemangler.h"
 
 #include "TClass.h"
 #include "TInterpreter.h"
 #include "TROOT.h"
 
-#include <iostream>
 #include <map>
 #include <string>
 
@@ -87,6 +87,7 @@ loadLibraryForClass(const char* classname)
 /// during lookup of a class name.  We try to load a library
 /// that provides the definition of the class using the SEAL
 /// Capabilities plugin.
+#include <iostream>
 static
 int
 AutoLoadCallback(const char* c)
@@ -235,7 +236,8 @@ GetClass(const type_info& typeinfo, bool load)
     return nullptr;
   }
   // FIXME: demangle the name here!
-  return GetClass(typeinfo.name(), load);
+  std::string demangledName = typeDemangle(typeinfo.name());
+  return GetClass(demangledName.c_str(), load);
 }
 
 void

--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -229,6 +229,7 @@ namespace edm {
       // Enable automatic Root library loading.
       if(autoLibraryLoader_) {
         RootAutoLibraryLoader::enable();
+        gInterpreter->SetClassAutoloading(1);
       }
 
       // Set ROOT parameters.

--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -125,6 +125,9 @@ public:
   void destruct(void* address, bool dealloc = true) const;
 };
 
+// A related free function
+bool hasDictionary(const std::type_info&);
+
 inline bool operator<(const TypeWithDict& a, const TypeWithDict& b)
 {
   return a.typeInfo().before(b.typeInfo());

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -137,13 +137,19 @@ TypeWithDict(const type_info& ti, long property /*= 0L*/)
 {
   type_ = gInterpreter->Type_Factory(ti);
   if (!gInterpreter->Type_TypeInfo(type_)) {
+    // This can happen if no dictionary has been loaded for the class or enum.
+    // If this is a class, trigger the loading of the dictionary.
+    class_ = TClass::GetClass(ti);
+  }
+  if (!gInterpreter->Type_TypeInfo(type_)) {
     // FIXME: Replace this with an exception!
     fprintf(stderr, "TypeWithDict(const type_info&, long): "
             "Type_TypeInfo returns nullptr!\n");
     abort();
   }
   dataType_ = TDataType::GetDataType(TDataType::GetType(ti));
-  if (!gInterpreter->Type_IsFundamental(type_) &&
+  if (class_ == nullptr &&
+      !gInterpreter->Type_IsFundamental(type_) &&
       !gInterpreter->Type_IsEnum(type_)) {
     // Must be a class, struct, or union.
     class_ = TClass::GetClass(ti);
@@ -893,6 +899,12 @@ destruct(void* address, bool dealloc) const
 //-------------------------------------------------------------
 //
 //
+
+// A related free function
+bool 
+hasDictionary(const std::type_info& ti) {
+  return gInterpreter->Type_TypeInfo(gInterpreter->Type_Factory(ti));
+}
 
 bool
 operator==(const TypeWithDict& a, const TypeWithDict& b)


### PR DESCRIPTION
This pull request is a critical bug fix for CMSSW code for ROOT6.  It fixes the automatic run-time loading of dictionaries, which was broken because the plugin name was not demangled.  With this fix, dictionaries are successfully loaded at run time.
