### PR TITLE
Fix consumes validation tracker hits

### DIFF
--- a/Validation/TrackerHits/interface/TrackerHitAnalyzer.h
+++ b/Validation/TrackerHits/interface/TrackerHitAnalyzer.h
@@ -10,7 +10,9 @@
 // framework & common header files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
 #include <string>
 
@@ -44,28 +46,17 @@ void endJob(void);
 
 private:
 
-  edm::InputTag SiTIBLowSrc_;
-  edm::InputTag SiTIBHighSrc_;
-  edm::InputTag SiTOBLowSrc_;
-  edm::InputTag SiTOBHighSrc_;
-  edm::InputTag SiTIDLowSrc_;
-  edm::InputTag SiTIDHighSrc_;
-  edm::InputTag SiTECLowSrc_;
-  edm::InputTag SiTECHighSrc_;
-  edm::InputTag PxlBrlLowSrc_;
-  edm::InputTag PxlBrlHighSrc_;
-  edm::InputTag PxlFwdLowSrc_;
-  edm::InputTag PxlFwdHighSrc_;
-  edm::InputTag G4TrkSrc_;
-
-//  edm::ParameterSet config_;
- 
- 
  bool verbose_;
- 
+
+ edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_pxlBrlLow_Token_, edmPSimHitContainer_pxlBrlHigh_Token_;
+ edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_pxlFwdLow_Token_, edmPSimHitContainer_pxlFwdHigh_Token_;
+ edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTIBLow_Token_, edmPSimHitContainer_siTIBHigh_Token_;
+ edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTOBLow_Token_, edmPSimHitContainer_siTOBHigh_Token_;
+ edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTIDLow_Token_, edmPSimHitContainer_siTIDHigh_Token_;
+ edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTECLow_Token_, edmPSimHitContainer_siTECHigh_Token_;
+ edm::EDGetTokenT<edm::SimTrackContainer> edmSimTrackContainerToken_;
+
  DQMStore* fDBE;
- 
- std::string fOutputFile;
 
  MonitorElement* htofeta;
  MonitorElement* htofphi;
@@ -116,6 +107,8 @@ private:
  MonitorElement* h4ly[12];
  MonitorElement* h5ly[12];
  MonitorElement* h6ly[12];
+
+ std::string fOutputFile;
 };
 
 #endif

--- a/Validation/TrackerHits/interface/TrackerHitAnalyzer.h
+++ b/Validation/TrackerHits/interface/TrackerHitAnalyzer.h
@@ -8,35 +8,14 @@
  *
 */
 // framework & common header files
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "DataFormats/Common/interface/Handle.h"
-
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
-#include "DataFormats/DetId/interface/DetId.h"
-
-#include "FWCore/ServiceRegistry/interface/Service.h"
-#include "DQMServices/Core/interface/DQMStore.h"
-
-#include "DQMServices/Core/interface/MonitorElement.h"
-
-#include <fstream>
-#include <map>
-#include <iostream>
-#include <stdlib.h>
 #include <string>
-#include <memory>
-#include <vector>
 
+class DQMStore;
+class MonitorElement;
 
 class TrackerHitAnalyzer: public edm::EDAnalyzer {
   

--- a/Validation/TrackerHits/interface/TrackerHitAnalyzer.h
+++ b/Validation/TrackerHits/interface/TrackerHitAnalyzer.h
@@ -50,6 +50,9 @@ TrackerHitAnalyzer(const edm::ParameterSet& ps);
 
 protected:
 
+/// Begin Run
+void beginRun( edm::Run const&, edm::EventSetup const&);
+
 /// Analyze
 void analyze(const edm::Event& e, const edm::EventSetup& c);
 

--- a/Validation/TrackerHits/interface/TrackerHitProducer.h
+++ b/Validation/TrackerHits/interface/TrackerHitProducer.h
@@ -5,12 +5,17 @@
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
 #include <string>
 #include <vector>
 
+namespace edm {
+  class HepMCProduct;
+}
 class PTrackerSimHit;
 
 class TrackerHitProducer : public edm::EDProducer
@@ -29,9 +34,6 @@ class TrackerHitProducer : public edm::EDProducer
   
  private:
 
-  //TrackerHitidation(const TrackerHitidation&);   
-  //const TrackerHitidation& operator=(const TrackerHitidation&);
-
   // production related methods
   void fillG4MC(edm::Event&);
   void storeG4MC(PTrackerSimHit&);
@@ -43,14 +45,29 @@ class TrackerHitProducer : public edm::EDProducer
  private:
 
   //  parameter information
-  std::string fName;
-  int verbosity;
-  std::string label;
   bool getAllProvenances;
   bool printProvenanceInfo;
+  int verbosity;
+
+  // private statistics information
+  unsigned int count;
+
+  int nRawGenPart;
+
+  edm::ParameterSet config_;
+
+  edm::EDGetTokenT<edm::HepMCProduct> edmHepMCProductToken_;
+  edm::EDGetTokenT<edm::SimVertexContainer> edmSimVertexContainerToken_;
+  edm::EDGetTokenT<edm::SimTrackContainer> edmSimTrackContainerToken_;
+  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_pxlBrlLow_Token_, edmPSimHitContainer_pxlBrlHigh_Token_;
+  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_pxlFwdLow_Token_, edmPSimHitContainer_pxlFwdHigh_Token_;
+  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTIBLow_Token_, edmPSimHitContainer_siTIBHigh_Token_;
+  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTOBLow_Token_, edmPSimHitContainer_siTOBHigh_Token_;
+  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTIDLow_Token_, edmPSimHitContainer_siTIDHigh_Token_;
+  edm::EDGetTokenT<edm::PSimHitContainer> edmPSimHitContainer_siTECLow_Token_, edmPSimHitContainer_siTECHigh_Token_;
+
 
   // G4MC info
-  int nRawGenPart;
   FloatVector G4VtxX; 
   FloatVector G4VtxY; 
   FloatVector G4VtxZ; 
@@ -86,27 +103,8 @@ class TrackerHitProducer : public edm::EDProducer
   FloatVector HitsEloss; 
   FloatVector HitsToF;
   
-  edm::InputTag SiTIBLowSrc_;
-  edm::InputTag SiTIBHighSrc_;
-  edm::InputTag SiTOBLowSrc_;
-  edm::InputTag SiTOBHighSrc_;
-  edm::InputTag SiTIDLowSrc_;
-  edm::InputTag SiTIDHighSrc_;
-  edm::InputTag SiTECLowSrc_;
-  edm::InputTag SiTECHighSrc_;
-  edm::InputTag PxlBrlLowSrc_;
-  edm::InputTag PxlBrlHighSrc_;
-  edm::InputTag PxlFwdLowSrc_;
-  edm::InputTag PxlFwdHighSrc_;
-  edm::InputTag G4VtxSrc_;
-  edm::InputTag G4TrkSrc_;
-
-  edm::ParameterSet config_;
-  std::string HepMClabel_;
-  std::string HepMCinstance_;
- 
-  // private statistics information
-  unsigned int count;
+  std::string fName;
+  std::string label;
 
 }; // end class declaration
   

--- a/Validation/TrackerHits/interface/TrackerHitProducer.h
+++ b/Validation/TrackerHits/interface/TrackerHitProducer.h
@@ -2,53 +2,17 @@
 #define TrackerHitProducer_h
 
 // framework & common header files
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-//#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/Provenance/interface/Provenance.h"
-//#include "FWCore/Framework/interface/Provenance.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
-#include "DataFormats/DetId/interface/DetId.h"
-
-// tracker info
-#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
-#include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
-#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
-#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
 
 
-// data in edm::event
-#include "SimDataFormats/ValidationFormats/interface/PValidationFormats.h"
-#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
-#include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
-#include "SimDataFormats/Track/interface/SimTrackContainer.h"
-#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
-#include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
-//#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
-//#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
-
-// helper files
-#include <CLHEP/Vector/LorentzVector.h>
-#include "CLHEP/Units/GlobalSystemOfUnits.h"
-
-#include <iostream>
-#include <stdlib.h>
 #include <string>
-#include <memory>
 #include <vector>
 
-#include "TString.h"
+class PTrackerSimHit;
 
-class PGlobalSimHit;
-  
 class TrackerHitProducer : public edm::EDProducer
 {
   

--- a/Validation/TrackerHits/src/TrackerHitAnalyzer.cc
+++ b/Validation/TrackerHits/src/TrackerHitAnalyzer.cc
@@ -1,10 +1,22 @@
 #include "Validation/TrackerHits/interface/TrackerHitAnalyzer.h"
 
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/DetId/interface/DetId.h"
+
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
 
 // tracker info
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
@@ -26,9 +38,13 @@
 #include <CLHEP/Vector/LorentzVector.h>
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
-
+#include <fstream>
 #include <iostream>
-#include "DQMServices/Core/interface/DQMStore.h"
+#include <map>
+#include <memory>
+#include <stdlib.h>
+#include <vector>
+
 using namespace edm;
 using namespace std;
 

--- a/Validation/TrackerHits/src/TrackerHitAnalyzer.cc
+++ b/Validation/TrackerHits/src/TrackerHitAnalyzer.cc
@@ -35,7 +35,6 @@ using namespace std;
 TrackerHitAnalyzer::TrackerHitAnalyzer(const edm::ParameterSet& ps) :
    G4TrkSrc_(ps.getParameter<edm::InputTag>("G4TrkSrc")) {
 
-   fDBE = Service<DQMStore>().operator->();
    fOutputFile = ps.getUntrackedParameter<string>("outputFile", "TrackerHitHisto.root");
    verbose_ = ps.getUntrackedParameter<bool>("Verbosity",false);
    //get Labels to use to extract information
@@ -52,9 +51,11 @@ TrackerHitAnalyzer::TrackerHitAnalyzer(const edm::ParameterSet& ps) :
    SiTIDHighSrc_ = ps.getParameter<edm::InputTag>("SiTIDHighSrc");
    SiTECLowSrc_ = ps.getParameter<edm::InputTag>("SiTECLowSrc");
    SiTECHighSrc_ = ps.getParameter<edm::InputTag>("SiTECHighSrc");
+}
 
-
+void TrackerHitAnalyzer::beginRun( edm::Run const&, edm::EventSetup const& ) {
 ////// booking histograms
+   fDBE = Service<DQMStore>().operator->();
    	
   Char_t  hname1[50], htitle1[80];
   Char_t  hname2[50], htitle2[80];

--- a/Validation/TrackerHits/src/TrackerHitAnalyzer.cc
+++ b/Validation/TrackerHits/src/TrackerHitAnalyzer.cc
@@ -27,10 +27,7 @@
 #include "SimDataFormats/ValidationFormats/interface/PValidationFormats.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 //#include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
-#include "SimDataFormats/Track/interface/SimTrackContainer.h"
-#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
-#include "SimDataFormats/Track/interface/SimTrack.h"
 #include "SimDataFormats/Vertex/interface/SimVertex.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 
@@ -48,25 +45,23 @@
 using namespace edm;
 using namespace std;
 
-TrackerHitAnalyzer::TrackerHitAnalyzer(const edm::ParameterSet& ps) :
-   G4TrkSrc_(ps.getParameter<edm::InputTag>("G4TrkSrc")) {
-
-   fOutputFile = ps.getUntrackedParameter<string>("outputFile", "TrackerHitHisto.root");
-   verbose_ = ps.getUntrackedParameter<bool>("Verbosity",false);
-   //get Labels to use to extract information
-   PxlBrlLowSrc_ = ps.getParameter<edm::InputTag>("PxlBrlLowSrc");
-   PxlBrlHighSrc_ = ps.getParameter<edm::InputTag>("PxlBrlHighSrc");
-   PxlFwdLowSrc_ = ps.getParameter<edm::InputTag>("PxlFwdLowSrc");
-   PxlFwdHighSrc_ = ps.getParameter<edm::InputTag>("PxlFwdHighSrc");
-   
-   SiTIBLowSrc_ = ps.getParameter<edm::InputTag>("SiTIBLowSrc");
-   SiTIBHighSrc_ = ps.getParameter<edm::InputTag>("SiTIBHighSrc");
-   SiTOBLowSrc_ = ps.getParameter<edm::InputTag>("SiTOBLowSrc");
-   SiTOBHighSrc_ = ps.getParameter<edm::InputTag>("SiTOBHighSrc");
-   SiTIDLowSrc_ = ps.getParameter<edm::InputTag>("SiTIDLowSrc");
-   SiTIDHighSrc_ = ps.getParameter<edm::InputTag>("SiTIDHighSrc");
-   SiTECLowSrc_ = ps.getParameter<edm::InputTag>("SiTECLowSrc");
-   SiTECHighSrc_ = ps.getParameter<edm::InputTag>("SiTECHighSrc");
+TrackerHitAnalyzer::TrackerHitAnalyzer(const edm::ParameterSet& ps)
+  : verbose_( ps.getUntrackedParameter<bool>( "Verbosity",false ) )
+  , edmPSimHitContainer_pxlBrlLow_Token_( consumes<edm::PSimHitContainer>( ps.getParameter<edm::InputTag>( "PxlBrlLowSrc" ) ) )
+  , edmPSimHitContainer_pxlBrlHigh_Token_( consumes<edm::PSimHitContainer>( ps.getParameter<edm::InputTag>( "PxlBrlHighSrc" ) ) )
+  , edmPSimHitContainer_pxlFwdLow_Token_( consumes<edm::PSimHitContainer>( ps.getParameter<edm::InputTag>( "PxlFwdLowSrc" ) ) )
+  , edmPSimHitContainer_pxlFwdHigh_Token_( consumes<edm::PSimHitContainer>( ps.getParameter<edm::InputTag>( "PxlFwdHighSrc" ) ) )
+  , edmPSimHitContainer_siTIBLow_Token_( consumes<edm::PSimHitContainer>( ps.getParameter<edm::InputTag>( "SiTIBLowSrc" ) ) )
+  , edmPSimHitContainer_siTIBHigh_Token_( consumes<edm::PSimHitContainer>( ps.getParameter<edm::InputTag>( "SiTIBHighSrc" ) ) )
+  , edmPSimHitContainer_siTOBLow_Token_( consumes<edm::PSimHitContainer>( ps.getParameter<edm::InputTag>( "SiTOBLowSrc" ) ) )
+  , edmPSimHitContainer_siTOBHigh_Token_( consumes<edm::PSimHitContainer>( ps.getParameter<edm::InputTag>( "SiTOBHighSrc" ) ) )
+  , edmPSimHitContainer_siTIDLow_Token_( consumes<edm::PSimHitContainer>( ps.getParameter<edm::InputTag>( "SiTIDLowSrc" ) ) )
+  , edmPSimHitContainer_siTIDHigh_Token_( consumes<edm::PSimHitContainer>( ps.getParameter<edm::InputTag>( "SiTIDHighSrc" ) ) )
+  , edmPSimHitContainer_siTECLow_Token_( consumes<edm::PSimHitContainer>( ps.getParameter<edm::InputTag>( "SiTECLowSrc" ) ) )
+  , edmPSimHitContainer_siTECHigh_Token_( consumes<edm::PSimHitContainer>( ps.getParameter<edm::InputTag>( "SiTECHighSrc" ) ) )
+  , edmSimTrackContainerToken_( consumes<edm::SimTrackContainer>( ps.getParameter<edm::InputTag>( "G4TrkSrc" ) ) )
+  , fDBE( NULL )
+  , fOutputFile( ps.getUntrackedParameter<std::string>( "outputFile", "TrackerHitHisto.root" ) ) {
 }
 
 void TrackerHitAnalyzer::beginRun( edm::Run const&, edm::EventSetup const& ) {
@@ -367,7 +362,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c)
   ////////////////////////////////
   // extract low container
   edm::Handle<edm::PSimHitContainer> PxlBrlLowContainer;
-  e.getByLabel(PxlBrlLowSrc_,PxlBrlLowContainer);
+  e.getByToken( edmPSimHitContainer_pxlBrlLow_Token_, PxlBrlLowContainer );
   if (!PxlBrlLowContainer.isValid()) {
     edm::LogError("TrackerHitAnalyzer::analyze")
       << "Unable to find TrackerHitsPixelBarrelLowTof in event!";
@@ -375,7 +370,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c)
   }  
   // extract high container
   edm::Handle<edm::PSimHitContainer> PxlBrlHighContainer;
-  e.getByLabel(PxlBrlHighSrc_,PxlBrlHighContainer);
+  e.getByToken( edmPSimHitContainer_pxlBrlHigh_Token_, PxlBrlHighContainer );
   if (!PxlBrlHighContainer.isValid()) {
     edm::LogError("TrackerHitAnalyzer::analyze")
       << "Unable to find TrackerHitsPixelBarrelHighTof in event!";
@@ -386,7 +381,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c)
   ////////////////////////////////
   // extract low container
   edm::Handle<edm::PSimHitContainer> PxlFwdLowContainer;
-  e.getByLabel(PxlFwdLowSrc_,PxlFwdLowContainer);
+  e.getByToken( edmPSimHitContainer_pxlFwdLow_Token_, PxlFwdLowContainer );
   if (!PxlFwdLowContainer.isValid()) {
     edm::LogError("TrackerHitAnalyzer::analyze")
       << "Unable to find TrackerHitsPixelEndcapLowTof in event!";
@@ -394,7 +389,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c)
   }
   // extract high container
   edm::Handle<edm::PSimHitContainer> PxlFwdHighContainer;
-  e.getByLabel(PxlFwdHighSrc_,PxlFwdHighContainer);
+  e.getByToken( edmPSimHitContainer_pxlFwdHigh_Token_, PxlFwdHighContainer );
   if (!PxlFwdHighContainer.isValid()) {
     edm::LogError("TrackerHitAnalyzer::analyze")
       << "Unable to find TrackerHitsPixelEndcapHighTof in event!";
@@ -406,18 +401,16 @@ void TrackerHitAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c)
   //////////////////////////////////
   // extract TIB low container
   edm::Handle<edm::PSimHitContainer> SiTIBLowContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsTIBLowTof",SiTIBLowContainer);
-  e.getByLabel(SiTIBLowSrc_,SiTIBLowContainer);
+  e.getByToken( edmPSimHitContainer_siTIBLow_Token_, SiTIBLowContainer );
   if (!SiTIBLowContainer.isValid()) {
     edm::LogError("TrackerHitProducer::analyze")
       << "Unable to find TrackerHitsTIBLowTof in event!";
     return;
   }
   //////////////////////////////////
-  // extract TIB low container
+  // extract TIB high container
   edm::Handle<edm::PSimHitContainer> SiTIBHighContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsTIBHighTof",SiTIBHighContainer);
-  e.getByLabel(SiTIBHighSrc_,SiTIBHighContainer);
+  e.getByToken( edmPSimHitContainer_siTIBHigh_Token_, SiTIBHighContainer );
   if (!SiTIBHighContainer.isValid()) {
     edm::LogError("TrackerHitProducer::analyze")
       << "Unable to find TrackerHitsTIBHighTof in event!";
@@ -428,18 +421,16 @@ void TrackerHitAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c)
   //////////////////////////////////
   // extract TOB low container
   edm::Handle<edm::PSimHitContainer> SiTOBLowContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsTOBLowTof",SiTOBLowContainer);
-  e.getByLabel(SiTOBLowSrc_,SiTOBLowContainer);
+  e.getByToken( edmPSimHitContainer_siTOBLow_Token_, SiTOBLowContainer );
   if (!SiTOBLowContainer.isValid()) {
     edm::LogError("TrackerHitProducer::analyze")
       << "Unable to find TrackerHitsTOBLowTof in event!";
     return;
   }
   //////////////////////////////////
-  // extract TOB low container
+  // extract TOB high container
   edm::Handle<edm::PSimHitContainer> SiTOBHighContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsTOBHighTof",SiTOBHighContainer);
-  e.getByLabel(SiTOBHighSrc_,SiTOBHighContainer);
+  e.getByToken( edmPSimHitContainer_siTOBHigh_Token_, SiTOBHighContainer );
   if (!SiTOBHighContainer.isValid()) {
     edm::LogError("TrackerHitProducer::analyze")
       << "Unable to find TrackerHitsTOBHighTof in event!";
@@ -451,18 +442,16 @@ void TrackerHitAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c)
   //////////////////////////////////
   // extract TID low container
   edm::Handle<edm::PSimHitContainer> SiTIDLowContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsTIDLowTof",SiTIDLowContainer);
-  e.getByLabel(SiTIDLowSrc_,SiTIDLowContainer);
+  e.getByToken( edmPSimHitContainer_siTIDLow_Token_, SiTIDLowContainer );
   if (!SiTIDLowContainer.isValid()) {
     edm::LogError("TrackerHitProducer::analyze")
       << "Unable to find TrackerHitsTIDLowTof in event!";
     return;
   }
   //////////////////////////////////
-  // extract TID low container
+  // extract TID high container
   edm::Handle<edm::PSimHitContainer> SiTIDHighContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsTIDHighTof",SiTIDHighContainer);
-  e.getByLabel(SiTIDHighSrc_,SiTIDHighContainer);
+  e.getByToken( edmPSimHitContainer_siTIDHigh_Token_, SiTIDHighContainer );
   if (!SiTIDHighContainer.isValid()) {
     edm::LogError("TrackerHitProducer::analyze")
       << "Unable to find TrackerHitsTIDHighTof in event!";
@@ -473,18 +462,16 @@ void TrackerHitAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c)
   //////////////////////////////////
   // extract TEC low container
   edm::Handle<edm::PSimHitContainer> SiTECLowContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsTECLowTof",SiTECLowContainer);
-  e.getByLabel(SiTECLowSrc_,SiTECLowContainer);
+  e.getByToken( edmPSimHitContainer_siTECLow_Token_, SiTECLowContainer );
   if (!SiTECLowContainer.isValid()) {
     edm::LogError("TrackerHitProducer::analyze")
       << "Unable to find TrackerHitsTECLowTof in event!";
     return;
   }
   //////////////////////////////////
-  // extract TEC low container
-  edm ::Handle<edm::PSimHitContainer> SiTECHighContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsTECHighTof",SiTECHighContainer);
-  e.getByLabel(SiTECHighSrc_,SiTECHighContainer);
+  // extract TEC high container
+  edm::Handle<edm::PSimHitContainer> SiTECHighContainer;
+  e.getByToken( edmPSimHitContainer_siTECHigh_Token_, SiTECHighContainer );
   if (!SiTECHighContainer.isValid()) {
     edm::LogError("TrackerHitProducer::analyze")
       << "Unable to find TrackerHitsTECHighTof in event!";
@@ -496,7 +483,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c)
   ///////////////////////////
   
   edm::Handle<edm::SimTrackContainer> G4TrkContainer;
-  e.getByLabel(G4TrkSrc_, G4TrkContainer);
+  e.getByToken( edmSimTrackContainerToken_, G4TrkContainer );
   if (!G4TrkContainer.isValid()) {
     edm::LogError("TrackerHitAnalyzer::analyze")
       << "Unable to find SimTrack in event!";

--- a/Validation/TrackerHits/src/TrackerHitAnalyzer.cc
+++ b/Validation/TrackerHits/src/TrackerHitAnalyzer.cc
@@ -35,15 +35,10 @@
 #include <CLHEP/Vector/LorentzVector.h>
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 
-#include <fstream>
-#include <iostream>
 #include <map>
 #include <memory>
 #include <stdlib.h>
 #include <vector>
-
-using namespace edm;
-using namespace std;
 
 TrackerHitAnalyzer::TrackerHitAnalyzer(const edm::ParameterSet& ps)
   : verbose_( ps.getUntrackedParameter<bool>( "Verbosity",false ) )
@@ -66,7 +61,7 @@ TrackerHitAnalyzer::TrackerHitAnalyzer(const edm::ParameterSet& ps)
 
 void TrackerHitAnalyzer::beginRun( edm::Run const&, edm::EventSetup const& ) {
 ////// booking histograms
-   fDBE = Service<DQMStore>().operator->();
+  fDBE = edm::Service<DQMStore>().operator->();
    	
   Char_t  hname1[50], htitle1[80];
   Char_t  hname2[50], htitle2[80];
@@ -353,7 +348,7 @@ void TrackerHitAnalyzer::endJob()
 void TrackerHitAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c)
 {
 
-   LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();
+  edm::LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();
    
   // iterator to access containers
   edm::PSimHitContainer::const_iterator itHit;
@@ -502,7 +497,7 @@ void TrackerHitAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c)
   for (itTrk = G4TrkContainer->begin(); itTrk != G4TrkContainer->end(); 
        ++itTrk) {
 
-//    cout << "itTrk = "<< itTrk << endl;
+//    std::cout << "itTrk = "<< itTrk << std::endl;
     double eta =0, p =0;
     const CLHEP::HepLorentzVector& G4Trk = CLHEP::HepLorentzVector(itTrk->momentum().x(),
                                                      itTrk->momentum().y(),
@@ -530,10 +525,10 @@ void TrackerHitAnalyzer::analyze(const edm::Event& e, const edm::EventSetup& c)
           if (eta>-2.0 && eta<=-1.5) ir = 9;
           if (eta>-2.5 && eta<=-2.0) ir = 10;
           if (eta<=-2.5) ir = 11;
-//          LogInfo("EventInfo") << " eta = " << eta << " ir = " << ir;
-//	  cout << " " <<endl;
-//          cout << "eta " << eta << " ir = " << ir << endl;                  
-//	  cout << " " <<endl;
+//          edm::LogInfo("EventInfo") << " eta = " << eta << " ir = " << ir;
+//	  std::cout << " " << std::endl;
+//          std::cout << "eta " << eta << " ir = " << ir << std::endl;                  
+//	  std::cout << " " << std::endl;
       }
   }	  
   ///////////////////////////////

--- a/Validation/TrackerHits/src/TrackerHitProducer.cc
+++ b/Validation/TrackerHits/src/TrackerHitProducer.cc
@@ -20,8 +20,6 @@
 // data in edm::event
 #include "SimDataFormats/ValidationFormats/interface/PValidationFormats.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
-#include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
-#include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
 
@@ -35,42 +33,35 @@
 #include <memory>
 #include <stdlib.h>
 
-TrackerHitProducer::TrackerHitProducer(const edm::ParameterSet& iPSet) :
-  fName(""), verbosity(0), label(""), getAllProvenances(false),
-  printProvenanceInfo(false), nRawGenPart(0),
-  G4VtxSrc_(iPSet.getParameter<edm::InputTag>("G4VtxSrc")),
-  G4TrkSrc_(iPSet.getParameter<edm::InputTag>("G4TrkSrc")),
-  config_(iPSet), count(0)
+TrackerHitProducer::TrackerHitProducer(const edm::ParameterSet& iPSet)
+  : getAllProvenances( iPSet.getParameter<edm::ParameterSet>( "ProvenanceLookup" ).getUntrackedParameter<bool>( "GetAllProvenances", false ) )
+  , printProvenanceInfo( iPSet.getParameter<edm::ParameterSet>( "ProvenanceLookup" ).getUntrackedParameter<bool>( "PrintProvenanceInfo", false ) )
+  , verbosity( iPSet.getUntrackedParameter<int>( "Verbosity", 0 ) )
+  , count( 0 )
+  , nRawGenPart( 0 )
+  , config_( iPSet )
+  , edmHepMCProductToken_( consumes<edm::HepMCProduct>( edm::InputTag( iPSet.getUntrackedParameter<std::string>( "HepMCProductLabel", "source" )
+                                                                     , iPSet.getUntrackedParameter<std::string>( "HepMCInputInstance", "" )
+								       )
+							)
+			   )
+  , edmSimVertexContainerToken_( consumes<edm::SimVertexContainer>( iPSet.getParameter<edm::InputTag>("G4VtxSrc") ) )
+  , edmSimTrackContainerToken_( consumes<edm::SimTrackContainer>( iPSet.getParameter<edm::InputTag>( "G4TrkSrc" ) ) )
+  , edmPSimHitContainer_pxlBrlLow_Token_( consumes<edm::PSimHitContainer>( iPSet.getParameter<edm::InputTag>( "PxlBrlLowSrc" ) ) )
+  , edmPSimHitContainer_pxlBrlHigh_Token_( consumes<edm::PSimHitContainer>( iPSet.getParameter<edm::InputTag>( "PxlBrlHighSrc" ) ) )
+  , edmPSimHitContainer_pxlFwdLow_Token_( consumes<edm::PSimHitContainer>( iPSet.getParameter<edm::InputTag>( "PxlFwdLowSrc" ) ) )
+  , edmPSimHitContainer_pxlFwdHigh_Token_( consumes<edm::PSimHitContainer>( iPSet.getParameter<edm::InputTag>( "PxlFwdHighSrc" ) ) )
+  , edmPSimHitContainer_siTIBLow_Token_( consumes<edm::PSimHitContainer>( iPSet.getParameter<edm::InputTag>( "SiTIBLowSrc" ) ) )
+  , edmPSimHitContainer_siTIBHigh_Token_( consumes<edm::PSimHitContainer>( iPSet.getParameter<edm::InputTag>( "SiTIBHighSrc" ) ) )
+  , edmPSimHitContainer_siTOBLow_Token_( consumes<edm::PSimHitContainer>( iPSet.getParameter<edm::InputTag>( "SiTOBLowSrc" ) ) )
+  , edmPSimHitContainer_siTOBHigh_Token_( consumes<edm::PSimHitContainer>( iPSet.getParameter<edm::InputTag>( "SiTOBHighSrc" ) ) )
+  , edmPSimHitContainer_siTIDLow_Token_( consumes<edm::PSimHitContainer>( iPSet.getParameter<edm::InputTag>( "SiTIDLowSrc" ) ) )
+  , edmPSimHitContainer_siTIDHigh_Token_( consumes<edm::PSimHitContainer>( iPSet.getParameter<edm::InputTag>( "SiTIDHighSrc" ) ) )
+  , edmPSimHitContainer_siTECLow_Token_( consumes<edm::PSimHitContainer>( iPSet.getParameter<edm::InputTag>( "SiTECLowSrc" ) ) )
+  , edmPSimHitContainer_siTECHigh_Token_( consumes<edm::PSimHitContainer>( iPSet.getParameter<edm::InputTag>( "SiTECHighSrc" ) ) )
+  , fName( iPSet.getUntrackedParameter<std::string>( "Name", "" ) )
+  , label( iPSet.getParameter<std::string>( "Label" ) )
 {
-  // get information from parameter set
-  fName = iPSet.getUntrackedParameter<std::string>("Name");
-  verbosity = iPSet.getUntrackedParameter<int>("Verbosity");
-  label = iPSet.getParameter<std::string>("Label");
-  edm::ParameterSet m_Prov =
-    iPSet.getParameter<edm::ParameterSet>("ProvenanceLookup");
-  getAllProvenances = 
-    m_Prov.getUntrackedParameter<bool>("GetAllProvenances");
-  printProvenanceInfo = 
-    m_Prov.getUntrackedParameter<bool>("PrintProvenanceInfo");
-
-  //get Labels to use to extract information
-  PxlBrlLowSrc_ = iPSet.getParameter<edm::InputTag>("PxlBrlLowSrc");
-  PxlBrlHighSrc_ = iPSet.getParameter<edm::InputTag>("PxlBrlHighSrc");
-  PxlFwdLowSrc_ = iPSet.getParameter<edm::InputTag>("PxlFwdLowSrc");
-  PxlFwdHighSrc_ = iPSet.getParameter<edm::InputTag>("PxlFwdHighSrc");
-
-  SiTIBLowSrc_ = iPSet.getParameter<edm::InputTag>("SiTIBLowSrc");
-  SiTIBHighSrc_ = iPSet.getParameter<edm::InputTag>("SiTIBHighSrc");
-  SiTOBLowSrc_ = iPSet.getParameter<edm::InputTag>("SiTOBLowSrc");
-  SiTOBHighSrc_ = iPSet.getParameter<edm::InputTag>("SiTOBHighSrc");
-  SiTIDLowSrc_ = iPSet.getParameter<edm::InputTag>("SiTIDLowSrc");
-  SiTIDHighSrc_ = iPSet.getParameter<edm::InputTag>("SiTIDHighSrc");
-  SiTECLowSrc_ = iPSet.getParameter<edm::InputTag>("SiTECLowSrc");
-  SiTECHighSrc_ = iPSet.getParameter<edm::InputTag>("SiTECHighSrc");
- 
-  HepMClabel_ = config_.getUntrackedParameter<std::string>("HepMCProductLabel","source");
-  HepMCinstance_ = config_.getUntrackedParameter<std::string>("HepMCInputInstance","");
- 
   // use value of first digit to determine default output level (inclusive)
   // 0 is none, 1 is basic, 2 is fill output, 3 is gather output
   verbosity %= 10;
@@ -88,30 +79,30 @@ TrackerHitProducer::TrackerHitProducer(const edm::ParameterSet& iPSet) :
       << "    Label     =" << label << "\n"
       << "    GetProv   =" << getAllProvenances << "\n"
       << "    PrintProv =" << printProvenanceInfo << "\n"
-      << "    PxlBrlLowSrc  = " << PxlBrlLowSrc_.label() 
-      << ":" << PxlBrlLowSrc_.instance() << "\n"
-      << "    PxlBrlHighSrc = " << PxlBrlHighSrc_.label() 
-      << ":" << PxlBrlHighSrc_.instance() << "\n"
-      << "    PxlFwdLowSrc  = " << PxlFwdLowSrc_.label() 
-      << ":" << PxlBrlLowSrc_.instance() << "\n"
-      << "    PxlFwdHighSrc = " << PxlFwdHighSrc_.label() 
-      << ":" << PxlBrlHighSrc_.instance() << "\n"
-      << "    SiTIBLowSrc   = " << SiTIBLowSrc_.label() 
-      << ":" << SiTIBLowSrc_.instance() << "\n"
-      << "    SiTIBHighSrc  = " << SiTIBHighSrc_.label() 
-      << ":" << SiTIBHighSrc_.instance() << "\n"
-      << "    SiTOBLowSrc   = " << SiTOBLowSrc_.label() 
-      << ":" << SiTOBLowSrc_.instance() << "\n"
-      << "    SiTOBHighSrc  = " << SiTOBHighSrc_.label() 
-      << ":" << SiTOBHighSrc_.instance() << "\n"
-      << "    SiTIDLowSrc   = " << SiTIDLowSrc_.label() 
-      << ":" << SiTIDLowSrc_.instance() << "\n"
-      << "    SiTIDHighSrc  = " << SiTIDHighSrc_.label() 
-      << ":" << SiTIDHighSrc_.instance() << "\n"
-      << "    SiTECLowSrc   = " << SiTECLowSrc_.label() 
-      << ":" << SiTECLowSrc_.instance() << "\n"
-      << "    SiTECHighSrc  = " << SiTECHighSrc_.label() 
-      << ":" << SiTECHighSrc_.instance() << "\n"
+      << "    PxlBrlLowSrc  = " << iPSet.getParameter<edm::InputTag>("PxlBrlLowSrc").label() 
+      << ":" << iPSet.getParameter<edm::InputTag>("PxlBrlLowSrc").instance() << "\n"
+      << "    PxlBrlHighSrc = " << iPSet.getParameter<edm::InputTag>("PxlBrlHighSrc").label() 
+      << ":" << iPSet.getParameter<edm::InputTag>("PxlBrlHighSrc").instance() << "\n"
+      << "    PxlFwdLowSrc  = " << iPSet.getParameter<edm::InputTag>("PxlFwdLowSrc").label() 
+      << ":" << iPSet.getParameter<edm::InputTag>("PxlFwdLowSrc").instance() << "\n"
+      << "    PxlFwdHighSrc = " << iPSet.getParameter<edm::InputTag>("PxlFwdHighSrc").label() 
+      << ":" << iPSet.getParameter<edm::InputTag>("PxlFwdHighSrc").instance() << "\n"
+      << "    SiTIBLowSrc   = " << iPSet.getParameter<edm::InputTag>("SiTIBLowSrc").label() 
+      << ":" << iPSet.getParameter<edm::InputTag>("SiTIBLowSrc").instance() << "\n"
+      << "    SiTIBHighSrc  = " << iPSet.getParameter<edm::InputTag>("SiTIBHighSrc").label() 
+      << ":" << iPSet.getParameter<edm::InputTag>("SiTIBHighSrc").instance() << "\n"
+      << "    SiTOBLowSrc   = " << iPSet.getParameter<edm::InputTag>("SiTOBLowSrc").label() 
+      << ":" << iPSet.getParameter<edm::InputTag>("SiTOBLowSrc").instance() << "\n"
+      << "    SiTOBHighSrc  = " << iPSet.getParameter<edm::InputTag>("SiTOBHighSrc").label() 
+      << ":" << iPSet.getParameter<edm::InputTag>("SiTOBHighSrc").instance() << "\n"
+      << "    SiTIDLowSrc   = " << iPSet.getParameter<edm::InputTag>("SiTIDLowSrc").label() 
+      << ":" << iPSet.getParameter<edm::InputTag>("SiTIDLowSrc").instance() << "\n"
+      << "    SiTIDHighSrc  = " << iPSet.getParameter<edm::InputTag>("SiTIDHighSrc").label() 
+      << ":" << iPSet.getParameter<edm::InputTag>("SiTIDHighSrc").instance() << "\n"
+      << "    SiTECLowSrc   = " << iPSet.getParameter<edm::InputTag>("SiTECLowSrc").label() 
+      << ":" << iPSet.getParameter<edm::InputTag>("SiTECLowSrc").instance() << "\n"
+      << "    SiTECHighSrc  = " << iPSet.getParameter<edm::InputTag>("SiTECHighSrc").label() 
+      << ":" << iPSet.getParameter<edm::InputTag>("SiTECHighSrc").instance() << "\n"
       << "===============================\n";  }
 }
 
@@ -232,7 +223,7 @@ void TrackerHitProducer::fillG4MC(edm::Event& iEvent)
   // get MC information
   /////////////////////
   edm::Handle<edm::HepMCProduct> HepMCEvt_;
-  iEvent.getByLabel(HepMClabel_, HepMCinstance_ ,HepMCEvt_);
+  iEvent.getByToken( edmHepMCProductToken_, HepMCEvt_ );
   if (!HepMCEvt_.isValid()) {
     edm::LogError("TrackerHitProducer::fillG4MC")
       << "Unable to find HepMCProduct in event!";
@@ -250,7 +241,7 @@ void TrackerHitProducer::fillG4MC(edm::Event& iEvent)
   // get G4Vertex information
   ////////////////////////////
   edm::Handle<edm::SimVertexContainer> G4VtxContainer;
-  iEvent.getByLabel(G4VtxSrc_, G4VtxContainer);
+  iEvent.getByToken( edmSimVertexContainerToken_, G4VtxContainer );
   if (!G4VtxContainer.isValid()) {
     edm::LogError("TrackerHitProducer::fillG4MC")
       << "Unable to find SimVertex in event!";
@@ -281,7 +272,7 @@ void TrackerHitProducer::fillG4MC(edm::Event& iEvent)
   // get G4Track information
   ///////////////////////////
   edm::Handle<edm::SimTrackContainer> G4TrkContainer;
-  iEvent.getByLabel(G4TrkSrc_, G4TrkContainer);
+  iEvent.getByToken( edmSimTrackContainerToken_, G4TrkContainer );
   if (!G4TrkContainer.isValid()) {
     edm::LogError("TrackerHitProducer::fillG4MC")
       << "Unable to find SimTrack in event!";
@@ -386,8 +377,7 @@ void TrackerHitProducer::fillTrk(edm::Event& iEvent,
   
   // extract low container
   edm::Handle<edm::PSimHitContainer> PxlBrlLowContainer;
-  iEvent.getByLabel(PxlBrlLowSrc_,PxlBrlLowContainer);
-//  iEvent.getByLabel("g4SimHits","TrackerHitsPixelBarrelLowTof",PxlBrlLowContainer);
+  iEvent.getByToken( edmPSimHitContainer_pxlBrlLow_Token_, PxlBrlLowContainer );
   if (!PxlBrlLowContainer.isValid()) {
     edm::LogError("TrackerHitProducer::fillTrk")
       << "Unable to find TrackerHitsPixelBarrelLowTof in event!";
@@ -444,8 +434,7 @@ void TrackerHitProducer::fillTrk(edm::Event& iEvent,
     
   // extract high container
   edm::Handle<edm::PSimHitContainer> PxlBrlHighContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsPixelBarrelHighTof",PxlBrlHighContainer);
-  iEvent.getByLabel(PxlBrlHighSrc_,PxlBrlHighContainer);
+  iEvent.getByToken( edmPSimHitContainer_pxlBrlHigh_Token_, PxlBrlHighContainer );
   if (!PxlBrlHighContainer.isValid()) {
     edm::LogError("TrackerHitProducer::fillTrk")
       << "Unable to find TrackerHitsPixelBarrelHighTof in event!";
@@ -500,8 +489,7 @@ void TrackerHitProducer::fillTrk(edm::Event& iEvent,
   ////////////////////////////////
   // extract low container
   edm::Handle<edm::PSimHitContainer> PxlFwdLowContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsPixelEndcapLowTof",PxlFwdLowContainer);
-  iEvent.getByLabel(PxlFwdLowSrc_,PxlFwdLowContainer);
+  iEvent.getByToken( edmPSimHitContainer_pxlFwdLow_Token_, PxlFwdLowContainer );
   if (!PxlFwdLowContainer.isValid()) {
     edm::LogError("TrackerHitProducer::fillTrk")
       << "Unable to find TrackerHitsPixelEndcapLowTof in event!";
@@ -552,8 +540,7 @@ void TrackerHitProducer::fillTrk(edm::Event& iEvent,
   
   // extract high container
   edm::Handle<edm::PSimHitContainer> PxlFwdHighContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsPixelEndcapHighTof",PxlFwdHighContainer);
-  iEvent.getByLabel(PxlFwdHighSrc_,PxlFwdHighContainer);
+  iEvent.getByToken( edmPSimHitContainer_pxlFwdHigh_Token_, PxlFwdHighContainer );
   if (!PxlFwdHighContainer.isValid()) {
     edm::LogError("TrackerHitProducer::fillTrk")
       << "Unable to find TrackerHitsPixelEndcapHighTof in event!";
@@ -607,8 +594,7 @@ void TrackerHitProducer::fillTrk(edm::Event& iEvent,
   //////////////////////////////////
   // extract TIB low container
   edm::Handle<edm::PSimHitContainer> SiTIBLowContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsTIBLowTof",SiTIBLowContainer);
-  iEvent.getByLabel(SiTIBLowSrc_,SiTIBLowContainer);
+  iEvent.getByToken( edmPSimHitContainer_siTIBLow_Token_, SiTIBLowContainer );
   if (!SiTIBLowContainer.isValid()) {
     edm::LogError("TrackerHitProducer::fillTrk")
       << "Unable to find TrackerHitsTIBLowTof in event!";
@@ -659,9 +645,8 @@ void TrackerHitProducer::fillTrk(edm::Event& iEvent,
   
   // extract TIB high container
   edm::Handle<edm::PSimHitContainer> SiTIBHighContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsTIBHighTof",SiTIBHighContainer);
-  iEvent.getByLabel(SiTIBHighSrc_,SiTIBHighContainer);
-    if (!SiTIBHighContainer.isValid()) {
+  iEvent.getByToken( edmPSimHitContainer_siTIBHigh_Token_, SiTIBHighContainer );
+  if (!SiTIBHighContainer.isValid()) {
     edm::LogError("TrackerHitProducer::fillTrk")
       << "Unable to find TrackerHitsTIBHighTof in event!";
     return;
@@ -713,9 +698,8 @@ void TrackerHitProducer::fillTrk(edm::Event& iEvent,
   //////////////////////////////////
   // extract TOB low container
   edm::Handle<edm::PSimHitContainer> SiTOBLowContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsTOBLowTof",SiTOBLowContainer);
-  iEvent.getByLabel(SiTOBLowSrc_,SiTOBLowContainer);
-    if (!SiTOBLowContainer.isValid()) {
+  iEvent.getByToken( edmPSimHitContainer_siTOBLow_Token_, SiTOBLowContainer );
+  if (!SiTOBLowContainer.isValid()) {
     edm::LogError("TrackerHitProducer::fillTrk")
       << "Unable to find TrackerHitsTOBLowTof in event!";
     return;
@@ -764,9 +748,8 @@ void TrackerHitProducer::fillTrk(edm::Event& iEvent,
     
   // extract TOB high container
   edm::Handle<edm::PSimHitContainer> SiTOBHighContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsTOBHighTof",SiTOBHighContainer);
-  iEvent.getByLabel(SiTOBHighSrc_,SiTOBHighContainer);
-    if (!SiTOBHighContainer.isValid()) {
+  iEvent.getByToken( edmPSimHitContainer_siTOBHigh_Token_, SiTOBHighContainer );
+  if (!SiTOBHighContainer.isValid()) {
     edm::LogError("TrackerHitProducer::fillTrk")
       << "Unable to find TrackerHitsTOBHighTof in event!";
     return;
@@ -818,9 +801,8 @@ void TrackerHitProducer::fillTrk(edm::Event& iEvent,
   ///////////////////////////////////
   // extract TID low container
   edm::Handle<edm::PSimHitContainer> SiTIDLowContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsTIDLowTof",SiTIDLowContainer);
-  iEvent.getByLabel(SiTIDLowSrc_,SiTIDLowContainer);
-    if (!SiTIDLowContainer.isValid()) {
+  iEvent.getByToken( edmPSimHitContainer_siTIDLow_Token_, SiTIDLowContainer );
+  if (!SiTIDLowContainer.isValid()) {
     edm::LogError("TrackerHitProducer::fillTrk")
       << "Unable to find TrackerHitsTIDLowTof in event!";
     return;
@@ -869,9 +851,8 @@ void TrackerHitProducer::fillTrk(edm::Event& iEvent,
       
   // extract TID high container
   edm::Handle<edm::PSimHitContainer> SiTIDHighContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsTIDHighTof",SiTIDHighContainer);
-  iEvent.getByLabel(SiTIDHighSrc_,SiTIDHighContainer);
-    if (!SiTIDHighContainer.isValid()) {
+  iEvent.getByToken( edmPSimHitContainer_siTIDHigh_Token_, SiTIDHighContainer );
+  if (!SiTIDHighContainer.isValid()) {
     edm::LogError("TrackerHitProducer::fillTrk")
       << "Unable to find TrackerHitsTIDHighTof in event!";
     return;
@@ -923,9 +904,8 @@ void TrackerHitProducer::fillTrk(edm::Event& iEvent,
   /////////////////////////////////// 
   // extract TEC low container
   edm::Handle<edm::PSimHitContainer> SiTECLowContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsTECLowTof",SiTECLowContainer);
-  iEvent.getByLabel(SiTECLowSrc_,SiTECLowContainer);
-    if (!SiTECLowContainer.isValid()) {
+  iEvent.getByToken( edmPSimHitContainer_siTECLow_Token_, SiTECLowContainer );
+  if (!SiTECLowContainer.isValid()) {
     edm::LogError("TrackerHitProducer::fillTrk")
       << "Unable to find TrackerHitsTECLowTof in event!";
     return;
@@ -975,9 +955,8 @@ void TrackerHitProducer::fillTrk(edm::Event& iEvent,
   
   // extract TEC high container
   edm::Handle<edm::PSimHitContainer> SiTECHighContainer;
-//  iEvent.getByLabel("g4SimHits","TrackerHitsTECHighTof",SiTECHighContainer);
-  iEvent.getByLabel(SiTECHighSrc_,SiTECHighContainer);
-    if (!SiTECHighContainer.isValid()) {
+  iEvent.getByToken( edmPSimHitContainer_siTECHigh_Token_, SiTECHighContainer );
+  if (!SiTECHighContainer.isValid()) {
     edm::LogError("TrackerHitProducer::fillTrk")
       << "Unable to find TrackerHitsTECHighTof in event!";
     return;

--- a/Validation/TrackerHits/src/TrackerHitProducer.cc
+++ b/Validation/TrackerHits/src/TrackerHitProducer.cc
@@ -1,5 +1,39 @@
 #include "Validation/TrackerHits/interface/TrackerHitProducer.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/Provenance/interface/Provenance.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
+
+// tracker info
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+
+// data in edm::event
+#include "SimDataFormats/ValidationFormats/interface/PValidationFormats.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
+#include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
+#include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
+
+// helper files
+#include <CLHEP/Vector/LorentzVector.h>
+#include "CLHEP/Units/GlobalSystemOfUnits.h"
+
+#include "TString.h"
+
 #include <cmath>
+#include <memory>
+#include <stdlib.h>
 
 TrackerHitProducer::TrackerHitProducer(const edm::ParameterSet& iPSet) :
   fName(""), verbosity(0), label(""), getAllProvenances(false),


### PR DESCRIPTION
Consumes fix for the following modules in Validation/TrackerHits:
TrackerHitAnalyzer
TrackerHitProducer
Tested with whiteRabbit.py, workflow 3.
GitHub warns it can merge automatically, I suppose because of
https://github.com/cms-sw/cmssw/commit/306fa5e305dd095c456c2645dde9f689f1dd8c44
