### PR TITLE
Remove useErrorsFromParam, hitErrorRZ, and hitErrorRPhi configuration parameters

### DIFF
--- a/RecoHI/HiTracking/python/hiMixedTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiMixedTripletStep_cff.py
@@ -29,17 +29,11 @@ hiMixedTripletSeedLayersA = cms.ESProducer("SeedingLayersESProducer",
                                              layerList = cms.vstring('FPix1_pos+FPix2_pos+TEC1_pos', 'FPix1_neg+FPix2_neg+TEC1_neg'),
                                                                      #'FPix2_pos+TEC2_pos+TEC3_pos', 'FPix2_neg+TEC2_neg+TEC3_neg'),
                                    BPix = cms.PSet(
-    useErrorsFromParam = cms.bool(True),
-    hitErrorRZ = cms.double(0.006),
-    hitErrorRPhi = cms.double(0.0027),
     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
     HitProducer = cms.string('siPixelRecHits'),
     skipClusters = cms.InputTag('hiMixedTripletClusters')
     ),
                                    FPix = cms.PSet(
-    useErrorsFromParam = cms.bool(True),
-    hitErrorRPhi = cms.double(0.0051),
-    hitErrorRZ = cms.double(0.0036),
     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
     HitProducer = cms.string('siPixelRecHits'),
     skipClusters = cms.InputTag('hiMixedTripletClusters')
@@ -84,9 +78,6 @@ hiMixedTripletSeedLayersB = cms.ESProducer("SeedingLayersESProducer",
     'BPix2+BPix3+TIB1',
     'BPix2+BPix3+TIB2'),
                                    BPix = cms.PSet(
-    useErrorsFromParam = cms.bool(True),
-    hitErrorRPhi = cms.double(0.0027),
-    hitErrorRZ = cms.double(0.006),
     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
     HitProducer = cms.string('siPixelRecHits'),
     skipClusters = cms.InputTag('hiMixedTripletClusters')

--- a/RecoPixelVertexing/PixelLowPtUtilities/python/common_cff.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/python/common_cff.py
@@ -14,20 +14,6 @@ TransientTrackBuilderESProducer = cms.ESProducer("TransientTrackBuilderESProduce
     ComponentName = cms.string('TransientTrackBuilder'),
 )
 
-# Pixel barrel errors
-BPixError = cms.PSet(
-    useErrorsFromParam = cms.bool(True),
-    hitErrorRPhi = cms.double(0.0027),
-    hitErrorRZ = cms.double(0.006)
-)
-
-# Pixel endcap errors
-FPixError = cms.PSet(
-    useErrorsFromParam = cms.bool(True),
-    hitErrorRPhi = cms.double(0.0051),
-    hitErrorRZ = cms.double(0.0036)
-)
-
 # Trajectory builder
 GroupedCkfTrajectoryBuilder.maxCand = 5
 GroupedCkfTrajectoryBuilder.intermediateCleaning = False

--- a/RecoPixelVertexing/PixelLowPtUtilities/python/secondStep_cff.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/python/secondStep_cff.py
@@ -25,8 +25,6 @@ secondStripRecHits.ClusterProducer = 'secondClusters'
 
 #################################
 # Secondary triplets
-from RecoPixelVertexing.PixelLowPtUtilities.common_cff import BPixError
-from RecoPixelVertexing.PixelLowPtUtilities.common_cff import FPixError
 secondLayerTriplets = cms.ESProducer("SeedingLayersESProducer",
     ComponentName = cms.string('SecondLayerTriplets'),
     layerList = cms.vstring('BPix1+BPix2+BPix3',
@@ -35,12 +33,10 @@ secondLayerTriplets = cms.ESProducer("SeedingLayersESProducer",
         'BPix1+FPix1_pos+FPix2_pos',
         'BPix1+FPix1_neg+FPix2_neg'),
     BPix = cms.PSet(
-        BPixError,
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
         HitProducer = cms.string('secondPixelRecHits')
     ),
     FPix = cms.PSet(
-        FPixError,
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
         HitProducer = cms.string('secondPixelRecHits')
     )

--- a/RecoPixelVertexing/PixelLowPtUtilities/python/thirdStep_cff.py
+++ b/RecoPixelVertexing/PixelLowPtUtilities/python/thirdStep_cff.py
@@ -26,8 +26,6 @@ thirdStripRecHits.ClusterProducer = 'thirdClusters'
 
 #################################
 # Tertiary pairs
-from RecoPixelVertexing.PixelLowPtUtilities.common_cff import BPixError
-from RecoPixelVertexing.PixelLowPtUtilities.common_cff import FPixError
 thirdLayerPairs = cms.ESProducer("SeedingLayersESProducer",
     ComponentName = cms.string('ThirdLayerPairs'),
     layerList = cms.vstring('BPix1+BPix2',
@@ -44,12 +42,10 @@ thirdLayerPairs = cms.ESProducer("SeedingLayersESProducer",
 #       'FPix1_pos+FPix2_pos',
 #       'FPix1_neg+FPix2_neg'),
     BPix = cms.PSet(
-        BPixError,
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
         HitProducer = cms.string('thirdPixelRecHits')
     ),
     FPix = cms.PSet(
-        FPixError,
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
         HitProducer = cms.string('thirdPixelRecHits')
     )

--- a/RecoPixelVertexing/PixelTriplets/python/quadrupletseedmerging_cff.py
+++ b/RecoPixelVertexing/PixelTriplets/python/quadrupletseedmerging_cff.py
@@ -27,18 +27,12 @@ pixelseedmergerlayers = cms.ESProducer( "SeedingLayersESProducer",
   ),
 
   BPix = cms.PSet( 
-    useErrorsFromParam = cms.bool( True ),
-    hitErrorRPhi = cms.double( 0.0027 ),
     TTRHBuilder = cms.string( "TTRHBuilderPixelOnly" ),
     HitProducer = cms.string( "hltSiPixelRecHits" ),
-    hitErrorRZ = cms.double( 0.0060 )
   ),
   FPix = cms.PSet( 
-    useErrorsFromParam = cms.bool( True ),
-    hitErrorRPhi = cms.double( 0.0051 ),
     TTRHBuilder = cms.string( "TTRHBuilderPixelOnly" ),
     HitProducer = cms.string( "hltSiPixelRecHits" ),
-    hitErrorRZ = cms.double( 0.0036 )
   ),
   TEC = cms.PSet(  )
 )

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep2_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep2_cff.py
@@ -89,19 +89,13 @@ conv2LayerPairs = cms.ESProducer("SeedingLayersESProducer",
                                                         ),
                                 
                                 BPix = cms.PSet(
-                                    hitErrorRZ = cms.double(0.006),
-                                    hitErrorRPhi = cms.double(0.0027),
                                     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
                                     HitProducer = cms.string('siPixelRecHits'),
-                                    useErrorsFromParam = cms.bool(True),
                                     skipClusters = cms.InputTag('conv2Clusters'),
                                     ),
                                 FPix = cms.PSet(
-                                    hitErrorRZ = cms.double(0.0036),
-                                    hitErrorRPhi = cms.double(0.0051),
                                     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
                                     HitProducer = cms.string('siPixelRecHits'),
-                                    useErrorsFromParam = cms.bool(True),
                                     skipClusters = cms.InputTag('conv2Clusters'),
                                     ),
                                 TIB1 = cms.PSet(

--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -102,19 +102,13 @@ convLayerPairs = cms.ESProducer("SeedingLayersESProducer",
                                                         ),
 
                                 BPix = cms.PSet(
-                                    hitErrorRZ = cms.double(0.006),
-                                    hitErrorRPhi = cms.double(0.0027),
                                     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
                                     HitProducer = cms.string('siPixelRecHits'),
-                                    useErrorsFromParam = cms.bool(True),
                                     skipClusters = cms.InputTag('convClusters'),
                                     ),
                                 FPix = cms.PSet(
-                                    hitErrorRZ = cms.double(0.0036),
-                                    hitErrorRPhi = cms.double(0.0051),
                                     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
                                     HitProducer = cms.string('siPixelRecHits'),
-                                    useErrorsFromParam = cms.bool(True),
                                     skipClusters = cms.InputTag('convClusters'),
                                     ),
                                 TIB1 = cms.PSet(

--- a/RecoTracker/ConversionSeedGenerators/python/Phase1PU140_ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/Phase1PU140_ConversionStep_cff.py
@@ -102,19 +102,13 @@ convLayerPairs = cms.ESProducer("SeedingLayersESProducer",
                                                         ),
 
                                 BPix = cms.PSet(
-                                    hitErrorRZ = cms.double(0.006),
-                                    hitErrorRPhi = cms.double(0.0027),
                                     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
                                     HitProducer = cms.string('siPixelRecHits'),
-                                    useErrorsFromParam = cms.bool(True),
                                     skipClusters = cms.InputTag('convClusters'),
                                     ),
                                 FPix = cms.PSet(
-                                    hitErrorRZ = cms.double(0.0036),
-                                    hitErrorRPhi = cms.double(0.0051),
                                     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
                                     HitProducer = cms.string('siPixelRecHits'),
-                                    useErrorsFromParam = cms.bool(True),
                                     skipClusters = cms.InputTag('convClusters'),
                                     ),
                                 TIB1 = cms.PSet(

--- a/RecoTracker/ConversionSeedGenerators/python/Phase1PU70_ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/Phase1PU70_ConversionStep_cff.py
@@ -102,19 +102,13 @@ convLayerPairs = cms.ESProducer("SeedingLayersESProducer",
                                                         ),
 
                                 BPix = cms.PSet(
-                                    hitErrorRZ = cms.double(0.006),
-                                    hitErrorRPhi = cms.double(0.0027),
                                     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
                                     HitProducer = cms.string('siPixelRecHits'),
-                                    useErrorsFromParam = cms.bool(True),
                                     skipClusters = cms.InputTag('convClusters'),
                                     ),
                                 FPix = cms.PSet(
-                                    hitErrorRZ = cms.double(0.0036),
-                                    hitErrorRPhi = cms.double(0.0051),
                                     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
                                     HitProducer = cms.string('siPixelRecHits'),
-                                    useErrorsFromParam = cms.bool(True),
                                     skipClusters = cms.InputTag('convClusters'),
                                     ),
                                 TIB1 = cms.PSet(

--- a/RecoTracker/ConversionSeedGenerators/python/PhotonConversionTrajectorySeedProducerFromQuadruplets_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/PhotonConversionTrajectorySeedProducerFromQuadruplets_cff.py
@@ -104,18 +104,12 @@ convLayerPairs = cms.ESProducer("SeedingLayersESProducer",
                                                         ),
 
                                 BPix = cms.PSet(
-                                    hitErrorRZ = cms.double(0.006),
-                                    hitErrorRPhi = cms.double(0.0027),
                                     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
                                     HitProducer = cms.string('convPixelRecHits'),
-                                    useErrorsFromParam = cms.bool(True)
                                     ),
                                 FPix = cms.PSet(
-                                    hitErrorRZ = cms.double(0.0036),
-                                    hitErrorRPhi = cms.double(0.0051),
                                     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
                                     HitProducer = cms.string('convPixelRecHits'),
-                                    useErrorsFromParam = cms.bool(True)
                                     ),
                                 TIB1 = cms.PSet(
                                     TTRHBuilder = cms.string('WithTrackAngle'),

--- a/RecoTracker/ConversionSeedGenerators/python/PhotonConversionTrajectorySeedProducerFromSingleLeg_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/PhotonConversionTrajectorySeedProducerFromSingleLeg_cff.py
@@ -113,18 +113,12 @@ convLayerPairs = cms.ESProducer("SeedingLayersESProducer",
                                                         ),
 
                                 BPix = cms.PSet(
-                                    hitErrorRZ = cms.double(0.006),
-                                    hitErrorRPhi = cms.double(0.0027),
                                     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
                                     HitProducer = cms.string('convPixelRecHits'),
-                                    useErrorsFromParam = cms.bool(True)
                                     ),
                                 FPix = cms.PSet(
-                                    hitErrorRZ = cms.double(0.0036),
-                                    hitErrorRPhi = cms.double(0.0051),
                                     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
                                     HitProducer = cms.string('convPixelRecHits'),
-                                    useErrorsFromParam = cms.bool(True)
                                     ),
                                 TIB1 = cms.PSet(
                                     TTRHBuilder = cms.string('WithTrackAngle'),

--- a/RecoTracker/ConversionSeedGenerators/python/PhotonConversionTrajectorySeedProducerFromSingleLeg_gsf_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/PhotonConversionTrajectorySeedProducerFromSingleLeg_gsf_cff.py
@@ -123,18 +123,12 @@ convLayerPairs = cms.ESProducer("SeedingLayersESProducer",
                                                         ),
 
                                 BPix = cms.PSet(
-                                    hitErrorRZ = cms.double(0.006),
-                                    hitErrorRPhi = cms.double(0.0027),
                                     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
                                     HitProducer = cms.string('convPixelRecHits'),
-                                    useErrorsFromParam = cms.bool(True)
                                     ),
                                 FPix = cms.PSet(
-                                    hitErrorRZ = cms.double(0.0036),
-                                    hitErrorRPhi = cms.double(0.0051),
                                     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
                                     HitProducer = cms.string('convPixelRecHits'),
-                                    useErrorsFromParam = cms.bool(True)
                                     ),
                                 TIB1 = cms.PSet(
                                     TTRHBuilder = cms.string('WithTrackAngle'),

--- a/RecoTracker/ConversionSeedGenerators/python/PostLS1_ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/PostLS1_ConversionStep_cff.py
@@ -102,19 +102,13 @@ convLayerPairs = cms.ESProducer("SeedingLayersESProducer",
                                                         ),
 
                                 BPix = cms.PSet(
-                                    hitErrorRZ = cms.double(0.006),
-                                    hitErrorRPhi = cms.double(0.0027),
                                     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
                                     HitProducer = cms.string('siPixelRecHits'),
-                                    useErrorsFromParam = cms.bool(True),
                                     skipClusters = cms.InputTag('convClusters'),
                                     ),
                                 FPix = cms.PSet(
-                                    hitErrorRZ = cms.double(0.0036),
-                                    hitErrorRPhi = cms.double(0.0051),
                                     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
                                     HitProducer = cms.string('siPixelRecHits'),
-                                    useErrorsFromParam = cms.bool(True),
                                     skipClusters = cms.InputTag('convClusters'),
                                     ),
                                 TIB1 = cms.PSet(

--- a/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/ElectronSeeds_cff.py
@@ -24,19 +24,13 @@ tripletElectronSeedLayers = cms.ESProducer("SeedingLayersESProducer",
                             'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg', 
                             'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg'),
     BPix = cms.PSet(
-    useErrorsFromParam = cms.bool(True),
-    hitErrorRPhi = cms.double(0.0027),
     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
     HitProducer = cms.string('siPixelRecHits'),
-    hitErrorRZ = cms.double(0.006),
     skipClusters = cms.InputTag('pixelLessStepSeedClusterMask')
     ),
     FPix = cms.PSet(
-    useErrorsFromParam = cms.bool(True),
-    hitErrorRPhi = cms.double(0.0051),
     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
     HitProducer = cms.string('siPixelRecHits'),
-    hitErrorRZ = cms.double(0.0036),
     skipClusters = cms.InputTag('pixelLessStepSeedClusterMask')
     )
 )
@@ -69,17 +63,11 @@ pixelPairElectronSeedLayers = cms.ESProducer("SeedingLayersESProducer",
                             'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
                             'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg'),
     BPix = cms.PSet(
-    useErrorsFromParam = cms.bool(True),
-    hitErrorRPhi = cms.double(0.0027),
-    hitErrorRZ = cms.double(0.006),
     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
     HitProducer = cms.string('siPixelRecHits'),
     skipClusters = cms.InputTag('tripletElectronClusterMask')
     ),
     FPix = cms.PSet(
-    useErrorsFromParam = cms.bool(True),
-    hitErrorRPhi = cms.double(0.0051),
-    hitErrorRZ = cms.double(0.0036),
     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
     HitProducer = cms.string('siPixelRecHits'),
     skipClusters = cms.InputTag('tripletElectronClusterMask')

--- a/RecoTracker/IterativeTracking/python/LowPU_MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPU_MixedTripletStep_cff.py
@@ -29,17 +29,11 @@ mixedTripletStepSeedLayersA = cms.ESProducer("SeedingLayersESProducer",
         'FPix1_pos+FPix2_pos+TEC2_pos', 'FPix1_neg+FPix2_neg+TEC2_neg',
         'FPix2_pos+TEC2_pos+TEC3_pos', 'FPix2_neg+TEC2_neg+TEC3_neg'),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRZ = cms.double(0.006),
-        hitErrorRPhi = cms.double(0.0027),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('mixedTripletStepClusters')
     ),
     FPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0051),
-        hitErrorRZ = cms.double(0.0036),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('mixedTripletStepClusters')
@@ -72,9 +66,6 @@ mixedTripletStepSeedLayersB = cms.ESProducer("SeedingLayersESProducer",
     ComponentName = cms.string('mixedTripletStepSeedLayersB'),
     layerList = cms.vstring('BPix2+BPix3+TIB1', 'BPix2+BPix3+TIB2'),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0027),
-        hitErrorRZ = cms.double(0.006),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('mixedTripletStepClusters')

--- a/RecoTracker/IterativeTracking/python/LowPU_PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/LowPU_PixelPairStep_cff.py
@@ -25,17 +25,11 @@ pixelPairStepSeedLayers = cms.ESProducer("SeedingLayersESProducer",
         'BPix1+FPix2_pos', 'BPix1+FPix2_neg', 
         'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg'),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0027),
-        hitErrorRZ = cms.double(0.006),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('pixelPairStepClusters')
     ),
     FPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0051),
-        hitErrorRZ = cms.double(0.0036),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('pixelPairStepClusters')

--- a/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/MixedTripletStep_cff.py
@@ -26,17 +26,11 @@ mixedTripletStepSeedLayersA = cms.ESProducer("SeedingLayersESProducer",
         'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg', 
         'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg'),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRZ = cms.double(0.006),
-        hitErrorRPhi = cms.double(0.0027),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('mixedTripletStepClusters')
     ),
     FPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0051),
-        hitErrorRZ = cms.double(0.0036),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('mixedTripletStepClusters')
@@ -77,9 +71,6 @@ mixedTripletStepSeedLayersB = cms.ESProducer("SeedingLayersESProducer",
     ComponentName = cms.string('mixedTripletStepSeedLayersB'),
     layerList = cms.vstring('BPix2+BPix3+TIB1'),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0027),
-        hitErrorRZ = cms.double(0.006),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('mixedTripletStepClusters')

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_ElectronSeeds_cff.py
@@ -28,19 +28,13 @@ tripletElectronSeedLayers = cms.ESProducer("SeedingLayersESProducer",
                             'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',
                             'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'),
     BPix = cms.PSet(
-    useErrorsFromParam = cms.bool(True),
-    hitErrorRPhi = cms.double(0.0027),
     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
     HitProducer = cms.string('siPixelRecHits'),
-    hitErrorRZ = cms.double(0.006),
     skipClusters = cms.InputTag('pixelPairStepSeedClusterMask')
     ),
     FPix = cms.PSet(
-    useErrorsFromParam = cms.bool(True),
-    hitErrorRPhi = cms.double(0.0051),
     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
     HitProducer = cms.string('siPixelRecHits'),
-    hitErrorRZ = cms.double(0.0036),
     skipClusters = cms.InputTag('pixelPairStepSeedClusterMask')
     )
 )

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_PixelPairStep_cff.py
@@ -26,17 +26,11 @@ pixelPairStepSeedLayers = cms.ESProducer("SeedingLayersESProducer",
                             'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg',
                             'FPix2_pos+FPix3_pos', 'FPix2_neg+FPix3_neg'),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0027),
-        hitErrorRZ = cms.double(0.006),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('pixelPairStepClusters')
     ),
     FPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0051),
-        hitErrorRZ = cms.double(0.0036),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('pixelPairStepClusters')

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_ElectronSeeds_cff.py
@@ -28,19 +28,13 @@ tripletElectronSeedLayers = cms.ESProducer("SeedingLayersESProducer",
                             'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',
                             'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg'),
     BPix = cms.PSet(
-    useErrorsFromParam = cms.bool(True),
-    hitErrorRPhi = cms.double(0.0027),
     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
     HitProducer = cms.string('siPixelRecHits'),
-    hitErrorRZ = cms.double(0.006),
     skipClusters = cms.InputTag('pixelPairStepSeedClusterMask')
     ),
     FPix = cms.PSet(
-    useErrorsFromParam = cms.bool(True),
-    hitErrorRPhi = cms.double(0.0051),
     TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
     HitProducer = cms.string('siPixelRecHits'),
-    hitErrorRZ = cms.double(0.0036),
     skipClusters = cms.InputTag('pixelPairStepSeedClusterMask')
     )
 )

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_MixedTripletStep_cff.py
@@ -28,17 +28,11 @@ mixedTripletStepSeedLayersA = cms.ESProducer("SeedingLayersESProducer",
                             'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg', 
                             'FPix2_pos+FPix3_pos+TEC1_pos', 'FPix2_neg+FPix3_neg+TEC1_neg'),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRZ = cms.double(0.006),
-        hitErrorRPhi = cms.double(0.0027),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('mixedTripletStepClusters')
     ),
     FPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0051),
-        hitErrorRZ = cms.double(0.0036),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('mixedTripletStepClusters')
@@ -81,9 +75,6 @@ mixedTripletStepSeedLayersB = cms.ESProducer("SeedingLayersESProducer",
     ComponentName = cms.string('mixedTripletStepSeedLayersB'),
     layerList = cms.vstring('BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4','BPix1+BPix2+BPix4', 'BPix1+BPix3+BPix4'),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0027),
-        hitErrorRZ = cms.double(0.006),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('mixedTripletStepClusters')

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_PixelPairStep_cff.py
@@ -26,17 +26,11 @@ pixelPairStepSeedLayers = cms.ESProducer("SeedingLayersESProducer",
                             'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg',
                             'FPix2_pos+FPix3_pos', 'FPix2_neg+FPix3_neg'),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0027),
-        hitErrorRZ = cms.double(0.006),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('pixelPairStepClusters')
     ),
     FPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0051),
-        hitErrorRZ = cms.double(0.0036),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('pixelPairStepClusters')

--- a/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PixelPairStep_cff.py
@@ -24,17 +24,11 @@ pixelPairStepSeedLayers = cms.ESProducer("SeedingLayersESProducer",
         'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
         'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg'),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0027),
-        hitErrorRZ = cms.double(0.006),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('pixelPairStepClusters')
     ),
     FPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0051),
-        hitErrorRZ = cms.double(0.0036),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('pixelPairStepClusters')

--- a/RecoTracker/IterativeTracking/python/PostLS1_MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PostLS1_MixedTripletStep_cff.py
@@ -28,17 +28,11 @@ mixedTripletStepSeedLayersA = cms.ESProducer("SeedingLayersESProducer",
         'FPix1_pos+FPix2_pos+TEC1_pos', 'FPix1_neg+FPix2_neg+TEC1_neg',
         'FPix2_pos+TEC2_pos+TEC3_pos', 'FPix2_neg+TEC2_neg+TEC3_neg'),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRZ = cms.double(0.006),
-        hitErrorRPhi = cms.double(0.0027),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('mixedTripletStepClusters')
     ),
     FPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0051),
-        hitErrorRZ = cms.double(0.0036),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('mixedTripletStepClusters')
@@ -79,9 +73,6 @@ mixedTripletStepSeedLayersB = cms.ESProducer("SeedingLayersESProducer",
     ComponentName = cms.string('mixedTripletStepSeedLayersB'),
     layerList = cms.vstring('BPix2+BPix3+TIB1', 'BPix2+BPix3+TIB2'),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0027),
-        hitErrorRZ = cms.double(0.006),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('mixedTripletStepClusters')

--- a/RecoTracker/IterativeTracking/python/PostLS1_PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/PostLS1_PixelPairStep_cff.py
@@ -24,17 +24,11 @@ pixelPairStepSeedLayers = cms.ESProducer("SeedingLayersESProducer",
         'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
         'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg'),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0027),
-        hitErrorRZ = cms.double(0.006),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('pixelPairStepClusters')
     ),
     FPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0051),
-        hitErrorRZ = cms.double(0.0036),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('pixelPairStepClusters')

--- a/RecoTracker/IterativeTracking/python/RunI_MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/RunI_MixedTripletStep_cff.py
@@ -28,17 +28,11 @@ mixedTripletStepSeedLayersA = cms.ESProducer("SeedingLayersESProducer",
         'FPix1_pos+FPix2_pos+TEC1_pos', 'FPix1_neg+FPix2_neg+TEC1_neg',
         'FPix2_pos+TEC2_pos+TEC3_pos', 'FPix2_neg+TEC2_neg+TEC3_neg'),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRZ = cms.double(0.006),
-        hitErrorRPhi = cms.double(0.0027),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('mixedTripletStepClusters')
     ),
     FPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0051),
-        hitErrorRZ = cms.double(0.0036),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('mixedTripletStepClusters')
@@ -79,9 +73,6 @@ mixedTripletStepSeedLayersB = cms.ESProducer("SeedingLayersESProducer",
     ComponentName = cms.string('mixedTripletStepSeedLayersB'),
     layerList = cms.vstring('BPix2+BPix3+TIB1', 'BPix2+BPix3+TIB2'),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0027),
-        hitErrorRZ = cms.double(0.006),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('mixedTripletStepClusters')

--- a/RecoTracker/IterativeTracking/python/RunI_PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/RunI_PixelPairStep_cff.py
@@ -24,17 +24,11 @@ pixelPairStepSeedLayers = cms.ESProducer("SeedingLayersESProducer",
         'BPix2+FPix1_pos', 'BPix2+FPix1_neg',
         'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg'),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0027),
-        hitErrorRZ = cms.double(0.006),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('pixelPairStepClusters')
     ),
     FPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0051),
-        hitErrorRZ = cms.double(0.0036),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         HitProducer = cms.string('siPixelRecHits'),
         skipClusters = cms.InputTag('pixelPairStepClusters')

--- a/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForBeamHalo_cfi.py
+++ b/RecoTracker/SpecialSeedGenerators/python/CombinatorialSeedGeneratorForBeamHalo_cfi.py
@@ -24,11 +24,8 @@ layerInfo = cms.PSet(
         rphiRecHits = cms.InputTag("siStripMatchedRecHits","rphiRecHit")
     ),
     FPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0051),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.0036)
     ),
     TEC = cms.PSet(
         minRing = cms.int32(5),

--- a/RecoTracker/TkSeedingLayers/interface/SeedingLayer.h
+++ b/RecoTracker/TkSeedingLayers/interface/SeedingLayer.h
@@ -3,7 +3,7 @@
 
 #include <string>
 #include <vector>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
@@ -26,8 +26,7 @@ public:
   SeedingLayer( const std::string & name, int seqNum,
                 const DetLayer* layer,
                 const TransientTrackingRecHitBuilder * hitBuilder,
-                const HitExtractor * hitExtractor,  
-                bool usePredefinedErrors = false, float hitErrorRZ = 0., float hitErrorRPhi=0.);
+                const HitExtractor * hitExtractor);
 
   std::string name() const;
   int seqNum() const;
@@ -41,13 +40,9 @@ public:
   
   const TransientTrackingRecHitBuilder * hitBuilder() const;
 
-  bool hasPredefinedHitErrors() const;
-  float predefinedHitErrorRZ() const;
-  float predefinedHitErrorRPhi() const;
- 
 private:
   class SeedingLayerImpl;
-  boost::shared_ptr<SeedingLayerImpl> theImpl;
+  std::shared_ptr<SeedingLayerImpl> theImpl;
 };
 
 }

--- a/RecoTracker/TkSeedingLayers/interface/SeedingLayerSetsBuilder.h
+++ b/RecoTracker/TkSeedingLayers/interface/SeedingLayerSetsBuilder.h
@@ -32,7 +32,6 @@ private:
     std::string pixelHitProducer; edm::InputTag matchedRecHits,rphiRecHits,stereoRecHits;  
     bool usePixelHitProducer, useMatchedRecHits, useRPhiRecHits, useStereoRecHits;
     std::string hitBuilder;
-    bool useErrorsFromParam; double hitErrorRPhi; double hitErrorRZ; 
     bool useRingSelector; int minRing; int maxRing;
     bool useSimpleRphiHitsCleaner;
     bool skipClusters; edm::InputTag clustersToSkip;

--- a/RecoTracker/TkSeedingLayers/python/MixedLayerPairs_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/MixedLayerPairs_cfi.py
@@ -34,18 +34,12 @@ mixedlayerpairs = cms.ESProducer("SeedingLayersESProducer",
         maxRing = cms.int32(1)
     ),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0027),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedPairs'),
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.006)
     ),
     FPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0051),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedPairs'),
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.0036)
     )
 )
 

--- a/RecoTracker/TkSeedingLayers/python/MixedLayerTriplets_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/MixedLayerTriplets_cfi.py
@@ -26,22 +26,16 @@ mixedlayertriplets = cms.ESProducer("SeedingLayersESProducer",
         TTRHBuilder = cms.string('WithTrackAngle')
     ),
     FPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0051),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.0036)
     ),
     TID = cms.PSet(
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
         TTRHBuilder = cms.string('WithTrackAngle')
     ),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0027),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.006)
     ),
     TIB = cms.PSet(
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),

--- a/RecoTracker/TkSeedingLayers/python/PixelAndStripLayerPairs_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/PixelAndStripLayerPairs_cfi.py
@@ -46,18 +46,12 @@ pixelandstriplayerpairs = cms.ESProducer("SeedingLayersESProducer",
         maxRing = cms.int32(1)
     ),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0027),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedPairs'),
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.006)
     ),
     FPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0051),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4MixedPairs'),
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.0036)
     )
 )
 

--- a/RecoTracker/TkSeedingLayers/python/PixelLayerPairs_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/PixelLayerPairs_cfi.py
@@ -16,18 +16,12 @@ pixellayerpairs = cms.ESProducer("SeedingLayersESProducer",
         'FPix1_pos+FPix2_pos', 
         'FPix1_neg+FPix2_neg'),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0027),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.006)
     ),
     FPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0051),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.0036)
     )
 )
 

--- a/RecoTracker/TkSeedingLayers/python/PixelLayerTriplets_cfi.py
+++ b/RecoTracker/TkSeedingLayers/python/PixelLayerTriplets_cfi.py
@@ -8,18 +8,12 @@ pixellayertriplets = cms.ESProducer("SeedingLayersESProducer",
         'BPix1+FPix1_pos+FPix2_pos', 
         'BPix1+FPix1_neg+FPix2_neg'),
     BPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0027),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.006)
     ),
     FPix = cms.PSet(
-        useErrorsFromParam = cms.bool(True),
-        hitErrorRPhi = cms.double(0.0051),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets'),
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.0036)
     )
 )
 

--- a/RecoTracker/TkSeedingLayers/src/SeedingLayer.cc
+++ b/RecoTracker/TkSeedingLayers/src/SeedingLayer.cc
@@ -17,19 +17,7 @@ public:
     theSeqNum(seqNum),
     theLayer(layer),
     theTTRHBuilder(hitBuilder),
-    theHitExtractor(hitExtractor),
-    theHasPredefinedHitErrors(false),thePredefinedHitErrorRZ(0.),thePredefinedHitErrorRPhi(0.) { }
-
-  SeedingLayerImpl(
-    const string & name, int seqNum,
-    const DetLayer* layer,
-    const TransientTrackingRecHitBuilder * hitBuilder,
-    const HitExtractor * hitExtractor,
-    float hitErrorRZ, float hitErrorRPhi)
-  : theName(name), theSeqNum(seqNum), theLayer(layer),
-    theTTRHBuilder(hitBuilder), theHitExtractor(hitExtractor),
-    theHasPredefinedHitErrors(true),
-    thePredefinedHitErrorRZ(hitErrorRZ), thePredefinedHitErrorRPhi(hitErrorRPhi) { }
+    theHitExtractor(hitExtractor) { }
 
   ~SeedingLayerImpl() { delete theHitExtractor; }
 
@@ -43,10 +31,6 @@ public:
   const DetLayer*  detLayer() const { return theLayer; }
   const TransientTrackingRecHitBuilder * hitBuilder() const { return theTTRHBuilder; }
 
-  bool  hasPredefinedHitErrors() const { return theHasPredefinedHitErrors; }
-  float predefinedHitErrorRZ() const { return thePredefinedHitErrorRZ; }
-  float predefinedHitErrorRPhi() const { return thePredefinedHitErrorRPhi; }
-
 private:
   SeedingLayerImpl(const SeedingLayerImpl &);
 
@@ -56,8 +40,6 @@ private:
   const DetLayer* theLayer;
   const TransientTrackingRecHitBuilder *theTTRHBuilder;
   const HitExtractor * theHitExtractor;
-  bool theHasPredefinedHitErrors;
-  float thePredefinedHitErrorRZ, thePredefinedHitErrorRPhi;
 };
 
 
@@ -67,13 +49,9 @@ SeedingLayer::SeedingLayer(
     const std::string & name, int seqNum,
     const DetLayer* layer, 
     const TransientTrackingRecHitBuilder * hitBuilder,
-    const HitExtractor * hitExtractor,
-    bool usePredefinedErrors, float hitErrorRZ, float hitErrorRPhi)
+    const HitExtractor * hitExtractor)
 {
-  SeedingLayerImpl * l = usePredefinedErrors ? 
-      new SeedingLayerImpl(name,seqNum,layer,hitBuilder,hitExtractor,hitErrorRZ,hitErrorRPhi)
-    : new SeedingLayerImpl(name,seqNum,layer,hitBuilder,hitExtractor);
-  theImpl = boost::shared_ptr<SeedingLayerImpl> (l);
+  theImpl = std::make_shared<SeedingLayerImpl> (name,seqNum,layer,hitBuilder,hitExtractor);
 }
 
 std::string SeedingLayer::name() const
@@ -99,19 +77,4 @@ const TransientTrackingRecHitBuilder * SeedingLayer::hitBuilder() const
 SeedingLayer::Hits SeedingLayer::hits(const edm::Event& ev, const edm::EventSetup& es) const
 {
   return  theImpl->hits( *this,ev,es);
-}
-
-bool SeedingLayer::hasPredefinedHitErrors() const 
-{
-  return theImpl->hasPredefinedHitErrors();
-}
-
-float SeedingLayer::predefinedHitErrorRZ() const
-{
-  return theImpl->predefinedHitErrorRZ();
-}
-
-float SeedingLayer::predefinedHitErrorRPhi() const
-{
-  return theImpl->predefinedHitErrorRPhi();
 }

--- a/RecoTracker/TkSeedingLayers/src/SeedingLayerSetsBuilder.cc
+++ b/RecoTracker/TkSeedingLayers/src/SeedingLayerSetsBuilder.cc
@@ -31,11 +31,7 @@ using namespace std;
 std::string SeedingLayerSetsBuilder::LayerSpec::print() const
 {
   std::ostringstream str;
-  str << "Layer="<<name<<", hitBldr: "<<hitBuilder<<", useErrorsFromParam: ";
-  if (useErrorsFromParam) {
-     str <<"true,"<<" errRPhi: "<<hitErrorRPhi<<", errRZ: "<<hitErrorRZ; 
-  }
-  else str<<"false";
+  str << "Layer="<<name<<", hitBldr: "<<hitBuilder;
 
   str << ", useRingSelector: ";
   if (useRingSelector) {
@@ -115,12 +111,6 @@ SeedingLayerSetsBuilder::SeedingLayerSetsBuilder(const edm::ParameterSet & cfg)
 	}
       }
       layer.hitBuilder  = cfgLayer.getParameter<string>("TTRHBuilder");
-
-      layer.useErrorsFromParam = cfgLayer.exists("useErrorsFromParam") ? cfgLayer.getParameter<bool>("useErrorsFromParam") : false; 
-      if(layer.useErrorsFromParam) {
-        layer.hitErrorRPhi = cfgLayer.getParameter<double>("hitErrorRPhi");
-        layer.hitErrorRZ   = cfgLayer.getParameter<double>("hitErrorRZ");
-      }
 
       layer.useRingSelector = cfgLayer.exists("useRingSlector") ? cfgLayer.getParameter<bool>("useRingSlector") : false;
       if (layer.useRingSelector) {
@@ -316,12 +306,7 @@ SeedingLayerSets SeedingLayerSetsBuilder::layers(const edm::EventSetup& es) cons
 	  return result;
 	}
 	int layerSetId = it->second;
-        if (layer.useErrorsFromParam) {
-          set.push_back( SeedingLayer( name, layerSetId, detLayer, builder.product(), 
-                                       extractor, true, layer.hitErrorRPhi,layer.hitErrorRZ));	  
-        } else {
-          set.push_back( SeedingLayer( name, layerSetId, detLayer, builder.product(), extractor));
-        }
+        set.push_back( SeedingLayer( name, layerSetId, detLayer, builder.product(), extractor));
       }
     
     }

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE.py
@@ -165,20 +165,14 @@ def customise_Reco(process,pileup):
     process.stripPairElectronSeedLayers.layerList = cms.vstring('BPix4+BPix5') # Optimize later
     process.stripPairElectronSeedLayers.BPix = cms.PSet(
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.006),
-        useErrorsFromParam = cms.bool(True),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         skipClusters = cms.InputTag("pixelPairStepClusters"),
-        hitErrorRPhi = cms.double(0.0027)
     )
     process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.layerList  = cms.vstring('BPix10+BPix9')  # Optimize later
     process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.BPix = cms.PSet(
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.006),
-        useErrorsFromParam = cms.bool(True),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         skipClusters = cms.InputTag("pixelPairStepClusters"),
-        hitErrorRPhi = cms.double(0.0027)
     )
     process.pixelTracks.SeedMergerPSet = cms.PSet(
         layerListName = cms.string('PixelSeedMergerQuadruplets'),

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5D.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5D.py
@@ -132,20 +132,14 @@ def customise_Reco(process):
     process.stripPairElectronSeedLayers.layerList = cms.vstring('BPix4+BPix5') # Optimize later
     process.stripPairElectronSeedLayers.BPix = cms.PSet(
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.006),
-        useErrorsFromParam = cms.bool(True),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         skipClusters = cms.InputTag("pixelPairStepClusters"),
-        hitErrorRPhi = cms.double(0.0027)
     )
     process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.layerList  = cms.vstring('BPix10+BPix9')  # Optimize later
     process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.BPix = cms.PSet(
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.006),
-        useErrorsFromParam = cms.bool(True),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         skipClusters = cms.InputTag("pixelPairStepClusters"),
-        hitErrorRPhi = cms.double(0.0027)
     )
     process.pixelTracks.SeedMergerPSet = cms.PSet(
         layerListName = cms.string('PixelSeedMergerQuadruplets'),

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkCustoms_LB_4LPS_2L2S.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkCustoms_LB_4LPS_2L2S.py
@@ -130,20 +130,14 @@ def customise_Reco(process):
     process.stripPairElectronSeedLayers.layerList = cms.vstring('BPix4+BPix5') # Optimize later
     process.stripPairElectronSeedLayers.BPix = cms.PSet(
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.006),
-        useErrorsFromParam = cms.bool(True),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         skipClusters = cms.InputTag("pixelPairStepClusters"),
-        hitErrorRPhi = cms.double(0.0027)
     )
     process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.layerList  = cms.vstring('BPix10+BPix9')  # Optimize later
     process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.BPix = cms.PSet(
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.006),
-        useErrorsFromParam = cms.bool(True),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         skipClusters = cms.InputTag("pixelPairStepClusters"),
-        hitErrorRPhi = cms.double(0.0027)
     )
     process.pixelTracks.SeedMergerPSet = cms.PSet(
         layerListName = cms.string('PixelSeedMergerQuadruplets'),

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkCustoms_LB_6PS.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkCustoms_LB_6PS.py
@@ -130,20 +130,14 @@ def customise_Reco(process):
     process.stripPairElectronSeedLayers.layerList = cms.vstring('BPix4+BPix5') # Optimize later
     process.stripPairElectronSeedLayers.BPix = cms.PSet(
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.006),
-        useErrorsFromParam = cms.bool(True),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         skipClusters = cms.InputTag("pixelPairStepClusters"),
-        hitErrorRPhi = cms.double(0.0027)
     )
     process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.layerList  = cms.vstring('BPix12+BPix11')  # Optimize later
     process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.BPix = cms.PSet(
         HitProducer = cms.string('siPixelRecHits'),
-        hitErrorRZ = cms.double(0.006),
-        useErrorsFromParam = cms.bool(True),
         TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
         skipClusters = cms.InputTag("pixelPairStepClusters"),
-        hitErrorRPhi = cms.double(0.0027)
     )
     process.pixelTracks.SeedMergerPSet = cms.PSet(
         layerListName = cms.string('PixelSeedMergerQuadruplets'),


### PR DESCRIPTION
Remove the parameters from configuration, and the corresponding members of SeedingLayer and SeedingLayerSetsBuilder. The members seem to have been unused since CMSSW_3. Removing the functionality simplifies further development of SeedingLayerSetsBuilder, and removing the parameters with no effect hopefully makes the configurations less confusing. The PR is based on 7_0_0_pre12.

HN thread: https://hypernews.cern.ch/HyperNews/CMS/get/recoTracking/1416.html

@Martin-Grunewald I hope this one is straightforward for ConfDB GUI, but let me know if anything further will be needed.
