### PR TITLE
Migrate PixelTrackFilter classes to getByToken

### DIFF
--- a/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
+++ b/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
@@ -50,9 +50,10 @@ PixelTracksProducer::PixelTracksProducer(const edm::ParameterSet& conf) :
   std::string fitterName = fitterPSet.getParameter<std::string>("ComponentName");
   theFitter = PixelFitterFactory::get()->create( fitterName, fitterPSet);
   
+  edm::ConsumesCollector iC = consumesCollector();
   const edm::ParameterSet& filterPSet = conf.getParameter<edm::ParameterSet>("FilterPSet");
   std::string filterName = filterPSet.getParameter<std::string>("ComponentName");
-  theFilter = PixelTrackFilterFactory::get()->create( filterName, filterPSet);
+  theFilter = PixelTrackFilterFactory::get()->create( filterName, filterPSet, iC);
   
   // The name of the seed producer
   seedProducer = conf.getParameter<edm::InputTag>("SeedProducer");

--- a/RecoHI/HiTracking/interface/HIPixelTrackFilter.h
+++ b/RecoHI/HiTracking/interface/HIPixelTrackFilter.h
@@ -11,11 +11,11 @@ class TrackerTopology;
 
 class HIPixelTrackFilter : public ClusterShapeTrackFilter {
 public:
-	HIPixelTrackFilter(const edm::ParameterSet& ps, const edm::EventSetup& es);
+	HIPixelTrackFilter(const edm::ParameterSet& ps, edm::ConsumesCollector& iC);
 	virtual ~HIPixelTrackFilter();
 	virtual bool operator() (const reco::Track*, const PixelTrackFilter::Hits & hits,
 				 const TrackerTopology *tTopo) const;
-	virtual void update(edm::Event& ev);
+	virtual void update(const edm::Event& ev, const edm::EventSetup& es) override;
 private:
 	double theTIPMax, theNSigmaTipMaxTolerance;
 	double theLIPMax, theNSigmaLipMaxTolerance;

--- a/RecoHI/HiTracking/interface/HIPixelTrackFilter.h
+++ b/RecoHI/HiTracking/interface/HIPixelTrackFilter.h
@@ -5,6 +5,7 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 namespace edm { class ParameterSet; class EventSetup; class Event;}
 class TrackerTopology;
@@ -22,6 +23,7 @@ private:
 	double theChi2Max, thePtMin;
 	bool useClusterShape;
 	edm::InputTag theVertexCollection; 	
+	edm::EDGetTokenT<reco::VertexCollection> theVertexCollectionToken;
 	const reco::VertexCollection *theVertices;
 
 };

--- a/RecoHI/HiTracking/interface/HIProtoTrackFilter.h
+++ b/RecoHI/HiTracking/interface/HIProtoTrackFilter.h
@@ -4,14 +4,15 @@
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilter.h"
 
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 namespace edm { class ParameterSet; class EventSetup; class Event;}
 
 class HIProtoTrackFilter : public PixelTrackFilter {
 public:
 	HIProtoTrackFilter(const edm::ParameterSet& ps, edm::ConsumesCollector& iC);
-	HIProtoTrackFilter(const edm::ParameterSet& ps);
 	virtual ~HIProtoTrackFilter();
 	virtual bool operator() (const reco::Track*, const PixelTrackFilter::Hits & hits) const;
 	virtual void update(const edm::Event& ev, const edm::EventSetup& es) override;
@@ -20,7 +21,8 @@ private:
 	double theChi2Max, thePtMin;
 	bool   doVariablePtMin;
 	edm::InputTag theBeamSpotTag; 
-	edm::InputTag theSiPixelRecHits;
+	edm::EDGetTokenT<reco::BeamSpot> theBeamSpotToken;
+	edm::EDGetTokenT<SiPixelRecHitCollection> theSiPixelRecHitsToken;
 	const reco::BeamSpot *theBeamSpot;
 	double theVariablePtMin;
 

--- a/RecoHI/HiTracking/interface/HIProtoTrackFilter.h
+++ b/RecoHI/HiTracking/interface/HIProtoTrackFilter.h
@@ -10,11 +10,11 @@ namespace edm { class ParameterSet; class EventSetup; class Event;}
 
 class HIProtoTrackFilter : public PixelTrackFilter {
 public:
-	HIProtoTrackFilter(const edm::ParameterSet& ps, const edm::EventSetup& es);
+	HIProtoTrackFilter(const edm::ParameterSet& ps, edm::ConsumesCollector& iC);
 	HIProtoTrackFilter(const edm::ParameterSet& ps);
 	virtual ~HIProtoTrackFilter();
 	virtual bool operator() (const reco::Track*, const PixelTrackFilter::Hits & hits) const;
-	virtual void update(edm::Event& ev);
+	virtual void update(const edm::Event& ev, const edm::EventSetup& es) override;
 private:
 	double theTIPMax;
 	double theChi2Max, thePtMin;

--- a/RecoHI/HiTracking/plugins/modules.cc
+++ b/RecoHI/HiTracking/plugins/modules.cc
@@ -27,7 +27,7 @@ DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, HITrackingRegionForPrimaryVtxPr
 // Pixel track filter
 #include "RecoHI/HiTracking/interface/HIPixelTrackFilter.h"
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilterFactory.h"
-DEFINE_EDM_PLUGIN(PixelTrackFilterWithESFactory, HIPixelTrackFilter, "HIPixelTrackFilter");
+DEFINE_EDM_PLUGIN(PixelTrackFilterFactory, HIPixelTrackFilter, "HIPixelTrackFilter");
 
 // Pixel prototrack filter
 #include "RecoHI/HiTracking/interface/HIProtoTrackFilter.h"

--- a/RecoHI/HiTracking/src/HIPixelTrackFilter.cc
+++ b/RecoHI/HiTracking/src/HIPixelTrackFilter.cc
@@ -5,6 +5,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackBase.h"
@@ -24,6 +25,7 @@ theChi2Max( ps.getParameter<double>("chi2") ),
 thePtMin( ps.getParameter<double>("ptMin") ),
 useClusterShape( ps.getParameter<bool>("useClusterShape") ),
 theVertexCollection( ps.getParameter<edm::InputTag>("VertexCollection")),
+theVertexCollectionToken( iC.consumes<reco::VertexCollection>(theVertexCollection)),
 theVertices(0)
 { 
 }
@@ -77,7 +79,7 @@ void HIPixelTrackFilter::update(const edm::Event& ev, const edm::EventSetup& es)
 
   // Get reco vertices
   edm::Handle<reco::VertexCollection> vc;
-  ev.getByLabel(theVertexCollection, vc);
+  ev.getByToken(theVertexCollectionToken, vc);
   theVertices = vc.product();
   
   if(theVertices->size()>0) {

--- a/RecoHI/HiTracking/src/HIPixelTrackFilter.cc
+++ b/RecoHI/HiTracking/src/HIPixelTrackFilter.cc
@@ -14,8 +14,8 @@ using namespace std;
 using namespace edm;
 
 /*****************************************************************************/
-HIPixelTrackFilter::HIPixelTrackFilter (const edm::ParameterSet& ps, const edm::EventSetup& es) :
-ClusterShapeTrackFilter(ps,es),
+HIPixelTrackFilter::HIPixelTrackFilter (const edm::ParameterSet& ps, edm::ConsumesCollector& iC) :
+ClusterShapeTrackFilter(ps, iC),
 theTIPMax( ps.getParameter<double>("tipMax") ),
 theNSigmaTipMaxTolerance( ps.getParameter<double>("nSigmaTipMaxTolerance")),
 theLIPMax( ps.getParameter<double>("lipMax") ),
@@ -71,9 +71,10 @@ bool HIPixelTrackFilter::operator() (const reco::Track* track,const PixelTrackFi
 }
 
 /*****************************************************************************/
-void HIPixelTrackFilter::update(edm::Event& ev)
+void HIPixelTrackFilter::update(const edm::Event& ev, const edm::EventSetup& es)
 {
-  
+  ClusterShapeTrackFilter::update(ev, es);
+
   // Get reco vertices
   edm::Handle<reco::VertexCollection> vc;
   ev.getByLabel(theVertexCollection, vc);

--- a/RecoHI/HiTracking/src/HIProtoTrackFilter.cc
+++ b/RecoHI/HiTracking/src/HIProtoTrackFilter.cc
@@ -5,6 +5,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackBase.h"
@@ -25,20 +26,8 @@ theChi2Max( ps.getParameter<double>("chi2") ),
 thePtMin( ps.getParameter<double>("ptMin") ),
 doVariablePtMin( ps.getParameter<bool>("doVariablePtMin") ),
 theBeamSpotTag( ps.getParameter<InputTag>("beamSpot")),
-theSiPixelRecHits( ps.getParameter<InputTag>("siPixelRecHits")),
-theBeamSpot(0),
-theVariablePtMin(0)
-{ 
-}
-
-/*****************************************************************************/
-HIProtoTrackFilter::HIProtoTrackFilter (const edm::ParameterSet& ps) :
-theTIPMax( ps.getParameter<double>("tipMax") ),
-theChi2Max( ps.getParameter<double>("chi2") ),
-thePtMin( ps.getParameter<double>("ptMin") ),
-doVariablePtMin( ps.getParameter<bool>("doVariablePtMin") ),
-theBeamSpotTag( ps.getParameter<InputTag>("beamSpot")),
-theSiPixelRecHits( ps.getParameter<InputTag>("siPixelRecHits")),
+theBeamSpotToken( iC.consumes<reco::BeamSpot>(theBeamSpotTag)),
+theSiPixelRecHitsToken( iC.consumes<SiPixelRecHitCollection>(ps.getParameter<InputTag>("siPixelRecHits"))),
 theBeamSpot(0),
 theVariablePtMin(0)
 { 
@@ -78,7 +67,7 @@ void HIProtoTrackFilter::update(const edm::Event& ev, const edm::EventSetup& es)
   
   // Get the beam spot
   edm::Handle<reco::BeamSpot> bsHandle;
-  ev.getByLabel( theBeamSpotTag, bsHandle);
+  ev.getByToken( theBeamSpotToken, bsHandle);
   theBeamSpot = bsHandle.product();
   
   if(theBeamSpot) {
@@ -92,7 +81,7 @@ void HIProtoTrackFilter::update(const edm::Event& ev, const edm::EventSetup& es)
 
   // Estimate multiplicity
   edm::Handle<SiPixelRecHitCollection> recHitColl;
-  ev.getByLabel(theSiPixelRecHits, recHitColl);
+  ev.getByToken(theSiPixelRecHitsToken, recHitColl);
   
   vector<const TrackingRecHit*> theChosenHits; 	 
   TrackerLayerIdAccessor acc; 	 

--- a/RecoHI/HiTracking/src/HIProtoTrackFilter.cc
+++ b/RecoHI/HiTracking/src/HIProtoTrackFilter.cc
@@ -19,7 +19,7 @@ using namespace std;
 using namespace edm;
 
 /*****************************************************************************/
-HIProtoTrackFilter::HIProtoTrackFilter (const edm::ParameterSet& ps, const edm::EventSetup& es) :
+HIProtoTrackFilter::HIProtoTrackFilter (const edm::ParameterSet& ps, edm::ConsumesCollector& iC) :
 theTIPMax( ps.getParameter<double>("tipMax") ),
 theChi2Max( ps.getParameter<double>("chi2") ),
 thePtMin( ps.getParameter<double>("ptMin") ),
@@ -73,7 +73,7 @@ bool HIProtoTrackFilter::operator() (const reco::Track* track,const PixelTrackFi
 }
 
 /*****************************************************************************/
-void HIProtoTrackFilter::update(edm::Event& ev)
+void HIProtoTrackFilter::update(const edm::Event& ev, const edm::EventSetup& es)
 {
   
   // Get the beam spot

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL1Muon.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL1Muon.cc
@@ -47,16 +47,20 @@ template <class T> T sqr( T t) {return t*t;}
 
 
 TSGFromL1Muon::TSGFromL1Muon(const edm::ParameterSet& cfg)
-  : theConfig(cfg),theRegionProducer(0),theHitGenerator(0),theFitter(0),theFilter(0),theMerger(0)
+  : theConfig(cfg),theRegionProducer(0),theHitGenerator(0),theFitter(0),theMerger(0)
 {
   produces<L3MuonTrajectorySeedCollection>();
   theSourceTag = cfg.getParameter<edm::InputTag>("L1MuonLabel");
+
+  edm::ConsumesCollector iC = consumesCollector();
+  edm::ParameterSet filterPSet = theConfig.getParameter<edm::ParameterSet>("FilterPSet");
+  std::string  filterName = filterPSet.getParameter<std::string>("ComponentName");
+  theFilter.reset(PixelTrackFilterFactory::get()->create( filterName, filterPSet, iC));
 }
 
 TSGFromL1Muon::~TSGFromL1Muon()
 {
   delete theMerger;
-  delete theFilter;
   delete theFitter;
   delete theHitGenerator;
   delete theRegionProducer;
@@ -79,10 +83,6 @@ void TSGFromL1Muon::beginRun(const edm::Run & run, const edm::EventSetup&es)
   std::string fitterName = fitterPSet.getParameter<std::string>("ComponentName");
   PixelFitter * f = PixelFitterFactory::get()->create( fitterName, fitterPSet);
   theFitter = dynamic_cast<L1MuonPixelTrackFitter* >(f);
-
-  edm::ParameterSet filterPSet = theConfig.getParameter<edm::ParameterSet>("FilterPSet");
-  std::string  filterName = filterPSet.getParameter<std::string>("ComponentName");
-  theFilter = PixelTrackFilterFactory::get()->create( filterName, filterPSet);
 
   edm::ParameterSet cleanerPSet = theConfig.getParameter<edm::ParameterSet>("CleanerPSet");
   std::string  cleanerName = cleanerPSet.getParameter<std::string>("ComponentName");

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL1Muon.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL1Muon.h
@@ -35,7 +35,7 @@ private:
   L1MuonRegionProducer * theRegionProducer;
   OrderedHitsGenerator * theHitGenerator;
   L1MuonPixelTrackFitter * theFitter;
-  PixelTrackFilter * theFilter;
+  std::unique_ptr<PixelTrackFilter> theFilter;
   L1MuonSeedsMerger * theMerger;
 
 };

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrackFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrackFilter.h
@@ -25,8 +25,9 @@ class ClusterShapeTrackFilter : public PixelTrackFilter
 {
  public:
   ClusterShapeTrackFilter(const edm::ParameterSet& ps,
-                          const edm::EventSetup& es);
+                          edm::ConsumesCollector& iC);
   virtual ~ClusterShapeTrackFilter();
+  void update(const edm::Event& ev, const edm::EventSetup& es) override;
   virtual bool operator()
     (const reco::Track*, const std::vector<const TrackingRecHit *> &hits, 
      const TrackerTopology *tTopo) const;

--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/ValidHitPairFilter.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/ValidHitPairFilter.h
@@ -20,8 +20,9 @@ class TrackerTopology;
 class ValidHitPairFilter : public PixelTrackFilter 
 {
 public:
-  ValidHitPairFilter(const edm::ParameterSet& ps, const edm::EventSetup& es);
+  ValidHitPairFilter(const edm::ParameterSet& ps, edm::ConsumesCollector& iC);
   virtual ~ValidHitPairFilter();
+  void update(const edm::Event& ev, const edm::EventSetup& es) override;
   virtual bool operator()(const reco::Track * track,
                           const std::vector<const TrackingRecHit *>& recHits,
 			  const TrackerTopology *tTopo) const;

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/modules.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/modules.cc
@@ -28,10 +28,10 @@ DEFINE_EDM_PLUGIN(HitTripletGeneratorFromPairAndLayersFactory, PixelTripletLowPt
 #include "RecoPixelVertexing/PixelLowPtUtilities/interface/ClusterShapeTrackFilter.h"
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilter.h"
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilterFactory.h"
-DEFINE_EDM_PLUGIN(PixelTrackFilterWithESFactory, ClusterShapeTrackFilter, "ClusterShapeTrackFilter");
+DEFINE_EDM_PLUGIN(PixelTrackFilterFactory, ClusterShapeTrackFilter, "ClusterShapeTrackFilter");
 
 #include "RecoPixelVertexing/PixelLowPtUtilities/interface/ValidHitPairFilter.h"
-DEFINE_EDM_PLUGIN(PixelTrackFilterWithESFactory, ValidHitPairFilter, "ValidHitPairFilter");
+DEFINE_EDM_PLUGIN(PixelTrackFilterFactory, ValidHitPairFilter, "ValidHitPairFilter");
 
 // Fitter
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelFitter.h"

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeTrackFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/ClusterShapeTrackFilter.cc
@@ -25,9 +25,22 @@ inline float sqr(float x) { return x*x; }
 using namespace std;
 
 /*****************************************************************************/
-ClusterShapeTrackFilter::ClusterShapeTrackFilter
-  (const edm::ParameterSet& ps, const edm::EventSetup& es)
+ClusterShapeTrackFilter::ClusterShapeTrackFilter(const edm::ParameterSet& ps, edm::ConsumesCollector& iC):
+  theTracker(nullptr),
+  theFilter(nullptr)
 {
+  // Get ptMin if available
+  ptMin = (ps.exists("ptMin") ? ps.getParameter<double>("ptMin") : 0.);
+  ptMax = (ps.exists("ptMax") ? ps.getParameter<double>("ptMax") : 999999.);
+}
+
+/*****************************************************************************/
+ClusterShapeTrackFilter::~ClusterShapeTrackFilter()
+{
+}
+
+/*****************************************************************************/
+void ClusterShapeTrackFilter::update(const edm::Event& ev, const edm::EventSetup& es) {
   // Get tracker geometry
   edm::ESHandle<TrackerGeometry> tracker;
   es.get<TrackerDigiGeometryRecord>().get(tracker);
@@ -37,15 +50,6 @@ ClusterShapeTrackFilter::ClusterShapeTrackFilter
   edm::ESHandle<ClusterShapeHitFilter> shape;
   es.get<CkfComponentsRecord>().get("ClusterShapeHitFilter",shape);
   theFilter = shape.product();
-
-  // Get ptMin if available
-  ptMin = (ps.exists("ptMin") ? ps.getParameter<double>("ptMin") : 0.);
-  ptMax = (ps.exists("ptMax") ? ps.getParameter<double>("ptMax") : 999999.);
-}
-
-/*****************************************************************************/
-ClusterShapeTrackFilter::~ClusterShapeTrackFilter()
-{
 }
 
 /*****************************************************************************/

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/ValidHitPairFilter.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/ValidHitPairFilter.cc
@@ -49,8 +49,16 @@ float spin(float ph)
 
 /*****************************************************************************/
 ValidHitPairFilter::ValidHitPairFilter
-  (const edm::ParameterSet& ps, const edm::EventSetup& es)
+  (const edm::ParameterSet& ps, edm::ConsumesCollector& iC)
 {
+}
+
+/*****************************************************************************/
+ValidHitPairFilter::~ValidHitPairFilter()
+{
+}
+/*****************************************************************************/
+void ValidHitPairFilter::update(const edm::Event& ev, const edm::EventSetup& es) {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopo;
   es.get<IdealGeometryRecord>().get(tTopo);
@@ -129,10 +137,6 @@ ValidHitPairFilter::ValidHitPairFilter
   }
 }
 
-/*****************************************************************************/
-ValidHitPairFilter::~ValidHitPairFilter()
-{
-}
 /*****************************************************************************/
 int ValidHitPairFilter::getLayer(const TrackingRecHit & recHit, const TrackerTopology *tTopo) const
 {

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilter.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilter.h
@@ -2,7 +2,7 @@
 #define PixelTrackFitting_PixelTrackFilter_H
 
 namespace reco { class Track; }
-namespace edm { class Event; }
+namespace edm { class Event; class EventSetup; class ConsumesCollector;}
 class TrackingRecHit;
 
 #include <vector>
@@ -12,7 +12,7 @@ class PixelTrackFilter {
 public:
   virtual ~PixelTrackFilter() {}
   typedef std::vector<const TrackingRecHit *> Hits;
-  virtual void update(edm::Event& ev) {}
+  virtual void update(const edm::Event& ev, const edm::EventSetup& es) = 0;
   virtual bool operator()(const reco::Track*) const {return false;}
   virtual bool operator()(const reco::Track*, const Hits&) const {return false;} 
 };

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilterByKinematics.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilterByKinematics.h
@@ -8,9 +8,10 @@ namespace edm {class ParameterSet; class EventSetup; }
 class PixelTrackFilterByKinematics : public PixelTrackFilter {
 public:
   PixelTrackFilterByKinematics( const edm::ParameterSet& cfg);
-  PixelTrackFilterByKinematics( const edm::ParameterSet& cfg, const edm::EventSetup& es);
+  PixelTrackFilterByKinematics( const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
   PixelTrackFilterByKinematics(double ptmin = 0.9, double tipmax = 0.1, double chi2max = 100.);
   virtual ~PixelTrackFilterByKinematics();
+  void update(const edm::Event&, const edm::EventSetup&) override;
   virtual bool operator()(const reco::Track*) const;
   virtual bool operator()(const reco::Track*, const PixelTrackFilter::Hits & hits) const;
 private:

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilterFactory.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackFilterFactory.h
@@ -5,9 +5,8 @@
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 
 //class PixelTrackFilter;
-namespace edm {class ParameterSet; class EventSetup; }
+namespace edm {class ParameterSet; class EventSetup; class ConsumesCollector;}
 
-typedef edmplugin::PluginFactory<PixelTrackFilter *(const edm::ParameterSet & )> PixelTrackFilterFactory;
-typedef edmplugin::PluginFactory<PixelTrackFilter *(const edm::ParameterSet &,const edm::EventSetup&  )> PixelTrackFilterWithESFactory;
+typedef edmplugin::PluginFactory<PixelTrackFilter *(const edm::ParameterSet &, edm::ConsumesCollector&)> PixelTrackFilterFactory;
  
 #endif

--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackReconstruction.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackReconstruction.h
@@ -30,7 +30,7 @@ public:
 private:
   edm::ParameterSet theConfig;
   const PixelFitter       * theFitter;
-  PixelTrackFilter  * theFilter;
+  std::unique_ptr<PixelTrackFilter> theFilter;
   PixelTrackCleaner * theCleaner;
   OrderedHitsGenerator * theGenerator;
   TrackingRegionProducer* theRegionProducer;

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackFilterByKinematics.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackFilterByKinematics.cc
@@ -8,7 +8,7 @@ template <class T> T sqr( T t) {return t*t;}
 
 #include <iostream>
 
-PixelTrackFilterByKinematics::PixelTrackFilterByKinematics( const edm::ParameterSet& cfg, const edm::EventSetup &es)
+PixelTrackFilterByKinematics::PixelTrackFilterByKinematics( const edm::ParameterSet& cfg, edm::ConsumesCollector& iC)
   : thePtMin( cfg.getParameter<double>("ptMin") ),
     theNSigmaInvPtTolerance( cfg.getParameter<double>("nSigmaInvPtTolerance")),
     theTIPMax( cfg.getParameter<double>("tipMax") ),
@@ -32,6 +32,8 @@ PixelTrackFilterByKinematics::PixelTrackFilterByKinematics(double ptmin, double 
 
 PixelTrackFilterByKinematics::~PixelTrackFilterByKinematics()
 { }
+
+void PixelTrackFilterByKinematics::update(const edm::Event&, const edm::EventSetup&) {}
 
 bool PixelTrackFilterByKinematics::operator()(const reco::Track* track, const PixelTrackFilter::Hits & hits) const
 { return (*this)(track); }

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackFilterFactory.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackFilterFactory.cc
@@ -3,5 +3,4 @@
 #include "FWCore/PluginManager/interface/PluginFactory.h"
 
 EDM_REGISTER_PLUGINFACTORY(PixelTrackFilterFactory,"PixelTrackFilterFactory");
-EDM_REGISTER_PLUGINFACTORY(PixelTrackFilterWithESFactory,"PixelTrackFilterWithESFactory");
 

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstruction.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelTrackReconstruction.cc
@@ -35,7 +35,7 @@ using edm::ParameterSet;
 
 PixelTrackReconstruction::PixelTrackReconstruction(const ParameterSet& cfg,
 	   edm::ConsumesCollector && iC)
-  : theConfig(cfg), theFitter(0), theFilter(0), theCleaner(0), theGenerator(0), theRegionProducer(0), theMerger_(0)
+  : theConfig(cfg), theFitter(0), theCleaner(0), theGenerator(0), theRegionProducer(0), theMerger_(0)
 {
   if ( cfg.exists("SeedMergerPSet") ) {
     edm::ParameterSet mergerPSet = theConfig.getParameter<edm::ParameterSet>( "SeedMergerPSet" );
@@ -50,10 +50,18 @@ PixelTrackReconstruction::PixelTrackReconstruction(const ParameterSet& cfg,
     theMerger_->setLayerListName( seedmergerLayerListName );
   }
 
+  ParameterSet filterPSet = theConfig.getParameter<ParameterSet>("FilterPSet");
+  std::string  filterName = filterPSet.getParameter<std::string>("ComponentName");
+  if (filterName != "none") {
+    theFilter.reset(PixelTrackFilterFactory::get()->create( filterName, filterPSet, iC));
+    if(theConfig.exists("useFilterWithES")) {
+      edm::LogInfo("Obsolete") << "useFilterWithES parameter is obsolete and can be removed";
+    }
+  }
+
   ParameterSet regfactoryPSet = theConfig.getParameter<ParameterSet>("RegionFactoryPSet");
   std::string regfactoryName = regfactoryPSet.getParameter<std::string>("ComponentName");
   theRegionProducer = TrackingRegionProducerFactory::get()->create(regfactoryName,regfactoryPSet, std::move(iC));
-
 }
   
 PixelTrackReconstruction::~PixelTrackReconstruction() 
@@ -64,7 +72,6 @@ PixelTrackReconstruction::~PixelTrackReconstruction()
 
 void PixelTrackReconstruction::halt()
 {
-  delete theFilter; theFilter=0;
   delete theFitter; theFitter=0;
   delete theCleaner; theCleaner=0;
   delete theGenerator; theGenerator=0;
@@ -82,14 +89,6 @@ void PixelTrackReconstruction::init(const edm::EventSetup& es)
   ParameterSet fitterPSet = theConfig.getParameter<ParameterSet>("FitterPSet");
   std::string fitterName = fitterPSet.getParameter<std::string>("ComponentName");
   theFitter = PixelFitterFactory::get()->create( fitterName, fitterPSet);
-
-  ParameterSet filterPSet = theConfig.getParameter<ParameterSet>("FilterPSet");
-  std::string  filterName = filterPSet.getParameter<std::string>("ComponentName");
-  if (filterName != "none") {
-    theFilter = theConfig.getParameter<bool>("useFilterWithES") ?
-      PixelTrackFilterWithESFactory::get()->create( filterName, filterPSet, es) :
-      PixelTrackFilterFactory::get()->create( filterName, filterPSet);
-  }
 
   ParameterSet cleanerPSet = theConfig.getParameter<ParameterSet>("CleanerPSet");
   std::string  cleanerName = cleanerPSet.getParameter<std::string>("ComponentName");
@@ -111,7 +110,7 @@ void PixelTrackReconstruction::run(TracksWithTTRHs& tracks, edm::Event& ev, cons
   es.get<IdealGeometryRecord>().get(tTopoHand);
   const TrackerTopology *tTopo=tTopoHand.product();
 
-  if (theFilter) theFilter->update(ev);
+  if (theFilter) theFilter->update(ev, es);
 
   for (IR ir=regions.begin(), irEnd=regions.end(); ir < irEnd; ++ir) {
     const TrackingRegion & region = **ir;


### PR DESCRIPTION
Migrate HIProtoTrackFilter and HIPixelTrackFilter to `getByToken()`. As a consequence, `PixelTrackFilter` objects are constructed from EDModule constructos in order to deliver `edm::ConsumesCollector`. In addition, `edm::EventSetup` is always delivered in `PixelTrackFilter::update`, and it is up to the deriving class to use it or not (previously `edm::EventSetup` was delivered in the `PixelTrackFilter` constructor if needed).

Configuration parameter `useFilterWithES` in `PixelTrackReconstruction` class became obsolete, I added LogInfo message for that.
