### PR TITLE
Updated GTs in AutoCond.py for CMSSW_7_0_0_pre13

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -1,23 +1,23 @@
 autoCond = { 
     # GlobalTag for MC production with perfectly aligned and calibrated detector
-    'mc'                :   'MC_70_V3::All',
+    'mc'                :   'MC_70_V4::All',
     # GlobalTag for MC production with realistic alignment and calibrations
-    'startup'           :   'START70_V4::All',
+    'startup'           :   'START70_V6::All',
     # GlobalTag for MC production of Heavy Ions events with realistic alignment and calibrations
-    'starthi'           :   'STARTHI70_V5::All',
+    'starthi'           :   'STARTHI70_V7::All',
     # GlobalTag for MC production of p-Pb events with realistic alignment and calibrations
-    'startpa'           :   'STARTHI70_V6::All',
+    'startpa'           :   'STARTHI70_V8::All',
     # GlobalTag for data reprocessing: this should always be the GR_R tag
-    'com10'             :   'GR_R_62_V3::All',
+    'com10'             :   'GR_R_70_V1::All',
     # GlobalTag for running HLT on recent data: this should be the GR_P (prompt reco) global tag until a compatible GR_H tag is available, 
     # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
     'hltonline'         :   'GR_H_V33::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for POSTLS1 upgrade studies:
-    'upgradePLS1'       :   'POSTLS162_V4::All',
-    'upgradePLS150ns'   :   'POSTLS162_V5::All',
-    'upgrade2017'       :   'DES17_70_V2::All', # placeholder (GT not meant for 62X)
-    'upgrade2019'       :   'DES19_70_V2::All', # placeholder (GT not meant for 62X)
-    'upgradePLS3'       :   'POSTLS262_V1::All' # placeholder (GT not meant for 62X)
+    'upgradePLS1'       :   'POSTLS170_V3::All',
+    'upgradePLS150ns'   :   'POSTLS170_V4::All',
+    'upgrade2017'       :   'DES17_70_V2::All', # placeholder (GT not meant for standard RelVal)
+    'upgrade2019'       :   'DES19_70_V2::All', # placeholder (GT not meant for standard RelVal)
+    'upgradePLS3'       :   'POSTLS262_V1::All' # placeholder (GT not meant for standard RelVal)
 }
 
 aliases = {


### PR DESCRIPTION
Fixing the autoCond.py with the correct GTs for 7_0_0_pre13 containing 
- updated e-gamma regression tags to be paired with the new reconstruction code: https://github.com/cms-sw/cmssw/pull/2202
- corrected HCAL tags for 'startup', 'startupHI', 'startupPa', upgradePLS1' and 'upgradePLS150ns' MC GTs (see https://hypernews.cern.ch/HyperNews/CMS/get/relval/2804/25/1.html)
- correct HCAL ZS treshold erroneously propagated to the DATA GT ('com10')
- updated GT for 'hltonline', in sync with https://github.com/cms-sw/cmssw/pull/2181
