### PR TITLE
Rearrange #ifdef STAT_TSB so file var statCount does not appear 

### DIFF
--- a/RecoTracker/CkfPattern/src/GroupedCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/GroupedCkfTrajectoryBuilder.cc
@@ -68,6 +68,7 @@ namespace {
     StatCount() { zero();}
     ~StatCount() { print();}
   };
+  StatCount statCount;
 
 #else
   struct StatCount {
@@ -76,9 +77,9 @@ namespace {
     void rebuilt(long long) {}
     void invalid() {}
   };
+  [[cms::thread_safe]] StatCount statCount;
 #endif
 
-  StatCount statCount;
 
 }
 

--- a/RecoTracker/CkfPattern/src/TrajectorySegmentBuilder.cc
+++ b/RecoTracker/CkfPattern/src/TrajectorySegmentBuilder.cc
@@ -50,6 +50,7 @@ namespace {
     StatCount() { zero();}
     ~StatCount() { print();}
   };
+  StatCount statCount;
 
 #else
   struct StatCount {
@@ -57,9 +58,9 @@ namespace {
     void truncated() {}
     void invalid() {}
   };
+  [[cms::thread_safe]] StatCount statCount;
 #endif
 
-  StatCount statCount;
 
 }
 
@@ -623,3 +624,4 @@ TrajectorySegmentBuilder::cleanCandidates (vector<TempTrajectory>& candidates) c
 }
 
 //==================================================
+

--- a/RecoTracker/FinalTrackSelectors/src/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/src/TrackListMerger.cc
@@ -76,6 +76,7 @@ inline volatile unsigned long long rdtsc() {
     StatCount() {}
     ~StatCount() { print();}
   };
+  StatCount statCount;
 
 #else
   struct StatCount {
@@ -90,9 +91,9 @@ inline volatile unsigned long long rdtsc() {
 
 
   };
+  [[cms::thread_safe]] StatCount statCount;
 #endif
 
-  StatCount statCount;
 
 }
 

--- a/RecoTracker/TrackProducer/src/TrackProducerAlgorithm.cc
+++ b/RecoTracker/TrackProducer/src/TrackProducerAlgorithm.cc
@@ -55,6 +55,7 @@ namespace {
     StatCount() {}
     ~StatCount() { print();}
   };
+  StatCount statCount;
 
 #else
   struct StatCount {
@@ -63,9 +64,9 @@ namespace {
     void gsf(){}
     void algo(int){}
   };
+  [[cms::thread_safe]] StatCount statCount;
 #endif
 
-  StatCount statCount;
 
 }
 


### PR DESCRIPTION
This is obviously used for local debugging and file vars are not thread safe.
