### PR TITLE
DataFormats/Histograms: rename `debug' macro to `METOEDMFORMAT_DEBUG'

### DIFF
--- a/DataFormats/Histograms/interface/MEtoEDMFormat.h
+++ b/DataFormats/Histograms/interface/MEtoEDMFormat.h
@@ -30,7 +30,7 @@
 #include <map>
 #include <stdint.h>
 
-#define debug 0
+#define METOEDMFORMAT_DEBUG 0
 
 template <class T>
 class MEtoEDM
@@ -92,7 +92,7 @@ class MEtoEDM
      }
      if (j >= nOldObjects) {
        // this value is only in the new container, not the old one
-#if debug
+#if METOEDMFORMAT_DEBUG
        std::cout << "WARNING MEtoEDM::mergeProducts(): adding new histogram '" << name << "'" << std::endl;
 #endif
        MEtoEdmObject.push_back(newMEtoEDMObject[i]);
@@ -116,7 +116,7 @@ class MEtoEDM
          MEtoEdmObject[j].object.Add(&newMEtoEDMObject[i].object);
        } else {
           std::cout << "ERROR MEtoEDM::mergeProducts(): found histograms with different axis limits, '" << name << "' not merged" <<  std::endl;
-#if debug
+#if METOEDMFORMAT_DEBUG
           std::cout << MEtoEdmObject[j].name                         << " " << newMEtoEDMObject[i].name                         << std::endl;
           std::cout << MEtoEdmObject[j].object.GetNbinsX()           << " " << newMEtoEDMObject[i].object.GetNbinsX()           << std::endl;
           std::cout << MEtoEdmObject[j].object.GetXaxis()->GetXmin() << " " << newMEtoEDMObject[i].object.GetXaxis()->GetXmin() << std::endl;
@@ -171,7 +171,7 @@ MEtoEDM<double>::mergeProduct(const MEtoEDM<double> &newMEtoEDM)
     }
     if (j >= nOldObjects) {
       // this value is only in the new container, not the old one
-#if debug
+#if METOEDMFORMAT_DEBUG
       std::cout << "WARNING MEtoEDM::mergeProducts(): adding new histogram '" << name << "'" << std::endl;
 #endif
       MEtoEdmObject.push_back(newMEtoEDMObject[i]);
@@ -208,7 +208,7 @@ MEtoEDM<int>::mergeProduct(const MEtoEDM<int> &newMEtoEDM)
     }
     if (j >= nOldObjects) {
       // this value is only in the new container, not the old one
-#if debug
+#if METOEDMFORMAT_DEBUG
       std::cout << "WARNING MEtoEDM::mergeProducts(): adding new histogram '" << name << "'" << std::endl;
 #endif
       MEtoEdmObject.push_back(newMEtoEDMObject[i]);
@@ -256,7 +256,7 @@ MEtoEDM<long long>::mergeProduct(const MEtoEDM<long long> &newMEtoEDM)
     }
     if (j >= nOldObjects) {
       // this value is only in the new container, not the old one
-#if debug
+#if METOEDMFORMAT_DEBUG
       std::cout << "WARNING MEtoEDM::mergeProducts(): adding new histogram '" << name << "'" << std::endl;
 #endif
       MEtoEdmObject.push_back(newMEtoEDMObject[i]);
@@ -304,7 +304,7 @@ MEtoEDM<TString>::mergeProduct(const MEtoEDM<TString> &newMEtoEDM)
     }
     if (j >= nOldObjects) {
       // this value is only in the new container, not the old one
-#if debug
+#if METOEDMFORMAT_DEBUG
       std::cout << "WARNING MEtoEDM::mergeProducts(): adding new histogram '" << name << "'" << std::endl;
 #endif
       MEtoEdmObject.push_back(newMEtoEDMObject[i]);


### PR DESCRIPTION
The following is needed for ROOT6.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
