### PR TITLE
Rename TClassAttributeMap -> TDictAttributeMap

### DIFF
--- a/CondCore/ORA/src/RflxPropList.h
+++ b/CondCore/ORA/src/RflxPropList.h
@@ -5,7 +5,7 @@
 #include "FWCore/Utilities/interface/MemberWithDict.h"
 
 #include <string>
-#include "TClassAttributeMap.h"
+#include "TDictAttributeMap.h"
 
 namespace Reflex {
 
@@ -24,7 +24,7 @@ namespace Reflex {
           PropertyList(const PropertyList &other) : m_wp(other.m_wp) { /* NOOP */ }
           PropertyList& operator=(const PropertyList &other) { m_wp = other.getMap(); return *this; }
 
-          TClassAttributeMap * getMap() const { return m_wp; }
+          TDictAttributeMap * getMap() const { return m_wp; }
 
           bool HasProperty (const std::string& key) const { 
               if (m_wp) {
@@ -43,7 +43,7 @@ namespace Reflex {
               return std::string("");
           }
       private:
-          TClassAttributeMap *m_wp;
+          TDictAttributeMap *m_wp;
 
     }; // end class PropertyList
 

--- a/DataFormats/Provenance/src/BranchDescription.cc
+++ b/DataFormats/Provenance/src/BranchDescription.cc
@@ -8,7 +8,7 @@
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include "FWCore/Utilities/interface/WrappedClassName.h"
 
-#include "TClassAttributeMap.h"
+#include "TDictAttributeMap.h"
 
 #include <cassert>
 #include <cstdio>
@@ -195,7 +195,7 @@ namespace edm {
     setTransient(false);
     setSplitLevel(invalidSplitLevel);
     setBasketSize(invalidBasketSize);
-    TClassAttributeMap* wp = wrappedType().getClass()->GetAttributeMap();
+    TDictAttributeMap* wp = wrappedType().getClass()->GetAttributeMap();
     if (wp && wp->HasKey("persistent") && !strcmp(wp->GetPropertyAsString("persistent"), "false")) {
       // Set transient if persistent == "false".
       setTransient(true);


### PR DESCRIPTION
ROOT6 had TClassAttributeMap renamed to TDictAttributeMap starting
Wed Jan 22 15:31:23 2014 +0100.

Commit in ROOT6: e8ef04b45b8c81af508d736f61fe165435abfc35

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
