### PR TITLE
Changes to get tests 3400 and 15001 to use the correct customisation for harvesting

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -2535,7 +2535,7 @@ steps['HARVESTUP19']={'-s':'HARVESTING:validationHarvesting+dqmHarvesting',
                    '--conditions':'auto:upgrade2019', 
                    '--mc':'',
                    '--magField' : '38T_PostLS1',
-                   '--customise' : 'SLHCUpgradeSimulations/Configuration/phase1TkCustoms.customise',
+                   '--customise' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2019',
 		   '--geometry' : 'Extended2019'
                    }
 
@@ -2643,7 +2643,7 @@ steps['HARVESTUP19300']={'-s':'HARVESTING:validationHarvesting+dqmHarvesting',
                    '--conditions':'W19_300_62E2::All', 
                    '--mc':'',
                    '--magField' : '38T_PostLS1',
-                   '--customise' : 'SLHCUpgradeSimulations/Configuration/phase1TkCustoms.customise',
+                   '--customise' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2019,SLHCUpgradeSimulations/Configuration/aging.customise_aging_300',
 		   '--geometry' : 'Extended2019'
                    }
 		   


### PR DESCRIPTION
Spot fix to use the correct customisation for harvesting in test 3400 and 15001.  Will also affect all 34xx and 15101,  16001, 17001, 17011, 18001, 18101, 19001 and 19101.

This is a short term fix while testing pull requests for SLHC8.  After then the matrix test declaration will be changed to be more flexible.

Tested 3400 and 15001 which now pass all steps (previously failed at step 4).
Also tested 3300, 4100, 4400, 40001, 50002, 60002, 60001, 4502, 4500, 5001 and 50001 (slightly pointless but it doesn't hurt to be safe).  All passed except 50001 and 60001 fail in step 1 with known error; 4502 failed with 'Disk quota exceeded'.  Assumed it would be fine with more space but didn't re-test.
