### PR TITLE
ROOT6 uses std::string, rather than std::basic_string<char>

### DIFF
--- a/FWCore/RootAutoLibraryLoader/test/rootautolibraryloader_t.cppunit.cpp
+++ b/FWCore/RootAutoLibraryLoader/test/rootautolibraryloader_t.cppunit.cpp
@@ -47,7 +47,7 @@ void testRootAutoLibraryLoader::testString()
    }
    edm::RootAutoLibraryLoader* loader = createLoader();
    
-   CPPUNIT_ASSERT(0!=loader->GetClass("edm::Wrapper<std::basic_string<char> >", true));
+   CPPUNIT_ASSERT(0!=loader->GetClass("edm::Wrapper<std::string>", true));
    
    CPPUNIT_ASSERT(0==loader->GetClass("ThisClassDoesNotExist",true));
 }

--- a/FWCore/Utilities/src/TypeDemangler.cc
+++ b/FWCore/Utilities/src/TypeDemangler.cc
@@ -128,8 +128,6 @@ namespace edm {
     // Strip default comparator
     std::string const comparator(",std::less<");
     removeParameter(demangledName, comparator);
-    // Replace 'std::string' with 'std::basic_string<char>'.
-    replaceDelimitedString(demangledName, "std::string", "std::basic_string<char>");
     // Put const qualifier before identifier.
     constBeforeIdentifier(demangledName);
     // No two consecutive '>' 


### PR DESCRIPTION
ROOT 6 uses std::string for the type name of a string, whereas ROOT5 used std::basic_string<char>. This pull request changes the code in the ROOT6 branch to use the ROOT6 names, and thereby fixes a failing unit test.
