### PR TITLE
RecoVertex/AdaptiveVertexFit: add missing dependency on RecoVertex/KalmanVertexFit

### DIFF
--- a/RecoVertex/AdaptiveVertexFit/BuildFile.xml
+++ b/RecoVertex/AdaptiveVertexFit/BuildFile.xml
@@ -3,6 +3,7 @@
 <use   name="DataFormats/GeometryVector"/>
 <use   name="TrackingTools/TrajectoryState"/>
 <use   name="RecoVertex/VertexPrimitives"/>
+<use   name="RecoVertex/KalmanVertexFit"/>
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
The following is visible on GCC pre-4.9.0 IB: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc490/CMSSW_7_1_X_2014-02-12-1400/RecoVertex/AdaptiveVertexFit

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
