### PR TITLE
Fix check for same type

### DIFF
--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -524,7 +524,7 @@ const void*
 TypeWithDict::
 pointerToBaseType(const void* ptr, const TypeWithDict& derivedType) const
 {
-  if (this == &derivedType) {
+  if (this->ti_ == derivedType.ti_ || *this->ti_ == *derivedType.ti_) {
     return ptr;
   }
   int offset = derivedType.getBaseClassOffset(*this);


### PR DESCRIPTION
This pull request fixes a bug in CMS ROOT6 specific code.  The function TypeWithDict::pointerToBase() compared two types for equality by comparing the TypeWithDict pointers.  This is a bug, because there can easily be more than one TypeWithDict object for the same type.
The fix is to compare the std::type_info (instead of TypeWithDict) for each of the two types, first by comparing the pointers, and, if the pointers are unequal, comparing the std::type_info's by value.
This fixes one framework unit test that was failing in the ROOT6 branch.
