### PR TITLE
Make static const in StringMap

### DIFF
--- a/DataFormats/PatCandidates/src/StringMap.cc
+++ b/DataFormats/PatCandidates/src/StringMap.cc
@@ -18,7 +18,7 @@ int32_t StringMap::operator[](const std::string &string) const {
 }
 
 const std::string & StringMap::operator[](int32_t number) const {
-    static std::string empty_;
+    static const std::string empty_;
     vector_type::const_iterator match = find(number);
     return (match == end() ? empty_ : match->first);
 }


### PR DESCRIPTION
StringMap operator[] defines a function local static for an empty string. By converting this to a const static the static analyzer no longer complains about this function.
