### PR TITLE
More fixes for root6 relvals

### DIFF
--- a/CondCore/ORA/src/PVectorHandler.h
+++ b/CondCore/ORA/src/PVectorHandler.h
@@ -7,7 +7,7 @@
 // externals
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 
-#include "RflxCollProxy.h"
+#include "TCollectionProxyInfo.h"
 
 namespace ora {
 
@@ -16,8 +16,8 @@ namespace ora {
 
     public:
     /// Constructor
-    PVectorIteratorHandler( const Reflex::Environ<long>& collEnv,
-                            Reflex::CollFuncTable& collProxy,
+    PVectorIteratorHandler( ROOT::TCollectionProxyInfo::Environ<long>& collEnv,
+                            ROOT::TCollectionProxyInfo& collProxy,
                             const edm::TypeWithDict& iteratorReturnType,
                             size_t startElement );
 
@@ -39,10 +39,10 @@ namespace ora {
     edm::TypeWithDict m_returnType;
 
     /// Structure containing parameters of the collection instance
-    Reflex::Environ<long> m_collEnv;
+    ROOT::TCollectionProxyInfo::Environ<long>& m_collEnv;
 
     /// Proxy of the generic collection
-    Reflex::CollFuncTable& m_collProxy;
+    ROOT::TCollectionProxyInfo& m_collProxy;
 
     /// Current element object pointer
     void* m_currentElement;
@@ -100,10 +100,10 @@ namespace ora {
       bool m_isAssociative;
 
       /// Structure containing parameters of the collection instance
-      Reflex::Environ<long> m_collEnv;
+      ROOT::TCollectionProxyInfo::Environ<long> m_collEnv;
 
       /// Proxy of the generic collection
-      std::auto_ptr<Reflex::CollFuncTable> m_collProxy;
+      std::auto_ptr<ROOT::TCollectionProxyInfo> m_collProxy;
 
       size_t m_persistentSizeAttributeOffset;
 

--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -85,6 +85,7 @@ public:
   std::string qualifiedName() const;
   std::string unscopedName() const;
   std::string name() const;
+  std::string unscopedNameWithTypedef() const;
   std::string userClassName() const;
   std::string friendlyClassName() const;
   std::string templateName() const;

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -25,6 +25,7 @@
 #include <typeinfo>
 
 #include <cxxabi.h>
+#include <iostream>
 
 namespace edm {
 
@@ -388,6 +389,14 @@ namespace edm {
       return "undefined";
     }
     return TypeID(*ti_).className();
+  }
+
+  std::string
+  TypeWithDict::unscopedNameWithTypedef() const {
+    if (type_ == nullptr) {
+      return "undefined";
+    }
+    return stripNamespace(gInterpreter->Type_QualifiedName(type_));
   }
 
   std::string


### PR DESCRIPTION
Two more fixes in conditions code for bugs causing all relvals in ROOT6 to throw fatal exceptions.
1) Reflex::CollFuncTable no longer exists in ROOT6.  Use ROOT::TCollectionProxyInfo instead where applicable.
2) The conditions code sometimes needs to retrieve the name of a typedef itself rather than the name of the underlying type.  Add support for this in edm::TypeWithDict, and use it where needed.

NOTE:  With these fixes, the relvals still fail later in the tests.  The failure next encountered is a segfault, which now needs to be fixed.  Do not reject this pull request because it results in the relvals segfaulting.  The bug causing the segfaults was already there, but was hidden due to fatal exceptions arising earlier in the tests.

NOTE2: The change in STLContainerStreamer.cc is much less than it appears.  The file was in DOS format.
I stripped the trailing carriage returns and trailing spaces.  git diff -b shows the real difference.
