### PR TITLE
Made MagGeometry thread safe

### DIFF
--- a/MagneticField/Engine/test/testMagneticField.cc
+++ b/MagneticField/Engine/test/testMagneticField.cc
@@ -485,16 +485,16 @@ const MagVolume6Faces* testMagneticField::findMasterVolume(int volume, int secto
 
   if (vbffield==0) return 0;
 
-  const vector<MagVolume6Faces*>& bvol = vbffield->barrelVolumes();
-  for (vector<MagVolume6Faces*>::const_iterator i=bvol.begin();
+  const vector<MagVolume6Faces const*>& bvol = vbffield->barrelVolumes();
+  for (vector<MagVolume6Faces const*>::const_iterator i=bvol.begin();
        i!=bvol.end(); i++) {
     if ((*i)->copyno == sector && (*i)->volumeNo==volume) {
       return (*i);
     }
   }
   
-  const vector<MagVolume6Faces*>& evol = vbffield->endcapVolumes();
-  for (vector<MagVolume6Faces*>::const_iterator i=evol.begin();
+  const vector<MagVolume6Faces const*>& evol = vbffield->endcapVolumes();
+  for (vector<MagVolume6Faces const*>::const_iterator i=evol.begin();
        i!=evol.end(); i++) {
     if ((*i)->copyno == sector && (*i)->volumeNo==volume) {
       return (*i);

--- a/MagneticField/GeomBuilder/test/stubs/MagGeometryAnalyzer.cc
+++ b/MagneticField/GeomBuilder/test/stubs/MagGeometryAnalyzer.cc
@@ -41,7 +41,7 @@ class MagGeometryAnalyzer : public edm::EDAnalyzer {
   }
   
  private:
-  void testGrids( const vector<MagVolume6Faces*>& bvol);
+  void testGrids( const vector<MagVolume6Faces const*>& bvol);
 };
 
 using namespace edm;
@@ -79,10 +79,10 @@ void MagGeometryAnalyzer::analyze(const edm::Event & event, const edm::EventSetu
 #include "VolumeGridTester.h"
 
 
-void MagGeometryAnalyzer::testGrids(const vector<MagVolume6Faces*>& bvol) {
+void MagGeometryAnalyzer::testGrids(const vector<MagVolume6Faces const*>& bvol) {
   static map<string,int> nameCalls;
 
-  for (vector<MagVolume6Faces*>::const_iterator i=bvol.begin();
+  for (vector<MagVolume6Faces const*>::const_iterator i=bvol.begin();
        i!=bvol.end(); i++) {
     if ((*i)->copyno != 1) {
       continue;

--- a/MagneticField/GeomBuilder/test/stubs/MagGeometryExerciser.cc
+++ b/MagneticField/GeomBuilder/test/stubs/MagGeometryExerciser.cc
@@ -16,8 +16,8 @@
 using namespace std;
 
 MagGeometryExerciser::MagGeometryExerciser(const MagGeometry * g) : theGeometry(g) {
-  const vector<MagVolume6Faces*>& theBVolumes = theGeometry->barrelVolumes();
-  const vector<MagVolume6Faces*>& theEVolumes = theGeometry->endcapVolumes();
+  const vector<MagVolume6Faces const*>& theBVolumes = theGeometry->barrelVolumes();
+  const vector<MagVolume6Faces const*>& theEVolumes = theGeometry->endcapVolumes();
 
   volumes = theBVolumes;
   volumes.insert(volumes.end(), theEVolumes.begin(), theEVolumes.end());
@@ -62,7 +62,7 @@ void MagGeometryExerciser::testFindVolume(int ntry){
 bool MagGeometryExerciser::testFindVolume(const GlobalPoint & gp){
   float tolerance = 0.;
   //  float tolerance = 0.03;  // Note: findVolume should handle tolerance himself.
-  MagVolume6Faces* vol = (MagVolume6Faces*) theGeometry->findVolume(gp, tolerance);
+  MagVolume6Faces const* vol = (MagVolume6Faces const*) theGeometry->findVolume(gp, tolerance);
   bool ok = (vol!=0);
 
   if (vol==0) {
@@ -73,7 +73,7 @@ bool MagGeometryExerciser::testFindVolume(const GlobalPoint & gp){
   
 
     // Try with a linear search
-    vol =  (MagVolume6Faces*) theGeometry->findVolume1(gp,tolerance);
+    vol =  (MagVolume6Faces const*) theGeometry->findVolume1(gp,tolerance);
     cout << "Was in volume: "
 	 << (vol !=0 ? vol->volumeNo : -1)
 	 << " (tolerance = " << tolerance << ")"
@@ -145,12 +145,12 @@ bool MagGeometryExerciser::testInside(const GlobalPoint & gp, float tolerance){
 
   bool reportSuccess = false;
 
-  vector<MagVolume6Faces*>& vols = volumes;
+  vector<MagVolume6Faces const*>& vols = volumes;
   // or use only barrel volumes:
-  // const vector<MagVolume6Faces*>& vols = theGeometry->barrelVolumes();
+  // const vector<MagVolume6Faces const*>& vols = theGeometry->barrelVolumes();
 
-  MagVolume6Faces * found = 0;
-  for (vector<MagVolume6Faces*>::const_iterator v = vols.begin();
+  MagVolume6Faces const* found = 0;
+  for (vector<MagVolume6Faces const*>::const_iterator v = vols.begin();
        v!=vols.end(); ++v){
     if ((*v)==0) {
       cout << endl << "ERROR: no magvlolume" << endl;
@@ -169,15 +169,15 @@ bool MagGeometryExerciser::testInside(const GlobalPoint & gp, float tolerance){
   
 
   if (found==0) {
-    MagVolume6Faces * foundP = 0;
-    MagVolume6Faces * foundN = 0;
+    MagVolume6Faces const * foundP = 0;
+    MagVolume6Faces const * foundN = 0;
     // Look for the closest neighbouring volumes
     const float phi=gp.phi();
     GlobalPoint gpP, gpN;
     int ntry=0;
     while ((foundP==0 || foundP==0) && ntry < 60) {
       ++ntry;
-      for (vector<MagVolume6Faces*>::const_iterator v = vols.begin();
+      for (vector<MagVolume6Faces const*>::const_iterator v = vols.begin();
 	   v!=vols.end(); ++v){
 	if (foundP==0) {
 	  float phiP=phi+ntry*0.008727;

--- a/MagneticField/GeomBuilder/test/stubs/MagGeometryExerciser.h
+++ b/MagneticField/GeomBuilder/test/stubs/MagGeometryExerciser.h
@@ -38,7 +38,7 @@ private:
   bool testFindVolume(const GlobalPoint & gp);
 
   const MagGeometry * theGeometry;
-  std::vector<MagVolume6Faces*> volumes;
+  std::vector<MagVolume6Faces const*> volumes;
 };
 #endif
 

--- a/MagneticField/VolumeBasedEngine/interface/MagGeometry.h
+++ b/MagneticField/VolumeBasedEngine/interface/MagGeometry.h
@@ -12,6 +12,7 @@
 #include "DetectorDescription/Core/interface/DDCompactView.h"
 
 #include <vector>
+#include <atomic>
 
 class MagBLayer;
 class MagESector;
@@ -31,6 +32,10 @@ public:
 			     const std::vector<MagESector *>& ,
 			     const std::vector<MagVolume6Faces*>& ,
 			     const std::vector<MagVolume6Faces*>& );
+  MagGeometry(const edm::ParameterSet& config, const std::vector<MagBLayer const*>& ,
+			     const std::vector<MagESector const*>& ,
+			     const std::vector<MagVolume6Faces const*>& ,
+			     const std::vector<MagVolume6Faces const*>& );
 
   /// Destructor
   ~MagGeometry();
@@ -39,36 +44,36 @@ public:
   GlobalVector fieldInTesla(const GlobalPoint & gp) const;
 
   /// Find a volume
-  MagVolume * findVolume(const GlobalPoint & gp, double tolerance=0.) const;
+  MagVolume const * findVolume(const GlobalPoint & gp, double tolerance=0.) const;
 
   // Deprecated, will be removed
   bool isZSymmetric() const {return false;}
 
   // FIXME: only for temporary tests, should be removed.
-  const std::vector<MagVolume6Faces*> & barrelVolumes() const {return theBVolumes;}
-  const std::vector<MagVolume6Faces*> & endcapVolumes() const {return theEVolumes;}
+  const std::vector<MagVolume6Faces const*> & barrelVolumes() const {return theBVolumes;}
+  const std::vector<MagVolume6Faces const*> & endcapVolumes() const {return theEVolumes;}
 
 private:
 
   friend class MagGeometryExerciser; // for debug purposes
 
   // Linear search (for debug purposes only)
-  MagVolume * findVolume1(const GlobalPoint & gp, double tolerance=0.) const;
+  MagVolume const* findVolume1(const GlobalPoint & gp, double tolerance=0.) const;
 
 
   bool inBarrel(const GlobalPoint& gp) const;
 
-  mutable MagVolume * lastVolume; // Cache last volume found
+  mutable std::atomic<MagVolume const*> lastVolume; // Cache last volume found
 
-  std::vector<MagBLayer *> theBLayers;
-  std::vector<MagESector *> theESectors;
+  std::vector<MagBLayer const*> theBLayers;
+  std::vector<MagESector const*> theESectors;
 
   // FIXME: only for temporary tests, should be removed.
-  std::vector<MagVolume6Faces*> theBVolumes;
-  std::vector<MagVolume6Faces*> theEVolumes;
+  std::vector<MagVolume6Faces const*> theBVolumes;
+  std::vector<MagVolume6Faces const*> theEVolumes;
 
-  MagBinFinders::GeneralBinFinderInR<double>* theBarrelBinFinder;
-  PeriodicBinFinderInPhi<float> * theEndcapBinFinder;
+  MagBinFinders::GeneralBinFinderInR<double> const* theBarrelBinFinder;
+  PeriodicBinFinderInPhi<float> const* theEndcapBinFinder;
 
   bool cacheLastVolume;
   int geometryVersion;

--- a/MagneticField/VolumeBasedEngine/src/MagGeometry.cc
+++ b/MagneticField/VolumeBasedEngine/src/MagGeometry.cc
@@ -24,7 +24,14 @@ using namespace edm;
 MagGeometry::MagGeometry(const edm::ParameterSet& config, const std::vector<MagBLayer *>& tbl,
 			 const std::vector<MagESector *>& tes,
 			 const std::vector<MagVolume6Faces*>& tbv,
-			 const std::vector<MagVolume6Faces*>& tev) : 
+			 const std::vector<MagVolume6Faces*>& tev) :
+  MagGeometry(config, reinterpret_cast<std::vector<MagBLayer const*> const&>(tbl), reinterpret_cast<std::vector<MagESector const*> const&>(tes), 
+	      reinterpret_cast<std::vector<MagVolume6Faces const*> const&>(tbv), reinterpret_cast<std::vector<MagVolume6Faces const*> const&>(tev)) {}
+
+MagGeometry::MagGeometry(const edm::ParameterSet& config, const std::vector<MagBLayer const*>& tbl,
+			 const std::vector<MagESector const*>& tes,
+			 const std::vector<MagVolume6Faces const*>& tbv,
+			 const std::vector<MagVolume6Faces const*>& tev) : 
   lastVolume(0), theBLayers(tbl), theESectors(tes), theBVolumes(tbv), theEVolumes(tev), geometryVersion(0)
 {
   
@@ -33,7 +40,7 @@ MagGeometry::MagGeometry(const edm::ParameterSet& config, const std::vector<MagB
 
   vector<double> rBorders;
 
-  for (vector<MagBLayer *>::const_iterator ilay = theBLayers.begin();
+  for (vector<MagBLayer const*>::const_iterator ilay = theBLayers.begin();
        ilay != theBLayers.end(); ++ilay) {
     if (verbose::debugOut) cout << "  Barrel layer at " << (*ilay)->minR() <<endl;
     //FIXME assume layers are already sorted in minR
@@ -43,7 +50,7 @@ MagGeometry::MagGeometry(const edm::ParameterSet& config, const std::vector<MagB
   theBarrelBinFinder = new MagBinFinders::GeneralBinFinderInR<double>(rBorders);
 
   if (verbose::debugOut) {
-    for (vector<MagESector *>::const_iterator isec = theESectors.begin();
+    for (vector<MagESector const*>::const_iterator isec = theESectors.begin();
 	 isec != theESectors.end(); ++isec) {
       cout << "  Endcap sector at " << (*isec)->minPhi() << endl;
     }
@@ -60,12 +67,12 @@ MagGeometry::~MagGeometry(){
   delete theBarrelBinFinder;
   delete theEndcapBinFinder;
 
-  for (vector<MagBLayer *>::const_iterator ilay = theBLayers.begin();
+  for (vector<MagBLayer const*>::const_iterator ilay = theBLayers.begin();
        ilay != theBLayers.end(); ++ilay) {
     delete (*ilay);
   }
 
-  for (vector<MagESector *>::const_iterator ilay = theESectors.begin();
+  for (vector<MagESector const*>::const_iterator ilay = theESectors.begin();
        ilay != theESectors.end(); ++ilay) {
     delete (*ilay);
   }
@@ -74,7 +81,7 @@ MagGeometry::~MagGeometry(){
 
 // Return field vector at the specified global point
 GlobalVector MagGeometry::fieldInTesla(const GlobalPoint & gp) const {
-  MagVolume * v = 0;
+  MagVolume const * v = 0;
 
   
   v = findVolume(gp);
@@ -95,13 +102,13 @@ GlobalVector MagGeometry::fieldInTesla(const GlobalPoint & gp) const {
 
 
 // Linear search implementation (just for testing)
-MagVolume* 
+MagVolume const* 
 MagGeometry::findVolume1(const GlobalPoint & gp, double tolerance) const {  
 
-  MagVolume6Faces * found = 0;
+  MagVolume6Faces const* found = 0;
 
   if (inBarrel(gp)) { // Barrel
-    for (vector<MagVolume6Faces*>::const_iterator v = theBVolumes.begin();
+    for (vector<MagVolume6Faces const*>::const_iterator v = theBVolumes.begin();
 	 v!=theBVolumes.end(); ++v){
       if ((*v)==0) { //FIXME: remove this check
 	cout << endl << "***ERROR: MagGeometry::findVolume: MagVolume not set" << endl;
@@ -114,7 +121,7 @@ MagGeometry::findVolume1(const GlobalPoint & gp, double tolerance) const {
     }
 
   } else { // Endcaps
-    for (vector<MagVolume6Faces*>::const_iterator v = theEVolumes.begin();
+    for (vector<MagVolume6Faces const*>::const_iterator v = theEVolumes.begin();
 	 v!=theEVolumes.end(); ++v){
       if ((*v)==0) {  //FIXME: remove this check
 	cout << endl << "***ERROR: MagGeometry::findVolume: MagVolume not set" << endl;
@@ -131,14 +138,15 @@ MagGeometry::findVolume1(const GlobalPoint & gp, double tolerance) const {
 }
 
 // Use hierarchical structure for fast lookup.
-MagVolume* 
+MagVolume const* 
 MagGeometry::findVolume(const GlobalPoint & gp, double tolerance) const{
   // Check volume cache
-  if (lastVolume!=0 && lastVolume->inside(gp)){
-    return lastVolume;
+  auto lastVolumeCheck = lastVolume.load(std::memory_order_acquire);
+  if (lastVolumeCheck!=nullptr && lastVolumeCheck->inside(gp)){
+    return lastVolumeCheck;
   }
 
-  MagVolume * result=0;
+  MagVolume const* result=0;
   if (inBarrel(gp)) { // Barrel
     double R = gp.perp();
     int bin = theBarrelBinFinder->binIndex(R);
@@ -171,7 +179,7 @@ MagGeometry::findVolume(const GlobalPoint & gp, double tolerance) const{
     result = findVolume(gp, 0.03);
   }
 
-  if (cacheLastVolume) lastVolume = result;
+  if (cacheLastVolume) lastVolume.store(result,std::memory_order_release);
 
   return result;
 }


### PR DESCRIPTION
Changed MagGeometry to use an std::atomic<> for its cache of the last volume used. This will allow thread-safe comparisions.
Changed const member functions to return const pointers to member data. This is also needed for thread-safety and was
caught by the static analyzer.
Also changed member data which were pointers to be const pointers in order to help  make future maintanence thread-safe.
