### PR TITLE
DQMRootOutputModule: implement support for multi-process cmsRun

### DIFF
--- a/DQMServices/FwkIO/plugins/BuildFile.xml
+++ b/DQMServices/FwkIO/plugins/BuildFile.xml
@@ -5,6 +5,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="FWCore/Catalog"/>
 <use   name="roothistmatrix"/>
+<use   name="boost_filesystem"/>
 <library   file="*.cc" name="DQMServicesFwkIOPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
implement postForkReacquireResources(...) for DQMRootOutputModule, adding _NNN to the file name along the same logic used by the PoolOutputModule.

same as #2190 for CMSSW 6.2.x
