### PR TITLE
Workaround for ROOT6 limitation

### DIFF
--- a/DataFormats/Common/src/classes.h
+++ b/DataFormats/Common/src/classes.h
@@ -1,3 +1,4 @@
+#include "FWCore/Utilities/interface/boostWorkAround.h"
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "DataFormats/Common/interface/Ptr.h"

--- a/DataFormats/FWLite/src/classes.h
+++ b/DataFormats/FWLite/src/classes.h
@@ -1,3 +1,4 @@
+#include "FWCore/Utilities/interface/boostWorkAround.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
 //Add includes for your classes here

--- a/DataFormats/Provenance/interface/WrapperInterfaceBase.h
+++ b/DataFormats/Provenance/interface/WrapperInterfaceBase.h
@@ -6,6 +6,10 @@
 WrapperInterfaceBase: The base class of all things that will be inserted into the Event.
 /
 ----------------------------------------------------------------------*/
+#ifdef __ROOTCLING__
+#define BOOST_SP_NO_ATOMIC_ACCESS
+#define BOOST_SP_DISABLE_THREADS
+#endif
 #include "boost/shared_ptr.hpp"
 
 #include <typeinfo>

--- a/DataFormats/Provenance/src/classes.h
+++ b/DataFormats/Provenance/src/classes.h
@@ -1,3 +1,4 @@
+#include "FWCore/Utilities/interface/boostWorkAround.h"
 #include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/BranchChildren.h"
 #include "DataFormats/Provenance/interface/BranchID.h"

--- a/DataFormats/Streamer/src/classes.h
+++ b/DataFormats/Streamer/src/classes.h
@@ -1,3 +1,4 @@
+#include "FWCore/Utilities/interface/boostWorkAround.h"
 #include "DataFormats/Streamer/interface/StreamedProducts.h"
 
 #include <vector>

--- a/DataFormats/TestObjects/src/classes.h
+++ b/DataFormats/TestObjects/src/classes.h
@@ -1,3 +1,4 @@
+#include "FWCore/Utilities/interface/boostWorkAround.h"
 #include "DataFormats/Common/interface/SortedCollection.h"
 #include "DataFormats/Common/interface/OwnVector.h"
 #include "DataFormats/Common/interface/AssociationVector.h"

--- a/DataFormats/WrappedStdDictionaries/src/classes.h
+++ b/DataFormats/WrappedStdDictionaries/src/classes.h
@@ -1,3 +1,4 @@
+#include "FWCore/Utilities/interface/boostWorkAround.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
 #include <map>

--- a/FWCore/Common/src/classes.h
+++ b/FWCore/Common/src/classes.h
@@ -1,3 +1,4 @@
+#include "FWCore/Utilities/interface/boostWorkAround.h"
 #include "FWCore/Common/interface/EventBase.h"
 #include "FWCore/Common/interface/LuminosityBlockBase.h"
 #include "FWCore/Common/interface/RunBase.h"

--- a/FWCore/MessageLogger/src/classes.h
+++ b/FWCore/MessageLogger/src/classes.h
@@ -1,3 +1,4 @@
+#include "FWCore/Utilities/interface/boostWorkAround.h"
 #include <vector>
 #include "FWCore/MessageLogger/interface/ErrorSummaryEntry.h"
 

--- a/FWCore/TFWLiteSelector/src/classes.h
+++ b/FWCore/TFWLiteSelector/src/classes.h
@@ -1,1 +1,2 @@
+#include "FWCore/Utilities/interface/boostWorkAround.h"
 #include "FWCore/TFWLiteSelector/interface/TFWLiteSelectorBasic.h"

--- a/FWCore/TFWLiteSelectorTest/src/classes.h
+++ b/FWCore/TFWLiteSelectorTest/src/classes.h
@@ -1,2 +1,3 @@
+#include "FWCore/Utilities/interface/boostWorkAround.h"
 #include "FWCore/TFWLiteSelectorTest/src/ThingsTSelector.h"
 #include "FWCore/TFWLiteSelectorTest/src/ThingsTSelector2.h"

--- a/FWCore/Utilities/interface/boostWorkAround.h
+++ b/FWCore/Utilities/interface/boostWorkAround.h
@@ -1,0 +1,4 @@
+#ifdef __ROOTCLING__
+#define BOOST_SP_NO_ATOMIC_ACCESS
+#define BOOST_SP_DISABLE_THREADS
+#endif


### PR DESCRIPTION
ROOT6 uses a version of the llvm just in time compiler that cannot handle embedded assembler code.
boost/shared_ptr.hpp contains (indirectly) two headers that contain assembler. This breaks many framework unit tests.
This workaround sets preprocessor variables recognized by boost that are used if and only if ROOTCLING is defined. These preprocessor definitions cause the assembler code to not be included. This fixes the unit test errors.
The final fix for this problem should be either that ROOT6 is fixed to handle assembler, OR that CMSSW replaces with std::shared_ptr those uses of boost::shared_ptr that cause problems 

I accidentally closed #1842.  This is a duplicate of #1842
