### PR TITLE
Scale down Castor photoelectron gain at digi step to avoid saturation in simulation of PbPb

### DIFF
--- a/Configuration/StandardSequences/python/SimWithCastorPP_cff.py
+++ b/Configuration/StandardSequences/python/SimWithCastorPP_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+def customise(process):
+    process.load("SimG4Core.Application.g4SimHits_cfi")
+    process.g4SimHits.Generator.MinEtaCut =-7.0
+    process.g4SimHits.Generator.MaxEtaCut = 5.5
+    process.load('SimCalorimetry.CastorSim.castordigi_cfi') 
+    process.simCastorDigis.castor.photoelectronsToAnalog = 4.24
+
+    return(process)

--- a/Configuration/StandardSequences/python/SimWithCastorPPb_cff.py
+++ b/Configuration/StandardSequences/python/SimWithCastorPPb_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+def customise(process):
+    process.load("SimG4Core.Application.g4SimHits_cfi")
+    process.g4SimHits.Generator.MinEtaCut =-7.0
+    process.g4SimHits.Generator.MaxEtaCut = 5.5
+    process.load('SimCalorimetry.CastorSim.castordigi_cfi')
+    process.simCastorDigis.castor.photoelectronsToAnalog = 0.848
+
+    return(process)

--- a/Configuration/StandardSequences/python/SimWithCastorPbPb_cff.py
+++ b/Configuration/StandardSequences/python/SimWithCastorPbPb_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+def customise(process):
+    process.load("SimG4Core.Application.g4SimHits_cfi") 
+    process.g4SimHits.Generator.MinEtaCut =-7.0
+    process.g4SimHits.Generator.MaxEtaCut = 5.5
+    process.load('SimCalorimetry.CastorSim.castordigi_cfi')
+    process.simCastorDigis.castor.photoelectronsToAnalog = 0.212
+
+    return(process)

--- a/SimCalorimetry/CastorSim/python/castordigi_cfi.py
+++ b/SimCalorimetry/CastorSim/python/castordigi_cfi.py
@@ -9,7 +9,7 @@ simCastorDigis = cms.EDProducer("CastorDigiProducer",
         samplingFactor = cms.double(16.75), ## pe/GeV
 
         doPhotoStatistics = cms.bool(True),
-        photoelectronsToAnalog = cms.double(0.848),
+        photoelectronsToAnalog = cms.double(0.212), #pPb: 0.848 = 4.24/5 => PbPb: 4.24/20 = 0.212
         simHitToPhotoelectrons = cms.double(1000.0),
         syncPhase = cms.bool(True),
         timePhase = cms.double(-4.0)

--- a/SimCalorimetry/CastorSim/python/castordigi_cfi.py
+++ b/SimCalorimetry/CastorSim/python/castordigi_cfi.py
@@ -9,7 +9,7 @@ simCastorDigis = cms.EDProducer("CastorDigiProducer",
         samplingFactor = cms.double(16.75), ## pe/GeV
 
         doPhotoStatistics = cms.bool(True),
-        photoelectronsToAnalog = cms.double(0.212), #pPb: 0.848 = 4.24/5 => PbPb: 4.24/20 = 0.212
+        photoelectronsToAnalog = cms.double(0.848), #pp: 4.24; pPb: 0.848 = 4.24/5; PbPb: 0.212 = 4.24/20
         simHitToPhotoelectrons = cms.double(1000.0),
         syncPhase = cms.bool(True),
         timePhase = cms.double(-4.0)


### PR DESCRIPTION
Castor calorimeter pmt gain, photoelectronsToAnalog, set to 4.24 divided by 20 to work around saturation of digital signals in PbPb simulation; this assumes also a corresponding check of conditions (previous setup was 4.24 / 5 and was valid for pPb)
