### PR TITLE
Keep ROOT from optimizing Streamers

### DIFF
--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -26,7 +26,7 @@
 #include "TSystem.h"
 #include "TUnixSystem.h"
 #include "TTree.h"
-#include "TThread.h"
+#include "TVirtualStreamerInfo.h"
 
 #include "TThread.h"
 #include "TClassTable.h"
@@ -305,6 +305,10 @@ namespace edm {
       TThread::Initialize();
       //When threading, also have to keep ROOT from logging all TObjects into a list
       TObject::SetObjectStat(false);
+      
+      //Have to avoid having Streamers modify themselves after they have been used
+      TVirtualStreamerInfo::Optimize(false);
+
       if(not this->autoLibraryLoader_) {
         RootAutoLibraryLoader::enable();
       }


### PR DESCRIPTION
ROOT will optimize Streamers such that adjoining member data of the same basic type are written/read
together. Sometimes ROOT decides this optimization should not be applied and de-optimizes the Streamer.
Unfortunately, the decision to de-optimize comes very late and can happen during the event loop and cause
a data race. Therefore we tell ROOT, for now, to never optimize.
