### PR TITLE
HCAL tags fixed in POSTLS1 and STARTUP GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,7 +2,7 @@ autoCond = {
     # GlobalTag for MC production with perfectly aligned and calibrated detector
     'mc'                :   'MC_70_V3::All',
     # GlobalTag for MC production with realistic alignment and calibrations
-    'startup'           :   'START70_V4::All',
+    'startup'           :   'START70_V5::All',
     # GlobalTag for MC production of Heavy Ions events with realistic alignment and calibrations
     'starthi'           :   'STARTHI70_V5::All',
     # GlobalTag for MC production of p-Pb events with realistic alignment and calibrations
@@ -13,8 +13,8 @@ autoCond = {
     # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
     'hltonline'         :   'PRE_P62_V10::All',
     # GlobalTag for POSTLS1 upgrade studies:
-    'upgradePLS1'       :   'POSTLS162_V4::All',
-    'upgradePLS150ns'   :   'POSTLS162_V5::All',
+    'upgradePLS1'       :   'POSTLS170_V1::All',
+    'upgradePLS150ns'   :   'POSTLS170_V2::All',
     'upgrade2017'       :   'DES17_70_V2::All', # placeholder (GT not meant for 62X)
     'upgrade2019'       :   'DES19_70_V2::All', # placeholder (GT not meant for 62X)
     'upgradePLS3'       :   'POSTLS262_V1::All' # placeholder (GT not meant for 62X)


### PR DESCRIPTION
 Fixing the autoCond.py with the correct GTs for STARTUP and POSTLS1, containing correct HCAL tags for HO reconstruction in 70X. For reference, see HN: https://hypernews.cern.ch/HyperNews/CMS/get/relval/2804/25/1.html .

N.B. 'startup' workflow should run HCAL reconstruction using the simulation of HO for Run1, while 'upgradePLS1' and 'upgradePLS150ns' should use the new SiPM description. Switch in the code for that is supposed to be provided already.
