### PR TITLE
Add missing include to fix compilation error of ROOT6 dictionary

### DIFF
--- a/DataFormats/TauReco/src/classes_1.h
+++ b/DataFormats/TauReco/src/classes_1.h
@@ -23,6 +23,7 @@
 #include "DataFormats/TauReco/interface/L2TauInfoAssociation.h"
 #include "DataFormats/TauReco/interface/HLTTau.h"
 #include "DataFormats/Common/interface/FwdPtr.h"
+#include "DataFormats/Common/interface/RefToPtr.h"
 #include "DataFormats/TauReco/interface/PFRecoTauChargedHadron.h"
 #include "DataFormats/TauReco/interface/PFRecoTauChargedHadronFwd.h"
 #include "DataFormats/TauReco/interface/PFJetChargedHadronAssociation.h"


### PR DESCRIPTION
Fix compilation error in compiling a ROOT6 dictionary by adding a missing #include to a classes.h file.
This will fix the compilation error in the most recent ROOT6 IBs.
Since the missing header is not specific to ROOT6, this is being requested in the main 7_1_X branch.
Since this request is purely technical, please bypass signatures if not signed in a timely manner.
