### PR TITLE
Backported patch 70f41398 to 4_4_X

### DIFF
--- a/Alignment/CommonAlignment/interface/Alignable.h
+++ b/Alignment/CommonAlignment/interface/Alignable.h
@@ -18,9 +18,6 @@ class SurfaceDeformation;
  * Any Alignable object can be moved and rotated.
  * Also an alignment uncertainty can be set.
  *
- *  $Date: 2010/10/29 12:16:28 $
- *  $Revision: 1.34 $
- *  (last update by $Author: mussgill $)
  */
 
 class AlignmentParameters;

--- a/Alignment/CommonAlignment/interface/Alignable.h
+++ b/Alignment/CommonAlignment/interface/Alignable.h
@@ -18,8 +18,8 @@ class SurfaceDeformation;
  * Any Alignable object can be moved and rotated.
  * Also an alignment uncertainty can be set.
  *
- *  $Date: 2011/05/23 20:53:16 $
- *  $Revision: 1.35 $
+ *  $Date: 2010/10/29 12:16:28 $
+ *  $Revision: 1.34 $
  *  (last update by $Author: mussgill $)
  */
 
@@ -198,7 +198,7 @@ public:
   /// cache the current position, rotation and other parameters (e.g. surface deformations)
   virtual void cacheTransformation();
 
-  /// restore the previously cached transformation
+  /// restore the previously cached transformation, also for possible components
   virtual void restoreCachedTransformation();
 
   /// Return survey info

--- a/Alignment/CommonAlignment/src/Alignable.cc
+++ b/Alignment/CommonAlignment/src/Alignable.cc
@@ -1,8 +1,5 @@
 /** \file Alignable.cc
  *
- *  $Date: 2010/10/29 12:20:22 $
- *  $Revision: 1.21 $
- *  (last update by $Author: mussgill $)
  */
 
 #include "Alignment/CommonAlignment/interface/AlignmentParameters.h"

--- a/Alignment/CommonAlignment/src/Alignable.cc
+++ b/Alignment/CommonAlignment/src/Alignable.cc
@@ -1,7 +1,7 @@
 /** \file Alignable.cc
  *
- *  $Date: 2011/05/23 20:53:18 $
- *  $Revision: 1.22 $
+ *  $Date: 2010/10/29 12:20:22 $
+ *  $Revision: 1.21 $
  *  (last update by $Author: mussgill $)
  */
 
@@ -250,9 +250,17 @@ void Alignable::cacheTransformation()
 
 void Alignable::restoreCachedTransformation()
 {
+  // first treat itself
   theSurface = theCachedSurface;
   theDisplacement = theCachedDisplacement;
   theRotation = theCachedRotation;
+
+  // now treat components (a clean design would move that to AlignableComposite...)
+  const Alignables comps(this->components());
+
+  for (Alignables::const_iterator it = comps.begin(); it != comps.end(); ++it) {
+    (*it)->restoreCachedTransformation();
+  }
 }
 
 //__________________________________________________________________________________________________


### PR DESCRIPTION
Backported patch 70f41398 to 4_4_X for fixing db file creation mistake with multiple IOV and only large structures are aligned
