### PR TITLE
CondCore/IOVService: fix include (testPayloadObj.h) to relocatable path

### DIFF
--- a/CondCore/IOVService/test/classes.h
+++ b/CondCore/IOVService/test/classes.h
@@ -1,1 +1,1 @@
-#include "testPayloadObj.h"
+#include "CondCore/IOVService/test/testPayloadObj.h"

--- a/CondCore/IOVService/test/testIOVCopy.cc
+++ b/CondCore/IOVService/test/testIOVCopy.cc
@@ -6,7 +6,7 @@
 #include "CondCore/DBCommon/interface/DbTransaction.h"
 #include "CondCore/DBCommon/interface/Exception.h"
 #include "CondCore/IOVService/interface/IOVEditor.h"
-#include "testPayloadObj.h"
+#include "CondCore/IOVService/test/testPayloadObj.h"
 #include <iostream>
 
 int main(){

--- a/CondCore/IOVService/test/testIOVDelete.cc
+++ b/CondCore/IOVService/test/testIOVDelete.cc
@@ -6,7 +6,7 @@
 #include "CondCore/DBCommon/interface/DbTransaction.h"
 #include "CondCore/DBCommon/interface/Exception.h"
 #include "CondCore/IOVService/interface/IOVEditor.h"
-#include "testPayloadObj.h"
+#include "CondCore/IOVService/test/testPayloadObj.h"
 #include <iostream>
 int main(){
   edmplugin::PluginManager::Config config;

--- a/CondCore/IOVService/test/testqueryPContainer.cc
+++ b/CondCore/IOVService/test/testqueryPContainer.cc
@@ -5,7 +5,7 @@
 #include "CondCore/DBCommon/interface/Exception.h"
 #include "CondCore/DBCommon/interface/DbTransaction.h"
 #include "CondCore/IOVService/interface/IOVEditor.h"
-#include "testPayloadObj.h"
+#include "CondCore/IOVService/test/testPayloadObj.h"
 #include <iostream>
 int main(){
   edmplugin::PluginManager::Config config;


### PR DESCRIPTION
testPayloadObj.h -> CondCore/IOVService/test/testPayloadObj.h

$CMSSW_RELEASE_BASE/src/CondCore/IOVService/test is not part of
$ROOT_INCLUDE_PATH. Re-adjust it to allow ROOT6 run-time to
find it.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
