### PR TITLE
Database format resolved centrally in connection pool

### DIFF
--- a/CondCore/CondDB/interface/ConnectionPool.h
+++ b/CondCore/CondDB/interface/ConnectionPool.h
@@ -26,6 +26,7 @@ namespace cond {
     // 
     enum DbAuthenticationSystem { UndefinedAuthentication=0,CondDbKey, CoralXMLFile };
 
+    // a wrapper for the coral connection service.  
     class ConnectionPool {
     public:
       ConnectionPool();
@@ -38,20 +39,24 @@ namespace cond {
       bool isLoggingEnabled() const;
       void setParameters( const edm::ParameterSet& connectionPset );
       void configure();
-      Session createSession( const std::string& connectionString, bool writeCapable=false );
+      Session createSession( const std::string& connectionString, bool writeCapable=false, BackendType backType=ORA_DB );
       Session createReadOnlySession( const std::string& connectionString, const std::string& transactionId );
       
     private:
-      Session createSession( const std::string& connectionString, const std::string& transactionId, bool writeCapable=false );
+      Session createSession( const std::string& connectionString, 
+			     const std::string& transactionId, 
+			     bool writeCapable=false, 
+			     BackendType backType=ORA_DB );
       void configure( coral::IConnectionServiceConfiguration& coralConfig);
     private:
       std::string m_authPath;
       int m_authSys = 0;
-      coral::MsgLevel m_messageLevel = coral::Info;
+      coral::MsgLevel m_messageLevel = coral::Error;
       bool m_loggingEnabled = false;
       // this one has to be moved!
       cond::CoralServiceManager* m_pluginManager = 0; 
       std::vector<std::string> m_refreshtablelist;
+      std::map<std::string,int> m_dbTypes;
     };
   }
 }

--- a/CondCore/CondDB/interface/Serialization.h
+++ b/CondCore/CondDB/interface/Serialization.h
@@ -28,8 +28,9 @@ namespace cond {
 
   // default payload factory
   template <typename T> T* createPayload( const std::string& payloadTypeName ){
-    if( demangledName( typeid(T) )!= payloadTypeName ) 
-      throwException(std::string("Type mismatch, target object is type \"")+payloadTypeName+"\"",
+    std::string userTypeName = demangledName( typeid(T) );
+    if( userTypeName != payloadTypeName ) 
+      throwException(std::string("Type mismatch, user type: \""+userTypeName+"\", target type: \"")+payloadTypeName+"\"",
 		     "createPayload" );
     return new T;
   }

--- a/CondCore/CondDB/interface/Session.h
+++ b/CondCore/CondDB/interface/Session.h
@@ -64,9 +64,6 @@ namespace cond {
       // constructor
       explicit Session( const std::shared_ptr<SessionImpl>& sessionImpl );
 
-      // constructor
-      Session( boost::shared_ptr<coral::ISessionProxy>& session, const std::string& connectionString );
-
       // 
       Session( const Session& rhs );
       
@@ -141,9 +138,10 @@ namespace cond {
       coral::ISchema& nominalSchema();
       
       bool isOraSession(); 
-      
+
     private:
       cond::Hash storePayloadData( const std::string& payloadObjectType, const cond::Binary& payloadData, const boost::posix_time::ptime& creationTime );
+      
     private:
       
       std::shared_ptr<SessionImpl> m_session;

--- a/CondCore/CondDB/interface/Types.h
+++ b/CondCore/CondDB/interface/Types.h
@@ -19,6 +19,10 @@
 
 namespace cond {
 
+  // to be removed after the transition to new DB
+  typedef enum { UNKNOWN_DB=0, COND_DB, ORA_DB } BackendType;
+  static constexpr BackendType DEFAULT_DB = ORA_DB;
+
   typedef enum { 
     SYNCHRONIZATION_UNKNOWN = -1,
     OFFLINE=0, 

--- a/CondCore/CondDB/interface/Utils.h
+++ b/CondCore/CondDB/interface/Utils.h
@@ -28,15 +28,19 @@ namespace cond {
     std::tuple<std::string,std::string,std::string> parseConnectionString( const std::string& connectionString ){
       size_t ptr = 0;
       size_t techEnd = connectionString.find( ':' );
-      if( techEnd == std::string::npos ) throwException( "Connection string is invalid (0)","parseConnectionString" );
+      if( techEnd == std::string::npos ) throwException( "Connection string "+connectionString+" is invalid format.",
+							 "parseConnectionString" );
       std::string technology = connectionString.substr(ptr,techEnd);
       std::string service("");
       ptr = techEnd+1;
-      if( technology != "sqlite_file" ){
-	if( connectionString.substr( ptr,2 )!="//" ) throwException( "Connection string is invalid (1)","parseConnectionString" );
+      if( technology != "sqlite_file" && technology != "sqlite" ){
+	if( connectionString.substr( ptr,2 )!="//" ) throwException( "Connection string "+connectionString+
+								     " is invalid format for technology \""+
+								     technology+"\".","parseConnectionString" );
 	ptr += 2;
 	size_t serviceEnd = connectionString.find( '/', ptr );
-	if( serviceEnd == std::string::npos ) throwException( "Connection string is invalid (2)","parseConnectionString" );
+	if( serviceEnd == std::string::npos ) throwException( "Connection string "+connectionString+" is invalid.",
+							      "parseConnectionString" );
 	service = connectionString.substr( ptr, serviceEnd-ptr );
 	ptr = serviceEnd+1;
       }

--- a/CondCore/CondDB/python/CondDB_cfi.py
+++ b/CondCore/CondDB/python/CondDB_cfi.py
@@ -3,8 +3,10 @@ import FWCore.ParameterSet.Config as cms
 CondDB = cms.PSet(
     DBParameters = cms.PSet(
         authenticationPath = cms.untracked.string(''),
+        authenticationSystem = cms.untracked.int32(0),
         messageLevel = cms.untracked.int32(0),
     ),
-    connect = cms.string('protocol://db/schema') ##db/schema"
+    connect = cms.string('protocol://db/schema'), ##db/schema"
+    dbFormat = cms.untracked.int32(0)
 )
 

--- a/CondCore/CondDB/src/Session.cc
+++ b/CondCore/CondDB/src/Session.cc
@@ -45,11 +45,6 @@ namespace cond {
       m_transaction( *m_session ){      
     }
 
-    Session::Session( boost::shared_ptr<coral::ISessionProxy>& session, const std::string& connectionString ):
-      m_session( new SessionImpl( session, connectionString ) ),
-      m_transaction( *m_session ){
-    }
-
     Session::Session( const Session& rhs ):
       m_session( rhs.m_session ),
       m_transaction( rhs.m_transaction ){

--- a/CondCore/CondDB/src/SessionImpl.cc
+++ b/CondCore/CondDB/src/SessionImpl.cc
@@ -57,13 +57,37 @@ namespace cond {
       cond::DbSession m_session;
     };
 
-    SessionImpl::SessionImpl():
-      coralSession(){
+    BackendType checkBackendType( boost::shared_ptr<coral::ISessionProxy>& coralSession, 
+				  const std::string& connectionString ){
+      BackendType ret = UNKNOWN_DB;
+      cond::DbSession oraSession;
+      oraSession.open( coralSession, connectionString ); 
+      oraSession.transaction().start( true );
+      std::unique_ptr<IIOVSchema> iovSchemaHandle( new OraIOVSchema( oraSession ) );
+      std::unique_ptr<IGTSchema> gtSchemaHandle( new OraGTSchema( oraSession ) );  		       
+      if( !iovSchemaHandle->exists() && !gtSchemaHandle->exists() ){
+	iovSchemaHandle.reset( new IOVSchema( coralSession->nominalSchema() ) );
+	if( iovSchemaHandle->exists() ){
+	  ret = COND_DB;
+	}
+      } else {
+	ret = ORA_DB;
+      }
+      oraSession.transaction().commit();
+      return ret;      
     }
 
-    SessionImpl::SessionImpl( boost::shared_ptr<coral::ISessionProxy>& session, const std::string& connectionStr ):
+    SessionImpl::SessionImpl():
+      coralSession(),
+      theBackendType( UNKNOWN_DB ){
+    }
+
+    SessionImpl::SessionImpl( boost::shared_ptr<coral::ISessionProxy>& session, 
+			      const std::string& connectionStr,
+			      BackendType backType ):
       coralSession( session ),
-      connectionString( connectionStr ){
+      connectionString( connectionStr ),
+      theBackendType( backType ){
     }
 
     SessionImpl::~SessionImpl(){
@@ -86,21 +110,20 @@ namespace cond {
 
     void SessionImpl::startTransaction( bool readOnly ){
       if( !transaction.get() ){ 
-	cond::DbConnection oraConnection;
-	cond::DbSession oraSession =  oraConnection.createSession();
-	oraSession.open( coralSession, connectionString ); 
-	transaction.reset( new OraTransaction( oraSession ) );
-	oraSession.transaction().start( readOnly );
-	iovSchemaHandle.reset( new OraIOVSchema( oraSession ) );
-	gtSchemaHandle.reset( new OraGTSchema( oraSession ) );  		       
-	if( !iovSchemaHandle->exists() && !gtSchemaHandle->exists() ){
-	  std::unique_ptr<IIOVSchema> iovSchema( new IOVSchema( coralSession->nominalSchema() ) );
-	  std::unique_ptr<IGTSchema> gtSchema( new GTSchema( coralSession->nominalSchema() ) );
-	  if( iovSchema->exists() ){
-	    iovSchemaHandle = std::move(iovSchema);
-	    gtSchemaHandle = std::move(gtSchema);
-	    transaction.reset( new CondDBTransaction( coralSession ) );
-	  }
+	if ( theBackendType == ORA_DB ) {
+	  cond::DbSession oraSession;
+	  oraSession.open( coralSession, connectionString ); 
+	  oraSession.transaction().start( readOnly );
+	  iovSchemaHandle.reset( new OraIOVSchema( oraSession ) );
+	  gtSchemaHandle.reset( new OraGTSchema( oraSession ) );  		       
+	  transaction.reset( new OraTransaction( oraSession ) );
+	} else if ( theBackendType == COND_DB ){
+	  coralSession->transaction().start( readOnly );
+	  iovSchemaHandle.reset( new IOVSchema( coralSession->nominalSchema() ) );
+	  gtSchemaHandle.reset( new GTSchema( coralSession->nominalSchema() ) );
+	  transaction.reset( new CondDBTransaction( coralSession ) );
+	} else {
+	  throwException( "No valid database found.", "SessionImpl::startTransaction" );
 	}
       } else {
 	if(!readOnly ) throwException( "An update transaction is already active.",

--- a/CondCore/CondDB/src/SessionImpl.h
+++ b/CondCore/CondDB/src/SessionImpl.h
@@ -1,6 +1,7 @@
 #ifndef CondCore_CondDB_SessionImpl_h
 #define CondCore_CondDB_SessionImpl_h
 
+#include "CondCore/CondDB/interface/Types.h"
 #include "IOVSchema.h"
 #include "GTSchema.h"
 //
@@ -35,13 +36,19 @@ namespace cond {
       bool isOra = false;
       size_t clients = 0;
     };
+
+    BackendType checkBackendType( boost::shared_ptr<coral::ISessionProxy>& session, 
+				  const std::string& connectionString );
     
     class SessionImpl {
     public:
       typedef enum { THROW, DO_NOT_THROW, CREATE } FailureOnOpeningPolicy;
     public:
       SessionImpl();
-      SessionImpl( boost::shared_ptr<coral::ISessionProxy>& session, const std::string& connectionString );
+      SessionImpl( boost::shared_ptr<coral::ISessionProxy>& session, 
+		   const std::string& connectionString, 
+		   BackendType backType );
+
       ~SessionImpl();
       
       void close();
@@ -63,6 +70,7 @@ namespace cond {
       boost::shared_ptr<coral::ISessionProxy> coralSession;
       // not really useful outside the ORA bridging...
       std::string connectionString;
+      BackendType theBackendType;
       std::unique_ptr<ITransaction> transaction;
       std::unique_ptr<IIOVSchema> iovSchemaHandle; 
       std::unique_ptr<IGTSchema> gtSchemaHandle; 

--- a/CondCore/DBCommon/src/DbSession.cc
+++ b/CondCore/DBCommon/src/DbSession.cc
@@ -207,16 +207,12 @@ const std::string& cond::DbSession::blobStreamingService() const
 
 cond::DbTransaction& cond::DbSession::transaction()
 {
-  if(!m_implementation->connection.get() || !m_implementation->connection->isOpen())
-    throw cond::Exception("DbSession::transaction: cannot open transaction. Underlying connection is closed.");
   if(!m_implementation->transaction.get())
     throw cond::Exception("DbSession::transaction: cannot get transaction. Session has not been open.");
   return *m_implementation->transaction;
 }
 
 ora::Database& cond::DbSession::storage(){
-  if(!m_implementation->connection.get() || !m_implementation->connection->isOpen())
-    throw cond::Exception("DbSession::storage: cannot access the storage. Underlying connection is closed.");
   if(!m_implementation->database.get())
     throw cond::Exception("DbSession::storage: cannot access the database. Session has not been open.");
   return *m_implementation->database;
@@ -299,7 +295,7 @@ std::string cond::DbSession::classNameForItem( const std::string& objectId ){
   std::string ret("");
   if( !oid.isInvalid() ){
     ora::Container cont = storage().containerHandle( oid.containerId() );
-    ret = cont.className();
+    ret = cont.realClassName();
   }
   return ret; 
 }

--- a/CondCore/DBCommon/test/testDbSession.cc
+++ b/CondCore/DBCommon/test/testDbSession.cc
@@ -82,30 +82,12 @@ int main(){
   try {
     std::cout << "######### test 9"<<std::endl;
     s2.transaction().start();
-    std::cout << "ERROR: expected exception not thrown (1)"<<std::endl;
-  } catch ( const cond::Exception& exc ){
-    std::cout << "Expected error 1: "<<exc.what()<<std::endl;
-  }
-  try {
-    std::cout << "######### test 10"<<std::endl;
     s2.nominalSchema();
-    std::cout << "ERROR: expected exception not thrown (2)"<<std::endl;
-  } catch ( const cond::Exception& exc ){
-    std::cout << "Expected error 2: "<<exc.what()<<std::endl;
-  }
-  try {
-    std::cout << "######### test 11"<<std::endl;
     s2.storage();
-    std::cout << "ERROR: expected exception not thrown (3)"<<std::endl;
-  } catch ( const cond::Exception& exc ){
-    std::cout << "Expected error 3: "<<exc.what()<<std::endl;
-  }
-  try {
-    std::cout << "######### test 12"<<std::endl;
     s2.getObject(std::string(""));
-    std::cout << "ERROR: expected exception not thrown (4)"<<std::endl;
-  } catch ( const cond::Exception& exc ){
-    std::cout << "Expected error 4: "<<exc.what()<<std::endl;
+    std::cout << "ERROR: expected exception not thrown"<<std::endl;
+  } catch ( const ora::Exception& exc ){
+    std::cout << "Expected error: "<<exc.what()<<std::endl;
   }
   
 }

--- a/CondCore/DBOutputService/src/PoolDBOutputService.cc
+++ b/CondCore/DBOutputService/src/PoolDBOutputService.cc
@@ -54,8 +54,9 @@ cond::service::PoolDBOutputService::PoolDBOutputService(const edm::ParameterSet 
   cond::persistency::ConnectionPool connection;
   connection.setParameters( connectionPset );
   connection.configure();
-
-  m_session = connection.createSession( iConfig.getParameter<std::string>("connect"), true ); 
+  std::string connectionString = iConfig.getParameter<std::string>("connect");
+  BackendType backType = (BackendType) iConfig.getUntrackedParameter<int>("dbFormat", DEFAULT_DB);
+  m_session = connection.createSession( connectionString, true, backType ); 
   
   //if( iConfig.exists("logconnect") ){
   //  m_logConnectionString = iConfig.getUntrackedParameter<std::string>("logconnect");

--- a/CondCore/ORA/interface/Container.h
+++ b/CondCore/ORA/interface/Container.h
@@ -61,6 +61,8 @@ namespace ora {
 
     const std::string& className();
 
+    std::string realClassName();
+
     const std::string& mappingVersion();
 
     size_t size();

--- a/CondCore/ORA/src/Container.cc
+++ b/CondCore/ORA/src/Container.cc
@@ -76,6 +76,13 @@ const std::string& ora::Container::className(){
   return m_dbContainer->className();
 }
 
+std::string ora::Container::realClassName(){
+  Reflex::Type type = ClassUtils::lookupDictionary( className() );
+  std::string ret = ClassUtils::demangledName( type.TypeInfo() ); 
+  ret.erase( std::remove( ret.begin(), ret.end(), ' ' ), ret.end() ); 
+  return ret;
+}
+
 const std::string& ora::Container::mappingVersion(){
   return m_dbContainer->mappingVersion();
 }

--- a/CondCore/Utilities/bin/conddb_migrate.cpp
+++ b/CondCore/Utilities/bin/conddb_migrate.cpp
@@ -78,7 +78,7 @@ int cond::MigrateUtilities::execute(){
 
   persistency::ConnectionPool connPool;
   std::cout <<"# Opening session on destination database..."<<std::endl;
-  persistency::Session session = connPool.createSession( destConnect, true );
+  persistency::Session session = connPool.createSession( destConnect, true, COND_DB );
     
   session.transaction().start( false );
   if( !session.existsDatabase() ) session.createDatabase();
@@ -132,13 +132,9 @@ int cond::MigrateUtilities::execute(){
 	session.transaction().rollback();
 	continue;
       }
-      std::string payloadType("");
-      if( sourceIov.payloadClasses().size() > 0 ) { 
-	payloadType = *(sourceIov.payloadClasses().begin());
-      } else {
-	std::string tk = sourceIov.begin()->token();
-	payloadType = sourcedb.classNameForItem( tk );
-      }
+      std::string tk = sourceIov.begin()->token();
+      std::string payloadType = sourcedb.classNameForItem( tk );
+      
       std::cout <<"    Importing tag. Size:"<<sourceIov.size()<<" timeType:"<<cond::timeTypeNames(tt)<<" payloadObjectType=\""<<payloadType<<"\""<<std::endl;
       editor = session.createIov( payloadType, destTag, (cond::TimeType)tt );
       editor.setDescription( "Tag "+t+" migrated from "+sourceConnect  );


### PR DESCRIPTION
Fix aiming performance improvement in the loading of condition.
The resolution of the database format ( in case of existing tables in the target DB) is done centrally at the first connection. For a given connection string, the db technology is stored and re-used for further connections.

PAckages involved:
CondCore/CondDB
CondCore/DBCommon
CondCore/DBOutputService
CondCore/ORA
CondCore/Utilities
