### PR TITLE
Made static in L1ExtraParticlesProd const

### DIFF
--- a/L1Trigger/L1ExtraFromDigis/interface/L1ExtraParticlesProd.h
+++ b/L1Trigger/L1ExtraFromDigis/interface/L1ExtraParticlesProd.h
@@ -71,7 +71,7 @@ class L1ExtraParticlesProd : public edm::EDProducer {
       edm::InputTag hfRingEtSumsSource_ ;
       edm::InputTag hfRingBitCountsSource_ ;
 
-      static double muonMassGeV_ ;
+      static const double muonMassGeV_ ;
 
       bool centralBxOnly_ ;
 

--- a/L1Trigger/L1ExtraFromDigis/src/L1ExtraParticlesProd.cc
+++ b/L1Trigger/L1ExtraFromDigis/src/L1ExtraParticlesProd.cc
@@ -59,7 +59,7 @@
 // static data member definitions
 //
 
-double L1ExtraParticlesProd::muonMassGeV_ = 0.105658369 ; // PDG06
+double const L1ExtraParticlesProd::muonMassGeV_ = 0.105658369 ; // PDG06
 
 //
 // constructors and destructor


### PR DESCRIPTION
The static analyzer complained about a non-const static being used. The static was set at initialization time and then never changed so it was trivial to make const.
