### PR TITLE
cmsRun returns non-zero if caught unix signal

### DIFF
--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -327,10 +327,13 @@ int main(int argc, char* argv[])
     }
     proc.on();
     bool onlineStateTransitions = false;
-    proc->runToCompletion(onlineStateTransitions);
+    rc = 0;
+    edm::EventProcessor::StatusCode status = proc->runToCompletion(onlineStateTransitions);
+    if (status == edm::EventProcessor::epSignal) {
+      rc = edm::errors::CaughtSignal;
+    }
     proc.off();
     proc->endJob();
-    rc = 0;
     // Disable Root Error Handler so we do not throw because of ROOT errors.
     edm::ServiceToken token = proc->getToken();
     edm::ServiceRegistry::Operate operate(token);

--- a/FWCore/Utilities/interface/EDMException.h
+++ b/FWCore/Utilities/interface/EDMException.h
@@ -64,7 +64,9 @@ namespace edm {
        ProductDoesNotSupportViews = 8024,
        ProductDoesNotSupportPtr = 8025,
 
-       NotFound = 8026
+       NotFound = 8026,
+
+       CaughtSignal = 9000
     };
 
   }


### PR DESCRIPTION
If any of the signals cmsRun catches (SIGINT and SIGUSR2) are caught, cmsRun now returns a non zero value. This was requested by data ops.
Backported from CMSSW_7_0_X.
