### PR TITLE
Undo workaround for ROOT6 namespace bug

### DIFF
--- a/DataFormats/Common/interface/RefToBase.h
+++ b/DataFormats/Common/interface/RefToBase.h
@@ -115,11 +115,7 @@ namespace edm {
     CMS_CLASS_VERSION(10)
   private:
     value_type const* getPtrImpl() const;
-    // FIXME: the "edm::" should not be needed here, but is here
-    // as a workaround for a ROOT6 bug.  It will be removed
-    // (with this reminder note) after the ROOT6 bug is fixed.
-    edm::reftobase::BaseHolder<value_type>* holder_;
-    //reftobase::BaseHolder<value_type>* holder_;
+    reftobase::BaseHolder<value_type>* holder_;
     friend class RefToBaseVector<T>;
     friend class RefToBaseProd<T>;
     template<typename B> friend class RefToBase;


### PR DESCRIPTION
A few days ago a temporary workaround for a ROOT6 bug was submitted and merged into the CMSSW ROOT6 branch. The ROOT team surprised us by fixing the bug within a day.  This pull request removes the workaround.
