### PR TITLE
Removed not so useful function BeamFitter::formatBTime() 

### DIFF
--- a/RecoVertex/BeamSpotProducer/interface/BeamFitter.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamFitter.h
@@ -134,7 +134,6 @@ class BeamFitter {
   }
  private:
 
-  const char * formatBTime( const std::time_t &);
   // Update the fbeginTimeOfFit etc from the refTime
   void updateBTime();
   std::vector<BSTrkParameters> fBSvector;

--- a/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
@@ -24,23 +24,14 @@ ________________________________________________________________**/
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
-// ----------------------------------------------------------------------
-// Useful function:
-// ----------------------------------------------------------------------
-const char * BeamFitter::formatBTime(const std::time_t & t)  {
-  struct std::tm * ptm;
-  ptm = gmtime(&t);
-  static char ts[] = "yyyy.mn.dd hh:mm:ss zzz ";
-  // This value should be taken directly from edm::Event::time(), which
-  // returns GMT (to be confirmed)
-  strftime(ts,sizeof(ts),"%Y.%m.%d %H:%M:%S GMT",ptm);
-  return ts;
-}
 // Update the string representations of the time
 void BeamFitter::updateBTime() {
-  const char* fbeginTime = formatBTime(freftime[0]);
+  char ts[] = "yyyy.mn.dd hh:mm:ss zzz ";
+  char* fbeginTime = ts;
+  strftime(fbeginTime,sizeof(ts),"%Y.%m.%d %H:%M:%S GMT",gmtime(&freftime[0]));
   sprintf(fbeginTimeOfFit,"%s",fbeginTime);
-  const char* fendTime = formatBTime(freftime[1]);
+  char* fendTime = ts;
+  strftime(fendTime,sizeof(ts),"%Y.%m.%d %H:%M:%S GMT",gmtime(&freftime[1]));
   sprintf(fendTimeOfFit,"%s",fendTime);
 }
 


### PR DESCRIPTION
which made "char ts[]" a static because otherwise the function returns the address of
a temporary. This function was only called by BeamFitter::updateBTime,
which was changed to produce the same results of  formating two GMT times as strings
and putting the results in member variables.
