### PR TITLE
Clang update EDMPluginDumper and FunctionDumper

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/create_calls_db.sh
+++ b/Utilities/StaticAnalyzers/scripts/create_calls_db.sh
@@ -14,6 +14,7 @@ ulimit -v 2000000
 ulimit -t 1200
 export USER_LLVM_CHECKERS="-disable-checker cplusplus -disable-checker unix -disable-checker threadsafety -disable-checker core -disable-checker security -disable-checker deadcode -disable-checker cms -enable-checker cms.FunctionDumper -enable-checker optional.EDMPluginDumper -enable-checker cms.FunctionChecker"
 cd ${CMSSW_BASE}
+touch tmp/function-dumper.txt.unsorted tmp/function-checker.txt.unsorted tmp/plugins.txt.unsorted
 scram b -k -j $J checker  2>&1 > tmp/function-dumper.log
 cd ${CMSSW_BASE}/tmp
 sort -u function-dumper.txt.unsorted >function-calls-db.txt

--- a/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/FunctionChecker.cpp
@@ -27,7 +27,6 @@ using namespace ento;
 using namespace llvm;
 
 namespace clangcms {
-[[edm::thread_safe]] static boost::interprocess::interprocess_semaphore file_mutex(1);
 
 class FWalker : public clang::StmtVisitor<FWalker> {
   clang::ento::BugReporter &BR;
@@ -113,17 +112,8 @@ void FWalker::ReportDeclRef ( const clang::DeclRefExpr * DRE) {
 		os << "function '"<<dname << "' accesses or modifies non-const static local variable '" << svname<< "'.\n";
 		BR.EmitBasicReport(D, "FunctionChecker : non-const static local variable accessed or modified","ThreadSafety",os.str(), DLoc);
 		std::string ostring =  "function '"+ sdname + "' static variable '" + vname + "'.\n";
-		file_mutex.wait();
-		std::fstream file(tname.c_str(),std::ios::in|std::ios::out|std::ios::app);
-		std::string filecontents((std::istreambuf_iterator<char>(file)),std::istreambuf_iterator<char>() );
-		if ( filecontents.find(ostring)  == std::string::npos ) {
-			file<<ostring;
-			file.close();
-			file_mutex.post();
-		} else {
-			file.close();
-			file_mutex.post();
-		}
+		std::ofstream file(tname.c_str(),std::ios::app);
+		file<<ostring;
 		return;
 	}
 
@@ -134,17 +124,8 @@ void FWalker::ReportDeclRef ( const clang::DeclRefExpr * DRE) {
 		os << "function '"<<dname<< "' accesses or modifies non-const static member data variable '" << svname << "'.\n";
 		BR.EmitBasicReport(D, "FunctionChecker : non-const static local variable accessed or modified","ThreadSafety",os.str(), DLoc);
 		std::string ostring =  "function '" + sdname + "' static variable '" + vname + "'.\n";
-		file_mutex.wait();
-		std::fstream file(tname.c_str(),std::ios::in|std::ios::out|std::ios::app);
-		std::string filecontents((std::istreambuf_iterator<char>(file)),std::istreambuf_iterator<char>() );
-		if ( filecontents.find(ostring)  == std::string::npos ) {
-			file<<ostring;
-			file.close();
-			file_mutex.post();
-		} else {
-			file.close();
-			file_mutex.post();
-		}
+		std::ofstream file(tname.c_str(),std::ios::app);
+		file<<ostring;
 	    return;
 	}
 
@@ -159,17 +140,8 @@ void FWalker::ReportDeclRef ( const clang::DeclRefExpr * DRE) {
 		os << "function '"<<dname << "' accesses or modifies non-const global static variable '" << svname << "'.\n";
 		BR.EmitBasicReport(D, "FunctionChecker : non-const static local variable accessed or modified","ThreadSafety",os.str(), DLoc);
 		std::string ostring =  "function '" + sdname + "' static variable '" + vname + "'.\n";
-		file_mutex.wait();
-		std::fstream file(tname.c_str(),std::ios::in|std::ios::out|std::ios::app);
-		std::string filecontents((std::istreambuf_iterator<char>(file)),std::istreambuf_iterator<char>() );
-		if ( filecontents.find(ostring)  == std::string::npos ) {
-			file<<ostring;
-			file.close();
-			file_mutex.post();
-		} else {
-			file.close();
-			file_mutex.post();
-		}
+		std::ofstream file(tname.c_str(),std::ios::app);
+		file<<ostring;
 	    return;
 	
 	}
@@ -209,17 +181,8 @@ void FunctionChecker::checkASTDecl(const FunctionDecl *FD, AnalysisManager& mgr,
 		std::string tname = ""; 
 		if ( pPath != NULL ) tname += std::string(pPath);
 		tname+="/tmp/function-checker.txt.unsorted";
-		file_mutex.wait();
-		std::fstream file(tname.c_str(),std::ios::in|std::ios::out|std::ios::app);
-		std::string filecontents((std::istreambuf_iterator<char>(file)),std::istreambuf_iterator<char>() );
-		if ( filecontents.find(ostring)  == std::string::npos ) {
-			file<<ostring;
-			file.close();
-			file_mutex.post();
-		} else {
-			file.close();
-			file_mutex.post();
-		}
+		std::ofstream file(tname.c_str(),std::ios::app);
+		file<<ostring;
         }
 }
 

--- a/Utilities/StaticAnalyzers/src/FunctionDumper.h
+++ b/Utilities/StaticAnalyzers/src/FunctionDumper.h
@@ -1,6 +1,7 @@
 #ifndef Utilities_StaticAnalyzers_FunctionDumper_h
 #define Utilities_StaticAnalyzers_FunctionDumper_h
 #include <clang/AST/DeclCXX.h>
+#include <clang/AST/ExprCXX.h>
 #include <clang/AST/Decl.h>
 #include <clang/AST/DeclTemplate.h>
 #include <clang/AST/StmtVisitor.h>


### PR DESCRIPTION
EDMPluginDumper now output template argument when the plugin is a template class.

FunctionDumper now logs cxx constructor calls. This is needed so that top level functions can be linked to constructor calls the access statics, eg gen::FortranInstance::InstanceWrapper
