### PR TITLE
Remove workarounds for two ROOT6 bugs that were fixed

### DIFF
--- a/DataFormats/Provenance/interface/IndexIntoFile.h
+++ b/DataFormats/Provenance/interface/IndexIntoFile.h
@@ -189,7 +189,7 @@ namespace edm {
       class SortedRunOrLumiItr;
       class IndexRunLumiEventKey;
 
-      typedef long EntryNumber_t;
+      typedef long long EntryNumber_t;
       static int const invalidIndex = -1;
       static RunNumber_t const invalidRun = 0U;
       static LuminosityBlockNumber_t const invalidLumi = 0U;
@@ -370,7 +370,6 @@ namespace edm {
 
       class RunOrLumiIndexes {
       public:
-        RunOrLumiIndexes();
         RunOrLumiIndexes(int processHistoryIDIndex, RunNumber_t run, LuminosityBlockNumber_t lumi, int indexToGetEntry);
 
         int processHistoryIDIndex() const {return processHistoryIDIndex_;}
@@ -780,10 +779,6 @@ namespace edm {
 
       class IndexRunKey {
       public:
-        IndexRunKey() :
-          processHistoryIDIndex_(invalidIndex),
-          run_(invalidRun) {
-        }
         IndexRunKey(int index, RunNumber_t run) :
           processHistoryIDIndex_(index),
           run_(run) {
@@ -809,11 +804,6 @@ namespace edm {
 
       class IndexRunLumiKey {
       public:
-        IndexRunLumiKey() :
-          processHistoryIDIndex_(invalidIndex),
-          run_(invalidRun),
-          lumi_(invalidLumi) {
-        }
         IndexRunLumiKey(int index, RunNumber_t run, LuminosityBlockNumber_t lumi) :
           processHistoryIDIndex_(index),
           run_(run),
@@ -845,13 +835,6 @@ namespace edm {
 
       class IndexRunLumiEventKey {
       public:
-        IndexRunLumiEventKey() :
-          processHistoryIDIndex_(invalidIndex),
-          run_(invalidRun),
-          lumi_(invalidLumi),
-          event_(invalidEvent) {
-        }
-
         IndexRunLumiEventKey(int index, RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) :
           processHistoryIDIndex_(index),
           run_(run),

--- a/DataFormats/Provenance/src/IndexIntoFile.cc
+++ b/DataFormats/Provenance/src/IndexIntoFile.cc
@@ -941,16 +941,6 @@ namespace edm {
   {
   }
 
-  IndexIntoFile::RunOrLumiIndexes::RunOrLumiIndexes() :
-    processHistoryIDIndex_(invalidIndex),
-    run_(invalidRun),
-    lumi_(invalidLumi),
-    indexToGetEntry_(invalidIndex),
-    beginEventNumbers_(-1),
-    endEventNumbers_(-1)
-  {
-  }
-
   IndexIntoFile::SortedRunOrLumiItr::SortedRunOrLumiItr(IndexIntoFile const* indexIntoFile, unsigned runOrLumi) :
     indexIntoFile_(indexIntoFile), runOrLumi_(runOrLumi) {
     assert(runOrLumi_ <= indexIntoFile_->runOrLumiEntries().size());


### PR DESCRIPTION
This pull request removes workaronds for two ROOT6 bugs that were fixed a while back.
This request reverts the two affected files to what they are in the 7_1_X branch.
The two ROOT6 bugs fixed were:
1) Infinite recursion of function calls if there is a persistent data member that is a container of (unsigned) long long.
2) Exceptions thrown if some transient data members did not have default constructors.
This request:
1) reverts long to long long
2) Removes the unnecessary default constructors.
Tested against the short relval matrix.  No changes observed.
