### PR TITLE
Fix logic error

### DIFF
--- a/DataFormats/Provenance/src/BranchDescription.cc
+++ b/DataFormats/Provenance/src/BranchDescription.cc
@@ -196,8 +196,8 @@ namespace edm {
     setSplitLevel(invalidSplitLevel);
     setBasketSize(invalidBasketSize);
     TClassAttributeMap* wp = wrappedType().getClass()->GetAttributeMap();
-    if (wp && wp->HasKey("persistent") && strcmp(wp->GetPropertyAsString("persistent"), "false")) {
-      // Set transient if persistent != "false".
+    if (wp && wp->HasKey("persistent") && !strcmp(wp->GetPropertyAsString("persistent"), "false")) {
+      // Set transient if persistent == "false".
       setTransient(true);
       return;
     }


### PR DESCRIPTION
This is a trivial ROOT 6 specific bug fix.  A product is transient if the "persistent" keyword in an XML specification file is "false".  The code was written mistakenly so that a product was transient if and only if the "persistent" keyword was specified with a value of "true".
This bug fix fixes one failing framework unit test.
