### PR TITLE
Adding accessors for setting either pt or e in correctors

### DIFF
--- a/JetMETCorrections/Algorithms/src/L1FastjetCorrector.cc
+++ b/JetMETCorrections/Algorithms/src/L1FastjetCorrector.cc
@@ -69,6 +69,7 @@ double L1FastjetCorrector::correction(const reco::Jet& fJet,
   double result(1.0);
   mCorrector->setJetEta(fJet.eta());
   mCorrector->setJetPt(fJet.pt());
+  mCorrector->setJetE(fJet.energy());
   mCorrector->setJetA(fJet.jetArea());
   mCorrector->setRho(*rho);
   result = mCorrector->getCorrection();  

--- a/JetMETCorrections/Algorithms/src/L1OffsetCorrector.cc
+++ b/JetMETCorrections/Algorithms/src/L1OffsetCorrector.cc
@@ -73,6 +73,7 @@ double L1OffsetCorrector::correction(const reco::Jet& fJet,
   if (NPV > 0) {
     mCorrector->setJetEta(fJet.eta());
     mCorrector->setJetPt(fJet.pt());
+    mCorrector->setJetE(fJet.energy());
     mCorrector->setNPV(NPV);
     result = mCorrector->getCorrection();
   }


### PR DESCRIPTION
For future compatibility (and for backwards compatibility with users code) it is useful to set both the E and pt for jet corrections. This has no underlying affect but will allow for possible future developments, and will help users to migrate their code correctly. 
