### PR TITLE
Removed DQM and PoolDBOutputServices from threaded jobs

### DIFF
--- a/FWCore/Concurrency/python/dropNonMTSafe.py
+++ b/FWCore/Concurrency/python/dropNonMTSafe.py
@@ -12,6 +12,8 @@ def dropNonMTSafe(process):
   if hasattr(process, "FastTimerService"): del process.FastTimerService
   if hasattr(process, "SiStripDetInfoFileReader"): del process.SiStripDetInfoFileReader
   if hasattr(process, "TkDetMap"): del process.TkDetMap
+  if hasattr(process, "DQM"): del process.DQM
+  if hasattr(process, "PoolDBOutputService"): del process.PoolDBOutputService
   #drop items dependent on TkDetMap
   _dropFromPaths(process,"siStripFEDMonitor")
   _dropFromPaths(process,"SiStripMonitorDigi")


### PR DESCRIPTION
The DQM and PoolDBOutputServices have not been updated to use the new Service APIs
and therefore can not run under the threaded framework. The dropNonMTSafe customize
function now excludes those two Services.
