### PR TITLE
Removed a function local static in SeedCleanerByHitPosition::good

### DIFF
--- a/RecoTracker/CkfPattern/src/SeedCleanerByHitPosition.cc
+++ b/RecoTracker/CkfPattern/src/SeedCleanerByHitPosition.cc
@@ -10,7 +10,7 @@ void SeedCleanerByHitPosition::done() {
         trajectories = 0; 
 }
 bool SeedCleanerByHitPosition::good(const TrajectorySeed *seed) {
-    static RecHitComparatorByPosition comp;
+    const RecHitComparatorByPosition comp;
     typedef TrajectorySeed::const_iterator SI;
     typedef Trajectory::RecHitContainer::const_iterator TI;
     TrajectorySeed::range range = seed->recHits();


### PR DESCRIPTION
The static analyzer complained about a non-const static being used in SeedCleanerByHitPosition::good.
The static was an instance of RecHitComparatorByPostion which is a class with no member data. Therefore
making it static didn't do anything useful. Removed the static and made it const just to make its use
clear.
