### PR TITLE
make file var shape_ const since it is only read

### DIFF
--- a/CondFormats/CastorObjects/interface/CastorQIEData.h
+++ b/CondFormats/CastorObjects/interface/CastorQIEData.h
@@ -22,7 +22,7 @@ $Revision: 1.9 $
 
 namespace
 {
-  CastorQIEShape shape_;
+  const CastorQIEShape shape_;
 }
 
 class CastorQIEData: public CastorCondObjectContainer<CastorQIECoder>


### PR DESCRIPTION
File vars need to be const qualified when possible for thread safety. Once instantiated this never gets modified in production.
