### PR TITLE
TVirtualCollectionProxy is owned by ROOT.  Don't use auto_ptr.

### DIFF
--- a/CondCore/ORA/src/STLContainerHandler.cc
+++ b/CondCore/ORA/src/STLContainerHandler.cc
@@ -73,8 +73,8 @@ ora::STLContainerHandler::STLContainerHandler( const edm::TypeWithDict& dictiona
   m_isAssociative = ClassUtils::isTypeKeyedContainer( m_type );
 
   TClass* cl = dictionary.getClass();
-  m_collProxy.reset( cl->GetCollectionProxy() );
-  if( !m_collProxy.get() ){
+  m_collProxy = cl->GetCollectionProxy();
+  if( !m_collProxy ){
     throwException( "Cannot create \"TVirtualCollectionProxy\" for type \""+m_type.qualifiedName()+"\"",
                     "STLContainerHandler::STLContainerHandler");
   }
@@ -92,7 +92,7 @@ size_t
 ora::STLContainerHandler::size( const void* address ){
   //m_collEnv.fObject = const_cast<void*>(address);
   //return *(static_cast<size_t*>(m_collProxy->size_func(&m_collEnv)));
-  TVirtualCollectionProxy::TPushPop helper(m_collProxy.get(), const_cast<void*>(address));
+  TVirtualCollectionProxy::TPushPop helper(m_collProxy, const_cast<void*>(address));
   return m_collProxy->Size();
 }
 
@@ -119,7 +119,7 @@ void
 ora::STLContainerHandler::clear( const void* address ){
   //m_collEnv.fObject = const_cast<void*>(address);
   //m_collProxy->clear_func(&m_collEnv);
-  TVirtualCollectionProxy::TPushPop helper(m_collProxy.get(), const_cast<void*>(address));
+  TVirtualCollectionProxy::TPushPop helper(m_collProxy, const_cast<void*>(address));
   return m_collProxy->Clear();
 }
 

--- a/CondCore/ORA/src/STLContainerHandler.h
+++ b/CondCore/ORA/src/STLContainerHandler.h
@@ -92,7 +92,7 @@ namespace ora {
       bool m_isAssociative;
 
       /// Proxy of the generic collection
-      std::auto_ptr<TVirtualCollectionProxy> m_collProxy;
+      TVirtualCollectionProxy* m_collProxy;
 
     };
 


### PR DESCRIPTION
This is a fix for the problem causing segfaults or similar errors in the relvals for ROOT6.
The TVirtualCollectionProxy objects used in CondCore/ORA are owned by ROOT. By mistake, the class using them held them by auto_ptr, which caused their deletion while they were still being used, thereby causing segfaults.

With this fix, many relvals (perhaps all) still fail, but later in their execution for errors unrelated to the
current segfaults.
