### PR TITLE
Protections against high pT pions becoming tracker-driven only gedGsfElectrons

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -101,7 +101,8 @@ class GsfElectronAlgo {
       // for backward compatibility
       bool ctfTracksCheck ;
       bool gedElectronMode;
-      float PreSelectMVA;		
+      float PreSelectMVA;	
+      float MaxElePtForOnlyMVA;
       // GED-Regression (ECAL and combination)
       bool useEcalRegression;
       bool useCombinationRegression;  

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -1005,13 +1005,16 @@ bool GsfElectronAlgo::isPreselected( GsfElectron * ele )
 	float mvaValue=generalData_->sElectronMVAEstimator->mva( *(ele),*(eventData_->event));
 	bool passCutBased=ele->passingCutBasedPreselection();
 	bool passPF=ele->passingPflowPreselection();
-	if(generalData_->strategyCfg.gedElectronMode==true){
+	if(generalData_->strategyCfg.gedElectronMode){
 		bool passmva=mvaValue>generalData_->strategyCfg.PreSelectMVA;
 		if(!ele->ecalDrivenSeed()){
-			return passmva;
+		  if(ele->pt() > generalData_->strategyCfg.MaxElePtForOnlyMVA) 
+		    return passmva && passCutBased;
+		  else
+		    return passmva;
 		}	
 		else{
-			return passCutBased || passPF || passmva;
+		  return passCutBased || passPF || passmva;
 		}
 	}
 	else{
@@ -1044,9 +1047,11 @@ void GsfElectronAlgo::setCutBasedPreselectionFlag( GsfElectron * ele, const reco
   // kind of seeding
   bool eg = ele->core()->ecalDrivenSeed() ;
   bool pf = ele->core()->trackerDrivenSeed() && !ele->core()->ecalDrivenSeed() ;
+  bool gedMode = generalData_->strategyCfg.gedElectronMode;
   if (eg&&pf) { throw cms::Exception("GsfElectronAlgo|BothEcalAndPureTrackerDriven")<<"An electron cannot be both egamma and purely pflow" ; }
   if ((!eg)&&(!pf)) { throw cms::Exception("GsfElectronAlgo|NeitherEcalNorPureTrackerDriven")<<"An electron cannot be neither egamma nor purely pflow" ; }
-  const CutsConfiguration * cfg = (eg?&generalData_->cutsCfg:&generalData_->cutsCfgPflow) ;
+
+  const CutsConfiguration * cfg = ((eg||gedMode)?&generalData_->cutsCfg:&generalData_->cutsCfgPflow);
 
   // Et cut
   double etaValue = EleRelPoint(ele->superCluster()->position(),bs.position()).eta() ;

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
@@ -47,6 +47,7 @@ void GsfElectronBaseProducer::fillDescription( edm::ParameterSetDescription & de
 
   desc.add<bool>("gedElectronMode",true) ;
   desc.add<double>("PreSelectMVA",-0.1) ;
+  desc.add<double>("MaxElePtForOnlyMVA",50.0) ;
 
   // steering
   desc.add<bool>("useGsfPfRecTracks",true) ;
@@ -215,6 +216,7 @@ GsfElectronBaseProducer::GsfElectronBaseProducer( const edm::ParameterSet& cfg )
   strategyCfg_.ctfTracksCheck = cfg.getParameter<bool>("ctfTracksCheck");
   strategyCfg_.gedElectronMode = cfg.getParameter<bool>("gedElectronMode");
   strategyCfg_.PreSelectMVA = cfg.getParameter<double>("PreSelectMVA");  
+  strategyCfg_.MaxElePtForOnlyMVA = cfg.getParameter<double>("MaxElePtForOnlyMVA");  
   strategyCfg_.useEcalRegression = cfg.getParameter<bool>("useEcalRegression");
   strategyCfg_.useCombinationRegression = cfg.getParameter<bool>("useCombinationRegression");
 

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
@@ -28,6 +28,7 @@ gedGsfElectronsTmp = cms.EDProducer("GEDGsfElectronProducer",
 
     gedElectronMode = cms.bool(True),
     PreSelectMVA = cms.double(-0.1),	
+    MaxElePtForOnlyMVA = cms.double(50.0),                                
     
     # steering
     useGsfPfRecTracks = cms.bool(True),
@@ -159,7 +160,7 @@ gedGsfElectronsTmp = cms.EDProducer("GEDGsfElectronProducer",
    # Iso Values 
    useIsolationValues = cms.bool(False),
  SoftElecMVAFilesString = cms.vstring(
-    "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_9Dec2013.weights.xml"
+    "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_27Jan2014.weights.xml"
                                 ),
 )
 

--- a/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
@@ -28,7 +28,8 @@ ecalDrivenGsfElectrons = cms.EDProducer("GsfElectronEcalDrivenProducer",
 
     gedElectronMode= cms.bool(False),
     PreSelectMVA = cms.double(-0.1),
-    
+    MaxElePtForOnlyMVA = cms.double(50.0),
+                                        
     # steering
     useGsfPfRecTracks = cms.bool(True),
     applyPreselection = cms.bool(False),


### PR DESCRIPTION
Tested in: CMSSW_7_0_X_2014-02-02-1400

Part 2 of splitting up #2241. Comes after #2242.

This pull request contains an update to gedGsfElectron producer to harmonize the pre-selection of tracker-driven-only gedGsfElectrons above 50 GeV as well as an update to the pre-selection MVA (as in #2241).

See old PR for plots.

This contains updates for high pT tracker-driven-only electron protections against pions.
