### PR TITLE
getByLabel -> getByToken and use of ak5PFJetsCHS collection for the single top modules

### DIFF
--- a/DQM/Physics/interface/TopDQMHelpers.h
+++ b/DQM/Physics/interface/TopDQMHelpers.h
@@ -234,7 +234,7 @@ SelectionStep<Object>::SelectionStep(const edm::ParameterSet& cfg, edm::Consumes
   cfg.exists("min") ? min_= cfg.getParameter<int>("min") : min_= -1;
   cfg.exists("max") ? max_= cfg.getParameter<int>("max") : max_= -1;
   //cout<<"// read electron extras if they exist"<<endl;
-  std::string mygSF = "gsfElectrons";
+  std::string mygSF = "gedGsfElectrons";
   gsfEs_ = iC.consumes<edm::View<reco::GsfElectron> >(cfg.getUntrackedParameter<edm::InputTag>("myGSF", mygSF));
   if(cfg.existsAs<edm::ParameterSet>("electronId")){ 
     edm::ParameterSet elecId=cfg.getParameter<edm::ParameterSet>("electronId");
@@ -320,15 +320,18 @@ bool SelectionStep<Object>::select(const edm::Event& event, const std::string& t
       reco::PFCandidate objtmp = dynamic_cast<const reco::PFCandidate&>(*obj);
       
       if (objtmp.muonRef().isNonnull() && type == "muon") {
+
         if(select_(*obj)){++n;
         }
       }
-      
       else if (objtmp.gsfElectronRef().isNonnull() && type == "electron") {
         if( !event.getByToken(gsfEs_, elecs_gsf) ) continue;
         if(select_(*obj)){
           if(elecs_gsf->refAt(idx_gsf).isNonnull()){
-            int eID = (int)(*electronId)[elecs_gsf->refAt(idx_gsf)];
+	    int eID=0;
+	    if (!electronId_.isUninitialized()){
+	      eID = (int)(*electronId)[elecs_gsf->refAt(idx_gsf)];
+	    }
             if( electronId_.isUninitialized() ? true : ( (eID & eidPattern_)  && (eID >= 5) ) )
               ++n;
 	    

--- a/DQM/Physics/python/DQMPhysics_cff.py
+++ b/DQM/Physics/python/DQMPhysics_cff.py
@@ -8,6 +8,7 @@ from DQM.Physics.qcdPhotonsDQM_cfi import *
 from DQM.Physics.topSingleLeptonDQM_cfi import *
 from DQM.Physics.topDiLeptonOfflineDQM_cfi import *
 from DQM.Physics.topSingleLeptonDQM_PU_cfi import *
+from DQM.Physics.singleTopDQM_cfi import *
 from DQM.Physics.ewkMuLumiMonitorDQM_cfi import *
 from DQM.Physics.susyDQM_cfi import *
 from DQM.Physics.HiggsDQM_cfi import *
@@ -23,7 +24,9 @@ dqmPhysics = cms.Sequence( bphysicsOniaDQM
                            *qcdPhotonsDQM
 			   *topSingleMuonMediumDQM
                            *topSingleElectronMediumDQM	
-			   *DiMuonDQM
+                           *singleTopMuonMediumDQM
+                           *singleTopElectronMediumDQM
+                           *DiMuonDQM
 			   *DiElectronDQM
 			   *ElecMuonDQM
                            *susyDQM

--- a/DQM/Physics/python/singleTopDQM_cfi.py
+++ b/DQM/Physics/python/singleTopDQM_cfi.py
@@ -16,7 +16,7 @@ singleTopDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
     ## [mandatory]
     sources = cms.PSet(
       muons = cms.InputTag("muons"),
-      elecs = cms.InputTag("gedGsfElectrons"),
+      elecs = cms.InputTag("particleFlow"),
       jets  = cms.InputTag("ak5PFJetsCHS"),
       mets  = cms.VInputTag("met", "tcMet", "pfMet"),
       pvs   = cms.InputTag("offlinePrimaryVertices")
@@ -36,7 +36,7 @@ singleTopDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
     ## will be filled w/o extras
     elecExtras = cms.PSet(
       ## when omitted electron plots will be filled w/o cut on electronId
-      electronId = cms.PSet( src = cms.InputTag("eidRobustLoose"), pattern = cms.int32(1) ),
+      electronId = cms.PSet( src = cms.InputTag("simpleEleId70cIso"), pattern = cms.int32(1) ),
       ## when omitted electron plots will be filled w/o additional pre-
       ## selection of the electron candidates                                                                                            
       select = cms.string("pt>15 & abs(eta)<2.5 & abs(gsfTrack.d0)<1 & abs(gsfTrack.dz)<20"),
@@ -101,10 +101,10 @@ singleTopDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
 #      select = cms.vstring(['HLT_Mu11', 'HLT_Ele15_LW_L1R', 'HLT_QuadJet30'])
 #    ),
     ## [optional] : when omitted no preselection is applied
-    vertex = cms.PSet(
-      src    = cms.InputTag("offlinePrimaryVertices"),
-      select = cms.string('abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake')
-    )                                        
+#    vertex = cms.PSet(
+#      src    = cms.InputTag("offlinePrimaryVertices"),
+#      select = cms.string('abs(x)<1. & abs(y)<1. & abs(z)<20. & tracksSize>3 & !isFake')
+#    )                                        
   ),  
   ## ------------------------------------------------------    
   ## SELECTION
@@ -144,7 +144,6 @@ singleTopMuonMediumDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
     ## [mandatory]
     sources = cms.PSet(
     muons = cms.InputTag("particleFlow"),
-#    muons = cms.InputTag("muons"),
     elecs_gsf = cms.InputTag("gedGsfElectrons"),
     elecs = cms.InputTag("particleFlow"),
     jets  = cms.InputTag("ak5PFJetsCHS"),
@@ -241,10 +240,10 @@ singleTopMuonMediumDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
 #      select = cms.vstring(['HLT_IsoMu17_eta2p1_CentralPFNoPUJet30_BTagIPIter_v1'])
 #    ),
     ## [optional] : when omitted no preselection is applied
-    vertex = cms.PSet(
-      src    = cms.InputTag("offlinePrimaryVertices"),
-      select = cms.string('!isFake && ndof >= 4 && abs(z)<24. && position.Rho <= 2.0')
-    )
+#    vertex = cms.PSet(
+#      src    = cms.InputTag("offlinePrimaryVertices"),
+#      select = cms.string('!isFake && ndof >= 4 && abs(z)<24. && position.Rho <= 2.0')
+#    )
   ),
   ## ------------------------------------------------------
   ## SELECTION
@@ -258,7 +257,7 @@ singleTopMuonMediumDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
    cms.PSet(
       label  = cms.string("presel"),
       src    = cms.InputTag("offlinePrimaryVertices"),
-#      select = cms.string('!isFake && ndof >= 4 && abs(z)<24. && position.Rho <= 2.0 '),
+      select = cms.string('!isFake && ndof >= 4 && abs(z)<24. && position.Rho <= 2.0 '),
      
    ),
    cms.PSet(
@@ -399,10 +398,10 @@ singleTopElectronMediumDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
 #     select = cms.vstring(['HLT_Ele15_SW_CaloEleId_L1R'])
 #    ),
     ## [optional] : when omitted no preselection is applied
-    vertex = cms.PSet(
-      src    = cms.InputTag("offlinePrimaryVertices"),
-      select = cms.string('!isFake && ndof >= 4 && abs(z)<24. && position.Rho <= 2.0')
-    )
+#    vertex = cms.PSet(
+#      src    = cms.InputTag("offlinePrimaryVertices"),
+#      select = cms.string('!isFake && ndof >= 4 && abs(z)<24. && position.Rho <= 2.0')
+#    )
   ),
   ## ------------------------------------------------------
   ## SELECTION
@@ -416,7 +415,7 @@ singleTopElectronMediumDQM = cms.EDAnalyzer("SingleTopTChannelLeptonDQM",
    cms.PSet(
       label  = cms.string("presel"),
       src    = cms.InputTag("offlinePrimaryVertices"),
-#      select = cms.string('!isFake && ndof >= 4 && abs(z)<24. && position.Rho <= 2.0'),
+      select = cms.string('!isFake && ndof >= 4 && abs(z)<24. && position.Rho <= 2.0'),
    ),
    cms.PSet(
       label = cms.string("elecs/pf:step0"),

--- a/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
+++ b/DQM/Physics/src/SingleTopTChannelLeptonDQM.h
@@ -16,6 +16,9 @@
 #include "JetMETCorrections/Objects/interface/JetCorrector.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/EDConsumerBase.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 /**
    \class   MonitorEnsemble TopDQMHelpers.h "DQM/Physics/interface/TopDQMHelpers.h"
@@ -43,7 +46,7 @@ namespace SingleTopTChannelLepton {
     
   public:
     /// default contructor
-    MonitorEnsemble(const char* label, const edm::ParameterSet& cfg, const edm::VParameterSet& vcfg);
+    MonitorEnsemble(const char* label, const edm::ParameterSet& cfg, const edm::VParameterSet& vcfg, edm::ConsumesCollector && iC );
     /// default destructor
     ~MonitorEnsemble(){};
     
@@ -80,18 +83,29 @@ namespace SingleTopTChannelLepton {
     /// instance label 
     std::string label_;
     /// considers a vector of METs
-    std::vector<edm::InputTag> mets_;
+    std::vector<edm::EDGetTokenT<edm::View<reco::MET> > > mets_;
+    //    std::vector<edm::InputTag> mets_;
     /// input sources for monitoring
-    edm::InputTag elecs_, elecs_gsf_, muons_, muons_reco_, jets_, pvs_; 
+    edm::EDGetTokenT<edm::View<reco::Jet> >  jets_; 
+    edm::EDGetTokenT<edm::View<reco::PFCandidate> > muons_;
+    edm::EDGetTokenT<edm::View<reco::GsfElectron> > elecs_gsf_;
+    edm::EDGetTokenT<edm::View<reco::PFCandidate> > elecs_;
+    edm::EDGetTokenT<edm::View<reco::Vertex> > pvs_;
+
+    //    edm::InputTag elecs_, elecs_gsf_, muons_, muons_reco_, jets_, pvs_; 
 
     /// trigger table
-    edm::InputTag triggerTable_;
+    //    edm::InputTag triggerTable_;
+    edm::EDGetTokenT<edm::TriggerResults> triggerTable_;
+
     /// trigger paths for monitoring, expected 
     /// to be of form signalPath:MonitorPath
     std::vector<std::string> triggerPaths_;
 
     /// electronId label
-    edm::InputTag electronId_;
+    //    edm::InputTag electronId_;
+    edm::EDGetTokenT<edm::ValueMap<float> > electronId_;
+
     /// electronId pattern we expect the following pattern:
     ///  0: fails
     ///  1: passes electron ID only
@@ -123,7 +137,9 @@ namespace SingleTopTChannelLepton {
     /// jetCorrector
     std::string jetCorrector_;
     /// jetID as an extra selection type 
-    edm::InputTag jetIDLabel_;
+    //    edm::InputTag jetIDLabel_;
+    edm::EDGetTokenT<reco::JetIDValueMap> jetIDLabel_;
+
     /// extra jetID selection on calo jets
     StringCutObjectSelector<reco::JetID>* jetIDSelect_;
     /// extra selection on jets (here given as std::string as it depends
@@ -133,7 +149,9 @@ namespace SingleTopTChannelLepton {
     /// to be determined from the cfg  
     bool includeBTag_;
     /// btag discriminator labels
-    edm::InputTag btagEff_, btagPur_, btagVtx_, btagCombVtx_;
+    //    edm::InputTag btagEff_, btagPur_, btagVtx_, btagCombVtx_;
+    edm::EDGetTokenT<reco::JetTagCollection> btagEff_, btagPur_, btagVtx_, btagCombVtx_;
+
     /// btag working points
     double btagEffWP_, btagPurWP_, btagVtxWP_, btagCombVtxWP_;
     /// mass window upper and lower edge
@@ -145,6 +163,7 @@ namespace SingleTopTChannelLepton {
     DQMStore* store_;
     /// histogram container  
     std::map<std::string,MonitorElement*> hists_;
+    edm::EDConsumerBase tmpConsumerBase;
   };
 
   inline void 
@@ -221,9 +240,26 @@ class SingleTopTChannelLeptonDQM : public edm::EDAnalyzer  {
   ~SingleTopTChannelLeptonDQM(){
     if( vertexSelect_ ) delete vertexSelect_;
     if( beamspotSelect_ ) delete beamspotSelect_;
-    //    if( selection_ ) delete selection_;
+    if( MuonStep) delete MuonStep;
+    if( PFMuonStep) delete PFMuonStep;
+    if( ElectronStep) delete ElectronStep;
+    if( PFElectronStep) delete PFElectronStep;
+    if( PvStep) delete PvStep;
+    for(unsigned int i = 0; i < JetSteps.size(); i++)
+      if( JetSteps[i]) delete JetSteps[i];
+    for(unsigned int i = 0; i < CaloJetSteps.size(); i++)
+      if( CaloJetSteps[i]) delete CaloJetSteps[i];
+    for(unsigned int i = 0; i < PFJetSteps.size(); i++)
+      if( PFJetSteps[i]) delete PFJetSteps[i];
+    if( METStep) delete METStep;
+
+
+
+
   };
-  
+
+
+
   /// do this during the event loop
   virtual void analyze(const edm::Event& event, const edm::EventSetup& setup);
     
@@ -237,16 +273,20 @@ class SingleTopTChannelLeptonDQM : public edm::EDAnalyzer  {
 
  private:
   /// trigger table
-  edm::InputTag triggerTable_;
+  //  edm::InputTag triggerTable_;
+  edm::EDGetTokenT<edm::TriggerResults> triggerTable__;
+
   /// trigger paths
   std::vector<std::string> triggerPaths_;
   /// primary vertex 
   edm::InputTag vertex_;
+  edm::EDGetTokenT<reco::Vertex> vertex__;
   /// string cut selector
   StringCutObjectSelector<reco::Vertex>* vertexSelect_;
 
   /// beamspot 
   edm::InputTag beamspot_;
+  edm::EDGetTokenT<reco::BeamSpot> beamspot__;
   /// string cut selector
   StringCutObjectSelector<reco::BeamSpot>* beamspotSelect_;
 
@@ -259,6 +299,17 @@ class SingleTopTChannelLeptonDQM : public edm::EDAnalyzer  {
   /// MonitoringEnsemble keeps an instance of the MonitorEnsemble class to 
   /// be filled _after_ each selection step
   std::map<std::string, std::pair<edm::ParameterSet, SingleTopTChannelLepton::MonitorEnsemble*> > selection_;
+  SelectionStep<reco::Muon> * MuonStep;
+  SelectionStep<reco::PFCandidate> * PFMuonStep;
+  SelectionStep<reco::GsfElectron> * ElectronStep;
+  SelectionStep<reco::PFCandidate> * PFElectronStep;
+  SelectionStep<reco::Vertex> * PvStep;
+  std::vector<SelectionStep<reco::Jet> * > JetSteps;
+  std::vector<SelectionStep<reco::CaloJet> * > CaloJetSteps;
+  std::vector<SelectionStep<reco::PFJet> * > PFJetSteps;
+  SelectionStep<reco::MET> * METStep;
+
+
 };
 
 #endif

--- a/DQM/Physics/test/topDQM_production_cfg.py
+++ b/DQM/Physics/test/topDQM_production_cfg.py
@@ -19,6 +19,7 @@ process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 ##process.GlobalTag.globaltag = 'GR_R_42_V14::All' 
 process.GlobalTag.globaltag = 'PRE_ST62_V8::All'
 
+
 #dbs search --query 'find file where site=srm-eoscms.cern.ch and dataset=/RelValTTbar/CMSSW_7_0_0_pre3-PRE_ST62_V8-v1/GEN-SIM-RECO'
 #dbs search --query 'find dataset where dataset=/RelValTTbar/CMSSW_7_0_0_pre6*/GEN-SIM-RECO'
 
@@ -29,15 +30,15 @@ process.source = cms.Source("PoolSource",
     #"/store/relval/CMSSW_6_2_0_pre1-START61_V8/RelValTTbarLepton/GEN-SIM-RECO/v1/00000/C6CC53CC-6E6D-E211-8EAB-003048D3756A.root',"
     
     #/RelValTTbar/CMSSW_7_0_0_pre6-PRE_ST62_V8-v1/GEN-SIM-RECO
-    '/store/relval/CMSSW_7_0_0_pre6/RelValTTbar/GEN-SIM-RECO/PRE_ST62_V8-v1/00000/B627D32C-0B3C-E311-BBE6-0026189438E6.root',
+    #'/store/relval/CMSSW_7_0_0_pre6/RelValTTbar/GEN-SIM-RECO/PRE_ST62_V8-v1/00000/B627D32C-0B3C-E311-BBE6-0026189438E6.root',
     #'/store/relval/CMSSW_7_0_0_pre6/RelValTTbar/GEN-SIM-RECO/PRE_ST62_V8-v1/00000/72477A84-F93B-E311-BF63-003048FFD720.root',
-    #'/store/relval/CMSSW_7_0_0_pre6/RelValTTbar/GEN-SIM-RECO/PRE_ST62_V8-v1/00000/12A06D7A-F93B-E311-AA64-003048678BEA.root'
+    '/store/relval/CMSSW_7_0_0_pre6/RelValTTbar/GEN-SIM-RECO/PRE_ST62_V8-v1/00000/12A06D7A-F93B-E311-AA64-003048678BEA.root'
     )
 )
 
 ## number of events
 process.maxEvents = cms.untracked.PSet(
-  input = cms.untracked.int32(500)
+  input = cms.untracked.int32(-1)
 )
 
 ## apply VBTF electronID (needed for the current implementation
@@ -87,16 +88,16 @@ process.MEtoEDMConverter.deleteAfterCopy = cms.untracked.bool(False)  ## line ad
 
 ## path definitions
 process.p      = cms.Path(
-    #process.simpleEleId70cIso          *
+    process.simpleEleId70cIso          *
     process.DiMuonDQM                  +
     process.DiElectronDQM              +
     process.ElecMuonDQM                +
     #process.topSingleMuonLooseDQM      +
     process.topSingleMuonMediumDQM     +
     #process.topSingleElectronLooseDQM  +
-    process.topSingleElectronMediumDQM #+
-   # process.singleTopMuonMediumDQM     +
-  #  process.singleTopElectronMediumDQM
+    process.topSingleElectronMediumDQM +
+    process.singleTopMuonMediumDQM     +
+    process.singleTopElectronMediumDQM
 )
 process.endjob = cms.Path(
     process.endOfProcess


### PR DESCRIPTION
Migration to the ak5PFJetsCHS collection (to be able to access the b-tagging info for PF jets), and replacement of getByLabel with getByToken for the single top modules
