### PR TITLE
TopQuarkAnalysis/TopSkimming: add missing dependency on DataFormats/Common

### DIFF
--- a/TopQuarkAnalysis/TopSkimming/BuildFile.xml
+++ b/TopQuarkAnalysis/TopSkimming/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="FWCore/ParameterSet"/>
+<use   name="DataFormats/Common"/>
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
The missing dependency is visible on GCC pre-4.9.0 IB: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc490/CMSSW_7_1_X_2014-02-14-0200/TopQuarkAnalysis/TopSkimming

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
