### PR TITLE
Need to declare a member variable transient for AssociationMaps

### DIFF
--- a/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
+++ b/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
@@ -10,7 +10,9 @@
    <class name="susybsm::HSCParticleRefProd"/>
    <class name="susybsm::HSCParticleRefVector"/>
    <class name="edm::Wrapper<susybsm::HSCParticleCollection>"/>
-   <class name="susybsm::TracksEcalRecHitsMap"/>
+   <class name="susybsm::TracksEcalRecHitsMap">
+      <field name="transientMap_" transient="true"/>
+   </class>
    <class name="edm::Wrapper<susybsm::TracksEcalRecHitsMap>"/>
    <class name="susybsm::HSCPIsolation" ClassVersion="10">
     <version ClassVersion="10" checksum="3676296078"/>


### PR DESCRIPTION
The storage specification for susybsm::TracksEcalRecHitsMap was missing a required
transient declartion for the member variable transientMap_. Without that declaration,
it is impossible for ROOT to create a StreamerInfo for the class and therefore impossible
to read/write instances of the class.
