### PR TITLE
EGM .cc and python patch for new regression tags in the DB

### DIFF
--- a/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
+++ b/RecoEcal/EgammaClusterAlgos/src/PFECALSuperClusterAlgo.cc
@@ -472,7 +472,7 @@ buildSuperCluster(CalibClusterPtr& seed,
   //apply regression energy corrections
   if( useRegression_ ) {    
     double cor = regr_->getCorrection(new_sc);
-    new_sc.setEnergy(cor*new_sc.energy());
+    new_sc.setEnergy(cor*new_sc.correctedEnergy());
   }
   
   // save the super cluster to the appropriate list (if it passes the final

--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -1,6 +1,35 @@
 import FWCore.ParameterSet.Config as cms
 import os
 
+from CondCore.DBCommon.CondDBCommon_cfi import CondDBCommon
+pfSCecalGBRESSource = cms.ESSource(
+    "PoolDBESSource",
+    CondDBCommon,
+    DumpStat=cms.untracked.bool(False),
+    toGet = cms.VPSet(
+    cms.PSet(
+    record = cms.string('GBRWrapperRcd'),
+    tag = cms.string('pfscecal_EBCorrection_offline_v1'),
+    label = cms.untracked.string('pfscecal_EBCorrection_offline_v1')
+    ),
+    cms.PSet(
+    record = cms.string('GBRWrapperRcd'),
+    tag = cms.string('pfscecal_EECorrection_offline_v1'),
+    label = cms.untracked.string('pfscecal_EECorrection_offline_v1')
+    ),
+    )
+)
+pfSCecalGBRESSource.connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000')
+
+pfSCecalPrefer = cms.ESPrefer(
+    'PoolDBESSource',
+    'pfSCecalGBRESSource',
+    GBRWrapperRcd = cms.vstring('GBRForest/pfscecal_EBCorrection_offline_v1',
+                                'GBRForest/pfscecal_EECorrection_offline_v1')
+)
+
+
+
 particleFlowSuperClusterECALBox = cms.EDProducer(
     "PFECALSuperClusterProducer",
     # verbosity 
@@ -105,8 +134,8 @@ particleFlowSuperClusterECALMustache = cms.EDProducer(
     # regression setup
     useRegression = cms.bool(True),
     regressionConfig = cms.PSet(
-       regressionKeyEB = cms.string('pfscecal_EBCorrection_offline'),
-       regressionKeyEE = cms.string('pfscecal_EECorrection_offline'),
+       regressionKeyEB = cms.string('pfscecal_EBCorrection_offline_v1'),
+       regressionKeyEE = cms.string('pfscecal_EECorrection_offline_v1'),
        vertexCollection = cms.InputTag("offlinePrimaryVertices"),
        ecalRecHitsEB = cms.InputTag('ecalRecHit','EcalRecHitsEB'),
        ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE')

--- a/RecoEgamma/EgammaElectronAlgos/src/RegressionHelper.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/RegressionHelper.cc
@@ -21,8 +21,8 @@ void RegressionHelper::applyEcalRegression(reco::GsfElectron & ele,
 					   const edm::Handle<EcalRecHitCollection>& rechitsEE) const {
   double cor, err;
   getEcalRegression(*ele.superCluster(), vertices, rechitsEB, rechitsEE, cor, err);
-  ele.setCorrectedEcalEnergy(cor * ele.superCluster()->energy());
-  ele.setCorrectedEcalEnergyError( err * ele.superCluster()->energy());	
+  ele.setCorrectedEcalEnergy(cor * ele.superCluster()->correctedEnergy());
+  ele.setCorrectedEcalEnergyError( err * ele.superCluster()->correctedEnergy());	
 
 }
 
@@ -148,7 +148,7 @@ void RegressionHelper::getEcalRegression(const reco::SuperCluster & sc,
   rInputs.resize(33);
   
   const double rawEnergy = sc.rawEnergy();
-  const double calibEnergy = sc.energy();
+  const double calibEnergy = sc.correctedEnergy();
   const edm::Ptr<reco::CaloCluster> seed(sc.seed());
   const size_t nVtx = vertices->size();
   float maxDR=999., maxDRDPhi=999., maxDRDEta=999., maxDRRawEnergy=0.;
@@ -173,12 +173,7 @@ void RegressionHelper::getEcalRegression(const reco::SuperCluster & sc,
       subClusDPhi[iclus] = this_dphi;
     }
   }
-  float scPreshowerSum = 0.0;
-  for( auto psclus = sc.preshowerClustersBegin();
-       psclus != sc.preshowerClustersEnd(); ++psclus ) {
-    scPreshowerSum += (*psclus)->energy();
-  }
-
+  float scPreshowerSum = sc.preshowerEnergy();
   if ( seed->hitsAndFractions()[0].first.subdetId()==EcalBarrel ) {
     const float eMax = EcalClusterTools::eMax( *seed, &*rechitsEB );
     const float e2nd = EcalClusterTools::e2nd( *seed, &*rechitsEB );

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
@@ -3,6 +3,53 @@ import FWCore.ParameterSet.Config as cms
 from RecoEcal.EgammaClusterProducers.hybridSuperClusters_cfi import *
 from RecoEcal.EgammaClusterProducers.multi5x5BasicClusters_cfi import *
 
+from CondCore.DBCommon.CondDBCommon_cfi import CondDBCommon
+gedelectronGBRESSource = cms.ESSource(
+    "PoolDBESSource",
+    CondDBCommon,
+    DumpStat=cms.untracked.bool(False),
+    toGet = cms.VPSet(
+    cms.PSet(
+    record = cms.string('GBRWrapperRcd'),
+    tag = cms.string('gedelectron_EBCorrection_offline_v1'),
+    label = cms.untracked.string('gedelectron_EBCorrection_offline_v1')
+    ),
+    cms.PSet(
+    record = cms.string('GBRWrapperRcd'),
+    tag = cms.string('gedelectron_EECorrection_offline_v1'),
+    label = cms.untracked.string('gedelectron_EECorrection_offline_v1')
+    ),
+    cms.PSet(
+    record = cms.string('GBRWrapperRcd'),
+    tag = cms.string('gedelectron_EBUncertainty_offline_v1'),
+    label = cms.untracked.string('gedelectron_EBUncertainty_offline_v1')
+    ),
+    cms.PSet(
+    record = cms.string('GBRWrapperRcd'),
+    tag = cms.string('gedelectron_EEUncertainty_offline_v1'),
+    label = cms.untracked.string('gedelectron_EEUncertainty_offline_v1')
+    ),
+    cms.PSet(
+    record = cms.string('GBRWrapperRcd'),
+    tag = cms.string('gedelectron_p4combination_offline'),
+    label = cms.untracked.string('gedelectron_p4combination_offline')
+    ),
+    )
+)
+gedelectronGBRESSource.connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000')
+
+gedelectronPrefer = cms.ESPrefer(
+    'PoolDBESSource',
+    'gedelectronGBRESSource',
+    GBRWrapperRcd = cms.vstring('GBRForest/gedelectron_EBCorrection_offline_v1',
+                                'GBRForest/gedelectron_EECorrection_offline_v1',
+                                'GBRForest/gedelectron_EBUncertainty_offline_v1',
+                                'GBRForest/gedelectron_EEUncertainty_offline_v1',
+                                'GBRForest/gedelectron_p4combination_offline')
+)
+
+
+
 gedGsfElectronsTmp = cms.EDProducer("GEDGsfElectronProducer",
 
     # input collections
@@ -143,10 +190,10 @@ gedGsfElectronsTmp = cms.EDProducer("GEDGsfElectronProducer",
     crackCorrectionFunction = cms.string("EcalClusterCrackCorrection"),
 
    # regression. The labels are needed in all cases
-   ecalRefinedRegressionWeightLabels = cms.vstring('gedelectron_EBCorrection_offline',
-                                                   'gedelectron_EECorrection_offline',
-                                                   'gedelectron_EBUncertainty_offline',
-                                                   'gedelectron_EEUncertainty_offline'),
+   ecalRefinedRegressionWeightLabels = cms.vstring('gedelectron_EBCorrection_offline_v1',
+                                                   'gedelectron_EECorrection_offline_v1',
+                                                   'gedelectron_EBUncertainty_offline_v1',
+                                                   'gedelectron_EEUncertainty_offline_v1'),
    combinationRegressionWeightLabels = cms.vstring('gedelectron_p4combination_offline'),
    
    ecalWeightsFromDB = cms.bool(True),

--- a/RecoEgamma/EgammaPhotonAlgos/src/PhotonEnergyCorrector.cc
+++ b/RecoEgamma/EgammaPhotonAlgos/src/PhotonEnergyCorrector.cc
@@ -171,8 +171,8 @@ void PhotonEnergyCorrector::calculate(edm::Event& evt, reco::Photon & thePhoton,
   if( gedRegression_ ) {
     gedRegression_->varCalc()->setEvent(evt);
     std::pair<float,float> cor = gedRegression_->getCorrectionWithErrors(*(thePhoton.superCluster()));
-    phoRegr1Energy = cor.first*thePhoton.superCluster()->energy();
-    phoRegr1EnergyError = cor.second*thePhoton.superCluster()->energy();
+    phoRegr1Energy = cor.first*thePhoton.superCluster()->correctedEnergy();
+    phoRegr1EnergyError = cor.second*thePhoton.superCluster()->correctedEnergy();
     // store the value in the Photon.h
     thePhoton.setCorrectedEnergy( reco::Photon::regression1, phoRegr1Energy, phoRegr1EnergyError,  false);
   }

--- a/RecoEgamma/EgammaPhotonProducers/python/gedPhotons_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/gedPhotons_cfi.py
@@ -6,6 +6,45 @@ from RecoEgamma.PhotonIdentification.mipVariable_cfi import *
 from RecoEcal.EgammaClusterProducers.hybridSuperClusters_cfi import *
 from RecoEcal.EgammaClusterProducers.multi5x5BasicClusters_cfi import *
 
+from CondCore.DBCommon.CondDBCommon_cfi import CondDBCommon
+gedphotonGBRESSource = cms.ESSource(
+    "PoolDBESSource",
+    CondDBCommon,
+    DumpStat=cms.untracked.bool(False),
+    toGet = cms.VPSet(
+    cms.PSet(
+    record = cms.string('GBRWrapperRcd'),
+    tag = cms.string('gedphoton_EBCorrection_offline_v1'),
+    label = cms.untracked.string('gedphoton_EBCorrection_offline_v1')
+    ),
+    cms.PSet(
+    record = cms.string('GBRWrapperRcd'),
+    tag = cms.string('gedphoton_EECorrection_offline_v1'),
+    label = cms.untracked.string('gedphoton_EECorrection_offline_v1')
+    ),
+    cms.PSet(
+    record = cms.string('GBRWrapperRcd'),
+    tag = cms.string('gedphoton_EBUncertainty_offline_v1'),
+    label = cms.untracked.string('gedphoton_EBUncertainty_offline_v1')
+    ),
+    cms.PSet(
+    record = cms.string('GBRWrapperRcd'),
+    tag = cms.string('gedphoton_EEUncertainty_offline_v1'),
+    label = cms.untracked.string('gedphoton_EEUncertainty_offline_v1')
+    ),
+    )
+)
+gedphotonGBRESSource.connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000')
+
+gedphotonPrefer = cms.ESPrefer(
+    'PoolDBESSource',
+    'gedphotonGBRESSource',
+    GBRWrapperRcd = cms.vstring('GBRForest/gedphoton_EBCorrection_offline_v1',
+                                'GBRForest/gedphoton_EECorrection_offline_v1',
+                                'GBRForest/gedphoton_EBUncertainty_offline_v1',
+                                'GBRForest/gedphoton_EEUncertainty_offline_v1')
+)
+
 #
 # producer for photons
 #
@@ -19,10 +58,10 @@ gedPhotons = cms.EDProducer("GEDPhotonProducer",
     # refined SC regression setup
     useRegression = cms.bool(True),
     regressionConfig = cms.PSet(
-       regressionKeyEB = cms.string('gedphoton_EBCorrection_offline'),
-       regressionKeyEE = cms.string('gedphoton_EECorrection_offline'),
-       uncertaintyKeyEB = cms.string('gedphoton_EBUncertainty_offline'),
-       uncertaintyKeyEE = cms.string('gedphoton_EEUncertainty_offline'),
+       regressionKeyEB = cms.string('gedphoton_EBCorrection_offline_v1'),
+       regressionKeyEE = cms.string('gedphoton_EECorrection_offline_v1'),
+       uncertaintyKeyEB = cms.string('gedphoton_EBUncertainty_offline_v1'),
+       uncertaintyKeyEE = cms.string('gedphoton_EEUncertainty_offline_v1'),
        vertexCollection = cms.InputTag("offlinePrimaryVertices"),
        ecalRecHitsEB = cms.InputTag('ecalRecHit','EcalRecHitsEB'),
        ecalRecHitsEE = cms.InputTag('ecalRecHit','EcalRecHitsEE')

--- a/RecoEgamma/EgammaTools/src/BaselinePFSCRegression.cc
+++ b/RecoEgamma/EgammaTools/src/BaselinePFSCRegression.cc
@@ -24,7 +24,7 @@ void BaselinePFSCRegression::set(const reco::SuperCluster& sc,
 				 std::vector<float>& vars     ) const {
   vars.clear();
   vars.resize(33);
-  const double rawEnergy = sc.rawEnergy(), calibEnergy = sc.energy();
+  const double rawEnergy = sc.rawEnergy(), calibEnergy = sc.correctedEnergy();
   const edm::Ptr<reco::CaloCluster> &seed = sc.seed();
   const size_t nVtx = vertices->size();
   float maxDR=999., maxDRDPhi=999., maxDRDEta=999., maxDRRawEnergy=0.;
@@ -49,11 +49,7 @@ void BaselinePFSCRegression::set(const reco::SuperCluster& sc,
       subClusDPhi[iclus] = this_dphi;
     }
   }
-  float scPreshowerSum = 0.0;
-  for( auto psclus = sc.preshowerClustersBegin(); 
-       psclus != sc.preshowerClustersEnd(); ++psclus ) {
-    scPreshowerSum += (*psclus)->energy();
-  }
+  float scPreshowerSum = sc.preshowerEnergy();
   switch( seed->hitsAndFractions().at(0).first.subdetId() ) {
   case EcalBarrel:
     {

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -2171,6 +2171,7 @@ buildRefinedSuperCluster(const PFEGammaAlgo::ProtoEGObject& RO) {
   clusptr = 
     edm::refToPtr<reco::PFClusterCollection>(RO.ecalclusters.front().
 					     first->clusterRef());
+  new_sc.setCorrectedEnergy(corrSCEnergy);
   new_sc.setSeed(clusptr);
   new_sc.setPreshowerEnergyPlane1(ps1_energy);
   new_sc.setPreshowerEnergyPlane2(ps2_energy);


### PR DESCRIPTION
The PR contains .cc updates and ESPrefers for the new regressions. 
The global tags are in preparation.

In general we see moderate to substantial improvements in the photon/electron energy response in all eta regions.

You can see the overview of the training here:
https://indico.cern.ch/getFile.py/access?contribId=3&resId=0&materialId=slides&confId=293993

The result of private reRECO (black) on top of vanilla pre12 (blue) attached for electrons (Zee 50ns PU, 13 TeV):
--- ecal energy only
![erecoetrue_hzz50ns_ged_forpre13_lin](https://f.cloud.github.com/assets/1068089/2019522/99d91928-8824-11e3-997e-bab0f8f0018a.png)
![erecoetrue_hzz50ns_ged_forpre13_log](https://f.cloud.github.com/assets/1068089/2019523/99dae6fe-8824-11e3-9980-26f277b310bd.png)

--- combined p4 measurement 
![e4petrue_hzz50ns_ged_forpre13_lin](https://f.cloud.github.com/assets/1068089/2019536/c174c284-8824-11e3-8694-5c8c4329bf43.png)
![e4petrue_hzz50ns_ged_forpre13_log](https://f.cloud.github.com/assets/1068089/2019537/c174fe66-8824-11e3-8bf4-7580475ebb3a.png)

and for photons (Hgg in 50ns PU, 13 TeV):
![erecoetrue_hgg50ns_ged_forpre13_lin](https://f.cloud.github.com/assets/1068089/2019548/e77f0796-8824-11e3-9212-1f5bac4fd8ff.png)
![erecoetrue_hgg50ns_ged_forpre13_log](https://f.cloud.github.com/assets/1068089/2019549/e7858206-8824-11e3-9cd8-f8d65bdf9665.png)
