### PR TITLE
Selector Utils : Updating electron and muon selections to official top PAG selections

### DIFF
--- a/PhysicsTools/SelectorUtils/interface/PFElectronSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/PFElectronSelector.h
@@ -25,7 +25,7 @@ class PFElectronSelector : public Selector<pat::Electron> {
     verbose_ = false;
     
     std::string versionStr = parameters.getParameter<std::string>("version");
-    rhoTag_ = parameters.getParameter< edm::InputTag> ("rho");
+    rhoTag_ = parameters.getParameter< edm::InputTag> ("rhoSrc");
     
     Version_t version = N_VERSIONS;
     

--- a/PhysicsTools/SelectorUtils/interface/PFElectronSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/PFElectronSelector.h
@@ -4,7 +4,7 @@
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
+#include "EgammaAnalysis/ElectronTools/interface/ElectronEffectiveArea.h"
 #include "PhysicsTools/SelectorUtils/interface/Selector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -16,7 +16,7 @@ class PFElectronSelector : public Selector<pat::Electron> {
   
   bool verbose_;
   
-  enum Version_t { SPRING11, N_VERSIONS };
+  enum Version_t { TOPPAG, N_VERSIONS };
   
   PFElectronSelector() {}
   
@@ -25,24 +25,25 @@ class PFElectronSelector : public Selector<pat::Electron> {
     verbose_ = false;
     
     std::string versionStr = parameters.getParameter<std::string>("version");
+    rhoTag_ = parameters.getParameter< edm::InputTag> ("rho");
     
     Version_t version = N_VERSIONS;
     
-    if ( versionStr == "SPRING11" ) {
-      version = SPRING11;
+    if ( versionStr == "TOPPAG" ) {
+      version = TOPPAG;
     }
     else {
-      throw cms::Exception("InvalidInput") << "Expect version to be one of SPRING11" << std::endl;
+      throw cms::Exception("InvalidInput") << "Expect version to be one of : TOPPAG" << std::endl;
     }
 
 
     initialize( version, 
-		parameters.getParameter<double>("MVA"),
-		parameters.getParameter<double>("D0")  ,
+		parameters.getParameter<bool>  ("Fiducial"),
 		parameters.getParameter<int>   ("MaxMissingHits"),
-		parameters.getParameter<std::string> ("electronIDused"),
+		parameters.getParameter<double>("D0"),
 		parameters.getParameter<bool>  ("ConversionRejection"),
-		parameters.getParameter<double>("PFIso")
+		parameters.getParameter<double>("PFIso"),
+		parameters.getParameter<double>("MVA")
 		);
     if ( parameters.exists("cutsToIgnore") )
       setIgnoredCuts( parameters.getParameter<std::vector<std::string> >("cutsToIgnore") );
@@ -52,46 +53,46 @@ class PFElectronSelector : public Selector<pat::Electron> {
   }
   
   void initialize( Version_t version,
-		   double mva = 0.4,
+		   bool fid=true,
+		   int nMissingHits = 0,
 		   double d0 = 0.02,
-		   int nMissingHits = 1,
-		   std::string eidUsed = "eidTightMC",
 		   bool convRej = true,
-		   double pfiso = 0.15 )
+		   double pfiso = 0.10,
+		   double mva = 0.4
+		   )
   {
     version_ = version; 
     
     //    size_t found;
     //    found = eidUsed.find("NONE");
     //  if ( found != string::npos)
-    electronIDvalue_ = eidUsed;
 
-    push_back("D0",        d0     );
+    push_back("Fiducial" );
     push_back("MaxMissingHits", nMissingHits  );
-    push_back("electronID");
+    push_back("D0",        d0     );
     push_back("ConversionRejection" );
     push_back("PFIso",    pfiso );
     push_back("MVA",       mva   );
 
-    set("D0");
+    set("Fiducial", fid);
     set("MaxMissingHits");
-    set("electronID");
+    set("D0");
     set("ConversionRejection", convRej);
     set("PFIso");   
     set("MVA");
 
-    indexD0_             = index_type(&bits_, "D0"           );
+    indexFid_            = index_type(&bits_, "Fiducial" );
     indexMaxMissingHits_ = index_type(&bits_, "MaxMissingHits" );
-    indexElectronId_     = index_type(&bits_, "electronID" );
+    indexD0_             = index_type(&bits_, "D0"           );
     indexConvRej_        = index_type(&bits_, "ConversionRejection" );
     indexPFIso_          = index_type(&bits_, "PFIso"       );
     indexMVA_            = index_type(&bits_, "MVA"         );
   }
 
   // Allow for multiple definitions of the cuts. 
-  bool operator()( const pat::Electron & electron, pat::strbitset & ret ) 
+  bool operator()( const pat::Electron & electron, edm::EventBase const & event, pat::strbitset & ret ) 
   { 
-    if (version_ == SPRING11 ) return spring11Cuts(electron, ret);
+    if (version_ == TOPPAG ) return topPAGRefCuts(electron, event, ret);
     else {
       return false;
     }
@@ -100,36 +101,39 @@ class PFElectronSelector : public Selector<pat::Electron> {
   using Selector<pat::Electron>::operator();
   
   // cuts based on top group L+J synchronization exercise
-  bool spring11Cuts( const pat::Electron & electron, pat::strbitset & ret)
+  bool topPAGRefCuts( const pat::Electron & electron, edm::EventBase const & event, pat::strbitset & ret)
   {
+
+
 
     ret.set(false);
 
-    double mva = electron.mva();
-    double missingHits = electron.gsfTrack()->trackerExpectedHitsInner().numberOfHits() ;
-    double corr_d0 = electron.dB();
+    edm::Handle<double> rhoHandle;
+    event.getByLabel(rhoTag_, rhoHandle);
 
-    // in >= 39x conversion rejection variables are accessible from Gsf electron
-    Double_t dist = electron.convDist(); // default value is -9999 if conversion partner not found
-    Double_t dcot = electron.convDcot(); // default value is -9999 if conversion partner not found
-    bool isNotConv = !(fabs(dist) < 0.02 && fabs(dcot) < 0.02);
+    double rhoIso = std::max(*(rhoHandle.product()), 0.0);
 
-    int bitWiseResults =  (int) electron.electronID( electronIDvalue_ );  
-    bool electronIDboolean = ((bitWiseResults & 1) == 1 );
-
+    double scEta   = electron.superCluster()->eta();
+    double dB      = electron.dB();
+    double AEff    = ElectronEffectiveArea::GetElectronEffectiveArea(ElectronEffectiveArea::kEleGammaAndNeutralHadronIso03, scEta, ElectronEffectiveArea::kEleEAData2012);
     double chIso = electron.userIsolation(pat::PfChargedHadronIso);
     double nhIso = electron.userIsolation(pat::PfNeutralHadronIso);
-    double gIso  = electron.userIsolation(pat::PfGammaIso);
-    double et    = electron.et() ;
+    double phIso  = electron.userIsolation(pat::PfGammaIso);
+    double pfIso = ( chIso + max(0.0, nhIso + phIso - rhoIso*AEff) )/ electron.ecalDrivenMomentum().pt();
+    int mHits  =  electron.gsfTrack()->trackerExpectedHitsInner().numberOfHits();   
+    double mva = electron.electronID("mvaTrigV0");
+    //Electron Selection for e+jets
+    //-----------------------------  
+    bool fid = ! (fabs(scEta) > 1.4442 &&  fabs(scEta) < 1.5660 );
 
-    double pfIso = (chIso + nhIso + gIso) / et;
+		
 
-    if ( missingHits   <= cut(indexMaxMissingHits_,  double()) || ignoreCut(indexMaxMissingHits_)   ) passCut(ret, indexMaxMissingHits_  );
-    if ( fabs(corr_d0) <  cut(indexD0_,              double()) || ignoreCut(indexD0_)               ) passCut(ret, indexD0_     );
-    if ( isNotConv                                             || ignoreCut(indexConvRej_)          ) passCut(ret, indexConvRej_     );
+    if ( fid                                                   || ignoreCut(indexFid_)              ) passCut(ret, indexFid_     );
+    if ( mHits         <= cut(indexMaxMissingHits_,  double()) || ignoreCut(indexMaxMissingHits_)   ) passCut(ret, indexMaxMissingHits_  );
+    if ( fabs(dB)      <  cut(indexD0_,              double()) || ignoreCut(indexD0_)               ) passCut(ret, indexD0_     );
+    if ( electron.passConversionVeto()                         || ignoreCut(indexConvRej_)          ) passCut(ret, indexConvRej_     );
     if ( pfIso         <  cut(indexPFIso_,           double()) || ignoreCut(indexPFIso_)            ) passCut(ret, indexPFIso_ );
     if ( mva           >  cut(indexMVA_,             double()) || ignoreCut(indexMVA_)              ) passCut(ret, indexMVA_ );
-    if ( electronIDboolean                                     || ignoreCut(indexElectronId_)       ) passCut(ret, indexElectronId_);
     setIgnored(ret);
     return (bool)ret;
   }
@@ -138,15 +142,18 @@ class PFElectronSelector : public Selector<pat::Electron> {
   
   Version_t version_;
 
-  index_type indexID;
+  index_type indexFid_;
   index_type indexMaxMissingHits_;
   index_type indexD0_;
   index_type indexConvRej_;
   index_type indexPFIso_;
   index_type indexMVA_;
-  index_type indexElectronId_;
+
 
   std::string electronIDvalue_;
+  edm::InputTag rhoTag_;
+
+  bool operator()( const pat::Electron & electron, pat::strbitset & ret ) { return false;}
 };
 
 #endif

--- a/PhysicsTools/SelectorUtils/interface/PFMuonSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/PFMuonSelector.h
@@ -144,8 +144,10 @@ class PFMuonSelector : public Selector<pat::Muon> {
     double chIso = muon.userIsolation(pat::PfChargedHadronIso);
     double nhIso = muon.userIsolation(pat::PfNeutralHadronIso);
     double gIso  = muon.userIsolation(pat::PfGammaIso);
+    double puIso = muon.userIsolation(pat::PfPUChargedHadronIso);
     double pt    = muon.pt() ;
-    double pfIso = (chIso + nhIso + gIso) / pt;
+
+    double pfIso = ( chIso + std::max( 0.0, nhIso + gIso - 0.5 * puIso) ) / pt;
 
 
     if ( isGlobal  || ignoreCut("GlobalMuon")  )  passCut(ret, "GlobalMuon" );

--- a/PhysicsTools/SelectorUtils/python/pfElectronSelector_cfi.py
+++ b/PhysicsTools/SelectorUtils/python/pfElectronSelector_cfi.py
@@ -3,6 +3,7 @@ import FWCore.ParameterSet.Config as cms
 #Electron Selector
 pfElectronSelector = cms.PSet(
     version = cms.string('TOPPAG'),
+    rhoSrc = cms.InputTag('kt6PFJets', 'rho'),
     Fiducial = cms.bool(True),
     MaxMissingHits = cms.int32(1),
     D0 = cms.double(0.02),

--- a/PhysicsTools/SelectorUtils/python/pfElectronSelector_cfi.py
+++ b/PhysicsTools/SelectorUtils/python/pfElectronSelector_cfi.py
@@ -2,12 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 #Electron Selector
 pfElectronSelector = cms.PSet(
-    version = cms.string('SPRING11'),
-    MVA = cms.double(-0.01),
+    version = cms.string('TOPPAG'),
+    Fiducial = cms.bool(True),
     MaxMissingHits = cms.int32(1),
     D0 = cms.double(0.02),
-    electronIDused = cms.string('eidTightMC'),
     ConversionRejection = cms.bool(True),
     PFIso = cms.double(0.1),
+    MVA = cms.double(0.5),
     cutsToIgnore = cms.vstring()
     )


### PR DESCRIPTION
Here is an update to the Selector Utils package to ensure that the electron and muon selections are up-to-date with respect to the TOP PAG recommendations here : 

https://twiki.cern.ch/twiki/bin/view/CMS/TWikiTopRefEventSel

Changes include : 

Muons : add delta-beta to the isolation definition.
Electrons : Add the effective area correction, latest conversion rejection, etc. 
