### PR TITLE
Pileup jet ID for JPT 

### DIFF
--- a/RecoJets/JetProducers/BuildFile.xml
+++ b/RecoJets/JetProducers/BuildFile.xml
@@ -8,6 +8,7 @@
 <use   name="SimDataFormats/CaloHit"/>
 <use   name="RecoJets/JetAlgorithms"/>
 <use   name="DataFormats/CastorReco"/>
+<use   name="CommonTools/Utils"/>
 <use   name="fastjet"/>
 <use   name="roottmva"/>
 <use   name="vdt"/>

--- a/RecoJets/JetProducers/data/download.url
+++ b/RecoJets/JetProducers/data/download.url
@@ -1,0 +1,6 @@
+http://cmsdoc.cern.ch/cms/data/CMSSW/RecoJets/JetProducers/data/TMVAClassificationCategory_JetID_53X_Dec2012.weights.xml.gz
+http://cmsdoc.cern.ch/cms/data/CMSSW/RecoJets/JetProducers/data/TMVAClassificationCategory_JetID_MET_53X_Dec2012.weights.xml.gz
+http://cmsdoc.cern.ch/cms/data/CMSSW/RecoJets/JetProducers/data/TMVAClassification_5x_BDT_chsFullPlusRMS.weights.xml.gz
+http://cmsdoc.cern.ch/cms/data/CMSSW/RecoJets/JetProducers/data/TMVAClassification_PUJetID_JPT_BDTG.weights.xml.gz
+http://cmsdoc.cern.ch/cms/data/CMSSW/RecoJets/JetProducers/data/TMVAClassification_PUJetID_JPT_BDTG.weights_F.xml.gz
+

--- a/RecoJets/JetProducers/interface/PileupJPTJetIdAlgo.h
+++ b/RecoJets/JetProducers/interface/PileupJPTJetIdAlgo.h
@@ -1,0 +1,53 @@
+#ifndef JetProducers_PileupJPTJetIdAlgo_h
+#define JetProducers_PileupJPTJetIdAlgo_h
+
+#include "DataFormats/JetReco/interface/JPTJet.h"
+
+// user include files
+#include <string>
+#include <memory>
+#include <map>
+#include<fstream>
+#include<iomanip>
+#include<iostream>
+#include<vector>
+
+using namespace std; 
+using namespace reco;
+
+namespace edm {
+  class Event;
+  class EventSetup;
+  class ParameterSets;
+}
+// For MVA analysis
+
+#include "TMVA/Tools.h"
+#include "TMVA/Reader.h"
+
+namespace cms
+{
+
+class PileupJPTJetIdAlgo
+{
+public:  
+
+  PileupJPTJetIdAlgo(const edm::ParameterSet& fParameters);
+
+  virtual ~PileupJPTJetIdAlgo();
+
+  void bookMVAReader(); 
+
+  float fillJPTBlock(const reco::JPTJet* jet 
+                  );
+private:
+     int verbosity;
+// Variables for multivariate analysis
+
+     float Nvtx,PtJ,EtaJ,Beta,MultCalo,dAxis1c,dAxis2c,MultTr,dAxis1t,dAxis2t;
+     TMVA::Reader * reader_; 
+     TMVA::Reader * readerF_;
+     std::string    tmvaWeights_, tmvaWeightsF_, tmvaMethod_;
+};
+}
+#endif

--- a/RecoJets/JetProducers/plugins/PileupJPTJetIdProducer.cc
+++ b/RecoJets/JetProducers/plugins/PileupJPTJetIdProducer.cc
@@ -1,0 +1,183 @@
+// -*- C++ -*-
+//
+// Package:    PileupJetIdProducer
+// Class:      PileupJetIdProducer
+// 
+/**\class PileupJPTJetIdProducer PileupJPTJetIdProducer.cc RecoJets/JetProducers/plugins/PileupJPTJetIdProducer.cc
+
+Description: [one line class summary]
+
+Implementation:
+[Notes on implementation]
+*/
+//
+// Original Author:  Olga Kodolova,40 R-A12,+41227671273,
+//         Created:  Fri Jan 11 15:30:47 CEST 2013
+// $Id: PileupJPTJetIdProducer.cc,v 1.1 2013/03/27 17:42:09 rkogler Exp $
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "DataFormats/JetReco/interface/Jet.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "RecoJets/JetProducers/interface/PileupJPTJetIdAlgo.h"
+#include "DataFormats/JetReco/interface/JPTJetCollection.h"
+#include "DataFormats/JetReco/interface/JPTJet.h"
+
+
+// ------------------------------------------------------------------------------------------
+class PileupJPTJetIdProducer : public edm::EDProducer {
+public:
+	explicit PileupJPTJetIdProducer(const edm::ParameterSet&);
+	~PileupJPTJetIdProducer();
+
+private:
+	virtual void beginJob() ;
+	virtual void produce(edm::Event&, const edm::EventSetup&);
+	virtual void endJob() ;
+      
+	virtual void beginRun(edm::Run&, edm::EventSetup const&);
+	virtual void endRun(edm::Run&, edm::EventSetup const&);
+	virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+	virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+
+	edm::InputTag jets_;
+             bool allowMissingInputs_;
+             int verbosity;
+        cms::PileupJPTJetIdAlgo* pualgo;
+	
+};
+
+// ------------------------------------------------------------------------------------------
+PileupJPTJetIdProducer::PileupJPTJetIdProducer(const edm::ParameterSet& iConfig)
+{
+	jets_ = iConfig.getParameter<edm::InputTag>("jets");
+            verbosity   = iConfig.getParameter<int>("Verbosity");
+            allowMissingInputs_=iConfig.getUntrackedParameter<bool>("AllowMissingInputs",false);
+        pualgo = new cms::PileupJPTJetIdAlgo(iConfig); 
+        pualgo->bookMVAReader();
+	produces<edm::ValueMap<float> > ("JPTPUDiscriminant");
+	produces<edm::ValueMap<int> > ("JPTPUId");
+}
+
+
+
+// ------------------------------------------------------------------------------------------
+PileupJPTJetIdProducer::~PileupJPTJetIdProducer()
+{
+}
+
+
+// ------------------------------------------------------------------------------------------
+void
+PileupJPTJetIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+	using namespace edm;
+	using namespace std;
+	using namespace reco;
+    edm::Handle<View<JPTJet> > jets;
+    iEvent.getByLabel(jets_, jets);
+             vector<float> mva;
+             vector<int> idflag;
+        for ( unsigned int i=0; i<jets->size(); ++i ) {
+        int b = -1;
+        const JPTJet & jet = jets->at(i);
+
+        float mvapu = pualgo->fillJPTBlock(&jet);
+
+        mva.push_back(mvapu);
+
+  // Get PUid type
+///|eta|<2.6
+//WP 95% JPT PUID > 0.3
+//WP 90% JPT PUID > 0.7
+//WP 80% JPT PUID > 0.9
+
+//|eta|>=2.6
+//WP 90% JPT PUID > -0.55
+//WP 80% JPT PUID > -0.3
+//WP 70% JPT PUID > -0.1
+        
+        if(fabs(jet.eta()) < 2.6 ) {
+           if( mvapu > 0.3 ) b = 0;
+           if( mvapu > 0.7 ) b = 1;
+           if( mvapu > 0.9 ) b = 2;
+        } else {
+           if( mvapu > -0.55 ) b = 0;
+           if( mvapu > -0.3 ) b = 1;
+           if( mvapu > -0.1 ) b = 2;
+        }
+
+        idflag.push_back(b); 
+
+       if(verbosity > 0) std::cout<<" PUID producer::Corrected JPT Jet is "<<jet.pt()<<" "<<jet.eta()<<" "<<jet.phi()<<" "<<jet.getSpecific().Zch<<std::endl; 
+    
+    }
+     
+        auto_ptr<ValueMap<float> > mvaout(new ValueMap<float>());
+        ValueMap<float>::Filler mvafiller(*mvaout);
+        mvafiller.insert(jets,mva.begin(),mva.end());
+        mvafiller.fill();
+        iEvent.put(mvaout,"JPTPUDiscriminant");
+
+        auto_ptr<ValueMap<int> > idflagout(new ValueMap<int>());
+        ValueMap<int>::Filler idflagfiller(*idflagout);
+        idflagfiller.insert(jets,idflag.begin(),idflag.end());
+        idflagfiller.fill();
+        iEvent.put(idflagout,"JPTPUId");
+
+	
+
+}
+
+// ------------------------------------------------------------------------------------------
+void 
+PileupJPTJetIdProducer::beginJob()
+{
+}
+
+// ------------------------------------------------------------------------------------------
+void 
+PileupJPTJetIdProducer::endJob() {
+}
+
+// ------------------------------------------------------------------------------------------
+void 
+PileupJPTJetIdProducer::beginRun(edm::Run&, edm::EventSetup const&)
+{
+}
+
+// ------------------------------------------------------------------------------------------
+void 
+PileupJPTJetIdProducer::endRun(edm::Run&, edm::EventSetup const&)
+{
+}
+
+// ------------------------------------------------------------------------------------------
+void 
+PileupJPTJetIdProducer::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+
+// ------------------------------------------------------------------------------------------
+void 
+PileupJPTJetIdProducer::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(PileupJPTJetIdProducer);

--- a/RecoJets/JetProducers/python/PileupJPTJetID_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJPTJetID_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+pileupJPTJetIdProducer = cms.EDProducer("PileupJPTJetIdProducer",
+   jets = cms.InputTag("ak5JPTJetsL1L2L3"),
+   Verbosity = cms.int32(0),
+   tmvaWeightsCentral = cms.string('RecoJets/JetProducers/data/TMVAClassification_PUJetID_JPT_BDTG.weights.xml.gz'),
+   tmvaWeightsForward = cms.string('RecoJets/JetProducers/data/TMVAClassification_PUJetID_JPT_BDTG.weights_F.xml.gz'),
+   tmvaMethod = cms.string('BDTG method')
+)
+

--- a/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
@@ -2,39 +2,10 @@ import FWCore.ParameterSet.Config as cms
 from RecoJets.JetProducers.PileupJetIDCutParams_cfi import *
 
 ####################################################################################################################  
-full_5x = cms.PSet(
- impactParTkThreshold = cms.double(1.) ,
- cutBased = cms.bool(False),
- tmvaWeights = cms.string("RecoJets/JetProducers/data/TMVAClassification_5x_BDT_fullPlusRMS.weights.xml"),
- tmvaMethod  = cms.string("BDT_fullPlusRMS"),
- version = cms.int32(-1),
- tmvaVariables = cms.vstring(
-    "frac01",
-    "frac02",
-    "frac03",
-    "frac04",
-    "frac05",
-    "dR2Mean",
-    "nvtx",
-    "nNeutrals",
-    "beta",
-    "betaStar",
-    "dZ",
-    "nCharged",
-    ),
- tmvaSpectators = cms.vstring(
-    "jetPt",
-    "jetEta",
-    ),
- JetIdParams = full_5x_wp,
- label = cms.string("full")
- )
-
-####################################################################################################################  
 full_5x_chs = cms.PSet(
  impactParTkThreshold = cms.double(1.) ,
  cutBased = cms.bool(False),
- tmvaWeights = cms.string("RecoJets/JetProducers/data/TMVAClassification_5x_BDT_chsFullPlusRMS.weights.xml"),
+ tmvaWeights = cms.string("RecoJets/JetProducers/data/TMVAClassification_5x_BDT_chsFullPlusRMS.weights.xml.gz"),
  tmvaMethod  = cms.string("BDT_chsFullPlusRMS"),
  version = cms.int32(-1),
  tmvaVariables = cms.vstring(
@@ -59,68 +30,10 @@ full_5x_chs = cms.PSet(
  label = cms.string("full")
  )
 ####################################################################################################################  
-full = cms.PSet(
- impactParTkThreshold = cms.double(1.) ,
- cutBased = cms.bool(False),
- tmvaWeights = cms.string("RecoJets/JetProducers/data/TMVAClassification_PuJetIdOptMVA.weights.xml"),
- tmvaMethod  = cms.string("PuJetIdOptMVA"),
- version = cms.int32(-1),
- tmvaVariables = cms.vstring(
-    "frac01",
-    "frac02",
-    "frac03",
-    "frac04",
-    "frac05",
-    "nvtx",
-    "nNeutrals",
-    "beta",
-    "betaStar",
-    "dZ",
-    "nCharged",
-    ),
- tmvaSpectators = cms.vstring(
-    "jetPt",
-    "jetEta",
-    ),
- JetIdParams = PuJetIdOptMVA_wp,
- label = cms.string("full")
- )
-
-####################################################################################################################  
 cutbased = cms.PSet( 
  impactParTkThreshold = cms.double(1.),
  cutBased = cms.bool(True),
  JetIdParams = PuJetIdCutBased_wp,
  label = cms.string("cutbased")
- )
-
-####################################################################################################################  
-PhilV1 = cms.PSet(
- impactParTkThreshold = cms.double(1.) ,
- cutBased = cms.bool(False),
- tmvaWeights = cms.string("RecoJets/JetProducers/data/mva_JetID_v1.weights.xml"),
- tmvaMethod  = cms.string("JetID"),
- version = cms.int32(-1),
- tmvaVariables = cms.vstring(
-    "nvtx",
-    "jetPt",
-    "jetEta",
-    "jetPhi",
-    "dZ",
-    "d0",
-    "beta",
-    "betaStar",
-    "nCharged",
-    "nNeutrals",
-    "dRMean",
-    "frac01",
-    "frac02",
-    "frac03",
-    "frac04",
-    "frac05",
-    ),
- tmvaSpectators = cms.vstring(),
- JetIdParams = JetIdParams,
- label = cms.string("philv1")
  )
 

--- a/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
@@ -189,13 +189,14 @@ float PileupJPTJetIdAlgo::fillJPTBlock(const reco::JPTJet* jet
       
   // W.r.t. principal axis
 
-                     double detavar = deta2-deta1*deta1;
-                     double dphivar = dphi2-dphi1*dphi1;
-                     double dphidetacov = dphideta - deta1*dphi1;
-
-                     double det = (detavar-dphivar)*(detavar-dphivar)+4*dphidetacov*dphidetacov;
-                     double x1 = (detavar+dphivar+sqrt(det))/2.;
-                     double x2 = (detavar+dphivar-sqrt(det))/2.;
+      double detavar = deta2-deta1*deta1;
+      double dphivar = dphi2-dphi1*dphi1;
+      double dphidetacov = dphideta - deta1*dphi1;
+      
+      double det = (detavar-dphivar)*(detavar-dphivar)+4*dphidetacov*dphidetacov;
+      det = sqrt(det);
+      double x1 = (detavar+dphivar+det)/2.;
+      double x2 = (detavar+dphivar-det)/2.;
       
       
   // Energy fraction in cone
@@ -279,13 +280,14 @@ std::cout<<" ncalo "<<ncalotowers<<" deta2 "<<deta2<<" dphi2 "<<dphi2<<" deta1 "
 
   // W.r.t. principal axis
 
-                     double detavart = detatr2-detatr1*detatr1;
-                     double dphivart = dphitr2-dphitr1*dphitr1;
-                     double dphidetacovt = dphidetatr - detatr1*dphitr1;
-
-                     double dettr = (detavart-dphivart)*(detavart-dphivart)+4*dphidetacovt*dphidetacovt;
-		     double x1tr = (detavart+dphivart+sqrt(dettr))/2.;
-		     double x2tr = (detavart+dphivart-sqrt(dettr))/2.;
+      double detavart = detatr2-detatr1*detatr1;
+      double dphivart = dphitr2-dphitr1*dphitr1;
+      double dphidetacovt = dphidetatr - detatr1*dphitr1;
+      
+      double dettr = (detavart-dphivart)*(detavart-dphivart)+4*dphidetacovt*dphidetacovt;
+      dettr = sqrt(dettr);
+      double x1tr = (detavart+dphivart+dettr)/2.;
+      double x2tr = (detavart+dphivart-dettr)/2.;
      
         if (verbosity > 0) std::cout<<" ntracks "<<ntracks<<" detatr2 "<<detatr2<<" dphitr2 "<<dphitr2<<" detatr1 "<<detatr1<<" dphitr1 "<<dphitr1<<" detavart "<<detavart<<" dphivart "<<dphivart<<" dphidetacovt "<<dphidetacovt<<" sqrt(det) "<<sqrt(dettr)<<" x1tr "<<x1tr<<" x2tr "<<x2tr<<std::endl;
  

--- a/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
@@ -1,0 +1,315 @@
+#include<fstream>
+#include<iomanip>
+#include<iostream>
+
+// DataFormat //
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Provenance/interface/Provenance.h"
+
+#include "DataFormats/JetReco/interface/Jet.h"
+#include "DataFormats/JetReco/interface/JetTracksAssociation.h"
+
+#include "DataFormats/JetReco/interface/CaloJetCollection.h"
+#include "DataFormats/JetReco/interface/CaloJet.h"
+
+#include "DataFormats/JetReco/interface/JPTJetCollection.h"
+#include "DataFormats/JetReco/interface/JPTJet.h"
+
+#include "DataFormats/JetReco/interface/JetID.h"
+
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/Math/interface/Vector3D.h"
+
+
+// FWCore //
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+// TrackingTools //
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+
+// Constants, Math //
+#include "CLHEP/Units/GlobalPhysicalConstants.h"
+#include "Math/GenVector/VectorUtil.h"
+#include "Math/GenVector/PxPyPzE4D.h"
+
+#include "CommonTools/Utils/interface/TMVAZipReader.h"
+
+#include <vector>
+
+///////////////////////////////////////////////////////////////////////////////////////
+
+#include "RecoJets/JetProducers/interface/PileupJPTJetIdAlgo.h"
+
+////////////////////////////////////////////////////////////////////////////////////////
+using namespace std;
+namespace cms
+{
+  
+  PileupJPTJetIdAlgo::PileupJPTJetIdAlgo(const edm::ParameterSet& iConfig)
+  {
+    
+    verbosity   = iConfig.getParameter<int>("Verbosity");
+    tmvaWeights_         = edm::FileInPath(iConfig.getParameter<std::string>("tmvaWeightsCentral")).fullPath();
+    tmvaWeightsF_         = edm::FileInPath(iConfig.getParameter<std::string>("tmvaWeightsForward")).fullPath();
+    tmvaMethod_          = iConfig.getParameter<std::string>("tmvaMethod");
+
+  }
+  
+  PileupJPTJetIdAlgo::~PileupJPTJetIdAlgo()
+  {
+  //  std::cout<<" JetPlusTrack destructor "<<std::endl;
+  }
+  
+  void PileupJPTJetIdAlgo::bookMVAReader()
+  {
+    
+// Read TMVA tree
+//    std::string mvaw     = "RecoJets/JetProducers/data/TMVAClassification_BDTG.weights.xml";       
+//    std::string mvawF     = "RecoJets/JetProducers/data/TMVAClassification_BDTG.weights_F.xml";
+//    tmvaWeights_         = edm::FileInPath(mvaw).fullPath();
+//    tmvaWeightsF_         = edm::FileInPath(mvawF).fullPath();
+//    tmvaMethod_          = "BDTG method";
+
+    if(verbosity>0) std::cout<<" TMVA method "<<tmvaMethod_.c_str()<<" "<<tmvaWeights_.c_str()<<std::endl;
+    reader_ = new TMVA::Reader( "!Color:!Silent" );
+
+    reader_->AddVariable( "Nvtx", &Nvtx );
+    reader_->AddVariable( "PtJ", &PtJ );
+    reader_->AddVariable( "EtaJ", &EtaJ );
+    reader_->AddVariable( "Beta", &Beta );
+    reader_->AddVariable( "MultCalo", &MultCalo );
+    reader_->AddVariable( "dAxis1c", &dAxis1c );
+    reader_->AddVariable( "dAxis2c", &dAxis2c );
+    reader_->AddVariable( "MultTr", &MultTr );
+    reader_->AddVariable( "dAxis1t", &dAxis1t );
+    reader_->AddVariable( "dAxis2t", &dAxis2t );
+
+    reco::details::loadTMVAWeights(reader_, tmvaMethod_.c_str(), tmvaWeights_.c_str());
+
+    //std::cout<<" Method booked "<<std::endl;
+
+
+    readerF_ = new TMVA::Reader( "!Color:!Silent" );
+
+    readerF_->AddVariable( "Nvtx", &Nvtx );
+    readerF_->AddVariable( "PtJ", &PtJ );
+    readerF_->AddVariable( "EtaJ", &EtaJ );
+    readerF_->AddVariable( "MultCalo", &MultCalo );
+    readerF_->AddVariable( "dAxis1c", &dAxis1c );
+    readerF_->AddVariable( "dAxis2c", &dAxis2c );
+
+    reco::details::loadTMVAWeights(readerF_, tmvaMethod_.c_str(), tmvaWeightsF_.c_str());
+
+   // std::cout<<" Method booked F "<<std::endl;
+  }
+
+float PileupJPTJetIdAlgo::fillJPTBlock(const reco::JPTJet* jet
+                                      )
+{
+
+      if (verbosity > 0) { 
+	std::cout<<"================================    JET LOOP  ====================  "   <<  std::endl;
+	std::cout<<"================    jetPt   =  "   << (*jet).pt()  <<  std::endl;
+	std::cout<<"================    jetEta   =  "   << (*jet).eta()  <<  std::endl;
+      }      
+
+    edm::RefToBase<reco::Jet> jptjetRef = jet->getCaloJetRef();
+    reco::CaloJet const * rawcalojet = dynamic_cast<reco::CaloJet const *>( &* jptjetRef);
+ 
+
+      int ncalotowers=0.;
+      double sumpt=0.;
+      double dphi2=0.;
+      double deta2=0.;
+      double dphi1=0.;
+      double dphideta=0.;     
+      double deta1=0.;
+      double ffrac01=0.;
+      double ffrac02=0.;
+      double ffrac03=0.;
+      double ffrac04=0.;
+      double ffrac05=0.;
+      double EE=0.;
+      double HE=0.;
+      double EELong=0.;
+      double EEShort=0.;
+ 
+      std::vector <CaloTowerPtr> calotwrs = (*rawcalojet).getCaloConstituents();
+
+      if (verbosity > 0) { std::cout<<"=======    CaloTowerPtr DONE   ==  "   <<  std::endl;}      
+      
+      for(std::vector <CaloTowerPtr>::const_iterator icalot = calotwrs.begin();
+	                                             icalot!= calotwrs.end(); icalot++) {
+	ncalotowers++;
+	
+	double  deta=(*jet).eta()-(*icalot)->eta();
+	double  dphi=(*jet).phi()-(*icalot)->phi();
+
+	if(dphi > 4.*atan(1.) ) dphi = dphi-8.*atan(1.);
+	if(dphi < -1.*4.*atan(1.) ) dphi = dphi+8.*atan(1.);
+
+       if (verbosity > 0)  std::cout<<" CaloTower jet eta "<<(*jet).eta()<<" tower eta "<<(*icalot)->eta()<<" jet phi "<<(*jet).phi()<<" tower phi "<<(*icalot)->phi()<<" dphi "<<dphi<<" "<<(*icalot)->pt()<<" ieta "<<(*icalot)->ieta()<<" "<<abs((*icalot)->ieta())<<std::endl;
+
+        double dr = sqrt(dphi*dphi+deta*deta);
+        double enc = (*icalot)->emEnergy()+(*icalot)->hadEnergy();
+        if(dr < 0.1) ffrac01 = ffrac01 + enc;
+        if(dr < 0.2) ffrac02 = ffrac02 + enc;
+        if(dr < 0.3) ffrac03 = ffrac03 + enc;
+        if(dr < 0.4) ffrac04 = ffrac04 + enc;
+        if(dr < 0.5) ffrac05 = ffrac05 + enc;
+	
+        if(abs((*icalot)->ieta())<30) EE = EE + (*icalot)->emEnergy();
+        if(abs((*icalot)->ieta())<30) HE = HE + (*icalot)->hadEnergy();
+        if(abs((*icalot)->ieta())>29) EELong = EELong + (*icalot)->emEnergy();
+        if(abs((*icalot)->ieta())>29) EEShort = EEShort + (*icalot)->hadEnergy();
+
+	sumpt = sumpt + (*icalot)->pt();
+	dphi2 = dphi2 + dphi*dphi*(*icalot)->pt();
+	deta2 = deta2 + deta*deta*(*icalot)->pt();	
+	dphi1 = dphi1 + dphi*(*icalot)->pt();
+        deta1 = deta1 + deta*(*icalot)->pt();	
+        dphideta = dphideta + dphi*deta*(*icalot)->pt();	
+
+      } // calojet constituents
+      
+            
+      if( sumpt > 0.) {
+		      deta1 = deta1/sumpt;
+		      dphi1 = dphi1/sumpt;
+		      deta2 = deta2/sumpt;
+		      dphi2 = dphi2/sumpt;
+		      dphideta = dphideta/sumpt;
+      }
+      
+  // W.r.t. principal axis
+
+                     double detavar = deta2-deta1*deta1;
+                     double dphivar = dphi2-dphi1*dphi1;
+                     double dphidetacov = dphideta - deta1*dphi1;
+
+                     double det = (detavar-dphivar)*(detavar-dphivar)+4*dphidetacov*dphidetacov;
+                     double x1 = (detavar+dphivar+sqrt(det))/2.;
+                     double x2 = (detavar+dphivar-sqrt(det))/2.;
+      
+      
+  // Energy fraction in cone
+ 
+      ffrac01 = ffrac01/(*jet).energy();
+      ffrac02 = ffrac02/(*jet).energy();
+      ffrac03 = ffrac03/(*jet).energy();
+      ffrac04 = ffrac04/(*jet).energy();
+      ffrac05 = ffrac05/(*jet).energy();
+  
+if (verbosity > 0)  
+std::cout<<" ncalo "<<ncalotowers<<" deta2 "<<deta2<<" dphi2 "<<dphi2<<" deta1 "<<deta1<<" dphi1 "<<dphi1<<" detavar "<<detavar<<" dphivar "<<dphivar<<" dphidetacov "<<dphidetacov<<" sqrt(det) "<<sqrt(det)<<" x1 "<<x1<<" x2 "<<x2<<std::endl;
+
+ 
+// For jets with |eta|<2 take also tracks shape
+      int ntracks=0.;
+      double sumpttr=0.;
+      double dphitr2=0.;
+      double detatr2=0.;
+      double dphitr1=0.;
+      double detatr1=0.;
+      double dphidetatr=0.;     
+
+      const reco::TrackRefVector pioninin = (*jet).getPionsInVertexInCalo();
+      
+      for(reco::TrackRefVector::const_iterator it = pioninin.begin(); it != pioninin.end(); it++) {      
+            if ((*it)->pt() > 0.5 && ((*it)->ptError()/(*it)->pt()) < 0.05 )
+              {              
+                 ntracks++;
+		 sumpttr = sumpttr + (*it)->pt();	
+		 double  deta=(*jet).eta()-(*it)->eta();
+	         double  dphi=(*jet).phi()-(*it)->phi();
+
+	         if(dphi > 4.*atan(1.) ) dphi = dphi-8.*atan(1.);
+	         if(dphi < -1.*4.*atan(1.) ) dphi = dphi+8.*atan(1.);
+
+	         dphitr2 = dphitr2 + dphi*dphi*(*it)->pt();
+	         detatr2 = detatr2 + deta*deta*(*it)->pt();	
+	         dphitr1 = dphitr1 + dphi*(*it)->pt();
+                 detatr1 = detatr1 + deta*(*it)->pt();	
+                 dphidetatr = dphidetatr + dphi*deta*(*it)->pt();
+        if(verbosity>0) std::cout<<" Tracks-in-in "<<(*it)->pt()<<" "<<(*it)->eta()<<" "<<(*it)->phi()<<" in jet "<<(*jet).eta()<<" "<<
+         (*jet).phi()<<" jet pt "<<(*jet).pt()<<std::endl;	
+              }
+      }// pioninin
+      
+      
+       const reco::TrackRefVector pioninout = (*jet).getPionsInVertexOutCalo();
+      
+      for(reco::TrackRefVector::const_iterator it = pioninout.begin(); it != pioninout.end(); it++) {      
+            if ((*it)->pt() > 0.5 && ((*it)->ptError()/(*it)->pt()) < 0.05 )
+              {              
+                 ntracks++;
+		 sumpttr = sumpttr + (*it)->pt();	
+		 double  deta=(*jet).eta()-(*it)->eta();
+	         double  dphi=(*jet).phi()-(*it)->phi();
+
+	         if(dphi > 4.*atan(1.) ) dphi = dphi-8.*atan(1.);
+	         if(dphi < -1.*4.*atan(1.) ) dphi = dphi+8.*atan(1.);
+
+	         dphitr2 = dphitr2 + dphi*dphi*(*it)->pt();
+	         detatr2 = detatr2 + deta*deta*(*it)->pt();	
+	         dphitr1 = dphitr1 + dphi*(*it)->pt();
+                 detatr1 = detatr1 + deta*(*it)->pt();	
+                 dphidetatr = dphidetatr + dphi*deta*(*it)->pt();	
+        if(verbosity>0) std::cout<<" Tracks-in-in "<<(*it)->pt()<<" "<<(*it)->eta()<<" "<<(*it)->phi()<<" in jet "<<(*jet).eta()<<" "<< 
+         (*jet).phi()<<" jet pt "<<(*jet).pt()<<std::endl;
+              }
+      }// pioninout
+
+      if(verbosity>0) std::cout<<" Number of tracks in-in and in-out "<<pioninin.size()<<" "<<pioninout.size()<<std::endl;
+
+      	       
+      if( sumpttr > 0.) {
+		      detatr1 = detatr1/sumpttr;
+		      dphitr1 = dphitr1/sumpttr;
+		      detatr2 = detatr2/sumpttr;
+		      dphitr2 = dphitr2/sumpttr;
+		      dphidetatr = dphidetatr/sumpttr;
+      }
+
+  // W.r.t. principal axis
+
+                     double detavart = detatr2-detatr1*detatr1;
+                     double dphivart = dphitr2-dphitr1*dphitr1;
+                     double dphidetacovt = dphidetatr - detatr1*dphitr1;
+
+                     double dettr = (detavart-dphivart)*(detavart-dphivart)+4*dphidetacovt*dphidetacovt;
+		     double x1tr = (detavart+dphivart+sqrt(dettr))/2.;
+		     double x2tr = (detavart+dphivart-sqrt(dettr))/2.;
+     
+        if (verbosity > 0) std::cout<<" ntracks "<<ntracks<<" detatr2 "<<detatr2<<" dphitr2 "<<dphitr2<<" detatr1 "<<detatr1<<" dphitr1 "<<dphitr1<<" detavart "<<detavart<<" dphivart "<<dphivart<<" dphidetacovt "<<dphidetacovt<<" sqrt(det) "<<sqrt(dettr)<<" x1tr "<<x1tr<<" x2tr "<<x2tr<<std::endl;
+ 
+// Multivariate analisis
+      PtJ = (*jet).pt();          
+      EtaJ = (*jet).eta();
+      Beta = (*jet).getSpecific().Zch;
+      dAxis2c = x2;
+      dAxis1c = x1;
+      dAxis2t = x2tr;
+      dAxis1t = x1tr;
+      MultCalo = ncalotowers;
+      MultTr = ntracks;
+
+     float mva_ = 1.;
+     if(fabs(EtaJ)<2.6) {
+       mva_ = reader_->EvaluateMVA( "BDTG method" );
+      // std::cout<<" MVA analysis "<<mva_<<std::endl;
+      } else {
+        mva_ = readerF_->EvaluateMVA( "BDTG method" );
+      // std::cout<<" MVA analysis Forward "<<mva_<<std::endl;
+      }
+  if (verbosity > 0) std::cout<<"=======  Computed MVA =  " << 
+                                           mva_  <<std::endl;   
+  return mva_;
+} // fillJPTBlock
+} // namespace

--- a/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJPTJetIdAlgo.cc
@@ -151,8 +151,8 @@ float PileupJPTJetIdAlgo::fillJPTBlock(const reco::JPTJet* jet
 	double  deta=(*jet).eta()-(*icalot)->eta();
 	double  dphi=(*jet).phi()-(*icalot)->phi();
 
-	if(dphi > 4.*atan(1.) ) dphi = dphi-8.*atan(1.);
-	if(dphi < -1.*4.*atan(1.) ) dphi = dphi+8.*atan(1.);
+	if(dphi > M_PI ) dphi = dphi-2.*M_PI;
+	if(dphi < -1.*M_PI ) dphi = dphi+2.*M_PI;
 
        if (verbosity > 0)  std::cout<<" CaloTower jet eta "<<(*jet).eta()<<" tower eta "<<(*icalot)->eta()<<" jet phi "<<(*jet).phi()<<" tower phi "<<(*icalot)->phi()<<" dphi "<<dphi<<" "<<(*icalot)->pt()<<" ieta "<<(*icalot)->ieta()<<" "<<abs((*icalot)->ieta())<<std::endl;
 
@@ -229,8 +229,8 @@ std::cout<<" ncalo "<<ncalotowers<<" deta2 "<<deta2<<" dphi2 "<<dphi2<<" deta1 "
 		 double  deta=(*jet).eta()-(*it)->eta();
 	         double  dphi=(*jet).phi()-(*it)->phi();
 
-	         if(dphi > 4.*atan(1.) ) dphi = dphi-8.*atan(1.);
-	         if(dphi < -1.*4.*atan(1.) ) dphi = dphi+8.*atan(1.);
+	         if(dphi > M_PI ) dphi = dphi-2.*M_PI;
+	         if(dphi < -1.*M_PI ) dphi = dphi+2.*M_PI;
 
 	         dphitr2 = dphitr2 + dphi*dphi*(*it)->pt();
 	         detatr2 = detatr2 + deta*deta*(*it)->pt();	
@@ -253,8 +253,8 @@ std::cout<<" ncalo "<<ncalotowers<<" deta2 "<<deta2<<" dphi2 "<<dphi2<<" deta1 "
 		 double  deta=(*jet).eta()-(*it)->eta();
 	         double  dphi=(*jet).phi()-(*it)->phi();
 
-	         if(dphi > 4.*atan(1.) ) dphi = dphi-8.*atan(1.);
-	         if(dphi < -1.*4.*atan(1.) ) dphi = dphi+8.*atan(1.);
+	         if(dphi > M_PI ) dphi = dphi-2.*M_PI;
+	         if(dphi < -1.*M_PI ) dphi = dphi+2.*M_PI;
 
 	         dphitr2 = dphitr2 + dphi*dphi*(*it)->pt();
 	         detatr2 = detatr2 + deta*deta*(*it)->pt();	

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -6,6 +6,8 @@
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "CommonTools/Utils/interface/TMVAZipReader.h"
+
 #include "TMatrixDSym.h"
 #include "TMatrixDSymEigen.h"
 
@@ -202,7 +204,7 @@ void PileupJetIdAlgo::bookReader()
 		}
 		reader_->AddSpectator( *it, variables_[ tmvaNames_[*it] ].first );
 	}
-	reader_->BookMVA(tmvaMethod_.c_str(), tmvaWeights_.c_str());
+	reco::details::loadTMVAWeights(reader_,  tmvaMethod_.c_str(), tmvaWeights_.c_str() ); 
 }
 
 // ------------------------------------------------------------------------------------------


### PR DESCRIPTION
Pileup jet ID for JPT jets included. This update also includes weight files for the standard pileup jet ID, which are now stored in an external package (and downloaded through download.url).
