### PR TITLE
drop dependency on curl/types.h which we were picking up from system 

### DIFF
--- a/DQMServices/XdaqCollector/interface/XmasToDQM.h
+++ b/DQMServices/XdaqCollector/interface/XmasToDQM.h
@@ -59,7 +59,6 @@
 #include "toolbox/task/TimerFactory.h"
 
 #include <curl/curl.h>
-#include <curl/types.h>
 #include <curl/easy.h>
 #include <fstream> // for ifstream, ofstream, ios_base
 #include <iostream>


### PR DESCRIPTION
DQMServices/XdaqCollector/interface/XmasToDQM.h  includes curl/types.h which is 
- empty file on slc5
- does not exist for slc6 curl distribution of cms
  53X slc6 IBs/releases were working as this file was picked up from system curl. dropping this should not harm as this file is empty anyway.
