### PR TITLE
cmsRun returns non-zero if caught unix signal

### DIFF
--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -281,7 +281,10 @@ int main(int argc, char* argv[]) {
       context = "Processing input";
       proc.on();
       bool onlineStateTransitions = false;
-      proc->runToCompletion(onlineStateTransitions);
+      edm::EventProcessor::StatusCode status = proc->runToCompletion(onlineStateTransitions);
+      if(status == edm::EventProcessor::epSignal) {
+	returnCode = edm::errors::CaughtSignal;
+      }
       proc.off();
 
       context = "Calling endJob";

--- a/FWCore/Utilities/interface/EDMException.h
+++ b/FWCore/Utilities/interface/EDMException.h
@@ -59,7 +59,9 @@ namespace edm {
        ProductDoesNotSupportPtr = 8025,
 
        NotFound = 8026,
-       FormatIncompatibility = 8027
+       FormatIncompatibility = 8027,
+
+       CaughtSignal = 9000
     };
 
   }


### PR DESCRIPTION
If any of the signals cmsRun catches (SIGINT and SIGUSR2) are caught, cmsRun now returns a non zero value. This was requested by data ops.
Backported from CMSSW_7_0_X.
