### PR TITLE
add originalXWGTUP() to LHEEvent and LHEEventProduct

### DIFF
--- a/GeneratorInterface/LHEInterface/interface/LHEEvent.h
+++ b/GeneratorInterface/LHEInterface/interface/LHEEvent.h
@@ -49,6 +49,7 @@ class LHEEvent {
 	void addWeight(const WGT& wgt) { weights_.push_back(wgt); }
 	void setPDF(std::auto_ptr<PDF> pdf) { this->pdf = pdf; }
 
+	double originalXWGTUP() const { return originalXWGTUP_; }
 	const std::vector<WGT>& weights() const { return weights_; }
 
 	void addComment(const std::string &line) { comments.push_back(line); }
@@ -83,6 +84,7 @@ class LHEEvent {
 	std::vector<std::string>		comments;
 	bool					counted;
 	int                                     readAttemptCounter;
+	double                                  originalXWGTUP_;
 };
 
 } // namespace lhef

--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEProducer.cc
@@ -154,7 +154,10 @@ ExternalLHEProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   if (!partonLevel)
     return;
 
-  std::auto_ptr<LHEEventProduct> product(new LHEEventProduct(*partonLevel->getHEPEUP()));
+  std::auto_ptr<LHEEventProduct> product(
+	       new LHEEventProduct(*partonLevel->getHEPEUP(),
+				   partonLevel->originalXWGTUP())
+	       );
   if (partonLevel->getPDF())
     product->setPDF(*partonLevel->getPDF());
   std::for_each(partonLevel->getComments().begin(),

--- a/GeneratorInterface/LHEInterface/plugins/LHESource.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.cc
@@ -149,7 +149,9 @@ LHESource::readEvent_(edm::EventPrincipal& eventPrincipal) {
 	eventPrincipal.fillEventPrincipal(aux, processHistoryRegistryForUpdate());
 
 	std::auto_ptr<LHEEventProduct> product(
-			new LHEEventProduct(*partonLevel->getHEPEUP()));
+		     new LHEEventProduct(*partonLevel->getHEPEUP(),
+					 partonLevel->originalXWGTUP())
+		     );
 	if (partonLevel->getPDF()) {
 		product->setPDF(*partonLevel->getPDF());
         }		

--- a/GeneratorInterface/LHEInterface/src/LHEEvent.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEEvent.cc
@@ -49,6 +49,9 @@ LHEEvent::LHEEvent(const boost::shared_ptr<LHERunInfo> &runInfo,
 			<< "Les Houches file contained invalid"
 			   " event header." << std::endl;
 
+	// store the original value of XWGTUP for the user
+	originalXWGTUP_ = hepeup.XWGTUP;
+
 	int idwtup = runInfo->getHEPRUP()->IDWTUP;
 	if (idwtup >= 0 && hepeup.XWGTUP < 0) {
 		edm::LogWarning("Generator|LHEInterface")

--- a/GeneratorInterface/MCatNLOInterface/plugins/MCatNLOSource.cc
+++ b/GeneratorInterface/MCatNLOInterface/plugins/MCatNLOSource.cc
@@ -186,7 +186,7 @@ void MCatNLOSource::produce(edm::Event &event)
   lhef::CommonBlocks::readHEPRUP(&heprup);
   lhef::CommonBlocks::readHEPEUP(&hepeup);
   hepeup.IDPRUP = heprup.LPRUP[0];
-  std::auto_ptr<LHEEventProduct> lhEvent(new LHEEventProduct(hepeup));
+  std::auto_ptr<LHEEventProduct> lhEvent(new LHEEventProduct(hepeup,hepeup.XWGTUP));
   lhEvent->addComment(makeConfigLine("#IHPRO", ihpro));
   event.put(lhEvent);
 }

--- a/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHEEventProduct.h
@@ -19,7 +19,11 @@ class LHEEventProduct {
 	typedef std::vector<std::string>::size_type size_type;
 
 	LHEEventProduct() {}
-	LHEEventProduct(const lhef::HEPEUP &hepeup) : hepeup_(hepeup) {}
+        LHEEventProduct(const lhef::HEPEUP &hepeup) : 
+	  hepeup_(hepeup), originalXWGTUP_(0) {}
+	LHEEventProduct(const lhef::HEPEUP &hepeup,
+			const double originalXWGTUP) : 
+	  hepeup_(hepeup), originalXWGTUP_(originalXWGTUP) {}
 	~LHEEventProduct() {}
 
 	void setPDF(const PDF &pdf) { pdf_.reset(new PDF(pdf)); }
@@ -28,6 +32,7 @@ class LHEEventProduct {
 	}
 	void addComment(const std::string &line) { comments_.push_back(line); }
 
+	double originalXWGTUP() const { return originalXWGTUP_; }
 	const std::vector<WGT>& weights() const { return weights_; }
 
 	const lhef::HEPEUP &hepeup() const { return hepeup_; }
@@ -86,6 +91,7 @@ class LHEEventProduct {
 	std::vector<std::string>	comments_;
 	std::auto_ptr<PDF>		pdf_;
 	std::vector<WGT>                weights_;
+	double                          originalXWGTUP_;
 };
 
 #endif // GeneratorEvent_LHEInterface_LHEEventProduct_h

--- a/SimDataFormats/GeneratorProducts/src/LHEEventProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/LHEEventProduct.cc
@@ -18,7 +18,7 @@ void LHEEventProduct::const_iterator::next()
 		   << std::uppercase
 		   << "    " << hepeup.NUP
 		   << "  " << hepeup.IDPRUP
-		   << "  " << hepeup.XWGTUP
+		   << "  " << event->originalXWGTUP()
 		   << "  " << hepeup.SCALUP
 		   << "  " << hepeup.AQEDUP
 		   << "  " << hepeup.AQCDUP << std::endl;

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -135,9 +135,10 @@
 	<class name="LHERunInfoProduct" ClassVersion="10">
   <version ClassVersion="10" checksum="2098560362"/>
  </class>
-	<class name="LHEEventProduct" ClassVersion="11">
+	<class name="LHEEventProduct" ClassVersion="12">
   <version ClassVersion="10" checksum="1026978494"/>
   <version ClassVersion="11" checksum="619154414"/>
+  <version ClassVersion="12" checksum="259352862"/>
  </class>
  <class name="gen::WeightsInfo" ClassVersion="10">
   <version ClassVersion="10" checksum="2663143460"/>


### PR DESCRIPTION
Add some book-keeping information to LHEEvent and LHEEventProduct so that reweighting is less cumbersome.

In the MG5 scheme, users can now do raw_ME_ratio[i] = eventInfo->weights()[i]/eventInfo->originalXWGTUP();

To get the raw matrix element ratio.

I have checked that this is stored correctly by writing out the LHE file that was read in. 
The XWGTUP parameters matched exactly.
