### PR TITLE
DQM/TrackingMonitorClient: add missing std::

### DIFF
--- a/DQM/TrackingMonitorClient/plugins/TrackingAnalyzer.cc
+++ b/DQM/TrackingMonitorClient/plugins/TrackingAnalyzer.cc
@@ -49,7 +49,7 @@ TrackingAnalyser::TrackingAnalyser(edm::ParameterSet const& ps) {
   tkMapPSet_ = ps.getParameter<edm::ParameterSet>("TkmapParameters");
 
   std::string localPath = std::string("DQM/TrackingMonitorClient/test/loader.html");
-  ifstream fin(edm::FileInPath(localPath).fullPath().c_str(), std::ios::in);
+  std::ifstream fin(edm::FileInPath(localPath).fullPath().c_str(), std::ios::in);
   char buf[BUF_SIZE];
   
   if (!fin) {

--- a/DQM/TrackingMonitorClient/src/TrackingActionExecutor.cc
+++ b/DQM/TrackingMonitorClient/src/TrackingActionExecutor.cc
@@ -76,7 +76,7 @@ void TrackingActionExecutor::fillStatusAtLumi(DQMStore* dqm_store) {
 //
 void TrackingActionExecutor::createDummyShiftReport(){
   //  std::cout << "[TrackingActionExecutor::createDummyShiftReport]" << std::endl;
-  ofstream report_file;
+  std::ofstream report_file;
   report_file.open("tracking_shift_report.txt", std::ios::out);
   report_file << " Nothing to report!!" << std::endl;
   report_file.close();
@@ -111,7 +111,7 @@ void TrackingActionExecutor::createShiftReport(DQMStore * dqm_store){
   shift_summary << std::endl;
   printShiftHistoParameters(dqm_store, layout_map, shift_summary);
   
-  ofstream report_file;
+  std::ofstream report_file;
   report_file.open("tracking_shift_report.txt", std::ios::out);
   report_file << shift_summary.str() << std::endl;
   report_file.close();


### PR DESCRIPTION
The following is required for ROOT6.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
