### PR TITLE
71X - update RelVal input

### DIFF
--- a/CommonTools/ParticleFlow/test/PF2PAT_cfg.py
+++ b/CommonTools/ParticleFlow/test/PF2PAT_cfg.py
@@ -9,18 +9,14 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1000)
 )
 
-
-# the following line does not work anymore:
-# process.load("CommonTools.ParticleFlow.Sources/Data/source_124120_cfi")
-
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
     'file:/uscms/home/rappocc/nobackup/analysis/GED/CMSSW_6_1_0_pre3/src/401.0_TTbar+TTbarFSPU2/step1.root'
-    
+
     ))
-    
-     
-                   
+
+
+
 print process.source
 
 # path ---------------------------------------------------------------
@@ -36,7 +32,7 @@ process.load("CommonTools.ParticleFlow.PF2PAT_cff")
 process.dump = cms.EDAnalyzer("EventContentAnalyzer")
 
 process.p = cms.Path(
-    process.PF2PAT 
+    process.PF2PAT
     )
 
 # output ------------------------------------------------------------
@@ -58,7 +54,7 @@ process.pf2pat.outputCommands.extend( process.PF2PATEventContent.outputCommands 
 process.pf2pat.outputCommands.extend( process.PF2PATStudiesEventContent.outputCommands )
 
 process.outpath = cms.EndPath(
-    process.pf2pat 
+    process.pf2pat
 #    process.aod
     )
 

--- a/CommonTools/ParticleFlow/test/PFAOD_cfg.py
+++ b/CommonTools/ParticleFlow/test/PFAOD_cfg.py
@@ -4,8 +4,7 @@ process = cms.Process("PFAOD")
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-#     '/store/relval/CMSSW_4_2_3/RelValZTT/GEN-SIM-RECO/START42_V12-v2/0062/4CEA9C47-287B-E011-BAB7-00261894396B.root'
-    '/store/data/Run2011A/HT/AOD/PromptReco-v4/000/166/921/F277100B-BA97-E011-998D-001D09F24D4E.root'
+    '/store/relval/CMSSW_6_2_0_pre8/SingleMu/RECO/PRE_62_V8_RelVal_mu2012D-v1/00000/005835E9-05E0-E211-BA7B-003048F1C7C0.root'
     )
 )
 
@@ -24,7 +23,7 @@ process.out = cms.OutputModule(
 process.load("CommonTools.ParticleFlow.PF2PAT_EventContent_cff")
 process.out.outputCommands.extend( process.prunedAODForPF2PATEventContent.outputCommands )
 
-# additional stuff for Maxime: 
+# additional stuff for Maxime:
 process.out.outputCommands.extend(
     [
       'keep GenEventInfoProduct_*_*_*',

--- a/CommonTools/ParticleFlow/test/pfIsolation_cfg.py
+++ b/CommonTools/ParticleFlow/test/pfIsolation_cfg.py
@@ -7,10 +7,10 @@ process = cms.Process("PFISO")
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
 )
- 
+
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('/store/relval/CMSSW_5_2_0/RelValH130GGgluonfusion/GEN-SIM-RECO/START52_V4A-v1/0248/5AEAC282-0B69-E111-A973-003048FF9AA6.root'))
-   
+    fileNames = cms.untracked.vstring('/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/GEN-SIM-RECO/START70_V5-v1/00000/14842A6B-2086-E311-B5CB-02163E00E8DA.root'))
+
 
 # Tae Jeong, could you please remove these from the PF2PAT sequence?
 # they are not used, and are creating problems in such kinds of manipulations:
@@ -49,8 +49,8 @@ process.pfIsoReader = cms.EDAnalyzer("PFIsoReaderDemo",
 
 process.p = cms.Path(
     # process.pfNoPileUpSequence +
-    process.pfParticleSelectionSequence + 
-    process.eleIsoSequence + 
+    process.pfParticleSelectionSequence +
+    process.eleIsoSequence +
     process.muIsoSequence+
     process.phoIsoSequence+
     process.pfIsoReader
@@ -65,7 +65,7 @@ process.out = cms.OutputModule("PoolOutputModule",
 )
 
 process.outpath = cms.EndPath(
-    process.out 
+    process.out
     )
 
 

--- a/CommonTools/TriggerUtils/test/genericTriggerEventFlagTest_cfg.py
+++ b/CommonTools/TriggerUtils/test/genericTriggerEventFlagTest_cfg.py
@@ -16,8 +16,7 @@ process.GlobalTag = GlobalTag( process.GlobalTag, 'auto:com10' )
 
 ## Source
 process.source = cms.Source( "PoolSource"
-#, fileNames  = cms.untracked.vstring( '/store/relval/CMSSW_6_1_0_pre3-GR_R_60_V7_RelVal_mu2011A/SingleMu/RECO/v1/00000/16461657-910C-E211-BD66-0026189438CB.root'
-, fileNames  = cms.untracked.vstring( '/store/relval/CMSSW_6_1_0_pre3-GR_R_60_V7_RelVal_mu2012B/SingleMu/RECO/v1/00000/08491D7D-CE0C-E211-A9BB-003048678D86.root'
+, fileNames  = cms.untracked.vstring( '/store/relval/CMSSW_6_2_0_pre8/SingleMu/RECO/PRE_62_V8_RelVal_mu2012D-v1/00000/005835E9-05E0-E211-BA7B-003048F1C7C0.root'
                                     )
 #, skipEvents = cms.untracked.uint32( 0 )
 )

--- a/CommonTools/UtilAlgos/test/TestTFileServiceAnalyzer.py
+++ b/CommonTools/UtilAlgos/test/TestTFileServiceAnalyzer.py
@@ -11,7 +11,7 @@ process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 ## Source
 process.source = cms.Source("PoolSource",
                                 fileNames = cms.untracked.vstring(
-            '/store/relval/CMSSW_3_3_0/RelValTTbar/GEN-SIM-RECO/STARTUP31X_V8-v1/0001/3291E09D-67B7-DE11-9ED6-003048678C9A.root'
+            '/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/GEN-SIM-RECO/START70_V5-v1/00000/14842A6B-2086-E311-B5CB-02163E00E8DA.root'
                 )
                             )
 ## Maximal Number of Events

--- a/EgammaAnalysis/ElectronTools/test/patToPat_electronId_cfg.py
+++ b/EgammaAnalysis/ElectronTools/test/patToPat_electronId_cfg.py
@@ -60,10 +60,12 @@ process.out.outputCommands.append( 'keep *_mvaTrigNoIPPAT_*_*' )
 #  parameters:
 ## ------------------------------------------------------
 #
-#   process.GlobalTag.globaltag =  ...    ##  (according to https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideFrontierConditions)
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS1')
 #                                         ##
-from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpGENSIMRECO
-process.source.fileNames = filesRelValTTbarPileUpGENSIMRECO
+#from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpGENSIMRECO
+#process.source.fileNames = filesRelValTTbarPileUpGENSIMRECO # currently not available at CERN
+from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarAODSIM
+process.source.fileNames = filesRelValProdTTbarAODSIM
 #                                         ##
 process.maxEvents.input = 100
 #                                         ##

--- a/JetMETCorrections/Configuration/test/run_ak5L2L3_cfg.py
+++ b/JetMETCorrections/Configuration/test/run_ak5L2L3_cfg.py
@@ -35,7 +35,7 @@ process = cms.Process("KT4L2L3")
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
 process.source = cms.Source(
     'PoolSource',
-    fileNames = cms.untracked.vstring('/store/relval/CMSSW_3_3_0/RelValTTbar/GEN-SIM-RECO/MC_31X_V9-v1/0008/CEAAC1F4-0BB7-DE11-93D7-000423D99AA2.root')
+    fileNames = cms.untracked.vstring('/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/GEN-SIM-RECO/START70_V5-v1/00000/14842A6B-2086-E311-B5CB-02163E00E8DA.root')
     )
 
 
@@ -54,7 +54,7 @@ process.TFileService=cms.Service("TFileService",fileName=cms.string('histos.root
 #! JET CORRECTION
 #!
 from JetMETCorrections.Configuration.JetCorrectionEra_cff import *
-JetCorrectionEra.era = 'Summer09_7TeV'
+JetCorrectionEra.era = 'Summer09_7TeV' # FIXME for input
 process.load('JetMETCorrections.Configuration.JetCorrectionProducers_cff')
 
 # correct kt4CaloJets

--- a/JetMETCorrections/Configuration/test/run_default_cfg.py
+++ b/JetMETCorrections/Configuration/test/run_default_cfg.py
@@ -10,7 +10,7 @@ process = cms.Process("JEC")
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
 process.source = cms.Source(
     'PoolSource',
-    fileNames = cms.untracked.vstring('/store/relval/CMSSW_3_8_0_pre7/RelValTTbar/GEN-SIM-RECO/START38_V4-v1/0002/DC19EA07-4286-DF11-BD2B-0030487CD16E.root')
+    fileNames = cms.untracked.vstring('/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/GEN-SIM-RECO/START70_V5-v1/00000/14842A6B-2086-E311-B5CB-02163E00E8DA.root')
     )
 
 #!
@@ -26,8 +26,8 @@ process.source = cms.Source(
 
 process.load('Configuration.StandardSequences.Services_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-process.GlobalTag.globaltag = 'START38_V8::All'
-#process.GlobalTag.connect = 'sqlite_file:START38_V6.db'
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup')
 process.load('JetMETCorrections.Configuration.DefaultJEC_cff')
 process.load('JetMETCorrections.Configuration.JetCorrectionProducersAllAlgos_cff')
 
@@ -67,9 +67,9 @@ process.ak5TrackL2L3Histos = process.ak5CaloL2L3Histos.clone(src = 'ak5TrackJets
 #
 process.run = cms.Path(
 #------ create the corrected calojet collection and run the histogram module ------
-process.ak5CaloJetsL2L3 * process.ak5CaloL2L3Histos * process.ak7CaloJetsL2L3 * process.ak7CaloL2L3Histos * 
-process.kt4CaloJetsL2L3 * process.kt4CaloL2L3Histos * 
-#process.kt6CaloJetsL2L3 * process.kt6CaloL2L3Histos * 
+process.ak5CaloJetsL2L3 * process.ak5CaloL2L3Histos * process.ak7CaloJetsL2L3 * process.ak7CaloL2L3Histos *
+process.kt4CaloJetsL2L3 * process.kt4CaloL2L3Histos *
+#process.kt6CaloJetsL2L3 * process.kt6CaloL2L3Histos *
 #------ create the corrected pfjet collection and run the histogram module --------
 process.ak5PFJetsL2L3 * process.ak5PFL2L3Histos * process.ak7PFJetsL2L3 * process.ak7PFL2L3Histos *
 process.kt4PFJetsL2L3 * process.kt4PFL2L3Histos *

--- a/JetMETCorrections/Configuration/test/run_kt4L2L3_cfg.py
+++ b/JetMETCorrections/Configuration/test/run_kt4L2L3_cfg.py
@@ -30,7 +30,7 @@ process = cms.Process("AK5L2L3")
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
 process.source = cms.Source(
     'PoolSource',
-    fileNames = cms.untracked.vstring('/store/relval/CMSSW_3_3_0/RelValTTbar/GEN-SIM-RECO/MC_31X_V9-v1/0008/CEAAC1F4-0BB7-DE11-93D7-000423D99AA2.root')
+    fileNames = cms.untracked.vstring('/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/GEN-SIM-RECO/START70_V5-v1/00000/14842A6B-2086-E311-B5CB-02163E00E8DA.root')
     )
 
 
@@ -49,7 +49,7 @@ process.TFileService=cms.Service("TFileService",fileName=cms.string('histos.root
 #! JET CORRECTION
 #!
 from JetMETCorrections.Configuration.JetCorrectionEra_cff import *
-JetCorrectionEra.era = 'Summer09_7TeV'
+JetCorrectionEra.era = 'Summer09_7TeV' # FIXME for input
 process.load('JetMETCorrections.Configuration.JetCorrectionProducers_cff')
 
 

--- a/PhysicsTools/FWLite/test/fwliteWithPythonConfig_cfg.py
+++ b/PhysicsTools/FWLite/test/fwliteWithPythonConfig_cfg.py
@@ -3,11 +3,11 @@ import FWCore.ParameterSet.Config as cms
 process = cms.PSet()
 
 process.fwliteInput = cms.PSet(
-    fileNames   = cms.vstring('rfio:///castor/cern.ch/cms/store/relval/CMSSW_4_1_3/RelValTTbar/GEN-SIM-RECO/START311_V2-v1/0037/648B6AA5-C751-E011-8208-001A928116C6.root'), ## mandatory
+    fileNames   = cms.vstring('root://eoscms//eos/cms/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/GEN-SIM-RECO/START70_V5-v1/00000/14842A6B-2086-E311-B5CB-02163E00E8DA.root'), ## mandatory
     maxEvents   = cms.int32(-1),                             ## optional
     outputEvery = cms.uint32(10),                            ## optional
 )
-    
+
 process.fwliteOutput = cms.PSet(
     fileName  = cms.string('analyzeFWLiteHistograms.root'),  ## mandatory
 )

--- a/PhysicsTools/FWLite/test/fwliteWithSelectorUtils_cfg.py
+++ b/PhysicsTools/FWLite/test/fwliteWithSelectorUtils_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.PSet()
 
 process.fwliteInput = cms.PSet(
-    fileNames   = cms.vstring('rfio:///castor/cern.ch/cms/store/relval/CMSSW_4_1_3/RelValTTbar/GEN-SIM-RECO/START311_V2-v1/0037/648B6AA5-C751-E011-8208-001A928116C6.root'),                                ## mandatory
+    fileNames   = cms.vstring('root://eoscms//eos/cms/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/GEN-SIM-RECO/START70_V5-v1/00000/14842A6B-2086-E311-B5CB-02163E00E8DA.root'),                                ## mandatory
     maxEvents   = cms.int32(-1),                             ## optional
     outputEvery = cms.uint32(10),                            ## optional
 )

--- a/PhysicsTools/PatAlgos/python/patInputFiles_cff.py
+++ b/PhysicsTools/PatAlgos/python/patInputFiles_cff.py
@@ -1,43 +1,56 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
 
-# /RelValProdTTbar/CMSSW_7_0_0_pre11-START70_V4-v1/AODSIM
+# /RelValProdTTbar/CMSSW_7_1_0_pre1-START70_V5-v1/AODSIM
 filesRelValProdTTbarAODSIM = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_0_0_pre11'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_1_0_pre1'
                         #, relVal        = 'RelValProdTTbar'
-                        #, globalTag     = 'START70_V4'
+                        #, globalTag     = 'START70_V5'
                         #, dataTier      = 'AODSIM'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_0_0_pre11/RelValProdTTbar/AODSIM/START70_V4-v1/00000/D0516C65-766A-E311-B744-00259059642E.root'
+        '/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/AODSIM/START70_V5-v1/00000/F4EB9159-3286-E311-8D80-02163E008DB4.root'
     )
 
-# /RelValProdTTbar/CMSSW_7_0_0_pre11-START70_V4-v1/GEN-SIM-RECO
+# /RelValProdTTbar/CMSSW_7_1_0_pre1-START70_V5-v1/GEN-SIM-RECO
 filesRelValProdTTbarGENSIMRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_0_0_pre11'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_1_0_pre1'
                         #, relVal        = 'RelValProdTTbar'
-                        #, globalTag     = 'START70_V4'
+                        #, globalTag     = 'START70_V5'
                         #, dataTier      = 'GEN-SIM-RECO'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_0_0_pre11/RelValProdTTbar/GEN-SIM-RECO/START70_V4-v1/00000/0EA82C3C-646A-E311-9CB3-0025905A6070.root'
+        '/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/GEN-SIM-RECO/START70_V5-v1/00000/14842A6B-2086-E311-B5CB-02163E00E8DA.root'
     )
 
-# /RelValTTbar_13/CMSSW_7_0_0_pre11-PU50ns_POSTLS162_V5-v1/GEN-SIM-RECO
+# /RelValTTbar/CMSSW_7_1_0_pre1-PU_START70_V5_FastSim-v2/GEN-SIM-DIGI-RECO
+filesRelValTTbarPileUpFastSimGENSIMDIGIRECO = cms.untracked.vstring(
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_1_0_pre1'
+                        #, relVal        = 'RelValTTbar'
+                        #, globalTag     = 'PU_START70_V5_FastSim'
+                        #, dataTier      = 'GEN-SIM-DIGI-RECO'
+                        #, maxVersions   = 2
+                        #, numberOfFiles = 1
+                        #, useDAS        = True
+                        #)
+        '/store/relval/CMSSW_7_1_0_pre1/RelValTTbar/GEN-SIM-DIGI-RECO/PU_START70_V5_FastSim-v2/00000/00865693-258F-E311-B41F-0025905A6092.root'
+    )
+
+# /RelValTTbar_13/CMSSW_7_1_0_pre1-PU50ns_POSTLS170_V1-v1/GEN-SIM-RECO
 filesRelValTTbarPileUpGENSIMRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_0_0_pre11'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_1_0_pre1'
                         #, relVal        = 'RelValTTbar_13'
-                        #, globalTag     = 'PU50ns_POSTLS162_V5'
+                        #, globalTag     = 'PU50ns_POSTLS170_V1'
                         #, dataTier      = 'GEN-SIM-RECO'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_0_0_pre11/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS162_V5-v1/00000/08DFDC0E-796A-E311-8912-5404A63886EC.root'
+        '/store/relval/CMSSW_7_1_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS170_V1-v1/00000/0E08B589-BC8B-E311-BD48-02163E00EA0D.root'
     )
 
 # /SingleMu/CMSSW_6_2_0_pre8-PRE_62_V8_RelVal_mu2012D-v1/RECO

--- a/PhysicsTools/PatAlgos/test/patTuple_fastsim_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_fastsim_cfg.py
@@ -14,8 +14,8 @@ process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 #
 #   process.GlobalTag.globaltag =  ...    ##  (according to https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideFrontierConditions)
 #                                         ##
-from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarAODSIM
-process.source.fileNames = filesRelValProdTTbarAODSIM
+from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpFastSimGENSIMDIGIRECO
+process.source.fileNames = filesRelValTTbarPileUpFastSimGENSIMDIGIRECO
 #                                         ##
 process.maxEvents.input = 100
 #                                         ##

--- a/PhysicsTools/PatAlgos/test/runtests.sh
+++ b/PhysicsTools/PatAlgos/test/runtests.sh
@@ -25,7 +25,7 @@ cmsRun ${LOCAL_TEST_DIR}/patTuple_addVertexInfo_cfg.py || die 'Failure using pat
 
 # cmsRun ${LOCAL_TEST_DIR}/patTuple_caloTaus_cfg.py || die 'Failure using patTuple_caloTaus_cfg.py' $?
 
-# cmsRun ${LOCAL_TEST_DIR}/patTuple_fastsim_cfg.py || die 'Failure using patTuple_fastsim_cfg.py' $? # currently no FastSim RelVals defined
+# cmsRun ${LOCAL_TEST_DIR}/patTuple_fastsim_cfg.py || die 'Failure using patTuple_fastsim_cfg.py' $? # Input RelVals currently not reachable (from CERN)
 
 # cmsRun ${LOCAL_TEST_DIR}/patTuple_topSelection_cfg.py || die 'Failure using patTuple_topSelection_cfg.py' $?
 

--- a/PhysicsTools/UtilAlgos/test/cmsswWithPythonConfig_cfg.py
+++ b/PhysicsTools/UtilAlgos/test/cmsswWithPythonConfig_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("Test")
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring(
-    "/store/relval/CMSSW_6_2_0_pre8/RelValZTT/GEN-SIM-RECO/PRE_ST62_V8-v1/00000/9ABFC689-F9E0-E211-9DD2-02163E008EAE.root"
+        '/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/GEN-SIM-RECO/START70_V5-v1/00000/14842A6B-2086-E311-B5CB-02163E00E8DA.root'
   )
 )
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )

--- a/PhysicsTools/UtilAlgos/test/fwliteWithPythonConfig_cfg.py
+++ b/PhysicsTools/UtilAlgos/test/fwliteWithPythonConfig_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.PSet()
 
 process.fwliteInput = cms.PSet(
-    fileNames   = cms.vstring('root://eoscms//eos/cms/store/relval/CMSSW_6_2_0_pre8/RelValZTT/GEN-SIM-RECO/PRE_ST62_V8-v1/00000/9ABFC689-F9E0-E211-9DD2-02163E008EAE.root'), ## mandatory
+    fileNames   = cms.vstring('root://eoscms//eos/cms/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/GEN-SIM-RECO/START70_V5-v1/00000/14842A6B-2086-E311-B5CB-02163E00E8DA.root'), ## mandatory
     maxEvents   = cms.int32(100),                            ## optional
     outputEvery = cms.uint32(10),                            ## optional
 )

--- a/PhysicsTools/UtilAlgos/test/select_error_events_cfg.py
+++ b/PhysicsTools/UtilAlgos/test/select_error_events_cfg.py
@@ -9,7 +9,7 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
 
 process.source = cms.Source("PoolSource",
-                            fileNames = cms.untracked.vstring('/store/relval/CMSSW_6_1_1-START61_V11/RelValZTT/GEN-SIM-RECO/v1/00000/0633BF33-EC76-E211-B3B6-003048F0E1BE.root'),
+                            fileNames = cms.untracked.vstring('/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/GEN-SIM-RECO/START70_V5-v1/00000/14842A6B-2086-E311-B5CB-02163E00E8DA.root'),
                             inputCommands = cms.untracked.vstring("keep *", "drop *_MEtoEDMConverter_*_*") # drop the DQM histograms
                             )
 ## Maximal Number of Events

--- a/PhysicsTools/UtilAlgos/test/testPrimaryVertexFilter_cfg.py
+++ b/PhysicsTools/UtilAlgos/test/testPrimaryVertexFilter_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("Test")
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring(
-    "/store/relval/CMSSW_6_2_0_pre8/RelValZTT/GEN-SIM-RECO/PRE_ST62_V8-v1/00000/9ABFC689-F9E0-E211-9DD2-02163E008EAE.root"
+        '/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/GEN-SIM-RECO/START70_V5-v1/00000/14842A6B-2086-E311-B5CB-02163E00E8DA.root'
   )
 )
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )

--- a/PhysicsTools/UtilAlgos/test/testPrimaryVertexObjectFilter_cfg.py
+++ b/PhysicsTools/UtilAlgos/test/testPrimaryVertexObjectFilter_cfg.py
@@ -4,7 +4,7 @@ process = cms.Process("Test")
 
 process.source = cms.Source("PoolSource",
   fileNames = cms.untracked.vstring(
-    "/store/relval/CMSSW_6_2_0_pre8/RelValZTT/GEN-SIM-RECO/PRE_ST62_V8-v1/00000/9ABFC689-F9E0-E211-9DD2-02163E008EAE.root"
+        '/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/GEN-SIM-RECO/START70_V5-v1/00000/14842A6B-2086-E311-B5CB-02163E00E8DA.root'
   )
 )
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )

--- a/TopQuarkAnalysis/TopEventSelection/test/ttFullHadSignalSelMVAComputer_cfg.py
+++ b/TopQuarkAnalysis/TopEventSelection/test/ttFullHadSignalSelMVAComputer_cfg.py
@@ -10,7 +10,7 @@ process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 ## define input
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-    #'/store/relval/CMSSW_3_4_0_pre1/RelValTTbar/GEN-SIM-RECO/MC_31X_V9-v1/0008/2C8CD8FE-B6B5-DE11-ACB8-001D09F2905B.root'
+    #'/store/relval/CMSSW_7_1_0_pre1/RelValProdTTbar/GEN-SIM-RECO/START70_V5-v1/00000/14842A6B-2086-E311-B5CB-02163E00E8DA.root'
 
     #'/store/user/eschliec/Summer09/7TeV/TTBar/MCatNLO/patTuple_1.root',
     #'/store/user/eschliec/Summer09/7TeV/TTBar/MCatNLO/patTuple_2.root'


### PR DESCRIPTION
Update of RelVal inputs over the whole AT area after removal of some older samples (s. https://github.com/cms-sw/cmssw/pull/2240#issuecomment-34874124 ).
It includes and updates also the changes proposed with #2312 .
