### PR TITLE
PLT and BCM1F in the CMS Geometry

### DIFF
--- a/Geometry/CMSCommonData/data/cms.xml
+++ b/Geometry/CMSCommonData/data/cms.xml
@@ -15,8 +15,8 @@
 		<Constant name="TrackBeamZ2" value="2.935*m"/>
 		<Constant name="TrackBeamR1" value="3.15*cm"/>
 		<Constant name="TrackBeamR2" value="7.40*cm"/>
-		<Constant name="TrackLumiZ1" value="1.722*m"/>
-		<Constant name="TrackLumiZ2" value="1.800*m"/>
+		<Constant name="TrackLumiZ1" value="1.700*m"/>
+		<Constant name="TrackLumiZ2" value="1.900*m"/>
 		<Constant name="TrackLumiR1" value="7.70*cm"/>
 		<Constant name="CalorBeamZ1" value="3.180*m"/>
 		<Constant name="CalorBeamZ2" value="5.541*m"/>

--- a/Geometry/CMSCommonData/data/materials.xml
+++ b/Geometry/CMSCommonData/data/materials.xml
@@ -4459,5 +4459,10 @@
     <rMaterial name="materials:Oxygen"/>
    </MaterialFraction>
   </CompositeMaterial>
- </MaterialSection>
+  <CompositeMaterial name="Diamond" density="3.52*g/cm3" symbol=" " method="mixture by weight">
+   <MaterialFraction fraction="1.00">
+    <rMaterial name="materials:Carbon"/>
+   </MaterialFraction>
+  </CompositeMaterial>  
+  </MaterialSection>
 </DDDefinition>

--- a/Geometry/ForwardCommonData/data/pltbcm.xml
+++ b/Geometry/ForwardCommonData/data/pltbcm.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0"?>
+<DDDefinition xmlns="http://www.cern.ch/cms/DDL" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.cern.ch/cms/DDL ../../../DetectorDescription/Schema/DDLSchema.xsd">
+ <ConstantsSection label="pltbcm">
+ <!-- PLT-BCM volume constants -->
+    <Constant name="PltBcmZ"             value="([cms:TrackLumiZ2]+[cms:TrackLumiZ1])/2"/>
+    <Constant name="PltBcmDZ"            value="([cms:TrackLumiZ2]-[cms:TrackLumiZ1])/2"/>
+    <Constant name="PltBcmInnerRadius"   value="[cms:TrackBeamR1]"/>
+    <Constant name="PltBcmOuterRadius"   value="[cms:TrackLumiR1]"/>
+ </ConstantsSection>
+ 
+ <!-- Create geometrical shapes of volumes-->
+ <SolidSection label="pltbcm">
+    <Tubs name="PLTBCM" rMin="[PltBcmInnerRadius]" rMax="[PltBcmOuterRadius]" dz="[PltBcmDZ]" startPhi="0*deg" deltaPhi="360*deg"/>
+ </SolidSection>
+ 
+ <!-- Define the materials of the geometrical shapes -->
+ <LogicalPartSection label="pltbcm">
+    <LogicalPart name="PLTBCM" category="unspecified">
+       <rSolid name="PLTBCM"/>
+       <rMaterial name="materials:Air"/>
+   </LogicalPart>
+ </LogicalPartSection>
+ 
+ <!-- Position --> 
+ <PosPartSection label="pltbcm">
+    <!-- Volumes in -Z and +Z --> 
+     <PosPart copyNumber="1">
+       <rParent name="cms:CMSE"/>
+       <rChild name="PLTBCM"/>
+       <rRotation name="rotations:000D"/>
+       <Translation x="0*fm" y="0*fm" z="[PltBcmZ]"/>
+    </PosPart>
+     <PosPart copyNumber="2">
+       <rParent name="cms:CMSE"/>
+       <rChild name="PLTBCM"/>
+       <rRotation name="rotations:180D"/>
+       <Translation x="0*fm" y="0*fm" z="-[PltBcmZ]"/>
+    </PosPart>
+ </PosPartSection>
+</DDDefinition>


### PR DESCRIPTION
This request change parameters of the cms geometry to include the detectors PLT and BCM1F, but that also affects the tracker volume. This has been discussed with the simulation group and the tracker group should take action to adapt to this new constraints.
