### PR TITLE
DataFormats/PatCandidates: export pat::Jet::numberOfDaughters() const

### DIFF
--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -426,7 +426,7 @@ namespace pat {
       ///    If using refactorized PAT, return that. (constituents size > 0)
       ///    Else check the old version of PAT (embedded constituents size > 0)
       ///    Else return the reco Jet number of constituents
-      virtual size_t numberOfDaughters() const {
+      virtual size_t numberOfDaughters() const dso_export {
 	if (isCaloJet() || isJPTJet()) {
 	  if ( embeddedCaloTowers_ ) {
 	    if ( caloTowersFwdPtr_.size() > 0 ) return caloTowersFwdPtr_.size();


### PR DESCRIPTION
The following call, `pat::Jet::numberOfDaughters()` const, is being
used by `testCommonToolsUtil` from `CommonTools/Utils`. It was generated
with LOCAL binding, export it with WEAK binding.

Visible on GCC pre-4.9.0 IB: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc490/CMSSW_7_1_X_2014-02-14-0200/CommonTools/Utils

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
