### PR TITLE
Fixed thread problem from reading provenance from file

### DIFF
--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -273,8 +273,8 @@ void FedRawDataInputSource::read(edm::EventPrincipal& eventPrincipal)
   edm::WrapperOwningHolder edp(new edm::Wrapper<FEDRawDataCollection>(rawData),
                                edm::Wrapper<FEDRawDataCollection>::getInterface());
   
-  eventPrincipal.put(daqProvenanceHelper_.constBranchDescription_, edp,
-                     daqProvenanceHelper_.dummyProvenance_);
+  eventPrincipal.put(daqProvenanceHelper_.branchDescription(), edp,
+                     daqProvenanceHelper_.dummyProvenance());
   
   return;
 }

--- a/FWCore/Sources/BuildFile.xml
+++ b/FWCore/Sources/BuildFile.xml
@@ -6,6 +6,7 @@
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/Utilities"/>
 <use   name="boost"/>
+<use   name="tbb"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/FWCore/Sources/src/DaqProvenanceHelper.cc
+++ b/FWCore/Sources/src/DaqProvenanceHelper.cc
@@ -192,4 +192,9 @@ namespace edm {
   DaqProvenanceHelper::mapBranchID(BranchID const& branchID) const {
     return(branchID == oldBranchID_ ? newBranchID_ : branchID);
   }
+
+  void DaqProvenanceHelper::setOldParentageIDToNew(ParentageID const& iOld, ParentageID const& iNew) {
+    parentageIDMap_.insert(std::make_pair(iOld, iNew));
+  }
+
 }

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -201,7 +201,7 @@ namespace edm {
       duplicateChecker_(duplicateChecker),
       provenanceAdaptor_(),
       provenanceReaderMaker_(),
-      eventProductProvenanceRetriever_(),
+      eventProductProvenanceRetrievers_(),
       parentageIDLookup_(),
       daqProvenanceHelper_() {
 
@@ -380,7 +380,7 @@ namespace edm {
         it->second.init();
         daqProvenanceHelper_.reset(new DaqProvenanceHelper(it->second.unwrappedTypeID()));
         // Create the new branch description
-        BranchDescription const& newBD = daqProvenanceHelper_->constBranchDescription_;
+        BranchDescription const& newBD = daqProvenanceHelper_->branchDescription();
         // Save info from the old and new branch descriptions
         daqProvenanceHelper_->saveInfo(it->second, newBD);
         // Map the new branch name to the old branch name.
@@ -525,7 +525,7 @@ namespace edm {
         daqProvenanceHelper_->fixMetaData(parents.parentsForUpdate());
         ParentageID newID = parents.id();
         if(newID != oldID) {
-          daqProvenanceHelper_->parentageIDMap_.insert(std::make_pair(oldID, newID));
+          daqProvenanceHelper_->setOldParentageIDToNew(oldID,newID);
         }
       }
       // For thread safety, don't update global registries when a secondary source opens a file.
@@ -561,7 +561,7 @@ namespace edm {
         daqProvenanceHelper_->fixMetaData(parents.parentsForUpdate());
         ParentageID newID = parents.id();
         if(newID != oldID) {
-          daqProvenanceHelper_->parentageIDMap_.insert(std::make_pair(oldID, newID));
+          daqProvenanceHelper_->setOldParentageIDToNew(oldID,newID);
         }
       }
       // For thread safety, don't update global registries when a secondary source opens a file.
@@ -1384,7 +1384,7 @@ namespace edm {
 
     // If this next assert shows up in performance profiling or significantly affects memory, then these three lines should be deleted.
     // The IndexIntoFile should guarantee that it never fails.
-    ProcessHistoryID idToCheck = (daqProvenanceHelper_ && fileFormatVersion().useReducedProcessHistoryID() ? *daqProvenanceHelper_->oldProcessHistoryID_ : eventAux().processHistoryID());
+    ProcessHistoryID idToCheck = (daqProvenanceHelper_ && fileFormatVersion().useReducedProcessHistoryID() ? *daqProvenanceHelper_->oldProcessHistoryID() : eventAux().processHistoryID());
     ProcessHistoryID const& reducedPHID = processHistoryRegistry_->reducedProcessHistoryID(idToCheck);
     assert(reducedPHID == indexIntoFile_.processHistoryID(indexIntoFileIter_.processHistoryIDIndex()));
 
@@ -1412,7 +1412,7 @@ namespace edm {
                                  *processHistoryRegistry_,
                                  std::move(eventSelectionIDs_),
                                  std::move(branchListIndexes_),
-                                 *(makeProductProvenanceRetriever()),
+                                 *(makeProductProvenanceRetriever(principal.streamID().value())),
                                  eventTree_.rootDelayedReader());
 
     // report event read from file
@@ -1741,12 +1741,15 @@ namespace edm {
   }
 
   boost::shared_ptr<ProductProvenanceRetriever>
-  RootFile::makeProductProvenanceRetriever() {
-    if(!eventProductProvenanceRetriever_) {
-      eventProductProvenanceRetriever_.reset(new ProductProvenanceRetriever(provenanceReaderMaker_->makeReader(eventTree_, daqProvenanceHelper_.get())));
+  RootFile::makeProductProvenanceRetriever(unsigned int iStreamID) {
+    if(eventProductProvenanceRetrievers_.size()<=iStreamID) {
+      eventProductProvenanceRetrievers_.resize(iStreamID+1);
     }
-    eventProductProvenanceRetriever_->reset();
-    return eventProductProvenanceRetriever_;
+    if(!eventProductProvenanceRetrievers_[iStreamID]) {
+      eventProductProvenanceRetrievers_[iStreamID].reset(new ProductProvenanceRetriever(provenanceReaderMaker_->makeReader(eventTree_, daqProvenanceHelper_.get())));
+    }
+    eventProductProvenanceRetrievers_[iStreamID]->reset();
+    return eventProductProvenanceRetrievers_[iStreamID];
   }
 
   class ReducedProvenanceReader : public ProvenanceReaderBase {

--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -170,7 +170,7 @@ namespace edm {
                                     std::vector<boost::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile);
 
     std::unique_ptr<MakeProvenanceReader> makeProvenanceReaderMaker(InputType inputType);
-    boost::shared_ptr<ProductProvenanceRetriever> makeProductProvenanceRetriever();
+    boost::shared_ptr<ProductProvenanceRetriever> makeProductProvenanceRetriever(unsigned int iStreamIndex);
 
     std::string const file_;
     std::string const logicalFile_;
@@ -214,7 +214,7 @@ namespace edm {
     boost::shared_ptr<DuplicateChecker> duplicateChecker_;
     std::unique_ptr<ProvenanceAdaptor> provenanceAdaptor_; // backward comatibility
     std::unique_ptr<MakeProvenanceReader> provenanceReaderMaker_;
-    mutable boost::shared_ptr<ProductProvenanceRetriever> eventProductProvenanceRetriever_;
+    mutable std::vector<boost::shared_ptr<ProductProvenanceRetriever>> eventProductProvenanceRetrievers_;
     std::vector<ParentageID> parentageIDLookup_;
     std::unique_ptr<DaqProvenanceHelper> daqProvenanceHelper_;
   }; // class RootFile


### PR DESCRIPTION
The provenance reading system in was sharing the ProductProvenanceRetriever
between Streams even though the objects have non-const state. Now each
Stream has their own ProductProvenanceRetriever instance. In addition,
the DaqProvenanceHelper is still shared across Streams. The one piece
of state that is being updated was a map which was trivial to change
to a tbb::concurrent_unordered_map. In addition, the DaqProvenanceHelper
had its member data made private to better encapsulate its functionality.

The API change to DaqProvenanceHelper required FedRawDataInputSource
to be updated to match.
