### PR TITLE
Remove ESPrefers for v1 EGM regressions

### DIFF
--- a/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
+++ b/RecoEcal/EgammaClusterProducers/python/particleFlowSuperClusterECAL_cfi.py
@@ -1,35 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 import os
 
-from CondCore.DBCommon.CondDBCommon_cfi import CondDBCommon
-pfSCecalGBRESSource = cms.ESSource(
-    "PoolDBESSource",
-    CondDBCommon,
-    DumpStat=cms.untracked.bool(False),
-    toGet = cms.VPSet(
-    cms.PSet(
-    record = cms.string('GBRWrapperRcd'),
-    tag = cms.string('pfscecal_EBCorrection_offline_v1'),
-    label = cms.untracked.string('pfscecal_EBCorrection_offline_v1')
-    ),
-    cms.PSet(
-    record = cms.string('GBRWrapperRcd'),
-    tag = cms.string('pfscecal_EECorrection_offline_v1'),
-    label = cms.untracked.string('pfscecal_EECorrection_offline_v1')
-    ),
-    )
-)
-pfSCecalGBRESSource.connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000')
-
-pfSCecalPrefer = cms.ESPrefer(
-    'PoolDBESSource',
-    'pfSCecalGBRESSource',
-    GBRWrapperRcd = cms.vstring('GBRForest/pfscecal_EBCorrection_offline_v1',
-                                'GBRForest/pfscecal_EECorrection_offline_v1')
-)
-
-
-
 particleFlowSuperClusterECALBox = cms.EDProducer(
     "PFECALSuperClusterProducer",
     # verbosity 

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
@@ -3,53 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from RecoEcal.EgammaClusterProducers.hybridSuperClusters_cfi import *
 from RecoEcal.EgammaClusterProducers.multi5x5BasicClusters_cfi import *
 
-from CondCore.DBCommon.CondDBCommon_cfi import CondDBCommon
-gedelectronGBRESSource = cms.ESSource(
-    "PoolDBESSource",
-    CondDBCommon,
-    DumpStat=cms.untracked.bool(False),
-    toGet = cms.VPSet(
-    cms.PSet(
-    record = cms.string('GBRWrapperRcd'),
-    tag = cms.string('gedelectron_EBCorrection_offline_v1'),
-    label = cms.untracked.string('gedelectron_EBCorrection_offline_v1')
-    ),
-    cms.PSet(
-    record = cms.string('GBRWrapperRcd'),
-    tag = cms.string('gedelectron_EECorrection_offline_v1'),
-    label = cms.untracked.string('gedelectron_EECorrection_offline_v1')
-    ),
-    cms.PSet(
-    record = cms.string('GBRWrapperRcd'),
-    tag = cms.string('gedelectron_EBUncertainty_offline_v1'),
-    label = cms.untracked.string('gedelectron_EBUncertainty_offline_v1')
-    ),
-    cms.PSet(
-    record = cms.string('GBRWrapperRcd'),
-    tag = cms.string('gedelectron_EEUncertainty_offline_v1'),
-    label = cms.untracked.string('gedelectron_EEUncertainty_offline_v1')
-    ),
-    cms.PSet(
-    record = cms.string('GBRWrapperRcd'),
-    tag = cms.string('gedelectron_p4combination_offline'),
-    label = cms.untracked.string('gedelectron_p4combination_offline')
-    ),
-    )
-)
-gedelectronGBRESSource.connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000')
-
-gedelectronPrefer = cms.ESPrefer(
-    'PoolDBESSource',
-    'gedelectronGBRESSource',
-    GBRWrapperRcd = cms.vstring('GBRForest/gedelectron_EBCorrection_offline_v1',
-                                'GBRForest/gedelectron_EECorrection_offline_v1',
-                                'GBRForest/gedelectron_EBUncertainty_offline_v1',
-                                'GBRForest/gedelectron_EEUncertainty_offline_v1',
-                                'GBRForest/gedelectron_p4combination_offline')
-)
-
-
-
 gedGsfElectronsTmp = cms.EDProducer("GEDGsfElectronProducer",
 
     # input collections

--- a/RecoEgamma/EgammaPhotonProducers/python/gedPhotons_cfi.py
+++ b/RecoEgamma/EgammaPhotonProducers/python/gedPhotons_cfi.py
@@ -6,45 +6,6 @@ from RecoEgamma.PhotonIdentification.mipVariable_cfi import *
 from RecoEcal.EgammaClusterProducers.hybridSuperClusters_cfi import *
 from RecoEcal.EgammaClusterProducers.multi5x5BasicClusters_cfi import *
 
-from CondCore.DBCommon.CondDBCommon_cfi import CondDBCommon
-gedphotonGBRESSource = cms.ESSource(
-    "PoolDBESSource",
-    CondDBCommon,
-    DumpStat=cms.untracked.bool(False),
-    toGet = cms.VPSet(
-    cms.PSet(
-    record = cms.string('GBRWrapperRcd'),
-    tag = cms.string('gedphoton_EBCorrection_offline_v1'),
-    label = cms.untracked.string('gedphoton_EBCorrection_offline_v1')
-    ),
-    cms.PSet(
-    record = cms.string('GBRWrapperRcd'),
-    tag = cms.string('gedphoton_EECorrection_offline_v1'),
-    label = cms.untracked.string('gedphoton_EECorrection_offline_v1')
-    ),
-    cms.PSet(
-    record = cms.string('GBRWrapperRcd'),
-    tag = cms.string('gedphoton_EBUncertainty_offline_v1'),
-    label = cms.untracked.string('gedphoton_EBUncertainty_offline_v1')
-    ),
-    cms.PSet(
-    record = cms.string('GBRWrapperRcd'),
-    tag = cms.string('gedphoton_EEUncertainty_offline_v1'),
-    label = cms.untracked.string('gedphoton_EEUncertainty_offline_v1')
-    ),
-    )
-)
-gedphotonGBRESSource.connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000')
-
-gedphotonPrefer = cms.ESPrefer(
-    'PoolDBESSource',
-    'gedphotonGBRESSource',
-    GBRWrapperRcd = cms.vstring('GBRForest/gedphoton_EBCorrection_offline_v1',
-                                'GBRForest/gedphoton_EECorrection_offline_v1',
-                                'GBRForest/gedphoton_EBUncertainty_offline_v1',
-                                'GBRForest/gedphoton_EEUncertainty_offline_v1')
-)
-
 #
 # producer for photons
 #


### PR DESCRIPTION
Remove the ESPrefers from the EGM reconstruction for v1 regressions, as they are now in the GT.
