### PR TITLE
dbs to das migration in 4.4

### DIFF
--- a/Configuration/PyReleaseValidation/python/Options.py
+++ b/Configuration/PyReleaseValidation/python/Options.py
@@ -237,10 +237,15 @@ expertSettings.add_option("--particle_table",
                           default=defaultOptions.particleTable,
                           dest="particleTable")
 
-expertSettings.add_option("--dbsquery",
-                          help="Allow to define the source.fileNames from the dbs search command",
+expertSettings.add_option("--dasquery",
+                          help="Allow to define the source.fileNames from the DAS search command",
                           default='',
-                          dest="dbsquery")
+                          dest="dasquery")
+
+expertSettings.add_option("--dbsquery",
+                          help="Deprecated. Please use dasquery option. Functions for backward compatibility",
+                          default='',
+                          dest="dasquery")
 
 expertSettings.add_option("--lazy_download",
                   help="Enable lazy downloading of input files",


### PR DESCRIPTION
Migration from dbs command line to das cli. There is a new option syntax --filein "das:" and dasquery, but the previous behavior is kept for backward compatibility.
