### PR TITLE
Fix bug that prevents putting a long long or unsigned long long into an event.

### DIFF
--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -174,8 +174,8 @@ namespace edm {
       {std::string("unsigned int"), TypeWithDict(typeid(unsigned int))},
       {std::string("long"), TypeWithDict(typeid(long))},
       {std::string("unsigned long"), TypeWithDict(typeid(unsigned long))},
-      {std::string("long long"), TypeWithDict(typeid(int))},
-      {std::string("unsigned long long"), TypeWithDict(typeid(int))},
+      {std::string("long long"), TypeWithDict(typeid(long long))},
+      {std::string("unsigned long long"), TypeWithDict(typeid(unsigned long long))},
       {std::string("float"), TypeWithDict(typeid(float))},
       {std::string("double"), TypeWithDict(typeid(double))},
       // {std::string("long double"), TypeWithDict(typeid(long double))}, // ROOT does not seem to know about long double


### PR DESCRIPTION
Frank Golf discovered that, in 7_0_X, one could not insert an EDProduct of type unsigned long long into an event.
This was due to a bug in FWCore/Utilities/src/TypeWithDict.cc which was a typo on two consecutilve lines that
was likely a cut and paste error when the code was written.

This is a very safe fix.  If it is not fixed, not only will EDProducts of (unsigned) long long not be able to be put into an event, but there may be other problems, such as using views to look at collections of long long.

This bug was introduced in 7_0_X. It does not affect prior release cycles.

This bug is ROOT 5 specific.  While this fix should be carried forward into 7_1_X, it cannot be carried forward to 7_1_ROOT6_X, because TypeWithDict.cc is totally different there.

A unit test has been enhanced so that this problem would have been found.  A separate pull request to 7_1_X will be issued for the unit test because, unlike this fix, the unit test should be carried forward into 7_1_ROOT6_X.
