### PR TITLE
delete the line 'export SCRAM_ARCH=slc5_amd64_gcc462'

### DIFF
--- a/GeneratorInterface/LHEInterface/data/create_lhe_powheg.sh
+++ b/GeneratorInterface/LHEInterface/data/create_lhe_powheg.sh
@@ -38,7 +38,6 @@ seed=$rnum
 file="events"
 # Release to be used to define the environment and the compiler needed
 export PRODHOME=`pwd`
-export SCRAM_ARCH=slc5_amd64_gcc462
 export RELEASE=${CMSSW_VERSION}
 export WORKDIR=`pwd`
 


### PR DESCRIPTION
The line is deleted because it's not needed and creates a problem when compiling in a different SCRAM_ARCH.
