### PR TITLE
Make consumes call check if edm::InputTag is empty

### DIFF
--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -82,22 +82,22 @@ namespace edm {
     template <typename ProductType, BranchType B=InEvent>
     EDGetTokenT<ProductType> consumes(edm::InputTag const& tag) {
       TypeToGet tid=TypeToGet::make<ProductType>();
-      return EDGetTokenT<ProductType>{recordConsumes(B,tid, tag,true)};
+      return EDGetTokenT<ProductType>{recordConsumes(B,tid, checkIfEmpty(tag),true)};
     }
 
     EDGetToken consumes(const TypeToGet& id, edm::InputTag const& tag) {
-      return EDGetToken{recordConsumes(InEvent, id, tag, true)};
+      return EDGetToken{recordConsumes(InEvent, id, checkIfEmpty(tag), true)};
     }
 
     template <BranchType B>
     EDGetToken consumes(TypeToGet const& id, edm::InputTag const& tag) {
-      return EDGetToken{recordConsumes(B, id, tag, true)};
+      return EDGetToken{recordConsumes(B, id, checkIfEmpty(tag), true)};
     }
 
     template <typename ProductType, BranchType B=InEvent>
     EDGetTokenT<ProductType> mayConsume(edm::InputTag const& tag) {
       TypeToGet tid=TypeToGet::make<ProductType>();
-      return EDGetTokenT<ProductType>{recordConsumes(B, tid, tag, false)};
+      return EDGetTokenT<ProductType>{recordConsumes(B, tid, checkIfEmpty(tag), false)};
     }
 
     EDGetToken mayConsume(const TypeToGet& id, edm::InputTag const& tag) {
@@ -106,7 +106,7 @@ namespace edm {
 
     template <BranchType B>
     EDGetToken mayConsume(const TypeToGet& id, edm::InputTag const& tag) {
-      return EDGetToken{recordConsumes(B,id,tag,false)};
+      return EDGetToken{recordConsumes(B,id,checkIfEmpty(tag),false)};
     }
 
     template <typename ProductType, BranchType B=InEvent>
@@ -136,6 +136,7 @@ namespace edm {
     void throwBadToken(edm::TypeID const& iType, EDGetToken iToken) const;
     void throwConsumesCallAfterFrozen(TypeToGet const&, InputTag const&) const;
 
+    edm::InputTag const& checkIfEmpty(edm::InputTag const& tag);
     // ---------- member data --------------------------------
 
     struct TokenLookupInfo {

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -65,9 +65,18 @@ EDConsumerBase::~EDConsumerBase()
 ConsumesCollector
 EDConsumerBase::consumesCollector() {
   ConsumesCollector c{this};
-  return std::move(c);
+  return c;
 }
 
+static const edm::InputTag kWasEmpty("@EmptyLabel@");
+
+edm::InputTag const&
+EDConsumerBase::checkIfEmpty(edm::InputTag const& iTag) {
+  if (iTag.label().empty()) {
+    return kWasEmpty;
+  }
+  return iTag;
+}
 
 unsigned int
 EDConsumerBase::recordConsumes(BranchType iBranch, TypeToGet const& iType, edm::InputTag const& iTag, bool iAlwaysGets) {

--- a/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
+++ b/FWCore/Framework/test/edconsumerbase_t.cppunit.cc
@@ -293,6 +293,21 @@ TestEDConsumerBase::testRegularType()
     //nothing to get since not here
     CPPUNIT_ASSERT(0 == indices.size());
   }
+
+  {
+    //Use an empty tag
+    std::vector<edm::InputTag> vTags={ {} };
+    IntsConsumer intConsumer{vTags};
+    intConsumer.updateLookup(edm::InEvent,helper);
+    
+    CPPUNIT_ASSERT(intConsumer.m_tokens[0].index()==0);
+    CPPUNIT_ASSERT(edm::ProductHolderIndexInvalid == intConsumer.indexFrom(intConsumer.m_tokens[0],edm::InEvent,typeID_vint).productHolderIndex());
+    
+    std::vector<edm::ProductHolderIndexAndSkipBit> indices;
+    intConsumer.itemsToGet(edm::InEvent,indices);
+    //nothing to get since not here
+    CPPUNIT_ASSERT(0 == indices.size());
+  }
 }
 
 void


### PR DESCRIPTION
Previously, passing an empty edm::InputTag to consumes would make the framework think you did a consumesMany (since internally an empty tag is used for that purpose). This change makes an empty tag passed to consumes behave the same way as if you had a tag for a non-existent label.
