### PR TITLE
Modify behavior of shared resources.

### DIFF
--- a/FWCore/Framework/src/SharedResourcesRegistry.cc
+++ b/FWCore/Framework/src/SharedResourcesRegistry.cc
@@ -11,6 +11,7 @@
 //
 
 // system include files
+#include <algorithm>
 #include <cassert>
 
 // user include files
@@ -20,7 +21,10 @@
 namespace edm {
 
   const std::string SharedResourcesRegistry::kLegacyModuleResourceName{"__legacy__"};
-  
+
+  SharedResourcesRegistry::SharedResourcesRegistry() : legacyRegistered_(false) {
+  }
+
   SharedResourcesRegistry*
   SharedResourcesRegistry::instance() {
     static SharedResourcesRegistry s_instance;
@@ -29,9 +33,24 @@ namespace edm {
   
   void
   SharedResourcesRegistry::registerSharedResource(const std::string& iString){
+    if(iString == kLegacyModuleResourceName) {
+      if(!legacyRegistered_) {
+        legacyRegistered_ = true;
+        for(auto & resource : resourceMap_) {
+          if(!resource.second.first) {
+            resource.second.first.reset(new std::recursive_mutex);
+          }
+        }
+      }
+    } else {
+      if(resourceMap_.find(iString) == resourceMap_.end()) {
+        nonLegacyResources_.push_back(iString);
+      }
+    }
+
     auto& values = resourceMap_[iString];
-    
-    if(values.second ==1) {
+
+    if(values.second == 1 || legacyRegistered_) {
       //only need to make the resource if more than 1 module wants it
       values.first = std::shared_ptr<std::recursive_mutex>( new std::recursive_mutex );
     }
@@ -50,15 +69,31 @@ namespace edm {
 
   
   SharedResourcesAcquirer
-  SharedResourcesRegistry::createAcquirer(std::vector<std::string> const &  iNames) const {
+  SharedResourcesRegistry::createAcquirer(std::vector<std::string> const& iNames) const {
+
+    std::vector<std::string> const* theNames = &iNames;
+
+    // Do not let legacy modules run concurrently with each other or
+    // any other module that has declared a shared resource.  To accomplish
+    // this, we say the legacy modules declare they depend on
+    // all other declared shared resources. In the special case where
+    // the only resource ever declared is legacy, then just let them all
+    // declare that.
+    if(legacyRegistered_ &&
+       std::find(iNames.begin(), iNames.end(), kLegacyModuleResourceName) != iNames.end() &&
+       !nonLegacyResources_.empty()) {
+
+      theNames = &nonLegacyResources_;
+    }
+
     //Sort by how often used and then by name
     std::map<std::pair<unsigned int, std::string>, std::recursive_mutex*> sortedResources;
     
-    for(auto const& name: iNames) {
+    for(auto const& name: *theNames) {
       auto itFound = resourceMap_.find(name);
       assert(itFound != resourceMap_.end());
       //If only one module wants it, it really isn't shared
-      if(itFound->second.second>1) {
+      if(itFound->second.second > 1 || legacyRegistered_) {
         sortedResources.insert(std::make_pair(std::make_pair(itFound->second.second, itFound->first),itFound->second.first.get()));
       }
     }

--- a/FWCore/Framework/src/SharedResourcesRegistry.h
+++ b/FWCore/Framework/src/SharedResourcesRegistry.h
@@ -53,9 +53,18 @@ namespace edm {
     // ---------- member functions ---------------------------
     ///A resource name must be registered before it can be used in the createAcquirer call
     void registerSharedResource(const std::string&);
-    
+
+#ifdef SHAREDRESOURCETESTACCESSORS
+    // The next 3 functions are only intended to be used in a unit test
+    std::map<std::string, std::pair<std::shared_ptr<std::recursive_mutex>,unsigned int>> const& resourceMap() const { return resourceMap_; }
+
+    bool legacyRegistered() const { return legacyRegistered_; }
+
+    std::vector<std::string> const& nonLegacyResources() const { return nonLegacyResources_; }
+#endif
+
   private:
-    SharedResourcesRegistry()=default;
+    SharedResourcesRegistry();
     ~SharedResourcesRegistry()=default;
 
     SharedResourcesRegistry(const SharedResourcesRegistry&) = delete; // stop default
@@ -67,6 +76,8 @@ namespace edm {
     
     std::shared_ptr<std::recursive_mutex> resourceForDelayedReader_;
     
+    bool legacyRegistered_;
+    std::vector<std::string> nonLegacyResources_;
   };
 }
 


### PR DESCRIPTION
With this change, modules that use the no argument
form of the usesResource function will not run
at the same time as any other module that has
declared any shared resource or used the no argument
usesResource function.
