### PR TITLE
Mark static arrays as thread-safe in EcalScDetId

### DIFF
--- a/DataFormats/EcalDetId/interface/EcalScDetId.h
+++ b/DataFormats/EcalDetId/interface/EcalScDetId.h
@@ -8,7 +8,7 @@
 #include <iosfwd>
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
-
+#include "FWCore/Utilities/interface/thread_safety_macros.h"
 
 /** \class EcalScDetId
  *  Supercrystal identifier class for the ECAL endcap.
@@ -195,11 +195,15 @@ private:
   
   /** Map of z,x,y index to hashed index. See hashedIndex/
    */
-  static short xyz2HashedIndex[IX_MAX][IY_MAX][nEndcaps];
+  CMS_THREAD_SAFE static short xyz2HashedIndex[IX_MAX][IY_MAX][nEndcaps];
   
   /** Map of hased index to x,y,z. See hashedIndex/
    */
-  static EcalScDetId hashedIndex2DetId[kSizeForDenseIndexing];
+  CMS_THREAD_SAFE static EcalScDetId hashedIndex2DetId[kSizeForDenseIndexing];
+  
+  /*The two arrays are thread safe since they are filled safely using std::call_once and
+    then only read and never modified.
+   */
 };
 
 


### PR DESCRIPTION
The static analyzer was given a false positive for the static arrays in EcalScDetId.
Used the thread safe macro to tell the static analyzer to ignore them. This is appropriate
since the static arrays are filled once in a thread safe way (std::call_once) and then
only read and never modified.
Future versions of C++ will give away to fill the arrays at construction time and therefore
we will be able to change them to const.
