### PR TITLE
Fix compilation warnings against ROOT6

### DIFF
--- a/FWCore/Utilities/interface/thread_safety_macros.h
+++ b/FWCore/Utilities/interface/thread_safety_macros.h
@@ -1,6 +1,6 @@
 #ifndef FWCore_Utilites_thread_safe_macros_h 
 #define FWCore_Utilites_thread_safe_macros_h 
-#ifndef __GCCXML__
+#ifndef __ROOTCLING__
 #define CMS_THREAD_SAFE [[cms::thread_safe]]
 #define CMS_THREAD_GUARD(_var_) [[cms::thread_guard("#_var_")]]
 #else 


### PR DESCRIPTION
Hide the thread safety attributes from rootcling.  This fixes many compilation warnings against ROOT6.
