### PR TITLE
Update Class Versions of classes impacted by ROOT 6

### DIFF
--- a/DataFormats/BeamSpot/src/classes_def.xml
+++ b/DataFormats/BeamSpot/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-  <class name="reco::BeamSpot" ClassVersion="10">
+  <class name="reco::BeamSpot" ClassVersion="11">
+   <version ClassVersion="11" checksum="999999999"/>
    <version ClassVersion="10" checksum="915260007"/>
   </class>
   <class name="edm::Wrapper<reco::BeamSpot>"/>

--- a/DataFormats/Candidate/src/classes_def.xml
+++ b/DataFormats/Candidate/src/classes_def.xml
@@ -17,12 +17,13 @@
    <version ClassVersion="10" checksum="783896264"/>
     <!-- <field name="mothers_" transient="true"/> -->
   </class>
-  <class name="reco::LeafCandidate"  ClassVersion="11">
+  <class name="reco::LeafCandidate"  ClassVersion="12">
    <field name="vertex_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" />
    <field name="p4Polar_" transient="true" />
    <field name="p4Cartesian_" transient="true" />
    <field name="cachePolarFixed_" transient="true" />
    <field name="cacheCartesianFixed_" transient="true" />
+   <version ClassVersion="12" checksum="9999999999"/>
    <version ClassVersion="11" checksum="1947948955"/>
    <version ClassVersion="10" checksum="4128105563"/>
   </class>
@@ -35,7 +36,8 @@
   <class name="reco::CompositeCandidate" ClassVersion="10">
    <version ClassVersion="10" checksum="2953566340"/>
   </class>
-  <class name="reco::VertexCompositeCandidate" ClassVersion="10">
+  <class name="reco::VertexCompositeCandidate" ClassVersion="11">
+   <version ClassVersion="11" checksum="9999999999"/>
    <version ClassVersion="10" checksum="4177206274"/>
   </class>
   <class name="reco::CompositeRefCandidate"  ClassVersion="10">

--- a/DataFormats/GsfTrackReco/src/classes_def.xml
+++ b/DataFormats/GsfTrackReco/src/classes_def.xml
@@ -4,7 +4,8 @@
   </class>
   <class name="std::vector<reco::GsfComponent5D>"/>
 
-  <class name="reco::GsfTangent" ClassVersion="10">
+  <class name="reco::GsfTangent" ClassVersion="11">
+   <version ClassVersion="11" checksum="9999999999"/>
    <version ClassVersion="10" checksum="3902664602"/>
      <field name="position_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
      <field name="momentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" />
@@ -23,7 +24,8 @@
   <class name="edm::Ref<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
   <class name="edm::RefVector<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
 
-  <class name="reco::GsfTrack" ClassVersion="11">
+  <class name="reco::GsfTrack" ClassVersion="12">
+   <version ClassVersion="12" checksum="9999999999"/>
    <version ClassVersion="11" checksum="1456169080"/>
     <field name="momentumMode_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
   </class>

--- a/DataFormats/JetReco/src/classes_def_4.xml
+++ b/DataFormats/JetReco/src/classes_def_4.xml
@@ -60,7 +60,8 @@
   <class name="std::vector<reco::PFJet::Specific>"   />
   <class name="std::vector<reco::JPTJet::Specific>" />
 
-  <class name="reco::TrackExtrapolation"  ClassVersion="10">
+  <class name="reco::TrackExtrapolation"  ClassVersion="11">
+   <version ClassVersion="11" checksum="9999999999"/>
    <version ClassVersion="10" checksum="4193842732"/>
   </class>
   <class name="std::vector<reco::TrackExtrapolation>" />

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -53,7 +53,8 @@
   <class name="std::vector<reco::MuonSegmentMatch>"/>
   <class name="std::vector<reco::MuonRPCHitMatch>"/>
 
-  <class name="reco::MuonIsolation" ClassVersion="10">
+  <class name="reco::MuonIsolation" ClassVersion="11">
+   <version ClassVersion="11" checksum="9999999999"/>
    <version ClassVersion="10" checksum="2078425999"/>
   </class>
   <class name="reco::MuonPFIsolation" ClassVersion="15">

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -5,7 +5,8 @@
   <class name="reco::TrackResiduals" ClassVersion="10">
    <version ClassVersion="10" checksum="2022291691"/>
   </class>
-  <class name="reco::TrackBase" ClassVersion="12">
+  <class name="reco::TrackBase" ClassVersion="13">
+   <version ClassVersion="13" checksum="9999999999"/>
    <version ClassVersion="12" checksum="2704717983"/>
     <field name="vertex_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
     <field name="momentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
@@ -17,7 +18,8 @@
    <version ClassVersion="10" checksum="3548207838"/>
   </class>
 
-  <class name="reco::TrackExtra" ClassVersion="10">
+  <class name="reco::TrackExtra" ClassVersion="11">
+   <version ClassVersion="11" checksum="9999999999"/>
    <version ClassVersion="10" checksum="1613098482"/>
     <field name="outerPosition_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
     <field name="outerMomentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 


### PR DESCRIPTION
This pull request fixes most (perhaps all) ROOT6 relval errors of the form:

 The StreamerInfo of class MyClass read from file MyFIle.root   has the same version (=10) as the active class but a different checksum.

The classes in question have different checksums in ROOT 5 and ROOT 6 for valid reasons.
This pull request updates the version numbers for these classes.  Because edmClassVersion is currently disabled in ROOT6, it is non-trivial to get the checksums for ROOT6 and guarantee that they are correct..  Therefore, "999999999" is used as a placeholder for the checksum in the ROOT6 version.  When edmCheckClassVersion is turned back on, each instance of "999999999" can then be easily changed to the correct checksum.
