### PR TITLE
add support for multiProcesses cmsRun to the DQMFileSaver

### DIFF
--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -10,6 +10,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/MessageLogger/interface/JobReport.h"
 #include <sys/stat.h>
+#include <sys/types.h>
 #include <unistd.h>
 #include <iostream>
 #include <vector>
@@ -47,8 +48,8 @@ DQMFileSaver::saveForOffline(const std::string &workflow, int run, int lumi)
   wflow = workflow;
   while ((pos = wflow.find('/', pos)) != std::string::npos)
     wflow.replace(pos++, 1, "__");
-    
-  std::string filename = fileBaseName_ + suffix + wflow + ".root";
+
+  std::string filename = fileBaseName_ + suffix + wflow + child_ + ".root";
 
   if (lumi == 0) // save for run
   {
@@ -155,7 +156,7 @@ DQMFileSaver::saveForOnline(const std::string &suffix, const std::string &rewrit
       if (MonitorElement* me = dbe_->get(systems[i] + "/EventInfo/processName"))
       {
 	doSaveForOnline(pastSavedFiles_, numKeepSavedFiles_, dbe_,
-			fileBaseName_ + me->getStringValue() + suffix + ".root",
+			fileBaseName_ + me->getStringValue() + suffix + child_ + ".root",
 			"", "^(Reference/)?([^/]+)", rewrite,
 	                (DQMStore::SaveReferenceTag) saveReference_,
 	                saveReferenceQMin_);
@@ -172,7 +173,7 @@ DQMFileSaver::saveForOnline(const std::string &suffix, const std::string &rewrit
       std::vector<MonitorElement*> pNamesVector = dbe_->getMatchingContents("^" + systems[i] + "/.*/EventInfo/processName",lat::Regexp::Perl);
       if (pNamesVector.size() > 0){
         doSaveForOnline(pastSavedFiles_, numKeepSavedFiles_, dbe_,
-                        fileBaseName_ + systems[i] + suffix + ".root",
+                        fileBaseName_ + systems[i] + suffix + child_ + ".root",
                         "", "^(Reference/)?([^/]+)", rewrite,
                         (DQMStore::SaveReferenceTag) saveReference_,
                         saveReferenceQMin_);
@@ -185,7 +186,7 @@ DQMFileSaver::saveForOnline(const std::string &suffix, const std::string &rewrit
   for (size_t i = 0, e = systems.size(); i != e; ++i)
     if (systems[i] != "Reference")
       doSaveForOnline(pastSavedFiles_, numKeepSavedFiles_, dbe_,
-                      fileBaseName_ + systems[i] + suffix + ".root",
+                      fileBaseName_ + systems[i] + suffix + child_ + ".root",
 	              systems[i], "^(Reference/)?([^/]+)", rewrite,
 	              (DQMStore::SaveReferenceTag) saveReference_,
 	              saveReferenceQMin_);
@@ -213,6 +214,7 @@ DQMFileSaver::DQMFileSaver(const edm::ParameterSet &ps)
     workflow_ (""),
     producer_ ("DQM"),
     dirName_ ("."),
+    child_ (""),
     version_ (1),
     runIsComplete_ (false),
     enableMultiThread_(ps.getUntrackedParameter<bool>("enableMultiThread", false)),
@@ -515,4 +517,23 @@ DQMFileSaver::endJob(void)
 	<< " job in Offline mode with run number overridden.";
   }
     
+}
+
+void
+DQMFileSaver::postForkReacquireResources(unsigned int childIndex, unsigned int numberOfChildren)
+{
+  // this is copied from IOPool/Output/src/PoolOutputModule.cc, for consistency
+  unsigned int digits = 0;
+  while (numberOfChildren != 0) {
+    ++digits;
+    numberOfChildren /= 10;
+  }
+  // protect against zero numberOfChildren
+  if (digits == 0) {
+    digits = 3;
+  }
+
+  char buffer[digits + 2];
+  snprintf(buffer, digits + 2, "_%0*d", digits, childIndex);
+  child_ = std::string(buffer);
 }

--- a/DQMServices/Components/src/DQMFileSaver.h
+++ b/DQMServices/Components/src/DQMFileSaver.h
@@ -20,6 +20,7 @@ protected:
   virtual void endLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup &);
   virtual void endRun(const edm::Run &, const edm::EventSetup &);
   virtual void endJob(void);
+  virtual void postForkReacquireResources(unsigned int childIndex, unsigned int numberOfChildren);
 
 private:
   void saveForOffline(const std::string &workflow, int run, int lumi);
@@ -36,6 +37,7 @@ private:
   std::string	workflow_;
   std::string	producer_;
   std::string	dirName_;
+  std::string   child_;
   int        	version_;
   bool		runIsComplete_;
   bool          enableMultiThread_;


### PR DESCRIPTION
Minimal patch to add support for "multiProcesses cmsRun" (i.e., forking children process from a cmsRun master) to the DQMFileSaver.

It adds _N to the the file names used by the DQM, using the ame logic as the PoolOutputModule.

The DQM files produced in this way should then be merged together to recover the original file name before begin loaded in the DQM GUI. 
