### PR TITLE
add to the FastTimerService support for unscheduled execution

### DIFF
--- a/HLTrigger/Timer/interface/FastTimer.h
+++ b/HLTrigger/Timer/interface/FastTimer.h
@@ -8,30 +8,37 @@ class FastTimer {
 public:
   typedef std::chrono::high_resolution_clock Clock;
   typedef std::chrono::nanoseconds           Duration;
-  enum class Status {
+  enum class State {
     kStopped,
-    kRunning
+    kRunning,
+    kPaused
   };
 
   FastTimer();
 
   void start();
+  void pause();
+  void resume();
   void stop();
   void reset();
 
   Duration value() const;
   Duration untilNow() const;
-  Status status() const;
+  double seconds() const;
+  double secondsUntilNow() const;
+  State state() const;
   Clock::time_point const & getStartTime() const;
   Clock::time_point const & getStopTime() const;
   void setStartTime(Clock::time_point const &);
   void setStopTime(Clock::time_point const &);
 
 private:
-  Duration          m_duration;
+  std::string const & describe() const;
+
   Clock::time_point m_start;
   Clock::time_point m_stop;
-  Status            m_status;
+  Duration          m_duration;
+  State             m_state;
 };
 
 #endif // ! FastTimer_h

--- a/HLTrigger/Timer/interface/FastTimerService.h
+++ b/HLTrigger/Timer/interface/FastTimerService.h
@@ -294,7 +294,6 @@ private:
   const bool                                    m_enable_dqm_byls;
   const bool                                    m_enable_dqm_bynproc;
 
-  bool                                          m_nproc_enabled;                // check if the plots by number of processes have been correctly enabled
   unsigned int                                  m_concurrent_runs;
   unsigned int                                  m_concurrent_streams;
   unsigned int                                  m_concurrent_threads;
@@ -310,7 +309,6 @@ private:
   const uint32_t                                m_dqm_ls_range;
   const std::string                             m_dqm_path;
   const edm::InputTag                           m_luminosity_label;     // label of the per-Event luminosity EDProduct
-  const std::vector<unsigned int>               m_supported_processes;  // possible number of concurrent processes
 
   // job configuration and caching
   std::string                                   m_first_path;           // the framework does not provide a pre-paths or pre-endpaths signal,
@@ -509,11 +507,6 @@ private:
     SummaryProfiles                                 dqm_byls;                   // plots per lumisection
     SummaryProfiles                                 dqm_byluminosity;           // plots vs. instantaneous luminosity
 
-    // plots to be summed over nodes with the same number of processes/threads
-    SummaryPlots                                    dqm_nproc;                  // event summary plots
-    SummaryProfiles                                 dqm_nproc_byls;             // plots per lumisection
-    SummaryProfiles                                 dqm_nproc_byluminosity;     // plots vs. instantaneous luminosity
-
     // plots by path
     TProfile *                                      dqm_paths_active_time;
     TProfile *                                      dqm_paths_total_time;
@@ -544,10 +537,6 @@ private:
       dqm(),
       dqm_byls(),
       dqm_byluminosity(),
-      // plots to be summed over nodes with the same number of processes/threads
-      dqm_nproc(),
-      dqm_nproc_byls(),
-      dqm_nproc_byluminosity(),
       // plots by path
       dqm_paths_active_time(nullptr),
       dqm_paths_total_time(nullptr),

--- a/HLTrigger/Timer/interface/FastTimerService.h
+++ b/HLTrigger/Timer/interface/FastTimerService.h
@@ -135,7 +135,8 @@ private:
   struct PathInfo;
 
   struct ModuleInfo {
-    double                      time_active;        // per-event timer: time actually spent in this module
+    FastTimer                   timer;              // per-event timer
+    double                      time_active;        // time actually spent in this module
     double                      summary_active;
     TH1F *                      dqm_active;
     PathInfo *                  run_in_path;        // the path inside which the module was atually active
@@ -143,6 +144,7 @@ private:
 
   public:
     ModuleInfo() :
+      timer(),
       time_active(0.),
       summary_active(0.),
       dqm_active(nullptr),
@@ -156,6 +158,7 @@ private:
 
     // reset the timers and DQM plots
     void reset() {
+      timer.reset();
       time_active = 0.;
       summary_active = 0.;
       // the DAQ destroys and re-creates the DQM and DQMStore services at each reconfigure, so we don't need to clean them up
@@ -167,13 +170,14 @@ private:
 
   struct PathInfo {
     std::vector<ModuleInfo *>   modules;            // list of all modules contributing to the path (duplicate modules stored as null pointers)
-    double                      time_active;        // per-event timer: time actually spent in this path
-    double                      time_exclusive;     // per-event timer: time actually spent in this path, in modules that are not run on any other paths
-    double                      time_premodules;    // per-event timer: time spent between "begin path" and the first "begin module"
-    double                      time_intermodules;  // per-event timer: time spent between modules
-    double                      time_postmodules;   // per-event timer: time spent between the last "end module" and "end path"
-    double                      time_overhead;      // per-event timer: sum of time_premodules, time_intermodules, time_postmodules
-    double                      time_total;         // per-event timer: sum of the time spent in all modules which would have run in this path (plus overhead)
+    FastTimer                   timer;              // per-event timer
+    double                      time_active;        // time actually spent in this path
+    double                      time_exclusive;     // time actually spent in this path, in modules that are not run on any other paths
+    double                      time_premodules;    // time spent between "begin path" and the first "begin module"
+    double                      time_intermodules;  // time spent between modules
+    double                      time_postmodules;   // time spent between the last "end module" and "end path"
+    double                      time_overhead;      // sum of time_premodules, time_intermodules, time_postmodules
+    double                      time_total;         // sum of the time spent in all modules which would have run in this path (plus overhead)
     double                      summary_active;
     double                      summary_premodules;
     double                      summary_intermodules;
@@ -197,6 +201,7 @@ private:
   public:
     PathInfo() :
       modules(),
+      timer(),
       time_active(0.),
       time_exclusive(0.),
       time_premodules(0.),
@@ -232,6 +237,7 @@ private:
     // reset the timers and DQM plots
     void reset() {
       modules.clear();
+      timer.reset();
       time_active = 0.;
       time_exclusive = 0.;
       time_premodules = 0.;
@@ -311,7 +317,6 @@ private:
   std::string                                   m_last_path;            // so we emulate them keeping track of the first and last path and endpath
   std::string                                   m_first_endpath;
   std::string                                   m_last_endpath;
-  bool                                          m_is_first_module;      // helper to measure the time spent between the beginning of the path and the execution of the first module
   bool                                          m_is_first_event;
 
   struct Timing {
@@ -398,7 +403,6 @@ private:
 
   };
 
-  std::vector<Timing>                           m_event;                // time accounting per-event (and per-stream)
   std::vector<Timing>                           m_run_summary;          // time accounting per-run
   Timing                                        m_job_summary;          // time accounting per-job
 
@@ -489,32 +493,53 @@ private:
   };
 
   struct StreamData {
+    // timers
+    FastTimer                                       timer_event;                // track time spent in each event
+    FastTimer                                       timer_source;               // track time spent in the source
+    FastTimer                                       timer_paths;                // track time spent in all paths
+    FastTimer                                       timer_endpaths;             // track time spent in all endpaths
+    FastTimer                                       timer_path;                 // track time spent in each path
+    FastTimer::Clock::time_point                    timer_last_path;            // record the stop of the last path run
+
+    // time accounting per-event
+    Timing                                          timing;
 
     // overall plots
-    SummaryPlots    dqm;                          // event summary plots
-    SummaryProfiles dqm_byls;                     // plots per lumisection
-    SummaryProfiles dqm_byluminosity;             // plots vs. instantaneous luminosity
+    SummaryPlots                                    dqm;                        // event summary plots
+    SummaryProfiles                                 dqm_byls;                   // plots per lumisection
+    SummaryProfiles                                 dqm_byluminosity;           // plots vs. instantaneous luminosity
 
     // plots to be summed over nodes with the same number of processes/threads
-    SummaryPlots    dqm_nproc;                    // event summary plots
-    SummaryProfiles dqm_nproc_byls;               // plots per lumisection
-    SummaryProfiles dqm_nproc_byluminosity;       // plots vs. instantaneous luminosity
+    SummaryPlots                                    dqm_nproc;                  // event summary plots
+    SummaryProfiles                                 dqm_nproc_byls;             // plots per lumisection
+    SummaryProfiles                                 dqm_nproc_byluminosity;     // plots vs. instantaneous luminosity
 
     // plots by path
-    TProfile *      dqm_paths_active_time;
-    TProfile *      dqm_paths_total_time;
-    TProfile *      dqm_paths_exclusive_time;
-    TProfile *      dqm_paths_interpaths;
+    TProfile *                                      dqm_paths_active_time;
+    TProfile *                                      dqm_paths_total_time;
+    TProfile *                                      dqm_paths_exclusive_time;
+    TProfile *                                      dqm_paths_interpaths;
 
     // per-path, per-module and per-module-type accounting
-    PathInfo *                                    current_path;
-    PathMap<PathInfo>                             paths;
-    std::unordered_map<std::string, ModuleInfo>   modules;
-    std::unordered_map<std::string, ModuleInfo>   moduletypes;
-    ModuleMap<ModuleInfo *>                       fast_modules;           // these assume that ModuleDescription are stored in the same object through the whole job,
-    ModuleMap<ModuleInfo *>                       fast_moduletypes;       // which is true only *after* the edm::Worker constructors have run
+    PathInfo *                                      current_path;
+    ModuleInfo *                                    current_module;
+    ModuleInfo *                                    first_module_in_path;
+    PathMap<PathInfo>                               paths;
+    std::unordered_map<std::string, ModuleInfo>     modules;
+    std::unordered_map<std::string, ModuleInfo>     moduletypes;
+    ModuleMap<ModuleInfo *>                         fast_modules;               // these assume that ModuleDescription are stored in the same object through the whole job,
+    ModuleMap<ModuleInfo *>                         fast_moduletypes;           // which is true only *after* the edm::Worker constructors have run
 
     StreamData() :
+      // timers
+      timer_event(),
+      timer_source(),
+      timer_paths(),
+      timer_endpaths(),
+      timer_path(),
+      timer_last_path(),
+      // time accounting per-event
+      timing(),
       // overall plots
       dqm(),
       dqm_byls(),
@@ -529,7 +554,9 @@ private:
       dqm_paths_exclusive_time(nullptr),
       dqm_paths_interpaths(nullptr),
       // per-path, per-module and per-module-type accounting
-      current_path(0),
+      current_path(nullptr),
+      current_module(nullptr),
+      first_module_in_path(nullptr),
       paths(),
       modules(),
       moduletypes(),
@@ -541,36 +568,10 @@ private:
 
   std::vector<StreamData> m_stream;
 
-  // timers
-  FastTimer                     m_timer_event;          // track time spent in each event
-  FastTimer                     m_timer_source;         // track time spent in the source
-  FastTimer                     m_timer_paths;          // track time spent in all paths
-  FastTimer                     m_timer_endpaths;       // track time spent in all endpaths
-  FastTimer                     m_timer_path;           // track time spent in each path
-  FastTimer                     m_timer_module;         // track time spent in each module
-  FastTimer::Clock::time_point  m_timer_first_module;   // record the start of the first active module in a path, if any
-
-  void start(FastTimer & times) const
-  {
-    times.start();
-  }
-
-  void stop(FastTimer & times) const
-  {
-    times.stop();
-  }
-
   static
   double delta(FastTimer::Clock::time_point const & first, FastTimer::Clock::time_point const & second)
   {
     return std::chrono::duration_cast<std::chrono::duration<double>>(second - first).count();
-  }
-
-  static
-  double delta(FastTimer const & times)
-  {
-    //return std::chrono::duration_cast<std::chrono::duration<double>>(times.value()).count();
-    return std::chrono::duration_cast<std::chrono::duration<double>>(times.getStopTime() - times.getStartTime()).count();
   }
 
   // associate to a path all the modules it contains

--- a/HLTrigger/Timer/interface/FastTimerService.h
+++ b/HLTrigger/Timer/interface/FastTimerService.h
@@ -320,10 +320,10 @@ private:
   bool                                          m_is_first_event;
 
   struct Timing {
-    double              event;                  // time spent processing the Event
     double              presource;              // time spent between the end of the previous Event, LumiSection or Run, and the beginning of the Source
     double              source;                 // time spent processing the Source
-    double              postsource;             // time spent between the end of the Source and the new Event, Lumisection or Run
+    double              preevent;               // time spent between the end of the Source and the new Event, Lumisection or Run
+    double              event;                  // time spent processing the Event
     double              all_paths;              // time spent processing all Paths
     double              all_endpaths;           // time spent processing all EndPaths
     double              interpaths;             // time spent between the Paths (and EndPaths - i.e. the sum of all the entries in the following vector)
@@ -331,10 +331,10 @@ private:
     unsigned int        count;                  // number of processed events (used by the per-run and per-job accounting)
 
     Timing() :
-      event         (0.),
       presource     (0.),
       source        (0.),
-      postsource    (0.),
+      preevent      (0.),
+      event         (0.),
       all_paths     (0.),
       all_endpaths  (0.),
       interpaths    (0.),
@@ -343,10 +343,10 @@ private:
     { }
 
     Timing(std::vector<double>::size_type size) :
-      event         (0.),
       presource     (0.),
       source        (0.),
-      postsource    (0.),
+      preevent      (0.),
+      event         (0.),
       all_paths     (0.),
       all_endpaths  (0.),
       interpaths    (0.),
@@ -355,10 +355,10 @@ private:
     { }
 
     void reset() {
-      event         = 0.;
       presource     = 0.;
       source        = 0.;
-      postsource    = 0.;
+      preevent      = 0.;
+      event         = 0.;
       all_paths     = 0.;
       all_endpaths  = 0.;
       interpaths    = 0.;
@@ -367,10 +367,10 @@ private:
     }
 
     void reset(std::vector<double>::size_type size) {
-      event         = 0.;
       presource     = 0.;
       source        = 0.;
-      postsource    = 0.;
+      preevent      = 0.;
+      event         = 0.;
       all_paths     = 0.;
       all_endpaths  = 0.;
       interpaths    = 0.;
@@ -381,10 +381,10 @@ private:
     Timing & operator+=(Timing const & other) {
       assert( paths_interpaths.size() == other.paths_interpaths.size() );
 
-      event         += other.event;
       presource     += other.presource;
       source        += other.source;
-      postsource    += other.postsource;
+      preevent      += other.preevent;
+      event         += other.event;
       all_paths     += other.all_paths;
       all_endpaths  += other.all_endpaths;
       interpaths    += other.interpaths;
@@ -410,29 +410,29 @@ private:
 
   // set of summary plots
   struct SummaryPlots {
-    TH1F *     event;
     TH1F *     presource;
     TH1F *     source;
-    TH1F *     postsource;
+    TH1F *     preevent;
+    TH1F *     event;
     TH1F *     all_paths;
     TH1F *     all_endpaths;
     TH1F *     interpaths;
 
     SummaryPlots() :
-      event         (nullptr),
       presource     (nullptr),
       source        (nullptr),
-      postsource    (nullptr),
+      preevent      (nullptr),
+      event         (nullptr),
       all_paths     (nullptr),
       all_endpaths  (nullptr),
       interpaths    (nullptr)
     { }
 
     void reset() {
-      event         = nullptr;
       presource     = nullptr;
       source        = nullptr;
-      postsource    = nullptr;
+      preevent      = nullptr;
+      event         = nullptr;
       all_paths     = nullptr;
       all_endpaths  = nullptr;
       interpaths    = nullptr;
@@ -440,10 +440,10 @@ private:
 
     void fill(Timing const & value) {
       // convert on the fly from seconds to ms
-      event         ->Fill( 1000. * value.event );
       presource     ->Fill( 1000. * value.presource );
       source        ->Fill( 1000. * value.source );
-      postsource    ->Fill( 1000. * value.postsource );
+      preevent      ->Fill( 1000. * value.preevent );
+      event         ->Fill( 1000. * value.event );
       all_paths     ->Fill( 1000. * value.all_paths );
       all_endpaths  ->Fill( 1000. * value.all_endpaths );
       interpaths    ->Fill( 1000. * value.interpaths );
@@ -452,39 +452,39 @@ private:
   };
 
   struct SummaryProfiles {
-    TProfile * event;
     TProfile * presource;
     TProfile * source;
-    TProfile * postsource;
+    TProfile * preevent;
+    TProfile * event;
     TProfile * all_paths;
     TProfile * all_endpaths;
     TProfile * interpaths;
 
     SummaryProfiles() :
-      event         (nullptr),
       presource     (nullptr),
       source        (nullptr),
-      postsource    (nullptr),
+      preevent      (nullptr),
+      event         (nullptr),
       all_paths     (nullptr),
       all_endpaths  (nullptr),
       interpaths    (nullptr)
     { }
 
     void reset() {
-      event         = nullptr;
       presource     = nullptr;
       source        = nullptr;
-      postsource    = nullptr;
+      preevent      = nullptr;
+      event         = nullptr;
       all_paths     = nullptr;
       all_endpaths  = nullptr;
       interpaths    = nullptr;
     }
 
     void fill(double x, Timing const & value) {
-      event         ->Fill( x, 1000. * value.event );
       presource     ->Fill( x, 1000. * value.presource );
       source        ->Fill( x, 1000. * value.source );
-      postsource    ->Fill( x, 1000. * value.postsource );
+      preevent      ->Fill( x, 1000. * value.preevent );
+      event         ->Fill( x, 1000. * value.event );
       all_paths     ->Fill( x, 1000. * value.all_paths );
       all_endpaths  ->Fill( x, 1000. * value.all_endpaths );
       interpaths    ->Fill( x, 1000. * value.interpaths );

--- a/HLTrigger/Timer/src/FastTimer.cc
+++ b/HLTrigger/Timer/src/FastTimer.cc
@@ -1,42 +1,69 @@
 // C++ headers
 #include <chrono>
-#include <iostream>     // cerr
+#include <iostream>
+#include <vector>
+#include <string>
 
 #include "HLTrigger/Timer/interface/FastTimer.h"
 
 FastTimer::FastTimer() :
-  m_duration(Duration::zero()),
   m_start(),
   m_stop(),
-  m_status(Status::kStopped)
+  m_duration(Duration::zero()),
+  m_state(State::kStopped)
 { }
 
 // start the timer - only if it was not running
 void FastTimer::start() {
-  if (m_status == Status::kStopped) {
+  if (m_state == State::kStopped) {
     m_start    = Clock::now();
-  //m_stop     = Clock::time_point();   // FIXME re-enable this once there is a better way to fill the interpath data
-    m_status   = Status::kRunning;
+    m_stop     = Clock::time_point();
+    m_duration = Duration::zero();
+    m_state    = State::kRunning;
   } else {
-    std::cerr << "attempting to start an already running timer" << std::endl;
+    std::cerr << "attempting to start a " << describe() << " timer" << std::endl;
   }
 }
 
 // stop the timer - only if it was running
 void FastTimer::stop() {
-  if (m_status == Status::kRunning) {
+  if (m_state == State::kRunning) {
     m_stop     = Clock::now();
     m_duration += std::chrono::duration_cast<Duration>(m_stop - m_start);
-    m_status   = Status::kStopped;
+    m_state    = State::kStopped;
+  } else {
+    std::cerr << "attempting to stop a " << describe() << " timer" << std::endl;
+  }
+}
+
+// pause the timer - only if it was running
+void FastTimer::pause() {
+  if (m_state == State::kRunning) {
+    m_stop     = Clock::now();
+    m_duration += std::chrono::duration_cast<Duration>(m_stop - m_start);
+    m_state    = State::kPaused;
+  } else {
+    std::cerr << "attempting to pause a " << describe() << " timer" << std::endl;
+  }
+}
+
+// resume the timer - only if it was not running
+void FastTimer::resume() {
+  if (m_state == State::kPaused) {
+    m_start    = Clock::now();
+    m_stop     = Clock::time_point();
+    m_state    = State::kRunning;
+  } else {
+    std::cerr << "attempting to resume a " << describe() << " timer" << std::endl;
   }
 }
 
 // reset the timer
 void FastTimer::reset() {
-  m_duration = Duration::zero();
   m_start    = Clock::time_point();
   m_stop     = Clock::time_point();
-  m_status   = Status::kStopped;
+  m_duration = Duration::zero();
+  m_state    = State::kStopped;
 }
 
 // read the accumulated time
@@ -44,14 +71,39 @@ FastTimer::Duration FastTimer::value() const {
   return m_duration;
 }
 
+// read the accumulated time, in seconds
+double FastTimer::seconds() const {
+  return std::chrono::duration_cast<std::chrono::duration<double>>(m_duration).count();
+}
+
 // if the timer is stopped, read the accumulate time
 // if the timer is running, also add the time up to "now" 
 FastTimer::Duration FastTimer::untilNow() const {
-  return m_duration + ( (m_status == Status::kRunning) ? std::chrono::duration_cast<Duration>(Clock::now() - m_start) : Duration::zero() );
+  return m_duration + ( (m_state == State::kRunning) ? std::chrono::duration_cast<Duration>(Clock::now() - m_start) : Duration::zero() );
 }
 
-FastTimer::Status FastTimer::status() const {
-  return m_status;
+double FastTimer::secondsUntilNow() const {
+  return std::chrono::duration_cast<std::chrono::duration<double>>(untilNow()).count();
+}
+
+// return the current state
+FastTimer::State FastTimer::state() const {
+  return m_state;
+}
+
+// descrbe the current state
+std::string const & FastTimer::describe() const {
+  static const std::vector<std::string> states{ "stopped", "running", "paused", "unknown" };
+
+  switch (m_state) {
+    case FastTimer::State::kStopped:
+    case FastTimer::State::kRunning:
+    case FastTimer::State::kPaused:
+      return states[static_cast<unsigned int>(m_state)];
+
+    default:
+      return states.back();
+  }
 }
 
 FastTimer::Clock::time_point const & FastTimer::getStartTime() const {

--- a/HLTrigger/Timer/src/FastTimerService.cc
+++ b/HLTrigger/Timer/src/FastTimerService.cc
@@ -232,9 +232,9 @@ void FastTimerService::preGlobalBeginRun( edm::GlobalContext const & )
         stream.dqm.source        = m_dqms->book1D("source",       "Source processing time",        modulebins, 0., m_dqm_moduletime_range)->getTH1F();
         stream.dqm.source        ->StatOverflows(true);
         stream.dqm.source        ->SetXTitle("processing time [ms]");
-        stream.dqm.postsource    = m_dqms->book1D("postsource",   "Post-Source processing time",   modulebins, 0., m_dqm_moduletime_range)->getTH1F();
-        stream.dqm.postsource    ->StatOverflows(true);
-        stream.dqm.postsource    ->SetXTitle("processing time [ms]");
+        stream.dqm.preevent      = m_dqms->book1D("preevent",     "Pre-Event processing time",     modulebins, 0., m_dqm_moduletime_range)->getTH1F();
+        stream.dqm.preevent      ->StatOverflows(true);
+        stream.dqm.preevent      ->SetXTitle("processing time [ms]");
         stream.dqm.all_paths     = m_dqms->book1D("all_paths",    "Paths processing time",         eventbins,  0., m_dqm_eventtime_range)->getTH1F();
         stream.dqm.all_paths     ->StatOverflows(true);
         stream.dqm.all_paths     ->SetXTitle("processing time [ms]");
@@ -263,10 +263,10 @@ void FastTimerService::preGlobalBeginRun( edm::GlobalContext const & )
           plot->StatOverflows(true);
           plot->SetXTitle("processing time [ms]");
           if (m_concurrent_threads == n) stream.dqm_nproc.source = plot;
-          plot = m_dqms->book1D("postsource",   "Post-Source processing time", modulebins, 0., m_dqm_moduletime_range)->getTH1F();
+          plot = m_dqms->book1D("preevent",     "Pre-Event processing time",   modulebins, 0., m_dqm_moduletime_range)->getTH1F();
           plot->StatOverflows(true);
           plot->SetXTitle("processing time [ms]");
-          if (m_concurrent_threads == n) stream.dqm_nproc.postsource = plot;
+          if (m_concurrent_threads == n) stream.dqm_nproc.preevent = plot;
           plot = m_dqms->book1D("all_paths",    "Paths processing time",       eventbins,  0., m_dqm_eventtime_range)->getTH1F();
           plot->StatOverflows(true);
           plot->SetXTitle("processing time [ms]");
@@ -327,10 +327,10 @@ void FastTimerService::preGlobalBeginRun( edm::GlobalContext const & )
         stream.dqm_byls.source       ->StatOverflows(true);
         stream.dqm_byls.source       ->SetXTitle("lumisection");
         stream.dqm_byls.source       ->SetYTitle("processing time [ms]");
-        stream.dqm_byls.postsource   = m_dqms->bookProfile("postsource_byls",   "Post-Source processing time, by LumiSection", m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-        stream.dqm_byls.postsource   ->StatOverflows(true);
-        stream.dqm_byls.postsource   ->SetXTitle("lumisection");
-        stream.dqm_byls.postsource   ->SetYTitle("processing time [ms]");
+        stream.dqm_byls.preevent     = m_dqms->bookProfile("preevent_byls",     "Pre-Event processing time, by LumiSection",   m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+        stream.dqm_byls.preevent     ->StatOverflows(true);
+        stream.dqm_byls.preevent     ->SetXTitle("lumisection");
+        stream.dqm_byls.preevent     ->SetYTitle("processing time [ms]");
         stream.dqm_byls.all_paths    = m_dqms->bookProfile("all_paths_byls",    "Paths processing time, by LumiSection",       m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
         stream.dqm_byls.all_paths    ->StatOverflows(true);
         stream.dqm_byls.all_paths    ->SetXTitle("lumisection");
@@ -365,11 +365,11 @@ void FastTimerService::preGlobalBeginRun( edm::GlobalContext const & )
           plot->SetXTitle("lumisection");
           plot->SetYTitle("processing time [ms]");
           if (m_concurrent_threads == n) stream.dqm_nproc_byls.source = plot;
-          plot = m_dqms->bookProfile("postsource_byls",   "Post-Source processing time, by LumiSection",   m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+          plot = m_dqms->bookProfile("preevent_byls",     "Pre-Event processing time, by LumiSection",   m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
           plot->StatOverflows(true);
           plot->SetXTitle("lumisection");
           plot->SetYTitle("processing time [ms]");
-          if (m_concurrent_threads == n) stream.dqm_nproc_byls.postsource = plot;
+          if (m_concurrent_threads == n) stream.dqm_nproc_byls.preevent = plot;
           plot = m_dqms->bookProfile("all_paths_byls",    "Paths processing time, by LumiSection",    m_dqm_ls_range, 0.5, m_dqm_ls_range+0.5, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
           plot->StatOverflows(true);
           plot->SetXTitle("lumisection");
@@ -403,10 +403,10 @@ void FastTimerService::preGlobalBeginRun( edm::GlobalContext const & )
         stream.dqm_byluminosity.source       ->StatOverflows(true);
         stream.dqm_byluminosity.source       ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
         stream.dqm_byluminosity.source       ->SetYTitle("processing time [ms]");
-        stream.dqm_byluminosity.postsource   = m_dqms->bookProfile("postsource_byluminosity",   "Post-Source processing time vs. instantaneous luminosity",  lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
-        stream.dqm_byluminosity.postsource   ->StatOverflows(true);
-        stream.dqm_byluminosity.postsource   ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
-        stream.dqm_byluminosity.postsource   ->SetYTitle("processing time [ms]");
+        stream.dqm_byluminosity.preevent     = m_dqms->bookProfile("preevent_byluminosity",     "Pre-Event processing time vs. instantaneous luminosity",    lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+        stream.dqm_byluminosity.preevent     ->StatOverflows(true);
+        stream.dqm_byluminosity.preevent     ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
+        stream.dqm_byluminosity.preevent     ->SetYTitle("processing time [ms]");
         stream.dqm_byluminosity.all_paths    = m_dqms->bookProfile("all_paths_byluminosity",    "Paths processing time vs. instantaneous luminosity",        lumibins, 0., m_dqm_luminosity_range, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
         stream.dqm_byluminosity.all_paths    ->StatOverflows(true);
         stream.dqm_byluminosity.all_paths    ->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
@@ -441,11 +441,11 @@ void FastTimerService::preGlobalBeginRun( edm::GlobalContext const & )
           plot->SetYTitle("processing time [ms]");
           plot->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
           if (m_concurrent_threads == n) stream.dqm_nproc_byluminosity.source = plot;
-          plot = m_dqms->bookProfile("postsource_byluminosity",   "Post-Source processing time vs. instantaneous luminosity", lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
+          plot = m_dqms->bookProfile("preevent_byluminosity",     "Pre-Event processing time vs. instantaneous luminosity",   lumibins, 0., m_dqm_luminosity_range, pathbins,  0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
           plot->StatOverflows(true);
           plot->SetYTitle("processing time [ms]");
           plot->SetXTitle("instantaneous luminosity [10^{30} cm^{-2}s^{-1}]");
-          if (m_concurrent_threads == n) stream.dqm_nproc_byluminosity.postsource = plot;
+          if (m_concurrent_threads == n) stream.dqm_nproc_byluminosity.preevent = plot;
           plot = m_dqms->bookProfile("all_paths_byluminosity",    "Paths processing time vs. instantaneous luminosity",       lumibins, 0., m_dqm_luminosity_range, eventbins, 0., std::numeric_limits<double>::infinity(), " ")->getTProfile();
           plot->StatOverflows(true);
           plot->SetYTitle("processing time [ms]");
@@ -602,7 +602,7 @@ FastTimerService::postEndJob()
     out << "FastReport " << (m_use_realtime ? "(real time) " : "(CPU time)  ") << '\n';
     out << "FastReport              " << std::right << std::setw(10) << m_job_summary.presource    / (double) m_job_summary.count << "  Pre-Source"    << '\n';
     out << "FastReport              " << std::right << std::setw(10) << m_job_summary.source       / (double) m_job_summary.count << "  Source"        << '\n';
-    out << "FastReport              " << std::right << std::setw(10) << m_job_summary.postsource   / (double) m_job_summary.count << "  Post-Source"   << '\n';
+    out << "FastReport              " << std::right << std::setw(10) << m_job_summary.preevent     / (double) m_job_summary.count << "  Pre-Event"     << '\n';
     out << "FastReport              " << std::right << std::setw(10) << m_job_summary.event        / (double) m_job_summary.count << "  Event"         << '\n';
     out << "FastReport              " << std::right << std::setw(10) << m_job_summary.all_paths    / (double) m_job_summary.count << "  all Paths"     << '\n';
     out << "FastReport              " << std::right << std::setw(10) << m_job_summary.all_endpaths / (double) m_job_summary.count << "  all EndPaths"  << '\n';
@@ -689,7 +689,7 @@ FastTimerService::postGlobalEndRun(edm::GlobalContext const &)
     out << "FastReport " << (m_use_realtime ? "(real time) " : "(CPU time)  ") << '\n';
     out << "FastReport              " << std::right << std::setw(10) << m_run_summary.presource    / (double) m_run_summary.count << "  Pre-Source"    << '\n';
     out << "FastReport              " << std::right << std::setw(10) << m_run_summary.source       / (double) m_run_summary.count << "  Source"        << '\n';
-    out << "FastReport              " << std::right << std::setw(10) << m_run_summary.postsource   / (double) m_run_summary.count << "  Post-Source"   << '\n';
+    out << "FastReport              " << std::right << std::setw(10) << m_run_summary.preevent     / (double) m_run_summary.count << "  Pre-Event"     << '\n';
     out << "FastReport              " << std::right << std::setw(10) << m_run_summary.event        / (double) m_run_summary.count << "  Event"         << '\n';
     out << "FastReport              " << std::right << std::setw(10) << m_run_summary.all_paths    / (double) m_run_summary.count << "  all Paths"     << '\n';
     out << "FastReport              " << std::right << std::setw(10) << m_run_summary.all_endpaths / (double) m_run_summary.count << "  all EndPaths"  << '\n';
@@ -778,7 +778,7 @@ void FastTimerService::preEvent(edm::StreamContext const & sc) {
   stream.timer_event.start();
 
   // account the time spent after the source
-  stream.timing.postsource = delta(stream.timer_source.getStopTime(), stream.timer_event.getStartTime());
+  stream.timing.preevent = delta(stream.timer_source.getStopTime(), stream.timer_event.getStartTime());
 
   // clear the event counters
   stream.timing.event        = 0;
@@ -970,7 +970,7 @@ void FastTimerService::preSourceEvent(edm::StreamID sid) {
 
   // clear the event counters
   stream.timing.source = 0.;
-  stream.timing.postsource = 0.;
+  stream.timing.preevent = 0.;
 }
 
 void FastTimerService::postSourceEvent(edm::StreamID sid) {

--- a/HLTrigger/Timer/test/testFastTimerService.py
+++ b/HLTrigger/Timer/test/testFastTimerService.py
@@ -1,0 +1,45 @@
+import FWCore.ParameterSet.Config as cms
+
+# import a full HLT menu
+import sys, os
+sys.path.append( '%s/src/HLTrigger/Configuration/test' % os.environ['CMSSW_BASE'] )
+sys.path.append( '%s/src/HLTrigger/Configuration/test' % os.environ['CMSSW_RELEASE_BASE'] )
+from OnData_HLT_GRun import process
+
+# options
+
+process.options = cms.untracked.PSet(
+    wantSummary = cms.untracked.bool( True )
+)
+
+process.source.fileNames = (
+    '/store/group/comm_trigger/TriggerStudiesGroup/Timing/run207515/run207515_lumi840.root',
+    '/store/group/comm_trigger/TriggerStudiesGroup/Timing/run207515/run207515_lumi841.root',
+)
+
+process.maxEvents.input = 1000
+
+# load and replace the FastTimerService
+if process.FastTimerService:
+  del process.FastTimerService
+
+process.load('HLTrigger/Timer/FastTimerService_cff')
+process.FastTimerService.useRealTimeClock         = False
+process.FastTimerService.enableTimingPaths        = True
+process.FastTimerService.enableTimingModules      = True
+process.FastTimerService.enableTimingExclusive    = True
+process.FastTimerService.enableTimingSummary      = True
+process.FastTimerService.skipFirstPath            = True
+process.FastTimerService.enableDQM                = True
+process.FastTimerService.enableDQMbyPathActive    = True
+process.FastTimerService.enableDQMbyPathTotal     = True
+process.FastTimerService.enableDQMbyPathOverhead  = True
+process.FastTimerService.enableDQMbyPathDetails   = True
+process.FastTimerService.enableDQMbyPathCounters  = True
+process.FastTimerService.enableDQMbyPathExclusive = True
+process.FastTimerService.enableDQMbyModule        = True
+process.FastTimerService.enableDQMbyModuleType    = True
+process.FastTimerService.enableDQMbyLuminosity    = True
+process.FastTimerService.enableDQMbyLumiSection   = True
+process.FastTimerService.enableDQMbyProcesses     = True
+process.FastTimerService.enableDQMSummary         = True


### PR DESCRIPTION
Properly pause (and resume) the per-module timer when a module is "paused" by the framework, to produce a collection it depends upon.
