### PR TITLE
Change default cfg track assoc 70 x

### DIFF
--- a/SimTracker/TrackAssociation/python/quickTrackAssociatorByHits_cfi.py
+++ b/SimTracker/TrackAssociation/python/quickTrackAssociatorByHits_cfi.py
@@ -3,13 +3,13 @@ import FWCore.ParameterSet.Config as cms
 quickTrackAssociatorByHits = cms.ESProducer("QuickTrackAssociatorByHitsESProducer",
 	AbsoluteNumberOfHits = cms.bool(False),
 	Cut_RecoToSim = cms.double(0.75),
-	SimToRecoDenominator = cms.string('sim'), # either "sim" or "reco"
+	SimToRecoDenominator = cms.string('reco'), # either "sim" or "reco"
 	Quality_SimToReco = cms.double(0.5),
 	Purity_SimToReco = cms.double(0.75),
 	ThreeHitTracksAreSpecial = cms.bool(True),
 	associatePixel = cms.bool(True),
 	associateStrip = cms.bool(True),
         ComponentName = cms.string('quickTrackAssociatorByHits'),
-        useClusterTPAssociation = cms.bool(False),
+        useClusterTPAssociation = cms.bool(True),
         cluster2TPSrc = cms.InputTag("tpClusterProducer")
 )

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -12,8 +12,6 @@ from SimTracker.TrackerHitAssociation.clusterTpAssociationProducer_cfi import *
 
 TrackAssociatorByHitsRecoDenom= SimTracker.TrackAssociation.quickTrackAssociatorByHits_cfi.quickTrackAssociatorByHits.clone(
     ComponentName = cms.string('TrackAssociatorByHitsRecoDenom'),  
-    useClusterTPAssociation = cms.bool(True),
-    SimToRecoDenominator = cms.string('reco')
     )
 # Validation iterative steps
 cutsRecoTracksZero = PhysicsTools.RecoAlgos.recoTrackSelector_cfi.recoTrackSelector.clone()

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -9,10 +9,12 @@ from Validation.RecoTrack.PostProcessorTracker_cfi import *
 import PhysicsTools.RecoAlgos.recoTrackSelector_cfi
 
 from SimTracker.TrackerHitAssociation.clusterTpAssociationProducer_cfi import *
+from SimTracker.TrackAssociation.trackingParticleRecoTrackAsssociation_cfi import *
 
 TrackAssociatorByHitsRecoDenom= SimTracker.TrackAssociation.quickTrackAssociatorByHits_cfi.quickTrackAssociatorByHits.clone(
     ComponentName = cms.string('TrackAssociatorByHitsRecoDenom'),  
-    )
+    )#actually not used but needed to have proper folder names
+
 # Validation iterative steps
 cutsRecoTracksZero = PhysicsTools.RecoAlgos.recoTrackSelector_cfi.recoTrackSelector.clone()
 cutsRecoTracksZero.algorithm=cms.vstring("iter0")
@@ -81,7 +83,7 @@ cutsRecoTracksTenthHp = PhysicsTools.RecoAlgos.recoTrackSelector_cfi.recoTrackSe
 cutsRecoTracksTenthHp.algorithm=cms.vstring("iter10")
 cutsRecoTracksTenthHp.quality=cms.vstring("highPurity")
 
-trackValidator= Validation.RecoTrack.MultiTrackValidator_cfi.multiTrackValidator.clone()
+trackValidator= Validation.RecoTrack.MultiTrackValidator_cfi.multiTrackValidator.clone(UseAssociators = cms.bool(False))
 
 trackValidator.label=cms.VInputTag(cms.InputTag("generalTracks"),
                                    cms.InputTag("cutsRecoTracksHp"),
@@ -132,6 +134,6 @@ tracksValidationSelectors = cms.Sequence( cutsRecoTracksHp*
                                 cutsRecoTracksTenthHp )
 
 # selectors go into separate "prevalidation" sequence
-tracksValidation = cms.Sequence( tpClusterProducer * trackValidator)
+tracksValidation = cms.Sequence( tpClusterProducer * trackingParticleRecoTrackAsssociation * trackValidator)
 tracksValidationFS = cms.Sequence( trackValidator )
 

--- a/Validation/RecoVertex/python/VertexValidation_cff.py
+++ b/Validation/RecoVertex/python/VertexValidation_cff.py
@@ -1,7 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from SimTracker.TrackAssociation.trackingParticleRecoTrackAsssociation_cff import *
-
 from Validation.RecoVertex.v0validator_cfi import *
 
-vertexValidation = cms.Sequence(trackingParticleRecoTrackAsssociation*v0Validator)
+vertexValidation = cms.Sequence(v0Validator)


### PR DESCRIPTION
Propagate the changes from the new TrackingParticles to the trackingParticleRecoTrackAsssociation and the V0 validator. Also, use the (now faster) trackingParticleRecoTrackAsssociation in the MultiTrackValidator so that a further speed gain is achieved.
On events with PU~20 (runTheMatrix 202.0) it reduced the time of trackingParticleRecoTrackAsssociation by 94% (!) and of trackValidator by 20%.
The output should be unchanged.

For 70X, 71X and 620SHLCX
