### PR TITLE
synchronize HLTTrackClusterRemover to the offline version w/ SiStripClusterChargeCut

### DIFF
--- a/RecoLocalTracker/SubCollectionProducers/python/hltTrackClusterRemover_cfi.py
+++ b/RecoLocalTracker/SubCollectionProducers/python/hltTrackClusterRemover_cfi.py
@@ -1,11 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
 hltTrackClusterRemover = cms.EDProducer( "HLTTrackClusterRemover",
-   trajectories = cms.InputTag( "hltPFlowTrackSelectionHighPurity" ),
-   doStrip = cms.bool( True ),
-   doPixel = cms.bool( True ),
-   stripClusters = cms.InputTag( "hltSiStripRawToClustersFacility" ),
-   pixelClusters = cms.InputTag( "hltSiPixelClusters" ),
+   trajectories          = cms.InputTag( "hltPFlowTrackSelectionHighPurity" ),
+   doStrip               = cms.bool( True ),
+   doPixel               = cms.bool( True ),
+   stripClusters         = cms.InputTag( "hltSiStripRawToClustersFacility" ),
+   pixelClusters         = cms.InputTag( "hltSiPixelClusters" ),
    oldClusterRemovalInfo = cms.InputTag( "" ),
-   Common = cms.PSet(  maxChi2 = cms.double( 9.0 ) )
+   Common = cms.PSet(
+      maxChi2            = cms.double( 9.0 ),
+      minGoodStripCharge = cms.double( 0.0) ## this value is coherent w/ any cuts apply (standard value is ~60)
+                                            ## for more details, look @https://indico.cern.ch/getFile.py/access?contribId=1&resId=0&materialId=slides&confId=292571 (for instance)
+   ),
+   doStripChargeCheck = cms.bool(False),
 )

--- a/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemover.cc
+++ b/RecoLocalTracker/SubCollectionProducers/src/HLTTrackClusterRemover.cc
@@ -43,15 +43,20 @@ class HLTTrackClusterRemover : public edm::EDProducer {
                 isSet_(true), 
                 usesCharge_(iConfig.exists("maxCharge")),
                 usesSize_(iConfig.exists("maxSize")),
+                cutOnPixelCharge_(iConfig.exists("minGoodPixelCharge")),
+                cutOnStripCharge_(iConfig.exists("minGoodStripCharge")),
                 maxChi2_(iConfig.getParameter<double>("maxChi2")),
                 maxCharge_(usesCharge_ ? iConfig.getParameter<double>("maxCharge") : 0), 
+                minGoodPixelCharge_(cutOnPixelCharge_ ? iConfig.getParameter<double>("minGoodPixelCharge") : 0), 
+                minGoodStripCharge_(cutOnStripCharge_ ? iConfig.getParameter<double>("minGoodStripCharge") : 0), 
                 maxSize_(usesSize_ ? iConfig.getParameter<uint32_t>("maxSize") : 0) { }
-            bool  isSet_, usesCharge_, usesSize_;
-            float maxChi2_, maxCharge_;
+            bool  isSet_, usesCharge_, usesSize_, cutOnPixelCharge_, cutOnStripCharge_;
+            float maxChi2_, maxCharge_, minGoodPixelCharge_, minGoodStripCharge_;
             size_t maxSize_;
         };
         static const unsigned int NumberOfParamBlocks = 6;
 
+        bool doTracks_;
         bool doStrip_, doPixel_;
         bool mergeOld_;
 
@@ -72,7 +77,7 @@ class HLTTrackClusterRemover : public edm::EDProducer {
         edm::ProductID pixelSourceProdID, stripSourceProdID; // ProdIDs refs must point to (for consistency tests)
 
         inline void process(const TrackingRecHit *hit, float chi2);
-        inline void process(const OmniClusterRef & cluRef, uint32_t subdet);
+  inline void process(const OmniClusterRef & cluRef, uint32_t subdet);
 
         template<typename T> 
         std::auto_ptr<edmNew::DetSetVector<T> >
@@ -82,9 +87,11 @@ class HLTTrackClusterRemover : public edm::EDProducer {
         // Carries in full removal info about a given det from oldRefs
         void mergeOld(reco::ClusterRemovalInfo::Indices &refs, const reco::ClusterRemovalInfo::Indices &oldRefs) ;
 
-        bool makeProducts_;
-        std::vector<bool> collectedRegStrips_;
-        std::vector<bool> collectedPixels_;        
+  bool makeProducts_;
+  bool doStripChargeCheck_, doPixelChargeCheck_;
+  std::vector<bool> collectedRegStrips_;
+  std::vector<bool> collectedPixels_;        
+
 };
 
 
@@ -111,11 +118,15 @@ HLTTrackClusterRemover::readPSet(const edm::ParameterSet& iConfig, const std::st
     }
 }
 
-HLTTrackClusterRemover::HLTTrackClusterRemover(const ParameterSet& iConfig):
-    doStrip_(iConfig.existsAs<bool>("doStrip") ? iConfig.getParameter<bool>("doStrip") : true),
-    doPixel_(iConfig.existsAs<bool>("doPixel") ? iConfig.getParameter<bool>("doPixel") : true),
-    mergeOld_(false),
-    makeProducts_(true)
+HLTTrackClusterRemover::HLTTrackClusterRemover(const ParameterSet& iConfig)
+  : doTracks_(iConfig.exists("trajectories"))
+  , doStrip_ (iConfig.existsAs<bool>("doStrip") ? iConfig.getParameter<bool>("doStrip") : true)
+  , doPixel_ (iConfig.existsAs<bool>("doPixel") ? iConfig.getParameter<bool>("doPixel") : true)
+  , mergeOld_(false)
+  , makeProducts_(true)
+  , doStripChargeCheck_(iConfig.existsAs<bool>("doStripChargeCheck") ? iConfig.getParameter<bool>("doStripChargeCheck") : false)
+  , doPixelChargeCheck_(iConfig.existsAs<bool>("doPixelChargeCheck") ? iConfig.getParameter<bool>("doPixelChargeCheck") : false)
+
 {
 
   if (iConfig.exists("oldClusterRemovalInfo"))
@@ -125,33 +136,40 @@ HLTTrackClusterRemover::HLTTrackClusterRemover(const ParameterSet& iConfig):
       if (not (iConfig.getParameter<InputTag>("oldClusterRemovalInfo")== edm::InputTag())) mergeOld_=true;
     }
 
+  if ((doPixelChargeCheck_ && !doPixel_) || (doStripChargeCheck_ && !doStrip_))
+    throw cms::Exception("Configuration Error") << "HLTTrackClusterRemover: Charge check asked without cluster collection ";
+  if (doPixelChargeCheck_)
+    throw cms::Exception("Configuration Error") << "HLTTrackClusterRemover: Pixel cluster charge check not yet implemented";
+
     fill(pblocks_, pblocks_+NumberOfParamBlocks, ParamBlock());
     readPSet(iConfig, "Common",-1);
     if (doPixel_) {
-        readPSet(iConfig, "Pixel" ,0,1);
-        readPSet(iConfig, "PXB" ,0);
-        readPSet(iConfig, "PXE" ,1);
+        readPSet(iConfig, "Pixel" , 0,1);
+        readPSet(iConfig, "PXB" ,   0);
+        readPSet(iConfig, "PXE" ,   1);
     }
     if (doStrip_) {
-        readPSet(iConfig, "Strip" ,2,3,4,5);
+        readPSet(iConfig, "Strip" ,     2,3,4,5);
         readPSet(iConfig, "StripInner" ,2,3);
         readPSet(iConfig, "StripOuter" ,4,5);
-        readPSet(iConfig, "TIB" ,2);
-        readPSet(iConfig, "TID" ,3);
-        readPSet(iConfig, "TOB" ,4);
-        readPSet(iConfig, "TEC" ,5);
+        readPSet(iConfig, "TIB" ,       2);
+        readPSet(iConfig, "TID" ,       3);
+        readPSet(iConfig, "TOB" ,       4);
+        readPSet(iConfig, "TEC" ,       5);
     }
 
     bool usingCharge = false;
     for (size_t i = 0; i < NumberOfParamBlocks; ++i) {
         if (!pblocks_[i].isSet_) throw cms::Exception("Configuration Error") << "HLTTrackClusterRemover: Missing configuration for detector with subDetID = " << (i+1);
         if (pblocks_[i].usesCharge_ && !usingCharge) {
-            throw cms::Exception("Configuration Error") << "HLTTrackClusterRemover: Configuration for subDetID = " << (i+1) << " uses cluster charge, which is not enabled.";
+	  throw cms::Exception("Configuration Error") << "HLTTrackClusterRemover: Configuration for subDetID = " << (i+1) << " uses cluster charge, which is not enabled.";
         }
     }
-    trajectories_ = consumes<vector<Trajectory> >(iConfig.getParameter<InputTag>("trajectories"));
+    
+    //    trajectories_ = consumes<vector<Trajectory> >(iConfig.getParameter<InputTag>("trajectories"));
+    if (doTracks_) trajectories_ = consumes<vector<Trajectory> >                  (iConfig.getParameter<InputTag>("trajectories") );
     if (doPixel_) pixelClusters_ = consumes<edmNew::DetSetVector<SiPixelCluster> >(iConfig.getParameter<InputTag>("pixelClusters"));
-    if (doStrip_) stripClusters_ = consumes<edm::LazyGetter<SiStripCluster> >(iConfig.getParameter<InputTag>("stripClusters"));
+    if (doStrip_) stripClusters_ = consumes<edm::LazyGetter<SiStripCluster> >     (iConfig.getParameter<InputTag>("stripClusters"));
     if (mergeOld_) {
       oldPxlMaskToken_ = consumes<PixelMaskContainer>(iConfig.getParameter<InputTag>("oldClusterRemovalInfo"));
       oldStrMaskToken_ = consumes<StripMaskContainer>(iConfig.getParameter<InputTag>("oldClusterRemovalInfo"));
@@ -171,7 +189,7 @@ HLTTrackClusterRemover::~HLTTrackClusterRemover()
 }
 
 void HLTTrackClusterRemover::mergeOld(ClusterRemovalInfo::Indices &refs,
-                                            const ClusterRemovalInfo::Indices &oldRefs) 
+				      const ClusterRemovalInfo::Indices &oldRefs) 
 {
         for (size_t i = 0, n = refs.size(); i < n; ++i) {
             refs[i] = oldRefs[refs[i]];
@@ -222,11 +240,14 @@ HLTTrackClusterRemover::cleanup(const edmNew::DetSetVector<T> &oldClusters, cons
 }
 
 void HLTTrackClusterRemover::process(OmniClusterRef const & clusterReg, uint32_t subdet) {
-   if (clusterReg.id() != stripSourceProdID) throw cms::Exception("Inconsistent Data") <<
+
+  if (clusterReg.id() != stripSourceProdID) throw cms::Exception("Inconsistent Data") <<
     "HLTTrackClusterRemover: strip cluster ref from Product ID = " << clusterReg.id() <<
     " does not match with source cluster collection (ID = " << stripSourceProdID << ")\n.";
+
   if (collectedRegStrips_.size()<=clusterReg.key()){
     edm::LogError("BadCollectionSize")<<collectedRegStrips_.size()<<" is smaller than "<<clusterReg.key();
+
     assert(collectedRegStrips_.size()>clusterReg.key());
   }
   collectedRegStrips_[clusterReg.key()]=true;
@@ -238,6 +259,7 @@ void HLTTrackClusterRemover::process(const TrackingRecHit *hit, float chi2) {
     DetId detid = hit->geographicalId(); 
     uint32_t subdet = detid.subdetId();
 
+
     assert ((subdet > 0) && (subdet <= NumberOfParamBlocks));
 
     // chi2 cut
@@ -245,46 +267,62 @@ void HLTTrackClusterRemover::process(const TrackingRecHit *hit, float chi2) {
 
     if ((subdet == PixelSubdetector::PixelBarrel) || (subdet == PixelSubdetector::PixelEndcap)) {
       //      std::cout<<"process pxl hit"<<std::endl;
-        if (!doPixel_) return;
-        // this is a pixel, and i *know* it is
-        const SiPixelRecHit *pixelHit = static_cast<const SiPixelRecHit *>(hit);
-
-        SiPixelRecHit::ClusterRef cluster = pixelHit->cluster();
-
-        if (cluster.id() != pixelSourceProdID) throw cms::Exception("Inconsistent Data") << 
-                "HLTTrackClusterRemover: pixel cluster ref from Product ID = " << cluster.id() << 
-                " does not match with source cluster collection (ID = " << pixelSourceProdID << ")\n.";
-
-        assert(cluster.id() == pixelSourceProdID);
-//DBG// cout << "HIT NEW PIXEL DETID = " << detid.rawId() << ", Cluster [ " << cluster.key().first << " / " <<  cluster.key().second << " ] " << endl;
-
-        // if requested, cut on cluster size
-        if (pblocks_[subdet-1].usesSize_ && (cluster->pixels().size() > pblocks_[subdet-1].maxSize_)) return;
-
-        // mark as used
-        //pixels[cluster.key()] = false;
-        assert(collectedPixels_.size() > cluster.key());
-        collectedPixels_[cluster.key()]=true;
+      if (!doPixel_) return;
+      // this is a pixel, and i *know* it is
+      const SiPixelRecHit *pixelHit = static_cast<const SiPixelRecHit *>(hit);
+      
+      SiPixelRecHit::ClusterRef cluster = pixelHit->cluster();
+      if (cluster.id() != pixelSourceProdID) throw cms::Exception("Inconsistent Data") << 
+	"HLTTrackClusterRemover: pixel cluster ref from Product ID = " << cluster.id() << 
+	" does not match with source cluster collection (ID = " << pixelSourceProdID << ")\n.";
+      
+      assert(cluster.id() == pixelSourceProdID);
+      //DBG// cout << "HIT NEW PIXEL DETID = " << detid.rawId() << ", Cluster [ " << cluster.key().first << " / " <<  cluster.key().second << " ] " << endl;
+      
+      // if requested, cut on cluster size
+      if (pblocks_[subdet-1].usesSize_ && (cluster->pixels().size() > pblocks_[subdet-1].maxSize_)) return;
+      
+      // mark as used
+      //pixels[cluster.key()] = false;
+      assert(collectedPixels_.size() > cluster.key());
+      collectedPixels_[cluster.key()]=true;
     } else { // aka Strip
-        if (!doStrip_) return;
-        const type_info &hitType = typeid(*hit);
-        if (hitType == typeid(SiStripRecHit2D)) {
-            const SiStripRecHit2D *stripHit = static_cast<const SiStripRecHit2D *>(hit);
-//DBG//     cout << "Plain RecHit 2D: " << endl;
-            process(stripHit->omniClusterRef(),subdet);}
-	else if (hitType == typeid(SiStripRecHit1D)) {
-	  const SiStripRecHit1D *hit1D = static_cast<const SiStripRecHit1D *>(hit);
-	  process(hit1D->omniClusterRef(),subdet);
-        } else if (hitType == typeid(SiStripMatchedRecHit2D)) {
-            const SiStripMatchedRecHit2D *matchHit = static_cast<const SiStripMatchedRecHit2D *>(hit);
-//DBG//     cout << "Matched RecHit 2D: " << endl;
-            process(matchHit->monoClusterRef(),subdet);
-            process(matchHit->stereoClusterRef(),subdet);
-        } else if (hitType == typeid(ProjectedSiStripRecHit2D)) {
-            const ProjectedSiStripRecHit2D *projHit = static_cast<const ProjectedSiStripRecHit2D *>(hit);
-//DBG//     cout << "Projected RecHit 2D: " << endl;
-            process(projHit->originalHit().omniClusterRef(),subdet);
-        } else throw cms::Exception("NOT IMPLEMENTED") << "Don't know how to handle " << hitType.name() << " on detid " << detid.rawId() << "\n";
+      if (!doStrip_) return;
+      const type_info &hitType = typeid(*hit);
+      if (hitType == typeid(SiStripRecHit2D)) {
+	const SiStripRecHit2D *stripHit = static_cast<const SiStripRecHit2D *>(hit);
+	//DBG//     cout << "Plain RecHit 2D: " << endl;
+	process(stripHit->omniClusterRef(),subdet);
+	//	  int clusCharge=0;
+	//	  for ( auto cAmp : stripHit->omniClusterRef().stripCluster().amplitudes() ) clusCharge+=cAmp;
+	//	  std::cout << "[HLTTrackClusterRemover::process (SiStripRecHit2D) chi2: " << chi2 << " [" << subdet << " --> charge: " << clusCharge << "]" << std::endl;
+      } else if (hitType == typeid(SiStripRecHit1D)) {
+	const SiStripRecHit1D *hit1D = static_cast<const SiStripRecHit1D *>(hit);
+	process(hit1D->omniClusterRef(),subdet);
+	//	  int clusCharge=0;
+	//	  for ( auto cAmp : hit1D->omniClusterRef().stripCluster().amplitudes() ) clusCharge+=cAmp;
+	//	  std::cout << "[HLTTrackClusterRemover::process (SiStripRecHit1D) chi2: " << chi2 << " [" << subdet << " --> charge: " << clusCharge << "]" << std::endl;
+      } else if (hitType == typeid(SiStripMatchedRecHit2D)) {
+	const SiStripMatchedRecHit2D *matchHit = static_cast<const SiStripMatchedRecHit2D *>(hit);
+	//DBG//     cout << "Matched RecHit 2D: " << endl;
+	process(matchHit->monoClusterRef(),  subdet);
+	//	    int clusCharge=0;
+	//	    for ( auto cAmp : matchHit->monoClusterRef().stripCluster().amplitudes() ) clusCharge+=cAmp;
+	//	    std::cout << "[HLTTrackClusterRemover::process (SiStripMatchedRecHit2D:mono) chi2: " << chi2 << " [" << subdet << " --> charge: " << clusCharge << "]" << std::endl;
+	
+	process(matchHit->stereoClusterRef(),subdet);
+	//	    clusCharge=0;
+	//	    for ( auto cAmp : matchHit->stereoClusterRef().stripCluster().amplitudes() ) clusCharge+=cAmp;
+	//	    std::cout << "[HLTTrackClusterRemover::process (SiStripMatchedRecHit2D:stereo) chi2: " << chi2 << " [" << subdet << " --> charge: " << clusCharge << "]" << std::endl;
+	
+      } else if (hitType == typeid(ProjectedSiStripRecHit2D)) {
+	const ProjectedSiStripRecHit2D *projHit = static_cast<const ProjectedSiStripRecHit2D *>(hit);
+	//DBG//     cout << "Projected RecHit 2D: " << endl;
+	process(projHit->originalHit().omniClusterRef(),subdet);
+	//	    int clusCharge=0;
+	//	    for ( auto cAmp : projHit->originalHit().omniClusterRef().stripCluster().amplitudes() ) clusCharge+=cAmp;
+	//	    std::cout << "[HLTTrackClusterRemover::process (ProjectedSiStripRecHit2D) chi2: " << chi2 << " [" << subdet << " --> charge: " << clusCharge << "]" << std::endl;
+      } else throw cms::Exception("NOT IMPLEMENTED") << "Don't know how to handle " << hitType.name() << " on detid " << detid.rawId() << "\n";
     }
 }
 
@@ -304,20 +342,20 @@ HLTTrackClusterRemover::produce(Event& iEvent, const EventSetup& iSetup)
 {
     ProductID pixelOldProdID, stripOldProdID;
 
-    Handle<edmNew::DetSetVector<SiPixelCluster> > pixelClusters;
+    edm::Handle<edmNew::DetSetVector<SiPixelCluster> > pixelClusters;
     if (doPixel_) {
         iEvent.getByToken(pixelClusters_, pixelClusters);
         pixelSourceProdID = pixelClusters.id();
     }
 
-    Handle<edm::LazyGetter<SiStripCluster> > stripClusters;
+    edm::Handle<edm::LazyGetter<SiStripCluster> > stripClusters;
     if (doStrip_) {
         iEvent.getByToken(stripClusters_, stripClusters);
         stripSourceProdID = stripClusters.id();
     }
 
     //Handle<TrajTrackAssociationCollection> trajectories; 
-    Handle<vector<Trajectory> > trajectories; 
+    edm::Handle<vector<Trajectory> > trajectories; 
     iEvent.getByToken(trajectories_, trajectories);
 
     if(mergeOld_) {
@@ -337,18 +375,47 @@ HLTTrackClusterRemover::produce(Event& iEvent, const EventSetup& iSetup)
 
     //for (TrajTrackAssociationCollection::const_iterator it = trajectories->begin(), ed = trajectories->end(); it != ed; ++it)  {
     //    const Trajectory &tj = * it->key;
-    for (vector<Trajectory>::const_iterator it = trajectories->begin(), ed = trajectories->end(); it != ed; ++it)  {
-        const Trajectory &tj = * it;
-        const vector<TrajectoryMeasurement> &tms = tj.measurements();
-        vector<TrajectoryMeasurement>::const_iterator itm, endtm;
-        for (itm = tms.begin(), endtm = tms.end(); itm != endtm; ++itm) {
-            const TrackingRecHit *hit = itm->recHit()->hit();
-            if (!hit->isValid()) continue; 
-	    //	    std::cout<<"process hit"<<std::endl;
-            process( hit, itm->estimate() );
-        }
+
+    for (std::vector<Trajectory>::const_iterator it = trajectories->begin(), ed = trajectories->end(); it != ed; ++it)  {
+      const Trajectory &tj = * it;
+      const std::vector<TrajectoryMeasurement> &tms = tj.measurements();
+      
+      std::vector<TrajectoryMeasurement>::const_iterator itm, endtm;
+      for (itm = tms.begin(), endtm = tms.end(); itm != endtm; ++itm) {
+	
+	const TrackingRecHit *hit = itm->recHit()->hit();
+	if (!hit->isValid()) continue; 
+	//	    std::cout<<"process hit"<<std::endl;
+	process( hit, itm->estimate() );
+      }
     }
     
+
+    //    std::cout << " => collectedRegStrips_: " << collectedRegStrips_.size() << std::endl;
+    //    std::cout << " total strip to skip (before charge check): "<<std::count(collectedRegStrips_.begin(),collectedRegStrips_.end(),true) << std::endl;
+    if (doStripChargeCheck_) {
+      int i = 0;
+      //      std::cout << "[HLTTrackClusterRemover::produce] doStripChargeCheck_: " << (doStripChargeCheck_ ? "true" : "false") << " stripClusters: " << stripClusters->size() << std::endl;
+
+      for (std::vector<SiStripCluster>::const_iterator icluster = stripClusters->begin_record(), ecluster = stripClusters->end_record();
+      	   icluster!=ecluster; ++icluster, i++){
+
+	DetId detid = icluster->geographicalId(); 
+	uint32_t subdet = detid.subdetId();
+	//	std::cout << " i: " << i << " --> detid: " << detid << " --> subdet: " << subdet << std::endl;
+
+	int clusCharge=0;
+	for ( auto cAmp : icluster->amplitudes() ) clusCharge+=cAmp;
+	  
+	//	if (clusCharge < pblocks_[subdet-1].minGoodStripCharge_) std::cout << " clusCharge: " << clusCharge << std::endl;
+	if (pblocks_[subdet-1].cutOnStripCharge_ && clusCharge > pblocks_[subdet-1].minGoodStripCharge_) continue;
+
+	collectedRegStrips_[i]=true;
+      }
+    }
+    
+    //    std::cout << " => collectedRegStrips_: " << collectedRegStrips_.size() << std::endl;
+    //    std::cout << " total strip to skip: "<<std::count(collectedRegStrips_.begin(),collectedRegStrips_.end(),true) << std::endl;
     std::auto_ptr<StripMaskContainer> removedStripClusterMask(
        new StripMaskContainer(edm::RefProd<edm::LazyGetter<SiStripCluster> >(stripClusters),collectedRegStrips_));
     LogDebug("TrackClusterRemover")<<"total strip to skip: "<<std::count(collectedRegStrips_.begin(),collectedRegStrips_.end(),true);
@@ -358,7 +425,8 @@ HLTTrackClusterRemover::produce(Event& iEvent, const EventSetup& iSetup)
        new PixelMaskContainer(edm::RefProd<edmNew::DetSetVector<SiPixelCluster> >(pixelClusters),collectedPixels_));      
     LogDebug("TrackClusterRemover")<<"total pxl to skip: "<<std::count(collectedPixels_.begin(),collectedPixels_.end(),true);
     iEvent.put( removedPixelClusterMask );
-    
+
+
 }
 
 #include "FWCore/PluginManager/interface/ModuleDef.h"


### PR DESCRIPTION
synchronize HLTTrackClusterRemover to the offline version w/ SiStripClusterChargeCut

the parameter which handles the switch of this cut (doStripChargeCheck) is set to FALSE as default value
=> this code update should be back-compatible

@perrotta @Martin-Grunewald @cerati @rovere
