### PR TITLE
consumes migration for Validation/EcalHits

### DIFF
--- a/Validation/EcalHits/interface/EcalBarrelSimHitsValidation.h
+++ b/Validation/EcalHits/interface/EcalBarrelSimHitsValidation.h
@@ -8,17 +8,17 @@
  *
 */
 
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+#include "DQMServices/Core/interface/MonitorElement.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
@@ -79,7 +79,10 @@ private:
  std::string g4InfoLabel;
  std::string EBHitsCollection;
  std::string ValidationCollection;
- 
+
+ edm::EDGetTokenT<edm::PCaloHitContainer> EBHitsToken;
+ edm::EDGetTokenT<PEcalValidInfo> ValidationCollectionToken;
+
  bool verbose_;
  
  DQMStore* dbe_;

--- a/Validation/EcalHits/interface/EcalEndcapSimHitsValidation.h
+++ b/Validation/EcalHits/interface/EcalEndcapSimHitsValidation.h
@@ -15,6 +15,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -79,6 +80,9 @@ private:
  std::string EEHitsCollection;
  std::string ValidationCollection;
  
+ edm::EDGetTokenT<edm::PCaloHitContainer> EEHitsToken;
+ edm::EDGetTokenT<PEcalValidInfo> ValidationCollectionToken;
+
  bool verbose_;
  
  DQMStore* dbe_;

--- a/Validation/EcalHits/interface/EcalPreshowerSimHitsValidation.h
+++ b/Validation/EcalHits/interface/EcalPreshowerSimHitsValidation.h
@@ -15,7 +15,7 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -63,6 +63,10 @@ private:
  std::string g4InfoLabel; 
  std::string EEHitsCollection;
  std::string ESHitsCollection;
+
+ edm::EDGetTokenT<edm::HepMCProduct> HepMCToken;
+ edm::EDGetTokenT<edm::PCaloHitContainer> EEHitsToken;
+ edm::EDGetTokenT<edm::PCaloHitContainer> ESHitsToken;
  
  bool verbose_;
  

--- a/Validation/EcalHits/src/EcalBarrelSimHitsValidation.cc
+++ b/Validation/EcalHits/src/EcalBarrelSimHitsValidation.cc
@@ -19,6 +19,8 @@ EcalBarrelSimHitsValidation::EcalBarrelSimHitsValidation(const edm::ParameterSet
   EBHitsCollection(ps.getParameter<std::string>("EBHitsCollection")),
   ValidationCollection(ps.getParameter<std::string>("ValidationCollection")){   
 
+  EBHitsToken               = consumes <edm::PCaloHitContainer> (edm::InputTag(std::string(g4InfoLabel),std::string(EBHitsCollection)));
+  ValidationCollectionToken = consumes <PEcalValidInfo>         (edm::InputTag(std::string(g4InfoLabel),std::string(ValidationCollection)));
   // verbosity switch
   verbose_ = ps.getUntrackedParameter<bool>("verbose", false);
  
@@ -159,13 +161,13 @@ void EcalBarrelSimHitsValidation::analyze(const edm::Event& e, const edm::EventS
   edm::LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();
   
   edm::Handle<edm::PCaloHitContainer> EcalHitsEB;
-  e.getByLabel(g4InfoLabel,EBHitsCollection,EcalHitsEB);
+  e.getByToken(EBHitsToken,EcalHitsEB);
 
   // Do nothing if no Barrel data available
   if( ! EcalHitsEB.isValid() ) return;
 
   edm::Handle<PEcalValidInfo> MyPEcalValidInfo;
-  e.getByLabel(g4InfoLabel,ValidationCollection,MyPEcalValidInfo);
+  e.getByToken(ValidationCollectionToken,MyPEcalValidInfo);
 
   std::vector<PCaloHit> theEBCaloHits;
   theEBCaloHits.insert(theEBCaloHits.end(), EcalHitsEB->begin(), EcalHitsEB->end());

--- a/Validation/EcalHits/src/EcalEndcapSimHitsValidation.cc
+++ b/Validation/EcalHits/src/EcalEndcapSimHitsValidation.cc
@@ -19,6 +19,8 @@ EcalEndcapSimHitsValidation::EcalEndcapSimHitsValidation(const edm::ParameterSet
   EEHitsCollection(ps.getParameter<std::string>("EEHitsCollection")),
   ValidationCollection(ps.getParameter<std::string>("ValidationCollection")){   
 
+  EEHitsToken               = consumes <edm::PCaloHitContainer> (edm::InputTag(std::string(g4InfoLabel),std::string(EEHitsCollection)));
+  ValidationCollectionToken = consumes <PEcalValidInfo>         (edm::InputTag(std::string(g4InfoLabel),std::string(ValidationCollection)));
   // verbosity switch
   verbose_ = ps.getUntrackedParameter<bool>("verbose", false);
  
@@ -173,13 +175,13 @@ void EcalEndcapSimHitsValidation::analyze(const edm::Event& e, const edm::EventS
   edm::LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();
   
   edm::Handle<edm::PCaloHitContainer> EcalHitsEE;
-  e.getByLabel(g4InfoLabel,EEHitsCollection,EcalHitsEE);
+  e.getByToken(EEHitsToken,EcalHitsEE);
 
   // Do nothing if no EndCap data available
   if( ! EcalHitsEE.isValid() ) return;
 
   edm::Handle<PEcalValidInfo> MyPEcalValidInfo;
-  e.getByLabel(g4InfoLabel,ValidationCollection,MyPEcalValidInfo);
+  e.getByToken(ValidationCollectionToken,MyPEcalValidInfo);
 
   std::vector<PCaloHit> theEECaloHits;
   theEECaloHits.insert(theEECaloHits.end(), EcalHitsEE->begin(), EcalHitsEE->end());

--- a/Validation/EcalHits/src/EcalPreshowerSimHitsValidation.cc
+++ b/Validation/EcalHits/src/EcalPreshowerSimHitsValidation.cc
@@ -22,6 +22,9 @@ EcalPreshowerSimHitsValidation::EcalPreshowerSimHitsValidation(const edm::Parame
   EEHitsCollection(ps.getParameter<std::string>("EEHitsCollection")),
   ESHitsCollection(ps.getParameter<std::string>("ESHitsCollection")){
 
+  HepMCToken   = consumes <edm::HepMCProduct>      (HepMCLabel);
+  EEHitsToken  = consumes <edm::PCaloHitContainer> (edm::InputTag(std::string(g4InfoLabel),std::string(EEHitsCollection)));
+  ESHitsToken  = consumes <edm::PCaloHitContainer> (edm::InputTag(std::string(g4InfoLabel),std::string(ESHitsCollection)));
   // verbosity switch
   verbose_ = ps.getUntrackedParameter<bool>("verbose", false);
  
@@ -132,13 +135,13 @@ void EcalPreshowerSimHitsValidation::analyze(const edm::Event& e, const edm::Eve
   edm::LogInfo("EventInfo") << " Run = " << e.id().run() << " Event = " << e.id().event();
   
   edm::Handle<edm::HepMCProduct> MCEvt;
-  e.getByLabel(HepMCLabel, MCEvt);
+  e.getByToken(HepMCToken, MCEvt);
 
   edm::Handle<edm::PCaloHitContainer> EcalHitsEE;
-  e.getByLabel(g4InfoLabel,EEHitsCollection,EcalHitsEE);
+  e.getByToken(EEHitsToken,EcalHitsEE);
 
   edm::Handle<edm::PCaloHitContainer> EcalHitsES;
-  e.getByLabel(g4InfoLabel,ESHitsCollection,EcalHitsES);
+  e.getByToken(ESHitsToken,EcalHitsES);
 
   std::vector<PCaloHit> theEECaloHits;  
   if( EcalHitsEE.isValid() ) {


### PR DESCRIPTION
Quick fix of 7 instances of getbylabel to getbytoken for this package.
