### PR TITLE
edm::refToPtr now handles null Refs

### DIFF
--- a/DataFormats/Common/interface/RefToPtr.h
+++ b/DataFormats/Common/interface/RefToPtr.h
@@ -18,6 +18,9 @@ namespace edm {
   Ptr<typename C::value_type> refToPtr(
     Ref<C, typename C::value_type, refhelper::FindUsingAdvance<C, typename C::value_type> > const& ref) {
     typedef typename C::value_type T;
+    if (ref.isNull()) {
+      return Ptr<T>();
+    }
     if (ref.isTransient()) {
       return Ptr<T>(ref.product(), ref.key());
     } else if (not ref.hasProductCache()) {


### PR DESCRIPTION
Previous, edm::refToPtr would cause an exception to happen if it was passed a ‘null’ edm::Ref. This change now just returns a null edm::Ptr in such a case.
