### PR TITLE
53X - add MET analyzers

### DIFF
--- a/BuildFile
+++ b/BuildFile
@@ -1,0 +1,10 @@
+<flags EDM_PLUGIN=1>
+<use name=DataFormats/METReco>
+<use name=FWCore/Framework>
+<use name=root>
+<export>
+   <lib name=RecoMETMETAnalyzers>
+   <use name=DataFormats/METReco>
+   <use name=FWCore/Framework>
+   <use name=root>
+</export>

--- a/BuildFile
+++ b/BuildFile
@@ -1,10 +1,16 @@
 <flags EDM_PLUGIN=1>
 <use name=DataFormats/METReco>
+<use name=DataFormats/L1GlobalTrigger>
+<use name=DataFormats/L1GlobalMuonTrigger>
+<use name=TrackingTools/TrackAssociator>	
 <use name=FWCore/Framework>
 <use name=root>
 <export>
    <lib name=RecoMETMETAnalyzers>
    <use name=DataFormats/METReco>
+   <use name=DataFormats/L1GlobalTrigger>
+   <use name=DataFormats/L1GlobalMuonTrigger>
+   <use name=TrackingTools/TrackAssociator>
    <use name=FWCore/Framework>
    <use name=root>
 </export>

--- a/BuildFile.xml
+++ b/BuildFile.xml
@@ -1,0 +1,10 @@
+<flags   EDM_PLUGIN="1"/>
+<use   name="DataFormats/METReco"/>
+<use   name="DataFormats/L1GlobalTrigger"/>
+<use   name="DataFormats/L1GlobalMuonTrigger"/>
+<use   name="TrackingTools/TrackAssociator"/>
+<use   name="FWCore/Framework"/>
+<use   name="root"/>
+<export>
+  <lib   name="1"/>
+</export>

--- a/interface/CSCHaloFilter.h
+++ b/interface/CSCHaloFilter.h
@@ -133,6 +133,9 @@ class CSCHaloFilter : public edm::EDFilter {
   edm::InputTag IT_CSCRecHit;
   edm::InputTag IT_CSCSegment;
   edm::InputTag IT_CSCHaloData;
+  edm::InputTag IT_BeamHaloSummary;
+  bool FilterCSCLoose;
+  bool FilterCSCTight;
 
   bool FilterDigiLevel;    //requires CSCALCTDigiCollection  (usually not available in RECO data tier)
   bool FilterTriggerLevel; //requires L1MuGMTReadoutCollection

--- a/interface/CSCHaloFilter.h
+++ b/interface/CSCHaloFilter.h
@@ -1,5 +1,5 @@
-#ifndef ALL_PURPOSE_FILTER_H
-#define ALL_PURPOSE_FILTER_H
+#ifndef CSC_HALO_FILTER_H
+#define CSC_HALO_FILTER_H
 
 #include "FWCore/Framework/interface/EDFilter.h"
 

--- a/interface/CSCHaloFilter.h
+++ b/interface/CSCHaloFilter.h
@@ -1,0 +1,181 @@
+#ifndef ALL_PURPOSE_FILTER_H
+#define ALL_PURPOSE_FILTER_H
+
+#include "FWCore/Framework/interface/EDFilter.h"
+
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCWireDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCWireDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCStripDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCStripDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCComparatorDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCComparatorDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCALCTDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCALCTDigiCollection.h"
+#include "DataFormats/CSCRecHit/interface/CSCRecHit2D.h"
+#include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
+#include "DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h"
+#include "DataFormats/CSCRecHit/interface/CSCSegment.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/GeometrySurface/interface/Cylinder.h"
+#include "DataFormats/GeometrySurface/interface/Plane.h"
+#include "DataFormats/GeometrySurface/interface/Cone.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/GeometryVector/interface/GlobalVector.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+#include "DataFormats/GeometryVector/interface/LocalVector.h"
+#include "DataFormats/L1CSCTrackFinder/interface/L1CSCTrackCollection.h"
+#include "DataFormats/L1CSCTrackFinder/interface/L1CSCStatusDigiCollection.h"
+#include "DataFormats/L1GlobalMuonTrigger/interface/L1MuRegionalCand.h"
+#include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTReadoutRecord.h"
+#include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTReadoutCollection.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/MuonDetId/interface/CSCIndexer.h"
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+#include "DataFormats/MuonDetId/interface/RPCDetId.h"
+#include "DataFormats/MuonDetId/interface/DTWireId.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
+#include "DataFormats/TrackingRecHit/interface/RecSegment.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+
+#include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
+#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/CSCGeometry/interface/CSCChamber.h"
+#include "Geometry/CSCGeometry/interface/CSCLayer.h"
+#include "Geometry/CSCGeometry/interface/CSCLayerGeometry.h"
+#include "Geometry/Records/interface/MuonGeometryRecord.h"
+#include "L1Trigger/CSCTrackFinder/interface/CSCSectorReceiverLUT.h"
+#include "L1Trigger/CSCTrackFinder/interface/CSCSectorReceiverLUT.h"
+#include "L1Trigger/CSCCommonTrigger/interface/CSCTriggerGeometry.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+
+#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
+#include "RecoMuon/TrackingTools/interface/MuonPatternRecoDumper.h"
+#include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHitBuilder.h"
+#include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
+
+#include "TrackingTools/GeomPropagators/interface/Propagator.h"
+#include "TrackingTools/GeomPropagators/interface/AnalyticalPropagator.h"
+#include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h"
+
+#include "DataFormats/METReco/interface/BeamHaloSummary.h"
+//Root Classes
+
+#include "TH1F.h"
+#include "TH2F.h"
+#include "TH1I.h"
+#include "TFile.h"
+#include "TDirectory.h"
+#include "TTree.h"
+#include "TStyle.h"
+#include "TCanvas.h"
+#include "TString.h"
+#include "TMath.h"
+#include "TLorentzVector.h"
+#include "TLegend.h"
+
+//Standard C++ classes
+#include <iostream>
+#include <string>
+#include <map>
+#include <vector>
+#include <utility>
+#include <ostream>
+#include <fstream>
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <iomanip>
+
+class CSCHaloFilter : public edm::EDFilter {
+ public:
+  
+  explicit CSCHaloFilter(const edm::ParameterSet & iConfig);
+  virtual ~CSCHaloFilter();
+  
+ private:
+  
+  virtual bool filter(edm::Event & iEvent, const edm::EventSetup & iSetup);
+
+  edm::InputTag IT_L1MuGMTReadout;
+  edm::InputTag IT_ALCTDigi;
+  edm::InputTag IT_CollisionMuon;
+  edm::InputTag IT_SACosmicMuon;
+  edm::InputTag IT_CSCRecHit;
+  edm::InputTag IT_CSCSegment;
+  edm::InputTag IT_CSCHaloData;
+
+  bool FilterDigiLevel;    //requires CSCALCTDigiCollection  (usually not available in RECO data tier)
+  bool FilterTriggerLevel; //requires L1MuGMTReadoutCollection
+  bool FilterRecoLevel;    //requires Cosmic reco::TrackCollection
+
+  //min value of deta between innermost and outermost hit of cosmic reco::Track in CSCs
+  float deta_threshold;  
+  //max value of dphi between innermost and outermost hit of cosmic reco::Track in CSCs
+  float dphi_threshold;
+  //max value of outer-momentum theta for cosmic reco::Track in CSCs
+  float max_outer_theta;
+  //min value of outer-momentum theta for cosmic reco::Track in CSCs
+  float min_outer_theta;
+  //min value of innermost constituent rechit radius for cosmic reco::Track in CSCs
+  float min_inner_radius;
+  //max value of innermost constituent rechit radius for cosmic reco::Track in CSCs
+  float max_inner_radius;
+  //min value of outermost constituent rechit radius for cosmic reco::Track in CSCs
+  float min_outer_radius;
+  //max value of outermost constituent rechit radius for cosmic reco::Track in CSCs
+  float max_outer_radius;
+  //threshold on chi2 of cosmic reco::Track in CSCs 
+  float norm_chi2_threshold;
+
+  //expected local BX number of ALCT Digi for collision induced LCTs (3 for Data, 6 for MC)
+  int expected_BX;
+
+  //dphi window for matching collision muon hits to L1 halo candidates
+  float matching_dphi_threshold;
+  //deta window for matching collision muon hits to L1 halo candidates
+  float matching_deta_threshold;
+  //dwire window for matching collision muon hits to early ALCT Digis
+  int matching_dwire_threshold; 
+
+  int min_nHaloDigis;
+  int min_nHaloTriggers;
+  int min_nHaloTracks; 
+  
+  TrackDetectorAssociator trackAssociator_;
+  TrackAssociatorParameters parameters_;
+
+
+
+};
+
+#endif

--- a/interface/CSCHaloFilter.h
+++ b/interface/CSCHaloFilter.h
@@ -156,6 +156,8 @@ class CSCHaloFilter : public edm::EDFilter {
   float max_outer_radius;
   //threshold on chi2 of cosmic reco::Track in CSCs 
   float norm_chi2_threshold;
+  //max value of dr/dz calculated using innermost and outermose rechit from cosmic reco::Track in CSCs
+  float max_dr_over_dz;
 
   //expected local BX number of ALCT Digi for collision induced LCTs (3 for Data, 6 for MC)
   int expected_BX;

--- a/interface/HcalNoiseInfoAnalyzer.h
+++ b/interface/HcalNoiseInfoAnalyzer.h
@@ -26,6 +26,7 @@
 
 // forward declarations
 class TH1D;
+class TH2D;
 class TFile;
 
 namespace reco {
@@ -47,13 +48,27 @@ namespace reco {
 
     // root file/histograms
     TFile* rootfile_;
-    TH1D* hNHPDHits_;
-    TH1D* hNHPDMaxHits_;
+
+    TH1D* hMaxZeros_;         // maximum # of zeros in an RBX channel
+    TH1D* hTotalZeros_;       // total # of zeros in an RBX
+    TH1D* hE2ts_;             // E(2ts) for the highest energy digi in an HPD
+    TH1D* hE10ts_;            // E(10ts) for the highest energy digi in an HPD
+    TH1D* hE2tsOverE10ts_;    // E(t2s)/E(10ts) for the highest energy digi in an HPD
+    TH1D* hRBXE2ts_;          // Sum RBX E(2ts)
+    TH1D* hRBXE10ts_;         // Sum RBX E(10ts)
+    TH1D* hRBXE2tsOverE10ts_; // Sum RBXE(t2s)/E(10ts)
+    TH1D* hHPDNHits_;         // Number of Hits with E>1.5 GeV in an HPD
+
+    TH1D* hFailures_;         // code designating which cut the event failed (if any)
+    TH1D* hBeforeRBXEnergy_;  // Total RecHit Energy in RBX before cuts
+    TH1D* hAfterRBXEnergy_;   // Total RecHit Energy in RBX after cuts
 
     // parameters
     std::string rbxCollName_;      // label for the HcalNoiseRBXCollection
-    std::string rootHistFilename_;   // name of the histogram file
-  
+    std::string rootHistFilename_; // name of the histogram file
+    int noisetype_;                // fill histograms for a specfic noise type
+                                   // 0=ionfeedback, 1=HPD discharge, 2=RBX noise, 3=all
+
   };
 
 } // end of namespace

--- a/interface/HcalNoiseInfoAnalyzer.h
+++ b/interface/HcalNoiseInfoAnalyzer.h
@@ -1,0 +1,61 @@
+#ifndef _RECOMET_METANALYZER_HCALNOISEINFOANALYZER_H_
+#define _RECOMET_METANALYZER_HCALNOISEINFOANALYZER_H_
+
+//
+// HcalNoiseInfoAnalyzer.h
+//
+//    description: Skeleton analyzer for the HCAL noise information
+//
+//    author: J.P. Chou, Brown
+//
+//
+
+// system include files
+#include <memory>
+#include <string>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+
+// forward declarations
+class TH1D;
+class TFile;
+
+namespace reco {
+
+  //
+  // class declaration
+  //
+
+  class HcalNoiseInfoAnalyzer : public edm::EDAnalyzer {
+  public:
+    explicit HcalNoiseInfoAnalyzer(const edm::ParameterSet&);
+    ~HcalNoiseInfoAnalyzer();
+  
+  
+  private:
+    virtual void beginJob(const edm::EventSetup&);
+    virtual void analyze(const edm::Event&, const edm::EventSetup&);
+    virtual void endJob();
+
+    // root file/histograms
+    TFile* rootfile_;
+    TH1D* hNHPDHits_;
+    TH1D* hNHPDMaxHits_;
+
+    // parameters
+    std::string rbxCollName_;      // label for the HcalNoiseRBXCollection
+    std::string rootHistFilename_;   // name of the histogram file
+  
+  };
+
+} // end of namespace
+
+#endif

--- a/python/CSCHaloFilter_cfi.py
+++ b/python/CSCHaloFilter_cfi.py
@@ -5,6 +5,19 @@ from TrackingTools.TrackAssociator.default_cfi import *
 
 CSCBasedHaloFilter = cms.EDFilter("CSCHaloFilter",
 
+                                  BeamHaloSummaryLabel = cms.InputTag("BeamHaloSummary"),
+                                  ### Do you want to filter based on BeamHaloSummary::CSCLooseHaloId() ( ~90% eff, 1E-3 mistag rate) 
+                                  FilterCSCLoose = cms.bool(False),
+                                  ### Do you want to filter based on BeamHaloSummary::CSCTightHaloId() ( ~65% eff, <1E-5 mistag rate)
+                                  FilterCSCTight = cms.bool(False),
+
+
+                                  #############  For Use Only if FilterCSCLoose and FilterCSCTight are false
+                                  #
+                                  #
+                                  #
+                                  #
+
                                   ### Do you want to use L1 CSC BeamHalo Trigger to identify halo? (For < 36X, this requires the RAW-DIGI )
                                   FilterTriggerLevel = cms.bool(True),
                                   ### Do you want to use early ALCT Digis to identify halo? (requires DIGI data tier)
@@ -66,11 +79,19 @@ CSCBasedHaloFilter = cms.EDFilter("CSCHaloFilter",
                                   
                                   # If this is MC, the expected collision bx for ALCT Digis will be 6 instead of 3
                                   ExpectedBX = cms.int32(3),
-
-
                                   TrackAssociatorParameters = TrackAssociatorParameterBlock.TrackAssociatorParameters
                                   )
                              
+
+###CSC Loose Only
+CSCLooseHaloFilter = CSCBasedHaloFilter.clone()
+CSCLooseHaloFilter.FilterCSCLoose = True
+CSCLooseHaloFilter.FilterCSCTight = False
+
+###CSC Tight Only
+CSCTightHaloFilter = CSCBasedHaloFilter.clone()
+CSCTightHaloFilter.FilterCSCLoose = False
+CSCTightHaloFilter.FilterCSCTight = True
 
 ###Trigger Level Only###
 CSCHaloFilterTriggerLevel = CSCBasedHaloFilter.clone()
@@ -113,12 +134,12 @@ CSCHaloFilterDigiOrRecoLevel = cms.Sequence( CSCHaloFilterDigiLevel * CSCHaloFil
 
 ### Digi OR Reco OR Trigger Level ###  (Loose Selection)
 CSCHaloFilterDigiOrRecoOrTriggerLevel = cms.Sequence( CSCHaloFilterDigiLevel * CSCHaloFilterRecoLevel * CSCHaloFilterTriggerLevel )
-CSCHaloFilterLoose = cms.Sequence(CSCHaloFilterDigiOrRecoOrTriggerLevel)
+#CSCHaloFilterLoose = cms.Sequence(CSCHaloFilterDigiOrRecoOrTriggerLevel)
 
 ### (Digi AND Reco) OR (Digi AND Trigger) OR (Reco AND Trigger)###  (Tight Selection)
 CSCHaloFilter_DigiAndReco_Or_DigiAndTrigger_Or_RecoAndTrigger = cms.Sequence( CSCHaloFilterRecoAndTriggerLevel *
                                                                               CSCHaloFilterDigiAndTriggerLevel *
                                                                               CSCHaloFilterDigiAndRecoLevel )
 
-CSCHaloFilterTight = cms.Sequence(CSCHaloFilter_DigiAndReco_Or_DigiAndTrigger_Or_RecoAndTrigger)
+#CSCHaloFilterTight = cms.Sequence(CSCHaloFilter_DigiAndReco_Or_DigiAndTrigger_Or_RecoAndTrigger)
 

--- a/python/CSCHaloFilter_cfi.py
+++ b/python/CSCHaloFilter_cfi.py
@@ -1,0 +1,73 @@
+import FWCore.ParameterSet.Config as cms
+
+from TrackingTools.TrackAssociator.default_cfi import *
+
+
+CSCBasedHaloFilter = cms.EDFilter("CSCHaloFilter",
+
+                                  ### Do you want to use L1 CSC BeamHalo Trigger to identify halo? 
+                                  FilterTriggerLevel = cms.bool(True),
+                                  ### Do you want to use early ALCT Digis to identify halo? (requires DIGI data tier)
+                                  FilterDigiLevel = cms.bool(True),
+                                  ### Do you want to use halo-like CSC cosmic reconstructed tracks to identify halo?   
+                                  FilterRecoLevel = cms.bool(True),
+                                  
+                                  # L1
+                                  L1MuGMTReadoutLabel = cms.InputTag("gtDigis"),
+                                  # Chamber Level Trigger Primitive
+                                  ALCTDigiLabel = cms.InputTag("muonCSCDigis","MuonCSCALCTDigi"),
+                                  # RecHit Level
+                                  CSCRecHitLabel = cms.InputTag("csc2DRecHits"),
+                                  # Higher Level Reco
+                                  CSCSegmentLabel= cms.InputTag("cscSegments"),
+                                  SACosmicMuonLabel= cms.InputTag("cosmicMuons"),
+                                  CollisionMuonLabel = cms.InputTag("muons"),
+                                  CSCHaloDataLabel = cms.InputTag("CSCHaloData"),
+                                  
+                                  ###### Cut Parameters
+                                  ### minimum delta-eta between innermost-outermost CSC track rechit 
+                                  Deta = cms.double(0.1),
+                                  ### maximum delta-phi between innermost-outermost CSC track rechit 
+                                  Dphi = cms.double(1.00),
+                                  ### maximum Chi-Square of CSC cosmic track
+                                  NormChi2  = cms.double(8.),
+                                  #InnerRMin = cms.double(140.),
+                                  #OuterRMin = cms.double(140.),
+                                  #InnerRMax = cms.double(310.),
+                                  #OuterRMax = cms.double(310.),
+                                  ### minimum radius of innermost CSC cosmic track rechit
+                                  InnerRMin = cms.double(0.),
+                                  ### minimum radius of outermost CSC cosmic track rechit
+                                  OuterRMin = cms.double(0.),
+                                  ### maximum radius of innermost CSC cosmic track rechit
+                                  InnerRMax = cms.double(99999.),
+                                  ### maximum radius of outermost CSC cosmic track rechit
+                                  OuterRMax = cms.double(99999.),
+                                  ### lower edge of theta exclusion window of CSC cosmic track
+                                  MinOuterMomentumTheta = cms.double(.10),
+                                  ### higher edge of theta exclusion window of CSC cosmic track
+                                  MaxOuterMomentumTheta = cms.double(3.0),
+                                  
+                                  ### Phi window for matching collision muon rechits to L1 Halo Triggers
+                                  MatchingDPhiThreshold = cms.double(0.18),
+                                  ### Eta window for matching collision muon rechits to L1 Halo Triggers
+                                  MatchingDEtaThreshold = cms.double(0.4),
+                                  ### Wire window for matching collision muon rechits to earl ALCT Digis  
+                                  MatchingDWireThreshold= cms.int32(5),
+
+                                  ### Min number of L1 Halo Triggers required to call event "halo" (requires FilterTriggerLevel=True) 
+                                  MinNumberOfHaloTriggers = cms.untracked.int32(1),
+                                  ### Min number of early ALCT Digis required to call event "halo" (requires FilterDigiLevel =True)
+                                  MinNumberOfOutOfTimeDigis = cms.untracked.int32(1),
+                                  ### Min number of halo-like CSC cosmic tracks to call event "halo" (requires FilterRecoLevel =True)
+                                  MinNumberOfHaloTracks = cms.untracked.int32(1),
+                                  
+                                  # If this is MC, the expected collision bx for ALCT Digis will be 6 instead of 3
+                                  ExpectedBX = cms.int32(3),
+
+
+                                  TrackAssociatorParameters = TrackAssociatorParameterBlock.TrackAssociatorParameters
+                                  )
+                             
+
+

--- a/python/CSCHaloFilter_cfi.py
+++ b/python/CSCHaloFilter_cfi.py
@@ -91,3 +91,5 @@ CSCHaloFilterDigiAndTriggerLevel = CSCBasedHaloFilter.clone()
 CSCHaloFilterDigiAndTriggerLevel.FilterRecoLevel = False
 CSCHaloFilterDigiAndRecoLevel = CSCBasedHaloFilter.clone()
 CSCHaloFilterDigiAndRecoLevel.FilterTriggerLevel = False
+
+CSCHaloFilterRecoAndDigiAndTriggerLevel = CSCBasedHaloFilter.clone()

--- a/python/CSCHaloFilter_cfi.py
+++ b/python/CSCHaloFilter_cfi.py
@@ -89,3 +89,5 @@ CSCHaloFilterRecoAndTriggerLevel = CSCBasedHaloFilter.clone()
 CSCHaloFilterRecoAndTriggerLevel.FilterDigiLevel = False
 CSCHaloFilterDigiAndTriggerLevel = CSCBasedHaloFilter.clone()
 CSCHaloFilterDigiAndTriggerLevel.FilterRecoLevel = False
+CSCHaloFilterDigiAndRecoLevel = CSCBasedHaloFilter.clone()
+CSCHaloFilterDigiAndRecoLevel.FilterTriggerLevel = False

--- a/python/CSCHaloFilter_cfi.py
+++ b/python/CSCHaloFilter_cfi.py
@@ -72,24 +72,53 @@ CSCBasedHaloFilter = cms.EDFilter("CSCHaloFilter",
                                   )
                              
 
-
+###Trigger Level Only###
 CSCHaloFilterTriggerLevel = CSCBasedHaloFilter.clone()
 CSCHaloFilterTriggerLevel.FilterRecoLevel = False
 CSCHaloFilterTriggerLevel.FilterDigiLevel = False
 
+###Reco Level Only ####
 CSCHaloFilterRecoLevel = CSCBasedHaloFilter.clone()
 CSCHaloFilterRecoLevel.FilterTriggerLevel = False
 CSCHaloFilterRecoLevel.FilterDigiLevel = False
 
+### Digi Level Only ###
 CSCHaloFilterDigiLevel = CSCBasedHaloFilter.clone()
 CSCHaloFilterDigiLevel.FilterTriggerLevel = False
 CSCHaloFilterDigiLevel.FilterRecoLevel = False
 
+### Reco AND Trigger Level ###
 CSCHaloFilterRecoAndTriggerLevel = CSCBasedHaloFilter.clone()
 CSCHaloFilterRecoAndTriggerLevel.FilterDigiLevel = False
+### Digi AND Trigger Level ###
 CSCHaloFilterDigiAndTriggerLevel = CSCBasedHaloFilter.clone()
 CSCHaloFilterDigiAndTriggerLevel.FilterRecoLevel = False
+### Digi AND Reco Level ###
 CSCHaloFilterDigiAndRecoLevel = CSCBasedHaloFilter.clone()
 CSCHaloFilterDigiAndRecoLevel.FilterTriggerLevel = False
 
+### Reco AND Digi AND Trigger Level ###  (Most Restrictive) 
 CSCHaloFilterRecoAndDigiAndTriggerLevel = CSCBasedHaloFilter.clone()
+
+### Sequences ####
+
+### Reco OR Trigger Level ###
+CSCHaloFilterRecoOrTriggerLevel = cms.Sequence( CSCHaloFilterTriggerLevel * CSCHaloFilterRecoLevel )
+
+### Digi OR Trigger Level ###
+CSCHaloFilterDigiOrTriggerLevel = cms.Sequence( CSCHaloFilterDigiLevel * CSCHaloFilterTriggerLevel )
+
+### Digi OR Reco Level ###
+CSCHaloFilterDigiOrRecoLevel = cms.Sequence( CSCHaloFilterDigiLevel * CSCHaloFilterRecoLevel )
+
+### Digi OR Reco OR Trigger Level ###  (Loose Selection)
+CSCHaloFilterDigiOrRecoOrTriggerLevel = cms.Sequence( CSCHaloFilterDigiLevel * CSCHaloFilterRecoLevel * CSCHaloFilterTriggerLevel )
+CSCHaloFilterLoose = cms.Sequence(CSCHaloFilterDigiOrRecoOrTriggerLevel)
+
+### (Digi AND Reco) OR (Digi AND Trigger) OR (Reco AND Trigger)###  (Tight Selection)
+CSCHaloFilter_DigiAndReco_Or_DigiAndTrigger_Or_RecoAndTrigger = cms.Sequence( CSCHaloFilterRecoAndTriggerLevel *
+                                                                              CSCHaloFilterDigiAndTriggerLevel *
+                                                                              CSCHaloFilterDigiAndRecoLevel )
+
+CSCHaloFilterTight = cms.Sequence(CSCHaloFilter_DigiAndReco_Or_DigiAndTrigger_Or_RecoAndTrigger)
+

--- a/python/CSCHaloFilter_cfi.py
+++ b/python/CSCHaloFilter_cfi.py
@@ -5,7 +5,7 @@ from TrackingTools.TrackAssociator.default_cfi import *
 
 CSCBasedHaloFilter = cms.EDFilter("CSCHaloFilter",
 
-                                  ### Do you want to use L1 CSC BeamHalo Trigger to identify halo? 
+                                  ### Do you want to use L1 CSC BeamHalo Trigger to identify halo? (For < 36X, this requires the RAW-DIGI )
                                   FilterTriggerLevel = cms.bool(True),
                                   ### Do you want to use early ALCT Digis to identify halo? (requires DIGI data tier)
                                   FilterDigiLevel = cms.bool(True),
@@ -47,6 +47,8 @@ CSCBasedHaloFilter = cms.EDFilter("CSCHaloFilter",
                                   MinOuterMomentumTheta = cms.double(.10),
                                   ### higher edge of theta exclusion window of CSC cosmic track
                                   MaxOuterMomentumTheta = cms.double(3.0),
+                                  ### maximum dr/dz calculated from innermost and outermost rechit of CSC cosmic track
+                                  MaxDROverDz = cms.double(0.13),
                                   
                                   ### Phi window for matching collision muon rechits to L1 Halo Triggers
                                   MatchingDPhiThreshold = cms.double(0.18),
@@ -71,3 +73,19 @@ CSCBasedHaloFilter = cms.EDFilter("CSCHaloFilter",
                              
 
 
+CSCHaloFilterTriggerLevel = CSCBasedHaloFilter.clone()
+CSCHaloFilterTriggerLevel.FilterRecoLevel = False
+CSCHaloFilterTriggerLevel.FilterDigiLevel = False
+
+CSCHaloFilterRecoLevel = CSCBasedHaloFilter.clone()
+CSCHaloFilterRecoLevel.FilterTriggerLevel = False
+CSCHaloFilterRecoLevel.FilterDigiLevel = False
+
+CSCHaloFilterDigiLevel = CSCBasedHaloFilter.clone()
+CSCHaloFilterDigiLevel.FilterTriggerLevel = False
+CSCHaloFilterDigiLevel.FilterRecoLevel = False
+
+CSCHaloFilterRecoAndTriggerLevel = CSCBasedHaloFilter.clone()
+CSCHaloFilterRecoAndTriggerLevel.FilterDigiLevel = False
+CSCHaloFilterDigiAndTriggerLevel = CSCBasedHaloFilter.clone()
+CSCHaloFilterDigiAndTriggerLevel.FilterRecoLevel = False

--- a/python/exampleanalyzer_cfi.py
+++ b/python/exampleanalyzer_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+demo = cms.EDAnalyzer('ExampleAnalyzer',
+caloMETlabel_       = cms.InputTag("met"),    
+tcMETlabel_         = cms.InputTag("tcMet"),      
+muCorrMETlabel_     = cms.InputTag("corMetGlobalMuons"),  
+pfMETlabel_         = cms.InputTag("pfMet"),      
+muJESCorrMETlabel_  = cms.InputTag("metMuonJESCorSC5"),
+muonLabel_          = cms.InputTag("muons"),
+muValueMaplabel_    = cms.InputTag("muonMETValueMapProducer", "muCorrData"),  
+tcMETValueMaplabel_ = cms.InputTag("muonTCMETValueMapProducer", "muCorrData")
+)

--- a/python/metSequence_cff.py
+++ b/python/metSequence_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from JetMETCorrections.Configuration.L2L3Corrections_Summer08Redigi_cff import *
+#from JetMETCorrections.Configuration.L2L3Corrections_Summer08Redigi_cff import *
 from JetMETCorrections.Type1MET.MetType1Corrections_cff import metJESCorSC5CaloJet
 
 metMuonJESCorSC5 = metJESCorSC5CaloJet.clone()

--- a/python/metSequence_cff.py
+++ b/python/metSequence_cff.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+from JetMETCorrections.Configuration.L2L3Corrections_Summer08Redigi_cff import *
+from JetMETCorrections.Type1MET.MetType1Corrections_cff import metJESCorSC5CaloJet
+
+metMuonJESCorSC5 = metJESCorSC5CaloJet.clone()
+metMuonJESCorSC5.inputUncorJetsLabel = "sisCone5CaloJets"
+metMuonJESCorSC5.corrector = "L2L3JetCorrectorSC5Calo"
+metMuonJESCorSC5.inputUncorMetLabel = "corMetGlobalMuons"
+
+metCorSequence = cms.Sequence(metMuonJESCorSC5)

--- a/src/CSCHaloFilter.cc
+++ b/src/CSCHaloFilter.cc
@@ -5,7 +5,7 @@
 
 using namespace std;
 using namespace edm;
-
+using namespace reco;
 CSCHaloFilter::CSCHaloFilter(const edm::ParameterSet & iConfig)
 {
   IT_L1MuGMTReadout = iConfig.getParameter<edm::InputTag>("L1MuGMTReadoutLabel");
@@ -15,6 +15,8 @@ CSCHaloFilter::CSCHaloFilter(const edm::ParameterSet & iConfig)
   IT_CSCRecHit = iConfig.getParameter<edm::InputTag>("CSCRecHitLabel");
   IT_CSCSegment = iConfig.getParameter<edm::InputTag>("CSCSegmentLabel");
   IT_CSCHaloData = iConfig.getParameter<edm::InputTag>("CSCHaloDataLabel");
+  IT_BeamHaloSummary = iConfig.getParameter<edm::InputTag>("BeamHaloSummaryLabel");
+
 
   deta_threshold = (float) iConfig.getParameter<double>("Deta");
   dphi_threshold = (float) iConfig.getParameter<double>("Dphi");
@@ -32,6 +34,9 @@ CSCHaloFilter::CSCHaloFilter(const edm::ParameterSet & iConfig)
   matching_dphi_threshold =  (float)iConfig.getParameter<double>("MatchingDPhiThreshold");
   matching_deta_threshold =  (float)iConfig.getParameter<double>("MatchingDEtaThreshold");
   matching_dwire_threshold  = iConfig.getParameter<int>("MatchingDWireThreshold");
+
+  FilterCSCLoose = iConfig.getParameter<bool>("FilterCSCLoose");
+  FilterCSCTight = iConfig.getParameter<bool>("FilterCSCTight");
 
   FilterTriggerLevel = iConfig.getParameter<bool>("FilterTriggerLevel");
   FilterDigiLevel = iConfig.getParameter<bool>("FilterDigiLevel");
@@ -51,7 +56,20 @@ CSCHaloFilter::~CSCHaloFilter(){}
 
 bool CSCHaloFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup) 
 {
- 
+
+  if( FilterCSCLoose || FilterCSCTight ) 
+    {
+      edm::Handle<BeamHaloSummary> TheBeamHaloSummary;
+      iEvent.getByLabel(IT_BeamHaloSummary,TheBeamHaloSummary);
+
+      const BeamHaloSummary TheSummary = (*TheBeamHaloSummary.product() );
+      
+      if( FilterCSCLoose ) 
+	return !TheSummary.CSCLooseHaloId();
+      else 
+	return !TheSummary.CSCTightHaloId();
+    }
+  
 
   //Get B-Field
   edm::ESHandle<MagneticField> TheMagneticField;

--- a/src/CSCHaloFilter.cc
+++ b/src/CSCHaloFilter.cc
@@ -85,10 +85,20 @@ bool CSCHaloFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup)
   edm::Handle<reco::CSCHaloData> TheCSCDataHandle;
   iEvent.getByLabel(IT_CSCHaloData,TheCSCDataHandle);
 
+
   int nHaloCands  = 0;
   int nHaloDigis  = 0;
   int nHaloTracks = 0;
 
+  if(TheCSCDataHandle.isValid())                                                                                                                        
+    {                                                                                                                                                     
+      const reco::CSCHaloData CSCData = (*TheCSCDataHandle.product());                                                                                    
+      nHaloDigis = CSCData.NumberOfOutOfTimeTriggers() ;                                                                                                    
+      nHaloCands = CSCData.NumberOfHaloTriggers();
+    }      
+
+
+  /*
   if( FilterTriggerLevel )
     {
       //Get L1MuGMT 
@@ -183,7 +193,7 @@ bool CSCHaloFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup)
     {
       //Get Chamber Anode Trigger Information                                                                                                                      
       edm::Handle<CSCALCTDigiCollection> TheALCTs;
-      iEvent.getByLabel (IT_ALCTDigi, TheALCTs);
+   iEvent.getByLabel (IT_ALCTDigi, TheALCTs);
       if(TheALCTs.isValid())
 	{
 	  for (CSCALCTDigiCollection::DigiRangeIterator j=TheALCTs->begin(); j!=TheALCTs->end(); j++)
@@ -195,7 +205,7 @@ bool CSCHaloFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup)
 		  if( (*digiIt).isValid() && ( (*digiIt).getBX() < expected_BX ) )
 		    {
 		      bool DigiIsHalo = true;
-		      /* MATCHING CHECK NOT AVAILABLE UNTIL 36X 
+		      // MATCHING CHECK NOT AVAILABLE UNTIL 36X 
 			 
 		      int digi_endcap  = detId.endcap();
 		      int digi_station = detId.station();
@@ -244,14 +254,14 @@ bool CSCHaloFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup)
 		      if( dwire <=  matching_dwire_threshold ) 
 		      DigiIsHalo = false;
 		      }
-		      */
+
 		      if( DigiIsHalo )
 			nHaloDigis++;
 		    }
 		}
 	    }
 	}
-      /*
+
 	else if( TheCSCDataHandle.isValid() )
 	{
 	//FOR >= 36X 
@@ -269,7 +279,7 @@ bool CSCHaloFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup)
 	nHaloDigis = CSCData.NumberOfOutOfTimeTriggers() ;
 	}
 	}
-      */
+
       else
 	{
 	  LogWarning("Collection Not Found") << "You have requested Digi-level filtering, but the CSCALCTDigiCollection does not appear"
@@ -278,6 +288,8 @@ bool CSCHaloFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup)
 	  FilterDigiLevel = false ; // NO DIGI LEVEL DECISION CAN BE MADE
 	}
     }
+
+*/
   
   if(FilterRecoLevel)
     {

--- a/src/CSCHaloFilter.cc
+++ b/src/CSCHaloFilter.cc
@@ -1,0 +1,368 @@
+#include "RecoMET/METAnalyzers/interface/CSCHaloFilter.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/View.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+using namespace std;
+using namespace edm;
+
+CSCHaloFilter::CSCHaloFilter(const edm::ParameterSet & iConfig)
+{
+  IT_L1MuGMTReadout = iConfig.getParameter<edm::InputTag>("L1MuGMTReadoutLabel");
+  IT_ALCTDigi = iConfig.getParameter<edm::InputTag>("ALCTDigiLabel");
+  IT_CollisionMuon = iConfig.getParameter<edm::InputTag>("CollisionMuonLabel");
+  IT_SACosmicMuon = iConfig.getParameter<edm::InputTag>("SACosmicMuonLabel");
+  IT_CSCRecHit = iConfig.getParameter<edm::InputTag>("CSCRecHitLabel");
+  IT_CSCSegment = iConfig.getParameter<edm::InputTag>("CSCSegmentLabel");
+  IT_CSCHaloData = iConfig.getParameter<edm::InputTag>("CSCHaloDataLabel");
+
+  deta_threshold = (float) iConfig.getParameter<double>("Deta");
+  dphi_threshold = (float) iConfig.getParameter<double>("Dphi");
+  min_inner_radius = (float) iConfig.getParameter<double>("InnerRMin");
+  max_inner_radius = (float) iConfig.getParameter<double>("InnerRMax");
+  min_outer_radius = (float) iConfig.getParameter<double>("OuterRMin");
+  max_outer_radius = (float) iConfig.getParameter<double>("OuterRMax");
+  norm_chi2_threshold = (float) iConfig.getParameter<double>("NormChi2");
+ 
+  expected_BX  = (short int) iConfig.getParameter<int>("ExpectedBX") ; 
+  min_outer_theta = (float)iConfig.getParameter<double>("MinOuterMomentumTheta");
+  max_outer_theta = (float)iConfig.getParameter<double>("MaxOuterMomentumTheta");
+
+  matching_dphi_threshold =  (float)iConfig.getParameter<double>("MatchingDPhiThreshold");
+  matching_deta_threshold =  (float)iConfig.getParameter<double>("MatchingDEtaThreshold");
+  matching_dwire_threshold  = iConfig.getParameter<int>("MatchingDWireThreshold");
+
+  min_nHaloTriggers =  iConfig.getUntrackedParameter<int>("MinNumberOfHaloTriggers",1);
+  min_nHaloDigis =  iConfig.getUntrackedParameter<int>("MinNumberOfOutOfTimeDigis",1);
+  min_nHaloTracks = iConfig.getUntrackedParameter<int>("MinNumberOfHaloTracks",1);
+
+  FilterTriggerLevel = iConfig.getParameter<bool>("FilterTriggerLevel");
+  FilterDigiLevel = iConfig.getParameter<bool>("FilterDigiLevel");
+  FilterRecoLevel = iConfig.getParameter<bool>("FilterRecoLevel");
+
+  // Load TrackDetectorAssociator parameters                                                                                                                   
+  edm::ParameterSet parameters = iConfig.getParameter<edm::ParameterSet>("TrackAssociatorParameters");
+  parameters_.loadParameters( parameters );
+}
+
+
+CSCHaloFilter::~CSCHaloFilter(){}
+
+bool CSCHaloFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup) 
+{
+ 
+  //Get B-Field
+  edm::ESHandle<MagneticField> TheMagneticField;
+  iSetup.get<IdealMagneticFieldRecord>().get(TheMagneticField);
+
+  //Get Propagator
+  edm::ESHandle<Propagator> propagator;
+  iSetup.get<TrackingComponentsRecord>().get("SteppingHelixPropagatorAny", propagator);
+  trackAssociator_.setPropagator(propagator.product());
+
+  //Get CSC Geometry
+  edm::ESHandle<CSCGeometry> TheCSCGeometry;
+  iSetup.get<MuonGeometryRecord>().get(TheCSCGeometry);
+
+  // Get Collision Muon Collection
+  edm::Handle<reco::MuonCollection> TheCollisionMuons;
+  iEvent.getByLabel(IT_CollisionMuon,TheCollisionMuons);
+    
+  //Get Cosmic  Stand-Alone Muons
+  edm::Handle<reco::TrackCollection> TheSACosmicMuons;
+  iEvent.getByLabel( IT_SACosmicMuon, TheSACosmicMuons);
+
+  //Get CSC Segments
+  //edm::Handle<CSCSegmentCollection> TheCSCSegments;
+  //iEvent.getByLabel(IT_CSCSegment, TheCSCSegments);
+  
+  //Get CSC RecHits
+  //Handle<CSCRecHit2DCollection> TheCSCRecHits;
+  //iEvent.getByLabel(IT_CSCRecHit, TheCSCRecHits);
+
+  if( FilterTriggerLevel )
+    {
+      //Get L1MuGMT 
+      edm::Handle < L1MuGMTReadoutCollection > TheL1GMTReadout ;
+      iEvent.getByLabel (IT_L1MuGMTReadout, TheL1GMTReadout);
+      int nHaloCands = 0;
+      if( TheL1GMTReadout.isValid() )
+	{
+	  L1MuGMTReadoutCollection const *MuGMT = TheL1GMTReadout.product ();
+	  std::vector < L1MuGMTReadoutRecord > TheRecords = MuGMT->getRecords ();
+	  std::vector < L1MuGMTReadoutRecord >::const_iterator iRecord;
+	  for (iRecord = TheRecords.begin (); iRecord != TheRecords.end (); iRecord++)
+	    {
+	      std::vector < L1MuRegionalCand >::const_iterator iCand;
+	      std::vector < L1MuRegionalCand > TheCands = iRecord->getCSCCands ();
+	      for (iCand = TheCands.begin (); iCand != TheCands.end (); iCand++)
+		{
+		  if (!(*iCand).empty ())
+		    {
+		      if ((*iCand).isFineHalo ())
+			{
+			  float halophi = iCand->phiValue();
+			  float haloeta = iCand->etaValue();
+			  halophi = halophi > TMath::Pi() ? halophi - 2.*TMath::Pi() : halophi;
+			  bool CandIsHalo = true;
+			  // Check if halo trigger is faked by any collision muons
+
+			  if( TheCollisionMuons.isValid() )
+			    {
+			      float dphi = 9999.;
+			      float deta = 9999.;
+			      for( reco::MuonCollection::const_iterator iMuon = TheCollisionMuons->begin(); iMuon != TheCollisionMuons->end() && CandIsHalo ; iMuon++ )
+				{
+				  std::vector<TrackDetMatchInfo> info;
+				  if( iMuon->isTrackerMuon() && !iMuon->innerTrack().isNull() )
+				    info.push_back( trackAssociator_.associate(iEvent, iSetup, *iMuon->innerTrack(), parameters_) );
+				  if( iMuon->isStandAloneMuon() && !iMuon->outerTrack().isNull() )
+				    {
+				      //make sure that this SA muon is not actually a halo-like muon
+                                      float theta =  iMuon->outerTrack()->outerMomentum().theta();
+                                      float deta = TMath::Abs(iMuon->outerTrack()->outerPosition().eta() - iMuon->outerTrack()->innerPosition().eta());
+                                      
+				      if( !( theta < min_outer_theta || theta > max_outer_theta) )  //halo-like                        
+					if ( deta <= deta_threshold ) //halo-like               	
+					  {
+					    if( iMuon->isGlobalMuon() || iMuon->isTrackerMuon() ) // NOT SA-Only 
+					      info.push_back( trackAssociator_.associate(iEvent, iSetup, *iMuon->outerTrack(), parameters_) );
+					  }
+				    }
+				  if ( iMuon->isGlobalMuon() && !iMuon->globalTrack().isNull() )
+				    info.push_back(trackAssociator_.associate(iEvent, iSetup, *iMuon->globalTrack(), parameters_) );
+				  
+				  for(unsigned int i = 0 ; i < info.size(); i++ )
+				    {
+				      for( std::vector<TAMuonChamberMatch>::const_iterator chamber=info[i].chambers.begin();
+					   chamber!=info[i].chambers.end(); chamber++ ){
+					if( chamber->detector() != MuonSubdetId::CSC ) continue;
+					  
+					  for( std::vector<TAMuonSegmentMatch>::const_iterator segment = chamber->segments.begin();
+					       segment != chamber->segments.end(); segment++ ) {
+
+					    float eta_ = segment->segmentGlobalPosition.eta();	
+					    float phi_ = segment->segmentGlobalPosition.phi();	
+					    float test_dphi = TMath::Abs(phi_ - halophi);
+					    test_dphi = TMath::ACos( TMath::Cos( test_dphi ) );
+					    float test_deta = TMath::Abs(eta_ - haloeta);
+					    dphi = dphi < test_dphi ? dphi : test_dphi;
+					    deta = deta < test_deta ? deta : test_deta;
+					  }
+				      }
+				    }
+				  if ( dphi < matching_dphi_threshold && deta < matching_deta_threshold ) //collision likely caused it
+				    CandIsHalo = false; 
+				}
+			      if(CandIsHalo)
+				nHaloCands++;
+			    }
+			}
+		    }
+		}
+	    }
+	  if(nHaloCands >= min_nHaloTriggers ) 
+	    return false;
+	}
+    }
+
+  if(FilterDigiLevel)
+    {
+      //Get Chamber Anode Trigger Information                                                                                                                      
+      edm::Handle<CSCALCTDigiCollection> TheALCTs;
+      iEvent.getByLabel (IT_ALCTDigi, TheALCTs);
+      int nHaloDigis =0;
+      if(TheALCTs.isValid())
+	{
+	  for (CSCALCTDigiCollection::DigiRangeIterator j=TheALCTs->begin(); j!=TheALCTs->end(); j++)
+	    {
+	      const CSCALCTDigiCollection::Range& range =(*j).second;
+	      CSCDetId detId((*j).first.rawId());
+	      for (CSCALCTDigiCollection::const_iterator digiIt = range.first; digiIt!=range.second; ++digiIt)
+		{
+		  if( (*digiIt).isValid() && ( (*digiIt).getBX() < expected_BX ) )
+		    {
+		      bool DigiIsHalo = true;
+		      /* MATCHING CHECK NOT AVAILABLE UNTIL 36X 
+			 
+		      int digi_endcap  = detId.endcap();
+		      int digi_station = detId.station();
+		      int digi_ring    = detId.ring();
+		      int digi_chamber = detId.chamber();
+		      int digi_wire    = digiIt->getKeyWG();
+		      
+		      if( digi_station == 1 && digi_ring == 4 )   //hack
+		      digi_ring = 1;
+		      
+		      int dwire = 999.;
+		      if( TheCollisionMuons.isValid() ) 
+		      {
+		      for( reco::MuonCollection::const_iterator iMuon = TheCollisionMuons->begin(); iMuon != TheCollisionMuons->end() && DigiIsHalo ; iMuon++ )
+		      {
+		      
+		      std::vector<TrackDetMatchInfo> info;
+		      if( iMuon->isTrackerMuon() && !iMuon->innerTrack().isNull() )
+		      info.push_back( trackAssociator_.associate(iEvent, iSetup, *iMuon->innerTrack(), parameters_) );
+		      if( iMuon->isStandAloneMuon() && !iMuon->outerTrack().isNull() )
+		      {
+		      //make sure that this SA muon is not actually a halo-like muon                           
+		      float theta =  iMuon->outerTrack()->outerMomentum().theta();
+		      float deta = TMath::Abs(iMuon->outerTrack()->outerPosition().eta() - iMuon->outerTrack()->innerPosition().eta());
+		      
+		      if( !( theta < min_outer_theta || theta > max_outer_theta ) )
+		      if ( deta > deta_threshold ) //halo-like 
+		      info.push_back( trackAssociator_.associate(iEvent, iSetup, *iMuon->outerTrack(), parameters_) );
+		      }
+		      if (iMuon->isGlobalMuon() && !iMuon->globalTrack().isNull() )
+		      info.push_back(trackAssociator_.associate(iEvent, iSetup, *iMuon->globalTrack(), parameters_) );
+		      for(unsigned int i = 0 ; i < info.size(); i++ )
+		      {
+		      for( std::vector<TAMuonChamberMatch>::const_iterator chamber=info[i].chambers.begin();
+		      chamber!=info[i].chambers.end(); chamber++ ){
+		      if( chamber->detector() != MuonSubdetId::CSC ) continue;
+		      
+		      for( std::vector<TAMuonSegmentMatch>::const_iterator segment = chamber->segments.begin();
+		      segment != chamber->segments.end(); segment++ ) {
+		      
+		      float eta_ = segment->segmentGlobalPosition.eta();	
+		      float phi_ = segment->segmentGlobalPosition.phi();	
+		      }
+		      }
+		      }
+		      if( dwire <=  matching_dwire_threshold ) 
+		      DigiIsHalo = false;
+		      }
+		      */
+		      if( DigiIsHalo )
+			nHaloDigis++;
+		    }
+		}
+	    }
+	}
+      else 
+	{
+	  //FOR >= 36X 
+	  /*
+	    If the user wants to use the info from the ALCT digis 
+	    but they aren't in the event, then the reco::CSCHaloData
+	    object can be used, albeit in limited scope,i.e.,
+	    ExpectedBX == 3 and no matching to collision muon hits
+	    is done until CMSSW_3_7_0.  
+	    
+	    //NOTE : THIS BLOCK OF CODE ONLY WORKS FOR >= 3_6_0 
+	    edm::Handle<reco::CSCHaloData> TheCSCDataHandle;
+	    iEvent.getByLabel(IT_CSCHaloData,TheCSCDataHandle);
+	    if(TheCSCDataHandle.isValid())
+	    {
+	    const reco::CSCHaloData CSCData = (*TheCSCDataHandle.product());
+	    nHaloDigis = CSCData.NumberOfOutOfTimeTriggers() ;
+	    }
+	  */
+	}
+      if( nHaloDigis >= min_nHaloDigis )  
+	return false;
+    }
+  
+  if(FilterRecoLevel)
+    {
+      int nHaloTracks = 0;
+      if(TheSACosmicMuons.isValid())
+	{
+	  for( reco::TrackCollection::const_iterator iTrack = TheSACosmicMuons->begin() ; iTrack != TheSACosmicMuons->end() ; iTrack++ )
+	    {
+	      bool TrackIsHalo = true;;
+	      // Calculate global phi coordinate for central most rechit in the track
+	      float innermost_global_z = 1500.;
+	      float outermost_global_z = 0.;
+	      
+	      GlobalPoint InnerMostGlobalPosition;  // smallest abs(z)
+	      GlobalPoint OuterMostGlobalPosition;  // largest abs(z)
+	      
+	      int nCSCHits = 0;
+	      for(unsigned int j = 0 ; j < iTrack->extra()->recHits().size(); j++ )
+		{
+		  edm::Ref<TrackingRecHitCollection> hit( iTrack->extra()->recHits(), j );
+		  if( !hit->isValid() ) continue;
+		  DetId TheDetUnitId(hit->geographicalId());
+		  if( TheDetUnitId.det() != DetId::Muon ) continue;
+
+		  if( TheDetUnitId.subdetId() != MuonSubdetId::CSC ) continue;
+
+		  const GeomDetUnit *TheUnit = TheCSCGeometry->idToDetUnit(TheDetUnitId);
+		  LocalPoint TheLocalPosition = hit->localPosition();  
+		  const BoundPlane TheSurface = TheUnit->surface();
+		  const GlobalPoint TheGlobalPosition = TheSurface.toGlobal(TheLocalPosition);
+
+		  float z = TheGlobalPosition.z();
+		  // Get consituent rechit closest to calorimetry
+		  if( TMath::Abs(z) < innermost_global_z )
+		    {
+		      innermost_global_z = TMath::Abs(z);
+		      InnerMostGlobalPosition = GlobalPoint( TheGlobalPosition);
+		    }
+		  // Get constituent rechit farthest from calorimetry
+		  if( TMath::Abs(z) > outermost_global_z )
+		    {
+		      outermost_global_z = TMath::Abs(z);
+		      OuterMostGlobalPosition = GlobalPoint( TheGlobalPosition );
+		    }
+		  nCSCHits ++;
+		}
+
+	      if( nCSCHits < 3 ) continue; // This needs to be optimized 
+	      
+	      float deta = TMath::Abs( OuterMostGlobalPosition.eta() - InnerMostGlobalPosition.eta() );
+	      float dphi = TMath::ACos( TMath::Cos( OuterMostGlobalPosition.phi() - InnerMostGlobalPosition.phi() ) ) ;
+	      float theta = iTrack->outerMomentum().theta();
+	      float innermost_x = InnerMostGlobalPosition.x() ;
+	      float innermost_y = InnerMostGlobalPosition.y();
+	      float outermost_x = OuterMostGlobalPosition.x();
+	      float outermost_y = OuterMostGlobalPosition.y();
+	      float innermost_r = TMath::Sqrt(innermost_x *innermost_x + innermost_y * innermost_y );
+	      float outermost_r = TMath::Sqrt(outermost_x *outermost_x + outermost_y * outermost_y );
+	      
+	      //float detadz = deta / ( innermost_global_z - outermost_global_z ) ;
+	      
+	      if( deta < deta_threshold )
+		TrackIsHalo = false;
+	      else if( theta > min_outer_theta && theta < max_outer_theta )
+		TrackIsHalo = false;
+	      else if( dphi > dphi_threshold )
+		TrackIsHalo = false;
+	      else if( innermost_r < min_inner_radius )
+		TrackIsHalo = false;
+	      else if( innermost_r > max_inner_radius )
+		TrackIsHalo = false;
+	      else if( outermost_r < min_outer_radius )
+		TrackIsHalo = false;
+	      else if( outermost_r > max_outer_radius )
+		TrackIsHalo = false;
+	      else if( iTrack->normalizedChi2() > norm_chi2_threshold )
+		TrackIsHalo = false;
+	      
+	      if( TrackIsHalo )
+		{
+		  nHaloTracks++;
+		  /*
+		  cout << "deta " << deta << endl;
+		  cout << "dphi " << dphi << endl;
+		  cout << "theta " << theta << endl;
+		  cout << "innermost_r " << innermost_r << endl;
+		  cout << "outermost_r " << outermost_r << endl;
+		  cout << "norm_chi2 " << iTrack->normalizedChi2() << endl;
+		  cout << "NValidHits " << iTrack->numberOfValidHits() << endl;
+		  cout << "nCSCHits " << nCSCHits << endl;
+		  cout << "deta/dz " << detadz << endl;
+		  */
+		}
+	    }
+	  if( nHaloTracks >= min_nHaloTracks )
+	    return false;
+	}
+    }
+
+  
+  return true;
+}
+  
+
+DEFINE_FWK_MODULE(CSCHaloFilter);

--- a/src/CSCHaloFilter.cc
+++ b/src/CSCHaloFilter.cc
@@ -171,7 +171,12 @@ bool CSCHaloFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup)
 	    }
 	}
       else
-	FilterTriggerLevel = false;  //NO TRIGGER DECISION CAN BE MADE
+	{
+	  LogWarning("Collection Not Found") << "You have requested Trigger-level filtering, but the L1MuGMTReadoutCollection does not appear"
+					     << "to be in the event! Trigger-level filtering will be disabled" ;
+
+	  FilterTriggerLevel = false;  //NO TRIGGER DECISION CAN BE MADE
+	}
     }
 
   if(FilterDigiLevel)
@@ -246,26 +251,32 @@ bool CSCHaloFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup)
 		}
 	    }
 	}
-      else if( TheCSCDataHandle.isValid() )
+      /*
+	else if( TheCSCDataHandle.isValid() )
 	{
-	  //FOR >= 36X 
-	  /*
-	    If the user wants to use the info from the ALCT digis 
-	    but they aren't in the event, then the reco::CSCHaloData
-	    object can be used, albeit in limited scope,i.e.,
-	    ExpectedBX == 3 and no matching to collision muon hits
-	    is done until CMSSW_3_7_0.  
-	    
-	    //NOTE : THIS BLOCK OF CODE ONLY WORKS FOR >= 3_6_0 
-	    if(TheCSCDataHandle.isValid())
-	    {
-	    const reco::CSCHaloData CSCData = (*TheCSCDataHandle.product());
-	    nHaloDigis = CSCData.NumberOfOutOfTimeTriggers() ;
-	    }
-	  */
+	//FOR >= 36X 
+	
+	If the user wants to use the info from the ALCT digis 
+	but they aren't in the event, then the reco::CSCHaloData
+	object can be used, albeit in limited scope,i.e.,
+	ExpectedBX == 3 and no matching to collision muon hits
+	is done until CMSSW_3_7_0.  
+	
+	//NOTE : THIS BLOCK OF CODE ONLY WORKS FOR >= 3_6_0 
+	if(TheCSCDataHandle.isValid())
+	{
+	const reco::CSCHaloData CSCData = (*TheCSCDataHandle.product());
+	nHaloDigis = CSCData.NumberOfOutOfTimeTriggers() ;
 	}
+	}
+      */
       else
-	FilterDigiLevel = false ; // NO DIGI LEVEL DECISION CAN BE MADE
+	{
+	  LogWarning("Collection Not Found") << "You have requested Digi-level filtering, but the CSCALCTDigiCollection does not appear"
+					     << "to be in the event! Digl-level filtering will be disabled" ;   
+	  
+	  FilterDigiLevel = false ; // NO DIGI LEVEL DECISION CAN BE MADE
+	}
     }
   
   if(FilterRecoLevel)
@@ -372,7 +383,12 @@ bool CSCHaloFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup)
 	    }
 	}
       else
-	FilterRecoLevel = false; //NO RECO LEVEL DECISION CAN BE MADE
+	{
+	  LogWarning("Collection Not Found") << "You have requested Reco-level filtering, but the cosmic stand-alone muon collection does not appear"
+					     << "to be in the event! Reco-level filtering will be disabled" ;   
+
+	  FilterRecoLevel = false; //NO RECO LEVEL DECISION CAN BE MADE
+	}
     }
 
   if(FilterRecoLevel && FilterDigiLevel && FilterTriggerLevel)

--- a/src/ExampleAnalyzer.cc
+++ b/src/ExampleAnalyzer.cc
@@ -1,0 +1,216 @@
+// -*- C++ -*-
+//
+// Package:    ExampleAnalyzer
+// Class:      ExampleAnalyzer
+// 
+/**\class ExampleAnalyzer ExampleAnalyzer.cc ExampleProducer/ExampleAnalyzer/src/ExampleAnalyzer.cc
+
+ Description: <one line class summary>
+
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author:  Frank GOLF
+//         Created:  Wed Aug 19 18:07:32 CEST 2009
+// $Id$
+//
+//
+
+
+// system include files
+#include <memory>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+// include these files to access the MET collections
+#include "DataFormats/METReco/interface/CaloMET.h"
+#include "DataFormats/METReco/interface/MET.h"
+#include "DataFormats/METReco/interface/PFMET.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/MuonReco/interface/MuonMETCorrectionData.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+
+//
+// class decleration
+//
+
+class ExampleAnalyzer : public edm::EDAnalyzer {
+   public:
+      explicit ExampleAnalyzer(const edm::ParameterSet&);
+      ~ExampleAnalyzer();
+
+
+   private:
+      virtual void beginJob() ;
+      virtual void analyze(const edm::Event&, const edm::EventSetup&);
+      virtual void endJob() ;
+
+      // ----------member data ---------------------------
+  edm::InputTag caloMETlabel;        // input label for raw calo MET 
+  edm::InputTag tcMETlabel;	     // input label for track-correct MET
+  edm::InputTag muCorrMETlabel;	     // input label for caloMET corrected for muons
+  edm::InputTag pfMETlabel;	     // input label for particle-flow MET
+  edm::InputTag muJESCorrMETlabel;   // input label for caloMET corrected for muons and JES
+  edm::InputTag muonLabel;           // input label for muon collection
+  edm::InputTag muValueMaplabel;     // input label for the muon correction value map
+  edm::InputTag tcMETValueMaplabel;  // input label for the tcMET value map 
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+ExampleAnalyzer::ExampleAnalyzer(const edm::ParameterSet& iConfig)
+
+{
+  caloMETlabel       = iConfig.getParameter<edm::InputTag>("caloMETlabel_"      );     
+  tcMETlabel         = iConfig.getParameter<edm::InputTag>("tcMETlabel_"        );       
+  muCorrMETlabel     = iConfig.getParameter<edm::InputTag>("muCorrMETlabel_"    );   
+  pfMETlabel         = iConfig.getParameter<edm::InputTag>("pfMETlabel_"        );       
+  muJESCorrMETlabel  = iConfig.getParameter<edm::InputTag>("muJESCorrMETlabel_" );
+  muonLabel          = iConfig.getParameter<edm::InputTag>("muonLabel_"         );
+  muValueMaplabel    = iConfig.getParameter<edm::InputTag>("muValueMaplabel_"   );
+  tcMETValueMaplabel = iConfig.getParameter<edm::InputTag>("tcMETValueMaplabel_");
+}
+
+
+ExampleAnalyzer::~ExampleAnalyzer()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to for each event  ------------
+void
+ExampleAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+
+  // get handles to collections
+
+  edm::Handle< edm::View<reco::CaloMET> > caloMEThandle;
+  iEvent.getByLabel(caloMETlabel, caloMEThandle);
+  
+  edm::Handle< edm::View<reco::CaloMET> > muCorrMEThandle;
+  iEvent.getByLabel(muCorrMETlabel, muCorrMEThandle);
+
+  edm::Handle< edm::View<reco::CaloMET> > muJESCorrMEThandle;
+  iEvent.getByLabel(muJESCorrMETlabel, muJESCorrMEThandle);
+
+  edm::Handle< edm::View<reco::MET> >     tcMEThandle;
+  iEvent.getByLabel(tcMETlabel, tcMEThandle);
+
+  edm::Handle< edm::View<reco::PFMET> >   pfMEThandle;
+  iEvent.getByLabel(pfMETlabel, pfMEThandle);
+
+  edm::Handle< reco::MuonCollection > muon_h;
+  iEvent.getByLabel(muonLabel, muon_h);
+
+  edm::Handle< edm::ValueMap<reco::MuonMETCorrectionData> > muVMhandle;
+  iEvent.getByLabel(muValueMaplabel, muVMhandle);
+
+  edm::Handle< edm::ValueMap<reco::MuonMETCorrectionData> > tcMETVMhandle;
+  iEvent.getByLabel(tcMETValueMaplabel, tcMETVMhandle);
+
+  // get MET and METphi from objects
+  
+  float caloMET         = (caloMEThandle->front() ).et();
+  float caloMETphi      = (caloMEThandle->front() ).phi();
+
+  float muCorrMET       = (muCorrMEThandle->front() ).et();
+  float muCorrMETphi    = (muCorrMEThandle->front() ).phi();
+  			  
+  float muJESCorrMET    = (muJESCorrMEThandle->front() ).et();
+  float muJESCorrMETphi = (muJESCorrMEThandle->front() ).phi();
+
+  float tcMET           = (tcMEThandle->front() ).et();
+  float tcMETphi        = (tcMEThandle->front() ).phi();
+			  
+  float pfMET           = (pfMEThandle->front() ).et();
+  float pfMETphi        = (pfMEThandle->front() ).phi();
+
+  const unsigned int nMuons = muon_h->size();
+
+  edm::ValueMap<reco::MuonMETCorrectionData> muVM = *muVMhandle;
+
+  std::vector<bool>  mu_flag;
+  std::vector<float> mu_x;
+  std::vector<float> mu_y;
+
+  // loop over ValueMap entries and extract flag and x, y components (one for each muon)
+
+  for( unsigned int mus = 0; mus < nMuons; mus++ ) {
+
+    reco::MuonRef muref( muon_h, mus);
+    reco::MuonMETCorrectionData muCorrData = (muVM)[muref];
+
+    mu_flag.push_back( muCorrData.type() );
+    mu_x.push_back( muCorrData.corrX() );
+    mu_y.push_back( muCorrData.corrY() );
+
+    std::cout << "flag = " << mu_flag[mus] << "\n";
+    std::cout << "mu_x = " << mu_x[mus]    << "\n";
+    std::cout << "mu_y = " << mu_y[mus]    << "\n";
+  }
+
+  edm::ValueMap<reco::MuonMETCorrectionData> tcVM = *tcMETVMhandle;
+
+  std::vector<bool>  tc_flag;
+  std::vector<float> tc_x;
+  std::vector<float> tc_y;
+
+  // same thing for tcMET
+
+  for( unsigned int mus = 0; mus < nMuons; mus++ ) {
+
+    reco::MuonRef muref( muon_h, mus);
+    reco::MuonMETCorrectionData muCorrData = (muVM)[muref];
+
+    tc_flag.push_back( muCorrData.type() );
+    tc_x.push_back( muCorrData.corrX() );
+    tc_y.push_back( muCorrData.corrY() );
+
+    std::cout << "flag = " << mu_flag[mus] << "\n";
+    std::cout << "mu_x = " << mu_x[mus]    << "\n";
+    std::cout << "mu_y = " << mu_y[mus]    << "\n";
+  }
+
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+ExampleAnalyzer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+ExampleAnalyzer::endJob() {
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(ExampleAnalyzer);

--- a/src/ExampleAnalyzer.cc
+++ b/src/ExampleAnalyzer.cc
@@ -13,7 +13,7 @@
 //
 // Original Author:  Frank GOLF
 //         Created:  Wed Aug 19 18:07:32 CEST 2009
-// $Id$
+// $Id: ExampleAnalyzer.cc,v 1.1 2009/08/25 12:41:33 fgolf Exp $
 //
 //
 
@@ -136,7 +136,8 @@ ExampleAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
   iEvent.getByLabel(tcMETValueMaplabel, tcMETVMhandle);
 
   // get MET and METphi from objects
-  
+
+  /*
   float caloMET         = (caloMEThandle->front() ).et();
   float caloMETphi      = (caloMEThandle->front() ).phi();
 
@@ -151,6 +152,8 @@ ExampleAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
 			  
   float pfMET           = (pfMEThandle->front() ).et();
   float pfMETphi        = (pfMEThandle->front() ).phi();
+  */
+
 
   const unsigned int nMuons = muon_h->size();
 

--- a/src/HcalNoiseInfoAnalyzer.cc
+++ b/src/HcalNoiseInfoAnalyzer.cc
@@ -8,7 +8,7 @@
 //
 
 #include "RecoMET/METAnalyzers/interface/HcalNoiseInfoAnalyzer.h"
-#include "RecoMET/METProducers/interface/HcalNoiseRBXArray.h"
+#include "RecoMET/METAlgorithms/interface/HcalNoiseRBXArray.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
 #include "TFile.h"

--- a/src/HcalNoiseInfoAnalyzer.cc
+++ b/src/HcalNoiseInfoAnalyzer.cc
@@ -13,6 +13,7 @@
 
 #include "TFile.h"
 #include "TH1D.h"
+#include "TH2D.h"
 
 using namespace reco;
   
@@ -25,6 +26,7 @@ HcalNoiseInfoAnalyzer::HcalNoiseInfoAnalyzer(const edm::ParameterSet& iConfig)
   // set parameters
   rbxCollName_    = iConfig.getParameter<std::string>("rbxCollName");
   rootHistFilename_ = iConfig.getParameter<std::string>("rootHistFilename");
+  noisetype_ = iConfig.getParameter<int>("noisetype");
 }
   
   
@@ -55,35 +57,62 @@ HcalNoiseInfoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   for(HcalNoiseRBXCollection::const_iterator rit=handle->begin(); rit!=handle->end(); ++rit) {
     // get the rbx
     HcalNoiseRBX rbx=(*rit);
-      
-    // get the highest rechit energy HPD in the RBX
     HcalNoiseHPD maxhpd=(*rbx.maxHPD());
-      
-    // loop over the HPDs in each RBX
-    int hpdcntr=0;
-    for(HcalNoiseHPDArray::const_iterator hit=rbx.beginHPD(); hit!=rbx.endHPD(); ++hit) {
+
+    // get the number of hits in the RBX to categorize the noise
+    int numhits = rbx.numRecHits(1.5);
+    if(numhits==0) continue;
+    if(numhits>=19 && noisetype_!=2 && noisetype_!=3) continue;
+    if(numhits>=9 && numhits<=18 && noisetype_!=1 && noisetype_!=3) continue;
+    if(numhits<=8 && noisetype_!=0 && noisetype_!=3) continue;
+
+    int failures=0;
+
+    hMaxZeros_->Fill(rbx.maxZeros());
+    hTotalZeros_->Fill(rbx.totalZeros());
+
+    if(rbx.maxZeros()>3)   failures |= 0x1;
+    if(rbx.totalZeros()>7) failures |= 0x2;
+
+    // loop over the HPDs in the RBX
+    double totale2ts=0;
+    double totale10ts=0;
+    for(std::vector<HcalNoiseHPD>::const_iterator hit=rbx.HPDs().begin(); hit!=rbx.HPDs().end(); ++hit) {
       HcalNoiseHPD hpd=(*hit);
-	
-      // loop over highest energy Digi
-      int cntr=0;
-      for(DigiArray::const_iterator dit=hpd.beginBigDigi(); dit!=hpd.endBigDigi(); ++dit) {
-	double fC=(*dit);
-	 
-      }
 
-      // loop over the 5 highest energy rechits in the HPD
-      // This is here for debugging purposes only: probably won't be available later
-      EnergySortedHBHERecHits rechits=hpd.recHits();
-      for(EnergySortedHBHERecHits::const_iterator it=rechits.begin(); it!=rechits.end(); ++it) {
+      // make sure we have at least 1 hit above 5 GeV
+      if(hpd.numRecHits(5.0)<1) continue;
 
-      }
+      totale2ts  += hpd.allDigiHighest2TS();
+      totale10ts += hpd.allDigiTotal();
 
-      hNHPDHits_->Fill(hpd.numHitsAboveThreshold());
+      double e2ts=hpd.bigDigiHighest2TS();
+      double e10ts=hpd.bigDigiTotal();
+
+      hE2ts_->Fill(e2ts);
+      hE10ts_->Fill(e10ts);
+      hE2tsOverE10ts_->Fill(e10ts ? e2ts/e10ts : -999);
+
+      if(e10ts && !(e2ts/e10ts<0.95 && e2ts/e10ts>0.70)) failures |= 0x4;
+      
+      int numhits = hpd.numRecHits(1.5);
+
+      hHPDNHits_->Fill(numhits);
+      if(numhits>16) failures |= 0x8;
+      
     }
+    hRBXE2ts_->Fill(totale2ts);
+    hRBXE10ts_->Fill(totale10ts);
+    hRBXE2tsOverE10ts_->Fill(totale10ts ? totale2ts/totale10ts : -999);
 
-    hNHPDMaxHits_->Fill(maxhpd.numHitsAboveThreshold());
+    if(totale10ts && totale2ts/totale10ts<0.70) failures |= 0x10;
+
+    hFailures_->Fill(failures);
+    double energy=rbx.recHitEnergy(1.5);
+
+    if(failures==0) hAfterRBXEnergy_->Fill(energy);
+    hBeforeRBXEnergy_->Fill(energy);
   }
-
 
   return;
 }
@@ -96,8 +125,19 @@ HcalNoiseInfoAnalyzer::beginJob(const edm::EventSetup&)
   // book histograms
   rootfile_ = new TFile(rootHistFilename_.c_str(), "RECREATE");
 
-  hNHPDHits_ = new TH1D("hNHPDHits","Number of RecHits in an HPD",19,0,19);
-  hNHPDMaxHits_ = new TH1D("hNHPDMaxHits","Number of RecHits in the highest energy HPD in the RBX",19,0,19);
+  hMaxZeros_ = new TH1D("hMaxZeros","Max # of zeros in an RBX",15,-0.5,14.5);
+  hTotalZeros_ = new TH1D("hTotalZeros","total # of zeros in an RBX",15,-0.5,14.5);
+  hE2ts_ = new TH1D("hE2ts","E(2ts) for the highest energy digi in an HPD",100,0,10000);
+  hE10ts_ = new TH1D("hE10ts","E(10ts) for the highest energy digi in an HPD",100,0,10000);
+  hE2tsOverE10ts_ = new TH1D("hE2tsOverE10ts","E(t2s)/E(10ts) for the highest energy digi in an HPD",100,-5,5);
+  hRBXE2ts_ = new TH1D("hRBXE2ts","Sum RBX E(2ts)",100,0,10000);
+  hRBXE10ts_ = new TH1D("hRBXE10ts","Sum RBX E(10ts)",100,0,10000);
+  hRBXE2tsOverE10ts_ = new TH1D("hRBXE2tsOverE10ts","Sum RBX E(t2s)/E(10ts)",100,-5,5);
+  hHPDNHits_ = new TH1D("hHPDNHits","Number of Hits with E>1.5 GeV in an HPD",19,-0.5,18.5);
+  
+  hFailures_ = new TH1D("hFailures","code designating which cut the event failed (if any)",32,-0.5,31.5);
+  hBeforeRBXEnergy_ = new TH1D("hBeforeRBXEnergy","Total RecHit Energy in RBX before cuts",100,0,1000);
+  hAfterRBXEnergy_ = new TH1D("hAfterRBXEnergy","Total RecHit Energy in RBX after cuts",100,0,1000);
 
 }
 
@@ -107,8 +147,21 @@ HcalNoiseInfoAnalyzer::endJob() {
 
   // write histograms
   rootfile_->cd();
-  hNHPDHits_->Write();
-  hNHPDMaxHits_->Write();
+
+  hMaxZeros_->Write();
+  hTotalZeros_->Write();
+  hE2ts_->Write();
+  hE10ts_->Write();
+  hE2tsOverE10ts_->Write();
+  hRBXE2ts_->Write();
+  hRBXE10ts_->Write();
+  hRBXE2tsOverE10ts_->Write();
+  hHPDNHits_->Write();
+  
+  hFailures_->Write();
+  hBeforeRBXEnergy_->Write();
+  hAfterRBXEnergy_->Write();
+
   rootfile_->Close();
 }
 

--- a/src/HcalNoiseInfoAnalyzer.cc
+++ b/src/HcalNoiseInfoAnalyzer.cc
@@ -1,0 +1,117 @@
+//
+// HcalNoiseInfoProducer.cc
+//
+//   description: Implementation of skeleton analyzer for the HCAL noise information
+//
+//   author: J.P. Chou, Brown
+//
+//
+
+#include "RecoMET/METAnalyzers/interface/HcalNoiseInfoAnalyzer.h"
+#include "DataFormats/METReco/interface/HcalNoiseRBXArray.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include "TFile.h"
+#include "TH1D.h"
+
+using namespace reco;
+  
+//
+// constructors and destructor
+//
+  
+HcalNoiseInfoAnalyzer::HcalNoiseInfoAnalyzer(const edm::ParameterSet& iConfig)
+{
+  // set parameters
+  rbxCollName_    = iConfig.getParameter<std::string>("rbxCollName");
+  rootHistFilename_ = iConfig.getParameter<std::string>("rootHistFilename");
+}
+  
+  
+HcalNoiseInfoAnalyzer::~HcalNoiseInfoAnalyzer()
+{
+}
+  
+  
+//
+// member functions
+//
+  
+// ------------ method called to for each event  ------------
+void
+HcalNoiseInfoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  using namespace edm;
+    
+  Handle<HcalNoiseRBXCollection> handle;
+  iEvent.getByLabel(rbxCollName_,handle);
+  if(!handle.isValid()) {
+    throw edm::Exception(edm::errors::ProductNotFound)
+      << " could not find HcalNoiseRBXCollection named " << rbxCollName_ << ".\n";
+    return;
+  }
+    
+  // loop over the RBXs
+  for(HcalNoiseRBXCollection::const_iterator rit=handle->begin(); rit!=handle->end(); ++rit) {
+    // get the rbx
+    HcalNoiseRBX rbx=(*rit);
+      
+    // get the highest rechit energy HPD in the RBX
+    HcalNoiseHPD maxhpd=(*rbx.maxHPD());
+      
+    // loop over the HPDs in each RBX
+    int hpdcntr=0;
+    for(HcalNoiseHPDArray::const_iterator hit=rbx.beginHPD(); hit!=rbx.endHPD(); ++hit) {
+      HcalNoiseHPD hpd=(*hit);
+	
+      // loop over highest energy Digi
+      int cntr=0;
+      for(DigiArray::const_iterator dit=hpd.beginBigDigi(); dit!=hpd.endBigDigi(); ++dit) {
+	double fC=(*dit);
+	 
+      }
+
+      // loop over the 5 highest energy rechits in the HPD
+      // This is here for debugging purposes only: probably won't be available later
+      EnergySortedHBHERecHits rechits=hpd.recHits();
+      for(EnergySortedHBHERecHits::const_iterator it=rechits.begin(); it!=rechits.end(); ++it) {
+
+      }
+
+      hNHPDHits_->Fill(hpd.numHitsAboveThreshold());
+    }
+
+    hNHPDMaxHits_->Fill(maxhpd.numHitsAboveThreshold());
+  }
+
+
+  return;
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+HcalNoiseInfoAnalyzer::beginJob(const edm::EventSetup&)
+{
+  // book histograms
+  rootfile_ = new TFile(rootHistFilename_.c_str(), "RECREATE");
+
+  hNHPDHits_ = new TH1D("hNHPDHits","Number of RecHits in an HPD",19,0,19);
+  hNHPDMaxHits_ = new TH1D("hNHPDMaxHits","Number of RecHits in the highest energy HPD in the RBX",19,0,19);
+
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+HcalNoiseInfoAnalyzer::endJob() {
+
+  // write histograms
+  rootfile_->cd();
+  hNHPDHits_->Write();
+  hNHPDMaxHits_->Write();
+  rootfile_->Close();
+}
+
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HcalNoiseInfoAnalyzer);

--- a/src/HcalNoiseInfoAnalyzer.cc
+++ b/src/HcalNoiseInfoAnalyzer.cc
@@ -8,7 +8,7 @@
 //
 
 #include "RecoMET/METAnalyzers/interface/HcalNoiseInfoAnalyzer.h"
-#include "DataFormats/METReco/interface/HcalNoiseRBXArray.h"
+#include "RecoMET/METProducers/interface/HcalNoiseRBXArray.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
 #include "TFile.h"

--- a/src/HcalNoiseInfoAnalyzer.cc
+++ b/src/HcalNoiseInfoAnalyzer.cc
@@ -74,20 +74,18 @@ HcalNoiseInfoAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& 
     if(rbx.maxZeros()>3)   failures |= 0x1;
     if(rbx.totalZeros()>7) failures |= 0x2;
 
+    double totale2ts=rbx.allChargeHighest2TS();
+    double totale10ts=rbx.allChargeTotal();
+
     // loop over the HPDs in the RBX
-    double totale2ts=0;
-    double totale10ts=0;
     for(std::vector<HcalNoiseHPD>::const_iterator hit=rbx.HPDs().begin(); hit!=rbx.HPDs().end(); ++hit) {
       HcalNoiseHPD hpd=(*hit);
 
       // make sure we have at least 1 hit above 5 GeV
       if(hpd.numRecHits(5.0)<1) continue;
 
-      totale2ts  += hpd.allDigiHighest2TS();
-      totale10ts += hpd.allDigiTotal();
-
-      double e2ts=hpd.bigDigiHighest2TS();
-      double e10ts=hpd.bigDigiTotal();
+      double e2ts=hpd.bigChargeHighest2TS();
+      double e10ts=hpd.bigChargeTotal();
 
       hE2ts_->Fill(e2ts);
       hE10ts_->Fill(e10ts);

--- a/test/Example-NoiseInfoAnalyzer_cfg.py
+++ b/test/Example-NoiseInfoAnalyzer_cfg.py
@@ -16,7 +16,7 @@ process.source = cms.Source ("PoolSource",
 # setup the analyzer
 process.hcalnoiseinfoanalyzer = cms.EDAnalyzer(
     'HcalNoiseInfoAnalyzer',
-    rbxCollName = cms.string('hcalnoiseinfoproducer'),
+    rbxCollName = cms.string('hcalnoise'),
     rootHistFilename = cms.string('plots.root'),
     noisetype = cms.int32(3)
     )

--- a/test/Example-NoiseInfoAnalyzer_cfg.py
+++ b/test/Example-NoiseInfoAnalyzer_cfg.py
@@ -1,0 +1,23 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('demo')
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.MessageLogger.cerr.FwkReport.reportEvery=cms.untracked.int32(10)
+
+# run over files
+readfiles = cms.untracked.vstring()
+readfiles.extend( ['file:test.root'] )
+process.source = cms.Source ("PoolSource",
+                             fileNames = readfiles)
+
+# setup the analyzer
+process.hcalnoiseinfoanalyzer = cms.EDAnalyzer(
+    'HcalNoiseInfoAnalyzer',
+    rbxCollName = cms.string('hcalnoiseinfoproducer'),
+    rootHistFilename = cms.string('plots.root')
+    )
+
+process.p = cms.Path(process.hcalnoiseinfoanalyzer)

--- a/test/Example-NoiseInfoAnalyzer_cfg.py
+++ b/test/Example-NoiseInfoAnalyzer_cfg.py
@@ -9,7 +9,7 @@ process.MessageLogger.cerr.FwkReport.reportEvery=cms.untracked.int32(10)
 
 # run over files
 readfiles = cms.untracked.vstring()
-readfiles.extend( ['file:test.root'] )
+readfiles.extend( ['file:noise_skim.root'] )
 process.source = cms.Source ("PoolSource",
                              fileNames = readfiles)
 
@@ -17,7 +17,8 @@ process.source = cms.Source ("PoolSource",
 process.hcalnoiseinfoanalyzer = cms.EDAnalyzer(
     'HcalNoiseInfoAnalyzer',
     rbxCollName = cms.string('hcalnoiseinfoproducer'),
-    rootHistFilename = cms.string('plots.root')
+    rootHistFilename = cms.string('plots.root'),
+    noisetype = cms.int32(3)
     )
 
 process.p = cms.Path(process.hcalnoiseinfoanalyzer)

--- a/test/ExampleHaloFilter_cfg.py
+++ b/test/ExampleHaloFilter_cfg.py
@@ -6,130 +6,27 @@ isData = False
 process.load("Configuration/StandardSequences/Geometry_cff")
 process.load("Configuration/StandardSequences/MagneticField_cff")
 process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
-
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMaskTechTrigConfig_cff')
 process.load('HLTrigger/HLTfilters/hltLevel1GTSeed_cfi')
-process.L1Tech=process.hltLevel1GTSeed.clone()
-process.L1Tech.L1TechTriggerSeeding = cms.bool(True)
-#process.L1Tech.L1SeedsLogicalExpression = cms.string('(0 OR 1 OR 2 OR 3 OR 4 OR 5 OR 6) AND (36 OR 37 OR 38 OR 39)')
-#process.L1Tech.L1SeedsLogicalExpression = cms.string('36 OR 37 OR 38 OR 39')
-process.L1Tech.L1SeedsLogicalExpression = cms.string('0 OR 1 OR 2 OR 3 OR 4 OR 5 OR 6')
-
-process.pathBPTXRequired = cms.Path( process.L1Tech ) 
 process.load("RecoMET/Configuration/RecoMET_BeamHaloId_cff")
 process.load('RecoMET.METAnalyzers.CSCHaloFilter_cfi')
 
-
 # Expected BX for ALCT Digis is (FOR MC = 6, FOR DATA =3)
 if isData:
-    process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
-    process.CSCBasedHaloFilter.ExpectedBX = cms.int32(3)
-    process.CSCHaloData.ExpectedBX = cms.int32(3)
-    process.GlobalTag.globaltag = 'GR_R_35X_V8::All'
-    process.pathCSCBasedHaloFilter = cms.Path( process.L1Tech *process.CSCBasedHaloFilter )
-    process.pathCSCHaloFilterTriggerLevel = cms.Path(process.L1Tech *process.CSCHaloFilterTriggerLevel)
-    process.pathCSCHaloFilterRecoLevel = cms.Path(process.L1Tech*  process.CSCHaloFilterRecoLevel )
-    process.pathCSCHaloFilterDigiLevel = cms.Path(process.muonCSCDigis*process.L1Tech*process.CSCHaloFilterDigiLevel )
-    process.pathCSCHaloFilterRecoAndTriggerLevel = cms.Path(process.L1Tech*process.CSCHaloFilterRecoAndTriggerLevel ) 
-    process.pathCSCHaloFilterRecoOrTriggerLevel = cms.Path(process.L1Tech*process.CSCHaloFilterRecoOrTriggerLevel )
-    process.pathCSCHaloFilterDigiAndTriggerLevel = cms.Path (process.L1Tech*process.CSCHaloFilterDigiAndTriggerLevel)
-    process.pathCSCHaloFilterDigiOrTriggerLevel = cms.Path(process.L1Tech*process.CSCHaloFilterDigiOrTriggerLevel)
-    process.pathCSCHaloFilterDigiAndRecoLevel = cms.Path(process.L1Tech*process.CSCHaloFilterDigiAndRecoLevel)
-    process.pathCSCHaloFilterDigiOrRecoLevel = cms.Path(process.L1Tech*process.CSCHaloFilterDigiOrRecoLevel)
-    process.pathCSCHaloFilterRecoAndDigiAndTriggerLevel = cms.Path( process.L1Tech* process.CSCHaloFilterRecoAndDigiAndTriggerLevel )
-    process.pathCSCHaloFilterLoose = cms.Path(process.L1Tech*process.CSCHaloFilterLoose )
-    process.pathCSCHaloFilterTight = cms.Path(process.L1Tech*process.CSCHaloFilterTight ) 
+    process.GlobalTag.globaltag = 'GR10_P_V12::All'
 else:
-    process.load("Configuration/StandardSequences/RawToDigi_cff")
-    process.CSCBasedHaloFilter.ExpectedBX = cms.int32(6)
-    process.CSCHaloFilterDigiLevel.ExpectedBX = 6
-    process.CSCHaloFilterDigiAndTriggerLevel.ExpectedBX = 6
-    process.CSCHaloFilterDigiAndRecoLevel.ExpectedBX = 6
-    process.CSCHaloData.ExpectedBX = cms.int32(6)
-    process.GlobalTag.globaltag = 'MC_3XY_V27::All'
-    process.pathCSCBasedHaloFilter = cms.Path( process.CSCBasedHaloFilter )
-    process.pathCSCHaloFilterTriggerLevel = cms.Path(process.CSCHaloFilterTriggerLevel)
-    process.pathCSCHaloFilterRecoLevel = cms.Path( process.CSCHaloFilterRecoLevel )
-    process.pathCSCHaloFilterDigiLevel = cms.Path(process.muonCSCDigis*process.CSCHaloFilterDigiLevel )
-    process.pathCSCHaloFilterRecoAndTriggerLevel = cms.Path( process.CSCHaloFilterRecoAndTriggerLevel ) 
-    process.pathCSCHaloFilterRecoOrTriggerLevel = cms.Path( process.CSCHaloFilterRecoOrTriggerLevel)
-    process.pathCSCHaloFilterDigiAndTriggerLevel = cms.Path (process.CSCHaloFilterDigiAndTriggerLevel)
-    process.pathCSCHaloFilterDigiOrTriggerLevel = cms.Path( process.CSCHaloFilterDigiOrTriggerLevel)
-    process.pathCSCHaloFilterDigiAndRecoLevel = cms.Path(process.CSCHaloFilterDigiAndRecoLevel)
-    process.pathCSCHaloFilterDigiOrRecoLevel = cms.Path(process.CSCHaloFilterDigiOrRecoLevel)
-    process.pathCSCHaloFilterRecoAndDigiAndTriggerLevel = cms.Path(process.CSCHaloFilterRecoAndDigiAndTriggerLevel )
-    process.pathCSCHaloFilterLoose = cms.Path(process.CSCHaloFilterLoose )
-    process.pathCSCHaloFilterTight = cms.Path(process.CSCHaloFilterTight ) 
-    
+    process.GlobalTag.globaltag = 'START39_V8::All'
 
-#process.load("Configuration/StandardSequences/ReconstructionCosmics_cff")
+
 process.load("RecoMuon/Configuration/RecoMuon_cff")
-
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 process.source = cms.Source("PoolSource",
                             fileNames = cms.untracked.vstring(
 
-    #'/store/relval/CMSSW_3_5_8/RelValMinBias/GEN-SIM-RECO/START3X_V26-v1/0017/E26CCE65-8F52-DF11-9FA4-00304867901A.root',
-    #'/store/relval/CMSSW_3_5_8/RelValMinBias/GEN-SIM-RECO/START3X_V26-v1/0016/C86F45C5-4D52-DF11-9725-001A92810AD4.root'
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0017/E608ED1A-8F52-DF11-B455-0030486790BA.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0016/E6A643C1-4E52-DF11-87FE-00261894392D.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0016/E62330A9-4852-DF11-A46E-001A92971B8C.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0016/70881F95-4252-DF11-A409-002618FDA248.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0016/5E421825-4952-DF11-91E5-002618943880.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0016/40796A28-4952-DF11-B6C6-00261894387E.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0016/36C1F1DB-4352-DF11-918A-002618FDA279.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0016/008C33BB-4752-DF11-BAE4-00304867D836.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0016/005017A4-4852-DF11-BF8A-0026189438AD.root'
-    
-    #'/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0017/46476117-8F52-DF11-8F82-00304866C398.root',
-    #'/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/FA3ED2C4-5B52-DF11-8DC9-001A92971B7E.root',
-    #'/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/F263C13D-5E52-DF11-BF2E-0026189438BC.root',
-    #'/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/BE8075FA-5452-DF11-AF79-0030486790BE.root',
-    #'/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/82C47C1C-5652-DF11-804B-001A92971ACC.root',
-    #'/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/60DCA072-5452-DF11-A7A5-00248C55CC3C.root'
- 
-    
-    #'rfio:/castor/cern.ch/user/r/rcr/SkimOutput_SingleMuon_1-10.root'
-    'file:/afs/cern.ch/user/r/rcr/scratch0/Skim_4.root'
-    #'/store/relval/CMSSW_3_5_8/RelValBeamHalo/GEN-SIM-RECO/START3X_V26-v1/0017/D6AA4854-9052-DF11-9317-0030486791BA.root',
-    #'/store/relval/CMSSW_3_5_8/RelValBeamHalo/GEN-SIM-RECO/START3X_V26-v1/0016/9E2F2DEB-6352-DF11-BC8D-002618943951.root'
-    
-    #'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_1.root',
-    #'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_2.root',
-    #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_3.root',
-    #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_4.root',
-    #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_5.root',
-    #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_6.root',
-    #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_7.root',
-    #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_8.root',
-    #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_9.root',
-    #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_10.root',
-    #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_11.root'
-
-
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/FEF2CEA0-4852-DF11-A066-001A92971B04.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/FC68FCA5-4252-DF11-B6A5-00261894393E.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/F6CDEB29-4852-DF11-8AF0-001BFCDBD176.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/E0811A9E-4852-DF11-8996-0026189437FA.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/D40776AA-4852-DF11-B986-002618943880.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/D25E1B46-4E52-DF11-ABE1-001A92810AD2.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/D01DB717-4252-DF11-A443-002618FDA259.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/CC99CBB1-4852-DF11-8B87-002618943800.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/9E8CEF9C-4752-DF11-AB2C-0026189437F9.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/92E8D320-4952-DF11-8E98-003048678D78.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/802E8BD1-4352-DF11-845F-002618943985.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/7E3A5327-4952-DF11-9501-001A92971BC8.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/6E1553BC-5C52-DF11-BB6C-002618943800.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/6AEA31A7-4952-DF11-B282-002618943957.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/5E83C295-4252-DF11-94E2-003048679006.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/54BEEFAE-4852-DF11-B5F8-0026189438B5.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/40DAD2D2-4352-DF11-A1E3-0026189438E0.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/36139940-4F52-DF11-9D71-00261894392C.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/24BBD52E-4852-DF11-87F0-003048678B00.root',
-    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/2085B0B6-4752-DF11-911D-001A92971BCA.root'
-    #'/store/relval/CMSSW_3_5_8/RelValBeamHalo/GEN-SIM-DIGI-RAW-HLTDEBUG/START3X_V26-v1/0016/7C8513EA-6352-DF11-9B7D-003048678A7E.root'
+     '/store/relval/CMSSW_3_9_7/RelValBeamHalo/GEN-SIM-RECO/START39_V8-v1/0047/08704CC8-830D-E011-9AD3-002618943852.root'
+     
     
     ),
 )
@@ -138,19 +35,10 @@ process.source = cms.Source("PoolSource",
 
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True))
 
+process.p = cms.Path(process.CSCTightHaloFilter)
+
 process.schedule = cms.Schedule(
-    process.pathCSCHaloFilterTriggerLevel,
-    process.pathCSCHaloFilterRecoLevel,
-    process.pathCSCHaloFilterDigiLevel,
-    process.pathCSCHaloFilterRecoAndTriggerLevel,
-    process.pathCSCHaloFilterRecoOrTriggerLevel,
-    process.pathCSCHaloFilterDigiAndTriggerLevel,
-    process.pathCSCHaloFilterDigiOrTriggerLevel,
-    process.pathCSCHaloFilterDigiOrRecoLevel,
-    process.pathCSCHaloFilterDigiAndRecoLevel,
-    process.pathCSCHaloFilterLoose,
-    process.pathCSCHaloFilterTight,
-    process.pathCSCHaloFilterRecoAndDigiAndTriggerLevel
+    process.p
     )
 
 

--- a/test/ExampleHaloFilter_cfg.py
+++ b/test/ExampleHaloFilter_cfg.py
@@ -34,10 +34,14 @@ if isData:
     process.pathCSCHaloFilterRecoOrTriggerLevel = cms.Path(process.L1Tech*process.CSCHaloFilterRecoLevel*process.CSCHaloFilterTriggerLevel ) 
     process.pathCSCHaloFilterDigiAndTriggerLevel = cms.Path (process.L1Tech*process.CSCHaloFilterDigiAndTriggerLevel)
     process.pathCSCHaloFilterDigiOrTriggerLevel = cms.Path(process.L1Tech*process.CSCHaloFilterDigiLevel * process.CSCHaloFilterTriggerLevel )
+    process.pathCSCHaloFilterDigiOrRecoLevel = cms.Path(process.L1Tech*process.CSCHaloFilterDigiLevel *process.CSCHaloFilterRecoLevel)
+    process.pathCSCHaloFilterDigiAndRecoLevel = cms.Path(process.L1Tech*process.CSCHaloFilterDigiAndRecoLevel)
+    process.pathCSCHaloFilterDigiOrTriggerOrRecoLevel = cms.Path(process.L1Tech*process.CSCHaloFilterDigiLevel*process.CSCHaloFilterTriggerLevel*process.CSCHaloFilterRecoLevel)
 else:
     process.CSCBasedHaloFilter.ExpectedBX = cms.int32(6)
     process.CSCHaloFilterDigiLevel.ExpectedBX = 6
     process.CSCHaloFilterDigiAndTriggerLevel.ExpectedBX = 6
+    process.CSCHaloFilterDigiAndRecoLevel.ExpectedBX = 6
     process.CSCHaloData.ExpectedBX = cms.int32(6)
     process.GlobalTag.globaltag = 'MC_3XY_V27::All'
     process.pathCSCBasedHaloFilter = cms.Path( process.CSCBasedHaloFilter )
@@ -48,6 +52,10 @@ else:
     process.pathCSCHaloFilterRecoOrTriggerLevel = cms.Path( process.CSCHaloFilterRecoLevel*process.CSCHaloFilterTriggerLevel ) 
     process.pathCSCHaloFilterDigiAndTriggerLevel = cms.Path (process.CSCHaloFilterDigiAndTriggerLevel)
     process.pathCSCHaloFilterDigiOrTriggerLevel = cms.Path( process.CSCHaloFilterDigiLevel * process.CSCHaloFilterTriggerLevel )
+    process.pathCSCHaloFilterDigiOrRecoLevel = cms.Path(process.CSCHaloFilterDigiLevel *process.CSCHaloFilterRecoLevel)
+    process.pathCSCHaloFilterDigiAndRecoLevel = cms.Path(process.CSCHaloFilterDigiAndRecoLevel)
+    process.pathCSCHaloFilterDigiOrTriggerOrRecoLevel = cms.Path(process.CSCHaloFilterDigiLevel*process.CSCHaloFilterTriggerLevel*process.CSCHaloFilterRecoLevel)
+
     
 process.pathCSCBasedHaloFilter = cms.Path(process.CSCBasedHaloFilter)
 
@@ -132,7 +140,10 @@ process.schedule = cms.Schedule(
     process.pathCSCHaloFilterRecoAndTriggerLevel,
     process.pathCSCHaloFilterRecoOrTriggerLevel,
     process.pathCSCHaloFilterDigiAndTriggerLevel,
-    process.pathCSCHaloFilterDigiOrTriggerLevel
+    process.pathCSCHaloFilterDigiOrTriggerLevel,
+    process.pathCSCHaloFilterDigiOrRecoLevel,
+    process.pathCSCHaloFilterDigiAndRecoLevel,
+    process.pathCSCHaloFilterDigiOrTriggerOrRecoLevel 
     )
 
 

--- a/test/ExampleHaloFilter_cfg.py
+++ b/test/ExampleHaloFilter_cfg.py
@@ -6,7 +6,7 @@ isData = False
 process.load("Configuration/StandardSequences/Geometry_cff")
 process.load("Configuration/StandardSequences/MagneticField_cff")
 process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
-process.load("Configuration/StandardSequences/RawToDigi_cff")
+
 process.load('Configuration.EventContent.EventContent_cff')
 process.load('L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMaskTechTrigConfig_cff')
 process.load('HLTrigger/HLTfilters/hltLevel1GTSeed_cfi')
@@ -23,21 +23,25 @@ process.load('RecoMET.METAnalyzers.CSCHaloFilter_cfi')
 
 # Expected BX for ALCT Digis is (FOR MC = 6, FOR DATA =3)
 if isData:
+    process.load("Configuration/StandardSequences/RawToDigi_Data_cff")
     process.CSCBasedHaloFilter.ExpectedBX = cms.int32(3)
     process.CSCHaloData.ExpectedBX = cms.int32(3)
     process.GlobalTag.globaltag = 'GR_R_35X_V8::All'
     process.pathCSCBasedHaloFilter = cms.Path( process.L1Tech *process.CSCBasedHaloFilter )
     process.pathCSCHaloFilterTriggerLevel = cms.Path(process.L1Tech *process.CSCHaloFilterTriggerLevel)
     process.pathCSCHaloFilterRecoLevel = cms.Path(process.L1Tech*  process.CSCHaloFilterRecoLevel )
-    process.pathCSCHaloFilterDigiLevel = cms.Path(process.L1Tech*process.CSCHaloFilterDigiLevel )
+    process.pathCSCHaloFilterDigiLevel = cms.Path(process.muonCSCDigis*process.L1Tech*process.CSCHaloFilterDigiLevel )
     process.pathCSCHaloFilterRecoAndTriggerLevel = cms.Path(process.L1Tech*process.CSCHaloFilterRecoAndTriggerLevel ) 
-    process.pathCSCHaloFilterRecoOrTriggerLevel = cms.Path(process.L1Tech*process.CSCHaloFilterRecoLevel*process.CSCHaloFilterTriggerLevel ) 
+    process.pathCSCHaloFilterRecoOrTriggerLevel = cms.Path(process.L1Tech*process.CSCHaloFilterRecoOrTriggerLevel )
     process.pathCSCHaloFilterDigiAndTriggerLevel = cms.Path (process.L1Tech*process.CSCHaloFilterDigiAndTriggerLevel)
-    process.pathCSCHaloFilterDigiOrTriggerLevel = cms.Path(process.L1Tech*process.CSCHaloFilterDigiLevel * process.CSCHaloFilterTriggerLevel )
-    process.pathCSCHaloFilterDigiOrRecoLevel = cms.Path(process.L1Tech*process.CSCHaloFilterDigiLevel *process.CSCHaloFilterRecoLevel)
+    process.pathCSCHaloFilterDigiOrTriggerLevel = cms.Path(process.L1Tech*process.CSCHaloFilterDigiOrTriggerLevel)
     process.pathCSCHaloFilterDigiAndRecoLevel = cms.Path(process.L1Tech*process.CSCHaloFilterDigiAndRecoLevel)
-    process.pathCSCHaloFilterDigiOrTriggerOrRecoLevel = cms.Path(process.L1Tech*process.CSCHaloFilterDigiLevel*process.CSCHaloFilterTriggerLevel*process.CSCHaloFilterRecoLevel)
+    process.pathCSCHaloFilterDigiOrRecoLevel = cms.Path(process.L1Tech*process.CSCHaloFilterDigiOrRecoLevel)
+    process.pathCSCHaloFilterRecoAndDigiAndTriggerLevel = cms.Path( process.L1Tech* process.CSCHaloFilterRecoAndDigiAndTriggerLevel )
+    process.pathCSCHaloFilterLoose = cms.Path(process.L1Tech*process.CSCHaloFilterLoose )
+    process.pathCSCHaloFilterTight = cms.Path(process.L1Tech*process.CSCHaloFilterTight ) 
 else:
+    process.load("Configuration/StandardSequences/RawToDigi_cff")
     process.CSCBasedHaloFilter.ExpectedBX = cms.int32(6)
     process.CSCHaloFilterDigiLevel.ExpectedBX = 6
     process.CSCHaloFilterDigiAndTriggerLevel.ExpectedBX = 6
@@ -49,24 +53,24 @@ else:
     process.pathCSCHaloFilterRecoLevel = cms.Path( process.CSCHaloFilterRecoLevel )
     process.pathCSCHaloFilterDigiLevel = cms.Path(process.muonCSCDigis*process.CSCHaloFilterDigiLevel )
     process.pathCSCHaloFilterRecoAndTriggerLevel = cms.Path( process.CSCHaloFilterRecoAndTriggerLevel ) 
-    process.pathCSCHaloFilterRecoOrTriggerLevel = cms.Path( process.CSCHaloFilterRecoLevel*process.CSCHaloFilterTriggerLevel ) 
+    process.pathCSCHaloFilterRecoOrTriggerLevel = cms.Path( process.CSCHaloFilterRecoOrTriggerLevel)
     process.pathCSCHaloFilterDigiAndTriggerLevel = cms.Path (process.CSCHaloFilterDigiAndTriggerLevel)
-    process.pathCSCHaloFilterDigiOrTriggerLevel = cms.Path( process.CSCHaloFilterDigiLevel * process.CSCHaloFilterTriggerLevel )
-    process.pathCSCHaloFilterDigiOrRecoLevel = cms.Path(process.CSCHaloFilterDigiLevel *process.CSCHaloFilterRecoLevel)
+    process.pathCSCHaloFilterDigiOrTriggerLevel = cms.Path( process.CSCHaloFilterDigiOrTriggerLevel)
     process.pathCSCHaloFilterDigiAndRecoLevel = cms.Path(process.CSCHaloFilterDigiAndRecoLevel)
-    process.pathCSCHaloFilterDigiOrTriggerOrRecoLevel = cms.Path(process.CSCHaloFilterDigiLevel*process.CSCHaloFilterTriggerLevel*process.CSCHaloFilterRecoLevel)
-
+    process.pathCSCHaloFilterDigiOrRecoLevel = cms.Path(process.CSCHaloFilterDigiOrRecoLevel)
+    process.pathCSCHaloFilterRecoAndDigiAndTriggerLevel = cms.Path(process.CSCHaloFilterRecoAndDigiAndTriggerLevel )
+    process.pathCSCHaloFilterLoose = cms.Path(process.CSCHaloFilterLoose )
+    process.pathCSCHaloFilterTight = cms.Path(process.CSCHaloFilterTight ) 
     
-process.pathCSCBasedHaloFilter = cms.Path(process.CSCBasedHaloFilter)
 
 #process.load("Configuration/StandardSequences/ReconstructionCosmics_cff")
-
 process.load("RecoMuon/Configuration/RecoMuon_cff")
 
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 process.source = cms.Source("PoolSource",
                             fileNames = cms.untracked.vstring(
+
     #'/store/relval/CMSSW_3_5_8/RelValMinBias/GEN-SIM-RECO/START3X_V26-v1/0017/E26CCE65-8F52-DF11-9FA4-00304867901A.root',
     #'/store/relval/CMSSW_3_5_8/RelValMinBias/GEN-SIM-RECO/START3X_V26-v1/0016/C86F45C5-4D52-DF11-9725-001A92810AD4.root'
     #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0017/E608ED1A-8F52-DF11-B455-0030486790BA.root',
@@ -88,7 +92,7 @@ process.source = cms.Source("PoolSource",
  
     
     #'rfio:/castor/cern.ch/user/r/rcr/SkimOutput_SingleMuon_1-10.root'
-    #'file:/afs/cern.ch/user/r/rcr/scratch0/Skim_4.root'
+    'file:/afs/cern.ch/user/r/rcr/scratch0/Skim_4.root'
     #'/store/relval/CMSSW_3_5_8/RelValBeamHalo/GEN-SIM-RECO/START3X_V26-v1/0017/D6AA4854-9052-DF11-9317-0030486791BA.root',
     #'/store/relval/CMSSW_3_5_8/RelValBeamHalo/GEN-SIM-RECO/START3X_V26-v1/0016/9E2F2DEB-6352-DF11-BC8D-002618943951.root'
     
@@ -125,7 +129,8 @@ process.source = cms.Source("PoolSource",
     #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/36139940-4F52-DF11-9D71-00261894392C.root',
     #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/24BBD52E-4852-DF11-87F0-003048678B00.root',
     #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/2085B0B6-4752-DF11-911D-001A92971BCA.root'
-    '/store/relval/CMSSW_3_5_8/RelValBeamHalo/GEN-SIM-DIGI-RAW-HLTDEBUG/START3X_V26-v1/0016/7C8513EA-6352-DF11-9B7D-003048678A7E.root'
+    #'/store/relval/CMSSW_3_5_8/RelValBeamHalo/GEN-SIM-DIGI-RAW-HLTDEBUG/START3X_V26-v1/0016/7C8513EA-6352-DF11-9B7D-003048678A7E.root'
+    
     ),
 )
 
@@ -143,7 +148,9 @@ process.schedule = cms.Schedule(
     process.pathCSCHaloFilterDigiOrTriggerLevel,
     process.pathCSCHaloFilterDigiOrRecoLevel,
     process.pathCSCHaloFilterDigiAndRecoLevel,
-    process.pathCSCHaloFilterDigiOrTriggerOrRecoLevel 
+    process.pathCSCHaloFilterLoose,
+    process.pathCSCHaloFilterTight,
+    process.pathCSCHaloFilterRecoAndDigiAndTriggerLevel
     )
 
 

--- a/test/ExampleHaloFilter_cfg.py
+++ b/test/ExampleHaloFilter_cfg.py
@@ -2,29 +2,51 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-isData = False
+isData = True
 process.load("Configuration/StandardSequences/Geometry_cff")
 process.load("Configuration/StandardSequences/MagneticField_cff")
 process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
 process.load("Configuration/StandardSequences/RawToDigi_cff")
 process.load('Configuration.EventContent.EventContent_cff')
+process.load('L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMaskTechTrigConfig_cff')
+process.load('HLTrigger/HLTfilters/hltLevel1GTSeed_cfi')
+process.L1Tech=process.hltLevel1GTSeed.clone()
+process.L1Tech.L1TechTriggerSeeding = cms.bool(True)
+#process.L1Tech.L1SeedsLogicalExpression = cms.string('(0 OR 1 OR 2 OR 3 OR 4 OR 5 OR 6) AND (36 OR 37 OR 38 OR 39)')
+#process.L1Tech.L1SeedsLogicalExpression = cms.string('36 OR 37 OR 38 OR 39')
+process.L1Tech.L1SeedsLogicalExpression = cms.string('0 OR 1 OR 2 OR 3 OR 4 OR 5 OR 6')
+
+process.pathBPTXRequired = cms.Path( process.L1Tech ) 
 process.load("RecoMET/Configuration/RecoMET_BeamHaloId_cff")
 process.load('RecoMET.METAnalyzers.CSCHaloFilter_cfi')
-process.CSCBasedHaloFilter.FilterDigiLevel = True    #### For < 36X, this requires the RAW-DIGI
-process.CSCBasedHaloFilter.FilterTriggerLevel = True
-process.CSCBasedHaloFilter.FilterRecoLevel = True 
 
-#FOR MC = 6, FOR DATA =3
+
+# Expected BX for ALCT Digis is (FOR MC = 6, FOR DATA =3)
 if isData:
     process.CSCBasedHaloFilter.ExpectedBX = cms.int32(3)
     process.CSCHaloData.ExpectedBX = cms.int32(3)
     process.GlobalTag.globaltag = 'GR_R_35X_V8::All'
+    process.pathCSCBasedHaloFilter = cms.Path( process.L1Tech *process.CSCBasedHaloFilter )
+    process.pathCSCHaloFilterTriggerLevel = cms.Path(process.L1Tech *process.CSCHaloFilterTriggerLevel)
+    process.pathCSCHaloFilterRecoLevel = cms.Path(process.L1Tech*  process.CSCHaloFilterRecoLevel )
+    process.pathCSCHaloFilterDigiLevel = cms.Path(process.L1Tech*process.CSCHaloFilterDigiLevel )
+    process.pathCSCHaloFilterRecoAndTriggerLevel = cms.Path(process.L1Tech*process.CSCHaloFilterRecoAndTriggerLevel ) 
+    process.pathCSCHaloFilterRecoOrTriggerLevel = cms.Path(process.L1Tech*process.CSCHaloFilterRecoLevel*process.CSCHaloFilterTriggerLevel ) 
+    process.pathCSCHaloFilterDigiAndTriggerLevel = cms.Path (process.L1Tech*process.CSCHaloFilterDigiAndTriggerLevel)
+    process.pathCSCHaloFilterDigiOrTriggerLevel = cms.Path(process.L1Tech*process.CSCHaloFilterDigiLevel * process.CSCHaloFilterTriggerLevel )
 else:
     process.CSCBasedHaloFilter.ExpectedBX = cms.int32(6)
     process.CSCHaloData.ExpectedBX = cms.int32(6)
     process.GlobalTag.globaltag = 'MC_3XY_V27::All'
-
-
+    process.pathCSCBasedHaloFilter = cms.Path( process.CSCBasedHaloFilter )
+    process.pathCSCHaloFilterTriggerLevel = cms.Path(process.CSCHaloFilterTriggerLevel)
+    process.pathCSCHaloFilterRecoLevel = cms.Path( process.CSCHaloFilterRecoLevel )
+    process.pathCSCHaloFilterDigiLevel = cms.Path( process.CSCHaloFilterDigiLevel )
+    process.pathCSCHaloFilterRecoAndTriggerLevel = cms.Path( process.CSCHaloFilterRecoAndTriggerLevel ) 
+    process.pathCSCHaloFilterRecoOrTriggerLevel = cms.Path( process.CSCHaloFilterRecoLevel*process.CSCHaloFilterTriggerLevel ) 
+    process.pathCSCHaloFilterDigiAndTriggerLevel = cms.Path (process.CSCHaloFilterDigiAndTriggerLevel)
+    process.pathCSCHaloFilterDigiOrTriggerLevel = cms.Path( process.CSCHaloFilterDigiLevel * process.CSCHaloFilterTriggerLevel )
+    
 process.pathCSCBasedHaloFilter = cms.Path(process.CSCBasedHaloFilter)
 
 
@@ -35,7 +57,6 @@ process.load("RecoMuon/Configuration/RecoMuon_cff")
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 
 process.source = cms.Source("PoolSource",
-
                             fileNames = cms.untracked.vstring(
     #'/store/relval/CMSSW_3_5_8/RelValMinBias/GEN-SIM-RECO/START3X_V26-v1/0017/E26CCE65-8F52-DF11-9FA4-00304867901A.root',
     #'/store/relval/CMSSW_3_5_8/RelValMinBias/GEN-SIM-RECO/START3X_V26-v1/0016/C86F45C5-4D52-DF11-9725-001A92810AD4.root'
@@ -49,50 +70,68 @@ process.source = cms.Source("PoolSource",
     #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0016/008C33BB-4752-DF11-BAE4-00304867D836.root',
     #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0016/005017A4-4852-DF11-BF8A-0026189438AD.root'
     
-#    '/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0017/46476117-8F52-DF11-8F82-00304866C398.root',
-#    '/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/FA3ED2C4-5B52-DF11-8DC9-001A92971B7E.root',
-#    '/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/F263C13D-5E52-DF11-BF2E-0026189438BC.root',
-#    '/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/BE8075FA-5452-DF11-AF79-0030486790BE.root',
-#    '/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/82C47C1C-5652-DF11-804B-001A92971ACC.root',
-#    '/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/60DCA072-5452-DF11-A7A5-00248C55CC3C.root'
+    #'/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0017/46476117-8F52-DF11-8F82-00304866C398.root',
+    #'/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/FA3ED2C4-5B52-DF11-8DC9-001A92971B7E.root',
+    #'/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/F263C13D-5E52-DF11-BF2E-0026189438BC.root',
+    #'/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/BE8075FA-5452-DF11-AF79-0030486790BE.root',
+    #'/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/82C47C1C-5652-DF11-804B-001A92971ACC.root',
+    #'/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/60DCA072-5452-DF11-A7A5-00248C55CC3C.root'
  
     
     #'rfio:/castor/cern.ch/user/r/rcr/SkimOutput_SingleMuon_1-10.root'
-    'file:/afs/cern.ch/user/r/rcr/scratch0/Skim_4.root'
+    #'file:/afs/cern.ch/user/r/rcr/scratch0/Skim_4.root'
     #'/store/relval/CMSSW_3_5_8/RelValBeamHalo/GEN-SIM-RECO/START3X_V26-v1/0017/D6AA4854-9052-DF11-9317-0030486791BA.root',
     #'/store/relval/CMSSW_3_5_8/RelValBeamHalo/GEN-SIM-RECO/START3X_V26-v1/0016/9E2F2DEB-6352-DF11-BC8D-002618943951.root'
     
-#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_1.root',
-#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_2.root',
-#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_3.root',
-#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_4.root',
-#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_5.root',
-#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_6.root',
-#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_7.root',
-#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_8.root',
-#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_9.root',
-#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_10.root',
-#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_11.root'
-    
+    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_1.root',
+    #'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_2.root',
+    #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_3.root',
+    #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_4.root',
+    #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_5.root',
+    #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_6.root',
+    #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_7.root',
+    #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_8.root',
+    #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_9.root',
+    #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_10.root',
+    #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_11.root'
+
+
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/FEF2CEA0-4852-DF11-A066-001A92971B04.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/FC68FCA5-4252-DF11-B6A5-00261894393E.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/F6CDEB29-4852-DF11-8AF0-001BFCDBD176.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/E0811A9E-4852-DF11-8996-0026189437FA.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/D40776AA-4852-DF11-B986-002618943880.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/D25E1B46-4E52-DF11-ABE1-001A92810AD2.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/D01DB717-4252-DF11-A443-002618FDA259.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/CC99CBB1-4852-DF11-8B87-002618943800.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/9E8CEF9C-4752-DF11-AB2C-0026189437F9.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/92E8D320-4952-DF11-8E98-003048678D78.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/802E8BD1-4352-DF11-845F-002618943985.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/7E3A5327-4952-DF11-9501-001A92971BC8.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/6E1553BC-5C52-DF11-BB6C-002618943800.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/6AEA31A7-4952-DF11-B282-002618943957.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/5E83C295-4252-DF11-94E2-003048679006.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/54BEEFAE-4852-DF11-B5F8-0026189438B5.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/40DAD2D2-4352-DF11-A1E3-0026189438E0.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/36139940-4F52-DF11-9D71-00261894392C.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/24BBD52E-4852-DF11-87F0-003048678B00.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/2085B0B6-4752-DF11-911D-001A92971BCA.root'
+    #'/store/relval/CMSSW_3_5_8/RelValBeamHalo/GEN-SIM-DIGI-RAW-HLTDEBUG/START3X_V26-v1/0016/7C8513EA-6352-DF11-9B7D-003048678A7E.root'
     ),
 )
 
-process.load('L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMaskTechTrigConfig_cff')
-process.load('HLTrigger/HLTfilters/hltLevel1GTSeed_cfi')
 
-#process.L1T1=process.hltLevel1GTSeed.clone()
-#process.L1T1.L1TechTriggerSeeding = cms.bool(True)
-#process.L1T1.L1SeedsLogicalExpression = cms.string('(0 OR 1 OR 2 OR 3 OR 4 OR 5 OR 6 OR 7) AND (36 OR 37 OR 38 OR 39)')
-#process.L1T1.L1SeedsLogicalExpression = cms.string('36 OR 37 OR 38 OR 39')
-#process.L1T1.L1SeedsLogicalExpression = cms.string('0 OR 1 OR 2 OR 3 OR 4 OR 5 OR 6 OR 7')
 
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True))
 
-
-process.p = cms.Path(process.CSCBasedHaloFilter)
-
 process.schedule = cms.Schedule(
-    process.p
+    process.pathCSCHaloFilterTriggerLevel,
+    process.pathCSCHaloFilterRecoLevel,
+    process.pathCSCHaloFilterDigiLevel,
+    process.pathCSCHaloFilterRecoAndTriggerLevel,
+    process.pathCSCHaloFilterRecoOrTriggerLevel,
+    process.pathCSCHaloFilterDigiAndTriggerLevel,
+    process.pathCSCHaloFilterDigiOrTriggerLevel
     )
 
 

--- a/test/ExampleHaloFilter_cfg.py
+++ b/test/ExampleHaloFilter_cfg.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-isData = True
+isData = False
 process.load("Configuration/StandardSequences/Geometry_cff")
 process.load("Configuration/StandardSequences/MagneticField_cff")
 process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
@@ -36,12 +36,14 @@ if isData:
     process.pathCSCHaloFilterDigiOrTriggerLevel = cms.Path(process.L1Tech*process.CSCHaloFilterDigiLevel * process.CSCHaloFilterTriggerLevel )
 else:
     process.CSCBasedHaloFilter.ExpectedBX = cms.int32(6)
+    process.CSCHaloFilterDigiLevel.ExpectedBX = 6
+    process.CSCHaloFilterDigiAndTriggerLevel.ExpectedBX = 6
     process.CSCHaloData.ExpectedBX = cms.int32(6)
     process.GlobalTag.globaltag = 'MC_3XY_V27::All'
     process.pathCSCBasedHaloFilter = cms.Path( process.CSCBasedHaloFilter )
     process.pathCSCHaloFilterTriggerLevel = cms.Path(process.CSCHaloFilterTriggerLevel)
     process.pathCSCHaloFilterRecoLevel = cms.Path( process.CSCHaloFilterRecoLevel )
-    process.pathCSCHaloFilterDigiLevel = cms.Path( process.CSCHaloFilterDigiLevel )
+    process.pathCSCHaloFilterDigiLevel = cms.Path(process.muonCSCDigis*process.CSCHaloFilterDigiLevel )
     process.pathCSCHaloFilterRecoAndTriggerLevel = cms.Path( process.CSCHaloFilterRecoAndTriggerLevel ) 
     process.pathCSCHaloFilterRecoOrTriggerLevel = cms.Path( process.CSCHaloFilterRecoLevel*process.CSCHaloFilterTriggerLevel ) 
     process.pathCSCHaloFilterDigiAndTriggerLevel = cms.Path (process.CSCHaloFilterDigiAndTriggerLevel)
@@ -49,8 +51,7 @@ else:
     
 process.pathCSCBasedHaloFilter = cms.Path(process.CSCBasedHaloFilter)
 
-
-process.load("Configuration/StandardSequences/ReconstructionCosmics_cff")
+#process.load("Configuration/StandardSequences/ReconstructionCosmics_cff")
 
 process.load("RecoMuon/Configuration/RecoMuon_cff")
 
@@ -83,7 +84,7 @@ process.source = cms.Source("PoolSource",
     #'/store/relval/CMSSW_3_5_8/RelValBeamHalo/GEN-SIM-RECO/START3X_V26-v1/0017/D6AA4854-9052-DF11-9317-0030486791BA.root',
     #'/store/relval/CMSSW_3_5_8/RelValBeamHalo/GEN-SIM-RECO/START3X_V26-v1/0016/9E2F2DEB-6352-DF11-BC8D-002618943951.root'
     
-    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_1.root',
+    #'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_1.root',
     #'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_2.root',
     #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_3.root',
     #    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_4.root',
@@ -116,7 +117,7 @@ process.source = cms.Source("PoolSource",
     #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/36139940-4F52-DF11-9D71-00261894392C.root',
     #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/24BBD52E-4852-DF11-87F0-003048678B00.root',
     #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/MC_3XY_V26-v1/0016/2085B0B6-4752-DF11-911D-001A92971BCA.root'
-    #'/store/relval/CMSSW_3_5_8/RelValBeamHalo/GEN-SIM-DIGI-RAW-HLTDEBUG/START3X_V26-v1/0016/7C8513EA-6352-DF11-9B7D-003048678A7E.root'
+    '/store/relval/CMSSW_3_5_8/RelValBeamHalo/GEN-SIM-DIGI-RAW-HLTDEBUG/START3X_V26-v1/0016/7C8513EA-6352-DF11-9B7D-003048678A7E.root'
     ),
 )
 

--- a/test/ExampleHaloFilter_cfg.py
+++ b/test/ExampleHaloFilter_cfg.py
@@ -1,0 +1,101 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TEST")
+
+isData = False
+process.load("Configuration/StandardSequences/Geometry_cff")
+process.load("Configuration/StandardSequences/MagneticField_cff")
+process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
+process.load("Configuration/StandardSequences/RawToDigi_cff")
+process.load('Configuration.EventContent.EventContent_cff')
+process.load("RecoMET/Configuration/RecoMET_BeamHaloId_cff")
+process.load('RecoMET.METAnalyzers.CSCHaloFilter_cfi')
+process.CSCBasedHaloFilter.FilterDigiLevel = True    #### For < 36X, this requires the RAW-DIGI
+process.CSCBasedHaloFilter.FilterTriggerLevel = True
+process.CSCBasedHaloFilter.FilterRecoLevel = True 
+
+#FOR MC = 6, FOR DATA =3
+if isData:
+    process.CSCBasedHaloFilter.ExpectedBX = cms.int32(3)
+    process.CSCHaloData.ExpectedBX = cms.int32(3)
+    process.GlobalTag.globaltag = 'GR_R_35X_V8::All'
+else:
+    process.CSCBasedHaloFilter.ExpectedBX = cms.int32(6)
+    process.CSCHaloData.ExpectedBX = cms.int32(6)
+    process.GlobalTag.globaltag = 'MC_3XY_V27::All'
+
+
+process.pathCSCBasedHaloFilter = cms.Path(process.CSCBasedHaloFilter)
+
+
+process.load("Configuration/StandardSequences/ReconstructionCosmics_cff")
+
+process.load("RecoMuon/Configuration/RecoMuon_cff")
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+process.source = cms.Source("PoolSource",
+
+                            fileNames = cms.untracked.vstring(
+    #'/store/relval/CMSSW_3_5_8/RelValMinBias/GEN-SIM-RECO/START3X_V26-v1/0017/E26CCE65-8F52-DF11-9FA4-00304867901A.root',
+    #'/store/relval/CMSSW_3_5_8/RelValMinBias/GEN-SIM-RECO/START3X_V26-v1/0016/C86F45C5-4D52-DF11-9725-001A92810AD4.root'
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0017/E608ED1A-8F52-DF11-B455-0030486790BA.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0016/E6A643C1-4E52-DF11-87FE-00261894392D.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0016/E62330A9-4852-DF11-A46E-001A92971B8C.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0016/70881F95-4252-DF11-A409-002618FDA248.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0016/5E421825-4952-DF11-91E5-002618943880.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0016/40796A28-4952-DF11-B6C6-00261894387E.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0016/36C1F1DB-4352-DF11-918A-002618FDA279.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0016/008C33BB-4752-DF11-BAE4-00304867D836.root',
+    #'/store/relval/CMSSW_3_5_8/RelValTTbar/GEN-SIM-RECO/MC_3XY_V26-v1/0016/005017A4-4852-DF11-BF8A-0026189438AD.root'
+    
+#    '/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0017/46476117-8F52-DF11-8F82-00304866C398.root',
+#    '/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/FA3ED2C4-5B52-DF11-8DC9-001A92971B7E.root',
+#    '/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/F263C13D-5E52-DF11-BF2E-0026189438BC.root',
+#    '/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/BE8075FA-5452-DF11-AF79-0030486790BE.root',
+#    '/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/82C47C1C-5652-DF11-804B-001A92971ACC.root',
+#    '/store/relval/CMSSW_3_5_8/RelValZMM/GEN-SIM-RECO/START3X_V26-v1/0016/60DCA072-5452-DF11-A7A5-00248C55CC3C.root'
+ 
+    
+    #'rfio:/castor/cern.ch/user/r/rcr/SkimOutput_SingleMuon_1-10.root'
+    'file:/afs/cern.ch/user/r/rcr/scratch0/Skim_4.root'
+    #'/store/relval/CMSSW_3_5_8/RelValBeamHalo/GEN-SIM-RECO/START3X_V26-v1/0017/D6AA4854-9052-DF11-9317-0030486791BA.root',
+    #'/store/relval/CMSSW_3_5_8/RelValBeamHalo/GEN-SIM-RECO/START3X_V26-v1/0016/9E2F2DEB-6352-DF11-BC8D-002618943951.root'
+    
+#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_1.root',
+#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_2.root',
+#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_3.root',
+#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_4.root',
+#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_5.root',
+#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_6.root',
+#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_7.root',
+#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_8.root',
+#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_9.root',
+#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_10.root',
+#    'rfio:/castor/cern.ch/user/r/rcr/ExpressPhysics/Skims/Run130445/ExpressPhysics__Commissioning10-Express-v3__FEVT____run130445_11.root'
+    
+    ),
+)
+
+process.load('L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMaskTechTrigConfig_cff')
+process.load('HLTrigger/HLTfilters/hltLevel1GTSeed_cfi')
+
+#process.L1T1=process.hltLevel1GTSeed.clone()
+#process.L1T1.L1TechTriggerSeeding = cms.bool(True)
+#process.L1T1.L1SeedsLogicalExpression = cms.string('(0 OR 1 OR 2 OR 3 OR 4 OR 5 OR 6 OR 7) AND (36 OR 37 OR 38 OR 39)')
+#process.L1T1.L1SeedsLogicalExpression = cms.string('36 OR 37 OR 38 OR 39')
+#process.L1T1.L1SeedsLogicalExpression = cms.string('0 OR 1 OR 2 OR 3 OR 4 OR 5 OR 6 OR 7')
+
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True))
+
+
+process.p = cms.Path(process.CSCBasedHaloFilter)
+
+process.schedule = cms.Schedule(
+    process.p
+    )
+
+
+
+                                         
+                                     

--- a/test/exampleanalyzer_cfg.py
+++ b/test/exampleanalyzer_cfg.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("Demo")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.load("RecoMET.METAnalyzers.metSequence_cff")
+
+process.load("RecoMET.METAnalyzers.exampleanalyzer_cfi")
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(5) )
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        'file:/home/fgolf/CMSSW_3_1_2/src/FEAFAB96-5683-DE11-A10B-001AA00AA41B.root'
+    )
+)
+
+process.p = cms.Path(process.metCorSequence*process.demo)


### PR DESCRIPTION
Add missing CSCTightHaloFilter (RecoMET/METAnalyzers V00-00-08) to 53X.
This was forgotten earlier, but it is even referred to from within the official release. If there was a proper test in RecoMET/METFilters, it would have been caught much earlier.
