### PR TITLE
Add DAS caching option to runTheMatrix.py

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixRunner.py
+++ b/Configuration/PyReleaseValidation/python/MatrixRunner.py
@@ -60,7 +60,7 @@ class MatrixRunner(object):
     	    
     	    print '\nPreparing to run %s %s' % (wf.numId, item)
           
-    	    current = WorkFlowRunner(wf,noRun,dryRun,cafVeto)
+    	    current = WorkFlowRunner(wf,noRun,dryRun,cafVeto, opt.dasCacheFile)
     	    self.threadList.append(current)
     	    current.start()
             if not dryRun:

--- a/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
+++ b/Configuration/PyReleaseValidation/python/WorkFlowRunner.py
@@ -7,7 +7,7 @@ import shutil
 from subprocess import Popen 
 
 class WorkFlowRunner(Thread):
-    def __init__(self, wf, noRun=False,dryRun=False,cafVeto=True):
+    def __init__(self, wf, noRun=False,dryRun=False,cafVeto=True,dasCacheFile=None):
         Thread.__init__(self)
         self.wf = wf
 
@@ -18,6 +18,7 @@ class WorkFlowRunner(Thread):
         self.noRun=noRun
         self.dryRun=dryRun
         self.cafVeto=cafVeto
+        self.dasCacheFile=dasCacheFile
         
         self.wfDir=str(self.wf.numId)+'_'+self.wf.nameId
         return
@@ -100,7 +101,7 @@ class WorkFlowRunner(Thread):
                     cmd2 =cmd+cmd2+closeCmd(istep,'lumiRanges')
                     lumiRangeFile='step%d_lumiRanges.log'%(istep,)
                     retStep = self.doCmd(cmd2)
-                cmd+=com.das()
+                cmd+=com.das(self.dasCacheFile)
                 cmd+=closeCmd(istep,'dasquery')
                 retStep = self.doCmd(cmd)
                 #don't use the file list executed, but use the das command of cmsDriver for next step

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -50,14 +50,15 @@ class InputInfo(object):
         self.ib_blacklist = ib_blacklist
         self.ib_block = ib_block
         
-    def das(self):
+    def das(self, query_cache):
         query_by = "block" if self.ib_block else "dataset"
         query_source = "{0}#{1}".format(self.dataSet, self.ib_block) if self.ib_block else self.dataSet
+        query_cache = query_cache and "--cache " + query_cache or ""
         if len(self.run) is not 0:
-            command = ";".join(["das_client.py --limit=0 --query 'file {0}={1} run={2}'".format(query_by, query_source, query_run) for query_run in self.run])
+            command = ";".join(["das_client.py {3} --limit=0 --query 'file {0}={1} run={2}'".format(query_by, query_source, query_run, query_cache) for query_run in self.run])
             command = "({0})".format(command)
         else:
-            command = "das_client.py --limit=0 --query 'file {0}={1} site=T2_CH_CERN'".format(query_by, query_source)
+            command = "das_client.py {2} --limit=0 --query 'file {0}={1} site=T2_CH_CERN'".format(query_by, query_source, query_cache)
        
         # Run filter on DAS output 
         if self.ib_blacklist:

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -180,6 +180,13 @@ if __name__ == '__main__':
                       default=False,
                       action='store_true')
 
+    parser.add_option('--das-cache-file',
+                      help='File with fallback DAS queries in case of outage.',
+                      dest='dasCacheFile',
+                      default=None,
+                      action='store')
+
+
 
     
     opt,args = parser.parse_args()


### PR DESCRIPTION
`das_client.py` has now an option to specify canned queries results in
case of DAS outages. This commit adds support for such a new option
to runTheMatrix.py so that jobs which need to query DAS simply
"pro-forma" (i.e. to make sure we do exactly what woul be done in
real production) are not stopped by occasional outages.

The goal is not to replace DAS queries, but simply to provide a
fallback option for the cases where we know data is there, most
notably IBs and pull request automated tests.

See also dmwm/DAS#4142 .
