### PR TITLE
improved fragments for SIM step

### DIFF
--- a/SimG4Core/Application/python/RussianRoulette_cff.py
+++ b/SimG4Core/Application/python/RussianRoulette_cff.py
@@ -1,16 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
-def customise(process):
+def customiseRR(process):
 
-    # advanced Geant4 physics
-    #process.g4SimHits.Physics.type = cms.string('SimG4Core/Physics/QGSP_FTFP_BERT_EML_New')
-
-    # extended geometric acceptance (full CASTOR acceptance)
-    #process.g4SimHits.Generator.MinEtaCut = cms.double(-6.7)
-    #process.g4SimHits.Generator.MaxEtaCut = cms.double(6.7)
-
-    # Russian roulette enabled
-    process.g4SimHits.StackingAction.RusRoGammaEnergyLimit = cms.double(5.0)
-    process.g4SimHits.StackingAction.RusRoNeutronEnergyLimit = cms.double(10.0)
+    # Russian roulette disabled - by default it is enabled
+  if hasattr(process,'g4SimHits'):
+    process.g4SimHits.StackingAction.RusRoGammaEnergyLimit = cms.double(0.0)
+    process.g4SimHits.StackingAction.RusRoNeutronEnergyLimit = cms.double(0.0)
 
     return(process)

--- a/SimG4Core/Application/python/reproc2011_2012_cff.py
+++ b/SimG4Core/Application/python/reproc2011_2012_cff.py
@@ -2,15 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 def customiseG4(process):
 
+  if hasattr(process,'g4SimHits'):
     process.g4SimHits.Physics.type = cms.string('SimG4Core/Physics/QGSP_FTFP_BERT_EML_New')
-
-    # extended geometric acceptance (full CASTOR acceptance)
-
-    process.g4SimHits.Generator.MinEtaCut = cms.double(-6.7)
-    process.g4SimHits.Generator.MaxEtaCut = cms.double(6.7)
-
     # use HF shower library instead of GFlash parameterization
-
     process.g4SimHits.HCalSD.UseShowerLibrary = cms.bool(True)
     process.g4SimHits.HCalSD.UseParametrize = cms.bool(False)
     process.g4SimHits.HCalSD.UsePMTHits = cms.bool(False)


### PR DESCRIPTION
This modification include similar fixes as submitted to 53X and 62X: custom fragment are enabled only if g4SimHits is present. RussianRoulette fragment disable RR, because in 70X by default it is enabled. 
