### PR TITLE
Workaround for ROOT bugs

### DIFF
--- a/DataFormats/FWLite/src/EntryFinder.cc
+++ b/DataFormats/FWLite/src/EntryFinder.cc
@@ -36,7 +36,7 @@ namespace fwlite {
     explicit FWLiteEventFinder(TBranch* auxBranch) : auxBranch_(auxBranch) {}
     virtual ~FWLiteEventFinder() {}
     virtual
-    edm::EventNumber_t getEventNumberOfEntry(long long entry) const override {
+    edm::EventNumber_t getEventNumberOfEntry(edm::IndexIntoFile::EntryNumber_t entry) const override {
       void* saveAddress = auxBranch_->GetAddress();
       edm::EventAuxiliary eventAux;
       edm::EventAuxiliary *pEvAux = &eventAux;

--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -189,7 +189,7 @@ namespace edm {
       class SortedRunOrLumiItr;
       class IndexRunLumiEventKey;
 
-      typedef long long EntryNumber_t;
+      typedef long EntryNumber_t;
       static int const invalidIndex = -1;
       static RunNumber_t const invalidRun = 0U;
       static LuminosityBlockNumber_t const invalidLumi = 0U;
@@ -370,6 +370,7 @@ namespace edm {
 
       class RunOrLumiIndexes {
       public:
+        RunOrLumiIndexes();
         RunOrLumiIndexes(int processHistoryIDIndex, RunNumber_t run, LuminosityBlockNumber_t lumi, int indexToGetEntry);
 
         int processHistoryIDIndex() const {return processHistoryIDIndex_;}
@@ -779,6 +780,10 @@ namespace edm {
 
       class IndexRunKey {
       public:
+        IndexRunKey() :
+          processHistoryIDIndex_(invalidIndex),
+          run_(invalidRun) {
+        }
         IndexRunKey(int index, RunNumber_t run) :
           processHistoryIDIndex_(index),
           run_(run) {
@@ -804,6 +809,11 @@ namespace edm {
 
       class IndexRunLumiKey {
       public:
+        IndexRunLumiKey() :
+          processHistoryIDIndex_(invalidIndex),
+          run_(invalidRun),
+          lumi_(invalidLumi) {
+        }
         IndexRunLumiKey(int index, RunNumber_t run, LuminosityBlockNumber_t lumi) :
           processHistoryIDIndex_(index),
           run_(run),
@@ -835,6 +845,13 @@ namespace edm {
 
       class IndexRunLumiEventKey {
       public:
+        IndexRunLumiEventKey() :
+          processHistoryIDIndex_(invalidIndex),
+          run_(invalidRun),
+          lumi_(invalidLumi),
+          event_(invalidEvent) {
+        }
+
         IndexRunLumiEventKey(int index, RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) :
           processHistoryIDIndex_(index),
           run_(run),

--- a/DataFormats/Provenance/src/IndexIntoFile.cc
+++ b/DataFormats/Provenance/src/IndexIntoFile.cc
@@ -941,6 +941,16 @@ namespace edm {
   {
   }
 
+  IndexIntoFile::RunOrLumiIndexes::RunOrLumiIndexes() :
+    processHistoryIDIndex_(invalidIndex),
+    run_(invalidRun),
+    lumi_(invalidLumi),
+    indexToGetEntry_(invalidIndex),
+    beginEventNumbers_(-1),
+    endEventNumbers_(-1)
+  {
+  }
+
   IndexIntoFile::SortedRunOrLumiItr::SortedRunOrLumiItr(IndexIntoFile const* indexIntoFile, unsigned runOrLumi) :
     indexIntoFile_(indexIntoFile), runOrLumi_(runOrLumi) {
     assert(runOrLumi_ <= indexIntoFile_->runOrLumiEntries().size());

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -1,4 +1,5 @@
 <lcgdict>
+ <enum name="edm::BranchType"/>
  <class name="edm::WrapperInterfaceBase"/>
  <class name="edm::ProductID" ClassVersion="11">
   <version ClassVersion="11" checksum="3913437934"/>


### PR DESCRIPTION
This is a workaround for the class edm::IndexIntoFile, which, in ROOT6 is affected by two ROOT6 bugs as described in:
https://sft.its.cern.ch/jira/browse/ROOT-5876?filter=-2
https://sft.its.cern.ch/jira/browse/ROOT-5880?filter=-2
Without this workaround, those ROOT6 bugs prevent any edm/ROOT file from being written by cmsRun.
