### PR TITLE
Fix consumes validation tracker rec hits

### DIFF
--- a/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
@@ -7,10 +7,11 @@
  * Created: 6/7/06
  */
 
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 
 #include <string>
 
@@ -39,15 +40,12 @@ class SiPixelRecHitsValid : public edm::EDAnalyzer {
 	void endJob();
 
    private:
-	DQMStore* dbe_;
-	std::string outputFile_;
-
-	edm::ParameterSet conf_;
-
 	void fillBarrel(const SiPixelRecHit &,const PSimHit &, DetId, const PixelGeomDetUnit *,	
 			 const TrackerTopology *tTopo);
 	void fillForward(const SiPixelRecHit &, const PSimHit &, DetId, const PixelGeomDetUnit *,
 			 const TrackerTopology *tTopo);
+
+	std::string outputFile_;
 
 	//Clusters BPIX
 	MonitorElement* clustYSizeModule[8];
@@ -110,7 +108,10 @@ class SiPixelRecHitsValid : public edm::EDAnalyzer {
 	MonitorElement* recHitYPullDisk1Plaquettes[7];
 	MonitorElement* recHitYPullDisk2Plaquettes[7];
 
-        edm::InputTag src_;
+        DQMStore* dbe_;
+
+        edm::ParameterSet conf_;
+        edm::EDGetTokenT<SiPixelRecHitCollection> siPixelRecHitCollectionToken_;
 };
 
 #endif

--- a/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
@@ -35,6 +35,7 @@ class SiPixelRecHitsValid : public edm::EDAnalyzer {
 
 	virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
 	void beginJob();
+        void beginRun( const edm::Run& r, const edm::EventSetup& c );
 	void endJob();
 
    private:

--- a/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
@@ -8,43 +8,18 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-
-#include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-//DWM histogram services
-#include "DQMServices/Core/interface/DQMStore.h"
-
-#include "FWCore/ServiceRegistry/interface/Service.h"
-
-//Simhit stuff
-#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
-#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
-
-#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
-#include "DataFormats/DetId/interface/DetId.h"
-
-#include "Geometry/CommonTopologies/interface/PixelTopology.h"
-#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
-#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
-
+#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include <string>
-#include "DQMServices/Core/interface/MonitorElement.h"
 
+class DQMStore;
+class DetId;
+class MonitorElement;
+class PSimHit;
+class PixelGeomDetUnit;
+class SiPixelRecHit;
 class TrackerTopology;
 
 class SiPixelRecHitsValid : public edm::EDAnalyzer {

--- a/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
@@ -41,6 +41,7 @@ class SiStripRecHitsValid : public edm::EDAnalyzer {
 
   virtual void analyze(const edm::Event& e, const edm::EventSetup& c);
   void beginJob();
+  void beginRun( const edm::Run& r, const edm::EventSetup& c );
   void endJob();
   
  private: 

--- a/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
@@ -14,14 +14,14 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometryVector/interface/LocalVector.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
 
 #include <string>
-#include <vector>
 #include <utility>
 
 class DQMStore;
@@ -46,8 +46,11 @@ class SiStripRecHitsValid : public edm::EDAnalyzer {
   
  private: 
   //Back-End Interface
-  DQMStore* dbe_;
+  std::pair<LocalPoint,LocalVector> projectHit( const PSimHit& hit, const StripGeomDetUnit* stripDet,
+						const BoundPlane& plane );
+  std::vector<PSimHit> matched;
   std::string outputFile_;
+  DQMStore* dbe_;
   MonitorElement*  meNumTotRphi;
   MonitorElement*  meNumTotSas;
   MonitorElement*  meNumTotMatched;
@@ -162,13 +165,7 @@ class SiStripRecHitsValid : public edm::EDAnalyzer {
   MonitorElement* meResyMatchedTEC[5];
   MonitorElement* meChi2MatchedTEC[5];
 
-  std::vector<PSimHit> matched;
-  std::pair<LocalPoint,LocalVector> projectHit( const PSimHit& hit, const StripGeomDetUnit* stripDet,
-							const BoundPlane& plane);
-  edm::ParameterSet conf_;
-  //const StripTopology* topol;
-
-  static const int MAXHIT = 1000;
+  static constexpr int MAXHIT = 1000;
   float rechitrphix[MAXHIT];
   float rechitrphierrx[MAXHIT];
   float rechitrphiy[MAXHIT];
@@ -201,8 +198,11 @@ class SiStripRecHitsValid : public edm::EDAnalyzer {
   float rechitmatchedresy[MAXHIT];
   float rechitmatchedchi2[MAXHIT];
 
+  edm::ParameterSet conf_;
+  //const StripTopology* topol;
 
-  edm::InputTag matchedRecHits_, rphiRecHits_, stereoRecHits_;
+  edm::EDGetTokenT<SiStripMatchedRecHit2DCollection> siStripMatchedRecHit2DCollectionToken_;
+  edm::EDGetTokenT<SiStripRecHit2DCollection> siStripRecHit2DCollection_rphi_Token_, siStripRecHit2DCollection_stereo_Token_;
 };
 
 #endif

--- a/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
@@ -13,39 +13,21 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-//only mine
-#include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-//DQM services for histogram
-#include "DQMServices/Core/interface/DQMStore.h"
-
-#include "FWCore/ServiceRegistry/interface/Service.h"
-
-//--- for SimHit association
-#include "SimDataFormats/TrackingHit/interface/PSimHit.h"  
-#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h" 
-
-#include "Geometry/CommonTopologies/interface/PixelTopology.h"
-#include "Geometry/CommonTopologies/interface/StripTopology.h"
-#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetType.h" 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h" 
-#include "Geometry/TrackerGeometryBuilder/interface/GluedGeomDet.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
-#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
-#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
+#include "DataFormats/GeometrySurface/interface/Plane.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+#include "DataFormats/GeometryVector/interface/LocalVector.h"
+
 #include <string>
-#include "DQMServices/Core/interface/MonitorElement.h"
+#include <vector>
+#include <utility>
+
+class DQMStore;
+class MonitorElement;
+class PSimHit;
+class StripGeomDetUnit;
 
 class SiStripRecHitsValid : public edm::EDAnalyzer {
 

--- a/Validation/TrackerRecHits/plugins/SiPixelRecHitsValid.cc
+++ b/Validation/TrackerRecHits/plugins/SiPixelRecHitsValid.cc
@@ -48,11 +48,7 @@
 
 #include <math.h>
 
-using namespace std;
-using namespace edm;
-
-
-SiPixelRecHitsValid::SiPixelRecHitsValid(const ParameterSet& ps)
+SiPixelRecHitsValid::SiPixelRecHitsValid(const edm::ParameterSet& ps)
   : outputFile_( ps.getUntrackedParameter<std::string>( "outputFile", "pixelrechitshisto.root" ) )
   , dbe_(0) 
   , conf_(ps)
@@ -68,7 +64,7 @@ void SiPixelRecHitsValid::beginJob() {
 }
 
 void SiPixelRecHitsValid::beginRun( const edm::Run& r, const edm::EventSetup& c ) {
-  dbe_ = Service<DQMStore>().operator->();
+  dbe_ = edm::Service<DQMStore>().operator->();
   //dbe_->showDirStructure();
   dbe_->setCurrentFolder("TrackerRecHitsV/TrackerRecHits/Pixel/clustBPIX");
   
@@ -280,9 +276,9 @@ void SiPixelRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
   es.get<IdealGeometryRecord>().get(tTopoHand);
   const TrackerTopology *tTopo=tTopoHand.product();
 
-  LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();
+  edm::LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();
   if ( (int) e.id().event() % 1000 == 0 )
-    cout << " Run = " << e.id().run() << " Event = " << e.id().event() << endl;
+    std::cout << " Run = " << e.id().run() << " Event = " << e.id().event() << std::endl;
   
   //Get RecHits
   edm::Handle<SiPixelRecHitCollection> recHitColl;

--- a/Validation/TrackerRecHits/plugins/SiPixelRecHitsValid.cc
+++ b/Validation/TrackerRecHits/plugins/SiPixelRecHitsValid.cc
@@ -59,6 +59,16 @@ SiPixelRecHitsValid::SiPixelRecHitsValid(const ParameterSet& ps):
   src_( ps.getParameter<edm::InputTag>( "src" ) ) 
 {
   outputFile_ = ps.getUntrackedParameter<string>("outputFile", "pixelrechitshisto.root");
+}
+
+SiPixelRecHitsValid::~SiPixelRecHitsValid() {
+}
+
+void SiPixelRecHitsValid::beginJob() {
+  
+}
+
+void SiPixelRecHitsValid::beginRun( const edm::Run& r, const edm::EventSetup& c ) {
   dbe_ = Service<DQMStore>().operator->();
   //dbe_->showDirStructure();
   dbe_->setCurrentFolder("TrackerRecHitsV/TrackerRecHits/Pixel/clustBPIX");
@@ -257,14 +267,6 @@ SiPixelRecHitsValid::SiPixelRecHitsValid(const ParameterSet& ps):
       sprintf(histo, "RecHit_YPull_Disk2_Plaquette%d", i+1);
       recHitYPullDisk2Plaquettes[i] = dbe_->book1D(histo, "RecHit YPull Disk2 by plaquette", 100, -10.0, 10.0);
     }
-
-}
-
-SiPixelRecHitsValid::~SiPixelRecHitsValid() {
-}
-
-void SiPixelRecHitsValid::beginJob() {
-  
 }
 
 void SiPixelRecHitsValid::endJob() {

--- a/Validation/TrackerRecHits/plugins/SiPixelRecHitsValid.cc
+++ b/Validation/TrackerRecHits/plugins/SiPixelRecHitsValid.cc
@@ -20,7 +20,6 @@
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
@@ -53,12 +52,12 @@ using namespace std;
 using namespace edm;
 
 
-SiPixelRecHitsValid::SiPixelRecHitsValid(const ParameterSet& ps): 
-  dbe_(0), 
-  conf_(ps),
-  src_( ps.getParameter<edm::InputTag>( "src" ) ) 
-{
-  outputFile_ = ps.getUntrackedParameter<string>("outputFile", "pixelrechitshisto.root");
+SiPixelRecHitsValid::SiPixelRecHitsValid(const ParameterSet& ps)
+  : outputFile_( ps.getUntrackedParameter<std::string>( "outputFile", "pixelrechitshisto.root" ) )
+  , dbe_(0) 
+  , conf_(ps)
+  , siPixelRecHitCollectionToken_( consumes<SiPixelRecHitCollection>( ps.getParameter<edm::InputTag>( "src" ) ) ) {
+
 }
 
 SiPixelRecHitsValid::~SiPixelRecHitsValid() {
@@ -287,7 +286,7 @@ void SiPixelRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
   
   //Get RecHits
   edm::Handle<SiPixelRecHitCollection> recHitColl;
-  e.getByLabel( src_, recHitColl);
+  e.getByToken( siPixelRecHitCollectionToken_, recHitColl );
   
   //Get event setup
   edm::ESHandle<TrackerGeometry> geom;

--- a/Validation/TrackerRecHits/plugins/SiPixelRecHitsValid.cc
+++ b/Validation/TrackerRecHits/plugins/SiPixelRecHitsValid.cc
@@ -9,26 +9,45 @@
 
 #include "Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h"
 
-#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
-
-#include "DataFormats/GeometryVector/interface/LocalPoint.h"
-#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
-
-#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
-#include "DataFormats/Common/interface/OwnVector.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
-#include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/OwnVector.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
+
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 
 #include <math.h>
-#include "DQMServices/Core/interface/DQMStore.h"
 
 using namespace std;
 using namespace edm;

--- a/Validation/TrackerRecHits/plugins/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/plugins/SiStripRecHitsValid.cc
@@ -5,24 +5,44 @@
 //
 //--------------------------------------------
 #include "Validation/TrackerRecHits/interface/SiStripRecHitsValid.h"
-#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h" 
 
-//needed for the geometry: 
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/OwnVector.h" 
 #include "DataFormats/DetId/interface/DetId.h" 
-#include "DataFormats/SiStripDetId/interface/StripSubdetector.h" 
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
-#include "DataFormats/GeometryVector/interface/LocalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
-
-
-//--- for RecHit
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h" 
 #include "DataFormats/SiStripCluster/interface/SiStripClusterCollection.h" 
-#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h" 
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h" 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h" 
-#include "DataFormats/Common/interface/OwnVector.h" 
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h" 
+
 #include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "Geometry/CommonDetUnit/interface/GeomDetType.h" 
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h" 
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "Geometry/CommonTopologies/interface/StripTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/GluedGeomDet.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
+
+#include "SimDataFormats/TrackingHit/interface/PSimHit.h"  
+
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h" 
 
 using namespace std;
 using namespace edm;

--- a/Validation/TrackerRecHits/plugins/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/plugins/SiStripRecHitsValid.cc
@@ -7,15 +7,11 @@
 #include "Validation/TrackerRecHits/interface/SiStripRecHitsValid.h"
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/Common/interface/OwnVector.h" 
-#include "DataFormats/DetId/interface/DetId.h" 
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h" 
 #include "DataFormats/SiStripCluster/interface/SiStripClusterCollection.h" 
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h" 
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h" 
-#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h" 
 
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
@@ -67,14 +63,14 @@ namespace helper {
 
 
 //Constructor
-SiStripRecHitsValid::SiStripRecHitsValid(const ParameterSet& ps) :
-  dbe_(0),	
-  conf_(ps),
-  matchedRecHits_( ps.getParameter<edm::InputTag>("matchedRecHits") ),
-  rphiRecHits_( ps.getParameter<edm::InputTag>("rphiRecHits") ),
-  stereoRecHits_( ps.getParameter<edm::InputTag>("stereoRecHits") ) {
+SiStripRecHitsValid::SiStripRecHitsValid(const ParameterSet& ps)
+  : outputFile_( ps.getUntrackedParameter<std::string>( "outputFile", "sistriprechitshisto.root" ) )
+  , dbe_(0)
+  , conf_(ps)
+  , siStripMatchedRecHit2DCollectionToken_( consumes<SiStripMatchedRecHit2DCollection>( ps.getParameter<edm::InputTag>( "matchedRecHits" ) ) )
+  , siStripRecHit2DCollection_rphi_Token_( consumes<SiStripRecHit2DCollection>( ps.getParameter<edm::InputTag>( "rphiRecHits" ) ) )
+  , siStripRecHit2DCollection_stereo_Token_( consumes<SiStripRecHit2DCollection>( ps.getParameter<edm::InputTag>("stereoRecHits") ) ) {
 
-  outputFile_ = ps.getUntrackedParameter<string>("outputFile", "sistriprechitshisto.root");
 }
 
 
@@ -368,9 +364,9 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
   edm::Handle<SiStripMatchedRecHit2DCollection> rechitsmatched;
   edm::Handle<SiStripRecHit2DCollection> rechitsrphi;
   edm::Handle<SiStripRecHit2DCollection> rechitsstereo;
-  e.getByLabel(matchedRecHits_, rechitsmatched);
-  e.getByLabel(rphiRecHits_, rechitsrphi);
-  e.getByLabel(stereoRecHits_, rechitsstereo);
+  e.getByToken( siStripMatchedRecHit2DCollectionToken_, rechitsmatched );
+  e.getByToken( siStripRecHit2DCollection_rphi_Token_, rechitsrphi );
+  e.getByToken( siStripRecHit2DCollection_stereo_Token_, rechitsstereo );
 
   int numrechitrphi   =0;
   int numrechitsas    =0;

--- a/Validation/TrackerRecHits/plugins/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/plugins/SiStripRecHitsValid.cc
@@ -75,6 +75,18 @@ SiStripRecHitsValid::SiStripRecHitsValid(const ParameterSet& ps) :
   stereoRecHits_( ps.getParameter<edm::InputTag>("stereoRecHits") ) {
 
   outputFile_ = ps.getUntrackedParameter<string>("outputFile", "sistriprechitshisto.root");
+}
+
+
+SiStripRecHitsValid::~SiStripRecHitsValid(){
+ //if ( outputFile_.size() != 0 && dbe_ ) dbe_->save(outputFile_);
+}
+
+void SiStripRecHitsValid::beginJob(){
+
+}
+
+void SiStripRecHitsValid::beginRun( const edm::Run& r, const edm::EventSetup& c ) {
   dbe_ = Service<DQMStore>().operator->();
   //dbe_->showDirStructure();
   dbe_->setCurrentFolder("TrackerRecHitsV/TrackerRecHits/Strip/SISTRIP");
@@ -330,16 +342,7 @@ SiStripRecHitsValid::SiStripRecHitsValid(const ParameterSet& ps) :
       sprintf(histo,"Chi2_matched_layer%dtec",i+1);
       meChi2MatchedTEC[i] = dbe_->book1D(histo,"RecHit Chi2 test",100,0., 50);  
     }
-  }
-}
-
-
-SiStripRecHitsValid::~SiStripRecHitsValid(){
- //if ( outputFile_.size() != 0 && dbe_ ) dbe_->save(outputFile_);
-}
-
-void SiStripRecHitsValid::beginJob(){
-
+  }  
 }
 
 void SiStripRecHitsValid::endJob() {

--- a/Validation/TrackerRecHits/plugins/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/plugins/SiStripRecHitsValid.cc
@@ -40,9 +40,6 @@
 
 #include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h" 
 
-using namespace std;
-using namespace edm;
-
 namespace helper { 
     struct GetDetId { 
         template<typename X> 
@@ -63,7 +60,7 @@ namespace helper {
 
 
 //Constructor
-SiStripRecHitsValid::SiStripRecHitsValid(const ParameterSet& ps)
+SiStripRecHitsValid::SiStripRecHitsValid(const edm::ParameterSet& ps)
   : outputFile_( ps.getUntrackedParameter<std::string>( "outputFile", "sistriprechitshisto.root" ) )
   , dbe_(0)
   , conf_(ps)
@@ -83,7 +80,7 @@ void SiStripRecHitsValid::beginJob(){
 }
 
 void SiStripRecHitsValid::beginRun( const edm::Run& r, const edm::EventSetup& c ) {
-  dbe_ = Service<DQMStore>().operator->();
+  dbe_ = edm::Service<DQMStore>().operator->();
   //dbe_->showDirStructure();
   dbe_->setCurrentFolder("TrackerRecHitsV/TrackerRecHits/Strip/SISTRIP");
 
@@ -353,8 +350,8 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
 
 
 
-  LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();  
-  //cout  << " Run = " << e.id().run() << " Event = " << e.id().event() << endl;  
+  edm::LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();  
+  //std::cout  << " Run = " << e.id().run() << " Event = " << e.id().event() << std::endl;
   
   //--- get RecHits
   
@@ -483,7 +480,7 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
 	float dist = 999999;
 	PSimHit closest;
 	if(!matched.empty()){
-	  for(vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
+	  for(std::vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
 	    dist = fabs(rechitrphix[i] - (*m).localPosition().x());
 	    if(dist<mindist){
 	      mindist = dist;
@@ -565,7 +562,7 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
 	matched.clear();
 	matched = associate.associateHit(rechit);
 	if(!matched.empty()){
-	  for(vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
+	  for(std::vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
 	    dist = fabs(rechitsasx[j] - (*m).localPosition().x());
 	    if(dist<mindist){
 	      mindist = dist;
@@ -655,7 +652,7 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
 
 	  //std::cout << " RECHIT position = " << position << std::endl;	  
 	  
-	  for(vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
+	  for(std::vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){
 	    //project simhit;
 	    hitPair= projectHit((*m),partnerstripdet,gluedDet->surface());
 	    distx = fabs(rechitmatchedx[k] - hitPair.first.x());


### PR DESCRIPTION
Consumes fix for the following modules in package Validation/TrackerRecHits:
SiPixelRecHitsValid
SiStripRecHitsValid
Tested with whiteRabbit.py, workflow 3.
