### PR TITLE
Migrate More to New Random Service Interface

### DIFF
--- a/SimG4CMS/Calo/BuildFile.xml
+++ b/SimG4CMS/Calo/BuildFile.xml
@@ -17,6 +17,7 @@
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="boost"/>
+<use   name="clhep"/>
 <use   name="geant4core"/>
 <use   name="hepmc"/>
 <use   name="root"/>

--- a/SimG4CMS/Calo/interface/HcalQie.h
+++ b/SimG4CMS/Calo/interface/HcalQie.h
@@ -11,6 +11,10 @@
 
 #include <vector>
 
+namespace CLHEP {
+  class HepRandomEngine;
+}
+
 class HcalQie {
 
 public:
@@ -18,7 +22,7 @@ public:
   HcalQie(edm::ParameterSet const & p);
   virtual ~HcalQie();
 
-  std::vector<int>     getCode(int, const std::vector<CaloHit>&);
+  std::vector<int>     getCode(int, const std::vector<CaloHit>&, CLHEP::HepRandomEngine*);
   double               getEnergy(const std::vector<int>&);
 
 private:

--- a/SimG4CMS/Calo/interface/HcalTestAnalysis.h
+++ b/SimG4CMS/Calo/interface/HcalTestAnalysis.h
@@ -27,6 +27,10 @@ class BeginOfRun;
 class BeginOfEvent;
 class EndOfEvent;
 
+namespace CLHEP {
+  class HepRandomEngine;
+}
+
 class HcalTestAnalysis : public SimWatcher,
 			 public Observer<const BeginOfJob *>, 
 			 public Observer<const BeginOfRun *>, 
@@ -50,7 +54,7 @@ private:
   std::vector<int> layerGrouping(int);
   std::vector<int> towersToAdd(int centre, int nadd);
   void   fill(const EndOfEvent * ev);
-  void   qieAnalysis();
+  void   qieAnalysis(CLHEP::HepRandomEngine*);
   void   layerAnalysis();
   double timeOfFlight(int det, int layer, double eta);
 

--- a/SimG4CMS/Calo/src/HcalTestAnalysis.cc
+++ b/SimG4CMS/Calo/src/HcalTestAnalysis.cc
@@ -23,6 +23,7 @@
 #include "G4HCofThisEvent.hh"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
+#include "CLHEP/Random/Random.h"
 
 #include <cmath>
 #include <iostream>
@@ -320,7 +321,8 @@ void HcalTestAnalysis::update(const EndOfEvent * evt) {
   LogDebug("HcalSim") << "HcalTestAnalysis:: ---  after Fill";
 
   // Qie analysis
-  qieAnalysis();
+  CLHEP::HepRandomEngine* engine = CLHEP::HepRandom::getTheEngine();
+  qieAnalysis(engine);
   LogDebug("HcalSim") << "HcalTestAnalysis:: ---  after QieAnalysis";
 
   // Layers tuples filling
@@ -471,7 +473,7 @@ void HcalTestAnalysis::fill(const EndOfEvent * evt) {
 }
 
 //-----------------------------------------------------------------------------
-void HcalTestAnalysis::qieAnalysis() {
+void HcalTestAnalysis::qieAnalysis(CLHEP::HepRandomEngine* engine) {
 
   //Fill tuple with hit information
   int hittot = caloHitCache.size();
@@ -546,7 +548,7 @@ void HcalTestAnalysis::qieAnalysis() {
 	  }
 	}
 
-	std::vector<int> cd = myqie->getCode(nhit,hits);
+	std::vector<int> cd = myqie->getCode(nhit, hits, engine);
 	double         eqie = myqie->getEnergy(cd);
 
 	LogDebug("HcalSim") << "HcalTestAnalysis::Qie: Energy in layer " 

--- a/SimG4CMS/HcalTestBeam/interface/HcalTB04Analysis.h
+++ b/SimG4CMS/HcalTestBeam/interface/HcalTB04Analysis.h
@@ -44,6 +44,10 @@ class EndOfEvent;
 
 class PHcalTB04Info;
 
+namespace CLHEP {
+  class HepRandomEngine;
+}
+
 class HcalTB04Analysis : public SimProducer,
 			 public Observer<const BeginOfRun *>,
 			 public Observer<const BeginOfEvent *>,
@@ -72,8 +76,8 @@ private:
 
   //User methods
   void fillBuffer(const EndOfEvent * evt);
-  void qieAnalysis();
-  void xtalAnalysis();
+  void qieAnalysis(CLHEP::HepRandomEngine*);
+  void xtalAnalysis(CLHEP::HepRandomEngine*);
   void finalAnalysis();
   void fillEvent(PHcalTB04Info&);
 

--- a/SimG4CMS/HcalTestBeam/plugins/HcalTB02Analysis.cc
+++ b/SimG4CMS/HcalTestBeam/plugins/HcalTB02Analysis.cc
@@ -27,18 +27,20 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/PluginManager/interface/ModuleDef.h"
-#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "CLHEP/Random/RandGaussQ.h"
-#include "FWCore/Utilities/interface/Exception.h"
 
 #include "G4SDManager.hh"
 #include "G4VProcess.hh"
 #include "G4HCofThisEvent.hh"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 #include "CLHEP/Units/GlobalPhysicalConstants.h"
+#include "CLHEP/Random/Random.h"
+
+namespace CLHEP {
+  class HepRandomEngine;
+}
 
 //
 // constructors and destructor
@@ -90,15 +92,8 @@ void HcalTB02Analysis::update(const BeginOfEvent * evt) {
 
 void HcalTB02Analysis::update(const EndOfEvent * evt) {
 
-  edm::Service<edm::RandomNumberGenerator> rng;
-  if ( ! rng.isAvailable()) {
-    throw cms::Exception("Configuration")
-      << "HcalTB02Analysis requires the RandomNumberGeneratorService\n"
-      << "which is not present in the configuration file. "
-      << "You must add the service\n in the configuration file or "
-      << "remove the modules that require it.";
-  }
-  CLHEP::RandGaussQ  randGauss(rng->getEngine());
+  CLHEP::HepRandomEngine* engine = CLHEP::HepRandom::getTheEngine();
+  CLHEP::RandGaussQ  randGauss(*engine);
 
   // Look for the Hit Collection
   LogDebug("HcalTBSim") << "HcalTB02Analysis::Fill event " 

--- a/SimG4Core/Application/plugins/OscarProducer.cc
+++ b/SimG4Core/Application/plugins/OscarProducer.cc
@@ -40,6 +40,12 @@ namespace {
     // static engine, thus we want to ensure that the one
     // we use for OscarProducer is unique to OscarProducer
     //
+    // !!! This not only sets the random engine used by GEANT.
+    // There are a few SimWatchers/SimProducers that generate
+    // random number and also use the global CLHEP random engine
+    // set by this code. If we ever change this design be careful
+    // not to forget about them!!!
+
     class StaticRandomEngineSetUnset {
     public:
         StaticRandomEngineSetUnset(edm::StreamID const&);

--- a/SimTransport/HectorProducer/interface/Hector.h
+++ b/SimTransport/HectorProducer/interface/Hector.h
@@ -35,7 +35,7 @@
 #include <string>
 #include <map>
 
-#include "TRandom3.h"
+class TRandom3;
 
 class Hector {
   
@@ -52,11 +52,11 @@ class Hector {
   /*!Adds the stable protons from the event \a ev to a beamline*/
   void add( const HepMC::GenEvent * ev , const edm::EventSetup & es);
   /*!propagate the particles through a beamline to FP420*/
-  void filterFP420();
+  void filterFP420(TRandom3*);
   /*!propagate the particles through a beamline to ZDC*/
-  void filterZDC();
+  void filterZDC(TRandom3*);
   /*!propagate the particles through a beamline to ZDC*/
-  void filterD1();
+  void filterD1(TRandom3*);
   
   int getDirect( unsigned int part_n ) const;
 
@@ -133,8 +133,5 @@ class Hector {
     bool m_ZDCTransport;
 
     std::vector<LHCTransportLink> theCorrespondenceMap;
-
-    TRandom3* rootEngine_;
-
 };
 #endif


### PR DESCRIPTION
Migrate SimWatchers and Hector related simulation code
to use the new interface of the random number generator
service designed to work with the multithreaded Framework.

The SimWatchers are different than other simulation
code because the call stack goes through GEANT
functions and engines cannot be percolated. So
SimWatchers use the global CLHEP engine (which is
the same thing the current version of GEANT does).
This CLHEP global will be a thread_local as soon
as planned changes are made to CLHEP.

The Hector code is different because it has TRandom3
hard coded in its interface, although it turns out
that does not really affect the migration.
