### PR TITLE
Enable RootAutoLibraryLoader in a stand alone unit test

### DIFF
--- a/FWCore/Framework/test/maker2_t.cppunit.cc
+++ b/FWCore/Framework/test/maker2_t.cppunit.cc
@@ -13,6 +13,7 @@
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "FWCore/Framework/src/WorkerMaker.h"
 #include "FWCore/Framework/src/MakeModuleParams.h"
+#include "FWCore/RootAutoLibraryLoader/interface/RootAutoLibraryLoader.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -42,7 +43,9 @@ CPPUNIT_TEST_SUITE(testmaker2);
 CPPUNIT_TEST(maker2Test);
 CPPUNIT_TEST_SUITE_END();
 public:
-  void setUp(){}
+  void setUp(){
+    RootAutoLibraryLoader::enable();
+  }
   void tearDown(){}
   void maker2Test();
 };


### PR DESCRIPTION
There is a bug in a unit test in FWCore/Framework. The unit test should have enabled the RootAutoLibraryLoader, but did not.  In ROOT 6, this causes the unit test to fail.  In ROOT 5, the unit test did not fail only because the dictionary that needed to be loaded was loaded for a different reason.
This fix is being queued to the main CMSSW_7_0_X branch (ROOT 5) for two reasons:
1) It is a bug fix that makes sense for CMSSW with ROOT 5, even if the bug did not cause a test failure.
2) It avoids a needless difference in CMSSW code between ROOT 5 and ROOT 6.
