### PR TITLE
Reduce fake rate loose tracks

### DIFF
--- a/RecoTracker/FinalTrackSelectors/src/AnalyticalTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/src/AnalyticalTrackSelector.cc
@@ -210,9 +210,21 @@ void AnalyticalTrackSelector::produce( edm::Event& evt, const edm::EventSetup& e
     selTracks_->push_back( Track( trk ) ); // clone and store
     if (ok && setQualityBit_[0]) {
       selTracks_->back().setQuality(qualityToSet_[0]);
+      if (qualityToSet_[0]==TrackBase::tight) {
+	selTracks_->back().setQuality(TrackBase::loose);
+      } 
+      else if (qualityToSet_[0]==TrackBase::highPurity) {
+	selTracks_->back().setQuality(TrackBase::loose);
+	selTracks_->back().setQuality(TrackBase::tight);
+      }
       if (!points.empty()) {
-	if (qualityToSet_[0]==TrackBase::loose) selTracks_->back().setQuality(TrackBase::looseSetWithPV);
-	else if (qualityToSet_[0]==TrackBase::highPurity) selTracks_->back().setQuality(TrackBase::highPuritySetWithPV);
+	if (qualityToSet_[0]==TrackBase::loose) {
+	  selTracks_->back().setQuality(TrackBase::looseSetWithPV);
+	}
+	else if (qualityToSet_[0]==TrackBase::highPurity) {
+	  selTracks_->back().setQuality(TrackBase::looseSetWithPV);
+	  selTracks_->back().setQuality(TrackBase::highPuritySetWithPV);
+	}
       }
     }
     if (copyExtras_) {

--- a/RecoTracker/FinalTrackSelectors/src/MultiTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/src/MultiTrackSelector.cc
@@ -265,11 +265,19 @@ void MultiTrackSelector::produce( edm::Event& evt, const edm::EventSetup& es )
       }
       if ( ok && setQualityBit_[i]) {
 	selTracks[current]= (selTracks[current] | (1<<qualityToSet_[i]));
+	if (qualityToSet_[i]==TrackBase::tight) {
+	  selTracks[current]=(selTracks[current] | (1<<TrackBase::loose));
+	} 
+	else if (qualityToSet_[i]==TrackBase::highPurity) {
+	  selTracks[current]=(selTracks[current] | (1<<TrackBase::loose));
+	  selTracks[current]=(selTracks[current] | (1<<TrackBase::tight));
+	}
 	if (!points.empty()) {
 	  if (qualityToSet_[i]==TrackBase::loose) {
 	    selTracks[current]=(selTracks[current] | (1<<TrackBase::looseSetWithPV));
 	  }
 	  else if (qualityToSet_[i]==TrackBase::highPurity) {
+	    selTracks[current]=(selTracks[current] | (1<<TrackBase::looseSetWithPV));
 	    selTracks[current]=(selTracks[current] | (1<<TrackBase::highPuritySetWithPV));
 	  }
 	}

--- a/RecoTracker/FinalTrackSelectors/src/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/src/TrackListMerger.cc
@@ -593,14 +593,12 @@ namespace cms
       mvaVec.push_back(trackMVAs[i]);
       if (selected[i]>1 ) {
 	outputTrks->back().setQualityMask(selected[i]-10);
-	if (trkUpdated[i]) {
+	if (trkUpdated[i]) 
 	  outputTrks->back().setQuality(qualityToSet_);
-	}
       }
       //might duplicate things, but doesnt hurt
-      if ( selected[i]==1 ) {
+      if ( selected[i]==1 ) 
 	outputTrks->back().setQualityMask(trackQuals[i]);
-      }
 
       // if ( beVerb ) std::cout << "selected " << outputTrks->back().pt() << " " << outputTrks->back().qualityMask() << " " << selected[i] << std::endl;
 

--- a/RecoTracker/FinalTrackSelectors/src/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/src/TrackListMerger.cc
@@ -321,6 +321,7 @@ namespace cms
     typedef std::pair<unsigned int, const TrackingRecHit*> IHit;
     std::vector<IHit> rh1[ngood];  // an array of vectors!
     //const TrackingRecHit*  fh1[ngood];  // first hit...
+    uint8_t algo[ngood];
     float score[ngood];
 
 
@@ -332,6 +333,7 @@ namespace cms
       unsigned int trackNum=j-trackCollFirsts[collNum];
       const reco::Track *track=&((trackColls[collNum])->at(trackNum));
 
+      algo[i]=track->algo();
       int validHits=track->numberOfValidHits();
       int lostHits=track->numberOfLostHits();
       score[i] = foundHitBonus_*validHits - lostHitPenalty_*lostHits - track->chi2();
@@ -455,9 +457,20 @@ namespace cms
 	      selected[j]=10+newQualityMask;  // add 10 to avoid the case where mask = 1
 	      trkUpdated[j]=true;
 	    }else{
-	      // If tracks from both iterations are virtually identical, choose the one with the best quality
-	      if ((trackQuals[j] & (1<<reco::TrackBase::loose|1<<reco::TrackBase::tight|1<<reco::TrackBase::highPurity) ) <= 
-		  (trackQuals[i] & (1<<reco::TrackBase::loose|1<<reco::TrackBase::tight|1<<reco::TrackBase::highPurity) )) {
+	      // If tracks from both iterations are virtually identical, choose the one with the best quality or with lower algo
+	      if (trackQuals[j]==trackQuals[i]) {
+		//same quality, pick earlier algo
+		if (algo[k1] <= algo[k2]) {
+		  selected[j]=0;
+		  selected[i]=10+newQualityMask; // add 10 to avoid the case where mask = 1
+		  trkUpdated[i]=true;
+		} else {
+		  selected[i]=0;
+		  selected[j]=10+newQualityMask; // add 10 to avoid the case where mask = 1
+		  trkUpdated[j]=true;		  
+		}
+	      } else if ((trackQuals[j] & (1<<reco::TrackBase::loose|1<<reco::TrackBase::tight|1<<reco::TrackBase::highPurity) ) <
+			 (trackQuals[i] & (1<<reco::TrackBase::loose|1<<reco::TrackBase::tight|1<<reco::TrackBase::highPurity) )) {
 		selected[j]=0;
 		selected[i]=10+newQualityMask; // add 10 to avoid the case where mask = 1
 		trkUpdated[i]=true;
@@ -580,12 +593,14 @@ namespace cms
       mvaVec.push_back(trackMVAs[i]);
       if (selected[i]>1 ) {
 	outputTrks->back().setQualityMask(selected[i]-10);
-	if (trkUpdated[i])
+	if (trkUpdated[i]) {
 	  outputTrks->back().setQuality(qualityToSet_);
+	}
       }
       //might duplicate things, but doesnt hurt
-      if ( selected[i]==1 )
+      if ( selected[i]==1 ) {
 	outputTrks->back().setQualityMask(trackQuals[i]);
+      }
 
       // if ( beVerb ) std::cout << "selected " << outputTrks->back().pt() << " " << outputTrks->back().qualityMask() << " " << selected[i] << std::endl;
 

--- a/RecoTracker/FinalTrackSelectors/src/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/src/TrackListMerger.cc
@@ -458,7 +458,8 @@ namespace cms
 	      trkUpdated[j]=true;
 	    }else{
 	      // If tracks from both iterations are virtually identical, choose the one with the best quality or with lower algo
-	      if (trackQuals[j]==trackQuals[i]) {
+	      if ((trackQuals[j] & (1<<reco::TrackBase::loose|1<<reco::TrackBase::tight|1<<reco::TrackBase::highPurity) ) ==
+		  (trackQuals[i] & (1<<reco::TrackBase::loose|1<<reco::TrackBase::tight|1<<reco::TrackBase::highPurity) )) {
 		//same quality, pick earlier algo
 		if (algo[k1] <= algo[k2]) {
 		  selected[j]=0;

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -114,11 +114,13 @@ initialStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.mul
         ),
     detachedTripletStepSelector.trackSelectors[4].clone(
         name = 'initialStepV2',
-        preFilterName=cms.string('')
+        preFilterName=cms.string(''),
+        keepAllTracks = cms.bool(False)
         ),
     detachedTripletStepSelector.trackSelectors[5].clone(
         name = 'initialStepV3',
-        preFilterName=cms.string('')
+        preFilterName=cms.string(''),
+        keepAllTracks = cms.bool(False)
         )
     ) #end of vpset
 )#end of clone

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -120,7 +120,9 @@ lowPtTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cf
     GBRForestLabel = cms.string('MVASelectorIter1'),
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+        #RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
             name = 'lowPtTripletStepLoose',
+            #preFilterName = '',
             ), #end of pset
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
             name = 'lowPtTripletStepTight',

--- a/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPtTripletStep_cff.py
@@ -120,9 +120,7 @@ lowPtTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cf
     GBRForestLabel = cms.string('MVASelectorIter1'),
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
-        #RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
             name = 'lowPtTripletStepLoose',
-            #preFilterName = '',
             ), #end of pset
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
             name = 'lowPtTripletStepTight',

--- a/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelLessStep_cff.py
@@ -185,42 +185,32 @@ pixelLessStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.m
             ),
         mixedTripletStepSelector.trackSelectors[4].clone(
             name = 'pixelLessStepVtx',
-            preFilterName=cms.string('')
+            preFilterName=cms.string(''),
+            keepAllTracks = cms.bool(False)
             ),
         mixedTripletStepSelector.trackSelectors[5].clone(
             name = 'pixelLessStepTrk',
-            preFilterName=cms.string('')
+            preFilterName=cms.string(''),
+            keepAllTracks = cms.bool(False)
             )
         ) #end of vpset
     ) #end of clone
 
 # need to merge the three sets
-pixelLessStep = cms.EDProducer("TrackListMerger",
-    ShareFrac = cms.double(0.19),
-    writeOnlyTrkQuals = cms.bool(True),
-    MinPT = cms.double(0.05),
-    allowFirstHitShare = cms.bool(True),
-    copyExtras = cms.untracked.bool(False),
-    Epsilon = cms.double(-0.001),
-    shareFrac = cms.double(0.11),
-    selectedTrackQuals = cms.VInputTag(cms.InputTag("pixelLessStepSelector","pixelLessStep"),
-                                       cms.InputTag("pixelLessStepSelector","pixelLessStepVtx"),
-                                       cms.InputTag("pixelLessStepSelector","pixelLessStepTrk")),
-    indivShareFrac = cms.vdouble(0.11, 0.11, 0.11),
-    MaxNormalizedChisq = cms.double(1000.0),
-    hasSelector = cms.vint32(1, 1, 1),
-    FoundHitBonus = cms.double(5.0),
-    setsToMerge = cms.VPSet(cms.PSet(
-        pQual = cms.bool(True),
-        tLists = cms.vint32(0, 1, 2)
-    )),
-    MinFound = cms.int32(3),
+import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
+pixelLessStep = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = cms.VInputTag(cms.InputTag("pixelLessStepTracks"),
                                    cms.InputTag("pixelLessStepTracks"),
                                    cms.InputTag("pixelLessStepTracks")),
-    LostHitPenalty = cms.double(20.0),
-    newQuality = cms.string('confirmed')
-)
+    hasSelector=cms.vint32(1,1,1),
+    shareFrac=cms.double(0.11),
+    indivShareFrac=cms.vdouble(0.11,0.11,0.11),
+    selectedTrackQuals = cms.VInputTag(cms.InputTag("pixelLessStepSelector","pixelLessStep"),
+                                       cms.InputTag("pixelLessStepSelector","pixelLessStepVtx"),
+                                       cms.InputTag("pixelLessStepSelector","pixelLessStepTrk")),
+    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2), pQual=cms.bool(True) )),
+    writeOnlyTrkQuals=cms.bool(True)
+)                        
 
 PixelLessStep = cms.Sequence(pixelLessStepClusters*
                              pixelLessStepSeedClusters*


### PR DESCRIPTION
Bug fixes for these two problems resulting in higher fakerate for generalTracks collection (when highPurity selection is not made):
1. Now we have highPurity without corresponding loose/tight selection => need to explicitly set loose and tight when highPurity is passed
2. New highPurity selection had ﬂag keepAllTracks=True so that, for some iterations, tracks not even passing loose cuts were saved in generalTracks collection

For more info:
https://indico.cern.ch/getFile.py/access?contribId=23&sessionId=5&resId=0&materialId=slides&confId=295861

This is meant to go in 700 (and 71X of course)
