### PR TITLE
70x improve unittest for fireworks configuration 

### DIFF
--- a/Fireworks/Core/test/unittest_fwconfiguration.cc
+++ b/Fireworks/Core/test/unittest_fwconfiguration.cc
@@ -129,7 +129,4 @@ BOOST_AUTO_TEST_CASE( fwconfiguration )
    BOOST_CHECK( 1 == pConf->m_config.stringValues()->size() );
    BOOST_CHECK( 0 == pConf->m_config.keyValues() );
    BOOST_CHECK( kValue == pConf->m_config.value() );
-   
-   BOOST_CHECK_THROW(confMgr.readFromFile("doesNotExist"), std::runtime_error);
-
 }

--- a/Fireworks/Core/test/unittest_fwconfiguration.cc
+++ b/Fireworks/Core/test/unittest_fwconfiguration.cc
@@ -15,6 +15,8 @@
 #include <boost/test/test_tools.hpp>
 #include <stdexcept>
 #include <iostream>
+#include <ios>
+#include <fstream>
 
 // user include files
 #include "Fireworks/Core/interface/FWConfiguration.h"
@@ -129,4 +131,12 @@ BOOST_AUTO_TEST_CASE( fwconfiguration )
    BOOST_CHECK( 1 == pConf->m_config.stringValues()->size() );
    BOOST_CHECK( 0 == pConf->m_config.keyValues() );
    BOOST_CHECK( kValue == pConf->m_config.value() );
+   
+   std::ofstream log("testConfig", std::ios_base::app | std::ios_base::out);
+   log << "line\n"; log.close();
+   try 
+   {
+      confMgr.readFromFile("testConfig");
+   }
+   catch (...) { std::cerr << "OK, checked parser exception \n"; }
 }


### PR DESCRIPTION
CmsShow checks for existence of non-empty configuration file at the time of parsing its arguments. Therefore this check does not make sense.

Add new check for configuration file parse errors.
