### PR TITLE
CondFormats/EgammaObjects: add missing dependency on roottmva

### DIFF
--- a/CondFormats/EgammaObjects/BuildFile.xml
+++ b/CondFormats/EgammaObjects/BuildFile.xml
@@ -1,8 +1,8 @@
-<flags   GENREFLEX_ARGS="--"/>
 <use   name="FWCore/Utilities"/>
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/PhysicsToolsObjects"/>
 <use   name="rootrflx"/>
+<use   name="roottmva"/>
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
The following is visible on GCC pre-4.9.0 IB: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc490/CMSSW_7_1_X_2014-02-12-1400/CondFormats/EgammaObjects

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
