### PR TITLE
Migrate to New Random Service Interface

### DIFF
--- a/RecoHI/HiEgammaAlgos/interface/TxCalculator.h
+++ b/RecoHI/HiEgammaAlgos/interface/TxCalculator.h
@@ -19,10 +19,11 @@
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
-#include "CLHEP/Random/RandFlat.h"
-
-
 #define PI 3.141592653
+
+namespace CLHEP {
+   class HepRandomEngine;
+}
 
 class TxCalculator
 {
@@ -41,7 +42,7 @@ class TxCalculator
  private:
    
    edm::Handle<reco::TrackCollection>  recCollection;
-   CLHEP::RandFlat *theDice;
+   CLHEP::HepRandomEngine *theDice;
 
    double dRDistance(double eta1,double phi1,double eta2,double phi2)
    {

--- a/RecoHI/HiEgammaAlgos/src/TxCalculator.cc
+++ b/RecoHI/HiEgammaAlgos/src/TxCalculator.cc
@@ -15,6 +15,8 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 
+#include "CLHEP/Random/RandomEngine.h"
+
 using namespace edm;
 using namespace reco;
 using namespace std;
@@ -31,9 +33,7 @@ TxCalculator::TxCalculator (const edm::Event &iEvent, const edm::EventSetup &iSe
          "which is not present in the configuration file.  You must add the service\n"
          "in the configuration file or remove the modules that require it.";
    }
-   CLHEP::HepRandomEngine& engine = rng->getEngine();
-   theDice = new CLHEP::RandFlat(engine, 0, 1);
-   
+   theDice = &rng->getEngine(iEvent.streamID());
 } 
 
 
@@ -98,7 +98,7 @@ double TxCalculator::getTx(const reco::Photon& cluster, double x, double thresho
    for(reco::TrackCollection::const_iterator
    	  recTrack = recCollection->begin(); recTrack!= recCollection->end(); recTrack++)
       {
-	 double diceNum = theDice->fire();
+	 double diceNum = theDice->flat();
 	 if ( (effRatio < 1 ) &&  ( diceNum > effRatio))
 	    continue;
 	 
@@ -135,7 +135,7 @@ double TxCalculator::getCTx(const reco::Photon& cluster, double x, double thresh
    for(reco::TrackCollection::const_iterator
    	  recTrack = recCollection->begin(); recTrack!= recCollection->end(); recTrack++)
       {
-	 double diceNum = theDice->fire();
+	 double diceNum = theDice->flat();
          if ( (effRatio < 1 ) &&  ( diceNum > effRatio))
             continue;
 	 


### PR DESCRIPTION
Migrate to the new random number service interface
designed for multithreaded execution.Also remove
a potential memory leak from TxCalculator. Note that
neither of the two classes modified is used or referenced
by anything in CMSSW.
