### PR TITLE
Use python package networkX to compute the call stack from 

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/create_calls_db.sh
+++ b/Utilities/StaticAnalyzers/scripts/create_calls_db.sh
@@ -9,17 +9,21 @@ else
 fi
 
 eval `scram runtime -sh`
-ulimit -m 2000000
-ulimit -v 2000000
+ulimit -m 8000000
+ulimit -v 8000000
 ulimit -t 1200
 export USER_LLVM_CHECKERS="-disable-checker cplusplus -disable-checker unix -disable-checker threadsafety -disable-checker core -disable-checker security -disable-checker deadcode -disable-checker cms -enable-checker cms.FunctionDumper -enable-checker optional.EDMPluginDumper -enable-checker cms.FunctionChecker"
-cd ${CMSSW_BASE}
+cd ${LOCALRT}
 touch tmp/function-dumper.txt.unsorted tmp/function-checker.txt.unsorted tmp/plugins.txt.unsorted
 scram b -k -j $J checker  2>&1 > tmp/function-dumper.log
-cd ${CMSSW_BASE}/tmp
+cd ${LOCALRT}/tmp
 sort -u function-dumper.txt.unsorted >function-calls-db.txt
 sort -u function-checker.txt.unsorted >function-statics-db.txt
-sort -u plugins.txt.unsorted >function-plugins-db.txt
-cat  function-calls-db.txt function-statics-db.txt function-plugins-db.txt >db.txt
+sort -u plugins.txt.unsorted > plugins.txt
+cat  function-calls-db.txt function-statics-db.txt >db.txt
 statics.py 2>&1 >module2statics.txt.unsorted
-sort -u module2statics.txt.unsorted >module2statics.txt
+sort -u module2statics.txt.unsorted > module2statics.txt.sorted
+awk -F\' 'NR==FNR{a[" "$0"::"]=1;next} {n=0;for(i in a){if(index($2,i) && $1 == "In call stack "){n=1}}} n' plugins.txt module2statics.txt.unsorted >module2statics.txt.tmp
+sort -u module2statics.txt.tmp > module2statics.txt
+awk -F\' 'NR==FNR{a[" "$0"::"]=1;next} {n=0;for(i in a){if(index($4,i) && $1 == "Non-const static variable "){n=1}}} n' plugins.txt module2statics.txt.unsorted >static2modules.txt.tmp
+sort -u static2modules.txt.tmp > static2modules.txt

--- a/Utilities/StaticAnalyzers/scripts/statics.py
+++ b/Utilities/StaticAnalyzers/scripts/statics.py
@@ -1,91 +1,38 @@
 #! /usr/bin/env python
 import re
-warning = re.compile("^function ")
-tab = re.compile("\s+")
 topfunc = re.compile("::produce\(|::analyze\(|::filter\(")
-edmns = re.compile("::ED(Producer|Analyzer|Filter)")
-keyword = re.compile("calls|overrides|variable|edmplugin")
-paths = re.compile(".*?\s*src/([A-Z].*?/[A-z].*?)(/.*?):(.*?):(.*?)")
-from collections import defaultdict
+statics = set()
+toplevelfuncs = set()
 
-gets = defaultdict(set)
-callby = defaultdict(set)
-calls = defaultdict(set)
-plugins = set()
+import networkx as nx
+G=nx.DiGraph()
 
 f = open('db.txt')
 
 for line in f :
 	fields = line.split("'")
-	if keyword.search(line) :
-		if fields[2] == ' calls function ' :
-			if fields[1] not in callby[fields[3]]:
-				callby[fields[3]].add(fields[1])
-			if fields[3] not in calls[fields[1]]:
-				calls[fields[1]].add(fields[3])
-		if fields[2] == ' overrides function ' :
-			if fields[3] not in callby[fields[1]] and not edmns.search(fields[3]) :
-				callby[fields[1]].add(fields[3])
-		if fields[2] == ' static variable ' :
-				if fields[1] not in gets[fields[3]]:
-					gets[fields[3]].add(fields[1])
-		if fields[0].strip() == 'edmplugin type':
-			plugins.add(fields[1])
+	if fields[2] == ' calls function ' :
+		G.add_edge(fields[1],fields[3])
+		if topfunc.search(fields[1]):
+			toplevelfuncs.add(fields[1])
+	if fields[2] == ' overrides function ' :
+		G.add_edge(fields[1],fields[3])
+	if fields[2] == ' static variable ' :
+		G.add_edge(fields[1],fields[3])
+		statics.add(fields[3])
 f.close()
 
-def stackup(str):
-	for call in callby[str]:
-		if call not in stack:
-			stack.append(call)
-			stackup(call)
-	return
+paths = nx.shortest_path(G)
 
-
-funcs=defaultdict(list)
-
-for key in gets: 
-	for get in gets[key]:
-		func = get+"#"+key
-		stack = list()
-		stack.append(get)
-		stackup(get)
-		funcs[func].append(stack)
-
-import copy
-
-for func in sorted(funcs.keys()):
-	get,var = func.split("#")
-	clone = copy.deepcopy(funcs[func])
-	for fields in clone:
-		found = ""
-		while fields:
-			field = fields.pop()
-			if topfunc.search(field) and not found:
-				fqn = topfunc.split(field)[0]
-				if fqn in plugins:
-					print "Non-const static var '"+var+"' is accessed in call stack '"+field+"->",
-					found = field
-			if field in calls[found] and found :
-				print field+"->",
-				found = field
-			if field == get and found :
-				print field 
-
-for func in sorted(funcs.keys()):
-	get,var = func.split("#")
-	clone = copy.deepcopy(funcs[func])
-	for fields in clone: 
-		found = ""
-		while fields:
-			field = fields.pop()
-			if topfunc.search(field) and not found:
-				fqn = topfunc.split(field)[0]
-				if fqn in plugins:
-					print "In call stack '"+field+"->",
-					found = field
-			if field in calls[found] and found :
-				print field+"->",
-				found = field
-			if field == get and found :
-				print field + "' non-const static var '"+var+"' is accessed."
+for static in statics:
+	for tfunc in toplevelfuncs:
+		if nx.has_path(G,tfunc,static):
+			print "Non-const static variable \'"+static+"\' is accessed in call stack \'",
+			for path in paths[tfunc][static]:
+				if not path == static : print path+"; ",
+			print "'."
+			print "In call stack '",
+			for path in paths[tfunc][static]:
+				if not path == static : print path+"; ",
+				else : print "\' non-const static variable \'"+static+"\' is accessed."
 

--- a/Utilities/StaticAnalyzers/src/EDMPluginDumper.cc
+++ b/Utilities/StaticAnalyzers/src/EDMPluginDumper.cc
@@ -14,40 +14,28 @@ namespace clangcms {
 
 void EDMPluginDumper::checkASTDecl(const clang::ClassTemplateDecl *TD,clang::ento::AnalysisManager& mgr,
                     clang::ento::BugReporter &BR ) const {
+
 	const clang::SourceManager &SM = BR.getSourceManager();
 	std::string tname = TD->getTemplatedDecl()->getQualifiedNameAsString();
 	if ( tname == "edm::WorkerMaker" ) {
-		for ( auto I = TD->spec_begin(), E = TD->spec_end(); I != E; ++I) 
-			{
-			for (unsigned J = 0, F = I->getTemplateArgs().size(); J!=F; ++J)
-				{
-				if (const clang::CXXRecordDecl * RD = I->getTemplateArgs().get(J).getAsType().getTypePtr()->getAsCXXRecordDecl()) {
-					const char * pPath = std::getenv("LOCALRT");
-					std::string rname = RD->getQualifiedNameAsString();
-					std::string dname(""); 
-					if ( pPath != NULL ) dname = std::string(pPath);
-					std::string fname("/tmp/plugins.txt.unsorted");
-					std::string tname = dname + fname;
-					std::string ostring = "edmplugin type '"+ rname +"'\n";
-					std::ofstream file(tname.c_str(),std::ios::app);
-					file<<ostring;
-					if (const ClassTemplateSpecializationDecl *SD = dyn_cast<ClassTemplateSpecializationDecl>(RD)) {
-						for (unsigned J = 0, F = SD->getTemplateArgs().size(); J!=F; ++J) {
-							if (SD->getTemplateArgs().get(J).getKind() == clang::TemplateArgument::Type && SD->getTemplateArgs().get(J).getAsType().getTypePtr()->isRecordType() ) 
-							{
-							const clang::CXXRecordDecl * D = SD->getTemplateArgs().get(J).getAsType().getTypePtr()->getAsCXXRecordDecl();
-							std::string dname = D->getQualifiedNameAsString();
-							std::string ostring = "edmplugin type '"+rname+"' template arg '"+ dname +"'\n";
-							std::ofstream file(tname.c_str(),std::ios::app);
-							file<<ostring;
-							
-							}
-						}
-					}	 
-				}
+		for ( auto I = TD->spec_begin(), E = TD->spec_end(); I != E; ++I) {
+			for (unsigned J = 0, F = I->getTemplateArgs().size(); J!=F; ++J)  {
+				llvm::SmallString<100> buf;
+				llvm::raw_svector_ostream os(buf);
+				I->getTemplateArgs().get(J).print(mgr.getASTContext().getPrintingPolicy(),os);
+				std::string rname = os.str();
+				const char * pPath = std::getenv("LOCALRT");
+				std::string dname("");
+				if ( pPath != NULL ) dname = std::string(pPath);
+				std::string fname("/tmp/plugins.txt.unsorted");
+				std::string tname = dname + fname;
+				std::string ostring = rname +"\n";
+				std::ofstream file(tname.c_str(),std::ios::app);
+				file<<ostring;
 			}
-		} 		
-	}
+		}
+	} 		
+
 } //end class
 
 


### PR DESCRIPTION
any of the top level functions to any function that accesses a  non-const static variable using the information from FunctionDumper and FunctionChecker static analyzers.

Update the way EDMPluginDumper outputs the type class name from the WorkerMaker template. Use this plugin list after statics.py script to only report for EDM plugin classes.
