### PR TITLE
Use free function hasDictionary()

### DIFF
--- a/DataFormats/FWLite/src/Record.cc
+++ b/DataFormats/FWLite/src/Record.cc
@@ -183,7 +183,7 @@ Record::get(const edm::TypeID& iType,
    std::pair<TBranch*,void*>& branch = m_branches[std::make_pair(iType,iLabel)];
    if(0==branch.first){
       branch.second=0;
-      if(!edm::TypeWithDict(iType.typeInfo()).hasDictionary()){
+      if(!edm::hasDictionary(iType.typeInfo())){
          returnValue = new cms::Exception("UnknownType");
          (*returnValue)<<"The type "
          <<iType.typeInfo().name()<<" was requested from Record "<<name()


### PR DESCRIPTION
This is a bug fix that fixes a framework unit test in DataFormats/FWLite.  In our ROOT6 code, unlike our ROOT 5 code, the constructor for TypeWithDict throws a fatal exception if the class in question does not have a dictionary.
Therefore, instead of invoking TypeWithDict(myTypeInfo).hasDictionary(), we must call the new free function hasDictionary(myTypeInfo) to check if the class has a dictionary.
This fix could, in principle, be made in the ROOT5 code as well, but that would involve some extra work.
