### PR TITLE
Attempt to load dictionary for class

### DIFF
--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -40,7 +40,13 @@ byName(string const& name, long property /*= 0L*/)
   //       separately.
   TType* type = gInterpreter->Type_Factory(name);
   if (!gInterpreter->Type_IsValid(type)) {
-    return TypeWithDict();
+    // This can happen if no dictionary has been loaded for the class or enum.
+    // If this is a class, trigger the loading of the dictionary.
+    TClass* theClass = TClass::GetClass(name.c_str());
+    if(theClass == nullptr || theClass->GetTypeInfo() == nullptr) {
+      return TypeWithDict();
+    }
+    return TypeWithDict(theClass, property);
   }
   return TypeWithDict(type, property);
 }


### PR DESCRIPTION
This is a ROOT6 specific bug fix that allows two more framework unit tests to pass.
If an attempt is made to construct a TypeWithDict from a class name, and the dictionary for the class has not yet been loaded, a default TypeWithDict  is constructed, rather than one for the class in question.
The fix calls TClass::GetClass for the class name, which will load the dictionary if RootAutoLibraryLoader is in use.
Then, the proper TypeWithDict can be constructed instead of a default one.
