### PR TITLE
DataFormats/TrackerRecHit2D: fix classes_def.xml for multiple definitions

### DIFF
--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -29,25 +29,17 @@
   </class>
 
   <class name="SiStripRecHit1D"  ClassVersion="12">
-   <version ClassVersion="12" checksum="3158843011"/>
-    <field name="sigmaPitch_" transient="true" />
-   <version ClassVersion="11" checksum="1486832741"/>
-    <field name="sigmaPitch_" transient="true" />
-    <!-- <field name="pos_" transient="true" /> -->
-    <!-- <field name="err_" transient="true" /> -->
-   <version ClassVersion="10" checksum="1325274892"/>
-    <field name="sigmaPitch_" transient="true" />
-    <!-- <field name="pos_" transient="true" /> -->
-    <!-- <field name="err_" transient="true" /> -->
+    <field name="sigmaPitch_" transient="true"/>
+    <version ClassVersion="12" checksum="3158843011"/>
+    <version ClassVersion="11" checksum="1486832741"/>
+    <version ClassVersion="10" checksum="1325274892"/>
   </class> 
 
   <class name="SiStripRecHit2D"  ClassVersion="12">
-   <version ClassVersion="12" checksum="2350660116"/>
-    <field name="sigmaPitch_" transient="true" />
-   <version ClassVersion="11" checksum="2157674799"/>
-    <field name="sigmaPitch_" transient="true" />
-   <version ClassVersion="10" checksum="4057204970"/>
-    <field name="sigmaPitch_" transient="true" />
+    <field name="sigmaPitch_" transient="true"/>
+    <version ClassVersion="12" checksum="2350660116"/>
+    <version ClassVersion="11" checksum="2157674799"/>
+    <version ClassVersion="10" checksum="4057204970"/>
   </class>
 
 


### PR DESCRIPTION
Clean classes_def.xml, not to have multiple definitions for `sigmaPitch_1`

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
