### PR TITLE
Added missing dictionaries for ROOT I/O

### DIFF
--- a/SimDataFormats/GeneratorProducts/src/classes.h
+++ b/SimDataFormats/GeneratorProducts/src/classes.h
@@ -33,6 +33,8 @@ namespace SimDataFormats_GeneratorProducts {
 		std::map<int, HepMC::GenParticle*> m_particle_barcodes;
 		std::pair<const int, HepMC::GenVertex*> prgv1;
 		std::pair<const int, HepMC::GenParticle*> prgp1;
+		std::pair<int, HepMC::GenVertex*> prgv1_nc;
+		std::pair<int, HepMC::GenParticle*> prgp1_nc;
 		std::map<int, HepMC::GenVertex*, std::greater<int> > dummy777;
 		std::vector<HepMC::GenParticle*> m_particles_out;
 		std::vector<HepMC::GenParticle*> m_particles_in;

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -74,8 +74,10 @@
 	<class name="edm::RefVector&lt;edm::HepMCProduct,HepMC::GenParticle,edm::refhelper::FindTrait&lt;edm::HepMCProduct,HepMC::GenParticle&gt;::Find&gt;"/>
 	<class name="std::map&lt;int,HepMC::GenVertex*&gt;"/>
 	<class name="std::pair&lt;const int,HepMC::GenVertex*&gt;"/>
+	<class name="std::pair&lt;int,HepMC::GenVertex*&gt;"/>
 	<class name="std::map&lt;int,HepMC::GenParticle*&gt;"/>
 	<class name="std::pair&lt;const int,HepMC::GenParticle*&gt;"/>
+	<class name="std::pair&lt;int,HepMC::GenParticle*&gt;"/>
 	<class name="std::map&lt;int,HepMC::GenVertex*,std::greater&lt;int&gt; &gt;"/>
 
 	<!-- Classes shared between different kinds of products -->


### PR DESCRIPTION
When storing a std::map, ROOT wants the first element of the stored
std::pair to be non-const for the dictionary declaration. If it
does not find the dictionary, it creates a dummy one but does it
at the wrong to for the threaded framework.
