### PR TITLE
Enable RootAutoLibraryLoader in a stand alone unit test

### DIFF
--- a/FWCore/Framework/test/maker2_t.cppunit.cc
+++ b/FWCore/Framework/test/maker2_t.cppunit.cc
@@ -13,6 +13,7 @@
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "FWCore/Framework/src/WorkerMaker.h"
 #include "FWCore/Framework/src/MakeModuleParams.h"
+#include "FWCore/RootAutoLibraryLoader/interface/RootAutoLibraryLoader.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -42,7 +43,9 @@ CPPUNIT_TEST_SUITE(testmaker2);
 CPPUNIT_TEST(maker2Test);
 CPPUNIT_TEST_SUITE_END();
 public:
-  void setUp(){}
+  void setUp(){
+    RootAutoLibraryLoader::enable();
+  }
   void tearDown(){}
   void maker2Test();
 };


### PR DESCRIPTION
Fix a failing stand-alone unit test by enabling the auto library loader in the test.
