### PR TITLE
Fireworks table entries and tooltips for CSCDetId 

### DIFF
--- a/CommonTools/Utils/src/findMethod.cc
+++ b/CommonTools/Utils/src/findMethod.cc
@@ -104,7 +104,7 @@ namespace reco {
         } else {
            oError = -1*casts;
            //is this a show stopper error?
-           if(fatalErrorCondition(oError)) {
+           if(fatalErrorCondition(oError) && err_fatal == 0) {
               err_fatal = oError;
            }
         }
@@ -114,6 +114,7 @@ namespace reco {
 
     if (oks.empty() && err_fatal)
     {
+       oError = err_fatal;
        return mem;
     }
 

--- a/CommonTools/Utils/src/findMethod.cc
+++ b/CommonTools/Utils/src/findMethod.cc
@@ -88,6 +88,7 @@ namespace reco {
     type = edm::TypeWithDict(type, 0L); // strip const, volatile, c++ ref, ..
 
     pair<edm::FunctionWithDict, bool> mem; mem.second = false;
+    int                               err_fatal = 0;
 
     // suitable members and number of integer->real casts required to get them
     vector<pair<int,edm::FunctionWithDict> > oks;
@@ -104,12 +105,18 @@ namespace reco {
            oError = -1*casts;
            //is this a show stopper error?
            if(fatalErrorCondition(oError)) {
-              return mem;
+              err_fatal = oError;
            }
         }
       }
     }
     //std::cout << "At base scope (type " << (type.name()) << ") found " << oks.size() << " methods." << std::endl; 
+
+    if (oks.empty() && err_fatal)
+    {
+       return mem;
+    }
+
     // found at least one method
     if (!oks.empty()) {
         if (oks.size() > 1) {

--- a/Fireworks/Core/macros/default.fwc
+++ b/Fireworks/Core/macros/default.fwc
@@ -1067,16 +1067,6 @@
       <string>phi</string>
       <string>3</string>
     </config>
-    <config name="edm::RangeMap&lt;CSCDetId,edm::OwnVector&lt;CSCSegment,edm::ClonePolicy&lt;CSCSegment&gt; &gt;,edm::ClonePolicy&lt;CSCSegment&gt; &gt;" version="1">
-      <string>number of segments</string>
-      <string>size</string>
-      <string>0</string>
-    </config>
-    <config name="edm::RangeMap&lt;DTChamberId,edm::OwnVector&lt;DTRecSegment4D,edm::ClonePolicy&lt;DTRecSegment4D&gt; &gt;,edm::ClonePolicy&lt;DTRecSegment4D&gt; &gt;" version="1">
-      <string>number of segments</string>
-      <string>size</string>
-      <string>0</string>
-    </config>
     <config name="reco::CaloJet" version="1">
       <string>Pt</string>
       <string>pt</string>
@@ -1305,8 +1295,6 @@
     <config name="typeNames" version="1">
       <string>CaloRecHit</string>
       <string>CaloTower</string>
-      <string>edm::RangeMap&lt;CSCDetId,edm::OwnVector&lt;CSCSegment,edm::ClonePolicy&lt;CSCSegment&gt; &gt;,edm::ClonePolicy&lt;CSCSegment&gt; &gt;</string>
-      <string>edm::RangeMap&lt;DTChamberId,edm::OwnVector&lt;DTRecSegment4D,edm::ClonePolicy&lt;DTRecSegment4D&gt; &gt;,edm::ClonePolicy&lt;DTRecSegment4D&gt; &gt;</string>
       <string>reco::CaloJet</string>
       <string>reco::GenParticle</string>
       <string>reco::GsfElectron</string>

--- a/Fireworks/Core/src/FWItemValueGetter.cc
+++ b/Fireworks/Core/src/FWItemValueGetter.cc
@@ -75,6 +75,19 @@ FWItemValueGetter::FWItemValueGetter(const edm::TypeWithDict& iType, const std::
    {
       addEntry("et", 1);
    }
+   else if ( iPurpose == "DT-segments")
+   {
+      addEntry("chamberId().wheel()", 0, "wh");
+      addEntry("chamberId().station()", 0, "st");
+      addEntry("chamberId().sector()", 0, "sc");
+
+   }
+   else if ( iPurpose == "CSC-segments")
+   {
+      addEntry("cscDetId().endcap()", 0, "ec");
+      addEntry("cscDetId().station()", 0, "st");
+      addEntry("cscDetId().ring()", 0, "rn");
+   }
    else {
       // by the default  add pt, et, or energy
       bool x = addEntry("pt", 1);

--- a/Fireworks/Core/src/FWTableViewManager.cc
+++ b/Fireworks/Core/src/FWTableViewManager.cc
@@ -135,7 +135,7 @@ FWTableViewManager::FWTableViewManager(FWGUIManager* iGUIMgr)
    column("hasPhi", -2, "hasPhi").
    column("hasZed", -2, "hasZed").
    column("chi2", 2, "chi2").
-   column("dof", 0, "degreesOfFreedom");
+   column("dof", 0, "degreesOfFreedom"); 
 
    table("DTRecHit1DPair").
    column("wheel", 0, "wireId.wheel").
@@ -145,6 +145,12 @@ FWTableViewManager::FWTableViewManager(FWGUIManager* iGUIMgr)
    column("layer", 0, "wireId.layer").
    column("wire", 0, "wireId.wire").
    column("digiTime", 2, "digiTime");
+
+   table("CSCSegment").
+   column("endcap", 0, "cscDetId.endcap").
+   column("station", 0, "cscDetId.station").
+   column("ring", 0, "cscDetId.ring").
+   column("chamber", 0, "cscDetId.chamber");
 
    table("reco::Vertex").
    column("x", 5).

--- a/Fireworks/Core/src/FWTableViewManager.cc
+++ b/Fireworks/Core/src/FWTableViewManager.cc
@@ -126,6 +126,26 @@ FWTableViewManager::FWTableViewManager(FWGUIManager* iGUIMgr)
    column("chi2", 3).
    column("ndof", TableEntry::INT);
 
+   table("DTRecSegment4D").
+   column("wheel", 0, "chamberId.wheel").
+   column("station", 0, "chamberId.station").
+   column("sector", 0, "chamberId.sector").
+   column("t0phi", 2, "phiSegment.t0").
+   column("t0theta", 2, "zSegment.t0").
+   column("hasPhi", -2, "hasPhi").
+   column("hasZed", -2, "hasZed").
+   column("chi2", 2, "chi2").
+   column("dof", 0, "degreesOfFreedom");
+
+   table("DTRecHit1DPair").
+   column("wheel", 0, "wireId.wheel").
+   column("station", 0, "wireId.station").
+   column("sector", 0, "wireId.sector").
+   column("SL", 0, "wireId.superlayer").
+   column("layer", 0, "wireId.layer").
+   column("wire", 0, "wireId.wire").
+   column("digiTime", 2, "digiTime");
+
    table("reco::Vertex").
    column("x", 5).
    column("xError", 5).


### PR DESCRIPTION
Pull request has two parts:

Fix bug in reco parser in checking of validity of function: https://hypernews.cern.ch/HyperNews/CMS/get/sw-develtools/1964.html

Second part are changes in Fireworks -- predefined table entries and auto-generated tooltips which depend on bugfix in reco parser.

Request for change was by @namapane .
![csctable](https://f.cloud.github.com/assets/2516492/1792235/af79d314-699b-11e3-97cd-759b368d9fe2.png)
