### PR TITLE
Standardize format

### DIFF
--- a/FWCore/Utilities/interface/DictionaryTools.h
+++ b/FWCore/Utilities/interface/DictionaryTools.h
@@ -29,7 +29,7 @@ find_nested_type_named(std::string const& nested_type,
 
 inline
 bool
-value_type_of(const TypeWithDict& t, TypeWithDict& found_type)
+value_type_of(TypeWithDict const& t, TypeWithDict& found_type)
 {
   return find_nested_type_named("value_type", t, found_type);
 }
@@ -37,7 +37,7 @@ value_type_of(const TypeWithDict& t, TypeWithDict& found_type)
 
 inline
 bool
-wrapper_type_of(const TypeWithDict& possible_wrapper,
+wrapper_type_of(TypeWithDict const& possible_wrapper,
                 TypeWithDict& found_wrapped_type)
 {
   return find_nested_type_named("wrapped_type",
@@ -46,26 +46,26 @@ wrapper_type_of(const TypeWithDict& possible_wrapper,
 }
 
 bool
-is_RefVector(const TypeWithDict& possible_ref_vector,
+is_RefVector(TypeWithDict const& possible_ref_vector,
              TypeWithDict& value_type);
 
 bool
-is_PtrVector(const TypeWithDict& possible_ref_vector,
+is_PtrVector(TypeWithDict const& possible_ref_vector,
              TypeWithDict& value_type);
 bool
-is_RefToBaseVector(const TypeWithDict& possible_ref_vector,
+is_RefToBaseVector(TypeWithDict const& possible_ref_vector,
                    TypeWithDict& value_type);
 
-void checkDictionaries(const std::string& name, bool noComponents = false);
+void checkDictionaries(std::string const& name, bool noComponents = false);
 void throwMissingDictionariesException();
 void loadMissingDictionaries();
 StringSet& missingTypes();
 StringSet& foundTypes();
 
-void public_base_classes(const TypeWithDict& type,
+void public_base_classes(TypeWithDict const& type,
                          std::vector<TypeWithDict>& baseTypes);
 
-const std::string& dictionaryPlugInPrefix();
+std::string const& dictionaryPlugInPrefix();
 
 } // namespace edm
 

--- a/FWCore/Utilities/interface/FunctionWithDict.h
+++ b/FWCore/Utilities/interface/FunctionWithDict.h
@@ -44,8 +44,8 @@ public:
   TypeWithDict declaringType() const;
   size_t functionParameterSize(bool required = false) const;
   size_t size() const;
-  void invoke(const ObjectWithDict& obj, ObjectWithDict* ret = nullptr, const std::vector<void*>& values = std::vector<void*>()) const;
-  void invoke(ObjectWithDict* ret = nullptr, const std::vector<void*>& values = std::vector<void*>()) const;
+  void invoke(ObjectWithDict const& obj, ObjectWithDict* ret = nullptr, std::vector<void*> const& values = std::vector<void*>()) const;
+  void invoke(ObjectWithDict* ret = nullptr, std::vector<void*> const& values = std::vector<void*>()) const;
   IterWithDict<TMethodArg> begin() const;
   IterWithDict<TMethodArg> end() const;
 };
@@ -62,7 +62,7 @@ namespace edm {
 template<typename T>
 inline
 void
-invokeByName(T& retval, const TypeWithDict& theType, const std::string& name)
+invokeByName(T& retval, TypeWithDict const& theType, std::string const& name)
 {
   if (!bool(theType)) {
     fprintf(stderr, "FunctionWithDict: invokeByName<%s>: "

--- a/FWCore/Utilities/interface/IterWithDict.h
+++ b/FWCore/Utilities/interface/IterWithDict.h
@@ -17,11 +17,11 @@ private:
   bool atEnd_;
 protected:
   void advance();
-  const TIter& iter() const;
+  TIter const& iter() const;
 public:
   IterWithDictBase();
   explicit IterWithDictBase(TList*);
-  bool operator!=(const IterWithDictBase&) const;
+  bool operator!=(IterWithDictBase const&) const;
 };
 
 template<typename T>

--- a/FWCore/Utilities/interface/MemberWithDict.h
+++ b/FWCore/Utilities/interface/MemberWithDict.h
@@ -33,7 +33,7 @@ public:
   TypeWithDict declaringType() const;
   TypeWithDict typeOf() const;
   ObjectWithDict get() const;
-  ObjectWithDict get(const ObjectWithDict&) const;
+  ObjectWithDict get(ObjectWithDict const&) const;
 };
 
 } // namespace edm

--- a/FWCore/Utilities/interface/ObjectWithDict.h
+++ b/FWCore/Utilities/interface/ObjectWithDict.h
@@ -21,16 +21,16 @@ private:
   TType* type_;
   void* address_;
 public:
-  static ObjectWithDict byType(const TypeWithDict&);
+  static ObjectWithDict byType(TypeWithDict const&);
 public:
   ObjectWithDict();
-  explicit ObjectWithDict(const TypeWithDict&, void* address);
-  explicit ObjectWithDict(const std::type_info&, void* address);
+  explicit ObjectWithDict(TypeWithDict const&, void* address);
+  explicit ObjectWithDict(std::type_info const&, void* address);
   explicit operator bool() const;
   void* address() const;
   TypeWithDict typeOf() const;
   TypeWithDict dynamicType() const;
-  ObjectWithDict get(const std::string& memberName) const;
+  ObjectWithDict get(std::string const& memberName) const;
   //ObjectWithDict construct() const;
   void destruct(bool dealloc) const;
   template<typename T>

--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -52,7 +52,7 @@ class TypeWithDict {
   friend class TypeDataMembers;
   friend class TypeFunctionMembers;
 private:
-  const std::type_info* ti_;
+  std::type_info const* ti_;
   TType* type_;
   TClass* class_;
   TEnum* enum_;
@@ -65,11 +65,11 @@ public:
   static TypeWithDict byName(std::string const& name, long property = 0L);
 public:
   TypeWithDict();
-  TypeWithDict& operator=(const TypeWithDict&);
-  TypeWithDict(const TypeWithDict&);
+  TypeWithDict& operator=(TypeWithDict const&);
+  TypeWithDict(TypeWithDict const&);
   // This copy constructor is for clearing const and reference.
-  explicit TypeWithDict(const TypeWithDict&, long property);
-  explicit TypeWithDict(const std::type_info&, long property = 0L);
+  explicit TypeWithDict(TypeWithDict const&, long property);
+  explicit TypeWithDict(std::type_info const&, long property = 0L);
   explicit TypeWithDict(TClass* type, long property = 0L);
   explicit TypeWithDict(TMethodArg* arg, long property = 0L);
   explicit TypeWithDict(TType* type, long property = 0L);
@@ -103,23 +103,23 @@ public:
   size_t arrayLength() const;
   size_t dataMemberSize() const;
   size_t functionMemberSize() const;
-  MemberWithDict dataMemberByName(const std::string&) const;
+  MemberWithDict dataMemberByName(std::string const&) const;
   // Note: Used only by FWCore/Modules/src/EventContentAnalyzer.cc
-  FunctionWithDict functionMemberByName(const std::string&) const;
+  FunctionWithDict functionMemberByName(std::string const&) const;
   // Note: Used only by Fireworks/Core/src/FWModelContextMenuHandler.cc:262
-  //FunctionWithDict functionMemberByName(const std::string& name, const TypeWithDict& signature, int mods, TypeMemberQuery memberQuery) const;
+  //FunctionWithDict functionMemberByName(std::string const& name, TypeWithDict const& signature, int mods, TypeMemberQuery memberQuery) const;
   TypeWithDict nestedType(char const*) const;
-  TypeWithDict nestedType(const std::string&) const;
+  TypeWithDict nestedType(std::string const&) const;
   TypeWithDict finalType() const;
   TypeWithDict toType() const;
   void print(std::ostream& os) const;
-  bool hasBase(const std::string&) const;
-  bool hasBase(const TypeWithDict& basety) const;
-  int getBaseClassOffset(const TypeWithDict& baseClass) const;
+  bool hasBase(std::string const&) const;
+  bool hasBase(TypeWithDict const& basety) const;
+  int getBaseClassOffset(TypeWithDict const& baseClass) const;
   TypeWithDict templateArgumentAt(size_t index) const;
-  const void* pointerToBaseType(const void* ptr, const TypeWithDict& derivedType) const;
-  const void* pointerToContainedType(const void* ptr, const TypeWithDict& derivedType) const;
-  int stringToEnumValue(const std::string&) const;
+  void const* pointerToBaseType(void const* ptr, TypeWithDict const& derivedType) const;
+  void const* pointerToContainedType(void const* ptr, TypeWithDict const& derivedType) const;
+  int stringToEnumValue(std::string const&) const;
   void* allocate() const;
   void deallocate(void* address) const;
   ObjectWithDict construct() const;
@@ -127,28 +127,28 @@ public:
 };
 
 // A related free function
-bool hasDictionary(const std::type_info&);
+bool hasDictionary(std::type_info const&);
 
-inline bool operator<(const TypeWithDict& a, const TypeWithDict& b)
+inline bool operator<(TypeWithDict const& a, TypeWithDict const& b)
 {
   return a.typeInfo().before(b.typeInfo());
 }
 
-bool operator==(const TypeWithDict& a, const TypeWithDict& b);
+bool operator==(TypeWithDict const& a, TypeWithDict const& b);
 
-inline bool operator!=(const TypeWithDict& a, const TypeWithDict& b)
+inline bool operator!=(TypeWithDict const& a, TypeWithDict const& b)
 {
   return !(a == b);
 }
 
-std::ostream& operator<<(std::ostream& os, const TypeWithDict& id);
+std::ostream& operator<<(std::ostream& os, TypeWithDict const& id);
 
 class TypeBases {
 private:
   TType* type_;
   TClass* class_;
 public:
-  explicit TypeBases(const TypeWithDict&);
+  explicit TypeBases(TypeWithDict const&);
   IterWithDict<TBaseClass> begin() const;
   IterWithDict<TBaseClass> end() const;
   size_t size() const;
@@ -159,7 +159,7 @@ private:
   TType* type_;
   TClass* class_;
 public:
-  explicit TypeDataMembers(const TypeWithDict&);
+  explicit TypeDataMembers(TypeWithDict const&);
   IterWithDict<TDataMember> begin() const;
   IterWithDict<TDataMember> end() const;
   size_t size() const;
@@ -170,7 +170,7 @@ private:
   TType* type_;
   TClass* class_;
 public:
-  explicit TypeFunctionMembers(const TypeWithDict&);
+  explicit TypeFunctionMembers(TypeWithDict const&);
   IterWithDict<TMethod> begin() const;
   IterWithDict<TMethod> end() const;
   size_t size() const;

--- a/FWCore/Utilities/src/BaseWithDict.cc
+++ b/FWCore/Utilities/src/BaseWithDict.cc
@@ -6,38 +6,25 @@
 
 namespace edm {
 
-BaseWithDict::
-BaseWithDict()
-  : baseClass_(nullptr)
-{
-}
+  BaseWithDict::BaseWithDict() : baseClass_(nullptr) {
+  }
 
-BaseWithDict::
-BaseWithDict(TBaseClass* baseClass)
-  : baseClass_(baseClass)
-{
-}
+  BaseWithDict::BaseWithDict(TBaseClass* baseClass) : baseClass_(baseClass) {
+  }
 
-bool
-BaseWithDict::
-isPublic() const
-{
-  return baseClass_->Property() & kIsPublic;
-}
+  bool
+  BaseWithDict::isPublic() const {
+    return baseClass_->Property() & kIsPublic;
+  }
 
-std::string
-BaseWithDict::
-name() const
-{
-  return baseClass_->GetName();
-}
+  std::string
+  BaseWithDict::name() const {
+    return baseClass_->GetName();
+  }
 
-TypeWithDict
-BaseWithDict::
-typeOf() const
-{
-  return TypeWithDict(baseClass_->GetClassPointer(), baseClass_->Property());
-}
+  TypeWithDict
+  BaseWithDict::typeOf() const {
+    return TypeWithDict(baseClass_->GetClassPointer(), baseClass_->Property());
+  }
 
 } // namespace edm
-

--- a/FWCore/Utilities/src/DictionaryTools.cc
+++ b/FWCore/Utilities/src/DictionaryTools.cc
@@ -18,303 +18,289 @@
 
 namespace edm {
 
-const std::string&
-dictionaryPlugInPrefix()
-{
-  static std::string const prefix("LCGReflex/");
-  return prefix;
-}
+  std::string const&
+  dictionaryPlugInPrefix() {
+    static std::string const prefix("LCGReflex/");
+    return prefix;
+  }
 
-static StringSet foundTypes_;
-static StringSet missingTypes_;
+  static StringSet foundTypes_;
+  static StringSet missingTypes_;
 
-bool
-find_nested_type_named(const std::string& nested_type,
-                       const TypeWithDict& typeToSearch,
-                         TypeWithDict& found_type)
-{
-  // Look for a sub-type named 'nested_type'
-  TypeWithDict ty = typeToSearch.nestedType(nested_type);
-  if (!bool(ty)) {
-    found_type = TypeWithDict();
+  bool
+  find_nested_type_named(std::string const& nested_type,
+                         TypeWithDict const& typeToSearch,
+                         TypeWithDict& found_type) {
+    // Look for a sub-type named 'nested_type'
+    TypeWithDict ty = typeToSearch.nestedType(nested_type);
+    if (!bool(ty)) {
+      found_type = TypeWithDict();
+      return false;
+    }
+    found_type = ty;
+    return true;
+  }
+
+  bool
+  is_RefVector(TypeWithDict const& possibleRefVector,
+               TypeWithDict& value_type) {
+    static std::string const template_name("edm::RefVector");
+    static std::string const member_type("member_type");
+    if (possibleRefVector.templateName() != template_name) {
+      value_type = TypeWithDict();
+      return false;
+    }
+    return find_nested_type_named(member_type, possibleRefVector, value_type);
+  }
+
+  bool
+  is_PtrVector(TypeWithDict const& possibleRefVector,
+               TypeWithDict& value_type) {
+    static std::string const template_name("edm::PtrVector");
+    static std::string const member_type("member_type");
+    static std::string const val_type("value_type");
+    if (possibleRefVector.templateName() != template_name) {
+      value_type = TypeWithDict();
+      return false;
+    }
+    TypeWithDict ptrType;
+    // FIXME: Is this right?
+    if (find_nested_type_named(val_type, possibleRefVector, ptrType)) {
+      return find_nested_type_named(val_type, ptrType, value_type);
+    }
     return false;
   }
-  found_type = ty;
-  return true;
-}
 
-bool
-is_RefVector(const TypeWithDict& possibleRefVector,
-             TypeWithDict& value_type)
-{
-  static const std::string template_name("edm::RefVector");
-  static const std::string member_type("member_type");
-  if (possibleRefVector.templateName() != template_name) {
-    value_type = TypeWithDict();
-    return false;
+  bool
+  is_RefToBaseVector(TypeWithDict const& possibleRefVector,
+                     TypeWithDict& value_type) {
+    static std::string const template_name("edm::RefToBaseVector");
+    static std::string const member_type("member_type");
+    if (possibleRefVector.templateName() != template_name) {
+      value_type = TypeWithDict();
+      return false;
+    }
+    return find_nested_type_named(member_type, possibleRefVector, value_type);
   }
-  return find_nested_type_named(member_type, possibleRefVector, value_type);
-}
 
-bool
-is_PtrVector(TypeWithDict const& possibleRefVector,
-             TypeWithDict& value_type)
-{
-  static const std::string template_name("edm::PtrVector");
-  static const std::string member_type("member_type");
-  static const std::string val_type("value_type");
-  if (possibleRefVector.templateName() != template_name) {
-    value_type = TypeWithDict();
-    return false;
+  static int const oneParamArraySize = 6;
+  std::string const oneParam[oneParamArraySize] = {
+    "vector",
+    "basic_string",
+    "set",
+    "list",
+    "deque",
+    "multiset"
+  };
+
+  static int const twoParamArraySize = 3;
+
+  static std::string const twoParam[twoParamArraySize] = {
+    "map",
+    "pair",
+    "multimap"
+  };
+
+  static
+  bool
+  hasCintDictionary(std::string const& name) {
+    ClassInfo_t* ci = gInterpreter->ClassInfo_Factory(name.c_str());
+    return gInterpreter->ClassInfo_IsValid(ci);
   }
-  TypeWithDict ptrType;
-  // FIXME: Is this right?
-  if (find_nested_type_named(val_type, possibleRefVector, ptrType)) {
-    return find_nested_type_named(val_type, ptrType, value_type);
-  }
-  return false;
-}
 
-bool
-is_RefToBaseVector(const TypeWithDict& possibleRefVector,
-                   TypeWithDict& value_type)
-{
-  static const std::string template_name("edm::RefToBaseVector");
-  static const std::string member_type("member_type");
-  if (possibleRefVector.templateName() != template_name) {
-    value_type = TypeWithDict();
-    return false;
-  }
-  return find_nested_type_named(member_type, possibleRefVector, value_type);
-}
-
-static int const oneParamArraySize = 6;
-std::string const oneParam[oneParamArraySize] = {
-  "vector",
-  "basic_string",
-  "set",
-  "list",
-  "deque",
-  "multiset"
-};
-
-static int const twoParamArraySize = 3;
-
-static std::string const twoParam[twoParamArraySize] = {
-  "map",
-  "pair",
-  "multimap"
-};
-
-static
-bool
-hasCintDictionary(const std::string& name)
-{
-  ClassInfo_t* ci = gInterpreter->ClassInfo_Factory(name.c_str());
-  return gInterpreter->ClassInfo_IsValid(ci);
-}
-
-// Checks if there is a dictionary for the Type t.
-// If noComponents is false, checks members and base classes recursively.
-// If noComponents is true, checks Type t only.
-static
-void
-checkType(TypeWithDict t, bool noComponents = false)
-{
-  // ToType strips const, volatile, array, pointer, reference, etc.,
-  // and also translates typedefs.
-  // To be safe, we do this recursively until we either get a void type or the same type.
-  for (TypeWithDict x(t.toType()); x != t &&
-       x.typeInfo() != typeid(void); t = x, x = t.toType()) {}
-  std::string name(t.name());
-  boost::trim(name);
-  if (foundTypes().end() != foundTypes().find(name) ||
-      missingTypes().end() != missingTypes().find(name)) {
-    // Already been processed. Prevents infinite loop.
-    return;
-  }
-  if (name.empty() || t.isFundamental() || t.isEnum() ||
-      t.typeInfo() == typeid(void)) {
-    foundTypes().insert(name);
-    return;
-  }
-  if (!bool(t)) {
-    if (hasCintDictionary(name)) {
+  // Checks if there is a dictionary for the Type t.
+  // If noComponents is false, checks members and base classes recursively.
+  // If noComponents is true, checks Type t only.
+  static
+  void
+  checkType(TypeWithDict t, bool noComponents = false) {
+    // ToType strips const, volatile, array, pointer, reference, etc.,
+    // and also translates typedefs.
+    // To be safe, we do this recursively until we either get a void type or the same type.
+    for (TypeWithDict x(t.toType()); x != t &&
+         x.typeInfo() != typeid(void); t = x, x = t.toType()) {}
+    std::string name(t.name());
+    boost::trim(name);
+    if (foundTypes().end() != foundTypes().find(name) ||
+        missingTypes().end() != missingTypes().find(name)) {
+      // Already been processed. Prevents infinite loop.
+      return;
+    }
+    if (name.empty() || t.isFundamental() || t.isEnum() ||
+        t.typeInfo() == typeid(void)) {
       foundTypes().insert(name);
+      return;
+    }
+    if (!bool(t)) {
+      if (hasCintDictionary(name)) {
+        foundTypes().insert(name);
+      }
+      else {
+        missingTypes().insert(name);
+      }
+      return;
+    }
+    foundTypes().insert(name);
+    if (noComponents) {
+      return;
+    }
+    if (name.find("std::") == 0) {
+      if (t.isTemplateInstance()) {
+        std::string::size_type n = name.find('<');
+        int cnt = 0;
+        if (std::find(oneParam, oneParam + oneParamArraySize, name.substr(5,
+                      n - 5)) != (oneParam + oneParamArraySize)) {
+          cnt = 1;
+        }
+        else if (std::find(twoParam, twoParam + twoParamArraySize, name.substr(5,
+                           n - 5)) != (twoParam + twoParamArraySize)) {
+          cnt = 2;
+        }
+        for (int i = 0; i < cnt; ++i) {
+          checkType(t.templateArgumentAt(i));
+        }
+      }
     }
     else {
-      missingTypes().insert(name);
-    }
-    return;
-  }
-  foundTypes().insert(name);
-  if (noComponents) {
-    return;
-  }
-  if (name.find("std::") == 0) {
-    if (t.isTemplateInstance()) {
-      std::string::size_type n = name.find('<');
-      int cnt = 0;
-      if (std::find(oneParam, oneParam + oneParamArraySize, name.substr(5,
-                    n - 5)) != (oneParam + oneParamArraySize)) {
-        cnt = 1;
+      TypeDataMembers members(t);
+      for (auto const& m : members) {
+        MemberWithDict M(m);
+        if (!M.isTransient() && !M.isStatic()) {
+          checkType(M.typeOf());
+        }
       }
-      else if (std::find(twoParam, twoParam + twoParamArraySize, name.substr(5,
-                         n - 5)) != (twoParam + twoParamArraySize)) {
-        cnt = 2;
-      }
-      for (int i = 0; i < cnt; ++i) {
-        checkType(t.templateArgumentAt(i));
+      TypeBases bases(t);
+      for (auto const& b : bases) {
+        BaseWithDict B(b);
+        checkType(B.typeOf());
       }
     }
   }
-  else {
-    TypeDataMembers members(t);
-    for (auto const & m : members) {
-      MemberWithDict M(m);
-      if (!M.isTransient() && !M.isStatic()) {
-        checkType(M.typeOf());
+
+  StringSet&
+  missingTypes() {
+    return missingTypes_;
+  }
+
+  StringSet&
+  foundTypes() {
+    // The only purpose of this cache is to stop infinite recursion.
+    // ROOT maintains its own internal cache.
+    return foundTypes_;
+  }
+
+  void
+  checkDictionaries(std::string const& name, bool noComponents) {
+    TypeWithDict null;
+    TypeWithDict t(TypeWithDict::byName(name));
+    if (!bool(t)) {
+      //if (name == std::string("void")) {
+      //  foundTypes().insert(name);
+      //}
+      //else {
+        missingTypes().insert(name);
+      //}
+      return;
+    }
+    checkType(t, noComponents);
+  }
+
+  void
+  throwMissingDictionariesException() {
+    if (!missingTypes().empty()) {
+      std::ostringstream ostr;
+      for (StringSet::const_iterator it = missingTypes().begin(),
+           itEnd = missingTypes().end();
+           it != itEnd; ++it) {
+        ostr << *it << "\n\n";
+      }
+      throw Exception(errors::DictionaryNotFound)
+          << "No REFLEX data dictionary found for the following classes:\n\n"
+          << ostr.str()
+          << "Most likely each dictionary was never generated,\n"
+          << "but it may be that it was generated in the wrong package.\n"
+          << "Please add (or move) the specification\n"
+          << "<class name=\"whatever\"/>\n"
+          << "to the appropriate classes_def.xml file.\n"
+          << "If the class is a template instance, you may need\n"
+          << "to define a dummy variable of this type in classes.h.\n"
+          << "Also, if this class has any transient members,\n"
+          << "you need to specify them in classes_def.xml.";
+    }
+  }
+
+  void
+  loadMissingDictionaries() {
+    while (!missingTypes().empty()) {
+      StringSet missing(missingTypes());
+      for (StringSet::const_iterator it = missing.begin(), itEnd = missing.end();
+           it != itEnd; ++it) {
+        try {
+          gROOT->GetClass(it->c_str(), kTRUE);
+        }
+        // We don't want to fail if we can't load a plug-in.
+        catch (...) {}
+      }
+      missingTypes().clear();
+      for (StringSet::const_iterator it = missing.begin(), itEnd = missing.end();
+           it != itEnd; ++it) {
+        checkDictionaries(*it);
+      }
+      if (missingTypes() == missing) {
+        break;
       }
     }
-    TypeBases bases(t);
-    for (auto const & b : bases) {
-      BaseWithDict B(b);
-      checkType(B.typeOf());
+    if (missingTypes().empty()) {
+      return;
     }
+    throwMissingDictionariesException();
   }
-}
 
-StringSet&
-missingTypes()
-{
-  return missingTypes_;
-}
-
-StringSet&
- foundTypes()
-{
-  // The only purpose of this cache is to stop infinite recursion.
-  // ROOT maintains its own internal cache.
-  return foundTypes_;
-}
-
-void
-checkDictionaries(std::string const& name, bool noComponents)
-{
-  TypeWithDict null;
-  TypeWithDict t(TypeWithDict::byName(name));
-  if (!bool(t)) {
-    //if (name == std::string("void")) {
-    //  foundTypes().insert(name);
-    //}
-    //else {
-      missingTypes().insert(name);
-    //}
-    return;
-  }
-  checkType(t, noComponents);
-}
-
-void
-throwMissingDictionariesException()
-{
-  if (!missingTypes().empty()) {
-    std::ostringstream ostr;
-    for (StringSet::const_iterator it = missingTypes().begin(),
-         itEnd = missingTypes().end();
-         it != itEnd; ++it) {
-      ostr << *it << "\n\n";
+  void
+  public_base_classes(TypeWithDict const& typeID,
+                      std::vector<TypeWithDict>& baseTypes) {
+    TypeWithDict type(typeID.typeInfo());
+    if (!type.isClass()) {
+      return;
     }
-    throw Exception(errors::DictionaryNotFound)
-        << "No REFLEX data dictionary found for the following classes:\n\n"
-        << ostr.str()
-        << "Most likely each dictionary was never generated,\n"
-        << "but it may be that it was generated in the wrong package.\n"
-        << "Please add (or move) the specification\n"
-        << "<class name=\"whatever\"/>\n"
-        << "to the appropriate classes_def.xml file.\n"
-        << "If the class is a template instance, you may need\n"
-        << "to define a dummy variable of this type in classes.h.\n"
-        << "Also, if this class has any transient members,\n"
-        << "you need to specify them in classes_def.xml.";
-  }
-}
-
-void
-loadMissingDictionaries()
-{
-  while (!missingTypes().empty()) {
-    StringSet missing(missingTypes());
-    for (StringSet::const_iterator it = missing.begin(), itEnd = missing.end();
-         it != itEnd; ++it) {
-      try {
-        gROOT->GetClass(it->c_str(), kTRUE);
+    TypeBases bases(type);
+    for (auto const& basex : bases) {
+      BaseWithDict base(basex);
+      if (!base.isPublic()) {
+        continue;
       }
-      // We don't want to fail if we can't load a plug-in.
-      catch (...) {}
-    }
-    missingTypes().clear();
-    for (StringSet::const_iterator it = missing.begin(), itEnd = missing.end();
-         it != itEnd; ++it) {
-      checkDictionaries(*it);
-    }
-    if (missingTypes() == missing) {
-      break;
+      TypeWithDict baseRflxType = base.typeOf();
+      if (!bool(baseRflxType)) {
+        continue;
+      }
+      TypeWithDict baseType(baseRflxType.typeInfo());
+      // Check to make sure this base appears only once in the
+      // inheritance heirarchy.
+      if (!search_all(baseTypes, baseType)) {
+        // Save the type and recursive look for its base types
+        baseTypes.push_back(baseType);
+        public_base_classes(baseType, baseTypes);
+      }
+      // For now just ignore it if the class appears twice,
+      // After some more testing we may decide to uncomment the following
+      // exception.
+      //
+      //else {
+      //  throw Exception(errors::UnimplementedFeature)
+      //    << "DataFormats/Common/src/DictionaryTools.cc in function public_base_classes.\n"
+      //    << "Encountered class that has a public base class that appears\n"
+      //    << "multiple times in its inheritance heirarchy.\n"
+      //    << "Please contact the EDM Framework group with details about\n"
+      //    << "this exception. It was our hope that this complicated situation\n"
+      //    << "would not occur. There are three possible solutions. 1. Change\n"
+      //    << "the class design so the public base class does not appear multiple\n"
+      //    << "times in the inheritance heirarchy. In many cases, this is a\n"
+      //    << "sign of bad design. 2. Modify the code that supports Views to\n"
+      //    << "ignore these base classes, but not supply support for creating a\n"
+      //    << "View of this base class. 3. Improve the View infrastructure to\n"
+      //    << "deal with this case. Class name of base class: " << baseType.Name() << "\n\n";
+      //}
     }
   }
-  if (missingTypes().empty()) {
-    return;
-  }
-  throwMissingDictionariesException();
-}
-
-void
-public_base_classes(const TypeWithDict& typeID,
-                    std::vector<TypeWithDict>& baseTypes)
-{
-  TypeWithDict type(typeID.typeInfo());
-  if (!type.isClass()) {
-    return;
-  }
-  TypeBases bases(type);
-  for (auto const & basex : bases) {
-    BaseWithDict base(basex);
-    if (!base.isPublic()) {
-      continue;
-    }
-    TypeWithDict baseRflxType = base.typeOf();
-    if (!bool(baseRflxType)) {
-      continue;
-    }
-    TypeWithDict baseType(baseRflxType.typeInfo());
-    // Check to make sure this base appears only once in the
-    // inheritance heirarchy.
-    if (!search_all(baseTypes, baseType)) {
-      // Save the type and recursive look for its base types
-      baseTypes.push_back(baseType);
-      public_base_classes(baseType, baseTypes);
-    }
-    // For now just ignore it if the class appears twice,
-    // After some more testing we may decide to uncomment the following
-    // exception.
-    //
-    //else {
-    //  throw Exception(errors::UnimplementedFeature)
-    //    << "DataFormats/Common/src/DictionaryTools.cc in function public_base_classes.\n"
-    //    << "Encountered class that has a public base class that appears\n"
-    //    << "multiple times in its inheritance heirarchy.\n"
-    //    << "Please contact the EDM Framework group with details about\n"
-    //    << "this exception. It was our hope that this complicated situation\n"
-    //    << "would not occur. There are three possible solutions. 1. Change\n"
-    //    << "the class design so the public base class does not appear multiple\n"
-    //    << "times in the inheritance heirarchy. In many cases, this is a\n"
-    //    << "sign of bad design. 2. Modify the code that supports Views to\n"
-    //    << "ignore these base classes, but not supply support for creating a\n"
-    //    << "View of this base class. 3. Improve the View infrastructure to\n"
-    //    << "deal with this case. Class name of base class: " << baseType.Name() << "\n\n";
-    //}
-  }
-}
 
 } // namespace edm
-

--- a/FWCore/Utilities/src/FunctionWithDict.cc
+++ b/FWCore/Utilities/src/FunctionWithDict.cc
@@ -10,173 +10,127 @@
 
 namespace edm {
 
-FunctionWithDict::
-FunctionWithDict()
-  : function_(nullptr)
-{
-}
-
-FunctionWithDict::
-FunctionWithDict(TMethod* meth)
-  : function_(meth)
-{
-}
-
-FunctionWithDict::
-operator bool() const
-{
-  if (function_ == nullptr) {
-    return false;
+  FunctionWithDict::FunctionWithDict() : function_(nullptr) {
   }
-  return function_->IsValid();
-}
 
-std::string
-FunctionWithDict::
-name() const
-{
-  return function_->GetName();
-}
-
-std::string
-FunctionWithDict::
-typeName() const
-{
-  return function_->GetReturnTypeName();
-}
-
-TypeWithDict
-FunctionWithDict::
-typeOf() const
-{
-  return TypeWithDict::byName(function_->GetReturnTypeName());
-}
-
-TypeWithDict
-FunctionWithDict::
-returnType() const
-{
-  return TypeWithDict::byName(function_->GetReturnTypeName());
-}
-
-TypeWithDict
-FunctionWithDict::
-finalReturnType() const
-{
-  return TypeWithDict::byName(function_->GetReturnTypeNormalizedName());
-}
-
-TypeWithDict
-FunctionWithDict::
-declaringType() const
-{
-  return TypeWithDict(function_->GetClass());
-}
-
-bool
-FunctionWithDict::
-isConst() const
-{
-  return function_->Property() & kIsConstMethod;
-}
-
-bool
-FunctionWithDict::
-isConstructor() const
-{
-  return function_->ExtraProperty() & kIsConstructor;
-}
-
-bool
-FunctionWithDict::
-isDestructor() const
-{
-  return function_->ExtraProperty() & kIsDestructor;
-}
-
-bool
-FunctionWithDict::
-isOperator() const
-{
-  return function_->ExtraProperty() & kIsOperator;
-}
-
-bool
-FunctionWithDict::
-isPublic() const
-{
-  return function_->Property() & kIsPublic;
-}
-
-bool FunctionWithDict::
-isStatic() const
-{
-  return function_->Property() & kIsStatic;
-}
-
-size_t
-FunctionWithDict::
-functionParameterSize(bool required/*= false*/) const
-{
-  if (required) {
-    return function_->GetNargs() - function_->GetNargsOpt();
+  FunctionWithDict::FunctionWithDict(TMethod* meth) : function_(meth) {
   }
-  return function_->GetNargs();
-}
 
-size_t
-FunctionWithDict::
-size() const
-{
-  return function_->GetNargs();
-}
-
-/// Call a member function.
-void
-FunctionWithDict::
-invoke(const ObjectWithDict& obj, ObjectWithDict* ret/*=nullptr*/,
-       const std::vector<void*>& values/*=std::vector<void*>()*/) const
-{
-  //Reflex::Object reflexReturn(ret->typeOf().type_, ret->address());
-  //function_.Invoke(Reflex::Object(obj.typeOf().type_, obj.address()), &reflexReturn, values);
-  if (ret == nullptr) {
-    gInterpreter->ExecuteWithArgsAndReturn(function_, obj.address(), values, 0);
-    return;
+  FunctionWithDict::operator bool() const {
+    if (function_ == nullptr) {
+      return false;
+    }
+    return function_->IsValid();
   }
-  gInterpreter->ExecuteWithArgsAndReturn(function_, obj.address(), values, ret->address());
-}
 
-/// Call a static function.
-void
-FunctionWithDict::
-invoke(ObjectWithDict* ret/*=nullptr*/,
-       const std::vector<void*>& values/*=std::vector<void*>()*/) const
-{
-  //Reflex::Object reflexReturn(ret->typeOf().type_, ret->address());
-  //function_.Invoke(obj.address()), &reflexReturn, values);
-  if (ret == nullptr) {
-    gInterpreter->ExecuteWithArgsAndReturn(function_, 0, values, 0);
-    return;
+  std::string FunctionWithDict::name() const {
+    return function_->GetName();
   }
-  gInterpreter->ExecuteWithArgsAndReturn(function_, 0, values, ret->address());
-}
 
-IterWithDict<TMethodArg>
-FunctionWithDict::
-begin() const
-{
-  if (function_ == nullptr) {
+  std::string
+  FunctionWithDict::typeName() const {
+    return function_->GetReturnTypeName();
+  }
+
+  TypeWithDict
+  FunctionWithDict::typeOf() const {
+    return TypeWithDict::byName(function_->GetReturnTypeName());
+  }
+
+  TypeWithDict
+  FunctionWithDict::returnType() const {
+    return TypeWithDict::byName(function_->GetReturnTypeName());
+  }
+
+  TypeWithDict
+  FunctionWithDict::finalReturnType() const {
+    return TypeWithDict::byName(function_->GetReturnTypeNormalizedName());
+  }
+
+  TypeWithDict
+  FunctionWithDict::declaringType() const {
+    return TypeWithDict(function_->GetClass());
+  }
+
+  bool
+  FunctionWithDict::isConst() const {
+    return function_->Property() & kIsConstMethod;
+  }
+
+  bool
+  FunctionWithDict::isConstructor() const {
+    return function_->ExtraProperty() & kIsConstructor;
+  }
+
+  bool
+  FunctionWithDict::isDestructor() const {
+    return function_->ExtraProperty() & kIsDestructor;
+  }
+
+  bool
+  FunctionWithDict::isOperator() const {
+    return function_->ExtraProperty() & kIsOperator;
+  }
+
+  bool
+  FunctionWithDict::isPublic() const {
+    return function_->Property() & kIsPublic;
+  }
+
+  bool FunctionWithDict::isStatic() const {
+    return function_->Property() & kIsStatic;
+  }
+
+  size_t
+  FunctionWithDict::functionParameterSize(bool required/*= false*/) const {
+    if (required) {
+      return function_->GetNargs() - function_->GetNargsOpt();
+    }
+    return function_->GetNargs();
+  }
+
+  size_t
+  FunctionWithDict::size() const {
+    return function_->GetNargs();
+  }
+
+  /// Call a member function.
+  void
+  FunctionWithDict::invoke(ObjectWithDict const& obj, ObjectWithDict* ret/*=nullptr*/,
+         std::vector<void*> const& values/*=std::vector<void*>()*/) const {
+    //Reflex::Object reflexReturn(ret->typeOf().type_, ret->address());
+    //function_.Invoke(Reflex::Object(obj.typeOf().type_, obj.address()), &reflexReturn, values);
+    if (ret == nullptr) {
+      gInterpreter->ExecuteWithArgsAndReturn(function_, obj.address(), values, 0);
+      return;
+    }
+    gInterpreter->ExecuteWithArgsAndReturn(function_, obj.address(), values, ret->address());
+  }
+
+  /// Call a static function.
+  void
+  FunctionWithDict::invoke(ObjectWithDict* ret/*=nullptr*/,
+         std::vector<void*> const& values/*=std::vector<void*>()*/) const {
+    //Reflex::Object reflexReturn(ret->typeOf().type_, ret->address());
+    //function_.Invoke(obj.address()), &reflexReturn, values);
+    if (ret == nullptr) {
+      gInterpreter->ExecuteWithArgsAndReturn(function_, 0, values, 0);
+      return;
+    }
+    gInterpreter->ExecuteWithArgsAndReturn(function_, 0, values, ret->address());
+  }
+
+  IterWithDict<TMethodArg>
+  FunctionWithDict::begin() const {
+    if (function_ == nullptr) {
+      return IterWithDict<TMethodArg>();
+    }
+    return IterWithDict<TMethodArg>(function_->GetListOfMethodArgs());
+  }
+
+  IterWithDict<TMethodArg>
+  FunctionWithDict::end() const {
     return IterWithDict<TMethodArg>();
   }
-  return IterWithDict<TMethodArg>(function_->GetListOfMethodArgs());
-}
-
-IterWithDict<TMethodArg>
-FunctionWithDict::
-end() const
-{
-  return IterWithDict<TMethodArg>();
-}
 
 } // namespace edm
-

--- a/FWCore/Utilities/src/IterWithDict.cc
+++ b/FWCore/Utilities/src/IterWithDict.cc
@@ -3,67 +3,52 @@
 
 namespace edm {
 
-void
-IterWithDictBase::
-advance()
-{
-  if (atEnd_) {
-    return;
+  void
+  IterWithDictBase::advance() {
+    if (atEnd_) {
+      return;
+    }
+    TObject* obj = iter_.Next();
+    if (obj == nullptr) {
+      atEnd_ = true;
+    }
   }
-  TObject* obj = iter_.Next();
-  if (obj == nullptr) {
-    atEnd_ = true;
-  }
-}
 
-const TIter&
-IterWithDictBase::
-iter() const
-{
-  return iter_;
-}
-
-IterWithDictBase::
-IterWithDictBase()
-  : iter_(static_cast<TList*>(nullptr))
-  , atEnd_(true)
-{
-  // This ctor is used by the framework for the end of a range,
-  // or for any type that does not have a TClass.
-  // An iterator constructed by this ctor must not be used
-  // as the left hand argument of operator!=().
-}
-
-IterWithDictBase::
-IterWithDictBase(TList* list)
-  : iter_(list)
-  , atEnd_(false)
-{
-  // With a TIter, you must call Next() once to point to the first element.
-  TObject* obj = iter_.Next();
-  if (obj == nullptr) {
-    atEnd_ = true;
+  TIter const&
+  IterWithDictBase::iter() const {
+    return iter_;
   }
-}
 
-bool
-IterWithDictBase::
-operator!=(const IterWithDictBase& rhs) const
-{
-  // The special cases are needed because TIter::operator!=()
-  // dereferences a null pointer (i.e. segfaults) if the left hand TIter
-  // was constucted with a nullptr argument (the first constructor above).
-  if (atEnd_ != rhs.atEnd_) {
-    // one iterator at end, but not both
-    return true;
+  IterWithDictBase::IterWithDictBase() : iter_(static_cast<TList*>(nullptr)), atEnd_(true) {
+    // This ctor is used by the framework for the end of a range,
+    // or for any type that does not have a TClass.
+    // An iterator constructed by this ctor must not be used
+    // as the left hand argument of operator!=().
   }
-  if (atEnd_) {
-    // both iterators at end
-    return false;
+
+  IterWithDictBase::IterWithDictBase(TList* list) : iter_(list), atEnd_(false) {
+    // With a TIter, you must call Next() once to point to the first element.
+    TObject* obj = iter_.Next();
+    if (obj == nullptr) {
+      atEnd_ = true;
+    }
   }
-  // neither iterator at end
-  return iter_ != rhs.iter_;
-}
+
+  bool
+  IterWithDictBase::operator!=(IterWithDictBase const& rhs) const {
+    // The special cases are needed because TIter::operator!=()
+    // dereferences a null pointer (i.e. segfaults) if the left hand TIter
+    // was constucted with a nullptr argument (the first constructor above).
+    if (atEnd_ != rhs.atEnd_) {
+      // one iterator at end, but not both
+      return true;
+    }
+    if (atEnd_) {
+      // both iterators at end
+      return false;
+    }
+    // neither iterator at end
+    return iter_ != rhs.iter_;
+  }
 
 } // namespace edm
-

--- a/FWCore/Utilities/src/MemberWithDict.cc
+++ b/FWCore/Utilities/src/MemberWithDict.cc
@@ -5,91 +5,64 @@
 
 namespace edm {
 
-MemberWithDict::MemberWithDict()
-  : dataMember_()
-{
-}
+  MemberWithDict::MemberWithDict() : dataMember_() {
+  }
 
-MemberWithDict::MemberWithDict(TDataMember* dataMember)
-  : dataMember_(dataMember)
-{
-}
+  MemberWithDict::MemberWithDict(TDataMember* dataMember) : dataMember_(dataMember) {
+  }
 
-MemberWithDict::
-operator bool() const
-{
-  return dataMember_ != nullptr;
-}
+  MemberWithDict::operator bool() const {
+    return dataMember_ != nullptr;
+  }
 
-std::string
-MemberWithDict::
-name() const
-{
-  return dataMember_->GetName();
-}
+  std::string
+  MemberWithDict::name() const {
+    return dataMember_->GetName();
+  }
 
-TypeWithDict
-MemberWithDict::
-typeOf() const
-{
-  return TypeWithDict::byName(dataMember_->GetTypeName(), dataMember_->Property());
-}
+  TypeWithDict
+  MemberWithDict::typeOf() const {
+    return TypeWithDict::byName(dataMember_->GetTypeName(), dataMember_->Property());
+  }
 
-TypeWithDict
-MemberWithDict::
-declaringType() const
-{
-  return TypeWithDict(dataMember_->GetClass(), dataMember_->Property());
-}
+  TypeWithDict
+  MemberWithDict::declaringType() const {
+    return TypeWithDict(dataMember_->GetClass(), dataMember_->Property());
+  }
 
-bool
-MemberWithDict::
-isConst() const
-{
-  return dataMember_->Property() & kIsConstant;
-}
+  bool
+  MemberWithDict::isConst() const {
+    return dataMember_->Property() & kIsConstant;
+  }
 
-bool
-MemberWithDict::
-isPublic() const
-{
-  return dataMember_->Property() & kIsPublic;
-}
+  bool
+  MemberWithDict::isPublic() const {
+    return dataMember_->Property() & kIsPublic;
+  }
 
-bool
-MemberWithDict::
-isStatic() const
-{
-  return dataMember_->Property() & kIsStatic;
-}
+  bool
+  MemberWithDict::isStatic() const {
+    return dataMember_->Property() & kIsStatic;
+  }
 
-bool
-MemberWithDict::
-isTransient() const
-{
-  return !dataMember_->IsPersistent();
-}
+  bool
+  MemberWithDict::isTransient() const {
+    return !dataMember_->IsPersistent();
+  }
 
-size_t
-MemberWithDict::
-offset() const
-{
-  return dataMember_->GetOffset();
-}
+  size_t
+  MemberWithDict::offset() const {
+    return dataMember_->GetOffset();
+  }
 
-ObjectWithDict
-MemberWithDict::
-get() const
-{
-  return ObjectWithDict(typeOf(), reinterpret_cast<void*>(dataMember_->GetOffset()));
-}
+  ObjectWithDict
+  MemberWithDict::get() const {
+    return ObjectWithDict(typeOf(), reinterpret_cast<void*>(dataMember_->GetOffset()));
+  }
 
-ObjectWithDict
-MemberWithDict::
-get(ObjectWithDict const& obj) const
-{
-  return ObjectWithDict(typeOf(), reinterpret_cast<char*>(obj.address()) + dataMember_->GetOffset());
-}
+  ObjectWithDict
+  MemberWithDict::get(ObjectWithDict const& obj) const {
+    return ObjectWithDict(typeOf(), reinterpret_cast<char*>(obj.address()) + dataMember_->GetOffset());
+  }
 
 } // namespace edm
-

--- a/FWCore/Utilities/src/ObjectWithDict.cc
+++ b/FWCore/Utilities/src/ObjectWithDict.cc
@@ -5,113 +5,87 @@
 
 namespace edm {
 
-ObjectWithDict
-ObjectWithDict::
-byType(const TypeWithDict& type)
-{
-  ObjectWithDict obj(type.construct());
-  return obj;
-}
+  ObjectWithDict
+  ObjectWithDict::byType(TypeWithDict const& type) {
+    ObjectWithDict obj(type.construct());
+    return obj;
+  }
 
-ObjectWithDict::
-ObjectWithDict()
-  : type_(nullptr)
-  , address_(nullptr)
-{
-}
+  ObjectWithDict::ObjectWithDict() : type_(nullptr), address_(nullptr) {
+  }
 
-ObjectWithDict::
-ObjectWithDict(const TypeWithDict& type, void* address)
-  : type_(gInterpreter->Type_Factory(type.typeInfo()))
-  , address_(address)
-{
-}
+  ObjectWithDict::ObjectWithDict(TypeWithDict const& type, void* address) :
+    type_(gInterpreter->Type_Factory(type.typeInfo())),
+    address_(address) {
+  }
 
-ObjectWithDict::ObjectWithDict(const std::type_info& ti, void* address)
-  : type_(gInterpreter->Type_Factory(ti))
-  , address_(address)
-{
-}
+  ObjectWithDict::ObjectWithDict(std::type_info const& ti, void* address) :
+    type_(gInterpreter->Type_Factory(ti)),
+    address_(address) {
+  }
 
-ObjectWithDict::
-operator bool() const
-{
-  return gInterpreter->Type_Bool(type_) && (address_ != nullptr);
-}
+  ObjectWithDict::operator bool() const {
+    return gInterpreter->Type_Bool(type_) && (address_ != nullptr);
+  }
 
-void*
-ObjectWithDict::
-address() const
-{
-  return address_;
-}
+  void*
+  ObjectWithDict::address() const {
+    return address_;
+  }
 
-TypeWithDict
-ObjectWithDict::
-typeOf() const
-{
-  return TypeWithDict(type_);
-}
-
-class DummyVT {
-public:
-  virtual ~DummyVT();
-};
-
-DummyVT::
-~DummyVT()
-{
-}
-
-TypeWithDict
-ObjectWithDict::
-dynamicType() const
-{
-  if (!gInterpreter->Type_IsVirtual(type_)) {
+  TypeWithDict
+  ObjectWithDict::typeOf() const {
     return TypeWithDict(type_);
   }
-  // Use a dirty trick, force the typeid() operator
-  // to consult the virtual table stored at address_.
-  return TypeWithDict(typeid(*(DummyVT*)address_));
-}
 
-ObjectWithDict
-ObjectWithDict::
-get(const std::string& memberName) const
-{
-  return TypeWithDict(type_).dataMemberByName(memberName).get(*this);
-}
+  class DummyVT {
+  public:
+    virtual ~DummyVT();
+  };
 
-//ObjectWithDict
-//ObjectWithDict::
-//construct() const
-//{
-//  TypeWithDict ty(type_);
-//  TClass* cl = ty.getClass();
-//  if (cl != nullptr) {
-//    return ObjectWithDict(ty, cl->New());
-//  }
-//  return ObjectWithDict(ty, new char[ty.size()]);
-//}
-
-void
-ObjectWithDict::
-destruct(bool dealloc) const
-{
-  TypeWithDict ty(type_);
-  TClass* cl = ty.getClass();
-  if (cl != nullptr) {
-    cl->Destructor(address_, !dealloc);
-    //if (dealloc) {
-    //  address_ = nullptr;
-    //}
-    return;
+  DummyVT::~DummyVT() {
   }
-  if (dealloc) {
-    delete[] reinterpret_cast<char*>(address_);
-    //address_ = nullptr;
+
+  TypeWithDict
+  ObjectWithDict::dynamicType() const {
+    if (!gInterpreter->Type_IsVirtual(type_)) {
+      return TypeWithDict(type_);
+    }
+    // Use a dirty trick, force the typeid() operator
+    // to consult the virtual table stored at address_.
+    return TypeWithDict(typeid(*(DummyVT*)address_));
   }
-}
+
+  ObjectWithDict
+  ObjectWithDict::get(std::string const& memberName) const {
+    return TypeWithDict(type_).dataMemberByName(memberName).get(*this);
+  }
+
+  //ObjectWithDict
+  //ObjectWithDict::construct() const {
+  //  TypeWithDict ty(type_);
+  //  TClass* cl = ty.getClass();
+  //  if (cl != nullptr) {
+  //    return ObjectWithDict(ty, cl->New());
+  //  }
+  //  return ObjectWithDict(ty, new char[ty.size()]);
+  //}
+
+  void
+  ObjectWithDict::destruct(bool dealloc) const {
+    TypeWithDict ty(type_);
+    TClass* cl = ty.getClass();
+    if (cl != nullptr) {
+      cl->Destructor(address_, !dealloc);
+      //if (dealloc) {
+      //  address_ = nullptr;
+      //}
+      return;
+    }
+    if (dealloc) {
+      delete[] reinterpret_cast<char*>(address_);
+      //address_ = nullptr;
+    }
+  }
 
 } // namespace edm
-

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -26,992 +26,850 @@
 
 #include <cxxabi.h>
 
-using namespace std;
-
 namespace edm {
 
-TypeWithDict
-TypeWithDict::
-byName(string const& name, long property /*= 0L*/)
-{
-  // Note: The property flag should include kIsConstant and
-  //       kIsReference if needed since a typeid() expression
-  //       ignores those properties, so we must store them
-  //       separately.
-  TType* type = gInterpreter->Type_Factory(name);
-  if (!gInterpreter->Type_IsValid(type)) {
-    // This can happen if no dictionary has been loaded for the class or enum.
-    // If this is a class, trigger the loading of the dictionary.
-    TClass* theClass = TClass::GetClass(name.c_str());
-    if(theClass == nullptr || theClass->GetTypeInfo() == nullptr) {
-      return TypeWithDict();
+  TypeWithDict
+  TypeWithDict::byName(std::string const& name, long property /*= 0L*/) {
+    // Note: The property flag should include kIsConstant and
+    //       kIsReference if needed since a typeid() expression
+    //       ignores those properties, so we must store them
+    //       separately.
+    TType* type = gInterpreter->Type_Factory(name);
+    if (!gInterpreter->Type_IsValid(type)) {
+      // This can happen if no dictionary has been loaded for the class or enum.
+      // If this is a class, trigger the loading of the dictionary.
+      TClass* theClass = TClass::GetClass(name.c_str());
+      if(theClass == nullptr || theClass->GetTypeInfo() == nullptr) {
+        return TypeWithDict();
+      }
+      return TypeWithDict(theClass, property);
     }
-    return TypeWithDict(theClass, property);
+    return TypeWithDict(type, property);
   }
-  return TypeWithDict(type, property);
-}
 
-void
-TypeWithDict::
-setProperty()
-{
-  // Note: typeid() ignores const and volatile qualifiers, and
-  //       cannot see references.
-  //       So:
-  //            typeid(int) == typeid(const int)
-  //                        == typeid(int&)
-  //                        == typeid(const int&)
-  //
-  if (type_ == nullptr) {
-    return;
+  void
+  TypeWithDict::setProperty() {
+    // Note: typeid() ignores const and volatile qualifiers, and
+    //       cannot see references.
+    //       So:
+    //            typeid(int) == typeid(int const)
+    //                        == typeid(int&)
+    //                        == typeid(int const&)
+    //
+    if (type_ == nullptr) {
+      return;
+    }
+    if (gInterpreter->Type_IsConst(type_)) {
+      // Note: This is not possible if created by typeid.
+      property_ |= (long) kIsConstant;
+    }
+    if (gInterpreter->Type_IsReference(type_)) {
+      // Note: This is not possible if created by typeid.
+      property_ |= (long) kIsReference;
+    }
   }
-  if (gInterpreter->Type_IsConst(type_)) {
-    // Note: This is not possible if created by typeid.
-    property_ |= (long) kIsConstant;
-  }
-  if (gInterpreter->Type_IsReference(type_)) {
-    // Note: This is not possible if created by typeid.
-    property_ |= (long) kIsReference;
-  }
-}
 
-TypeWithDict::
-TypeWithDict()
-  : ti_(&typeid(void))
-  , type_(nullptr)
-  , class_(nullptr)
-  , enum_(nullptr)
-  , dataType_(nullptr)
-  , property_(0L)
-{
-}
+  TypeWithDict::TypeWithDict() :
+    ti_(&typeid(void)),
+    type_(nullptr),
+    class_(nullptr),
+    enum_(nullptr),
+    dataType_(nullptr),
+    property_(0L) {
+  }
 
-TypeWithDict::
-TypeWithDict(const TypeWithDict& rhs)
-  : ti_(rhs.ti_)
-  , type_(rhs.type_)
-  , class_(rhs.class_)
-  , enum_(rhs.enum_)
-  , dataType_(rhs.dataType_)
-  , property_(rhs.property_)
-{
-}
+  TypeWithDict::TypeWithDict(TypeWithDict const& rhs) :
+    ti_(rhs.ti_),
+    type_(rhs.type_),
+    class_(rhs.class_),
+    enum_(rhs.enum_),
+    dataType_(rhs.dataType_),
+    property_(rhs.property_) {
+  }
 
-TypeWithDict::
-TypeWithDict(TypeWithDict const& type, long prop)
-  : ti_(type.ti_)
-  , type_(type.type_)
-  , class_(type.class_)
-  , enum_(type.enum_)
-  , dataType_(type.dataType_)
-  , property_(type.property_)
-{
-  // Unconditionally modifies const and reference
-  // properties, and only those properties.
-  property_ &= ~((long) kIsConstant | (long) kIsReference);
-  if (prop & kIsConstant) {
-    property_ |= kIsConstant;
+  TypeWithDict::TypeWithDict(TypeWithDict const& type, long prop) :
+    ti_(type.ti_),
+    type_(type.type_),
+    class_(type.class_),
+    enum_(type.enum_),
+    dataType_(type.dataType_),
+    property_(type.property_) {
+    // Unconditionally modifies const and reference
+    // properties, and only those properties.
+    property_ &= ~((long) kIsConstant | (long) kIsReference);
+    if (prop & kIsConstant) {
+      property_ |= kIsConstant;
+    }
+    if (prop & kIsReference) {
+      property_ |= kIsReference;
+    }
   }
-  if (prop & kIsReference) {
-    property_ |= kIsReference;
-  }
-}
 
-TypeWithDict&
-TypeWithDict::
-operator=(const TypeWithDict& rhs)
-{
-  if (this != &rhs) {
-    ti_ = rhs.ti_;
-    type_ = rhs.type_;
-    class_ = rhs.class_;
-    enum_ = rhs.enum_;
-    dataType_ = rhs.dataType_;
-    property_ = rhs.property_;
+  TypeWithDict&
+  TypeWithDict::operator=(TypeWithDict const& rhs) {
+    if (this != &rhs) {
+      ti_ = rhs.ti_;
+      type_ = rhs.type_;
+      class_ = rhs.class_;
+      enum_ = rhs.enum_;
+      dataType_ = rhs.dataType_;
+      property_ = rhs.property_;
+    }
+    return *this;
   }
-  return *this;
-}
 
-TypeWithDict::
-TypeWithDict(const type_info& ti, long property /*= 0L*/)
-  : ti_(&ti)
-  , type_(nullptr)
-  , class_(nullptr)
-  , enum_(nullptr)
-  , dataType_(nullptr)
-  , property_(property)
-{
-  type_ = gInterpreter->Type_Factory(ti);
-  if (!gInterpreter->Type_TypeInfo(type_)) {
-    // This can happen if no dictionary has been loaded for the class or enum.
-    // If this is a class, trigger the loading of the dictionary.
-    class_ = TClass::GetClass(ti);
-  }
-  if (!gInterpreter->Type_TypeInfo(type_)) {
-    // FIXME: Replace this with an exception!
-    fprintf(stderr, "TypeWithDict(const type_info&, long): "
-            "Type_TypeInfo returns nullptr!\n");
-    abort();
-  }
-  dataType_ = TDataType::GetDataType(TDataType::GetType(ti));
-  if (class_ == nullptr &&
-      !gInterpreter->Type_IsFundamental(type_) &&
-      !gInterpreter->Type_IsEnum(type_)) {
-    // Must be a class, struct, or union.
-    class_ = TClass::GetClass(ti);
-  }
-  if (gInterpreter->Type_IsEnum(type_)) {
-    processEnumeration();
-  }
-}
+  TypeWithDict::TypeWithDict(std::type_info const& ti, long property /*= 0L*/) :
+    ti_(&ti),
+    type_(nullptr),
+    class_(nullptr),
+    enum_(nullptr),
+    dataType_(nullptr),
+    property_(property) {
 
-TypeWithDict::
-TypeWithDict(TClass* cl, long property /*= 0L*/)
-  : ti_(&typeid(void))
-  , type_(nullptr)
-  , class_(cl)
-  , enum_(nullptr)
-  , dataType_(nullptr)
-  , property_((long) kIsClass | property)
-{
-  ti_ = cl->GetTypeInfo();
-  type_ = gInterpreter->Type_Factory(*cl->GetTypeInfo());
-}
-
-TypeWithDict::
-TypeWithDict(TMethodArg* arg, long property /*= 0L*/)
-  : TypeWithDict(byName(arg->GetTypeName(), arg->Property() | property))
-{
-}
-
-TypeWithDict::
-TypeWithDict(TType* ttype, long property /*= 0L*/)
-  : ti_(&typeid(void))
-  , type_(ttype)
-  , class_(nullptr)
-  , enum_(nullptr)
-  , dataType_(nullptr)
-  , property_(property)
-{
-  if (!ttype) {
-    return;
-  }
-  {
-    const type_info* info = gInterpreter->Type_TypeInfo(ttype);
-    if (!info) {
+    type_ = gInterpreter->Type_Factory(ti);
+    if (!gInterpreter->Type_TypeInfo(type_)) {
+      // This can happen if no dictionary has been loaded for the class or enum.
+      // If this is a class, trigger the loading of the dictionary.
+      class_ = TClass::GetClass(ti);
+    }
+    if (!gInterpreter->Type_TypeInfo(type_)) {
       // FIXME: Replace this with an exception!
-      fprintf(stderr, "TypeWithDict(TType*, property): "
+      fprintf(stderr, "TypeWithDict(std::type_info const&, long): "
               "Type_TypeInfo returns nullptr!\n");
       abort();
     }
-    ti_ = info;
+    dataType_ = TDataType::GetDataType(TDataType::GetType(ti));
+    if (class_ == nullptr &&
+        !gInterpreter->Type_IsFundamental(type_) &&
+        !gInterpreter->Type_IsEnum(type_)) {
+      // Must be a class, struct, or union.
+      class_ = TClass::GetClass(ti);
+    }
+    if (gInterpreter->Type_IsEnum(type_)) {
+      processEnumeration();
+    }
   }
-  if (gInterpreter->Type_IsConst(ttype)) {
-    // Note: This is not possible if created by typeid.
-    property_ |= (long) kIsConstant;
+
+  TypeWithDict::TypeWithDict(TClass* cl, long property /*= 0L*/) :
+    ti_(&typeid(void)),
+    type_(nullptr),
+    class_(cl),
+    enum_(nullptr),
+    dataType_(nullptr),
+    property_((long) kIsClass | property) {
+
+    ti_ = cl->GetTypeInfo();
+    type_ = gInterpreter->Type_Factory(*cl->GetTypeInfo());
   }
-  if (gInterpreter->Type_IsReference(ttype)) {
-    // Note: This is not possible if created by typeid.
-    property_ |= (long) kIsReference;
+
+  TypeWithDict::TypeWithDict(TMethodArg* arg, long property /*= 0L*/) :
+    TypeWithDict(byName(arg->GetTypeName(), arg->Property() | property)) {
   }
-  dataType_ = TDataType::GetDataType(TDataType::GetType(*ti_));
-  if (!gInterpreter->Type_IsFundamental(ttype) &&
-      !gInterpreter->Type_IsEnum(ttype)) {
-    // Must be a class, struct, or union.
-    class_ = TClass::GetClass(*ti_);
+
+  TypeWithDict::TypeWithDict(TType* ttype, long property /*= 0L*/) :
+    ti_(&typeid(void)),
+    type_(ttype),
+    class_(nullptr),
+    enum_(nullptr),
+    dataType_(nullptr),
+    property_(property) {
+
+    if (!ttype) {
+      return;
+    }
+    {
+      std::type_info const* info = gInterpreter->Type_TypeInfo(ttype);
+      if (!info) {
+        // FIXME: Replace this with an exception!
+        fprintf(stderr, "TypeWithDict(TType*, property): "
+                "Type_TypeInfo returns nullptr!\n");
+        abort();
+      }
+      ti_ = info;
+    }
+    if (gInterpreter->Type_IsConst(ttype)) {
+      // Note: This is not possible if created by typeid.
+      property_ |= (long) kIsConstant;
+    }
+    if (gInterpreter->Type_IsReference(ttype)) {
+      // Note: This is not possible if created by typeid.
+      property_ |= (long) kIsReference;
+    }
+    dataType_ = TDataType::GetDataType(TDataType::GetType(*ti_));
+    if (!gInterpreter->Type_IsFundamental(ttype) &&
+        !gInterpreter->Type_IsEnum(ttype)) {
+      // Must be a class, struct, or union.
+      class_ = TClass::GetClass(*ti_);
+    }
+    if (gInterpreter->Type_IsEnum(type_)) {
+      processEnumeration();
+    }
   }
-  if (gInterpreter->Type_IsEnum(type_)) {
-    processEnumeration();
+
+  TypeWithDict::operator bool() const {
+    if (*ti_ == typeid(void)) {
+      return false;
+    }
+    if (type_ == nullptr) {
+      // FIXME: Replace this with an exception!
+      fprintf(stderr, "TypeWithDict::operator bool(): "
+              "type_ is nullptr!\n");
+      abort();
+    }
+    return gInterpreter->Type_Bool(type_);
   }
-}
 
-TypeWithDict::
-operator bool() const
-{
-  if (*ti_ == typeid(void)) {
-    return false;
+  bool
+  TypeWithDict::hasDictionary() const {
+    if (*ti_ == typeid(void)) {
+      return true;
+    }
+    if (type_ == nullptr) {
+      // FIXME: Replace this with an exception!
+      fprintf(stderr, "TypeWithDict::hasDictionary(): "
+              "type_ is nullptr!\n");
+      abort();
+    }
+    return gInterpreter->Type_Bool(type_);
   }
-  if (type_ == nullptr) {
-    // FIXME: Replace this with an exception!
-    fprintf(stderr, "TypeWithDict::operator bool(): "
-            "type_ is nullptr!\n");
-    abort();
+
+  std::type_info const&
+  TypeWithDict::typeInfo() const {
+    return *ti_;
   }
-  return gInterpreter->Type_Bool(type_);
-}
 
-bool
-TypeWithDict::
-hasDictionary() const
-{
-  if (*ti_ == typeid(void)) {
-    return true;
+  std::type_info const&
+  TypeWithDict::id() const {
+    return *ti_;
   }
-  if (type_ == nullptr) {
-    // FIXME: Replace this with an exception!
-    fprintf(stderr, "TypeWithDict::hasDictionary(): "
-            "type_ is nullptr!\n");
-    abort();
+
+  TType*
+  TypeWithDict::getType() const {
+    return type_;
   }
-  return gInterpreter->Type_Bool(type_);
-}
 
-const type_info&
-TypeWithDict::
-typeInfo() const
-{
-  return *ti_;
-}
-
-const type_info&
-TypeWithDict::
-id() const
-{
-  return *ti_;
-}
-
-TType*
-TypeWithDict::
-getType() const
-{
-  return type_;
-}
-
-TClass*
-TypeWithDict::
-getClass() const
-{
-  return class_;
-}
-
-TEnum*
-TypeWithDict::
-getEnum() const
-{
-  return enum_;
-}
-
-TDataType*
-TypeWithDict::
-getDataType() const
-{
-  return dataType_;
-}
-
-long
-TypeWithDict::
-getProperty() const
-{
-  return property_;
-}
-
-bool
-TypeWithDict::
-isClass() const
-{
-  // Note: This really means is class, struct, or union.
-  if (type_ == nullptr) {
-    return false;
+  TClass*
+  TypeWithDict::getClass() const {
+    return class_;
   }
-  return gInterpreter->Type_IsClass(type_);
-}
 
-bool
-TypeWithDict::
-isConst() const
-{
-  // Note: We must check the property flags here too because
-  //       typeid() ignores const.
-  if (type_ == nullptr) {
-    return false;
+  TEnum*
+  TypeWithDict::getEnum() const {
+    return enum_;
   }
-  return gInterpreter->Type_IsConst(type_) || (property_ & (long) kIsConstant);
-}
 
-bool
-TypeWithDict::
-isArray() const
-{
-  if (type_ == nullptr) {
-    return false;
+  TDataType*
+  TypeWithDict::getDataType() const {
+    return dataType_;
   }
-  return gInterpreter->Type_IsArray(type_);
-}
 
-bool
-TypeWithDict::
-isEnum() const
-{
-  if (type_ == nullptr) {
-    return false;
+  long
+  TypeWithDict::getProperty() const {
+    return property_;
   }
-  return gInterpreter->Type_IsEnum(type_);
-}
 
-bool
-TypeWithDict::
-isFundamental() const
-{
-  if (type_ == nullptr) {
-    return false;
+  bool
+  TypeWithDict::isClass() const {
+    // Note: This really means is class, struct, or union.
+    if (type_ == nullptr) {
+      return false;
+    }
+    return gInterpreter->Type_IsClass(type_);
   }
-  return gInterpreter->Type_IsFundamental(type_);
-}
 
-bool
-TypeWithDict::
-isPointer() const
-{
-  if (type_ == nullptr) {
-    return false;
+  bool
+  TypeWithDict::isConst() const {
+    // Note: We must check the property flags here too because
+    //       typeid() ignores const.
+    if (type_ == nullptr) {
+      return false;
+    }
+    return gInterpreter->Type_IsConst(type_) || (property_ & (long) kIsConstant);
   }
-  return gInterpreter->Type_IsPointer(type_);
-}
 
-bool
-TypeWithDict::
-isReference() const
-{
-  // Note: We must check the property flags here too because
-  //       typeid() ignores references.
-  if (type_ == nullptr) {
-    return false;
+  bool
+  TypeWithDict::isArray() const {
+    if (type_ == nullptr) {
+      return false;
+    }
+    return gInterpreter->Type_IsArray(type_);
   }
-  return gInterpreter->Type_IsReference(type_) ||
-         (property_ & (long) kIsReference);
-}
 
-bool
-TypeWithDict::
-isTemplateInstance() const
-{
-  if (type_ == nullptr) {
-    return false;
+  bool
+  TypeWithDict::isEnum() const {
+    if (type_ == nullptr) {
+      return false;
+    }
+    return gInterpreter->Type_IsEnum(type_);
   }
-  return gInterpreter->Type_IsTemplateInstance(type_);
-}
 
-bool
-TypeWithDict::
-isTypedef() const
-{
-  if (type_ == nullptr) {
-    return false;
+  bool
+  TypeWithDict::isFundamental() const {
+    if (type_ == nullptr) {
+      return false;
+    }
+    return gInterpreter->Type_IsFundamental(type_);
   }
-  return gInterpreter->Type_IsTypedef(type_);
-}
 
-bool
-TypeWithDict::
-isVirtual() const
-{
-  if (type_ == nullptr) {
-    return false;
+  bool
+  TypeWithDict::isPointer() const {
+    if (type_ == nullptr) {
+      return false;
+    }
+    return gInterpreter->Type_IsPointer(type_);
   }
-  return gInterpreter->Type_IsVirtual(type_);
-}
 
-void
-TypeWithDict::
-print(ostream& os) const
-{
-  os << name();
-}
+  bool
+  TypeWithDict::isReference() const {
+    // Note: We must check the property flags here too because
+    //       typeid() ignores references.
+    if (type_ == nullptr) {
+      return false;
+    }
+    return gInterpreter->Type_IsReference(type_) ||
+           (property_ & (long) kIsReference);
+  }
 
-string
-TypeWithDict::
-qualifiedName() const
-{
-  if (type_ == nullptr) {
-    return "undefined";
+  bool
+  TypeWithDict::isTemplateInstance() const {
+    if (type_ == nullptr) {
+      return false;
+    }
+    return gInterpreter->Type_IsTemplateInstance(type_);
   }
-  string qname(name());
-  if (isConst()) {
-    qname = "const " + qname;
-  }
-  if (isReference()) {
-    qname += '&';
-  }
-  return qname;
-}
 
-string
-TypeWithDict::
-unscopedName() const
-{
-  if (type_ == nullptr) {
-    return "undefined";
+  bool
+  TypeWithDict::isTypedef() const {
+    if (type_ == nullptr) {
+      return false;
+    }
+    return gInterpreter->Type_IsTypedef(type_);
   }
-  return stripNamespace(name());
-}
 
-string
-TypeWithDict::
-name() const
-{
-  if (type_ == nullptr) {
-    return "undefined";
+  bool
+  TypeWithDict::isVirtual() const {
+    if (type_ == nullptr) {
+      return false;
+    }
+    return gInterpreter->Type_IsVirtual(type_);
   }
-  return TypeID(*ti_).className();
-}
 
-string
-TypeWithDict::
-userClassName() const
-{
-  //FIXME: What about const and reference?
-  if (type_ == nullptr) {
-    return "undefined";
+  void
+  TypeWithDict::print(std::ostream& os) const {
+    os << name();
   }
-  return TypeID(*ti_).userClassName();
-}
 
-string
-TypeWithDict::
-friendlyClassName() const
-{
-  //FIXME: What about const and reference?
-  if (type_ == nullptr) {
-    return "undefined";
+  std::string
+  TypeWithDict::qualifiedName() const {
+    if (type_ == nullptr) {
+      return "undefined";
+    }
+    std::string qname(name());
+    if (isConst()) {
+      qname = "const " + qname;
+    }
+    if (isReference()) {
+      qname += '&';
+    }
+    return qname;
   }
-  return TypeID(*ti_).friendlyClassName();
-}
 
-size_t
-TypeWithDict::
-size() const
-{
-  if (type_ == nullptr) {
+  std::string
+  TypeWithDict::unscopedName() const {
+    if (type_ == nullptr) {
+      return "undefined";
+    }
+    return stripNamespace(name());
+  }
+
+  std::string
+  TypeWithDict::name() const {
+    if (type_ == nullptr) {
+      return "undefined";
+    }
+    return TypeID(*ti_).className();
+  }
+
+  std::string
+  TypeWithDict::userClassName() const {
+    //FIXME: What about const and reference?
+    if (type_ == nullptr) {
+      return "undefined";
+    }
+    return TypeID(*ti_).userClassName();
+  }
+
+  std::string
+  TypeWithDict::friendlyClassName() const {
+    //FIXME: What about const and reference?
+    if (type_ == nullptr) {
+      return "undefined";
+    }
+    return TypeID(*ti_).friendlyClassName();
+  }
+
+  size_t
+  TypeWithDict::size() const {
+    if (type_ == nullptr) {
+      return 0;
+    }
+    return gInterpreter->Type_Size(type_);
+  }
+
+  size_t
+  TypeWithDict::arrayLength() const {
+    if (type_ == nullptr) {
+      return 0;
+    }
+    return gInterpreter->Type_ArraySize(type_);
+  }
+
+  size_t
+  TypeWithDict::dataMemberSize() const {
+    if (class_ != nullptr) {
+      return class_->GetListOfDataMembers()->GetSize();
+    }
+    if (enum_ != nullptr) {
+      return enum_->GetConstants()->GetSize();
+    }
     return 0;
   }
-  return gInterpreter->Type_Size(type_);
-}
 
-size_t
-TypeWithDict::
-arrayLength() const
-{
-  if (type_ == nullptr) {
+  size_t
+  TypeWithDict::functionMemberSize() const {
+    if (class_ != nullptr) {
+      return class_->GetListOfMethods()->GetSize();
+    }
     return 0;
   }
-  return gInterpreter->Type_ArraySize(type_);
-}
 
-size_t
-TypeWithDict::
-dataMemberSize() const
-{
-  if (class_ != nullptr) {
-    return class_->GetListOfDataMembers()->GetSize();
+  void const*
+  TypeWithDict::pointerToBaseType(void const* ptr, TypeWithDict const& derivedType) const {
+    if (this->ti_ == derivedType.ti_ || *this->ti_ == *derivedType.ti_) {
+      return ptr;
+    }
+    int offset = derivedType.getBaseClassOffset(*this);
+    if (offset < 0) {
+      return nullptr;
+    }
+    return static_cast<char const*>(ptr) + offset;
   }
-  if (enum_ != nullptr) {
-    return enum_->GetConstants()->GetSize();
+
+  void const*
+  TypeWithDict::pointerToContainedType(void const* ptr, TypeWithDict const& derivedType) const {
+    return pointerToBaseType(ptr, derivedType);
   }
-  return 0;
-}
 
-size_t
-TypeWithDict::
-functionMemberSize() const
-{
-  if (class_ != nullptr) {
-    return class_->GetListOfMethods()->GetSize();
+  TypeWithDict
+  TypeWithDict::nestedType(char const* nestedName) const {
+    return byName(name() + "::" + nestedName);
   }
-  return 0;
-}
 
-const void*
-TypeWithDict::
-pointerToBaseType(const void* ptr, const TypeWithDict& derivedType) const
-{
-  if (this->ti_ == derivedType.ti_ || *this->ti_ == *derivedType.ti_) {
-    return ptr;
+  TypeWithDict
+  TypeWithDict::nestedType(std::string const& nestedName) const {
+    return byName(name() + "::" + nestedName);
   }
-  int offset = derivedType.getBaseClassOffset(*this);
-  if (offset < 0) {
-    return nullptr;
+
+  MemberWithDict
+  TypeWithDict::dataMemberByName(std::string const& member) const {
+    if (class_ != nullptr) {
+      return MemberWithDict(class_->GetDataMember(member.c_str()));
+    }
+    if (enum_ != nullptr) {
+      TClass* cl = enum_->GetClass();
+      return MemberWithDict(cl->GetDataMember(member.c_str()));
+    }
+    return MemberWithDict();
   }
-  return static_cast<char const*>(ptr) + offset;
-}
 
-const void*
-TypeWithDict::
-pointerToContainedType(const void* ptr, const TypeWithDict& derivedType) const
-{
-  return pointerToBaseType(ptr, derivedType);
-}
-
-TypeWithDict
-TypeWithDict::
-nestedType(char const* nestedName) const
-{
-  return byName(name() + "::" + nestedName);
-}
-
-TypeWithDict
-TypeWithDict::
-nestedType(const string& nestedName) const
-{
-  return byName(name() + "::" + nestedName);
-}
-
-MemberWithDict
-TypeWithDict::
-dataMemberByName(const string& member) const
-{
-  if (class_ != nullptr) {
-    return MemberWithDict(class_->GetDataMember(member.c_str()));
+  FunctionWithDict
+  TypeWithDict::functionMemberByName(std::string const& member) const {
+    if (class_ == nullptr) {
+      return FunctionWithDict();
+    }
+    TMethod* meth = reinterpret_cast<TMethod*>(
+      class_->GetListOfMethods()->FindObject(member.c_str()));
+    if (meth == nullptr) {
+      return FunctionWithDict();
+    }
+    return FunctionWithDict(meth);
   }
-  if (enum_ != nullptr) {
-    TClass* cl = enum_->GetClass();
-    return MemberWithDict(cl->GetDataMember(member.c_str()));
-  }
-  return MemberWithDict();
-}
 
-FunctionWithDict
-TypeWithDict::
-functionMemberByName(const string& member) const
-{
-  if (class_ == nullptr) {
-    return FunctionWithDict();
-  }
-  TMethod* meth = reinterpret_cast<TMethod*>(
-    class_->GetListOfMethods()->FindObject(member.c_str()));
-  if (meth == nullptr) {
-    return FunctionWithDict();
-  }
-  return FunctionWithDict(meth);
-}
+  //FunctionWithDict
+  //TypeWithDict::functionMemberByName(std::string const& member, TypeWithDict const& signature, int mods, TypeMemberQuery memberQuery) const {
+  //  return FunctionWithDict(type_.FunctionMemberByName(member, signature.type_,
+  //                          mods, static_cast<Reflex::EMEMBERQUERY>(memberQuery)));
+  //}
 
-//FunctionWithDict
-//TypeWithDict::
-//functionMemberByName(string const& member, TypeWithDict const& signature, int mods, TypeMemberQuery memberQuery) const
-//{
-//  return FunctionWithDict(type_.FunctionMemberByName(member, signature.type_,
-//                          mods, static_cast<Reflex::EMEMBERQUERY>(memberQuery)));
-//}
-
-TypeWithDict
-TypeWithDict::
-finalType() const
-{
-  TypeWithDict ret;
-  if (type_ == nullptr) {
+  TypeWithDict
+  TypeWithDict::finalType() const {
+    TypeWithDict ret;
+    if (type_ == nullptr) {
+      return ret;
+    }
+    TType* ty = gInterpreter->Type_FinalType(type_);
+    if (ty == nullptr) {
+      return ret;
+    }
+    std::type_info const* ti = gInterpreter->Type_TypeInfo(ty);
+    if (ti == nullptr) {
+      return ret;
+    }
+    ret = TypeWithDict(*ti);
     return ret;
   }
-  TType* ty = gInterpreter->Type_FinalType(type_);
-  if (ty == nullptr) {
-    return ret;
-  }
-  const std::type_info* ti = gInterpreter->Type_TypeInfo(ty);
-  if (ti == nullptr) {
-    return ret;
-  }
-  ret = TypeWithDict(*ti);
-  return ret;
-}
 
-TypeWithDict
-TypeWithDict::
-toType() const
-{
-  TypeWithDict ret;
-  if (type_ == nullptr) {
+  TypeWithDict
+  TypeWithDict::toType() const {
+    TypeWithDict ret;
+    if (type_ == nullptr) {
+      return ret;
+    }
+    TType* ty = gInterpreter->Type_ToType(type_);
+    if (ty == nullptr) {
+      return ret;
+    }
+    std::type_info const* ti = gInterpreter->Type_TypeInfo(ty);
+    if (ti == nullptr) {
+      return ret;
+    }
+    ret = TypeWithDict(*ti);
     return ret;
   }
-  TType* ty = gInterpreter->Type_ToType(type_);
-  if (ty == nullptr) {
-    return ret;
-  }
-  const std::type_info* ti = gInterpreter->Type_TypeInfo(ty);
-  if (ti == nullptr) {
-    return ret;
-  }
-  ret = TypeWithDict(*ti);
-  return ret;
-}
 
-string
-TypeWithDict::
-templateName() const
-{
-  if (!isTemplateInstance()) {
-    return "";
-  }
-  string templateName(name());
-  auto begin = templateName.find('<');
-  assert(begin != string::npos);
-  auto end = templateName.rfind('<');
-  assert(end != string::npos);
-  assert(begin <= end);
-  if (begin < end) {
-    int depth = 1;
-    for (auto idx = begin + 1; idx <= end; ++idx) {
-      char c = templateName[idx];
-      if (c == '<') {
-        if (depth == 0) {
-          begin = idx;
+  std::string
+  TypeWithDict::templateName() const {
+    if (!isTemplateInstance()) {
+      return "";
+    }
+    std::string templateName(name());
+    auto begin = templateName.find('<');
+    assert(begin != std::string::npos);
+    auto end = templateName.rfind('<');
+    assert(end != std::string::npos);
+    assert(begin <= end);
+    if (begin < end) {
+      int depth = 1;
+      for (auto idx = begin + 1; idx <= end; ++idx) {
+        char c = templateName[idx];
+        if (c == '<') {
+          if (depth == 0) {
+            begin = idx;
+          }
+          ++depth;
         }
+        else if (c == '>') {
+          --depth;
+          assert(depth >= 0);
+        }
+      }
+    }
+    return templateName.substr(0, begin);
+  }
+
+  TypeWithDict
+  TypeWithDict::templateArgumentAt(size_t index) const {
+    std::string className(unscopedName());
+    auto begin = className.find('<');
+    if (begin == std::string::npos) {
+      return TypeWithDict();
+    }
+    ++begin;
+    auto end = className.rfind('>');
+    assert(end != std::string::npos);
+    assert(begin < end);
+    int depth = 0;
+    size_t argCount = 0;
+    for (auto idx = begin; idx < end; ++idx) {
+      char c = className[idx];
+      if (c == '<') {
         ++depth;
       }
       else if (c == '>') {
         --depth;
         assert(depth >= 0);
       }
-    }
-  }
-  return templateName.substr(0, begin);
-}
-
-TypeWithDict
-TypeWithDict::
-templateArgumentAt(size_t index) const
-{
-  string className(unscopedName());
-  auto begin = className.find('<');
-  if (begin == string::npos) {
-    return TypeWithDict();
-  }
-  ++begin;
-  auto end = className.rfind('>');
-  assert(end != string::npos);
-  assert(begin < end);
-  int depth = 0;
-  size_t argCount = 0;
-  for (auto idx = begin; idx < end; ++idx) {
-    char c = className[idx];
-    if (c == '<') {
-      ++depth;
-    }
-    else if (c == '>') {
-      --depth;
-      assert(depth >= 0);
-    }
-    else if ((depth == 0) && (c == ',')) {
-      if (argCount < index) {
-        begin = idx + 1;
-        ++argCount;
-      }
-      else {
-        end = idx;
-        break;
+      else if ((depth == 0) && (c == ',')) {
+        if (argCount < index) {
+          begin = idx + 1;
+          ++argCount;
+        }
+        else {
+          end = idx;
+          break;
+        }
       }
     }
+    assert(depth == 0);
+    if (argCount < index) {
+      return TypeWithDict();
+    }
+    return byName(className.substr(begin, end - begin));
   }
-  assert(depth == 0);
-  if (argCount < index) {
-    return TypeWithDict();
-  }
-  return byName(className.substr(begin, end - begin));
-}
 
-bool
-TypeWithDict::
-hasBase(const string& basename) const
-{
-  if (class_ == nullptr) {
-    // FIXME: Turn this into a throw!
-    fprintf(stderr, "TypeWithDict::hasBase(basename): "
-            "type is not a class!\n");
-    abort();
+  bool
+  TypeWithDict::hasBase(std::string const& basename) const {
+    if (class_ == nullptr) {
+      // FIXME: Turn this into a throw!
+      fprintf(stderr, "TypeWithDict::hasBase(basename): "
+              "type is not a class!\n");
+      abort();
+    }
+    TClass* cl = class_->GetBaseClass(basename.c_str());
+    if (cl != nullptr) {
+      return true;
+    }
+    return false;
   }
-  TClass* cl = class_->GetBaseClass(basename.c_str());
-  if (cl != nullptr) {
-    return true;
-  }
-  return false;
-}
 
-bool
-TypeWithDict::
-hasBase(const TypeWithDict& basety) const
-{
-  if (class_ == nullptr) {
-    // FIXME: Turn this into a throw!
-    fprintf(stderr, "TypeWithDict::hasBase(const TypeWithDict&): "
-            "type is not a class!\n");
-    abort();
+  bool
+  TypeWithDict::hasBase(TypeWithDict const& basety) const {
+    if (class_ == nullptr) {
+      // FIXME: Turn this into a throw!
+      fprintf(stderr, "TypeWithDict::hasBase(TypeWithDict const&): "
+              "type is not a class!\n");
+      abort();
+    }
+    if (basety.class_ == nullptr) {
+      // FIXME: Turn this into a throw!
+      fprintf(stderr, "TypeWithDict::hasBase(TypeWithDict const&): "
+              "basety is not a class!\n");
+      abort();
+    }
+    TClass* cl = class_->GetBaseClass(basety.name().c_str());
+    if (cl != nullptr) {
+      return true;
+    }
+    return false;
   }
-  if (basety.class_ == nullptr) {
-    // FIXME: Turn this into a throw!
-    fprintf(stderr, "TypeWithDict::hasBase(const TypeWithDict&): "
-            "basety is not a class!\n");
-    abort();
-  }
-  TClass* cl = class_->GetBaseClass(basety.name().c_str());
-  if (cl != nullptr) {
-    return true;
-  }
-  return false;
-}
 
-int
-TypeWithDict::
-getBaseClassOffset(const TypeWithDict& baseClass) const
-{
-  if (class_ == nullptr) {
-    // FIXME: Turn this into a throw!
-    fprintf(stderr, "TypeWithDict::getBaseClassOffset(const TypeWithDict&): "
-            "type is not a class!\n");
-    abort();
+  int
+  TypeWithDict::getBaseClassOffset(TypeWithDict const& baseClass) const {
+    if (class_ == nullptr) {
+      // FIXME: Turn this into a throw!
+      fprintf(stderr, "TypeWithDict::getBaseClassOffset(TypeWithDict const&): "
+              "type is not a class!\n");
+      abort();
+    }
+    if (baseClass.class_ == nullptr) {
+      // FIXME: Turn this into a throw!
+      fprintf(stderr, "TypeWithDict::getBaseClassOffset(TypeWithDict const&): "
+              "baseClass is not a class!\n");
+      abort();
+    }
+    int offset = class_->GetBaseClassOffset(baseClass.class_);
+    return offset;
   }
-  if (baseClass.class_ == nullptr) {
-    // FIXME: Turn this into a throw!
-    fprintf(stderr, "TypeWithDict::getBaseClassOffset(const TypeWithDict&): "
-            "baseClass is not a class!\n");
-    abort();
-  }
-  int offset = class_->GetBaseClassOffset(baseClass.class_);
-  return offset;
-}
 
-int
-TypeWithDict::
-stringToEnumValue(const string& name) const
-{
-  if (enum_ == nullptr) {
-    fprintf(stderr, "TypeWithDict::stringToEnumValue(name): "
-            "type is not an enum!\n");
-    abort();
+  int
+  TypeWithDict::stringToEnumValue(std::string const& name) const {
+    if (enum_ == nullptr) {
+      fprintf(stderr, "TypeWithDict::stringToEnumValue(name): "
+              "type is not an enum!\n");
+      abort();
+    }
+    TEnumConstant const* ec = enum_->GetConstant(name.c_str());
+    if (!ec) {
+      // FIXME: Turn this into a throw!
+      fprintf(stderr, "TypeWithDict::stringToEnumValue(name): "
+              "no enum constant named '%s'!\n", name.c_str());
+      abort();
+    }
+    return static_cast<int>(ec->GetValue());
   }
-  const TEnumConstant* ec = enum_->GetConstant(name.c_str());
-  if (!ec) {
-    // FIXME: Turn this into a throw!
-    fprintf(stderr, "TypeWithDict::stringToEnumValue(name): "
-            "no enum constant named '%s'!\n", name.c_str());
-    abort();
+
+  void*
+  TypeWithDict::allocate() const {
+    return new char[size()];
   }
-  return static_cast<int>(ec->GetValue());
-}
 
-void*
-TypeWithDict::
-allocate() const
-{
-  return new char[size()];
-}
-
-void
-TypeWithDict::
-deallocate(void* address) const
-{
-  delete[] reinterpret_cast<char*>(address);
-}
-
-ObjectWithDict
-TypeWithDict::
-construct() const
-{
-  if (class_ != nullptr) {
-    return ObjectWithDict(*this, class_->New());
-  }
-  return ObjectWithDict(*this, new char[size()]);
-}
-
-void
-TypeWithDict::
-destruct(void* address, bool dealloc) const
-{
-  if (class_ != nullptr) {
-    class_->Destructor(address, !dealloc);
-    return;
-  }
-  if (dealloc) {
+  void
+  TypeWithDict::deallocate(void* address) const {
     delete[] reinterpret_cast<char*>(address);
   }
-}
 
-void
-TypeWithDict::processEnumeration() {
-  TType* TTy = gInterpreter->Type_GetParent(type_);
-  if (TTy != nullptr) {
-    // The enum is a class member.
-    TypeWithDict Tycl(*gInterpreter->Type_TypeInfo(TTy));
-    if (Tycl.class_ == nullptr) {
-      // FIXME: Replace this with an exception!
-      fprintf(stderr, "TypeWithDict(const type_info&, long): "
-              "Enum parent is not a class!\n");
-      abort();
+  ObjectWithDict
+  TypeWithDict::construct() const {
+    if (class_ != nullptr) {
+      return ObjectWithDict(*this, class_->New());
     }
-    TObject* tobj =
-      Tycl.class_->GetListOfEnums()->FindObject(unscopedName().c_str());
-    if (tobj == nullptr) {
-      // FIXME: Replace this with an exception!
-      fprintf(stderr, "TypeWithDict(const type_info&, long): "
-              "Enum not found in containing class!\n");
-      abort();
-    }
-    enum_ = reinterpret_cast<TEnum*>(tobj);
-  } else if (name().size() != unscopedName().size()) {
-    // Must be a namespace member.
-    assert(name().size() >= unscopedName().size() + 2);
-    std::string theNamespace(name().substr(0, name().size() - unscopedName().size() - 2));
-    TClass* cl = TClass::GetClass(theNamespace.c_str());
-    assert(cl != nullptr);
-    TObject* tobj = cl->GetListOfEnums()->FindObject(unscopedName().c_str());
-    if (tobj == nullptr) {
-      // FIXME: Replace this with an exception!
-      fprintf(stderr, "TypeWithDict(const type_info&, long): "
-              "Enum not found in named namespace!\n");
-      abort();
-    }
-    enum_ = reinterpret_cast<TEnum*>(tobj);
-  } else {
-    // Must be a global namespace member.
-    //gROOT->GetListOfEnums()->Dump();
-    TObject* tobj = gROOT->GetListOfEnums()->FindObject(name().c_str());
-    if (tobj == nullptr) {
-      // FIXME: Replace this with an exception!
-      fprintf(stderr, "TypeWithDict(const type_info&, long): "
-              "Enum not found in global namespace!\n");
-      abort();
-    }
-    enum_ = reinterpret_cast<TEnum*>(tobj);
+    return ObjectWithDict(*this, new char[size()]);
   }
-  if (enum_ == nullptr) {
-    // FIXME: Replace this with an exception!
-    fprintf(stderr, "TypeWithDict(const type_info&, long): "
-            "enum_ not set for enum type!\n");
-    abort();
+
+  void
+  TypeWithDict::destruct(void* address, bool dealloc) const {
+    if (class_ != nullptr) {
+      class_->Destructor(address, !dealloc);
+      return;
+    }
+    if (dealloc) {
+      delete[] reinterpret_cast<char*>(address);
+    }
   }
-}
-//-------------------------------------------------------------
-//
-//
 
-// A related free function
-bool 
-hasDictionary(const std::type_info& ti) {
-  return gInterpreter->Type_TypeInfo(gInterpreter->Type_Factory(ti));
-}
+  void
+  TypeWithDict::processEnumeration() {
+    TType* TTy = gInterpreter->Type_GetParent(type_);
+    if (TTy != nullptr) {
+      // The enum is a class member.
+      TypeWithDict Tycl(*gInterpreter->Type_TypeInfo(TTy));
+      if (Tycl.class_ == nullptr) {
+        // FIXME: Replace this with an exception!
+        fprintf(stderr, "TypeWithDict(std::type_info const&, long): "
+                "Enum parent is not a class!\n");
+        abort();
+      }
+      TObject* tobj =
+        Tycl.class_->GetListOfEnums()->FindObject(unscopedName().c_str());
+      if (tobj == nullptr) {
+        // FIXME: Replace this with an exception!
+        fprintf(stderr, "TypeWithDict(std::type_info const&, long): "
+                "Enum not found in containing class!\n");
+        abort();
+      }
+      enum_ = reinterpret_cast<TEnum*>(tobj);
+    } else if (name().size() != unscopedName().size()) {
+      // Must be a namespace member.
+      assert(name().size() >= unscopedName().size() + 2);
+      std::string theNamespace(name().substr(0, name().size() - unscopedName().size() - 2));
+      TClass* cl = TClass::GetClass(theNamespace.c_str());
+      assert(cl != nullptr);
+      TObject* tobj = cl->GetListOfEnums()->FindObject(unscopedName().c_str());
+      if (tobj == nullptr) {
+        // FIXME: Replace this with an exception!
+        fprintf(stderr, "TypeWithDict(std::type_info const&, long): "
+                "Enum not found in named namespace!\n");
+        abort();
+      }
+      enum_ = reinterpret_cast<TEnum*>(tobj);
+    } else {
+      // Must be a global namespace member.
+      //gROOT->GetListOfEnums()->Dump();
+      TObject* tobj = gROOT->GetListOfEnums()->FindObject(name().c_str());
+      if (tobj == nullptr) {
+        // FIXME: Replace this with an exception!
+        fprintf(stderr, "TypeWithDict(std::type_info const&, long): "
+                "Enum not found in global namespace!\n");
+        abort();
+      }
+      enum_ = reinterpret_cast<TEnum*>(tobj);
+    }
+    if (enum_ == nullptr) {
+      // FIXME: Replace this with an exception!
+      fprintf(stderr, "TypeWithDict(std::type_info const&, long): "
+              "enum_ not set for enum type!\n");
+      abort();
+    }
+  }
+  //-------------------------------------------------------------
+  //
+  //
 
-bool
-operator==(const TypeWithDict& a, const TypeWithDict& b)
-{
-  return a.typeInfo() == b.typeInfo();
-}
+  // A related free function
+  bool
+  hasDictionary(std::type_info const& ti) {
+    return gInterpreter->Type_TypeInfo(gInterpreter->Type_Factory(ti));
+  }
 
-ostream&
-operator<<(ostream& os, const TypeWithDict& ty)
-{
-  ty.print(os);
-  return os;
-}
+  bool
+  operator==(TypeWithDict const& a, TypeWithDict const& b) {
+    return a.typeInfo() == b.typeInfo();
+  }
 
-//-------------------------------------------------------------
-//
-//
+  std::ostream&
+  operator<<(std::ostream& os, TypeWithDict const& ty) {
+    ty.print(os);
+    return os;
+  }
 
-TypeBases::
-TypeBases(const TypeWithDict& type)
-  : type_(type.type_)
-  , class_(type.class_)
-{
-}
+  //-------------------------------------------------------------
+  //
+  //
 
-IterWithDict<TBaseClass>
-TypeBases::
-begin() const
-{
-  if (class_ == nullptr) {
+  TypeBases::TypeBases(TypeWithDict const& type) :
+    type_(type.type_),
+    class_(type.class_) {
+  }
+
+  IterWithDict<TBaseClass>
+  TypeBases::begin() const {
+    if (class_ == nullptr) {
+      return IterWithDict<TBaseClass>();
+    }
+    return IterWithDict<TBaseClass>(class_->GetListOfBases());
+  }
+
+  IterWithDict<TBaseClass>
+  TypeBases::end() const {
     return IterWithDict<TBaseClass>();
   }
-  return IterWithDict<TBaseClass>(class_->GetListOfBases());
-}
 
-IterWithDict<TBaseClass>
-TypeBases::
-end() const
-{
-  return IterWithDict<TBaseClass>();
-}
-
-size_t
-TypeBases::
-size() const
-{
-  if (class_ == nullptr) {
-    return 0;
+  size_t
+  TypeBases::size() const {
+    if (class_ == nullptr) {
+      return 0;
+    }
+    return class_->GetListOfBases()->GetSize();
   }
-  return class_->GetListOfBases()->GetSize();
-}
 
-//-------------------------------------------------------------
-//
-//
+  //-------------------------------------------------------------
+  //
+  //
 
-TypeDataMembers::
-TypeDataMembers(const TypeWithDict& type)
-  : type_(type.type_)
-  , class_(type.class_)
-{
-}
+  TypeDataMembers::TypeDataMembers(TypeWithDict const& type) :
+    type_(type.type_),
+    class_(type.class_) {
+  }
 
-IterWithDict<TDataMember>
-TypeDataMembers::
-begin() const
-{
-  if (class_ == nullptr) {
+  IterWithDict<TDataMember>
+  TypeDataMembers::begin() const {
+    if (class_ == nullptr) {
+      return IterWithDict<TDataMember>();
+    }
+    return IterWithDict<TDataMember>(class_->GetListOfDataMembers());
+  }
+
+  IterWithDict<TDataMember>
+  TypeDataMembers::end() const {
     return IterWithDict<TDataMember>();
   }
-  return IterWithDict<TDataMember>(class_->GetListOfDataMembers());
-}
 
-IterWithDict<TDataMember>
-TypeDataMembers::
-end() const
-{
-  return IterWithDict<TDataMember>();
-}
-
-size_t
-TypeDataMembers::
-size() const
-{
-  if (class_ == nullptr) {
-    return 0;
+  size_t
+  TypeDataMembers::size() const {
+    if (class_ == nullptr) {
+      return 0;
+    }
+    return class_->GetListOfDataMembers()->GetSize();
   }
-  return class_->GetListOfDataMembers()->GetSize();
-}
 
-//-------------------------------------------------------------
-//
-//
+  //-------------------------------------------------------------
+  //
+  //
 
-TypeFunctionMembers::
-TypeFunctionMembers(const TypeWithDict& type)
-  : type_(type.type_)
-  , class_(type.class_)
-{
-}
+  TypeFunctionMembers::TypeFunctionMembers(TypeWithDict const& type) :
+    type_(type.type_),
+    class_(type.class_) {
+  }
 
-IterWithDict<TMethod>
-TypeFunctionMembers::
-begin() const
-{
-  if (class_ == nullptr) {
+  IterWithDict<TMethod>
+  TypeFunctionMembers::begin() const {
+    if (class_ == nullptr) {
+      return IterWithDict<TMethod>();
+    }
+    return IterWithDict<TMethod>(class_->GetListOfMethods());
+  }
+
+  IterWithDict<TMethod>
+  TypeFunctionMembers::end() const {
     return IterWithDict<TMethod>();
   }
-  return IterWithDict<TMethod>(class_->GetListOfMethods());
-}
 
-IterWithDict<TMethod>
-TypeFunctionMembers::
-end() const
-{
-  return IterWithDict<TMethod>();
-}
-
-size_t
-TypeFunctionMembers::
-size() const
-{
-  if (class_ == nullptr) {
-    return 0;
+  size_t
+  TypeFunctionMembers::size() const {
+    if (class_ == nullptr) {
+      return 0;
+    }
+    return class_->GetListOfMethods()->GetSize();
   }
-  return class_->GetListOfMethods()->GetSize();
-}
 
 } // namespace edm
-


### PR DESCRIPTION
The files in FWCore/Utilities that handle ROOT6 dictionaries were all extensively modified a while back by Paul Russo.  I now need to make changes to them, so I am converting the files back to my coding style to preserve my sanity.
The only changes are:
1) Reformatting white space and indentation.
2) putting the const qualifiers after the type, rather than before
3) Removing one "using namespace std" and adding std:: where needed.
This is only being done in FWCore/Utilities/_/_Dict*
These changes have been tested.
