### PR TITLE
Handle root6 class naming

### DIFF
--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -40,8 +40,10 @@ namespace edm {
       return boost::regex_replace(iIn, reAllSpaces,emptyString);
     }
     static boost::regex const reWrapper("edm::Wrapper<(.*)>");
-    static boost::regex const reString("std::basic_string<char>");
+    static boost::regex const reString("std::string");
     static boost::regex const reSorted("edm::SortedCollection<(.*), *edm::StrictWeakOrdering<\\1 *> >");
+    static boost::regex const reULongLong("ULong64_t");
+    static boost::regex const reLongLong("Long64_t");
     static boost::regex const reUnsigned("unsigned ");
     static boost::regex const reLong("long ");
     static boost::regex const reVector("std::vector");
@@ -71,6 +73,8 @@ namespace edm {
        name = regex_replace(name,reAIKR,"");
        name = regex_replace(name,reString,"String");
        name = regex_replace(name,reSorted,"sSorted<$1>");
+       name = regex_replace(name,reULongLong,"ull");
+       name = regex_replace(name,reLongLong,"ll");
        name = regex_replace(name,reUnsigned,"u");
        name = regex_replace(name,reLong,"l");
        name = regex_replace(name,reVector,"s");


### PR DESCRIPTION
This pull request fixes the fatal exceptions seen in some of the ROOT6 relvals.
In ROOT 6, the normalized names of three types are different than those used by Reflex in ROOT5.
The code calculating the friendly class name for the purpose of branch naming did not handle the new names.
So, a class name containing Long64_t (the ROOT6 name for long long) was not translated.  The framework cannot handle underscores in friendly class names, since underscore is a field separator in branch names.
This request fixes this problem, so the affected relvals will get further along.
