### PR TITLE
Enhance unit test to check TypeWithDict::byName

### DIFF
--- a/DataFormats/Common/test/DictionaryTools_t.cpp
+++ b/DataFormats/Common/test/DictionaryTools_t.cpp
@@ -4,6 +4,7 @@
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "FWCore/Utilities/interface/DictionaryTools.h"
 #include "FWCore/Utilities/interface/TypeDemangler.h"
+#include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
 
@@ -135,6 +136,13 @@ namespace {
     if(bool(type)) {
       std::string demangledName(edm::typeDemangle(typeid(T).name()));
       CPPUNIT_ASSERT(type.name() == demangledName);
+
+      edm::TypeID tid(type.typeInfo());
+      CPPUNIT_ASSERT(tid.className() == demangledName);
+
+      edm::TypeWithDict typeFromName = edm::TypeWithDict::byName(demangledName);
+      edm::TypeID tidFromName(typeFromName.typeInfo());
+      CPPUNIT_ASSERT(tidFromName.className() == demangledName);
     }
   }
 
@@ -143,6 +151,7 @@ namespace {
     checkIt<std::vector<T> >();
     checkIt<edm::Wrapper<T> >();
     checkIt<edm::Wrapper<std::vector<T> > >();
+    checkIt<T>();
   }
 }
 
@@ -162,6 +171,5 @@ void TestDictionaries::demangling() {
   checkDemangling<double>();
   checkDemangling<bool>();
   checkDemangling<std::string>();
-  checkIt<std::string>();
 }
 


### PR DESCRIPTION
This pull request is an enhancement to the dictionary tools unit tests.  This enhancement would have found the error found in 7_0_X that caused an exception to be thrown if an attempt is made to put a long long or unsigned long long EDProduct into an event.  This test applies equally well to ROOT5 and ROOT6.
