### PR TITLE
EcalCondObjectContainer.h: remove not defined inline function warning

### DIFF
--- a/CondFormats/EcalObjects/interface/EcalCondObjectContainer.h
+++ b/CondFormats/EcalObjects/interface/EcalCondObjectContainer.h
@@ -128,7 +128,7 @@ class EcalCondObjectContainer {
                         }
                 }
 #else
-;
+		{ }
 #endif
                 
                 inline


### PR DESCRIPTION
The warning is produced by ROOT6 run-time (Cling/Clang).

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
