### PR TITLE
moved dict for ValueMap of vector of PFCandidateRef from EgammaCandidate...

### DIFF
--- a/DataFormats/EgammaCandidates/src/classes.h
+++ b/DataFormats/EgammaCandidates/src/classes.h
@@ -79,8 +79,6 @@ namespace DataFormats_EgammaCandidates {
     // std::vector<std::pair<reco::PFCandidateRef,bool> > values_pfiso;
     //edm::ValueMap<std::vector<std::pair<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> >,bool> > >  valueMap_iso; 
     //edm::Wrapper<edm::ValueMap<std::vector<std::pair<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> >,bool> > > > valueMap_iso_wr;
-    edm::Wrapper<edm::ValueMap<std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > > > valueMap_iso_wr;
-    edm::ValueMap<std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > >  valueMap_iso; 
 
     reco::Photon::FiducialFlags pff ;
     reco::Photon::ShowerShape pss ;

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -83,8 +83,6 @@
   <class name="edm::ValueMap<std::vector<std::pair<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> >,bool> > >"/> 
   <class name="edm::Wrapper<edm::ValueMap<std::vector<std::pair<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> >,bool> > > >"/>
    -->
-  <class name="edm::Wrapper<edm::ValueMap<std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > > >"/>
-  <class name="edm::ValueMap<std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > >"/>
 
 
   <class name="std::vector<reco::Electron>"/>

--- a/DataFormats/ParticleFlowCandidate/src/classes.h
+++ b/DataFormats/ParticleFlowCandidate/src/classes.h
@@ -46,6 +46,9 @@ namespace DataFormats_ParticleFlowCandidate {
     edm::Wrapper<edm::ValueMap<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > > bla333;
     edm::ValueMap<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > >  bla334;
     std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > bla335;
+    edm::Wrapper<edm::ValueMap<std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > > > valueMap_iso_wr;
+    edm::ValueMap<std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > >  valueMap_iso; 
+
     edm::Wrapper<edm::ValueMap<edm::Ptr<reco::PFCandidate> > > bla336;
     edm::ValueMap<edm::Ptr<std::vector<reco::PFCandidate> > >  bla337;
     std::vector<edm::Ptr<std::vector<reco::PFCandidate> > > bla338;

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -32,6 +32,8 @@
   <class name="edm::Wrapper<edm::ValueMap<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > >"/>
   <class name="edm::ValueMap<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > "/>
   <class name="std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > "/>
+  <class name="edm::Wrapper<edm::ValueMap<std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > > >"/>
+  <class name="edm::ValueMap<std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > >"/>
   <class name="edm::Wrapper<edm::ValueMap<edm::Ptr<reco::PFCandidate> > >"/>
   <class name="edm::ValueMap<edm::Ptr<std::vector<reco::PFCandidate> > >"/>
   <class name="std::vector<edm::Ptr<std::vector<reco::PFCandidate> > >"/>


### PR DESCRIPTION
...s to ParticleFlowCandidate

Fairly trivial.
I picked it up from the dict checker.
Also available in 
https://cmssdt.cern.ch/SDT/cgi-bin/showDupDict.py//slc5_amd64_gcc481/www/tue/7.0-tue-02/CMSSW_7_0_X_2014-01-07-0200/testLogs/dupDict-lostDefs.log
