### PR TITLE
Avoid infinite recursion

### DIFF
--- a/CondCore/ORA/src/ClassUtils.cc
+++ b/CondCore/ORA/src/ClassUtils.cc
@@ -420,9 +420,8 @@ edm::TypeWithDict ora::ClassUtils::containerSubType(const edm::TypeWithDict& typ
 }
 
 edm::TypeWithDict ora::ClassUtils::resolvedType(const edm::TypeWithDict& typ){
-  edm::TypeWithDict resolvedType = typ;
-  while(resolvedType.isTypedef()){
-    resolvedType = resolvedType.finalType();
+  if (typ.isTypedef()){
+    return typ.finalType();
   }
-  return resolvedType;
+  return typ;
 }


### PR DESCRIPTION
ROOT6 specific bug fix for infinite recursive call of finalType().  This fix is necessary (but not sufficient) for any relvals to run successfully.
