### PR TITLE
Make standalone test independent of auto dictionary loading

### DIFF
--- a/IOPool/TFileAdaptor/BuildFile.xml
+++ b/IOPool/TFileAdaptor/BuildFile.xml
@@ -4,3 +4,6 @@
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/Catalog"/>
 <use   name="rootcore"/>
+<export>
+  <lib   name="1"/>
+</export>

--- a/IOPool/TFileAdaptor/test/BuildFile.xml
+++ b/IOPool/TFileAdaptor/test/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="FWCore/PluginManager"/>
+<use   name="IOPool/TFileAdaptor"/>
 <use   name="Utilities/StorageFactory"/>
 <use   name="rootcore"/>
 <bin   name="test_TFileAdaptor_TFile" file="tfileTest.cpp">


### PR DESCRIPTION
Make the standalone unit test in package IOPool/TFileAdaptor independent of automatic dictionary loading by adding a missing link dependency on the library containing the dictionary needed, which is IOPool/TFileAdaptor itself.
