### PR TITLE
fixed usage of Geant4 constructors of G4Polycone and G4Polyhedra in CMS ...

### DIFF
--- a/SimG4Core/Geometry/src/DDG4SolidConverter.cc
+++ b/SimG4Core/Geometry/src/DDG4SolidConverter.cc
@@ -130,6 +130,14 @@ G4VSolid * DDG4SolidConverter::polycone_rz(const DDSolid & s)
     count++;
    }
    LogDebug("SimG4CoreGeometry") << "sp=" << (*par_)[0]/deg << " ep=" << (*par_)[1]/deg ;
+   /*
+   std::cout << "### Polycone_RZ: " << "sp=" << (*par_)[0]/deg 
+	     << " ep=" << (*par_)[1]/deg 
+	     << " N= " << count << std::endl;
+   for(int i=0; i<count; ++i) { 
+     std::cout << " R= " << r[i] << " Z= " << z[i] << std::endl;
+   }
+   */
    return new G4Polycone(s.name().name(), (*par_)[0], (*par_)[1], // start,delta-phi
 			 count, // numRZ
 			 &(r[0]),
@@ -155,6 +163,14 @@ G4VSolid * DDG4SolidConverter::polycone_rrz(const DDSolid & s)
       count++;
     }
     LogDebug("SimG4CoreGeometry") << "sp=" << (*par_)[0]/deg << " ep=" << (*par_)[1]/deg ;
+    /*
+    std::cout << "### Polycone_RRZ: " << "sp=" << (*par_)[0]/deg 
+	      << " ep=" << (*par_)[1]/deg 
+	      << " N= " << count << std::endl;
+    for(int i=0; i<count; ++i) { 
+      std::cout << " R1= " << rmin_p[i] << " R1= " << rmax_p[i] << " Z= " << z_p[i] << std::endl;
+    }
+    */
     return new G4Polycone(s.name().name(), (*par_)[0], (*par_)[1], // start,delta-phi
                         count, // sections
 			&(z_p[0]),

--- a/SimG4Core/Geometry/test/testVolumes.cpp
+++ b/SimG4Core/Geometry/test/testVolumes.cpp
@@ -308,7 +308,13 @@ doPolycone2( const std::string& name, double phiStart, double phiTotal,
 	     const std::vector<double> & z,
 	     const std::vector<double> & r )
 {  
-  G4Polycone g4( name, phiStart, phiTotal, z.size(), &z[0], &r[0] );
+  std::cout << "### doPolycone_RZ: " << "phi1=" << phiStart/deg 
+  	    << " phi2=" << phiTotal/deg 
+  	    << " N= " << z.size() << std::endl;
+  for(size_t i=0; i<z.size(); ++i) { 
+    std::cout << " R= " << r[i] << " Z= " << z[i] << std::endl;
+  }
+  G4Polycone g4( name, phiStart, phiTotal, z.size(), &r[0], &z[0] );
   DDI::Polycone dd( phiStart, phiTotal, z, r );
   DDPolycone dds = DDSolidFactory::polycone( name, phiStart, phiTotal, z, r );
   dd.stream(std::cout);
@@ -358,7 +364,7 @@ doPolyhedra2( const std::string& name, int sides, double phiStart, double phiTot
 	      const std::vector<double> & z,
 	      const std::vector<double> & r )
 {  
-  G4Polyhedra g4( name, phiStart, phiTotal, sides, z.size(), &z[0], &r[0] );
+  G4Polyhedra g4( name, phiStart, phiTotal, sides, z.size(), &r[0], &z[0] );
   DDI::Polyhedra dd( sides, phiStart, phiTotal, z, r );
   DDPolyhedra dds = DDSolidFactory::polyhedra( name, sides, phiStart, phiTotal, z, r );
   dd.stream(std::cout);
@@ -653,7 +659,7 @@ main( int argc, char *argv[] )
   doPolycone1( name, phiStart, phiTotal, z, rInner, rOuter );
   std::cout << std::endl;
 
-  doPolycone2( name, phiStart, phiTotal, z, rOuter );
+  doPolycone2( name, phiStart, phiTotal, z, rOuter);
   std::cout << std::endl;
 
 //


### PR DESCRIPTION
Fixed geometry unit test, which likely has problem in previous versions of CMSSW but better to apply this only for GEANT10_X branch
