### PR TITLE
Update tp selection for 620 slhcx

### DIFF
--- a/Validation/RecoTrack/python/MTVHistoProducerAlgoForTrackerBlock_cfi.py
+++ b/Validation/RecoTrack/python/MTVHistoProducerAlgoForTrackerBlock_cfi.py
@@ -24,9 +24,9 @@ MTVHistoProducerAlgoForTrackerBlock = cms.PSet(
     # to be added here all the other histogram settings
 
     #
-    minEta = cms.double(-5.0),
-    maxEta = cms.double(5.0),
-    nintEta = cms.int32(50),
+    minEta = cms.double(-4.5),
+    maxEta = cms.double(4.5),
+    nintEta = cms.int32(90),
     useFabsEta = cms.bool(False),
     #
     minPt = cms.double(0.1),
@@ -68,8 +68,8 @@ MTVHistoProducerAlgoForTrackerBlock = cms.PSet(
 
     # Pileup vertices
     minVertcount = cms.double(-0.5),
-    maxVertcount = cms.double(120.5),
-    nintVertcount = cms.int32(121),
+    maxVertcount = cms.double(160.5),
+    nintVertcount = cms.int32(161),
     #
     #parameters for resolution plots
     ptRes_rangeMin = cms.double(-0.1),

--- a/Validation/RecoTrack/python/TrackingParticleSelectionForEfficiency_cfi.py
+++ b/Validation/RecoTrack/python/TrackingParticleSelectionForEfficiency_cfi.py
@@ -6,9 +6,9 @@ TrackingParticleSelectionForEfficiency = cms.PSet(
     stableOnlyTP = cms.bool(False),
     pdgIdTP = cms.vint32(),
     signalOnlyTP = cms.bool(False),
-    minRapidityTP = cms.double(-5.0),
+    minRapidityTP = cms.double(-4.5),
     minHitTP = cms.int32(0),
     ptMinTP = cms.double(0.005),
-    maxRapidityTP = cms.double(5.0),
+    maxRapidityTP = cms.double(4.5),
     tipTP = cms.double(60)
 )

--- a/Validation/RecoTrack/python/TrackingParticleSelectionsForEfficiency_cff.py
+++ b/Validation/RecoTrack/python/TrackingParticleSelectionsForEfficiency_cff.py
@@ -6,10 +6,10 @@ generalTpSelectorBlock = cms.PSet(
     pdgId = cms.vint32(),
     signalOnly = cms.bool(True),
     stableOnly = cms.bool(False),
-    minRapidity = cms.double(-5.0),
+    minRapidity = cms.double(-4.5),
     minHit = cms.int32(0),
     ptMin = cms.double(0.9),
-    maxRapidity = cms.double(5.0),
+    maxRapidity = cms.double(4.5),
     tip = cms.double(3.5)
 )
 
@@ -20,10 +20,10 @@ TpSelectorForEfficiencyVsEtaBlock = cms.PSet(
     pdgId = cms.vint32(),
     signalOnly = cms.bool(True),
     stableOnly = cms.bool(False),
-    minRapidity = cms.double(-5.0),
+    minRapidity = cms.double(-4.5),
     minHit = cms.int32(0),
     ptMin = cms.double(0.9),
-    maxRapidity = cms.double(5.0),
+    maxRapidity = cms.double(4.5),
     tip = cms.double(3.5)
 )
 
@@ -34,7 +34,7 @@ TpSelectorForEfficiencyVsPhiBlock = cms.PSet(
     signalOnly = cms.bool(True),
     stableOnly = cms.bool(False),
     minRapidity = cms.double(-2.5),
-    minHit = cms.int32(3),
+    minHit = cms.int32(0),
     ptMin = cms.double(0.9),
     maxRapidity = cms.double(2.5),
     tip = cms.double(3.5)
@@ -47,7 +47,7 @@ TpSelectorForEfficiencyVsPtBlock = cms.PSet(
     stableOnly = cms.bool(False),
     minRapidity = cms.double(-2.5),
     maxRapidity = cms.double(2.5),
-    minHit = cms.int32(3),
+    minHit = cms.int32(0),
     ptMin = cms.double(0.050),
     tip = cms.double(3.5),
     lip = cms.double(30.0),
@@ -59,11 +59,11 @@ TpSelectorForEfficiencyVsVTXRBlock = cms.PSet(
     signalOnly = cms.bool(True),
     stableOnly = cms.bool(False),
     minRapidity = cms.double(-2.5),
-    minHit = cms.int32(3),
+    minHit = cms.int32(0),
     ptMin = cms.double(0.9),
     maxRapidity = cms.double(2.5),
     lip = cms.double(30.0),
-    tip = cms.double(30.0)
+    tip = cms.double(60.0)
 )
 
 TpSelectorForEfficiencyVsVTXZBlock = cms.PSet(
@@ -72,9 +72,9 @@ TpSelectorForEfficiencyVsVTXZBlock = cms.PSet(
     signalOnly = cms.bool(True),
     stableOnly = cms.bool(False),
     minRapidity = cms.double(-2.5),
-    minHit = cms.int32(3),
+    minHit = cms.int32(0),
     ptMin = cms.double(0.9),
     maxRapidity = cms.double(2.5),
-    lip = cms.double(35.0),
+    lip = cms.double(30.0),
     tip = cms.double(3.5)
 )


### PR DESCRIPTION
Updating the TP selection for the 6_2_0_SLHCX branch. The main change is reducing the minHit requirement to 0. The eta range has also been changed to (-4.5, 4.5) and the number of bins for the efficiency v/s eta plot has been increased to 90.
