### PR TITLE
Allow cmsDriver.py to accept multiple --customise options

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -740,7 +740,9 @@ class ConfigBuilder(object):
     def addCustomise(self):
         """Include the customise code """
 
-        custOpt=self._options.customisation_file.split(",")
+	custOpt=[]
+	for c in self._options.customisation_file:
+		custOpt.extend(c.split(","))
 	custMap={}
 	for opt in custOpt:
 		if opt=='': continue

--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -106,7 +106,8 @@ expertSettings.add_option("--beamspot",
 
 expertSettings.add_option("--customise",
                           help="Specify the file where the code to modify the process object is stored.",
-                          default="",
+                          default=[],
+                          action="append",
                           dest="customisation_file")
 expertSettings.add_option("--customise_commands",
                           help="Specify a string of commands",


### PR DESCRIPTION
To make it easier to globally modify the behavior of IB RelVals generated
by runTheMatrix, we modified cmsDriver.py option handling to allow it to
properly handle multiple --customise options. The previous behavior allowed
multiple --customise but ignored all but the last one.

This change was tested on
- no --customise options
- one --customise option
- multiple --customise options
- one --customise option with multiple arguments seperated by ','
