### PR TITLE
Fix corruption of dat files

### DIFF
--- a/EventFilter/Utilities/plugins/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/plugins/EvFDaqDirector.cc
@@ -618,6 +618,7 @@ namespace evf {
   }
   
   void EvFDaqDirector::unlockAndCloseMergeStream() {
+    fflush(data_rw_stream);
     fcntl(data_readwrite_fd_, F_SETLKW, &data_rw_fulk);
     fclose(data_rw_stream);
   }

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -172,6 +172,7 @@ namespace evf {
   template<typename Consumer>
   void RecoEventOutputModuleForFU<Consumer>::endLuminosityBlock(edm::LuminosityBlockPrincipal const &ls, edm::ModuleCallingContext const*){
     std::cout << "RecoEventOutputModuleForFU : end lumi " << std::endl;
+    c_->closeOutputFile();
     processed_.value() = fms_->getEventsProcessedForLumi(ls.luminosityBlock());
     if(processed_.value()!=0){
       int b;

--- a/EventFilter/Utilities/plugins/RecoEventWriterForFU.cc
+++ b/EventFilter/Utilities/plugins/RecoEventWriterForFU.cc
@@ -3,10 +3,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 namespace evf {
-  RecoEventWriterForFU::RecoEventWriterForFU(edm::ParameterSet const& ps) :
-    stream_writer_preamble_(0),
-    stream_writer_events_(0)
-  {
+  RecoEventWriterForFU::RecoEventWriterForFU(edm::ParameterSet const& ps) {
   }
 
   RecoEventWriterForFU::~RecoEventWriterForFU() {
@@ -47,6 +44,10 @@ namespace evf {
 
   void RecoEventWriterForFU::setOutputFile(std::string const& events){
     stream_writer_events_.reset(new StreamerOutputFile(events));
+  }
+
+  void RecoEventWriterForFU::closeOutputFile(){
+    stream_writer_events_.reset();
   }
 
 } //namespace edm

--- a/EventFilter/Utilities/plugins/RecoEventWriterForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventWriterForFU.h
@@ -29,21 +29,23 @@ namespace evf
 
     void setInitMessageFile(std::string const&);
     void setOutputFile(std::string const&);
+    void closeOutputFile();
+
     void doOutputHeader(InitMsgBuilder const& init_message);    
     void doOutputHeader(InitMsgView const& init_message);    
 
     void doOutputEvent(EventMsgBuilder const& msg);
     void doOutputEvent(EventMsgView const& msg);
 
-    void start(){}
+    void start(){};
     void stop(){};
 
     uint32 get_adler32() const { return stream_writer_events_->adler32();}
 
   private:
 
-    std::auto_ptr<StreamerOutputFile> stream_writer_preamble_;
-    std::auto_ptr<StreamerOutputFile> stream_writer_events_;
+    boost::shared_ptr<StreamerOutputFile> stream_writer_preamble_;
+    boost::shared_ptr<StreamerOutputFile> stream_writer_events_;
 
   };
 }


### PR DESCRIPTION
Fix 2 issues which can cause data corruption. This only affects the file-based filter farm.
