### PR TITLE
tracking DQM: FractionOfGoodTracks back to standard distribution

### DIFF
--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -33,6 +33,7 @@ Monitoring source for general quantities related to tracks.
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
 class DQMStore;
 class TrackAnalyzer;
@@ -78,7 +79,6 @@ class TrackingMonitor : public edm::EDAnalyzer
 	edm::EDGetTokenT<reco::VertexCollection> pvSrcToken_;
 
 	edm::EDGetTokenT<reco::TrackCollection> allTrackToken_;
-
 	edm::EDGetTokenT<reco::TrackCollection> trackToken_;
 	edm::EDGetTokenT<TrackCandidateCollection> trackCandidateToken_;
 	edm::EDGetTokenT<edm::View<TrajectorySeed> > seedToken_;
@@ -156,6 +156,10 @@ class TrackingMonitor : public edm::EDAnalyzer
 	bool doFractionPlot_;
 
         GenericTriggerEventFlag* genTriggerEventFlag_;
+
+	StringCutObjectSelector<reco::Track,true> numSelection_;
+	StringCutObjectSelector<reco::Track,true> denSelection_;
+
 };
 
 #endif //define TrackingMonitor_H

--- a/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
@@ -5,6 +5,8 @@ from DQM.TrackingMonitor.BXlumiParameters_cfi import BXlumiSetup
 TrackMon = cms.EDAnalyzer("TrackingMonitor",
     
     # input tags
+    numCut           = cms.string(" pt >= 1 & quality('highPurity') "),
+    denCut           = cms.string(" pt >= 1 "),
     allTrackProducer = cms.InputTag("generalTracks"),
     TrackProducer    = cms.InputTag("generalTracks"),
     SeedProducer     = cms.InputTag("initialStepSeeds"),

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -589,7 +589,7 @@ void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
     if ( doRecHitVsPhiVsEtaPerTrack_ || doAllPlots_ )
       NumberOfRecHitVsPhiVsEtaPerTrack->Fill(eta,phi,nRecHits);
     
-    int nLayers = track.hitPattern().stripLayersWithMeasurement();    
+    int nLayers = track.hitPattern().trackerLayersWithMeasurement();    
     // layers
     NumberOfLayersPerTrack->Fill(nLayers);
 
@@ -1236,27 +1236,27 @@ void TrackAnalyzer::fillHistosForTrackerSpecific(const reco::Track & track)
     switch(substr) {
     case StripSubdetector::TIB :
       nValidLayers  = track.hitPattern().stripTIBLayersWithMeasurement();       // case 0: strip TIB
-      nValidRecHits = track.hitPattern().stripTIBLayersWithMeasurement();       // case 0: strip TIB
+      nValidRecHits = track.hitPattern().numberOfValidStripTIBHits();           // case 0: strip TIB
       break;
     case StripSubdetector::TID :
       nValidLayers  = track.hitPattern().stripTIDLayersWithMeasurement();       // case 0: strip TID
-      nValidRecHits = track.hitPattern().stripTIDLayersWithMeasurement();       // case 0: strip TID
+      nValidRecHits = track.hitPattern().numberOfValidStripTIDHits();           // case 0: strip TID
       break;
     case StripSubdetector::TOB :
       nValidLayers  = track.hitPattern().stripTOBLayersWithMeasurement();       // case 0: strip TOB
-      nValidRecHits = track.hitPattern().stripTOBLayersWithMeasurement();       // case 0: strip TOB
+      nValidRecHits = track.hitPattern().numberOfValidStripTOBHits();           // case 0: strip TOB
       break;
     case StripSubdetector::TEC :
       nValidLayers  = track.hitPattern().stripTECLayersWithMeasurement();       // case 0: strip TEC
-      nValidRecHits = track.hitPattern().stripTECLayersWithMeasurement();       // case 0: strip TEC
+      nValidRecHits = track.hitPattern().numberOfValidStripTECHits();           // case 0: strip TEC
       break;
     case PixelSubdetector::PixelBarrel :
       nValidLayers  = track.hitPattern().pixelBarrelLayersWithMeasurement();    // case 0: pixel PXB
-      nValidRecHits = track.hitPattern().pixelBarrelLayersWithMeasurement();    // case 0: pixel PXB
+      nValidRecHits = track.hitPattern().numberOfValidPixelBarrelHits();        // case 0: pixel PXB
       break;
     case PixelSubdetector::PixelEndcap :
       nValidLayers  = track.hitPattern().pixelEndcapLayersWithMeasurement();    // case 0: pixel PXF
-      nValidRecHits = track.hitPattern().pixelEndcapLayersWithMeasurement();    // case 0: pixel PXF
+      nValidRecHits = track.hitPattern().numberOfValidPixelEndcapHits();        // case 0: pixel PXF
       break;
     default :
       break;

--- a/DQM/TrackingMonitorSource/python/TrackCollections2monitor_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackCollections2monitor_cff.py
@@ -6,6 +6,8 @@ sequenceName = {}
 trackPtMin = {}
 trackPtMax = {}
 doPlotsPCA = {}
+numCutString = {}
+denCutString = {}
 
 selectedTracks = []
 
@@ -14,6 +16,8 @@ vertexfolderName['generalTracks'] = 'Tracking/PrimaryVertices/generalTracks'
 trackPtMin      ['generalTracks'] = cms.double(0.)
 trackPtMax      ['generalTracks'] = cms.double(100.)
 doPlotsPCA      ['generalTracks'] = cms.bool(False)
+numCutString    ['generalTracks'] = cms.string("")
+denCutString    ['generalTracks'] = cms.string("")
 
 trackSelector = cms.EDFilter('TrackSelector',
     src = cms.InputTag('generalTracks'),
@@ -29,6 +33,8 @@ mainfolderName  ['highPurityPtRange0to1'] = 'Tracking/TrackParameters/highPurity
 vertexfolderName['highPurityPtRange0to1'] = 'Tracking/PrimaryVertices/highPurityTracks/pt_0to1'
 trackPtMin      ['highPurityPtRange0to1'] = cms.double(0.)
 trackPtMax      ['highPurityPtRange0to1'] = cms.double(1.)
+numCutString    ['highPurityPtRange0to1'] = cms.string("") # default: " pt >= 1 & quality('highPurity') "
+denCutString    ['highPurityPtRange0to1'] = cms.string(" pt >= 0 & pt < 1 ") # it is as in the default config (just be sure)
 
 highPurityPtRange1to10 = trackSelector.clone()
 highPurityPtRange1to10.cut = cms.string("quality('highPurity') & pt >= 1 & pt < 10 ")
@@ -38,6 +44,8 @@ mainfolderName  ['highPurityPtRange1to10'] = 'Tracking/TrackParameters/highPurit
 vertexfolderName['highPurityPtRange1to10'] = 'Tracking/PrimaryVertices/highPurityTracks/pt_1to10'
 trackPtMin      ['highPurityPtRange1to10'] = cms.double(1.)
 trackPtMax      ['highPurityPtRange1to10'] = cms.double(10.)
+numCutString    ['highPurityPtRange1to10'] = cms.string("") # default: " pt >= 1 & quality('highPurity') "
+denCutString    ['highPurityPtRange1to10'] = cms.string(" pt >= 1 & pt < 10 ") # it is as in the default config (just be sure)
 
 
 highPurityPt10 = trackSelector.clone()
@@ -48,6 +56,8 @@ mainfolderName  ['highPurityPt10'] = 'Tracking/TrackParameters/highPurityTracks/
 vertexfolderName['highPurityPt10'] = 'Tracking/PrimaryVertices/highPurityTracks/pt_10'
 trackPtMin      ['highPurityPt10'] = cms.double(10.)
 trackPtMax      ['highPurityPt10'] = cms.double(110.)
+numCutString    ['highPurityPt10'] = cms.string("") # default: " pt >= 1 & quality('highPurity') "
+denCutString    ['highPurityPt10'] = cms.string(" pt >= 10 ") # it is as in the default config (just be sure)
 
 
 ###### old monitored track collections
@@ -60,6 +70,8 @@ vertexfolderName['highPurityPt1'] = 'Tracking/PrimaryVertices/highPurityTracks/p
 trackPtMin      ['highPurityPt1'] = cms.double(0.)
 trackPtMax      ['highPurityPt1'] = cms.double(100.)
 doPlotsPCA      ['highPurityPt1'] = cms.bool(True)
+numCutString    ['highPurityPt1'] = cms.string("") # default: " pt >= 1 & quality('highPurity') "
+denCutString    ['highPurityPt1'] = cms.string(" pt >= 1 ") # it is as in the default config (just be sure)
 
 selectedTracks.extend( ['generalTracks'] )
 #selectedTracks.extend( ['highPurityPtRange0to1']  )

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -23,6 +23,8 @@ for tracks in selectedTracks :
     locals()[label].doDCAPlots       = doPlotsPCA[tracks]
     locals()[label].doDCAwrtPVPlots  = doPlotsPCA[tracks]
     locals()[label].doDCAwrt000Plots = doPlotsPCA[tracks]
+    locals()[label].numCut           = numCutString[tracks]
+    locals()[label].denCut           = denCutString[tracks]
     locals()[label].setLabel(label)
     
 
@@ -38,6 +40,8 @@ for tracks in selectedTracks :
     locals()[label].doDCAPlots       = doPlotsPCA[tracks]
     locals()[label].doDCAwrtPVPlots  = doPlotsPCA[tracks]
     locals()[label].doDCAwrt000Plots = doPlotsPCA[tracks]
+    locals()[label].numCut           = numCutString[tracks]
+    locals()[label].denCut           = denCutString[tracks]
     locals()[label].setLabel(label)
 
 


### PR DESCRIPTION
previous pull request (https://github.com/cms-sw/cmssw/pull/2034) has been used as default

in previous commit the definition of the fraction of good tracks changed
this commit is therefore aimed to have back the standard definition

2 new parameters have been added
- numSelection
- denSelection

they are StringCutObjectSelectors and they are used in order to specify the proper track selections which have to be applied on the numerator and denominator of the considered, respectively

the configuration file for proton collision jobs has been updated as well
