### PR TITLE
Add missing link dependency

### DIFF
--- a/IOPool/Common/bin/BuildFile.xml
+++ b/IOPool/Common/bin/BuildFile.xml
@@ -8,6 +8,7 @@
   <use   name="FWCore/Services"/>
   <use   name="FWCore/Utilities"/>
   <use   name="DataFormats/StdDictionaries"/>
+  <use   name="DataFormats/WrappedStdDictionaries"/>
 </bin>
 <bin   name="edmFileUtil" file="EdmFileUtil.cpp,CollUtil.cc">
   <use   name="boost"/>


### PR DESCRIPTION
The standalone tool edmProvDump needs the dictionaries in DataFormats/WrappedStdDictionaries to function properly.  This link dependency was missing from the build file. The tool depended on automatic loading of dictionaries to dynamically load these dictionaries.  This pull request simply adds the missing link dependency.
