### PR TITLE
Avoid ROOT6 limitation by replaceing LinkDef files with xml specs.

### DIFF
--- a/SimDataFormats/CaloHit/interface/CastorShowerEvent.h
+++ b/SimDataFormats/CaloHit/interface/CastorShowerEvent.h
@@ -62,7 +62,7 @@
     float getPrimY()             { return primY; };
     float getPrimZ()             { return primZ; };
     
-    ClassDef(CastorShowerEvent,1)
+    ClassDef(CastorShowerEvent,2)
     
   };
 

--- a/SimDataFormats/CaloHit/src/CastorEventLinkDef.h
+++ b/SimDataFormats/CaloHit/src/CastorEventLinkDef.h
@@ -1,8 +1,0 @@
-#include "SimDataFormats/CaloHit/interface/CastorShowerEvent.h"
-#include "SimDataFormats/CaloHit/interface/CastorShowerLibraryInfo.h"
-#ifdef __CINT__
-
-#pragma link C++ class CastorShowerEvent+;
-#pragma link C++ class CastorShowerLibraryInfo+;
-#pragma link C++ class SLBin+;
-#endif

--- a/SimDataFormats/CaloHit/src/CastorShowerEvent.cc
+++ b/SimDataFormats/CaloHit/src/CastorShowerEvent.cc
@@ -1,8 +1,6 @@
 #include "SimDataFormats/CaloHit/interface/CastorShowerEvent.h"
 #include <iostream>
 
-ClassImp(CastorShowerEvent)
-
 CastorShowerEvent::CastorShowerEvent() {
    // Clear();
    // std::cout << "\n    *** CastorShowerEvent object created ***    " << std::endl;

--- a/SimDataFormats/CaloHit/src/CastorShowerLibraryInfo.cc
+++ b/SimDataFormats/CaloHit/src/CastorShowerLibraryInfo.cc
@@ -1,8 +1,6 @@
 #include "SimDataFormats/CaloHit/interface/CastorShowerLibraryInfo.h"
 #include <iostream>
 
-ClassImp(CastorShowerLibraryInfo)
-
 CastorShowerLibraryInfo::CastorShowerLibraryInfo() {
    // Clear();
    // std::cout << "\n    *** CastorShowerLibraryInfo object created ***    " << std::endl;

--- a/SimDataFormats/CaloHit/src/classes.h
+++ b/SimDataFormats/CaloHit/src/classes.h
@@ -1,3 +1,5 @@
+#include "SimDataFormats/CaloHit/interface/CastorShowerEvent.h"
+#include "SimDataFormats/CaloHit/interface/CastorShowerLibraryInfo.h"
 #include "SimDataFormats/CaloHit/interface/HFShowerLibraryEventInfo.h"
 #include "SimDataFormats/CaloHit/interface/HFShowerPhoton.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"

--- a/SimDataFormats/CaloHit/src/classes_def.xml
+++ b/SimDataFormats/CaloHit/src/classes_def.xml
@@ -10,6 +10,15 @@
   </class>
   <class name="std::vector<HFShowerPhoton>"/>
   <class name="edm::Wrapper<std::vector<HFShowerPhoton> >"/>
+  <class name="CastorShowerEvent" ClassVersion="2">
+   <version ClassVersion="2" checksum="1459927119"/>
+  </class>
+  <class name="CastorShowerLibraryInfo" ClassVersion="1">
+   <version ClassVersion="1" checksum="12401705"/>
+  </class>
+  <class name="SLBin" ClassVersion="1">
+   <version ClassVersion="1" checksum="4099215368"/>
+  </class>
   <class name="HFShowerLibraryEventInfo" ClassVersion="10">
    <version ClassVersion="10" checksum="1929526838"/>
   </class>


### PR DESCRIPTION
This pull request fixes many (possibly all) cases of two errors in the ROOT6 relvals.
One error is:
Could not find the StreamerInfo for version 9 of the class TBranchElement, object skipped at offset 344
The other error is:
0 violated at line 988 of `/build/cmsbuild/jenkins-workarea/workspace/ib-CMSSW_7_1_ROOT6_X-slc5_amd64_gcc481/237/w/BUILD/slc5_amd64_gcc481/lcg/root/5.99.06/root-5.99.06/io/io/src/TStreamerInfo.cxx'
With this fix, the tests that failed for these reasons fail at a later stage due to other errors.  One of the other errors (seen in relval 25.0) is related to this fix However, this fix still needs to be merged, as 25.0 now fails much earlier in its execution.  So, this is progress in ROOT6 land.
