### PR TITLE
reFix-harvesting-input 71x

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1259,7 +1259,6 @@ steps['HARVESTUP15']={'-s':'HARVESTING:validationHarvesting+dqmHarvesting', # to
                    '--conditions':'auto:upgradePLS1', 
                    '--magField'    : '38T_PostLS1',
                    '--mc':'',
-                   '--filein'    :'file:step3_inDQM.root',
                    '--customise' : 'SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1',
 		   '--geometry' : 'Extended2015'
                    }


### PR DESCRIPTION
- undo what was done in pull 2169: fundamental fix provided in PR 2180 and keep flexibility that HARVEST step may not be step4
- this PR needs to be taken in 71x together with the PR already submitted for 70x number 2180
