### PR TITLE
Use Long64 t and ULong64_t

### DIFF
--- a/FWCore/Utilities/src/TypeDemangler.cc
+++ b/FWCore/Utilities/src/TypeDemangler.cc
@@ -134,6 +134,10 @@ namespace edm {
     constBeforeIdentifier(demangledName);
     // No two consecutive '>' 
     replaceString(demangledName, ">>", "> >");
+    // For ROOT 6 and beyond, replace 'long long' with 'Long64_t'
+    replaceString(demangledName, "long long", "Long64_t");
+    // For ROOT 6 and beyond, replace 'unsigned long long' with 'ULong64_t'
+    replaceString(demangledName, "unsigned long long", "ULong64_t");
     return demangledName;
   }
 }


### PR DESCRIPTION
Adapt to the fact that ROOT6 (unlike ROOT5) uses Long64_t and ULong64_t in plugin names instead of 'long long' and 'unsigned long long'.
