### PR TITLE
Force creating of ROOT Streamers at begin of job

### DIFF
--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -28,6 +28,11 @@
 #include "TTree.h"
 #include "TThread.h"
 
+#include "TThread.h"
+#include "TClassTable.h"
+#include "Reflex/Type.h"
+
+
 namespace {
   enum class SeverityLevel {
     kInfo,
@@ -38,6 +43,8 @@ namespace {
   };
   
   static thread_local bool s_ignoreWarnings = false;
+
+  static bool s_ignoreEverything = false;
 
   void RootErrorHandlerImpl(int level, char const* location, char const* message) {
 
@@ -55,6 +62,10 @@ namespace {
       el_severity = SeverityLevel::kError;
     } else if (level >= kWarning) {
       el_severity = s_ignoreWarnings ? SeverityLevel::kInfo : SeverityLevel::kWarning;
+    }
+
+    if(s_ignoreEverything) {
+      el_severity = SeverityLevel::kInfo;
     }
 
   // Adapt C-strings to std::strings
@@ -286,6 +297,63 @@ namespace edm {
       }
       if(not this->loadAllDictionaries_) {
         RootAutoLibraryLoader::loadAll();
+      }
+
+      //Must force all streamers into existence
+      std::vector<const char*> knownClassNames;
+      int const kNClasses = gClassTable->Classes();
+      knownClassNames.reserve(kNClasses);
+      for(int i = 0; i<kNClasses; ++i) {
+	auto const name = gClassTable->At(i);
+	knownClassNames.push_back(name);
+      }
+
+      const std::string kFalse("false");
+      //Wrappers are required to work
+      for(auto name : knownClassNames) {
+	if(strncmp(name,"edm::Wrapper<",13)==0) {
+	  TClass* c=TClass::GetClass(name);
+	  //can't use the name to lookup ReflexType becuase ROOT removes 'std::'
+	  assert(c->GetTypeInfo());
+	  auto t = Reflex::Type::ByTypeInfo(*(c->GetTypeInfo()));
+	  Reflex::PropertyList wp = t.Properties();
+	  if(wp.HasProperty("persistent") and wp.PropertyAsString("persistent") == kFalse) continue;
+	  //std::cout <<"start GetStreamerInfo for "<<name<<std::endl;
+	  c->GetStreamerInfo();
+	}
+      }
+
+      const std::vector<const char*> kKnownNames = {"TH2F","TArrayF"};
+      for(auto name: kKnownNames) {
+	TClass* c=TClass::GetClass(name);
+	assert(c);
+	c->GetStreamerInfo();
+      }
+
+      s_ignoreEverything=true;
+      std::shared_ptr<void*> guard(nullptr,[](void*) { s_ignoreEverything=false;});
+
+      const Reflex::Type kDefaultType;
+      for(auto name : knownClassNames) {
+	if(strncmp(name,"edm::Wrapper<",13)==0) continue;
+	//std::cout <<"look at class "<<name<<std::endl;
+	TClass* c=TClass::GetClass(name);
+	if(c == nullptr) continue;
+	auto id = c->GetTypeInfo();
+	if( nullptr == id) continue;
+	auto t = Reflex::Type::ByTypeInfo(*id);
+	if(t == kDefaultType) continue;
+	Reflex::PropertyList wp = t.Properties();
+	if(wp.HasProperty("persistent") and wp.PropertyAsString("persistent") == kFalse) continue;
+
+	if( (not (c->Property() & kIsAbstract) ) and 
+            c->HasDefaultConstructor() and 
+            (0 != c->GetClassVersion())  and
+	    ( 0 == (gClassTable->GetPragmaBits(name) & TClassTable::kNoStreamer) )
+	    ) {
+	  //std::cout <<"start GetStreamerInfo for "<<name<<" "<<c->GetClassVersion()<<std::endl;
+	  c->GetStreamerInfo();
+	}
       }
     }
     


### PR DESCRIPTION
The code which constructs ROOT Streamers is not thread safe. Unfortunately,
Streamers normally get created the first time they are needed which would
be too late for our case. This change forces all Streamers to be created,
even if we do not need them for this job.
