### PR TITLE
Declare several classes as non-storable

### DIFF
--- a/RecoParticleFlow/PFRootEvent/src/classes_def.xml
+++ b/RecoParticleFlow/PFRootEvent/src/classes_def.xml
@@ -1,9 +1,9 @@
 
 <lcgdict>
-  <class name="PFRootEventManager">
+  <class name="PFRootEventManager" persistent="false">
     <!-- <field name="pdgTable_" transient="true"/> -->
   </class>
-  <class name="PFRootEventManagerColin"/>
+  <class name="PFRootEventManagerColin" persistent="false"/>
   <class name="TauEvent"/>
   <class name="NeutralEvent"/>
   <class name="EventColin"/>
@@ -18,6 +18,6 @@
   <class name="EventColin::Block"/>
   <class name="std::vector<EventColin::Block>"/>
   <class name="ResidualFitter"/>
-  <class name="DialogFrame"/>
-  <class name="DisplayManager"/>
+  <class name="DialogFrame" persistent="false"/>
+  <class name="DisplayManager" persistent="false"/>
 </lcgdict>


### PR DESCRIPTION
Several of the classes which are only used for interactive use
can not be stored since they will cause ROOT to crash if one requests
their StreamerInfo. This change just marks those classes as non persistent.
This change is needed for the threaded framework to know not to request
the construction of the StreamInfo for those classes.
