### PR TITLE
Fixes for relvals

### DIFF
--- a/CondCore/ORA/src/ObjectStreamer.cc
+++ b/CondCore/ORA/src/ObjectStreamer.cc
@@ -74,11 +74,14 @@ void ora::ObjectStreamerBase::buildBaseDataMembers( DataElement& dataElement,
 	}
         processDataMember( dataMemberElement, relationalData, dataMemberType, dataMemberMapping, operationBuffer );
       } else {
+/*
+        // FIXME: Commented out because ROOT6 does not yet support attributes on "field name=" lines.
         if( !isLoosePersistencyDataMember( dataMember ) ){
 	  throwException( "Data member \"" + dataMemberName +
                           "\" not found in the mapping element of variable \""+m_mapping.variableName()+"\".",
                           "ObjectStreamerBase::buildBaseDataMembers" );
 	}
+*/
       }
     }
   }
@@ -128,11 +131,14 @@ bool ora::ObjectStreamerBase::buildDataMembers( DataElement& dataElement,
       }
       processDataMember( dataMemberElement, relationalData, dataMemberType, dataMemberMapping, operationBuffer );
     } else {
+/*
+      // FIXME: Commented out because ROOT6 does not yet support attributes on "field name=" lines.
       if(!isLoosePersistencyDataMember( dataMember ) ){
         throwException( "Data member \"" + dataMemberName +
                         "\" not found in the mapping element of variable \""+m_mapping.variableName()+"\".",
                         "ObjectStreamerBase::buildDataMembers" );
       }
+*/
     }
   }
   return true;

--- a/CondFormats/Common/interface/IOVSequence.h
+++ b/CondFormats/Common/interface/IOVSequence.h
@@ -26,7 +26,7 @@ namespace cond {
     typedef ora::QueryableVector<Item> Container;
     typedef Container::iterator iterator;
     typedef Container::const_iterator const_iterator;
-    typedef enum { Unknown=-1, Obsolete, Tag, TagInGT, ChildTag, ChildTagInGT } ScopeType;
+    enum ScopeType { Unknown=-1, Obsolete, Tag, TagInGT, ChildTag, ChildTagInGT };
 
     IOVSequence();
 


### PR DESCRIPTION
Fixes/workarounds for two ROOT6 limitations that are causing all relvals to fail.  Note that even with these fixes, the relvals will still fail for other reasons.

1) Root 6 cannot yet handle unnamed enums properly. Replace
typedef enum { Unknown=-1, Obsolete, Tag, TagInGT, ChildTag, ChildTagInGT } ScopeType;
with
enum ScopeType { Unknown=-1, Obsolete, Tag, TagInGT, ChildTag, ChildTagInGT };
This change can be permanent.

2) Root 6 cannot yet handle user defined attributes on "field name=" lines in xml selection files.
Comment out exceptions that would otherwise be thrown due to this limitation.
This change will be reverted once ROOT fixes this.
