### PR TITLE
Fixes for file-based filter farm

### DIFF
--- a/EventFilter/Utilities/plugins/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/plugins/EvFDaqDirector.cc
@@ -31,8 +31,7 @@ namespace evf {
 							     false)
 			   ),
     base_dir_(
-	      pset.getUntrackedParameter<std::string> ("baseDir",
-						       "/data")
+	      pset.getUntrackedParameter<std::string> ("baseDir", "/data")
 	      ),
     bu_base_dir_(
 		 pset.getUntrackedParameter<std::string> ("buBaseDir", "/data")
@@ -78,11 +77,11 @@ namespace evf {
   {
     reg.watchPreBeginRun(this, &EvFDaqDirector::preBeginRun);
     reg.watchPostEndRun(this, &EvFDaqDirector::postEndRun);
-    char srunno[7];
-    sprintf(srunno,"%06d",run_);
-    run_dir_name_ = "run";
-    run_dir_name_ += srunno;
-    run_dir_ = base_dir_+"/"+run_dir_name_;
+
+    std::stringstream ss;
+    ss << "run" << std::setfill('0') << std::setw(6) << run_;
+    run_string_ = ss.str();
+    run_dir_ = base_dir_+"/"+run_string_;
 
     //save hostname for later 
     char hostname[33];
@@ -101,7 +100,7 @@ namespace evf {
 
     if (directorBu_) 
       {
-	bu_run_dir_ = base_dir_ + "/" + run_dir_name_;
+	bu_run_dir_ = bu_base_dir_ + "/" + run_string_;
 	std::string bulockfile = bu_run_dir_ + "/bu.lock";
 	std::string fulockfile = bu_run_dir_ + "/fu.lock";
 
@@ -173,7 +172,7 @@ namespace evf {
 					      << base_dir_ << " mkdir error:" << strerror(errno) << "\n";
 	}
 
-	bu_run_dir_ = bu_base_dir_ + "/" + run_dir_name_;
+	bu_run_dir_ = bu_base_dir_ + "/" + run_string_;
 	std::string fulockfile = bu_run_dir_ + "/fu.lock";
 	openFULockfileStream(fulockfile, false);
       }
@@ -222,7 +221,7 @@ namespace evf {
 					  << sm_base_dir_ << " mkdir error:" << strerror(errno) << "\n";
       return false;
     }
-    std::string mergedRunDir = sm_base_dir_ + "/" + run_dir_name_;
+    std::string mergedRunDir = sm_base_dir_ + "/" + run_string_;
     std::string mergedDataDir = mergedRunDir + "/data";
     std::string mergedMonDir = mergedRunDir + "/mon";
     retval = mkdir(mergedRunDir.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
@@ -251,15 +250,43 @@ namespace evf {
     return true;
   }
 
-  std::string EvFDaqDirector::getRawFilePath(unsigned int ls, unsigned int index) {
-    return formatRawFilePath(ls, index);
+  std::string EvFDaqDirector::getRawFilePath(const unsigned int ls, const unsigned int index) const {
+    return bu_run_dir_ + "/" + inputFileNameStem(ls, index) + ".raw";
   }
 
-  std::string EvFDaqDirector::getOpenRawFilePath(unsigned int ls,unsigned int index){
-    return formatOpenRawFilePath(ls, index);
+  std::string EvFDaqDirector::getOpenRawFilePath(const unsigned int ls, const unsigned int index) const {
+    return bu_run_dir_ + "/open/" + inputFileNameStem(ls, index) + ".raw";
   }
 
-  std::string EvFDaqDirector::getPathForFU() {
+  std::string EvFDaqDirector::getOpenDatFilePath(const unsigned int ls, std::string const& stream) const {
+    return run_dir_ + "/open/" + outputFileNameStem(ls,stream) + ".dat";
+  }
+
+  std::string EvFDaqDirector::getOutputJsonFilePath(const unsigned int ls, std::string const& stream) const {
+    return run_dir_ + "/" + outputFileNameStem(ls,stream) + ".jsn";
+  }
+
+  std::string EvFDaqDirector::getMergedDatFilePath(const unsigned int ls, std::string const& stream) const {
+    return run_dir_ + "/" + mergedFileNameStem(ls,stream) + ".dat";
+  }
+
+  std::string EvFDaqDirector::getInitFilePath(std::string const& stream) const {
+    return run_dir_ + "/" + initFileName(stream);
+  }
+
+  std::string EvFDaqDirector::getEoLSFilePathOnBU(const unsigned int ls) const {
+    return bu_run_dir_ + "/" + eolsFileName(ls);
+  }
+
+  std::string EvFDaqDirector::getEoLSFilePathOnFU(const unsigned int ls) const {
+    return run_dir_ + "/" + eolsFileName(ls);
+  }
+
+  std::string EvFDaqDirector::getEoRFilePath() const {
+    return bu_run_dir_ + "/" + eorFileName();
+  }
+
+  std::string EvFDaqDirector::getPathForFU() const {
     return sm_base_dir_;
   }
 
@@ -313,10 +340,7 @@ namespace evf {
 
     eorSeen = false;
     struct stat buf;
-    stringstream ss;
-    ss << bu_run_dir_ << "/EoR_"<< std::setw(6) 
-       << std::setfill('0') << run_<<".jsn";
-    eorSeen = (stat(ss.str().c_str(), &buf) == 0);
+    eorSeen = (stat(getEoRFilePath().c_str(), &buf) == 0);
     bool valid = false;
 
     // if the stream is readable
@@ -493,7 +517,7 @@ namespace evf {
     nextIndex++;
 
     // 1. Check suggested file
-    nextFile = formatRawFilePath(ls,index);
+    nextFile = getRawFilePath(ls,index);
     bool found = (stat(nextFile.c_str(), &buf) == 0);
     // if found
     if (found) {
@@ -503,12 +527,12 @@ namespace evf {
     }
     // 2. No file -> lumi ended? (and how many?)
     else {
-      bool eolFound = (stat(formatEndOfLS(ls).c_str(), &buf) == 0);
+      bool eolFound = (stat(getEoLSFilePathOnBU(ls).c_str(), &buf) == 0);
       unsigned int startingLumi = ls;
       while (eolFound) {
 	// this lumi ended, check for files
 	++ls;
-	nextFile = formatRawFilePath(ls,0);
+	nextFile = getRawFilePath(ls,0);
 	found = (stat(nextFile.c_str(), &buf) == 0);
 	// update highest ls even if there is no file
 	// input source can now end its' LS when an EoL jsn file is seen
@@ -520,9 +544,9 @@ namespace evf {
 	  
 	  if (testModeNoBuilderUnit_) {
 	    // rename ended lumi to + 2
-	    string sourceEol = formatEndOfLS(startingLumi);
+	    string sourceEol = getEoLSFilePathOnBU(startingLumi);
 	    
-	    string destEol = formatEndOfLS(startingLumi+2);
+	    string destEol = getEoLSFilePathOnBU(startingLumi+2);
 	    
 	    string cpCmd = "cp " + sourceEol + " " + destEol;
 	    edm::LogInfo("EvFDaqDirector") << " testmode: Running copy cmd = " << cpCmd;
@@ -534,7 +558,7 @@ namespace evf {
 	  
 	  return true;
 	}
-	eolFound = (stat(formatEndOfLS(ls).c_str(), &buf) == 0);
+	eolFound = (stat(getEoLSFilePathOnBU(ls).c_str(), &buf) == 0);
       }
     }
     // no new file found
@@ -580,7 +604,7 @@ namespace evf {
 
   //create if does not exist then lock the merge destination file
   FILE *EvFDaqDirector::maybeCreateAndLockFileHeadForStream(unsigned int ls, std::string &stream) {
-    data_rw_stream = fopen(formatMergeFilePath(ls,stream).c_str(), "a"); //open stream for appending
+    data_rw_stream = fopen(getMergedDatFilePath(ls,stream).c_str(), "a"); //open stream for appending
     data_readwrite_fd_ = fileno(data_rw_stream);
     if (data_readwrite_fd_ == -1)
       edm::LogError("EvFDaqDirector") << "problem with creating filedesc for datamerge "
@@ -598,40 +622,50 @@ namespace evf {
     fclose(data_rw_stream);
   }
 
-  std::string EvFDaqDirector::formatRawFilePath(unsigned int ls, unsigned int index) const {
+  std::string EvFDaqDirector::inputFileNameStem(const unsigned int ls, const unsigned int index) const {
     std::stringstream ss;
-    ss << bu_run_dir_ << "/run" << std::setfill('0') << std::setw(6) << run_ 
+    ss << run_string_
        << "_ls" << std::setfill('0') << std::setw(4) << ls
-       << "_index" << std::setfill('0') << std::setw(6) << index 
-       << ".raw";
-    return ss.str();
-  }
-  std::string EvFDaqDirector::formatOpenRawFilePath(unsigned int ls, unsigned int index) const {
-    std::stringstream ss;
-    ss << bu_run_dir_ << "/open/run" << std::setfill('0') << std::setw(6) << run_ 
-       << "_ls" << std::setfill('0') << std::setw(4) << ls
-       << "_index" << std::setfill('0') << std::setw(6) << index 
-       << ".raw";
-    return ss.str();
-  }
-  std::string EvFDaqDirector::formatMergeFilePath(unsigned int ls, std::string &stream) const {
-    std::stringstream ss;
-    ss << run_dir_ << "/run" << std::setfill('0') << std::setw(6) << run_ 
-       << "_ls" << std::setfill('0') << std::setw(4) << ls
-       << "_" << stream << "_"<< hostname_ << ".dat";
-    return ss.str();
-  }
-  std::string EvFDaqDirector::formatEndOfLS(unsigned int ls) const {
-    std::stringstream ss;
-    ss << bu_run_dir_ << "/EoLS_" << std::setfill('0') << std::setw(4)
-       << ls << ".jsn";
+       << "_index" << std::setfill('0') << std::setw(6) << index;
     return ss.str();
   }
 
-  std::string EvFDaqDirector::formatEndOfLSSlave(unsigned int ls) const {
+  std::string EvFDaqDirector::outputFileNameStem(const unsigned int ls, std::string const& stream) const {
     std::stringstream ss;
-    ss << run_dir_ << "/EoLS_" << std::setfill('0') << std::setw(4)
-       << ls << ".jsn";
+    ss << run_string_
+       << "_ls" << std::setfill('0') << std::setw(4) << ls
+       << "_" << stream
+       << "_pid" << std::setfill('0') << std::setw(5) << getpid();
+    return ss.str();
+  }
+
+  std::string EvFDaqDirector::mergedFileNameStem(const unsigned int ls, std::string const& stream) const {
+    std::stringstream ss;
+    ss << run_string_
+       << "_ls" << std::setfill('0') << std::setw(4) << ls
+       << "_" << stream
+       << "_" << hostname_;
+    return ss.str();
+  }
+
+  std::string EvFDaqDirector::initFileName(std::string const& stream) const {
+    std::stringstream ss;
+    ss << run_string_
+       << "_" << stream
+       << "_pid" << std::setfill('0') << std::setw(5) << getpid()
+       << ".ini";
+    return ss.str();
+  }
+
+  std::string EvFDaqDirector::eolsFileName(const unsigned int ls) const {
+    std::stringstream ss;
+    ss << "EoLS_" << std::setfill('0') << std::setw(4) << ls << ".jsn";
+    return ss.str();
+  }
+
+  std::string EvFDaqDirector::eorFileName() const {
+    std::stringstream ss;
+    ss << "EoR_" << std::setfill('0') << std::setw(6) << run_ << ".jsn";
     return ss.str();
   }
 }

--- a/EventFilter/Utilities/plugins/EvFDaqDirector.h
+++ b/EventFilter/Utilities/plugins/EvFDaqDirector.h
@@ -41,9 +41,16 @@ namespace evf{
       std::string findCurrentRunDir(){ return dirManager_.findRunDir(run_);}
       std::string findHighestRunDirStem();
       unsigned int findHighestRun(){return dirManager_.findHighestRun();}
-      std::string getRawFilePath(unsigned int ls, unsigned int index);
-      std::string getOpenRawFilePath(unsigned int ls, unsigned int index);
-      std::string getPathForFU();
+      std::string getRawFilePath(const unsigned int ls, const unsigned int index) const;
+      std::string getOpenRawFilePath(const unsigned int ls, const unsigned int index) const;
+      std::string getOpenDatFilePath(const unsigned int ls, std::string const& stream) const;
+      std::string getOutputJsonFilePath(const unsigned int ls, std::string const& stream) const;
+      std::string getMergedDatFilePath(const unsigned int ls, std::string const& stream) const;
+      std::string getInitFilePath(std::string const& stream) const;
+      std::string getEoLSFilePathOnBU(const unsigned int ls) const;
+      std::string getEoLSFilePathOnFU(const unsigned int ls) const;
+      std::string getEoRFilePath() const;
+      std::string getPathForFU() const;
       void removeFile(unsigned int ls, unsigned int index);
       void removeFile(std::string );
       void updateBuLock(unsigned int ls);
@@ -58,15 +65,10 @@ namespace evf{
       unsigned int getRunNumber() const { return run_; }
       unsigned int getJumpLS() const { return jumpLS_; }
       unsigned int getJumpIndex() const { return jumpIndex_; }
-      std::string getJumpFilePath() const { return formatRawFilePath(jumpLS_,jumpIndex_); }
+      std::string getJumpFilePath() const { return bu_run_dir_ + "/" + inputFileNameStem(jumpLS_,jumpIndex_) + ".raw"; }
       bool getTestModeNoBuilderUnit() { return testModeNoBuilderUnit_;}
       FILE * maybeCreateAndLockFileHeadForStream(unsigned int ls, std::string &stream);
       void unlockAndCloseMergeStream();
-      std::string formatRawFilePath(unsigned int ls, unsigned int index) const;
-      std::string formatOpenRawFilePath(unsigned int ls, unsigned int index) const;
-      std::string formatMergeFilePath(unsigned int ls, std::string &stream) const;
-      std::string formatEndOfLS(unsigned int ls) const;
-      std::string formatEndOfLSSlave(unsigned int ls) const;
 
     private:
       bool bulock();
@@ -80,6 +82,12 @@ namespace evf{
       bool bumpFile(unsigned int& ls, unsigned int& index, std::string& nextFile);
       bool findHighestActiveLS(unsigned int& startingLS) const;
       void openFULockfileStream(std::string& fuLockFilePath, bool create);
+      std::string inputFileNameStem(const unsigned int ls, const unsigned int index) const;
+      std::string outputFileNameStem(const unsigned int ls, std::string const& stream) const;
+      std::string mergedFileNameStem(const unsigned int ls, std::string const& stream) const;
+      std::string initFileName(std::string const& stream) const;
+      std::string eolsFileName(const unsigned int ls) const;
+      std::string eorFileName() const;
 
       bool testModeNoBuilderUnit_;
       std::string base_dir_;
@@ -90,7 +98,7 @@ namespace evf{
       unsigned int run_;
 
       std::string hostname_;
-      std::string run_dir_name_;
+      std::string run_string_;
       std::string run_dir_;
       std::string bu_run_dir_;
       std::string bu_run_open_dir_;

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -113,7 +113,7 @@ void FedRawDataInputSource::maybeOpenNewLumiSection(const uint32_t lumiSection)
 
     if ( currentLumiSection_ > 0 ) {
       const string fuEoLS =
-        edm::Service<evf::EvFDaqDirector>()->formatEndOfLSSlave(currentLumiSection_);
+        edm::Service<evf::EvFDaqDirector>()->getEoLSFilePathOnFU(currentLumiSection_);
       struct stat buf;
       bool found = (stat(fuEoLS.c_str(), &buf) == 0);
       if ( !found ) {

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -78,19 +78,10 @@ FedRawDataInputSource::~FedRawDataInputSource()
 bool FedRawDataInputSource::checkNextEvent()
 {
   int eventAvailable = cacheNextEvent();
-  if (  eventAvailable <0 ) {
+  if (eventAvailable < 0) {
     // run has ended
     resetLuminosityBlockAuxiliary();
-
-    if (fileStream_) {
-      edm::LogInfo("FedRawDataInputSource") << "Closing input stream ";
-      fclose(fileStream_);
-      fileStream_ = 0;
-      if (!testModeNoBuilderUnit_) {
-        edm::LogInfo("FedRawDataInputSource") << "Removing last input file used : " << openFile_.string();
-        boost::filesystem::remove(openFile_); // won't work in case of forked children
-      }
-    }
+    closeCurrentFile();
     return false;
   }
   else if(eventAvailable == 0) {
@@ -201,6 +192,7 @@ int FedRawDataInputSource::readNextChunkIntoBuffer()
   // lumi section to account for 
   int fileStatus = 100; //file is healthy for now 
   if (eofReached()){
+    closeCurrentFile();
     fileStatus = openNextFile(); // this can now return even if there is 
                                  //no file only temporarily
     if(fileStatus==0) return -100; //should only happen when requesting the next event header and the run is over
@@ -235,6 +227,23 @@ bool FedRawDataInputSource::eofReached() const
   ungetc(c, fileStream_);
 
   return (c == EOF);
+}
+
+void FedRawDataInputSource::closeCurrentFile()
+{
+  if (fileStream_) {
+
+    edm::LogInfo("FedRawDataInputSource") << "Closing input file " << openFile_.string();
+
+    fclose(fileStream_);
+    fileStream_ = 0;
+
+    if (!testModeNoBuilderUnit_) {
+      boost::filesystem::remove(openFile_); // won't work in case of forked children
+    } else {
+      renameToNextFree();
+    }
+  }
 }
 
 int FedRawDataInputSource::openNextFile()
@@ -399,17 +408,6 @@ bool FedRawDataInputSource::grabNextJsonFile(boost::filesystem::path const& json
 
 void FedRawDataInputSource::openDataFile(std::string const& nextFile)
 {
-  if (fileStream_) {
-    fclose(fileStream_);
-    fileStream_ = 0;
-
-    if (!testModeNoBuilderUnit_) {
-      boost::filesystem::remove(openFile_); // won't work in case of forked children
-    } else {
-      renameToNextFree();
-    }
-  }
-
   const int fileDescriptor = open(nextFile.c_str(), O_RDONLY);
   if (fileDescriptor != -1) {
     fileStream_ = fdopen(fileDescriptor, "rb");

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.h
@@ -40,6 +40,7 @@ private:
   void maybeOpenNewLumiSection(const uint32_t lumiSection);
   int cacheNextEvent();
   edm::Timestamp fillFEDRawDataCollection(std::auto_ptr<FEDRawDataCollection>&) const;
+  void closeCurrentFile();
   int openNextFile();
   int searchForNextFile();
   bool grabNextJsonFile(boost::filesystem::path const&);

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -70,6 +70,7 @@ namespace evf {
     std::string baseDir_;
     std::string smpath_;
     std::string jsonDefPath_;
+    boost::filesystem::path openDatFilePath_;
     IntJ processed_;
     mutable IntJ accepted_;
     StringJ filelist_;
@@ -114,14 +115,12 @@ namespace evf {
   {
     std::cout << "RecoEventOutputModuleForFU: start() method " << std::endl;
     
-    std::string init_filename_ = smpath_+"/"+stream_label_+".ini"; 
-    std::string eof_filename_ = smpath_+"/"+stream_label_+".eof";
+    const std::string initFileName = edm::Service<evf::EvFDaqDirector>()->getInitFilePath(stream_label_);
     
-    std::string first =  events_base_filename_ + "000001.dat";
     std::cout << "RecoEventOutputModuleForFU, initializing streams. init stream: " 
-	      <<init_filename_ << " eof stream " << eof_filename_ << " event stream " << first << std::endl;
+	      << initFileName << std::endl;
 
-    c_->setOutputFiles(init_filename_,eof_filename_);
+    c_->setInitMessageFile(initFileName);
     c_->start();
   }
   
@@ -165,29 +164,21 @@ namespace evf {
   template<typename Consumer>
   void RecoEventOutputModuleForFU<Consumer>::beginLuminosityBlock(edm::LuminosityBlockPrincipal const &ls, edm::ModuleCallingContext const*){
     std::cout << "RecoEventOutputModuleForFU : begin lumi " << std::endl;
-	std::ostringstream ost;
-	string runDirName = fms_->getRunDirName();
-	ost << runDirName << "_ls" << std::setfill('0') << std::setw(4)
-			<< ls.luminosityBlock() << "_" << stream_label_ << "_pid"
-			<< std::setfill('0') << std::setw(5) << getpid() << ".dat";
-	std::string filenameFull = smpath_ + "/open/" + ost.str();
-	std::string filenameJson = ost.str();
-	c_->setOutputFile(filenameFull);
-
-	filelist_ = filenameJson;
+	openDatFilePath_ = edm::Service<evf::EvFDaqDirector>()->getOpenDatFilePath(ls.luminosityBlock(),stream_label_);
+	c_->setOutputFile(openDatFilePath_.string());
+	filelist_ = openDatFilePath_.filename().string();
   }
 
   template<typename Consumer>
   void RecoEventOutputModuleForFU<Consumer>::endLuminosityBlock(edm::LuminosityBlockPrincipal const &ls, edm::ModuleCallingContext const*){
     std::cout << "RecoEventOutputModuleForFU : end lumi " << std::endl;
-    std::string fullDataOutputPath = smpath_ + "/open/" + filelist_.value();
     processed_.value() = fms_->getEventsProcessedForLumi(ls.luminosityBlock());
     if(processed_.value()!=0){
       int b;
       // move dat file to one level up - this is VERRRRRY inefficient, come up with a smarter idea
 
       FILE *des = edm::Service<evf::EvFDaqDirector>()->maybeCreateAndLockFileHeadForStream(ls.luminosityBlock(),stream_label_);
-      FILE *src = fopen(fullDataOutputPath.c_str(),"r");
+      FILE *src = fopen(openDatFilePath_.string().c_str(),"r");
       if(des != 0 && src !=0){
 	while((b=fgetc(src))!= EOF){
 	  fputc((unsigned char)b,des);
@@ -198,29 +189,19 @@ namespace evf {
       fclose(src);
     }
     //remove file
-    remove(fullDataOutputPath.c_str());
+    remove(openDatFilePath_.string().c_str());
 
-/* 	boost::filesystem::path openDatPath(fullDataOutputPath); */
-/* 	boost::filesystem::path closedDatPath( */
-/* 			openDatPath.parent_path().parent_path()); */
-/* 	closedDatPath /= openDatPath.filename(); */
-/* 	boost::filesystem::rename(openDatPath, closedDatPath); */
-
-	// output jsn file
+    // output jsn file
     if(processed_.value()!=0){
 	jsonMonitor_->snap(false, "");
-	std::stringstream outputJsonNameStream;
-	string runDirName = fms_->getRunDirName();
-	outputJsonNameStream << smpath_ << "/";
-	outputJsonNameStream << runDirName << "_ls" << std::setfill('0')
-			<< std::setw(4) << ls.luminosityBlock() << "_" << stream_label_
-			<< "_pid" << std::setfill('0') << std::setw(5) << getpid()
-			<< ".jsn";
-	jsonMonitor_->outputFullHistoDataPoint(outputJsonNameStream.str());
+	const std::string outputJsonNameStream =
+	  edm::Service<evf::EvFDaqDirector>()->getOutputJsonFilePath(ls.luminosityBlock(),stream_label_);
+	jsonMonitor_->outputFullHistoDataPoint(outputJsonNameStream);
     }
-	// reset monitoring params
-	accepted_.value() = 0;
-	filelist_ = "";
+
+    // reset monitoring params
+    accepted_.value() = 0;
+    filelist_ = "";
   }
 
 } // end of namespace-edm

--- a/EventFilter/Utilities/plugins/RecoEventWriterForFU.cc
+++ b/EventFilter/Utilities/plugins/RecoEventWriterForFU.cc
@@ -23,14 +23,6 @@ namespace evf {
     stream_writer_preamble_->write(init_message);
   }
 
-  void RecoEventWriterForFU::doOutputHeaderFragment(RecoEventWriterForFUHeaderParams const& hdrParams) {
-    //Write the Init Message to Streamer file
-    stream_writer_preamble_->writeInitFragment(hdrParams.fragmentIndex,
-					       hdrParams.fragmentCount,
-					       hdrParams.dataPtr,
-					       hdrParams.dataSize);
-  }
-
   void RecoEventWriterForFU::doOutputEvent(EventMsgView const& msg) {
     //Write the Event Message to Streamer file
     stream_writer_events_->write(msg);
@@ -41,23 +33,17 @@ namespace evf {
     doOutputEvent(eview);
   }
 
-  void RecoEventWriterForFU::doOutputEventFragment(RecoEventWriterForFUEventParams const& evtParams) {
-    //Write the Event Message to Streamer file
-    stream_writer_events_->writeEventFragment(evtParams.fragmentIndex,
-					      evtParams.fragmentCount,
-					      evtParams.dataPtr,
-					      evtParams.dataSize);
-  }
-
   void RecoEventWriterForFU::fillDescription(edm::ParameterSetDescription& desc) {
     desc.setComment("Writes events into a streamer output file.");
     desc.addUntracked<std::string>("fileName", "teststreamfile.dat")->setComment("Name of output file.");
   }
-  void RecoEventWriterForFU::setOutputFiles(std::string &init, std::string &eof){
+
+  void RecoEventWriterForFU::setInitMessageFile(std::string const& init){
     stream_writer_preamble_.reset(new StreamerOutputFile(init));
-    //    stream_writer_events_.reset(new StreamerOutputFile(events));
   }
-  void RecoEventWriterForFU::setOutputFile(std::string &events){
+
+  void RecoEventWriterForFU::setOutputFile(std::string const& events){
     stream_writer_events_.reset(new StreamerOutputFile(events));
   }
+
 } //namespace edm

--- a/EventFilter/Utilities/plugins/RecoEventWriterForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventWriterForFU.h
@@ -17,31 +17,6 @@
 
 namespace evf
 {
-  struct RecoEventWriterForFUHeaderParams
-  {
-    uint32 runNumber;
-    uint32 hltCount;
-    const char* headerPtr;
-    uint32 headerSize;
-
-    uint32 fragmentIndex;
-    uint32 fragmentCount;
-    const char* dataPtr;
-    uint32 dataSize;
-  };
-
-  struct RecoEventWriterForFUEventParams
-  {
-    std::vector<unsigned char> hltBits;
-    const char* headerPtr;
-    uint32 headerSize;
-
-    uint32 fragmentIndex;
-    uint32 fragmentCount;
-    const char* dataPtr;
-    uint32 dataSize;
-  };
-
   class ParameterSetDescription;
   class RecoEventWriterForFU 
   {
@@ -52,15 +27,13 @@ namespace evf
 
     static void fillDescription(edm::ParameterSetDescription& desc);
 
-    void setOutputFiles(std::string &, std::string &);
-    void setOutputFile(std::string &);
+    void setInitMessageFile(std::string const&);
+    void setOutputFile(std::string const&);
     void doOutputHeader(InitMsgBuilder const& init_message);    
     void doOutputHeader(InitMsgView const& init_message);    
-    void doOutputHeaderFragment(RecoEventWriterForFUHeaderParams const&);
 
     void doOutputEvent(EventMsgBuilder const& msg);
     void doOutputEvent(EventMsgView const& msg);
-    void doOutputEventFragment(RecoEventWriterForFUEventParams const&);
 
     void start(){}
     void stop(){};

--- a/IOPool/Streamer/interface/EventMessage.h
+++ b/IOPool/Streamer/interface/EventMessage.h
@@ -44,6 +44,8 @@ hlt_count 4 | hltbits hlt_count/4 |
 adler32_chksum 4 | host name length 1 | host name {Fixed size}
 eventdatalength 4 | eventdata blob {variable} 
 
+Protocol Version 10: identical to version 9, but incremented to keep in sync with init msg version 
+
 */
 
 #ifndef IOPool_Streamer_EventMessage_h

--- a/IOPool/Streamer/interface/InitMessage.h
+++ b/IOPool/Streamer/interface/InitMessage.h
@@ -22,6 +22,10 @@ Protocol Version 8: added data blob checksum and hostname
 code 1 | size 4 | protocol version 1 | pset 16 | run 4 | Init Header Size 4| Event Header Size 4| releaseTagLength 1 | ReleaseTag var| processNameLength 1 | processName var| outputModuleLabelLength 1 | outputModuleLabel var | outputModuleId 4 | HLT Trig count 4| HLT Trig Length 4 | HLT Trig names var | HLT Selection count 4| HLT Selection Length 4 | HLT Selection names var | L1 Trig Count 4| L1 TrigName len 4| L1 Trig Names var | adler32 chksum 4| host name length 4| host name var|desc legth 4 | description blob var
 
 Protocol Version 9: identical to version 8, but incremented to keep in sync with event msg protocol version 
+
+Protocol Version 10: removed hostname
+code 1 | size 4 | protocol version 1 | pset 16 | run 4 | Init Header Size 4| Event Header Size 4| releaseTagLength 1 | ReleaseTag var| processNameLength 1 | processName var| outputModuleLabelLength 1 | outputModuleLabel var | outputModuleId 4 | HLT Trig count 4| HLT Trig Length 4 | HLT Trig names var | HLT Selection count 4| HLT Selection Length 4 | HLT Selection names var | L1 Trig Count 4| L1 TrigName len 4| L1 Trig Names var | adler32 chksum 4| desc legth 4 | description blob var
+
 */
 
 #ifndef IOPool_Streamer_InitMessage_h
@@ -32,7 +36,7 @@ Protocol Version 9: identical to version 8, but incremented to keep in sync with
 
 struct Version
 {
-  Version(const uint8* pset):protocol_(9)
+  Version(const uint8* pset):protocol_(10)
   { std::copy(pset,pset+sizeof(pset_id_),&pset_id_[0]); }
 
   uint8 protocol_; // version of the protocol

--- a/IOPool/Streamer/interface/InitMsgBuilder.h
+++ b/IOPool/Streamer/interface/InitMsgBuilder.h
@@ -18,7 +18,7 @@ public:
                  const Strings& hlt_names,
                  const Strings& hlt_selections,
                  const Strings& l1_names,
-                 uint32 adler32_chksum, const char* host_name);
+                 uint32 adler32_chksum);
 
   uint8* startAddress() const { return buf_; }
   void setDataLength(uint32 registry_length);

--- a/IOPool/Streamer/src/EventMessage.cc
+++ b/IOPool/Streamer/src/EventMessage.cc
@@ -15,9 +15,9 @@ EventMsgView::EventMsgView(void* buf):
 
   // 18-Jul-2008, wmtan - payload changed for version 7.
   // So we no longer support previous formats.
-  if (protocolVersion() != 9) {
+  if (protocolVersion() != 10) {
     throw cms::Exception("EventMsgView", "Invalid Message Version:")
-      << "Only message version 9 is currently supported \n"
+      << "Only message version 10 is currently supported \n"
       << "(invalid value = " << protocolVersion() << ").\n"
       << "We support only reading and converting streamer files\n"
       << "using the same version of CMSSW used to created the\n"

--- a/IOPool/Streamer/src/EventMsgBuilder.cc
+++ b/IOPool/Streamer/src/EventMsgBuilder.cc
@@ -15,7 +15,7 @@ EventMsgBuilder::EventMsgBuilder(void* buf, uint32 size,
   buf_((uint8*)buf),size_(size)
 {
   EventHeader* h = (EventHeader*)buf_;
-  h->protocolVersion_ = 9;
+  h->protocolVersion_ = 10;
   convert(run,h->run_);
   convert(event,h->event_);
   convert(lumi,h->lumi_);

--- a/IOPool/Streamer/src/InitMessage.cc
+++ b/IOPool/Streamer/src/InitMessage.cc
@@ -86,10 +86,14 @@ InitMsgView::InitMsgView(void* buf) :
 
   if (protocolVersion() > 7) {
     adler32_chksum_ = convert32(pos);
-    host_name_start_ = pos + sizeof(uint32);
-    host_name_len_ = *host_name_start_;
-    host_name_start_ += sizeof(uint8);
-    pos = host_name_start_ + host_name_len_;
+    pos += sizeof(uint32);
+
+    if (protocolVersion() <= 9) {
+      host_name_start_ = pos;
+      host_name_len_ = *host_name_start_;
+      host_name_start_ += sizeof(uint8);
+      pos = host_name_start_ + host_name_len_;
+    }
   }
 
   desc_start_ = pos;
@@ -185,12 +189,16 @@ uint32 InitMsgView::initHeaderSize() const
 
 std::string InitMsgView::hostName() const
 {
-   //return std::string(reinterpret_cast<char *>(host_name_start_),host_name_len_);
-   std::string host_name(reinterpret_cast<char *>(host_name_start_),host_name_len_);
-   size_t found = host_name.find('\0');
-   if(found != std::string::npos) {
-     return std::string(host_name, 0, found);
-   } else {
-     return host_name;
-   }
+  if (host_name_start_) {
+    std::string host_name(reinterpret_cast<char *>(host_name_start_),host_name_len_);
+    size_t found = host_name.find('\0');
+    if(found != std::string::npos) {
+      return std::string(host_name, 0, found);
+    } else {
+      return host_name;
+    }
+  }
+  else {
+    return "n/a";
+  }
 }

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -184,7 +184,7 @@ namespace edm {
                            getReleaseVersion().c_str() , processName.c_str(),
                            moduleLabel.c_str(), outputModuleId_,
                            hltTriggerNames, hltTriggerSelections_, l1_names,
-                           (uint32)serializeDataBuffer_.adler32_chksum(), host_name_));
+                           (uint32)serializeDataBuffer_.adler32_chksum()));
 
     // copy data into the destination message
     unsigned char* src = serializeDataBuffer_.bufferPointer();

--- a/IOPool/Streamer/test/EventMessageTest.cpp
+++ b/IOPool/Streamer/test/EventMessageTest.cpp
@@ -57,13 +57,12 @@ int main() try {
   crc = crc32(crc, crcbuf, outputModuleLabel.length());
 
   uint32 adler32_chksum = (uint32)cms::Adler32((char*)&test_value[0], sizeof(test_value));
-  std::string host_name = "mytestnode.cms";
 
   InitMsgBuilder init(&buf[0],buf.size(),12,
                       Version((const uint8*)psetid),(const char*)reltag,
 		      processName.c_str(),outputModuleLabel.c_str(), crc,
                       hlt_names,hlt_names,l1_names,
-                      adler32_chksum, host_name.c_str());
+                      adler32_chksum);
 
 
   init.setDataLength(sizeof(test_value));
@@ -79,7 +78,6 @@ int main() try {
   view.l1TriggerNames(l12);
 
   uint32 adler32_2 = view.adler32_chksum();
-  std::string host_name2 = view.hostName();
 
 
   InitMsgBuilder init2(&buf2[0],buf2.size(),
@@ -88,8 +86,7 @@ int main() try {
                        view.releaseTag().c_str(),
                        processName.c_str(),outputModuleLabel.c_str(), crc,
                        hlt2,hlt2,l12,
-                       adler32_2,
-                       host_name2.c_str());
+                       adler32_2);
 
   init2.setDataLength(view.descLength());
   std::copy(view.descData(),view.descData()+view.size(),
@@ -115,7 +112,7 @@ int main() try {
   l1bit[3]=false;  l1bit[7]=false;  l1bit[11]=true;  l1bit[15]=true;
 
   adler32_chksum = (uint32)cms::Adler32((char*)&test_value[0], sizeof(test_value));
-  //host_name = "mytestnode.cms";
+  std::string host_name = "mytestnode.cms";
 
   EventMsgBuilder emb(&buf[0],buf.size(),45,2020,2,0xdeadbeef,3,
                       l1bit,hltbits,hltsize, adler32_chksum, host_name.c_str());
@@ -134,7 +131,7 @@ int main() try {
   eview.l1TriggerBits(l1_out);
   eview.hltTriggerBits(hlt_out);
   adler32_2 = eview.adler32_chksum();
-  host_name2 = eview.hostName();
+  std::string host_name2 = eview.hostName();
 
   EventMsgBuilder emb2(&buf2[0],buf.size(),
                        eview.run(),

--- a/IOPool/Streamer/test/WriteStreamerFile.cpp
+++ b/IOPool/Streamer/test/WriteStreamerFile.cpp
@@ -63,14 +63,13 @@ int main() try {
   crc = crc32(crc, crcbuf, outputModuleLabel.length());
 
   uint32 adler32_chksum = (uint32)cms::Adler32((char*)&test_value[0], sizeof(test_value));
-  std::string host_name = "mytestnode.cms";
 
   InitMsgBuilder init(&buf[0],buf.size(),12,
                       Version((const uint8*)psetid),
                       (const char*)reltag, processName.c_str(),
                       outputModuleLabel.c_str(), crc,
                       hlt_names,hlt_names,l1_names,
-                      adler32_chksum, host_name.c_str());
+                      adler32_chksum);
 
   init.setDataLength(sizeof(test_value));
   std::copy(&test_value[0],&test_value[0]+sizeof(test_value),
@@ -102,7 +101,7 @@ int main() try {
   //Lets Build 10 Events and then Write them into Streamer file.
 
   adler32_chksum = (uint32)cms::Adler32((char*)&test_value_event[0], sizeof(test_value_event));
-  //host_name = "mytestnode.cms";
+  std::string host_name = "mytestnode.cms";
 
   for (uint32 eventId = 2000; eventId != 2000+NO_OF_EVENTS; ++eventId) {
     EventMsgBuilder emb(&buf2[0],buf2.size(),45,eventId,2,0xdeadbeef,3,


### PR DESCRIPTION
This request removes the hostname from the INIT message header. The header encoded the hostname where the INIT message is created. This was useful for the old StorageManager in DAQ1. However, for the FFF, this information is misleading as only one INIT file is preserved which contains a random hostname. In addition, it causes problems to easily check that the INIT messages are identical (beside the hostname). The hostname is also found in each event header. Therefore, it is still possible to trace back any event to its origin in case of data corruption.

In addition, there are a couple of fixes for the file-based filter farm.
