### PR TITLE
Fix for manual offline egamma HLT validation script

### DIFF
--- a/HLTriggerOffline/Egamma/test/egammaHltValidate.py
+++ b/HLTriggerOffline/Egamma/test/egammaHltValidate.py
@@ -171,7 +171,7 @@ def findDataSetFromSampleName(sampleSpec, version, cdToReleaseDir):
 
     datasetToSearchFor= knownDatasets[sampleSpec]['dataset'] % { "version": version }
 
-    dbs_cmd = 'dbs search --query="find dataset where dataset=' + datasetToSearchFor + ' and site=srm-cms.cern.ch and release = CMSSW_' + version + '" | grep "HLTDEBUG"'
+    dbs_cmd = 'python ./das_client.py --query=dataset=' + datasetToSearchFor + ' | grep "HLTDEBUG"'
 
     cmssw_release_dir = findCMSSWreleaseDir(version)
 

--- a/HLTriggerOffline/Egamma/test/egammaHltValidate.py
+++ b/HLTriggerOffline/Egamma/test/egammaHltValidate.py
@@ -171,7 +171,7 @@ def findDataSetFromSampleName(sampleSpec, version, cdToReleaseDir):
 
     datasetToSearchFor= knownDatasets[sampleSpec]['dataset'] % { "version": version }
 
-    dbs_cmd = 'python ./das_client.py --query=dataset=' + datasetToSearchFor + ' | grep "HLTDEBUG"'
+    dbs_cmd = 'das_client.py --query=dataset=' + datasetToSearchFor + ' | grep "HLTDEBUG"'
 
     cmssw_release_dir = findCMSSWreleaseDir(version)
 


### PR DESCRIPTION
Fixed the script for manual egamma HLT offline validation which used internally a 'dbs search' query. Replaced this with a das_client.py query to make it usable again.
