### PR TITLE
Add missing dictionaries needed for ROOT 6.

### DIFF
--- a/DataFormats/ParticleFlowReco/interface/PFLayer.h
+++ b/DataFormats/ParticleFlowReco/interface/PFLayer.h
@@ -22,10 +22,10 @@ class PFLayer {
 
  public:
   /// constructor
-  PFLayer();
+  PFLayer() {}
 
   /// destructor
-  virtual ~PFLayer() = 0;
+  ~PFLayer() {}
 
   /// layer definition
   enum Layer {PS2          = -12, 

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -14,6 +14,10 @@
   <class name="reco::PFCluster::EEtoPSAssociation"/>
   <class name="edm::Wrapper<reco::PFCluster::EEtoPSAssociation>"/>
 
+  <class name="PFLayer" ClassVersion="10">
+   <version ClassVersion="10" checksum="85611"/>
+  </class>
+  <enum name="PFLayer::Layer"/> 
   <class name="reco::PFRecHitFraction" ClassVersion="10">
    <version ClassVersion="10" checksum="3960206"/>
   </class>


### PR DESCRIPTION
Add missing dictionaries needed for ROOT 6.  These dictionaries are meaningful and harmless for ROOT 5, so this is being submitted to the main 7_1_X branch to maintain commonality for this package.
This request will fix the fatal exception seen in relval 5.0 in the ROOT6 branch, once it is carried into the ROOT6 branch.
This request was tested successfully with the short relval matrix, which includes test 5.0.
As this is a purely technical change, signatures should be bypassed if not signed in a timely manner.

Note that the abstract destructor of PFLayer prevented the dictionary from compiling, so needed to be corrected. PFLayer does not need a virtual destructor because no class is ever derived from it.
