### PR TITLE
Fix bugs in type resolution in conditions code

### DIFF
--- a/CondCore/ORA/src/ClassUtils.cc
+++ b/CondCore/ORA/src/ClassUtils.cc
@@ -60,6 +60,10 @@ bool ora::ClassUtils::checkMappedType( const edm::TypeWithDict& type,
     return mappedTypeName=="int";
   } else if ( isTypeOraVector( type ) ){
     return isTypeNameOraVector( mappedTypeName );
+  } else if ( type.qualifiedName()=="Long64_t" ){
+    return (mappedTypeName=="Long64_t" || mappedTypeName=="long long");
+  } else if ( type.qualifiedName()=="unsigned Long64_t" ){
+    return (mappedTypeName=="unsigned Long64_t" || mappedTypeName=="unsigned long long");
   } else {
     return type.qualifiedName()==mappedTypeName;
   }
@@ -418,7 +422,7 @@ edm::TypeWithDict ora::ClassUtils::containerSubType(const edm::TypeWithDict& typ
 edm::TypeWithDict ora::ClassUtils::resolvedType(const edm::TypeWithDict& typ){
   edm::TypeWithDict resolvedType = typ;
   while(resolvedType.isTypedef()){
-    resolvedType = resolvedType.toType();
+    resolvedType = resolvedType.finalType();
   }
   return resolvedType;
 }


### PR DESCRIPTION
This pull request is a fix for two ROOT6 specific bugs that were causing nearly all relvals and other tests to fail with the error message:

Exception Message:
Missing dictionary information for data member "m_timestamp" of class "cond::UpdateStamp" from ObjectStreamerBase::buildBaseDataMembers 

1) Before checking that a type had a dictionary, typedefs were not resolved correctly.  TypeWithDict::toType() was called, instead of the correct TypeWithDict::finalType().
2) The code did not account for the fact that, for ROOT6, "Long64_t" has replaced "long long" as the normalized name of the "long long" data type, and the same for unsigned long long.
Note:  This request fixes the observed errors, but it is unknown whether the relvals will pass with these fixes or will fail later for an unrelated reason.
