### PR TITLE
Protect CSCOfflineMonitor from crashing when job ends early

### DIFF
--- a/DQMOffline/Muon/src/CSCOfflineMonitor.cc
+++ b/DQMOffline/Muon/src/CSCOfflineMonitor.cc
@@ -12,7 +12,9 @@ using namespace std;
 ///////////////////
 //  CONSTRUCTOR  //
 ///////////////////
-CSCOfflineMonitor::CSCOfflineMonitor(const edm::ParameterSet& pset){
+CSCOfflineMonitor::CSCOfflineMonitor(const edm::ParameterSet& pset):
+  dbe(nullptr)
+{
 
   param = pset;
 
@@ -468,7 +470,9 @@ void CSCOfflineMonitor::endRun( edm::Run const &, edm::EventSetup const & ){
 }
 
 void CSCOfflineMonitor::endJob(){
-  
+  if(nullptr == dbe) {
+    return;
+  }
   finalize() ;
   finalizedHistograms_ = true ;
   


### PR DESCRIPTION
If the cmsRun job ended before the beginRun was called, CSCOfflineMonitor would seg fault. We now protected against that condtion.
