### PR TITLE
Add  PU ID for btagging

### DIFF
--- a/DQMOffline/RecoB/interface/BTagDifferentialPlot.h
+++ b/DQMOffline/RecoB/interface/BTagDifferentialPlot.h
@@ -49,9 +49,7 @@ class BTagDifferentialPlot {
   TH1F * getDifferentialHistoB_ni   () { return theDifferentialHistoB_ni->getTH1F()   ; }
   TH1F * getDifferentialHistoB_dus  () { return theDifferentialHistoB_dus->getTH1F()  ; }
   TH1F * getDifferentialHistoB_dusg () { return theDifferentialHistoB_dusg->getTH1F() ; }
-  
-  
-
+  TH1F * getDifferentialHistoB_pu   () { return theDifferentialHistoB_pu->getTH1F()   ; }
 
   
  private:
@@ -98,6 +96,7 @@ class BTagDifferentialPlot {
   MonitorElement * theDifferentialHistoB_ni   ;
   MonitorElement * theDifferentialHistoB_dus  ;
   MonitorElement * theDifferentialHistoB_dusg ;
+  MonitorElement * theDifferentialHistoB_pu   ;
 
   // the plot Canvas
 //   TCanvas * thePlotCanvas ;

--- a/DQMOffline/RecoB/interface/EffPurFromHistos.h
+++ b/DQMOffline/RecoB/interface/EffPurFromHistos.h
@@ -17,9 +17,10 @@ class EffPurFromHistos {
  public:
 
   EffPurFromHistos ( const std::string & ext, TH1F * h_d, TH1F * h_u,
-	TH1F * h_s, TH1F * h_c, TH1F * h_b, TH1F * h_g,	TH1F * h_ni,
-		     TH1F * h_dus, TH1F * h_dusg, const std::string& label, const unsigned int& mc,
-	int nBin = 100 , double startO = 0.005 , double endO = 1.005 ) ;
+		     TH1F * h_s, TH1F * h_c, TH1F * h_b, TH1F * h_g,	TH1F * h_ni,
+		     TH1F * h_dus, TH1F * h_dusg, TH1F * h_pu, 
+		     const std::string& label, const unsigned int& mc,
+		     int nBin = 100 , double startO = 0.005 , double endO = 1.005 ) ;
 	// defaults reasonable for lifetime based tags
 
   EffPurFromHistos (const FlavourHistograms<double> * dDiscriminatorFC, const std::string& label, const unsigned int& mc,
@@ -32,8 +33,7 @@ class EffPurFromHistos {
   void compute () ;
 
   // return the newly created histos
-  TH1F * getEffFlavVsBEff_d    () { 
-    return EffFlavVsBEff_d->getTH1F()    ; };
+  TH1F * getEffFlavVsBEff_d    () { return EffFlavVsBEff_d->getTH1F()    ; };
   TH1F * getEffFlavVsBEff_u    () { return EffFlavVsBEff_u->getTH1F()    ; };
   TH1F * getEffFlavVsBEff_s    () { return EffFlavVsBEff_s ->getTH1F()   ; };
   TH1F * getEffFlavVsBEff_c    () { return EffFlavVsBEff_c ->getTH1F()   ; };
@@ -42,6 +42,7 @@ class EffPurFromHistos {
   TH1F * getEffFlavVsBEff_ni   () { return EffFlavVsBEff_ni ->getTH1F()  ; };
   TH1F * getEffFlavVsBEff_dus  () { return EffFlavVsBEff_dus ->getTH1F() ; };
   TH1F * getEffFlavVsBEff_dusg () { return EffFlavVsBEff_dusg ->getTH1F(); };
+  TH1F * getEffFlavVsBEff_pu   () { return EffFlavVsBEff_pu ->getTH1F(); };
 
  
 
@@ -84,6 +85,7 @@ class EffPurFromHistos {
   TH1F * effVersusDiscr_ni   ;
   TH1F * effVersusDiscr_dus  ;
   TH1F * effVersusDiscr_dusg ;
+  TH1F * effVersusDiscr_pu   ;
 
 
   // the corresponding output histograms (flavour-eff vs. b-efficiency)
@@ -105,6 +107,7 @@ class EffPurFromHistos {
   MonitorElement * EffFlavVsBEff_ni   ;
   MonitorElement * EffFlavVsBEff_dus  ;
   MonitorElement * EffFlavVsBEff_dusg ;
+  MonitorElement * EffFlavVsBEff_pu   ;
 
   //  DQMStore * dqmStore_; 
   std::string label_;

--- a/DQMOffline/RecoB/interface/FlavourHistorgrams.h
+++ b/DQMOffline/RecoB/interface/FlavourHistorgrams.h
@@ -88,6 +88,7 @@ public:
   inline TH1F * histo_ni   () const { return theHisto_ni->getTH1F()   ; }
   inline TH1F * histo_dus  () const { return theHisto_dus->getTH1F()  ; }
   inline TH1F * histo_dusg () const { return theHisto_dusg->getTH1F() ; }
+  inline TH1F * histo_pu () const { return theHisto_pu->getTH1F() ; }
 
   std::vector<TH1F*> getHistoVector() const;
   
@@ -129,6 +130,7 @@ protected:
   MonitorElement *theHisto_ni   ;
   MonitorElement *theHisto_dus  ;
   MonitorElement *theHisto_dusg ;
+  MonitorElement *theHisto_pu ;
 
   //  DQMStore * dqmStore_; 
 
@@ -192,6 +194,7 @@ FlavourHistograms<T>::FlavourHistograms (const std::string& baseNameTitle_ , con
       theHisto_b     = (prov.book1D ( theBaseNameTitle + "B"    , theBaseNameDescription + " b-jets"    , theNBins , theLowerBound , theUpperBound )) ; 
       theHisto_ni    = (prov.book1D ( theBaseNameTitle + "NI"   , theBaseNameDescription + " ni-jets"   , theNBins , theLowerBound , theUpperBound )) ; 
       theHisto_dusg  = (prov.book1D ( theBaseNameTitle + "DUSG" , theBaseNameDescription + " dusg-jets" , theNBins , theLowerBound , theUpperBound )) ;
+      theHisto_pu    = (prov.book1D ( theBaseNameTitle + "PU"   , theBaseNameDescription + " pu-jets"   , theNBins , theLowerBound , theUpperBound )) ; 
     }else{
       theHisto_d = 0;
       theHisto_u = 0;
@@ -202,6 +205,7 @@ FlavourHistograms<T>::FlavourHistograms (const std::string& baseNameTitle_ , con
       theHisto_ni = 0;
       theHisto_dus = 0;
       theHisto_dusg = 0;
+      theHisto_pu = 0;
     }
 
       // statistics if requested
@@ -219,6 +223,7 @@ FlavourHistograms<T>::FlavourHistograms (const std::string& baseNameTitle_ , con
 	theHisto_b   ->getTH1F()->Sumw2() ; 
 	theHisto_ni  ->getTH1F()->Sumw2() ; 
 	theHisto_dusg->getTH1F()->Sumw2() ;
+	theHisto_pu  ->getTH1F()->Sumw2() ;
       }
     }
   } else {
@@ -236,6 +241,7 @@ FlavourHistograms<T>::FlavourHistograms (const std::string& baseNameTitle_ , con
       theHisto_b     = prov.access(theBaseNameTitle + "B"   ) ; 
       theHisto_ni    = prov.access(theBaseNameTitle + "NI"  ) ; 
       theHisto_dusg  = prov.access(theBaseNameTitle + "DUSG") ;
+      theHisto_pu  = prov.access(theBaseNameTitle + "PU") ;
     }
   }
 
@@ -317,6 +323,7 @@ void FlavourHistograms<T>::settitle(const char* title) {
       theHisto_b   ->setAxisTitle(title) ;
       theHisto_ni  ->setAxisTitle(title) ;
       theHisto_dusg->setAxisTitle(title) ;
+      theHisto_pu->setAxisTitle(title) ;
     }
 }
 
@@ -490,6 +497,7 @@ void FlavourHistograms<T>::divide ( const FlavourHistograms<T> & bHD ) const {
       theHisto_b    ->getTH1F()-> Divide ( theHisto_b ->getTH1F()   , bHD.histo_b   () , 1.0 , 1.0 , "b" ) ;
       theHisto_ni   ->getTH1F()-> Divide ( theHisto_ni->getTH1F()   , bHD.histo_ni  () , 1.0 , 1.0 , "b" ) ;
       theHisto_dusg ->getTH1F()-> Divide ( theHisto_dusg->getTH1F() , bHD.histo_dusg() , 1.0 , 1.0 , "b" ) ;
+      theHisto_pu   ->getTH1F()-> Divide ( theHisto_pu->getTH1F() , bHD.histo_pu() , 1.0 , 1.0 , "b" ) ;
     }
 }
   
@@ -541,6 +549,9 @@ void FlavourHistograms<T>::fillVariable ( const int & flavour , const T & var , 
     case 12321:
       if (theBaseNameDescription == "Jet Multiplicity") theHisto_dusg->Fill( var ,w);
       return;
+    case 20:
+      theHisto_pu->Fill( var ,w);
+      return;
     default:
       theHisto_ni->Fill( var ,w);
       return;
@@ -564,6 +575,7 @@ std::vector<TH1F*> FlavourHistograms<T>::getHistoVector() const
       histoVector.push_back ( theHisto_b->getTH1F()   );
       histoVector.push_back ( theHisto_ni->getTH1F()  );
       histoVector.push_back ( theHisto_dusg->getTH1F());
+      histoVector.push_back ( theHisto_pu->getTH1F());
     }
   return histoVector;
 }

--- a/DQMOffline/RecoB/interface/FlavourHistorgrams2D.h
+++ b/DQMOffline/RecoB/interface/FlavourHistorgrams2D.h
@@ -85,6 +85,7 @@ public:
   inline TH2F * histo_ni   () const { return theHisto_ni->getTH2F()   ; }
   inline TH2F * histo_dus  () const { return theHisto_dus->getTH2F()  ; }
   inline TH2F * histo_dusg () const { return theHisto_dusg->getTH2F() ; }
+  inline TH2F * histo_pu   () const { return theHisto_pu->getTH2F()   ; }
 
   TProfile * profile_all  () const { return theProfile_all->getTProfile()  ; }    
   TProfile * profile_d    () const { return theProfile_d ->getTProfile()   ; }    
@@ -96,6 +97,7 @@ public:
   TProfile * profile_ni   () const { return theProfile_ni->getTProfile()   ; }
   TProfile * profile_dus  () const { return theProfile_dus->getTProfile()  ; }
   TProfile * profile_dusg () const { return theProfile_dusg->getTProfile() ; }
+  TProfile * profile_pu   () const { return theProfile_pu->getTProfile()   ; }
 
   std::vector<TH2F*> getHistoVector() const;
 
@@ -140,6 +142,7 @@ protected:
   MonitorElement *theHisto_ni   ;
   MonitorElement *theHisto_dus  ;
   MonitorElement *theHisto_dusg ;
+  MonitorElement *theHisto_pu ;
 
   // the profiles
   MonitorElement *theProfile_all  ;    
@@ -152,6 +155,7 @@ protected:
   MonitorElement *theProfile_ni   ;
   MonitorElement *theProfile_dus  ;
   MonitorElement *theProfile_dusg ;
+  MonitorElement *theProfile_pu ;
 
   //  DQMStore * dqmStore_; 
 
@@ -208,6 +212,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
       theHisto_b     = (prov.book2D ( theBaseNameTitle + "B"    , theBaseNameDescription + " b-jets"    , theNBinsX , theLowerBoundX , theUpperBoundX , theNBinsY, theLowerBoundY, theUpperBoundY)) ; 
       theHisto_ni    = (prov.book2D ( theBaseNameTitle + "NI"   , theBaseNameDescription + " ni-jets"   , theNBinsX , theLowerBoundX , theUpperBoundX , theNBinsY, theLowerBoundY, theUpperBoundY)) ; 
       theHisto_dusg  = (prov.book2D ( theBaseNameTitle + "DUSG" , theBaseNameDescription + " dusg-jets" , theNBinsX , theLowerBoundX , theUpperBoundX , theNBinsY, theLowerBoundY, theUpperBoundY)) ;
+      theHisto_pu    = (prov.book2D ( theBaseNameTitle + "PU"   , theBaseNameDescription + " pu-jets"   , theNBinsX , theLowerBoundX , theUpperBoundX , theNBinsY, theLowerBoundY, theUpperBoundY)) ;
     }else{
       theHisto_d = 0;
       theHisto_u = 0;
@@ -218,6 +223,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
       theHisto_ni = 0;
       theHisto_dus = 0;
       theHisto_dusg = 0;
+      theHisto_pu = 0;
     }
 
     if (createProfile_) {
@@ -242,6 +248,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
         theProfile_b     = (prov.bookProfile ( theBaseNameTitle + "_Profile_B"    , theBaseNameDescription + " b-jets"    , theNBinsX , theLowerBoundX , theUpperBoundX , theNBinsY, theLowerBoundY, theUpperBoundY)) ; 
         theProfile_ni    = (prov.bookProfile ( theBaseNameTitle + "_Profile_NI"   , theBaseNameDescription + " ni-jets"   , theNBinsX , theLowerBoundX , theUpperBoundX , theNBinsY, theLowerBoundY, theUpperBoundY)) ; 
         theProfile_dusg  = (prov.bookProfile ( theBaseNameTitle + "_Profile_DUSG" , theBaseNameDescription + " dusg-jets" , theNBinsX , theLowerBoundX , theUpperBoundX , theNBinsY, theLowerBoundY, theUpperBoundY)) ;
+        theProfile_pu    = (prov.bookProfile ( theBaseNameTitle + "_Profile_PU"   , theBaseNameDescription + " pu-jets"   , theNBinsX , theLowerBoundX , theUpperBoundX , theNBinsY, theLowerBoundY, theUpperBoundY)) ;
       } else{
           theProfile_d = 0;
           theProfile_u = 0;
@@ -252,6 +259,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
           theProfile_ni = 0;
           theProfile_dus = 0;
           theProfile_dusg = 0;
+          theProfile_pu = 0;
       } 
     }  else {
           theProfile_all = 0;
@@ -264,6 +272,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
           theProfile_ni = 0;
           theProfile_dus = 0;
           theProfile_dusg = 0;
+          theProfile_pu = 0;
     }
       // statistics if requested
     if ( theStatistics ) {
@@ -282,6 +291,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
 	theHisto_b   ->getTH2F()->Sumw2() ; 
 	theHisto_ni  ->getTH2F()->Sumw2() ; 
 	theHisto_dusg->getTH2F()->Sumw2() ;
+	theHisto_pu  ->getTH2F()->Sumw2() ;
 
         if(createProfile) {
 	  if (mcPlots_>2) {
@@ -295,6 +305,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
 	  theProfile_b   ->getTProfile()->Sumw2() ; 
 	  theProfile_ni  ->getTProfile()->Sumw2() ; 
 	  theProfile_dusg->getTProfile()->Sumw2() ;
+	  theProfile_pu  ->getTProfile()->Sumw2() ;
         }
       }
     }
@@ -313,6 +324,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
       theHisto_b     = prov.access(theBaseNameTitle + "B"   ) ; 
       theHisto_ni    = prov.access(theBaseNameTitle + "NI"  ) ; 
       theHisto_dusg  = prov.access(theBaseNameTitle + "DUSG") ;
+      theHisto_pu    = prov.access(theBaseNameTitle + "PU"  ) ;
     }
 
     if(createProfile_) {
@@ -329,6 +341,7 @@ FlavourHistograms2D<T, G>::FlavourHistograms2D (TString baseNameTitle_ , TString
         theProfile_b     = prov.access(theBaseNameTitle + "_Profile_B"   ) ; 
         theProfile_ni    = prov.access(theBaseNameTitle + "_Profile_NI"  ) ; 
         theProfile_dusg  = prov.access(theBaseNameTitle + "_Profile_DUSG") ;
+        theProfile_pu    = prov.access(theBaseNameTitle + "_Profile_PU"  ) ;
       }
     }
   }
@@ -420,6 +433,7 @@ void FlavourHistograms2D<T, G>::settitle(const char* titleX, const char* titleY)
       if(theHisto_ni) theHisto_ni  ->setAxisTitle(titleY, 2) ;
       if(theHisto_dus) theHisto_dus ->setAxisTitle(titleY, 2) ;
       if(theHisto_dusg)theHisto_dusg->setAxisTitle(titleY, 2) ;
+      if(theHisto_pu) theHisto_pu  ->setAxisTitle(titleY, 2) ;
     }
 
   if(createProfile_) {
@@ -445,6 +459,7 @@ void FlavourHistograms2D<T, G>::settitle(const char* titleX, const char* titleY)
       if(theProfile_ni) theProfile_ni  ->setAxisTitle(titleY, 2) ;
       if(theProfile_dus) theProfile_dus ->setAxisTitle(titleY, 2) ;
       if(theProfile_dusg)theProfile_dusg->setAxisTitle(titleY, 2) ;
+      if(theProfile_pu) theProfile_pu  ->setAxisTitle(titleY, 2) ;
     }
   }
 }
@@ -471,6 +486,7 @@ void FlavourHistograms2D<T, G>::divide ( const FlavourHistograms2D<T, G> & bHD )
       theHisto_b    ->getTH2F()-> Divide ( theHisto_b ->getTH2F()   , bHD.histo_b   () , 1.0 , 1.0 , "b" ) ;
       theHisto_ni   ->getTH2F()-> Divide ( theHisto_ni->getTH2F()   , bHD.histo_ni  () , 1.0 , 1.0 , "b" ) ;
       theHisto_dusg ->getTH2F()-> Divide ( theHisto_dusg->getTH2F() , bHD.histo_dusg() , 1.0 , 1.0 , "b" ) ;
+      theHisto_pu   ->getTH2F()-> Divide ( theHisto_pu->getTH2F()   , bHD.histo_pu  () , 1.0 , 1.0 , "b" ) ;
     }
 }
   
@@ -559,6 +575,11 @@ template <class T, class G>
         theProfile_dusg->Fill(varX, varY);
       }
       return;
+    case 20:
+      theHisto_pu->Fill( varX, varY,w );
+      //if(createProfile_) theProfile_pu->Fill(varX, varY,w);                                                                                                                                 
+      if(createProfile_) theProfile_pu->Fill(varX, varY);
+      return;
     default:
       theHisto_ni->Fill( varX, varY,w );
       //if(createProfile_) theProfile_ni->Fill(varX, varY,w);
@@ -584,6 +605,7 @@ std::vector<TH2F*> FlavourHistograms2D<T, G>::getHistoVector() const
       histoVector.push_back ( theHisto_b->getTH2F()   );
       histoVector.push_back ( theHisto_ni->getTH2F()  );
       histoVector.push_back ( theHisto_dusg->getTH2F());
+      histoVector.push_back ( theHisto_pu->getTH2F()  );
     }
   return histoVector;
 }
@@ -606,6 +628,7 @@ std::vector<TProfile*> FlavourHistograms2D<T, G>::getProfileVector() const
         profileVector.push_back ( theProfile_b->getTProfile()   );
         profileVector.push_back ( theProfile_ni->getTProfile()  );
         profileVector.push_back ( theProfile_dusg->getTProfile());
+        profileVector.push_back ( theProfile_pu->getTProfile()  );
       }
   }
   return profileVector;

--- a/DQMOffline/RecoB/python/bTagSequences_cff.py
+++ b/DQMOffline/RecoB/python/bTagSequences_cff.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 #define you jet ID
-jetID = cms.InputTag("ak5PFJets")
-
+jetID = cms.InputTag("ak5PFJetsCHS")
+corr = 'ak5PFCHSL1FastL2L3'
 #JTA for your jets
 from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import *
 myak5JetTracksAssociatorAtVertex = cms.EDProducer("JetTracksAssociatorAtVertex",
@@ -44,13 +44,18 @@ bTagHLT  = hltHighLevel.clone(TriggerResultsTag = "TriggerResults::HLT", HLTPath
 JetCut=cms.string("neutralHadronEnergyFraction < 0.99 && neutralEmEnergyFraction < 0.99 && nConstituents > 1 && chargedHadronEnergyFraction > 0.0 && chargedMultiplicity > 0.0 && chargedEmEnergyFraction < 0.99")
 
 from JetMETCorrections.Configuration.DefaultJEC_cff import *
-ak5PFJetsJEC = ak5PFJetsL2L3.clone(
-        src = 'ak5PFJets',
-        correctors = ['ak5PFL2L3']
-        )
+from JetMETCorrections.Configuration.JetCorrectionServices_cff import *
+ak5PFCHSL1Fastjet.algorithm = 'AK5PFchs'
+ak5PFCHSL2Relative.algorithm = 'AK5PFchs'
+ak5PFCHSL3Absolute.algorithm = 'AK5PFchs'
+ak5PFCHSResidual.algorithm = 'AK5PFchs'
+
+ak5JetsJEC = ak5PFJetsL2L3.clone(
+        src = jetID,
+        correctors = [corr]        )
 
 PFJetsFilter = cms.EDFilter("PFJetSelector",
-                            src = cms.InputTag("ak5PFJetsJEC"),
+                            src = cms.InputTag("ak5JetsJEC"),
                             cut = JetCut,
                             filter = cms.bool(True)
                             )

--- a/DQMOffline/RecoB/src/BTagDifferentialPlot.cc
+++ b/DQMOffline/RecoB/src/BTagDifferentialPlot.cc
@@ -31,7 +31,8 @@ BTagDifferentialPlot::BTagDifferentialPlot (const double& bEff, const ConstVarTy
 	theDifferentialHistoB_g    ( 0 ) ,
 	theDifferentialHistoB_ni   ( 0 ) ,
 	theDifferentialHistoB_dus  ( 0 ) ,
-	theDifferentialHistoB_dusg ( 0 )  {}
+	theDifferentialHistoB_dusg ( 0 ) ,
+	theDifferentialHistoB_pu   ( 0 ) {}
 
 
 BTagDifferentialPlot::~BTagDifferentialPlot () {
@@ -259,6 +260,7 @@ void BTagDifferentialPlot::bookHisto () {
   theDifferentialHistoB_ni   = (prov.book1D ( "NI_"   + commonName , "NI_"   + commonName , nBins , binArray )) ;
   theDifferentialHistoB_dus  = (prov.book1D ( "DUS_"  + commonName , "DUS_"  + commonName , nBins , binArray )) ;
   theDifferentialHistoB_dusg = (prov.book1D ( "DUSG_" + commonName , "DUSG_" + commonName , nBins , binArray )) ;
+  theDifferentialHistoB_pu   = (prov.book1D ( "PU_"   + commonName , "PU_"   + commonName , nBins , binArray )) ;
 }
 
 
@@ -304,6 +306,7 @@ void BTagDifferentialPlot::fillHisto () {
     effPurDifferentialPairs.push_back ( make_pair ( currentEffPurFromHistos->getEffFlavVsBEff_ni()   , theDifferentialHistoB_ni ->getTH1F()  ) ) ;
     effPurDifferentialPairs.push_back ( make_pair ( currentEffPurFromHistos->getEffFlavVsBEff_dus()  , theDifferentialHistoB_dus->getTH1F()  ) ) ;
     effPurDifferentialPairs.push_back ( make_pair ( currentEffPurFromHistos->getEffFlavVsBEff_dusg() , theDifferentialHistoB_dusg->getTH1F() ) ) ;
+    effPurDifferentialPairs.push_back ( make_pair ( currentEffPurFromHistos->getEffFlavVsBEff_pu()   , theDifferentialHistoB_pu->getTH1F()   ) ) ;
 
     for ( vector< pair<TH1F*,TH1F*> >::const_iterator itP  = effPurDifferentialPairs.begin() ;
 	                                              itP != effPurDifferentialPairs.end()   ; ++itP ) {

--- a/DQMOffline/RecoB/src/EffPurFromHistos.cc
+++ b/DQMOffline/RecoB/src/EffPurFromHistos.cc
@@ -18,14 +18,16 @@ using namespace RecoBTag;
 
 
 EffPurFromHistos::EffPurFromHistos ( const std::string & ext, TH1F * h_d, TH1F * h_u,
-	TH1F * h_s, TH1F * h_c, TH1F * h_b, TH1F * h_g,	TH1F * h_ni,
-	TH1F * h_dus, TH1F * h_dusg, const std::string& label, const unsigned int& mc, int nBin, double startO, double endO) :
+				     TH1F * h_s, TH1F * h_c, TH1F * h_b, TH1F * h_g,	TH1F * h_ni,
+				     TH1F * h_dus, TH1F * h_dusg, TH1F * h_pu, 
+				     const std::string& label, const unsigned int& mc, int nBin, double startO, double endO) :
 	//BTagPlotPrintC(),
         fromDiscriminatorDistr(false),
 	histoExtension(ext), effVersusDiscr_d(h_d), effVersusDiscr_u(h_u),
 	effVersusDiscr_s(h_s), effVersusDiscr_c(h_c), effVersusDiscr_b(h_b),
 	effVersusDiscr_g(h_g), effVersusDiscr_ni(h_ni), effVersusDiscr_dus(h_dus),
-	effVersusDiscr_dusg(h_dusg), nBinOutput(nBin), startOutput(startO),
+	effVersusDiscr_dusg(h_dusg), effVersusDiscr_pu(h_pu), 
+	nBinOutput(nBin), startOutput(startO),
 	endOutput(endO),  mcPlots_(mc), label_(label)
 {
   // consistency check
@@ -71,6 +73,7 @@ EffPurFromHistos::EffPurFromHistos
     effVersusDiscr_b =    discrCutEfficScan->histo_b   ();
     effVersusDiscr_ni =   discrCutEfficScan->histo_ni  ();
     effVersusDiscr_dusg = discrCutEfficScan->histo_dusg();
+    effVersusDiscr_pu = discrCutEfficScan->histo_pu();
 
   
     if(mcPlots_>2){
@@ -93,6 +96,8 @@ EffPurFromHistos::EffPurFromHistos
     effVersusDiscr_ni->GetXaxis()->SetTitleOffset ( 0.75 );
     effVersusDiscr_dusg->SetXTitle ( "Discriminant" );
     effVersusDiscr_dusg->GetXaxis()->SetTitleOffset ( 0.75 );
+    effVersusDiscr_pu->SetXTitle ( "Discriminant" );
+    effVersusDiscr_pu->GetXaxis()->SetTitleOffset ( 0.75 );
   }
   else{
     effVersusDiscr_d =    0;
@@ -104,6 +109,7 @@ EffPurFromHistos::EffPurFromHistos
     effVersusDiscr_ni =   0;
     effVersusDiscr_dus =  0;
     effVersusDiscr_dusg = 0;
+    effVersusDiscr_pu = 0;
   }
 
   // discr. for computation
@@ -283,6 +289,7 @@ void EffPurFromHistos::plot (TPad * plotCanvas /* = 0 */) {
   EffFlavVsBEff_b ->getTH1F()-> SetMinimum(0.01);
   EffFlavVsBEff_ni ->getTH1F()-> SetMinimum(0.01);
   EffFlavVsBEff_dusg ->getTH1F()-> SetMinimum(0.01);
+  EffFlavVsBEff_pu ->getTH1F()-> SetMinimum(0.01);
 
   // plot separately u,d and s
 //  EffFlavVsBEff_d ->GetXaxis()->SetTitle ( "b-jet efficiency" );
@@ -343,6 +350,7 @@ void EffPurFromHistos::check () {
   const int& nBins_b    = effVersusDiscr_b    -> GetNbinsX();
   const int& nBins_ni   = effVersusDiscr_ni   -> GetNbinsX();
   const int& nBins_dusg = effVersusDiscr_dusg -> GetNbinsX();
+  const int& nBins_pu   = effVersusDiscr_pu   -> GetNbinsX();
 
   const bool& lNBins =
     ( (nBins_d == nBins_u    &&
@@ -355,7 +363,8 @@ void EffPurFromHistos::check () {
        nBins_d == nBins_dusg)||
       (nBins_c == nBins_b    &&
        nBins_c == nBins_dusg &&
-       nBins_c == nBins_ni)    );
+       nBins_c == nBins_ni   &&
+       nBins_c == nBins_pu)    );
 
   if ( !lNBins ) {
     throw cms::Exception("Configuration")
@@ -380,6 +389,7 @@ void EffPurFromHistos::check () {
   const float& sBin_b    = effVersusDiscr_b    -> GetBinCenter(1);
   const float& sBin_ni   = effVersusDiscr_ni   -> GetBinCenter(1);
   const float& sBin_dusg = effVersusDiscr_dusg -> GetBinCenter(1);
+  const float& sBin_pu   = effVersusDiscr_pu   -> GetBinCenter(1);
 
   const bool& lSBin =
     ( (sBin_d == sBin_u    &&
@@ -392,7 +402,8 @@ void EffPurFromHistos::check () {
        sBin_d == sBin_dusg)||
       (sBin_c == sBin_b    &&
        sBin_c == sBin_dusg &&
-       sBin_c == sBin_ni)    );
+       sBin_c == sBin_ni   &&
+       sBin_c == sBin_pu)    );
 
   if ( !lSBin ) {
     throw cms::Exception("Configuration")
@@ -417,6 +428,7 @@ void EffPurFromHistos::check () {
   const float& eBin_b    = effVersusDiscr_b    -> GetBinCenter( nBins_d - 1 );
   const float& eBin_ni   = effVersusDiscr_ni   -> GetBinCenter( nBins_d - 1 );
   const float& eBin_dusg = effVersusDiscr_dusg -> GetBinCenter( nBins_d - 1 );
+  const float& eBin_pu   = effVersusDiscr_pu   -> GetBinCenter( nBins_d - 1 );
 
   const bool& lEBin =
     ( (eBin_d == eBin_u    &&
@@ -429,7 +441,8 @@ void EffPurFromHistos::check () {
        eBin_d == eBin_dusg)||
       (eBin_c == eBin_b    &&
        eBin_c == eBin_dusg &&
-       eBin_c == eBin_ni)     );
+       eBin_c == eBin_ni   &&
+       eBin_c == eBin_pu)     );
 
   if ( !lEBin ) {
     throw cms::Exception("Configuration")
@@ -451,6 +464,7 @@ void EffPurFromHistos::compute ()
     EffFlavVsBEff_ni = 0; 
     EffFlavVsBEff_dus = 0; 
     EffFlavVsBEff_dusg = 0; 
+    EffFlavVsBEff_pu = 0; 
     
     return; 
  
@@ -483,6 +497,7 @@ void EffPurFromHistos::compute ()
   EffFlavVsBEff_b    = (prov.book1D ( hB + "B"    + hE , hB + "B"    + hE , nBinOutput , startOutput , endOutput )) ;
   EffFlavVsBEff_ni   = (prov.book1D ( hB + "NI"   + hE , hB + "NI"   + hE , nBinOutput , startOutput , endOutput )) ;
   EffFlavVsBEff_dusg = (prov.book1D ( hB + "DUSG" + hE , hB + "DUSG" + hE , nBinOutput , startOutput , endOutput )) ;
+  EffFlavVsBEff_pu   = (prov.book1D ( hB + "PU"   + hE , hB + "PU"   + hE , nBinOutput , startOutput , endOutput )) ;
 
   if(mcPlots_>2){
     EffFlavVsBEff_d->getTH1F()->SetXTitle ( "b-jet efficiency" );
@@ -522,6 +537,10 @@ void EffPurFromHistos::compute ()
   EffFlavVsBEff_dusg->getTH1F()->SetYTitle ( "non b-jet efficiency" );
   EffFlavVsBEff_dusg->getTH1F()->GetXaxis()->SetTitleOffset ( 0.75 );
   EffFlavVsBEff_dusg->getTH1F()->GetYaxis()->SetTitleOffset ( 0.75 );
+  EffFlavVsBEff_pu->getTH1F()->SetXTitle ( "b-jet efficiency" );
+  EffFlavVsBEff_pu->getTH1F()->SetYTitle ( "non b-jet efficiency" );
+  EffFlavVsBEff_pu->getTH1F()->GetXaxis()->SetTitleOffset ( 0.75 );
+  EffFlavVsBEff_pu->getTH1F()->GetYaxis()->SetTitleOffset ( 0.75 );
 
 
   // loop over eff. vs. discriminator cut b-histo and look in which bin the closest entry is;
@@ -555,6 +574,7 @@ void EffPurFromHistos::compute ()
       EffFlavVsBEff_b    -> Fill ( effBMid , effVersusDiscr_b   ->GetBinContent ( binClosest ) );
       EffFlavVsBEff_ni   -> Fill ( effBMid , effVersusDiscr_ni  ->GetBinContent ( binClosest ) );
       EffFlavVsBEff_dusg -> Fill ( effBMid , effVersusDiscr_dusg->GetBinContent ( binClosest ) );
+      EffFlavVsBEff_pu   -> Fill ( effBMid , effVersusDiscr_pu  ->GetBinContent ( binClosest ) );
 
       if(mcPlots_>2){
 	EffFlavVsBEff_d  ->getTH1F()  -> SetBinError ( iBinB , effVersusDiscr_d   ->GetBinError ( binClosest ) );
@@ -567,6 +587,7 @@ void EffPurFromHistos::compute ()
       EffFlavVsBEff_b  ->getTH1F()  -> SetBinError ( iBinB , effVersusDiscr_b   ->GetBinError ( binClosest ) );
       EffFlavVsBEff_ni ->getTH1F()  -> SetBinError ( iBinB , effVersusDiscr_ni  ->GetBinError ( binClosest ) );
       EffFlavVsBEff_dusg->getTH1F() -> SetBinError ( iBinB , effVersusDiscr_dusg->GetBinError ( binClosest ) );
+      EffFlavVsBEff_pu ->getTH1F()  -> SetBinError ( iBinB , effVersusDiscr_pu  ->GetBinError ( binClosest ) );
     }
     else {
       //cout << "Did not find right bin for b-efficiency : " << effBMid << endl;

--- a/DQMOffline/RecoB/src/JetTagPlotter.cc
+++ b/DQMOffline/RecoB/src/JetTagPlotter.cc
@@ -24,7 +24,7 @@ JetTagPlotter::JetTagPlotter (const std::string & tagName, const EtaPtBin & etaP
 
   //added to count the number of jets by event : 0=DATA or NI, 1to5=quarks u,d,s,c,b , 6=gluon
   int nFl = 1;
-  if(mcPlots_) nFl = 7;
+  if(mcPlots_) nFl = 8;
   nJets = new int [nFl];
   for(int i = 0; i < nFl; i++){
     nJets[i]=0;
@@ -197,12 +197,13 @@ void JetTagPlotter::analyzeTag(const float& w)
     int totNJets = 0;
     int udsNJets = 0;
     int udsgNJets = 0;
-    for(int i = 0; i < 7; i++){
+    for(int i = 0; i < 8; i++){
       totNJets += nJets[i];
       if(i > 0 && i < 4) udsNJets += nJets[i];
       if((i > 0 && i < 4) || i == 6) udsgNJets += nJets[i];
       if(i <= 5 && i >= 1) JetMultiplicity->fill(i, nJets[i], w);
       else if (i==6) JetMultiplicity->fill(21, nJets[i], w);
+      else if (i==7) JetMultiplicity->fill(20, nJets[i], w);
       else JetMultiplicity->fill(0, nJets[i], w);
       nJets[i] = 0; //reset to 0 before the next event
     }
@@ -213,7 +214,7 @@ void JetTagPlotter::analyzeTag(const float& w)
   else 
     {
       int totNJets = 0;
-      for(int i = 0; i < 7; i++){
+      for(int i = 0; i < 8; i++){
 	totNJets += nJets[i];
 	nJets[i] = 0;
       }
@@ -232,6 +233,7 @@ void JetTagPlotter::analyzeTag(const reco::Jet & jet,
 //   dJetPartonPseudoRapidity->fill(jetFlavour, jetFlavour.underlyingParton4Vec().Eta() );
     if(abs(jetFlavour)>0 && abs(jetFlavour)<6) nJets[abs(jetFlavour)]+=1; //quarks 1 to 5
     else if(abs(jetFlavour)==21) nJets[6]+=1; //gluons
+    else if(jetFlavour==20) nJets[7]+=1; //PU
     else nJets[0]+=1; //NI
   }
   else{
@@ -259,6 +261,7 @@ void JetTagPlotter::analyzeTag(const reco::Jet & jet,
 //   dJetPartonPseudoRapidity->fill(jetFlavour, jetFlavour.underlyingParton4Vec().Eta() );
     if(abs(jetFlavour)>0 && abs(jetFlavour)<6) nJets[abs(jetFlavour)]+=1; //quarks 1 to 5
     else if(abs(jetFlavour)==21) nJets[6]+=1; //gluons
+    else if(jetFlavour==20) nJets[7]+=1; //PU
     else nJets[0]+=1; //NI
   }
   else{
@@ -285,6 +288,7 @@ void JetTagPlotter::analyzeTag(const reco::JetTag & jetTag,
 //   dJetPartonPseudoRapidity->fill(jetFlavour, jetFlavour.underlyingParton4Vec().Eta() );
   if(abs(jetFlavour)>0 && abs(jetFlavour)<6) nJets[abs(jetFlavour)]+=1; //quarks 1 to 5
   else if(abs(jetFlavour)==21) nJets[6]+=1; //gluons
+  else if(jetFlavour==20) nJets[7]+=1; //PU  
   else nJets[0]+=1; //NI
   }
   else{
@@ -311,6 +315,7 @@ void JetTagPlotter::analyzeTag(const reco::JetTag & jetTag,
 //   dJetPartonPseudoRapidity->fill(jetFlavour, jetFlavour.underlyingParton4Vec().Eta() );
     if(abs(jetFlavour)>0 && abs(jetFlavour)<6) nJets[abs(jetFlavour)]+=1; //quarks 1 to 5
     else if(abs(jetFlavour)==21) nJets[6]+=1; //gluons
+    else if(jetFlavour==20) nJets[7]+=1; //PU  
     else nJets[0]+=1; //NI
   }
   else{

--- a/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.h
+++ b/Validation/RecoB/plugins/BTagPerformanceAnalyzerMC.h
@@ -18,8 +18,6 @@
 #include "DQMOffline/RecoB/interface/TagCorrelationPlotter.h"
 #include "DQMOffline/RecoB/interface/BaseTagInfoPlotter.h"
 #include "DQMOffline/RecoB/interface/Tools.h"
-//#include "RecoBTag/MCTools/interface/JetFlavourIdentifier.h"
-//#include "RecoBTag/MCTools/interface/JetFlavour.h"
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "SimDataFormats/JetMatching/interface/JetFlavourMatching.h"
@@ -29,6 +27,8 @@
 #include "DQMOffline/RecoB/interface/MatchJet.h"
 
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "DataFormats/JetReco/interface/GenJet.h"
+#include "DataFormats/Common/interface/Association.h"
 
 #include <string>
 #include <vector>
@@ -71,9 +71,11 @@ typedef std::map<edm::RefToBase<reco::Jet>, unsigned int, JetRefCompare> Flavour
 typedef std::map<edm::RefToBase<reco::Jet>, reco::JetFlavour::Leptons, JetRefCompare> LeptonMap;
   //  reco::JetFlavour getJetFlavour(
   //	edm::RefToBase<reco::Jet> caloRef, FlavourMap flavours);
-  bool getJetWithFlavour( edm::RefToBase<reco::Jet> caloRef,
+  bool getJetWithFlavour(edm::RefToBase<reco::Jet> caloRef,
                          const FlavourMap& _flavours, JetWithFlavour &jetWithFlavour,
-                         const edm::EventSetup & es);
+			 const edm::EventSetup & es, 
+			 edm::Handle<edm::Association<reco::GenJetCollection> > genJetsMatched);
+  bool getJetWithGenJet(edm::RefToBase<reco::Jet> jetRef, edm::Handle<edm::Association<reco::GenJetCollection> > genJetsMatched); 
 
   std::vector<std::string> tiDataFormatType;
   bool partonKinematics;
@@ -90,6 +92,7 @@ typedef std::map<edm::RefToBase<reco::Jet>, reco::JetFlavour::Leptons, JetRefCom
 
   edm::InputTag jetMCSrc;
   edm::InputTag slInfoTag;
+  edm::InputTag genJetsMatchedSrc;
 
   std::vector< std::vector<JetTagPlotter*> > binJetTagPlotters;
   std::vector< std::vector<TagCorrelationPlotter*> > binTagCorrelationPlotters;
@@ -110,17 +113,18 @@ typedef std::map<edm::RefToBase<reco::Jet>, reco::JetFlavour::Leptons, JetRefCom
   CorrectJet jetCorrector;
   MatchJet jetMatcher;
 
+  bool doPUid; 
   bool eventInitialized;
   bool electronPlots, muonPlots, tauPlots;
 
   //add consumes 
   edm::EDGetTokenT<GenEventInfoProduct> genToken;
+  edm::EDGetTokenT<edm::Association<reco::GenJetCollection>> genJetsMatchedToken;
   edm::EDGetTokenT<reco::JetFlavourMatchingCollection> jetToken;
   edm::EDGetTokenT<reco::SoftLeptonTagInfoCollection> slInfoToken;
   std::vector< edm::EDGetTokenT<reco::JetTagCollection> > jetTagToken;
   std::vector< std::pair<edm::EDGetTokenT<reco::JetTagCollection>, edm::EDGetTokenT<reco::JetTagCollection>> > tagCorrelationToken;
   std::vector<std::vector <edm::EDGetTokenT<edm::View<reco::BaseTagInfo>> >> tagInfoToken;
-
 };
 
 

--- a/Validation/RecoB/python/bTagAnalysis_cfi.py
+++ b/Validation/RecoB/python/bTagAnalysis_cfi.py
@@ -102,5 +102,7 @@ bTagValidation = cms.EDAnalyzer("BTagPerformanceAnalyzerMC",
 
     flavPlots = cms.string("allbcl"),                            
     differentialPlots = cms.bool(False), #not needed in validation procedure, put True to produce them  
-    leptonPlots = cms.uint32(0)
+    leptonPlots = cms.uint32(0),
+    genJetsMatched = cms.InputTag("patJetGenJetMatch"),                            
+    doPUid = cms.bool(False)
 )

--- a/Validation/RecoB/test/validation_cfg.py
+++ b/Validation/RecoB/test/validation_cfg.py
@@ -65,6 +65,19 @@ if runOnMC:
     process.bTagValidation.allHistograms = True 
     process.bTagValidation.applyPtHatWeight = False
     process.bTagValidation.flavPlots = "allbcl" #if contains "noall" plots for all jets not booked, if contains "dusg" all histograms booked, default : all, b, c, udsg, ni
+    #process.bTagValidation.ptRecJetMin = cms.double(20.)
+    process.bTagValidation.genJetsMatched = cms.InputTag("patJetGenJetMatch")
+    process.bTagValidation.doPUid = cms.bool(True)
+    process.ak5GenJetsForPUid = cms.EDFilter("GenJetSelector",
+                                             src = cms.InputTag("ak5GenJets"),
+                                             cut = cms.string('pt > 8.'),
+                                             filter = cms.bool(False)
+                                             )
+    process.load("PhysicsTools.PatAlgos.mcMatchLayer0.jetMatch_cfi")
+    process.patJetGenJetMatch.src = newjetID
+    process.patJetGenJetMatch.matched = cms.InputTag("ak5GenJetsForPUid")
+    process.patJetGenJetMatch.maxDeltaR = cms.double(0.25)
+    process.patJetGenJetMatch.resolveAmbiguities = cms.bool(True)
 else :
     process.ak5JetsJEC.correctors[0] += 'Residual'
     process.load("DQMOffline.RecoB.bTagAnalysisData_cfi")
@@ -79,7 +92,7 @@ process.source = cms.Source("PoolSource",
 process.jetSequences = cms.Sequence(process.goodOfflinePrimaryVertices * process.JECAlgo * process.btagSequence)
 
 if runOnMC:
-    process.dqmSeq = cms.Sequence(process.flavourSeq * process.bTagValidation * process.dqmSaver)
+    process.dqmSeq = cms.Sequence(process.ak5GenJetsForPUid * process.patJetGenJetMatch * process.flavourSeq * process.bTagValidation * process.dqmSaver)
 else:
     process.dqmSeq = cms.Sequence(process.bTagAnalysis * process.dqmSaver)
 

--- a/Validation/RecoB/test/validation_cfg.py
+++ b/Validation/RecoB/test/validation_cfg.py
@@ -7,7 +7,7 @@ import FWCore.ParameterSet.VarParsing as VarParsing
 options = VarParsing.VarParsing ('analysis')
 
 options.register ('jets',
-                  "ak5PF", # default value, allowed : "ak5PF", "ak5PFJEC", ak5PFJECL1", "ak5PFnoPU"
+                  "ak5PFCHS", # default value, allowed : "ak5PF", "ak5PFCHS"
                   VarParsing.VarParsing.multiplicity.singleton,
                   VarParsing.VarParsing.varType.string,  
                   "jet collection to use")
@@ -17,7 +17,7 @@ options.parseArguments()
 whichJets  = options.jets 
 useTrigger = False
 runOnMC    = True
-tag =  'START60_V1::All'
+tag =  'START70_V4::All'
 
 ###prints###
 print "jet collcetion asked : ", whichJets
@@ -46,36 +46,15 @@ process.load("DQMServices.Core.DQM_cfg")
 process.load("DQMOffline.RecoB.bTagSequences_cff")
 #process.bTagHLT.HLTPaths = ["HLT_PFJet80_v*"] #uncomment this line if you want to use different trigger
 
-if whichJets=="ak5PFnoPU":
-    process.out = cms.OutputModule("PoolOutputModule",
-                                   outputCommands = cms.untracked.vstring('drop *'),
-                                   fileName = cms.untracked.string('EmptyFile.root')
-                                   )
-    process.load("PhysicsTools.PatAlgos.patSequences_cff")
-    from PhysicsTools.PatAlgos.tools.pfTools import *
-    postfix="PF2PAT"
-    usePF2PAT(process,runPF2PAT=True, jetAlgo="AK5", runOnMC=runOnMC, postfix=postfix)
-    applyPostfix(process,"patJetCorrFactors",postfix).payload = cms.string('AK5PFchs')
-    process.pfPileUpPF2PAT.Vertices = cms.InputTag('goodOfflinePrimaryVertices')
-    process.pfPileUpPF2PAT.checkClosestZVertex = cms.bool(False)
-    from DQMOffline.RecoB.bTagSequences_cff import JetCut
-    process.selectedPatJetsPF2PAT.cut = JetCut
-    process.JECAlgo = cms.Sequence( getattr(process,"patPF2PATSequence"+postfix) )
-    newjetID=cms.InputTag("selectedPatJetsPF2PAT")
-elif whichJets=="ak5PFJEC" or whichJets=="ak5PFJECL1":
-    if whichJets=="ak5PFJECL1":
-        if not runOnMC : process.ak5PFJetsJEC.correctors = ['ak5PFL1FastL2L3Residual']
-        else : process.ak5PFJetsJEC.correctors = ['ak5PFL1FastL2L3']
-        process.PFJetsFilter.src = cms.InputTag("ak5PFJetsJEC")
-    process.JECAlgo = cms.Sequence(process.ak5PFJetsJEC * process.PFJetsFilter)
-    newjetID=cms.InputTag("PFJetsFilter")
-
-if not whichJets=="ak5PF":
-    process.myak5JetTracksAssociatorAtVertex.jets = newjetID
-    process.softPFMuonsTagInfos.jets             = newjetID
-    process.softPFElectronsTagInfos.jets          = newjetID
-    process.AK5byRef.jets                         = newjetID
-
+process.JECAlgo = cms.Sequence(process.ak5JetsJEC * process.PFJetsFilter)
+newjetID=cms.InputTag("PFJetsFilter")
+process.myak5JetTracksAssociatorAtVertex.jets = newjetID
+process.softPFMuonsTagInfos.jets              = newjetID
+process.softPFElectronsTagInfos.jets          = newjetID
+process.AK5byRef.jets                         = newjetID
+if whichJets=="ak5PF":
+    process.ak5JetsJEC.src = 'ak5PFJets'
+    process.ak5JetsJEC.correctors = ['ak5PFL1L2L3']
 ###
 print "inputTag : ", process.myak5JetTracksAssociatorAtVertex.jets
 ###
@@ -84,10 +63,10 @@ if runOnMC:
     process.load("Validation.RecoB.bTagAnalysis_cfi")
     process.bTagValidation.jetMCSrc = 'AK5byValAlgo'
     process.bTagValidation.allHistograms = True 
-    #process.bTagValidation.fastMC = True
     process.bTagValidation.applyPtHatWeight = False
     process.bTagValidation.flavPlots = "allbcl" #if contains "noall" plots for all jets not booked, if contains "dusg" all histograms booked, default : all, b, c, udsg, ni
-else:
+else :
+    process.ak5JetsJEC.correctors[0] += 'Residual'
     process.load("DQMOffline.RecoB.bTagAnalysisData_cfi")
 
 process.maxEvents = cms.untracked.PSet(
@@ -97,10 +76,7 @@ process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring()
 )
 
-if whichJets=="ak5PF":
-    process.jetSequences = cms.Sequence(process.goodOfflinePrimaryVertices * process.btagSequence)
-else:
-    process.jetSequences = cms.Sequence(process.goodOfflinePrimaryVertices * process.JECAlgo * process.btagSequence)
+process.jetSequences = cms.Sequence(process.goodOfflinePrimaryVertices * process.JECAlgo * process.btagSequence)
 
 if runOnMC:
     process.dqmSeq = cms.Sequence(process.flavourSeq * process.bTagValidation * process.dqmSaver)

--- a/Validation/RecoB/test/validation_cfg.py
+++ b/Validation/RecoB/test/validation_cfg.py
@@ -54,7 +54,7 @@ process.softPFElectronsTagInfos.jets          = newjetID
 process.AK5byRef.jets                         = newjetID
 if whichJets=="ak5PF":
     process.ak5JetsJEC.src = 'ak5PFJets'
-    process.ak5JetsJEC.correctors = ['ak5PFL1L2L3']
+    process.ak5JetsJEC.correctors = ['ak5PFL1FastL2L3']
 ###
 print "inputTag : ", process.myak5JetTracksAssociatorAtVertex.jets
 ###


### PR DESCRIPTION
First implementation of a PU category in b-tagging validation code. Allow possibility to identify PU-jets based on gen-jets information. Option not yet switch on for RelVal production.
