### PR TITLE
Close file after writing the init message.

### DIFF
--- a/EventFilter/Utilities/plugins/RecoEventWriterForFU.cc
+++ b/EventFilter/Utilities/plugins/RecoEventWriterForFU.cc
@@ -19,8 +19,11 @@ namespace evf {
   }
 
   void RecoEventWriterForFU::doOutputHeader(InitMsgView const& init_message) {
-    //Write the Init Message to Streamer file
-    stream_writer_preamble_->write(init_message);
+    //Write the Init Message to init file and close it
+    if ( stream_writer_preamble_.get() ) {
+      stream_writer_preamble_->write(init_message);
+      stream_writer_preamble_.reset();
+    }
   }
 
   void RecoEventWriterForFU::doOutputEvent(EventMsgView const& msg) {


### PR DESCRIPTION
Assure that the file containing the ini message is closed. This is only relevant for the DAQ2 file-based filter farm.
