### PR TITLE
Bug Fix for Exception Behavior

### DIFF
--- a/FWCore/Framework/src/WorkerMaker.h
+++ b/FWCore/Framework/src/WorkerMaker.h
@@ -35,7 +35,6 @@ protected:
     ModuleDescription createModuleDescription(MakeModuleParams const& p) const;
 
     void throwConfigurationException(ModuleDescription const& md,
-                                     signalslot::Signal<void(ModuleDescription const&)>& post,
                                      cms::Exception & iException) const;
 
     void throwValidationException(MakeModuleParams const& p,


### PR DESCRIPTION
Fix bug which would cause problems after an unrelated
exception was thrown in a module constructor or the
service post module construction methods. In some cases,
the post method would have been called twice which could
in turn cause a seg fault in some services. If an exception
was thrown in the service post method, the process could
have been immediately terminated.
