### PR TITLE
Fixes to Cluster Shape Variables monitored in EXO DQM + #1986 Code Review 

### DIFF
--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h
@@ -162,7 +162,7 @@ static std::vector<float> scLocalCovariances(const reco::SuperCluster &cluster, 
                 static Cluster2ndMoments cluster2ndMoments( const reco::BasicCluster &basicCluster, const EcalRecHitCollection &recHits, double phiCorrectionFactor=0.8, double w0=4.7, bool useLogWeights=true);
 
                 static Cluster2ndMoments cluster2ndMoments( const reco::SuperCluster &superCluster, const EcalRecHitCollection &recHits, double phiCorrectionFactor=0.8, double w0=4.7, bool useLogWeights=true);
-                static Cluster2ndMoments cluster2ndMoments( const std::vector<const EcalRecHit*>& RH_ptrs, double  phiCorrectionFactor=0.8, double  w0=4.7, bool useLogWeights=true);
+                static Cluster2ndMoments cluster2ndMoments( const std::vector<std::pair<const EcalRecHit*, float> >& RH_ptrs_fracs, double  phiCorrectionFactor=0.8, double  w0=4.7, bool useLogWeights=true);
 
                 static double zernike20( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, double R0 = 6.6, bool logW = true, float w0 = 4.7 );
                 static double zernike42( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloGeometry *geometry, double R0 = 6.6, bool logW = true, float w0 = 4.7 );
@@ -192,7 +192,7 @@ static std::pair<DetId, float> getMaximum( const std::vector< std::pair<DetId, f
 		//Shower shape variables return vector <Roundness, Angle> of a photon
 		static std::vector<float> roundnessBarrelSuperClusters( const reco::SuperCluster &superCluster ,const EcalRecHitCollection &recHits, int weightedPositionMethod = 0, float energyThreshold = 0.0);
 		static std::vector<float> roundnessBarrelSuperClustersUserExtended( const reco::SuperCluster &superCluster ,const EcalRecHitCollection &recHits, int ieta_delta=0, int iphi_delta=0, float energyRHThresh=0.00000, int weightedPositionMethod=0);
-		static std::vector<float> roundnessSelectedBarrelRecHits(const std::vector<const EcalRecHit*>&rhVector, int weightedPositionMethod = 0);
+		static std::vector<float> roundnessSelectedBarrelRecHits(const std::vector<std::pair<const EcalRecHit*,float> >&rhVector, int weightedPositionMethod = 0);
         private:
                 struct EcalClusterEnergyDeposition
                 { 
@@ -244,14 +244,14 @@ static std::pair<float,float> mean5x5PositionInXY(const reco::BasicCluster &clus
                 static float getDPhiEndcap(const DetId& crysId,float meanX,float meanY);
                 static float getNrCrysDiffInEta(const DetId& crysId,const DetId& orginId);
                 static float getNrCrysDiffInPhi(const DetId& crysId,const DetId& orginId);
-
-				//useful functions for showerRoundnessBarrel function
-				static int deltaIEta(int seed_ieta, int rh_ieta);
-				static int deltaIPhi(int seed_iphi, int rh_iphi);
-				static std::vector<int> getSeedPosition(const std::vector<const EcalRecHit*>&RH_ptrs);
-				static float getSumEnergy(const std::vector<const EcalRecHit*>&RH_ptrs);
-				static float computeWeight(float eRH, float energyTotal, int weightedPositionMethod);
-
+		
+		//useful functions for showerRoundnessBarrel function
+		static int deltaIEta(int seed_ieta, int rh_ieta);
+		static int deltaIPhi(int seed_iphi, int rh_iphi);
+		static std::vector<int> getSeedPosition(const std::vector<std::pair<const EcalRecHit*,float> >&RH_ptrs);
+		static float getSumEnergy(const std::vector<std::pair<const EcalRecHit*,float> >&RH_ptrs_fracs);
+		static float computeWeight(float eRH, float energyTotal, int weightedPositionMethod);
+		
 };
 
 #endif

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterTools.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterTools.cc
@@ -192,52 +192,44 @@ float EcalClusterTools::e2x2( const reco::BasicCluster &cluster, const EcalRecHi
 {
     DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
     std::list<float> energies;
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id, -1, 0, -1, 0 ) );
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id, -1, 0,  0, 1 ) );
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id,  0, 1,  0, 1 ) );
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id,  0, 1, -1, 0 ) );
-
-
-    return *std::max_element(energies.begin(),energies.end());
-
+    float max_E =  matrixEnergy( cluster, recHits, topology, id, -1, 0, -1, 0 );
+    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, -1, 0,  0, 1 ) );
+    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id,  0, 1,  0, 1 ) );
+    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id,  0, 1, -1, 0 ) );
+    return max_E;
 }
 
 
 float EcalClusterTools::e2x2( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
 {
     DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    std::list<float> energies;
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id, -1, 0, -1, 0,flagsexcl, severitiesexcl, sevLv ) );
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id, -1, 0,  0, 1,flagsexcl, severitiesexcl, sevLv ) );
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id,  0, 1,  0, 1,flagsexcl, severitiesexcl, sevLv ) );
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id,  0, 1, -1, 0,flagsexcl, severitiesexcl, sevLv ) );
-
-
-    return *std::max_element(energies.begin(),energies.end());
-
+    float max_E = matrixEnergy( cluster, recHits, topology, id, -1, 0, -1, 0,flagsexcl, severitiesexcl, sevLv );
+    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, -1, 0,  0, 1,flagsexcl, severitiesexcl, sevLv ) );
+    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id,  0, 1,  0, 1,flagsexcl, severitiesexcl, sevLv ) );
+    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id,  0, 1, -1, 0,flagsexcl, severitiesexcl, sevLv ) );
+    return max_E;
 }
 
 
 float EcalClusterTools::e3x2( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
 {
     DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    std::list<float> energies;
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id, -1, 1, -1, 0 ) );
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id,  0, 1, -1, 1 ) );
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id, -1, 1,  0, 1 ) );
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id, -1, 0, -1, 1 ) );
-    return *std::max_element(energies.begin(),energies.end());
+    float max_E = matrixEnergy( cluster, recHits, topology, id, -1, 1, -1, 0 );
+    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id,  0, 1, -1, 1 ) );
+    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, -1, 1,  0, 1 ) );
+    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, -1, 0, -1, 1 ) );
+    return max_E;
 }
 
 float EcalClusterTools::e3x2( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
 {
     DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
     std::list<float> energies;
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id, -1, 1, -1, 0,flagsexcl, severitiesexcl, sevLv ) );
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id,  0, 1, -1, 1,flagsexcl, severitiesexcl, sevLv ) );
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id, -1, 1,  0, 1,flagsexcl, severitiesexcl, sevLv ) );
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id, -1, 0, -1, 1,flagsexcl, severitiesexcl, sevLv ) );
-    return *std::max_element(energies.begin(),energies.end());
+    float max_E =  matrixEnergy( cluster, recHits, topology, id, -1, 1, -1, 0,flagsexcl, severitiesexcl, sevLv );
+    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id,  0, 1, -1, 1,flagsexcl, severitiesexcl, sevLv ) );
+    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, -1, 1,  0, 1,flagsexcl, severitiesexcl, sevLv ) );
+    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, -1, 0, -1, 1,flagsexcl, severitiesexcl, sevLv ) );
+    return max_E;
 }
 
 float EcalClusterTools::e3x3( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
@@ -256,24 +248,23 @@ float EcalClusterTools::e3x3( const reco::BasicCluster &cluster, const EcalRecHi
 
 float EcalClusterTools::e4x4( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology )
 {
-    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
-    std::list<float> energies;
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id, -1, 2, -2, 1 ) );
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id, -2, 1, -2, 1 ) );
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id, -2, 1, -1, 2 ) );
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id, -1, 2, -1, 2 ) );
-    return *std::max_element(energies.begin(),energies.end());
+    DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;    
+    float max_E = matrixEnergy( cluster, recHits, topology, id, -1, 2, -2, 1 );
+    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, -2, 1, -2, 1 ) );
+    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, -2, 1, -1, 2 ) );
+    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, -1, 2, -1, 2 ) );
+    return max_E;
 }
 
 float EcalClusterTools::e4x4( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const CaloTopology* topology, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
 {
     DetId id = getMaximum( cluster.hitsAndFractions(), recHits ).first;
     std::list<float> energies;
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id, -1, 2, -2, 1,flagsexcl, severitiesexcl, sevLv ) );
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id, -2, 1, -2, 1,flagsexcl, severitiesexcl, sevLv ) );
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id, -2, 1, -1, 2,flagsexcl, severitiesexcl, sevLv ) );
-    energies.push_back( matrixEnergy( cluster, recHits, topology, id, -1, 2, -1, 2,flagsexcl, severitiesexcl, sevLv ) );
-    return *std::max_element(energies.begin(),energies.end());
+    float max_E = matrixEnergy( cluster, recHits, topology, id, -1, 2, -2, 1,flagsexcl, severitiesexcl, sevLv );
+    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, -2, 1, -2, 1,flagsexcl, severitiesexcl, sevLv ) );
+    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, -2, 1, -1, 2,flagsexcl, severitiesexcl, sevLv ) );
+    max_E = std::max( max_E, matrixEnergy( cluster, recHits, topology, id, -1, 2, -1, 2,flagsexcl, severitiesexcl, sevLv ) );
+    return max_E;
 }
 
 
@@ -303,28 +294,30 @@ float EcalClusterTools::eMax( const reco::BasicCluster &cluster, const EcalRecHi
 
 float EcalClusterTools::e2nd( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits )
 {
-    std::list<float> energies;
-    std::vector< std::pair<DetId, float> > v_id = cluster.hitsAndFractions();
+    std::vector<float> energies;
+    const std::vector< std::pair<DetId, float> >& v_id = cluster.hitsAndFractions();
+    energies.reserve( v_id.size() );
     if ( v_id.size() < 2 ) return 0;
     for ( size_t i = 0; i < v_id.size(); ++i ) {
         energies.push_back( recHitEnergy( v_id[i].first, recHits ) * v_id[i].second );
     }
-    energies.sort(); 	         
-    return *--(--energies.end());
+    std::partial_sort( energies.begin(), energies.begin()+2, energies.end(), std::greater<float>() );
+    return energies[1];
 
 
 }
 
 float EcalClusterTools::e2nd( const reco::BasicCluster &cluster, const EcalRecHitCollection *recHits, const std::vector<int>& flagsexcl, const std::vector<int>& severitiesexcl, const EcalSeverityLevelAlgo *sevLv )
 {
-    std::list<float> energies;
-    std::vector< std::pair<DetId, float> > v_id = cluster.hitsAndFractions();
+    std::vector<float> energies;
+    const std::vector< std::pair<DetId, float> >& v_id = cluster.hitsAndFractions();
+    energies.reserve( v_id.size() );
     if ( v_id.size() < 2 ) return 0;
     for ( size_t i = 0; i < v_id.size(); ++i ) {
         energies.push_back( recHitEnergy( v_id[i].first, recHits,flagsexcl, severitiesexcl, sevLv ) * v_id[i].second );
     }
-    energies.sort(); 	         
-    return *--(--energies.end());
+    std::partial_sort( energies.begin(), energies.begin()+2, energies.end(), std::greater<float>() );
+    return energies[1];
 
 
 }
@@ -603,11 +596,11 @@ std::vector<EcalClusterTools::EcalClusterEnergyDeposition> EcalClusterTools::get
     theta_axis *= 1.0/theta_axis.mag();
     CLHEP::Hep3Vector phi_axis = theta_axis.cross(clDir);
 
-    std::vector< std::pair<DetId, float> > clusterDetIds = cluster.hitsAndFractions();
+    const std::vector< std::pair<DetId, float> >& clusterDetIds = cluster.hitsAndFractions();
 
     EcalClusterEnergyDeposition clEdep;
     EcalRecHit testEcalRecHit;
-    std::vector< std::pair<DetId, float> >::iterator posCurrent;
+    std::vector< std::pair<DetId, float> >::const_iterator posCurrent;
     // loop over crystals
     for(posCurrent=clusterDetIds.begin(); posCurrent!=clusterDetIds.end(); ++posCurrent) {
         EcalRecHitCollection::const_iterator itt = recHits->find( (*posCurrent).first );
@@ -718,11 +711,15 @@ math::XYZVector EcalClusterTools::meanClusterPosition( const reco::BasicCluster 
 {
     // find mean energy position of a 5x5 cluster around the maximum
     math::XYZVector meanPosition(0.0, 0.0, 0.0);
+    const std::vector<std::pair<DetId,float> >& hsAndFs = cluster.hitsAndFractions();
     std::vector<DetId> v_id = matrixDetId( topology, getMaximum( cluster, recHits ).first, -2, 2, -2, 2 );
-    for ( std::vector<DetId>::const_iterator it = v_id.begin(); it != v_id.end(); ++it ) {
-        GlobalPoint positionGP = geometry->getSubdetectorGeometry( *it )->getGeometry( *it )->getPosition();
-        math::XYZVector position(positionGP.x(),positionGP.y(),positionGP.z());
-        meanPosition = meanPosition + recHitEnergy( *it, recHits ) * position;
+    for( const std::pair<DetId,float>& hitAndFrac : hsAndFs ) {
+      for( std::vector<DetId>::const_iterator it = v_id.begin(); it != v_id.end(); ++it ) {
+	if( hitAndFrac.first != *it ) continue;
+	GlobalPoint positionGP = geometry->getSubdetectorGeometry( *it )->getGeometry( *it )->getPosition();
+	math::XYZVector position(positionGP.x(),positionGP.y(),positionGP.z());
+	meanPosition = meanPosition + recHitEnergy( *it, recHits ) * position * hitAndFrac.second;
+      }
     }
     return meanPosition / e5x5( cluster, recHits, topology );
 }
@@ -733,11 +730,15 @@ math::XYZVector EcalClusterTools::meanClusterPosition( const reco::BasicCluster 
 {
     // find mean energy position of a 5x5 cluster around the maximum
     math::XYZVector meanPosition(0.0, 0.0, 0.0);
+    const std::vector<std::pair<DetId,float> >& hsAndFs = cluster.hitsAndFractions();
     std::vector<DetId> v_id = matrixDetId( topology, getMaximum( cluster, recHits ).first, -2, 2, -2, 2 );
-    for ( std::vector<DetId>::const_iterator it = v_id.begin(); it != v_id.end(); ++it ) {
+    for( const std::pair<DetId,float>& hitAndFrac : hsAndFs ) {
+      for( std::vector<DetId>::const_iterator it = v_id.begin(); it != v_id.end(); ++it ) {
+	if( hitAndFrac.first != *it ) continue;
         GlobalPoint positionGP = geometry->getSubdetectorGeometry( *it )->getGeometry( *it )->getPosition();
         math::XYZVector position(positionGP.x(),positionGP.y(),positionGP.z());
-        meanPosition = meanPosition + recHitEnergy( *it, recHits,flagsexcl, severitiesexcl, sevLv ) * position;
+        meanPosition = meanPosition + recHitEnergy( *it, recHits,flagsexcl, severitiesexcl, sevLv ) * position * hitAndFrac.second;
+      }
     }
     return meanPosition / e5x5( cluster, recHits, topology,flagsexcl, severitiesexcl, sevLv );
 }
@@ -757,13 +758,17 @@ std::pair<float,float>  EcalClusterTools::mean5x5PositionInLocalCrysCoord(const 
     float meanDPhi=0.;
     float energySum=0.;
 
+    const std::vector<std::pair<DetId,float> >& hsAndFs = cluster.hitsAndFractions();
     std::vector<DetId> v_id = matrixDetId( topology,seedId, -2, 2, -2, 2 );
-    for ( std::vector<DetId>::const_iterator it = v_id.begin(); it != v_id.end(); ++it ) {  
-        float energy = recHitEnergy(*it,recHits);
+    for( const std::pair<DetId,float>& hAndF : hsAndFs ) {
+      for ( std::vector<DetId>::const_iterator it = v_id.begin(); it != v_id.end(); ++it ) {  
+	if( hAndF.first != *it ) continue;
+        float energy = recHitEnergy(*it,recHits) * hAndF.second;
         if(energy<0.) continue;//skipping negative energy crystals
         meanDEta += energy * getNrCrysDiffInEta(*it,seedId);
         meanDPhi += energy * getNrCrysDiffInPhi(*it,seedId);	
         energySum +=energy;
+      }
     }
     meanDEta /=energySum;
     meanDPhi /=energySum;
@@ -777,13 +782,17 @@ std::pair<float,float>  EcalClusterTools::mean5x5PositionInLocalCrysCoord(const 
     float meanDPhi=0.;
     float energySum=0.;
 
+    const std::vector<std::pair<DetId,float> >& hsAndFs = cluster.hitsAndFractions();
     std::vector<DetId> v_id = matrixDetId( topology,seedId, -2, 2, -2, 2 );
-    for ( std::vector<DetId>::const_iterator it = v_id.begin(); it != v_id.end(); ++it ) {  
-        float energy = recHitEnergy(*it,recHits,flagsexcl, severitiesexcl, sevLv);
+    for( const std::pair<DetId,float>& hAndF : hsAndFs ) {
+      for ( std::vector<DetId>::const_iterator it = v_id.begin(); it != v_id.end(); ++it ) {  
+	if( hAndF.first != *it ) continue;
+        float energy = recHitEnergy(*it,recHits,flagsexcl, severitiesexcl, sevLv) * hAndF.second;
         if(energy<0.) continue;//skipping negative energy crystals
         meanDEta += energy * getNrCrysDiffInEta(*it,seedId);
         meanDPhi += energy * getNrCrysDiffInPhi(*it,seedId);	
         energySum +=energy;
+      }
     }
     meanDEta /=energySum;
     meanDPhi /=energySum;
@@ -805,13 +814,17 @@ std::pair<float,float> EcalClusterTools::mean5x5PositionInXY(const reco::BasicCl
 
     float energySum=0.;
 
+    const std::vector<std::pair<DetId,float> >& hsAndFs = cluster.hitsAndFractions();
     std::vector<DetId> v_id = matrixDetId( topology,seedId, -2, 2, -2, 2 );
-    for ( std::vector<DetId>::const_iterator it = v_id.begin(); it != v_id.end(); ++it ) {  
-        float energy = recHitEnergy(*it,recHits);
+    for( const std::pair<DetId,float>& hAndF : hsAndFs ) {
+      for ( std::vector<DetId>::const_iterator it = v_id.begin(); it != v_id.end(); ++it ) {  
+	if( hAndF.first != *it ) continue;
+        float energy = recHitEnergy(*it,recHits) * hAndF.second;
         if(energy<0.) continue;//skipping negative energy crystals
         meanXY.first += energy * getNormedIX(*it);
         meanXY.second += energy * getNormedIY(*it);
         energySum +=energy;
+      }
     }
     meanXY.first/=energySum;
     meanXY.second/=energySum;
@@ -827,13 +840,17 @@ std::pair<float,float> EcalClusterTools::mean5x5PositionInXY(const reco::BasicCl
 
     float energySum=0.;
 
+    const std::vector<std::pair<DetId,float> >& hsAndFs = cluster.hitsAndFractions();
     std::vector<DetId> v_id = matrixDetId( topology,seedId, -2, 2, -2, 2 );
-    for ( std::vector<DetId>::const_iterator it = v_id.begin(); it != v_id.end(); ++it ) {  
-        float energy = recHitEnergy(*it,recHits,flagsexcl, severitiesexcl, sevLv);
+    for( const std::pair<DetId,float>& hAndF : hsAndFs ) {
+      for ( std::vector<DetId>::const_iterator it = v_id.begin(); it != v_id.end(); ++it ) {  
+	if( hAndF.first != *it ) continue;
+        float energy = recHitEnergy(*it,recHits,flagsexcl, severitiesexcl, sevLv) * hAndF.second;
         if(energy<0.) continue;//skipping negative energy crystals
         meanXY.first += energy * getNormedIX(*it);
         meanXY.second += energy * getNormedIY(*it);
         energySum +=energy;
+      }
     }
     meanXY.first/=energySum;
     meanXY.second/=energySum;
@@ -1077,7 +1094,7 @@ std::vector<float> EcalClusterTools::localCovariances(const reco::BasicCluster &
 
     if (e_5x5 >= 0.) {
         //double w0_ = parameterMap_.find("W0")->second;
-        std::vector< std::pair<DetId, float> > v_id = cluster.hitsAndFractions();
+        const std::vector< std::pair<DetId, float> >& v_id = cluster.hitsAndFractions();
         std::pair<float,float> mean5x5PosInNrCrysFromSeed =  mean5x5PositionInLocalCrysCoord( cluster, recHits, topology,flagsexcl, severitiesexcl, sevLv );
         std::pair<float,float> mean5x5XYPos =  mean5x5PositionInXY(cluster,recHits,topology,flagsexcl, severitiesexcl, sevLv);
 
@@ -1523,34 +1540,20 @@ std::vector<float> EcalClusterTools::scLocalCovariances(const reco::SuperCluster
 
 Cluster2ndMoments EcalClusterTools::cluster2ndMoments( const reco::BasicCluster &basicCluster, const EcalRecHitCollection &recHits, double phiCorrectionFactor, double w0, bool useLogWeights) {
 
-  Cluster2ndMoments returnMoments;
-  returnMoments.sMaj = -1.;
-  returnMoments.sMin = -1.;
-  returnMoments.alpha = 0.;
-
   // for now implemented only for EB:
   //  if( fabs( basicCluster.eta() ) < 1.479 ) { 
 
-    std::vector<const EcalRecHit*> RH_ptrs;
-    
-    std::vector< std::pair<DetId, float> > myHitsPair = basicCluster.hitsAndFractions();
-    std::vector<DetId> usedCrystals;
-    for(unsigned int i=0; i< myHitsPair.size(); i++){
-      usedCrystals.push_back(myHitsPair[i].first);
-    }
-    
-    for(unsigned int i=0; i<usedCrystals.size(); i++){
-      //get pointer to recHit object
-      EcalRecHitCollection::const_iterator myRH = recHits.find(usedCrystals[i]);
-      RH_ptrs.push_back(  &(*myRH)  );
-    }
-
-      returnMoments = EcalClusterTools::cluster2ndMoments(RH_ptrs, phiCorrectionFactor, w0, useLogWeights);
-
-      //  }
-
-  return returnMoments;
-
+  std::vector<std::pair<const EcalRecHit*, float> > RH_ptrs_fracs;
+  
+  const std::vector< std::pair<DetId, float> >& myHitsPair = basicCluster.hitsAndFractions();
+  
+  for(unsigned int i=0; i<myHitsPair.size(); i++){
+    //get pointer to recHit object
+    EcalRecHitCollection::const_iterator myRH = recHits.find(myHitsPair[i].first);
+    RH_ptrs_fracs.push_back(  std::make_pair(&(*myRH) , myHitsPair[i].second)  );
+  }
+  
+  return EcalClusterTools::cluster2ndMoments(RH_ptrs_fracs, phiCorrectionFactor, w0, useLogWeights);
 }
 
 
@@ -1572,11 +1575,11 @@ Cluster2ndMoments EcalClusterTools::cluster2ndMoments( const reco::SuperCluster 
 }
 
 
-Cluster2ndMoments EcalClusterTools::cluster2ndMoments( const std::vector<const EcalRecHit*>& RH_ptrs, double phiCorrectionFactor, double w0, bool useLogWeights) {
+Cluster2ndMoments EcalClusterTools::cluster2ndMoments( const std::vector<std::pair<const EcalRecHit*, float> >& RH_ptrs_fracs, double phiCorrectionFactor, double w0, bool useLogWeights) {
 
   double mid_eta(0),mid_phi(0),mid_x(0),mid_y(0);
   
-  double Etot = EcalClusterTools::getSumEnergy(  RH_ptrs  );
+  double Etot = EcalClusterTools::getSumEnergy(  RH_ptrs_fracs  );
  
   double max_phi=-10.;
   double min_phi=100.;
@@ -1593,23 +1596,25 @@ Cluster2ndMoments EcalClusterTools::cluster2ndMoments( const std::vector<const E
   bool isBarrel(1);
 
   // loop over rechits and compute weights:
-  for(std::vector<const EcalRecHit*>::const_iterator rh_ptr = RH_ptrs.begin(); rh_ptr != RH_ptrs.end(); rh_ptr++){
+  for(std::vector<std::pair<const EcalRecHit*, float> >::const_iterator rhf_ptr = RH_ptrs_fracs.begin(); rhf_ptr != RH_ptrs_fracs.end(); rhf_ptr++){
+    const EcalRecHit* rh_ptr = rhf_ptr->first;
+
 
     //get iEta, iPhi
     double temp_eta(0),temp_phi(0),temp_x(0),temp_y(0);
-    isBarrel = (*rh_ptr)->detid().subdetId()==EcalBarrel;
+    isBarrel = rh_ptr->detid().subdetId()==EcalBarrel;
     
     if(isBarrel) {
-      temp_eta = (getIEta((*rh_ptr)->detid()) > 0. ? getIEta((*rh_ptr)->detid()) + 84.5 : getIEta((*rh_ptr)->detid()) + 85.5);
-      temp_phi= getIPhi((*rh_ptr)->detid()) - 0.5;
+      temp_eta = (getIEta(rh_ptr->detid()) > 0. ? getIEta(rh_ptr->detid()) + 84.5 : getIEta(rh_ptr->detid()) + 85.5);
+      temp_phi= getIPhi(rh_ptr->detid()) - 0.5;
     }
     else {
-      temp_eta = getIEta((*rh_ptr)->detid());  
-      temp_x =  getNormedIX((*rh_ptr)->detid());
-      temp_y =  getNormedIY((*rh_ptr)->detid());
+      temp_eta = getIEta(rh_ptr->detid());  
+      temp_x =  getNormedIX(rh_ptr->detid());
+      temp_y =  getNormedIY(rh_ptr->detid());
     }	  
 
-    double temp_ene=(*rh_ptr)->energy();
+    double temp_ene=rh_ptr->energy() * rhf_ptr->second;
     
     double temp_wi=((useLogWeights) ?
                     std::max(0., w0 + log( fabs(temp_ene)/Etot ))
@@ -1706,20 +1711,16 @@ Cluster2ndMoments EcalClusterTools::cluster2ndMoments( const std::vector<const E
 // you can select linear weighting = energy_recHit/total_energy         (weightedPositionMethod=0) default
 // or log weighting = max( 0.0, 4.2 + log(energy_recHit/total_energy) ) (weightedPositionMethod=1)
 std::vector<float> EcalClusterTools::roundnessBarrelSuperClusters( const reco::SuperCluster &superCluster ,const EcalRecHitCollection &recHits, int weightedPositionMethod, float energyThreshold){//int positionWeightingMethod=0){
-    std::vector<const EcalRecHit*>RH_ptrs;
-    std::vector< std::pair<DetId, float> > myHitsPair = superCluster.hitsAndFractions();
-    std::vector<DetId> usedCrystals;
-    for(unsigned int i=0; i< myHitsPair.size(); i++){
-        usedCrystals.push_back(myHitsPair[i].first);
-    }
-    for(unsigned int i=0; i<usedCrystals.size(); i++){
+  std::vector<std::pair<const EcalRecHit*, float> > RH_ptrs_fracs;
+    const std::vector< std::pair<DetId, float> >& myHitsPair = superCluster.hitsAndFractions();    
+    for(unsigned int i=0; i< myHitsPair.size(); ++i){
         //get pointer to recHit object
-        EcalRecHitCollection::const_iterator myRH = recHits.find(usedCrystals[i]);
-        if( myRH != recHits.end() && myRH->energy() > energyThreshold){ //require rec hit to have positive energy
-            RH_ptrs.push_back(  &(*myRH)  );
+        EcalRecHitCollection::const_iterator myRH = recHits.find(myHitsPair[i].first);
+        if( myRH != recHits.end() && myRH->energy()*myHitsPair[i].second > energyThreshold){ //require rec hit to have positive energy
+	  RH_ptrs_fracs.push_back(  std::make_pair(&(*myRH) , myHitsPair[i].second)  );
         }
     }
-    std::vector<float> temp = EcalClusterTools::roundnessSelectedBarrelRecHits(RH_ptrs,weightedPositionMethod); 
+    std::vector<float> temp = EcalClusterTools::roundnessSelectedBarrelRecHits(RH_ptrs_fracs,weightedPositionMethod); 
     return temp;
 }
 
@@ -1730,25 +1731,21 @@ std::vector<float> EcalClusterTools::roundnessBarrelSuperClusters( const reco::S
 
 std::vector<float> EcalClusterTools::roundnessBarrelSuperClustersUserExtended( const reco::SuperCluster &superCluster ,const EcalRecHitCollection &recHits, int ieta_delta, int iphi_delta, float energyRHThresh, int weightedPositionMethod){
 
-    std::vector<const EcalRecHit*>RH_ptrs;
-    std::vector< std::pair<DetId, float> > myHitsPair = superCluster.hitsAndFractions();
-    std::vector<DetId> usedCrystals;
-    for(unsigned int i=0; i< myHitsPair.size(); i++){
-        usedCrystals.push_back(myHitsPair[i].first);
-    }
-
-    for(unsigned int i=0; i<usedCrystals.size(); i++){
+  std::vector<std::pair<const EcalRecHit*, float> > RH_ptrs_fracs;
+    const std::vector< std::pair<DetId, float> >& myHitsPair = superCluster.hitsAndFractions();
+    for(unsigned int i=0; i<myHitsPair.size(); ++i){
         //get pointer to recHit object
-        EcalRecHitCollection::const_iterator myRH = recHits.find(usedCrystals[i]);
-        if(myRH != recHits.end() && myRH->energy() > energyRHThresh)
-            RH_ptrs.push_back(  &(*myRH)  );
+        EcalRecHitCollection::const_iterator myRH = recHits.find(myHitsPair[i].first);
+        if(myRH != recHits.end() && myRH->energy()*myHitsPair[i].second > energyRHThresh)
+	  RH_ptrs_fracs.push_back(  std::make_pair(&(*myRH) , myHitsPair[i].second) );
     }
 
 
-    std::vector<int> seedPosition = EcalClusterTools::getSeedPosition(  RH_ptrs  );
+    std::vector<int> seedPosition = EcalClusterTools::getSeedPosition(  RH_ptrs_fracs  );
 
     for(EcalRecHitCollection::const_iterator rh = recHits.begin(); rh != recHits.end(); rh++){
         EBDetId EBdetIdi( rh->detid() );
+	float the_fraction = 0;
         //if(rh != recHits.end())
         bool inEtaWindow = (   abs(  deltaIEta(seedPosition[0],EBdetIdi.ieta())  ) <= ieta_delta   );
         bool inPhiWindow = (   abs(  deltaIPhi(seedPosition[1],EBdetIdi.iphi())  ) <= iphi_delta   );
@@ -1757,62 +1754,65 @@ std::vector<float> EcalClusterTools::roundnessBarrelSuperClustersUserExtended( c
 
         // figure out if the rechit considered now is already inside the SC
         bool is_SCrh_inside_recHits = false;
-        for(unsigned int i=0; i<usedCrystals.size(); i++){
-            EcalRecHitCollection::const_iterator SCrh = recHits.find(usedCrystals[i]);
+        for(unsigned int i=0; i<myHitsPair.size(); i++){
+            EcalRecHitCollection::const_iterator SCrh = recHits.find(myHitsPair[i].first);
             if(SCrh != recHits.end()){
+	      the_fraction = myHitsPair[i].second;
                 is_SCrh_inside_recHits = true;
                 if( rh->detid() == SCrh->detid()  ) alreadyCounted = true;
             }
         }//for loop over SC's recHits
 
         if( is_SCrh_inside_recHits && !alreadyCounted && passEThresh && inEtaWindow && inPhiWindow){
-            RH_ptrs.push_back( &(*rh) );
+	  RH_ptrs_fracs.push_back( std::make_pair(&(*rh),the_fraction) );
         }
 
     }//for loop over rh
-    return EcalClusterTools::roundnessSelectedBarrelRecHits(RH_ptrs,weightedPositionMethod);
+    return EcalClusterTools::roundnessSelectedBarrelRecHits(RH_ptrs_fracs,weightedPositionMethod);
 }
 
 // this function computes the roundness and angle variables for vector of pointers to recHits you pass it
 // you can select linear weighting = energy_recHit/total_energy         (weightedPositionMethod=0)
 // or log weighting = max( 0.0, 4.2 + log(energy_recHit/total_energy) ) (weightedPositionMethod=1)
-std::vector<float> EcalClusterTools::roundnessSelectedBarrelRecHits( const std::vector<const EcalRecHit*>& RH_ptrs, int weightedPositionMethod){//int weightedPositionMethod = 0){
+std::vector<float> EcalClusterTools::roundnessSelectedBarrelRecHits( const std::vector<std::pair<const EcalRecHit*,float> >& RH_ptrs_fracs, int weightedPositionMethod){//int weightedPositionMethod = 0){
     //positionWeightingMethod = 0 linear weighting, 1 log energy weighting
 
     std::vector<float> shapes; // this is the returning vector
 
     //make sure photon has more than one crystal; else roundness and angle suck
-    if(RH_ptrs.size()<2){
+    if(RH_ptrs_fracs.size()<2){
         shapes.push_back( -3 );
         shapes.push_back( -3 );
         return shapes;
     }
 
     //Find highest E RH (Seed) and save info, compute sum total energy used
-    std::vector<int> seedPosition = EcalClusterTools::getSeedPosition(  RH_ptrs  );// *recHits);
+    std::vector<int> seedPosition = EcalClusterTools::getSeedPosition(  RH_ptrs_fracs  );// *recHits);
     int tempInt = seedPosition[0];
     if(tempInt <0) tempInt++;
-    float energyTotal = EcalClusterTools::getSumEnergy(  RH_ptrs  );
+    float energyTotal = EcalClusterTools::getSumEnergy(  RH_ptrs_fracs  );
 
     //1st loop over rechits: compute new weighted center position in coordinates centered on seed
     float centerIEta = 0.;
     float centerIPhi = 0.;
     float denominator = 0.;
 
-    for(std::vector<const EcalRecHit*>::const_iterator rh_ptr = RH_ptrs.begin(); rh_ptr != RH_ptrs.end(); rh_ptr++){
+    for(std::vector<std::pair<const EcalRecHit*,float> >::const_iterator rhf_ptr = RH_ptrs_fracs.begin(); rhf_ptr != RH_ptrs_fracs.end(); rhf_ptr++){
+      const EcalRecHit* rh_ptr = rhf_ptr->first;
         //get iEta, iPhi
-        EBDetId EBdetIdi( (*rh_ptr)->detid() );
+        EBDetId EBdetIdi( rh_ptr->detid() );
         if(fabs(energyTotal) < 0.0001){
             // don't /0, bad!
             shapes.push_back( -2 );
             shapes.push_back( -2 );
             return shapes;
         }
+	float rh_energy = rh_ptr->energy() * rhf_ptr->second;
         float weight = 0;
         if(fabs(weightedPositionMethod)<0.0001){ //linear
-            weight = (*rh_ptr)->energy()/energyTotal;
+            weight = rh_energy/energyTotal;
         }else{ //logrithmic
-            weight = std::max(0.0, 4.2 + log((*rh_ptr)->energy()/energyTotal));
+            weight = std::max(0.0, 4.2 + log(rh_energy/energyTotal));
         }
         denominator += weight;
         centerIEta += weight*deltaIEta(seedPosition[0],EBdetIdi.ieta()); 
@@ -1834,9 +1834,10 @@ std::vector<float> EcalClusterTools::roundnessSelectedBarrelRecHits( const std::
     double inertia01 = 0.;// = inertia10 b/c matrix should be symmetric
     double inertia11 = 0.;
     int i = 0;
-    for(std::vector<const EcalRecHit*>::const_iterator rh_ptr = RH_ptrs.begin(); rh_ptr != RH_ptrs.end(); rh_ptr++){
+    for(std::vector<std::pair<const EcalRecHit*,float> >::const_iterator rhf_ptr = RH_ptrs_fracs.begin(); rhf_ptr != RH_ptrs_fracs.end(); rhf_ptr++){
+      const EcalRecHit* rh_ptr = rhf_ptr->first;
         //get iEta, iPhi
-        EBDetId EBdetIdi( (*rh_ptr)->detid() );
+        EBDetId EBdetIdi( rh_ptr->detid() );
 
         if(fabs(energyTotal) < 0.0001){
             // don't /0, bad!
@@ -1844,11 +1845,12 @@ std::vector<float> EcalClusterTools::roundnessSelectedBarrelRecHits( const std::
             shapes.push_back( -2 );
             return shapes;
         }
+	float rh_energy = rh_ptr->energy() * rhf_ptr->second;
         float weight = 0;
         if(fabs(weightedPositionMethod) < 0.0001){ //linear
-            weight = (*rh_ptr)->energy()/energyTotal;
+            weight = rh_energy/energyTotal;
         }else{ //logrithmic
-            weight = std::max(0.0, 4.2 + log((*rh_ptr)->energy()/energyTotal));
+            weight = std::max(0.0, 4.2 + log(rh_energy/energyTotal));
         }
 
         float ieta_rh_to_center = deltaIEta(seedPosition[0],EBdetIdi.ieta()) - centerIEta;
@@ -1925,19 +1927,20 @@ int EcalClusterTools::deltaIEta(int seed_ieta, int rh_ieta){
 }
 
 //return (ieta,iphi) of highest energy recHit of the recHits passed to this function
-std::vector<int> EcalClusterTools::getSeedPosition(const std::vector<const EcalRecHit*>& RH_ptrs){
+std::vector<int> EcalClusterTools::getSeedPosition(const std::vector<std::pair<const EcalRecHit*, float> >& RH_ptrs_fracs){
     std::vector<int> seedPosition;
     float eSeedRH = 0;
     int iEtaSeedRH = 0;
     int iPhiSeedRH = 0;
 
-    for(std::vector<const EcalRecHit*>::const_iterator rh_ptr = RH_ptrs.begin(); rh_ptr != RH_ptrs.end(); rh_ptr++){
-
+    for(std::vector<std::pair<const EcalRecHit*,float> >::const_iterator rhf_ptr = RH_ptrs_fracs.begin(); rhf_ptr != RH_ptrs_fracs.end(); rhf_ptr++){
+      const EcalRecHit* rh_ptr = rhf_ptr->first;
         //get iEta, iPhi
-        EBDetId EBdetIdi( (*rh_ptr)->detid() );
+        EBDetId EBdetIdi( rh_ptr->detid() );
+	float rh_energy = rh_ptr->energy() * rhf_ptr->second;
 
-        if(eSeedRH < (*rh_ptr)->energy()){
-            eSeedRH = (*rh_ptr)->energy();
+        if(eSeedRH < rh_energy){
+            eSeedRH = rh_energy;
             iEtaSeedRH = EBdetIdi.ieta();
             iPhiSeedRH = EBdetIdi.iphi();
         }
@@ -1950,13 +1953,10 @@ std::vector<int> EcalClusterTools::getSeedPosition(const std::vector<const EcalR
 }
 
 // return the total energy of the recHits passed to this function
-float EcalClusterTools::getSumEnergy(const std::vector<const EcalRecHit*>& RH_ptrs){
-
+float EcalClusterTools::getSumEnergy(const std::vector<std::pair<const EcalRecHit*, float> >& RH_ptrs_fracs){
     float sumE = 0.;
-
-    for(std::vector<const EcalRecHit*>::const_iterator rh_ptr = RH_ptrs.begin(); rh_ptr != RH_ptrs.end(); rh_ptr++){
-        sumE += (*rh_ptr)->energy();
-    }// for loop
-
+    for( const auto& hAndF : RH_ptrs_fracs ) {
+      sumE += hAndF.first->energy() * hAndF.second;
+    }    
     return sumE;
 }

--- a/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/GEDPhotonProducer.cc
@@ -41,6 +41,15 @@
 #include "RecoEcal/EgammaCoreTools/plugins/EcalClusterCrackCorrection.h"
 #include "RecoEgamma/EgammaIsolationAlgos/interface/EgammaHadTower.h"
 
+namespace {
+  inline double ptFast( const double energy, 
+			const math::XYZPoint& position,
+			const math::XYZPoint& origin ) {
+    const auto v = position - origin;
+    return energy*std::sqrt(v.perp2()/v.mag2());
+  }
+}
+
 GEDPhotonProducer::GEDPhotonProducer(const edm::ParameterSet& config) : 
 
   conf_(config)
@@ -462,10 +471,12 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
     }
 
     
+    
+
     // SC energy preselection
     if (parentSCRef.isNonnull() &&
-	parentSCRef->energy()/cosh(parentSCRef->eta()) <= preselCutValues[0] ) continue;
-    // calculate HoE
+	ptFast(parentSCRef->energy(),parentSCRef->position(),math::XYZPoint(0,0,0)) <= preselCutValues[0] ) continue;
+    // calculate HoE    
 
     const CaloTowerCollection* hcalTowersColl = hcalTowersHandle.product();
     EgammaTowerIsolation towerIso1(hOverEConeSize_,0.,0.,1,hcalTowersColl) ;  
@@ -630,7 +641,7 @@ void GEDPhotonProducer::fillPhotonCollection(edm::Event& evt,
   
     // SC energy preselection
     if (parentSCRef.isNonnull() &&
-	parentSCRef->energy()/cosh(parentSCRef->eta()) <= preselCutValues[0] ) continue;
+	ptFast(parentSCRef->energy(),parentSCRef->position(),math::XYZPoint(0,0,0)) <= preselCutValues[0] ) continue;
     reco::Photon newCandidate(*phoRef);
     iSC++;    
   


### PR DESCRIPTION
Based on pre11 + #1986:

This PR addresses the following issues:
- Fixes the shower shape issue found in the EXO DQM
  - https://twiki.cern.ch/twiki/bin/viewauth/CMS/Exo_700pre9GEDwrt700pre9_MC
  - This was caused by not using the rechit fractions to calculate these shower shapes.
- Some additional fraction clean-up (mean positions in 5x5s weren't using them)
  - Causes small changes in cluster covariances, but calculation is internally consistent now.
- Code Review : Uses faster calculation of pT and avoids lots of unneeded de-referencing.
