### PR TITLE
Backport of 70f413982 to 5_3_X

### DIFF
--- a/Alignment/CommonAlignment/interface/Alignable.h
+++ b/Alignment/CommonAlignment/interface/Alignable.h
@@ -198,7 +198,7 @@ public:
   /// cache the current position, rotation and other parameters (e.g. surface deformations)
   virtual void cacheTransformation();
 
-  /// restore the previously cached transformation
+  /// restore the previously cached transformation, also for possible components
   virtual void restoreCachedTransformation();
 
   /// Return survey info

--- a/Alignment/CommonAlignment/src/Alignable.cc
+++ b/Alignment/CommonAlignment/src/Alignable.cc
@@ -250,9 +250,18 @@ void Alignable::cacheTransformation()
 
 void Alignable::restoreCachedTransformation()
 {
+  // first treat itself
   theSurface = theCachedSurface;
   theDisplacement = theCachedDisplacement;
   theRotation = theCachedRotation;
+
+  // now treat components (a clean design would move that to AlignableComposite...)
+  const Alignables comps(this->components());
+
+  for (auto it = comps.begin(); it != comps.end(); ++it) {
+    (*it)->restoreCachedTransformation();
+  }
+ 
 }
 
 //__________________________________________________________________________________________________


### PR DESCRIPTION
This backports a bugfix to 5_3_X to enable correct db-file output in case multiple IOV are used and only large structures were aligned.
