### PR TITLE
Proxy must be for STL collection

### DIFF
--- a/CondCore/ORA/src/PVectorHandler.cc
+++ b/CondCore/ORA/src/PVectorHandler.cc
@@ -63,7 +63,7 @@ ora::PVectorHandler::PVectorHandler( const edm::TypeWithDict& dictionary ):
   if(privateVectorAttribute){
     assert(!strcmp("ora::PVector<cond::IOVElement>",m_type.qualifiedName().c_str()));
     m_vecAttributeOffset = privateVectorAttribute.offset();
-    ROOT::TCollectionProxyInfo* collProxyPtr = ROOT::TCollectionProxyInfo::Generate(ROOT::TCollectionProxyInfo::Pushback<ora::PVector<cond::IOVElement> >());
+    ROOT::TCollectionProxyInfo* collProxyPtr = ROOT::TCollectionProxyInfo::Generate(ROOT::TCollectionProxyInfo::Pushback<std::vector<cond::IOVElement> >());
     m_collProxy.reset( collProxyPtr );
     if(! m_collProxy.get() ){
       throwException( "Cannot find \"createTCollectionProxyInfo\" function for type \""+m_type.qualifiedName()+"\"",


### PR DESCRIPTION
Fix for segfault in relvals due to a TCollectionProxyInfo being created for the wrong class.

With this fix, the relvals now throw an exception later in their execution due to a bug unrelated to this one.
