### PR TITLE
Use correct Root6 type names

### DIFF
--- a/CondCore/ORA/src/ClassUtils.cc
+++ b/CondCore/ORA/src/ClassUtils.cc
@@ -52,6 +52,18 @@ bool ora::ClassUtils::isType( const edm::TypeWithDict& type,
   return ret;
 }
 
+static
+void
+replaceString(std::string& name, std::string const& from, std::string const& to) {
+  // from must not be a substring of to.
+  std::string::size_type length = from.size();
+  std::string::size_type pos = 0;
+  while((pos = name.find(from, pos)) != std::string::npos) {
+     name.replace(pos, length, to);
+  }
+}
+
+
 bool ora::ClassUtils::checkMappedType( const edm::TypeWithDict& type, 
 				                       const std::string& mappedTypeName ){
   if( isTypeString( type ) ){
@@ -60,13 +72,15 @@ bool ora::ClassUtils::checkMappedType( const edm::TypeWithDict& type,
     return mappedTypeName=="int";
   } else if ( isTypeOraVector( type ) ){
     return isTypeNameOraVector( mappedTypeName );
-  } else if ( type.qualifiedName()=="Long64_t" ){
-    return (mappedTypeName=="Long64_t" || mappedTypeName=="long long");
-  } else if ( type.qualifiedName()=="unsigned Long64_t" ){
-    return (mappedTypeName=="unsigned Long64_t" || mappedTypeName=="unsigned long long");
-  } else {
-    return type.qualifiedName()==mappedTypeName;
+  } else if ( type.qualifiedName() == mappedTypeName ) {
+    return true;
   }
+  // ROOT 6 uses these typedefs in names.
+  std::string typeName(mappedTypeName); 
+  replaceString(typeName, "unsigned long long", "ULong64_t");
+  replaceString(typeName, "long long", "Long64_t");
+  replaceString(typeName, "std::basic_string<char> ", "std::string");
+  return (type.qualifiedName() == typeName );
 }
 
 bool ora::ClassUtils::findBaseType( edm::TypeWithDict& type, edm::TypeWithDict& baseType, size_t& func ){

--- a/FWCore/Utilities/src/TypeDemangler.cc
+++ b/FWCore/Utilities/src/TypeDemangler.cc
@@ -132,10 +132,10 @@ namespace edm {
     constBeforeIdentifier(demangledName);
     // No two consecutive '>' 
     replaceString(demangledName, ">>", "> >");
-    // For ROOT 6 and beyond, replace 'long long' with 'Long64_t'
-    replaceString(demangledName, "long long", "Long64_t");
     // For ROOT 6 and beyond, replace 'unsigned long long' with 'ULong64_t'
     replaceString(demangledName, "unsigned long long", "ULong64_t");
+    // For ROOT 6 and beyond, replace 'long long' with 'Long64_t'
+    replaceString(demangledName, "long long", "Long64_t");
     return demangledName;
   }
 }


### PR DESCRIPTION
Fix for fatal exception in relvals due to change in normalized type names from ROOT 5 to ROOT 6.
ROOT6 uses Long64_t, ULong64_t, and std::string for what were, in ROOT5 long long, unsigned long long, and std::basic_string<char> respectively.

With this fix, the relvals now fail later in their execution due to an unrelated exception.  That now needs to be fixed.
