### PR TITLE
Add missing std:: qualifiers

### DIFF
--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaGui.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaGui.h
@@ -179,20 +179,20 @@
 ///       TEcnaParPaths* pCnaParPaths = new TEcnaParPaths(MyEcnaObjectManager);
 ///       if( pCnaParPaths->GetPaths() == kTRUE )
 ///         {
-///           cout << "*EcnaGuiEB> Starting ROOT session" << endl;
+///           std::cout << "*EcnaGuiEB> Starting ROOT session" << std::endl;
 ///           TRint theApp("App", &argc, argv);
 ///           
-///           cout << "*EcnaGuiEB> Starting ECNA session" << endl;
+///           std::cout << "*EcnaGuiEB> Starting ECNA session" << std::endl;
 ///           TEcnaGui* mainWin = new TEcnaGui(MyEcnaObjectManager, "EB", gClient->GetRoot(), 395, 710);
 ///           mainWin->DialogBox();
 ///           Bool_t retVal = kTRUE;
 ///           theApp.Run(retVal);
-///           cout << "*EcnaGuiEB> End of ECNA session." << endl;
+///           std::cout << "*EcnaGuiEB> End of ECNA session." << std::endl;
 ///           delete mainWin;
 ///     
-///           cout << "*EcnaGuiEB> End of ROOT session." << endl;
+///           std::cout << "*EcnaGuiEB> End of ROOT session." << std::endl;
 ///           theApp.Terminate(0);
-///           cout << "*EcnaGuiEB> Exiting main program." << endl;
+///           std::cout << "*EcnaGuiEB> Exiting main program." << std::endl;
 ///           exit(0);
 ///         }
 ///     }
@@ -878,7 +878,7 @@ class TEcnaGui : public TGMainFrame {
 
   //==================================================== Miscellaneous parameters
 
-  //ofstream fFcout_f;
+  //std::ofstream fFcout_f;
 
   TString  fKeyAnaType;           // Type of analysis
 

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaParPaths.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaParPaths.h
@@ -36,11 +36,11 @@ class TEcnaParPaths : public TObject {
 
   Int_t   fCnaCommand,  fCnaError;
 
-  ifstream fFcin_rr;          // stream for results root files 
-  ifstream fFcin_ra;          // stream for results ascii files 
-  ifstream fFcin_lor;         // stream for list of runs files
-  //  ifstream fFcin_anapar;      // stream for EcnaAnalyzer parameters files
-  ifstream fFcin_cmssw;       // stream for cmssw version and subsystem 
+  std::ifstream fFcin_rr;          // stream for results root files 
+  std::ifstream fFcin_ra;          // stream for results ascii files 
+  std::ifstream fFcin_lor;         // stream for list of runs files
+  //  std::ifstream fFcin_anapar;      // stream for EcnaAnalyzer parameters files
+  std::ifstream fFcin_cmssw;       // stream for cmssw version and subsystem 
 
   TString fCfgResultsRootFilePath;     // absolute path for the results .root files (/afs/etc...)
   TString fFileForResultsRootFilePath; // name of the file containing the results .root  file path

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaRead.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaRead.h
@@ -96,7 +96,7 @@
 ///
 ///     if( MyCnaRead->LookAtRootFile() == kFALSE )
 ///        {
-///          cout << "*** ERROR: ROOT file not found" << endl;
+///          std::cout << "*** ERROR: ROOT file not found" << std::endl;
 ///        }
 ///      else
 ///        {
@@ -122,7 +122,7 @@
 ///             }
 ///           else
 ///             {
-///               cout << "problem while reading file. data not available. " << endl;
+///               std::cout << "problem while reading file. data not available. " << std::endl;
 ////            }
 ///
 ///        }

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaRun.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaRun.h
@@ -504,7 +504,7 @@ class TEcnaRun: public TObject {
   Int_t**     fT2dCrysNumbersTable;
   Int_t*      fT1dCrysNumbersTable;
 
-  ofstream    fFcout_f;
+  std::ofstream    fFcout_f;
 
   Int_t       fFlagPrint;
   Int_t       fCodePrintComments, fCodePrintWarnings, fCodePrintAllComments, fCodePrintNoComment;

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaWrite.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/interface/TEcnaWrite.h
@@ -58,7 +58,7 @@ class TEcnaWrite : public TObject {
   TEcnaParPaths  *fCnaParPaths;
   TEcnaParCout   *fCnaParCout;
 
-  ofstream fFcout_f;
+  std::ofstream fFcout_f;
 
   //...................................... Codes for file names
   Int_t fCodeHeaderAscii;

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaGui.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaGui.cc
@@ -21,8 +21,8 @@ ClassImp(TEcnaGui)
 
 #define DEST
 #ifdef DEST
-  // cout << "TEcnaGui> Entering destructor" << endl;
-  // cout << "            fCnew = " << fCnew << ", fCdelete = " << fCdelete << endl;
+  // std::cout << "TEcnaGui> Entering destructor" << std::endl;
+  // std::cout << "            fCnew = " << fCnew << ", fCdelete = " << fCdelete << std::endl;
  
   //.... general variables 
   //if ( fHistos             != 0 ) {delete fHistos;             fCdelete++;}
@@ -578,13 +578,13 @@ ClassImp(TEcnaGui)
 
   if ( fCnew != fCdelete )
     {
-      cout << "*TEcnaGui> WRONG MANAGEMENT OF ALLOCATIONS: fCnew = "
-	   << fCnew << ", fCdelete = " << fCdelete << endl;
+      std::cout << "*TEcnaGui> WRONG MANAGEMENT OF ALLOCATIONS: fCnew = "
+	   << fCnew << ", fCdelete = " << fCdelete << std::endl;
     }
   else
     {
-      //cout << "*TEcnaGui> BRAVO! GOOD MANAGEMENT OF ALLOCATIONS: fCnew = "
-      //   << fCnew << ", fCdelete = " << fCdelete << endl;
+      //std::cout << "*TEcnaGui> BRAVO! GOOD MANAGEMENT OF ALLOCATIONS: fCnew = "
+      //   << fCnew << ", fCdelete = " << fCdelete << std::endl;
     }
 
 #endif // DEST
@@ -593,21 +593,21 @@ ClassImp(TEcnaGui)
 #ifndef MGRA
   if ( fCnewRoot != fCdeleteRoot )
     {
-      cout << "*TEcnaGui> WRONG MANAGEMENT OF ROOT ALLOCATIONS: fCnewRoot = "
-	   << fCnewRoot << ", fCdeleteRoot = " << fCdeleteRoot << endl;
+      std::cout << "*TEcnaGui> WRONG MANAGEMENT OF ROOT ALLOCATIONS: fCnewRoot = "
+	   << fCnewRoot << ", fCdeleteRoot = " << fCdeleteRoot << std::endl;
     }
   else
     {
-      cout << "*TEcnaGui> BRAVO! GOOD MANAGEMENT OF ROOT ALLOCATIONS:"
+      std::cout << "*TEcnaGui> BRAVO! GOOD MANAGEMENT OF ROOT ALLOCATIONS:"
 	   << " fCnewRoot = " << fCnewRoot <<", fCdeleteRoot = "
-	   << fCdeleteRoot << endl;
+	   << fCdeleteRoot << std::endl;
     }
 #endif // MGRA
 
-  // cout << "TEcnaGui> Leaving destructor" << endl;
-  // cout << "            fCnew = " << fCnew << ", fCdelete = " << fCdelete << endl;
+  // std::cout << "TEcnaGui> Leaving destructor" << std::endl;
+  // std::cout << "            fCnew = " << fCnew << ", fCdelete = " << fCdelete << std::endl;
 
-  // cout << "[Info Management] CLASS: TEcnaGui.           DESTROY OBJECT: this = " << this << endl;
+  // std::cout << "[Info Management] CLASS: TEcnaGui.           DESTROY OBJECT: this = " << this << std::endl;
 
 }
 //   end of destructor
@@ -626,10 +626,10 @@ TEcnaGui::TEcnaGui()
 TEcnaGui::TEcnaGui(TEcnaObject* pObjectManager, const TString& SubDet, const TGWindow *p, UInt_t w, UInt_t h):
 TGMainFrame(p, w, h) 
 {
-  // cout << "[Info Management] CLASS: TEcnaGui.           CREATE OBJECT: this = " << this << endl;
+  // std::cout << "[Info Management] CLASS: TEcnaGui.           CREATE OBJECT: this = " << this << std::endl;
 
-  // cout << "TEcnaGui> Entering constructor with arguments" << endl;
-  // cout << "            fCnew = " << fCnew << ", fCdelete = " << fCdelete << endl;
+  // std::cout << "TEcnaGui> Entering constructor with arguments" << std::endl;
+  // std::cout << "            fCnew = " << fCnew << ", fCdelete = " << fCdelete << std::endl;
 
   Init();
 
@@ -3259,9 +3259,9 @@ void TEcnaGui::DialogBox()
 //  fKeyPyf = listchain;
   
 //  fCnaCommand++;
-//  cout << "   *TEcnaGui [" << fCnaCommand
+//  std::cout << "   *TEcnaGui [" << fCnaCommand
 //       << "]> Registration of file name for python file source sector -> "
-//       << fKeyPyf.Data() << endl;
+//       << fKeyPyf.Data() << std::endl;
 //}
 //----------------------------------------------------------------------
 void TEcnaGui::DoButtonAna()
@@ -3273,9 +3273,9 @@ void TEcnaGui::DoButtonAna()
   fKeyAnaType = bufferchain;
   
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of analysis name -> "
-       << fKeyAnaType << endl;
+       << fKeyAnaType << std::endl;
 }
 
 //----------------------------------------------------------------------
@@ -3290,11 +3290,11 @@ void TEcnaGui::DoButtonNors()
   if ( !(fKeyNbOfSamples >= 1 && fKeyNbOfSamples <= fEcal->MaxSampADC()) )
     {
       fCnaError++;
-      cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===>"
+      std::cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===>"
 	   << " Number of required samples for reading ROOT file = " << fKeyNbOfSamples
-	   << ": OUT OF RANGE, " << endl 
+	   << ": OUT OF RANGE, " << std::endl 
 	   << "                                        forced to the default value (="
-	   << fEcal->MaxSampADC() << ")." << fTTBELL << endl;
+	   << fEcal->MaxSampADC() << ")." << fTTBELL << std::endl;
       fKeyNbOfSamples = fEcal->MaxSampADC();
       DisplayInEntryField(fNorsText,fKeyNbOfSamples);
     }
@@ -3316,9 +3316,9 @@ void TEcnaGui::DoButtonNors()
   fSampBut->SetText(xSampButText);
   
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of number of samples in ROOT file -> "
-       << fKeyNbOfSamples << endl;
+       << fKeyNbOfSamples << std::endl;
 }
 //----------------------------------------------------------------------
 void TEcnaGui::DoButtonNbSampForCalc()
@@ -3332,18 +3332,18 @@ void TEcnaGui::DoButtonNbSampForCalc()
   if ( !(fKeyNbOfSampForCalc >= 1 && fKeyNbOfSampForCalc <= fKeyNbOfSamples) )
     {
       fCnaError++;
-      cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===>"
+      std::cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===>"
 	   << " Number of required samples for calculations = " << fKeyNbOfSampForCalc
-	   << ": OUT OF RANGE, " << endl 
+	   << ": OUT OF RANGE, " << std::endl 
 	   << "                                        forced to the default value (="
-	   << fKeyNbOfSamples << ")." << fTTBELL << endl;
+	   << fKeyNbOfSamples << ")." << fTTBELL << std::endl;
       fKeyNbOfSampForCalc = fKeyNbOfSamples;
       DisplayInEntryField(fNbSampForCalcText,fKeyNbOfSampForCalc);
     }
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of number of samples for calculations -> "
-       << fKeyNbOfSampForCalc << endl;
+       << fKeyNbOfSampForCalc << std::endl;
 }
 
 //----------------------------------------------------------------------
@@ -3356,9 +3356,9 @@ void TEcnaGui::DoButtonRun()
   fKeyRunNumberString = bufferchain;
   fKeyRunNumber = atoi(bufferchain);
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of run number -> "
-       << fKeyRunNumber << endl;
+       << fKeyRunNumber << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3373,16 +3373,16 @@ void TEcnaGui::DoButtonFev()
   if ( fKeyFirstReqEvtNumber <= 0)
     {
       fCnaError++;
-      cout << "   !TEcnaGui (" << fCnaError << ") *ERROR* ===> "
+      std::cout << "   !TEcnaGui (" << fCnaError << ") *ERROR* ===> "
 	   << " First event number = " << fKeyFirstReqEvtNumber
-	   << ": negative. " << endl 
-	   << fTTBELL << endl;
+	   << ": negative. " << std::endl 
+	   << fTTBELL << std::endl;
     }
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of first requested event number -> "
-       << fKeyFirstReqEvtNumber << endl;
+       << fKeyFirstReqEvtNumber << std::endl;
 }
 //-------------------------------------------------------------------
 void TEcnaGui::DoButtonLev()
@@ -3396,16 +3396,16 @@ void TEcnaGui::DoButtonLev()
   if ( fKeyLastReqEvtNumber <= fKeyFirstReqEvtNumber )
     {
       fCnaError++;
-      cout << "   !TEcnaGui (" << fCnaError << ") *WARNING* ===> "
+      std::cout << "   !TEcnaGui (" << fCnaError << ") *WARNING* ===> "
 	   << " Last requested event number = " << fKeyLastReqEvtNumber
 	   << ": less than first requested event number (= " << fKeyFirstReqEvtNumber << ")." 
-	   << endl;
+	   << std::endl;
     }
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of last requested event number -> "
-       << fKeyLastReqEvtNumber << endl;
+       << fKeyLastReqEvtNumber << std::endl;
 }
 //-------------------------------------------------------------------
 void TEcnaGui::DoButtonRev()
@@ -3421,26 +3421,26 @@ void TEcnaGui::DoButtonRev()
   if( fKeyLastReqEvtNumber < fKeyFirstReqEvtNumber)
     {
       fCnaError++;
-      cout << "   !TEcnaGui (" << fCnaError << ") *WARNING* ===> "
+      std::cout << "   !TEcnaGui (" << fCnaError << ") *WARNING* ===> "
 	   << " Last requested event number = " << fKeyLastReqEvtNumber
 	   << " less than first requested event number = " << fKeyFirstReqEvtNumber
-	   << endl;
+	   << std::endl;
     }
 
   if ( fKeyLastReqEvtNumber >= fKeyFirstReqEvtNumber && fKeyReqNbOfEvts > nb_range_evts )
     {
       fCnaError++;
-      cout << "   !TEcnaGui (" << fCnaError << ") *WARNING* ===> "
+      std::cout << "   !TEcnaGui (" << fCnaError << ") *WARNING* ===> "
 	   << " Nb of requested events = " << fKeyReqNbOfEvts
 	   << ": out of range (range = " << fKeyFirstReqEvtNumber << ","
 	   << fKeyLastReqEvtNumber << ") => " << nb_range_evts << " events."
-	   << endl;
+	   << std::endl;
     }
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of requested number of events -> "
-       << fKeyReqNbOfEvts << endl;
+       << fKeyReqNbOfEvts << std::endl;
 }
 
 //-------------------------------------------------------------------
@@ -3455,9 +3455,9 @@ void TEcnaGui::DoButtonStex()
   if( fSubDet == "EB" )
     {
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
+      std::cout << "   *TEcnaGui [" << fCnaCommand
 	   << "]> Registration of SuperModule number -> "
-	   << fKeyStexNumber << endl;
+	   << fKeyStexNumber << std::endl;
 
       //.......... Positive number for EB- [-1,-18] -> [19,36]  
       if( fKeyStexNumber < 0 ){fKeyStexNumber = - fKeyStexNumber + fEcal->MaxSMInEB()/2;}
@@ -3465,11 +3465,11 @@ void TEcnaGui::DoButtonStex()
       if( (fKeyStexNumber < 0) || (fKeyStexNumber > fEcal->MaxSMInEB() )  )
 	{
 	  fCnaError++;
-	  cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> "
+	  std::cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> "
 	       << " EB / SM number = " << fKeyStexNumber
 	       << ": out of range. Range = 0 (EB) or [ 1 ," << fEcal->MaxSMInEB() << " ] (SM)"
 	       << " or [ -" << fEcal->MaxSMInEBMinus() << ", +" <<  fEcal->MaxSMInEBPlus() << "] (SM)"
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
     }
 
@@ -3503,17 +3503,17 @@ void TEcnaGui::DoButtonStex()
 	}
       //............................................ Command message
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
+      std::cout << "   *TEcnaGui [" << fCnaCommand
 	   << "]> Registration of Dee number -> "
-	   << fKeyStexNumber << endl;
+	   << fKeyStexNumber << std::endl;
       
       if ( (fKeyStexNumber < 0) || (fKeyStexNumber > fEcal->MaxDeeInEE() )  )
 	{
 	  fCnaError++;
-	  cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> "
+	  std::cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> "
 	       << " EE / Dee number = " << fKeyStexNumber
 	       << ": out of range. Range = 0 (EE) or [ 1 ," << fEcal->MaxDeeInEE() << " ] (Dee)"
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
     }  // -- end of if( fSubDet == "EE" ) -------
 }
@@ -3528,9 +3528,9 @@ void TEcnaGui::DoButtonVminD_NOE_ChNb()
   fKeyVminD_NOE_ChNb = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymin for plot 'number of events' -> "
-       << fKeyVminD_NOE_ChNb << endl;
+       << fKeyVminD_NOE_ChNb << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3543,9 +3543,9 @@ void TEcnaGui::DoButtonVmaxD_NOE_ChNb()
   fKeyVmaxD_NOE_ChNb = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymax for plot 'number of events' -> "
-       << fKeyVmaxD_NOE_ChNb << endl;
+       << fKeyVmaxD_NOE_ChNb << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3558,9 +3558,9 @@ void TEcnaGui::DoButtonVminD_Ped_ChNb()
   fKeyVminD_Ped_ChNb = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymin for plot 'pedestal' -> "
-       << fKeyVminD_Ped_ChNb << endl;
+       << fKeyVminD_Ped_ChNb << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3573,9 +3573,9 @@ void TEcnaGui::DoButtonVmaxD_Ped_ChNb()
   fKeyVmaxD_Ped_ChNb = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymax for plot 'pedestal' -> "
-       << fKeyVmaxD_Ped_ChNb << endl;
+       << fKeyVmaxD_Ped_ChNb << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3588,9 +3588,9 @@ void TEcnaGui::DoButtonVminD_TNo_ChNb()
   fKeyVminD_TNo_ChNb = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymin for plot 'total noise' -> "
-       << fKeyVminD_TNo_ChNb << endl;
+       << fKeyVminD_TNo_ChNb << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3603,9 +3603,9 @@ void TEcnaGui::DoButtonVmaxD_TNo_ChNb()
   fKeyVmaxD_TNo_ChNb = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymax for plot 'total noise' -> "
-       << fKeyVmaxD_TNo_ChNb << endl;
+       << fKeyVmaxD_TNo_ChNb << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3618,9 +3618,9 @@ void TEcnaGui::DoButtonVminD_MCs_ChNb()
   fKeyVminD_MCs_ChNb = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymin for plot 'mean cor(s,s')' -> "
-       << fKeyVminD_MCs_ChNb << endl;
+       << fKeyVminD_MCs_ChNb << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3633,9 +3633,9 @@ void TEcnaGui::DoButtonVmaxD_MCs_ChNb()
   fKeyVmaxD_MCs_ChNb = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymax for plot 'mean cor(s,s')' -> "
-       << fKeyVmaxD_MCs_ChNb << endl;
+       << fKeyVmaxD_MCs_ChNb << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3649,9 +3649,9 @@ void TEcnaGui::DoButtonVminD_LFN_ChNb()
   fKeyVminD_LFN_ChNb = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymin for plot 'low frequency noise' -> "
-       << fKeyVminD_LFN_ChNb << endl;
+       << fKeyVminD_LFN_ChNb << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3664,9 +3664,9 @@ void TEcnaGui::DoButtonVmaxD_LFN_ChNb()
   fKeyVmaxD_LFN_ChNb = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymax for plot 'low frequency noise' -> "
-       << fKeyVmaxD_LFN_ChNb << endl;
+       << fKeyVmaxD_LFN_ChNb << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3679,9 +3679,9 @@ void TEcnaGui::DoButtonVminD_HFN_ChNb()
   fKeyVminD_HFN_ChNb = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymin for plot 'high frequency noise' -> "
-       << fKeyVminD_HFN_ChNb << endl;
+       << fKeyVminD_HFN_ChNb << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3694,9 +3694,9 @@ void TEcnaGui::DoButtonVmaxD_HFN_ChNb()
   fKeyVmaxD_HFN_ChNb = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymax for plot 'high frequency noise' -> "
-       << fKeyVmaxD_HFN_ChNb << endl;
+       << fKeyVmaxD_HFN_ChNb << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3709,9 +3709,9 @@ void TEcnaGui::DoButtonVminD_SCs_ChNb()
   fKeyVminD_SCs_ChNb = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymin for plot 'sigma of cor(s,s')' -> "
-       << fKeyVminD_SCs_ChNb << endl;
+       << fKeyVminD_SCs_ChNb << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3724,9 +3724,9 @@ void TEcnaGui::DoButtonVmaxD_SCs_ChNb()
   fKeyVmaxD_SCs_ChNb = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymax for plot 'sigma of cor(s,s')' -> "
-       << fKeyVmaxD_SCs_ChNb << endl;
+       << fKeyVmaxD_SCs_ChNb << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3739,9 +3739,9 @@ void TEcnaGui::DoButtonVminLFccMos()
   fKeyVminLFccMos = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymin for plot 'mean LF |cor(c,c')|' -> "
-       << fKeyVminLFccMos << endl;
+       << fKeyVminLFccMos << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3754,9 +3754,9 @@ void TEcnaGui::DoButtonVmaxLFccMos()
   fKeyVmaxLFccMos = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymax for plot 'mean LF |cor(c,c')|' -> "
-       << fKeyVmaxLFccMos << endl;
+       << fKeyVmaxLFccMos << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3769,9 +3769,9 @@ void TEcnaGui::DoButtonVminHFccMos()
   fKeyVminHFccMos = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymin for plot 'mean HF |cor(c,c')|' -> "
-       << fKeyVminHFccMos << endl;
+       << fKeyVminHFccMos << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3784,9 +3784,9 @@ void TEcnaGui::DoButtonVmaxHFccMos()
   fKeyVmaxHFccMos = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymax for plot 'mean HF |cor(c,c')|' -> "
-       << fKeyVmaxHFccMos << endl;
+       << fKeyVmaxHFccMos << std::endl;
 }
 
 //-------------------------------------------------------------------
@@ -3800,9 +3800,9 @@ void TEcnaGui::DoButtonVminLHFcc()
   fKeyVminLHFcc = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymin for plot 'cor(c,c') in "
-       << fStinName.Data() << "s' -> " << fKeyVminLHFcc << endl;
+       << fStinName.Data() << "s' -> " << fKeyVminLHFcc << std::endl;
 }
 //-------------------------------------------------------------------
 
@@ -3815,9 +3815,9 @@ void TEcnaGui::DoButtonVmaxLHFcc()
   fKeyVmaxLHFcc = (Double_t)atof(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of Ymax for plot 'cor(c,c') in "
-       << fStinName.Data() << "s' -> " << fKeyVmaxLHFcc << endl;
+       << fStinName.Data() << "s' -> " << fKeyVmaxLHFcc << std::endl;
 }
 
 //-------------------------------------------------------------------
@@ -3842,26 +3842,26 @@ void TEcnaGui::DoButtonStinA()
   if( fSubDet == "EB" )
     {
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
+      std::cout << "   *TEcnaGui [" << fCnaCommand
 	   << "]> Registration of " << fStinName.Data() << " number -> "
-	   << xReadStinANumberForCons << endl;
+	   << xReadStinANumberForCons << std::endl;
 
       if ( (fKeyStinANumber < 1) || (fKeyStinANumber > fEcal->MaxStinEcnaInStex())  )
 	{
 	  fCnaError++;
-	  cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> " << fStinName.Data()
+	  std::cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> " << fStinName.Data()
 	       << " number = " << fKeyStinANumber
 	       << ": out of range ( range = [ 1 ," << fEcal->MaxStinEcnaInStex() << " ] ) "
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
     }
   
   if( fSubDet == "EE" )
     {
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
+      std::cout << "   *TEcnaGui [" << fCnaCommand
 	   << "]> Registration of " << fStinName.Data() << " number for construction -> "
-	   << xReadStinANumberForCons << endl;
+	   << xReadStinANumberForCons << std::endl;
 
       if( fKeyStexNumber > 0 && fKeyStexNumber <= fEcal->MaxDeeInEE() )
 	{
@@ -3872,18 +3872,18 @@ void TEcnaGui::DoButtonStinA()
 	      xReadStinANumberForCons > fEcal->MaxSCForConsInDee()+off_set_cons )
 	    {
 	      fCnaError++;
-	      cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> SC nb for construction = "
+	      std::cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> SC nb for construction = "
 		   << xReadStinANumberForCons << ". Out of range ( range = [ " << off_set_cons+1
 		   << "," << fEcal->MaxSCForConsInDee()+off_set_cons << "] )"
-		   << fTTBELL << endl;
+		   << fTTBELL << std::endl;
 	    }
 	}
       else
 	{
 	  fCnaError++;
-	  cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> DeeNumber = " <<  fKeyStexNumber
+	  std::cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> DeeNumber = " <<  fKeyStexNumber
 	       << ". Out of range ( range = [1," << fEcal->MaxDeeInEE() << "] )"
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}      
     }
 }
@@ -3902,19 +3902,19 @@ void TEcnaGui::DoButtonStinB()
     {fKeyStinBNumber = fEcalNumbering->Get1DeeSCEcnaFromDeeSCCons(fKeyStexNumber, xReadStinBNumberForCons);}
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of " << fStinName.Data() << "' number -> "
-       << xReadStinBNumberForCons << endl;
+       << xReadStinBNumberForCons << std::endl;
 
   if( fSubDet == "EB" )
     {
       if ( (fKeyStinBNumber < 1) || (fKeyStinBNumber > fEcal->MaxStinEcnaInStex())  )
 	{
 	  fCnaError++;
-	  cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> " << fStinName.Data()
+	  std::cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> " << fStinName.Data()
 	       << "' number = " << fKeyStinBNumber
 	       << ": out of range ( range = [ 1 ," << fEcal->MaxStinEcnaInStex() << " ] ) "
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
     }
   
@@ -3929,18 +3929,18 @@ void TEcnaGui::DoButtonStinB()
 	      xReadStinBNumberForCons > fEcal->MaxSCForConsInDee()+off_set_cons )
 	    {
 	      fCnaError++;
-	      cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> SC nb for construction = "
+	      std::cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> SC nb for construction = "
 		   << xReadStinBNumberForCons << ". Out of range ( range = [ " << off_set_cons+1
 		   << "," << fEcal->MaxSCForConsInDee()+off_set_cons << "] )"
-		   << fTTBELL << endl;
+		   << fTTBELL << std::endl;
 	    }
 	}
       else
 	{
 	  fCnaError++;
-	  cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> DeeNumber = " <<  fKeyStexNumber
+	  std::cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> DeeNumber = " <<  fKeyStexNumber
 	       << ". Out of range ( range = [1," << fEcal->MaxDeeInEE() << "] )"
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}      
     }
 }
@@ -3967,18 +3967,18 @@ void TEcnaGui::DoButtonChan()
 
   fKeyChanNumber = xReadNumber-Choffset;   // fKeyChanNumber : range = [0,25]
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of " << ChString.Data() << " number -> "
-       << xReadNumber << endl;
+       << xReadNumber << std::endl;
   
   if ( (fKeyChanNumber < 0) || (fKeyChanNumber > fEcal->MaxCrysInStin()-1 )  )
     {
       fCnaError++;
-      cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> "
+      std::cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> "
 	   << ChString.Data() << " number in " << fStinName.Data() << " = " << xReadNumber
 	   << ": out of range ( range = [" << Choffset << ","
 	   << fEcal->MaxCrysInStin()-1+Choffset << "] )"
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
     } 
 }
 //-------------------------------------------------------------------
@@ -3990,17 +3990,17 @@ void TEcnaGui::DoButtonSamp()
   Int_t xKeySampNumber = atoi(bufferchain);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of sample number -> "
-       << xKeySampNumber << endl;
+       << xKeySampNumber << std::endl;
 
   if ( (xKeySampNumber < 1) || (xKeySampNumber > fKeyNbOfSamples )  )
     {
       fCnaError++;
-      cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> "
+      std::cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> "
      	   << " Sample number = " << xKeySampNumber
      	   << ": out of range ( range = [ 1 ," << fKeyNbOfSamples << " ] )"
-     	   << fTTBELL << endl;
+     	   << fTTBELL << std::endl;
     }
 
   fKeySampNumber = xKeySampNumber-1;
@@ -4016,9 +4016,9 @@ void TEcnaGui::DoButtonRul()
   if( listchain[0] == '\0' )
     {
       fCnaError++;
-      cout << "   !TEcnaGui (" << fCnaError << ") *ERROR* ===> "
+      std::cout << "   !TEcnaGui (" << fCnaError << ") *ERROR* ===> "
 	   << " Empty file name in entry for TIME EVOLUTION plots."
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
       fKeyFileNameRunList = fKeyRunListInitCode;
     }
   else
@@ -4033,18 +4033,18 @@ void TEcnaGui::DoButtonRul()
 	  listchain[0] == tchiffr [8] || listchain[0] == tchiffr [9] )
 	{
 	  fCnaError++;
-	  cout << "   !TEcnaGui (" << fCnaError << ") *ERROR* ===> "
+	  std::cout << "   !TEcnaGui (" << fCnaError << ") *ERROR* ===> "
 	       << " Please, enter a file name beginning with an alphabetic letter."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       else
 	{
 	  fKeyFileNameRunList = listchain;
 	  
 	  fCnaCommand++;
-	  cout << "   *TEcnaGui [" << fCnaCommand
+	  std::cout << "   *TEcnaGui [" << fCnaCommand
 	       << "]> Registration of run list file name for history plots -> "
-	       << fKeyFileNameRunList.Data() << endl;
+	       << fKeyFileNameRunList.Data() << std::endl;
 	}
     }
 }
@@ -4058,9 +4058,9 @@ void TEcnaGui::DoButtonGent()
   fKeyGeneralTitle = listchain;
   
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Registration of general title -> "
-       << fKeyGeneralTitle.Data() << endl;
+       << fKeyGeneralTitle.Data() << std::endl;
 }
 //-------------------------------------------------------------------
 //
@@ -4076,8 +4076,8 @@ void TEcnaGui::DoButtonLogx()
   fMemoScaleX = fKeyScaleX;
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
-       << "]> X axis -> " << fKeyScaleX << " scale " << endl;
+  std::cout << "   *TEcnaGui [" << fCnaCommand
+       << "]> X axis -> " << fKeyScaleX << " scale " << std::endl;
 }
 void TEcnaGui::DoButtonLogy()
 {
@@ -4086,8 +4086,8 @@ void TEcnaGui::DoButtonLogy()
   fMemoScaleY = fKeyScaleY;
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
-       << "]> Y axis -> " << fKeyScaleY << " scale " << endl;
+  std::cout << "   *TEcnaGui [" << fCnaCommand
+       << "]> Y axis -> " << fKeyScaleY << " scale " << std::endl;
 }
 
 void TEcnaGui::DoButtonProjy()
@@ -4097,8 +4097,8 @@ void TEcnaGui::DoButtonProjy()
   fMemoProjY = fKeyProjY;
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
-       << "]> 1D Histo display -> " << fKeyProjY << " mode " << endl;
+  std::cout << "   *TEcnaGui [" << fCnaCommand
+       << "]> 1D Histo display -> " << fKeyProjY << " mode " << std::endl;
 }
 
 //------------------------------------------------------------------- Colors + Exit
@@ -4116,16 +4116,16 @@ void TEcnaGui::DoButtonColPal()
     {sColPalComment = "Rainbow option:   red-orange-yellow-green-blue-indigo-purple";}
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
-       << "]> Color palette -> " << sColPalComment << endl;
+  std::cout << "   *TEcnaGui [" << fCnaCommand
+       << "]> Color palette -> " << sColPalComment << std::endl;
 }
 
 void TEcnaGui::DoButtonExit()
 {
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Exit CNA session."
-       << endl;
+       << std::endl;
   //............................ Quit the ROOT session
   fButExit->SetCommand(".q");
 }
@@ -4135,8 +4135,8 @@ void TEcnaGui::DoButtonExit()
 void TEcnaGui::DoButtonClone()
 {
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
-       << "]> Clone last canvas. " << endl;
+  std::cout << "   *TEcnaGui [" << fCnaCommand
+       << "]> Clone last canvas. " << std::endl;
 
   if( fHistos == 0 ){fHistos = new TEcnaHistos(fObjectManager, fSubDet.Data());      /*fCnew++*/ ;}
   fHistos->PlotCloneOfCurrentCanvas();
@@ -4145,18 +4145,18 @@ void TEcnaGui::DoButtonClone()
 void TEcnaGui::DoButtonRoot()
 {
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> This is ROOT version " << gROOT->GetVersion()
-       << endl;
+       << std::endl;
 }
 //-------------------------------------------------------------------
 void TEcnaGui::DoButtonHelp()
 {
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
-       << "]> HELP: for documentation, see the ECNA web page: " << endl
+  std::cout << "   *TEcnaGui [" << fCnaCommand
+       << "]> HELP: for documentation, see the ECNA web page: " << std::endl
        << "    http://cms-fabbro.web.cern.ch/cms-fabbro/cna_new/Correlated_Noise_Analysis/ECNA_main_page.htm"
-       << endl;
+       << std::endl;
 }
 
 //===================================================================
@@ -4411,8 +4411,8 @@ void TEcnaGui::HandleMenu(Int_t id)
     {
       if(fKeyFileNameRunList == fKeyRunListInitCode )
 	{fCnaError++;
-	  cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> "
-	       << " EMPTY STRING for list of run file name (TIME EVOLUTION plots)." << fTTBELL << endl;}
+	  std::cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===> "
+	       << " EMPTY STRING for list of run file name (TIME EVOLUTION plots)." << fTTBELL << std::endl;}
       else
 	{
 	  //........................................ Pedestals                 (HandleMenu / ViewHistime)
@@ -4611,8 +4611,8 @@ void TEcnaGui::SubmitOnBatchSystem(const TString& QueueCode)
   if( (fConfirmSubmit == 1) && (fConfirmRunNumber == fKeyRunNumber) )
     {
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
-	   << "]> Submitting job in batch mode for run " << fConfirmRunNumber << endl;
+      std::cout << "   *TEcnaGui [" << fCnaCommand
+	   << "]> Submitting job in batch mode for run " << fConfirmRunNumber << std::endl;
 
       //.......................... get the path "modules/data"
       // /afs/cern.ch/user/U/USERNAME/cmssw/CMSSW_X_Y_Z/src/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/data/
@@ -4747,17 +4747,17 @@ void TEcnaGui::SubmitOnBatchSystem(const TString& QueueCode)
 
       if( i_exec_python != 0 )
 	{
-	  cout << "*TEcnaGui> Script for python file building was executed with error code = "
-	       << i_exec_python << "." << endl
-	       << "           python file: " << fPythonFileName.Data() << ".py" << endl
-	       << "           Command: " << CnaExecPythonCommand.Data() << endl
-	       << fTTBELL << endl;
+	  std::cout << "*TEcnaGui> Script for python file building was executed with error code = "
+	       << i_exec_python << "." << std::endl
+	       << "           python file: " << fPythonFileName.Data() << ".py" << std::endl
+	       << "           Command: " << CnaExecPythonCommand.Data() << std::endl
+	       << fTTBELL << std::endl;
 	}
       else
 	{
-	  cout << "*TEcnaGui> Script for python file building was successfully executed." << endl
-	       << "           python file: " << fPythonFileName.Data() << ".py" << endl
-	       << "           (Command: " << CnaExecPythonCommand.Data() << ")" << endl;
+	  std::cout << "*TEcnaGui> Script for python file building was successfully executed." << std::endl
+	       << "           python file: " << fPythonFileName.Data() << ".py" << std::endl
+	       << "           (Command: " << CnaExecPythonCommand.Data() << ")" << std::endl;
 
 	  //========================================================== Job submission script
 	  TString CnaSubmitCommand = ModulesdataPath;
@@ -4793,16 +4793,16 @@ void TEcnaGui::SubmitOnBatchSystem(const TString& QueueCode)
       
 	  if( i_exec_submit != 0 )
 	    {
-	      cout << "*TEcnaGui> Script for job submission was executed with error code = "
-		   << i_exec_submit << "."  << endl
-		   << "          Command: " << CnaExecSubmitCommand.Data() << endl
-		   << fTTBELL << endl;
+	      std::cout << "*TEcnaGui> Script for job submission was executed with error code = "
+		   << i_exec_submit << "."  << std::endl
+		   << "          Command: " << CnaExecSubmitCommand.Data() << std::endl
+		   << fTTBELL << std::endl;
 	    }
 	  else
 	    {
-	      cout << "*TEcnaGui> Job with configuration file: " << fPythonFileName.Data()
-		   << " was successfully submitted." << endl
-		   << "          (Command: " << CnaExecSubmitCommand.Data() << ")" << endl;	  
+	      std::cout << "*TEcnaGui> Job with configuration file: " << fPythonFileName.Data()
+		   << " was successfully submitted." << std::endl
+		   << "          (Command: " << CnaExecSubmitCommand.Data() << ")" << std::endl;	  
 	    }
       
 	  fConfirmSubmit          = 0;
@@ -4815,10 +4815,10 @@ void TEcnaGui::SubmitOnBatchSystem(const TString& QueueCode)
       if( fKeyAnaType.BeginsWith("Adc") )
 	{
 	  fCnaCommand++;
-	  cout << "   *TEcnaGui [" << fCnaCommand
+	  std::cout << "   *TEcnaGui [" << fCnaCommand
 	       << "]> Request for submitting job in batch mode for run " << fKeyRunNumber
 	       << ". Syntax OK. Please, click again to confirm."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	  
 	  fConfirmSubmit          = 1;
 	  fConfirmRunNumber       = fKeyRunNumber;
@@ -4827,10 +4827,10 @@ void TEcnaGui::SubmitOnBatchSystem(const TString& QueueCode)
       else
 	{
 	  fCnaError++;
-	  cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===>"
+	  std::cout << "   !TEcnaGui (" << fCnaError << ") *** ERROR *** ===>"
 	       << " Analysis name = " << fKeyAnaType
 	       << ": should begin with 'Adc'."
-	       << " Please, change the analysis name." << fTTBELL << endl;
+	       << " Please, change the analysis name." << fTTBELL << std::endl;
 	  
 	  fConfirmSubmit          = 0;
 	  fConfirmRunNumber       = 0;
@@ -4850,9 +4850,9 @@ void TEcnaGui::CleanBatchFiles(const TString& clean_code)
   //Clean python files, submission scripts,...
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Clean requested with code: " << clean_code
-       << endl;
+       << std::endl;
 
   //================================ CLEAN SUBMISSION SCRIPTS ===================================
   if( clean_code == "Sub"  || clean_code == "All")
@@ -4885,16 +4885,16 @@ void TEcnaGui::CleanBatchFiles(const TString& clean_code)
 
       if( i_exec_cleansubmission != 0 )
 	{
-	  cout << "*TEcnaGui> Script for submission script clean was executed with error code = "
-	       << i_exec_cleansubmission << "."  << endl
-	       << "          Command: " << CnaExecCleanSubmissionCommand.Data() << endl
-	       << fTTBELL << endl;
+	  std::cout << "*TEcnaGui> Script for submission script clean was executed with error code = "
+	       << i_exec_cleansubmission << "."  << std::endl
+	       << "          Command: " << CnaExecCleanSubmissionCommand.Data() << std::endl
+	       << fTTBELL << std::endl;
 	}
       else
 	{
-	  cout << "*TEcnaGui> Script for submission script clean"
-	       << " was successfully executed." << endl
-	       << "          (Command: " << CnaExecCleanSubmissionCommand.Data() << ")" << endl;	  
+	  std::cout << "*TEcnaGui> Script for submission script clean"
+	       << " was successfully executed." << std::endl
+	       << "          (Command: " << CnaExecCleanSubmissionCommand.Data() << ")" << std::endl;	  
 	}
 
     }
@@ -4930,16 +4930,16 @@ void TEcnaGui::CleanBatchFiles(const TString& clean_code)
 
       if( i_exec_cleanjobreport != 0 )
 	{
-	  cout << "*TEcnaGui> Script for LSFJOB report clean was executed with error code = "
-	       << i_exec_cleanjobreport << "."  << endl
-	       << "          Command: " << CnaExecCleanJobreportCommand.Data() << endl
-	       << fTTBELL << endl;
+	  std::cout << "*TEcnaGui> Script for LSFJOB report clean was executed with error code = "
+	       << i_exec_cleanjobreport << "."  << std::endl
+	       << "          Command: " << CnaExecCleanJobreportCommand.Data() << std::endl
+	       << fTTBELL << std::endl;
 	}
       else
 	{
-	  cout << "*TEcnaGui> Script for LSFJOB report clean"
-	       << " was successfully executed." << endl
-	       << "          (Command: " << CnaExecCleanJobreportCommand.Data() << ")" << endl;	  
+	  std::cout << "*TEcnaGui> Script for LSFJOB report clean"
+	       << " was successfully executed." << std::endl
+	       << "          (Command: " << CnaExecCleanJobreportCommand.Data() << ")" << std::endl;	  
 	}
     }
 
@@ -4971,16 +4971,16 @@ void TEcnaGui::CleanBatchFiles(const TString& clean_code)
 
       if( i_exec_cleanpython != 0 )
 	{
-	  cout << "*TEcnaGui> Script for python file clean was executed with error code = "
-	       << i_exec_cleanpython << "."  << endl
-	       << "          Command: " << CnaExecCleanPythonCommand.Data() << endl
-	       << fTTBELL << endl;
+	  std::cout << "*TEcnaGui> Script for python file clean was executed with error code = "
+	       << i_exec_cleanpython << "."  << std::endl
+	       << "          Command: " << CnaExecCleanPythonCommand.Data() << std::endl
+	       << fTTBELL << std::endl;
 	}
       else
 	{
-	  cout << "*TEcnaGui> Script for python file clean"
-	       << " was successfully executed." << endl
-	       << "          (Command: " << CnaExecCleanPythonCommand.Data() << ")" << endl;	  
+	  std::cout << "*TEcnaGui> Script for python file clean"
+	       << " was successfully executed." << std::endl
+	       << "          (Command: " << CnaExecCleanPythonCommand.Data() << ")" << std::endl;	  
 	}
     }
 }
@@ -4996,9 +4996,9 @@ void TEcnaGui::Calculations(const TString& calc_code)
   //Calculations of quantities (Pedestals, correlations, ... )
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Calculations requested with code: " << calc_code
-       << endl;
+       << std::endl;
 
   //===== Check if Analysis name is right 
   if( fKeyAnaType == "AdcPed1"  || fKeyAnaType == "AdcSPed1"  ||   
@@ -5031,9 +5031,9 @@ void TEcnaGui::Calculations(const TString& calc_code)
 
 		  if( MyRun->ReadSampleAdcValues(fKeyNbOfSampForCalc) == kTRUE )
 		    {
-		      cout << "*TEcnaGui::Calculations> File "
+		      std::cout << "*TEcnaGui::Calculations> File "
 			   << MyRun->GetRootFileNameShort() << " found. Starting calculations."
-			   << endl;
+			   << std::endl;
 
 		      MyRun->GetReadyToCompute();
 
@@ -5050,7 +5050,7 @@ void TEcnaGui::Calculations(const TString& calc_code)
 			    {
 			      //------ Additional calculations:
 			      //       "correlations" between Xtals and Stins (long time, big file)
-			      cout << "*TEcnaGui::Calculations> Please, wait." << endl;
+			      std::cout << "*TEcnaGui::Calculations> Please, wait." << std::endl;
 			  
 			      MyRun->Expert1Calculations();    //   (long time, big file)
 			      // <=> MyRun->LowFrequencyCorrelationsBetweenChannels();     //   (big file)
@@ -5065,7 +5065,7 @@ void TEcnaGui::Calculations(const TString& calc_code)
 			    {
 			      //---Additional calculations:
 			      //   "correlations" between Stins (long time, "normal" size file)
-			      cout << "*TEcnaGui::Calculations> Please, wait." << endl;
+			      std::cout << "*TEcnaGui::Calculations> Please, wait." << std::endl;
 
 			      MyRun->Expert2Calculations();    //  (long time but not big file)
 
@@ -5139,20 +5139,20 @@ void TEcnaGui::Calculations(const TString& calc_code)
 
 		      if( MyRun->WriteNewRootFile(calc_file_name.Data()) == kTRUE )
 			{
-			  cout << "*TEcnaGui::Calculations> Done. Write ROOT file: "
-			       << MyRun->GetNewRootFileNameShort() << " OK" << endl << endl;
+			  std::cout << "*TEcnaGui::Calculations> Done. Write ROOT file: "
+			       << MyRun->GetNewRootFileNameShort() << " OK" << std::endl << std::endl;
 			}
 		      else 
 			{
-			  cout << "!TEcnaGui::Calculations> Writing ROOT file failure for file "
+			  std::cout << "!TEcnaGui::Calculations> Writing ROOT file failure for file "
 			       << MyRun->GetNewRootFileNameShort()
-			       << fTTBELL << endl << endl;
+			       << fTTBELL << std::endl << std::endl;
 			}
 		    }
 		  else
 		    {
-		      cout << "!TEcnaGui::Calculations> " << MyRun->GetRootFileNameShort() << ": file not found."
-			   << fTTBELL << endl << endl;
+		      std::cout << "!TEcnaGui::Calculations> " << MyRun->GetRootFileNameShort() << ": file not found."
+			   << fTTBELL << std::endl << std::endl;
 		    }
 		  //.......................................................................
 		  delete MyRun; MyRun = 0;                    fCdelete++;
@@ -5161,28 +5161,28 @@ void TEcnaGui::Calculations(const TString& calc_code)
 	    } // end of if( fKeyNbOfSamples >= fKeyNbOfSampForCalc )
 	  else
 	    {
-	      cout << "!TEcnaGui::Calculations> *** ERROR *** Number of samples in file (=" << fKeyNbOfSamples
-		   << ") less than number of samples for calculations (= " << fKeyNbOfSampForCalc << "). " << endl;
+	      std::cout << "!TEcnaGui::Calculations> *** ERROR *** Number of samples in file (=" << fKeyNbOfSamples
+		   << ") less than number of samples for calculations (= " << fKeyNbOfSampForCalc << "). " << std::endl;
 	    }
 	} // end of if( calc_code == "Std" || ( ( calc_code == "Scc" || calc_code == "Stt" ) && fConfirmCalcScc == 1 ) )
       else
 	{
-	  cout << "   *TEcnaGui [" << fCnaCommand
+	  std::cout << "   *TEcnaGui [" << fCnaCommand
 	       << "]> Calculation requested with option " << calc_code
 	       << ". This can last more than 5 minutes. Please, click again to confirm."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	  fConfirmCalcScc = 1;
 	}
     }
   else
     {
-      cout << "!TEcnaGui::Calculations> fKeyAnaType = " << fKeyAnaType
-	   << "  : wrong code in analysis name." << endl
-	   << "                        List of available standard analysis names for calculations: " << endl
-	   << "                        AdcPed1,  AdcPed6,  AdcPed12,  AdcPeg12,  AdcLaser,  AdcPes12," << endl
-	   << "                        AdcSPed1, AdcSPed6, AdcSPed12, AdcSPeg12, AdcSLaser, AdcSPes12," << endl
+      std::cout << "!TEcnaGui::Calculations> fKeyAnaType = " << fKeyAnaType
+	   << "  : wrong code in analysis name." << std::endl
+	   << "                        List of available standard analysis names for calculations: " << std::endl
+	   << "                        AdcPed1,  AdcPed6,  AdcPed12,  AdcPeg12,  AdcLaser,  AdcPes12," << std::endl
+	   << "                        AdcSPed1, AdcSPed6, AdcSPed12, AdcSPeg12, AdcSLaser, AdcSPes12," << std::endl
 	   << "                        AdcPhys,  AdcAny (all names must begin with 'Adc')."
-	   << fTTBELL << endl; 
+	   << fTTBELL << std::endl; 
     }
 }
 //==========================================================================
@@ -5196,14 +5196,14 @@ void TEcnaGui::MessageCnaCommandReplyA(const TString& first_same_plot)
 {
   // reply message of the Cna command
 
-  cout << ". Analysis: " << fKeyAnaType << ", Run: " << fKeyRunNumber
+  std::cout << ". Analysis: " << fKeyAnaType << ", Run: " << fKeyRunNumber
        << ", 1st req. evt#: " << fKeyFirstReqEvtNumber
-       << ", last req. evt#: " << fKeyLastReqEvtNumber << endl;
+       << ", last req. evt#: " << fKeyLastReqEvtNumber << std::endl;
   
   if( first_same_plot == "ASCII" )
     {
-      cout  << "                   " << fStexName.Data() << ": " << fKeyStexNumber
-	    << ", option: " << first_same_plot << endl;
+      std::cout  << "                   " << fStexName.Data() << ": " << fKeyStexNumber
+	    << ", option: " << first_same_plot << std::endl;
     }
 }
 
@@ -5219,15 +5219,15 @@ void TEcnaGui::MessageCnaCommandReplyB(const TString& first_same_plot)
 	    {
 	      TString xAsciiFileName = fHistos->AsciiFileName();
 	      if( xAsciiFileName != "?" )
-		{cout  << "               Histo written in ASCII file: " << xAsciiFileName.Data();}
+		{std::cout  << "               Histo written in ASCII file: " << xAsciiFileName.Data();}
 	    }
 	}
       else
 	{
-	  cout  << "               No writing in ASCII file since "
+	  std::cout  << "               No writing in ASCII file since "
 		<< fStexName.Data() << " number = " << fKeyStexNumber;
 	}
-      cout << endl;
+      std::cout << std::endl;
     }
 }
 
@@ -5246,7 +5246,7 @@ void TEcnaGui::ViewMatrixLowFrequencyMeanCorrelationsBetweenStins(const TString&
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Low Frequency Mean Cor(c,c') for each pair of " << fStinName.Data()
        << "s. Option: "
        << option_plot;
@@ -5268,7 +5268,7 @@ void TEcnaGui::ViewMatrixHighFrequencyMeanCorrelationsBetweenStins(const TString
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> High Frequency Mean Cor(c,c') for each pair of " << fStinName.Data()
        << "s. Option: "
        << option_plot;
@@ -5293,7 +5293,7 @@ void TEcnaGui::ViewMatrixLowFrequencyCorrelationsBetweenChannels(const Int_t&  c
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);
   
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Low Frequency Correlation matrix between channels. "
        << fStinName.Data() << " A: " << cStexStin_A
        << ", " << fStinName.Data() << " B: " << cStexStin_B
@@ -5317,7 +5317,7 @@ void TEcnaGui::ViewMatrixHighFrequencyCorrelationsBetweenChannels(const Int_t&  
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);
   
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> High Frequency Correlation matrix between channels. "
        << fStinName.Data() << " A: " << cStexStin_A
        << ", " << fStinName.Data() << " B: " << cStexStin_B
@@ -5341,7 +5341,7 @@ void TEcnaGui::ViewStexLowFrequencyCorcc()
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> LF Correlations between channels for each " << fStinName.Data()
        << " in " << fStexName.Data() << ". 2D histo. "
        << fStexName.Data() << ": " << fKeyStexNumber;
@@ -5364,7 +5364,7 @@ void TEcnaGui::ViewStexHighFrequencyCorcc()
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> HF Correlations between channels for each " << fStinName.Data()
        << " in " << fStexName.Data() << ". 2D histo. "
        << fStexName.Data() << ": " << fKeyStexNumber;
@@ -5392,7 +5392,7 @@ void TEcnaGui::ViewMatrixCorrelationSamples(const Int_t&  cStexStin_A, const Int
   if(fSubDet == "EE"){ChOffset = 1;}
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Correlation matrix between samples. "
        << fStinName.Data() << ": " << cStexStin_A  << ", channel " << i0StinEcha + ChOffset
        << ", option: " << option_plot;
@@ -5420,7 +5420,7 @@ void TEcnaGui::ViewMatrixCovarianceSamples(const Int_t&  cStexStin_A, const Int_
   if(fSubDet == "EE"){ChOffset = 1;}
   
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Covariance matrix between samples. "
        << fStinName.Data() << ": " << cStexStin_A  << ", channel " << i0StinEcha + ChOffset
        << ", option: " << option_plot;
@@ -5450,7 +5450,7 @@ void TEcnaGui::ViewStinCorrelationSamples(const Int_t& cStexStin)
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);
   
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Correlation matrices between samples for each channel of "
        << fStinName.Data() << " " << cStexStin;
   MessageCnaCommandReplyA("DUMMY"); 
@@ -5472,7 +5472,7 @@ void TEcnaGui::ViewStinCovarianceSamples(const Int_t& cStexStin)
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);
   
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Covariance matrices between samples for each channel of "
        << fStinName.Data() << " " << cStexStin;
   MessageCnaCommandReplyA("DUMMY");
@@ -5499,7 +5499,7 @@ void TEcnaGui::ViewSorSNumberOfEvents()
       fHistos->FileParameters(fKeyAnaType, fKeyNbOfSamples, fKeyRunNumber,
 			      fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);      
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
+      std::cout << "   *TEcnaGui [" << fCnaCommand
 	   << "]> Number of Events. 2D histo. "
 	   << fStexName.Data() << ": " << fKeyStexNumber;
     }
@@ -5508,7 +5508,7 @@ void TEcnaGui::ViewSorSNumberOfEvents()
       fHistos->FileParameters(fKeyAnaType, fKeyNbOfSamples, fKeyRunNumber,
 			      fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, 0);
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
+      std::cout << "   *TEcnaGui [" << fCnaCommand
 	   << "]> Average Number of Events. 2D histo for "
 	   << fSubDet.Data();
     }
@@ -5535,7 +5535,7 @@ void TEcnaGui::ViewSorSPedestals()
       fHistos->FileParameters(fKeyAnaType, fKeyNbOfSamples, fKeyRunNumber,
 			      fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);      
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
+      std::cout << "   *TEcnaGui [" << fCnaCommand
 	   << "]> Pedestals. 2D histo. "
 	   << fStexName.Data() << ": " << fKeyStexNumber;
     }
@@ -5544,7 +5544,7 @@ void TEcnaGui::ViewSorSPedestals()
       fHistos->FileParameters(fKeyAnaType, fKeyNbOfSamples, fKeyRunNumber,
 			      fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, 0);
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
+      std::cout << "   *TEcnaGui [" << fCnaCommand
 	   << "]> Pedestals. 2D histo for "
 	   << fSubDet.Data();
     }
@@ -5571,7 +5571,7 @@ void TEcnaGui::ViewSorSTotalNoise()
       fHistos->FileParameters(fKeyAnaType, fKeyNbOfSamples, fKeyRunNumber,
 			      fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);      
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
+      std::cout << "   *TEcnaGui [" << fCnaCommand
 	   << "]> Total noise. 2D histo. "
 	   << fStexName.Data() << ": " << fKeyStexNumber;
     }
@@ -5580,7 +5580,7 @@ void TEcnaGui::ViewSorSTotalNoise()
       fHistos->FileParameters(fKeyAnaType, fKeyNbOfSamples, fKeyRunNumber,
 			      fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, 0);
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
+      std::cout << "   *TEcnaGui [" << fCnaCommand
 	   << "]> Average total noise. 2D histo for "
 	   << fSubDet.Data();
     }
@@ -5607,7 +5607,7 @@ void TEcnaGui::ViewSorSLowFrequencyNoise()
       fHistos->FileParameters(fKeyAnaType, fKeyNbOfSamples, fKeyRunNumber,
 			      fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);      
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
+      std::cout << "   *TEcnaGui [" << fCnaCommand
 	   << "]> Low frequency noise. 2D histo. "
 	   << fStexName.Data() << ": " << fKeyStexNumber;
     }
@@ -5616,7 +5616,7 @@ void TEcnaGui::ViewSorSLowFrequencyNoise()
       fHistos->FileParameters(fKeyAnaType, fKeyNbOfSamples, fKeyRunNumber,
 			      fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, 0);
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
+      std::cout << "   *TEcnaGui [" << fCnaCommand
 	   << "]> Average low frequency noise. 2D histo for "
 	   << fSubDet.Data();
     }
@@ -5642,7 +5642,7 @@ void TEcnaGui::ViewSorSHighFrequencyNoise()
       fHistos->FileParameters(fKeyAnaType, fKeyNbOfSamples, fKeyRunNumber,
 			      fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);      
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
+      std::cout << "   *TEcnaGui [" << fCnaCommand
 	   << "]> High frequency noise. 2D histo. "
 	   << fStexName.Data() << ": " << fKeyStexNumber;
     }
@@ -5651,7 +5651,7 @@ void TEcnaGui::ViewSorSHighFrequencyNoise()
       fHistos->FileParameters(fKeyAnaType, fKeyNbOfSamples, fKeyRunNumber,
 			      fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, 0);
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
+      std::cout << "   *TEcnaGui [" << fCnaCommand
 	   << "]> Average high frequency noise. 2D histo for "
 	   << fSubDet.Data();
     }
@@ -5681,7 +5681,7 @@ void TEcnaGui::ViewSorSMeanCorss()
       fHistos->FileParameters(fKeyAnaType, fKeyNbOfSamples, fKeyRunNumber,
 			      fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);      
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
+      std::cout << "   *TEcnaGui [" << fCnaCommand
 	   << "]> Mean cor(s,s'). 2D histo. "
 	   << fStexName.Data() << ": " << fKeyStexNumber;
     }
@@ -5690,7 +5690,7 @@ void TEcnaGui::ViewSorSMeanCorss()
       fHistos->FileParameters(fKeyAnaType, fKeyNbOfSamples, fKeyRunNumber,
 			      fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, 0);
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
+      std::cout << "   *TEcnaGui [" << fCnaCommand
 	   << "]> Average mean cor(s,s'). 2D histo for "
 	   << fSubDet.Data();
     }
@@ -5720,7 +5720,7 @@ void TEcnaGui::ViewSorSSigmaOfCorss()
       fHistos->FileParameters(fKeyAnaType, fKeyNbOfSamples, fKeyRunNumber,
 			      fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);      
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
+      std::cout << "   *TEcnaGui [" << fCnaCommand
 	   << "]> Sigma of Cor(s,s'). 2D histo. "
 	   << fStexName.Data() << ": " << fKeyStexNumber;
     }
@@ -5729,7 +5729,7 @@ void TEcnaGui::ViewSorSSigmaOfCorss()
       fHistos->FileParameters(fKeyAnaType, fKeyNbOfSamples, fKeyRunNumber,
 			      fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, 0);
       fCnaCommand++;
-      cout << "   *TEcnaGui [" << fCnaCommand
+      std::cout << "   *TEcnaGui [" << fCnaCommand
 	   << "]> Average sigma of Cor(s,s'). 2D histo for "
 	   << fSubDet.Data();
     }
@@ -5765,9 +5765,9 @@ void TEcnaGui::ViewStinCrystalNumbering(const Int_t& StexStinEcna)
     {StinNumber = fEcalNumbering->GetDeeSCConsFrom1DeeSCEcna(fKeyStexNumber,StexStinEcna);}
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Crystal numbering for " << " " << fStexName.Data() << " "
-       << fKeyStexNumber << ", " << fStinName.Data() << " " << StinNumber << endl;
+       << fKeyStexNumber << ", " << fStinName.Data() << " " << StinNumber << std::endl;
 
   if( fHistos == 0 ){fHistos = new TEcnaHistos(fObjectManager, fSubDet.Data());       /*fCnew++*/ ;} 
   fHistos->GeneralTitle(fKeyGeneralTitle);
@@ -5787,9 +5787,9 @@ void TEcnaGui::ViewStexStinNumbering()
   // and is in the entry field of the Stex button (fKeyStexNumber)
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> " << fStinName.Data() << " numbering for " << fStexName.Data()
-       << " " << fKeyStexNumber << endl;
+       << " " << fKeyStexNumber << std::endl;
 
   if( fHistos == 0 ){fHistos = new TEcnaHistos(fObjectManager, fSubDet.Data());       /*fCnew++*/ ;}
   fHistos->GeneralTitle(fKeyGeneralTitle);
@@ -5813,7 +5813,7 @@ void TEcnaGui::ViewHistoSorSNumberOfEventsOfCrystals(const TString& first_same_p
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Number of events for crystals";
   MessageCnaCommandReplyA(first_same_plot);
 
@@ -5836,7 +5836,7 @@ void TEcnaGui::ViewHistoSorSNumberOfEventsDistribution(const TString& first_same
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Number of events distribution";
   MessageCnaCommandReplyA(first_same_plot);
 
@@ -5860,7 +5860,7 @@ void TEcnaGui::ViewHistoSorSPedestalsOfCrystals(const TString& first_same_plot)
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Pedestals";
   MessageCnaCommandReplyA(first_same_plot);
 
@@ -5883,7 +5883,7 @@ void TEcnaGui::ViewHistoSorSPedestalsDistribution(const TString& first_same_plot
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Pedestals distribution";
   MessageCnaCommandReplyA(first_same_plot);
 
@@ -5907,7 +5907,7 @@ void TEcnaGui::ViewHistoSorSTotalNoiseOfCrystals(const TString& first_same_plot)
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Total noise";
   MessageCnaCommandReplyA(first_same_plot);
 
@@ -5930,7 +5930,7 @@ void TEcnaGui::ViewHistoSorSTotalNoiseDistribution(const TString& first_same_plo
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber);  
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Total noise distribution";
   MessageCnaCommandReplyA(first_same_plot);
 
@@ -5955,7 +5955,7 @@ void TEcnaGui::ViewHistoSorSLowFrequencyNoiseOfCrystals(const TString& first_sam
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber); 
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Low frequency noise";
   MessageCnaCommandReplyA(first_same_plot);
 
@@ -5978,7 +5978,7 @@ void TEcnaGui::ViewHistoSorSLowFrequencyNoiseDistribution(const TString& first_s
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber); 
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Low frequency noise distribution";
   MessageCnaCommandReplyA(first_same_plot);
 
@@ -6002,7 +6002,7 @@ void TEcnaGui::ViewHistoSorSHighFrequencyNoiseOfCrystals(const TString& first_sa
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber); 
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> High frequency noise";
   MessageCnaCommandReplyA(first_same_plot);
 
@@ -6025,7 +6025,7 @@ void TEcnaGui::ViewHistoSorSHighFrequencyNoiseDistribution(const TString& first_
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber); 
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> High frequency noise distribution";
   MessageCnaCommandReplyA(first_same_plot);
 
@@ -6049,7 +6049,7 @@ void TEcnaGui::ViewHistoSorSMeanCorssOfCrystals(const TString& first_same_plot)
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber); 
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Mean cor(s,s')";
   MessageCnaCommandReplyA(first_same_plot);
 
@@ -6072,7 +6072,7 @@ void TEcnaGui::ViewHistoSorSMeanCorssDistribution(const TString& first_same_plot
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber); 
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Mean cor(s,s') distribution";
   MessageCnaCommandReplyA(first_same_plot);
 
@@ -6095,7 +6095,7 @@ void TEcnaGui::ViewHistoSorSSigmaOfCorssOfCrystals(const TString& first_same_plo
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber); 
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Sigma of cor(s,s')";
   MessageCnaCommandReplyA(first_same_plot);
 
@@ -6118,7 +6118,7 @@ void TEcnaGui::ViewHistoSorSSigmaOfCorssDistribution(const TString& first_same_p
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber); 
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Sigma of cor(s,s') distribution";
   MessageCnaCommandReplyA(first_same_plot);
 
@@ -6143,12 +6143,12 @@ void TEcnaGui::ViewHistoCrystalSampleMeans(const Int_t&  cStexStin_A, const Int_
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber); 
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Sample means"
        << ". Analysis: " << fKeyAnaType << ", Run: " << fKeyRunNumber
        << ", 1st req. evt#: " << fKeyFirstReqEvtNumber << ", last req. evt#: " << fKeyLastReqEvtNumber
        << ", Stex: " << fKeyStexNumber << ", " << fStinName.Data() << ": " << cStexStin_A << ", crystal" << crystal
-       << ", option: " << first_same_plot << endl;
+       << ", option: " << first_same_plot << std::endl;
 
   fHistos->SetHistoMin(fKeyVminD_Ped_ChNb);
   fHistos->SetHistoMax(fKeyVmaxD_Ped_ChNb);
@@ -6169,12 +6169,12 @@ void TEcnaGui::ViewHistoCrystalSampleMeansDistribution(const Int_t&  cStexStin_A
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber); 
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Sample means"
        << ". Analysis: " << fKeyAnaType << ", Run: " << fKeyRunNumber
        << ", 1st req. evt#: " << fKeyFirstReqEvtNumber << ", last req. evt#: " << fKeyLastReqEvtNumber
        << ", Stex: " << fKeyStexNumber << ", " << fStinName.Data() << ": " << cStexStin_A << ", crystal" << crystal
-       << ", option: " << first_same_plot << endl;
+       << ", option: " << first_same_plot << std::endl;
 
   fHistos->SetHistoMin(fKeyVminD_Ped_ChNb);
   fHistos->SetHistoMax(fKeyVmaxD_Ped_ChNb);
@@ -6194,12 +6194,12 @@ void TEcnaGui::ViewHistoCrystalSampleSigmas(const Int_t&  cStexStin_A, const Int
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber); 
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Sample sigmas"
        << ". Analysis: " << fKeyAnaType << ", Run: " << fKeyRunNumber
        << ", 1st req. evt#: " << fKeyFirstReqEvtNumber << ", last req. evt#: " << fKeyLastReqEvtNumber
        << ", Stex: " << fKeyStexNumber << ", " << fStinName.Data() << ": " << cStexStin_A << ", crystal:" << crystal
-       << ", option: " << first_same_plot << endl;
+       << ", option: " << first_same_plot << std::endl;
 
   fHistos->SetHistoMin(fKeyVminD_TNo_ChNb);
   fHistos->SetHistoMax(fKeyVmaxD_TNo_ChNb); 
@@ -6219,12 +6219,12 @@ void TEcnaGui::ViewHistoCrystalSampleSigmasDistribution(const Int_t&  cStexStin_
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber); 
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Sample sigmas"
        << ". Analysis: " << fKeyAnaType << ", Run: " << fKeyRunNumber
        << ", 1st req. evt#: " << fKeyFirstReqEvtNumber << ", last req. evt#: " << fKeyLastReqEvtNumber
        << ", Stex: " << fKeyStexNumber << ", " << fStinName.Data() << ": " << cStexStin_A << ", crystal:" << crystal
-       << ", option: " << first_same_plot << endl;
+       << ", option: " << first_same_plot << std::endl;
 
   fHistos->SetHistoMin(fKeyVminD_TNo_ChNb);
   fHistos->SetHistoMax(fKeyVmaxD_TNo_ChNb); 
@@ -6246,12 +6246,12 @@ void TEcnaGui::ViewHistoCrystalSampleValues(const Int_t& cStexStin_A, const Int_
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber); 
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> ADC sample values"
        << ". Analysis: " << fKeyAnaType << ", Run: " << fKeyRunNumber
        << ", 1st req. evt#: " << fKeyFirstReqEvtNumber << ", last req. evt#: " << fKeyLastReqEvtNumber
        << ", Stex: " << fKeyStexNumber << ", " << fStinName.Data() << ": " << cStexStin_A << ", crystal: " << crystal
-       << ", sample: " << n1Sample << ", option: " << first_same_plot << endl;
+       << ", sample: " << n1Sample << ", option: " << first_same_plot << std::endl;
 
   fHistos->SetHistoMin(fKeyVminD_Ped_ChNb);
   fHistos->SetHistoMax(fKeyVmaxD_Ped_ChNb); 
@@ -6272,12 +6272,12 @@ void TEcnaGui::ViewHistoSampleEventDistribution(const Int_t& cStexStin_A, const 
 			  fKeyFirstReqEvtNumber, fKeyLastReqEvtNumber, fKeyReqNbOfEvts, fKeyStexNumber); 
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> ADC event distribution"
        << ". Analysis: " << fKeyAnaType << ", Run: " << fKeyRunNumber
        << ", 1st req. evt#: " << fKeyFirstReqEvtNumber << ", last req. evt#: " << fKeyLastReqEvtNumber
        << ", Stex: " << fKeyStexNumber << ", " << fStinName.Data() << ": " << cStexStin_A << ", crystal: " << crystal
-       << ", sample " << n1Sample << ", option: " << first_same_plot << endl;
+       << ", sample " << n1Sample << ", option: " << first_same_plot << std::endl;
  
   fHistos->SetHistoMin(fKeyVminD_Ped_ChNb);
   fHistos->SetHistoMax(fKeyVmaxD_Ped_ChNb);
@@ -6297,11 +6297,11 @@ void TEcnaGui::ViewHistimeCrystalPedestals(const TString&  run_par_file_name,
   if( fHistos == 0 ){fHistos = new TEcnaHistos(fObjectManager, fSubDet.Data());       /*fCnew++*/ ;}
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Pedestal history"
        << ". Run parameters file name: " << run_par_file_name
        << ", " << fStinName.Data() << ": " << cStexStin_A << ", channel: " << i0StinEcha
-       << ", option: " << first_same_plot << endl;
+       << ", option: " << first_same_plot << std::endl;
 
   fHistos->SetHistoMin(fKeyVminD_Ped_ChNb);
   fHistos->SetHistoMax(fKeyVmaxD_Ped_ChNb); 
@@ -6322,11 +6322,11 @@ void TEcnaGui::ViewHistimeCrystalPedestalsRuns(const TString&  run_par_file_name
   if( fHistos == 0 ){fHistos = new TEcnaHistos(fObjectManager, fSubDet.Data());       /*fCnew++*/ ;}
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Pedestal history distribution"
        << ". Run parameters file name: " << run_par_file_name
        << ", " << fStinName.Data() << ": " << cStexStin_A << ", channel: " << i0StinEcha
-       << ", option: " << first_same_plot << endl;
+       << ", option: " << first_same_plot << std::endl;
 
   fHistos->SetHistoMin(fKeyVminD_Ped_ChNb);
   fHistos->SetHistoMax(fKeyVmaxD_Ped_ChNb); 
@@ -6348,11 +6348,11 @@ void TEcnaGui::ViewHistimeCrystalTotalNoise(const TString&  run_par_file_name,
   if( fHistos == 0 ){fHistos = new TEcnaHistos(fObjectManager, fSubDet.Data());       /*fCnew++*/ ;}
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Total noise history"
        << ". Run parameters file name: " << run_par_file_name
        << ", " << fStinName.Data() << ": " << cStexStin_A << ", channel: " << i0StinEcha
-       << ", option: " << first_same_plot << endl;
+       << ", option: " << first_same_plot << std::endl;
 
   fHistos->SetHistoMin(fKeyVminD_TNo_ChNb);
   fHistos->SetHistoMax(fKeyVmaxD_TNo_ChNb); 
@@ -6373,11 +6373,11 @@ void TEcnaGui::ViewHistimeCrystalTotalNoiseRuns(const TString&  run_par_file_nam
   if( fHistos == 0 ){fHistos = new TEcnaHistos(fObjectManager, fSubDet.Data());       /*fCnew++*/ ;}
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Total noise history distribution"
        << ". Run parameters file name: " << run_par_file_name
        << ", " << fStinName.Data() << ": " << cStexStin_A << ", channel: " << i0StinEcha
-       << ", option: " << first_same_plot << endl;
+       << ", option: " << first_same_plot << std::endl;
 
   fHistos->SetHistoMin(fKeyVminD_TNo_ChNb);
   fHistos->SetHistoMax(fKeyVmaxD_TNo_ChNb); 
@@ -6398,11 +6398,11 @@ void TEcnaGui::ViewHistimeCrystalLowFrequencyNoise(const TString&  run_par_file_
   if( fHistos == 0 ){fHistos = new TEcnaHistos(fObjectManager, fSubDet.Data());       /*fCnew++*/ ;}
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Low frequency noise history"
        << ". Run parameters file name: " << run_par_file_name
        << ", " << fStinName.Data() << ": " << cStexStin_A << ", channel: " << i0StinEcha
-       << ", option: " << first_same_plot << endl;
+       << ", option: " << first_same_plot << std::endl;
 
   fHistos->SetHistoMin(fKeyVminD_LFN_ChNb);
   fHistos->SetHistoMax(fKeyVmaxD_LFN_ChNb); 
@@ -6423,11 +6423,11 @@ void TEcnaGui::ViewHistimeCrystalLowFrequencyNoiseRuns(const TString&  run_par_f
   if( fHistos == 0 ){fHistos = new TEcnaHistos(fObjectManager, fSubDet.Data());       /*fCnew++*/ ;}
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Low frequency noise history distribution"
        << ". Run parameters file name: " << run_par_file_name
        << ", " << fStinName.Data() << ": " << cStexStin_A << ", channel: " << i0StinEcha
-       << ", option: " << first_same_plot << endl;
+       << ", option: " << first_same_plot << std::endl;
 
   fHistos->SetHistoMin(fKeyVminD_LFN_ChNb);
   fHistos->SetHistoMax(fKeyVmaxD_LFN_ChNb); 
@@ -6448,11 +6448,11 @@ void TEcnaGui::ViewHistimeCrystalHighFrequencyNoise(const TString&  run_par_file
   if( fHistos == 0 ){fHistos = new TEcnaHistos(fObjectManager, fSubDet.Data());       /*fCnew++*/ ;}
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> High frequency noise history"
        << ". Run parameters file name: " << run_par_file_name
        << ", " << fStinName.Data() << ": " << cStexStin_A << ", channel: " << i0StinEcha
-       << ", option: " << first_same_plot << endl;
+       << ", option: " << first_same_plot << std::endl;
 
   fHistos->SetHistoMin(fKeyVminD_HFN_ChNb);
   fHistos->SetHistoMax(fKeyVmaxD_HFN_ChNb); 
@@ -6473,11 +6473,11 @@ void TEcnaGui::ViewHistimeCrystalHighFrequencyNoiseRuns(const TString&  run_par_
   if( fHistos == 0 ){fHistos = new TEcnaHistos(fObjectManager, fSubDet.Data());       /*fCnew++*/ ;}
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> High frequency noise history distribution"
        << ". Run parameters file name: " << run_par_file_name
        << ", " << fStinName.Data() << ": " << cStexStin_A << ", channel: " << i0StinEcha
-       << ", option: " << first_same_plot << endl;
+       << ", option: " << first_same_plot << std::endl;
 
   fHistos->SetHistoMin(fKeyVminD_HFN_ChNb);
   fHistos->SetHistoMax(fKeyVmaxD_HFN_ChNb); 
@@ -6498,11 +6498,11 @@ void TEcnaGui::ViewHistimeCrystalMeanCorss(const TString&  run_par_file_name,
   if( fHistos == 0 ){fHistos = new TEcnaHistos(fObjectManager, fSubDet.Data());       /*fCnew++*/ ;}
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Mean corss history"
        << ". Run parameters file name: " << run_par_file_name
        << ", " << fStinName.Data() << ": " << cStexStin_A << ", channel: " << i0StinEcha
-       << ", option: " << first_same_plot << endl;
+       << ", option: " << first_same_plot << std::endl;
 
   fHistos->SetHistoMin(fKeyVminD_MCs_ChNb);
   fHistos->SetHistoMax(fKeyVmaxD_MCs_ChNb);
@@ -6523,11 +6523,11 @@ void TEcnaGui::ViewHistimeCrystalMeanCorssRuns(const TString&  run_par_file_name
   if( fHistos == 0 ){fHistos = new TEcnaHistos(fObjectManager, fSubDet.Data());       /*fCnew++*/ ;}
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Mean corss history distribution"
        << ". Run parameters file name: " << run_par_file_name
        << ", " << fStinName.Data() << ": " << cStexStin_A << ", channel: " << i0StinEcha
-       << ", option: " << first_same_plot << endl;
+       << ", option: " << first_same_plot << std::endl;
 
   fHistos->SetHistoMin(fKeyVminD_MCs_ChNb);
   fHistos->SetHistoMax(fKeyVmaxD_MCs_ChNb);
@@ -6548,11 +6548,11 @@ void TEcnaGui::ViewHistimeCrystalSigmaOfCorss(const TString& run_par_file_name,
   if( fHistos == 0 ){fHistos = new TEcnaHistos(fObjectManager, fSubDet.Data());       /*fCnew++*/;}
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Sigma of corss history"
        << ". Run parameters file name: " << run_par_file_name
        << ", " << fStinName.Data() << ": " << cStexStin_A << ", channel: " << i0StinEcha
-       << ", option: " << first_same_plot << endl;
+       << ", option: " << first_same_plot << std::endl;
 
   fHistos->SetHistoMin(fKeyVminD_SCs_ChNb);
   fHistos->SetHistoMax(fKeyVmaxD_SCs_ChNb);
@@ -6573,11 +6573,11 @@ void TEcnaGui::ViewHistimeCrystalSigmaOfCorssRuns(const TString& run_par_file_na
   if( fHistos == 0 ){fHistos = new TEcnaHistos(fObjectManager, fSubDet.Data());       /*fCnew++*/;}
 
   fCnaCommand++;
-  cout << "   *TEcnaGui [" << fCnaCommand
+  std::cout << "   *TEcnaGui [" << fCnaCommand
        << "]> Sigma of corss history distribution"
        << ". Run parameters file name: " << run_par_file_name
        << ", " << fStinName.Data() << ": " << cStexStin_A << ", channel: " << i0StinEcha
-       << ", option: " << first_same_plot << endl;
+       << ", option: " << first_same_plot << std::endl;
 
   fHistos->SetHistoMin(fKeyVminD_SCs_ChNb);
   fHistos->SetHistoMax(fKeyVmaxD_SCs_ChNb);

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaHeader.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaHeader.cc
@@ -22,7 +22,7 @@ TEcnaHeader::TEcnaHeader(TEcnaObject* pObjectManager, const Text_t* name, const 
   // Please give a name and a title containing info about what
   // you are doing and saving in the ROOT file
 
-  // cout << "[Info Management] CLASS: TEcnaHeader.        CREATE OBJECT: this = " << this << endl;
+  // std::cout << "[Info Management] CLASS: TEcnaHeader.        CREATE OBJECT: this = " << this << std::endl;
   
   Init();
   Long_t i_this = (Long_t)this;
@@ -32,7 +32,7 @@ TEcnaHeader::TEcnaHeader(TEcnaObject* pObjectManager, const Text_t* name, const 
 TEcnaHeader::~TEcnaHeader() {
   //destructor
 
- // cout << "[Info Management] CLASS: TEcnaHeader.        DESTROY OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaHeader.        DESTROY OBJECT: this = " << this << std::endl;
 }
 
 void TEcnaHeader::Init()
@@ -107,7 +107,7 @@ void TEcnaHeader::HeaderParameters(const TString&      typ_ana,           const 
   // Please give a name and a title containing info about what
   // you are doing and saving in the ROOT file
  
- // cout << "[Info Management] CLASS: TEcnaHeader.        CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaHeader.        CREATE OBJECT: this = " << this << std::endl;
 
   Init();
 
@@ -128,7 +128,7 @@ void TEcnaHeader::HeaderParameters(const TString&      typ_ana,           const 
 				   const Int_t& aLastReqEvtNumber, const Int_t& aReqNbOfEvts,
 				   const Int_t& Stex)
  {
- // cout << "[Info Management] CLASS: TEcnaHeader.        CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaHeader.        CREATE OBJECT: this = " << this << std::endl;
 
   Init();
 
@@ -143,75 +143,75 @@ void TEcnaHeader::HeaderParameters(const TString&      typ_ana,           const 
 
 void TEcnaHeader::Print() {
   // Print the header
-  cout << endl;
-  cout << "     Header parameters " << endl;
-  cout << endl;
-  cout << "Run number                   : " << fRunNumber         << endl;
-  cout << "First requested event number : " << fFirstReqEvtNumber << endl;
-  cout << "Last requested event number  : " << fLastReqEvtNumber  << endl;
-  cout << "Requested number of events   : " << fReqNbOfEvts       << endl;
-  cout << "SM or Dee number             : " << fStex              << endl;
-  cout << "Time first event             : " << fStartTime         << endl;
-  cout << "Time last event              : " << fStopTime          << endl;
-  cout << "Date first event             : " << fStartDate.Data()  << endl;
-  cout << "Date last event              : " << fStopDate.Data()   << endl;
-  cout << "Run type                     : " << fRunType           << endl;
-  cout << endl;
-  cout << "     Header counters " << endl;
-  cout << endl;
-  cout << "Stin Numbers                                 : "
-       << fStinNumbersCalc << endl;
-  cout << "Numbers of found evts                        : "
-       << fNbOfEvtsCalc << endl;
-  cout << "Samples as a function of time histograms     : "
-       << fAdcEvtCalc << endl;
-  cout << "Expectation values histogram                 : "
-       << fMSpCalc    << endl;
-  cout << "Variances histogram                          : "
-       << fSSpCalc   << endl;
-  cout << "Average total noise                         : "
-       << fAvTnoCalc  << endl;
-  cout << "Average low frequency noise                 : "
-       << fAvLfnCalc  << endl;
-  cout << "Average high frequency noise                : "
-       << fAvHfnCalc  << endl;
+  std::cout << std::endl;
+  std::cout << "     Header parameters " << std::endl;
+  std::cout << std::endl;
+  std::cout << "Run number                   : " << fRunNumber         << std::endl;
+  std::cout << "First requested event number : " << fFirstReqEvtNumber << std::endl;
+  std::cout << "Last requested event number  : " << fLastReqEvtNumber  << std::endl;
+  std::cout << "Requested number of events   : " << fReqNbOfEvts       << std::endl;
+  std::cout << "SM or Dee number             : " << fStex              << std::endl;
+  std::cout << "Time first event             : " << fStartTime         << std::endl;
+  std::cout << "Time last event              : " << fStopTime          << std::endl;
+  std::cout << "Date first event             : " << fStartDate.Data()  << std::endl;
+  std::cout << "Date last event              : " << fStopDate.Data()   << std::endl;
+  std::cout << "Run type                     : " << fRunType           << std::endl;
+  std::cout << std::endl;
+  std::cout << "     Header counters " << std::endl;
+  std::cout << std::endl;
+  std::cout << "Stin Numbers                                 : "
+       << fStinNumbersCalc << std::endl;
+  std::cout << "Numbers of found evts                        : "
+       << fNbOfEvtsCalc << std::endl;
+  std::cout << "Samples as a function of time histograms     : "
+       << fAdcEvtCalc << std::endl;
+  std::cout << "Expectation values histogram                 : "
+       << fMSpCalc    << std::endl;
+  std::cout << "Variances histogram                          : "
+       << fSSpCalc   << std::endl;
+  std::cout << "Average total noise                         : "
+       << fAvTnoCalc  << std::endl;
+  std::cout << "Average low frequency noise                 : "
+       << fAvLfnCalc  << std::endl;
+  std::cout << "Average high frequency noise                : "
+       << fAvHfnCalc  << std::endl;
 
-  cout << "Nb of (sample,sample) covariance  matrices   : "
-       << fCovCssCalc << endl;
-  cout << "Nb of (sample,sample) correlation matrices   : "
-       << fCorCssCalc << endl;
-  cout << "Nb of (channel,channel) covariance  matrices : "
-       << fHfCovCalc << endl;
-  cout << "Nb of (channel,channel) correlation matrices : "
-       << fHfCorCalc << endl;
-  cout << "Nb of (channel,channel) cov mat mean on samp : "
-       << fLfCovCalc << endl;
-  cout << "Nb of (channel,channel) cor mat mean on samp : "
-       << fLfCorCalc << endl;
-  cout << "Nb of mean cov(c,c) mean on samp, all Stins  : "
-       << fLfCovCalc << endl;
-  cout << "Nb of mean cor(c,c) mean on samp, all Stins  : "
-       << fLfCorCalc << endl;
+  std::cout << "Nb of (sample,sample) covariance  matrices   : "
+       << fCovCssCalc << std::endl;
+  std::cout << "Nb of (sample,sample) correlation matrices   : "
+       << fCorCssCalc << std::endl;
+  std::cout << "Nb of (channel,channel) covariance  matrices : "
+       << fHfCovCalc << std::endl;
+  std::cout << "Nb of (channel,channel) correlation matrices : "
+       << fHfCorCalc << std::endl;
+  std::cout << "Nb of (channel,channel) cov mat mean on samp : "
+       << fLfCovCalc << std::endl;
+  std::cout << "Nb of (channel,channel) cor mat mean on samp : "
+       << fLfCorCalc << std::endl;
+  std::cout << "Nb of mean cov(c,c) mean on samp, all Stins  : "
+       << fLfCovCalc << std::endl;
+  std::cout << "Nb of mean cor(c,c) mean on samp, all Stins  : "
+       << fLfCorCalc << std::endl;
 
-  cout << "Exp. val. of the exp. val. of the samples    : "
-       << fPedCalc     << endl;
-  cout << "Expect. val. of the sigmas of the samples    : "
-       << fTnoCalc    << endl;
-  cout << "Expect. val. of the (samp,samp) correlations : "
-       << fMeanCorssCalc << endl;
+  std::cout << "Exp. val. of the exp. val. of the samples    : "
+       << fPedCalc     << std::endl;
+  std::cout << "Expect. val. of the sigmas of the samples    : "
+       << fTnoCalc    << std::endl;
+  std::cout << "Expect. val. of the (samp,samp) correlations : "
+       << fMeanCorssCalc << std::endl;
 
-  cout << "Sigmas of the exp. val. of the samples       : "
-       << fLfnCalc     << endl;
-  cout << "Sigmas of the sigmas of the samples          : "
-       << fHfnCalc     << endl;
-  cout << "Sigmas of the (samp,samp) correlations       : "
-       << fSigCorssCalc     << endl;
+  std::cout << "Sigmas of the exp. val. of the samples       : "
+       << fLfnCalc     << std::endl;
+  std::cout << "Sigmas of the sigmas of the samples          : "
+       << fHfnCalc     << std::endl;
+  std::cout << "Sigmas of the (samp,samp) correlations       : "
+       << fSigCorssCalc     << std::endl;
 
-  cout << "Average pedestals                           : "
-       << fAvPedCalc  << endl;
-  cout << "Average mean cor(s,s)                    : "
-       << fAvMeanCorssCalc << endl;
-  cout << "Average sigma of Cor(s,s)                   : "
-       << fAvSigCorssCalc << endl;
-  cout << endl;
+  std::cout << "Average pedestals                           : "
+       << fAvPedCalc  << std::endl;
+  std::cout << "Average mean cor(s,s)                    : "
+       << fAvMeanCorssCalc << std::endl;
+  std::cout << "Average sigma of Cor(s,s)                   : "
+       << fAvSigCorssCalc << std::endl;
+  std::cout << std::endl;
 }

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaHistos.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaHistos.cc
@@ -64,34 +64,34 @@ TEcnaHistos::~TEcnaHistos()
 
   if ( fCnew != fCdelete )
     {
-      cout << "*TEcnaHistos> WRONG MANAGEMENT OF ALLOCATIONS: fCnew = "
-	   << fCnew << ", fCdelete = " << fCdelete << fTTBELL << endl;
+      std::cout << "*TEcnaHistos> WRONG MANAGEMENT OF ALLOCATIONS: fCnew = "
+	   << fCnew << ", fCdelete = " << fCdelete << fTTBELL << std::endl;
     }
   else
     {
-     //  cout << "*TEcnaHistos> BRAVO! GOOD MANAGEMENT OF ALLOCATIONS: fCnew = "
-     //	      << fCnew << ", fCdelete = " << fCdelete << endl;
+     //  std::cout << "*TEcnaHistos> BRAVO! GOOD MANAGEMENT OF ALLOCATIONS: fCnew = "
+     //	      << fCnew << ", fCdelete = " << fCdelete << std::endl;
     }
 
 #define MGRA
 #ifndef MGRA
   if ( fCnewRoot != fCdeleteRoot )
     {
-      cout << "*TEcnaHistos> WRONG MANAGEMENT OF ROOT ALLOCATIONS: fCnewRoot = "
-	   << fCnewRoot << ", fCdeleteRoot = " << fCdeleteRoot << endl;
+      std::cout << "*TEcnaHistos> WRONG MANAGEMENT OF ROOT ALLOCATIONS: fCnewRoot = "
+	   << fCnewRoot << ", fCdeleteRoot = " << fCdeleteRoot << std::endl;
     }
   else
     {
-      cout << "*TEcnaHistos> BRAVO! GOOD MANAGEMENT OF ROOT ALLOCATIONS:"
+      std::cout << "*TEcnaHistos> BRAVO! GOOD MANAGEMENT OF ROOT ALLOCATIONS:"
 	   << " fCnewRoot = " << fCnewRoot <<", fCdeleteRoot = "
-	   << fCdeleteRoot << endl;
+	   << fCdeleteRoot << std::endl;
     }
 #endif // MGRA
 
-  // cout << "TEcnaHistos> Leaving destructor" << endl;
-  // cout << "            fCnew = " << fCnew << ", fCdelete = " << fCdelete << endl;
+  // std::cout << "TEcnaHistos> Leaving destructor" << std::endl;
+  // std::cout << "            fCnew = " << fCnew << ", fCdelete = " << fCdelete << std::endl;
 
- // cout << "[Info Management] CLASS: TEcnaHistos.        DESTROY OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaHistos.        DESTROY OBJECT: this = " << this << std::endl;
 
 }
 
@@ -103,14 +103,14 @@ TEcnaHistos::~TEcnaHistos()
 TEcnaHistos::TEcnaHistos(){
 // Constructor without argument. Call to Init() 
 
- // cout << "[Info Management] CLASS: TEcnaHistos.        CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaHistos.        CREATE OBJECT: this = " << this << std::endl;
 
   Init();
 }
 
 TEcnaHistos::TEcnaHistos(TEcnaObject* pObjectManager, const TString& SubDet)
 {
- // cout << "[Info Management] CLASS: TEcnaHistos.        CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaHistos.        CREATE OBJECT: this = " << this << std::endl;
 
 
   Long_t i_this = (Long_t)this;
@@ -916,7 +916,7 @@ void TEcnaHistos::PlotMatrix(const TMatrixD& read_matrix_corcc,
     }
   else
     {fFlagUserHistoMin = "OFF"; fFlagUserHistoMax = "OFF";
-      cout << "!TEcnaHistos::PlotMatrix(...)> Histo cannot be reached." << fTTBELL << endl;}
+      std::cout << "!TEcnaHistos::PlotMatrix(...)> Histo cannot be reached." << fTTBELL << std::endl;}
 }
 
 void TEcnaHistos::PlotMatrix(const TString& UserCorOrCov, const TString& UserBetweenWhat)
@@ -944,7 +944,7 @@ void TEcnaHistos::PlotMatrix(const TString& UserCorOrCov, const TString& UserBet
     }
   else
     {fFlagUserHistoMin = "OFF"; fFlagUserHistoMax = "OFF";
-      cout << "!TEcnaHistos::PlotMatrix(...)> Histo cannot be reached." << fTTBELL << endl;}
+      std::cout << "!TEcnaHistos::PlotMatrix(...)> Histo cannot be reached." << fTTBELL << std::endl;}
 }
 
 //....................................... Corcc for channels (cStexStin_A, cStexStin_B)
@@ -989,7 +989,7 @@ void TEcnaHistos::PlotMatrix(const TMatrixD& read_matrix,
     }
   else
     {fFlagUserHistoMin = "OFF"; fFlagUserHistoMax = "OFF";
-      cout << "!TEcnaHistos::PlotMatrix(...)> Histo cannot be reached." << fTTBELL << endl;}
+      std::cout << "!TEcnaHistos::PlotMatrix(...)> Histo cannot be reached." << fTTBELL << std::endl;}
 }
 
 void TEcnaHistos::PlotMatrix(const TString& UserCorOrCov, const TString& UserBetweenWhat,
@@ -1029,7 +1029,7 @@ void TEcnaHistos::PlotMatrix(const TString& UserCorOrCov, const TString& UserBet
     }
   else
     {fFlagUserHistoMin = "OFF"; fFlagUserHistoMax = "OFF";
-      cout << "!TEcnaHistos::PlotMatrix(...)> Histo cannot be reached." << fTTBELL << endl;}
+      std::cout << "!TEcnaHistos::PlotMatrix(...)> Histo cannot be reached." << fTTBELL << std::endl;}
 }
 
 //---------------------------------------------------------------------------------------
@@ -1061,11 +1061,11 @@ void TEcnaHistos::PlotDetector(const TString& UserHistoCode, const TString& User
 	}
       else
 	{fFlagUserHistoMin = "OFF"; fFlagUserHistoMax = "OFF";
-	  cout << "!TEcnaHistos::PlotDetector(...)> Histo cannot be reached." << fTTBELL << endl;}
+	  std::cout << "!TEcnaHistos::PlotDetector(...)> Histo cannot be reached." << fTTBELL << std::endl;}
     }
   else
     {fFlagUserHistoMin = "OFF"; fFlagUserHistoMax = "OFF";
-      cout << "!TEcnaHistos::PlotDetector(...)> Histo cannot be reached." << fTTBELL << endl;}
+      std::cout << "!TEcnaHistos::PlotDetector(...)> Histo cannot be reached." << fTTBELL << std::endl;}
 }
 
 void TEcnaHistos::PlotDetector(const TVectorD& read_histo, const TString& UserHistoCode, const TString& UserDetector)
@@ -1093,11 +1093,11 @@ void TEcnaHistos::PlotDetector(const TVectorD& read_histo, const TString& UserHi
 	}
       else
 	{fFlagUserHistoMin = "OFF"; fFlagUserHistoMax = "OFF";
-	  cout << "!TEcnaHistos::PlotDetector(...)> Histo cannot be reached." << fTTBELL << endl;}
+	  std::cout << "!TEcnaHistos::PlotDetector(...)> Histo cannot be reached." << fTTBELL << std::endl;}
     }
   else
     {fFlagUserHistoMin = "OFF"; fFlagUserHistoMax = "OFF";
-      cout << "!TEcnaHistos::PlotDetector(...)> Histo cannot be reached." << fTTBELL << endl;}
+      std::cout << "!TEcnaHistos::PlotDetector(...)> Histo cannot be reached." << fTTBELL << std::endl;}
 }
 
 //---------------------------------------------------------------------------------------
@@ -1134,11 +1134,11 @@ void TEcnaHistos::Plot1DHisto(const TVectorD& InputHisto,
 	}
       else
 	{fFlagUserHistoMin = "OFF"; fFlagUserHistoMax = "OFF";
-	  cout << "!TEcnaHistos::Plot1DHisto(...)> Histo cannot be reached." << fTTBELL << endl;}
+	  std::cout << "!TEcnaHistos::Plot1DHisto(...)> Histo cannot be reached." << fTTBELL << std::endl;}
     }
   else
     {fFlagUserHistoMin = "OFF"; fFlagUserHistoMax = "OFF";
-      cout << "!TEcnaHistos::Plot1DHisto(...)> Histo cannot be reached." << fTTBELL << endl;}
+      std::cout << "!TEcnaHistos::Plot1DHisto(...)> Histo cannot be reached." << fTTBELL << std::endl;}
 }
 
 void TEcnaHistos::Plot1DHisto(const TString& User_X_Quantity, const TString& User_Y_Quantity,
@@ -1166,11 +1166,11 @@ void TEcnaHistos::Plot1DHisto(const TString& User_X_Quantity, const TString& Use
 	}
       else
 	{fFlagUserHistoMin = "OFF"; fFlagUserHistoMax = "OFF";
-	  cout << "!TEcnaHistos::Plot1DHisto(...)> Histo cannot be reached." << fTTBELL << endl;}
+	  std::cout << "!TEcnaHistos::Plot1DHisto(...)> Histo cannot be reached." << fTTBELL << std::endl;}
     }
   else
     {fFlagUserHistoMin = "OFF"; fFlagUserHistoMax = "OFF";
-      cout << "!TEcnaHistos::Plot1DHisto(...)> Histo cannot be reached." << fTTBELL << endl;}
+      std::cout << "!TEcnaHistos::Plot1DHisto(...)> Histo cannot be reached." << fTTBELL << std::endl;}
 }
 
 
@@ -1235,7 +1235,7 @@ void TEcnaHistos::Plot1DHisto(const TVectorD& InputHisto,
     }
   else
     {fFlagUserHistoMin = "OFF"; fFlagUserHistoMax = "OFF";
-      cout << "!TEcnaHistos::Plot1DHisto(...)> Histo cannot be reached." << fTTBELL << endl;}
+      std::cout << "!TEcnaHistos::Plot1DHisto(...)> Histo cannot be reached." << fTTBELL << std::endl;}
 }
 
 void TEcnaHistos::Plot1DHisto(const TString& User_X_Quantity, const TString& User_Y_Quantity,
@@ -1274,7 +1274,7 @@ void TEcnaHistos::Plot1DHisto(const TString& User_X_Quantity, const TString& Use
     }
   else
     {fFlagUserHistoMin = "OFF"; fFlagUserHistoMax = "OFF";
-      cout << "!TEcnaHistos::Plot1DHisto(...)> Histo cannot be reached." << fTTBELL << endl;}
+      std::cout << "!TEcnaHistos::Plot1DHisto(...)> Histo cannot be reached." << fTTBELL << std::endl;}
 }
 
 void TEcnaHistos::Plot1DHisto(const TVectorD& InputHisto,
@@ -1304,7 +1304,7 @@ void TEcnaHistos::Plot1DHisto(const TVectorD& InputHisto,
     }
   else
     {fFlagUserHistoMin = "OFF"; fFlagUserHistoMax = "OFF";
-      cout << "!TEcnaHistos::Plot1DHisto(...)> Histo cannot be reached." << fTTBELL << endl;}
+      std::cout << "!TEcnaHistos::Plot1DHisto(...)> Histo cannot be reached." << fTTBELL << std::endl;}
 }
 
 void TEcnaHistos::Plot1DHisto(const TString& User_X_Quantity, const TString& User_Y_Quantity,
@@ -1331,7 +1331,7 @@ void TEcnaHistos::Plot1DHisto(const TString& User_X_Quantity, const TString& Use
     }
   else
     {fFlagUserHistoMin = "OFF"; fFlagUserHistoMax = "OFF";
-      cout << "!TEcnaHistos::Plot1DHisto(...)> Histo cannot be reached." << fTTBELL << endl;}
+      std::cout << "!TEcnaHistos::Plot1DHisto(...)> Histo cannot be reached." << fTTBELL << std::endl;}
 }
 
 //---------------------------------------------------------------------------------------
@@ -1363,7 +1363,7 @@ void TEcnaHistos::PlotHistory(const TString& User_X_Quantity, const TString& Use
     }
   else
     {fFlagUserHistoMin = "OFF"; fFlagUserHistoMax = "OFF";
-      cout << "!TEcnaHistos::PlotHistory(...)> Histo cannot be reached." << fTTBELL << endl;} 
+      std::cout << "!TEcnaHistos::PlotHistory(...)> Histo cannot be reached." << fTTBELL << std::endl;} 
 }
 
 //=============================================================================================
@@ -1435,8 +1435,8 @@ void TEcnaHistos::ViewMatrix(const TMatrixD& arg_read_matrix, const Int_t&  arg_
 	    {
 	      fFapNbOfEvts = fMyRootFile->GetNumberOfEvents(fFapReqNbOfEvts, fFapStexNumber);
 	      TString fp_name_short = fMyRootFile->GetRootFileNameShort();
-	      // cout << "*TEcnaHistos::ViewMatrix(...)> Data are analyzed from file ----> "
-	      //      << fp_name_short << endl;
+	      // std::cout << "*TEcnaHistos::ViewMatrix(...)> Data are analyzed from file ----> "
+	      //      << fp_name_short << std::endl;
 	      //...................................................................... (ViewMatrix) 
 	      for(Int_t i=0; i<fEcal->MaxStinEcnaInStex(); i++){vStin(i)=(Double_t)0.;}
 	      vStin = fMyRootFile->ReadStinNumbers(fEcal->MaxStinEcnaInStex());
@@ -1854,9 +1854,9 @@ void TEcnaHistos::ViewMatrix(const TMatrixD& arg_read_matrix, const Int_t&  arg_
 			      TCanvas *MainCanvas = new TCanvas(f_in, f_in, canv_w , canv_h);   fCnewRoot++;
 			      fCurrentCanvas = MainCanvas; fCurrentCanvasName = f_in;
 			  
-			      // cout << "*TEcnaHistos::ViewMatrix(...)> Plot is displayed on canvas ----> "
-			      //      << fCurrentCanvasName << endl;
-			      // cout << "*TEcnaHistos::ViewMatrix(...)> fCurrentCanvas = " << fCurrentCanvas << endl;
+			      // std::cout << "*TEcnaHistos::ViewMatrix(...)> Plot is displayed on canvas ----> "
+			      //      << fCurrentCanvasName << std::endl;
+			      // std::cout << "*TEcnaHistos::ViewMatrix(...)> fCurrentCanvas = " << fCurrentCanvas << std::endl;
 			  
 			      delete [] f_in; f_in = 0;                         fCdelete++;
 
@@ -1904,19 +1904,19 @@ void TEcnaHistos::ViewMatrix(const TMatrixD& arg_read_matrix, const Int_t&  arg_
 		    {
 		      if(BetweenWhat == fBetweenSamples)
 			{
-			  cout << "*TEcnaHistos::ViewMatrix(...)> *ERROR* ==> Wrong channel number in "
+			  std::cout << "*TEcnaHistos::ViewMatrix(...)> *ERROR* ==> Wrong channel number in "
 			       << fFapStinName.Data() << ". Value = "
 			       << i0StinEcha << " (required range: [0, "
 			       << fEcal->MaxCrysInStin()-1 << "] )"
-			       << fTTBELL << endl;
+			       << fTTBELL << std::endl;
 			}
 
 		     // if( BetweenWhat == fLFBetweenChannels || BetweenWhat == fHFBetweenChannels )
 		     //	{
-			 // cout << "*TEcnaHistos::ViewMatrix(...)> *ERROR* ==> Wrong sample index. Value = "
+			 // std::cout << "*TEcnaHistos::ViewMatrix(...)> *ERROR* ==> Wrong sample index. Value = "
 			 //      << i0Sample << " (required range: [0, "
 			 //      << fFapNbOfSamples-1 << "] )"
-			 //      << fTTBELL << endl;
+			 //      << fTTBELL << std::endl;
 			//}
 		    }
 		}
@@ -1927,7 +1927,7 @@ void TEcnaHistos::ViewMatrix(const TMatrixD& arg_read_matrix, const Int_t&  arg_
 		    {
 		      if( fFlagSubDet == "EB") 
 			{
-			  cout << "*TEcnaHistos::ViewMatrix(...)> *ERROR* =====> "
+			  std::cout << "*TEcnaHistos::ViewMatrix(...)> *ERROR* =====> "
 			       << fFapStinName.Data() << " "
 			       << StexStin_A << ", "
 			       << fFapStinName.Data() << " not found. Available numbers = ";
@@ -1935,14 +1935,14 @@ void TEcnaHistos::ViewMatrix(const TMatrixD& arg_read_matrix, const Int_t&  arg_
 			    {
 			      if( vStin(i) > 0 )
 				{
-				  cout << vStin(i) << ", ";
+				  std::cout << vStin(i) << ", ";
 				}
 			    }
 			}
 
 		      if( fFlagSubDet == "EE") 
 			{
-			  cout << "*TEcnaHistos::ViewMatrix(...)> *ERROR* =====> "
+			  std::cout << "*TEcnaHistos::ViewMatrix(...)> *ERROR* =====> "
 			       << fFapStinName.Data() << " "
 			       << fEcalNumbering->GetDeeSCConsFrom1DeeSCEcna(fFapStexNumber, StexStin_A) << ", "
 			       << fFapStinName.Data() << " not found. Available numbers = ";
@@ -1950,18 +1950,18 @@ void TEcnaHistos::ViewMatrix(const TMatrixD& arg_read_matrix, const Int_t&  arg_
 			    {
 			      if( vStin(i) > 0 )
 				{
-				  cout << fEcalNumbering->GetDeeSCConsFrom1DeeSCEcna(fFapStexNumber, (Int_t)vStin(i)) << ", ";
+				  std::cout << fEcalNumbering->GetDeeSCConsFrom1DeeSCEcna(fFapStexNumber, (Int_t)vStin(i)) << ", ";
 				}
 			    }
 			}
-		      cout << fTTBELL << endl;
+		      std::cout << fTTBELL << std::endl;
 		    }
 		  if ( Stin_Y_ok != 1 )
 		    {
 
 		      if( fFlagSubDet == "EB") 
 			{
-			  cout << "*TEcnaHistos::ViewMatrix(...)> *ERROR* =====> "
+			  std::cout << "*TEcnaHistos::ViewMatrix(...)> *ERROR* =====> "
 			       << fFapStinName.Data() << " "
 			       << StexStin_B << ", "
 			       << fFapStinName.Data() << " not found. Available numbers = ";
@@ -1969,14 +1969,14 @@ void TEcnaHistos::ViewMatrix(const TMatrixD& arg_read_matrix, const Int_t&  arg_
 			    {
 			      if( vStin(i) > 0 )
 				{
-				  cout << vStin(i) << ", ";
+				  std::cout << vStin(i) << ", ";
 				}
 			    }
 			}
 
 		      if( fFlagSubDet == "EE") 
 			{
-			  cout << "*TEcnaHistos::ViewMatrix(...)> *ERROR* =====> "
+			  std::cout << "*TEcnaHistos::ViewMatrix(...)> *ERROR* =====> "
 			       << fFapStinName.Data() << " "
 			       << fEcalNumbering->GetDeeSCConsFrom1DeeSCEcna(fFapStexNumber, StexStin_B) << ", "
 			       << fFapStinName.Data() << " not found. Available numbers = ";
@@ -1984,19 +1984,19 @@ void TEcnaHistos::ViewMatrix(const TMatrixD& arg_read_matrix, const Int_t&  arg_
 			    {
 			      if( vStin(i) > 0 )
 				{
-				  cout << fEcalNumbering->GetDeeSCConsFrom1DeeSCEcna(fFapStexNumber, (Int_t)vStin(i)) << ", ";
+				  std::cout << fEcalNumbering->GetDeeSCConsFrom1DeeSCEcna(fFapStexNumber, (Int_t)vStin(i)) << ", ";
 				}
 			    }
 			}     
-		      cout << fTTBELL << endl;
+		      std::cout << fTTBELL << std::endl;
 		    }
 		}
 	    } // end of if ( fMyRootFile->DataExist() == kTRUE )
 	  else
 	    {
 	      fStatusDataExist = kFALSE;
-	      cout  << "!TEcnaHistos::ViewMatrix(...)> *ERROR* =====> "
-		    << " Histo not available." << fTTBELL << endl;
+	      std::cout  << "!TEcnaHistos::ViewMatrix(...)> *ERROR* =====> "
+		    << " Histo not available." << fTTBELL << std::endl;
 	      fFlagUserHistoMin = "OFF";
 	      fFlagUserHistoMax = "OFF";
 	    }
@@ -2004,15 +2004,15 @@ void TEcnaHistos::ViewMatrix(const TMatrixD& arg_read_matrix, const Int_t&  arg_
       else
 	{
 	  fStatusFileFound = kFALSE;
-	  cout  << "!TEcnaHistos::ViewMatrix(...)> *ERROR* =====> "
-		<< " ROOT file not found" << fTTBELL << endl;
+	  std::cout  << "!TEcnaHistos::ViewMatrix(...)> *ERROR* =====> "
+		<< " ROOT file not found" << fTTBELL << std::endl;
 	}
     } // ---- end of if( (fFapStexNumber > 0) &&  (fFapStexNumber <= fEcal->MaxStexInStas()) ) -----
   else
     {
-      cout << "!TEcnaHistos::ViewMatrix(...)> " << fFapStexName.Data()
+      std::cout << "!TEcnaHistos::ViewMatrix(...)> " << fFapStexName.Data()
 	   << " = " << fFapStexNumber << ". Out of range (range = [1,"
-	   << fEcal->MaxStexInStas() << "]) " << fTTBELL << endl;
+	   << fEcal->MaxStexInStas() << "]) " << fTTBELL << std::endl;
     }
 }  // end of ViewMatrix(...)
 
@@ -2068,8 +2068,8 @@ void TEcnaHistos::ViewStin(const Int_t& cStexStin, const TString& CorOrCov)
 
 	  fFapNbOfEvts = fMyRootFile->GetNumberOfEvents(fFapReqNbOfEvts, fFapStexNumber);
 	  TString fp_name_short = fMyRootFile->GetRootFileNameShort(); 
-	  // cout << "*TEcnaHistos::ViewStin(...)> Data are analyzed from file ----> "
-	  //      << fp_name_short << endl;
+	  // std::cout << "*TEcnaHistos::ViewStin(...)> Data are analyzed from file ----> "
+	  //      << fp_name_short << std::endl;
 
 	  TVectorD vStin(fEcal->MaxStinEcnaInStex());
 	  for(Int_t i=0; i<fEcal->MaxStinEcnaInStex(); i++){vStin(i)=(Double_t)0.;}
@@ -2235,7 +2235,7 @@ void TEcnaHistos::ViewStin(const Int_t& cStexStin, const TString& CorOrCov)
 		      TCanvas *MainCanvas = new TCanvas(f_in, f_in, canv_w, canv_h);   fCnewRoot++;
 		      fCurrentCanvas = MainCanvas; fCurrentCanvasName = f_in;
 		  
-		      // cout << "*TEcnaHistos::ViewStin(...)> Plot is displayed on canvas ----> " << f_in << endl;
+		      // std::cout << "*TEcnaHistos::ViewStin(...)> Plot is displayed on canvas ----> " << f_in << std::endl;
 		  
 		      delete [] f_in; f_in = 0;                                 fCdelete++;
 		  
@@ -2274,7 +2274,7 @@ void TEcnaHistos::ViewStin(const Int_t& cStexStin, const TString& CorOrCov)
 		}
 	      else
 		{
-		  cout << "!TEcnaHistos::ViewStin(...)> *ERROR* =====> "
+		  std::cout << "!TEcnaHistos::ViewStin(...)> *ERROR* =====> "
 		       << fFapStinName.Data() << " "
 		       << cStexStin << " not found."
 		       << " Available numbers = ";
@@ -2282,12 +2282,12 @@ void TEcnaHistos::ViewStin(const Int_t& cStexStin, const TString& CorOrCov)
 		    {
 		      if( vStin(i) > 0 )
 			{
-			  if( fFlagSubDet == "EB" ){cout << (Int_t)vStin(i) << ", ";}
+			  if( fFlagSubDet == "EB" ){std::cout << (Int_t)vStin(i) << ", ";}
 			  if( fFlagSubDet == "EE" )
-			    {cout << fEcalNumbering->GetDeeSCConsFrom1DeeSCEcna(fFapStexNumber, (Int_t)vStin(i)) << ", ";}
+			    {std::cout << fEcalNumbering->GetDeeSCConsFrom1DeeSCEcna(fFapStexNumber, (Int_t)vStin(i)) << ", ";}
 			}
 		    }
-		  cout << fTTBELL << endl;  
+		  std::cout << fTTBELL << std::endl;  
 		}
 	    }  // end of if ( myRootFile->DataExist() == kTRUE )
 	  else
@@ -2299,15 +2299,15 @@ void TEcnaHistos::ViewStin(const Int_t& cStexStin, const TString& CorOrCov)
 	{
 	  fStatusFileFound = kFALSE;
 
-	  cout << "!TEcnaHistos::ViewStin(...)> *ERROR* =====> "
-	       << " ROOT file not found" << fTTBELL << endl;
+	  std::cout << "!TEcnaHistos::ViewStin(...)> *ERROR* =====> "
+	       << " ROOT file not found" << fTTBELL << std::endl;
 	}
     }
   else
     {
-      cout << "!TEcnaHistos::ViewStin(...)> " << fFapStexName.Data()
+      std::cout << "!TEcnaHistos::ViewStin(...)> " << fFapStexName.Data()
 	   << " = " << fFapStexNumber << ". Out of range (range = [1,"
-	   << fEcal->MaxStexInStas() << "]) " << fTTBELL << endl;
+	   << fEcal->MaxStexInStas() << "]) " << fTTBELL << std::endl;
     }
 }  // end of ViewStin(...)
 
@@ -2400,8 +2400,8 @@ void TEcnaHistos::TowerCrystalNumbering(const Int_t& SMNumber, const Int_t& n1SM
       TCanvas *MainCanvas = new TCanvas(f_in, f_in, canv_w , canv_h);    fCnewRoot++;
       fCurrentCanvas = MainCanvas; fCurrentCanvasName = f_in;
 
-      // cout << "*TEcnaHistosEB::TowerCrystalNumbering(...)> Plot is displayed on canvas ----> "
-      //      << f_in << endl;
+      // std::cout << "*TEcnaHistosEB::TowerCrystalNumbering(...)> Plot is displayed on canvas ----> "
+      //      << f_in << std::endl;
 
       Double_t x_margin = fCnaParHistos->BoxLeftX("bottom_left_box") - 0.005;
       Double_t y_margin = fCnaParHistos->BoxTopY("bottom_right_box") + 0.005;  
@@ -2517,8 +2517,8 @@ void TEcnaHistos::TowerCrystalNumbering(const Int_t& SMNumber, const Int_t& n1SM
     }
   else
     {
-      cout << "!TEcnaHistos::TowerCrystalNumbering(...)> SM = " << SMNumber
-	   << ". Out of range ( range = [1," << fEcal->MaxSMInEB() << "] )" << fTTBELL << endl;
+      std::cout << "!TEcnaHistos::TowerCrystalNumbering(...)> SM = " << SMNumber
+	   << ". Out of range ( range = [1," << fEcal->MaxSMInEB() << "] )" << fTTBELL << std::endl;
     }
 }
 //---------------->  end of TowerCrystalNumbering()
@@ -2593,8 +2593,8 @@ void TEcnaHistos::SCCrystalNumbering(const Int_t& DeeNumber, const Int_t& n1DeeS
       TCanvas *MainCanvas = new TCanvas(f_in, f_in, canv_w , canv_h);    fCnewRoot++;
       fCurrentCanvas = MainCanvas; fCurrentCanvasName = f_in;
 
-      // cout << "*TEcnaHistosEE::SCCrystalNumbering(...)> Plot is displayed on canvas ----> "
-      //      << f_in << endl;
+      // std::cout << "*TEcnaHistosEE::SCCrystalNumbering(...)> Plot is displayed on canvas ----> "
+      //      << f_in << std::endl;
 
       Double_t x_margin = fCnaParHistos->BoxLeftX("bottom_left_box") - 0.005;
       Double_t y_margin = fCnaParHistos->BoxTopY("bottom_right_box") + 0.005;
@@ -2664,8 +2664,8 @@ void TEcnaHistos::SCCrystalNumbering(const Int_t& DeeNumber, const Int_t& n1DeeS
     }
   else
     {
-      cout << "!TEcnaHistos::SCCrystalNumbering(...)> Dee = " << DeeNumber
-	   << ". Out of range ( range = [1," << fEcal->MaxDeeInEE() << "] )" << fTTBELL << endl;
+      std::cout << "!TEcnaHistos::SCCrystalNumbering(...)> Dee = " << DeeNumber
+	   << ". Out of range ( range = [1," << fEcal->MaxDeeInEE() << "] )" << fTTBELL << std::endl;
     }
 }
 //---------------->  end of SCCrystalNumbering()
@@ -2831,7 +2831,7 @@ void TEcnaHistos::ViewTowerGrid(const Int_t&  SMNumber,
   if ( x_direction == "-x" )   // NEVER  IN THIS CASE: xmin->xmax <=> right->left ("-x") direction
     {sup_axis_x = new TGaxis( -(Float_t)MatSize, (Float_t)0, (Float_t)(size_eta*MatSize), (Float_t)0.,
 			      "f1", size_eta, "BCS" , 0.);                                fCnewRoot++;
-    cout << "TEcnaHistosEB::ViewTowerGrid()> non foreseen case. eta with -x direction." << fTTBELL << endl;}
+    std::cout << "TEcnaHistosEB::ViewTowerGrid()> non foreseen case. eta with -x direction." << fTTBELL << std::endl;}
 
   if ( x_direction == "x" )    // ALWAYS IN THIS CASE: xmin->xmax <=> left->right ("x") direction
     {sup_axis_x = new TGaxis( (Float_t)0.      , (Float_t)0., (Float_t)(size_eta*MatSize), (Float_t)0.,
@@ -3082,8 +3082,8 @@ void TEcnaHistos::ViewStex(const TVectorD& arg_read_histo, const Int_t& arg_Alre
 	{
 	  fFapNbOfEvts = fMyRootFile->GetNumberOfEvents(fFapReqNbOfEvts, fFapStexNumber);
 	  TString fp_name_short = fMyRootFile->GetRootFileNameShort();
-	  // cout << "*TEcnaHistos::ViewStex(...)> Data are analyzed from file ----> "
-	  //      << fp_name_short << endl;
+	  // std::cout << "*TEcnaHistos::ViewStex(...)> Data are analyzed from file ----> "
+	  //      << fp_name_short << std::endl;
 	  
 	  fStartDate = fMyRootFile->GetStartDate();
 	  fStopDate  = fMyRootFile->GetStopDate();
@@ -3284,7 +3284,7 @@ void TEcnaHistos::ViewStex(const TVectorD& arg_read_histo, const Int_t& arg_Alre
 	  TCanvas *MainCanvas = new TCanvas(f_in, f_in, canv_w, canv_h);   fCnewRoot++;
 	  fCurrentCanvas = MainCanvas; fCurrentCanvasName = f_in;
 
-	  // cout << "*TEcnaHistos::ViewStex(...)> Plot is displayed on canvas ----> " << f_in << endl;
+	  // std::cout << "*TEcnaHistos::ViewStex(...)> Plot is displayed on canvas ----> " << f_in << std::endl;
 	  
 	  delete [] f_in; f_in = 0;                                 fCdelete++;
 	  
@@ -3333,8 +3333,8 @@ void TEcnaHistos::ViewStex(const TVectorD& arg_read_histo, const Int_t& arg_Alre
     {
       fStatusFileFound = kFALSE;
 
-      cout << "!TEcnaHistos::ViewStex(...)> *ERROR* =====> "
-	   << " ROOT file not found" << fTTBELL << endl;
+      std::cout << "!TEcnaHistos::ViewStex(...)> *ERROR* =====> "
+	   << " ROOT file not found" << fTTBELL << std::endl;
     }
 }  // end of ViewStex(...)
 
@@ -3362,8 +3362,8 @@ void TEcnaHistos::StexHocoVecoLHFCorcc(const TString& Freq)
 
       fFapNbOfEvts = fMyRootFile->GetNumberOfEvents(fFapReqNbOfEvts, fFapStexNumber);
       TString fp_name_short = fMyRootFile->GetRootFileNameShort(); 
-      //cout << "*TEcnaHistos::StexHocoVecoLHFCorcc(...)> Data are analyzed from file ----> "
-      //     << fp_name_short << endl;
+      //std::cout << "*TEcnaHistos::StexHocoVecoLHFCorcc(...)> Data are analyzed from file ----> "
+      //     << fp_name_short << std::endl;
 
       fStartDate = fMyRootFile->GetStartDate();
       fStopDate  = fMyRootFile->GetStopDate();
@@ -3525,8 +3525,8 @@ void TEcnaHistos::StexHocoVecoLHFCorcc(const TString& Freq)
 	      TCanvas *MainCanvas = new TCanvas(f_in, f_in, canv_w, canv_h);   fCnewRoot++;
 	      fCurrentCanvas = MainCanvas; fCurrentCanvasName = f_in;
 
-	      // cout << "*TEcnaHistos::StexHocoVecoLHFCorcc(...)> Plot is displayed on canvas ----> "
-	      //      << f_in << endl;
+	      // std::cout << "*TEcnaHistos::StexHocoVecoLHFCorcc(...)> Plot is displayed on canvas ----> "
+	      //      << f_in << std::endl;
 	      
 	      delete [] f_in; f_in = 0;                                 fCdelete++;
 	     
@@ -3577,8 +3577,8 @@ void TEcnaHistos::StexHocoVecoLHFCorcc(const TString& Freq)
     {
       fStatusFileFound = kFALSE;
 
-      cout << "!TEcnaHistos::StexHocoVecoLHFCorcc(...)> *ERROR* =====> "
-	   << " ROOT file not found" << fTTBELL << endl;
+      std::cout << "!TEcnaHistos::StexHocoVecoLHFCorcc(...)> *ERROR* =====> "
+	   << " ROOT file not found" << fTTBELL << std::endl;
     }
 } // end of StexHocoVecoLHFCorcc
 
@@ -3746,7 +3746,7 @@ void TEcnaHistos::SMTowerNumbering(const Int_t& SMNumber)
       TCanvas *MainCanvas = new TCanvas(f_in, f_in, canv_w, canv_h);   fCnewRoot++;
       fCurrentCanvas = MainCanvas; fCurrentCanvasName = f_in;
 
-      // cout << "*TEcnaHistosEB::ViewSM(...)> Plot is displayed on canvas ----> " << f_in << endl;
+      // std::cout << "*TEcnaHistosEB::ViewSM(...)> Plot is displayed on canvas ----> " << f_in << std::endl;
   
       delete [] f_in; f_in = 0;                                 fCdelete++;
 
@@ -3775,8 +3775,8 @@ void TEcnaHistos::SMTowerNumbering(const Int_t& SMNumber)
     }
   else
     {
-      cout << "!TEcnaHistos::SMTowerNumbering(...)> SM = " << SMNumber
-	   << ". Out of range ( range = [1," << fEcal->MaxSMInEB() << "] )" << fTTBELL << endl;
+      std::cout << "!TEcnaHistos::SMTowerNumbering(...)> SM = " << SMNumber
+	   << ". Out of range ( range = [1," << fEcal->MaxSMInEB() << "] )" << fTTBELL << std::endl;
     }
 }
 // end of SMTowerNumbering
@@ -4191,7 +4191,7 @@ void TEcnaHistos::DeeSCNumbering(const Int_t& DeeNumber)
       TCanvas *MainCanvas = new TCanvas(f_in, f_in, canv_w, canv_h);   fCnewRoot++;
       fCurrentCanvas = MainCanvas; fCurrentCanvasName = f_in;
 
-      // cout << "*TEcnaHistosEE::ViewDee(...)> Plot is displayed on canvas ----> " << f_in << endl;
+      // std::cout << "*TEcnaHistosEE::ViewDee(...)> Plot is displayed on canvas ----> " << f_in << std::endl;
   
       delete [] f_in; f_in = 0;                                 fCdelete++;
 
@@ -4230,8 +4230,8 @@ void TEcnaHistos::DeeSCNumbering(const Int_t& DeeNumber)
     }
   else
     {
-      cout << "!TEcnaHistos::DeeSCNumbering(...)> Dee = " << DeeNumber
-	   << ". Out of range ( range = [1," << fEcal->MaxDeeInEE() << "] )" << fTTBELL << endl;
+      std::cout << "!TEcnaHistos::DeeSCNumbering(...)> Dee = " << DeeNumber
+	   << ". Out of range ( range = [1," << fEcal->MaxDeeInEE() << "] )" << fTTBELL << std::endl;
     }
 }
 // end of DeeSCNumbering
@@ -4732,9 +4732,9 @@ void TEcnaHistos::SqrtContourLevels(const Int_t& nb_niv, Double_t* cont_niv)
       Int_t ind_niv = num_niv + nb_niv2 - 1;
       if ( ind_niv < 0 || ind_niv > nb_niv )
 	{
-	  cout << "!TEcnaHistos::ContourLevels(...)> *** ERROR *** "
+	  std::cout << "!TEcnaHistos::ContourLevels(...)> *** ERROR *** "
 	       << "wrong contour levels for correlation matrix"
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       else
 	{
@@ -4748,9 +4748,9 @@ void TEcnaHistos::SqrtContourLevels(const Int_t& nb_niv, Double_t* cont_niv)
       Int_t ind_niv = num_niv + nb_niv2 - 1;
       if ( ind_niv < 0 || ind_niv > nb_niv )
 	{
-	  cout << "!TEcnaHistos::ContourLevels(...)> *** ERROR *** "
+	  std::cout << "!TEcnaHistos::ContourLevels(...)> *** ERROR *** "
 	       << "wrong contour levels for correlation matrix"
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       else
 	{
@@ -4904,8 +4904,8 @@ void TEcnaHistos::ViewStas(const TVectorD& arg_read_histo, const Int_t& arg_Alre
 	    {
 	      xFapNbOfEvts[iStasStex] = fMyRootFile->GetNumberOfEvents(fFapReqNbOfEvts, n1StasStex);
 	      TString fp_name_short = fMyRootFile->GetRootFileNameShort();
-	      // cout << "*TEcnaHistos::ViewStas(...)> Data are analyzed from file ----> "
-	      //      << fp_name_short << endl;
+	      // std::cout << "*TEcnaHistos::ViewStas(...)> Data are analyzed from file ----> "
+	      //      << fp_name_short << std::endl;
 	      
 	      //....................... search for first and last dates
 	      if( iStasStex == 0 )
@@ -4947,8 +4947,8 @@ void TEcnaHistos::ViewStas(const TVectorD& arg_read_histo, const Int_t& arg_Alre
 	  else
 	    {
 	      fStatusFileFound = kFALSE;
-	      cout << "!TEcnaHistos::ViewStas(...)> *ERROR* =====> "
-		   << " ROOT file not found" << fTTBELL << endl;
+	      std::cout << "!TEcnaHistos::ViewStas(...)> *ERROR* =====> "
+		   << " ROOT file not found" << fTTBELL << std::endl;
 	    }
 	}
 
@@ -5039,18 +5039,18 @@ void TEcnaHistos::ViewStas(const TVectorD& arg_read_histo, const Int_t& arg_Alre
 	    {
 	      fStatusDataExist = kFALSE;
 
-	      cout << "!TEcnaHistos::ViewStas(...)>  "
+	      std::cout << "!TEcnaHistos::ViewStas(...)>  "
 		   << " Data not available for " << fFapStexName << " " << iStasStex+1
-		   << " (Quantity not present in the ROOT file)" << fTTBELL << endl;
+		   << " (Quantity not present in the ROOT file)" << fTTBELL << std::endl;
 	    }
 	} // end of if( fMyRootFile->LookAtRootFile() == kTRUE )	  (ViewStas)
       else
 	{
 	  fStatusFileFound = kFALSE;
 
-	  cout << "!TEcnaHistos::ViewStas(...)>  "
+	  std::cout << "!TEcnaHistos::ViewStas(...)>  "
 	       << " Data not available for " << fFapStexName << " " << iStasStex+1
-	       << " (ROOT file not found)"  << fTTBELL << endl;
+	       << " (ROOT file not found)"  << fTTBELL << std::endl;
 	}
 
       if( fFapNbOfEvts <= xFapNbOfEvts[iStasStex] ){fFapNbOfEvts = xFapNbOfEvts[iStasStex];}
@@ -5142,7 +5142,7 @@ void TEcnaHistos::ViewStas(const TVectorD& arg_read_histo, const Int_t& arg_Alre
       TCanvas *MainCanvas = new TCanvas(f_in, f_in, canv_w, canv_h);   fCnewRoot++;
       fCurrentCanvas = MainCanvas; fCurrentCanvasName = f_in;
 
-      // cout << "*TEcnaHistos::ViewStas(...)> Plot is displayed on canvas ----> " << f_in << endl;
+      // std::cout << "*TEcnaHistos::ViewStas(...)> Plot is displayed on canvas ----> " << f_in << std::endl;
 	  
       delete [] f_in; f_in = 0;                                 fCdelete++;
 
@@ -6113,7 +6113,7 @@ void TEcnaHistos::XtalSamplesEv(const TVectorD& arg_read_histo, const Int_t& arg
 	      else
 		{
 		  fStatusFileFound = kFALSE;
-		  cout << "!TEcnaHistos::XtalSamplesEv(...)> Data not available (ROOT file not found)." << endl;
+		  std::cout << "!TEcnaHistos::XtalSamplesEv(...)> Data not available (ROOT file not found)." << std::endl;
 		}
 	      if( fStatusFileFound == kTRUE && fStatusDataExist == kTRUE ){aOKData = kTRUE;}
 	    }
@@ -6132,16 +6132,16 @@ void TEcnaHistos::XtalSamplesEv(const TVectorD& arg_read_histo, const Int_t& arg
 	      for( Int_t i0_stin_echa=0; i0_stin_echa<fEcal->MaxCrysInStin(); i0_stin_echa++)
 		{
 		  if( fFapStexName == "SM" )
-		    {cout << "*TEcnaHistos::XtalSamplesEv(...)> channel " << setw(2) << i0_stin_echa << ": ";}
+		    {std::cout << "*TEcnaHistos::XtalSamplesEv(...)> channel " << std::setw(2) << i0_stin_echa << ": ";}
 		  if( fFapStexName == "Dee" )
-		    {cout << "*TEcnaHistos::XtalSamplesEv(...)> Xtal " << setw(2) << i0_stin_echa+1 << ": ";}
+		    {std::cout << "*TEcnaHistos::XtalSamplesEv(...)> Xtal " << std::setw(2) << i0_stin_echa+1 << ": ";}
 		  
 		  for( Int_t i0_samp=0; i0_samp<fFapNbOfSamples; i0_samp++ )
 		    {
 		      read_histo_samps(i0_samp) = read_histo(i0_stin_echa*fFapNbOfSamples+i0_samp);
-		      cout << setprecision(4) << setw(8) << read_histo_samps(i0_samp) << ", " ;
+		      std::cout << std::setprecision(4) << std::setw(8) << read_histo_samps(i0_samp) << ", " ;
 		    }
-		  cout << endl;
+		  std::cout << std::endl;
 		  ViewHisto(read_histo_samps, xAlreadyRead,
 			    StexStin_A, i0_stin_echa, fZerv, "D_MSp_SpNb", fAllXtalsInStinPlot);
 		  xAlreadyRead++;
@@ -6150,7 +6150,7 @@ void TEcnaHistos::XtalSamplesEv(const TVectorD& arg_read_histo, const Int_t& arg
 	    }
 	  else
 	    {
-	      cout << "!TEcnaHistos::XtalSamplesEv(...)> Data not available." << endl;
+	      std::cout << "!TEcnaHistos::XtalSamplesEv(...)> Data not available." << std::endl;
 	    }
 	}
       
@@ -6164,8 +6164,8 @@ void TEcnaHistos::XtalSamplesEv(const TVectorD& arg_read_histo, const Int_t& arg
     }
   else
     {
-      cout << "!TEcnaHistos::XtalSamplesEv(...)> " << fFapStexName.Data() << " number = " << fFapStexNumber
-	   << " out of range (range = [1," << fEcal->MaxStexInStas() << "])" << fTTBELL << endl;
+      std::cout << "!TEcnaHistos::XtalSamplesEv(...)> " << fFapStexName.Data() << " number = " << fFapStexNumber
+	   << " out of range (range = [1," << fEcal->MaxStexInStas() << "])" << fTTBELL << std::endl;
     }
 }
 
@@ -6205,7 +6205,7 @@ void TEcnaHistos::EvSamplesXtals(const TVectorD& arg_read_histo, const Int_t& ar
 	      else
 		{
 		  fStatusFileFound = kFALSE;
-		  cout << "!TEcnaHistos::EvSamplesXtals(...)> Data not available (ROOT file not found)." << endl;
+		  std::cout << "!TEcnaHistos::EvSamplesXtals(...)> Data not available (ROOT file not found)." << std::endl;
 		}
 	      if( fStatusFileFound == kTRUE && fStatusDataExist == kTRUE ){aOKData = kTRUE;}
 	    }
@@ -6223,16 +6223,16 @@ void TEcnaHistos::EvSamplesXtals(const TVectorD& arg_read_histo, const Int_t& ar
 	      for( Int_t i0_stin_echa=0; i0_stin_echa<fEcal->MaxCrysInStin(); i0_stin_echa++)
 		{
 		  if( fFapStexName == "SM" )
-		    {cout << "*TEcnaHistos::EvSamplesXtals(...)> channel " << setw(2) << i0_stin_echa << ": ";}
+		    {std::cout << "*TEcnaHistos::EvSamplesXtals(...)> channel " << std::setw(2) << i0_stin_echa << ": ";}
 		  if( fFapStexName == "Dee" )
-		    {cout << "*TEcnaHistos::EvSamplesXtals(...)> Xtal " << setw(2) << i0_stin_echa+1 << ": ";}
+		    {std::cout << "*TEcnaHistos::EvSamplesXtals(...)> Xtal " << std::setw(2) << i0_stin_echa+1 << ": ";}
 		  
 		  for( Int_t i0_samp=0; i0_samp<fFapNbOfSamples; i0_samp++ )
 		    {
 		      read_histo_samps(i0_samp) = read_histo(i0_stin_echa*fFapNbOfSamples+i0_samp);
-		      cout << setprecision(4) << setw(8) << read_histo_samps(i0_samp) << ", " ;
+		      std::cout << std::setprecision(4) << std::setw(8) << read_histo_samps(i0_samp) << ", " ;
 		    }
-		  cout << endl;
+		  std::cout << std::endl;
 		  ViewHisto(read_histo_samps, xAlreadyRead,
 			    StexStin_A, i0_stin_echa, fZerv, "D_MSp_SpDs", fAllXtalsInStinPlot);
 		  xAlreadyRead++;
@@ -6241,7 +6241,7 @@ void TEcnaHistos::EvSamplesXtals(const TVectorD& arg_read_histo, const Int_t& ar
 	    }
 	  else
 	    {
-	      cout << "!TEcnaHistos::EvSamplesXtals(...)> Data not available." << endl;
+	      std::cout << "!TEcnaHistos::EvSamplesXtals(...)> Data not available." << std::endl;
 	    }
 	}
       
@@ -6255,8 +6255,8 @@ void TEcnaHistos::EvSamplesXtals(const TVectorD& arg_read_histo, const Int_t& ar
     }
   else
     {
-      cout << "!TEcnaHistos::EvSamplesXtals(...)> " << fFapStexName.Data() << " number = " << fFapStexNumber
-	   << " out of range (range = [1," << fEcal->MaxStexInStas() << "])" << fTTBELL << endl;
+      std::cout << "!TEcnaHistos::EvSamplesXtals(...)> " << fFapStexName.Data() << " number = " << fFapStexNumber
+	   << " out of range (range = [1," << fEcal->MaxStexInStas() << "])" << fTTBELL << std::endl;
     }
 } // end of EvSamplesXtals(...)
 
@@ -6296,7 +6296,7 @@ void TEcnaHistos::XtalSamplesSigma(const TVectorD& arg_read_histo, const Int_t& 
 	      else
 		{
 		  fStatusFileFound = kFALSE;
-		  cout << "!TEcnaHistos::XtalSamplesSigma(...)> Data not available (ROOT file not found)." << endl;
+		  std::cout << "!TEcnaHistos::XtalSamplesSigma(...)> Data not available (ROOT file not found)." << std::endl;
 		}
 	      if( fStatusFileFound == kTRUE && fStatusDataExist == kTRUE ){aOKData = kTRUE;}
 	    }
@@ -6314,16 +6314,16 @@ void TEcnaHistos::XtalSamplesSigma(const TVectorD& arg_read_histo, const Int_t& 
 	      for( Int_t i0_stin_echa=0; i0_stin_echa<fEcal->MaxCrysInStin(); i0_stin_echa++)
 		{
 		  if( fFapStexName == "SM" )
-		    {cout << "*TEcnaHistos::XtalSamplesSigma(...)> channel " << setw(2) << i0_stin_echa << ": ";}
+		    {std::cout << "*TEcnaHistos::XtalSamplesSigma(...)> channel " << std::setw(2) << i0_stin_echa << ": ";}
 		  if( fFapStexName == "Dee" )
-		    {cout << "*TEcnaHistos::XtalSamplesSigma(...)> Xtal " << setw(2) << i0_stin_echa+1 << ": ";}
+		    {std::cout << "*TEcnaHistos::XtalSamplesSigma(...)> Xtal " << std::setw(2) << i0_stin_echa+1 << ": ";}
 		  
 		  for( Int_t i0_samp=0; i0_samp<fFapNbOfSamples; i0_samp++ )
 		    {
 		      read_histo_samps(i0_samp) = read_histo(i0_stin_echa*fFapNbOfSamples+i0_samp);
-		      cout << setprecision(3) << setw(6) << read_histo_samps(i0_samp) << ", " ;
+		      std::cout << std::setprecision(3) << std::setw(6) << read_histo_samps(i0_samp) << ", " ;
 		    }
-		  cout << endl;
+		  std::cout << std::endl;
 		  ViewHisto(read_histo_samps, xAlreadyRead,
 			    StexStin_A, i0StinEcha, fZerv, "D_SSp_SpNb", fAllXtalsInStinPlot);
 		  xAlreadyRead++;    
@@ -6332,7 +6332,7 @@ void TEcnaHistos::XtalSamplesSigma(const TVectorD& arg_read_histo, const Int_t& 
 	    }
 	  else
 	    {
-	      cout << "!TEcnaHistos::XtalSamplesSigma(...)> Data not available." << endl;
+	      std::cout << "!TEcnaHistos::XtalSamplesSigma(...)> Data not available." << std::endl;
 	    }
 	}
 
@@ -6346,8 +6346,8 @@ void TEcnaHistos::XtalSamplesSigma(const TVectorD& arg_read_histo, const Int_t& 
     }
   else
     {
-      cout << "!TEcnaHistos::XtalSamplesSigma(...)> " << fFapStexName.Data() << " number = " << fFapStexNumber
-	   << " out of range (range = [1," << fEcal->MaxStexInStas() << "])" << fTTBELL << endl;
+      std::cout << "!TEcnaHistos::XtalSamplesSigma(...)> " << fFapStexName.Data() << " number = " << fFapStexNumber
+	   << " out of range (range = [1," << fEcal->MaxStexInStas() << "])" << fTTBELL << std::endl;
     }
 }
 
@@ -6387,7 +6387,7 @@ void TEcnaHistos::SigmaSamplesXtals(const TVectorD& arg_read_histo, const Int_t&
 	      else
 		{
 		  fStatusFileFound = kFALSE;
-		  cout << "!TEcnaHistos::SigmaSamplesXtals(...)> Data not available (ROOT file not found)." << endl;
+		  std::cout << "!TEcnaHistos::SigmaSamplesXtals(...)> Data not available (ROOT file not found)." << std::endl;
 		}
 	      if( fStatusFileFound == kTRUE && fStatusDataExist == kTRUE ){aOKData = kTRUE;}
 	    }
@@ -6406,16 +6406,16 @@ void TEcnaHistos::SigmaSamplesXtals(const TVectorD& arg_read_histo, const Int_t&
 	      for( Int_t i0_stin_echa=0; i0_stin_echa<fEcal->MaxCrysInStin(); i0_stin_echa++)
 		{
 		  if( fFapStexName == "SM" )
-		    {cout << "*TEcnaHistos::SigmaSamplesXtals(...)> channel " << setw(2) << i0_stin_echa << ": ";}
+		    {std::cout << "*TEcnaHistos::SigmaSamplesXtals(...)> channel " << std::setw(2) << i0_stin_echa << ": ";}
 		  if( fFapStexName == "Dee" )
-		    {cout << "*TEcnaHistos::SigmaSamplesXtals(...)> Xtal " << setw(2) << i0_stin_echa+1 << ": ";}
+		    {std::cout << "*TEcnaHistos::SigmaSamplesXtals(...)> Xtal " << std::setw(2) << i0_stin_echa+1 << ": ";}
 		  
 		  for( Int_t i0_samp=0; i0_samp<fFapNbOfSamples; i0_samp++ )
 		    {
 		      read_histo_samps(i0_samp) = read_histo(i0_stin_echa*fFapNbOfSamples+i0_samp);
-		      cout << setprecision(3) << setw(6) << read_histo_samps(i0_samp) << ", " ;
+		      std::cout << std::setprecision(3) << std::setw(6) << read_histo_samps(i0_samp) << ", " ;
 		    }
-		  cout << endl;
+		  std::cout << std::endl;
 		  ViewHisto(read_histo_samps, xAlreadyRead,
 			    StexStin_A, i0StinEcha, fZerv, "D_SSp_SpDs", fAllXtalsInStinPlot);
 		  xAlreadyRead++;    
@@ -6424,7 +6424,7 @@ void TEcnaHistos::SigmaSamplesXtals(const TVectorD& arg_read_histo, const Int_t&
 	    }
 	  else
 	    {
-	      cout << "!TEcnaHistos::SigmaSamplesXtals(...)> Data not available." << endl;
+	      std::cout << "!TEcnaHistos::SigmaSamplesXtals(...)> Data not available." << std::endl;
 	    }
 	}
       
@@ -6438,8 +6438,8 @@ void TEcnaHistos::SigmaSamplesXtals(const TVectorD& arg_read_histo, const Int_t&
     }
   else
     {
-      cout << "!TEcnaHistos::SigmaSamplesXtals(...)> " << fFapStexName.Data() << " number = " << fFapStexNumber
-	   << " out of range (range = [1," << fEcal->MaxStexInStas() << "])" << fTTBELL << endl;
+      std::cout << "!TEcnaHistos::SigmaSamplesXtals(...)> " << fFapStexName.Data() << " number = " << fFapStexNumber
+	   << " out of range (range = [1," << fEcal->MaxStexInStas() << "])" << fTTBELL << std::endl;
     }
 } // end of SigmaSamplesXtals(...)
 
@@ -6483,10 +6483,10 @@ void TEcnaHistos::ViewHisto(const TVectorD& arg_read_histo, const Int_t&  arg_Al
       main_subpad = ActivePad(HistoCode.Data(), opt_plot.Data());  // => return 0 if canvas has been closed
       if( main_subpad == 0 )
 	{
-	  cout << "*TEcnaHistos::ViewHisto(...)> WARNING ===> Canvas has been closed in option SAME or SAME n."
-	       << endl
+	  std::cout << "*TEcnaHistos::ViewHisto(...)> WARNING ===> Canvas has been closed in option SAME or SAME n."
+	       << std::endl
 	       << "                              Please, restart with a new canvas."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	  
 	  ReInitCanvas(HistoCode, opt_plot);
 	  xCanvasExists = 0;
@@ -6512,12 +6512,12 @@ void TEcnaHistos::ViewHisto(const TVectorD& arg_read_histo, const Int_t&  arg_Al
 	  
 	  if( XVarHisto != XVariableMemo )
 	    {
-	      cout << "!TEcnaHistos::ViewHisto(...)> *** ERROR *** ===> X coordinate changed in option SAME n." << endl
-		   << "                              Present  X = " << XVarHisto << endl
-		   << "                              Present  Y = " << YVarHisto << endl
-		   << "                              Previous X = " << XVariableMemo << endl
+	      std::cout << "!TEcnaHistos::ViewHisto(...)> *** ERROR *** ===> X coordinate changed in option SAME n." << std::endl
+		   << "                              Present  X = " << XVarHisto << std::endl
+		   << "                              Present  Y = " << YVarHisto << std::endl
+		   << "                              Previous X = " << XVariableMemo << std::endl
 		   << "                              Previous Y = " << YVariableMemo 
-		   << fTTBELL << endl;
+		   << fTTBELL << std::endl;
 	      SameXVarMemo = 0;
 	    }
 	  else
@@ -6544,12 +6544,12 @@ void TEcnaHistos::ViewHisto(const TVectorD& arg_read_histo, const Int_t&  arg_Al
 	  
 	  if( YVarHisto != YVariableMemo )
 	    {
-	      cout << "!TEcnaHistos::ViewHisto(...)> *** ERROR *** ===> Y coordinate changed in option SAME n." << endl
-		   << "                              Present  X = " << XVarHisto << endl
-		   << "                              Present  Y = " << YVarHisto << endl
-		   << "                              Previous X = " << XVariableMemo << endl
+	      std::cout << "!TEcnaHistos::ViewHisto(...)> *** ERROR *** ===> Y coordinate changed in option SAME n." << std::endl
+		   << "                              Present  X = " << XVarHisto << std::endl
+		   << "                              Present  Y = " << YVarHisto << std::endl
+		   << "                              Previous X = " << XVariableMemo << std::endl
 		   << "                              Previous Y = " << YVariableMemo 
-		   << fTTBELL << endl;
+		   << fTTBELL << std::endl;
 	      SameYVarMemo = 0;
 	    }
 	  else
@@ -6574,8 +6574,8 @@ void TEcnaHistos::ViewHisto(const TVectorD& arg_read_histo, const Int_t&  arg_Al
       Int_t NbBinsMemo = GetNbBinsFromMemo(HistoCode, opt_plot);
       if( xNbBins != NbBinsMemo )
 	{
-	  cout << "!TEcnaHistos::ViewHisto(...)> *** ERROR *** ===> Number of bins changed in option SAME or SAME n."
-	       << " Present number = " << xNbBins << ", requested number = " << NbBinsMemo << fTTBELL << endl;
+	  std::cout << "!TEcnaHistos::ViewHisto(...)> *** ERROR *** ===> Number of bins changed in option SAME or SAME n."
+	       << " Present number = " << xNbBins << ", requested number = " << NbBinsMemo << fTTBELL << std::endl;
 	  OkBinsMemoSameOne = 0;
 	}
     }
@@ -6651,8 +6651,8 @@ void TEcnaHistos::ViewHisto(const TVectorD& arg_read_histo, const Int_t&  arg_Al
 			{
 			  xFapNbOfEvts[iStasStex] = fMyRootFile->GetNumberOfEvents(fFapReqNbOfEvts, n1StasStex);
 			  fp_name_short = fMyRootFile->GetRootFileNameShort();
-			  // cout << "*TEcnaHistos::ViewHisto(...)> Data are analyzed from file ----> "
-			  //      << fp_name_short << endl;
+			  // std::cout << "*TEcnaHistos::ViewHisto(...)> Data are analyzed from file ----> "
+			  //      << fp_name_short << std::endl;
 			  //....................... search for first and last dates
 			  if( iStasStex == 0 )
 			    {
@@ -6730,8 +6730,8 @@ void TEcnaHistos::ViewHisto(const TVectorD& arg_read_histo, const Int_t&  arg_Al
 				    }
 				  else
 				    {
-				      cout << "!TEcnaHistos::ViewHisto(...)> <EB> i_xgeo = " << i_xgeo
-					   << ". OUT OF RANGE ( range = [0,"<< SizeForPlot << "] " << endl;
+				      std::cout << "!TEcnaHistos::ViewHisto(...)> <EB> i_xgeo = " << i_xgeo
+					   << ". OUT OF RANGE ( range = [0,"<< SizeForPlot << "] " << std::endl;
 				    }  
 				}
 			      //...................................... EE    (ViewHisto)
@@ -6831,21 +6831,21 @@ void TEcnaHistos::ViewHisto(const TVectorD& arg_read_histo, const Int_t&  arg_Al
 					}// end of if(StexDSStin >=1 && StexDSStin <= fEcalNumbering->GetMaxSCInDS(StexDataSector))
 				      else
 					{
-					  cout << "!TEcnaHistos::ViewHisto(...)> <EE>  StexDSStin = " << StexDSStin
+					  std::cout << "!TEcnaHistos::ViewHisto(...)> <EE>  StexDSStin = " << StexDSStin
 					       << ". OUT OF RANGE ( range = [1,"
 					       << fEcalNumbering->GetMaxSCInDS(StexDataSector)
 					       << "]. DeeNumber =  " << DeeNumber
 					       << ", n1DeeSCEcna = " << n1DeeSCEcna
 					       << ", StexDataSector = "  << StexDataSector 
-					       << ", i_xgeo = "  << i_xgeo << endl;
+					       << ", i_xgeo = "  << i_xgeo << std::endl;
 					}
 				    }// end of if( StexDataSector >= 1 && StexDataSector <= 9 )
 				  else
 				    {
-				      //cout << "!TEcnaHistos::ViewHisto(...)> <EE>  StexDataSector = " << StexDataSector
+				      //std::cout << "!TEcnaHistos::ViewHisto(...)> <EE>  StexDataSector = " << StexDataSector
 				      //     << ". OUT OF RANGE ( range = [1,9]. DeeNumber = " << DeeNumber
 				      //     << ", n1DeeSCEcna = " << n1DeeSCEcna
-				      //     << ", i_xgeo = "  << i_xgeo << endl;
+				      //     << ", i_xgeo = "  << i_xgeo << std::endl;
 				    }
 				  //......................................... transfert read_histo -> histo_for_plot
 				  if( i_xgeo >= -1 && i_xgeo < SizeForPlot )
@@ -6901,26 +6901,26 @@ void TEcnaHistos::ViewHisto(const TVectorD& arg_read_histo, const Int_t&  arg_Al
 				    } // end of if( i_xgeo >= -1 && i_xgeo < SizeForPlot )
 				  else
 				    {
-				      //cout << "!TEcnaHistos::ViewHisto(...)> <EE>  i_xgeo = " << i_xgeo
-				      //     << ". OUT OF RANGE ( range = [0,"<< SizeForPlot << "] " << endl;
+				      //std::cout << "!TEcnaHistos::ViewHisto(...)> <EE>  i_xgeo = " << i_xgeo
+				      //     << ". OUT OF RANGE ( range = [0,"<< SizeForPlot << "] " << std::endl;
 				    }
 				}// end of if( fFlagSubDet == "EE" )
 			    }// end of for(Int_t i0StexStinEcna=0; i0StexStinEcna<fEcal->MaxStinEcnaInStex(); i0StexStinEcna++)
 			}
 		      else
 			{
-			  cout << "!TEcnaHistos::ViewHisto(...)>  "
+			  std::cout << "!TEcnaHistos::ViewHisto(...)>  "
 			       << " Data not available for " << fFapStexName << " " << iStasStex+1
-			       << " (Quantity not present in the ROOT file)" << endl;
+			       << " (Quantity not present in the ROOT file)" << std::endl;
 			}
 		    } // end of if ( fMyRootFile->LookAtRootFile() == kTRUE )   (ViewHisto/Stas)
 		  else
 		    {
 		      fStatusFileFound = kFALSE;
 
-		      cout << "!TEcnaHistos::ViewHisto(...)>  "
+		      std::cout << "!TEcnaHistos::ViewHisto(...)>  "
 			   << " Data not available for " << fFapStexName << " " << iStasStex+1
-			   << " (ROOT file not found)" << endl;
+			   << " (ROOT file not found)" << std::endl;
 		    }
 
 		  if( fFapNbOfEvts <= xFapNbOfEvts[iStasStex] ){fFapNbOfEvts = xFapNbOfEvts[iStasStex];}
@@ -6955,8 +6955,8 @@ void TEcnaHistos::ViewHisto(const TVectorD& arg_read_histo, const Int_t&  arg_Al
 		    {
 		      fFapNbOfEvts = fMyRootFile->GetNumberOfEvents(fFapReqNbOfEvts, fFapStexNumber);
 		      fp_name_short = fMyRootFile->GetRootFileNameShort();
-		      // cout << "*TEcnaHistos::ViewHisto(...)> Data are analyzed from file ----> "
-		      //      << fp_name_short << endl;
+		      // std::cout << "*TEcnaHistos::ViewHisto(...)> Data are analyzed from file ----> "
+		      //      << fp_name_short << std::endl;
 		      
 		      fStartDate = fMyRootFile->GetStartDate();
 		      fStopDate  = fMyRootFile->GetStopDate();
@@ -7078,7 +7078,7 @@ void TEcnaHistos::ViewHisto(const TVectorD& arg_read_histo, const Int_t&  arg_Al
 						      histo_for_plot_memo[i_xgeo]++;
 						      if( histo_for_plot_memo[i_xgeo] >= 2 )
 							{
-							  cout << "! histo_memo[" << i_xgeo
+							  std::cout << "! histo_memo[" << i_xgeo
 							       << "] = " << histo_for_plot_memo[i_xgeo]
 							       << ", nSCCons = " <<  nSCCons
 							       << ", SC_in_DS = " << SC_in_DS
@@ -7086,7 +7086,7 @@ void TEcnaHistos::ViewHisto(const TVectorD& arg_read_histo, const Int_t&  arg_Al
 							       << ", SCOffset = " << SCOffset
 							       << ", n1DeeSCEcna = " << n1DeeSCEcna
 							       << ", n1SCEcha = " << n1SCEcha
-							       << ", n1FinalSCEcha = " << n1FinalSCEcha << endl;
+							       << ", n1FinalSCEcha = " << n1FinalSCEcha << std::endl;
 							}
 						      //.............................. transfert read_histo -> histo_for_plot
 						      if( i_xgeo >= 0 && i_xgeo < SizeForPlot )
@@ -7096,51 +7096,51 @@ void TEcnaHistos::ViewHisto(const TVectorD& arg_read_histo, const Int_t&  arg_Al
 							}
 						      else
 							{
-							  cout << "!TEcnaHistos::ViewHisto(...)> <EE>  i_xgeo = " << i_xgeo
-							       << ". OUT OF RANGE ( range = [0,"<< SizeForPlot << "] " << endl;
+							  std::cout << "!TEcnaHistos::ViewHisto(...)> <EE>  i_xgeo = " << i_xgeo
+							       << ". OUT OF RANGE ( range = [0,"<< SizeForPlot << "] " << std::endl;
 							}
 						    } // end of  if( read_histo[i0DeeEcha] > 0 )
 						} // end of if( SC_in_DS >= 1 && SC_in_DS <= fEcalNumbering->GetMaxSCInDS(DataSector) )
 					      else
 						{
-						  cout << "!TEcnaHistos::ViewHisto(...)> <EE>  SC_in_DS = " << SC_in_DS
+						  std::cout << "!TEcnaHistos::ViewHisto(...)> <EE>  SC_in_DS = " << SC_in_DS
 						       << ". OUT OF RANGE ( range = [1,"
 						       << fEcalNumbering->GetMaxSCInDS(DataSector) << "] "
 						       << ", DataSector = " << DataSector
 						       << ", n1DeeSCEcna = " << n1DeeSCEcna
 						       << ", n1SCEcha = " << n1SCEcha
 						       << ", i0DeeEcha = " << i0DeeEcha
-						       << endl;
+						       << std::endl;
 						}
 					    } // end of if( DataSector >= 1 && DataSector <= 9 )
 					  else
 					    {
 					      if( DataSector != 0 )
 						{
-						  cout << "!TEcnaHistos::ViewHisto(...)> <EE>  DataSector = " << DataSector
+						  std::cout << "!TEcnaHistos::ViewHisto(...)> <EE>  DataSector = " << DataSector
 						       << ". OUT OF RANGE ( range = [1,9] "
 						       << ", n1DeeSCEcna = " << n1DeeSCEcna
 						       << ", n1SCEcha = " << n1SCEcha
 						       << ", i0DeeEcha = " << i0DeeEcha
-						       << endl;
+						       << std::endl;
 						}
 					    }
 					} // end of if( n1DeeSCEcna >= 1 && n1DeeSCEcna <= fEcal->MaxSCEcnaInDee() )
 				      else
 					{
-					  cout << "!TEcnaHistos::ViewHisto(...)> <EE>  n1DeeSCEcna = " << n1DeeSCEcna
+					  std::cout << "!TEcnaHistos::ViewHisto(...)> <EE>  n1DeeSCEcna = " << n1DeeSCEcna
 					       << ". OUT OF RANGE ( range = [1,"<< fEcal->MaxSCEcnaInDee() << "] "
 					       << ", n1SCEcha = " << n1SCEcha
 					       << ", i0DeeEcha = " << i0DeeEcha
-					       << endl;
+					       << std::endl;
 					}
 				    } // end of if(n1SCEcha >= 1 && n1SCEcha <= fEcal->MaxCrysInSC() )
 				  else
 				    {
-				      cout << "!TEcnaHistos::ViewHisto(...)> <EE>  n1SCEcha = " << n1SCEcha
+				      std::cout << "!TEcnaHistos::ViewHisto(...)> <EE>  n1SCEcha = " << n1SCEcha
 					   << ". OUT OF RANGE ( range = [1,"<< fEcal->MaxCrysInSC() << "] "
 					   << ", i0DeeEcha = " << i0DeeEcha
-					   << endl;
+					   << std::endl;
 				    }
 				}
 			    } // end of if( OKPlot == 1 && opt_plot != "ASCII" )
@@ -7148,16 +7148,16 @@ void TEcnaHistos::ViewHisto(const TVectorD& arg_read_histo, const Int_t&  arg_Al
 		    } // end of if(ok_view_histo == kTRUE)
 		  else
 		    {
-		      cout << "!TEcnaHistos::ViewHisto(...)> *ERROR* =====> "
-			   << " ok_view_histo != kTRUE " << fTTBELL << endl;
+		      std::cout << "!TEcnaHistos::ViewHisto(...)> *ERROR* =====> "
+			   << " ok_view_histo != kTRUE " << fTTBELL << std::endl;
 		    }
 		} // end of if(fMyRootFile->LookAtRootFile() == kTRUE)
 	      else
 		{
 		  fStatusFileFound = kFALSE;
 
-		  cout << "!TEcnaHistos::ViewHisto(...)> *ERROR* =====> "
-		       << " ROOT file not found" << fTTBELL << endl;
+		  std::cout << "!TEcnaHistos::ViewHisto(...)> *ERROR* =====> "
+		       << " ROOT file not found" << fTTBELL << std::endl;
 		}
 	    } // end of if(fFapStexNumber > 0)
 	} // end of if( HistoType == "Global" || HistoType == "Proj" || HistoType == "SampGlobal" || HistoType == "SampProj" )
@@ -7202,15 +7202,15 @@ void TEcnaHistos::ViewHisto(const TVectorD& arg_read_histo, const Int_t&  arg_Al
 		}
 	      else
 		{
-		  cout << "!TEcnaHistos::ViewHisto(...)> *ERROR* =====> "
-		       << " ROOT file not found" << fTTBELL << endl;
+		  std::cout << "!TEcnaHistos::ViewHisto(...)> *ERROR* =====> "
+		       << " ROOT file not found" << fTTBELL << std::endl;
 		}
 	    }
 	  else
 	    {
-	      cout << "!TEcnaHistos::ViewHisto(...)> " << fFapStexName.Data()
+	      std::cout << "!TEcnaHistos::ViewHisto(...)> " << fFapStexName.Data()
 		   << " = " << fFapStexNumber << ". Out of range (range = [1,"
-		   << fEcal->MaxStexInStas() << "]) " << fTTBELL << endl;
+		   << fEcal->MaxStexInStas() << "]) " << fTTBELL << std::endl;
 	    }
 	}
 
@@ -7466,8 +7466,8 @@ void TEcnaHistos::ViewHisto(const TVectorD& arg_read_histo, const Int_t&  arg_Al
 		} // end of if( OKPlot > 0 )
 	      else
 		{
-		  cout << "!TEcnaHistos::ViewHisto(...)> Histo not available."
-		       << fTTBELL << endl;
+		  std::cout << "!TEcnaHistos::ViewHisto(...)> Histo not available."
+		       << fTTBELL << std::endl;
 		}
 	    }
 	}
@@ -7914,14 +7914,14 @@ Int_t TEcnaHistos::ModifiedSCEchaForNotConnectedSCs(const Int_t& n1DeeNumber,
      //======================= ERROR message if ModifiedSCEcha is not correct
   if( ModifiedSCEcha < 1 || ModifiedSCEcha > fEcal->MaxCrysInSC() )
     {
-      cout << "! *** ERROR *** > ModifiedSCEcha = " << ModifiedSCEcha
+      std::cout << "! *** ERROR *** > ModifiedSCEcha = " << ModifiedSCEcha
 	   << ", SC_in_DS = " << SC_in_DS
 	   << ", nSCCons = " << nSCCons
 	   << ", n1DeeSCEcna = " << n1DeeSCEcna
 	   << ", n1SCEcha = " << n1SCEcha
 	   << ", ModifiedSCEcha = " << ModifiedSCEcha
 	   << ", TypQuad = " << TypQuad
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
     }
 
  
@@ -7964,10 +7964,10 @@ void TEcnaHistos::ViewHistime(const TString& list_of_run_file_name,
       main_subpad = ActivePad(HistoCode.Data(), opt_plot.Data());  // => return 0 if canvas has been closed
       if( main_subpad == 0 )
 	{
-	  cout << "*TEcnaHistos::ViewHistime(...)> WARNING ===> Canvas has been closed in option SAME or SAME n."
-	       << endl
+	  std::cout << "*TEcnaHistos::ViewHistime(...)> WARNING ===> Canvas has been closed in option SAME or SAME n."
+	       << std::endl
 	       << "                               Please, restart with a new canvas."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	  
 	  ReInitCanvas(HistoCode, opt_plot);
 	  xCanvasExists = 0;
@@ -7993,12 +7993,12 @@ void TEcnaHistos::ViewHistime(const TString& list_of_run_file_name,
 	  
 	  if( XVarHisto != XVariableMemo )
 	    {
-	      cout << "!TEcnaHistos::ViewHistime(...)> *** ERROR *** ===> X coordinate changed in option SAME n." << endl
-		   << "                               Present  X = " << XVarHisto << endl
-		   << "                               Present  Y = " << YVarHisto << endl
-		   << "                               Previous X = " << XVariableMemo << endl
+	      std::cout << "!TEcnaHistos::ViewHistime(...)> *** ERROR *** ===> X coordinate changed in option SAME n." << std::endl
+		   << "                               Present  X = " << XVarHisto << std::endl
+		   << "                               Present  Y = " << YVarHisto << std::endl
+		   << "                               Previous X = " << XVariableMemo << std::endl
 		   << "                               Previous Y = " << YVariableMemo 
-		   << fTTBELL << endl;
+		   << fTTBELL << std::endl;
 	      SameXVarMemo = 0;
 	    }
 	  else
@@ -8025,12 +8025,12 @@ void TEcnaHistos::ViewHistime(const TString& list_of_run_file_name,
 	  
 	  if( YVarHisto != YVariableMemo )
 	    {
-	      cout << "!TEcnaHistos::ViewHistime(...)> *** ERROR *** ===> Y coordinate changed in option SAME n." << endl
-		   << "                               Present  X = " << XVarHisto << endl
-		   << "                               Present  Y = " << YVarHisto << endl
-		   << "                               Previous X = " << XVariableMemo << endl
+	      std::cout << "!TEcnaHistos::ViewHistime(...)> *** ERROR *** ===> Y coordinate changed in option SAME n." << std::endl
+		   << "                               Present  X = " << XVarHisto << std::endl
+		   << "                               Present  Y = " << YVarHisto << std::endl
+		   << "                               Previous X = " << XVariableMemo << std::endl
 		   << "                               Previous Y = " << YVariableMemo 
-		   << fTTBELL << endl;
+		   << fTTBELL << std::endl;
 	      SameYVarMemo = 0;
 	    }
 	  else
@@ -8133,9 +8133,9 @@ void TEcnaHistos::ViewHistime(const TString& list_of_run_file_name,
 		    {
 		      fStatusFileFound = kFALSE;
 
-		      cout << "!TEcnaHistos::ViewHistime(...)> *ERROR* =====> "
+		      std::cout << "!TEcnaHistos::ViewHistime(...)> *ERROR* =====> "
 			   << " ROOT file not found for run " << fT1DRunNumber[i_run]
-			   << fTTBELL << endl << endl;
+			   << fTTBELL << std::endl << std::endl;
 		    }
 		} // end of for(Int_t i_run = 0; i_run < nb_of_runs_in_list; i_run++)
 
@@ -8231,8 +8231,8 @@ void TEcnaHistos::ViewHistime(const TString& list_of_run_file_name,
 			    }
 			  else
 			    {
-			      cout << "!TEcnaHistos::ViewHistime(...)> Histo not available. "
-				   << fTTBELL << endl;
+			      std::cout << "!TEcnaHistos::ViewHistime(...)> Histo not available. "
+				   << fTTBELL << std::endl;
 			    }
 			} // end of if ( fMyRootFile->LookAtRootFile() == kTRUE )
 		      else
@@ -8530,19 +8530,19 @@ void TEcnaHistos::ViewHistime(const TString& list_of_run_file_name,
 		}
 	      else
 		{
-		  cout << "!TEcnaHistos::ViewHistime(...)> The list of runs in file: " << list_of_run_file_name 
-		       << " has " << nb_of_runs_in_list << " run numbers" << endl
+		  std::cout << "!TEcnaHistos::ViewHistime(...)> The list of runs in file: " << list_of_run_file_name 
+		       << " has " << nb_of_runs_in_list << " run numbers" << std::endl
 		       << " but none of them correspond to an existing ROOT file."
-		       << fTTBELL << endl;
+		       << fTTBELL << std::endl;
 		}
 	    } // end of if( fFapStexNumber > 0 )
 	  else
 	    {
-	      cout << "!TEcnaHistos::ViewHistime(...)> *ERROR* =====> "
+	      std::cout << "!TEcnaHistos::ViewHistime(...)> *ERROR* =====> "
 		   << fFapStexName << " number = " << fFapStexNumber << ". "
 		   << fFapStexName << " number must be in range [1," << fEcal->MaxStexInStas() << "] ";
-	      if( fFlagSubDet == "EB" ){cout << " (or [-18,+18])";}
-		cout << fTTBELL << endl;
+	      if( fFlagSubDet == "EB" ){std::cout << " (or [-18,+18])";}
+		std::cout << fTTBELL << std::endl;
 	    }
 	  delete [] exist_indic;  exist_indic = 0;         fCdelete++;
 	} // end of if( nb_of_runs_in_list > 0 )
@@ -8550,13 +8550,13 @@ void TEcnaHistos::ViewHistime(const TString& list_of_run_file_name,
 	{
 	  if( nb_of_runs_in_list == 0 )
 	    {
-	      cout << "!TEcnaHistos::ViewHistime(...)> The list of runs in file: " << list_of_run_file_name
-		   << " is empty !" << fTTBELL << endl;
+	      std::cout << "!TEcnaHistos::ViewHistime(...)> The list of runs in file: " << list_of_run_file_name
+		   << " is empty !" << fTTBELL << std::endl;
 	    }
 	  if( nb_of_runs_in_list < 0 )
 	    {
-	      cout << "!TEcnaHistos::ViewHistime(...)> " << list_of_run_file_name
-		   << ": file not found in directory: " << fCfgHistoryRunListFilePath.Data() << fTTBELL << endl;
+	      std::cout << "!TEcnaHistos::ViewHistime(...)> " << list_of_run_file_name
+		   << ": file not found in directory: " << fCfgHistoryRunListFilePath.Data() << fTTBELL << std::endl;
 	    }
 	}
     }  // end of if( OKHisto == 1 )
@@ -8599,8 +8599,8 @@ Int_t TEcnaHistos::GetHistoryRunListParameters(const TString& list_of_run_file_n
   //========= immediate return if file name is an empty string
   if( list_of_run_file_name.Data() == '\0' )
     {
-      cout << "!TEcnaHistos::GetHistoryRunListParameters(...)> *** ERROR *** =====> "
-	   << " EMPTY STRING for list of run file name." << fTTBELL << endl;
+      std::cout << "!TEcnaHistos::GetHistoryRunListParameters(...)> *** ERROR *** =====> "
+	   << " EMPTY STRING for list of run file name." << fTTBELL << std::endl;
     }
   else
     {
@@ -8648,7 +8648,7 @@ Int_t TEcnaHistos::GetHistoryRunListParameters(const TString& list_of_run_file_n
 	{   
 	  //...................................... first reading to get the number of runs in the list
 	  fFcin_f.clear();
-	  string xHeadComment;
+	  std::string xHeadComment;
 	  fFcin_f >> xHeadComment;
 	  Int_t cRunNumber;
 	  Int_t list_size_read = 0;
@@ -8660,10 +8660,10 @@ Int_t TEcnaHistos::GetHistoryRunListParameters(const TString& list_of_run_file_n
 
 	  //====== Return to the beginning of the file =====
 	  fFcin_f.clear();
-	  fFcin_f.seekg(0, ios::beg);
+	  fFcin_f.seekg(0, std::ios::beg);
 	  //================================================
 
-	  string yHeadComment;
+	  std::string yHeadComment;
 	  fFcin_f >> yHeadComment;
 
 	  //....................... Set fFapMaxNbOfRuns to -1 at first call (first read file)
@@ -8695,12 +8695,12 @@ Int_t TEcnaHistos::GetHistoryRunListParameters(const TString& list_of_run_file_n
 	  //................. check maximum value for allocation
 	  if( fFapMaxNbOfRuns > fCnaParHistos->MaxNbOfRunsInLists() )
 	    {
-	      cout << "TEcnaHistos::GetHistoryRunListParameters(...)> Max number of runs in HistoryRunList = "
+	      std::cout << "TEcnaHistos::GetHistoryRunListParameters(...)> Max number of runs in HistoryRunList = "
 		   << fFapMaxNbOfRuns
 		   << " too large, forced to parameter TEcnaParHistos->fMaxNbOfRunsInLists value (= "
 		   << fCnaParHistos->MaxNbOfRunsInLists()
 		   << "). Please, set this parameter to a larger value than " << fFapMaxNbOfRuns
-		   << fTTBELL << endl;
+		   << fTTBELL << std::endl;
 	      fFapMaxNbOfRuns = fCnaParHistos->MaxNbOfRunsInLists();
 	    }
 	  //................................. Alloc of the array and init
@@ -8712,8 +8712,8 @@ Int_t TEcnaHistos::GetHistoryRunListParameters(const TString& list_of_run_file_n
 		}
 	      else
 		{
-		  cout << "!TEcnaHistos::GetHistoryRunListParameters(...)> *** ERROR *** =====> fFapMaxNbOfRuns = "
-		       << fFapMaxNbOfRuns << ". Forced to 1." << fTTBELL << endl;
+		  std::cout << "!TEcnaHistos::GetHistoryRunListParameters(...)> *** ERROR *** =====> fFapMaxNbOfRuns = "
+		       << fFapMaxNbOfRuns << ". Forced to 1." << fTTBELL << std::endl;
 		  fFapMaxNbOfRuns = 1;
 		  fT1DRunNumber = new Int_t[fFapMaxNbOfRuns];               fCnew++;
 		}
@@ -8735,8 +8735,8 @@ Int_t TEcnaHistos::GetHistoryRunListParameters(const TString& list_of_run_file_n
       else
 	{
 	  fFcin_f.clear();
-	  cout << "!TEcnaHistos::GetHistoryRunListParameters(...)> *** ERROR *** =====> "
-	       << xFileNameRunList.Data() << " : file not found." << fTTBELL << endl;
+	  std::cout << "!TEcnaHistos::GetHistoryRunListParameters(...)> *** ERROR *** =====> "
+	       << xFileNameRunList.Data() << " : file not found." << fTTBELL << std::endl;
 	  nb_of_runs_in_list = -1;
 	}
     }
@@ -8781,8 +8781,8 @@ void TEcnaHistos::SetRunNumberFromList(const Int_t& xArgIndexRun, const Int_t& M
     }
   else
     {
-      cout << "!TEcnaHistos::SetRunNumberFromList(...)> **** ERROR **** Run index out of range in list of runs. xArgIndexRun = "
-	   << xArgIndexRun << " (MaxNbOfRuns = "<< MaxNbOfRuns << ")" << endl;
+      std::cout << "!TEcnaHistos::SetRunNumberFromList(...)> **** ERROR **** Run index out of range in list of runs. xArgIndexRun = "
+	   << xArgIndexRun << " (MaxNbOfRuns = "<< MaxNbOfRuns << ")" << std::endl;
     }
 }
 
@@ -8849,7 +8849,7 @@ Bool_t TEcnaHistos::GetOkViewHisto(TEcnaRead*    aMyRootFile,
 	    Int_t StinNumber = StexStin_A;
 	    if( fFlagSubDet == "EE" )
 	      {StinNumber = fEcalNumbering->GetDeeSCConsFrom1DeeSCEcna(fFapStexNumber, StexStin_A);}
-	    cout << "!TEcnaHistos::GetOkViewHisto(...)> *ERROR* =====> " << "File: " << root_file_name
+	    std::cout << "!TEcnaHistos::GetOkViewHisto(...)> *ERROR* =====> " << "File: " << root_file_name
 		 << ", " << fFapStinName.Data() << " "
 		 << StinNumber
 		 << " not found. Available numbers = ";
@@ -8857,12 +8857,12 @@ Bool_t TEcnaHistos::GetOkViewHisto(TEcnaRead*    aMyRootFile,
 	      {
 		if( vStin(i) > 0 )
 		  {
-		    if( fFlagSubDet == "EB" ){cout << vStin(i) << ", ";}
+		    if( fFlagSubDet == "EB" ){std::cout << vStin(i) << ", ";}
 		    if( fFlagSubDet == "EE" )
-		      {cout << fEcalNumbering->GetDeeSCConsFrom1DeeSCEcna(fFapStexNumber, (Int_t)vStin(i)) << ", ";}
+		      {std::cout << fEcalNumbering->GetDeeSCConsFrom1DeeSCEcna(fFapStexNumber, (Int_t)vStin(i)) << ", ";}
 		  }
 	      }
-	    cout << fTTBELL << endl;
+	    std::cout << fTTBELL << std::endl;
 	    ok_view = -1;
 	  }
 	  else 
@@ -8885,16 +8885,16 @@ Bool_t TEcnaHistos::GetOkViewHisto(TEcnaRead*    aMyRootFile,
 	  if( fFlagSubDet == "EE" ){Choffset = 1;}
 	  if( ( (HistoType == "H1Basic") || (HistoType == "Evol") || (HistoType == "EvolProj") )
 	      && !( (i0StinEcha >= 0) && (i0StinEcha<fEcal->MaxCrysInStin()) ) )
-	    {cout << "!TEcnaHistos::GetOkViewHisto(...)> *ERROR* =====> " << "File: " << root_file_name
+	    {std::cout << "!TEcnaHistos::GetOkViewHisto(...)> *ERROR* =====> " << "File: " << root_file_name
 		  << ". Wrong channel number. Value = " << i0StinEcha << " (required range: [" << Choffset << ", "
 		  << fEcal->MaxCrysInStin()-1+Choffset << "] )"
-		  << fTTBELL << endl;}
+		  << fTTBELL << std::endl;}
 	  if( (HistoCode == "D_Adc_EvDs" || HistoCode == "D_Adc_EvNb") &&
 	      !((i0Sample >= 0) && (i0Sample <fFapNbOfSamples)) )
-	    {cout << "!TEcnaHistos::GetOkViewHisto(...)> *ERROR* =====> " << "File: " << root_file_name
+	    {std::cout << "!TEcnaHistos::GetOkViewHisto(...)> *ERROR* =====> " << "File: " << root_file_name
 		  << ". Wrong sample index. Value = " << i0Sample << " (required range: [0, "
 		  << fFapNbOfSamples-1 << "] )"
-		  << fTTBELL << endl;}
+		  << fTTBELL << std::endl;}
 	  ok_max_elt = -1;
 	}
       
@@ -8904,16 +8904,16 @@ Bool_t TEcnaHistos::GetOkViewHisto(TEcnaRead*    aMyRootFile,
 	}
       else
 	{
-	  cout << "!TEcnaHistos::GetOkViewHisto(...)> At least one ERROR has been detected. ok_view = " << ok_view
-	       << ", ok_max_elt = " << ok_max_elt << fTTBELL << endl;
+	  std::cout << "!TEcnaHistos::GetOkViewHisto(...)> At least one ERROR has been detected. ok_view = " << ok_view
+	       << ", ok_max_elt = " << ok_max_elt << fTTBELL << std::endl;
 	}
     }
   else
     {
       fStatusDataExist = kFALSE;
 
-      cout << "!TEcnaHistos::GetOkViewHisto(...)> No data in ROOT file "
-	   << ", aMyRootFile->DataExist() = " << aMyRootFile->DataExist() << fTTBELL << endl;
+      std::cout << "!TEcnaHistos::GetOkViewHisto(...)> No data in ROOT file "
+	   << ", aMyRootFile->DataExist() = " << aMyRootFile->DataExist() << fTTBELL << std::endl;
     }
   return ok_view_histo;
 }
@@ -9176,7 +9176,7 @@ void TEcnaHistos::HistoPlot(TH1D* h_his0,               const Int_t&   HisSize,
       {MainCanvas = CreateCanvas(HistoCode, opt_plot, canvas_name, canv_w, canv_h);
       fCurrentPad = gPad; fCurrentCanvas = MainCanvas; fCurrentCanvasName = canvas_name.Data();}}
 
-  // cout << "*TEcnaHistos::HistoPlot(...)> Plot is displayed on canvas ----> " << canvas_name.Data() << endl;
+  // std::cout << "*TEcnaHistos::HistoPlot(...)> Plot is displayed on canvas ----> " << canvas_name.Data() << std::endl;
 
   //--------------- EE => SC for construction, EB => Xtal in SM (default: Stin ECNA number, i0StinEcha)
   Int_t Stex_StinCons = StexStin_A;   // Stex_StinCons = Tower for EB, SC for construction for EE
@@ -9830,8 +9830,8 @@ void TEcnaHistos::HistoPlot(TH1D* h_his0,               const Int_t&   HisSize,
     }
   else    // else du if(main_subpad !=0)
     {
-      cout << "*TEcnaHistos::HistoPlot(...)> Canvas not found. Previously closed in option SAME."
-	   << fTTBELL << endl;
+      std::cout << "*TEcnaHistos::HistoPlot(...)> Canvas not found. Previously closed in option SAME."
+	   << fTTBELL << std::endl;
 
       ReInitCanvas(HistoCode, opt_plot);
       xMemoPlotSame = 0;
@@ -10092,7 +10092,7 @@ void TEcnaHistos::HistimePlot(TGraph*       g_graph0,
 	}
     }
   
-  // cout << "*TEcnaHistos::HistimePlot(...)> Plot is displayed on canvas ----> " << canvas_name.Data() << endl;
+  // std::cout << "*TEcnaHistos::HistimePlot(...)> Plot is displayed on canvas ----> " << canvas_name.Data() << std::endl;
 
   //--------------- EE => SC for construction, EB => Xtal in SM (default: Stin ECNA number, i0StinEcha)
   Int_t Stex_StinCons = StexStin_A;   // Stex_StinCons = Tower for EB, SC for construction for EE
@@ -10439,8 +10439,8 @@ void TEcnaHistos::HistimePlot(TGraph*       g_graph0,
     }
   else    // else du if(main_subpad !=0)
     {
-      cout << "*TEcnaHistos::HistimePlot(...)> Canvas not found. Previously closed in option SAME."
-	   << fTTBELL << endl;
+      std::cout << "*TEcnaHistos::HistimePlot(...)> Canvas not found. Previously closed in option SAME."
+	   << fTTBELL << std::endl;
 
       ReInitCanvas(HistoCode, opt_plot);
       xMemoPlotSame = 0;
@@ -11118,14 +11118,14 @@ TVectorD TEcnaHistos::GetHistoValues(const TVectorD& arg_read_histo, const Int_t
 
   if( arg_AlreadyRead >= 1 )
     {
-      //cout << "*TEcnaHistos::GetHistoValues(...)> arg_AlreadyRead = " << arg_AlreadyRead << endl;
+      //std::cout << "*TEcnaHistos::GetHistoValues(...)> arg_AlreadyRead = " << arg_AlreadyRead << std::endl;
       for(Int_t i=0; i<HisSizeRead; i++){plot_histo(i)=arg_read_histo(i);}
       fStatusDataExist = kTRUE; i_data_exist++;
     }
 
   if( arg_AlreadyRead == 0 )
     {
-      //cout << "*TEcnaHistos::GetHistoValues(...)> arg_AlreadyRead = " << arg_AlreadyRead << endl;
+      //std::cout << "*TEcnaHistos::GetHistoValues(...)> arg_AlreadyRead = " << arg_AlreadyRead << std::endl;
       TVectorD read_histo(HisSizeRead); for(Int_t i=0; i<HisSizeRead; i++){read_histo(i)=(Double_t)0.;}
 
       if( HistoCode == "D_MSp_SpNb" || HistoCode == "D_MSp_SpDs" ||
@@ -11150,9 +11150,9 @@ TVectorD TEcnaHistos::GetHistoValues(const TVectorD& arg_read_histo, const Int_t
 	    }
 	  else
 	    {
-	      cout << "!TEcnaHistos::GetHistoValues(...)> *** ERROR *** > HisSizeRead greater than HisSizePlot"
+	      std::cout << "!TEcnaHistos::GetHistoValues(...)> *** ERROR *** > HisSizeRead greater than HisSizePlot"
 		   << " for plot as a function of sample#. HisSizeRead = " << HisSizeRead
-		   << ", HisSizePlot = " << HisSizePlot << fTTBELL << endl;
+		   << ", HisSizePlot = " << HisSizePlot << fTTBELL << std::endl;
 	    }
 	} // end of if( HistoCode == "D_MSp_SpNb" || HistoCode == "D_SSp_SpNb" " ||
 	  //            HistoCode == "D_SSp_SpNb" || HistoCode == "D_SSp_SpDs" )
@@ -11222,16 +11222,16 @@ TVectorD TEcnaHistos::GetHistoValues(const TVectorD& arg_read_histo, const Int_t
 	    }
 	  else
 	    {
-	      cout << "!TEcnaHistos::GetHistoValues(...)> *** ERROR *** > HisSizeRead not equal to HisSizePlot."
+	      std::cout << "!TEcnaHistos::GetHistoValues(...)> *** ERROR *** > HisSizeRead not equal to HisSizePlot."
 		   << " HisSizeRead = " << HisSizeRead
-		   << ", HisSizePlot = " << HisSizePlot << fTTBELL << endl;
+		   << ", HisSizePlot = " << HisSizePlot << fTTBELL << std::endl;
 	    }
 	}  // end of if( !(HistoCode == "D_MSp_SpNb" || HistoCode == "D_SSp_SpNb") )
     }  // end of if( arg_AlreadyRead == 0 )
 
   if( i_data_exist == 0 )
     {
-      cout << "!TEcnaHistos::GetHistoValues(...)> Histo not found." << fTTBELL << endl;
+      std::cout << "!TEcnaHistos::GetHistoValues(...)> Histo not found." << fTTBELL << std::endl;
     }
 
   return plot_histo;
@@ -12813,15 +12813,15 @@ void TEcnaHistos::PlotCloneOfCurrentCanvas()
 	}
       else
 	{
-	  cout << "TEcnaHistos::PlotCloneOfCurrentCanvas()> Last canvas has been removed. No clone can be done."
-	       << endl << "                                        Please, display the canvas again."
-	       << fTTBELL << endl;
+	  std::cout << "TEcnaHistos::PlotCloneOfCurrentCanvas()> Last canvas has been removed. No clone can be done."
+	       << std::endl << "                                        Please, display the canvas again."
+	       << fTTBELL << std::endl;
 	}
     }
   else
     {
-      cout << "TEcnaHistos::PlotCloneOfCurrentCanvas()> No canvas has been created. No clone can be done."
-	   << fTTBELL << endl;
+      std::cout << "TEcnaHistos::PlotCloneOfCurrentCanvas()> No canvas has been created. No clone can be done."
+	   << fTTBELL << std::endl;
     }
 }
 
@@ -12974,8 +12974,8 @@ TVirtualPad* TEcnaHistos::ActivePad(const TString& HistoCode, const TString& opt
     }
     
   if( main_subpad == 0 )
-    {cout << "*TEcnaHistos::ActivePad(...)> main_subpad = "
-	  << main_subpad << ". This canvas has been closed." << endl;}
+    {std::cout << "*TEcnaHistos::ActivePad(...)> main_subpad = "
+	  << main_subpad << ". This canvas has been closed." << std::endl;}
 
   return main_subpad;
 }
@@ -13023,7 +13023,7 @@ void TEcnaHistos::DoCanvasClosed()
   fCurrentOptPlot = "NADA";  // to avoid fClosed... = kTRUE if other canvas than those above Closed (i.e. 2D plots)
   fCurrentHistoCode = "NADA";
 
-  cout << "!TEcnaHistos::DoCanvasClosed(...)> WARNING: canvas has been closed." << endl;
+  std::cout << "!TEcnaHistos::DoCanvasClosed(...)> WARNING: canvas has been closed." << std::endl;
 }
 
 void TEcnaHistos::SetParametersPavTxt(const TString& HistoCode, const TString& opt_plot)
@@ -13116,7 +13116,7 @@ TPaveText* TEcnaHistos::ActivePavTxt(const TString& HistoCode, const TString& op
     }
   
   if( main_pavtxt == 0 )
-    {cout << "*TEcnaHistos::ActivePavTxt(...)> ERROR: main_pavtxt = " << main_pavtxt << endl;}
+    {std::cout << "*TEcnaHistos::ActivePavTxt(...)> ERROR: main_pavtxt = " << main_pavtxt << std::endl;}
 
   return main_pavtxt;
 }
@@ -13653,9 +13653,9 @@ void TEcnaHistos::NewCanvas(const TString& opt_plot)
     }
   else
     {
-      cout << "TEcnaHistos::NewCanvas(...)> *** ERROR *** " << opt_plot.Data() << ": "
+      std::cout << "TEcnaHistos::NewCanvas(...)> *** ERROR *** " << opt_plot.Data() << ": "
 	   << "unknown option for NewCanvas. Only " << fSameOnePlot << " option is accepted."
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
     }
 }
 
@@ -13982,7 +13982,7 @@ TString TEcnaHistos::AsciiFileName(){return fAsciiFileName.Data();}
 //======= A T T E N T I O N ========= A T T E N T I O N ========= A T T E N T I O N ==============!!!!
 //      A EVITER ABSOLUMENT quand on est sous TEcnaGui CAR LE cin >> BLOQUE X11
 //      puisqu'on n'a pas la main dans la fenetre de compte-rendu de la CNA
-//     {Int_t cintoto; cout << "taper 0 pour continuer" << endl; cin >> cintoto;}
+//     {Int_t cintoto; std::cout << "taper 0 pour continuer" << std::endl; cin >> cintoto;}
 //                         *=================================================*
 //                         |                                                 |
 //++++++++++++++++++++++++|  A T T E N T I O N:  PAS DE TEST "cintoto" ici! |+++++++++++++++++++++!!!!

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaNArrayD.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaNArrayD.cc
@@ -25,7 +25,7 @@ ClassImp(TEcnaNArrayD)
 TEcnaNArrayD::TEcnaNArrayD(){
 //constructor without argument
 
- // cout << "[Info Management] CLASS: TEcnaNArrayD.          CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaNArrayD.          CREATE OBJECT: this = " << this << std::endl;
 
   Init();
 }
@@ -33,7 +33,7 @@ TEcnaNArrayD::TEcnaNArrayD(){
 TEcnaNArrayD::TEcnaNArrayD(const TEcnaNArrayD &orig) {
 //copy constructor
 
- // cout << "[Info Management] CLASS: TEcnaNArrayD.          CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaNArrayD.          CREATE OBJECT: this = " << this << std::endl;
 
   fNd = orig.fNd;
   fN1 = orig.fN1;
@@ -49,7 +49,7 @@ TEcnaNArrayD::TEcnaNArrayD(const TEcnaNArrayD &orig) {
 TEcnaNArrayD::TEcnaNArrayD(TEcnaObject* pObjectManager, Int_t n1) {
 //constructor for a 1 dimensional array of size n1. Array is put to 0
 
- // cout << "[Info Management] CLASS: TEcnaNArrayD.          CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaNArrayD.          CREATE OBJECT: this = " << this << std::endl;
 
   Long_t i_this = (Long_t)this;
   pObjectManager->RegisterPointer("TEcnaNArrayD", i_this);
@@ -65,7 +65,7 @@ TEcnaNArrayD::TEcnaNArrayD(TEcnaObject* pObjectManager, Int_t n1) {
 TEcnaNArrayD::TEcnaNArrayD(TEcnaObject* pObjectManager, Int_t n1,Int_t n2) {
 //constructor for a 2 dimensional array of sizes n1,n2. Array is put to 0
 
- // cout << "[Info Management] CLASS: TEcnaNArrayD.          CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaNArrayD.          CREATE OBJECT: this = " << this << std::endl;
 
   Long_t i_this = (Long_t)this;
   pObjectManager->RegisterPointer("TEcnaNArrayD", i_this);
@@ -82,7 +82,7 @@ TEcnaNArrayD::TEcnaNArrayD(TEcnaObject* pObjectManager, Int_t n1,Int_t n2) {
 TEcnaNArrayD::TEcnaNArrayD(TEcnaObject* pObjectManager, Int_t n1,Int_t n2,Int_t n3) {
 //constructor 3 dimensional array of sizes n1,n2,n3. Array is put to 0
 
- // cout << "[Info Management] CLASS: TEcnaNArrayD.          CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaNArrayD.          CREATE OBJECT: this = " << this << std::endl;
 
   Long_t i_this = (Long_t)this;
   pObjectManager->RegisterPointer("TEcnaNArrayD", i_this);
@@ -100,7 +100,7 @@ TEcnaNArrayD::TEcnaNArrayD(TEcnaObject* pObjectManager, Int_t n1,Int_t n2,Int_t 
 TEcnaNArrayD::TEcnaNArrayD(TEcnaObject* pObjectManager, Int_t n1,Int_t n2,Int_t n3,Int_t n4) {
 //constructor for a 4 dimensional array of sizes n1,n2,n3,n4. Array is put to 0
 
- // cout << "[Info Management] CLASS: TEcnaNArrayD.          CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaNArrayD.          CREATE OBJECT: this = " << this << std::endl;
 
   Long_t i_this = (Long_t)this;
   pObjectManager->RegisterPointer("TEcnaNArrayD", i_this);
@@ -119,7 +119,7 @@ TEcnaNArrayD::TEcnaNArrayD(TEcnaObject* pObjectManager, Int_t n1,Int_t n2,Int_t 
 TEcnaNArrayD::TEcnaNArrayD(TEcnaObject* pObjectManager, Int_t n1,Int_t n2,Int_t n3,Int_t n4,Int_t n5) {
 //constructor for a 5 dimensional array of sizes n1,n2,n3,n4,n5. Array is put to 0
 
- // cout << "[Info Management] CLASS: TEcnaNArrayD.          CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaNArrayD.          CREATE OBJECT: this = " << this << std::endl;
 
   Long_t i_this = (Long_t)this;
   pObjectManager->RegisterPointer("TEcnaNArrayD", i_this);
@@ -139,7 +139,7 @@ TEcnaNArrayD::TEcnaNArrayD(TEcnaObject* pObjectManager, Int_t n1,Int_t n2,Int_t 
 TEcnaNArrayD::TEcnaNArrayD(TEcnaObject* pObjectManager, Int_t n1,Int_t n2,Int_t n3,Int_t n4,Int_t n5,Int_t n6) {
 //constructor for a 6 dimensional array of sizes n1,n2,n3,n4,n5,n6. Array is put to 0
 
- // cout << "[Info Management] CLASS: TEcnaNArrayD.          CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaNArrayD.          CREATE OBJECT: this = " << this << std::endl;
 
   Long_t i_this = (Long_t)this;
   pObjectManager->RegisterPointer("TEcnaNArrayD", i_this);
@@ -161,7 +161,7 @@ TEcnaNArrayD::TEcnaNArrayD(TEcnaObject* pObjectManager, Int_t n1,Int_t n2,Int_t 
 TEcnaNArrayD::~TEcnaNArrayD() {
 //destructor
 
- // cout << "[Info Management] CLASS: TEcnaNArrayD.          DESTROY OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaNArrayD.          DESTROY OBJECT: this = " << this << std::endl;
 
   Clean();
 }
@@ -191,8 +191,8 @@ inline Int_t TEcnaNArrayD::OneDim(Int_t i1) const {
   if ((i1>=fNL - 1) || (i1<0)) {
     i1 = fNL - 1;
     Error("OneDim","Index outside bounds");
-    cout << "i1  = " << i1
-    << "; fNL = " << fNL << endl;
+    std::cout << "i1  = " << i1
+    << "; fNL = " << fNL << std::endl;
   }
   return i1;
 }
@@ -203,8 +203,8 @@ inline Int_t TEcnaNArrayD::OneDim(Int_t i1,Int_t i2) const {
   if ((i>=fNL - 1) || (i<0)) {
     i = fNL - 1;
     Error("OneDim","Index outside bounds");
-    cout << "i1  = " << i1  << ", i2 = "  << i2
-    	 << "; fN1 = " << fN1 << ", fNL = " << fNL << endl;
+    std::cout << "i1  = " << i1  << ", i2 = "  << i2
+    	 << "; fN1 = " << fN1 << ", fNL = " << fNL << std::endl;
   }
   return i;
 }
@@ -215,8 +215,8 @@ inline Int_t TEcnaNArrayD::OneDim(Int_t i1,Int_t i2,Int_t i3) const {
   if ((i>=fNL - 1) || (i<0)) {
     i = fNL - 1;
     Error("OneDim","Index outside bounds");
-    cout << "i1  = " << i1  << ", i2 = "  << i2  << ", i3 = "  << i3
-	 << "; fN1 = " << fN1 << ", fN2 = " << fN2 << ", fNL = " << fNL << endl;
+    std::cout << "i1  = " << i1  << ", i2 = "  << i2  << ", i3 = "  << i3
+	 << "; fN1 = " << fN1 << ", fN2 = " << fN2 << ", fNL = " << fNL << std::endl;
   }
   return i;
 }

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaNumbering.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaNumbering.cc
@@ -34,7 +34,7 @@ ClassImp(TEcnaNumbering)
 TEcnaNumbering::TEcnaNumbering() {
 // Constructor without argument: call to method Init()
 
-//  cout << "[Info Management] CLASS: TEcnaNumbering.    CREATE OBJECT: this = " << this << endl;
+//  std::cout << "[Info Management] CLASS: TEcnaNumbering.    CREATE OBJECT: this = " << this << std::endl;
 
   Init();
 }
@@ -42,7 +42,7 @@ TEcnaNumbering::TEcnaNumbering() {
 TEcnaNumbering::TEcnaNumbering(TEcnaObject* pObjectManager, const TString& SubDet) {
 // Constructor with argument: call to methods Init() and SetEcalSubDetector(const TString&)
 
- // cout << "[Info Management] CLASS: TEcnaNumbering.    CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaNumbering.    CREATE OBJECT: this = " << this << std::endl;
 
   Init();
   Long_t i_this = (Long_t)this;
@@ -63,7 +63,7 @@ TEcnaNumbering::TEcnaNumbering(TEcnaObject* pObjectManager, const TString& SubDe
 TEcnaNumbering::TEcnaNumbering(const TString& SubDet, const TEcnaParEcal* pEcal) {
 // Constructor with argument: call to methods Init() and SetEcalSubDetector(const TString&)
 
- // cout << "[Info Management] CLASS: TEcnaNumbering.    CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaNumbering.    CREATE OBJECT: this = " << this << std::endl;
 
   Init();
   SetEcalSubDetector(SubDet.Data(), pEcal);
@@ -102,7 +102,7 @@ TEcnaNumbering::~TEcnaNumbering() {
   if (fT2d_RecovDeeSC != 0){delete [] fT2d_RecovDeeSC; fCdelete++;}
   if (fT1d_RecovDeeSC != 0){delete [] fT1d_RecovDeeSC; fCdelete++;}
 
- // cout << "[Info Management] CLASS: TEcnaNumbering.    DESTROY OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaNumbering.    DESTROY OBJECT: this = " << this << std::endl;
 
 }
 //------------------------------------------------------------- Init()
@@ -321,7 +321,7 @@ void TEcnaNumbering::BuildBarrelCrysTable()
 	      fT1dTowEcha[n1SMCrys-1] = ic-1;          // fT1dTowEcha[] : range = [0,24]
 	    }
 	}
-      // cout << "#TEcnaNumbering::TBuildBarrelCrysTable()> Crys Table Building done" << endl;
+      // std::cout << "#TEcnaNumbering::TBuildBarrelCrysTable()> Crys Table Building done" << std::endl;
 
       delete [] jch_type;                       fCdelete++;
       delete [] jch_type_d1;                    fCdelete++;
@@ -331,7 +331,7 @@ void TEcnaNumbering::BuildBarrelCrysTable()
     }
   else
     {
-      // cout << "#TEcnaNumbering::TBuildBarrelCrysTable()> No Building of Crys Table since it is already done." << endl;
+      // std::cout << "#TEcnaNumbering::TBuildBarrelCrysTable()> No Building of Crys Table since it is already done." << std::endl;
     }
 }
 
@@ -360,15 +360,15 @@ Int_t TEcnaNumbering::Get1SMCrysFrom1SMTowAnd0TowEcha(const Int_t& n1SMTow,
       else
 	{
 	  n1SMCrys = -2;   // Electronic Cnannel in Tower out of range 
-	  cout << "!TEcnaNumbering::Get1SMCrysFrom1SMTowAnd0TowEcha(...)> Electronic Channel in Tower out of range."
-	       << " i0TowEcha = " << i0TowEcha << "(n1SMTow = " << n1SMTow << ")" << fTTBELL << endl;
+	  std::cout << "!TEcnaNumbering::Get1SMCrysFrom1SMTowAnd0TowEcha(...)> Electronic Channel in Tower out of range."
+	       << " i0TowEcha = " << i0TowEcha << "(n1SMTow = " << n1SMTow << ")" << fTTBELL << std::endl;
 	}
     }
   else
     {
       n1SMCrys = -3;   // Tower number in SM out of range
-      cout << "!TEcnaNumbering::Get1SMCrysFrom1SMTowAnd0TowEcha(...)> Tower number in SM out of range."
-	   << " n1SMTow = " << n1SMTow << "(i0TowEcha = " << i0TowEcha << ")" << fTTBELL << endl;
+      std::cout << "!TEcnaNumbering::Get1SMCrysFrom1SMTowAnd0TowEcha(...)> Tower number in SM out of range."
+	   << " n1SMTow = " << n1SMTow << "(i0TowEcha = " << i0TowEcha << ")" << fTTBELL << std::endl;
     }
 
   return n1SMCrys;   // Range = [1,1700]
@@ -393,8 +393,8 @@ Int_t TEcnaNumbering::Get0TowEchaFrom1SMCrys(const Int_t& n1SMCrys)
   else
     {
       i0TowEcha = -2;
-      cout << "!TEcnaNumbering::Get0TowEchaFrom1SMCrys(...)> Crystal number in SM out of range."
-	   << " n1SMCrys = " << n1SMCrys << fTTBELL << endl;
+      std::cout << "!TEcnaNumbering::Get0TowEchaFrom1SMCrys(...)> Crystal number in SM out of range."
+	   << " n1SMCrys = " << n1SMCrys << fTTBELL << std::endl;
     }
   return i0TowEcha;   // range = [0,24]
 }
@@ -412,8 +412,8 @@ Int_t TEcnaNumbering::Get1SMTowFrom1SMCrys(const Int_t& n1SMCrys)
   else
     {
       n1SMtox = -1;
-      cout << "!TEcnaNumbering::Get1SMTowFrom1SMCrys(...)> Crystal number in SM out of range."
-	   << " n1SMCrys = " << n1SMCrys << fTTBELL << endl;
+      std::cout << "!TEcnaNumbering::Get1SMTowFrom1SMCrys(...)> Crystal number in SM out of range."
+	   << " n1SMCrys = " << n1SMCrys << fTTBELL << std::endl;
     }
   return n1SMtox;   // range = [1,68]
 }
@@ -545,9 +545,9 @@ Double_t TEcnaNumbering::GetEta(const Int_t& n1EBSM, const Int_t& n1SMTow,
     }
   else
     {
-      cout << "TEcnaNumbering::GetEta(...)> SM = " << n1EBSM
+      std::cout << "TEcnaNumbering::GetEta(...)> SM = " << n1EBSM
 	   << ". Out of range (range = [1," << fEcal->MaxSMInEB() << "])" 
-	   << fTTBELL << endl; 
+	   << fTTBELL << std::endl; 
     }
   return eta;
 }
@@ -738,9 +738,9 @@ Double_t TEcnaNumbering::GetPhiInSM(const Int_t& n1EBSM,
     }
   else
     {
-      cout << "TEcnaNumbering::GetPhiInSM(...)> SM = " << n1EBSM
+      std::cout << "TEcnaNumbering::GetPhiInSM(...)> SM = " << n1EBSM
 	   << ". Out of range (range = [1," << fEcal->MaxSMInEB() << "])" 
-	   << fTTBELL << endl; 
+	   << fTTBELL << std::endl; 
     }
   phi_in_SM = 20 - phi_in_SM;
   return phi_in_SM;
@@ -762,9 +762,9 @@ Double_t TEcnaNumbering::GetPhi(const Int_t& n1EBSM,
     }
   else
     {
-      cout << "TEcnaNumbering::GetPhi(...)> SM = " << n1EBSM
+      std::cout << "TEcnaNumbering::GetPhi(...)> SM = " << n1EBSM
 	   << ". Out of range (range = [1," << fEcal->MaxSMInEB() << "])" 
-	   << fTTBELL << endl; 
+	   << fTTBELL << std::endl; 
     }
   return phi;
 }
@@ -1176,14 +1176,14 @@ void TEcnaNumbering::BuildEndcapCrysTable()
 		}
 	    }
 	}
-      // cout << "#TEcnaNumbering::TBuildEndcapCrysTable()> Crys Table Building done" << endl;
+      // std::cout << "#TEcnaNumbering::TBuildEndcapCrysTable()> Crys Table Building done" << std::endl;
 
       delete [] type;                           fCdelete++;
       delete [] type_d1;                        fCdelete++;
     }
   else
     {
-      // cout << "#TEcnaNumbering::TBuildEndcapCrysTable()> No Building of Crys Table since it is already done " << endl;
+      // std::cout << "#TEcnaNumbering::TBuildEndcapCrysTable()> No Building of Crys Table since it is already done " << std::endl;
     }
 }
 
@@ -1809,15 +1809,15 @@ Int_t TEcnaNumbering::Get1DeeCrysFrom1DeeSCEcnaAnd0SCEcha(const Int_t&  n1DeeSCE
       else
 	{
 	  n1DeeCrys = -2;   // Electronic Cnannel in Super-Crystal out of range
-	  cout << "!TEcnaNumbering::Get1DeeCrysFrom1DeeSCEcnaAnd0SCEcha(...)> Electronic Channel in SuperCrystal = "
-	       << i0SCEcha+1 << ". Out of range (range = [1," << fEcal->MaxCrysInSC() << "])" << fTTBELL << endl;
+	  std::cout << "!TEcnaNumbering::Get1DeeCrysFrom1DeeSCEcnaAnd0SCEcha(...)> Electronic Channel in SuperCrystal = "
+	       << i0SCEcha+1 << ". Out of range (range = [1," << fEcal->MaxCrysInSC() << "])" << fTTBELL << std::endl;
 	}
     }
   else
     {
       n1DeeCrys = -3;   // Super-Crystal number in Dee out of range
-      cout << "!TEcnaNumbering::Get1DeeCrysFrom1DeeSCEcnaAnd0SCEcha(...)> Super-Crystal number in Dee out of range."
-	   << " n1DeeSCEcna = " << n1DeeSCEcna << fTTBELL << endl;
+      std::cout << "!TEcnaNumbering::Get1DeeCrysFrom1DeeSCEcnaAnd0SCEcha(...)> Super-Crystal number in Dee out of range."
+	   << " n1DeeSCEcna = " << n1DeeSCEcna << fTTBELL << std::endl;
     }
 
   return n1DeeCrys;  // Range = [1,5000]
@@ -1843,8 +1843,8 @@ Int_t TEcnaNumbering::Get1SCEchaFrom1DeeCrys(const Int_t& n1DeeCrys, const TStri
   else
     {
       n1SCEcha = -2;
-      cout << "!TEcnaNumbering::Get1SCEchaFrom1DeeCrys(...)> Crystal number in Dee out of range."
-	   << " n1DeeCrys = " << n1DeeCrys << "(max = " << fEcal->MaxCrysEcnaInDee() << ")" << fTTBELL << endl;
+      std::cout << "!TEcnaNumbering::Get1SCEchaFrom1DeeCrys(...)> Crystal number in Dee out of range."
+	   << " n1DeeCrys = " << n1DeeCrys << "(max = " << fEcal->MaxCrysEcnaInDee() << ")" << fTTBELL << std::endl;
     }
   return n1SCEcha;   // range = [1,25]
 }
@@ -1863,8 +1863,8 @@ Int_t TEcnaNumbering::Get1DeeSCEcnaFrom1DeeCrys(const Int_t& n1DeeCrys, const TS
   else
     {
       n1DeeSCEcna = -1;
-      cout << "!TEcnaNumbering::Get1DeeSCEcnaFrom1DeeCrys(...)> Crystal number in Dee out of range."
-	   << " n1DeeCrys = " << n1DeeCrys << "(max = " << fEcal->MaxCrysEcnaInDee() << ")" << fTTBELL << endl;
+      std::cout << "!TEcnaNumbering::Get1DeeSCEcnaFrom1DeeCrys(...)> Crystal number in Dee out of range."
+	   << " n1DeeCrys = " << n1DeeCrys << "(max = " << fEcal->MaxCrysEcnaInDee() << ")" << fTTBELL << std::endl;
     }
   return n1DeeSCEcna;  // range = [1,200]
 }
@@ -1920,24 +1920,24 @@ Int_t TEcnaNumbering::GetDSFrom1DeeSCEcna(const Int_t& n1DeeNumber, const Int_t&
 	}
       else
 	{
-	  cout << "!TEcnaNumbering::GetDSFrom1DeeSCEcna(...)> n1DeeSCEcna = " << n1DeeSCEcna
+	  std::cout << "!TEcnaNumbering::GetDSFrom1DeeSCEcna(...)> n1DeeSCEcna = " << n1DeeSCEcna
 	       << ". Out of range ( range = [1," << fEcal->MaxSCEcnaInDee() << "] )"
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
     }
   else
     {
       if( n1DeeNumber != 0 )
 	{
-	  cout << "!TEcnaNumbering::GetDSFrom1DeeSCEcna(...)> n1DeeNumber = " << n1DeeNumber 
+	  std::cout << "!TEcnaNumbering::GetDSFrom1DeeSCEcna(...)> n1DeeNumber = " << n1DeeNumber 
 	       << ". Out of range ( range = [1," << fEcal->MaxDeeInEE() << "] )"
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       else
 	{
-	  cout << "TEcnaNumbering::GetDSFrom1DeeSCEcna(...)> Dee = " << n1DeeNumber
+	  std::cout << "TEcnaNumbering::GetDSFrom1DeeSCEcna(...)> Dee = " << n1DeeNumber
 	       << ". Out of range (range = [1," << fEcal->MaxDeeInEE() << "])" 
-	       << fTTBELL << endl; 
+	       << fTTBELL << std::endl; 
 	}
     }
   return data_sector;
@@ -1979,24 +1979,24 @@ Int_t TEcnaNumbering::GetDSSCFrom1DeeSCEcna(const Int_t& n1DeeNumber, const Int_
 	}
       else
 	{
-	  cout << "!TEcnaNumbering::GetDSSCFrom1DeeSCEcna(...)> n1DeeSCEcna = " << n1DeeSCEcna
+	  std::cout << "!TEcnaNumbering::GetDSSCFrom1DeeSCEcna(...)> n1DeeSCEcna = " << n1DeeSCEcna
 	       << ". Out of range ( range = [1," << fEcal->MaxSCEcnaInDee() << "] )"
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
     }
   else
     {
       if( n1DeeNumber != 0 )
 	{
-	  cout << "!TEcnaNumbering::GetDSSCFrom1DeeSCEcna(...)> n1DeeNumber = " << n1DeeNumber 
+	  std::cout << "!TEcnaNumbering::GetDSSCFrom1DeeSCEcna(...)> n1DeeNumber = " << n1DeeNumber 
 	       << ". Out of range ( range = [1," << fEcal->MaxDeeInEE() << "] )"
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       else
 	{
-	  cout << "TEcnaNumbering::GetDSSCFrom1DeeSCEcna(...)> Dee = " << n1DeeNumber
+	  std::cout << "TEcnaNumbering::GetDSSCFrom1DeeSCEcna(...)> Dee = " << n1DeeNumber
 	       << ". Out of range (range = [1," << fEcal->MaxDeeInEE() << "])" 
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
     }
   return ds_sc;
@@ -2016,9 +2016,9 @@ Int_t TEcnaNumbering::GetDeeSCConsFrom1DeeSCEcna(const Int_t& n1DeeNumber, const
 	}
       else
 	{
-	  cout << "!TEcnaNumbering::GetDeeSCConsFrom1DeeSCEcna(...)> *** WARNING *** n1DeeSCEcna = " << n1DeeSCEcna
+	  std::cout << "!TEcnaNumbering::GetDeeSCConsFrom1DeeSCEcna(...)> *** WARNING *** n1DeeSCEcna = " << n1DeeSCEcna
 	       << ". Out of range ( range = [1," << fEcal->MaxSCEcnaInDee()
-	       << "] ). Nb for const. forced to " << fT2d_DeeSCCons[n1DeeNumber-1][19] << "." << endl;
+	       << "] ). Nb for const. forced to " << fT2d_DeeSCCons[n1DeeNumber-1][19] << "." << std::endl;
 	  dee_sc_cons = fT2d_DeeSCCons[n1DeeNumber-1][19];
 	}
     }
@@ -2026,15 +2026,15 @@ Int_t TEcnaNumbering::GetDeeSCConsFrom1DeeSCEcna(const Int_t& n1DeeNumber, const
     {
       if( n1DeeNumber != 0 )
 	{
-	  cout << "!TEcnaNumbering::GetDeeSCConsFrom1DeeSCEcna(...)> n1DeeNumber = " << n1DeeNumber 
+	  std::cout << "!TEcnaNumbering::GetDeeSCConsFrom1DeeSCEcna(...)> n1DeeNumber = " << n1DeeNumber 
 	       << ". Out of range ( range = [1," << fEcal->MaxDeeInEE() << "] )"
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       else
 	{
-	  cout << "TEcnaNumbering::GetDeeSCConsFrom1DeeSCEcna(...)> Dee = " << n1DeeNumber
+	  std::cout << "TEcnaNumbering::GetDeeSCConsFrom1DeeSCEcna(...)> Dee = " << n1DeeNumber
 	       << ". Out of range (range = [1," << fEcal->MaxDeeInEE() << "])" 
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
     }
   return dee_sc_cons;
@@ -2080,25 +2080,25 @@ Int_t TEcnaNumbering::Get1DeeSCEcnaFromDeeSCCons(const Int_t& n1DeeNumber, const
 	}
       else
 	{
-	  cout << "!TEcnaNumbering::Get1DeeSCEcnaFromDeeSCCons(...)> DeeSCCons = " << DeeSCCons
+	  std::cout << "!TEcnaNumbering::Get1DeeSCEcnaFromDeeSCCons(...)> DeeSCCons = " << DeeSCCons
 	       << ". Out of range ( range = [ " << off_set_cons+1
 	       << "," << fEcal->MaxSCForConsInDee()+off_set_cons << "] )"
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
     }
   else
     {
       if( n1DeeNumber != 0 )
 	{
-	  cout << "!TEcnaNumbering::Get1DeeSCEcnaFromDeeSCCons(...)> n1DeeNumber = " << n1DeeNumber 
+	  std::cout << "!TEcnaNumbering::Get1DeeSCEcnaFromDeeSCCons(...)> n1DeeNumber = " << n1DeeNumber 
 	       << ". Out of range ( range = [1," << fEcal->MaxDeeInEE() << "] )"
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       else
 	{
-	  cout << "TEcnaNumbering::Get1DeeSCEcnaFromDeeSCCons(...)> Dee = " << n1DeeNumber
+	  std::cout << "TEcnaNumbering::Get1DeeSCEcnaFromDeeSCCons(...)> Dee = " << n1DeeNumber
 	       << ". Out of range (range = [1," << fEcal->MaxDeeInEE() << "])" 
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
     }
   return dee_sc_ecna;
@@ -2473,10 +2473,10 @@ Int_t TEcnaNumbering::Get0StexEchaFrom1StexStinAnd0StinEcha(const Int_t& n1StexS
     {StexEcha = (n1StexStin-1)*fEcal->MaxCrysInStin() + i0StinEcha;}
   else
     {
-      cout << "!TEcnaNumbering::Get0StexEchaFrom1StexStinAnd0StinEcha *** ERROR ***> VALUE"
+      std::cout << "!TEcnaNumbering::Get0StexEchaFrom1StexStinAnd0StinEcha *** ERROR ***> VALUE"
 	   << " OUT OF RANGE. Forced to -1. Argument values: n1StexStin = " << n1StexStin
 	   << ", channel = " << i0StinEcha
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
     }
   return StexEcha;
 }
@@ -2631,8 +2631,8 @@ Int_t TEcnaNumbering::MaxCrysInStinEcna(const Int_t& n1DeeNumber, const Int_t& n
 	}
       else
 	{
-	  cout << "!TEcnaNumbering::MaxCrysInStinEcna(...)> " << s_option
-	       << ": unknown option." << fTTBELL << endl;
+	  std::cout << "!TEcnaNumbering::MaxCrysInStinEcna(...)> " << s_option
+	       << ": unknown option." << fTTBELL << std::endl;
 	}
     }
   return max_crys;

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaObject.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaObject.cc
@@ -17,7 +17,7 @@ ClassImp(TEcnaObject)
 {
 //destructor
 
-//  cout << "[Info Management] CLASS: TEcnaObject.      DESTROY OBJECT: this = " << this << endl;
+//  std::cout << "[Info Management] CLASS: TEcnaObject.      DESTROY OBJECT: this = " << this << std::endl;
 }
 
 //===================================================================
@@ -29,7 +29,7 @@ TEcnaObject::TEcnaObject()
 {
 // Constructor without argument
 
-//  cout << "[Info Management] CLASS: TEcnaObject.      CREATE OBJECT: this = " << this << endl;
+//  std::cout << "[Info Management] CLASS: TEcnaObject.      CREATE OBJECT: this = " << this << std::endl;
 
   Long_t PointerValue = (Long_t)this;
   Int_t un = 1;
@@ -221,8 +221,8 @@ Bool_t TEcnaObject::RegisterPointer(const TString& ClassName, const Long_t& Poin
   //.........................................................................................
   if( ClassFound == kFALSE )
     {
-      cout << "!TEcnaObject::RegisterPointer(...)> Class " << ClassName
-	   << " not found." << fTTBELL << endl;
+      std::cout << "!TEcnaObject::RegisterPointer(...)> Class " << ClassName
+	   << " not found." << fTTBELL << std::endl;
     }
 
   return ClassFound;
@@ -338,12 +338,12 @@ void TEcnaObject::NumberCreateObjectMessage(const TString& ClassName, const Long
 {
 #define NOCM
 #ifndef NOCM
-  cout << "*TEcnaObject::NumberCreateObjectMessage(...)> New ECNA object (pointer = "
+  std::cout << "*TEcnaObject::NumberCreateObjectMessage(...)> New ECNA object (pointer = "
        << PointerValue << ") from TEcnaObject " << this 
-       << ". Object# = " << setw(8) << NbOfObjects
+       << ". Object# = " << std::setw(8) << NbOfObjects
        << ", Class: " << ClassName;
-  if( NbOfObjects > 1 ){cout << " (INFO: more than 1 object)";}
-  cout << endl;
+  if( NbOfObjects > 1 ){std::cout << " (INFO: more than 1 object)";}
+  std::cout << std::endl;
 #endif // NOCM
 }
 
@@ -353,10 +353,10 @@ void TEcnaObject::NumberReuseObjectMessage(const TString& ClassName, const Long_
 #ifndef NOCR
   if( PointerValue != (Long_t)0 )
     {
-      cout << "*TEcnaObject::NumberReuseObjectMessage(...)> INFO: pointer " << PointerValue
+      std::cout << "*TEcnaObject::NumberReuseObjectMessage(...)> INFO: pointer " << PointerValue
 	   << " used again from TEcnaObject " << this
-	   << ". " << setw(8) << NbOfObjects << " times, class: " << ClassName;
+	   << ". " << std::setw(8) << NbOfObjects << " times, class: " << ClassName;
     }
-  cout << endl;
+  std::cout << std::endl;
 #endif // NOCR
 }

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaParCout.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaParCout.cc
@@ -17,7 +17,7 @@ ClassImp(TEcnaParCout)
   TEcnaParCout::~TEcnaParCout()
 {
 //destructor
- // cout << "[Info Management] CLASS: TEcnaParCout.       DESTROY OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaParCout.       DESTROY OBJECT: this = " << this << std::endl;
 }
 //===================================================================
 //
@@ -28,7 +28,7 @@ TEcnaParCout::TEcnaParCout()
 {
 // Constructor without argument
 
- // cout << "[Info Management] CLASS: TEcnaParCout.       CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaParCout.       CREATE OBJECT: this = " << this << std::endl;
 
   Init();
 }
@@ -37,7 +37,7 @@ TEcnaParCout::TEcnaParCout(TEcnaObject* pObjectManager)
 {
 // Constructor with argument
 
- // cout << "[Info Management] CLASS: TEcnaParCout.       CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaParCout.       CREATE OBJECT: this = " << this << std::endl;
 
   Init();
   Long_t i_this = (Long_t)this;

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaParEcal.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaParEcal.cc
@@ -17,7 +17,7 @@ ClassImp(TEcnaParEcal)
 TEcnaParEcal::TEcnaParEcal(){
 // Constructor without argument. Call to Init()
 
- // cout << "[Info Management] CLASS: TEcnaParEcal.   CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaParEcal.   CREATE OBJECT: this = " << this << std::endl;
 
   Init();
 }
@@ -25,7 +25,7 @@ TEcnaParEcal::TEcnaParEcal(){
 TEcnaParEcal::TEcnaParEcal(TEcnaObject* pObjectManager, const TString& SubDet){
 // Constructor with argument. Call to Init() and set the subdetector flag
 
-  //cout << "[Info Management] CLASS: TEcnaParEcal.   CREATE OBJECT: this = " << this << endl;
+  //std::cout << "[Info Management] CLASS: TEcnaParEcal.   CREATE OBJECT: this = " << this << std::endl;
 
   Init();
   Long_t i_this = (Long_t)this;
@@ -37,7 +37,7 @@ TEcnaParEcal::TEcnaParEcal(TEcnaObject* pObjectManager, const TString& SubDet){
 TEcnaParEcal::TEcnaParEcal(const TString& SubDet){
 // Constructor with argument. Call to Init() and set the subdetector flag
 
-  //cout << "[Info Management] CLASS: TEcnaParEcal.   CREATE OBJECT: this = " << this << endl;
+  //std::cout << "[Info Management] CLASS: TEcnaParEcal.   CREATE OBJECT: this = " << this << std::endl;
 
   Init();
   SetEcalSubDetector(SubDet.Data());
@@ -47,7 +47,7 @@ TEcnaParEcal::TEcnaParEcal(const TString& SubDet){
 TEcnaParEcal::~TEcnaParEcal() {
 //destructor
 
-  //cout << "[Info Management] CLASS: TEcnaParEcal.   DESTROY OBJECT: this = " << this << endl;
+  //std::cout << "[Info Management] CLASS: TEcnaParEcal.   DESTROY OBJECT: this = " << this << std::endl;
 }
 
 void TEcnaParEcal::Init()
@@ -201,8 +201,8 @@ void TEcnaParEcal::SetEcalSubDetector(const TString& SubDet){
 
   if( SubDet != fCodeEB && SubDet != fCodeEE )
     {
-      cout << "!TEcnaParEcal::SetEcalSubDetector(...)> " << SubDet
-	   << " : unknown subdetector code (requested: EB or EE)" << fTTBELL << endl;
+      std::cout << "!TEcnaParEcal::SetEcalSubDetector(...)> " << SubDet
+	   << " : unknown subdetector code (requested: EB or EE)" << fTTBELL << std::endl;
     }
   else
     {
@@ -212,8 +212,8 @@ void TEcnaParEcal::SetEcalSubDetector(const TString& SubDet){
 
       if( fFlagSubDet != fCodeEB && fFlagSubDet != fCodeEE )
 	{
-	  cout << "!TEcnaParEcal::SetEcalSubDetector(...)> fFlagSubDet = " << fFlagSubDet
-	       << " : CODE PROBLEM, subdetector flag not initialized." << fTTBELL << endl;
+	  std::cout << "!TEcnaParEcal::SetEcalSubDetector(...)> fFlagSubDet = " << fFlagSubDet
+	       << " : CODE PROBLEM, subdetector flag not initialized." << fTTBELL << std::endl;
 	}
 
       if(fFlagSubDet == fCodeEB)

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaParHistos.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaParHistos.cc
@@ -22,7 +22,7 @@ ClassImp(TEcnaParHistos)
   //if (fEcalNumbering != 0){delete  fEcalNumbering; fCdelete++;}
   //if (fEcal          != 0){delete  fEcal;          fCdelete++;}
   
-  //cout << "[Info Management] CLASS: TEcnaParHistos.     DESTROY OBJECT: this = " << this << endl;
+  //std::cout << "[Info Management] CLASS: TEcnaParHistos.     DESTROY OBJECT: this = " << this << std::endl;
 }
 
 //===================================================================
@@ -34,7 +34,7 @@ TEcnaParHistos::TEcnaParHistos()
 {
 // Constructor without argument
 
-  //cout << "[Info Management] CLASS: TEcnaParHistos.     CREATE OBJECT: this = " << this << endl;
+  //std::cout << "[Info Management] CLASS: TEcnaParHistos.     CREATE OBJECT: this = " << this << std::endl;
 
   Init();
 }
@@ -43,7 +43,7 @@ TEcnaParHistos::TEcnaParHistos(TEcnaObject* pObjectManager, const TString& SubDe
 {
 // Constructor without argument
 
-  //cout << "[Info Management] CLASS: TEcnaParHistos.     CREATE OBJECT: this = " << this << endl;
+  //std::cout << "[Info Management] CLASS: TEcnaParHistos.     CREATE OBJECT: this = " << this << std::endl;
 
   Init();
   Long_t i_this = (Long_t)this;
@@ -76,7 +76,7 @@ TEcnaParHistos::TEcnaParHistos(const TString& SubDet,
 {
 // Constructor with argument
 
-  //cout << "[Info Management] CLASS: TEcnaParHistos.     CREATE OBJECT: this = " << this << endl;
+  //std::cout << "[Info Management] CLASS: TEcnaParHistos.     CREATE OBJECT: this = " << this << std::endl;
 
   Init();
   SetEcalSubDetector(SubDet.Data(), pEcal, pEcalNumbering);
@@ -2237,10 +2237,10 @@ TString TEcnaParHistos::GetYVarHisto(const TString& HistoCode, const TString& Su
       if( HistoCode == "H_SCs_Date" ){YVarHisto = "Sigma Cor(s,s')";}
     }
 
-//  cout << endl << "*TEcnaParHistos::GetYVarHisto(...)> HistoType = " << HistoType
+//  std::cout << std::endl << "*TEcnaParHistos::GetYVarHisto(...)> HistoType = " << HistoType
 //       << ", HistoCode = " << HistoCode
 //       << ", StexNumber = " << StexNumber
-//       << ", YVarHisto = " << YVarHisto << endl;
+//       << ", YVarHisto = " << YVarHisto << std::endl;
 
   return YVarHisto;
 
@@ -2467,9 +2467,9 @@ TString TEcnaParHistos::BuildStandardDetectorCode(const TString& UserDetector)
 
    if( StandardDetectorCode == "?" )
     {
-      cout << "*TEcnaParHistos::BuildStandardDetectorCode(...)> UserDetector = " << UserDetector
+      std::cout << "*TEcnaParHistos::BuildStandardDetectorCode(...)> UserDetector = " << UserDetector
 	   << " : code not found."
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
 
       ListOfStandardCodes("DetectorCode");
     }
@@ -2536,9 +2536,9 @@ TString TEcnaParHistos::BuildStandardPlotOption(const TString& CallingMethod, co
   //...................................................
   if( StandardPlotOption == "?" )
     {
-      cout << "*TEcnaParHistos::BuildStandardPlotOption(...)> UserPlotOption = " << UserPlotOption
+      std::cout << "*TEcnaParHistos::BuildStandardPlotOption(...)> UserPlotOption = " << UserPlotOption
 	   << " : code not found."
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
 
       ListOfStandardCodes("PlotOption");
     }
@@ -2602,9 +2602,9 @@ TString TEcnaParHistos::BuildStandard1DHistoCodeX(const TString& CallingMethod, 
   //---------------------------------------------
   if( StandardHistoCode == "?" )
     {
-      cout << "*TEcnaParHistos::BuildStandard1DHistoCodeX(...)> UserHistoCode = " << UserHistoCode
+      std::cout << "*TEcnaParHistos::BuildStandard1DHistoCodeX(...)> UserHistoCode = " << UserHistoCode
 	   << " : code not found."
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
 
       ListOfStandardCodes("1DHistoCodeX");
     }
@@ -2646,9 +2646,9 @@ TString TEcnaParHistos::BuildStandard1DHistoCodeY(const TString& CallingMethod, 
   //---------------------------------------------
   if( StandardHistoCode == "?" )
     {
-      cout << "*TEcnaParHistos::BuildStandard1DHistoCodeY(...)> UserHistoCode = " << UserHistoCode
+      std::cout << "*TEcnaParHistos::BuildStandard1DHistoCodeY(...)> UserHistoCode = " << UserHistoCode
 	   << " : code not found."
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
 
       ListOfStandardCodes("1DHistoCodeY");
     }
@@ -2736,9 +2736,9 @@ TString TEcnaParHistos::BuildStandard1DHistoCodeXY(const TString& UserHistoCode)
   //---------------------------------------------
   if( StandardHistoCode == "?" )
     {
-      cout << "*TEcnaParHistos::BuildStandard1DHistoCodeXY(...)> UserHistoCode = " << UserHistoCode
+      std::cout << "*TEcnaParHistos::BuildStandard1DHistoCodeXY(...)> UserHistoCode = " << UserHistoCode
 	   << " : code not found."
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
 
       ListOfStandardCodes("1DHistoCodeXY");
     }
@@ -2769,9 +2769,9 @@ TString TEcnaParHistos::BuildStandardCovOrCorCode(const TString& CallingMethod, 
   //---------------------------------------------
   if( StandardHistoCode == "?" )
     {
-      cout << "*TEcnaParHistos::BuildStandardCovOrCorCode(...)> UserHistoCode = " << UserHistoCode
+      std::cout << "*TEcnaParHistos::BuildStandardCovOrCorCode(...)> UserHistoCode = " << UserHistoCode
 	   << " : code not found."
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
 
       ListOfStandardCodes("CovOrCorCode");
     }
@@ -2831,9 +2831,9 @@ TString TEcnaParHistos::BuildStandardBetweenWhatCode(const TString& CallingMetho
   //---------------------------------------------
   if( StandardHistoCode == "?" )
     {
-      cout << "*TEcnaParHistos::BuildStandardBetweenWhatCode(...)> UserHistoCode = " << UserHistoCode
+      std::cout << "*TEcnaParHistos::BuildStandardBetweenWhatCode(...)> UserHistoCode = " << UserHistoCode
 	   << " : code not found."
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
 
       ListOfStandardCodes("BetweenWhatCode");
     }
@@ -2848,92 +2848,92 @@ void TEcnaParHistos::ListOfStandardCodes(const TString& TypeOfCode)
 
   if(TypeOfCode == "DetectorCode")
     {
-      cout << "*--------------------------------------- Standard detector codes:" << endl;
-      cout << "    EB   (ECAL Barrel) " << endl;
-      cout << "    EE   (ECAL Endcap) " << endl;
-      cout << "    SM   (Barrel Super Module) " << endl;
-      cout << "    Dee  (Encap Dee) " << endl;
-      cout << " Other codes are available" << endl;
-      cout << " See source file: TEcnaParHistos::BuildStandardDetectorCode(...)." << endl;
-      cout << "*----------------------------------------------------------------" << endl;
+      std::cout << "*--------------------------------------- Standard detector codes:" << std::endl;
+      std::cout << "    EB   (ECAL Barrel) " << std::endl;
+      std::cout << "    EE   (ECAL Endcap) " << std::endl;
+      std::cout << "    SM   (Barrel Super Module) " << std::endl;
+      std::cout << "    Dee  (Encap Dee) " << std::endl;
+      std::cout << " Other codes are available" << std::endl;
+      std::cout << " See source file: TEcnaParHistos::BuildStandardDetectorCode(...)." << std::endl;
+      std::cout << "*----------------------------------------------------------------" << std::endl;
     }
 
   if(TypeOfCode == "PlotOption")
     {
-      cout << "*--------------------------------------- Standard plot options:" << endl;
-      cout << "    All ROOT DRAW options and: " << endl;
-      cout << "   (nothing) " << endl;
-      cout << "    SAME n   " << endl;
-      cout << "    ASCII    " << endl;
-      cout << " Other codes are available" << endl;
-      cout << " See source file: TEcnaParHistos::BuildStandardPlotOption(...)." << endl;
-      cout << "*--------------------------------------------------------------" << endl;
+      std::cout << "*--------------------------------------- Standard plot options:" << std::endl;
+      std::cout << "    All ROOT DRAW options and: " << std::endl;
+      std::cout << "   (nothing) " << std::endl;
+      std::cout << "    SAME n   " << std::endl;
+      std::cout << "    ASCII    " << std::endl;
+      std::cout << " Other codes are available" << std::endl;
+      std::cout << " See source file: TEcnaParHistos::BuildStandardPlotOption(...)." << std::endl;
+      std::cout << "*--------------------------------------------------------------" << std::endl;
     }
 
   if(TypeOfCode == "1DHistoCodeX")
     {
-      cout << "*---------------------- Standard 1D histo codes for X coordinate:" << endl;
-      cout << "    Tow  (SM tower) " << endl;
-      cout << "    SC   (Dee super crystal) " << endl;
-      cout << "    Xtal (crystal) " << endl;
-      cout << "    Smp  (Adc sample) " << endl;
-      cout << "    Evt  (event) " << endl;
-      cout << " Other codes are available" << endl;
-      cout << " See source file: TEcnaParHistos::BuildStandard1DHistoCodeX(...)." << endl;
-      cout << "*----------------------------------------------------------------" << endl;
+      std::cout << "*---------------------- Standard 1D histo codes for X coordinate:" << std::endl;
+      std::cout << "    Tow  (SM tower) " << std::endl;
+      std::cout << "    SC   (Dee super crystal) " << std::endl;
+      std::cout << "    Xtal (crystal) " << std::endl;
+      std::cout << "    Smp  (Adc sample) " << std::endl;
+      std::cout << "    Evt  (event) " << std::endl;
+      std::cout << " Other codes are available" << std::endl;
+      std::cout << " See source file: TEcnaParHistos::BuildStandard1DHistoCodeX(...)." << std::endl;
+      std::cout << "*----------------------------------------------------------------" << std::endl;
     }
 
   if(TypeOfCode == "1DHistoCodeY")
     {
-      cout << "*---------------------- Standard 1D histo codes for Y coordinate;" << endl;
-      cout << "    NOX  (number of crystals) " << endl;
-      cout << "    NOS  (number of samples) " << endl;
-      cout << "    NOR  (number of runs) " << endl;
-      cout << " Other codes are available" << endl;
-      cout << " See source file: TEcnaParHistos::BuildStandard1DHistoCodeY(...)." << endl;
-      cout << "*----------------------------------------------------------------" << endl;
+      std::cout << "*---------------------- Standard 1D histo codes for Y coordinate;" << std::endl;
+      std::cout << "    NOX  (number of crystals) " << std::endl;
+      std::cout << "    NOS  (number of samples) " << std::endl;
+      std::cout << "    NOR  (number of runs) " << std::endl;
+      std::cout << " Other codes are available" << std::endl;
+      std::cout << " See source file: TEcnaParHistos::BuildStandard1DHistoCodeY(...)." << std::endl;
+      std::cout << "*----------------------------------------------------------------" << std::endl;
     }
 
   if(TypeOfCode == "1DHistoCodeXY")
     {
-      cout << "*------------------ Standard 1D histo codes for X or Y coordinate;" << endl;
-      cout << "    NOE  (number of events) " << endl;
-      cout << "    Ped  (pedestal) " << endl;
-      cout << "    TNo  (total noise) " << endl;
-      cout << "    LFN  (low frequency noise) " << endl;
-      cout << "    HFN  (high frequency noise) " << endl;
-      cout << "    MCs  (mean correlation between samples) " << endl;
-      cout << "    SCs  (sigma of correlations between samples) " << endl;
-      cout << "    MSp  (sample mean) " << endl;
-      cout << "    SSp  (sample sigma) " << endl;
-      cout << "    Time (time, date) " << endl;
-      cout << "    Adc  (ADC sample value) " << endl;
-      cout << " Other codes are available" << endl;
-      cout << " See source file: TEcnaParHistos::BuildStandard1DHistoCodeXY(...)." << endl;
-      cout << "*-----------------------------------------------------------------" << endl;
+      std::cout << "*------------------ Standard 1D histo codes for X or Y coordinate;" << std::endl;
+      std::cout << "    NOE  (number of events) " << std::endl;
+      std::cout << "    Ped  (pedestal) " << std::endl;
+      std::cout << "    TNo  (total noise) " << std::endl;
+      std::cout << "    LFN  (low frequency noise) " << std::endl;
+      std::cout << "    HFN  (high frequency noise) " << std::endl;
+      std::cout << "    MCs  (mean correlation between samples) " << std::endl;
+      std::cout << "    SCs  (sigma of correlations between samples) " << std::endl;
+      std::cout << "    MSp  (sample mean) " << std::endl;
+      std::cout << "    SSp  (sample sigma) " << std::endl;
+      std::cout << "    Time (time, date) " << std::endl;
+      std::cout << "    Adc  (ADC sample value) " << std::endl;
+      std::cout << " Other codes are available" << std::endl;
+      std::cout << " See source file: TEcnaParHistos::BuildStandard1DHistoCodeXY(...)." << std::endl;
+      std::cout << "*-----------------------------------------------------------------" << std::endl;
     }
 
   if(TypeOfCode == "CovOrCorCode")
     {
-      cout << "*-------- Standard codes for matrix type (correlation or covariance);" << endl;
-      cout << "    Cor  (correlation) " << endl;
-      cout << "    cov  (covariance) " << endl;
-      cout << " Other codes are available" << endl;
-      cout << " See source file: TEcnaParHistos::BuildStandardCovOrCorCode(...)." << endl;
-      cout << "*--------------------------------------------------------------------" << endl;
+      std::cout << "*-------- Standard codes for matrix type (correlation or covariance);" << std::endl;
+      std::cout << "    Cor  (correlation) " << std::endl;
+      std::cout << "    cov  (covariance) " << std::endl;
+      std::cout << " Other codes are available" << std::endl;
+      std::cout << " See source file: TEcnaParHistos::BuildStandardCovOrCorCode(...)." << std::endl;
+      std::cout << "*--------------------------------------------------------------------" << std::endl;
     }
 
   if(TypeOfCode == "BetweenWhatCode")
     {
-      cout << "*-------- Standard codes for quantities in correlation or covariance;" << endl;
-      cout << "    Mss    (between samples) " << endl;
-      cout << "    MccLF  (low  frequency between channels) " << endl;
-      cout << "    MccHF  (high frequency between channels) " << endl;
-      cout << "    MttLF  (low  frequency between towers [if EB] or SC [if EE]) " << endl;
-      cout << "    MttLF  (high frequency between towers [if EB] or SC [if EE]) " << endl;
-      cout << " Other codes are available" << endl;
-      cout << " See source file: TEcnaParHistos::BuildStandardBetweenWhatCode(...)." << endl;
-      cout << "*--------------------------------------------------------------------" << endl;
+      std::cout << "*-------- Standard codes for quantities in correlation or covariance;" << std::endl;
+      std::cout << "    Mss    (between samples) " << std::endl;
+      std::cout << "    MccLF  (low  frequency between channels) " << std::endl;
+      std::cout << "    MccHF  (high frequency between channels) " << std::endl;
+      std::cout << "    MttLF  (low  frequency between towers [if EB] or SC [if EE]) " << std::endl;
+      std::cout << "    MttLF  (high frequency between towers [if EB] or SC [if EE]) " << std::endl;
+      std::cout << " Other codes are available" << std::endl;
+      std::cout << " See source file: TEcnaParHistos::BuildStandardBetweenWhatCode(...)." << std::endl;
+      std::cout << "*--------------------------------------------------------------------" << std::endl;
     }
 }
 
@@ -2954,8 +2954,8 @@ TString TEcnaParHistos::GetTechHistoCode(const TString& StandardHistoCode)
 
   if( TechHistoCode == "?" )
     {
-      cout << "*TEcnaParHistos::GetTechHistoCode(...)> StandardHistoCode = " << StandardHistoCode
-	   << " : code not found " << fTTBELL << endl;
+      std::cout << "*TEcnaParHistos::GetTechHistoCode(...)> StandardHistoCode = " << StandardHistoCode
+	   << " : code not found " << fTTBELL << std::endl;
     }
   return TechHistoCode;
 }
@@ -3011,8 +3011,8 @@ TString TEcnaParHistos::GetTechHistoCode(const TString& X_Quantity, const TStrin
 
   if( TechHistoCode == "?" )
     {
-      cout << "TEcnaParHistos::GetTechHistoCode(...)> HistoCode not found. X_Quantity = " << X_Quantity
-	   << ", Y_Quantity = "<< Y_Quantity << endl;
+      std::cout << "TEcnaParHistos::GetTechHistoCode(...)> HistoCode not found. X_Quantity = " << X_Quantity
+	   << ", Y_Quantity = "<< Y_Quantity << std::endl;
     }
   return TechHistoCode;
 }

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaParPaths.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaParPaths.cc
@@ -19,7 +19,7 @@ ClassImp(TEcnaParPaths)
 {
 //destructor
 
- // cout << "[Info Management] CLASS: TEcnaParPaths.      DESTROY OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaParPaths.      DESTROY OBJECT: this = " << this << std::endl;
 }
 
 //===================================================================
@@ -30,14 +30,14 @@ ClassImp(TEcnaParPaths)
 TEcnaParPaths::TEcnaParPaths()
 {
 // Constructor without argument
- // cout << "[Info Management] CLASS: TEcnaParPaths.      CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaParPaths.      CREATE OBJECT: this = " << this << std::endl;
   Init();
 }
 
 TEcnaParPaths::TEcnaParPaths(TEcnaObject* pObjectManager)
 {
 // Constructor without argument
- // cout << "[Info Management] CLASS: TEcnaParPaths.      CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaParPaths.      CREATE OBJECT: this = " << this << std::endl;
   Init();
   Long_t i_this = (Long_t)this;
   pObjectManager->RegisterPointer("TEcnaParPaths", i_this);
@@ -99,7 +99,7 @@ Bool_t TEcnaParPaths::GetPathForResultsRootFiles(const TString& argFileName)
 
   if ( argFileName == "" )
     {
-      string cFileNameForCnaPaths = "ECNA/path_results_root";     // config file name
+      std::string cFileNameForCnaPaths = "ECNA/path_results_root";     // config file name
       TString s_file_name = cFileNameForCnaPaths.c_str();
       const Text_t *t_file_name = (const Text_t *)s_file_name.Data();
       
@@ -121,7 +121,7 @@ Bool_t TEcnaParPaths::GetPathForResultsRootFiles(const TString& argFileName)
   if(fFcin_rr.fail() == kFALSE)
     {
       fFcin_rr.clear();
-      string xResultsFileP;
+      std::string xResultsFileP;
       fFcin_rr >> xResultsFileP;
       fCfgResultsRootFilePath = xResultsFileP.c_str();
       fFcin_rr.close();
@@ -131,20 +131,20 @@ Bool_t TEcnaParPaths::GetPathForResultsRootFiles(const TString& argFileName)
     {
       fFcin_rr.clear();
       fCnaError++;
-      cout << fTTBELL << endl
-	   << " ***************************************************************************************** " << endl;
-      cout << "   !CNA(TEcnaParPaths) (" << fCnaError << ") *** ERROR *** " << endl << endl
-	   << "     " << fFileForResultsRootFilePath.Data() << ": file not found. " << endl << endl
-	   << "     Please create a subdirectory named ECNA in your HOME directory (if not already done)" << endl
-	   << "     and create a file named path_results_root in the subdirectory ECNA." << endl << endl
-           << "     The file " << fFileForResultsRootFilePath.Data() << " is a configuration file" << endl
-	   << "     for ECNA and must contain one line with the following syntax:" << endl << endl
-	   << "        PATH_FOR_THE_RESULTS_ROOT_FILE (without slash at the end of line)" << endl
+      std::cout << fTTBELL << std::endl
+	   << " ***************************************************************************************** " << std::endl;
+      std::cout << "   !CNA(TEcnaParPaths) (" << fCnaError << ") *** ERROR *** " << std::endl << std::endl
+	   << "     " << fFileForResultsRootFilePath.Data() << ": file not found. " << std::endl << std::endl
+	   << "     Please create a subdirectory named ECNA in your HOME directory (if not already done)" << std::endl
+	   << "     and create a file named path_results_root in the subdirectory ECNA." << std::endl << std::endl
+           << "     The file " << fFileForResultsRootFilePath.Data() << " is a configuration file" << std::endl
+	   << "     for ECNA and must contain one line with the following syntax:" << std::endl << std::endl
+	   << "        PATH_FOR_THE_RESULTS_ROOT_FILE (without slash at the end of line)" << std::endl
 	   << "                                        ================================"
-	   << endl << endl
-	   << "     Example: $HOME/scratch0/ecna/results_root" << endl << endl
+	   << std::endl << std::endl
+	   << "     Example: $HOME/scratch0/ecna/results_root" << std::endl << std::endl
 	   << " ***************************************************************************************** "
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
 
       fFcin_rr.close();
       FileHere = kFALSE;
@@ -178,7 +178,7 @@ Bool_t TEcnaParPaths::GetPathForResultsAsciiFiles(const TString& argFileName)
 
   if ( argFileName == "" )
     {
-      string cFileNameForCnaPaths = "ECNA/path_results_ascii";     // config file name
+      std::string cFileNameForCnaPaths = "ECNA/path_results_ascii";     // config file name
       TString s_file_name = cFileNameForCnaPaths.c_str();
       const Text_t *t_file_name = (const Text_t *)s_file_name.Data();
       
@@ -199,7 +199,7 @@ Bool_t TEcnaParPaths::GetPathForResultsAsciiFiles(const TString& argFileName)
   if(fFcin_ra.fail() == kFALSE)
     {
       fFcin_ra.clear();
-      string xResultsFileP;
+      std::string xResultsFileP;
       fFcin_ra >> xResultsFileP;
       fCfgResultsAsciiFilePath = xResultsFileP.c_str();
       fFcin_ra.close();
@@ -209,20 +209,20 @@ Bool_t TEcnaParPaths::GetPathForResultsAsciiFiles(const TString& argFileName)
     {
       fFcin_ra.clear();
       fCnaError++;
-      cout << fTTBELL << endl
-	   << " ***************************************************************************************** " << endl;
-      cout << "   !CNA(TEcnaParPaths) (" << fCnaError << ") *** ERROR *** " << endl << endl
-	   << "     " << fFileForResultsAsciiFilePath.Data() << ": file not found. " << endl << endl
-	   << "     Please create a subdirectory named ECNA in your HOME directory (if not already done)" << endl
-	   << "     and create a file named path_results_ascii in the subdirectory ECNA." << endl << endl
-           << "     The file " << fFileForResultsAsciiFilePath.Data() << " is a configuration file" << endl
-	   << "     for ECNA and must contain one line with the following syntax:" << endl << endl
-	   << "        PATH_FOR_THE_RESULTS_ASCII_FILE (without slash at the end of line)" << endl
+      std::cout << fTTBELL << std::endl
+	   << " ***************************************************************************************** " << std::endl;
+      std::cout << "   !CNA(TEcnaParPaths) (" << fCnaError << ") *** ERROR *** " << std::endl << std::endl
+	   << "     " << fFileForResultsAsciiFilePath.Data() << ": file not found. " << std::endl << std::endl
+	   << "     Please create a subdirectory named ECNA in your HOME directory (if not already done)" << std::endl
+	   << "     and create a file named path_results_ascii in the subdirectory ECNA." << std::endl << std::endl
+           << "     The file " << fFileForResultsAsciiFilePath.Data() << " is a configuration file" << std::endl
+	   << "     for ECNA and must contain one line with the following syntax:" << std::endl << std::endl
+	   << "        PATH_FOR_THE_RESULTS_ASCII_FILE (without slash at the end of line)" << std::endl
 	   << "                                         ================================"
-	   << endl << endl
-	   << "     Example: $HOME/scratch0/ecna/results_ascii" << endl << endl
+	   << std::endl << std::endl
+	   << "     Example: $HOME/scratch0/ecna/results_ascii" << std::endl << std::endl
 	   << " ***************************************************************************************** "
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
 
       fFcin_ra.close();
       FileHere = kFALSE;
@@ -256,7 +256,7 @@ Bool_t TEcnaParPaths::GetPathForHistoryRunListFiles(const TString& argFileName)
 
   if ( argFileName == "" )
     {
-      string cFileNameForCnaPaths = "ECNA/path_runlist_history_plots";     // config file name
+      std::string cFileNameForCnaPaths = "ECNA/path_runlist_history_plots";     // config file name
       TString s_file_name = cFileNameForCnaPaths.c_str();
       const Text_t *t_file_name = (const Text_t *)s_file_name.Data();
       
@@ -277,7 +277,7 @@ Bool_t TEcnaParPaths::GetPathForHistoryRunListFiles(const TString& argFileName)
   if(fFcin_lor.fail() == kFALSE)
     {
       fFcin_lor.clear();
-      string xHistoryRunListP;
+      std::string xHistoryRunListP;
       fFcin_lor >> xHistoryRunListP;
       fCfgHistoryRunListFilePath = xHistoryRunListP.c_str();
       fFcin_lor.close();
@@ -287,20 +287,20 @@ Bool_t TEcnaParPaths::GetPathForHistoryRunListFiles(const TString& argFileName)
     {
       fFcin_lor.clear();
       fCnaError++;
-      cout << fTTBELL << endl
-	   << " ******************************************************************************************************** " << endl;
-      cout << "   !CNA(TEcnaParPaths) (" << fCnaError << ") *** ERROR *** " << endl << endl
-	   << "     " << fFileForHistoryRunListFilePath.Data() << ": file not found. " << endl << endl
-	   << "     Please create a subdirectory named ECNA in your HOME directory (if not already done)" << endl
-	   << "     and create a file named path_runlist_history_plots in the subdirectory ECNA." << endl << endl
-           << "     The file " << fFileForHistoryRunListFilePath.Data() << " is a configuration file" << endl
-	   << "     for ECNA and must contain one line with the following syntax:" << endl << endl
-	   << "        PATH_FOR_THE_LIST_OF_RUNS_FOR_HISTORY_PLOTS_FILE (without slash at the end of line)" << endl
+      std::cout << fTTBELL << std::endl
+	   << " ******************************************************************************************************** " << std::endl;
+      std::cout << "   !CNA(TEcnaParPaths) (" << fCnaError << ") *** ERROR *** " << std::endl << std::endl
+	   << "     " << fFileForHistoryRunListFilePath.Data() << ": file not found. " << std::endl << std::endl
+	   << "     Please create a subdirectory named ECNA in your HOME directory (if not already done)" << std::endl
+	   << "     and create a file named path_runlist_history_plots in the subdirectory ECNA." << std::endl << std::endl
+           << "     The file " << fFileForHistoryRunListFilePath.Data() << " is a configuration file" << std::endl
+	   << "     for ECNA and must contain one line with the following syntax:" << std::endl << std::endl
+	   << "        PATH_FOR_THE_LIST_OF_RUNS_FOR_HISTORY_PLOTS_FILE (without slash at the end of line)" << std::endl
 	   << "                                                          ================================"
-	   << endl << endl
-	   << "     Example: $HOME/scratch0/ecna/runlist_history_plots" << endl << endl
+	   << std::endl << std::endl
+	   << "     Example: $HOME/scratch0/ecna/runlist_history_plots" << std::endl << std::endl
 	   << " ******************************************************************************************************** "
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
 
       fFcin_lor.close();
       FileHere = kFALSE;
@@ -330,9 +330,9 @@ void TEcnaParPaths::GetCMSSWParameters()
   char* ch_cmssw_base = getenv("CMSSW_BASE");
   if( ch_cmssw_base == 0 )
     {
-      cout << "*TEcnaParPaths::GetCMSSWParameters()> CMSSW_BASE not defined."
+      std::cout << "*TEcnaParPaths::GetCMSSWParameters()> CMSSW_BASE not defined."
 	   << " Please, set up the environment (command: eval `scramv1 runtime -csh`)"
-	   << fTTBELL << endl; 
+	   << fTTBELL << std::endl; 
     }
   else
     {
@@ -344,9 +344,9 @@ void TEcnaParPaths::GetCMSSWParameters()
   char* ch_scram_arch = getenv("SCRAM_ARCH");
   if( ch_scram_arch == 0 )
     {
-      cout << "*TEcnaParPaths::GetCMSSWParameters()> SCRAM_ARCH not defined."
+      std::cout << "*TEcnaParPaths::GetCMSSWParameters()> SCRAM_ARCH not defined."
 	   << " Please, set up the environment (command: eval `scramv1 runtime -csh`)"
-	   << fTTBELL << endl; 
+	   << fTTBELL << std::endl; 
     }
   else
     {

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRead.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRead.cc
@@ -19,7 +19,7 @@ ClassImp(TEcnaRead)
 TEcnaRead::TEcnaRead()
 {
   Init();
-  // cout << "[Info Management] CLASS: TEcnaRead.          CREATE OBJECT: this = " << this << endl;
+  // std::cout << "[Info Management] CLASS: TEcnaRead.          CREATE OBJECT: this = " << this << std::endl;
 }
 //Constructor without argument
 
@@ -104,7 +104,7 @@ TEcnaRead::TEcnaRead(TEcnaObject* pObjectManager, const TString& SubDet)
   Init();
   SetEcalSubDetector(SubDet.Data());
 
- // cout << "[Info Management] CLASS: TEcnaRead.          CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaRead.          CREATE OBJECT: this = " << this << std::endl;
 }
 
 void TEcnaRead::Init()
@@ -186,8 +186,8 @@ void TEcnaRead::Anew(const TString& VarName)
   // allocation survey for new
   
   fCnew++;
-  // cout << "TEcnaRead::Anew---> new " << setw(4) << fCnew << " --------------> " << setw(25)
-  //      << VarName.Data() << " / object(this): " << this << endl;
+  // std::cout << "TEcnaRead::Anew---> new " << std::setw(4) << fCnew << " --------------> " << std::setw(25)
+  //      << VarName.Data() << " / object(this): " << this << std::endl;
 }
 
 void TEcnaRead::Adelete(const TString& VarName)
@@ -195,8 +195,8 @@ void TEcnaRead::Adelete(const TString& VarName)
   // allocation survey for delete
   
   fCdelete++;
-  // cout << "TEcnaRead::Adelete> ========== delete" << setw(4) << fCdelete << " -> " << setw(25)
-  //      << VarName.Data() << " / object(this): " << this << endl;
+  // std::cout << "TEcnaRead::Adelete> ========== delete" << std::setw(4) << fCdelete << " -> " << std::setw(25)
+  //      << VarName.Data() << " / object(this): " << this << std::endl;
 }
 
 //=========================================== private copy ==========
@@ -233,9 +233,9 @@ void  TEcnaRead::fCopy(const TEcnaRead& rund)
 
 TEcnaRead::TEcnaRead(const TEcnaRead& dcop)
 {
-  cout << "*TEcnaRead::TEcnaRead(const TEcnaRead& dcop)> "
+  std::cout << "*TEcnaRead::TEcnaRead(const TEcnaRead& dcop)> "
        << " It is time to write a copy constructor"
-       << endl;
+       << std::endl;
   
   // { Int_t cintoto;  cin >> cintoto; }
   
@@ -265,10 +265,10 @@ TEcnaRead::~TEcnaRead()
 {
 //Destructor
   
-  // cout << "[Info Management] CLASS: TEcnaRead.          DESTROY OBJECT: this = " << this << endl;
+  // std::cout << "[Info Management] CLASS: TEcnaRead.          DESTROY OBJECT: this = " << this << std::endl;
 
   if(fFlagPrint == fCodePrintAllComments || fFlagPrint == fCodePrintComments){
-    cout << "*TEcnaRead::~TEcnaRead()> Entering destructor" << endl;}
+    std::cout << "*TEcnaRead::~TEcnaRead()> Entering destructor" << std::endl;}
   
   //if (fFileHeader    != 0){delete fFileHeader;    Adelete("fFileHeader");}
   //if (fEcal          != 0){delete fEcal;          Adelete("fEcal");}
@@ -286,17 +286,17 @@ TEcnaRead::~TEcnaRead()
 
   if ( fCnew != fCdelete )
     {
-      cout << "!TEcnaRead/destructor> WRONG MANAGEMENT OF ALLOCATIONS: fCnew = "
-	   << fCnew << ", fCdelete = " << fCdelete << fTTBELL << endl;
+      std::cout << "!TEcnaRead/destructor> WRONG MANAGEMENT OF ALLOCATIONS: fCnew = "
+	   << fCnew << ", fCdelete = " << fCdelete << fTTBELL << std::endl;
     }
   else
     {
-      // cout << "*TEcnaRead/destructor> BRAVO! GOOD MANAGEMENT OF ALLOCATIONS: fCnew = "
-      //      << fCnew << ", fCdelete = " << fCdelete << endl;
+      // std::cout << "*TEcnaRead/destructor> BRAVO! GOOD MANAGEMENT OF ALLOCATIONS: fCnew = "
+      //      << fCnew << ", fCdelete = " << fCdelete << std::endl;
     }
   
   if(fFlagPrint == fCodePrintAllComments || fFlagPrint == fCodePrintComments){
-    cout << "*TEcnaRead::~TEcnaRead()> End of destructor " << endl;}
+    std::cout << "*TEcnaRead::~TEcnaRead()> End of destructor " << std::endl;}
 }
 
 //@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@ -330,18 +330,18 @@ TVectorD TEcnaRead::Read1DHisto(const Int_t& VecDim,     const TString& UserQuan
       else
 	{
 	  for(Int_t i=0; i<VecDim; i++){vec(i) = (double_t)0.;}
-	  cout <<"!TEcnaRead::Read1DHisto(...)>  UserQuantity = " << UserQuantity
+	  std::cout <<"!TEcnaRead::Read1DHisto(...)>  UserQuantity = " << UserQuantity
 	       << "(StandardQuantity = " << StandardQuantity
-	       << "). Wrong code, no file reading." << fTTBELL << endl;
+	       << "). Wrong code, no file reading." << fTTBELL << std::endl;
 	}
       return vec;
     }
   else
     {
       TVectorD vec(VecDim); for(Int_t i=0; i<VecDim; i++){vec(i) = (double_t)0.;}
-      cout <<"!TEcnaRead::Read1DHisto(...)> UserQuantity = " << UserQuantity
+      std::cout <<"!TEcnaRead::Read1DHisto(...)> UserQuantity = " << UserQuantity
 	   << ", VecDim = " << VecDim << "(VecDimTest = " << VecDimTest << ")"
-	   << ". Wrong code or array dimension. No file reading." << fTTBELL << endl;
+	   << ". Wrong code or array dimension. No file reading." << fTTBELL << std::endl;
       return vec;
     }
 }  // end of Read1DHisto / ReadSampleAdcValues
@@ -364,18 +364,18 @@ TVectorD TEcnaRead::Read1DHisto(const Int_t& VecDim, const TString& UserQuantity
       else
 	{
 	  for(Int_t i=0; i<VecDim; i++){vec(i) = (double_t)0.;}
-	  cout <<"!TEcnaRead::Read1DHisto(...)>  UserQuantity = " << UserQuantity
+	  std::cout <<"!TEcnaRead::Read1DHisto(...)>  UserQuantity = " << UserQuantity
 	       << ", StandardQuantity = " << StandardQuantity
-	       << ". Wrong code, no file reading." << fTTBELL << endl;
+	       << ". Wrong code, no file reading." << fTTBELL << std::endl;
 	}
       return vec;
     }
   else
     {
       TVectorD vec(VecDim); for(Int_t i=0; i<VecDim; i++){vec(i) = (double_t)0.;}
-      cout <<"!TEcnaRead::Read1DHisto(...)> UserQuantity = " << UserQuantity
+      std::cout <<"!TEcnaRead::Read1DHisto(...)> UserQuantity = " << UserQuantity
 	   << ", VecDim = " << VecDim << "(VecDimTest = " << VecDimTest << ")"
-	   << ". Wrong code or array dimension. No file reading." << fTTBELL << endl; 
+	   << ". Wrong code or array dimension. No file reading." << fTTBELL << std::endl; 
       return vec;
     }
 }  // end of Read1DHisto / ReadSampleMeans , ReadSampleSigmas
@@ -468,8 +468,8 @@ TVectorD TEcnaRead::Read1DHisto(const Int_t& VecDim, const TString& UserQuantity
 		    }
 		  else
 		    {
-		      cout  << "!TEcnaRead::Read1DHisto(const TString&, const TString&)> *ERROR* =====> "
-			    << " ROOT file not found" << fTTBELL << endl;
+		      std::cout  << "!TEcnaRead::Read1DHisto(const TString&, const TString&)> *ERROR* =====> "
+			    << " ROOT file not found" << fTTBELL << std::endl;
 		    }
 		}
 	    }
@@ -477,18 +477,18 @@ TVectorD TEcnaRead::Read1DHisto(const Int_t& VecDim, const TString& UserQuantity
       else
 	{
 	  for(Int_t i=0; i<VecDim; i++){vec(i) = (double_t)0.;}
-	  cout <<"!TEcnaRead::Read1DHisto(...)> UserQuantity = " << UserQuantity
+	  std::cout <<"!TEcnaRead::Read1DHisto(...)> UserQuantity = " << UserQuantity
 	       << ", UserDetector = " << UserDetector
-	       << ". Wrong code(s). No file reading." << fTTBELL << endl;
+	       << ". Wrong code(s). No file reading." << fTTBELL << std::endl;
 	}
       return vec;
     }
   else
     {
       TVectorD vec(VecDim); for(Int_t i=0; i<VecDim; i++){vec(i) = (double_t)0.;}
-      cout <<"!TEcnaRead::Read1DHisto(...)> UserQuantity = " << UserQuantity
+      std::cout <<"!TEcnaRead::Read1DHisto(...)> UserQuantity = " << UserQuantity
 	   << ", UserDetector = " << UserDetector << ", VecDim = " << VecDim
-	   << ". Wrong code(s) or array dimension. No file reading." << fTTBELL << endl; 
+	   << ". Wrong code(s) or array dimension. No file reading." << fTTBELL << std::endl; 
       return vec;
     }
 }  // end of Read1DHisto / Stex and Stas histos
@@ -546,9 +546,9 @@ TMatrixD TEcnaRead::ReadMatrix(const Int_t& MatDim,   const TString& UserCorOrCo
       for(Int_t i=0; i-MatDim<0; i++)
 	{for(Int_t j=0; j-MatDim<0; j++)
 	    {mat(i,j) = (double_t)0.;}}
-      cout <<"!TEcnaRead::ReadMatrix(...)> UserCorOrCov = " << UserCorOrCov
+      std::cout <<"!TEcnaRead::ReadMatrix(...)> UserCorOrCov = " << UserCorOrCov
 	   << ", UserBetweenWhat = " << UserBetweenWhat
-	   << ". Wrong code(s), no file reading." << fTTBELL << endl;
+	   << ". Wrong code(s), no file reading." << fTTBELL << std::endl;
     }
   return mat;
 }
@@ -591,9 +591,9 @@ TMatrixD TEcnaRead::ReadMatrix(const Int_t& MatDim, const TString& UserCorOrCov,
       for(Int_t i=0; i-MatDim<0; i++)
 	{for(Int_t j=0; j-MatDim<0; j++)
 	    {mat(i,j) = (double_t)0.;}}
-      cout <<"!TEcnaRead::ReadMatrix(...)> UserCorOrCov = " << UserCorOrCov
+      std::cout <<"!TEcnaRead::ReadMatrix(...)> UserCorOrCov = " << UserCorOrCov
 	   << ", UserBetweenWhat = " << UserBetweenWhat
-	   << ". Wrong code(s), no file reading." << fTTBELL << endl;
+	   << ". Wrong code(s), no file reading." << fTTBELL << std::endl;
     }
   return mat;
 }
@@ -609,9 +609,9 @@ TString TEcnaRead::GetTechReadCode(const TString& StandardQuantity, const TStrin
 
   if( dTechDetector == "?")
     {
-      cout << "!TEcnaRead::GetTechReadCode(...)> *** ERROR: wrong standard code *** dTechDetector = "
+      std::cout << "!TEcnaRead::GetTechReadCode(...)> *** ERROR: wrong standard code *** dTechDetector = "
 	   << dTechDetector << ", StandardDetector = " << StandardDetector
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
     }
   else
     {
@@ -633,9 +633,9 @@ TString TEcnaRead::GetTechReadCode(const TString& StandardQuantity, const TStrin
 
   if( rTechReadCode == "?")
     {
-      cout << "!TEcnaRead::GetTechReadCode(...)> *** ERROR: wrong standard code *** rTechReadCode = " << rTechReadCode
+      std::cout << "!TEcnaRead::GetTechReadCode(...)> *** ERROR: wrong standard code *** rTechReadCode = " << rTechReadCode
 	   << ", StandardQuantity = " << StandardQuantity
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
     }
 
   return rTechReadCode;
@@ -707,26 +707,26 @@ void TEcnaRead::FileParameters(const TString&      typ_ana,    const Int_t& nb_o
 
   if( fFlagPrint == fCodePrintAllComments || fFlagPrint == fCodePrintComments )
     {
-      cout << endl;
-      cout << "*TEcnaRead::FileParameters(...)>" << endl
-	   << "          The method has been called with the following argument values:" << endl
+      std::cout << std::endl;
+      std::cout << "*TEcnaRead::FileParameters(...)>" << std::endl
+	   << "          The method has been called with the following argument values:" << std::endl
 	   << "          Analysis name                = "
-	   << fFileHeader->fTypAna << endl
+	   << fFileHeader->fTypAna << std::endl
 	   << "          Nb of required samples       = "
-	   << fFileHeader->fNbOfSamples << endl
+	   << fFileHeader->fNbOfSamples << std::endl
 	   << "          Run number                   = "
-	   << fFileHeader->fRunNumber << endl
+	   << fFileHeader->fRunNumber << std::endl
 	   << "          First requested event number = "
-	   << fFileHeader->fFirstReqEvtNumber << endl
+	   << fFileHeader->fFirstReqEvtNumber << std::endl
 	   << "          Last requested event number  = "
-	   << fFileHeader->fLastReqEvtNumber << endl
+	   << fFileHeader->fLastReqEvtNumber << std::endl
 	   << "          Requested number of events   = "
-	   << fFileHeader->fReqNbOfEvts << endl
+	   << fFileHeader->fReqNbOfEvts << std::endl
 	   << "          Stex number                  = "
-	   << fFileHeader->fStex << endl
+	   << fFileHeader->fStex << std::endl
 	   << "          Path for the ROOT file       = "
-	   << fPathRoot << endl
-	   << endl;
+	   << fPathRoot << std::endl
+	   << std::endl;
     }
   
   fReadyToReadRootFile = 1;           // set flag
@@ -817,8 +817,8 @@ Bool_t TEcnaRead::OpenRootFile(const Text_t *name, const TString& status) {
   // if( gCnaRootFile != 0 )
   //  {
   //    Int_t iPointer = (Int_t)gCnaRootFile;
-  //   cout << "*TEcnaRead::OpenRootFile(...)> RootFile pointer not (re)initialized to 0. gCnaRootFile = "
-  //	   << gCnaRootFile << ", pointer =  " << iPointer << fTTBELL << endl;
+  //   std::cout << "*TEcnaRead::OpenRootFile(...)> RootFile pointer not (re)initialized to 0. gCnaRootFile = "
+  //	   << gCnaRootFile << ", pointer =  " << iPointer << fTTBELL << std::endl;
   //
   //   delete gCnaRootFile; gCnaRootFile = 0;  Adelete("gCnaRootFile");
   //  }
@@ -845,7 +845,7 @@ Bool_t TEcnaRead::OpenRootFile(const Text_t *name, const TString& status) {
 
   if ( ok_open == kFALSE )
     {
-      cout << "!TEcnaRead::OpenRootFile> " << s_name.Data() << ": file not found." << endl;
+      std::cout << "!TEcnaRead::OpenRootFile> " << s_name.Data() << ": file not found." << std::endl;
       //if( gCnaRootFile != 0 )
       //  {delete gCnaRootFile; gCnaRootFile = 0;  Adelete("gCnaRootFile");}
     }
@@ -853,15 +853,15 @@ Bool_t TEcnaRead::OpenRootFile(const Text_t *name, const TString& status) {
     {
       if(fFlagPrint == fCodePrintAllComments)
 	{
-	  cout << "*TEcnaRead::OpenRootFile> Open ROOT file " << s_name.Data() << " OK "
-	       << ", gCnaRootFile = " << gCnaRootFile << endl;
+	  std::cout << "*TEcnaRead::OpenRootFile> Open ROOT file " << s_name.Data() << " OK "
+	       << ", gCnaRootFile = " << gCnaRootFile << std::endl;
 	}      
       fOpenRootFile = kTRUE;
       fCurrentlyOpenFileName = s_name;
       if(fFlagPrint == fCodePrintAllComments)
 	{
-	  cout << "*TEcnaRead::OpenRootFile> Open ROOT file: " << fCurrentlyOpenFileName.Data() << " => OK "
-	       << ", gCnaRootFile = " << gCnaRootFile << endl << endl;
+	  std::cout << "*TEcnaRead::OpenRootFile> Open ROOT file: " << fCurrentlyOpenFileName.Data() << " => OK "
+	       << ", gCnaRootFile = " << gCnaRootFile << std::endl << std::endl;
 	}
     }
   return ok_open;
@@ -885,11 +885,11 @@ Bool_t TEcnaRead::CloseRootFile(const Text_t *name) {
 	  
 	  if(fFlagPrint == fCodePrintAllComments){
 	    TString e_path;  e_path.Append(name);
-	    cout << "*TEcnaRead::CloseRootFile> Close ROOT file " << e_path.Data() << " OK " << endl;}
+	    std::cout << "*TEcnaRead::CloseRootFile> Close ROOT file " << e_path.Data() << " OK " << std::endl;}
 	  if(fFlagPrint == fCodePrintAllComments){
 	    Long_t pointer_value = (Long_t)gCnaRootFile;
-	    cout << "*TEcnaRead::CloseRootFile(...)> going to delete gCnaRootFile, gCnaRootFile = " << gCnaRootFile
-		 << ", pointer = " << pointer_value << endl;}
+	    std::cout << "*TEcnaRead::CloseRootFile(...)> going to delete gCnaRootFile, gCnaRootFile = " << gCnaRootFile
+		 << ", pointer = " << pointer_value << std::endl;}
 
 	  //delete gCnaRootFile;   gCnaRootFile = 0;  Adelete("gCnaRootFile");
 	  
@@ -900,15 +900,15 @@ Bool_t TEcnaRead::CloseRootFile(const Text_t *name) {
 	}
       else
 	{
-	  cout << "*TEcnaRead::CloseRootFile(...)> RootFile pointer equal to zero. Close not possible. gCnaRootFile = "
+	  std::cout << "*TEcnaRead::CloseRootFile(...)> RootFile pointer equal to zero. Close not possible. gCnaRootFile = "
 	       << gCnaRootFile
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
     }
   else
     {
-      cout << "*TEcnaRead::CloseRootFile(...)> no close since no file is open. fOpenRootFile = " << fOpenRootFile
-	   << endl;
+      std::cout << "*TEcnaRead::CloseRootFile(...)> no close since no file is open. fOpenRootFile = " << fOpenRootFile
+	   << std::endl;
     }
   return ok_close;
 }
@@ -953,15 +953,15 @@ Bool_t TEcnaRead::LookAtRootFile()
 	}
       else
 	{
-	  cout << "!TEcnaRead::LookAtRootFile()> *** ERROR ***>"
-	       << " ROOT file not found " << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::LookAtRootFile()> *** ERROR ***>"
+	       << " ROOT file not found " << fTTBELL << std::endl;
 	  return kFALSE; 
 	}
     }
   else
     {
-      cout << "!TEcnaRead::LookAtRootFile()> *** ERROR ***>"
-	   << " FileParameters not called " << fTTBELL << endl;
+      std::cout << "!TEcnaRead::LookAtRootFile()> *** ERROR ***>"
+	   << " FileParameters not called " << fTTBELL << std::endl;
       return kFALSE;      
     }
   return kFALSE;
@@ -992,8 +992,8 @@ Bool_t TEcnaRead::ReadRootFileHeader(const Int_t& i_print)
   const Text_t *file_name = (const Text_t *)fCnaWrite->fRootFileNameShort.Data();
   const Text_t *current_file_name = (const Text_t *)fCurrentlyOpenFileName.Data();
 
-  if( i_print == 1 ){cout << "*TEcnaRead::ReadRootFileHeader> file_name = "
-			 << fCnaWrite->fRootFileNameShort.Data() << endl;}
+  if( i_print == 1 ){std::cout << "*TEcnaRead::ReadRootFileHeader> file_name = "
+			 << fCnaWrite->fRootFileNameShort.Data() << std::endl;}
 
   Bool_t ok_open = kFALSE;
  
@@ -1002,8 +1002,8 @@ Bool_t TEcnaRead::ReadRootFileHeader(const Int_t& i_print)
 
   //  if( fOpenRootFile )
   //    {
-  //      cout << "!TEcnaRead::ReadRootFileHeader(...)*** ERROR ***> "
-  //	   << "Reading header on file already open." << endl;
+  //      std::cout << "!TEcnaRead::ReadRootFileHeader(...)*** ERROR ***> "
+  //	   << "Reading header on file already open." << std::endl;
   //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -1020,8 +1020,8 @@ Bool_t TEcnaRead::ReadRootFileHeader(const Int_t& i_print)
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadRootFileHeader(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadRootFileHeader(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	}
     }
@@ -1080,19 +1080,19 @@ void  TEcnaRead::TestArrayDimH1(const TString& CallingMethod, const TString& Max
 
   if( MaxValue != VecDim)
     {
-      cout << "!TEcnaRead::TestArrayDimH1(...)> No matching for array dimension: CallingMethod: " << CallingMethod.Data()
+      std::cout << "!TEcnaRead::TestArrayDimH1(...)> No matching for array dimension: CallingMethod: " << CallingMethod.Data()
 	   << ", MaxName: " << MaxName.Data()
 	   << ", Maxvalue = " << MaxValue
-	   << ", VecDim = " << VecDim << fTTBELL << endl;
+	   << ", VecDim = " << VecDim << fTTBELL << std::endl;
     }
 #define NOPM
 #ifndef NOPM
   else
     {
-      cout << "!TEcnaRead::TestArrayDimH1(...)> matching array dimension: OK. CallingMethod: " << CallingMethod.Data()
+      std::cout << "!TEcnaRead::TestArrayDimH1(...)> matching array dimension: OK. CallingMethod: " << CallingMethod.Data()
 	   << ", MaxName: " << MaxName.Data()
 	   << ", Maxvalue = " << MaxValue
-	   << ", VecDim = " << VecDim << endl;
+	   << ", VecDim = " << VecDim << std::endl;
     }
 #endif // NOPM
 }
@@ -1104,19 +1104,19 @@ void  TEcnaRead::TestArrayDimH2(const TString& CallingMethod, const TString& Max
 
   if( MaxValue != MatDim)
     {
-      cout << "!TEcnaRead::TestArrayDimH2(...)> No matching for array dimension: CallingMethod: " << CallingMethod.Data()
+      std::cout << "!TEcnaRead::TestArrayDimH2(...)> No matching for array dimension: CallingMethod: " << CallingMethod.Data()
 	   << ", MaxName: " << MaxName.Data()
 	   << ", Maxvalue = " << MaxValue
-	   << ", MatDim = " << MatDim << fTTBELL << endl;
+	   << ", MatDim = " << MatDim << fTTBELL << std::endl;
     }
 #define NOPN
 #ifndef NOPN
   else
     {
-      cout << "!TEcnaRead::TestArrayDimH2(...)> matching array dimension: OK. CallingMethod: " << CallingMethod.Data()
+      std::cout << "!TEcnaRead::TestArrayDimH2(...)> matching array dimension: OK. CallingMethod: " << CallingMethod.Data()
 	   << ", MaxName: " << MaxName.Data()
 	   << ", Maxvalue = " << MaxValue
-	   << ", MatDim = " << MatDim << endl;
+	   << ", MatDim = " << MatDim << std::endl;
     }
 #endif // NOPN
 }
@@ -1158,8 +1158,8 @@ TVectorD TEcnaRead::ReadStinNumbers(const Int_t& VecDim)
 
 //      if ( fOpenRootFile )
 //	{
-//	  cout << "!TEcnaRead::ReadStinNumbers(...) *** ERROR ***> Reading on file already open."
-//	       << fTTBELL << endl;
+//	  std::cout << "!TEcnaRead::ReadStinNumbers(...) *** ERROR ***> Reading on file already open."
+//	       << fTTBELL << std::endl;
 //	}
 
       if( FileNameLong == fCurrentlyOpenFileName )
@@ -1177,8 +1177,8 @@ TVectorD TEcnaRead::ReadStinNumbers(const Int_t& VecDim)
 	    }
 	  else
 	    {
-	      cout << "!TEcnaRead::ReadStinNumbers(...) *** ERROR ***> Open .root file failed for file: "
-		   << file_name << fTTBELL << endl;
+	      std::cout << "!TEcnaRead::ReadStinNumbers(...) *** ERROR ***> Open .root file failed for file: "
+		   << file_name << fTTBELL << std::endl;
 	      allowed_to_read = kFALSE;
 	      ok_read = kFALSE;
 	    }
@@ -1203,11 +1203,11 @@ TVectorD TEcnaRead::ReadStinNumbers(const Int_t& VecDim)
 	  else
 	    {
 	      fDataExist = kFALSE;
-	      cout << "!TEcnaRead::ReadStinNumbers(...) *** ERROR ***> "
-		   << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	      std::cout << "!TEcnaRead::ReadStinNumbers(...) *** ERROR ***> "
+		   << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 		   << "                                                -> quantity: <"
 		   << GetTypeOfQuantity(typ) << "> not available in file."
-		   << fTTBELL << endl;
+		   << fTTBELL << std::endl;
 	    }
 	  CloseRootFile(file_name);
 	}
@@ -1219,8 +1219,8 @@ TVectorD TEcnaRead::ReadStinNumbers(const Int_t& VecDim)
 	    {
 	      for(Int_t i=0; i < VecDim; i++)
 		{
-		  cout << "*TEcnaRead::ReadStinNumbers(...)> StinNumber[" << i << "] = "
-		       << vec[i] << endl;
+		  std::cout << "*TEcnaRead::ReadStinNumbers(...)> StinNumber[" << i << "] = "
+		       << vec[i] << std::endl;
 		}
 	    }
 	}
@@ -1273,8 +1273,8 @@ TVectorD TEcnaRead::ReadSampleAdcValues(const Int_t& n1StexStin, const Int_t& i0
   
   //  if ( fOpenRootFile )
   //   {
-  //     cout << "!TEcnaRead::ReadSampleAdcValues(...) *** ERROR ***> "
-  // 	   << "Reading on file already open." << fTTBELL << endl;
+  //     std::cout << "!TEcnaRead::ReadSampleAdcValues(...) *** ERROR ***> "
+  // 	   << "Reading on file already open." << fTTBELL << std::endl;
   //   }
   
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -1292,8 +1292,8 @@ TVectorD TEcnaRead::ReadSampleAdcValues(const Int_t& n1StexStin, const Int_t& i0
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadSampleAdcValues(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadSampleAdcValues(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -1314,11 +1314,11 @@ TVectorD TEcnaRead::ReadSampleAdcValues(const Int_t& n1StexStin, const Int_t& i0
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadSampleAdcValues(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadSampleAdcValues(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                 -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -1361,8 +1361,8 @@ TVectorD TEcnaRead::ReadSampleMeans(const Int_t & n1StexStin, const Int_t & i0St
     
   // if ( fOpenRootFile )
   //  {
-  //    cout << "!TEcnaRead::ReadSampleMeans(...) *** ERROR ***> "
-  // 	   << " Reading on file already open." << fTTBELL << endl;
+  //    std::cout << "!TEcnaRead::ReadSampleMeans(...) *** ERROR ***> "
+  // 	   << " Reading on file already open." << fTTBELL << std::endl;
   //  }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -1379,8 +1379,8 @@ TVectorD TEcnaRead::ReadSampleMeans(const Int_t & n1StexStin, const Int_t & i0St
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadSampleMeans(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadSampleMeans(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -1402,11 +1402,11 @@ TVectorD TEcnaRead::ReadSampleMeans(const Int_t & n1StexStin, const Int_t & i0St
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadSampleMeans(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadSampleMeans(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -1440,8 +1440,8 @@ TVectorD TEcnaRead::ReadSampleMeans(const Int_t & n1StexStin, const Int_t & VecD
       
   //if ( fOpenRootFile )
   //  {
-  //    cout << "!TEcnaRead::ReadSampleMeans(...) *** ERROR ***> "
-  //	   << " Reading on file already open." << fTTBELL << endl;
+  //    std::cout << "!TEcnaRead::ReadSampleMeans(...) *** ERROR ***> "
+  //	   << " Reading on file already open." << fTTBELL << std::endl;
   //  }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -1459,8 +1459,8 @@ TVectorD TEcnaRead::ReadSampleMeans(const Int_t & n1StexStin, const Int_t & VecD
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadSampleMeans(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadSampleMeans(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -1488,11 +1488,11 @@ TVectorD TEcnaRead::ReadSampleMeans(const Int_t & n1StexStin, const Int_t & VecD
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadSampleMeans(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadSampleMeans(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -1529,8 +1529,8 @@ TVectorD TEcnaRead::ReadSampleSigmas(const Int_t & n1StexStin, const Int_t & i0S
      
   //if ( fOpenRootFile )
   //  {
-  //    cout << "!TEcnaRead::ReadSampleSigmas(...) *** ERROR ***> "
-  //	   << "Reading on file already open." << fTTBELL << endl;
+  //    std::cout << "!TEcnaRead::ReadSampleSigmas(...) *** ERROR ***> "
+  //	   << "Reading on file already open." << fTTBELL << std::endl;
   //  }
 
   if (FileNameLong != fCurrentlyOpenFileName)
@@ -1540,8 +1540,8 @@ TVectorD TEcnaRead::ReadSampleSigmas(const Int_t & n1StexStin, const Int_t & i0S
 
       if(!(OpenRootFile(file_name, "READ")))
 	{
-	  cout << "!TEcnaRead::ReadSampleSigmas(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadSampleSigmas(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
           return vec;
 	}
     }
@@ -1559,11 +1559,11 @@ TVectorD TEcnaRead::ReadSampleSigmas(const Int_t & n1StexStin, const Int_t & i0S
   else
     {
       fDataExist = kFALSE;
-      cout << "!TEcnaRead::ReadSampleSigmas(...) *** ERROR ***> "
-           << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+      std::cout << "!TEcnaRead::ReadSampleSigmas(...) *** ERROR ***> "
+           << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
            << "                                                 -> quantity: <"
            << GetTypeOfQuantity(typ) << "> not available in file."
-           << fTTBELL << endl;
+           << fTTBELL << std::endl;
     }
   CloseRootFile(file_name);
   return vec;
@@ -1595,8 +1595,8 @@ TVectorD TEcnaRead::ReadSampleSigmas(const Int_t & n1StexStin, const Int_t & Vec
        
   //if ( fOpenRootFile )
   //  {
-  //    cout << "!TEcnaRead::ReadSampleSigmas(...) *** ERROR ***> "
-  //	   << "Reading on file already open." << fTTBELL << endl;
+  //    std::cout << "!TEcnaRead::ReadSampleSigmas(...) *** ERROR ***> "
+  //	   << "Reading on file already open." << fTTBELL << std::endl;
   // }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -1614,8 +1614,8 @@ TVectorD TEcnaRead::ReadSampleSigmas(const Int_t & n1StexStin, const Int_t & Vec
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadSampleSigmas(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadSampleSigmas(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -1643,11 +1643,11 @@ TVectorD TEcnaRead::ReadSampleSigmas(const Int_t & n1StexStin, const Int_t & Vec
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadSampleSigmas(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadSampleSigmas(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                 -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -1735,8 +1735,8 @@ TMatrixD TEcnaRead::ReadNumberOfEventsForSamples(const Int_t& n1StexStin,
 	  
 	  //	  if ( fOpenRootFile )
 	  //	    {
-	  //	      cout << "!TEcnaRead::ReadNumberOfEventsForSamples(...) *** ERROR ***> "
-	  //		   << " Reading on file already open." << fTTBELL << endl;
+	  //	      std::cout << "!TEcnaRead::ReadNumberOfEventsForSamples(...) *** ERROR ***> "
+	  //		   << " Reading on file already open." << fTTBELL << std::endl;
 	  //	    }
 
 	  if( FileNameLong == fCurrentlyOpenFileName  )
@@ -1753,8 +1753,8 @@ TMatrixD TEcnaRead::ReadNumberOfEventsForSamples(const Int_t& n1StexStin,
 		}
 	      else
 		{
-		  cout << "!TEcnaRead::ReadNumberOfEventsForSamples(...) *** ERROR ***> Open .root file failed for file: "
-		       << file_name << fTTBELL << endl;
+		  std::cout << "!TEcnaRead::ReadNumberOfEventsForSamples(...) *** ERROR ***> Open .root file failed for file: "
+		       << file_name << fTTBELL << std::endl;
 		  allowed_to_read = kFALSE;
 		  ok_read = kFALSE;
 		}
@@ -1780,20 +1780,20 @@ TMatrixD TEcnaRead::ReadNumberOfEventsForSamples(const Int_t& n1StexStin,
 	      else
 		{
 		  fDataExist = kFALSE;
-		  cout << "!TEcnaRead::ReadNumberOfEventsForSamples(...) *** ERROR ***> "
-		       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+		  std::cout << "!TEcnaRead::ReadNumberOfEventsForSamples(...) *** ERROR ***> "
+		       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 		       << "                                                                 -> quantity: <"
 		       << GetTypeOfQuantity(typ) << "> not available in file."
-		       << fTTBELL << endl;
+		       << fTTBELL << std::endl;
 		}
 	    }
 	  CloseRootFile(file_name);
 	}  // end of if (fLookAtRootFile == 1)
       else
 	{
-	  cout << "!TEcnaRead::ReadNumberOfEventsForSamples(...) *** ERROR ***> "
+	  std::cout << "!TEcnaRead::ReadNumberOfEventsForSamples(...) *** ERROR ***> "
 	       << "It is not possible to access the number of found events: the ROOT file has not been read."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
     }  // end of if (Stin_index >= 0)
   return mat;
@@ -1829,8 +1829,8 @@ TVectorD TEcnaRead::ReadPedestals(const Int_t& VecDim)
   
 //    if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadPedestals(...) *** ERROR ***> "
-//	   << "Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadPedestals(...) *** ERROR ***> "
+//	   << "Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -1847,8 +1847,8 @@ TVectorD TEcnaRead::ReadPedestals(const Int_t& VecDim)
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadPedestals(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadPedestals(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -1870,11 +1870,11 @@ TVectorD TEcnaRead::ReadPedestals(const Int_t& VecDim)
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadPedestals(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadPedestals(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                              -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -1909,8 +1909,8 @@ TVectorD TEcnaRead::ReadTotalNoise(const Int_t& VecDim)
   
   //  if ( fOpenRootFile )
   //  {
-  //    cout << "!TEcnaRead::ReadTotalNoise(...) *** ERROR ***> "
-  //	   << "Reading on file already open." << fTTBELL << endl;
+  //    std::cout << "!TEcnaRead::ReadTotalNoise(...) *** ERROR ***> "
+  //	   << "Reading on file already open." << fTTBELL << std::endl;
   //  }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -1927,8 +1927,8 @@ TVectorD TEcnaRead::ReadTotalNoise(const Int_t& VecDim)
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadTotalNoise(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadTotalNoise(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -1950,11 +1950,11 @@ TVectorD TEcnaRead::ReadTotalNoise(const Int_t& VecDim)
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadTotalNoise(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadTotalNoise(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                               -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -1989,8 +1989,8 @@ TVectorD TEcnaRead::ReadMeanCorrelationsBetweenSamples(const Int_t& VecDim)
    
   //if ( fOpenRootFile )
   //  {
-  //    cout << "!TEcnaRead::ReadMeanCorrelationsBetweenSamples(...) *** ERROR ***> "
-  //	   << "Reading on file already open." << fTTBELL << endl;
+  //    std::cout << "!TEcnaRead::ReadMeanCorrelationsBetweenSamples(...) *** ERROR ***> "
+  //	   << "Reading on file already open." << fTTBELL << std::endl;
   //  }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -2007,8 +2007,8 @@ TVectorD TEcnaRead::ReadMeanCorrelationsBetweenSamples(const Int_t& VecDim)
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadMeanCorrelationsBetweenSamples(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadMeanCorrelationsBetweenSamples(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -2030,11 +2030,11 @@ TVectorD TEcnaRead::ReadMeanCorrelationsBetweenSamples(const Int_t& VecDim)
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadMeanCorrelationsBetweenSamples(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadMeanCorrelationsBetweenSamples(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                                   ->  quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -2069,8 +2069,8 @@ TVectorD TEcnaRead::ReadLowFrequencyNoise(const Int_t& VecDim)
     
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadLowFrequencyNoise(...) *** ERROR ***> "
-//	   << "Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadLowFrequencyNoise(...) *** ERROR ***> "
+//	   << "Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -2088,8 +2088,8 @@ TVectorD TEcnaRead::ReadLowFrequencyNoise(const Int_t& VecDim)
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadLowFrequencyNoise(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadLowFrequencyNoise(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -2111,11 +2111,11 @@ TVectorD TEcnaRead::ReadLowFrequencyNoise(const Int_t& VecDim)
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadLowFrequencyNoise(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadLowFrequencyNoise(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                      -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -2150,8 +2150,8 @@ TVectorD TEcnaRead::ReadHighFrequencyNoise(const Int_t& VecDim)
 
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadHighFrequencyNoise(...) *** ERROR ***> "
-//	   << "Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadHighFrequencyNoise(...) *** ERROR ***> "
+//	   << "Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -2169,8 +2169,8 @@ TVectorD TEcnaRead::ReadHighFrequencyNoise(const Int_t& VecDim)
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadHighFrequencyNoise(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadHighFrequencyNoise(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -2192,11 +2192,11 @@ TVectorD TEcnaRead::ReadHighFrequencyNoise(const Int_t& VecDim)
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadHighFrequencyNoise(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadHighFrequencyNoise(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                       -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -2232,8 +2232,8 @@ TVectorD TEcnaRead::ReadSigmaOfCorrelationsBetweenSamples(const Int_t& VecDim)
   
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadSigmaOfCorrelationsBetweenSamples(...) *** ERROR ***> "
-//	   << "Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadSigmaOfCorrelationsBetweenSamples(...) *** ERROR ***> "
+//	   << "Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -2251,8 +2251,8 @@ TVectorD TEcnaRead::ReadSigmaOfCorrelationsBetweenSamples(const Int_t& VecDim)
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadSigmaOfCorrelationsBetweenSamples(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadSigmaOfCorrelationsBetweenSamples(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -2274,11 +2274,11 @@ TVectorD TEcnaRead::ReadSigmaOfCorrelationsBetweenSamples(const Int_t& VecDim)
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadSigmaOfCorrelationsBetweenSamples(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadSigmaOfCorrelationsBetweenSamples(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                                      -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -2383,8 +2383,8 @@ TVectorD TEcnaRead::ReadAveragePedestals(const Int_t& VecDim)
   
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadAveragePedestals(...) *** ERROR ***> "
-//	   << "Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadAveragePedestals(...) *** ERROR ***> "
+//	   << "Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -2402,8 +2402,8 @@ TVectorD TEcnaRead::ReadAveragePedestals(const Int_t& VecDim)
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadAveragePedestals(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadAveragePedestals(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -2425,11 +2425,11 @@ TVectorD TEcnaRead::ReadAveragePedestals(const Int_t& VecDim)
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadAveragePedestals(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadAveragePedestals(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                     -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -2466,8 +2466,8 @@ TVectorD TEcnaRead::ReadAverageTotalNoise(const Int_t& VecDim)
   
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadAverageTotalNoise(...) *** ERROR ***> "
-//	   << "Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadAverageTotalNoise(...) *** ERROR ***> "
+//	   << "Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -2485,8 +2485,8 @@ TVectorD TEcnaRead::ReadAverageTotalNoise(const Int_t& VecDim)
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadAverageTotalNoise(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadAverageTotalNoise(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -2508,11 +2508,11 @@ TVectorD TEcnaRead::ReadAverageTotalNoise(const Int_t& VecDim)
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadAverageTotalNoise(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadAverageTotalNoise(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                      -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -2549,8 +2549,8 @@ TVectorD TEcnaRead::ReadAverageLowFrequencyNoise(const Int_t& VecDim)
 
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadAverageLowFrequencyNoise(...) *** ERROR ***> "
-//	   << "Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadAverageLowFrequencyNoise(...) *** ERROR ***> "
+//	   << "Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -2568,8 +2568,8 @@ TVectorD TEcnaRead::ReadAverageLowFrequencyNoise(const Int_t& VecDim)
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadAverageLowFrequencyNoise(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadAverageLowFrequencyNoise(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -2591,11 +2591,11 @@ TVectorD TEcnaRead::ReadAverageLowFrequencyNoise(const Int_t& VecDim)
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadAverageLowFrequencyNoise(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadAverageLowFrequencyNoise(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                             -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -2632,8 +2632,8 @@ TVectorD TEcnaRead::ReadAverageHighFrequencyNoise(const Int_t& VecDim)
   
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadAverageHighFrequencyNoise(...) *** ERROR ***> "
-//	   << "Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadAverageHighFrequencyNoise(...) *** ERROR ***> "
+//	   << "Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -2651,8 +2651,8 @@ TVectorD TEcnaRead::ReadAverageHighFrequencyNoise(const Int_t& VecDim)
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadAverageHighFrequencyNoise(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadAverageHighFrequencyNoise(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -2674,11 +2674,11 @@ TVectorD TEcnaRead::ReadAverageHighFrequencyNoise(const Int_t& VecDim)
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadAverageHighFrequencyNoise(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadAverageHighFrequencyNoise(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                              -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -2716,8 +2716,8 @@ TVectorD TEcnaRead::ReadAverageMeanCorrelationsBetweenSamples(const Int_t& VecDi
     
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadAverageMeanCorrelationsBetweenSamples(...) *** ERROR ***> "
-//	   << "Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadAverageMeanCorrelationsBetweenSamples(...) *** ERROR ***> "
+//	   << "Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -2735,8 +2735,8 @@ TVectorD TEcnaRead::ReadAverageMeanCorrelationsBetweenSamples(const Int_t& VecDi
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadAverageMeanCorrelationsBetweenSamples(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadAverageMeanCorrelationsBetweenSamples(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -2758,11 +2758,11 @@ TVectorD TEcnaRead::ReadAverageMeanCorrelationsBetweenSamples(const Int_t& VecDi
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadAverageMeanCorrelationsBetweenSamples(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadAverageMeanCorrelationsBetweenSamples(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                                          -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -2800,8 +2800,8 @@ TVectorD TEcnaRead::ReadAverageSigmaOfCorrelationsBetweenSamples(const Int_t& Ve
       
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadAverageSigmaOfCorrelationsBetweenSamples(...) *** ERROR ***> "
-//	   << "Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadAverageSigmaOfCorrelationsBetweenSamples(...) *** ERROR ***> "
+//	   << "Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -2819,8 +2819,8 @@ TVectorD TEcnaRead::ReadAverageSigmaOfCorrelationsBetweenSamples(const Int_t& Ve
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadAverageSigmaOfCorrelationsBetweenSamples(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadAverageSigmaOfCorrelationsBetweenSamples(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -2842,11 +2842,11 @@ TVectorD TEcnaRead::ReadAverageSigmaOfCorrelationsBetweenSamples(const Int_t& Ve
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadAverageSigmaOfCorrelationsBetweenSamples(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadAverageSigmaOfCorrelationsBetweenSamples(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                                             -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -2893,8 +2893,8 @@ TMatrixD TEcnaRead::ReadCovariancesBetweenSamples(const Int_t & n1StexStin, cons
       
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadCovariancesBetweenSamples(...) *** ERROR ***> "
-//	   << "Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadCovariancesBetweenSamples(...) *** ERROR ***> "
+//	   << "Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -2912,8 +2912,8 @@ TMatrixD TEcnaRead::ReadCovariancesBetweenSamples(const Int_t & n1StexStin, cons
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadCovariancesBetweenSamples(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadCovariancesBetweenSamples(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -2937,11 +2937,11 @@ TMatrixD TEcnaRead::ReadCovariancesBetweenSamples(const Int_t & n1StexStin, cons
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadCovariancesBetweenSamples() *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadCovariancesBetweenSamples() *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                           -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -2980,8 +2980,8 @@ TMatrixD TEcnaRead::ReadCorrelationsBetweenSamples(const Int_t & n1StexStin, con
       
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadCorrelationsBetweenSamples(...) *** ERROR ***> "
-//	   << "Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadCorrelationsBetweenSamples(...) *** ERROR ***> "
+//	   << "Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -2999,8 +2999,8 @@ TMatrixD TEcnaRead::ReadCorrelationsBetweenSamples(const Int_t & n1StexStin, con
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadCorrelationsBetweenSamples(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadCorrelationsBetweenSamples(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -3020,11 +3020,11 @@ TMatrixD TEcnaRead::ReadCorrelationsBetweenSamples(const Int_t & n1StexStin, con
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadCorrelationsBetweenSamples() *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadCorrelationsBetweenSamples() *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                            -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -3063,8 +3063,8 @@ TVectorD TEcnaRead::ReadRelevantCorrelationsBetweenSamples(const Int_t & n1StexS
 
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadRelevantCorrelationsBetweenSamples(...) *** ERROR ***> "
-//	   << "Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadRelevantCorrelationsBetweenSamples(...) *** ERROR ***> "
+//	   << "Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -3082,8 +3082,8 @@ TVectorD TEcnaRead::ReadRelevantCorrelationsBetweenSamples(const Int_t & n1StexS
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadRelevantCorrelationsBetweenSamples(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadRelevantCorrelationsBetweenSamples(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -3105,11 +3105,11 @@ TVectorD TEcnaRead::ReadRelevantCorrelationsBetweenSamples(const Int_t & n1StexS
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadRelevantCorrelationsBetweenSamples() *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadRelevantCorrelationsBetweenSamples() *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                                    -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -3154,8 +3154,8 @@ TMatrixD TEcnaRead::ReadLowFrequencyCovariancesBetweenChannels(const Int_t& n1St
   
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadLowFrequencyCovariancesBetweenChannels(...) *** ERROR ***>"
-//	   << " Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadLowFrequencyCovariancesBetweenChannels(...) *** ERROR ***>"
+//	   << " Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -3173,8 +3173,8 @@ TMatrixD TEcnaRead::ReadLowFrequencyCovariancesBetweenChannels(const Int_t& n1St
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadLowFrequencyCovariancesBetweenChannels(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadLowFrequencyCovariancesBetweenChannels(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -3201,11 +3201,11 @@ TMatrixD TEcnaRead::ReadLowFrequencyCovariancesBetweenChannels(const Int_t& n1St
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadLowFrequencyCovariancesBetweenChannels(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadLowFrequencyCovariancesBetweenChannels(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                                           -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -3249,8 +3249,8 @@ TMatrixD TEcnaRead::ReadLowFrequencyCorrelationsBetweenChannels(const Int_t & n1
   
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadLowFrequencyCorrelationsBetweenChannels(...) *** ERROR ***>"
-//	   << " Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadLowFrequencyCorrelationsBetweenChannels(...) *** ERROR ***>"
+//	   << " Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -3268,8 +3268,8 @@ TMatrixD TEcnaRead::ReadLowFrequencyCorrelationsBetweenChannels(const Int_t & n1
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadLowFrequencyCorrelationsBetweenChannels(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadLowFrequencyCorrelationsBetweenChannels(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -3297,11 +3297,11 @@ TMatrixD TEcnaRead::ReadLowFrequencyCorrelationsBetweenChannels(const Int_t & n1
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadLowFrequencyCorrelationsBetweenChannels(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadLowFrequencyCorrelationsBetweenChannels(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                                            -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -3346,8 +3346,8 @@ TMatrixD TEcnaRead::ReadHighFrequencyCovariancesBetweenChannels(const Int_t & n1
   
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadHighFrequencyCovariancesBetweenChannels(...) *** ERROR ***>"
-//	   << " Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadHighFrequencyCovariancesBetweenChannels(...) *** ERROR ***>"
+//	   << " Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -3365,8 +3365,8 @@ TMatrixD TEcnaRead::ReadHighFrequencyCovariancesBetweenChannels(const Int_t & n1
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadHighFrequencyCovariancesBetweenChannels(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadHighFrequencyCovariancesBetweenChannels(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -3393,11 +3393,11 @@ TMatrixD TEcnaRead::ReadHighFrequencyCovariancesBetweenChannels(const Int_t & n1
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadHighFrequencyCovariancesBetweenChannels(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadHighFrequencyCovariancesBetweenChannels(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                                            -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -3442,8 +3442,8 @@ TMatrixD TEcnaRead::ReadHighFrequencyCorrelationsBetweenChannels(const Int_t & n
     
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadHighFrequencyCorrelationsBetweenChannels(...) *** ERROR ***>"
-//	   << " Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadHighFrequencyCorrelationsBetweenChannels(...) *** ERROR ***>"
+//	   << " Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -3461,8 +3461,8 @@ TMatrixD TEcnaRead::ReadHighFrequencyCorrelationsBetweenChannels(const Int_t & n
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadHighFrequencyCorrelationsBetweenChannels(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadHighFrequencyCorrelationsBetweenChannels(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -3490,11 +3490,11 @@ TMatrixD TEcnaRead::ReadHighFrequencyCorrelationsBetweenChannels(const Int_t & n
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadHighFrequencyCorrelationsBetweenChannels(...) *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadHighFrequencyCorrelationsBetweenChannels(...) *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                                             -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -3538,8 +3538,8 @@ TMatrixD TEcnaRead::ReadLowFrequencyCovariancesBetweenChannels(const Int_t& MatD
   
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadLowFrequencyCovariancesBetweenChannels() *** ERROR ***>"
-//	   << " Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadLowFrequencyCovariancesBetweenChannels() *** ERROR ***>"
+//	   << " Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -3557,8 +3557,8 @@ TMatrixD TEcnaRead::ReadLowFrequencyCovariancesBetweenChannels(const Int_t& MatD
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadLowFrequencyCovariancesBetweenChannels(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadLowFrequencyCovariancesBetweenChannels(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -3600,11 +3600,11 @@ TMatrixD TEcnaRead::ReadLowFrequencyCovariancesBetweenChannels(const Int_t& MatD
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadLowFrequencyCovariancesBetweenChannels() *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadLowFrequencyCovariancesBetweenChannels() *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                                        -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -3648,8 +3648,8 @@ TMatrixD TEcnaRead::ReadLowFrequencyCorrelationsBetweenChannels(const Int_t& Mat
     
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadLowFrequencyCorrelationsBetweenChannels() *** ERROR ***>"
-//	   << " Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadLowFrequencyCorrelationsBetweenChannels() *** ERROR ***>"
+//	   << " Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -3667,8 +3667,8 @@ TMatrixD TEcnaRead::ReadLowFrequencyCorrelationsBetweenChannels(const Int_t& Mat
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadLowFrequencyCorrelationsBetweenChannels(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadLowFrequencyCorrelationsBetweenChannels(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -3710,11 +3710,11 @@ TMatrixD TEcnaRead::ReadLowFrequencyCorrelationsBetweenChannels(const Int_t& Mat
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadLowFrequencyCorrelationsBetweenChannels() *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadLowFrequencyCorrelationsBetweenChannels() *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                                         ->  quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -3758,8 +3758,8 @@ TMatrixD TEcnaRead::ReadHighFrequencyCovariancesBetweenChannels(const Int_t& Mat
 
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadHighFrequencyCovariancesBetweenChannels() *** ERROR ***>"
-//	   << " Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadHighFrequencyCovariancesBetweenChannels() *** ERROR ***>"
+//	   << " Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -3777,8 +3777,8 @@ TMatrixD TEcnaRead::ReadHighFrequencyCovariancesBetweenChannels(const Int_t& Mat
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadHighFrequencyCovariancesBetweenChannels(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadHighFrequencyCovariancesBetweenChannels(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -3820,11 +3820,11 @@ TMatrixD TEcnaRead::ReadHighFrequencyCovariancesBetweenChannels(const Int_t& Mat
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadHighFrequencyCovariancesBetweenChannels() *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadHighFrequencyCovariancesBetweenChannels() *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                                         -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -3868,8 +3868,8 @@ TMatrixD TEcnaRead::ReadHighFrequencyCorrelationsBetweenChannels(const Int_t& Ma
   
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadHighFrequencyCorrelationsBetweenChannels() *** ERROR ***>"
-//	   << " Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadHighFrequencyCorrelationsBetweenChannels() *** ERROR ***>"
+//	   << " Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -3887,8 +3887,8 @@ TMatrixD TEcnaRead::ReadHighFrequencyCorrelationsBetweenChannels(const Int_t& Ma
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadHighFrequencyCorrelationsBetweenChannels(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadHighFrequencyCorrelationsBetweenChannels(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -3930,11 +3930,11 @@ TMatrixD TEcnaRead::ReadHighFrequencyCorrelationsBetweenChannels(const Int_t& Ma
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadHighFrequencyCorrelationsBetweenChannels() *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadHighFrequencyCorrelationsBetweenChannels() *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                                          -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -3979,8 +3979,8 @@ TMatrixD TEcnaRead::ReadLowFrequencyMeanCorrelationsBetweenStins(const Int_t& Ma
     
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadLowFrequencyMeanCorrelationsBetweenStins() *** ERROR ***>"
-//	   << " Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadLowFrequencyMeanCorrelationsBetweenStins() *** ERROR ***>"
+//	   << " Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -3998,8 +3998,8 @@ TMatrixD TEcnaRead::ReadLowFrequencyMeanCorrelationsBetweenStins(const Int_t& Ma
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadLowFrequencyMeanCorrelationsBetweenStins(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadLowFrequencyMeanCorrelationsBetweenStins(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -4033,11 +4033,11 @@ TMatrixD TEcnaRead::ReadLowFrequencyMeanCorrelationsBetweenStins(const Int_t& Ma
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadLowFrequencyMeanCorrelationsBetweenStins() *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadLowFrequencyMeanCorrelationsBetweenStins() *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                                          -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -4081,8 +4081,8 @@ TMatrixD TEcnaRead::ReadHighFrequencyMeanCorrelationsBetweenStins(const Int_t& M
   
 //  if ( fOpenRootFile )
 //    {
-//      cout << "!TEcnaRead::ReadHighFrequencyMeanCorrelationsBetweenStins() *** ERROR ***>"
-//	   << " Reading on file already open." << fTTBELL << endl;
+//      std::cout << "!TEcnaRead::ReadHighFrequencyMeanCorrelationsBetweenStins() *** ERROR ***>"
+//	   << " Reading on file already open." << fTTBELL << std::endl;
 //    }
 
   if( FileNameLong == fCurrentlyOpenFileName )
@@ -4100,8 +4100,8 @@ TMatrixD TEcnaRead::ReadHighFrequencyMeanCorrelationsBetweenStins(const Int_t& M
 	}
       else
 	{
-	  cout << "!TEcnaRead::ReadHighFrequencyMeanCorrelationsBetweenStins(...) *** ERROR ***> Open .root file failed for file: "
-	       << file_name << fTTBELL << endl;
+	  std::cout << "!TEcnaRead::ReadHighFrequencyMeanCorrelationsBetweenStins(...) *** ERROR ***> Open .root file failed for file: "
+	       << file_name << fTTBELL << std::endl;
 	  allowed_to_read = kFALSE;
 	  ok_read = kFALSE;
 	}
@@ -4135,11 +4135,11 @@ TMatrixD TEcnaRead::ReadHighFrequencyMeanCorrelationsBetweenStins(const Int_t& M
       else
 	{
 	  fDataExist = kFALSE;
-	  cout << "!TEcnaRead::ReadHighFrequencyMeanCorrelationsBetweenStins() *** ERROR ***> "
-	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+	  std::cout << "!TEcnaRead::ReadHighFrequencyMeanCorrelationsBetweenStins() *** ERROR ***> "
+	       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 	       << "                                                                           -> quantity: <"
 	       << GetTypeOfQuantity(typ) << "> not available in file."
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	}
       CloseRootFile(file_name);
     }
@@ -4236,11 +4236,11 @@ Double_t*** TEcnaRead::ReadSampleAdcValuesSameFile(const Int_t& DimX, const Int_
 	      else                                                        //  (ReadSampleAdcValuesSameFile)
 		{
 		  fDataExist = kFALSE;
-		  cout << "!TEcnaRead::ReadSampleAdcValuesSameFile(...) *** ERROR ***> "
-		       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << endl
+		  std::cout << "!TEcnaRead::ReadSampleAdcValuesSameFile(...) *** ERROR ***> "
+		       << fCnaWrite->fRootFileNameShort.Data() << ": .root file failed" << std::endl
 		       << "                                                         -> quantity: <"
 		       << GetTypeOfQuantity(typ) << "> not available in file."
-		       << fTTBELL << endl;
+		       << fTTBELL << std::endl;
 		}
 	    }
 	  else
@@ -4252,15 +4252,15 @@ Double_t*** TEcnaRead::ReadSampleAdcValuesSameFile(const Int_t& DimX, const Int_
     }
   else
     {
-      cout  << "*TEcnaRead::ReadSampleAdcValuesSameFile(...)> *ERROR* =====> "
-	    << " ROOT file not found" << fTTBELL << endl;
+      std::cout  << "*TEcnaRead::ReadSampleAdcValuesSameFile(...)> *ERROR* =====> "
+	    << " ROOT file not found" << fTTBELL << std::endl;
     }
 
   if(i_entry_fail > 0 )
     {
-      cout  << "*TEcnaRead::ReadSampleAdcValuesSameFile(...)> *ERROR* =====> "
+      std::cout  << "*TEcnaRead::ReadSampleAdcValuesSameFile(...)> *ERROR* =====> "
 	    << " Entry reading failure(s). i_entry_fail = "
-	    << i_entry_fail << fTTBELL << endl;
+	    << i_entry_fail << fTTBELL << std::endl;
     }
   return fT3d_AdcValues;
 }
@@ -4387,10 +4387,10 @@ Int_t  TEcnaRead::GetStinIndex(const Int_t & n1StexStin)
 //Get the index of the Stin from its number in Stex
 
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "*TEcnaRead::GetStinIndex(...)> fEcal->MaxStinEcnaInStex() = "
-	 << fEcal->MaxStinEcnaInStex() << endl
+    std::cout << "*TEcnaRead::GetStinIndex(...)> fEcal->MaxStinEcnaInStex() = "
+	 << fEcal->MaxStinEcnaInStex() << std::endl
 	 << "                              n1StexStin = " << n1StexStin
-	 << endl << endl;}
+	 << std::endl << std::endl;}
 
   Int_t Stin_index = n1StexStin-1;    // suppose les 68 tours 
 
@@ -4406,23 +4406,23 @@ Int_t  TEcnaRead::GetStinIndex(const Int_t & n1StexStin)
   for(Int_t i=0; i < fEcal->MaxStinEcnaInStex(); i++)
     {
       if(fFlagPrint == fCodePrintAllComments){
-        cout << "*TEcnaRead::GetStinIndex(...)> StinNumber[" << i << "] = "
-             << vec[i] << endl;}
+        std::cout << "*TEcnaRead::GetStinIndex(...)> StinNumber[" << i << "] = "
+             << vec[i] << std::endl;}
       if ( vec[i] == n1StexStin ){Stin_index = i;}
     }
 
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-" << endl;
-    cout << "*TEcnaRead::GetStinIndex> Stin number: " << n1StexStin  << endl
-         << "                          Stin index : " << Stin_index << endl;
-    cout << "~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-" << endl;}
+    std::cout << "~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-" << std::endl;
+    std::cout << "*TEcnaRead::GetStinIndex> Stin number: " << n1StexStin  << std::endl
+         << "                          Stin index : " << Stin_index << std::endl;
+    std::cout << "~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-~-" << std::endl;}
 
   if ( Stin_index < 0 )
     {
       if(fFlagPrint == fCodePrintAllComments){
-	cout << "!TEcnaRead::GetStinIndex *** WARNING ***> n1StexStin" << n1StexStin << " : "
+	std::cout << "!TEcnaRead::GetStinIndex *** WARNING ***> n1StexStin" << n1StexStin << " : "
 	     << "index Stin not found"
-	     << fTTBELL << endl;}
+	     << fTTBELL << std::endl;}
     }
 #endif // NOGT
 
@@ -4440,7 +4440,7 @@ void  TEcnaRead::PrintComments()
 // Set flags to authorize printing of some comments concerning initialisations (default)
 
   fFlagPrint = fCodePrintComments;
-  cout << "*TEcnaRead::PrintComments()> Warnings and some comments on init will be printed" << endl;
+  std::cout << "*TEcnaRead::PrintComments()> Warnings and some comments on init will be printed" << std::endl;
 }
 
 void  TEcnaRead::PrintWarnings()
@@ -4448,7 +4448,7 @@ void  TEcnaRead::PrintWarnings()
 // Set flags to authorize printing of warnings
 
   fFlagPrint = fCodePrintWarnings;
-  cout << "*TEcnaRead::PrintWarnings()> Warnings will be printed" << endl;
+  std::cout << "*TEcnaRead::PrintWarnings()> Warnings will be printed" << std::endl;
 }
 
 void  TEcnaRead::PrintAllComments()
@@ -4456,7 +4456,7 @@ void  TEcnaRead::PrintAllComments()
 // Set flags to authorize printing of the comments of all the methods
 
   fFlagPrint = fCodePrintAllComments;
-  cout << "*TEcnaRead::PrintAllComments()> All the comments will be printed" << endl;
+  std::cout << "*TEcnaRead::PrintAllComments()> All the comments will be printed" << std::endl;
 }
 
 void  TEcnaRead::PrintNoComment()

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaResultType.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaResultType.cc
@@ -22,7 +22,7 @@ ClassImp(TEcnaResultType)
 TEcnaResultType::TEcnaResultType()
 {
   
-  // cout << "[Info Management] CLASS: TEcnaResultType.    CREATE OBJECT: this = " << this << endl;
+  // std::cout << "[Info Management] CLASS: TEcnaResultType.    CREATE OBJECT: this = " << this << std::endl;
 
   fMatMat.ReSet(1,1);
   fMatHis.ReSet(1,1);
@@ -31,7 +31,7 @@ TEcnaResultType::TEcnaResultType()
 TEcnaResultType::TEcnaResultType(TEcnaObject* pObjectManager)
 {
   
-  // cout << "[Info Management] CLASS: TEcnaResultType.    CREATE OBJECT: this = " << this << endl;
+  // std::cout << "[Info Management] CLASS: TEcnaResultType.    CREATE OBJECT: this = " << this << std::endl;
 
   Long_t i_this = (Long_t)this;
   pObjectManager->RegisterPointer("TEcnaResultType", i_this);
@@ -49,7 +49,7 @@ TEcnaResultType::TEcnaResultType(CnaResultTyp  typ,          Int_t   i,
 {
 //constructor
 
-  // cout << "[Info Management] CLASS: TEcnaResultType.    CREATE OBJECT: this = " << this << endl;
+  // std::cout << "[Info Management] CLASS: TEcnaResultType.    CREATE OBJECT: this = " << this << std::endl;
 
   fTypOfCnaResult = typ;
   fIthElement     = i;
@@ -73,7 +73,7 @@ TEcnaResultType::TEcnaResultType(CnaResultTyp  typ,          Int_t   i,
 TEcnaResultType::~TEcnaResultType() {
 //destructor
 
-  // cout << "[Info Management] CLASS: TEcnaResultType.    DESTROY OBJECT: this = " << this << endl;
+  // std::cout << "[Info Management] CLASS: TEcnaResultType.    DESTROY OBJECT: this = " << this << std::endl;
 }
 
 void TEcnaResultType::SetSizeMat(Int_t nrow, Int_t ncol) {

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRootFile.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRootFile.cc
@@ -21,7 +21,7 @@ ClassImp(TEcnaRootFile)
 TEcnaRootFile::TEcnaRootFile() {
 //constructor without arguments
 
-  // cout << "[Info Management] CLASS: TEcnaRootFile.      CREATE OBJECT: this = " << this << endl;
+  // std::cout << "[Info Management] CLASS: TEcnaRootFile.      CREATE OBJECT: this = " << this << std::endl;
 
   Init();
 }
@@ -29,7 +29,7 @@ TEcnaRootFile::TEcnaRootFile() {
 TEcnaRootFile::TEcnaRootFile(TEcnaObject* pObjectManager, const Text_t *name, const TString& status) {
 //constructor
 
- // cout << "[Info Management] CLASS: TEcnaRootFile.      CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaRootFile.      CREATE OBJECT: this = " << this << std::endl;
 
   Init();
   Long_t i_this = (Long_t)this;
@@ -42,7 +42,7 @@ TEcnaRootFile::TEcnaRootFile(TEcnaObject* pObjectManager, const Text_t *name, co
 TEcnaRootFile::TEcnaRootFile(TEcnaObject* pObjectManager, const Text_t *name) {
 //constructor
 
- // cout << "[Info Management] CLASS: TEcnaRootFile.      CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaRootFile.      CREATE OBJECT: this = " << this << std::endl;
 
   Init();
   Long_t i_this = (Long_t)this;
@@ -55,7 +55,7 @@ TEcnaRootFile::TEcnaRootFile(TEcnaObject* pObjectManager, const Text_t *name) {
 TEcnaRootFile::TEcnaRootFile(const Text_t *name, const TString& status) {
 //constructor
 
- // cout << "[Info Management] CLASS: TEcnaRootFile.      CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaRootFile.      CREATE OBJECT: this = " << this << std::endl;
 
   Init();
   fRootFileName   = name;
@@ -65,7 +65,7 @@ TEcnaRootFile::TEcnaRootFile(const Text_t *name, const TString& status) {
 TEcnaRootFile::TEcnaRootFile(const Text_t *name) {
 //constructor
 
- // cout << "[Info Management] CLASS: TEcnaRootFile.      CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaRootFile.      CREATE OBJECT: this = " << this << std::endl;
 
   Init();
   fRootFileName = name;
@@ -75,7 +75,7 @@ TEcnaRootFile::TEcnaRootFile(const Text_t *name) {
 TEcnaRootFile::~TEcnaRootFile() {
 //destructor
 
-  //cout << "[Info Management] CLASS: TEcnaRootFile.      DESTROY OBJECT: this = " << this << endl;
+  //std::cout << "[Info Management] CLASS: TEcnaRootFile.      DESTROY OBJECT: this = " << this << std::endl;
 
   if( fCnaIndivResult != 0 ){delete fCnaIndivResult;}
 }

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRun.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaRun.cc
@@ -20,14 +20,14 @@ TEcnaRun::TEcnaRun()
 {
 //Constructor without argument: nothing special done
 
- // cout << "[Info Management] CLASS: TEcnaRun.           CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaRun.           CREATE OBJECT: this = " << this << std::endl;
 }
 
 TEcnaRun::TEcnaRun(TEcnaObject* pObjectManager, const TString& SubDet)
 {
 //Constructor with argument: call to Init() and declare fEcal according to SubDet value ("EB" or "EE")
 
- // cout << "[Info Management] CLASS: TEcnaRun.           CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaRun.           CREATE OBJECT: this = " << this << std::endl;
 
   Init();
   fObjectManager = (TEcnaObject*)pObjectManager;
@@ -122,9 +122,9 @@ TEcnaRun::TEcnaRun(TEcnaObject* pObjectManager, const TString& SubDet, const Int
     }
   else
     {
-      cout << "TEcnaRun/CONSTRUCTOR> Number of required samples = " << NbOfSamples
+      std::cout << "TEcnaRun/CONSTRUCTOR> Number of required samples = " << NbOfSamples
 	   << ": OUT OF RANGE. Set to the default value (= " << fEcal->MaxSampADC() << ")."
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
       fNbSampForFic = fEcal->MaxSampADC(); // DEFAULT Number of samples for file reading
     }
 
@@ -299,9 +299,9 @@ void  TEcnaRun::SetEcalSubDetector(const TString& SubDet)
 
 TEcnaRun::TEcnaRun(const TEcnaRun& dcop)
 {
-  cout << "*TEcnaRun::TEcnaRun(const TEcnaRun& dcop)> "
+  std::cout << "*TEcnaRun::TEcnaRun(const TEcnaRun& dcop)> "
        << " Now is the time to write a copy constructor" 
-       << endl;
+       << std::endl;
   
   //{ Int_t cintoto;  cin >> cintoto; }
   
@@ -332,19 +332,19 @@ TEcnaRun::~TEcnaRun()
   
   if(fFlagPrint == fCodePrintAllComments)
     {
-      cout << "*TEcnaRun::~TEcnaRun()> Entering destructor." << endl;
+      std::cout << "*TEcnaRun::~TEcnaRun()> Entering destructor." << std::endl;
     }
 
   if(fFlagPrint != fCodePrintNoComment || fFlagPrint == fCodePrintWarnings )
     {
       if( fBuildEvtNotSkipped > 0 )
 	{
-	  cout << "************************************************************************************* "
-	       << endl;
-	  cout << "*TEcnaRun::~TEcnaRun()> Nb of calls to GetSampleAdcValues by cmsRun: "
-	       << fBuildEvtNotSkipped << endl;
-	  cout << "************************************************************************************* "
-	       << endl;
+	  std::cout << "************************************************************************************* "
+	       << std::endl;
+	  std::cout << "*TEcnaRun::~TEcnaRun()> Nb of calls to GetSampleAdcValues by cmsRun: "
+	       << fBuildEvtNotSkipped << std::endl;
+	  std::cout << "************************************************************************************* "
+	       << std::endl;
 	}
     }
 
@@ -355,18 +355,18 @@ TEcnaRun::~TEcnaRun()
 	{
 	  if( fMiscDiag[i] != 0 )
 	    {
-	      cout << "                          fMiscDiag Counter "
-		   << setw(3) << i << " = " << setw(9) << fMiscDiag[i]
-		   << " (INFO: alloc on non zero freed zone) " << endl;
+	      std::cout << "                          fMiscDiag Counter "
+		   << std::setw(3) << i << " = " << std::setw(9) << fMiscDiag[i]
+		   << " (INFO: alloc on non zero freed zone) " << std::endl;
 	    }
 	  else
 	    {
 	      misc_czero++;
 	    }
 	}
-      cout << "                          Nb of fMiscDiag counters at zero: "
+      std::cout << "                          Nb of fMiscDiag counters at zero: "
 	   << misc_czero << " (total nb of counters: "
-	   << fNbOfMiscDiagCounters << ")" << endl;
+	   << fNbOfMiscDiagCounters << ")" << std::endl;
     }
   
   if (fMiscDiag                != 0){delete [] fMiscDiag;                 fCdelete++;}
@@ -470,23 +470,23 @@ TEcnaRun::~TEcnaRun()
 
   if ( fCnew != fCdelete )
     {
-      cout << "!TEcnaRun::~TEcnaRun()> WRONG MANAGEMENT OF MEMORY ALLOCATIONS: fCnew = "
-	   << fCnew << ", fCdelete = " << fCdelete << fTTBELL << endl;
+      std::cout << "!TEcnaRun::~TEcnaRun()> WRONG MANAGEMENT OF MEMORY ALLOCATIONS: fCnew = "
+	   << fCnew << ", fCdelete = " << fCdelete << fTTBELL << std::endl;
     }
   else
     {
-      // cout << "*TEcnaRun::~TEcnaRun()> Management of memory allocations: OK. fCnew = "
-      //   << fCnew << ", fCdelete = " << fCdelete << endl;
+      // std::cout << "*TEcnaRun::~TEcnaRun()> Management of memory allocations: OK. fCnew = "
+      //   << fCnew << ", fCdelete = " << fCdelete << std::endl;
     }
 
   if(fFlagPrint == fCodePrintAllComments)
     {
-      cout << "*TEcnaRun::~TEcnaRun()> Exiting destructor (this = " << this << ")." << endl
+      std::cout << "*TEcnaRun::~TEcnaRun()> Exiting destructor (this = " << this << ")." << std::endl
 	   << "~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#~#"
-	   << endl;
+	   << std::endl;
     }
 
- // cout << "[Info Management] CLASS: TEcnaRun.           DESTROY OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaRun.           DESTROY OBJECT: this = " << this << std::endl;
 }
 
 //@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@@ -529,17 +529,17 @@ void TEcnaRun::GetReadyToReadData( const TString&       typ_ana, const Int_t& ru
     {
       if( nlast >= nfirst )
 	{
-	  cout << "*TEcnaRun::GetReadyToReadData(...)> --- WARNING ---> number of events = " << nbevts
-	       << ", out of range (range = " << nfirst << "," << nlast << ")" << endl
-	       << "                                    The number of found events will be less " << endl
-	       << "                                    than the number of requested events." << endl;
+	  std::cout << "*TEcnaRun::GetReadyToReadData(...)> --- WARNING ---> number of events = " << nbevts
+	       << ", out of range (range = " << nfirst << "," << nlast << ")" << std::endl
+	       << "                                    The number of found events will be less " << std::endl
+	       << "                                    than the number of requested events." << std::endl;
 	}
       if( nlast < nfirst )
 	{
-	  cout << "*TEcnaRun::GetReadyToReadData(...)> --- INFO ---> last requested event number = " << nlast
-	       << ", less than first requested event number (= " << nfirst << ")" << endl
-	       << "                                    File will be read until EOF if the number of found events" << endl
-	       << "                                    remains less than the number of requested events." << endl;
+	  std::cout << "*TEcnaRun::GetReadyToReadData(...)> --- INFO ---> last requested event number = " << nlast
+	       << ", less than first requested event number (= " << nfirst << ")" << std::endl
+	       << "                                    File will be read until EOF if the number of found events" << std::endl
+	       << "                                    remains less than the number of requested events." << std::endl;
 	}
 
     }
@@ -586,7 +586,7 @@ void TEcnaRun::GetReadyToReadData( const TString&       typ_ana, const Int_t& ru
 		  
 		  // fFileHeader->Print();
 		  
-		  // {Int_t cintoto; cout << "taper 0 pour continuer" << endl; cin >> cintoto;}
+		  // {Int_t cintoto; std::cout << "taper 0 pour continuer" << std::endl; cin >> cintoto;}
 		  
 		  //  fFileHeader->SetName("CnaHeader");              *======> voir FXG
 		  //  fFileHeader->SetTitle("CnaHeader");
@@ -660,10 +660,10 @@ void TEcnaRun::GetReadyToReadData( const TString&       typ_ana, const Int_t& ru
 		  if(fT3d_AdcValues == 0)
 		    {
 		      //............ Allocation for the 3d array 
-		      cout << "*TEcnaRun::GetReadyToReadData(...)> Allocation of 3D array for ADC distributions."
-			   << " Nb of requested evts = " << fFileHeader->fReqNbOfEvts << endl
+		      std::cout << "*TEcnaRun::GetReadyToReadData(...)> Allocation of 3D array for ADC distributions."
+			   << " Nb of requested evts = " << fFileHeader->fReqNbOfEvts << std::endl
 			   << "                                    This number must not be too large"
-			   << " (no failure after this message means alloc OK)." << endl;
+			   << " (no failure after this message means alloc OK)." << std::endl;
 
 		      fT3d_AdcValues = new Double_t**[fEcal->MaxCrysEcnaInStex()];        fCnew++;  
 
@@ -728,86 +728,86 @@ void TEcnaRun::GetReadyToReadData( const TString&       typ_ana, const Int_t& ru
 		    }
 		  else
 		    {
-		      cerr << "!TEcnaRun::GetReadyToReadData(...)> *** ERROR *** No allocation for fT2d_NbOfEvts!"
-			   << " Pointer already not NULL " << fTTBELL << endl;
-		      // {Int_t cintoto; cout << "Enter: 0 and RETURN to continue or: CTRL C to exit"
-		      //		   << endl; cin >> cintoto;}
+		      std::cerr << "!TEcnaRun::GetReadyToReadData(...)> *** ERROR *** No allocation for fT2d_NbOfEvts!"
+			   << " Pointer already not NULL " << fTTBELL << std::endl;
+		      // {Int_t cintoto; std::cout << "Enter: 0 and RETURN to continue or: CTRL C to exit"
+		      //		   << std::endl; std::cin >> cintoto;}
 		    }
 		}
 	      else
 		{
-		  cerr << endl
+		  std::cerr << std::endl
 		       << "!TEcnaRun::GetReadyToReadData(...)> "
-		       << " *** ERROR *** " << endl
+		       << " *** ERROR *** " << std::endl
 		       << " --------------------------------------------------"
-		       << endl
-		       << " NULL or NEGATIVE values for arguments" << endl
-		       << " with expected positive values:"        << endl
-		       << " Number of Stins in Stex = " << fEcal->MaxStinEcnaInStex()  << endl
-		       << " Number of crystals in Stin     = " << fEcal->MaxCrysInStin() << endl
-		       << " Number of samples by channel    = " << fNbSampForFic << endl
-		       << endl
-		       << endl
-		       << " hence, no memory allocation for array member has been performed." << endl;
+		       << std::endl
+		       << " NULL or NEGATIVE values for arguments" << std::endl
+		       << " with expected positive values:"        << std::endl
+		       << " Number of Stins in Stex = " << fEcal->MaxStinEcnaInStex()  << std::endl
+		       << " Number of crystals in Stin     = " << fEcal->MaxCrysInStin() << std::endl
+		       << " Number of samples by channel    = " << fNbSampForFic << std::endl
+		       << std::endl
+		       << std::endl
+		       << " hence, no memory allocation for array member has been performed." << std::endl;
 		  
-		  cout << "Enter: 0 and RETURN to continue or: CTRL C to exit";
+		  std::cout << "Enter: 0 and RETURN to continue or: CTRL C to exit";
 		  Int_t toto;
-		  cin >> toto;
+		  std::cin >> toto;
 		}
 	      //----------------------------------------------------------- (GetReadyToReadData)
 	      if(fFlagPrint == fCodePrintAllComments ){
-		cout << endl;
-		cout << "*TEcnaRun::GetReadyToReadData(...)>" << endl
-		     << "          The method has been called with the following argument values:"  << endl
+		std::cout << std::endl;
+		std::cout << "*TEcnaRun::GetReadyToReadData(...)>" << std::endl
+		     << "          The method has been called with the following argument values:"  << std::endl
 		     << "          Analysis name                = "
-		     << fFileHeader->fTypAna << endl
+		     << fFileHeader->fTypAna << std::endl
 		     << "          Run number                   = "
-		     << fFileHeader->fRunNumber << endl
+		     << fFileHeader->fRunNumber << std::endl
 		     << "          Run type                     = "
-		     << fFileHeader->fRunType << endl
+		     << fFileHeader->fRunType << std::endl
 		     << "          First requested event number = "
-		     << fFileHeader->fFirstReqEvtNumber << endl
+		     << fFileHeader->fFirstReqEvtNumber << std::endl
 		     << "          Last requested event number  = "
-		     << fFileHeader->fLastReqEvtNumber << endl
+		     << fFileHeader->fLastReqEvtNumber << std::endl
 		     << "          " << fStexName.Data() << " number                  = "
-		     << fFileHeader->fStex << endl
+		     << fFileHeader->fStex << std::endl
 		     << "          Number of " << fStinName.Data()
 		     << " in " << fStexName.Data() << "       = "
-		     << fEcal->MaxStinEcnaInStex()  << endl
+		     << fEcal->MaxStinEcnaInStex()  << std::endl
 		     << "          Number of crystals in " << fStinName.Data() << "  = "
-		     << fEcal->MaxCrysInStin()  << endl
+		     << fEcal->MaxCrysInStin()  << std::endl
 		     << "          Number of samples by channel = "
-		     << fNbSampForFic  << endl
-		     << endl;}
+		     << fNbSampForFic  << std::endl
+		     << std::endl;}
 	      
 	      fReadyToReadData = 1;                        // set flag
 	    }
 	  else
 	    {
 	      if (fFlagPrint != fCodePrintNoComment){
-		cout << "!TEcnaRun::GetReadyToReadData(...) > WARNING/CORRECTION:" << endl
+		std::cout << "!TEcnaRun::GetReadyToReadData(...) > WARNING/CORRECTION:" << std::endl
 		     << "! The fisrt requested event number is not positive (nfirst = " << nfirst << ") "
-		     << fTTBELL << endl;}
+		     << fTTBELL << std::endl;}
 	    }
 	}
       else
 	{
 	  if (fFlagPrint != fCodePrintNoComment){
-	    cout << endl << "!TEcnaRun::GetReadyToReadData(...)> WARNING/CORRECTION:" << endl
-		 << "! The number of requested events (nbevts = " << nbevts << ") is too large." << endl
+	    std::cout << std::endl << "!TEcnaRun::GetReadyToReadData(...)> WARNING/CORRECTION:" << std::endl
+		 << "! The number of requested events (nbevts = " << nbevts << ") is too large." << std::endl
 		 << "! Last event number = " << nlast << " > number of entries = " << nentries << ". "
-		 << fTTBELL << endl << endl;}
+		 << fTTBELL << std::endl << std::endl;}
 	}
     }
   else
     {
-      cout << "!TEcnaRun::GetReadyToReadData(...) *** ERROR ***> "
+      std::cout << "!TEcnaRun::GetReadyToReadData(...) *** ERROR ***> "
 	   << " The first requested event number is greater than the number of entries."
-	   << fTTBELL << endl;
+	   << fTTBELL << std::endl;
     }
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "*TEcnaRun::GetReadyToReadData(...)> Leaving the method. fReadyToReadData = "
-	 << fReadyToReadData << endl; }
+    std::cout << "*TEcnaRun::GetReadyToReadData(...)> Leaving the method. fReadyToReadData = "
+	 << fReadyToReadData << std::endl; }
 
 } // end of GetReadyToReadData
 
@@ -880,33 +880,33 @@ Bool_t TEcnaRun::GetSampleAdcValues(const Int_t&    n1EventNumber, const Int_t& 
 				{
 				  if( fStinIndexBuilt == 1 )
 				    {
-				      cout << endl << "*TEcnaRun::GetSampleAdcValues(...)> event " << n1EventNumber
+				      std::cout << std::endl << "*TEcnaRun::GetSampleAdcValues(...)> event " << n1EventNumber
 					   << " : first event for " << fStexName.Data() << " " << fFileHeader->fStex
 					   << "; " << fStinName.Data() << "s : ";
 				    }
 				  if( fFlagSubDet == "EB" )
-				    {cout << fT1d_StexStinFromIndex[i0StexStinEcna] << ", ";}
+				    {std::cout << fT1d_StexStinFromIndex[i0StexStinEcna] << ", ";}
 				  if( fFlagSubDet == "EE" )
-				    {cout << fEcalNumbering->
+				    {std::cout << fEcalNumbering->
 				       GetDeeSCConsFrom1DeeSCEcna(fFileHeader->fStex, fT1d_StexStinFromIndex[i0StexStinEcna])
 					  << ", ";}
 				}
 			      //.................................................... (GetSampleAdcValues)
 			      if(fFlagPrint == fCodePrintAllComments)
 				{
-				  cout << " (" << fStinIndexBuilt << " " << fStinName.Data()
-				       << " found), channel " << i0StinEcha << ", i0Sample " << i0Sample << endl;
+				  std::cout << " (" << fStinIndexBuilt << " " << fStinName.Data()
+				       << " found), channel " << i0StinEcha << ", i0Sample " << i0Sample << std::endl;
 				}
 			      ret_code = kTRUE;
 			    } // if ( fT1d_StexStinFromIndex[i0StexStinEcna] == fSpecialStexStinNotIndexed )
 			  else
 			    {
-			      cout << "!TEcnaRun::GetSampleAdcValues(...)> *** ERROR ***> NOT ALLOWED if RESULT. " 
+			      std::cout << "!TEcnaRun::GetSampleAdcValues(...)> *** ERROR ***> NOT ALLOWED if RESULT. " 
 				   << " n1StexStin = " << n1StexStin << ", fT1d_StexStinFromIndex["
 				   << i0StexStinEcna << "] = "
 				   << fT1d_StexStinFromIndex[i0StexStinEcna]
 				   << ", fStinIndexBuilt = " << fStinIndexBuilt
-				   << fTTBELL << endl;
+				   << fTTBELL << std::endl;
 			      ret_code = kFALSE;
 			    }
 			}  //  if (i_trouve != 1 )
@@ -914,9 +914,9 @@ Bool_t TEcnaRun::GetSampleAdcValues(const Int_t&    n1EventNumber, const Int_t& 
 		    } //  if( fT1d_StexStinFromIndex != 0 ) 
 		  else
 		    {
-		      cout << "!TEcnaRun, GetSampleAdcValues *** ERROR ***> "
+		      std::cout << "!TEcnaRun, GetSampleAdcValues *** ERROR ***> "
 			   << " fT1d_StexStinFromIndex = " << fT1d_StexStinFromIndex
-			   << " fT1d_StexStinFromIndex[] ALLOCATION NOT DONE" << fTTBELL << endl;
+			   << " fT1d_StexStinFromIndex[] ALLOCATION NOT DONE" << fTTBELL << std::endl;
 		      ret_code = kFALSE;
 		    } //.................................................................. (GetSampleAdcValues)
 		} // end of if( i0Sample >= 0 && i0Sample < fNbSampForFic )
@@ -926,10 +926,10 @@ Bool_t TEcnaRun::GetSampleAdcValues(const Int_t&    n1EventNumber, const Int_t& 
 		  //       (not fNbSampForFic, the later is used only for calculations)
 		  if( i0Sample >= fEcal->MaxSampADC() )
 		    {
-		      cout << "!TEcnaRun::GetSampleAdcValues(...) *** ERROR ***> "
+		      std::cout << "!TEcnaRun::GetSampleAdcValues(...) *** ERROR ***> "
 			   << " sample number = " << i0Sample << ". OUT OF BOUNDS"
 			   << " (max = " << fNbSampForFic << ")"
-			   << fTTBELL << endl;
+			   << fTTBELL << std::endl;
 		      ret_code = kFALSE;
 		    }
 		  else
@@ -940,19 +940,19 @@ Bool_t TEcnaRun::GetSampleAdcValues(const Int_t&    n1EventNumber, const Int_t& 
 	    } // end of if( i0StinEcha >= 0 && i0StinEcha < fEcal->MaxCrysInStin() )
 	  else
 	    {
-	      cout << "!TEcnaRun::GetSampleAdcValues(...) *** ERROR ***> "
+	      std::cout << "!TEcnaRun::GetSampleAdcValues(...) *** ERROR ***> "
 		   << " channel number in " << fStinName.Data() << " = " << i0StinEcha << ". OUT OF BOUNDS"
 		   << " (max = " << fEcal->MaxCrysInStin() << ")" 
-		   << fTTBELL << endl;
+		   << fTTBELL << std::endl;
 	      ret_code = kFALSE;
 	    } // else of if( i0StinEcha >= 0 && i0StinEcha < fEcal->MaxCrysInStin() )
 	}
       else
 	{
-	  cout << "!TEcnaRun::GetSampleAdcValues(...) *** ERROR ***> "
+	  std::cout << "!TEcnaRun::GetSampleAdcValues(...) *** ERROR ***> "
 	       << fStinName.Data() << " number in " << fStexName.Data() << " = " << n1StexStin << ". OUT OF BOUNDS"
 	       << " (max = " << fEcal->MaxStinEcnaInStex() << ")"
-	       << fTTBELL << endl;
+	       << fTTBELL << std::endl;
 	  ret_code = kFALSE;
 	}
 
@@ -995,56 +995,56 @@ Bool_t TEcnaRun::GetSampleAdcValues(const Int_t&    n1EventNumber, const Int_t& 
 		    }
 		  else
 		    {
-		      cout << "!TEcnaRun::GetSampleAdcValues(...) *** ERROR ***> "
+		      std::cout << "!TEcnaRun::GetSampleAdcValues(...) *** ERROR ***> "
 			   << " sample index = " << i0Sample << ". OUT OF BOUNDS"
 			   << " (max = " << fNbSampForFic << ")"
-			   << fTTBELL << endl;
+			   << fTTBELL << std::endl;
 		    }
 		}
 	      else
 		{
-		  cout << "!TEcnaRun::GetSampleAdcValues(...) *** ERROR ***> "
+		  std::cout << "!TEcnaRun::GetSampleAdcValues(...) *** ERROR ***> "
 		       << " event number = " << n1EventNumber << ". OUT OF BOUNDS"
 		       << " (max = " << fFileHeader->fReqNbOfEvts << ")"
-		       << fTTBELL << endl;
+		       << fTTBELL << std::endl;
 		  ret_code = kFALSE;
 		}
 	    }
 	  else
 	    {
-	      cout << "!TEcnaRun::GetSampleAdcValues(...) *** ERROR ***> "
-		   << " CHANNEL NUMBER OUT OF BOUNDS" << endl
+	      std::cout << "!TEcnaRun::GetSampleAdcValues(...) *** ERROR ***> "
+		   << " CHANNEL NUMBER OUT OF BOUNDS" << std::endl
 		   << " i0StexEcha number = " << i0StexEcha
 		   << " , n1StexStin = " << n1StexStin
 		   << " , i0StinEcha = " << i0StinEcha
 		   << " , fEcal->MaxCrysEcnaInStex() = " << fEcal->MaxCrysEcnaInStex() 
-		   << fTTBELL << endl; 
+		   << fTTBELL << std::endl; 
 	      ret_code = kFALSE;
-	      // {Int_t cintoto; cout << "TAPER 0 POUR CONTINUER" << endl; cin >> cintoto;}
+	      // {Int_t cintoto; std::cout << "TAPER 0 POUR CONTINUER" << std::endl; cin >> cintoto;}
 	    }
 	} // end of if( ret_code == kTRUE )
       else
 	{
-	  cout << "!TEcnaRun::GetSampleAdcValues(...) *** ERROR ***> ret_code = kFALSE "
-	       << fTTBELL << endl;
+	  std::cout << "!TEcnaRun::GetSampleAdcValues(...) *** ERROR ***> ret_code = kFALSE "
+	       << fTTBELL << std::endl;
 	}
     } // end of if(fReadyToReadData == 1)
   else
     {
-      cout << "!TEcnaRun::GetSampleAdcValues(...) *** ERROR ***> GetReadyToReadData(...) not called."
-	   << fTTBELL << endl;
+      std::cout << "!TEcnaRun::GetSampleAdcValues(...) *** ERROR ***> GetReadyToReadData(...) not called."
+	   << fTTBELL << std::endl;
       ret_code = kFALSE;
     }
   //.................................................................. (GetSampleAdcValues)
   if (ret_code == kFALSE)
     {
-      cout << "!TEcnaRun::GetSampleAdcValues(...)> *** ERROR ***> ret_code = " << ret_code
+      std::cout << "!TEcnaRun::GetSampleAdcValues(...)> *** ERROR ***> ret_code = " << ret_code
 	   << " (FALSE). Event: " << n1EventNumber
 	   << ", " << fStexName.Data() << ": " << fFileHeader->fStex
 	   << ", " << fStinName.Data() << ": " << n1StexStin
 	   << ", channel: " << i0StinEcha
 	   << ", Sample: "   << i0Sample
-	   << ", ADC value: " << adcvalue << endl;
+	   << ", ADC value: " << adcvalue << std::endl;
     } 
   return ret_code;
 }
@@ -1089,8 +1089,8 @@ Bool_t TEcnaRun::ReadSampleAdcValues(const Int_t& nb_samp_for_calc)
     {
       fRootFileName      = MyRootFile->GetRootFileName();
       fRootFileNameShort = MyRootFile->GetRootFileNameShort();
-      cout << "*TEcnaRun::ReadSampleAdcValues> Reading sample ADC values from file: " << endl
-	   << "           " << fRootFileName << endl;
+      std::cout << "*TEcnaRun::ReadSampleAdcValues> Reading sample ADC values from file: " << std::endl
+	   << "           " << fRootFileName << std::endl;
       
       size_t i_no_data = 0;
 
@@ -1164,14 +1164,14 @@ Bool_t TEcnaRun::ReadSampleAdcValues(const Int_t& nb_samp_for_calc)
 	}
       if(i_no_data)
 	{
-	  cout << "!TEcnaRun::ReadSampleAdcValues(...)> *ERROR* =====> "
-	       << " Read failure. i_no_data = " << i_no_data << fTTBELL << endl;  
+	  std::cout << "!TEcnaRun::ReadSampleAdcValues(...)> *ERROR* =====> "
+	       << " Read failure. i_no_data = " << i_no_data << fTTBELL << std::endl;  
 	}
     }
   else
     {
-      cout << "!TEcnaRun::ReadSampleAdcValues(...)> *ERROR* =====> "
-	   << " ROOT file not found" << fTTBELL << endl;     
+      std::cout << "!TEcnaRun::ReadSampleAdcValues(...)> *ERROR* =====> "
+	   << " ROOT file not found" << fTTBELL << std::endl;     
     }
   delete MyRootFile;        //  fCdelete++;
   return ok_read;
@@ -1241,7 +1241,7 @@ void TEcnaRun::GetReadyToCompute()
     }
   else
     {
-      cout << "*TEcnaRun::GetReadyToCompute()> no data? fT2d_NbOfEvts = " << fT2d_NbOfEvts << endl;
+      std::cout << "*TEcnaRun::GetReadyToCompute()> no data? fT2d_NbOfEvts = " << fT2d_NbOfEvts << std::endl;
     }
 }  
 //  end of GetReadyToCompute()
@@ -1331,10 +1331,10 @@ void TEcnaRun::SampleMeans()
 // Calculation of the expectation values over events
 // for the samples 0 to fNbSampForCalc and for all the StexEchas
 
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::SampleMeans() " << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::SampleMeans() " << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout  << "           Calculation: sample expectation values over the events"
-	  << " for each channel." << endl;}
+    std::cout  << "           Calculation: sample expectation values over the events"
+	  << " for each channel." << std::endl;}
   
   //................... Allocation fT2d_ev
   if ( fT2d_ev == 0 ){
@@ -1382,10 +1382,10 @@ void TEcnaRun::SampleSigmas()
 {
 //Calculation of the sigmas of the samples for all the StexEchas
   
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::SampleSigmas()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::SampleSigmas()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation: sample ADC sigmas over the events "
-	 << " for each channel." << endl;}
+    std::cout << "           Calculation: sample ADC sigmas over the events "
+	 << " for each channel." << std::endl;}
   
   //... preliminary calculation of the expectation values if not done yet.
   //    The tag is set to 1 after call to the method. It is reset to 0
@@ -1450,10 +1450,10 @@ void TEcnaRun::CovariancesBetweenSamples()
 {
   //Calculation of the covariances between samples for all the StexEchas
   
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::CovariancesBetweenSamples()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::CovariancesBetweenSamples()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation: covariances between samples"
-         << " for each channel." << endl;}
+    std::cout << "           Calculation: covariances between samples"
+         << " for each channel." << std::endl;}
   
   //................... Allocations cov_ss
   if( fT3d_cov_ss == 0 ){
@@ -1518,10 +1518,10 @@ void TEcnaRun::CorrelationsBetweenSamples()
   for (Int_t j0StexEcha = 0 ; j0StexEcha < fEcal->MaxCrysEcnaInStex() ; j0StexEcha++)
     {fTagCovCss[j0StexEcha] = 0;}}
   
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::CorrelationsBetweenSamples()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::CorrelationsBetweenSamples()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation: correlations between samples"
-	 << " for each channel." << endl;}
+    std::cout << "           Calculation: correlations between samples"
+	 << " for each channel." << std::endl;}
 
   //................... Allocations cor_ss
   if( fT3d_cor_ss == 0){
@@ -1596,11 +1596,11 @@ void TEcnaRun::Pedestals()
       {fMiscDiag[11]++; fT1d_ev_ev[i0StexEcha] = (Double_t)0;}}
   
   //..................... Calculation
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::Pedestals()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::Pedestals()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation, for all the channels, of the expectation values (over the samples 1 to "
-	 << fNbSampForCalc << ")" << endl
-	 << "          of the ADC expectation values (over the events)." << endl;}
+    std::cout << "           Calculation, for all the channels, of the expectation values (over the samples 1 to "
+	 << fNbSampForCalc << ")" << std::endl
+	 << "          of the ADC expectation values (over the events)." << std::endl;}
   
   for(Int_t i0StexEcha = 0; i0StexEcha < fEcal->MaxCrysEcnaInStex(); i0StexEcha++)
     {     
@@ -1641,11 +1641,11 @@ void TEcnaRun::TotalNoise()
       {fMiscDiag[12]++; fT1d_evsamp_of_sigevt[i0StexEcha] = (Double_t)0;}}
   
   //..................... Calculation
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::TotalNoise()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::TotalNoise()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation, for all the channels, of the expectation values (over the samples 1 to "
-	 << fNbSampForCalc << ")" << endl
-	 << "          of the ADC expectation values (over the events)." << endl;}
+    std::cout << "           Calculation, for all the channels, of the expectation values (over the samples 1 to "
+	 << fNbSampForCalc << ")" << std::endl
+	 << "          of the ADC expectation values (over the events)." << std::endl;}
 
   for(Int_t i0StexEcha = 0; i0StexEcha < fEcal->MaxCrysEcnaInStex(); i0StexEcha++)
     {     
@@ -1653,8 +1653,8 @@ void TEcnaRun::TotalNoise()
 	{
 	  if( fT2d_sig[i0StexEcha][i0Sample] < 0)
 	    {
-	      cout << "!TEcnaRun::TotalNoise() *** ERROR ***> Negative sigma!"
-		   << fTTBELL << endl;
+	      std::cout << "!TEcnaRun::TotalNoise() *** ERROR ***> Negative sigma!"
+		   << fTTBELL << std::endl;
 	    }
 	  else
 	    {
@@ -1698,11 +1698,11 @@ void TEcnaRun::LowFrequencyNoise()
   for(Int_t i=0; i<fNumberOfEvents; i++){mean_over_samples(i)=(Double_t)0.;}
 
   //..................... Calculation
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::LowFrequencyNoise()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::LowFrequencyNoise()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation, for each channel, of the sigma (over the events)" << endl
+    std::cout << "           Calculation, for each channel, of the sigma (over the events)" << std::endl
 	 << "           of the ADC expectation values (over the samples 1 to "
-	 <<  fNbSampForCalc << ")." << endl;}
+	 <<  fNbSampForCalc << ")." << std::endl;}
 
   for(Int_t i0StexEcha = 0; i0StexEcha < fEcal->MaxCrysEcnaInStex(); i0StexEcha++)
     {
@@ -1770,11 +1770,11 @@ void TEcnaRun::HighFrequencyNoise()
   for(Int_t i=0; i<fNumberOfEvents; i++){sigma_over_samples(i)=(Double_t)0.;}
 
   //..................... Calculation
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::HighFrequencyNoise()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::HighFrequencyNoise()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation, for each channel, of the sigma (over the events)" << endl
+    std::cout << "           Calculation, for each channel, of the sigma (over the events)" << std::endl
 	 << "           of the ADC expectation values (over the samples 1 to "
-	 <<  fNbSampForCalc << ")." << endl;}
+	 <<  fNbSampForCalc << ")." << std::endl;}
 
   for(Int_t i0StexEcha = 0; i0StexEcha < fEcal->MaxCrysEcnaInStex(); i0StexEcha++)
     {
@@ -1795,7 +1795,7 @@ void TEcnaRun::HighFrequencyNoise()
 	  var_over_samples /= (Double_t)fNbSampForCalc;
 	  
 	  if( var_over_samples < 0)
-	    {cout << "!TEcnaRun::HighFrequencyNoise() *** ERROR ***> Negative variance! " << fTTBELL << endl;}
+	    {std::cout << "!TEcnaRun::HighFrequencyNoise() *** ERROR ***> Negative variance! " << fTTBELL << std::endl;}
 	  else
 	    {sigma_over_samples(n_event) = sqrt(var_over_samples);}
 	}
@@ -1847,10 +1847,10 @@ void TEcnaRun::MeanCorrelationsBetweenSamples()
   TVectorD  half_cor_ss(ndim); for(Int_t i=0; i<ndim; i++){half_cor_ss(i)=(Double_t)0.;}
 
   //..................... Calculation
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::MeanCorrelationsBetweenSamples()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::MeanCorrelationsBetweenSamples()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation, for all the channels, of the expectation values of the" << endl
-	 << "           correlations between the first " << fNbSampForCalc << " samples." << endl;}
+    std::cout << "           Calculation, for all the channels, of the expectation values of the" << std::endl
+	 << "           correlations between the first " << fNbSampForCalc << " samples." << std::endl;}
 
   for(Int_t i0StexEcha = 0; i0StexEcha < fEcal->MaxCrysEcnaInStex(); i0StexEcha++)
     {
@@ -1906,10 +1906,10 @@ void  TEcnaRun::SigmaOfCorrelationsBetweenSamples()
 	{fMiscDiag[16]++; fT1d_sig_cor_ss[i0StexEcha] = (Double_t)0;}
     }
 
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::SigmasOfCorrelationsBetweenSamples()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::SigmasOfCorrelationsBetweenSamples()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation of the sigmas of the (sample,sample)" << endl
-	 << "           correlations for all the channels." << endl;}
+    std::cout << "           Calculation of the sigmas of the (sample,sample)" << std::endl
+	 << "           correlations for all the channels." << std::endl;}
 
   //.......... 1D array half_cor_ss[N(N-1)/2] to put the N (sample,sample) correlations
   //           (half of them minus the diagonal)
@@ -1964,10 +1964,10 @@ void TEcnaRun::AveragePedestals()
     {if( fT1d_av_mped[i0StexStinEcna] != (Double_t)0 )
       {fMiscDiag[41]++; fT1d_av_mped[i0StexStinEcna] = (Double_t)0;}}
  
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::AveragePedestals()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::AveragePedestals()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation, for all the "
-	 << fStinName.Data() << "s, of the average Pedestals" << endl;}
+    std::cout << "           Calculation, for all the "
+	 << fStinName.Data() << "s, of the average Pedestals" << std::endl;}
 
   //................... Calculation
   for(Int_t i0StexStinEcna = 0; i0StexStinEcna < fEcal->MaxStinEcnaInStex(); i0StexStinEcna++)
@@ -2025,10 +2025,10 @@ void TEcnaRun::AverageTotalNoise()
     {if( fT1d_av_totn[i0StexStinEcna] != (Double_t)0 )
       {fMiscDiag[42]++; fT1d_av_totn[i0StexStinEcna] = (Double_t)0;}}
 
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::AverageTotalNoise()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::AverageTotalNoise()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation, for all the "
-	 << fStinName.Data() << "s, of the average total Noise" << endl;}
+    std::cout << "           Calculation, for all the "
+	 << fStinName.Data() << "s, of the average total Noise" << std::endl;}
 
   //................... Calculation
   for(Int_t i0StexStinEcna = 0; i0StexStinEcna < fEcal->MaxStinEcnaInStex(); i0StexStinEcna++)
@@ -2085,10 +2085,10 @@ void TEcnaRun::AverageLowFrequencyNoise()
     {if( fT1d_av_lofn[i0StexStinEcna] != (Double_t)0 )
       {fMiscDiag[43]++; fT1d_av_lofn[i0StexStinEcna] = (Double_t)0;}}
 
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::AverageLowFrequencyNoise()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::AverageLowFrequencyNoise()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation, for all the "
-	 << fStinName.Data() << "s, of the average Low Frequency Noise" << endl;}
+    std::cout << "           Calculation, for all the "
+	 << fStinName.Data() << "s, of the average Low Frequency Noise" << std::endl;}
 
   //................... Calculation
   for(Int_t i0StexStinEcna = 0; i0StexStinEcna < fEcal->MaxStinEcnaInStex(); i0StexStinEcna++)
@@ -2145,10 +2145,10 @@ void TEcnaRun::AverageHighFrequencyNoise()
     {if( fT1d_av_hifn[i0StexStinEcna] != (Double_t)0 )
       {fMiscDiag[44]++; fT1d_av_hifn[i0StexStinEcna] = (Double_t)0;}}
 
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::AverageHighFrequencyNoise()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::AverageHighFrequencyNoise()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation, for all the "
-	 << fStinName.Data() << "s, of the average High Frequency Noise" << endl;}
+    std::cout << "           Calculation, for all the "
+	 << fStinName.Data() << "s, of the average High Frequency Noise" << std::endl;}
 
   //................... Calculation
   for(Int_t i0StexStinEcna = 0; i0StexStinEcna < fEcal->MaxStinEcnaInStex(); i0StexStinEcna++)
@@ -2205,10 +2205,10 @@ void TEcnaRun::AverageMeanCorrelationsBetweenSamples()
     {if( fT1d_av_ev_corss[i0StexStinEcna] != (Double_t)0 )
       {fMiscDiag[45]++; fT1d_av_ev_corss[i0StexStinEcna] = (Double_t)0;}}
 
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::AverageMeanCorrelationsBetweenSamples()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::AverageMeanCorrelationsBetweenSamples()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation, for all the "
-	 << fStinName.Data() << "s, of the average mean cor(s,s)" << endl;}
+    std::cout << "           Calculation, for all the "
+	 << fStinName.Data() << "s, of the average mean cor(s,s)" << std::endl;}
 
   //................... Calculation
   for(Int_t i0StexStinEcna = 0; i0StexStinEcna < fEcal->MaxStinEcnaInStex(); i0StexStinEcna++)
@@ -2265,10 +2265,10 @@ void TEcnaRun::AverageSigmaOfCorrelationsBetweenSamples()
     {if( fT1d_av_sig_corss[i0StexStinEcna] != (Double_t)0 )
       {fMiscDiag[46]++; fT1d_av_sig_corss[i0StexStinEcna] = (Double_t)0;}}
 
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::AverageSigmaOfCorrelationsBetweenSamples()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::AverageSigmaOfCorrelationsBetweenSamples()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation, for all the "
-	 << fStinName.Data() << "s, of the average sigma of cor(s,s)" << endl;}
+    std::cout << "           Calculation, for all the "
+	 << fStinName.Data() << "s, of the average sigma of cor(s,s)" << std::endl;}
 
   //................... Calculation
   for(Int_t i0StexStinEcna = 0; i0StexStinEcna < fEcal->MaxStinEcnaInStex(); i0StexStinEcna++)
@@ -2336,9 +2336,9 @@ void TEcnaRun::LowFrequencyCovariancesBetweenChannels()
 {
 //Calculation of the Low Frequency Covariances between channels
   
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::LowFrequencyCovariancesBetweenChannels()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::LowFrequencyCovariancesBetweenChannels()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation of the Low Frequency Covariances between channels" << endl;}
+    std::cout << "           Calculation of the Low Frequency Covariances between channels" << std::endl;}
 
   //................. allocation fT2d_lf_cov + init to zero (mandatory)
   if( fT2d_lf_cov == 0 ){
@@ -2369,11 +2369,11 @@ void TEcnaRun::LowFrequencyCovariancesBetweenChannels()
 
   //................... Calculation  
   if(fFlagPrint != fCodePrintNoComment){
-    cout << "          Calculation, for each pair of channels, of the covariance (over the events)" << endl
+    std::cout << "          Calculation, for each pair of channels, of the covariance (over the events)" << std::endl
 	 << "          between the ADC expectation values (over the samples 1 to "
-	 <<  fNbSampForCalc << ")." << endl;}
+	 <<  fNbSampForCalc << ")." << std::endl;}
 
-  cout << " Please, wait (end at i= " << fEcal->MaxCrysEcnaInStex() << "): " << endl;
+  std::cout << " Please, wait (end at i= " << fEcal->MaxCrysEcnaInStex() << "): " << std::endl;
 
   for(Int_t i0StexEcha = 0; i0StexEcha < fEcal->MaxCrysEcnaInStex(); i0StexEcha++)
     {
@@ -2422,10 +2422,10 @@ void TEcnaRun::LowFrequencyCovariancesBetweenChannels()
 		  fT2d_lf_cov[j0StexEcha][i0StexEcha] = fT2d_lf_cov[i0StexEcha][j0StexEcha];
 		}
 	    }
-	  if( i0StexEcha%100 == 0 ){cout << i0StexEcha << "[LFN Cov], ";}
+	  if( i0StexEcha%100 == 0 ){std::cout << i0StexEcha << "[LFN Cov], ";}
 	}
     }
-  cout << endl;
+  std::cout << std::endl;
   fTagLfCov[0] = 1;    fFileHeader->fLfCovCalc++;
 }
 //---------- (end of LowFrequencyCovariancesBetweenChannels ) --------------------
@@ -2445,11 +2445,11 @@ void TEcnaRun::LowFrequencyCorrelationsBetweenChannels()
   if ( fTagLfCov[0] != 1 )
     {LowFrequencyCovariancesBetweenChannels(); fTagLfCov[0] = 0;}
   
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::LowFrequencyCorrelationsBetweenChannels()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::LowFrequencyCorrelationsBetweenChannels()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "          Calculation of the Low Frequency Correlations between channels" << endl
+    std::cout << "          Calculation of the Low Frequency Correlations between channels" << std::endl
 	 << "          Starting allocation. "
-	 << endl;}
+	 << std::endl;}
 
   //................. allocation fT2d_lf_cor + init to zero (mandatory)
   if( fT2d_lf_cor == 0 ){
@@ -2497,9 +2497,9 @@ void TEcnaRun::LowFrequencyCorrelationsBetweenChannels()
 		}
 	    }
 	}
-      if( i0StexEcha%100 == 0 ){cout << i0StexEcha << "[LFN Cor], ";}
+      if( i0StexEcha%100 == 0 ){std::cout << i0StexEcha << "[LFN Cor], ";}
     }
-  cout << endl;
+  std::cout << std::endl;
   
   fTagLfCor[0] = 1;    fFileHeader->fLfCorCalc++;
 }
@@ -2524,9 +2524,9 @@ void TEcnaRun::HighFrequencyCovariancesBetweenChannels()
 {
 //Calculation of the High Frequency Covariances between channels
   
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::HighFrequencyCovariancesBetweenChannels()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::HighFrequencyCovariancesBetweenChannels()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation of the High Frequency Covariances between channels" << endl;}
+    std::cout << "           Calculation of the High Frequency Covariances between channels" << std::endl;}
 
   //................. allocation fT2d_hf_cov + init to zero (mandatory)
   if( fT2d_hf_cov == 0 ){
@@ -2559,11 +2559,11 @@ void TEcnaRun::HighFrequencyCovariancesBetweenChannels()
 
   //........................................... Calculation    (HighFrequencyCovariancesBetweenChannels)
   if(fFlagPrint != fCodePrintNoComment){
-    cout << "          Calculation of the mean (over the events)" << endl
+    std::cout << "          Calculation of the mean (over the events)" << std::endl
 	 << "          of the covariances between the channels (over the samples 1 to "
-	 <<  fNbSampForCalc << ")." << endl;}
+	 <<  fNbSampForCalc << ")." << std::endl;}
 
-  cout << " Please, wait (end at i= " << fEcal->MaxCrysEcnaInStex() << "): " << endl;
+  std::cout << " Please, wait (end at i= " << fEcal->MaxCrysEcnaInStex() << "): " << std::endl;
 
   for(Int_t i0StexEcha = 0; i0StexEcha < fEcal->MaxCrysEcnaInStex(); i0StexEcha++)
     {
@@ -2579,11 +2579,11 @@ void TEcnaRun::HighFrequencyCovariancesBetweenChannels()
 	      mean_over_samples(i0StexEcha, n_event) /= (Double_t)fNbSampForCalc;
 	    }
 	}
-      if( i0StexEcha%100 == 0 ){cout << i0StexEcha << "[HFNa Cov], ";}
+      if( i0StexEcha%100 == 0 ){std::cout << i0StexEcha << "[HFNa Cov], ";}
     }
-  cout << endl;
+  std::cout << std::endl;
 
-  cout << " Please, wait (end at i= " << fEcal->MaxCrysEcnaInStex() << "): " << endl;
+  std::cout << " Please, wait (end at i= " << fEcal->MaxCrysEcnaInStex() << "): " << std::endl;
 
   //... Calculation of half of the matrix, diagonal included    (HighFrequencyCovariancesBetweenChannels)
   for(Int_t i0StexEcha = 0; i0StexEcha < fEcal->MaxCrysEcnaInStex(); i0StexEcha++)
@@ -2622,9 +2622,9 @@ void TEcnaRun::HighFrequencyCovariancesBetweenChannels()
 		}
 	    }
 	}
-      if( i0StexEcha%100 == 0 ){cout << i0StexEcha << "[HFNb Cov], ";}
+      if( i0StexEcha%100 == 0 ){std::cout << i0StexEcha << "[HFNb Cov], ";}
     }
-  cout << endl;
+  std::cout << std::endl;
 
   fTagHfCov[0] = 1;    fFileHeader->fHfCovCalc++;
 }
@@ -2645,11 +2645,11 @@ void TEcnaRun::HighFrequencyCorrelationsBetweenChannels()
   if ( fTagHfCov[0] != 1 )
     {HighFrequencyCovariancesBetweenChannels(); fTagHfCov[0] = 0;}
   
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::HighFrequencyCorrelationsBetweenChannels()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::HighFrequencyCorrelationsBetweenChannels()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation of the High Frequency Correlations between channels" << endl
+    std::cout << "           Calculation of the High Frequency Correlations between channels" << std::endl
 	 << "          Starting allocation. "
-	 << endl;}
+	 << std::endl;}
 
   //................. allocation fT2d_hf_cor + init to zero (mandatory)
   if( fT2d_hf_cor == 0 ){
@@ -2699,9 +2699,9 @@ void TEcnaRun::HighFrequencyCorrelationsBetweenChannels()
 		}
 	    }
 	}
-      if( i0StexEcha%100 == 0 ){cout << i0StexEcha << "[HFN Cor], ";}
+      if( i0StexEcha%100 == 0 ){std::cout << i0StexEcha << "[HFN Cor], ";}
     }
-  cout << endl;  
+  std::cout << std::endl;  
   
   fTagHfCor[0] = 1;    fFileHeader->fHfCorCalc++;
 }
@@ -2733,11 +2733,11 @@ void TEcnaRun::LowFrequencyMeanCorrelationsBetweenStins()
   if(fTagLfCor[0] != 1){LowFrequencyCorrelationsBetweenChannels(); fTagLfCor[0]=0;}
 
   //..... mean fT2d_lfcc_mostins for each pair (Stin_X,Stin_Y)
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::LowFrequencyMeanCorrelationsBetweenStins()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::LowFrequencyMeanCorrelationsBetweenStins()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation of the mean, for each "
-	 << fStinName.Data() << ", of the" << endl
-	 << "           Low Frequency Correlations between channels." << endl;}
+    std::cout << "           Calculation of the mean, for each "
+	 << fStinName.Data() << ", of the" << std::endl
+	 << "           Low Frequency Correlations between channels." << std::endl;}
   
   //................. allocation fT2d_lfcc_mostins + init to zero (mandatory)
   if( fT2d_lfcc_mostins == 0 ){
@@ -2771,11 +2771,11 @@ void TEcnaRun::LowFrequencyMeanCorrelationsBetweenStins()
   TVectorD  half_LFccMos(ndim); for(Int_t i=0; i<ndim; i++){half_LFccMos(i)=(Double_t)0.;}
 
   //..................... Calculation
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::LowFrequencyMeanCorrelationsBetweenStins()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::LowFrequencyMeanCorrelationsBetweenStins()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation, for each "
-	 << fStinName.Data() << ", of the mean " << endl
-	 << "           Low Frequency cor(c,c)." << endl;}
+    std::cout << "           Calculation, for each "
+	 << fStinName.Data() << ", of the mean " << std::endl
+	 << "           Low Frequency cor(c,c)." << std::endl;}
 
   for(Int_t i0StexStinEcna=0; i0StexStinEcna<fEcal->MaxStinEcnaInStex(); i0StexStinEcna++)
     {
@@ -2793,8 +2793,8 @@ void TEcnaRun::LowFrequencyMeanCorrelationsBetweenStins()
 		       (j0StexEcha>= 0 && j0StexEcha < fEcal->MaxCrysEcnaInStex())  )
 		  {half_LFccMos(i_count) = fT2d_lf_cor[i0StexEcha][j0StexEcha]; i_count++;}
 		  else
-		    {cout << "!TEcnaRun::LowFrequencyMeanCorrelationsBetweenStins()> Channel number out of range."
-			  << "i0StexEcha = " << i0StexEcha <<", j0StexEcha = " << j0StexEcha << fTTBELL << endl; }
+		    {std::cout << "!TEcnaRun::LowFrequencyMeanCorrelationsBetweenStins()> Channel number out of range."
+			  << "i0StexEcha = " << i0StexEcha <<", j0StexEcha = " << j0StexEcha << fTTBELL << std::endl; }
 		}
 	    }
 	  //...... Calculation of the mean absolute values of the LF mean Correlations(c,c')
@@ -2805,9 +2805,9 @@ void TEcnaRun::LowFrequencyMeanCorrelationsBetweenStins()
 	    }
 	  fT2d_lfcc_mostins[i0StexStinEcna][j0StexStinEcna] /= (Double_t)ndim;
 	}
-      if( i0StexStinEcna%10 == 0 ){cout << i0StexStinEcna << "[LFN MCtt], ";}
+      if( i0StexStinEcna%10 == 0 ){std::cout << i0StexStinEcna << "[LFN MCtt], ";}
     }
-  cout << endl;
+  std::cout << std::endl;
 
   fTagLFccMoStins[0] = 1;           fFileHeader->fLFccMoStinsCalc++;
 } // ------- end of LowFrequencyMeanCorrelationsBetweenStins() -------
@@ -2831,11 +2831,11 @@ void TEcnaRun::HighFrequencyMeanCorrelationsBetweenStins()
   if(fTagHfCor[0] != 1){HighFrequencyCorrelationsBetweenChannels();fTagHfCor[0]=0;}
 
   //..... mean fT2d_hfcc_mostins for each pair (Stin_X,Stin_Y)
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::HighFrequencyMeanCorrelationsBetweenStins()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::HighFrequencyMeanCorrelationsBetweenStins()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation of the mean, for each "
-	 << fFlagSubDet.Data() << ", of the" << endl
-         << "           High Frequency Correlations between channels." << endl;}
+    std::cout << "           Calculation of the mean, for each "
+	 << fFlagSubDet.Data() << ", of the" << std::endl
+         << "           High Frequency Correlations between channels." << std::endl;}
 
   //................. allocation fT2d_hfcc_mostins + init to zero (mandatory)
   if( fT2d_hfcc_mostins == 0 ){
@@ -2868,11 +2868,11 @@ void TEcnaRun::HighFrequencyMeanCorrelationsBetweenStins()
 
   TVectorD half_HFccMos(ndim); for(Int_t i=0; i<ndim; i++){half_HFccMos(i)=(Double_t)0.;}
 
-  if(fFlagPrint != fCodePrintNoComment){cout << "*TEcnaRun::HighFrequencyMeanCorrelationsBetweenStins()" << endl;}
+  if(fFlagPrint != fCodePrintNoComment){std::cout << "*TEcnaRun::HighFrequencyMeanCorrelationsBetweenStins()" << std::endl;}
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "           Calculation, for each "
-	 << fFlagSubDet.Data()  << ", of the mean " << endl
-	 << "           High Frequency cor(c,c)." << endl;}
+    std::cout << "           Calculation, for each "
+	 << fFlagSubDet.Data()  << ", of the mean " << std::endl
+	 << "           High Frequency cor(c,c)." << std::endl;}
 
   //..................... Calculation
   for(Int_t i0StexStinEcna=0; i0StexStinEcna<fEcal->MaxStinEcnaInStex(); i0StexStinEcna++)
@@ -2891,8 +2891,8 @@ void TEcnaRun::HighFrequencyMeanCorrelationsBetweenStins()
 		       (j0StexEcha>= 0 && j0StexEcha < fEcal->MaxCrysEcnaInStex())  )
 		    {half_HFccMos(i_count) = fT2d_hf_cor[i0StexEcha][j0StexEcha]; i_count++;}
 		  else
-		    {cout << "!TEcnaRun::HighFrequencyMeanCorrelationsBetweenStins()> Channel number out of range."
-			  << "i0StexEcha = " << i0StexEcha <<", j0StexEcha = " << j0StexEcha << fTTBELL << endl; }
+		    {std::cout << "!TEcnaRun::HighFrequencyMeanCorrelationsBetweenStins()> Channel number out of range."
+			  << "i0StexEcha = " << i0StexEcha <<", j0StexEcha = " << j0StexEcha << fTTBELL << std::endl; }
 		}
 	    }
 	  //..... Calculation of the mean absolute values of the HF mean Correlations(c,c')
@@ -2903,9 +2903,9 @@ void TEcnaRun::HighFrequencyMeanCorrelationsBetweenStins()
 	    }
 	  fT2d_hfcc_mostins[i0StexStinEcna][j0StexStinEcna] /= (Double_t)ndim;
 	}
-      if( i0StexStinEcna%10 == 0 ){cout << i0StexStinEcna << "[HFN MCtt], ";}
+      if( i0StexStinEcna%10 == 0 ){std::cout << i0StexStinEcna << "[HFN MCtt], ";}
     }
-  cout << endl;
+  std::cout << std::endl;
 
   fTagHFccMoStins[0] = 1;                   fFileHeader->fHFccMoStinsCalc++;
 } // ------- end of HighFrequencyMeanCorrelationsBetweenStins() -------
@@ -2954,12 +2954,12 @@ Bool_t TEcnaRun::OpenRootFile(const Text_t *name, const TString& status) {
 
   if (!ok_open) // unable to open file
     {
-      cout << "TEcnaRun::OpenRootFile> Cannot open file " << s_name.Data() << endl;
+      std::cout << "TEcnaRun::OpenRootFile> Cannot open file " << s_name.Data() << std::endl;
     }
   else
     {
       if(fFlagPrint == fCodePrintAllComments)
-	{cout << "*TEcnaRun::OpenRootFile> Open ROOT file OK for file " << s_name.Data() << endl;}  
+	{std::cout << "*TEcnaRun::OpenRootFile> Open ROOT file OK for file " << s_name.Data() << std::endl;}  
       fOpenRootFile  = kTRUE;
     }
   return ok_open;
@@ -2984,7 +2984,7 @@ Bool_t TEcnaRun::CloseRootFile(const Text_t *name) {
       gCnaRootFile->CloseFile();
 
       if(fFlagPrint != fCodePrintAllComments){
-	cout << "*TEcnaRun::CloseRootFile> ROOT file " << s_name.Data() << " closed." << endl;}
+	std::cout << "*TEcnaRun::CloseRootFile> ROOT file " << s_name.Data() << " closed." << std::endl;}
 
       //     delete gCnaRootFile;     gCnaRootFile = 0;          fCdelete++;
 
@@ -2993,8 +2993,8 @@ Bool_t TEcnaRun::CloseRootFile(const Text_t *name) {
     }
   else
     {
-      cout << "*TEcnaRun::CloseRootFile(...)> No close since no file is open."
-	   << fTTBELL << endl;
+      std::cout << "*TEcnaRun::CloseRootFile(...)> No close since no file is open."
+	   << fTTBELL << std::endl;
     }
   return ok_close;
 }
@@ -3032,15 +3032,15 @@ Bool_t TEcnaRun::WriteRootFile(){
   if ( nCountEvts <= 0 )
     {
       //============== no write if no event found
-      cout << "!TEcnaRun::WriteRootFile()> No event found for file " << fCnaWrite->GetRootFileNameShort().Data()
-	   << ". File will not be written." << endl;
+      std::cout << "!TEcnaRun::WriteRootFile()> No event found for file " << fCnaWrite->GetRootFileNameShort().Data()
+	   << ". File will not be written." << std::endl;
       ok_write = kTRUE;
     }
   else
     {    
       if(fFlagPrint == fCodePrintAllComments){
-	cout << "*TEcnaRun::WriteRootFile()> Results are going to be written in the ROOT file: " << endl
-	     << "                           " << fCnaWrite->GetRootFileName().Data() << endl;}
+	std::cout << "*TEcnaRun::WriteRootFile()> Results are going to be written in the ROOT file: " << std::endl
+	     << "                           " << fCnaWrite->GetRootFileName().Data() << std::endl;}
 
       const Text_t *FileShortName = (const Text_t *)fCnaWrite->GetRootFileNameShort().Data();
       ok_write = WriteRootFile(FileShortName, fFileHeader->fNbOfSamples);
@@ -3048,13 +3048,13 @@ Bool_t TEcnaRun::WriteRootFile(){
       if( ok_write == kTRUE )
 	{
 	  if(fFlagPrint != fCodePrintNoComment)
-	    {cout << "*TEcnaRun::WriteRootFile()> Writing OK for file " << fCnaWrite->GetRootFileName().Data()
-		  << endl;}
+	    {std::cout << "*TEcnaRun::WriteRootFile()> Writing OK for file " << fCnaWrite->GetRootFileName().Data()
+		  << std::endl;}
 	}
       else
 	{
-	  cout << "!TEcnaRun::WriteRootFile()> Writing FAILLED for file " << fCnaWrite->GetRootFileName().Data()
-	       << fTTBELL << endl;
+	  std::cout << "!TEcnaRun::WriteRootFile()> Writing FAILLED for file " << fCnaWrite->GetRootFileName().Data()
+	       << fTTBELL << std::endl;
 	}
     }
   return ok_write;
@@ -3086,8 +3086,8 @@ Bool_t TEcnaRun::WriteNewRootFile(const TString& TypAna){
   const Text_t *FileShortName = (const Text_t *)fNewRootFileNameShort.Data();
 
   if(fFlagPrint == fCodePrintAllComments){
-    cout << "*TEcnaRun::WriteNewRootFile()> Results are going to be written in the ROOT file: " << endl
-	 << "                              " << fNewRootFileNameShort.Data() << endl;}
+    std::cout << "*TEcnaRun::WriteNewRootFile()> Results are going to be written in the ROOT file: " << std::endl
+	 << "                              " << fNewRootFileNameShort.Data() << std::endl;}
 
   ok_write = WriteRootFile(FileShortName, fNbSampForCalc);
 
@@ -3118,8 +3118,8 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 
   if ( fOpenRootFile )
     {
-      cout << "!TEcnaRun::WriteRootFile(...) *** ERROR ***> Writing on file already open."
-	   << fTTBELL << endl;
+      std::cout << "!TEcnaRun::WriteRootFile(...) *** ERROR ***> Writing on file already open."
+	   << fTTBELL << std::endl;
     }
   else
     {
@@ -3199,9 +3199,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
 
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3213,10 +3213,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatMat.ReSet(1,1);
 	      TRootStinNumbers();
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
 
       //-------------------------- Average Pedestals (1 value per Stin)
       //       1   fMatHis(1, StexStin)   (12)  cTypAvPed      1*(1,  68) =     68
@@ -3231,9 +3231,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
  
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3245,10 +3245,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatMat.ReSet(1,1);
 	      TRootAvPed();
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
 
       //-------------------------- Average Total noise
       // StexEcha   fMatHis(1, StexStin)     ( 3)  cTypAvTno      1*(1,  68) =     68
@@ -3263,9 +3263,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
 
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3277,10 +3277,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatMat.ReSet(1,1);
 	      TRootAvTno();
 	      gCnaRootFile->fCnaResultsTree->Fill(); 
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
 
       //-------------------------- Average Low frequency noise
       //       1   fMatHis(1, StexStin)   ( 4)  cTypAvLfn      1*(1,  68) =     68
@@ -3295,9 +3295,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
  
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
       
       for (Int_t i = 0; i < v_nb_times; i++)
       	{
@@ -3309,10 +3309,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatMat.ReSet(1,1);
 	      TRootAvLfn();
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
       	    }
       	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
       
       //-------------------------- Average High frequency noise
       //       1   fMatHis(1, StexStin)   ( 5)  cTypAvHfn      1*(1,  68) =     68
@@ -3327,9 +3327,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
  
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
       
       for (Int_t i = 0; i < v_nb_times; i++)
      	{
@@ -3341,10 +3341,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatMat.ReSet(1,1);
 	      TRootAvHfn();
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
       	    }
       	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
 
       //-------------------------- Average mean cor(s,s)
       //       1   fMatHis(1, StexStin)   (13)  cTypAvMeanCorss      1*(1,  68) =     68
@@ -3359,9 +3359,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
  
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3373,10 +3373,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatMat.ReSet(1,1);
 	      TRootAvEvCorss();
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
       
       //--------------------------  Average sigma of cor(s,s)
       //       1   fMatHis(1, StexStin)    (14)  cTypAvSigCorss      1*(1,  68) =     68
@@ -3391,9 +3391,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
  
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3405,10 +3405,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatMat.ReSet(1,1);
 	      TRootAvSigCorss();
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
 
       //-------------------------- Expectation values of the expectation values of the samples (pedestals)
       //       1   fMatHis(1,StexEcha)         (16)  cTypPed                1*(   1,1700) =      1 700
@@ -3423,9 +3423,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
 
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3437,10 +3437,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatMat.ReSet(1,1);
 	      TRootPed();
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
                   
       //-------------------------- Expectation values of the sigmas the samples
       //       1   fMatHis(1,StexEcha)         (17)  cTypTno               1*(   1,1700) =      1 700
@@ -3455,9 +3455,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
 
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3469,10 +3469,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatMat.ReSet(1,1);
 	      TRootTno();
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
                                      
       //-------------------------- Expectation values of the correlations between the samples
       //       1   fMatHis(1,StexEcha)         (10)  cTypMeanCorss            1*(   1,1700) =      1 700
@@ -3487,9 +3487,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
 
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3501,10 +3501,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatMat.ReSet(1,1);
 	      TRootMeanCorss();
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	} 
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
       
       //-------------------------- Sigmas of the expectation values of the samples  
       //       1   fMatHis(1,StexEcha)         (18)  cTypLfn               1*(   1,1700) =      1 700
@@ -3519,9 +3519,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
 
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3533,10 +3533,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatMat.ReSet(1,1);
 	      TRootLfn();
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	} 
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
       
       //-------------------------- Sigmas of the sigmas of the samples  
       //       1   fMatHis(1,StexEcha)         (19)  cTypHfn              1*(   1,1700) =      1 700
@@ -3551,9 +3551,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
 
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
  
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3565,10 +3565,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatMat.ReSet(1,1);
 	      TRootHfn();
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
                     
       //-------------------------- Sigmas of the correlations between the samples  
       //       1   fMatHis(1,StexEcha)         (11)  cTypSigCorss           1*(   1,1700) =      1 700
@@ -3583,9 +3583,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
 
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
    
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3597,10 +3597,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatMat.ReSet(1,1);
 	      TRootSigCorss();
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
 
       //----- Mean Covariances between StexEchas (averaged over samples) for all (Stin_X,Stin_Y)
       //       1   fMatMat(Stin,Stin)       (23)  cTypLFccMoStins         1*(  68,  68) =      4 624
@@ -3615,9 +3615,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
  
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3629,10 +3629,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatHis.ReSet(1,1);
 	      TRootLFccMoStins();
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	} 
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
             
       //----- Mean Correlations between StexEchas (averaged over samples) for all (Stin_X,Stin_Y)
       //       1   fMatMat(Stin,Stin)       (24)  cTypHFccMoStins         1*(  68,  68) =      4 624
@@ -3647,9 +3647,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
  
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3661,10 +3661,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatHis.ReSet(1,1);
 	      TRootHFccMoStins();
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
       
       //-------------------------- Numbers of found events (NbOfEvts)
       //       1   fMatHis(StexEcha, sample)   (15)  cTypNbOfEvts       1*(1700,  10) =     17 000
@@ -3679,9 +3679,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
  
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3693,10 +3693,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatMat.ReSet(1,1);
 	      TRootNbOfEvts(argNbSampWrite);
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
                   
       //-------------------------- Expectation values of the samples
       //       1   fMatHis(StexEcha, sample)   ( 1)  cTypMSp                  1*(1700,  10) =     17 000
@@ -3711,9 +3711,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
  
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3725,10 +3725,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatMat.ReSet(1,1);
 	      TRootMSp(argNbSampWrite);
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
       
       //-------------------------- Sigmas of the samples     
       //       1   fMatHis(StexEcha, sample)   ( 2)  cTypSSp                 1*(1700,  10) =     17 000
@@ -3743,9 +3743,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
  
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3757,10 +3757,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatMat.ReSet(1,1);
 	      TRootSSp(argNbSampWrite);
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
 
       //-------------------------- Covariances between samples
 
@@ -3776,9 +3776,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
  
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i0StexEcha = 0; i0StexEcha < v_nb_times; i0StexEcha++)
 	{
@@ -3791,10 +3791,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      TRootCovCss(i0StexEcha, argNbSampWrite);
 	      gCnaRootFile->fCnaResultsTree->Fill();
 	      if( i0StexEcha == 0  && fFlagPrint == fCodePrintAllComments)
-		{cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+		{std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
       
       //-------------------------- Correlations between samples   
       // StexEcha   fMatMat(sample,  sample)   ( 9)  cTypCorCss           1700*(  10,  10) =    170 000
@@ -3809,9 +3809,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
 
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
  
       for (Int_t i0StexEcha = 0; i0StexEcha < v_nb_times; i0StexEcha++)
 	{
@@ -3824,10 +3824,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      TRootCorCss(i0StexEcha, argNbSampWrite);
 	      gCnaRootFile->fCnaResultsTree->Fill();
 	      if( i0StexEcha == 0  && fFlagPrint == fCodePrintAllComments)
-		{cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+		{std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }	  
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
 
       //-------------------------- Samples as a function of event = events distributions
       // StexEcha   fMatHis(sample,  bins)     (20)  cTypAdcEvt,        1700*(  10, 150) =  2 550 000
@@ -3842,9 +3842,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
  
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i0StexEcha = 0; i0StexEcha < v_nb_times; i0StexEcha++)
 	{
@@ -3857,10 +3857,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      TRootAdcEvt(i0StexEcha, argNbSampWrite);
 	      gCnaRootFile->fCnaResultsTree->Fill();
 	      if( i0StexEcha == 0  && fFlagPrint == fCodePrintAllComments )
-		{cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+		{std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
 
       //-------------------------- Low Frequency Covariances between StexEchas
       //  sample   fMatMat(StexEcha, StexEcha)  (21)  cTypLfCov           1*(1700,1700) =  2 890 000
@@ -3875,9 +3875,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
  
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i = 0; i < v_nb_times; i++)
 	{      //=================================== Record type EB
@@ -3889,10 +3889,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatHis.ReSet(1,1);
 	      TRootLfCov();
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
       
       //-------------------------- Low Frequency Correlations between StexEchas
       //  sample   fMatMat(StexEcha, StexEcha)  (22)  cTypLfCor           1*(1700,1700) =  2 890 000
@@ -3907,9 +3907,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
 
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3921,10 +3921,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatHis.ReSet(1,1);
 	      TRootLfCor();
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
 
       //-------------------------- High Frequency Covariances between StexEchas
       //  sample   fMatMat(StexEcha, StexEcha)  (6)  cTypHfCov           1*(1700,1700) =  2 890 000
@@ -3939,9 +3939,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
  
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3953,10 +3953,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatHis.ReSet(1,1);
 	      TRootHfCov();
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
       
       //-------------------------- High Frequency Correlations between StexEchas
       //  sample   fMatMat(StexEcha, StexEcha)  (7)  cTypHfCor           1*(1700,1700) =  2 890 000
@@ -3971,9 +3971,9 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
       v_tot     += v_size;
 
       if(fFlagPrint == fCodePrintAllComments){
-      cout << "*TEcnaRun::WriteRootFile(...)> " << setw(18) << typ_name << ": " << setw(4) << v_nb_times
-	   << " * ("  << setw(4) << v_dim_one << ","  << setw(4) << v_dim_two  << ") = "
-	   << setw(9) << v_size;}
+      std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(18) << typ_name << ": " << std::setw(4) << v_nb_times
+	   << " * ("  << std::setw(4) << v_dim_one << ","  << std::setw(4) << v_dim_two  << ") = "
+	   << std::setw(9) << v_size;}
 
       for (Int_t i = 0; i < v_nb_times; i++)
 	{
@@ -3985,10 +3985,10 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 	      gCnaRootFile->fCnaIndivResult->fMatHis.ReSet(1,1);
 	      TRootHfCor();
 	      gCnaRootFile->fCnaResultsTree->Fill();
-	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
+	      if( i == 0 && fFlagPrint == fCodePrintAllComments ){std::cout << " => WRITTEN ON FILE "; v_tot_writ += v_size;}
 	    }
 	}
-      if(fFlagPrint == fCodePrintAllComments){cout << endl;}
+      if(fFlagPrint == fCodePrintAllComments){std::cout << std::endl;}
 
       //---------------------------------------------- WRITING 
       //...................................... file 
@@ -3998,14 +3998,14 @@ Bool_t TEcnaRun::WriteRootFile(const Text_t* name, Int_t& argNbSampWrite)
 
       //...................................... status message
       if(fFlagPrint == fCodePrintAllComments){
-	cout << "*TEcnaRun::WriteRootFile(...)> " << setw(20) << "TOTAL: "
-	     << setw(21) << "CALCULATED = " << setw(9) <<  v_tot
-	     << " => WRITTEN ON FILE = "    << setw(9) << v_tot_writ << endl;}
+	std::cout << "*TEcnaRun::WriteRootFile(...)> " << std::setw(20) << "TOTAL: "
+	     << std::setw(21) << "CALCULATED = " << std::setw(9) <<  v_tot
+	     << " => WRITTEN ON FILE = "    << std::setw(9) << v_tot_writ << std::endl;}
 
       if(fFlagPrint == fCodePrintAllComments){
-	cout << "*TEcnaRun::WriteRootFile(...)> Write OK in file " << file_name << " in directory:" << endl
+	std::cout << "*TEcnaRun::WriteRootFile(...)> Write OK in file " << file_name << " in directory:" << std::endl
 	     << "                           " << fCnaParPaths->ResultsRootFilePath().Data()
-	     << endl;}
+	     << std::endl;}
 
       ok_write = kTRUE;
 
@@ -4530,7 +4530,7 @@ void TEcnaRun::PrintComments()
 // Set flags to authorize printing of some comments concerning initialisations (default)
 
   fFlagPrint = fCodePrintComments;
-  cout << "*TEcnaRun::PrintComments()> Warnings and some comments on init will be printed" << endl;
+  std::cout << "*TEcnaRun::PrintComments()> Warnings and some comments on init will be printed" << std::endl;
 }
 
 void TEcnaRun::PrintWarnings()
@@ -4538,7 +4538,7 @@ void TEcnaRun::PrintWarnings()
 // Set flags to authorize printing of warnings
 
   fFlagPrint = fCodePrintWarnings;
-  cout << "*TEcnaRun::PrintWarnings()> Warnings will be printed" << endl;
+  std::cout << "*TEcnaRun::PrintWarnings()> Warnings will be printed" << std::endl;
 }
 
 void TEcnaRun::PrintAllComments()
@@ -4546,7 +4546,7 @@ void TEcnaRun::PrintAllComments()
 // Set flags to authorize printing of the comments of all the methods
 
   fFlagPrint = fCodePrintAllComments;
-  cout << "*TEcnaRun::PrintAllComments()> All the comments will be printed" << endl;
+  std::cout << "*TEcnaRun::PrintAllComments()> All the comments will be printed" << std::endl;
 }
 
 void  TEcnaRun::PrintNoComment()

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaWrite.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/src/TEcnaWrite.cc
@@ -23,7 +23,7 @@ ClassImp(TEcnaWrite)
   //if (fCnaParPaths   != 0){delete fCnaParPaths;   fCdelete++;}
   //if (fCnaParCout    != 0){delete fCnaParCout;    fCdelete++;}
   
-  // cout << "[Info Management] CLASS: TEcnaWrite.         DESTROY OBJECT: this = " << this << endl;
+  // std::cout << "[Info Management] CLASS: TEcnaWrite.         DESTROY OBJECT: this = " << this << std::endl;
 }
 
 //===================================================================
@@ -34,14 +34,14 @@ ClassImp(TEcnaWrite)
 TEcnaWrite::TEcnaWrite()
 {
 
- // cout << "[Info Management] CLASS: TEcnaWrite.         CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaWrite.         CREATE OBJECT: this = " << this << std::endl;
 
   Init();
 }
 
 TEcnaWrite::TEcnaWrite(TEcnaObject* pObjectManager, const TString& SubDet)
 {
- // cout << "[Info Management] CLASS: TEcnaWrite.         CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaWrite.         CREATE OBJECT: this = " << this << std::endl;
 
   Init();
   Long_t i_this = (Long_t)this;
@@ -95,7 +95,7 @@ TEcnaWrite::TEcnaWrite(const TString& SubDet,
 		       const TEcnaNumbering* pEcalNumbering)
 {
 
- // cout << "[Info Management] CLASS: TEcnaWrite.         CREATE OBJECT: this = " << this << endl;
+ // std::cout << "[Info Management] CLASS: TEcnaWrite.         CREATE OBJECT: this = " << this << std::endl;
 
   Init();
 
@@ -455,52 +455,52 @@ Int_t TEcnaWrite::NumberOfEventsAnalysis(Int_t*       ArrayNbOfEvts, const Int_t
     {
       if( MaxArray == fEcal->MaxCrysInSM() )  // (EB)
 	{
-	  cout << "!TEcnaWrite::NumberOfEventsAnalysis()> *** WARNING *** "
+	  std::cout << "!TEcnaWrite::NumberOfEventsAnalysis()> *** WARNING *** "
 	       << EmptyChannel << " empty channels detected in SM " << StexNumber
-	       << " (EB " << fEcalNumbering->PlusMinusSMNumber(StexNumber) << ")" << endl;
+	       << " (EB " << fEcalNumbering->PlusMinusSMNumber(StexNumber) << ")" << std::endl;
 	}
       if( MaxArray == fEcal->MaxCrysEcnaInDee() )  // (EE)
 	{
 	  EmptyChannel -= fEcal->EmptyChannelsInDeeMatrixIncompleteSCIncluded();
 	  if( EmptyChannel > 0 )
 	    {
-	      cout << "!TEcnaWrite::NumberOfEventsAnalysis()> *** WARNING *** "
-		   << EmptyChannel << " empty channels detected in Dee " << StexNumber << endl;
+	      std::cout << "!TEcnaWrite::NumberOfEventsAnalysis()> *** WARNING *** "
+		   << EmptyChannel << " empty channels detected in Dee " << StexNumber << std::endl;
 	    }
 	}
     }
 
   if( DifferentMinusValue > 0 || DifferentPlusValue > 0 )
     {
-      cout << "!TEcnaWrite::NumberOfEventsAnalysis()> " << endl;
+      std::cout << "!TEcnaWrite::NumberOfEventsAnalysis()> " << std::endl;
 
       if( MaxArray == fEcal->MaxCrysInSM() )  // (EB)
 	{
-	  cout << "************** W A R N I N G  :  NUMBER OF EVENTS NOT CONSTANT FOR SM " << StexNumber
+	  std::cout << "************** W A R N I N G  :  NUMBER OF EVENTS NOT CONSTANT FOR SM " << StexNumber
 	       << " (EB " << fEcalNumbering->PlusMinusSMNumber(StexNumber) << ")  *********************";
 	}
 
       if( MaxArray == fEcal->MaxCrysEcnaInDee() )  // (EE)
 	{
-	  cout << "****************** W A R N I N G  :  NUMBER OF EVENTS NOT CONSTANT FOR Dee " << StexNumber
+	  std::cout << "****************** W A R N I N G  :  NUMBER OF EVENTS NOT CONSTANT FOR Dee " << StexNumber
 	       << " **************************";
 	}
 
-      cout << endl
-	   << "  Result ROOT file: " << fRootFileName << endl
-	   << "  The number of events is not the same for all the non-empty channels." << endl	   
+      std::cout << std::endl
+	   << "  Result ROOT file: " << fRootFileName << std::endl
+	   << "  The number of events is not the same for all the non-empty channels." << std::endl	   
 	   << "  The maximum number (" << rNumberOfEvents << ") is considered as the number of events for calculations "
-	   << endl	
-	   << "  of pedestals, noises and correlations." << endl
+	   << std::endl	
+	   << "  of pedestals, noises and correlations." << std::endl
 	   << "  Number of channels with 0 < nb of evts < " << rNumberOfEvents << " : " << DifferentMinusValue
-	   << endl
-	// << "  Number of channels with nb of evts > " << rNumberOfEvents << " = " << DifferentPlusValue  << endl
-	   << "  Number of empty channels : " << EmptyChannel << endl
-	   << "  Some values of pedestals, noises and correlations may be wrong for channels" << endl
-	   << "  with number of events different from " << rNumberOfEvents << "." << endl
-	   << "  Please, check the histogram 'Numbers of events'." << endl
+	   << std::endl
+	// << "  Number of channels with nb of evts > " << rNumberOfEvents << " = " << DifferentPlusValue  << std::endl
+	   << "  Number of empty channels : " << EmptyChannel << std::endl
+	   << "  Some values of pedestals, noises and correlations may be wrong for channels" << std::endl
+	   << "  with number of events different from " << rNumberOfEvents << "." << std::endl
+	   << "  Please, check the histogram 'Numbers of events'." << std::endl
 	   << "*******************************************************************************************************"
-	   << endl;
+	   << std::endl;
     }
   else
     {
@@ -508,8 +508,8 @@ Int_t TEcnaWrite::NumberOfEventsAnalysis(Int_t*       ArrayNbOfEvts, const Int_t
 	{
 	  if( rNumberOfEvents < NbOfReqEvts )
 	    {
-	      cout << "*TEcnaWrite::NumberOfEventsAnalysis()> *** INFO *** Number of events found in data = "
-		   << rNumberOfEvents << ": less than number of requested events ( = " << NbOfReqEvts << ")" << endl;
+	      std::cout << "*TEcnaWrite::NumberOfEventsAnalysis()> *** INFO *** Number of events found in data = "
+		   << rNumberOfEvents << ": less than number of requested events ( = " << NbOfReqEvts << ")" << std::endl;
 	    }
 	}
     }
@@ -562,21 +562,21 @@ Int_t TEcnaWrite::NumberOfEventsAnalysis(Int_t**      T2d_NbOfEvts,   const Int_
 
   if( DifferentMinusValue > 0 || DifferentPlusValue > 0 )
     {
-      cout << "!TEcnaWrite::NumberOfEventsAnalysis()> " << endl
+      std::cout << "!TEcnaWrite::NumberOfEventsAnalysis()> " << std::endl
 	   << "****************** W A R N I N G  :  NUMBER OF EVENTS NOT CONSTANT !  *********************************"
-	   << endl
-	   << "  Result ROOT file: " << fRootFileName << endl
-	   << "  The number of events is not the same for all the non-empty channels" << endl	   
-	   << "  The maximum number (" << rNumberOfEvents << ") is considered as the number of events " << endl	
-	   << "  for calculations of pedestals, noises and correlations." << endl
-	   << "  Number of channels with 0 < nb of evts < " << rNumberOfEvents << " : " << DifferentMinusValue << endl
-	// << "  Number of channels with nb of evts > " << rNumberOfEvents << " : " << DifferentPlusValue  << endl
-	// << "  Number of empty channels : " << EmptyChannel << endl
-	   << "  Some values of pedestals, noises and correlations may be wrong for channels" << endl
-	   << "  with number of events different from " << rNumberOfEvents << "." << endl
-	   << "  Please, check the histogram 'Numbers of events'." << endl
+	   << std::endl
+	   << "  Result ROOT file: " << fRootFileName << std::endl
+	   << "  The number of events is not the same for all the non-empty channels" << std::endl	   
+	   << "  The maximum number (" << rNumberOfEvents << ") is considered as the number of events " << std::endl	
+	   << "  for calculations of pedestals, noises and correlations." << std::endl
+	   << "  Number of channels with 0 < nb of evts < " << rNumberOfEvents << " : " << DifferentMinusValue << std::endl
+	// << "  Number of channels with nb of evts > " << rNumberOfEvents << " : " << DifferentPlusValue  << std::endl
+	// << "  Number of empty channels : " << EmptyChannel << std::endl
+	   << "  Some values of pedestals, noises and correlations may be wrong for channels" << std::endl
+	   << "  with number of events different from " << rNumberOfEvents << "." << std::endl
+	   << "  Please, check the histogram 'Numbers of events'." << std::endl
 	   << "*******************************************************************************************************"
-	   << endl;
+	   << std::endl;
     }
   else
     {
@@ -584,8 +584,8 @@ Int_t TEcnaWrite::NumberOfEventsAnalysis(Int_t**      T2d_NbOfEvts,   const Int_
 	{
 	  if( rNumberOfEvents < NbOfReqEvts )
 	    {
-	      cout << "*TEcnaWrite::NumberOfEventsAnalysis()> *** INFO *** Number of events found in data = "
-		   << rNumberOfEvents << ": less than number of requested events ( = " << NbOfReqEvts << ")" << endl;
+	      std::cout << "*TEcnaWrite::NumberOfEventsAnalysis()> *** INFO *** Number of events found in data = "
+		   << rNumberOfEvents << ": less than number of requested events ( = " << NbOfReqEvts << ")" << std::endl;
 	    }
 	}
     }
@@ -690,15 +690,15 @@ void TEcnaWrite::fMakeResultsFileName(const Int_t&  i_code)
     {
       if( fCnaParPaths->ResultsRootFilePath().Data() == sPointInterrog.Data() )
 	{
-	  cout << "!TEcnaWrite::fMakeResultsFileName>  * * * W A R N I N G * * * " << endl << endl
-	       << "    Path for results .root file not defined. Default option will be used here:" << endl
-	       << "    your results files will be written in your HOME directory." << endl << endl
-	       << "    In order to write the .root results file in a specific directory," << endl
-               << "    you have to create a file named path_results_root in a subdirectory named ECNA" << endl
-	       << "    previously created in your home directory." << endl 
-	       << "    This file must have only one line containing the path of the directory" << endl 
-	       << "    where must be the .root result files." << endl
-	       << endl;
+	  std::cout << "!TEcnaWrite::fMakeResultsFileName>  * * * W A R N I N G * * * " << std::endl << std::endl
+	       << "    Path for results .root file not defined. Default option will be used here:" << std::endl
+	       << "    your results files will be written in your HOME directory." << std::endl << std::endl
+	       << "    In order to write the .root results file in a specific directory," << std::endl
+               << "    you have to create a file named path_results_root in a subdirectory named ECNA" << std::endl
+	       << "    previously created in your home directory." << std::endl 
+	       << "    This file must have only one line containing the path of the directory" << std::endl 
+	       << "    where must be the .root result files." << std::endl
+	       << std::endl;
 
 	  TString home_path = gSystem->Getenv("HOME");
 	  fCnaParPaths->SetResultsRootFilePath(home_path.Data());  
@@ -730,15 +730,15 @@ void TEcnaWrite::fMakeResultsFileName(const Int_t&  i_code)
 	{
 	  if( fCnaParPaths->ResultsAsciiFilePath().Data() == sPointInterrog.Data() )
 	    {
-	      cout << "!TEcnaWrite::fMakeResultsFileName>  * * * W A R N I N G * * * " << endl << endl
-		   << "    Path for results .ascii file not defined. Default option will be used here:" << endl
-		   << "    your results files will be written in your HOME directory." << endl << endl
-		   << "    In order to write the .ascii results file in a specific directory," << endl
-		   << "    you have to create a file named path_results_ascii in a subdirectory named ECNA" << endl
-		   << "    previously created in your home directory." << endl 
-		   << "    This file must have only one line containing the path of the directory" << endl 
-		   << "    where must be the .ascii result files." << endl
-		   << endl;
+	      std::cout << "!TEcnaWrite::fMakeResultsFileName>  * * * W A R N I N G * * * " << std::endl << std::endl
+		   << "    Path for results .ascii file not defined. Default option will be used here:" << std::endl
+		   << "    your results files will be written in your HOME directory." << std::endl << std::endl
+		   << "    In order to write the .ascii results file in a specific directory," << std::endl
+		   << "    you have to create a file named path_results_ascii in a subdirectory named ECNA" << std::endl
+		   << "    previously created in your home directory." << std::endl 
+		   << "    This file must have only one line containing the path of the directory" << std::endl 
+		   << "    where must be the .ascii result files." << std::endl
+		   << std::endl;
 	      
 	      TString home_path = gSystem->Getenv("HOME");
 	      fCnaParPaths->SetResultsAsciiFilePath(home_path.Data());  
@@ -945,8 +945,8 @@ void TEcnaWrite::fMakeResultsFileName(const Int_t&  i_code)
   //----------------------------------------------------------- (fMakeResultsFileName)
 
   // default:
-  //    cout << "*TEcnaWrite::fMakeResultsFileName(const Int_t&  i_code)> "
-  //	 << "wrong header code , i_code = " << i_code << endl; 
+  //    std::cout << "*TEcnaWrite::fMakeResultsFileName(const Int_t&  i_code)> "
+  //	 << "wrong header code , i_code = " << i_code << std::endl; 
   //  }
 
   //======================================= f_name
@@ -986,9 +986,9 @@ void TEcnaWrite::fMakeResultsFileName(const Int_t&  i_code)
     }
   else
     {
-      cout << "*TEcnaWrite::fMakeResultsFileName(...)> Name too long (for f_name)."
+      std::cout << "*TEcnaWrite::fMakeResultsFileName(...)> Name too long (for f_name)."
 	   << " No room enough for the extension. (ii = " << ii << ")"
-	   << fTTBELL << endl; 
+	   << fTTBELL << std::endl; 
     }
 
 
@@ -1030,9 +1030,9 @@ void TEcnaWrite::fMakeResultsFileName(const Int_t&  i_code)
     }
   else
     {
-      cout << "*TEcnaWrite::fMakeResultsFileName(...)> Name too long (for f_name_short)."
+      std::cout << "*TEcnaWrite::fMakeResultsFileName(...)> Name too long (for f_name_short)."
 	   << " No room enough for the extension. (ii = " << ii << ")"
-	   << fTTBELL  << endl; 
+	   << fTTBELL  << std::endl; 
     }
     delete [] f_name;        f_name       = 0;         fCdelete++;
     delete [] f_name_short;  f_name_short = 0;         fCdelete++;
@@ -1074,20 +1074,20 @@ void TEcnaWrite::fAsciiFileWriteHeader(const Int_t&  i_code)
   fFcout_f.open(fAsciiFileName.Data());
 
   fFcout_f << "*** File: " << fAsciiFileName
-	   << " *** " << endl << endl;
-  fFcout_f << "*Analysis name                : " << fAnaType       << endl;
-  fFcout_f << "*First-Last samples           : 1 - " << fNbOfSamples   << endl; 
-  fFcout_f << "*Run number                   : " << fRunNumber     << endl;
-  fFcout_f << "*First requested event number : " << fFirstReqEvtNumber << endl;
-  fFcout_f << "*Last  requested event number : " << fLastReqEvtNumber << endl;
-  fFcout_f << "*Requested number of events   : " << fReqNbOfEvts << endl;
+	   << " *** " << std::endl << std::endl;
+  fFcout_f << "*Analysis name                : " << fAnaType       << std::endl;
+  fFcout_f << "*First-Last samples           : 1 - " << fNbOfSamples   << std::endl; 
+  fFcout_f << "*Run number                   : " << fRunNumber     << std::endl;
+  fFcout_f << "*First requested event number : " << fFirstReqEvtNumber << std::endl;
+  fFcout_f << "*Last  requested event number : " << fLastReqEvtNumber << std::endl;
+  fFcout_f << "*Requested number of events   : " << fReqNbOfEvts << std::endl;
   if( fFlagSubDet == "EB" )
-    {fFcout_f << "*SuperModule number           : " << fStexNumber   << endl;}
+    {fFcout_f << "*SuperModule number           : " << fStexNumber   << std::endl;}
   if( fFlagSubDet == "EE" )
-    {fFcout_f << "*Dee number                   : " << fStexNumber   << endl;}
+    {fFcout_f << "*Dee number                   : " << fStexNumber   << std::endl;}
   fFcout_f << "*Date first requested event   : " << fStartDate;
-  fFcout_f << "*Date last requested event    : " << fStopDate      << endl;
-  fFcout_f << endl;
+  fFcout_f << "*Date last requested event    : " << fStopDate      << std::endl;
+  fFcout_f << std::endl;
 
   //========================================================================= 
   //   closing of the results file if i_code = fCodeHeaderAscii only.
@@ -1207,19 +1207,19 @@ void TEcnaWrite::WriteAsciiHisto(const TString& HistoCode, const Int_t& HisSize,
   fAsciiFileWriteHeader(i_code);   // => Open of the file associated with stream fFcout_f
 
   //..................................... format numerical values
-  fFcout_f << setiosflags(ios::showpoint | ios::uppercase);
-  fFcout_f << setprecision(3) << setw(6);
-  fFcout_f.setf(ios::dec, ios::basefield);
-  fFcout_f.setf(ios::fixed, ios::floatfield);
-  fFcout_f.setf(ios::left, ios::adjustfield);
-  fFcout_f.setf(ios::right, ios::adjustfield);
+  fFcout_f << std::setiosflags(std::ios::showpoint | std::ios::uppercase);
+  fFcout_f << std::setprecision(3) << std::setw(6);
+  fFcout_f.setf(std::ios::dec, std::ios::basefield);
+  fFcout_f.setf(std::ios::fixed, std::ios::floatfield);
+  fFcout_f.setf(std::ios::left, std::ios::adjustfield);
+  fFcout_f.setf(std::ios::right, std::ios::adjustfield);
   
-  cout << setiosflags(ios::showpoint | ios::uppercase);
-  cout << setprecision(3) << setw(6);
-  cout.setf(ios::dec, ios::basefield);
-  cout.setf(ios::fixed, ios::floatfield);
-  cout.setf(ios::left, ios::adjustfield);
-  cout.setf(ios::right, ios::adjustfield);
+  std::cout << std::setiosflags(std::ios::showpoint | std::ios::uppercase);
+  std::cout << std::setprecision(3) << std::setw(6);
+  std::cout.setf(std::ios::dec, std::ios::basefield);
+  std::cout.setf(std::ios::fixed, std::ios::floatfield);
+  std::cout.setf(std::ios::left, std::ios::adjustfield);
+  std::cout.setf(std::ios::right, std::ios::adjustfield);
 
   //........................................................ WriteAsciiHisto
   TString aStexName;
@@ -1324,7 +1324,7 @@ void TEcnaWrite::WriteAsciiHisto(const TString& HistoCode, const Int_t& HisSize,
 	      if( HistoCode == "D_HFN_ChNb" ){aSpecif1 = "  High Fq"; aSpecif2 = "   noise     ";}
 	      if( HistoCode == "D_SCs_ChNb" ){aSpecif1 = " Sigma of"; aSpecif2 = "   cor(s,s)  ";}
 	      
-	      fFcout_f << endl;
+	      fFcout_f << std::endl;
 	  
 	      fFcout_f << aSpecifa.Data()
 		       << "  " << aStinName.Data() << "#   "
@@ -1332,7 +1332,7 @@ void TEcnaWrite::WriteAsciiHisto(const TString& HistoCode, const Int_t& HisSize,
 		       << aSpecifd.Data()
 		       << aHoco.Data()
 		       << aVeco.Data()
-		       << aSpecif1.Data() << endl;
+		       << aSpecif1.Data() << std::endl;
 	  
 	      fFcout_f << "  in " << aStexName.Data()
 		       << "  in " << aStexName.Data()
@@ -1340,43 +1340,43 @@ void TEcnaWrite::WriteAsciiHisto(const TString& HistoCode, const Int_t& HisSize,
 		       << "  in " << aSpecife.Data()
 		       << "  in " << aStexName.Data()
 		       << "  in " << aStexName.Data()
-		       << aSpecif2.Data()  << endl << endl;
+		       << aSpecif2.Data()  << std::endl << std::endl;
 	    }
  
 	  Double_t value = read_histo(i0StexEcha);
 
 	  if( fFlagSubDet == "EB" )
 	    {
-	      fFcout_f  << setw(7)  << i0StexEcha
-			<< setw(8)  << n1StexStin
-			<< setw(11) << i0StinEcha   // (Electronic channel number in tower)
-			<< setw(10) << n1StexCrys
-			<< setw(10) << (Int_t)fEcalNumbering->GetEta(fStexNumber, StexStinEcna, i0StinEcha)
-			<< setw(10) << (Int_t)fEcalNumbering->GetPhiInSM(fStexNumber, StexStinEcna, i0StinEcha);
+	      fFcout_f  << std::setw(7)  << i0StexEcha
+			<< std::setw(8)  << n1StexStin
+			<< std::setw(11) << i0StinEcha   // (Electronic channel number in tower)
+			<< std::setw(10) << n1StexCrys
+			<< std::setw(10) << (Int_t)fEcalNumbering->GetEta(fStexNumber, StexStinEcna, i0StinEcha)
+			<< std::setw(10) << (Int_t)fEcalNumbering->GetPhiInSM(fStexNumber, StexStinEcna, i0StinEcha);
 	    }
 	  if( fFlagSubDet == "EE" )
 	    {
 	      Int_t n1StinEcha_m = n1StinEcha-1;
-	      fFcout_f  << setw(7)  << n1DataSector
-			<< setw(8)  << n1StexStin
-			<< setw(11) << n1StinEcha   // (Xtal number for construction in SC)
-			<< setw(10) << n1SCinDS
-			<< setw(10) << fEcalNumbering->GetIXCrysInDee(fStexNumber, StexStinEcna, n1StinEcha_m)
-			<< setw(10) << fEcalNumbering->GetJYCrysInDee(fStexNumber, StexStinEcna, n1StinEcha_m);
+	      fFcout_f  << std::setw(7)  << n1DataSector
+			<< std::setw(8)  << n1StexStin
+			<< std::setw(11) << n1StinEcha   // (Xtal number for construction in SC)
+			<< std::setw(10) << n1SCinDS
+			<< std::setw(10) << fEcalNumbering->GetIXCrysInDee(fStexNumber, StexStinEcna, n1StinEcha_m)
+			<< std::setw(10) << fEcalNumbering->GetJYCrysInDee(fStexNumber, StexStinEcna, n1StinEcha_m);
 	    }
 
 	  if( HistoCode == "D_NOE_ChNb")
 	    {
 	      Int_t ivalue = (Int_t)value;
-	      fFcout_f 	<< setw(13) << ivalue;
-	      fFcout_f 	<< setw(4) << "(" << setw(6) << fReqNbOfEvts << ")";
+	      fFcout_f 	<< std::setw(13) << ivalue;
+	      fFcout_f 	<< std::setw(4) << "(" << std::setw(6) << fReqNbOfEvts << ")";
 	    }
 	  else
 	    {
-	      fFcout_f  << setw(13) << value;
+	      fFcout_f  << std::setw(13) << value;
 	    }
 
-	  fFcout_f  << endl;
+	  fFcout_f  << std::endl;
 	}
     } // end of loop:  for (Int_t i0StexEcha=0; i0StexEcha<HisSize; i0StexEcha++)
 
@@ -1384,9 +1384,9 @@ void TEcnaWrite::WriteAsciiHisto(const TString& HistoCode, const Int_t& HisSize,
   
   // if(fFlagPrint != fCodePrintNoComment)
   // {
-      cout << "*TEcnaWrite::WriteAsciiHisto(...)> INFO: "
-	   << "histo has been written in file: " << endl
-	   << "            " << fAsciiFileName.Data() << endl;
+      std::cout << "*TEcnaWrite::WriteAsciiHisto(...)> INFO: "
+	   << "histo has been written in file: " << std::endl
+	   << "            " << fAsciiFileName.Data() << std::endl;
       // }
 } // end of TEcnaWrite::WriteAsciiHisto
 
@@ -1479,19 +1479,19 @@ void  TEcnaWrite::fT2dWriteAscii(const Int_t&    i_code,
   
   //------------ formatage des nombres en faisant appel a la classe ios
   
-  fFcout_f << setiosflags(ios::showpoint | ios::uppercase);
-  fFcout_f.setf(ios::dec, ios::basefield);
-  fFcout_f.setf(ios::fixed, ios::floatfield);
-  fFcout_f.setf(ios::left, ios::adjustfield);
-  fFcout_f.setf(ios::right, ios::adjustfield);
-  fFcout_f << setprecision(3) << setw(6);
+  fFcout_f << std::setiosflags(std::ios::showpoint | std::ios::uppercase);
+  fFcout_f.setf(std::ios::dec, std::ios::basefield);
+  fFcout_f.setf(std::ios::fixed, std::ios::floatfield);
+  fFcout_f.setf(std::ios::left, std::ios::adjustfield);
+  fFcout_f.setf(std::ios::right, std::ios::adjustfield);
+  fFcout_f << std::setprecision(3) << std::setw(6);
   
-  cout << setiosflags(ios::showpoint | ios::uppercase);
-  cout.setf(ios::dec, ios::basefield);
-  cout.setf(ios::fixed, ios::floatfield);
-  cout.setf(ios::left, ios::adjustfield);
-  cout.setf(ios::right, ios::adjustfield);
-  cout << setprecision(3) << setw(6);  
+  std::cout << std::setiosflags(std::ios::showpoint | std::ios::uppercase);
+  std::cout.setf(std::ios::dec, std::ios::basefield);
+  std::cout.setf(std::ios::fixed, std::ios::floatfield);
+  std::cout.setf(std::ios::left, std::ios::adjustfield);
+  std::cout.setf(std::ios::right, std::ios::adjustfield);
+  std::cout << std::setprecision(3) << std::setw(6);  
 
   //--------------------- fin du formatage standard C++ -------------------
 
@@ -1726,7 +1726,7 @@ void  TEcnaWrite::fT2dWriteAscii(const Int_t&    i_code,
       isy_max = justap_samp;
     }
   
-  fFcout_f << endl;
+  fFcout_f << std::endl;
 
   //............... Calcul des nombres de secteurs selon x
   //                i_pasx  = taille secteur en x 
@@ -1767,11 +1767,11 @@ void  TEcnaWrite::fT2dWriteAscii(const Int_t&    i_code,
     {
       fFcout_f << "sector size = " << fSectChanSizeX 
 	       << " , number of sectors = " << n_sctx << " x " << n_scty
-	       << endl;
+	       << std::endl;
     }
 #endif // NBSC
 
-  fFcout_f << endl;
+  fFcout_f << std::endl;
 
   //............... impression matrice par secteurs i_pas x i_pas  
   //........................... boucles pour display des secteurs 
@@ -1808,7 +1808,7 @@ void  TEcnaWrite::fT2dWriteAscii(const Int_t&    i_code,
 		{fFcout_f.width(6);}
 	      fFcout_f << iy_c << "  ";
 	    }	  
-	  fFcout_f << endl << endl;
+	  fFcout_f << std::endl << std::endl;
 	  
 	  for (Int_t ix_c = ix_inf ; ix_c < ix_sup ; ix_c++)
 	    { 
@@ -1843,9 +1843,9 @@ void  TEcnaWrite::fT2dWriteAscii(const Int_t&    i_code,
 		      fFcout_f << fjustap_2d_ss[ix_c][iy_c] << "  ";
 		    }
 		}
-	      fFcout_f << endl;
+	      fFcout_f << std::endl;
 	    }
-	  fFcout_f << endl;
+	  fFcout_f << std::endl;
 	}
     }
 
@@ -1855,9 +1855,9 @@ void  TEcnaWrite::fT2dWriteAscii(const Int_t&    i_code,
   
   if(fFlagPrint != fCodePrintNoComment)
     {
-      cout << "*TEcnaWrite::fT2dWriteAscii(....)> INFO: "
-	   << "matrix has been written in file: " << endl
-	   << "            " << fAsciiFileName.Data() << endl;
+      std::cout << "*TEcnaWrite::fT2dWriteAscii(....)> INFO: "
+	   << "matrix has been written in file: " << std::endl
+	   << "            " << fAsciiFileName.Data() << std::endl;
     }
   
 }// end of TEcnaWrite::fT2dWriteAscii

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/test/EcnaCalculationsExample.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/test/EcnaCalculationsExample.cc
@@ -32,11 +32,11 @@ int main ( int argc, char **argv )
 
   TEcnaObject* myTEcnaManager = new TEcnaObject();
   
-  cout << "!EcnaCalculationsExample> CONTROLE 1" << endl;
+  std::cout << "!EcnaCalculationsExample> CONTROLE 1" << std::endl;
 
   TEcnaRun* MyRunEB = new TEcnaRun(myTEcnaManager, "EB", fKeyNbOfSamples);       xCnew++;
   
-  cout << "!EcnaCalculationsExample> CONTROLE 2" << endl;
+  std::cout << "!EcnaCalculationsExample> CONTROLE 2" << std::endl;
 
   //.............. Declarations and default values
 
@@ -75,36 +75,36 @@ int main ( int argc, char **argv )
 
       if( ok_root_file == kTRUE )
 	{
-	  cout << "*EcnaCalculationsExample> Write ROOT file OK" << endl;
+	  std::cout << "*EcnaCalculationsExample> Write ROOT file OK" << std::endl;
 	}
       else 
 	{
-	  cout << "!EcnaCalculationsExample> Writing ROOT file failure."
-	       << fTTBELL << endl;
+	  std::cout << "!EcnaCalculationsExample> Writing ROOT file failure."
+	       << fTTBELL << std::endl;
 	}
     }
   else
     {
-      cout << "!EcnaCalculationsExample> ROOT file not found."
-	   << fTTBELL << endl;
+      std::cout << "!EcnaCalculationsExample> ROOT file not found."
+	   << fTTBELL << std::endl;
     }
   //.......................................................................
 
   delete MyRunEB;                          xCdelete++;
 
-      cout << "*H4Cna(main)> End of the example."  << endl;
+      std::cout << "*H4Cna(main)> End of the example."  << std::endl;
 
   if ( xCnew != xCdelete )
     {
-      cout << "!H4Cna(main)> WRONG MANAGEMENT OF ALLOCATIONS: xCnew = "
-	   << xCnew << ", xCdelete = " << xCdelete << '\007' << endl;
+      std::cout << "!H4Cna(main)> WRONG MANAGEMENT OF ALLOCATIONS: xCnew = "
+	   << xCnew << ", xCdelete = " << xCdelete << '\007' << std::endl;
     }
   else
     {
-      //  cout << "*H4Cna(main)> BRAVO! GOOD MANAGEMENT OF ALLOCATIONS: xCnew = "
-      //      << xCnew << ", xCdelete = " << xCdelete << endl;
+      //  std::cout << "*H4Cna(main)> BRAVO! GOOD MANAGEMENT OF ALLOCATIONS: xCnew = "
+      //      << xCnew << ", xCdelete = " << xCdelete << std::endl;
     }
 
-  cout << "*EcnaCalculationsExample> Exiting main program." << endl;
+  std::cout << "*EcnaCalculationsExample> Exiting main program." << std::endl;
   exit(0);
 }

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/test/EcnaGuiEB.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/test/EcnaGuiEB.cc
@@ -34,20 +34,20 @@ int main(int argc, char **argv)
   TEcnaParPaths* pCnaParPaths = new TEcnaParPaths(MyEcnaObjectManager);
   if( pCnaParPaths->GetPaths() == kTRUE )
     {
-      cout << "*EcnaGuiEB> Starting ROOT session" << endl;
+      std::cout << "*EcnaGuiEB> Starting ROOT session" << std::endl;
       TRint theApp("App", &argc, argv);
       
-      cout << "*EcnaGuiEB> Starting ECNA session" << endl;
+      std::cout << "*EcnaGuiEB> Starting ECNA session" << std::endl;
       TEcnaGui* mainWin = new TEcnaGui(MyEcnaObjectManager, "EB", gClient->GetRoot(), 395, 710);
       mainWin->DialogBox();
       Bool_t retVal = kTRUE;
       theApp.Run(retVal);
-      cout << "*EcnaGuiEB> End of ECNA session." << endl;
+      std::cout << "*EcnaGuiEB> End of ECNA session." << std::endl;
       delete mainWin;
 
-      cout << "*EcnaGuiEB> End of ROOT session." << endl;
+      std::cout << "*EcnaGuiEB> End of ROOT session." << std::endl;
       theApp.Terminate(0);
-      cout << "*EcnaGuiEB> Exiting main program." << endl;
+      std::cout << "*EcnaGuiEB> Exiting main program." << std::endl;
       exit(0);
     }
 }

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/test/EcnaGuiEE.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/test/EcnaGuiEE.cc
@@ -34,20 +34,20 @@ int main(int argc, char **argv)
   TEcnaParPaths* pCnaParPaths = new TEcnaParPaths(MyEcnaObjectManager);
   if( pCnaParPaths->GetPaths() == kTRUE )
     {
-      cout << "*EcnaGuiEE> Starting ROOT session" << endl;
+      std::cout << "*EcnaGuiEE> Starting ROOT session" << std::endl;
       TRint theApp("App", &argc, argv);
       
-      cout << "*EcnaGuiEE> Starting ECNA session" << endl;
+      std::cout << "*EcnaGuiEE> Starting ECNA session" << std::endl;
       TEcnaGui* mainWin = new TEcnaGui(MyEcnaObjectManager, "EE", gClient->GetRoot(), 395, 710);
       mainWin->DialogBox();
       Bool_t retVal = kTRUE;
       theApp.Run(retVal);
-      cout << "*EcnaGuiEE> End of ECNA session." << endl;
+      std::cout << "*EcnaGuiEE> End of ECNA session." << std::endl;
       delete mainWin;
       
-      cout << "*EcnaGuiEE> End of ROOT session." << endl;
+      std::cout << "*EcnaGuiEE> End of ROOT session." << std::endl;
       theApp.Terminate(0);
-      cout << "*EcnaGuiEE> Exiting main program." << endl;
+      std::cout << "*EcnaGuiEE> Exiting main program." << std::endl;
       exit(0);
     }
 }

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/test/EcnaHistosExample1.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/test/EcnaHistosExample1.cc
@@ -25,7 +25,7 @@ int main ( int argc, char **argv )
 
   if( fEcnaParPathsEB->GetPaths() == kTRUE && fEcnaParPathsEE->GetPaths() == kTRUE )
     {
-      cout << "*EcnaHistosExample> Starting ROOT session" << endl;
+      std::cout << "*EcnaHistosExample> Starting ROOT session" << std::endl;
       TRint theApp("App", &argc, argv);
 
       //--------------------------------------------------------------------
@@ -109,13 +109,13 @@ int main ( int argc, char **argv )
       MyHistosEB->SetHistoMax(2.5);  MyHistosEB->SetHistoScaleY("LOG");
       //MyHistosEB->Plot1DHisto("LowFrequencyNoise", "NbOfXtals", "SM", "SAME");
 
-      cout << "*EcnaHistosExample1> *** TEST OF WRONG CODE (BEGINNING)."
-	   << " MESSAGE: < code not found > (and lists after) ARE THERE ON PURPOSE."  << endl << endl;
+      std::cout << "*EcnaHistosExample1> *** TEST OF WRONG CODE (BEGINNING)."
+	   << " MESSAGE: < code not found > (and lists after) ARE THERE ON PURPOSE."  << std::endl << std::endl;
 
       MyHistosEB->Plot1DHisto("LowFrequencyNoise", "NbOfXtal", "SM", "SAME");
-      cout << endl <<
+      std::cout << std::endl <<
         "*EcnaHistosExample1> *** TEST OF WRONG CODE (END)."
-	   << " MESSAGE: < code not found > (and lists after) WERE THERE ON PURPOSE."  << endl;
+	   << " MESSAGE: < code not found > (and lists after) WERE THERE ON PURPOSE."  << std::endl;
 
       //.................................
       fKeySuMoNumber = 4;
@@ -273,14 +273,14 @@ int main ( int argc, char **argv )
 #endif // SIGE
       //.......................................................................
 
-      cout << "*EcnaHistosExample1> End of the example. You can quit ROOT (.q)"  << endl;
+      std::cout << "*EcnaHistosExample1> End of the example. You can quit ROOT (.q)"  << std::endl;
 
       Bool_t retVal = kTRUE;
       theApp.Run(retVal);
-      cout << endl
-	   << "*EcnaHistosExample> Terminating ROOT session." << endl;
+      std::cout << std::endl
+	   << "*EcnaHistosExample> Terminating ROOT session." << std::endl;
       theApp.Terminate(0);
-      cout << "*EcnaHistosExample> Exiting main program." << endl;
+      std::cout << "*EcnaHistosExample> Exiting main program." << std::endl;
       exit(0);
 
       delete MyHistosEB;                          xCdelete++;
@@ -288,13 +288,13 @@ int main ( int argc, char **argv )
 
       if ( xCnew != xCdelete )
 	{
-	  cout << "!EcnaHistosExample1> WRONG MANAGEMENT OF ALLOCATIONS: xCnew = "
-	       << xCnew << ", xCdelete = " << xCdelete << '\007' << endl;
+	  std::cout << "!EcnaHistosExample1> WRONG MANAGEMENT OF ALLOCATIONS: xCnew = "
+	       << xCnew << ", xCdelete = " << xCdelete << '\007' << std::endl;
 	}
       else
 	{
-	  //  cout << "*EcnaHistosExample1> BRAVO! GOOD MANAGEMENT OF ALLOCATIONS: xCnew = "
-	  //      << xCnew << ", xCdelete = " << xCdelete << endl;
+	  //  std::cout << "*EcnaHistosExample1> BRAVO! GOOD MANAGEMENT OF ALLOCATIONS: xCnew = "
+	  //      << xCnew << ", xCdelete = " << xCdelete << std::endl;
 	}
     }
 }

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/test/EcnaHistosExample2.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisAlgos/test/EcnaHistosExample2.cc
@@ -32,7 +32,7 @@ int main ( int argc, char **argv )
   //                      Init
   //--------------------------------------------------------------------
   
-  cout << "*EcalCorrelatedNoiseExampleHistos> Starting ROOT session" << endl;
+  std::cout << "*EcalCorrelatedNoiseExampleHistos> Starting ROOT session" << std::endl;
   TRint theApp("App", &argc, argv);
 
   TString    fTTBELL = "\007";
@@ -116,8 +116,8 @@ int main ( int argc, char **argv )
 	}
       else
 	{
-	  cout  << "!EcnaHistosExample2> *ERROR* =====> "
-		<< " ROOT file not found" << fTTBELL << endl;
+	  std::cout  << "!EcnaHistosExample2> *ERROR* =====> "
+		<< " ROOT file not found" << fTTBELL << std::endl;
 	}
 
 #endif //  HGLO
@@ -143,8 +143,8 @@ int main ( int argc, char **argv )
 	}
       else
 	{
-	  cout  << "!EcnaHistosExample2> *ERROR* =====> "
-		<< " ROOT file not found" << fTTBELL << endl;
+	  std::cout  << "!EcnaHistosExample2> *ERROR* =====> "
+		<< " ROOT file not found" << fTTBELL << std::endl;
 	}
 #endif // HBAE 
 
@@ -168,8 +168,8 @@ int main ( int argc, char **argv )
 	}
       else
 	{
-	  cout  << "!EcnaHistosExample2> *ERROR* =====> "
-		<< " ROOT file not found" << fTTBELL << endl;
+	  std::cout  << "!EcnaHistosExample2> *ERROR* =====> "
+		<< " ROOT file not found" << fTTBELL << std::endl;
 	}
 #endif // PMCC
 
@@ -192,25 +192,25 @@ int main ( int argc, char **argv )
 
 	  MyHistosEB->FileParameters(fMyRootFileEB);
 
-	  cout << "EcnahistosExample2> *************** Plot1DHisto 1 crystal ONLYONE  ******************" << endl;
+	  std::cout << "EcnahistosExample2> *************** Plot1DHisto 1 crystal ONLYONE  ******************" << std::endl;
 	  TowEcha = 12;
 	  read_histo_2 = fMyRootFileEB->Read1DHisto(fEcalParEB->MaxCrysInTow()*fEcalParEB->MaxSampADC(),
 						    "SigmaOfSamples", SMtower);
 
-	  cout << "*EcnaHistosExample2> channel " << setw(2) << TowEcha << ": ";
+	  std::cout << "*EcnaHistosExample2> channel " << std::setw(2) << TowEcha << ": ";
 	  for( Int_t i0_samp=0; i0_samp<fEcalParEB->MaxSampADC(); i0_samp++ )
 	    {
 	      read_histo_samps(i0_samp) = read_histo_2(TowEcha*fEcalParEB->MaxSampADC()+i0_samp);
-	      cout << setprecision(4) << setw(8) << read_histo_samps(i0_samp) << ", " ;
+	      std::cout << std::setprecision(4) << std::setw(8) << read_histo_samps(i0_samp) << ", " ;
 	    }
-	  cout << endl;
+	  std::cout << std::endl;
 
 	  MyHistosEB->Plot1DHisto(read_histo_samps, "Sample", "SSp", SMtower, TowEcha);
       
-	  cout << "EcnahistosExample2> ***************** Plot1DHisto 1 crystal ONLYONE  ****************" << endl;
+	  std::cout << "EcnahistosExample2> ***************** Plot1DHisto 1 crystal ONLYONE  ****************" << std::endl;
 	  MyHistosEB->Plot1DHisto("Sample", "SSp", SMtower,  TowEcha);
       
-	  cout << "EcnahistosExample2> ******************** All Xtals Plot1DHisto **********************" << endl;
+	  std::cout << "EcnahistosExample2> ******************** All Xtals Plot1DHisto **********************" << std::endl;
 	  SMtower = 59;
 	  read_histo_2 = fMyRootFileEB->Read1DHisto(fEcalParEB->MaxCrysInTow()*fEcalParEB->MaxSampADC(),
 						    "SampleMean", SMtower);
@@ -219,48 +219,48 @@ int main ( int argc, char **argv )
 	  MyHistosEB->SetHistoMin(180.); MyHistosEB->SetHistoMax(220.); 
 	  MyHistosEB->Plot1DHisto(read_histo_2, "Sample#", "SampleMean", SMtower); 
       
-	  cout << "EcnahistosExample2> ****************** Plot1DHisto 1 crystal SAME *******************" << endl;
+	  std::cout << "EcnahistosExample2> ****************** Plot1DHisto 1 crystal SAME *******************" << std::endl;
 
 	  TowEcha = 13;
-	  cout << "*EcnaHistosExample2> channel " << setw(2) << TowEcha << ": ";
+	  std::cout << "*EcnaHistosExample2> channel " << std::setw(2) << TowEcha << ": ";
 	  for( Int_t i0_samp=0; i0_samp<fEcalParEB->MaxSampADC(); i0_samp++ )
 	    {
 	      read_histo_samps(i0_samp) = read_histo_2(TowEcha*fEcalParEB->MaxSampADC()+i0_samp);
-	      cout << setprecision(4) << setw(8) << read_histo_samps(i0_samp) << ", " ;
+	      std::cout << std::setprecision(4) << std::setw(8) << read_histo_samps(i0_samp) << ", " ;
 	    }
-	  cout << endl;
+	  std::cout << std::endl;
 	  MyHistosEB->SetHistoMin(180.); MyHistosEB->SetHistoMax(220.); 
 	  MyHistosEB->Plot1DHisto(read_histo_samps, "Sample", "SampleMean", SMtower, TowEcha, "SAME");
 
 	  TowEcha = 14;
-	  cout << "*EcnaHistosExample2> channel " << setw(2) << TowEcha << ": ";
+	  std::cout << "*EcnaHistosExample2> channel " << std::setw(2) << TowEcha << ": ";
 	  for( Int_t i0_samp=0; i0_samp<fEcalParEB->MaxSampADC(); i0_samp++ )
 	    {
 	      read_histo_samps(i0_samp) = read_histo_2(TowEcha*fEcalParEB->MaxSampADC()+i0_samp);
-	      cout << setprecision(4) << setw(8) << read_histo_samps(i0_samp) << ", " ;
+	      std::cout << std::setprecision(4) << std::setw(8) << read_histo_samps(i0_samp) << ", " ;
 	    }
-	  cout << endl;
+	  std::cout << std::endl;
 	  MyHistosEB->Plot1DHisto(read_histo_samps, "SampleNumber", "SampleMean", SMtower, TowEcha, "SAME");
 
 	  TowEcha = 15;
-	  cout << "*EcnaHistosExample2> channel " << setw(2) << TowEcha << ": ";
+	  std::cout << "*EcnaHistosExample2> channel " << std::setw(2) << TowEcha << ": ";
 	  for( Int_t i0_samp=0; i0_samp<fEcalParEB->MaxSampADC(); i0_samp++ )
 	    {
 	      read_histo_samps(i0_samp) = read_histo_2(TowEcha*fEcalParEB->MaxSampADC()+i0_samp);
-	      cout << setprecision(4) << setw(8) << read_histo_samps(i0_samp) << ", " ;
+	      std::cout << std::setprecision(4) << std::setw(8) << read_histo_samps(i0_samp) << ", " ;
 	    }
-	  cout << endl;
+	  std::cout << std::endl;
 	  MyHistosEB->Plot1DHisto(read_histo_samps, "Sample#", "SampleMean", SMtower, TowEcha, "SAME");
 
 
-	  cout << "EcnahistosExample2> ******************** Plot1DHisto 1 crystal ONLYONE **************" << endl;
+	  std::cout << "EcnahistosExample2> ******************** Plot1DHisto 1 crystal ONLYONE **************" << std::endl;
 	  MyHistosEB->SetHistoMin(180.); MyHistosEB->SetHistoMax(220.); 
 	  MyHistosEB->Plot1DHisto(read_histo_samps, "Sample", "SampMean", SMtower, TowEcha);
 	}
       else
 	{
-	  cout  << "!EcnaHistosExample2> *ERROR* =====> "
-		<< " ROOT file not found" << fTTBELL << endl;
+	  std::cout  << "!EcnaHistosExample2> *ERROR* =====> "
+		<< " ROOT file not found" << fTTBELL << std::endl;
 	}
 
 #endif // NODR
@@ -294,8 +294,8 @@ int main ( int argc, char **argv )
 	    }
 	  else
 	    {
-	      cout  << "!EcnaHistosExample2> *ERROR* =====> "
-		    << " ROOT file not found" << fTTBELL << endl;
+	      std::cout  << "!EcnaHistosExample2> *ERROR* =====> "
+		    << " ROOT file not found" << fTTBELL << std::endl;
 	    }
 	}
       
@@ -335,8 +335,8 @@ int main ( int argc, char **argv )
 	    }
 	  else
 	    {
-	      cout  << "!EcnaHistosExample2> *ERROR* =====> "
-		    << " ROOT file not found" << fTTBELL << endl;
+	      std::cout  << "!EcnaHistosExample2> *ERROR* =====> "
+		    << " ROOT file not found" << fTTBELL << std::endl;
 	    }
 	}
       
@@ -382,8 +382,8 @@ int main ( int argc, char **argv )
 	    }
 	  else
 	    {
-	      cout  << "!EcnaHistosExample2> *ERROR* =====> "
-		    << " ROOT file not found" << fTTBELL << endl;
+	      std::cout  << "!EcnaHistosExample2> *ERROR* =====> "
+		    << " ROOT file not found" << fTTBELL << std::endl;
 	    }
 	}
       
@@ -444,8 +444,8 @@ int main ( int argc, char **argv )
 	    }
 	  else
 	    {
-	      cout  << "!EcnaHistosExample2> *ERROR* =====> "
-		    << " ROOT file not found" << fTTBELL << endl;
+	      std::cout  << "!EcnaHistosExample2> *ERROR* =====> "
+		    << " ROOT file not found" << fTTBELL << std::endl;
 	    }
 	}
       
@@ -477,14 +477,14 @@ int main ( int argc, char **argv )
       //
       //=====================================================================
 
-      cout << "*H4Cna(main)> End of the example. You can quit ROOT (.q)"  << endl;
+      std::cout << "*H4Cna(main)> End of the example. You can quit ROOT (.q)"  << std::endl;
 
       Bool_t retVal = kTRUE;
       theApp.Run(retVal);
-      cout << endl
-	   << "*EcalCorrelatedNoiseExampleHistos> Terminating ROOT session." << endl;
+      std::cout << std::endl
+	   << "*EcalCorrelatedNoiseExampleHistos> Terminating ROOT session." << std::endl;
       theApp.Terminate(0);
-      cout << "*EcalCorrelatedNoiseExampleHistos> Exiting main program." << endl;
+      std::cout << "*EcalCorrelatedNoiseExampleHistos> Exiting main program." << std::endl;
       exit(0);
       
       delete MyHistosEB;  // always after exit(0) (because of TEcnaHistos::DoCanvasClosed())

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/interface/EcnaAnalyzer.h
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/interface/EcnaAnalyzer.h
@@ -154,11 +154,11 @@ class EcnaAnalyzer : public edm::EDAnalyzer {
   unsigned int verbosity_;
   Int_t  nChannels_;
   Int_t  iEvent_; // should be removed when we can access class EventID
-  string eventHeaderProducer_;
-  string digiProducer_;
-  string eventHeaderCollection_;
-  string EBdigiCollection_;
-  string EEdigiCollection_;
+  std::string eventHeaderProducer_;
+  std::string digiProducer_;
+  std::string eventHeaderCollection_;
+  std::string EBdigiCollection_;
+  std::string EEdigiCollection_;
 
   TString  sAnalysisName_;
   TString  sNbOfSamples_;
@@ -181,7 +181,7 @@ class EcnaAnalyzer : public edm::EDAnalyzer {
 
   TString  fCfgAnalyzerParametersFilePath;  // absolute path for the analyzer parameters files (/afs/etc...)
   TString  fCfgAnalyzerParametersFileName;  // name of the analyzer parameters file 
-  ifstream fFcin_f;
+  std::ifstream fFcin_f;
 
   TString fAnalysisName;
   Int_t   fChozenGainNumber;     // determined from fAnalysisName

--- a/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/src/EcnaAnalyzer.cc
+++ b/CalibCalorimetry/EcalCorrelatedNoiseAnalysisModules/src/EcnaAnalyzer.cc
@@ -56,30 +56,30 @@ EcnaAnalyzer::EcnaAnalyzer(const edm::ParameterSet& pSet) :
   TEcnaParPaths* myPathEB = new TEcnaParPaths(fMyEcnaEBObjectManager);
   TEcnaParPaths* myPathEE = new TEcnaParPaths(fMyEcnaEEObjectManager);
 
-  std::cout << "*EcnaAnalyzer-constructor> Check path for resultsq Root files." << endl;
+  std::cout << "*EcnaAnalyzer-constructor> Check path for resultsq Root files." << std::endl;
 
   if( myPathEB->GetPathForResultsRootFiles() == kFALSE )
     {
-      std::cout << "*EcnaAnalyzer-constructor> *** ERROR *** Path for result files not found." << endl;
+      std::cout << "*EcnaAnalyzer-constructor> *** ERROR *** Path for result files not found." << std::endl;
       kill(getpid(),SIGUSR2);
     }
   else
     {
-      std::cout << "*EcnaAnalyzer-constructor> Path for result files found = " << myPathEB->ResultsRootFilePath() << endl;
+      std::cout << "*EcnaAnalyzer-constructor> Path for result files found = " << myPathEB->ResultsRootFilePath() << std::endl;
     }
 
   if( myPathEE->GetPathForResultsRootFiles() == kFALSE )
     {
-      std::cout << "*EcnaAnalyzer-constructor> *** ERROR *** Path for result files not found." << endl;
+      std::cout << "*EcnaAnalyzer-constructor> *** ERROR *** Path for result files not found." << std::endl;
       kill(getpid(),SIGUSR2);
     }
   else
     {
-      std::cout << "*EcnaAnalyzer-constructor> Path for result files found = " << myPathEE->ResultsRootFilePath() << endl;
+      std::cout << "*EcnaAnalyzer-constructor> Path for result files found = " << myPathEE->ResultsRootFilePath() << std::endl;
     }
 
 
-  std::cout << "*EcnaAnalyzer-constructor> Parameter initialization." << endl;
+  std::cout << "*EcnaAnalyzer-constructor> Parameter initialization." << std::endl;
 
   fgMaxCar = (Int_t)512;
   fTTBELL = '\007';
@@ -400,17 +400,17 @@ EcnaAnalyzer::EcnaAnalyzer(const edm::ParameterSet& pSet) :
   fFedId  = -1;
   fFedTcc = -1;
 
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fAnalysisName        = " << fAnalysisName << endl;
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fNbOfSamples         = " << fNbOfSamples << endl;
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fFirstReqEvent       = " << fFirstReqEvent << endl;
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fLastReqEvent        = " << fLastReqEvent << endl;
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fReqNbOfEvts         = " << fReqNbOfEvts << endl;
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fStexName            = " << fStexName << endl;
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fStexNumber          = " << fStexNumber << endl;
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fChozenRunTypeNumber = " << fChozenRunTypeNumber << endl;
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fChozenGainNumber    = " << fChozenGainNumber  << endl << endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fAnalysisName        = " << fAnalysisName << std::endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fNbOfSamples         = " << fNbOfSamples << std::endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fFirstReqEvent       = " << fFirstReqEvent << std::endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fLastReqEvent        = " << fLastReqEvent << std::endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fReqNbOfEvts         = " << fReqNbOfEvts << std::endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fStexName            = " << fStexName << std::endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fStexNumber          = " << fStexNumber << std::endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fChozenRunTypeNumber = " << fChozenRunTypeNumber << std::endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> fChozenGainNumber    = " << fChozenGainNumber  << std::endl << std::endl;
 
-  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> Init done. " << endl;
+  std::cout << "*EcnaAnalyzer::EcnaAnalyzer-constructor> Init done. " << std::endl;
 }
 // end of constructor
 
@@ -421,14 +421,14 @@ EcnaAnalyzer::~EcnaAnalyzer()
 
   using namespace std;
   //..................................... format numerical values
-  cout << setiosflags(ios::showpoint | ios::uppercase);
-  cout << setprecision(3) << setw(6);
-  cout.setf(ios::dec, ios::basefield);
-  cout.setf(ios::fixed, ios::floatfield);
-  cout.setf(ios::left, ios::adjustfield);
-  cout.setf(ios::right, ios::adjustfield);
+  std::cout << std::setiosflags(std::ios::showpoint | std::ios::uppercase);
+  std::cout << std::setprecision(3) << std::setw(6);
+  cout.setf(std::ios::dec, std::ios::basefield);
+  cout.setf(std::ios::fixed, std::ios::floatfield);
+  cout.setf(std::ios::left, std::ios::adjustfield);
+  cout.setf(std::ios::right, std::ios::adjustfield);
 
-  std::cout << "EcnaAnalyzer::~EcnaAnalyzer()> destructor is going to be executed." << endl;
+  std::cout << "EcnaAnalyzer::~EcnaAnalyzer()> destructor is going to be executed." << std::endl;
 
   if( fOutcomeError == kTRUE )return;
 
@@ -437,13 +437,13 @@ EcnaAnalyzer::~EcnaAnalyzer()
   //....................................................... EB (SM)
   if( fMyCnaEBSM == 0 && fStexName == "SM" )
     {
-      std::cout << endl << "!EcnaAnalyzer-destructor> **** ERROR **** fMyCnaEBSM = " << fMyCnaEBSM
-		<< ". !===> ECNA HAS NOT BEEN INITIALIZED." << endl
+      std::cout << std::endl << "!EcnaAnalyzer-destructor> **** ERROR **** fMyCnaEBSM = " << fMyCnaEBSM
+		<< ". !===> ECNA HAS NOT BEEN INITIALIZED." << std::endl
 		<< "  Last event run type = " << runtype(fRunTypeNumber)
 		<< ", fRunTypeNumber = " << fRunTypeNumber
 		<< ", last event Mgpa gain = " << gainvalue(fMgpaGainNumber)
 		<< ", fMgpaGainNumber = " << fMgpaGainNumber
-		<< ", last event fFedId(+601) = " << fFedId+601 << endl << endl;
+		<< ", last event fFedId(+601) = " << fFedId+601 << std::endl << std::endl;
     }
   else
     {
@@ -463,13 +463,13 @@ EcnaAnalyzer::~EcnaAnalyzer()
 	      if( fMyCnaEBSM[iSM]->WriteRootFile() == kFALSE )
 		{
 		  std::cout << "!EcnaAnalyzer-destructor> PROBLEM with write ROOT file for SM" << iSM+1
-			    << fTTBELL << endl;
+			    << fTTBELL << std::endl;
 		}
 	    }
 	  else
 	    {
 	      std::cout << "*EcnaAnalyzer-destructor> Calculations and writing on file already done for SM "
-			<< iSM+1 << endl;
+			<< iSM+1 << std::endl;
 	    }
 	}
       delete fMyCnaEBSM;
@@ -478,13 +478,13 @@ EcnaAnalyzer::~EcnaAnalyzer()
 
   if( fMyCnaEEDee == 0 && fStexName == "Dee" )
     {
-      std::cout << endl << "!EcnaAnalyzer-destructor> **** ERROR **** fMyCnaEEDee = " << fMyCnaEEDee
-		<< ". !===> ECNA HAS NOT BEEN INITIALIZED." << endl
+      std::cout << std::endl << "!EcnaAnalyzer-destructor> **** ERROR **** fMyCnaEEDee = " << fMyCnaEEDee
+		<< ". !===> ECNA HAS NOT BEEN INITIALIZED." << std::endl
 		<< "  Last event run type = " << runtype(fRunTypeNumber)
 		<< ", fRunTypeNumber = " << fRunTypeNumber
 		<< ", last event Mgpa gain = " << gainvalue(fMgpaGainNumber)
 		<< ", fMgpaGainNumber = " << fMgpaGainNumber
-		<< ", last event fFedId(+601) = " << fFedId+601 << endl << endl;
+		<< ", last event fFedId(+601) = " << fFedId+601 << std::endl << std::endl;
     }
   else
     {
@@ -504,13 +504,13 @@ EcnaAnalyzer::~EcnaAnalyzer()
 	      if(fMyCnaEEDee[iDee]->WriteRootFile() == kFALSE )
 		{
 		  std::cout << "!EcnaAnalyzer-destructor> PROBLEM with write ROOT file for Dee" << iDee+1
-			    << fTTBELL << endl;
+			    << fTTBELL << std::endl;
 		}
 	    }
 	  else
 	    {
 	      std::cout << "*EcnaAnalyzer-destructor> Calculations and writing on file already done for Dee "
-			<< iDee+1 << endl;
+			<< iDee+1 << std::endl;
 	    }
 	}
       delete fMyCnaEEDee;
@@ -520,7 +520,7 @@ EcnaAnalyzer::~EcnaAnalyzer()
   //-----------------------------------------------------------------------------------
 
   std::cout << "*EcnaAnalyzer-destructor> Status of events returned by GetSampleAdcValues(): "
-	    << endl;
+	    << std::endl;
 
   for(Int_t i0Stex=fStexIndexBegin; i0Stex<fStexIndexStop; i0Stex++ )
     {
@@ -528,53 +528,53 @@ EcnaAnalyzer::~EcnaAnalyzer()
 		<< " / ERROR(S): " << fBuildEventDistribBad[i0Stex];
       if( fBuildEventDistribBad[i0Stex] > 0 )
 	{std::cout << " <=== SHOULD BE EQUAL TO ZERO ! " << fTTBELL;}
-      std::cout << endl;
+      std::cout << std::endl;
     }
 
-  std::cout << endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  endl;
+  std::cout << std::endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  std::endl;
   
-  std::cout << "*EcnaAnalyzer-destructor> Run types seen in event headers before selection:" << endl;
+  std::cout << "*EcnaAnalyzer-destructor> Run types seen in event headers before selection:" << std::endl;
 
   for(Int_t i=0; i<fMaxRunTypeCounter; i++)
     {
-      std::cout << " => " << setw(10) << fRunTypeCounter[i]
-		<< " event header(s) with run type " << runtype(i) << endl; 
+      std::cout << " => " << std::setw(10) << fRunTypeCounter[i]
+		<< " event header(s) with run type " << runtype(i) << std::endl; 
     }
 
-  std::cout << endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  endl;
+  std::cout << std::endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  std::endl;
 
-  std::cout << "*EcnaAnalyzer-destructor> Mgpa gains seen in event headers before selection:" << endl;
+  std::cout << "*EcnaAnalyzer-destructor> Mgpa gains seen in event headers before selection:" << std::endl;
 
   for(Int_t i=0; i<fMaxMgpaGainCounter; i++)
     {
-      std::cout << " => " << setw(10) << fMgpaGainCounter[i]
-		<< " event header(s) with gain " << gainvalue(i) << endl; 
+      std::cout << " => " << std::setw(10) << fMgpaGainCounter[i]
+		<< " event header(s) with gain " << gainvalue(i) << std::endl; 
     }
 
-  std::cout << endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  endl;
+  std::cout << std::endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  std::endl;
 
-  std::cout << "*EcnaAnalyzer-destructor> Numbers of selected events for each FED:" << endl;
+  std::cout << "*EcnaAnalyzer-destructor> Numbers of selected events for each FED:" << std::endl;
 
   for(Int_t i=0; i<fMaxFedIdCounter; i++)
     {
 	  std::cout << " => FedId " << i+601 << ": "
-		    << setw(10) << fFedIdCounter[i] << " events" << endl;
+		    << std::setw(10) << fFedIdCounter[i] << " events" << std::endl;
     }
 
-  std::cout << endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  endl;
+  std::cout << std::endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  std::endl;
 
   if( fStexNumber == 0 )
     {
-      // std::cout << "*EcnaAnalyzer-destructor> fDateFirst = " << fDateFirst[0] << endl
-      //           << "                          fDateLast  = " << fDateLast[fMaxTreatedStexCounter-1] << endl << endl;
+      // std::cout << "*EcnaAnalyzer-destructor> fDateFirst = " << fDateFirst[0] << std::endl
+      //           << "                          fDateLast  = " << fDateLast[fMaxTreatedStexCounter-1] << std::endl << std::endl;
     }
   if( fStexNumber > 0 )
     {
-      std::cout << "*EcnaAnalyzer-destructor> fDateFirst = " << fDateFirst[fStexNumber-1] << endl
-		<< "                          fDateLast  = " << fDateLast[fStexNumber-1] << endl << endl;
+      std::cout << "*EcnaAnalyzer-destructor> fDateFirst = " << fDateFirst[fStexNumber-1] << std::endl
+		<< "                          fDateLast  = " << fDateLast[fStexNumber-1] << std::endl << std::endl;
     }
 
-  std::cout << endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  endl;
+  std::cout << std::endl<< "- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - " <<  std::endl;
 
   Int_t n0 =0; CheckMsg(n0);
 
@@ -584,7 +584,7 @@ EcnaAnalyzer::~EcnaAnalyzer()
   delete fMyEBEcal;
   delete fMyEEEcal;
 
-  std::cout << "*EcnaAnalyzer-destructor> End of execution." << endl;
+  std::cout << "*EcnaAnalyzer-destructor> End of execution." << std::endl;
 }
 // end of destructor
 
@@ -598,12 +598,12 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 {
   using namespace std;
   //..................................... format numerical values
-  cout << setiosflags(ios::showpoint | ios::uppercase);
-  cout << setprecision(3) << setw(6);
-  cout.setf(ios::dec, ios::basefield);
-  cout.setf(ios::fixed, ios::floatfield);
-  cout.setf(ios::left, ios::adjustfield);
-  cout.setf(ios::right, ios::adjustfield);
+  std::cout << std::setiosflags(std::ios::showpoint | std::ios::uppercase);
+  std::cout << std::setprecision(3) << std::setw(6);
+  cout.setf(std::ios::dec, std::ios::basefield);
+  cout.setf(std::ios::fixed, std::ios::floatfield);
+  cout.setf(std::ios::left, std::ios::adjustfield);
+  cout.setf(std::ios::right, std::ios::adjustfield);
 
   using namespace edm;
 
@@ -781,15 +781,15 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 							       fFirstReqEvent, fLastReqEvent, fReqNbOfEvts,
 							       i0SM+1,         fRunTypeNumber);
 		      
-			  std::cout << "*EcnaAnalyzer::analyze(...)> ********* INIT ECNA EB ********* " << endl
-				    << "                                   fAnalysisName = " << fAnalysisName << endl
-				    << "                                      fRunNumber = " << fRunNumber << endl
-				    << "                                  fFirstReqEvent = " << fFirstReqEvent << endl
-				    << "                                   fLastReqEvent = " << fLastReqEvent << endl
-				    << "                                    fReqNbOfEvts = " << fReqNbOfEvts << endl
-				    << "                                              SM = " << i0SM+1 << endl
+			  std::cout << "*EcnaAnalyzer::analyze(...)> ********* INIT ECNA EB ********* " << std::endl
+				    << "                                   fAnalysisName = " << fAnalysisName << std::endl
+				    << "                                      fRunNumber = " << fRunNumber << std::endl
+				    << "                                  fFirstReqEvent = " << fFirstReqEvent << std::endl
+				    << "                                   fLastReqEvent = " << fLastReqEvent << std::endl
+				    << "                                    fReqNbOfEvts = " << fReqNbOfEvts << std::endl
+				    << "                                              SM = " << i0SM+1 << std::endl
 				    << "                                        run type = " << runtype(fRunTypeNumber)
-				    << endl;
+				    << std::endl;
 			  //============================================================================
 			}
 		      
@@ -816,10 +816,10 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 				  fTimeLast[i0SM]  = i_current_ev_time;
 				  fDateLast[i0SM]  = astime;
 				  std::cout << "*----> beginning of analysis for " << fStexName << i0SM+1
-					    << ". First analyzed event date : " << astime << endl;
-				  //      << " t_current_ev_time = " << t_current_ev_time  << endl
-				  //      << " i_current_ev_time = " << i_current_ev_time  << endl
-				  //      << " p_current_ev_time = " << p_current_ev_time  << endl
+					    << ". First analyzed event date : " << astime << std::endl;
+				  //      << " t_current_ev_time = " << t_current_ev_time  << std::endl
+				  //      << " i_current_ev_time = " << i_current_ev_time  << std::endl
+				  //      << " p_current_ev_time = " << p_current_ev_time  << std::endl
 				}
 
 			      if( i_current_ev_time < fTimeFirst[i0SM] )
@@ -871,7 +871,7 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 				  else
 				    {
 				      std::cout << "EcnaAnalyzer::analyze(...)> NbOfSamplesFromDigis out of bounds = "
-						<< NbOfSamplesFromDigis << endl;
+						<< NbOfSamplesFromDigis << std::endl;
 				    }
 				} // end of if( (fStexNumber > 0 && i0SM == fStexNumber-1) || (fStexNumber == 0) )
 			    } // end of if( fStexNbOfTreatedEvents[i0SM] >= 1 && fStexNbOfTreatedEvents[i0SM] <= fReqNbOfEvts )
@@ -956,15 +956,15 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 								 fFirstReqEvent, fLastReqEvent, fReqNbOfEvts,
 								 i0Dee+1,         fRunTypeNumber);
 			  
-			  std::cout << "*EcnaAnalyzer::analyze(...)> ********* INIT ECNA EE ********* " << endl
-				    << "                                   fAnalysisName = " << fAnalysisName << endl
-				    << "                                      fRunNumber = " << fRunNumber << endl
-				    << "                                  fFirstReqEvent = " << fFirstReqEvent << endl
-				    << "                                   fLastReqEvent = " << fLastReqEvent << endl
-				    << "                                    fReqNbOfEvts = " << fReqNbOfEvts << endl
-				    << "                                             Dee = " << i0Dee+1 << endl
+			  std::cout << "*EcnaAnalyzer::analyze(...)> ********* INIT ECNA EE ********* " << std::endl
+				    << "                                   fAnalysisName = " << fAnalysisName << std::endl
+				    << "                                      fRunNumber = " << fRunNumber << std::endl
+				    << "                                  fFirstReqEvent = " << fFirstReqEvent << std::endl
+				    << "                                   fLastReqEvent = " << fLastReqEvent << std::endl
+				    << "                                    fReqNbOfEvts = " << fReqNbOfEvts << std::endl
+				    << "                                             Dee = " << i0Dee+1 << std::endl
 				    << "                                        run type = " << runtype(fRunTypeNumber)
-				    << endl;
+				    << std::endl;
 			  //============================================================================
 			}
 
@@ -1053,13 +1053,13 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 				  fDateFirst[i0Dee] = astime;
 				  fTimeLast[i0Dee]  = i_current_ev_time;
 				  fDateLast[i0Dee]  = astime;
-				  std::cout << "----- beginning of analysis for " << fStexName << i0Dee+1 << "-------"  << endl
-				    //<< " t_current_ev_time = " << t_current_ev_time  << endl
-				    //<< " i_current_ev_time = " << i_current_ev_time  << endl
-				    //<< " p_current_ev_time = " << p_current_ev_time  << endl
-					    << " First event date  = " << astime << endl
-					    << " Nb of selected evts = " << fNbOfSelectedEvents << endl
-					    << "---------------------------------------------------------------"  << endl;
+				  std::cout << "----- beginning of analysis for " << fStexName << i0Dee+1 << "-------"  << std::endl
+				    //<< " t_current_ev_time = " << t_current_ev_time  << std::endl
+				    //<< " i_current_ev_time = " << i_current_ev_time  << std::endl
+				    //<< " p_current_ev_time = " << p_current_ev_time  << std::endl
+					    << " First event date  = " << astime << std::endl
+					    << " Nb of selected evts = " << fNbOfSelectedEvents << std::endl
+					    << "---------------------------------------------------------------"  << std::endl;
 				  fMemoDateFirstEvent[i0Dee]++;
 				}
 
@@ -1108,7 +1108,7 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 				  else
 				    {
 				      std::cout << "EcnaAnalyzer::analyze(...)> NbOfSamplesFromDigis out of bounds = "
-						<< NbOfSamplesFromDigis << endl;
+						<< NbOfSamplesFromDigis << std::endl;
 				    }
 				} // end of if( (fStexNumber > 0 && i0Dee == fStexNumber-1) || (fStexNumber == 0) )
 			    } // end of if( fFedNbOfTreatedEvents[fESFromFedTcc[fFedTcc-1]-1] >= 1 &&
@@ -1240,16 +1240,16 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 	  //if( i_current_ev_time > fTimeLast[i0Stex] )
 	  // {fTimeLast[i0Stex] = i_current_ev_time; fDateLast[i0Stex] = astime;}
 	  
-	  std::cout << "---------- End of analysis for " << fStexName << i0Stex+1 << " -----------" << endl;
+	  std::cout << "---------- End of analysis for " << fStexName << i0Stex+1 << " -----------" << std::endl;
 	  Int_t n3 = 3; CheckMsg(n3, i0Stex);
-	  // std::cout 	   << " t_current_ev_time = " << t_current_ev_time  << endl
-	  //<< " i_current_ev_time = " << i_current_ev_time  << endl
-	  //<< " p_current_ev_time = " << p_current_ev_time  << endl
-	  // std::cout 	    << " Last analyzed event date  = " << astime << endl;
-	  std::cout 	    << " Number of selected events = " << fNbOfSelectedEvents << endl;
-	  std::cout << endl << fNbOfTreatedStexs << " " << fStexName
-		    << "'s with " << fReqNbOfEvts << " events analyzed." << endl
-		    << "---------------------------------------------------------"  << endl;
+	  // std::cout 	   << " t_current_ev_time = " << t_current_ev_time  << std::endl
+	  //<< " i_current_ev_time = " << i_current_ev_time  << std::endl
+	  //<< " p_current_ev_time = " << p_current_ev_time  << std::endl
+	  // std::cout 	    << " Last analyzed event date  = " << astime << std::endl;
+	  std::cout 	    << " Number of selected events = " << fNbOfSelectedEvents << std::endl;
+	  std::cout << std::endl << fNbOfTreatedStexs << " " << fStexName
+		    << "'s with " << fReqNbOfEvts << " events analyzed." << std::endl
+		    << "---------------------------------------------------------"  << std::endl;
 	  
 	  //================================= WRITE RESULTS FILE
 	  if( fStexName == "SM" )
@@ -1268,12 +1268,12 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 		  if( fMyCnaEBSM[i0Stex]->WriteRootFile() == kFALSE )
 		    {
 		      std::cout << "!EcnaAnalyzer::analyze> PROBLEM with write ROOT file for SM" << i0Stex+1
-				<< fTTBELL << endl;
+				<< fTTBELL << std::endl;
 		    }
 		}
 	      // set pointer to zero in order to avoid recalculation and rewriting at the destructor level
 	      delete fMyCnaEBSM[i0Stex];  fMyCnaEBSM[i0Stex] = 0;
-	      std::cout << "!EcnaAnalyzer::analyze> Set memory free: delete done for SM " << i0Stex+1 << endl;
+	      std::cout << "!EcnaAnalyzer::analyze> Set memory free: delete done for SM " << i0Stex+1 << std::endl;
 	    }
 
 	  if( fStexName == "Dee" )
@@ -1292,16 +1292,16 @@ void EcnaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 		  if(fMyCnaEEDee[i0Stex]->WriteRootFile() == kFALSE )
 		    {
 		      std::cout << "!EcnaAnalyzer::analyze> PROBLEM with write ROOT file for Dee" << i0Stex+1
-				<< fTTBELL << endl;
+				<< fTTBELL << std::endl;
 		    }
 		}
 	      // set pointer to zero in order to avoid recalculation and rewriting at the destructor level
 	      delete fMyCnaEEDee[i0Stex]; fMyCnaEEDee[i0Stex] = 0;
-	      std::cout << "!EcnaAnalyzer::analyze> Set memory free: delete done for Dee " << i0Stex+1 << endl;
+	      std::cout << "!EcnaAnalyzer::analyze> Set memory free: delete done for Dee " << i0Stex+1 << std::endl;
 	    }
 
 	  fStexStatus[i0Stex] = 2;        // set fStexStatus[i0Stex] to 2 definitively
-	  std::cout << "*---------------------------------------------------------------------------- " << endl;
+	  std::cout << "*---------------------------------------------------------------------------- " << std::endl;
 
 	} // end of if( fStexStatus[i0Stex] == 1 )
     } // end of for(Int_t i0Stex=fStexIndexBegin; i0Stex<fStexIndexStop; i0Stex++)
@@ -1326,21 +1326,21 @@ Bool_t EcnaAnalyzer::AnalysisOutcome(const TString& s_opt)
 	    (fLastReqEvent >= fFirstReqEvent && fCurrentEventNumber <= fLastReqEvent) )
 	  )
 	{
-	  std::cout << endl
-		    << "**************************** ANALYSIS REPORT > OK **************************************" << endl
-		    << "*EcnaAnalyzer::AnalysisOutcome(...)> The maximum requested number of events and the maximum" << endl
+	  std::cout << std::endl
+		    << "**************************** ANALYSIS REPORT > OK **************************************" << std::endl
+		    << "*EcnaAnalyzer::AnalysisOutcome(...)> The maximum requested number of events and the maximum" << std::endl
 		    << "                                     number of treated " << fStexName
-		    << "'s have been reached." << endl
-		    << "                                     Analysis successfully ended from EcnaAnalyzer " << endl
-		    << "                                     by SIGNAL: kill(getpid(),SIGUSR2)." << endl
-		    << "                                     Number of selected events   = " << fNbOfSelectedEvents << endl
-		    << "                                     Last requested event number = " << fLastReqEvent << endl
-		    << "                                     Current event number        = " << fCurrentEventNumber << endl;
+		    << "'s have been reached." << std::endl
+		    << "                                     Analysis successfully ended from EcnaAnalyzer " << std::endl
+		    << "                                     by SIGNAL: kill(getpid(),SIGUSR2)." << std::endl
+		    << "                                     Number of selected events   = " << fNbOfSelectedEvents << std::endl
+		    << "                                     Last requested event number = " << fLastReqEvent << std::endl
+		    << "                                     Current event number        = " << fCurrentEventNumber << std::endl;
 
 	  Int_t n0 = 0; CheckMsg(n0);
 
-	  std::cout << "****************************************************************************************" << endl
-		    << endl;
+	  std::cout << "****************************************************************************************" << std::endl
+		    << std::endl;
 
 	  result = kTRUE;
 	  kill(getpid(),SIGUSR2);
@@ -1350,19 +1350,19 @@ Bool_t EcnaAnalyzer::AnalysisOutcome(const TString& s_opt)
 	  ! ( (fStexNumber > 0 && fNbOfTreatedStexs == 1) ||
 	      (fStexNumber == 0 && fNbOfTreatedStexs == MaxNbOfStex) ) )
 	{
-	  std::cout << endl
-		    << "**************************** ANALYSIS REPORT >>> *** WARNING *** WARNING *** WARNING ***" << endl
-		    << "*EcnaAnalyzer::AnalysisOutcome(...)> Last event reached before completion of analysis." << endl
-		    << "                                     Analysis ended from EcnaAnalyzer " << endl
-		    << "                                     by SIGNAL: kill(getpid(),SIGUSR2)." << endl
-		    << "                                     Number of selected events   = " << fNbOfSelectedEvents << endl
-		    << "                                     Last requested event number = " << fLastReqEvent << endl
-		    << "                                     Current event number        = " << fCurrentEventNumber << endl;
+	  std::cout << std::endl
+		    << "**************************** ANALYSIS REPORT >>> *** WARNING *** WARNING *** WARNING ***" << std::endl
+		    << "*EcnaAnalyzer::AnalysisOutcome(...)> Last event reached before completion of analysis." << std::endl
+		    << "                                     Analysis ended from EcnaAnalyzer " << std::endl
+		    << "                                     by SIGNAL: kill(getpid(),SIGUSR2)." << std::endl
+		    << "                                     Number of selected events   = " << fNbOfSelectedEvents << std::endl
+		    << "                                     Last requested event number = " << fLastReqEvent << std::endl
+		    << "                                     Current event number        = " << fCurrentEventNumber << std::endl;
 
 	  Int_t n0 = 0; CheckMsg(n0);
 
-	  std::cout << "****************************************************************************************" << endl
-		    << endl;
+	  std::cout << "****************************************************************************************" << std::endl
+		    << std::endl;
       
 	  result = kTRUE;
 	  kill(getpid(),SIGUSR2);
@@ -1372,31 +1372,31 @@ Bool_t EcnaAnalyzer::AnalysisOutcome(const TString& s_opt)
     {
       if( s_opt == "ERR_FNEG" )
 	{
-	  std::cout << endl
-		    << "**************************** ANALYSIS REPORT >>> **** ERROR **** ERROR **** ERROR ******" << endl
+	  std::cout << std::endl
+		    << "**************************** ANALYSIS REPORT >>> **** ERROR **** ERROR **** ERROR ******" << std::endl
 		    << "*EcnaAnalyzer::AnalysisOutcome(...)> First event number = " << fFirstReqEvent
-		    << ". Should be strictly potitive." << endl
-		    << "                             Analysis ended from EcnaAnalyzer " << endl
-		    << "                             by SIGNAL: kill(getpid(),SIGUSR2)." << endl;
+		    << ". Should be strictly potitive." << std::endl
+		    << "                             Analysis ended from EcnaAnalyzer " << std::endl
+		    << "                             by SIGNAL: kill(getpid(),SIGUSR2)." << std::endl;
 
-	  std::cout << "****************************************************************************************" << endl
-		    << endl;
+	  std::cout << "****************************************************************************************" << std::endl
+		    << std::endl;
 
 	  result = kTRUE;
 	  kill(getpid(),SIGUSR2);
 	}
       if( s_opt == "ERR_LREQ" )
 	{
-	  std::cout << endl
-		    << "**************************** ANALYSIS REPORT >>> **** ERROR **** ERROR **** ERROR ******" << endl
-		    << "*EcnaAnalyzer::analyze(...)> Requested number of events = " << fReqNbOfEvts << "." << endl
+	  std::cout << std::endl
+		    << "**************************** ANALYSIS REPORT >>> **** ERROR **** ERROR **** ERROR ******" << std::endl
+		    << "*EcnaAnalyzer::analyze(...)> Requested number of events = " << fReqNbOfEvts << "." << std::endl
 		    << "                             Too large compared to the event range: "
-		    << fFirstReqEvent << " - " << fLastReqEvent << endl
-		    << "                             Analysis ended from EcnaAnalyzer " << endl
-		    << "                             by SIGNAL: kill(getpid(),SIGUSR2)." << endl;
+		    << fFirstReqEvent << " - " << fLastReqEvent << std::endl
+		    << "                             Analysis ended from EcnaAnalyzer " << std::endl
+		    << "                             by SIGNAL: kill(getpid(),SIGUSR2)." << std::endl;
 
-	  std::cout << "****************************************************************************************" << endl
-		    << endl;
+	  std::cout << "****************************************************************************************" << std::endl
+		    << std::endl;
 
 	  result = kTRUE;
 	  kill(getpid(),SIGUSR2);
@@ -1413,28 +1413,28 @@ void EcnaAnalyzer::CheckMsg(const Int_t& MsgNum, const Int_t& i0Stex)
   //------ Cross-check messages
 
   if( MsgNum == 1 )
-    {std::cout << "---------------- CROSS-CHECK A ------------------ " << endl
-	       << "**************** CURRENT EVENT ****************** " << endl;}
+    {std::cout << "---------------- CROSS-CHECK A ------------------ " << std::endl
+	       << "**************** CURRENT EVENT ****************** " << std::endl;}
   if( MsgNum == 2 )
-    {std::cout << "---------------- CROSS-CHECK B ------------------ " << endl
-	       << "**** FIRST EVENT PASSING USER'S ANALYSIS CUT **** " << endl;}
+    {std::cout << "---------------- CROSS-CHECK B ------------------ " << std::endl
+	       << "**** FIRST EVENT PASSING USER'S ANALYSIS CUT **** " << std::endl;}
   if( MsgNum == 3 )
-    {std::cout << "---------------- CROSS-CHECK C ------------------ " << endl
-	       << "*** CURRENT VALUES BEFORE RESULT FILE WRITING *** " << endl;}
+    {std::cout << "---------------- CROSS-CHECK C ------------------ " << std::endl
+	       << "*** CURRENT VALUES BEFORE RESULT FILE WRITING *** " << std::endl;}
   if( MsgNum == 3 || MsgNum == 4 )
-    {std::cout << "          fRecNumber = " << fRecNumber << endl
-	       << "          fEvtNumber = " << fEvtNumber << endl;}
+    {std::cout << "          fRecNumber = " << fRecNumber << std::endl
+	       << "          fEvtNumber = " << fEvtNumber << std::endl;}
   
-  std::cout << " fCurrentEventNumber = " << fCurrentEventNumber << endl
-	    << " fNbOfSelectedEvents = " << fNbOfSelectedEvents << endl
-	    << "          fRunNumber = " << fRunNumber << endl
-	    << "     Chozen run type = " << runtype(fChozenRunTypeNumber) << endl
-	    << "            Run type = " << runtype(fRunTypeNumber) << endl
-	    << "             fFedTcc = " << fFedTcc << endl
-	    << "        fFedId(+601) = " << fFedId+601 << endl
-	    << "           fStexName = " << fStexName << endl
-	    << "         Chozen gain = " << gainvalue(fChozenGainNumber) << endl 
-	    << "           Mgpa Gain = " << gainvalue(fMgpaGainNumber) << endl << endl;
+  std::cout << " fCurrentEventNumber = " << fCurrentEventNumber << std::endl
+	    << " fNbOfSelectedEvents = " << fNbOfSelectedEvents << std::endl
+	    << "          fRunNumber = " << fRunNumber << std::endl
+	    << "     Chozen run type = " << runtype(fChozenRunTypeNumber) << std::endl
+	    << "            Run type = " << runtype(fRunTypeNumber) << std::endl
+	    << "             fFedTcc = " << fFedTcc << std::endl
+	    << "        fFedId(+601) = " << fFedId+601 << std::endl
+	    << "           fStexName = " << fStexName << std::endl
+	    << "         Chozen gain = " << gainvalue(fChozenGainNumber) << std::endl 
+	    << "           Mgpa Gain = " << gainvalue(fMgpaGainNumber) << std::endl << std::endl;
 	  
   if( fAnalysisName == "AdcPeg12" || fAnalysisName == "AdcSPeg12" ||
       fAnalysisName == "AdcPhys"  || fAnalysisName == "AdcAny" )
@@ -1447,11 +1447,11 @@ void EcnaAnalyzer::CheckMsg(const Int_t& MsgNum, const Int_t& i0Stex)
 	      if( fStexStatus[j0Stex] == 1 ){nStexNbOfTreatedEvents = fStexNbOfTreatedEvents[j0Stex];}
 	      if( fStexStatus[j0Stex] == 2 ){nStexNbOfTreatedEvents = fStexNbOfTreatedEvents[j0Stex];}
 	      
-	      std::cout << fStexName << setw(3) << j0Stex+1 << ": "
-			<< setw(5) << nStexNbOfTreatedEvents << " events. "
+	      std::cout << fStexName << std::setw(3) << j0Stex+1 << ": "
+			<< std::setw(5) << nStexNbOfTreatedEvents << " events. "
 			<< fStexName << " status: " << fStexStatus[j0Stex];
 	      if( j0Stex == i0Stex ){std::cout << " (going to write file for this " << fStexName << ").";}
-	      std::cout << endl; 
+	      std::cout << std::endl; 
 	    }
 	}
 
@@ -1463,31 +1463,31 @@ void EcnaAnalyzer::CheckMsg(const Int_t& MsgNum, const Int_t& i0Stex)
 	      if( fFedStatus[i0FedES] == 1 ){nFedNbOfTreatedEvents = fFedNbOfTreatedEvents[i0FedES];}
 	      if( fFedStatus[i0FedES] == 2 ){nFedNbOfTreatedEvents = fFedNbOfTreatedEvents[i0FedES];}
 	      
-	      std::cout << "Fed (ES) " << setw(3) << i0FedES+1 << ": "
-			<< setw(5) << nFedNbOfTreatedEvents << " events."
+	      std::cout << "Fed (ES) " << std::setw(3) << i0FedES+1 << ": "
+			<< std::setw(5) << nFedNbOfTreatedEvents << " events."
 			<< " Fed status: " << fFedStatus[i0FedES]
-			<< ", order: " << setw(3) << fFedStatusOrder[i0FedES]
-			<< " (" << fDeeNumberString[i0FedES] << ")" << endl;
+			<< ", order: " << std::setw(3) << fFedStatusOrder[i0FedES]
+			<< " (" << fDeeNumberString[i0FedES] << ")" << std::endl;
 	    }
 	  
 	  for(Int_t j0Stex=fStexIndexBegin; j0Stex<fStexIndexStop; j0Stex++)
 	    {
-	      std::cout << fStexName << setw(3) << j0Stex+1 << ": "
-			<< setw(5) << fNbOfTreatedFedsInStex[j0Stex] << " analyzed Fed(s). "
+	      std::cout << fStexName << std::setw(3) << j0Stex+1 << ": "
+			<< std::setw(5) << fNbOfTreatedFedsInStex[j0Stex] << " analyzed Fed(s). "
 			<< fStexName << " status: " << fStexStatus[j0Stex];
 	      if( j0Stex == i0Stex ){std::cout << " (going to write file for this " << fStexName << ").";}
-	      std::cout << endl; 
+	      std::cout << std::endl; 
 	    }
 	}
 
       std::cout << "Number of " << fStexName << "'s with "
-		<< fReqNbOfEvts << " events analyzed: " << fNbOfTreatedStexs << endl;
+		<< fReqNbOfEvts << " events analyzed: " << fNbOfTreatedStexs << std::endl;
     }
   
   if( MsgNum == 1 || MsgNum == 2 )
-    {std::cout << "*---------------------------------------------------------------------------- " << endl;}
+    {std::cout << "*---------------------------------------------------------------------------- " << std::endl;}
   if( MsgNum == 3 )
-    {std::cout << "*............................................................................ " << endl;}
+    {std::cout << "*............................................................................ " << std::endl;}
 
 } // end of EcnaAnalyzer::CheckMsg(const Int_t& MsgNum, const Int_t& i0Stex)
 


### PR DESCRIPTION
Fix about 1300 compilation errors in the ROOT6 IB by adding missing std:: qualifiers in these two packages.
There are no other changes in this pull request.

This is being submitted to the main 7_1_X branch fo keep the code consistent.

Please bypass signatures and merge promptly unless there is something wrong, as without this the ROOT6 IB is useless.
