### PR TITLE
Reenable edmWriteConfigs

### DIFF
--- a/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
+++ b/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
@@ -148,7 +148,6 @@ namespace {
 
 int main (int argc, char **argv)
 try {
-/*
   boost::filesystem::path initialWorkingDirectory =
     boost::filesystem::initial_path<boost::filesystem::path>();
 
@@ -316,7 +315,6 @@ try {
       << std::endl;
     return 1;
   }
-*/
   return 0;
 } catch(cms::Exception const& e) {
   std::cerr << e.explainSelf() << std::endl;


### PR DESCRIPTION
Reenabling edmWriteConfigs was merged into CMSSW_7_0_ROOT6_X, but never made it into CMSSW_7_1_ROOT6_X.  This pull request remedies that.  Please merge as soon as convenient or provide a reason for not doing it.
