### PR TITLE
increase me11 sensitive region dimes by ~1/2 strip width at each edge

### DIFF
--- a/Geometry/MuonCommonData/data/mf.xml
+++ b/Geometry/MuonCommonData/data/mf.xml
@@ -82,8 +82,8 @@
   <Trd1 name="ME_FR4Skin_2_ME11Layer" dz="81*cm " dy1="[ME11FR4SkinHalfThick]" dy2="[ME11FR4SkinHalfThick]" dx1="15.065*cm " dx2="30.45*cm "/>
   <Trd1 name="MECU_1_ME11Layer" dz="81*cm " dy1="[ME11CuFoilHalfThick]" dy2="[ME11CuFoilHalfThick]" dx1="15.065*cm " dx2="30.45*cm "/>
   <Trd1 name="MECU_2_ME11Layer" dz="81*cm " dy1="[ME11CuFoilHalfThick]" dy2="[ME11CuFoilHalfThick]" dx1="15.065*cm" dx2="30.45*cm "/>
-  <Trd1 name="ME1A_ActiveGasVol" dz="21.56*cm" dy1="[ME11ActiveGasVolHalfThick]" dy2="[ME11ActiveGasVolHalfThick]" dx1="9.35*cm" dx2="13.365*cm"/>
-  <Trd1 name="ME11_ActiveGasVol" dz="52.81*cm" dy1="[ME11ActiveGasVolHalfThick]" dy2="[ME11ActiveGasVolHalfThick]" dx1="13.365*cm" dx2="23.31*cm"/>
+  <Trd1 name="ME1A_ActiveGasVol" dz="22.2*cm" dy1="[ME11ActiveGasVolHalfThick]" dy2="[ME11ActiveGasVolHalfThick]" dx1="9.57*cm" dx2="13.7*cm"/>
+  <Trd1 name="ME11_ActiveGasVol" dz="53.75*cm" dy1="[ME11ActiveGasVolHalfThick]" dy2="[ME11ActiveGasVolHalfThick]" dx1="13.7*cm" dx2="23.7*cm"/>
   <Box name="MEEQ" dx="15*cm " dy="2.5*cm " dz="30*cm "/>
   <Tubs name="AlgPinNarrowEnd" rMin="0*mm " rMax="4.06*mm " dz="18.8*mm " startPhi="0*deg" deltaPhi="360*deg"/>
   <Tubs name="AlgPinWideEnd" rMin="0*mm " rMax="4.06*mm " dz="18.8*mm " startPhi="0*deg" deltaPhi="360*deg"/>


### PR DESCRIPTION
Slightly increase the dimensions in local x and y for the CSC ME1/1 chamber layers, because we have found they are a little too small at present: hit strip distributions are currently slightly narrower in simulated data than in real data. Increase by about ½ a strip width at each edge, so this is a small correction (about 2% increase in linear dimensions.)
