### PR TITLE
reduce buffer size for FEVTHLTDEBUG output given the 2000++ branches tha...

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -292,7 +292,7 @@ FEVTDEBUGEventContent = cms.PSet(
 FEVTDEBUGHLTEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *'),
     splitLevel = cms.untracked.int32(0),
-    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
+    eventAutoFlushCompressedSize=cms.untracked.int32(1*1024*1024)
 )
 
 #


### PR DESCRIPTION
Change buffer size from 5MB to 1MB. should help reduce crashes in relval due to memory blowups from writing the output file.
