### PR TITLE
Refactored internals of edm::Principal to make future changes easier

### DIFF
--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -182,6 +182,8 @@ namespace edm {
                                  bool fillOnDemand,
                                  ModuleCallingContext const* mcc) const override;
 
+    virtual void readFromSource_(ProductHolderBase const& phb, ModuleCallingContext const* mcc) const override;
+
     virtual unsigned int transitionIndex_() const override;
     
   private:

--- a/FWCore/Framework/interface/EventPrincipal.h
+++ b/FWCore/Framework/interface/EventPrincipal.h
@@ -178,10 +178,6 @@ namespace edm {
     virtual bool unscheduledFill(std::string const& moduleLabel,
                                  ModuleCallingContext const* mcc) const override;
 
-    virtual void resolveProduct_(ProductHolderBase const& phb,
-                                 bool fillOnDemand,
-                                 ModuleCallingContext const* mcc) const override;
-
     virtual void readFromSource_(ProductHolderBase const& phb, ModuleCallingContext const* mcc) const override;
 
     virtual unsigned int transitionIndex_() const override;

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -191,10 +191,7 @@ namespace edm {
 
     std::vector<unsigned int> const& lookupProcessOrder() const { return lookupProcessOrder_; }
 
-    ConstProductHolderPtr getProductHolderByIndex(ProductHolderIndex const& oid,
-                                      bool resolveProd,
-                                      bool fillOnDemand,
-                                      ModuleCallingContext const* mcc) const;
+    ConstProductHolderPtr getProductHolderByIndex(ProductHolderIndex const& oid) const;
 
     bool isComplete() const {return isComplete_();}
 

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -179,13 +179,11 @@ namespace edm {
 
     ProductData const* findProductByTag(TypeID const& typeID, InputTag const& tag, ModuleCallingContext const* mcc) const;
 
-    // Make my DelayedReader get the EDProduct for a ProductHolder or
-    // trigger unscheduled execution if required.  The ProductHolder is
-    // a cache, and so can be modified through the const reference.
+    // Make my DelayedReader get the EDProduct for a ProductHolder.
+    // The ProductHolder is a cache, and so can be modified through the const
+    // reference.
     // We do not change the *number* of products through this call, and so
     // *this is const.
-    void resolveProduct(ProductHolderBase const& phb, bool fillOnDemand, ModuleCallingContext const* mcc) const {resolveProduct_(phb, fillOnDemand,mcc);}
-    
     void readFromSource(ProductHolderBase const& phb, ModuleCallingContext const* mcc) const {
       readFromSource_(phb, mcc);
     }
@@ -237,10 +235,6 @@ namespace edm {
                                           std::string const& process,
                                           EDConsumerBase const* consumer,
                                           ModuleCallingContext const* mcc) const;
-
-    // defaults to no-op unless overridden in derived class.
-    virtual void resolveProduct_(ProductHolderBase const&, bool /*fillOnDemand*/,
-                                 ModuleCallingContext const*) const {}
 
     virtual void readFromSource_(ProductHolderBase const& phb, ModuleCallingContext const* mcc) const {}
 

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -172,10 +172,7 @@ namespace edm {
 
     DelayedReader* reader() const {return reader_;}
 
-    ConstProductHolderPtr getProductHolder(BranchID const& oid,
-                                     bool resolveProd,
-                                     bool fillOnDemand,
-                                     ModuleCallingContext const* mcc) const;
+    ConstProductHolderPtr getProductHolder(BranchID const& oid) const;
 
     ProductData const* findProductByTag(TypeID const& typeID, InputTag const& tag, ModuleCallingContext const* mcc) const;
 

--- a/FWCore/Framework/interface/Principal.h
+++ b/FWCore/Framework/interface/Principal.h
@@ -185,6 +185,10 @@ namespace edm {
     // We do not change the *number* of products through this call, and so
     // *this is const.
     void resolveProduct(ProductHolderBase const& phb, bool fillOnDemand, ModuleCallingContext const* mcc) const {resolveProduct_(phb, fillOnDemand,mcc);}
+    
+    void readFromSource(ProductHolderBase const& phb, ModuleCallingContext const* mcc) const {
+      readFromSource_(phb, mcc);
+    }
 
     virtual bool unscheduledFill(std::string const& moduleLabel,
                                  ModuleCallingContext const* mcc) const = 0;
@@ -237,6 +241,8 @@ namespace edm {
     // defaults to no-op unless overridden in derived class.
     virtual void resolveProduct_(ProductHolderBase const&, bool /*fillOnDemand*/,
                                  ModuleCallingContext const*) const {}
+
+    virtual void readFromSource_(ProductHolderBase const& phb, ModuleCallingContext const* mcc) const {}
 
     virtual bool isComplete_() const {return true;}
 

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -243,7 +243,7 @@ namespace edm {
   BasicHandle
   EventPrincipal::getByProductID(ProductID const& pid) const {
     BranchID bid = pidToBid(pid);
-    ConstProductHolderPtr const phb = getProductHolder(bid, true, false, nullptr);
+    ConstProductHolderPtr const phb = getProductHolder(bid);
     if(phb == nullptr) {
       return BasicHandle(makeHandleExceptionFactory([pid]()->std::shared_ptr<cms::Exception> {
         std::shared_ptr<cms::Exception> whyFailed(std::make_shared<Exception>(errors::ProductNotFound, "InvalidID"));
@@ -263,11 +263,14 @@ namespace edm {
       return BasicHandle(makeHandleExceptionFactory([pid]()->std::shared_ptr<cms::Exception> {
         std::shared_ptr<cms::Exception> whyFailed(std::make_shared<Exception>(errors::ProductNotFound, "InvalidID"));
         *whyFailed
-        << "get by product ID: no product with given id: " << pid << "\n"
-        << "onDemand production failed to produce it.\n";
+        << "get by ProductID: could not get product with id: " << pid << "\n"
+        << "Unscheduled execution not allowed to get via ProductID.\n";
         return whyFailed;
       }));
     }
+    ProductHolderBase::ResolveStatus status;
+    phb->resolveProduct(status,false,nullptr);
+
     return BasicHandle(phb->productData());
   }
 

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -176,12 +176,16 @@ namespace edm {
       }
       return;
     }
+    readFromSource(phb,mcc);
+  }
 
+   void
+  EventPrincipal::readFromSource_(ProductHolderBase const& phb, ModuleCallingContext const* mcc) const {
     if(phb.branchDescription().produced()) return; // nothing to do.
     if(phb.product()) return; // nothing to do.
     if(phb.productUnavailable()) return; // nothing to do.
     if(!reader()) return; // nothing to do.
-
+    
     // must attempt to load from persistent store
     BranchKey const bk = BranchKey(phb.branchDescription());
     {
@@ -193,9 +197,9 @@ namespace edm {
           postModuleDelayedGetSignal_.emit(*(mcc->getStreamContext()),*mcc);
         }
       });
-
+      
       WrapperOwningHolder edp(reader()->getProduct(bk, phb.productData().getInterface(), this));
-
+      
       // Now fix up the ProductHolder
       checkUniquenessAndType(edp, &phb);
       phb.putProduct(edp);

--- a/FWCore/Framework/src/EventPrincipal.cc
+++ b/FWCore/Framework/src/EventPrincipal.cc
@@ -165,20 +165,6 @@ namespace edm {
     phb->putProduct(edp, productProvenance);
   }
 
-  void
-  EventPrincipal::resolveProduct_(ProductHolderBase const& phb, bool fillOnDemand,
-                                  ModuleCallingContext const* mcc) const {
-    // Try unscheduled production.
-    if(phb.onDemand()) {
-      if(fillOnDemand) {
-        unscheduledFill(phb.resolvedModuleLabel(),
-                        mcc);
-      }
-      return;
-    }
-    readFromSource(phb,mcc);
-  }
-
    void
   EventPrincipal::readFromSource_(ProductHolderBase const& phb, ModuleCallingContext const* mcc) const {
     if(phb.branchDescription().produced()) return; // nothing to do.

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -435,7 +435,12 @@ namespace edm {
     auto returnValue = getProductHolderByIndex(index);
     
     if(nullptr != returnValue and resolveProd and !returnValue->productUnavailable()) {
-      this->resolveProduct(*returnValue, fillOnDemand, mcc);
+      if (not fillOnDemand and returnValue->onDemand()) {
+        //if requested, skip onDemand if it was onDemand
+        return returnValue;
+      }
+      ProductHolderBase::ResolveStatus status;
+      returnValue->resolveProduct(status,false,mcc);
     }
     
     return returnValue;

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -432,20 +432,19 @@ namespace edm {
     if(index == ProductHolderIndexInvalid){
        return ConstProductHolderPtr();
     }
-    return getProductHolderByIndex(index, resolveProd, fillOnDemand, mcc);
+    auto returnValue = getProductHolderByIndex(index);
+    
+    if(nullptr != returnValue and resolveProd and !returnValue->productUnavailable()) {
+      this->resolveProduct(*returnValue, fillOnDemand, mcc);
+    }
+    
+    return returnValue;
   }
 
   Principal::ConstProductHolderPtr
-  Principal::getProductHolderByIndex(ProductHolderIndex const& index, bool resolveProd, bool fillOnDemand,
-                               ModuleCallingContext const* mcc) const {
+  Principal::getProductHolderByIndex(ProductHolderIndex const& index) const {
 
     ConstProductHolderPtr const phb = productHolders_[index].get();
-    if(nullptr == phb) {
-      return phb;
-    }
-    if(resolveProd && !phb->productUnavailable()) {
-      this->resolveProduct(*phb, fillOnDemand, mcc);
-    }
     return phb;
   }
 

--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -426,24 +426,12 @@ namespace edm {
   }
 
   Principal::ConstProductHolderPtr
-  Principal::getProductHolder(BranchID const& bid, bool resolveProd, bool fillOnDemand,
-                              ModuleCallingContext const* mcc) const {
+  Principal::getProductHolder(BranchID const& bid) const {
     ProductHolderIndex index = preg_->indexFrom(bid);
     if(index == ProductHolderIndexInvalid){
        return ConstProductHolderPtr();
     }
-    auto returnValue = getProductHolderByIndex(index);
-    
-    if(nullptr != returnValue and resolveProd and !returnValue->productUnavailable()) {
-      if (not fillOnDemand and returnValue->onDemand()) {
-        //if requested, skip onDemand if it was onDemand
-        return returnValue;
-      }
-      ProductHolderBase::ResolveStatus status;
-      returnValue->resolveProduct(status,false,mcc);
-    }
-    
-    return returnValue;
+    return getProductHolderByIndex(index);
   }
 
   Principal::ConstProductHolderPtr
@@ -727,7 +715,7 @@ namespace edm {
   OutputHandle
   Principal::getForOutput(BranchID const& bid, bool getProd,
                           ModuleCallingContext const* mcc) const {
-    ConstProductHolderPtr const phb = getProductHolder(bid, getProd, true, mcc);
+    ConstProductHolderPtr const phb = getProductHolder(bid);
     if(phb == nullptr) {
       throwProductNotFoundException("getForOutput", errors::LogicError, bid);
     }
@@ -736,6 +724,10 @@ namespace edm {
                                    phb->moduleLabel(),
                                    phb->productInstanceName(),
                                    phb->processName());
+    }
+    if(getProd) {
+      ProductHolderBase::ResolveStatus status;
+      phb->resolveProduct(status,false,mcc);
     }
     if(!phb->provenance() || (!phb->product() && !phb->productProvenancePtr())) {
       return OutputHandle();
@@ -746,7 +738,7 @@ namespace edm {
   Provenance
   Principal::getProvenance(BranchID const& bid,
                            ModuleCallingContext const* mcc) const {
-    ConstProductHolderPtr const phb = getProductHolder(bid, false, true, mcc);
+    ConstProductHolderPtr const phb = getProductHolder(bid);
     if(phb == nullptr) {
       throwProductNotFoundException("getProvenance", errors::ProductNotFound, bid);
     }

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -237,7 +237,7 @@ namespace edm {
 	<< principal_.productRegistry()
 	<< '\n';
     }
-    ProductHolderBase const*  phb = principal_.getProductHolderByIndex(index, false, false, nullptr);
+    ProductHolderBase const*  phb = principal_.getProductHolderByIndex(index);
     assert(phb != nullptr);
     return phb->branchDescription();
   }

--- a/FWCore/Framework/src/ProductHolder.cc
+++ b/FWCore/Framework/src/ProductHolder.cc
@@ -42,7 +42,7 @@ namespace edm {
       throwProductDeletedException();
     }
     if(!productUnavailable()) {
-      principal_->resolveProduct(*this, false, mcc);
+      principal_->readFromSource(*this, mcc);
       // If the product is a dummy filler, product holder will now be marked unavailable.
       if(product() && !productUnavailable()) {
         // Found the match

--- a/FWCore/Framework/src/ProductHolder.cc
+++ b/FWCore/Framework/src/ProductHolder.cc
@@ -419,7 +419,7 @@ namespace edm {
         return nullptr;
       }
       if (matchingHolders_[k] != ProductHolderIndexInvalid) {
-        ProductHolderBase const* productHolder = principal_->getProductHolderByIndex(matchingHolders_[k], false, false, mcc);
+        ProductHolderBase const* productHolder = principal_->getProductHolderByIndex(matchingHolders_[k]);
         ProductData const* pd =  productHolder->resolveProduct(resolveStatus, skipCurrentProcess, mcc);
         if(pd != nullptr) return pd;
       }

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -499,10 +499,10 @@ namespace edm {
   SubProcess::propagateProducts(BranchType type, Principal const& parentPrincipal, Principal& principal) const {
     SelectedProducts const& keptVector = keptProducts()[type];
     for(auto const& item : keptVector) {
-      ProductHolderBase const* parentProductHolder = parentPrincipal.getProductHolder(item->branchID(), false, false, nullptr);
+      ProductHolderBase const* parentProductHolder = parentPrincipal.getProductHolder(item->branchID());
       if(parentProductHolder != nullptr) {
         ProductData const& parentData = parentProductHolder->productData();
-        ProductHolderBase const* productHolder = principal.getProductHolder(item->branchID(), false, false, nullptr);
+        ProductHolderBase const* productHolder = principal.getProductHolder(item->branchID());
         if(productHolder != nullptr) {
           ProductData& thisData = const_cast<ProductData&>(productHolder->productData());
           //Propagate the per event(run)(lumi) data for this product to the subprocess.

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -730,7 +730,7 @@ void testEvent::deleteProduct() {
       id = iDesc.branchID();
     }});
 
-  const ProductHolderBase* phb = principal_->getProductHolder(id,false,false,nullptr);
+  const ProductHolderBase* phb = principal_->getProductHolder(id);
   CPPUNIT_ASSERT(phb != nullptr);
   
   CPPUNIT_ASSERT(!phb->productWasDeleted());  


### PR DESCRIPTION
edm::Principal is the base class for the classes which deal with Run, Lumi and Event data products. The way we get data will change for the threaded-framework. This refactoring lays the ground work for those changes. No functionality should change from this refactoring.
