### PR TITLE
DQMStore: avoid cloning MonitorElements that are not going to be merged

### DIFF
--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -350,15 +350,14 @@ void DQMStore::mergeAndResetMEsRunSummaryCache(uint32_t run,
         || i->data_.streamId != streamId
         || i->data_.moduleId != moduleId)
       break;
-    MonitorElement global_me(*i);
 
     // Handle Run-based histograms only.
-
-    if (global_me.getLumiFlag()) {
+    if (i->getLumiFlag()) {
       ++i;
       continue;
     }
 
+    MonitorElement global_me(*i);
     global_me.globalize();
     std::set<MonitorElement>::const_iterator me = data_.find(global_me);
     if (me != data_.end()) {
@@ -403,15 +402,14 @@ void DQMStore::mergeAndResetMEsLuminositySummaryCache(uint32_t run,
         || i->data_.streamId != streamId
         || i->data_.moduleId != moduleId)
       break;
-    MonitorElement global_me(*i);
 
     // Handle LS-based histograms only.
-
-    if (!global_me.getLumiFlag()) {
+    if (not i->getLumiFlag()) {
       ++i;
       continue;
     }
 
+    MonitorElement global_me(*i);
     global_me.globalize();
     global_me.setLumi(lumi);
     std::set<MonitorElement>::const_iterator me = data_.find(global_me);


### PR DESCRIPTION
In DQMStore::mergeAndResetMEsRunSummaryCache and DQMStore::mergeAndResetMEsLuminositySummaryCache, move the check to merge or not a ME before cloning it. 
