### PR TITLE
Preparation for new mixing part 8

### DIFF
--- a/FastSimulation/Configuration/python/CommonInputs_cff.py
+++ b/FastSimulation/Configuration/python/CommonInputs_cff.py
@@ -37,7 +37,6 @@ from RecoLocalCalo.EcalRecAlgos.EcalSeverityLevelESProducer_cfi import *
 CaloMode = 3
 
 # This flag is to switch between GEN-level and SIM/RECO-level pileup mixing
-# 1: GEN-level <---- DEFAULT
-# 2: SIM/RECO-level; to be used only if CaloMode==3
 
-MixingMode = 1
+MixingMode = 'GenMixing' # GEN-level <---- DEFAULT
+#MixingMode = 'DigiRecoMixing' # SIM/RECO-level; can be used only if CaloMode==3

--- a/FastSimulation/Configuration/python/FamosSequences_cff.py
+++ b/FastSimulation/Configuration/python/FamosSequences_cff.py
@@ -202,7 +202,7 @@ famosConversionSequence = cms.Sequence(conversionTrackSequenceNoEcalSeeded*allCo
 
 if (MixingMode=='DigiRecoMixing'):
     generalConversionTrackProducer.TrackProducer = 'generalTracksBeforeMixing'
-    
+
 from TrackingTools.GsfTracking.CkfElectronCandidateMaker_cff import *
 from TrackingTools.GsfTracking.FwdElectronPropagator_cfi import *
 import TrackingTools.GsfTracking.GsfElectronFit_cfi
@@ -365,7 +365,7 @@ elif(CaloMode==3):
             iterativeTracking+ 
             vertexreco
             )
-    else:
+    elif(MixingMode=='DigiRecoMixing'):
         #dump = cms.EDAnalyzer("EventContentAnalyzer") #TEMP
         simulationSequence = cms.Sequence(
             offlineBeamSpot+
@@ -377,7 +377,7 @@ elif(CaloMode==3):
             iterativeTracking
             )
         digitizationSequence = cms.Sequence(
-            cms.SequencePlaceholder("mix")+
+            cms.SequencePlaceholder("mix")+ # mixHitsAndTracks ?
             muonDigi+
             caloDigis
             )
@@ -390,6 +390,8 @@ elif(CaloMode==3):
         trackVertexReco = cms.Sequence( # for backward compatibility
             trackDigiVertexSequence
             )
+    else:
+        print 'unsupported MixingMode label'
 # out of the 'if':
     caloTowersSequence = cms.Sequence(
         caloRecHits+
@@ -400,11 +402,13 @@ elif(CaloMode==3):
             simulationSequence+
             digitizationSequence#+ # temporary; eventually it will be a block of its own, but it requires intervention on ConfigBuilder
             )
-    else:
+    elif(MixingMode=='DigiRecoMixing'):
         famosSimulationSequence = cms.Sequence( 
             simulationSequence+
             trackDigiVertexSequence
         )        
+    else:
+        print 'unsupported MixingMode label'
 
 famosEcalDrivenElectronSequence = cms.Sequence(
     famosGsfTrackSequence+
@@ -441,7 +445,7 @@ if(CaloMode==3):
             famosBTaggingSequence+
             famosPFTauTaggingSequence
             )
-    else:
+    elif(MixingMode=='DigiRecoMixing'):
         reconstructionWithFamos = cms.Sequence(
             caloTowersSequence+
             particleFlowCluster+
@@ -467,6 +471,8 @@ if(CaloMode==3):
             famosBTaggingSequence+
             famosPFTauTaggingSequence
             )
+    else:
+        print 'unsupported MixingMode label'
 else:
     reconstructionWithFamos = cms.Sequence(
         trackVertexReco+

--- a/FastSimulation/Configuration/python/FamosSequences_cff.py
+++ b/FastSimulation/Configuration/python/FamosSequences_cff.py
@@ -109,12 +109,6 @@ from SimMuon.Configuration.SimMuon_cff import *
 simMuonCSCDigis.strips.doCorrelatedNoise = False ## Saves a little bit of time
 
 
-#if (MixingMode==2):
-#    simMuonCSCDigis.mixLabel = 'mixSimCaloHits'
-#    simMuonDTDigis.mixLabel = 'mixSimCaloHits'
-#    simMuonRPCDigis.mixLabel = 'mixSimCaloHits'
-#else:
-#if (MixingMode==1):
 simMuonCSCDigis.InputCollection = 'MuonSimHitsMuonCSCHits'
 simMuonDTDigis.InputCollection = 'MuonSimHitsMuonDTHits'
 simMuonRPCDigis.InputCollection = 'MuonSimHitsMuonRPCHits'
@@ -206,7 +200,7 @@ from RecoEgamma.Configuration.RecoEgamma_cff import egammaHighLevelRecoPostPF
 allConversions.src = 'gsfGeneralConversionTrackMerger'
 famosConversionSequence = cms.Sequence(conversionTrackSequenceNoEcalSeeded*allConversionSequence)
 
-if (MixingMode==2):
+if (MixingMode=='DigiRecoMixing'):
     generalConversionTrackProducer.TrackProducer = 'generalTracksBeforeMixing'
     
 from TrackingTools.GsfTracking.CkfElectronCandidateMaker_cff import *
@@ -354,7 +348,7 @@ elif(CaloMode==2):
         caloTowersRec
         )
 elif(CaloMode==3):
-    if(MixingMode==1):
+    if(MixingMode=='GenMixing'):
         simulationSequence = cms.Sequence(
             offlineBeamSpot+
             cms.SequencePlaceholder("famosMixing")+
@@ -401,7 +395,7 @@ elif(CaloMode==3):
         caloRecHits+
         caloTowersRec
         )
-    if(MixingMode==1):
+    if(MixingMode=='GenMixing'):
         famosSimulationSequence = cms.Sequence( 
             simulationSequence+
             digitizationSequence#+ # temporary; eventually it will be a block of its own, but it requires intervention on ConfigBuilder
@@ -419,7 +413,7 @@ famosEcalDrivenElectronSequence = cms.Sequence(
 
 # The reconstruction sequence
 if(CaloMode==3):
-    if(MixingMode==1):
+    if(MixingMode=='GenMixing'):
         reconstructionWithFamos = cms.Sequence(
             digitizationSequence+ # temporary; repetition!
             trackVertexReco+

--- a/FastSimulation/Configuration/python/FamosSequences_cff.py
+++ b/FastSimulation/Configuration/python/FamosSequences_cff.py
@@ -377,7 +377,7 @@ elif(CaloMode==3):
             iterativeTracking
             )
         digitizationSequence = cms.Sequence(
-            cms.SequencePlaceholder("mix")+ # mixHitsAndTracks ?
+            cms.SequencePlaceholder("mixHitsAndTracks")+
             muonDigi+
             caloDigis
             )

--- a/FastSimulation/Configuration/python/FamosSequences_cff.py
+++ b/FastSimulation/Configuration/python/FamosSequences_cff.py
@@ -206,6 +206,9 @@ from RecoEgamma.Configuration.RecoEgamma_cff import egammaHighLevelRecoPostPF
 allConversions.src = 'gsfGeneralConversionTrackMerger'
 famosConversionSequence = cms.Sequence(conversionTrackSequenceNoEcalSeeded*allConversionSequence)
 
+if (MixingMode==2):
+    generalConversionTrackProducer.TrackProducer = 'generalTracksBeforeMixing'
+    
 from TrackingTools.GsfTracking.CkfElectronCandidateMaker_cff import *
 from TrackingTools.GsfTracking.FwdElectronPropagator_cfi import *
 import TrackingTools.GsfTracking.GsfElectronFit_cfi
@@ -351,9 +354,6 @@ elif(CaloMode==2):
         caloTowersRec
         )
 elif(CaloMode==3):
-    
-    dump = cms.EDAnalyzer("EventContentAnalyzer") #TEMP
-
     if(MixingMode==1):
         simulationSequence = cms.Sequence(
             offlineBeamSpot+
@@ -372,6 +372,7 @@ elif(CaloMode==3):
             vertexreco
             )
     else:
+        #dump = cms.EDAnalyzer("EventContentAnalyzer") #TEMP
         simulationSequence = cms.Sequence(
             offlineBeamSpot+
             famosSimHits+
@@ -388,6 +389,7 @@ elif(CaloMode==3):
             )
         trackDigiVertexSequence = cms.Sequence(
             trackReco+
+            #dump+ #TEMP
             digitizationSequence+
             vertexreco
             )

--- a/FastSimulation/Configuration/python/MixingHitsAndTracks_cff.py
+++ b/FastSimulation/Configuration/python/MixingHitsAndTracks_cff.py
@@ -1,7 +1,6 @@
 #from FastSimulation.Configuration.mixNoPU_cfi import * 
 
 from SimGeneral.PileupInformation.AddPileupSummary_cfi import *
-#addPileupInfo.PileupMixingLabel = 'mixSimCaloHits'
 addPileupInfo.PileupMixingLabel = 'mix'
 addPileupInfo.simHitLabel = 'g4SimHits'
 
@@ -10,16 +9,4 @@ mixHitsAndTracks = cms.Sequence(
     mix+
     addPileupInfo
     )
-    
-
-#from FastSimulation.Configuration.mixHitsWithPU_cfi import *
-#mixHits = cms.Sequence(
-#    mixSimCaloHits+
-#    addPileupInfo
-#    )
-    
-#from FastSimulation.Configuration.mixTracksWithPU_cfi import *
-#mixTracks = cms.Sequence(
-#    mixRecoTracks
-#    )
     

--- a/FastSimulation/Configuration/python/mixFastSimObjects_cfi.py
+++ b/FastSimulation/Configuration/python/mixFastSimObjects_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from FastSimulation.Configuration.CommonInputs_cff import * # temporary, just to select the MixingMode
 
-if (MixingMode==2):
+if (MixingMode=='DigiRecoMixing'):
     mixReconstructedTracks = cms.PSet(
         input = cms.VInputTag(cms.InputTag("generalTracks")),
         type = cms.string('RecoTrack')

--- a/FastSimulation/Configuration/python/mixHitsAndTracksWithPU_cfi.py
+++ b/FastSimulation/Configuration/python/mixHitsAndTracksWithPU_cfi.py
@@ -1,28 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
-simEcalUnsuppressedDigis = cms.EDAlias( #remove?
-    mixSimCaloHits = cms.VPSet(
-    cms.PSet(type = cms.string('EBDigiCollection')),
-    cms.PSet(type = cms.string('EEDigiCollection')),
-    cms.PSet(type = cms.string('ESDigiCollection'))
-    )
-    )
-
 simEcalUnsuppressedDigis = cms.EDAlias(
     mix = cms.VPSet(
     cms.PSet(type = cms.string('EBDigiCollection')),
     cms.PSet(type = cms.string('EEDigiCollection')),
     cms.PSet(type = cms.string('ESDigiCollection'))
-    )
-    )
-
-simHcalUnsuppressedDigis = cms.EDAlias(#remove?
-    mixSimCaloHits = cms.VPSet(
-    cms.PSet(type = cms.string('HBHEDataFramesSorted')),
-    cms.PSet(type = cms.string('HFDataFramesSorted')),
-    cms.PSet(type = cms.string('HODataFramesSorted')),
-    cms.PSet(type = cms.string('HcalUpgradeDataFramesSorted')),
-    cms.PSet(type = cms.string('ZDCDataFramesSorted'))
     )
     )
 
@@ -37,7 +19,15 @@ simHcalUnsuppressedDigis = cms.EDAlias(
     )
 
 generalTracks = cms.EDAlias(
-    mix = cms.VPSet( cms.PSet(type=cms.string('recoTracks') ) )
+    mix = cms.VPSet( cms.PSet(type=cms.string('recoTracks'),
+                              fromProductInstance = cms.string('generalTracks'),
+                              toProductInstance = cms.string('') ),
+                     cms.PSet(type=cms.string('recoTrackExtras'),
+                              fromProductInstance = cms.string('generalTracks'),
+                              toProductInstance = cms.string('') ),
+                     cms.PSet(type=cms.string('TrackingRecHitsOwned'),
+                              fromProductInstance = cms.string('generalTracks'),
+                              toProductInstance = cms.string('') ) )
     )
 
 
@@ -75,7 +65,7 @@ mix = cms.EDProducer("MixingModule",
                                            tracker = cms.PSet(trackAccumulator)),
                      LabelPlayback = cms.string(''),
                      maxBunch = cms.int32(0),
-                     minBunch = cms.int32(0), ## -4in terms of 25nsec
+                     minBunch = cms.int32(0), ## in terms of 25nsec
 
                      bunchspace = cms.int32(250), ##ns
                      mixProdStep1 = cms.bool(False),
@@ -87,7 +77,7 @@ mix = cms.EDProducer("MixingModule",
                      
                      input = cms.SecSource("PoolSource",
                          nbPileupEvents = cms.PSet(
-                         averageNumber = cms.double(16.)  ###fede prova tracce
+                         averageNumber = cms.double(0.) 
                          ),
                          type = cms.string('poisson'),
                          sequential = cms.untracked.bool(False),

--- a/FastSimulation/Configuration/python/mixHitsAndTracksWithPU_cfi.py
+++ b/FastSimulation/Configuration/python/mixHitsAndTracksWithPU_cfi.py
@@ -30,7 +30,6 @@ generalTracks = cms.EDAlias(
                               toProductInstance = cms.string('') ) )
     )
 
-
 from SimGeneral.MixingModule.ecalDigitizer_cfi import *
 import SimCalorimetry.EcalSimProducers.ecalDigiParameters_cff
 ecal_digi_parameters =SimCalorimetry.EcalSimProducers.ecalDigiParameters_cff.ecal_digi_parameters.clone()

--- a/FastSimulation/ParticleFlow/python/ParticleFlowFastSimNeutralHadron_cff.py
+++ b/FastSimulation/ParticleFlow/python/ParticleFlowFastSimNeutralHadron_cff.py
@@ -47,7 +47,7 @@ particleFlowClusterHFHAD.thresh_Clean_Endcap = cms.double(1E5)
 
 ### With the new mixing scheme, the label of the Trajectory collection for the primary event is different:
 from FastSimulation.Configuration.CommonInputs_cff import *
-if(CaloMode==3 and MixingMode==2):
+if(CaloMode==3 and MixingMode=='DigiRecoMixing'):
     trackerDrivenElectronSeeds.TkColList = cms.VInputTag(cms.InputTag("generalTracksBeforeMixing"))
 
 

--- a/FastSimulation/ParticleFlow/python/ParticleFlowFastSimNeutralHadron_cff.py
+++ b/FastSimulation/ParticleFlow/python/ParticleFlowFastSimNeutralHadron_cff.py
@@ -45,6 +45,11 @@ particleFlowClusterHFHAD.thresh_Clean_Endcap = cms.double(1E5)
 #particleFlow.usePFConversions = cms.bool(True)
 #particleFlow.usePFDecays = cms.bool(True)
 
+### With the new mixing scheme, the label of the Trajectory collection for the primary event is different:
+from FastSimulation.Configuration.CommonInputs_cff import *
+if(CaloMode==3 and MixingMode==2):
+    trackerDrivenElectronSeeds.TkColList = cms.VInputTag(cms.InputTag("generalTracksBeforeMixing"))
+
 
 famosParticleFlowSequence = cms.Sequence(
     caloTowersRec+

--- a/FastSimulation/ParticleFlow/python/ParticleFlowFastSim_cff.py
+++ b/FastSimulation/ParticleFlow/python/ParticleFlowFastSim_cff.py
@@ -46,7 +46,7 @@ particleFlowClusterHFHAD.thresh_Clean_Endcap = cms.double(1E5)
 
 ### With the new mixing scheme, the label of the Trajectory collection for the primary event is different:
 from FastSimulation.Configuration.CommonInputs_cff import *
-if(CaloMode==3 and MixingMode==2):
+if(CaloMode==3 and MixingMode=='DigiRecoMixing'):
     trackerDrivenElectronSeeds.TkColList = cms.VInputTag(cms.InputTag("generalTracksBeforeMixing"))
 
 

--- a/FastSimulation/ParticleFlow/python/ParticleFlowFastSim_cff.py
+++ b/FastSimulation/ParticleFlow/python/ParticleFlowFastSim_cff.py
@@ -44,6 +44,11 @@ particleFlowClusterHFHAD.thresh_Clean_Endcap = cms.double(1E5)
 #particleFlow.usePFConversions = cms.bool(True)
 #particleFlow.usePFDecays = cms.bool(True)
 
+### With the new mixing scheme, the label of the Trajectory collection for the primary event is different:
+from FastSimulation.Configuration.CommonInputs_cff import *
+if(CaloMode==3 and MixingMode==2):
+    trackerDrivenElectronSeeds.TkColList = cms.VInputTag(cms.InputTag("generalTracksBeforeMixing"))
+
 
 famosParticleFlowSequence = cms.Sequence(
     caloTowersRec+

--- a/FastSimulation/PileUpProducer/python/mix_2012_Summer_inTimeOnly_cff.py
+++ b/FastSimulation/PileUpProducer/python/mix_2012_Summer_inTimeOnly_cff.py
@@ -65,15 +65,11 @@ prob = cms.vdouble(
 
 from FastSimulation.Configuration.CommonInputs_cff import * # CaloMode and MixingMode are defined here
 
-if (MixingMode==2):
+if (MixingMode=='DigiRecoMixing'):
     # mix at SIM and RECO levels:
     from FastSimulation.Configuration.MixingHitsAndTracks_cff import *
     mix.input.nbPileupEvents.probFunctionVariable = npu
     mix.input.nbPileupEvents.probValue = prob
-#    mixSimCaloHits.input.nbPileupEvents.probFunctionVariable = npu
-#    mixSimCaloHits.input.nbPileupEvents.probValue = prob
-#    mixRecoTracks.input.nbPileupEvents.probFunctionVariable = npu
-#    mixRecoTracks.input.nbPileupEvents.probValue = prob
 else:
     # mix at GEN level:
     from FastSimulation.Configuration.MixingFull_cff import *

--- a/FastSimulation/PileUpProducer/python/mix_2012_Summer_inTimeOnly_cff.py
+++ b/FastSimulation/PileUpProducer/python/mix_2012_Summer_inTimeOnly_cff.py
@@ -1,4 +1,4 @@
-from FastSimulation.PileUpProducer.PileUpSimulator8TeV_cfi import *
+from FastSimulation.PileUpProducer.PileUpSimulator13TeV_cfi import *
 
 npu = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59)
 prob = cms.vdouble(
@@ -63,16 +63,18 @@ prob = cms.vdouble(
                          1.570E-05,
                          5.005E-06)
 
-from FastSimulation.Configuration.CommonInputs_cff import * # CaloMode and MixingMode are defined here
+from FastSimulation.Configuration.CommonInputs_cff import MixingMode # CaloMode and MixingMode are defined here
 
 if (MixingMode=='DigiRecoMixing'):
     # mix at SIM and RECO levels:
     from FastSimulation.Configuration.MixingHitsAndTracks_cff import *
     mix.input.nbPileupEvents.probFunctionVariable = npu
     mix.input.nbPileupEvents.probValue = prob
-else:
+elif (MixingMode=='GenMixing'):
     # mix at GEN level:
     from FastSimulation.Configuration.MixingFull_cff import *
     mixGenPU.input.nbPileupEvents.probFunctionVariable = npu
     mixGenPU.input.nbPileupEvents.probValue = prob
+else:
+    print 'unsupported MixingMode label'
     

--- a/FastSimulation/PileUpProducer/python/mix_E8TeV_AVE_10_BX_inTimeOnly.py
+++ b/FastSimulation/PileUpProducer/python/mix_E8TeV_AVE_10_BX_inTimeOnly.py
@@ -2,7 +2,7 @@ from FastSimulation.PileUpProducer.PileUpSimulator8TeV_cfi import *
 
 from FastSimulation.Configuration.CommonInputs_cff import *
 
-if (MixingMode==2):
+if (MixingMode=='DigiRecoMixing'):
     # mix at SIM level:
     from FastSimulation.Configuration.MixingHitsAndTracks_cff import *
     mixSimCaloHits.input.nbPileupEvents.averageNumber = cms.double(10.0) 

--- a/FastSimulation/PileUpProducer/python/mix_E8TeV_AVE_140_BX_inTimeOnly.py
+++ b/FastSimulation/PileUpProducer/python/mix_E8TeV_AVE_140_BX_inTimeOnly.py
@@ -2,7 +2,7 @@ from FastSimulation.PileUpProducer.PileUpSimulator8TeV_cfi import *
 
 from FastSimulation.Configuration.CommonInputs_cff import *
 
-if (MixingMode==2):
+if (MixingMode=='DigiRecoMixing'):
     # mix at SIM level:
     from FastSimulation.Configuration.MixingHitsAndTracks_cff import *
     mixSimCaloHits.input.nbPileupEvents.averageNumber = cms.double(140.0) 

--- a/FastSimulation/PileUpProducer/python/mix_E8TeV_AVE_200_BX_inTimeOnly.py
+++ b/FastSimulation/PileUpProducer/python/mix_E8TeV_AVE_200_BX_inTimeOnly.py
@@ -2,7 +2,7 @@ from FastSimulation.PileUpProducer.PileUpSimulator8TeV_cfi import *
 
 from FastSimulation.Configuration.CommonInputs_cff import *
 
-if (MixingMode==2):
+if (MixingMode=='DigiRecoMixing'):
     # mix at SIM level:
     from FastSimulation.Configuration.MixingHitsAndTracks_cff import *
     mixSimCaloHits.input.nbPileupEvents.averageNumber = cms.double(200.0) 

--- a/FastSimulation/PileUpProducer/python/mix_E8TeV_AVE_70_BX_inTimeOnly.py
+++ b/FastSimulation/PileUpProducer/python/mix_E8TeV_AVE_70_BX_inTimeOnly.py
@@ -2,8 +2,8 @@ from FastSimulation.PileUpProducer.PileUpSimulator8TeV_cfi import *
 
 from FastSimulation.Configuration.CommonInputs_cff import *
 
-if (MixingMode==2):
-    # mix at SIM level:
+if (MixingMode=='DigiRecoMixing'):
+    # mix at SIM/RECO level:
     from FastSimulation.Configuration.MixingHitsAndTracks_cff import *
     mixSimCaloHits.input.nbPileupEvents.averageNumber = cms.double(70.0) 
     mixSimCaloHits.input.type = cms.string('poisson')

--- a/FastSimulation/PileUpProducer/python/mix_NoPileUp_cfi.py
+++ b/FastSimulation/PileUpProducer/python/mix_NoPileUp_cfi.py
@@ -2,12 +2,8 @@ from FastSimulation.PileUpProducer.PileUpSimulator8TeV_cfi import *
 
 from FastSimulation.Configuration.CommonInputs_cff import *
 
-if (MixingMode==2):
-    # mix at SIM level:
+if (MixingMode=='DigiRecoMixing'):
+    # mix at SIM and RECO level:
     from FastSimulation.Configuration.MixingHitsAndTracks_cff import *
     mix.input.nbPileupEvents.averageNumber = cms.double(0.0) 
     mix.input.type = cms.string('poisson')
-#    mixSimCaloHits.input.nbPileupEvents.averageNumber = cms.double(0.0) 
-#    mixSimCaloHits.input.type = cms.string('poisson')
-#    mixRecoTracks.input.nbPileupEvents.averageNumber = cms.double(0.0) 
-#    mixRecoTracks.input.type = cms.string('poisson')

--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
@@ -3,12 +3,20 @@
 #include "FWCore/Framework/interface/one/EDProducer.h"
 
 RecoTrackAccumulator::RecoTrackAccumulator(const edm::ParameterSet& conf, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
-  GeneralTrackInput_(conf.getParameter<edm::InputTag>("GeneralTrackInput")),
-  GeneralTrackOutput_(conf.getParameter<std::string>("GeneralTrackOutput"))
+  InputSignal_(conf.getParameter<edm::InputTag>("InputSignal")),
+  InputPileup_(conf.getParameter<edm::InputTag>("InputPileup")),
+  GeneralTrackOutput_(conf.getParameter<std::string>("GeneralTrackOutput")),
+  HitOutput_(conf.getParameter<std::string>("HitOutput")),
+  GeneralTrackExtraOutput_(conf.getParameter<std::string>("GeneralTrackExtraOutput"))
 {
 
   mixMod.produces<reco::TrackCollection>(GeneralTrackOutput_);
-  iC.consumes<reco::TrackCollection>(GeneralTrackInput_);
+  mixMod.produces<TrackingRecHitCollection>(HitOutput_);
+  mixMod.produces<reco::TrackExtraCollection>(GeneralTrackExtraOutput_);
+
+  iC.consumes<reco::TrackCollection>(InputSignal_);
+  iC.consumes<TrackingRecHitCollection>(InputSignal_);
+  iC.consumes<reco::TrackExtraCollection>(InputSignal_);
 }
   
 RecoTrackAccumulator::~RecoTrackAccumulator() {
@@ -18,6 +26,12 @@ RecoTrackAccumulator::~RecoTrackAccumulator() {
 void RecoTrackAccumulator::initializeEvent(edm::Event const& e, edm::EventSetup const& iSetup) {
     
   NewTrackList_ = std::auto_ptr<reco::TrackCollection>(new reco::TrackCollection());
+  NewHitList_ = std::auto_ptr<TrackingRecHitCollection>(new TrackingRecHitCollection());
+  NewTrackExtraList_ = std::auto_ptr<reco::TrackExtraCollection>(new reco::TrackExtraCollection());
+
+  // this is needed to get the ProductId of the TrackExtra and TrackingRecHit collections
+  rTrackExtras=const_cast<edm::Event&>( e ).getRefBeforePut<reco::TrackExtraCollection>(GeneralTrackExtraOutput_);
+  rHits=const_cast<edm::Event&>( e ).getRefBeforePut<TrackingRecHitCollection>(HitOutput_);
 
 }
   
@@ -25,35 +39,64 @@ void RecoTrackAccumulator::accumulate(edm::Event const& e, edm::EventSetup const
   
 
   edm::Handle<reco::TrackCollection> tracks;
-  e.getByLabel(GeneralTrackInput_, tracks);
-  
-  if (tracks.isValid()) {
-    for (auto const& track : *tracks) {
-      NewTrackList_->push_back(track);
-    }
-  }
+  edm::Handle<TrackingRecHitCollection> hits;
+  edm::Handle<reco::TrackExtraCollection> trackExtras;
+  e.getByLabel(InputSignal_, tracks);
+  e.getByLabel(InputSignal_, hits);
+  e.getByLabel(InputSignal_, trackExtras);
+
+  // Call the templated version that does the same for both signal and pileup events
+  accumulateEvent( e, iSetup, tracks, trackExtras, hits );
 
 }
+
 
 void RecoTrackAccumulator::accumulate(PileUpEventPrincipal const& e, edm::EventSetup const& iSetup) {
 
   if (e.bunchCrossing()==0) {
     edm::Handle<reco::TrackCollection> tracks;
-    e.getByLabel(GeneralTrackInput_, tracks);
+    edm::Handle<TrackingRecHitCollection> hits;
+    edm::Handle<reco::TrackExtraCollection> trackExtras;
+    e.getByLabel(InputPileup_, tracks);
+    e.getByLabel(InputPileup_, hits);
+    e.getByLabel(InputPileup_, trackExtras);
     
-    if (tracks.isValid()) {
-      for (reco::TrackCollection::const_iterator track = tracks->begin();  track != tracks->end();  ++track) {
-	NewTrackList_->push_back(*track);
-      }
-    }
-  }
+    // Call the templated version that does the same for both signal and pileup events
+    accumulateEvent( e, iSetup, tracks, trackExtras, hits );
 
+  }
 }
 
 void RecoTrackAccumulator::finalizeEvent(edm::Event& e, const edm::EventSetup& iSetup) {
   
   e.put( NewTrackList_, GeneralTrackOutput_ );
+  e.put( NewHitList_, HitOutput_ );
+  e.put( NewTrackExtraList_, GeneralTrackExtraOutput_ );
 
 }
 
 
+template<class T> void RecoTrackAccumulator::accumulateEvent(const T& e, edm::EventSetup const& iSetup, edm::Handle<reco::TrackCollection> tracks, edm::Handle<reco::TrackExtraCollection> tracksExtras, edm::Handle<TrackingRecHitCollection> hits) {
+
+  if (tracks.isValid()) {
+    short track_counter = 0;
+    //    short hit_counter = 0;
+    for (auto const& track : *tracks) {
+      NewTrackList_->push_back(track);
+      // track extras:
+      NewTrackExtraList_->push_back(tracksExtras->at(track_counter));
+      NewTrackList_->back().setExtra( reco::TrackExtraRef( rTrackExtras, NewTrackExtraList_->size() - 1) );
+      //reco::TrackExtra & tx = NewTrackExtraList_->back();
+      //tx.setResiduals(track.residuals());
+      // rechits:
+      for( trackingRecHit_iterator hit = track.recHitsBegin(); hit != track.recHitsEnd(); ++ hit ) {
+	NewHitList_->push_back( (*hit)->clone() ); // is this safe?
+	//	tx.add( TrackingRecHitRef( rHits, NewHitList_->size() - 1) );
+	//	hit_counter++;
+      }
+
+      track_counter++;
+    }
+  }
+
+}

--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
@@ -21,17 +21,9 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
+#include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
 
 
-/*
-namespace edm {
-  class EDProducer;
-  class Event;
-  class EventSetup;
-  class ParameterSet;
-  template<typename T> class Handle;
-}
-*/
 namespace edm {
   class ConsumesCollector;
   template<typename T> class Handle;
@@ -53,9 +45,22 @@ class RecoTrackAccumulator : public DigiAccumulatorMixMod
   virtual void finalizeEvent(edm::Event& e, edm::EventSetup const& c);
   
  private:
+  template<class T> void accumulateEvent(const T& e, edm::EventSetup const& c, edm::Handle<reco::TrackCollection> t, edm::Handle<reco::TrackExtraCollection> tx, edm::Handle<TrackingRecHitCollection> h);
+
   std::auto_ptr<reco::TrackCollection> NewTrackList_;
-  edm::InputTag GeneralTrackInput_;
+  std::auto_ptr<reco::TrackExtraCollection> NewTrackExtraList_;
+  std::auto_ptr<TrackingRecHitCollection> NewHitList_;
+
+  reco::TrackExtraRefProd rTrackExtras;
+  TrackingRecHitRefProd rHits;
+
+  edm::InputTag InputSignal_;
+  edm::InputTag InputPileup_;
+
   std::string GeneralTrackOutput_;
+  std::string HitOutput_;
+  std::string GeneralTrackExtraOutput_;
+
 };
 
 

--- a/FastSimulation/Tracking/python/GeneralTracks_cfi.py
+++ b/FastSimulation/Tracking/python/GeneralTracks_cfi.py
@@ -34,7 +34,7 @@ generalTracksBase = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackLis
 
 # this block is to switch between defaul behaviour (MixingMode==1) and new mixing
 from FastSimulation.Configuration.CommonInputs_cff import MixingMode
-if (MixingMode==1):
+if (MixingMode=='GenMixing'):
     generalTracks = generalTracksBase.clone()
 else: 
     generalTracksBeforeMixing = generalTracksBase.clone()

--- a/FastSimulation/Tracking/python/GeneralTracks_cfi.py
+++ b/FastSimulation/Tracking/python/GeneralTracks_cfi.py
@@ -32,7 +32,7 @@ generalTracksBase = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackLis
     )
 
 
-# this block is to switch between defaul behaviour (MixingMode==1) and new mixing
+# this block is to switch between defaul behaviour (MixingMode=='GenMixing') and new mixing
 from FastSimulation.Configuration.CommonInputs_cff import MixingMode
 if (MixingMode=='GenMixing'):
     generalTracks = generalTracksBase.clone()

--- a/FastSimulation/Tracking/python/GeneralTracks_cfi.py
+++ b/FastSimulation/Tracking/python/GeneralTracks_cfi.py
@@ -36,5 +36,7 @@ generalTracksBase = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackLis
 from FastSimulation.Configuration.CommonInputs_cff import MixingMode
 if (MixingMode=='GenMixing'):
     generalTracks = generalTracksBase.clone()
-else: 
+elif (MixingMode=='DigiRecoMixing'):
     generalTracksBeforeMixing = generalTracksBase.clone()
+else: 
+    print 'unsupported MixingMode label'

--- a/FastSimulation/Tracking/python/GeneralTracks_cfi.py
+++ b/FastSimulation/Tracking/python/GeneralTracks_cfi.py
@@ -1,23 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-#generalTracks = cms.EDProducer("FastTrackMerger",
-#    # new quality setting
-#    newQuality = cms.untracked.string('confirmed'),
-#    # set new quality for confirmed tracks
-#    promoteTrackQuality = cms.untracked.bool(True),
-#    TrackProducers = cms.VInputTag(
-#       cms.InputTag("zeroStepFilter"),
-#       cms.InputTag("zerofivefilter"),
-#       cms.InputTag("firstfilter"),
-#       cms.InputTag("secfilter"),
-#       cms.InputTag("thfilter"),
-#       cms.InputTag("foufilter"),
-#       cms.InputTag("fifthfilter"),
-#    )
-#)
-
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
-generalTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
+generalTracksBase = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = (cms.InputTag('initialStepTracks'),
                       cms.InputTag('lowPtTripletStepTracks'),
                       cms.InputTag('pixelPairStepTracks'),
@@ -25,10 +9,10 @@ generalTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMer
                       cms.InputTag('mixedTripletStepTracks'),
                       cms.InputTag('pixelLessStepTracks'),
                       cms.InputTag('tobTecStepTracks'),
-#### not validated yet                      cms.InputTag('muonSeededTracksOutIn'),
-#### not validated yet                      cms.InputTag('muonSeededTracksInOut')
+                      #### not validated yet                      cms.InputTag('muonSeededTracksOutIn'),
+                      #### not validated yet                      cms.InputTag('muonSeededTracksInOut')
                       ),
-###    hasSelector=cms.vint32(1,1,1,1,1,1,1,1,1),
+    ###    hasSelector=cms.vint32(1,1,1,1,1,1,1,1,1),
     hasSelector=cms.vint32(1,1,1,1,1,1,1),
     selectedTrackQuals = cms.VInputTag(cms.InputTag("initialStepSelector","initialStep"),
                                        cms.InputTag("lowPtTripletStepSelector","lowPtTripletStep"),
@@ -37,12 +21,20 @@ generalTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMer
                                        cms.InputTag("mixedTripletStep"),
                                        cms.InputTag("pixelLessStepSelector","pixelLessStep"),
                                        cms.InputTag("tobTecStepSelector","tobTecStep"),
-#### not validated yet                                       cms.InputTag("muonSeededTracksOutInSelector","muonSeededTracksOutInHighPurity"),
-#### not validated yet                                       cms.InputTag("muonSeededTracksInOutSelector","muonSeededTracksInOutHighPurity")
+                                       #### not validated yet                                       cms.InputTag("muonSeededTracksOutInSelector","muonSeededTracksOutInHighPurity"),
+                                       #### not validated yet                                       cms.InputTag("muonSeededTracksInOutSelector","muonSeededTracksInOutHighPurity")
                                        ),
-###    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6,7,8), pQual=cms.bool(True) )
+    ###    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6,7,8), pQual=cms.bool(True) )
     setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6), pQual=cms.bool(True) )
                              ),
     copyExtras = True,
     makeReKeyedSeeds = cms.untracked.bool(False)
     )
+
+
+# this block is to switch between defaul behaviour (MixingMode==1) and new mixing
+from FastSimulation.Configuration.CommonInputs_cff import MixingMode
+if (MixingMode==1):
+    generalTracks = generalTracksBase.clone()
+else: 
+    generalTracksBeforeMixing = generalTracksBase.clone()

--- a/FastSimulation/Tracking/python/IterativeTracking_cff.py
+++ b/FastSimulation/Tracking/python/IterativeTracking_cff.py
@@ -21,9 +21,11 @@ if (MixingMode=='DigiRecoMixing'):
 #    generalTracksBeforeMixing = FastSimulation.Tracking.GeneralTracks_cfi.generalTracks.clone()
     trackExtrapolator.trackSrc = cms.InputTag("generalTracksBeforeMixing")
     lastTrackingSteps = cms.Sequence(generalTracksBeforeMixing+trackExtrapolator)
-else:
+elif (MixingMode=='GenMixing'):
     lastTrackingSteps = cms.Sequence(generalTracks+trackExtrapolator)
-
+else:
+    print 'unsupported MixingMode label'
+        
 import RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi
 MeasurementTrackerEvent = RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi.MeasurementTrackerEvent.clone(
     pixelClusterProducer = '',

--- a/FastSimulation/Tracking/python/IterativeTracking_cff.py
+++ b/FastSimulation/Tracking/python/IterativeTracking_cff.py
@@ -15,7 +15,7 @@ from FastSimulation.Tracking.IterativePixelLessStep_cff import *
 from FastSimulation.Tracking.IterativeTobTecStep_cff import *
 from FastSimulation.Tracking.MuonSeededStep_cff import *
 
-# this block is to switch between defaul behaviour (MixingMode==1) and new mixing
+# this block is to switch between defaul behaviour (MixingMode=='GenMixing') and new mixing
 from FastSimulation.Configuration.CommonInputs_cff import MixingMode
 if (MixingMode=='DigiRecoMixing'):
 #    generalTracksBeforeMixing = FastSimulation.Tracking.GeneralTracks_cfi.generalTracks.clone()

--- a/FastSimulation/Tracking/python/IterativeTracking_cff.py
+++ b/FastSimulation/Tracking/python/IterativeTracking_cff.py
@@ -15,6 +15,15 @@ from FastSimulation.Tracking.IterativePixelLessStep_cff import *
 from FastSimulation.Tracking.IterativeTobTecStep_cff import *
 from FastSimulation.Tracking.MuonSeededStep_cff import *
 
+# this block is to switch between defaul behaviour (MixingMode==1) and new mixing
+from FastSimulation.Configuration.CommonInputs_cff import MixingMode
+if (MixingMode==2):
+#    generalTracksBeforeMixing = FastSimulation.Tracking.GeneralTracks_cfi.generalTracks.clone()
+    trackExtrapolator.trackSrc = cms.InputTag("generalTracksBeforeMixing")
+    lastTrackingSteps = cms.Sequence(generalTracksBeforeMixing+trackExtrapolator)
+else:
+    lastTrackingSteps = cms.Sequence(generalTracks+trackExtrapolator)
+
 import RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi
 MeasurementTrackerEvent = RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi.MeasurementTrackerEvent.clone(
     pixelClusterProducer = '',
@@ -33,7 +42,7 @@ iterativeTracking = cms.Sequence(pixelTracking+pixelVertexing
                                  +iterativePixelLessStep
                                  +iterativeTobTecStep
 # not validated yet:                                 +muonSeededStep 
-                                 +generalTracks
-                                 +trackExtrapolator)
-
+#                                 +generalTracks
+#                                 +trackExtrapolator)
+                                 +lastTrackingSteps)
 

--- a/FastSimulation/Tracking/python/IterativeTracking_cff.py
+++ b/FastSimulation/Tracking/python/IterativeTracking_cff.py
@@ -17,7 +17,7 @@ from FastSimulation.Tracking.MuonSeededStep_cff import *
 
 # this block is to switch between defaul behaviour (MixingMode==1) and new mixing
 from FastSimulation.Configuration.CommonInputs_cff import MixingMode
-if (MixingMode==2):
+if (MixingMode=='DigiRecoMixing'):
 #    generalTracksBeforeMixing = FastSimulation.Tracking.GeneralTracks_cfi.generalTracks.clone()
     trackExtrapolator.trackSrc = cms.InputTag("generalTracksBeforeMixing")
     lastTrackingSteps = cms.Sequence(generalTracksBeforeMixing+trackExtrapolator)

--- a/FastSimulation/Tracking/python/recoTrackAccumulator_cfi.py
+++ b/FastSimulation/Tracking/python/recoTrackAccumulator_cfi.py
@@ -1,8 +1,14 @@
 import FWCore.ParameterSet.Config as cms
 
 trackAccumulator = cms.PSet(
-    GeneralTrackInput = cms.InputTag("generalTracks"),
+
+    InputSignal = cms.InputTag("generalTracksBeforeMixing"),
+    InputPileup = cms.InputTag("generalTracks"),
+
     GeneralTrackOutput = cms.string("generalTracks"),
+    GeneralTrackExtraOutput = cms.string("generalTracks"),
+    HitOutput = cms.string("generalTracks"),
+
     accumulatorType = cms.string("RecoTrackAccumulator"),
     makeDigiSimLinks = cms.untracked.bool(False)
     )


### PR DESCRIPTION
Same as pull request 2016, plus a modification to give meaningful names (instead of numbers) to the mixing options.
The default is still the old mixing.
The issue pointed out by @Dr15Jones (about which TrackingRecHits are accessed) is not solved yet, but I'd like to get this pull request merged into a release as soon as possible anyway, to prevent my code from further diverging from CMSSW. It only affects the new mixing (not default), and the code compiles and runs even so.
