### PR TITLE
Use simple signal handlers at exit

### DIFF
--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -188,6 +188,10 @@ namespace {
       }
       ::abort();
     }
+    
+    void sig_abort(int sig, siginfo_t*, void*) {
+      ::abort();
+    }
   }
 }  // end of unnamed namespace
 
@@ -218,8 +222,17 @@ namespace edm {
         gSystem->ResetSignal(kSigSegmentationViolation);
         gSystem->ResetSignal(kSigIllegalInstruction);
         installCustomHandler(SIGBUS,sig_dostack_then_abort);
+        sigBusHandler_ = std::shared_ptr<const void>(nullptr,[](void*) {
+          installCustomHandler(SIGBUS,sig_abort);
+        });
         installCustomHandler(SIGSEGV,sig_dostack_then_abort);
+        sigSegvHandler_ = std::shared_ptr<const void>(nullptr,[](void*) {
+          installCustomHandler(SIGSEGV,sig_abort);
+        });
         installCustomHandler(SIGILL,sig_dostack_then_abort);
+        sigIllHandler_ = std::shared_ptr<const void>(nullptr,[](void*) {
+          installCustomHandler(SIGILL,sig_abort);
+        });
       }
 
       if(resetErrHandler_) {

--- a/FWCore/Services/src/InitRootHandlers.h
+++ b/FWCore/Services/src/InitRootHandlers.h
@@ -1,6 +1,7 @@
 #ifndef FWCore_Services_InitRootHandlers_h
 #define FWCore_Services_InitRootHandlers_h
 
+#include <memory>
 #include "FWCore/Utilities/interface/RootHandlers.h"
 
 namespace edm {
@@ -22,6 +23,9 @@ namespace edm {
       bool unloadSigHandler_;
       bool resetErrHandler_;
       bool autoLibraryLoader_;
+      std::shared_ptr<const void> sigBusHandler_;
+      std::shared_ptr<const void> sigSegvHandler_;
+      std::shared_ptr<const void> sigIllHandler_;
     };
 
     inline


### PR DESCRIPTION
Before exiting the program, we want to make sure to switch to a simpler signal handler. This is to avoid cases where a signal is thrown while parts of ROOT or the message logger have already been deallocated. This also avoids a problem happening in the threaded build were jemalloc causes a signal while it is still holding its internal lock and then the complex signal handler asks jemalloc for more memory and the program deadlocks.
