### PR TITLE
custom fragments for SIM step are improved

### DIFF
--- a/SimG4Core/Application/python/RussianRoulette_cff.py
+++ b/SimG4Core/Application/python/RussianRoulette_cff.py
@@ -1,21 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
-def customise(process):
+def customiseRR(process):
 
-    # advanced Geant4 physics
-    #process.g4SimHits.Physics.type = cms.string('SimG4Core/Physics/QGSP_FTFP_BERT_EML_New')
-
-    # extended geometric acceptance (full CASTOR acceptance)
-    #process.g4SimHits.Generator.MinEtaCut = cms.double(-6.7)
-    #process.g4SimHits.Generator.MaxEtaCut = cms.double(6.7)
-
-    # Russian roulette parameters
+    # Russian roulette enabled
+  if hasattr(process,'g4SimHits'):
     process.g4SimHits.Physics.RusRoGammaEnergyLimit = cms.double(5.)
-    process.g4SimHits.Physics.RusRoEcalGamma     = cms.double(0.3)
-    process.g4SimHits.Physics.RusRoHcalGamma     = cms.double(0.1)
-    process.g4SimHits.Physics.RusRoMuonIronGamma = cms.double(0.1)
-    process.g4SimHits.Physics.RusRoPreShowerGamma= cms.double(0.3)
-    process.g4SimHits.Physics.RusRoWorldGamma    = cms.double(0.1)
+    process.g4SimHits.Physics.RusRoEcalGamma     = cms.double(1.0)
+    process.g4SimHits.Physics.RusRoHcalGamma     = cms.double(0.3)
+    process.g4SimHits.Physics.RusRoMuonIronGamma = cms.double(0.3)
+    process.g4SimHits.Physics.RusRoPreShowerGamma= cms.double(1.0)
+    process.g4SimHits.Physics.RusRoWorldGamma    = cms.double(0.3)
 
     process.g4SimHits.StackingAction.RusRoEcalNeutronLimit = cms.double(10.)
     process.g4SimHits.StackingAction.RusRoEcalNeutron     = cms.double(0.1)

--- a/SimG4Core/Application/python/reproc2011_2012_cff.py
+++ b/SimG4Core/Application/python/reproc2011_2012_cff.py
@@ -2,15 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 def customiseG4(process):
 
+  if hasattr(process,'g4SimHits'):
     process.g4SimHits.Physics.type = cms.string('SimG4Core/Physics/QGSP_FTFP_BERT_EML_New')
-
-    # extended geometric acceptance (full CASTOR acceptance)
-
-    process.g4SimHits.Generator.MinEtaCut = cms.double(-6.7)
-    process.g4SimHits.Generator.MaxEtaCut = cms.double(6.7)
-
     # use HF shower library instead of GFlash parameterization
-
     process.g4SimHits.HCalSD.UseShowerLibrary = cms.bool(True)
     process.g4SimHits.HCalSD.UseParametrize = cms.bool(False)
     process.g4SimHits.HCalSD.UsePMTHits = cms.bool(False)


### PR DESCRIPTION
It is forward port of minor fix of custom fragments - they are enabled only if g4SimHits exist. Russian roulette parameters are tuned according the most recent validation results and are not compatible with 7_0_X. No change in regular runs.
