### PR TITLE
Propagate exceptions from TFile opening

### DIFF
--- a/FWCore/Utilities/interface/ExceptionPropagate.h
+++ b/FWCore/Utilities/interface/ExceptionPropagate.h
@@ -1,0 +1,13 @@
+#ifndef FWCore_Utilities_ExceptionPropagate_h
+#define FWCore_Utilities_ExceptionPropagate_h
+
+#include <exception>
+
+namespace edm {
+  namespace threadLocalException {
+    void setException(std::exception_ptr e);
+    std::exception_ptr getException();
+  }
+}
+
+#endif

--- a/FWCore/Utilities/src/ExceptionPropagate.cc
+++ b/FWCore/Utilities/src/ExceptionPropagate.cc
@@ -1,0 +1,15 @@
+#include "FWCore/Utilities/interface/ExceptionPropagate.h"
+
+namespace edm {
+  namespace threadLocalException {
+    static thread_local std::exception_ptr stdExceptionPtr;
+    void setException(std::exception_ptr e) {
+      stdExceptionPtr = e;
+    }
+    std::exception_ptr getException() {
+      return stdExceptionPtr;
+    }
+  }
+
+}
+

--- a/IOPool/Input/src/InputFile.cc
+++ b/IOPool/Input/src/InputFile.cc
@@ -5,8 +5,10 @@ Holder for an input TFile.
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/ExceptionPropagate.h"
 #include "FWCore/Utilities/interface/TimeOfDay.h"
 
+#include <exception>
 #include <iomanip>
 
 namespace edm {
@@ -15,6 +17,11 @@ namespace edm {
 
     logFileAction(msg, fileName);
     file_.reset(TFile::Open(fileName));
+    std::exception_ptr e = edm::threadLocalException::getException();
+    if(e != std::exception_ptr()) {
+      edm::threadLocalException::setException(std::exception_ptr());
+      std::rethrow_exception(e);
+    }
     if(!file_) {
       return;
     }
@@ -70,7 +77,7 @@ namespace edm {
     Service<JobReport> reportSvc;
     reportSvc->reportSkippedFile(fileName, logicalFileName);
   }
- 
+
   void
   InputFile::reportFallbackAttempt(std::string const& pfn, std::string const& logicalFileName, std::string const& errorMessage) {
     Service<JobReport> reportSvc;

--- a/IOPool/Output/src/RootOutputFile.cc
+++ b/IOPool/Output/src/RootOutputFile.cc
@@ -30,6 +30,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/ExceptionPropagate.h"
 
 #include "TROOT.h"
 #include "TTree.h"
@@ -61,6 +62,17 @@ namespace edm {
         lh->processName() < rh->processName() ? true :
         false;
     }
+
+    TFile*
+    openTFile(char const* name, int compressionLevel) {
+      TFile* file = TFile::Open(name, "recreate", "", compressionLevel);
+      std::exception_ptr e = edm::threadLocalException::getException();
+      if(e != std::exception_ptr()) {
+        edm::threadLocalException::setException(std::exception_ptr());
+        std::rethrow_exception(e);
+      }
+      return file;
+    }
   }
 
   RootOutputFile::RootOutputFile(PoolOutputModule* om, std::string const& fileName, std::string const& logicalFileName) :
@@ -70,7 +82,7 @@ namespace edm {
       om_(om),
       whyNotFastClonable_(om_->whyNotFastClonable()),
       canFastCloneAux_(false),
-      filePtr_(TFile::Open(file_.c_str(), "recreate", "", om_->compressionLevel())),
+      filePtr_(openTFile(file_.c_str(), om_->compressionLevel())),
       fid_(),
       eventEntryNumber_(0LL),
       lumiEntryNumber_(0LL),
@@ -470,9 +482,9 @@ namespace edm {
                                         &desc, om_->basketSize(), 0))
       throw Exception(errors::FatalRootError)
         << "Failed to create a branch for Parentages in the output file";
-    
+
     ParentageRegistry& ptReg = *ParentageRegistry::instance();
-    
+
     std::vector<ParentageID> orderedIDs(parentageIDs_.size());
     for(auto const& parentageID : parentageIDs_) {
       orderedIDs[parentageID.second] = parentageID.first;
@@ -484,7 +496,7 @@ namespace edm {
       // so a null value of desc can't be fatal.
       // Root will default construct an object in that case.
       parentageTree_->Fill();
-    }    
+    }
   }
 
   void RootOutputFile::writeFileFormatVersion() {
@@ -724,7 +736,7 @@ namespace edm {
       dummy.first->Destructor(const_cast<void *>(dummy.second));
     }
   }
-  
+
   bool
   RootOutputFile::insertProductProvenance(const edm::ProductProvenance& iProv,
                                           std::set<edm::StoredProductProvenance>& oToInsert) {

--- a/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
+++ b/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
@@ -5,6 +5,7 @@
 #include "Utilities/StorageFactory/interface/StatisticsSenderService.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/ExceptionPropagate.h"
 #include "ReadRepacker.h"
 #include "TFileCacheRead.h"
 #include "TSystem.h"
@@ -84,6 +85,7 @@ static StorageAccount::Counter *s_statsWrite = 0;
 static StorageAccount::Counter *s_statsCWrite = 0;
 static StorageAccount::Counter *s_statsXWrite = 0;
 
+
 static inline StorageAccount::Counter &
 storageCounter(StorageAccount::Counter *&c, const char *label)
 {
@@ -111,7 +113,11 @@ TStorageFactoryFile::TStorageFactoryFile(const char *path,
   : TFile(path, "NET", ftitle, compress), // Pass "NET" to prevent local access in base class
     storage_(0)
 {
-  Initialize(path, option);
+  try {
+    Initialize(path, option);
+  } catch (...) {
+    edm::threadLocalException::setException(std::current_exception()); // capture
+  }
 }
 
 TStorageFactoryFile::TStorageFactoryFile(const char *path,
@@ -121,7 +127,11 @@ TStorageFactoryFile::TStorageFactoryFile(const char *path,
   : TFile(path, "NET", ftitle, compress), // Pass "NET" to prevent local access in base class
     storage_(0)
 {
-  Initialize(path, option);
+  try {
+    Initialize(path, option);
+  } catch (...) {
+    edm::threadLocalException::setException(std::current_exception()); // capture
+  }
 }
 
 void
@@ -374,7 +384,7 @@ TStorageFactoryFile::ReadBuffersSync(char *buf, Long64_t *pos, Int_t *len, Int_t
 
   Int_t remaining = nbuf; // Number of read requests left to process.
   Int_t pack_count; // Number of read requests processed by this iteration.
-    
+
   IOSize remaining_buffer_size=0;
   // Calculate the remaining buffer size for the ROOT-owned buffer by adding
   // the size of the various requests.
@@ -409,7 +419,7 @@ TStorageFactoryFile::ReadBuffersSync(char *buf, Long64_t *pos, Int_t *len, Int_t
 
     current_pos += pack_count;
     current_len += pack_count;
-    remaining   -= pack_count; 
+    remaining   -= pack_count;
 
   }
   assert(remaining_buffer_size == 0);


### PR DESCRIPTION
This is a fix for numerous relval failures in the ROOT6 branch.  It is being queued to the main 7_1_X because it is 100% compatible with ROOT5.
ROOT6 cannot propagate exceptions across the just-in-time interpreter, which is used every time cmsRun opens a TFile.   This means that, if a file cannot be opened for any reason, our TFileAdaptor throws an exception, which JIT makes into a call to terminate().  This fix uses a thread local static std::exception_ptr to
store the exception instead of immediately throwing it.  Then the caller of TFile::Open can check if there was an exception and rethrow it.
Attempts to open a TFile outside of cmsRun jobs do not have this problem, because they use the standard ROOT adaptor, which does not throw.
This request has been tested with the short relval matrix.  There were no errors.
Please merge this in a timely manner after testing and after it is signed.
