### PR TITLE
Disable the triggerCache in the multithreaded environment.

### DIFF
--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -56,7 +56,8 @@ namespace edm {
     cacheSize_(cacheSize),
     treeAutoFlush_(0),
     enablePrefetching_(enablePrefetching),
-    enableTriggerCache_(branchType_ == InEvent),
+    //enableTriggerCache_(branchType_ == InEvent),
+    enableTriggerCache_(false), // Disable, for now. Using the trigger cache in the multithreaded environment causes the assert on line 331 to fire occasionally.
     rootDelayedReader_(new RootDelayedReader(*this, filePtr, inputType)),
     branchEntryInfoBranch_(metaTree_ ? getProductProvenanceBranch(metaTree_, branchType_) : (tree_ ? getProductProvenanceBranch(tree_, branchType_) : 0)),
     infoTree_(dynamic_cast<TTree*>(filePtr_.get() != nullptr ? filePtr->Get(BranchTypeToInfoTreeName(branchType).c_str()) : nullptr)) // backward compatibility


### PR DESCRIPTION
There are two separate caches used by PoolSource for reading events in input files.   The secondary one, called the trigger cache, is used only in unusual circumstances.  However, in the multithreaded environment, having the trigger cache enabled can cause occasional fatal asserts due to a yet undiscovered bug in its implementation.  Since there is doubt that the trigger cache is useful in a multithreaded environment, this pull request simply disables it for now. This eliminates the asserts.
