### PR TITLE
Fix consumes validation reco vertex

### DIFF
--- a/Validation/RecoVertex/interface/PrimaryVertexAnalyzer.h
+++ b/Validation/RecoVertex/interface/PrimaryVertexAnalyzer.h
@@ -87,13 +87,13 @@ private:
   bool isFinalstateParticle(const HepMC::GenParticle * p);
   bool isCharged(const HepMC::GenParticle * p);
  
-  void printRecVtxs(const edm::Handle<reco::VertexCollection> recVtxs);
-  void printSimVtxs(const edm::Handle<edm::SimVertexContainer> simVtxs);
-  void printSimTrks(const edm::Handle<edm::SimTrackContainer> simVtrks);
-  std::vector<simPrimaryVertex> getSimPVs(const edm::Handle<edm::HepMCProduct> evtMC, std::string suffix);
-  std::vector<simPrimaryVertex> getSimPVs(const edm::Handle<edm::HepMCProduct> evt, 
-					  const edm::Handle<edm::SimVertexContainer> simVtxs, 
-					  const edm::Handle<edm::SimTrackContainer> simTrks);
+  void printRecVtxs(const edm::Handle<reco::VertexCollection> & recVtxs);
+  void printSimVtxs(const edm::Handle<edm::SimVertexContainer> & simVtxs);
+  void printSimTrks(const edm::Handle<edm::SimTrackContainer> & simVtrks);
+  std::vector<simPrimaryVertex> getSimPVs(const edm::Handle<edm::HepMCProduct> & evtMC, const std::string & suffix = "");
+  std::vector<simPrimaryVertex> getSimPVs(const edm::Handle<edm::HepMCProduct> & evt, 
+					  const edm::Handle<edm::SimVertexContainer> & simVtxs, 
+					  const edm::Handle<edm::SimTrackContainer> & simTrks);
   // ----------member data ---------------------------
   bool verbose_;
   double simUnit_;     

--- a/Validation/RecoVertex/interface/PrimaryVertexAnalyzer.h
+++ b/Validation/RecoVertex/interface/PrimaryVertexAnalyzer.h
@@ -25,36 +25,30 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-//generator level
+// generator level
+#include "HepMC/SimpleVector.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
-#include "HepMC/GenEvent.h"
-#include "HepMC/GenVertex.h"
-#include "HepMC/GenParticle.h"
- 
-// vertex stuff
-#include <DataFormats/VertexReco/interface/VertexFwd.h>
-#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
 
-// simulated vertices,..., add <use name=SimDataFormats/Vertex> and <../Track>
-#include <SimDataFormats/Vertex/interface/SimVertex.h>
-#include <SimDataFormats/Vertex/interface/SimVertexContainer.h>
-#include <SimDataFormats/Track/interface/SimTrack.h>
-#include <SimDataFormats/Track/interface/SimTrackContainer.h>
+// reco track
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
+// reco vertex
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
+// simulated track
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+
+// simulated vertex
+#include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
+
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
 
-// Root
-#include <TH1.h>
-#include <TFile.h>
-#include <TDirectory.h>
-
-
+// ROOT forward declarations
+class TDirectory;
+class TFile;
+class TH1;
 
 // class declaration
 class PrimaryVertexAnalyzer : public edm::EDAnalyzer {
@@ -101,19 +95,19 @@ private:
 					  const edm::Handle<edm::SimVertexContainer> simVtxs, 
 					  const edm::Handle<edm::SimTrackContainer> simTrks);
   // ----------member data ---------------------------
-  std::string recoTrackProducer_;
-  std::string outputFile_;       // output file
-  std::vector<std::string> vtxSample_;        // which vertices to analyze
-  std::vector<std::string> suffixSample_;
-  TFile*  rootFile_;             
   bool verbose_;
-  edm::InputTag simG4_;
   double simUnit_;     
   edm::ESHandle < ParticleDataTable > pdt;
-     
-
-	std::map<std::string, TH1*> h;
-	std::map<std::string, TDirectory*> hdir;
+  edm::EDGetTokenT< reco::TrackCollection > recoTrackCollectionToken_;
+  edm::EDGetTokenT< edm::SimVertexContainer > edmSimVertexContainerToken_;
+  edm::EDGetTokenT< edm::SimTrackContainer > edmSimTrackContainerToken_;
+  edm::EDGetTokenT< edm::HepMCProduct > edmHepMCProductToken_;
+  std::vector< edm::EDGetTokenT< reco::VertexCollection > > recoVertexCollectionTokens_;
+  std::string outputFile_;       // output file
+  std::vector<std::string> suffixSample_; // which vertices to analyze
+  TFile*  rootFile_;
+  std::map<std::string, TH1*> h;
+  std::map<std::string, TDirectory*> hdir;
 	
 };
 

--- a/Validation/RecoVertex/interface/PrimaryVertexAnalyzer4PU.h
+++ b/Validation/RecoVertex/interface/PrimaryVertexAnalyzer4PU.h
@@ -18,61 +18,50 @@
 #include <memory>
 #include <string>
 #include <vector>
- 
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-
-//generator level
+// generator level
+#include "HepMC/SimpleVector.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
-#include "HepMC/GenEvent.h"
-#include "HepMC/GenVertex.h"
-#include "HepMC/GenParticle.h"
-
-// vertex stuff
-/////#include <DataFormats/VertexReco/interface/Vertex.h>
-#include <DataFormats/VertexReco/interface/VertexFwd.h>
-#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
-
-// simulated vertices,..., add <use name=SimDataFormats/Vertex> and <../Track>
-#include <SimDataFormats/Vertex/interface/SimVertex.h>
-#include <SimDataFormats/Vertex/interface/SimVertexContainer.h>
-#include <SimDataFormats/Track/interface/SimTrack.h>
-#include <SimDataFormats/Track/interface/SimTrackContainer.h>
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
-//#include "DataFormats/Math/interface/LorentzVector.h"
-#include <SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h>
-#include <SimDataFormats/TrackingAnalysis/interface/TrackingVertex.h>
-#include <SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h>
-#include "SimTracker/Records/interface/TrackAssociatorRecord.h"
-#include "SimTracker/TrackAssociation/interface/TrackAssociatorBase.h"
-#include "SimTracker/TrackAssociation/interface/TrackAssociatorByHits.h"
-#include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 
-//Track et al
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
+// math
+#include "DataFormats/Math/interface/LorentzVector.h"
 #include "DataFormats/Math/interface/Point3D.h"
-#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
+
+// reco track
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
+// reco vertex
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
+// simulated track
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimTracker/TrackAssociation/interface/TrackAssociatorBase.h"
+
+// simulated vertex
+#include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
+
+// pile-up
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
+
+// tracking
 #include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"
 
-// Root
-#include <TH1.h>
-#include <TFile.h>
-
+// vertexing
 #include "RecoVertex/PrimaryVertexProducer/interface/TrackFilterForPVFinding.h"
 
+// ROOT
+#include <TH1.h>
 
-
+// ROOT forward declarations
+class TFile;
 
 // class declaration
 class PrimaryVertexAnalyzer4PU : public edm::EDAnalyzer {
@@ -323,25 +312,17 @@ private:
 
 
   // ----------member data ---------------------------
-  std::string recoTrackProducer_;
-  std::string outputFile_;       // output file
-  std::vector<std::string> vtxSample_;        // make this a a vector to keep cfg compatibility with PrimaryVertexAnalyzer
-  double fBfield_;
-  TFile*  rootFile_;             
   bool verbose_;
   bool doMatching_;
   bool printXBS_;
-  edm::InputTag simG4_;
-  double simUnit_;     
-  double zmatch_;
-  edm::ESHandle < ParticleDataTable > pdt_;
-  math::XYZPoint myBeamSpot;
+  bool dumpThisEvent_;
+  bool dumpPUcandidates_;
+  bool DEBUG_;
+
   // local counters
   int eventcounter_;
   int dumpcounter_;
   int ndump_;
-  bool dumpThisEvent_;
-  bool dumpPUcandidates_;
 
   // from the event setup
   int run_;
@@ -350,8 +331,26 @@ private:
   int bunchCrossing_;
   int orbitNumber_;
 
-  bool DEBUG_;
-  
+  double fBfield_;
+  double simUnit_;     
+  double zmatch_;
+  double wxy2_;
+
+  math::XYZPoint myBeamSpot;
+  reco::RecoToSimCollection r2s_;
+  TrackFilterForPVFinding theTrackFilter;
+  reco::BeamSpot vertexBeamSpot_;
+
+  edm::ESHandle< ParticleDataTable > pdt_;
+  edm::Handle<reco::BeamSpot> recoBeamSpotHandle_;
+  edm::ESHandle<TransientTrackBuilder> theB_;
+
+  TFile* rootFile_;             
+  TrackAssociatorBase * associatorByHits_;
+
+  std::string recoTrackProducer_;
+  std::string outputFile_;       // output file
+  std::vector<std::string> vtxSample_;        // make this a a vector to keep cfg compatibility with PrimaryVertexAnalyzer
 
   std::map<std::string, TH1*> hBS;
   std::map<std::string, TH1*> hnoBS;
@@ -360,15 +359,17 @@ private:
   std::map<std::string, TH1*> hMVF;
   std::map<std::string, TH1*> hsimPV;
 
-  TrackAssociatorBase * associatorByHits_;
-  reco::RecoToSimCollection r2s_;
   std::map<double, TrackingParticleRef> z2tp_;
-
-  TrackFilterForPVFinding theTrackFilter;
-  reco::BeamSpot vertexBeamSpot_;
-  double wxy2_;
-  edm::Handle<reco::BeamSpot> recoBeamSpotHandle_;
-  edm::ESHandle<TransientTrackBuilder> theB_;
-  edm::InputTag beamSpot_;
+  
+  edm::EDGetTokenT< std::vector<PileupSummaryInfo> > vecPileupSummaryInfoToken_;
+  edm::EDGetTokenT<reco::VertexCollection> recoVertexCollectionToken_, recoVertexCollection_BS_Token_, recoVertexCollection_DA_Token_;
+  edm::EDGetTokenT<reco::TrackCollection> recoTrackCollectionToken_;
+  edm::EDGetTokenT<reco::BeamSpot> recoBeamSpotToken_;
+  edm::EDGetTokenT< edm::View<reco::Track> > edmView_recoTrack_Token_;
+  edm::EDGetTokenT<edm::SimVertexContainer> edmSimVertexContainerToken_;
+  edm::EDGetTokenT<edm::SimTrackContainer> edmSimTrackContainerToken_;
+  edm::EDGetTokenT<TrackingParticleCollection> trackingParticleCollectionToken_;
+  edm::EDGetTokenT<TrackingVertexCollection> trackingVertexCollectionToken_;
+  edm::EDGetTokenT<edm::HepMCProduct> edmHepMCProductToken_;
 };
 

--- a/Validation/RecoVertex/interface/TrackParameterAnalyzer.h
+++ b/Validation/RecoVertex/interface/TrackParameterAnalyzer.h
@@ -18,47 +18,27 @@
 
 
 // system include files
-#include <memory>
 #include <string>
-#include <vector>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-// Hep MC stuff from CLHEP, add  <use name=clhep> to the buildfile
-#include "HepMC/GenEvent.h"
-#include "HepMC/GenVertex.h"
-#include "HepMC/GenParticle.h"
-#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
-#include "CLHEP/Vector/LorentzVector.h"
+// simulated vertex
+#include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 
-// simulated vertices,..., add <use name=SimDataFormats/Vertex> and <../Track>
-#include <SimDataFormats/Vertex/interface/SimVertex.h>
-#include <SimDataFormats/Vertex/interface/SimVertexContainer.h>
-#include <SimDataFormats/Track/interface/SimTrack.h>
-#include <SimDataFormats/Track/interface/SimTrackContainer.h>
+// simulated track
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
 
-// vertex stuff
-#include <DataFormats/VertexReco/interface/Vertex.h>
-#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
-// perigee 
-#include <TrackingTools/TrajectoryParametrization/interface/PerigeeTrajectoryParameters.h>
-//#include <TrackingTools/TrajectoryState/interface/TrajectoryStateClosestToPoint.h>
+// track
+#include "DataFormats/TrackReco/interface/TrackBase.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
-// Root
-#include <TH1.h>
-#include <TH2.h>
-#include <TFile.h>
-
+// ROOT forward declarations
+class TFile;
+class TH1;
+class TH2;
 
 // class declaration
 //
@@ -76,7 +56,9 @@ class TrackParameterAnalyzer : public edm::EDAnalyzer {
    private:
        bool match(const ParameterVector  &a, const ParameterVector &b);
       // ----------member data ---------------------------
-      std::string recoTrackProducer_;
+      edm::EDGetTokenT<edm::SimVertexContainer> edmSimVertexContainerToken_;
+      edm::EDGetTokenT<edm::SimTrackContainer> edmSimTrackContainerToken_;
+      edm::EDGetTokenT<reco::TrackCollection> recoTrackCollectionToken_;
       // root file to store histograms
       std::string outputFile_; // output file
       TFile*  rootFile_;
@@ -97,8 +79,6 @@ class TrackParameterAnalyzer : public edm::EDAnalyzer {
       TH1*   h1_par2_;
       TH1*   h1_par3_;
       TH1*   h1_par4_;
-
-      edm::InputTag simG4_;
-      bool verbose_;
       double simUnit_;               
+      bool verbose_;
 };

--- a/Validation/RecoVertex/interface/V0Validator.h
+++ b/Validation/RecoVertex/interface/V0Validator.h
@@ -272,9 +272,14 @@ private:
 
 
   std::string theDQMRootFileName;
-  edm::InputTag k0sCollectionTag;
-  edm::InputTag lamCollectionTag;
   std::string dirName;
-
+  edm::EDGetTokenT<reco::RecoToSimCollection> recoRecoToSimCollectionToken_;
+  edm::EDGetTokenT<reco::SimToRecoCollection> recoSimToRecoCollectionToken_;
+  edm::EDGetTokenT<TrackingParticleCollection> trackingParticleCollection_Eff_Token_, trackingParticleCollectionToken_;
+  edm::EDGetTokenT< edm::View<reco::Track> > edmView_recoTrack_Token_;
+  edm::EDGetTokenT<edm::SimTrackContainer> edmSimTrackContainerToken_;
+  edm::EDGetTokenT<edm::SimVertexContainer> edmSimVertexContainerToken_;
+  edm::EDGetTokenT< std::vector<reco::Vertex> > vec_recoVertex_Token_;
+  edm::EDGetTokenT<reco::VertexCompositeCandidateCollection> recoVertexCompositeCandidateCollection_k0s_Token_, recoVertexCompositeCandidateCollection_lambda_Token_;
 };
 

--- a/Validation/RecoVertex/interface/VertexHistogramMaker.h
+++ b/Validation/RecoVertex/interface/VertexHistogramMaker.h
@@ -2,26 +2,28 @@
 #define Validation_RecoVertex_VertexHistogramMaker_H
 
 #include <string>
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DPGAnalysis/SiStripTools/interface/RunHistogramManager.h"
-
-namespace edm {
-  class ParameterSet;
-  class Event;
-  class Run;
-}
 
 class TH1F;
 class TH2F;
 class TProfile;
 class TFileDirectory;
 
+namespace edm {
+  class ConsumesCollector;
+}
+
+class LumiDetails;
+
 class VertexHistogramMaker {
 
  public:
   VertexHistogramMaker();
-  VertexHistogramMaker(const edm::ParameterSet& iConfig);
+  VertexHistogramMaker(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC);
  
   ~VertexHistogramMaker();
 
@@ -44,6 +46,7 @@ class VertexHistogramMaker {
   const bool m_runHisto2D;
   const bool m_bsConstrained;
   const edm::ParameterSet m_histoParameters;
+  edm::EDGetTokenT<LumiDetails> m_lumiDetailsToken;
 
   RunHistogramManager m_rhm;
   RunHistogramManager m_fhm;

--- a/Validation/RecoVertex/src/AnotherPrimaryVertexAnalyzer.cc
+++ b/Validation/RecoVertex/src/AnotherPrimaryVertexAnalyzer.cc
@@ -29,7 +29,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -83,7 +83,7 @@ private:
 // constructors and destructor
 //
 AnotherPrimaryVertexAnalyzer::AnotherPrimaryVertexAnalyzer(const edm::ParameterSet& iConfig)
-  : _vhm(iConfig.getParameter<edm::ParameterSet>("vHistogramMakerPSet"))
+  : _vhm(iConfig.getParameter<edm::ParameterSet>("vHistogramMakerPSet"), consumesCollector())
   , _recoVertexCollectionToken(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("pvCollection")))
   , _firstOnly(iConfig.getUntrackedParameter<bool>("firstOnly",false))
   , _weightprov(iConfig.getParameter<bool>("usePrescaleWeight")

--- a/Validation/RecoVertex/src/AnotherPrimaryVertexAnalyzer.cc
+++ b/Validation/RecoVertex/src/AnotherPrimaryVertexAnalyzer.cc
@@ -119,7 +119,6 @@ AnotherPrimaryVertexAnalyzer::~AnotherPrimaryVertexAnalyzer()
 void
 AnotherPrimaryVertexAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  using namespace edm;
 
   // compute event weigth
 
@@ -129,7 +128,7 @@ AnotherPrimaryVertexAnalyzer::analyze(const edm::Event& iEvent, const edm::Event
 
   // get PV
 
-  Handle<reco::VertexCollection> pvcoll;
+  edm::Handle<reco::VertexCollection> pvcoll;
   iEvent.getByToken(_recoVertexCollectionToken,pvcoll);
 
   if(_firstOnly) {

--- a/Validation/RecoVertex/src/AnotherPrimaryVertexAnalyzer.cc
+++ b/Validation/RecoVertex/src/AnotherPrimaryVertexAnalyzer.cc
@@ -65,7 +65,7 @@ private:
       // ----------member data ---------------------------
 
   VertexHistogramMaker _vhm;
-  edm::InputTag _pvcollection;
+  edm::EDGetTokenT<reco::VertexCollection> _recoVertexCollectionToken;
   bool _firstOnly;
 
   PrescaleWeightProvider* _weightprov;
@@ -82,12 +82,14 @@ private:
 //
 // constructors and destructor
 //
-AnotherPrimaryVertexAnalyzer::AnotherPrimaryVertexAnalyzer(const edm::ParameterSet& iConfig):
-  _vhm(iConfig.getParameter<edm::ParameterSet>("vHistogramMakerPSet")),
-  _pvcollection(iConfig.getParameter<edm::InputTag>("pvCollection")),
-  _firstOnly(iConfig.getUntrackedParameter<bool>("firstOnly",false)),
-  _weightprov(iConfig.getParameter<bool>("usePrescaleWeight") ?
-	      new PrescaleWeightProvider(iConfig.getParameter<edm::ParameterSet>("prescaleWeightProviderPSet"), consumesCollector()) : 0)
+AnotherPrimaryVertexAnalyzer::AnotherPrimaryVertexAnalyzer(const edm::ParameterSet& iConfig)
+  : _vhm(iConfig.getParameter<edm::ParameterSet>("vHistogramMakerPSet"))
+  , _recoVertexCollectionToken(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("pvCollection")))
+  , _firstOnly(iConfig.getUntrackedParameter<bool>("firstOnly",false))
+  , _weightprov(iConfig.getParameter<bool>("usePrescaleWeight")
+		? new PrescaleWeightProvider(iConfig.getParameter<edm::ParameterSet>("prescaleWeightProviderPSet"), consumesCollector())
+		: 0
+		)
 {
    //now do what ever initialization is needed
 
@@ -128,7 +130,7 @@ AnotherPrimaryVertexAnalyzer::analyze(const edm::Event& iEvent, const edm::Event
   // get PV
 
   Handle<reco::VertexCollection> pvcoll;
-  iEvent.getByLabel(_pvcollection,pvcoll);
+  iEvent.getByToken(_recoVertexCollectionToken,pvcoll);
 
   if(_firstOnly) {
     reco::VertexCollection firstpv;

--- a/Validation/RecoVertex/src/BSvsPVAnalyzer.cc
+++ b/Validation/RecoVertex/src/BSvsPVAnalyzer.cc
@@ -63,8 +63,8 @@ private:
       // ----------member data ---------------------------
 
   BSvsPVHistogramMaker _bspvhm;
-  edm::InputTag _pvcollection;
-  edm::InputTag _bscollection;
+  edm::EDGetTokenT<reco::VertexCollection> _recoVertexCollectionToken;
+  edm::EDGetTokenT<reco::BeamSpot> _recoBeamSpotToken;
   bool _firstOnly;
 
 };
@@ -80,11 +80,11 @@ private:
 //
 // constructors and destructor
 //
-BSvsPVAnalyzer::BSvsPVAnalyzer(const edm::ParameterSet& iConfig):
-  _bspvhm(iConfig.getParameter<edm::ParameterSet>("bspvHistogramMakerPSet")),
-  _pvcollection(iConfig.getParameter<edm::InputTag>("pvCollection")),
-  _bscollection(iConfig.getParameter<edm::InputTag>("bsCollection")),
-  _firstOnly(iConfig.getUntrackedParameter<bool>("firstOnly",false))
+BSvsPVAnalyzer::BSvsPVAnalyzer(const edm::ParameterSet& iConfig)
+  : _bspvhm(iConfig.getParameter<edm::ParameterSet>("bspvHistogramMakerPSet"))
+  , _recoVertexCollectionToken(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("pvCollection")))
+  , _recoBeamSpotToken(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("bsCollection")))
+  , _firstOnly(iConfig.getUntrackedParameter<bool>("firstOnly",false))
 {
    //now do what ever initialization is needed
 
@@ -117,12 +117,12 @@ BSvsPVAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   // get BS
 
   Handle<reco::BeamSpot> bs;
-  iEvent.getByLabel(_bscollection,bs);
+  iEvent.getByToken(_recoBeamSpotToken,bs);
 
   // get PV
 
   Handle<reco::VertexCollection> pvcoll;
-  iEvent.getByLabel(_pvcollection,pvcoll);
+  iEvent.getByToken(_recoVertexCollectionToken,pvcoll);
 
   if(_firstOnly) {
     reco::VertexCollection firstpv;

--- a/Validation/RecoVertex/src/BSvsPVAnalyzer.cc
+++ b/Validation/RecoVertex/src/BSvsPVAnalyzer.cc
@@ -112,16 +112,15 @@ BSvsPVAnalyzer::~BSvsPVAnalyzer()
 void
 BSvsPVAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  using namespace edm;
   
   // get BS
 
-  Handle<reco::BeamSpot> bs;
+  edm::Handle<reco::BeamSpot> bs;
   iEvent.getByToken(_recoBeamSpotToken,bs);
 
   // get PV
 
-  Handle<reco::VertexCollection> pvcoll;
+  edm::Handle<reco::VertexCollection> pvcoll;
   iEvent.getByToken(_recoVertexCollectionToken,pvcoll);
 
   if(_firstOnly) {

--- a/Validation/RecoVertex/src/BeamSpotAnalyzer.cc
+++ b/Validation/RecoVertex/src/BeamSpotAnalyzer.cc
@@ -61,7 +61,7 @@ private:
       // ----------member data ---------------------------
 
   BeamSpotHistogramMaker _bshm;
-  edm::InputTag _bscollection;
+  edm::EDGetTokenT<reco::BeamSpot> _recoBeamSpotToken;
 
 
 };
@@ -77,9 +77,9 @@ private:
 //
 // constructors and destructor
 //
-AnotherBeamSpotAnalyzer::AnotherBeamSpotAnalyzer(const edm::ParameterSet& iConfig):
-  _bshm(iConfig.getParameter<edm::ParameterSet>("bsHistogramMakerPSet")),
-  _bscollection(iConfig.getParameter<edm::InputTag>("bsCollection"))
+AnotherBeamSpotAnalyzer::AnotherBeamSpotAnalyzer(const edm::ParameterSet& iConfig)
+  : _bshm(iConfig.getParameter<edm::ParameterSet>("bsHistogramMakerPSet"))
+  , _recoBeamSpotToken(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("bsCollection")))
 {
    //now do what ever initialization is needed
 
@@ -112,7 +112,7 @@ AnotherBeamSpotAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup
   // get BS
 
   Handle<reco::BeamSpot> bs;
-  iEvent.getByLabel(_bscollection,bs);
+  iEvent.getByToken(_recoBeamSpotToken,bs);
   _bshm.fill(iEvent.orbitNumber(),*bs);
 
 }

--- a/Validation/RecoVertex/src/BeamSpotAnalyzer.cc
+++ b/Validation/RecoVertex/src/BeamSpotAnalyzer.cc
@@ -107,11 +107,10 @@ AnotherBeamSpotAnalyzer::~AnotherBeamSpotAnalyzer()
 void
 AnotherBeamSpotAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  using namespace edm;
   
   // get BS
 
-  Handle<reco::BeamSpot> bs;
+  edm::Handle<reco::BeamSpot> bs;
   iEvent.getByToken(_recoBeamSpotToken,bs);
   _bshm.fill(iEvent.orbitNumber(),*bs);
 

--- a/Validation/RecoVertex/src/MCVerticesAnalyzer.cc
+++ b/Validation/RecoVertex/src/MCVerticesAnalyzer.cc
@@ -156,12 +156,11 @@ MCVerticesAnalyzer::~MCVerticesAnalyzer()
 void
 MCVerticesAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-   using namespace edm;
 
    double weight = 1.;
 
    if(m_useweight) {
-     Handle<double> weightprod;
+     edm::Handle<double> weightprod;
      iEvent.getByToken( m_doubleToken, weightprod );
 
      weight = *weightprod;
@@ -169,7 +168,7 @@ MCVerticesAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
    }
 
 
-   Handle<std::vector<PileupSummaryInfo> >  pileupinfos;
+   edm::Handle<std::vector<PileupSummaryInfo> >  pileupinfos;
    iEvent.getByToken( m_vecPileupSummaryInfoToken, pileupinfos );
 
    //
@@ -210,7 +209,7 @@ MCVerticesAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
    }
    // main interaction part
 
-   Handle< HepMCProduct > EvtHandle ;
+   edm::Handle< edm::HepMCProduct > EvtHandle ;
    iEvent.getByToken( m_hepMCProductToken, EvtHandle );
 
    if(EvtHandle.isValid()) {

--- a/Validation/RecoVertex/src/MCVerticesAnalyzer.cc
+++ b/Validation/RecoVertex/src/MCVerticesAnalyzer.cc
@@ -70,10 +70,11 @@ private:
 
   
 
-  edm::InputTag m_pileupcollection;
-  edm::InputTag m_mctruthcollection;
   const bool m_useweight;
-  edm::InputTag m_weight;
+
+  edm::EDGetTokenT< double > m_doubleToken;
+  edm::EDGetTokenT< std::vector<PileupSummaryInfo> > m_vecPileupSummaryInfoToken;
+  edm::EDGetTokenT< edm::HepMCProduct > m_hepMCProductToken;
 
   TH1F* m_hnvtx;
   TH1F* m_hlumi;
@@ -98,13 +99,11 @@ private:
 //
 // constructors and destructor
 //
-MCVerticesAnalyzer::MCVerticesAnalyzer(const edm::ParameterSet& iConfig):
-  m_pileupcollection(iConfig.getParameter<edm::InputTag>("pileupSummaryCollection")),
-  m_mctruthcollection(iConfig.getParameter<edm::InputTag>("mcTruthCollection")),
-  m_useweight(iConfig.getParameter<bool>("useWeight")),
-  m_weight(iConfig.getParameter<edm::InputTag>("weightProduct"))
-
-
+MCVerticesAnalyzer::MCVerticesAnalyzer(const edm::ParameterSet& iConfig)
+  : m_useweight( iConfig.getParameter< bool >( "useWeight" ) )
+  , m_doubleToken( consumes< double >( iConfig.getParameter< edm::InputTag >( "weightProduct" ) ) )
+  , m_vecPileupSummaryInfoToken( consumes< std::vector<PileupSummaryInfo> >( iConfig.getParameter< edm::InputTag >( "pileupSummaryCollection" ) ) )
+  , m_hepMCProductToken( consumes< edm::HepMCProduct >( iConfig.getParameter< edm::InputTag >( "mcTruthCollection" ) ) )
 {
    //now do what ever initialization is needed
 
@@ -163,7 +162,7 @@ MCVerticesAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 
    if(m_useweight) {
      Handle<double> weightprod;
-     iEvent.getByLabel(m_weight,weightprod);
+     iEvent.getByToken( m_doubleToken, weightprod );
 
      weight = *weightprod;
 
@@ -171,7 +170,7 @@ MCVerticesAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 
 
    Handle<std::vector<PileupSummaryInfo> >  pileupinfos;
-   iEvent.getByLabel(m_pileupcollection,pileupinfos);
+   iEvent.getByToken( m_vecPileupSummaryInfoToken, pileupinfos );
 
    //
 
@@ -212,7 +211,7 @@ MCVerticesAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
    // main interaction part
 
    Handle< HepMCProduct > EvtHandle ;
-   iEvent.getByLabel(m_mctruthcollection, EvtHandle ) ;
+   iEvent.getByToken( m_hepMCProductToken, EvtHandle );
 
    if(EvtHandle.isValid()) {
 

--- a/Validation/RecoVertex/src/MCVerticesWeight.cc
+++ b/Validation/RecoVertex/src/MCVerticesWeight.cc
@@ -102,13 +102,12 @@ MCVerticesWeight::~MCVerticesWeight()
 bool
 MCVerticesWeight::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  using namespace edm;
   
-  bool selected = true;
-  
-  double computed_weight(1);
-
-  Handle<std::vector<PileupSummaryInfo> > pileupinfos;
+   bool selected = true;
+   
+   double computed_weight(1);
+   
+   edm::Handle<std::vector<PileupSummaryInfo> > pileupinfos;
    iEvent.getByToken( m_vecPileupSummaryInfoToken, pileupinfos );
 
 
@@ -135,7 +134,7 @@ MCVerticesWeight::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
      
      // main interaction part
      
-     Handle< HepMCProduct > EvtHandle ;
+     edm::Handle< edm::HepMCProduct > EvtHandle ;
      iEvent.getByToken( m_hepMCProductToken, EvtHandle );
      
      const HepMC::GenEvent* Evt = EvtHandle->GetEvent();

--- a/Validation/RecoVertex/src/MCVerticesWeight.cc
+++ b/Validation/RecoVertex/src/MCVerticesWeight.cc
@@ -58,8 +58,8 @@ class MCVerticesWeight : public edm::EDFilter {
       
       // ----------member data ---------------------------
 
-  edm::InputTag m_pileupcollection;
-  edm::InputTag m_mctruthcollection;
+  edm::EDGetTokenT< std::vector<PileupSummaryInfo> > m_vecPileupSummaryInfoToken;
+  edm::EDGetTokenT< edm::HepMCProduct > m_hepMCProductToken;
   const VertexWeighter m_weighter;
 
 };
@@ -75,10 +75,10 @@ class MCVerticesWeight : public edm::EDFilter {
 //
 // constructors and destructor
 //
-MCVerticesWeight::MCVerticesWeight(const edm::ParameterSet& iConfig):
-  m_pileupcollection(iConfig.getParameter<edm::InputTag>("pileupSummaryCollection")),
-  m_mctruthcollection(iConfig.getParameter<edm::InputTag>("mcTruthCollection")),
-  m_weighter(iConfig.getParameter<edm::ParameterSet>("weighterConfig"))
+MCVerticesWeight::MCVerticesWeight(const edm::ParameterSet& iConfig)
+  : m_vecPileupSummaryInfoToken( consumes< std::vector<PileupSummaryInfo> >( iConfig.getParameter< edm::InputTag >( "pileupSummaryCollection" ) ) )
+  , m_hepMCProductToken( consumes< edm::HepMCProduct >( iConfig.getParameter< edm::InputTag >( "mcTruthCollection" ) ) )
+  , m_weighter( iConfig.getParameter<edm::ParameterSet>( "weighterConfig" ) )
 {
 
   produces<double>();
@@ -109,7 +109,7 @@ MCVerticesWeight::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
   double computed_weight(1);
 
   Handle<std::vector<PileupSummaryInfo> > pileupinfos;
-   iEvent.getByLabel(m_pileupcollection,pileupinfos);
+   iEvent.getByToken( m_vecPileupSummaryInfoToken, pileupinfos );
 
 
   // look for the intime PileupSummaryInfo
@@ -136,7 +136,7 @@ MCVerticesWeight::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
      // main interaction part
      
      Handle< HepMCProduct > EvtHandle ;
-     iEvent.getByLabel(m_mctruthcollection, EvtHandle ) ;
+     iEvent.getByToken( m_hepMCProductToken, EvtHandle );
      
      const HepMC::GenEvent* Evt = EvtHandle->GetEvent();
      

--- a/Validation/RecoVertex/src/MCvsRecoVerticesAnalyzer.cc
+++ b/Validation/RecoVertex/src/MCvsRecoVerticesAnalyzer.cc
@@ -193,19 +193,18 @@ MCvsRecoVerticesAnalyzer::~MCvsRecoVerticesAnalyzer()
 void
 MCvsRecoVerticesAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  using namespace edm;
   
   double weight = 1.;
   
   if(m_useweight) {
-    Handle<double> weightprod;
+    edm::Handle< double > weightprod;
     iEvent.getByToken( m_doubleToken, weightprod );
     
     weight = *weightprod;
     
   }
   
-  Handle<std::vector<PileupSummaryInfo> > pileupinfos;
+  edm::Handle< std::vector<PileupSummaryInfo> > pileupinfos;
   iEvent.getByToken( m_vecPileupSummaryInfoToken, pileupinfos );
 
   // look for the intime PileupSummaryInfo
@@ -220,7 +219,7 @@ MCvsRecoVerticesAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetu
   
   //
   
-  Handle<reco::VertexCollection> pvcoll;
+  edm::Handle< reco::VertexCollection > pvcoll;
   iEvent.getByToken( m_recoVertexCollectionToken, pvcoll );
   
 
@@ -249,7 +248,7 @@ MCvsRecoVerticesAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetu
     }
     //
     
-    Handle< HepMCProduct > EvtHandle ;
+    edm::Handle< edm::HepMCProduct > EvtHandle ;
     iEvent.getByToken( m_hepMCProductToken, EvtHandle );
     
     const HepMC::GenEvent* Evt = EvtHandle->GetEvent();

--- a/Validation/RecoVertex/src/MCvsRecoVerticesAnalyzer.cc
+++ b/Validation/RecoVertex/src/MCvsRecoVerticesAnalyzer.cc
@@ -72,13 +72,13 @@ private:
 
   
 
-  edm::InputTag m_pileupcollection;
-  edm::InputTag m_mctruthcollection;
-  edm::InputTag m_pvcollection;
   const bool m_useweight;
-  edm::InputTag m_weight;
   const bool m_useVisibleVertices;
   const edm::ParameterSet m_histoParameters;
+  edm::EDGetTokenT< double > m_doubleToken;
+  edm::EDGetTokenT< std::vector<PileupSummaryInfo> > m_vecPileupSummaryInfoToken;
+  edm::EDGetTokenT< reco::VertexCollection > m_recoVertexCollectionToken;
+  edm::EDGetTokenT< edm::HepMCProduct > m_hepMCProductToken;
 
   TH2F* m_hrecovsmcnvtx2d;
   TProfile* m_hrecovsmcnvtxprof;
@@ -108,14 +108,14 @@ private:
 //
 // constructors and destructor
 //
-MCvsRecoVerticesAnalyzer::MCvsRecoVerticesAnalyzer(const edm::ParameterSet& iConfig):
-  m_pileupcollection(iConfig.getParameter<edm::InputTag>("pileupSummaryCollection")),
-  m_mctruthcollection(iConfig.getParameter<edm::InputTag>("mcTruthCollection")),
-  m_pvcollection(iConfig.getParameter<edm::InputTag>("pvCollection")),
-  m_useweight(iConfig.getParameter<bool>("useWeight")),
-  m_weight(iConfig.getParameter<edm::InputTag>("weightProduct")),
-  m_useVisibleVertices(iConfig.getParameter<bool>("useVisibleVertices")),
-  m_histoParameters(iConfig.getUntrackedParameter<edm::ParameterSet>("histoParameters",edm::ParameterSet()))
+MCvsRecoVerticesAnalyzer::MCvsRecoVerticesAnalyzer(const edm::ParameterSet& iConfig)
+  : m_useweight( iConfig.getParameter< bool >( "useWeight" ) )
+  , m_useVisibleVertices( iConfig.getParameter< bool >( "useVisibleVertices" ) )
+  , m_histoParameters( iConfig.getUntrackedParameter< edm::ParameterSet >( "histoParameters", edm::ParameterSet() ) )
+  , m_doubleToken( consumes< double >( iConfig.getParameter< edm::InputTag >( "weightProduct" ) ) )
+  , m_vecPileupSummaryInfoToken( consumes< std::vector<PileupSummaryInfo> >( iConfig.getParameter< edm::InputTag >( "pileupSummaryCollection" ) ) )
+  , m_recoVertexCollectionToken( consumes< reco::VertexCollection >( iConfig.getParameter< edm::InputTag >( "pvCollection" ) ) )
+  , m_hepMCProductToken( consumes< edm::HepMCProduct >( iConfig.getParameter< edm::InputTag >( "mcTruthCollection" ) ) )
 {
    //now do what ever initialization is needed
 
@@ -199,14 +199,14 @@ MCvsRecoVerticesAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetu
   
   if(m_useweight) {
     Handle<double> weightprod;
-    iEvent.getByLabel(m_weight,weightprod);
+    iEvent.getByToken( m_doubleToken, weightprod );
     
     weight = *weightprod;
     
   }
   
   Handle<std::vector<PileupSummaryInfo> > pileupinfos;
-  iEvent.getByLabel(m_pileupcollection,pileupinfos);
+  iEvent.getByToken( m_vecPileupSummaryInfoToken, pileupinfos );
 
   // look for the intime PileupSummaryInfo
 
@@ -221,7 +221,7 @@ MCvsRecoVerticesAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetu
   //
   
   Handle<reco::VertexCollection> pvcoll;
-  iEvent.getByLabel(m_pvcollection,pvcoll);
+  iEvent.getByToken( m_recoVertexCollectionToken, pvcoll );
   
 
    //
@@ -250,7 +250,7 @@ MCvsRecoVerticesAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetu
     //
     
     Handle< HepMCProduct > EvtHandle ;
-    iEvent.getByLabel(m_mctruthcollection, EvtHandle ) ;
+    iEvent.getByToken( m_hepMCProductToken, EvtHandle );
     
     const HepMC::GenEvent* Evt = EvtHandle->GetEvent();
     

--- a/Validation/RecoVertex/src/PrimaryVertexAnalyzer.cc
+++ b/Validation/RecoVertex/src/PrimaryVertexAnalyzer.cc
@@ -186,7 +186,7 @@ bool PrimaryVertexAnalyzer::isCharged(const HepMC::GenParticle * p){
   }
 }
 
-void PrimaryVertexAnalyzer::printRecVtxs(const edm::Handle<reco::VertexCollection> recVtxs){
+void PrimaryVertexAnalyzer::printRecVtxs(const edm::Handle<reco::VertexCollection> & recVtxs){
     int ivtx=0;
     for(reco::VertexCollection::const_iterator v=recVtxs->begin(); 
 	v!=recVtxs->end(); ++v){
@@ -205,7 +205,7 @@ void PrimaryVertexAnalyzer::printRecVtxs(const edm::Handle<reco::VertexCollectio
 }
 
 
-void PrimaryVertexAnalyzer::printSimVtxs(const edm::Handle<edm::SimVertexContainer> simVtxs){
+void PrimaryVertexAnalyzer::printSimVtxs(const edm::Handle<edm::SimVertexContainer> & simVtxs){
     int i=0;
     for(edm::SimVertexContainer::const_iterator vsim=simVtxs->begin();
 	vsim!=simVtxs->end(); ++vsim){
@@ -221,7 +221,7 @@ void PrimaryVertexAnalyzer::printSimVtxs(const edm::Handle<edm::SimVertexContain
 }
 
 
-void PrimaryVertexAnalyzer::printSimTrks(const edm::Handle<edm::SimTrackContainer> simTrks){
+void PrimaryVertexAnalyzer::printSimTrks(const edm::Handle<edm::SimTrackContainer> & simTrks){
   std::cout <<  " simTrks   type, (momentum), vertIndex, genpartIndex"  << std::endl;
   int i=1;
   for(edm::SimTrackContainer::const_iterator t=simTrks->begin();
@@ -240,8 +240,8 @@ void PrimaryVertexAnalyzer::printSimTrks(const edm::Handle<edm::SimTrackContaine
 }
 
 
-std::vector<PrimaryVertexAnalyzer::simPrimaryVertex> PrimaryVertexAnalyzer::getSimPVs( const edm::Handle<edm::HepMCProduct> evtMC
-										     , std::string suffix=""
+std::vector<PrimaryVertexAnalyzer::simPrimaryVertex> PrimaryVertexAnalyzer::getSimPVs( const edm::Handle<edm::HepMCProduct> & evtMC
+										     , const std::string & suffix
 										       )
 {
   std::vector<PrimaryVertexAnalyzer::simPrimaryVertex> simpv;
@@ -331,9 +331,9 @@ std::vector<PrimaryVertexAnalyzer::simPrimaryVertex> PrimaryVertexAnalyzer::getS
 
 
 
-std::vector<PrimaryVertexAnalyzer::simPrimaryVertex> PrimaryVertexAnalyzer::getSimPVs( const edm::Handle<edm::HepMCProduct> evtMC
-										     , const edm::Handle<edm::SimVertexContainer> simVtxs 
-										     , const edm::Handle<edm::SimTrackContainer> simTrks
+std::vector<PrimaryVertexAnalyzer::simPrimaryVertex> PrimaryVertexAnalyzer::getSimPVs( const edm::Handle<edm::HepMCProduct> & evtMC
+										     , const edm::Handle<edm::SimVertexContainer> & simVtxs 
+										     , const edm::Handle<edm::SimTrackContainer> & simTrks
 										       )
 {
    // simvertices don't have enough information to decide, 

--- a/Validation/RecoVertex/src/PrimaryVertexAnalyzer.cc
+++ b/Validation/RecoVertex/src/PrimaryVertexAnalyzer.cc
@@ -31,8 +31,6 @@
 #include <gsl/gsl_eigen.h>
 
 
-using namespace edm;
-using namespace reco;
 //
 // constants, enums and typedefs
 //
@@ -44,7 +42,7 @@ using namespace reco;
 //
 // constructors and destructor
 //
-PrimaryVertexAnalyzer::PrimaryVertexAnalyzer(const ParameterSet& iConfig)
+PrimaryVertexAnalyzer::PrimaryVertexAnalyzer(const edm::ParameterSet& iConfig)
   : verbose_( iConfig.getUntrackedParameter<bool>( "verbose", false ) )
   , simUnit_( 1.0 ) // starting with CMSSW_1_2_x ??
   , recoTrackCollectionToken_( consumes< reco::TrackCollection >( edm::InputTag( iConfig.getUntrackedParameter<std::string>( "recoTrackProducer" ) ) ) )
@@ -188,7 +186,7 @@ bool PrimaryVertexAnalyzer::isCharged(const HepMC::GenParticle * p){
   }
 }
 
-void PrimaryVertexAnalyzer::printRecVtxs(const Handle<reco::VertexCollection> recVtxs){
+void PrimaryVertexAnalyzer::printRecVtxs(const edm::Handle<reco::VertexCollection> recVtxs){
     int ivtx=0;
     for(reco::VertexCollection::const_iterator v=recVtxs->begin(); 
 	v!=recVtxs->end(); ++v){
@@ -207,9 +205,9 @@ void PrimaryVertexAnalyzer::printRecVtxs(const Handle<reco::VertexCollection> re
 }
 
 
-void PrimaryVertexAnalyzer::printSimVtxs(const Handle<SimVertexContainer> simVtxs){
+void PrimaryVertexAnalyzer::printSimVtxs(const edm::Handle<edm::SimVertexContainer> simVtxs){
     int i=0;
-    for(SimVertexContainer::const_iterator vsim=simVtxs->begin();
+    for(edm::SimVertexContainer::const_iterator vsim=simVtxs->begin();
 	vsim!=simVtxs->end(); ++vsim){
       std::cout << i++ << ")" << std::scientific
                 << " evtid=" << vsim->eventId().event() 
@@ -223,10 +221,10 @@ void PrimaryVertexAnalyzer::printSimVtxs(const Handle<SimVertexContainer> simVtx
 }
 
 
-void PrimaryVertexAnalyzer::printSimTrks(const Handle<SimTrackContainer> simTrks){
+void PrimaryVertexAnalyzer::printSimTrks(const edm::Handle<edm::SimTrackContainer> simTrks){
   std::cout <<  " simTrks   type, (momentum), vertIndex, genpartIndex"  << std::endl;
   int i=1;
-  for(SimTrackContainer::const_iterator t=simTrks->begin();
+  for(edm::SimTrackContainer::const_iterator t=simTrks->begin();
       t!=simTrks->end(); ++t){
     //HepMC::GenParticle* gp=evtMC->GetEvent()->particle( (*t).genpartIndex() );
     std::cout << i++ << ")" 
@@ -242,8 +240,9 @@ void PrimaryVertexAnalyzer::printSimTrks(const Handle<SimTrackContainer> simTrks
 }
 
 
-std::vector<PrimaryVertexAnalyzer::simPrimaryVertex> PrimaryVertexAnalyzer::getSimPVs(
-				      const Handle<HepMCProduct> evtMC, std::string suffix="")
+std::vector<PrimaryVertexAnalyzer::simPrimaryVertex> PrimaryVertexAnalyzer::getSimPVs( const edm::Handle<edm::HepMCProduct> evtMC
+										     , std::string suffix=""
+										       )
 {
   std::vector<PrimaryVertexAnalyzer::simPrimaryVertex> simpv;
   const HepMC::GenEvent* evt=evtMC->GetEvent();
@@ -332,17 +331,17 @@ std::vector<PrimaryVertexAnalyzer::simPrimaryVertex> PrimaryVertexAnalyzer::getS
 
 
 
-std::vector<PrimaryVertexAnalyzer::simPrimaryVertex> PrimaryVertexAnalyzer::getSimPVs(
-				      const Handle<HepMCProduct> evtMC, 
-				      const Handle<SimVertexContainer> simVtxs, 
-				      const Handle<SimTrackContainer> simTrks)
+std::vector<PrimaryVertexAnalyzer::simPrimaryVertex> PrimaryVertexAnalyzer::getSimPVs( const edm::Handle<edm::HepMCProduct> evtMC
+										     , const edm::Handle<edm::SimVertexContainer> simVtxs 
+										     , const edm::Handle<edm::SimTrackContainer> simTrks
+										       )
 {
    // simvertices don't have enough information to decide, 
    // genVertices don't have the simulated coordinates  ( with VtxSmeared they might)
    // go through simtracks to get the link between simulated and generated vertices
    std::vector<PrimaryVertexAnalyzer::simPrimaryVertex> simpv;
    int idx=0;
-   for(SimTrackContainer::const_iterator t=simTrks->begin();
+   for(edm::SimTrackContainer::const_iterator t=simTrks->begin();
        t!=simTrks->end(); ++t){
      if ( !(t->noVertex()) && !(t->type()==-99) ){
        double ptsq=0;
@@ -408,32 +407,32 @@ std::vector<PrimaryVertexAnalyzer::simPrimaryVertex> PrimaryVertexAnalyzer::getS
 
 // ------------ method called to produce the data  ------------
 void
-PrimaryVertexAnalyzer::analyze(const Event& iEvent, const EventSetup& iSetup)
+PrimaryVertexAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
   
-  Handle<reco::TrackCollection> recTrks;
+  edm::Handle<reco::TrackCollection> recTrks;
   iEvent.getByToken( recoTrackCollectionToken_, recTrks );
 
-  Handle<SimVertexContainer> simVtxs;
+  edm::Handle<edm::SimVertexContainer> simVtxs;
   iEvent.getByToken( edmSimVertexContainerToken_, simVtxs );
   
-  Handle<SimTrackContainer> simTrks;
+  edm::Handle<edm::SimTrackContainer> simTrks;
   iEvent.getByToken( edmSimTrackContainerToken_, simTrks );
 
   for (int ivtxSample=0; ivtxSample!= (int)recoVertexCollectionTokens_.size(); ++ivtxSample) {
     std::string isuffix = suffixSample_[ivtxSample];
 
-    Handle<reco::VertexCollection> recVtxs;
+    edm::Handle<reco::VertexCollection> recVtxs;
     iEvent.getByToken( recoVertexCollectionTokens_[ ivtxSample ], recVtxs );
 
     try{
       iSetup.getData(pdt);
-    }catch(const Exception&){
+    }catch(const edm::Exception&){
       std::cout << "Some problem occurred with the particle data table. This may not work !." <<std::endl;
     }
 
     bool MC=false;
-    Handle<HepMCProduct> evtMC;
+    edm::Handle<edm::HepMCProduct> evtMC;
     iEvent.getByToken( edmHepMCProductToken_, evtMC );
     if (!evtMC.isValid()) {
       MC=false;

--- a/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PU.cc
+++ b/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PU.cc
@@ -1,38 +1,47 @@
 #include "Validation/RecoVertex/interface/PrimaryVertexAnalyzer4PU.h"
 
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 
+//generator level + CLHEP
+#include "HepMC/GenEvent.h"
+#include "HepMC/GenVertex.h"
+#include "HepMC/GenParticle.h"
+
 // reco track and vertex 
-#include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/Math/interface/Point3D.h"
 #include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
 
-// simulated vertices,..., add <use name=SimDataFormats/Vertex> and <../Track>
-#include <SimDataFormats/Vertex/interface/SimVertex.h>
-#include <SimDataFormats/Vertex/interface/SimVertexContainer.h>
+// simulated track
 #include <SimDataFormats/Track/interface/SimTrack.h>
-#include <SimDataFormats/Track/interface/SimTrackContainer.h>
 
+// simulated vertex
+#include "SimDataFormats/Vertex/interface/SimVertex.h"
+
+// crossing frame
 #include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
 #include "SimDataFormats/CrossingFrame/interface/CrossingFramePlaybackInfo.h"
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 
-//generator level + CLHEP
-#include "HepMC/GenEvent.h"
-#include "HepMC/GenVertex.h"
-
-
 // TrackingParticle
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
-//associator
-#include "SimTracker/Records/interface/TrackAssociatorRecord.h"
 
+// tracking tools
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+
+// clustering
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+
+// associator
+#include "SimTracker/Records/interface/TrackAssociatorRecord.h"
 
 // fit
 #include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
@@ -40,10 +49,7 @@
 
 #include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
 
-#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
-
-// Root
-#include <TH1.h>
+// ROOT
 #include <TH2.h>
 #include <TFile.h>
 #include <TProfile.h>
@@ -51,13 +57,6 @@
 #include <cmath>
 #include <gsl/gsl_math.h>
 #include <gsl/gsl_eigen.h>
-
-
-// cluster stufff
-//#include "DataFormats/TrackRecoTrack.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
-#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
-
 
 using namespace edm;
 using namespace reco;
@@ -73,33 +72,56 @@ typedef reco::Vertex::trackRef_iterator trackit_t;
 //
 // constructors and destructor
 //
-PrimaryVertexAnalyzer4PU::PrimaryVertexAnalyzer4PU(const ParameterSet& iConfig) :
-  theTrackFilter(iConfig.getParameter<edm::ParameterSet>("TkFilterParameters")),
-  beamSpot_(iConfig.getParameter<edm::InputTag>("beamSpot"))
+PrimaryVertexAnalyzer4PU::PrimaryVertexAnalyzer4PU(const ParameterSet& iConfig)
+  : verbose_( iConfig.getUntrackedParameter<bool>( "verbose", false ) )
+  , doMatching_( iConfig.getUntrackedParameter<bool>( "matching", false ) )
+  , printXBS_( iConfig.getUntrackedParameter<bool>( "XBS", false ) )
+  , dumpThisEvent_( false )
+  , dumpPUcandidates_( iConfig.getUntrackedParameter<bool>( "dumpPUcandidates", false ) )
+  , DEBUG_( false )
+  , eventcounter_( 0 )
+  , dumpcounter_( 0 )
+  , ndump_( 10 )
+  , run_( 0 )
+  , luminosityBlock_( 0 )
+  , event_( 0 )
+  , bunchCrossing_( 0 )
+  , orbitNumber_( 0 )
+  , fBfield_( 0. )
+  , simUnit_( 1.0 )  // starting with CMSSW_1_2_x ??
+  , zmatch_( iConfig.getUntrackedParameter<double>( "zmatch", 0.0500 ) )
+  , wxy2_( 0. )
+  , theTrackFilter( iConfig.getParameter<edm::ParameterSet>( "TkFilterParameters" ) )
+  , recoTrackProducer_( iConfig.getUntrackedParameter<std::string>("recoTrackProducer") )
+  , outputFile_( iConfig.getUntrackedParameter<std::string>( "outputFile" ) )
+  , vecPileupSummaryInfoToken_( consumes< std::vector<PileupSummaryInfo> >( edm::InputTag( std::string( "addPileupInfo" ) ) ) )
+  , recoVertexCollectionToken_( consumes<reco::VertexCollection>( edm::InputTag( std::string( "offlinePrimaryVertices" ) ) ) )
+  , recoVertexCollection_BS_Token_( consumes<reco::VertexCollection>( edm::InputTag( std::string( "offlinePrimaryVerticesWithBS" ) ) ) )
+  , recoVertexCollection_DA_Token_( consumes<reco::VertexCollection>( edm::InputTag( std::string( "offlinePrimaryVerticesDA" ) ) ) )
+  , recoTrackCollectionToken_( consumes<reco::TrackCollection>( edm::InputTag( iConfig.getUntrackedParameter<std::string>( "recoTrackProducer" ) ) ) )
+  , recoBeamSpotToken_( consumes<reco::BeamSpot>( iConfig.getParameter<edm::InputTag>( "beamSpot" ) ) )
+  , edmView_recoTrack_Token_( consumes< edm::View<reco::Track> >( edm::InputTag( iConfig.getUntrackedParameter<std::string>( "recoTrackProducer" ) ) ) )
+  , edmSimVertexContainerToken_( consumes<edm::SimVertexContainer>( iConfig.getParameter<edm::InputTag>( "simG4" ) ) )
+  , edmSimTrackContainerToken_( consumes<edm::SimTrackContainer>( iConfig.getParameter<edm::InputTag>( "simG4" ) ) )
+  , trackingParticleCollectionToken_( consumes<TrackingParticleCollection>( edm::InputTag( std::string( "mix" )
+											 , std::string( "MergedTrackTruth" ) 
+											   ) 
+									    ) 
+				      )
+  , trackingVertexCollectionToken_( consumes<TrackingVertexCollection>( edm::InputTag( std::string( "mix" )
+										     , std::string( "MergedTrackTruth" ) 
+										       ) 
+									) 
+				    )
+  , edmHepMCProductToken_( consumes<edm::HepMCProduct>( edm::InputTag( std::string( "generator" ) ) ) ) // starting with 3_1_0 pre something
 {
    //now do what ever initialization is needed
-  simG4_=iConfig.getParameter<edm::InputTag>( "simG4" );
-  recoTrackProducer_= iConfig.getUntrackedParameter<std::string>("recoTrackProducer");
   // open output file to store histograms}
-  outputFile_  = iConfig.getUntrackedParameter<std::string>("outputFile");
-
   rootFile_ = TFile::Open(outputFile_.c_str(),"RECREATE");
-  verbose_= iConfig.getUntrackedParameter<bool>("verbose", false);
-  doMatching_= iConfig.getUntrackedParameter<bool>("matching", false);
-  printXBS_= iConfig.getUntrackedParameter<bool>("XBS", false);
-  simUnit_= 1.0;  // starting with CMSSW_1_2_x ??
   if ( (edm::getReleaseVersion()).find("CMSSW_1_1_",0)!=std::string::npos){
     simUnit_=0.1;  // for use in  CMSSW_1_1_1 tutorial
   }
-  
-  dumpPUcandidates_=iConfig.getUntrackedParameter<bool>("dumpPUcandidates", false);
-
-  zmatch_=iConfig.getUntrackedParameter<double>("zmatch", 0.0500);
   cout << "PrimaryVertexAnalyzer4PU: zmatch=" << zmatch_ << endl;
-  eventcounter_=0;
-  dumpcounter_=0;
-  ndump_=10;
-  DEBUG_=false;
   //DEBUG_=true;
 }
 
@@ -1994,7 +2016,6 @@ PrimaryVertexAnalyzer4PU::analyze(const Event& iEvent, const EventSetup& iSetup)
   std::vector<simPrimaryVertex> simpv;  //  a list of primary MC vertices
   std::vector<float> pui_z;
   std::vector<SimPart> tsim;
-  std::string mcproduct="generator";  // starting with 3_1_0 pre something
 
   eventcounter_++;
   run_             = iEvent.id().run();
@@ -2003,7 +2024,6 @@ PrimaryVertexAnalyzer4PU::analyze(const Event& iEvent, const EventSetup& iSetup)
   bunchCrossing_   = iEvent.bunchCrossing();
   orbitNumber_     = iEvent.orbitNumber();
 
-  dumpThisEvent_ = false;
 
 
 
@@ -2027,7 +2047,7 @@ PrimaryVertexAnalyzer4PU::analyze(const Event& iEvent, const EventSetup& iSetup)
     
     //get the pileup information  
     Handle< vector<PileupSummaryInfo> > puinfoH;
-    iEvent.getByLabel("addPileupInfo",puinfoH);
+    iEvent.getByToken( vecPileupSummaryInfoToken_, puinfoH );
     PileupSummaryInfo puinfo; 
   
     for (unsigned int puinfo_ite=0;puinfo_ite<(*puinfoH).size();++puinfo_ite){ 
@@ -2046,24 +2066,16 @@ PrimaryVertexAnalyzer4PU::analyze(const Event& iEvent, const EventSetup& iSetup)
   }
 
   Handle<reco::VertexCollection> recVtxs;
-  bool bnoBS=iEvent.getByLabel("offlinePrimaryVertices", recVtxs);
+  bool bnoBS = iEvent.getByToken( recoVertexCollectionToken_, recVtxs );
   
   Handle<reco::VertexCollection> recVtxsBS;
-  bool bBS=iEvent.getByLabel("offlinePrimaryVerticesWithBS", recVtxsBS);
+  bool bBS = iEvent.getByToken( recoVertexCollection_BS_Token_, recVtxsBS );
   
   Handle<reco::VertexCollection> recVtxsDA;
-  bool bDA=iEvent.getByLabel("offlinePrimaryVerticesDA", recVtxsDA);
-
-//   Handle<reco::VertexCollection> recVtxsPIX;
-//   bool bPIX=iEvent.getByLabel("pixelVertices", recVtxsPIX);
-//   bPIX=false;
-
-//   Handle<reco::VertexCollection> recVtxsMVF;
-//   bool bMVF=iEvent.getByLabel("offlinePrimaryVerticesMVF", recVtxsMVF);
+  bool bDA = iEvent.getByToken( recoVertexCollection_DA_Token_, recVtxsDA );
 
   Handle<reco::TrackCollection> recTrks;
-  iEvent.getByLabel(recoTrackProducer_, recTrks);
-
+  iEvent.getByToken( recoTrackCollectionToken_, recTrks );
 
   int nhighpurity=0, ntot=0;
   for(reco::TrackCollection::const_iterator t=recTrks->begin(); t!=recTrks->end(); ++t){  
@@ -2080,7 +2092,7 @@ PrimaryVertexAnalyzer4PU::analyze(const Event& iEvent, const EventSetup& iSetup)
 
   
 
-  if(iEvent.getByLabel(beamSpot_, recoBeamSpotHandle_)){
+  if(iEvent.getByToken(recoBeamSpotToken_, recoBeamSpotHandle_)){
     vertexBeamSpot_= *recoBeamSpotHandle_;
     wxy2_=pow(vertexBeamSpot_.BeamWidthX(),2)+pow(vertexBeamSpot_.BeamWidthY(),2);
     Fill(hsimPV, "xbeam",vertexBeamSpot_.x0()); Fill(hsimPV, "wxbeam",vertexBeamSpot_.BeamWidthX());
@@ -2113,25 +2125,23 @@ PrimaryVertexAnalyzer4PU::analyze(const Event& iEvent, const EventSetup& iSetup)
  
   // for the associator
   Handle<View<Track> > trackCollectionH;
-  iEvent.getByLabel(recoTrackProducer_,trackCollectionH);
+  iEvent.getByToken( edmView_recoTrack_Token_, trackCollectionH );
 
   Handle<HepMCProduct> evtMC;
 
   Handle<SimVertexContainer> simVtxs;
-  iEvent.getByLabel( simG4_, simVtxs);
+  iEvent.getByToken( edmSimVertexContainerToken_, simVtxs );
   
   Handle<SimTrackContainer> simTrks;
-  iEvent.getByLabel( simG4_, simTrks);
-
+  iEvent.getByToken( edmSimTrackContainerToken_, simTrks );
 
 
 
 
   edm::Handle<TrackingParticleCollection>  TPCollectionH ;
   edm::Handle<TrackingVertexCollection>    TVCollectionH ;
-  bool gotTP=iEvent.getByLabel("mix","MergedTrackTruth",TPCollectionH);
-  bool gotTV=iEvent.getByLabel("mix","MergedTrackTruth",TVCollectionH);
-
+  bool gotTP = iEvent.getByToken( trackingParticleCollectionToken_, TPCollectionH );
+  bool gotTV = iEvent.getByToken( trackingVertexCollectionToken_, TVCollectionH );
 
   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",theB_);
   fBfield_=((*theB_).field()->inTesla(GlobalPoint(0.,0.,0.))).z();
@@ -2163,7 +2173,7 @@ PrimaryVertexAnalyzer4PU::analyze(const Event& iEvent, const EventSetup& iSetup)
       for(TrackingVertexCollection::const_iterator iv=tpVtxs->begin(); iv!=tpVtxs->end(); iv++){
 	cout << *iv << endl;
       }
-      if(iEvent.getByLabel(mcproduct,evtMC)){
+      if( iEvent.getByToken( edmHepMCProductToken_, evtMC ) ){
 	cout << "dumping simTracks" << endl;
 	for(SimTrackContainer::const_iterator t=simTrks->begin();  t!=simTrks->end(); ++t){
 	  cout << *t << endl;
@@ -2205,7 +2215,7 @@ PrimaryVertexAnalyzer4PU::analyze(const Event& iEvent, const EventSetup& iSetup)
     simpv=getSimPVs(TVCollectionH);
     
 
-  }else if(iEvent.getByLabel(mcproduct,evtMC)){
+  }else if( iEvent.getByToken( edmHepMCProductToken_, evtMC ) ) {
 
     simpv=getSimPVs(evtMC);
 

--- a/Validation/RecoVertex/src/TrackParameterAnalyzer.cc
+++ b/Validation/RecoVertex/src/TrackParameterAnalyzer.cc
@@ -128,7 +128,6 @@ bool TrackParameterAnalyzer::match(const ParameterVector  &a,
 void
 TrackParameterAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-   using namespace edm;
    using CLHEP::HepLorentzVector;
 
    //edm::ESHandle<TransientTrackBuilder> theB;
@@ -136,7 +135,7 @@ TrackParameterAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
    //double fBfield=((*theB).field()->inTesla(GlobalPoint(0.,0.,0.))).z();
    const double fBfield=3.8;
   
-   Handle<edm::SimVertexContainer> simVtcs;
+   edm::Handle<edm::SimVertexContainer> simVtcs;
    iEvent.getByToken( edmSimVertexContainerToken_, simVtcs );
    if(verbose_){
      std::cout << "SimVertex " << simVtcs->size() << std::endl;
@@ -154,7 +153,7 @@ TrackParameterAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
    }
    
    // get the simulated tracks, extract perigee parameters
-   Handle<SimTrackContainer> simTrks;
+   edm::Handle<edm::SimTrackContainer> simTrks;
    iEvent.getByToken( edmSimTrackContainerToken_, simTrks );
    
    if(verbose_){std::cout << "simtrks " << simTrks->size() << std::endl;}
@@ -226,7 +225,7 @@ TrackParameterAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
    // loop over tracks and try to match them to simulated tracks
 
 
-   Handle<reco::TrackCollection> recTracks;
+   edm::Handle<reco::TrackCollection> recTracks;
    iEvent.getByToken( recoTrackCollectionToken_, recTracks );
 
    for(reco::TrackCollection::const_iterator t=recTracks->begin();

--- a/Validation/RecoVertex/src/TrackParameterAnalyzer.cc
+++ b/Validation/RecoVertex/src/TrackParameterAnalyzer.cc
@@ -1,9 +1,25 @@
 #include "Validation/RecoVertex/interface/TrackParameterAnalyzer.h"
-#include <string>
+
+//system includes
+#include <memory>
 #include <vector>
+
+// core framework
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
-#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+
+// Hep MC stuff from CLHEP
+#include "CLHEP/Vector/LorentzVector.h"
+
+// track
+#include "DataFormats/TrackReco/interface/Track.h"
+
+// Root
+#include <TH1.h>
+#include <TH2.h>
+#include <TFile.h>
 
 //
 //
@@ -17,21 +33,20 @@
 //
 // constructors and destructor
 //
-TrackParameterAnalyzer::TrackParameterAnalyzer(const edm::ParameterSet& iConfig) :
-  simG4_( iConfig.getParameter<edm::InputTag>( "simG4" ) ) {
+TrackParameterAnalyzer::TrackParameterAnalyzer(const edm::ParameterSet& iConfig)
+  : edmSimVertexContainerToken_( consumes<edm::SimVertexContainer>( iConfig.getParameter<edm::InputTag>( "simG4" ) ) )
+  , edmSimTrackContainerToken_( consumes<edm::SimTrackContainer>( iConfig.getParameter<edm::InputTag>( "simG4" ) ) )
+  , recoTrackCollectionToken_( consumes<reco::TrackCollection>( edm::InputTag( iConfig.getUntrackedParameter<std::string>( "recoTrackProducer" ) ) ) )
+  , outputFile_( iConfig.getUntrackedParameter<std::string>( "outputFile" ) )
+  , simUnit_( 1.0 ) //  starting from  CMSSW_1_2_x, I think
+  , verbose_( iConfig.getUntrackedParameter<bool>( "verbose", false ) ) {
    //now do whatever initialization is needed
-
-  recoTrackProducer_   = iConfig.getUntrackedParameter<std::string>("recoTrackProducer");
   // open output file to store histograms}
-  outputFile_   = iConfig.getUntrackedParameter<std::string>("outputFile");
   TString tversion(edm::getReleaseVersion());
   tversion = tversion.Remove(0,1);
   tversion = tversion.Remove(tversion.Length()-1,tversion.Length());
   outputFile_  = std::string(tversion)+"_"+outputFile_;
-
   rootFile_ = TFile::Open(outputFile_.c_str(),"RECREATE"); 
-  verbose_= iConfig.getUntrackedParameter<bool>("verbose", false);
-  simUnit_=1.0;  //  starting from  CMSSW_1_2_x, I think
   if ( (edm::getReleaseVersion()).find("CMSSW_1_1_",0)!=std::string::npos){
     simUnit_=0.1;  // for use in  CMSSW_1_1_1 tutorial
   }
@@ -122,7 +137,7 @@ TrackParameterAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
    const double fBfield=3.8;
   
    Handle<edm::SimVertexContainer> simVtcs;
-   iEvent.getByLabel( simG4_, simVtcs);
+   iEvent.getByToken( edmSimVertexContainerToken_, simVtcs );
    if(verbose_){
      std::cout << "SimVertex " << simVtcs->size() << std::endl;
      for(edm::SimVertexContainer::const_iterator v=simVtcs->begin();
@@ -140,7 +155,7 @@ TrackParameterAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
    
    // get the simulated tracks, extract perigee parameters
    Handle<SimTrackContainer> simTrks;
-   iEvent.getByLabel( simG4_, simTrks);
+   iEvent.getByToken( edmSimTrackContainerToken_, simTrks );
    
    if(verbose_){std::cout << "simtrks " << simTrks->size() << std::endl;}
    std::vector<ParameterVector > tsim;
@@ -212,7 +227,7 @@ TrackParameterAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup&
 
 
    Handle<reco::TrackCollection> recTracks;
-   iEvent.getByLabel(recoTrackProducer_, recTracks);
+   iEvent.getByToken( recoTrackCollectionToken_, recTracks );
 
    for(reco::TrackCollection::const_iterator t=recTracks->begin();
        t!=recTracks->end(); ++t){

--- a/Validation/RecoVertex/src/VertexHistogramMaker.cc
+++ b/Validation/RecoVertex/src/VertexHistogramMaker.cc
@@ -1,37 +1,38 @@
 #include "Validation/RecoVertex/interface/VertexHistogramMaker.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/Luminosity/interface/LumiDetails.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
 #include "TH2F.h"
 #include "TH1F.h"
 #include "TProfile.h"
 
 
-VertexHistogramMaker::VertexHistogramMaker():
-  m_currdir(0), m_maxLS(100), m_weightThreshold(0.5), m_trueOnly(true), 
-  m_runHisto(true), m_runHistoProfile(true), m_runHistoBXProfile(true), m_runHistoBXProfile2D(false), m_runHisto2D(false), 
-  m_bsConstrained(false),
-  m_histoParameters() { }
+VertexHistogramMaker::VertexHistogramMaker()
+  : m_currdir(0), m_maxLS(100), m_weightThreshold(0.5), m_trueOnly(true)
+  , m_runHisto(true), m_runHistoProfile(true), m_runHistoBXProfile(true), m_runHistoBXProfile2D(false), m_runHisto2D(false)
+  , m_bsConstrained(false)
+  , m_histoParameters() { }
 
-VertexHistogramMaker::VertexHistogramMaker(const edm::ParameterSet& iConfig):
-  m_currdir(0),
-  m_maxLS(iConfig.getParameter<unsigned int>("maxLSBeforeRebin")),
-  m_weightThreshold(iConfig.getUntrackedParameter<double>("weightThreshold",0.5)),
-  m_trueOnly(iConfig.getUntrackedParameter<bool>("trueOnly",true)),
-  m_runHisto(iConfig.getUntrackedParameter<bool>("runHisto",true)),
-  m_runHistoProfile(iConfig.getUntrackedParameter<bool>("runHistoProfile",true)),
-  m_runHistoBXProfile(iConfig.getUntrackedParameter<bool>("runHistoBXProfile",true)),
-  m_runHistoBXProfile2D(iConfig.getUntrackedParameter<bool>("runHistoBXProfile2D",false)),
-  m_runHisto2D(iConfig.getUntrackedParameter<bool>("runHisto2D",false)),
-  m_bsConstrained(iConfig.getParameter<bool>("bsConstrained")),
-  m_histoParameters(iConfig.getUntrackedParameter<edm::ParameterSet>("histoParameters",edm::ParameterSet())),
-  m_rhm(false),m_fhm(true)
+VertexHistogramMaker::VertexHistogramMaker(const edm::ParameterSet& iConfig, edm::ConsumesCollector&& iC)
+  : m_currdir(0)
+  , m_maxLS(iConfig.getParameter<unsigned int>("maxLSBeforeRebin"))
+  , m_weightThreshold(iConfig.getUntrackedParameter<double>("weightThreshold",0.5))
+  , m_trueOnly(iConfig.getUntrackedParameter<bool>("trueOnly",true))
+  , m_runHisto(iConfig.getUntrackedParameter<bool>("runHisto",true))
+  , m_runHistoProfile(iConfig.getUntrackedParameter<bool>("runHistoProfile",true))
+  , m_runHistoBXProfile(iConfig.getUntrackedParameter<bool>("runHistoBXProfile",true))
+  , m_runHistoBXProfile2D(iConfig.getUntrackedParameter<bool>("runHistoBXProfile2D",false))
+  , m_runHisto2D(iConfig.getUntrackedParameter<bool>("runHisto2D",false))
+  , m_bsConstrained(iConfig.getParameter<bool>("bsConstrained"))
+  , m_histoParameters(iConfig.getUntrackedParameter<edm::ParameterSet>("histoParameters",edm::ParameterSet()))
+  , m_lumiDetailsToken( iC.consumes< LumiDetails, edm::InLumi >( edm::InputTag( std::string( "lumiProducer" ) ) ) )
+  , m_rhm(false),m_fhm(true)
 { }
 
 
@@ -355,7 +356,7 @@ void VertexHistogramMaker::fill(const edm::Event& iEvent, const reco::VertexColl
   // get luminosity
 
   edm::Handle<LumiDetails> ld;
-  iEvent.getLuminosityBlock().getByLabel("lumiProducer",ld);
+  iEvent.getLuminosityBlock().getByToken( m_lumiDetailsToken, ld );
 
   float bxlumi = -1.;
 


### PR DESCRIPTION
Consumes fix for the following modules in package Validation/RecoVertex:
Validation/RecoVertex/src/AnotherPrimaryVertexAnalyzer.cc
Validation/RecoVertex/src/BSvsPVAnalyzer.cc
Validation/RecoVertex/src/BeamSpotAnalyzer.cc
Validation/RecoVertex/src/MCVerticesAnalyzer.cc
Validation/RecoVertex/src/MCVerticesWeight.cc
Validation/RecoVertex/src/MCvsRecoVerticesAnalyzer.cc
Validation/RecoVertex/src/PrimaryVertexAnalyzer.cc
Validation/RecoVertex/src/PrimaryVertexAnalyzer4PU.cc
Validation/RecoVertex/src/TrackParameterAnalyzer.cc
Validation/RecoVertex/src/V0Validator.cc
Validation/RecoVertex/src/VertexHistogramMaker.cc
Tested with workflow 3 of whiteRabbit.
As a general comment, some of those modules should be rewritten from scratch. I tried to optimise a bit PrimaryVertexAnalyzer, but in the case of PrimaryVertexAnalyzer4PU what I did was just removing getByLabel and unneeded includes. Please inform developers about them.
