### PR TITLE
Force (via bool) simHit matching without CF pointers from digiSimLinks

### DIFF
--- a/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
+++ b/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
@@ -74,13 +74,15 @@ class TrackerHitAssociator {
   //  std::vector<SimHitIdpr> associateSimpleRecHit(const SiStripRecHit2D * simplerechit);
   void associateSimpleRecHit(const SiStripRecHit2D * simplerechit,std::vector<SimHitIdpr> & simhitid);
   void associateSiStripRecHit1D(const SiStripRecHit1D * simplerechit,std::vector<SimHitIdpr> & simhitid);
+  /*
   void associateSimpleRecHitCluster(const SiStripCluster* clust,
 				    const uint32_t& detID,
 				    std::vector<SimHitIdpr>& theSimtrackid,
-				    std::vector<PSimHit>& simhit);
+				    std::vector<PSimHit>& clusterSimHits);
   void associateSimpleRecHitCluster(const SiStripCluster* clust,
 				    const uint32_t& detID,
-				    std::vector<PSimHit>& simhit);
+				    std::vector<PSimHit>& clusterSimHits);
+  */
   void associateSimpleRecHitCluster(const SiStripCluster* clust,
 				    const uint32_t& detID,
 				    std::vector<SimHitIdpr>& simtrackid);
@@ -98,6 +100,7 @@ class TrackerHitAssociator {
   typedef std::map<unsigned int, std::vector<PSimHit> > simhit_map;
   typedef simhit_map::iterator simhit_map_iterator;
   simhit_map SimHitMap;
+  simhit_map SimHitSubdetMap;
   std::vector<PSimHit> thePixelHits;
  
  private:
@@ -108,7 +111,7 @@ class TrackerHitAssociator {
   //ADDED NOW AS A PRIVATE MEMBER
   edm::Handle<CrossingFrame<PSimHit> > cf_simhit;
   std::vector<const CrossingFrame<PSimHit> *> cf_simhitvec;
-  MixCollection<PSimHit>  TrackerHits;
+  /* MixCollection<PSimHit>  TrackerHits; */
 
   edm::Handle< edm::DetSetVector<StripDigiSimLink> >  stripdigisimlink;
   edm::Handle< edm::DetSetVector<PixelDigiSimLink> >  pixeldigisimlink;
@@ -121,6 +124,7 @@ class TrackerHitAssociator {
   bool StripHits;
   
   bool doPixel_, doStrip_, doTrackAssoc_;
+  bool useCFpos_;
   
 };  
 


### PR DESCRIPTION
This change is to restore the hit residuals in relMon that were broken at CMSSW_6_2_0_pre8 as a side effect of the revised tracking particles. A branch in the code that was already in place for pixels is now executed for the strips as well. This branch doesn't depend on the (broken) crossing-frame pointers of the digiSimLinks. Modified files:
SimTracker / TrackerHitAssociation / interface / TrackerHitAssociator.h
SimTracker / TrackerHitAssociation / src / TrackerHitAssociator.cc
