### PR TITLE
rename typedef to avoid duplicate def with ElectronSeedRefVector::iterator

### DIFF
--- a/DataFormats/ParticleFlowReco/interface/ConvBremSeedFwd.h
+++ b/DataFormats/ParticleFlowReco/interface/ConvBremSeedFwd.h
@@ -16,7 +16,7 @@ namespace reco {
   /// vector of objects in the same collection of ConvBremSeed objects
   typedef edm::RefVector<ConvBremSeedCollection> ConvBremSeedRefVector;
   /// iterator over a vector of reference to ConvBremSeed objects
-  typedef ConvBremSeedRefVector::iterator electronephltseed_iterator;
+  typedef ConvBremSeedRefVector::iterator convbremphltseed_iterator;
 }
 
 #endif


### PR DESCRIPTION
somewhat trivial fix to a duplicate typedef
this is needed for root6
