### PR TITLE
LumiCorrectionSource: workaround CORAL not handling Timestamps

### DIFF
--- a/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.cc
+++ b/RecoLuminosity/LumiProducer/plugins/LumiCorrectionSource.cc
@@ -302,6 +302,8 @@ LumiCorrectionSource::fillparamcache(unsigned int runnumber){
     coral::IQuery* lumiparamQuery=schema.newQuery();
     lumiparamQuery->addToTableList(std::string("LUMIDATA"));
     lumiparamQuery->setCondition(conditionStr,lumidataBindVariables);
+    lumiparamQuery->addToOutputList("NCOLLIDINGBUNCHES");
+    lumiparamQuery->defineOutput(lumiparamOutput);
     coral::ICursor& lumiparamcursor=lumiparamQuery->execute();
     unsigned int ncollidingbx=0;
     while( lumiparamcursor.next() ){


### PR DESCRIPTION
This patch changes the query from 

```
SELECT * FROM "CMS_LUMI_PROD"."LUMIDATA" "LUMIDATA" WHERE "DATA_ID"=:"dataid"
```

to

```
SELECT "NCOLLIDINGBUNCHES" FROM "CMS_LUMI_PROD"."LUMIDATA" "LUMIDATA" WHERE "DATA_ID"=:"dataid"
```

since NCOLLIDINGBUNCHES is the only variable that is read anyway.
This avoids trying to parse the timestamps (from the STARTTIME and STOPTIME columns), which CORAL does not seem to handle properly.
