### PR TITLE
Disable edmWriteConfigs

### DIFF
--- a/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
+++ b/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
@@ -148,6 +148,7 @@ namespace {
 
 int main (int argc, char **argv)
 try {
+/*
   boost::filesystem::path initialWorkingDirectory =
     boost::filesystem::initial_path<boost::filesystem::path>();
 
@@ -315,6 +316,7 @@ try {
       << std::endl;
     return 1;
   }
+*/
   return 0;
 } catch(cms::Exception const& e) {
   std::cerr << e.explainSelf() << std::endl;


### PR DESCRIPTION
edmwriteConfigs takes an enormous amount of time to run in ROOT6, and will continue to do so until precompiled modules are available.  This pull request comments out the code in edmWriteConfigs so that it just returns success immediately.  This will greatly speed up ROOT6 IB's which now take 14 to 16 hours.
The configuration files written by edmWriteConfigs are needed to run the relvals successfully, but the config files
generated by ROOT5 can be used. for running the relvals for the time being. 
