### PR TITLE
Default format for new DB in output reverted to ORA

### DIFF
--- a/CondCore/CondDB/interface/ConnectionPool.h
+++ b/CondCore/CondDB/interface/ConnectionPool.h
@@ -51,6 +51,7 @@ namespace cond {
       bool m_loggingEnabled = false;
       // this one has to be moved!
       cond::CoralServiceManager* m_pluginManager = 0; 
+      std::vector<std::string> m_refreshtablelist;
     };
   }
 }

--- a/CondCore/CondDB/interface/PayloadProxy.h
+++ b/CondCore/CondDB/interface/PayloadProxy.h
@@ -100,20 +100,19 @@ namespace cond {
       
       virtual void invalidateCache() {
 	m_data.reset();
+	m_currentPayloadId.clear();
 	m_currentIov.clear();
 	m_requests.clear();
       }
 
     protected:
       virtual void loadPayload() {
-	if( m_currentPayloadId != m_currentIov.payloadId ){
-          if( m_currentIov.payloadId.empty() ){
-	    throwException( "Can't load payload: no valid IOV found.","PayloadProxy::loadPayload" );
-	  }
-	  m_data = m_session.fetchPayload<DataT>( m_currentIov.payloadId );
-	  m_currentPayloadId = m_currentIov.payloadId;	  
-	  m_requests.push_back( m_currentIov );
+	if( m_currentIov.payloadId.empty() ){
+	  throwException( "Can't load payload: no valid IOV found.","PayloadProxy::loadPayload" );
 	}
+	m_data = m_session.fetchPayload<DataT>( m_currentIov.payloadId );
+	m_currentPayloadId = m_currentIov.payloadId;	  
+	m_requests.push_back( m_currentIov );
       }
       
     private:

--- a/CondCore/CondDB/src/ConnectionPool.cc
+++ b/CondCore/CondDB/src/ConnectionPool.cc
@@ -7,6 +7,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 // coral includes
 #include "RelationalAccess/ConnectionService.h"
+#include "RelationalAccess/IWebCacheControl.h"
 #include "RelationalAccess/ISessionProxy.h"
 #include "RelationalAccess/IConnectionServiceConfiguration.h"
 #include "CoralKernel/Context.h"
@@ -24,7 +25,18 @@ namespace cond {
       m_authSys(0),
       m_messageLevel( coral::Error ),
       m_loggingEnabled( false ),
-      m_pluginManager( new cond::CoralServiceManager ){
+      m_pluginManager( new cond::CoralServiceManager ),
+      m_refreshtablelist(){
+      m_refreshtablelist.reserve(6);
+      //table names for IOVSequence in the old POOL mapping
+      m_refreshtablelist.push_back("IOV");
+      m_refreshtablelist.push_back("IOV_DATA");
+      //table names for IOVSequence in ORA
+      m_refreshtablelist.push_back("ORA_C_COND_IOVSEQUENCE");
+      m_refreshtablelist.push_back("ORA_C_COND_IOVSEQU_A0");
+      m_refreshtablelist.push_back("ORA_C_COND_IOVSEQU_A1");
+      //table names for IOVSequence in CONDDB
+      m_refreshtablelist.push_back("TAG");
       configure();
     }
  
@@ -129,7 +141,11 @@ namespace cond {
 
     Session ConnectionPool::createSession( const std::string& connectionString, const std::string& transactionId, bool writeCapable ){
       coral::ConnectionService connServ;
-      boost::shared_ptr<coral::ISessionProxy> coralSession( connServ.connect( getRealConnectionString( connectionString, transactionId ), 
+      std::pair<std::string,std::string> fullConnectionPars = getRealConnectionString( connectionString, transactionId );
+      if( !fullConnectionPars.second.empty() ) 
+	for( auto tableName : m_refreshtablelist ) connServ.webCacheControl().refreshTable( fullConnectionPars.second, tableName );
+
+      boost::shared_ptr<coral::ISessionProxy> coralSession( connServ.connect( fullConnectionPars.first, 
 									      writeCapable?coral::Update:coral::ReadOnly ) );
       return Session( coralSession, connectionString );
     }

--- a/CondCore/CondDB/src/DbConnectionString.cc
+++ b/CondCore/CondDB/src/DbConnectionString.cc
@@ -24,7 +24,7 @@ namespace cond {
       return count;
     }
 
-    std::string makeFrontierConnectionString( const std::string& initialConnection, 
+    std::pair<std::string,std::string> makeFrontierConnectionString( const std::string& initialConnection, 
 					      const std::string& transactionId ){
       std::string realConn = initialConnection;
       std::string proto("frontier://");
@@ -58,18 +58,18 @@ namespace cond {
 	  refreshConnect.insert(0, "http://");
 	}
       }
-      return realConn;
+      return std::make_pair(realConn,refreshConnect);
     }
     
-    std::string getRealConnectionString( const std::string& initialConnection ){
+    std::pair<std::string,std::string> getRealConnectionString( const std::string& initialConnection ){
       return getRealConnectionString( initialConnection, "" );
     }
     
-    std::string getRealConnectionString( const std::string& initialConnection, 
-					 const std::string& transId ){
+    std::pair<std::string,std::string> getRealConnectionString( const std::string& initialConnection, 
+								const std::string& transId ){
       auto connData = parseConnectionString( initialConnection );
       if( std::get<0>(connData) == "frontier" ) return makeFrontierConnectionString(  initialConnection, transId );    
-      return initialConnection;
+      return std::make_pair(initialConnection,"");
     }
 
   }

--- a/CondCore/CondDB/src/DbConnectionString.h
+++ b/CondCore/CondDB/src/DbConnectionString.h
@@ -8,9 +8,9 @@ namespace cond {
 
   namespace persistency {
 
-    std::string getRealConnectionString( const std::string& initialConnection );
+    std::pair<std::string,std::string> getRealConnectionString( const std::string& initialConnection );
 
-    std::string getRealConnectionString( const std::string& initialConnection, const std::string& transId );
+    std::pair<std::string,std::string> getRealConnectionString( const std::string& initialConnection, const std::string& transId );
 
   }
 

--- a/CondCore/CondDB/src/SessionImpl.cc
+++ b/CondCore/CondDB/src/SessionImpl.cc
@@ -57,6 +57,8 @@ namespace cond {
       cond::DbSession m_session;
     };
 
+    static const char* NEW_CONDDB("NEW_CONDDB");
+
     SessionImpl::SessionImpl():
       coralSession(){
     }
@@ -86,27 +88,27 @@ namespace cond {
 
     void SessionImpl::startTransaction( bool readOnly ){
       if( !transaction.get() ){ 
-	transaction.reset( new CondDBTransaction( coralSession ) );
-	coralSession->transaction().start( readOnly );
-	iovSchemaHandle.reset( new IOVSchema( coralSession->nominalSchema() ) );
-	gtSchemaHandle.reset( new GTSchema( coralSession->nominalSchema() ) );  		       
-	std::unique_ptr<IIOVSchema> iovSchema( new IOVSchema( coralSession->nominalSchema() ) );
-	std::unique_ptr<IGTSchema> gtSchema( new GTSchema( coralSession->nominalSchema() ) );
-	if( !iovSchemaHandle->exists() ){
-	  cond::DbConnection oraConnection;
-	  cond::DbSession oraSession =  oraConnection.createSession();
-	  oraSession.open( coralSession, connectionString ); 
-	  std::unique_ptr<IIOVSchema> oraIovSchema( new OraIOVSchema( oraSession ) );
-	  std::unique_ptr<IGTSchema> oraGtSchema( new OraGTSchema( oraSession ) );
-	  oraSession.transaction().start( readOnly );
-	  // try if it is an old iov or GT schema
-	  if( oraIovSchema->exists() ||  oraGtSchema->exists() ){
-	    iovSchemaHandle = std::move(oraIovSchema);
-	    gtSchemaHandle = std::move(oraGtSchema);
-	    transaction.reset( new OraTransaction( oraSession ) );
-	  } 
+	cond::DbConnection oraConnection;
+	cond::DbSession oraSession =  oraConnection.createSession();
+	oraSession.open( coralSession, connectionString ); 
+	transaction.reset( new OraTransaction( oraSession ) );
+	oraSession.transaction().start( readOnly );
+	iovSchemaHandle.reset( new OraIOVSchema( oraSession ) );
+	gtSchemaHandle.reset( new OraGTSchema( oraSession ) );  		       
+	if( !iovSchemaHandle->exists() && !gtSchemaHandle->exists() ){
+	  std::unique_ptr<IIOVSchema> iovSchema( new IOVSchema( coralSession->nominalSchema() ) );
+	  std::unique_ptr<IGTSchema> gtSchema( new GTSchema( coralSession->nominalSchema() ) );
+	  bool newCondDb = iovSchema->exists();
+	  if( !newCondDb && !readOnly ){
+	    const char* new_conddb_env = ::getenv( NEW_CONDDB );
+	    if( new_conddb_env ) newCondDb = true;
+	  }
+	  if( newCondDb ){
+	    iovSchemaHandle = std::move(iovSchema);
+	    gtSchemaHandle = std::move(gtSchema);
+	    transaction.reset( new CondDBTransaction( coralSession ) );
+	  }
 	}
-        
       } else {
 	if(!readOnly ) throwException( "An update transaction is already active.",
 				       "SessionImpl::startTransaction" );

--- a/CondCore/CondDB/src/SessionImpl.cc
+++ b/CondCore/CondDB/src/SessionImpl.cc
@@ -57,8 +57,6 @@ namespace cond {
       cond::DbSession m_session;
     };
 
-    static const char* NEW_CONDDB("NEW_CONDDB");
-
     SessionImpl::SessionImpl():
       coralSession(){
     }
@@ -98,12 +96,7 @@ namespace cond {
 	if( !iovSchemaHandle->exists() && !gtSchemaHandle->exists() ){
 	  std::unique_ptr<IIOVSchema> iovSchema( new IOVSchema( coralSession->nominalSchema() ) );
 	  std::unique_ptr<IGTSchema> gtSchema( new GTSchema( coralSession->nominalSchema() ) );
-	  bool newCondDb = iovSchema->exists();
-	  if( !newCondDb && !readOnly ){
-	    const char* new_conddb_env = ::getenv( NEW_CONDDB );
-	    if( new_conddb_env ) newCondDb = true;
-	  }
-	  if( newCondDb ){
+	  if( iovSchema->exists() ){
 	    iovSchemaHandle = std::move(iovSchema);
 	    gtSchemaHandle = std::move(gtSchema);
 	    transaction.reset( new CondDBTransaction( coralSession ) );

--- a/CondCore/CondDB/test/BuildFile.xml
+++ b/CondCore/CondDB/test/BuildFile.xml
@@ -12,3 +12,5 @@
 <bin   file="testPayloadProxy.cpp" name="testPayloadProxy">
   <lib   name="testCondDBDict"/>
 </bin>
+<bin   file="testFrontier.cpp" name="testFrontier">
+</bin>

--- a/CondCore/CondDB/test/testFrontier.cpp
+++ b/CondCore/CondDB/test/testFrontier.cpp
@@ -1,0 +1,50 @@
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/PluginManager/interface/SharedLibrary.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+//
+#include "CondCore/CondDB/interface/ConnectionPool.h"
+#include "CondCore/CondDB/interface/PayloadProxy.h"
+//
+#include "MyTestData.h"
+//
+#include <fstream>
+#include <iomanip>
+#include <cstdlib>
+#include <iostream>
+
+using namespace cond::persistency;
+
+int main (int argc, char** argv)
+{
+  edmplugin::PluginManager::Config config;
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+
+  std::vector<edm::ParameterSet> psets;
+  edm::ParameterSet pSet;
+  pSet.addParameter("@service_type",std::string("SiteLocalConfigService"));
+  psets.push_back(pSet);
+  static const edm::ServiceToken services(edm::ServiceRegistry::createSet(psets));
+  static const edm::ServiceRegistry::Operate operate(services);
+
+  std::string connectionString("frontier://FrontierProd/CMS_COND_31X_RUN_INFO");
+  std::cout <<"# Connecting with db in "<<connectionString<<std::endl;
+  try{
+    //*************
+    ConnectionPool connPool;
+    connPool.setMessageVerbosity( coral::Debug );
+    Session session = connPool.createSession( connectionString );
+    session.transaction().start();
+    IOVProxy iov = session.readIov( "runinfo_31X_hlt", true );
+    std::cout << "Loaded size="<<iov.loadedSize()<<std::endl;
+    session.transaction().commit();
+  } catch (const std::exception& e){
+    std::cout << "ERROR: " << e.what() << std::endl;
+    return -1;
+  } catch (...){
+    std::cout << "UNEXPECTED FAILURE." << std::endl;
+    return -1;
+  }
+}
+

--- a/CondCore/IOVService/src/IOVProxy.cc
+++ b/CondCore/IOVService/src/IOVProxy.cc
@@ -274,6 +274,7 @@ int cond::IOVProxy::size() const {
 }
 
 cond::IOVSequence const & cond::IOVProxy::iov() const {
+  if( !m_iov->data.get() ) throwException( "No data found.", "IOVProxy::iov" );
   return *(m_iov->data);
 }
 

--- a/CondCore/MetaDataService/src/MetaData.cc
+++ b/CondCore/MetaDataService/src/MetaData.cc
@@ -37,7 +37,6 @@ cond::MetaData::addMapping(const std::string& name,
                            const std::string& iovtoken, 
                            cond::TimeType ){
   try{
-    if(!m_userSession.storage().exists()) return false;
     ora::OId oid;
     oid.fromString( iovtoken );
     m_userSession.storage().setObjectName( name, oid );
@@ -53,7 +52,6 @@ const std::string
 cond::MetaData::getToken( const std::string& name ) const{
   bool ok=false;
   std::string iovtoken("");
-  if(!m_userSession.storage().exists()) return iovtoken;
   try{
     ora::OId oid;
     ok = m_userSession.storage().getItemId( name, oid );
@@ -69,7 +67,6 @@ cond::MetaData::getToken( const std::string& name ) const{
 
 bool cond::MetaData::hasTag( const std::string& name ) const{
   bool result=false;
-  if(!m_userSession.storage().exists()) return result;
   try{
     ora::OId oid;
     result = m_userSession.storage().getItemId( name, oid );

--- a/CondCore/MetaDataService/test/testMetaData.cpp
+++ b/CondCore/MetaDataService/test/testMetaData.cpp
@@ -23,10 +23,17 @@ int main(){
     coralDb.open("sqlite_file:meta.db");
 
     //test errors
-    coralDb.transaction().start(true);
+    coralDb.transaction().start(false);
+    if(coralDb.storage().exists()){
+      coralDb.storage().drop();
+    }
     coralDb.createDatabase();
+
+    coralDb.transaction().commit();
+
+    coralDb.transaction().start(true);
     cond::MetaData metadata(coralDb);
-    if(metadata.hasTag("crap")) std::cout << "wrong" << std::endl;
+    if(metadata.hasTag("crap")) std::cout << "ERROR: wrong assertion" << std::endl;
     /**
     try {
       cond::MetaDataEntry result; 

--- a/CondCore/Utilities/bin/conddb_test_gt_load.cpp
+++ b/CondCore/Utilities/bin/conddb_test_gt_load.cpp
@@ -173,7 +173,7 @@ int cond::TestGTLoad::execute(){
 
   ConnectionPool connPool;
   if( hasDebug() ) connPool.setMessageVerbosity( coral::Debug );
-  Session session = connPool.createSession( connect, true );
+  Session session = connPool.createSession( connect );
   session.transaction().start();
   
   std::cout <<"Loading Global Tag "<<gtag<<std::endl;


### PR DESCRIPTION
The auto-generation of Condition DB schemas is reverted to construct by default the old layout (ORA). In order to generate output with the new format, the environment variable NEW_CONDDB has to be set.
Additional fixes concern:
- test for fronTier
- MetadataService error policy for non-existing tags

Packages involved:
CondCore/CondDB
CondCore/IOVService
CondCore/MetaDataService
CondCore/Utilities
