### PR TITLE
Temporary workaround for ROOT6 bug

### DIFF
--- a/DataFormats/Common/interface/RefToBase.h
+++ b/DataFormats/Common/interface/RefToBase.h
@@ -115,7 +115,11 @@ namespace edm {
     CMS_CLASS_VERSION(10)
   private:
     value_type const* getPtrImpl() const;
-    reftobase::BaseHolder<value_type>* holder_;
+    // FIXME: the "edm::" should not be needed here, but is here
+    // as a workaround for a ROOT6 bug.  It will be removed
+    // (with this reminder note) after the ROOT6 bug is fixed.
+    edm::reftobase::BaseHolder<value_type>* holder_;
+    //reftobase::BaseHolder<value_type>* holder_;
     friend class RefToBaseVector<T>;
     friend class RefToBaseProd<T>;
     template<typename B> friend class RefToBase;


### PR DESCRIPTION
There appears to be a bug in ROOT6.  If a class that has a dictionary contains a data member whose type includes a namespace, but the namespace is not the complete scope, (i.e.) does not include the outermost namespace, a look up for the type of the data member will fail because the name used is not fully scoped.
This occurs in the RefToBase template, which causes many framework unit tests to fail.
This pull request is a workaround. It adds full scope to the type.  Although this workaround is compatible with ROOT5, I prefer to submit it to the ROOT6 branch only, and remove it after the ROOT6 bug is fixed.
Thus RefToBase.h for ROOT5 and ROOT6 will remain the same.
