### PR TITLE
Legacy modules and shared resources

### DIFF
--- a/FWCore/Framework/src/SharedResourcesRegistry.cc
+++ b/FWCore/Framework/src/SharedResourcesRegistry.cc
@@ -11,6 +11,7 @@
 //
 
 // system include files
+#include <algorithm>
 #include <cassert>
 
 // user include files
@@ -28,16 +29,34 @@ namespace edm {
   }
   
   void
-  SharedResourcesRegistry::registerSharedResource(const std::string& iString){
-    auto& values = resourceMap_[iString];
-    
-    if(values.second ==1) {
-      //only need to make the resource if more than 1 module wants it
-      values.first = std::shared_ptr<std::recursive_mutex>( new std::recursive_mutex );
+  SharedResourcesRegistry::registerSharedResource(const std::string& resourceName){
+
+    auto& mutexAndCounter = resourceMap_[resourceName];
+
+    if(resourceName == kLegacyModuleResourceName) {
+      for(auto & resource : resourceMap_) {
+        if(!resource.second.first) {
+          resource.second.first.reset(new std::recursive_mutex);
+        }
+        ++resource.second.second;
+      }
+    } else {
+      if(mutexAndCounter.second == 0) {
+        for(auto & resource : resourceMap_) {
+          if(resource.first == kLegacyModuleResourceName) {
+            mutexAndCounter.first.reset(new std::recursive_mutex);
+            mutexAndCounter.second += resource.second.second;
+            break;
+          }
+        }
+      } else if(mutexAndCounter.second == 1 && !mutexAndCounter.first) {
+        // make the resource if more than 1 module wants it
+        mutexAndCounter.first = std::shared_ptr<std::recursive_mutex>( new std::recursive_mutex );
+      }
+      ++mutexAndCounter.second;
     }
-    ++(values.second);
   }
-  
+
   SharedResourcesAcquirer
   SharedResourcesRegistry::createAcquirerForSourceDelayedReader() {
     if(not resourceForDelayedReader_) {
@@ -48,27 +67,54 @@ namespace edm {
     return SharedResourcesAcquirer(std::move(mutexes));
   }
 
-  
   SharedResourcesAcquirer
-  SharedResourcesRegistry::createAcquirer(std::vector<std::string> const &  iNames) const {
-    //Sort by how often used and then by name
+  SharedResourcesRegistry::createAcquirer(std::vector<std::string> const& resourceNames) const {
+
+    // The acquirer will acquire the shared resources declared by a module
+    // so that only it can use those resources while it runs. The other
+    // modules using the same resource will not be run until the module
+    // that acquired the resources completes its task.
+
+    // The legacy shared resource is special.
+    // Legacy modules cannot run concurrently with each other or
+    // any other module that has declared any shared resource. Treat
+    // one modules that call usesResource with no argument in the
+    // same way.
+
+    // Sort by how often used and then by name
+    // Consistent sorting avoids deadlocks and this particular order optimizes performance
     std::map<std::pair<unsigned int, std::string>, std::recursive_mutex*> sortedResources;
-    
-    for(auto const& name: iNames) {
-      auto itFound = resourceMap_.find(name);
-      assert(itFound != resourceMap_.end());
-      //If only one module wants it, it really isn't shared
-      if(itFound->second.second>1) {
-        sortedResources.insert(std::make_pair(std::make_pair(itFound->second.second, itFound->first),itFound->second.first.get()));
+
+    // Is this acquirer for a module that depends on the legacy shared resource?
+    if(std::find(resourceNames.begin(), resourceNames.end(), kLegacyModuleResourceName) != resourceNames.end()) {
+
+      for(auto const& resource : resourceMap_) {
+        // It's redundant to declare legacy if the legacy modules
+        // all declare all the other resources, so just skip it.
+        // But if the only shared resource is the legacy resource don't skip it.
+        if(resource.first == kLegacyModuleResourceName && resourceMap_.size() > 1) continue;
+        //If only one module wants it, it really isn't shared
+        if(resource.second.second > 1) {
+          sortedResources.insert(std::make_pair(std::make_pair(resource.second.second, resource.first),resource.second.first.get()));
+        }
+      }
+    // Handle cases where the module does not declare the legacy resource
+    } else {
+      for(auto const& name : resourceNames) {
+        auto resource = resourceMap_.find(name);
+        assert(resource != resourceMap_.end());
+        //If only one module wants it, it really isn't shared
+        if(resource->second.second > 1) {
+          sortedResources.insert(std::make_pair(std::make_pair(resource->second.second, resource->first),resource->second.first.get()));
+        }
       }
     }
+
     std::vector<std::recursive_mutex*> mutexes;
     mutexes.reserve(sortedResources.size());
     for(auto const& resource: sortedResources) {
       mutexes.push_back(resource.second);
     }
-    
     return SharedResourcesAcquirer(std::move(mutexes));
   }
-  
 }

--- a/FWCore/Framework/src/SharedResourcesRegistry.h
+++ b/FWCore/Framework/src/SharedResourcesRegistry.h
@@ -53,7 +53,12 @@ namespace edm {
     // ---------- member functions ---------------------------
     ///A resource name must be registered before it can be used in the createAcquirer call
     void registerSharedResource(const std::string&);
-    
+
+#ifdef SHAREDRESOURCETESTACCESSORS
+    // The next function is intended to be used only in a unit test
+    std::map<std::string, std::pair<std::shared_ptr<std::recursive_mutex>,unsigned int>> const& resourceMap() const { return resourceMap_; }
+#endif
+
   private:
     SharedResourcesRegistry()=default;
     ~SharedResourcesRegistry()=default;

--- a/FWCore/Framework/src/SharedResourcesRegistry.h
+++ b/FWCore/Framework/src/SharedResourcesRegistry.h
@@ -60,7 +60,7 @@ namespace edm {
 #endif
 
   private:
-    SharedResourcesRegistry()=default;
+    SharedResourcesRegistry();
     ~SharedResourcesRegistry()=default;
 
     SharedResourcesRegistry(const SharedResourcesRegistry&) = delete; // stop default
@@ -71,7 +71,8 @@ namespace edm {
     std::map<std::string, std::pair<std::shared_ptr<std::recursive_mutex>,unsigned int>> resourceMap_;
     
     std::shared_ptr<std::recursive_mutex> resourceForDelayedReader_;
-    
+
+    unsigned int nLegacy_;
   };
 }
 

--- a/FWCore/Framework/test/sharedresourcesregistry_t.cppunit.cc
+++ b/FWCore/Framework/test/sharedresourcesregistry_t.cppunit.cc
@@ -8,6 +8,7 @@
 
 #include "cppunit/extensions/HelperMacros.h"
 
+#define SHAREDRESOURCETESTACCESSORS 1
 #include "FWCore/Framework/src/SharedResourcesRegistry.h"
 #include "FWCore/Framework/interface/SharedResourcesAcquirer.h"
 
@@ -38,7 +39,9 @@ CPPUNIT_TEST_SUITE_REGISTRATION(testSharedResourcesRegistry);
 void testSharedResourcesRegistry::oneTest()
 {
   edm::SharedResourcesRegistry reg;
-  
+
+  CPPUNIT_ASSERT(reg.resourceMap().size() == 0);
+
   reg.registerSharedResource("foo");
   reg.registerSharedResource("bar");
   reg.registerSharedResource("zoo");
@@ -65,7 +68,7 @@ void testSharedResourcesRegistry::legacyTest()
     
     reg.registerSharedResource(edm::SharedResourcesRegistry::kLegacyModuleResourceName);
     auto tester = reg.createAcquirer(res);
-    
+
     CPPUNIT_ASSERT(0 == tester.numberOfResources());
   }
   {
@@ -79,11 +82,47 @@ void testSharedResourcesRegistry::legacyTest()
     CPPUNIT_ASSERT(1 == tester.numberOfResources());
     
   }
+  {
+    edm::SharedResourcesRegistry reg;
+
+    reg.registerSharedResource("foo");
+    reg.registerSharedResource("zoo");
+
+    auto const& resourceMap = reg.resourceMap();
+    CPPUNIT_ASSERT(resourceMap.at(std::string("foo")).first.get() == nullptr);
+    CPPUNIT_ASSERT(resourceMap.at(std::string("zoo")).first.get() == nullptr);
+    CPPUNIT_ASSERT(resourceMap.size() == 2);
+    CPPUNIT_ASSERT(resourceMap.at(std::string("foo")).second == 1);
+    CPPUNIT_ASSERT(resourceMap.at(std::string("zoo")).second == 1);
+
+    reg.registerSharedResource(edm::SharedResourcesRegistry::kLegacyModuleResourceName);
+    CPPUNIT_ASSERT(resourceMap.at(std::string("foo")).first.get() != nullptr);
+    CPPUNIT_ASSERT(resourceMap.at(std::string("zoo")).first.get() != nullptr);
+    CPPUNIT_ASSERT(resourceMap.at(edm::SharedResourcesRegistry::kLegacyModuleResourceName).first.get() != nullptr);
+    CPPUNIT_ASSERT(resourceMap.at(std::string("foo")).second == 2);
+    CPPUNIT_ASSERT(resourceMap.at(std::string("zoo")).second == 2);
+    CPPUNIT_ASSERT(resourceMap.at(edm::SharedResourcesRegistry::kLegacyModuleResourceName).second == 1);
+    CPPUNIT_ASSERT(resourceMap.size() == 3);
+
+    reg.registerSharedResource(edm::SharedResourcesRegistry::kLegacyModuleResourceName);
+    reg.registerSharedResource("bar");
+    reg.registerSharedResource("zoo");
+    CPPUNIT_ASSERT(resourceMap.at(std::string("bar")).first.get() != nullptr);
+    CPPUNIT_ASSERT(resourceMap.at(std::string("bar")).second == 3);
+    CPPUNIT_ASSERT(resourceMap.at(std::string("foo")).second == 3);
+    CPPUNIT_ASSERT(resourceMap.at(std::string("zoo")).second == 4);
+    CPPUNIT_ASSERT(resourceMap.at(edm::SharedResourcesRegistry::kLegacyModuleResourceName).second == 2);
+
+    auto tester = reg.createAcquirer(res);
+
+    CPPUNIT_ASSERT(3 == tester.numberOfResources());
+  }
 }
 
 void testSharedResourcesRegistry::multipleTest()
 {
   edm::SharedResourcesRegistry reg;
+  auto const& resourceMap = reg.resourceMap();
   
   reg.registerSharedResource("foo");
   reg.registerSharedResource("bar");
@@ -91,7 +130,15 @@ void testSharedResourcesRegistry::multipleTest()
   reg.registerSharedResource("zoo");
   reg.registerSharedResource("bar");
   reg.registerSharedResource("zoo");
-  
+
+  CPPUNIT_ASSERT(resourceMap.at(std::string("foo")).first.get() == nullptr);
+  CPPUNIT_ASSERT(resourceMap.at(std::string("zoo")).first.get() != nullptr);
+  CPPUNIT_ASSERT(resourceMap.at(std::string("bar")).first.get() != nullptr);
+  CPPUNIT_ASSERT(resourceMap.at(std::string("bar")).second == 2);
+  CPPUNIT_ASSERT(resourceMap.at(std::string("foo")).second == 1);
+  CPPUNIT_ASSERT(resourceMap.at(std::string("zoo")).second == 3);
+  CPPUNIT_ASSERT(resourceMap.size() == 3);
+
   {
     std::vector<std::string> res{"foo","bar","zoo"};
     auto tester = reg.createAcquirer(res);


### PR DESCRIPTION
With this change, modules that use the no argument
form of the usesResource function will not run
concurrently with any other module that has
declared any shared resource with a named resource
using the usesResource function or used the no argument
usesResource function. All legacy modules automatically
call the no argument usesResource function.
