### PR TITLE
delete the export SCRAM_ARCH line

### DIFF
--- a/GeneratorInterface/LHEInterface/data/create_lhe_powheg.sh
+++ b/GeneratorInterface/LHEInterface/data/create_lhe_powheg.sh
@@ -38,7 +38,6 @@ seed=$rnum
 file="events"
 # Release to be used to define the environment and the compiler needed
 export PRODHOME=`pwd`
-export SCRAM_ARCH=slc5_amd64_gcc462
 export RELEASE=${CMSSW_VERSION}
 export WORKDIR=`pwd`
 


### PR DESCRIPTION
As pointed out by Fabio Cossutti, this line is not needed and it creates a problem that the statement 
will force the use of a wrong architecture, creating troubles when you compile and mostly link.
