### PR TITLE
Force creation of TStreamerInfos at TFile open time

### DIFF
--- a/IOPool/Input/src/InputFile.cc
+++ b/IOPool/Input/src/InputFile.cc
@@ -1,6 +1,9 @@
 /*----------------------------------------------------------------------
 Holder for an input TFile.
 ----------------------------------------------------------------------*/
+#include "TList.h"
+#include "TStreamerInfo.h"
+#include "TClass.h"
 #include "InputFile.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -22,6 +25,27 @@ namespace edm {
       file_.reset();
       return;
     }
+    
+    //Force construction of all StreamerInfos in the file since update the list is not thread-safe
+    std::unique_ptr<TList> streamers{ file_->GetStreamerInfoList() };
+    TIter it(streamers.get());
+    TStreamerInfo* item =nullptr;
+    while( nullptr != (item = dynamic_cast<TStreamerInfo*>(it.Next())) ) {
+      TClass* cls = item->GetClass();
+      if(nullptr == cls) {
+        cls=TClass::GetClass(item->GetName());
+      }
+      assert(cls);
+      auto checksum =item->GetCheckSum();
+      if(checksum != 0) {
+        auto* vinfo = cls->FindStreamerInfo(checksum);
+        assert(vinfo);
+        cls->GetStreamerInfo( vinfo->GetClassVersion() );
+      } else {
+        cls->GetStreamerInfo( item->GetClassVersion() );
+      }
+    }
+      
     logFileAction("  Successfully opened file ", fileName);
   }
 


### PR DESCRIPTION
The global container of TStreamerInfos is not thread-safe. Therefore the ROOT team advised to create all TStreamerInfos needed for a job up front. We already create all TStreamerInfos for schemas corresponding to the present class layouts. However, a TFile can contain old schemas and will wants to create their TStreamerInfos the first time the class is read from the file. For our purposes, that is too late and therefore we need to force ROOT to create them at file open time.
