### PR TITLE
Move numberOfDaughters() and daughter(size_t) outside class declaration

### DIFF
--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -402,23 +402,7 @@ namespace pat {
       ///    If using refactorized PAT, return that. (constituents size > 0)
       ///    Else check the old version of PAT (embedded constituents size > 0)
       ///    Else return the reco Jet number of constituents
-      virtual const reco::Candidate * daughter(size_t i) const {
-	if (isCaloJet() || isJPTJet() ) {
-	  if ( embeddedCaloTowers_ ) {
-	    if ( caloTowersFwdPtr_.size() > 0 ) return caloTowersFwdPtr_[i].get();
-	    else if ( caloTowers_.size() > 0 ) return &caloTowers_[i];
-	    else return reco::Jet::daughter(i);
-	  }
-	}
-	if (isPFJet()) {
-	  if ( embeddedPFCandidates_ ) {
-	    if ( pfCandidatesFwdPtr_.size() > 0 ) return pfCandidatesFwdPtr_[i].get();
-	    else if ( pfCandidates_.size() > 0 ) return &pfCandidates_[i];
-	    else return reco::Jet::daughter(i);
-	  }
-	}
-	return reco::Jet::daughter(i);
-      }
+      virtual const reco::Candidate * daughter(size_t i) const;
 
       using reco::LeafCandidate::daughter; // avoid hiding the base implementation
 
@@ -426,23 +410,7 @@ namespace pat {
       ///    If using refactorized PAT, return that. (constituents size > 0)
       ///    Else check the old version of PAT (embedded constituents size > 0)
       ///    Else return the reco Jet number of constituents
-      virtual size_t numberOfDaughters() const {
-	if (isCaloJet() || isJPTJet()) {
-	  if ( embeddedCaloTowers_ ) {
-	    if ( caloTowersFwdPtr_.size() > 0 ) return caloTowersFwdPtr_.size();
-	    else if ( caloTowers_.size() > 0 ) return caloTowers_.size();
-	    else return reco::Jet::numberOfDaughters();
-	  }
-	}
-	if (isPFJet()) {
-	  if ( embeddedPFCandidates_ ) {
-	    if ( pfCandidatesFwdPtr_.size() > 0 ) return pfCandidatesFwdPtr_.size();
-	    else if ( pfCandidates_.size() > 0 ) return pfCandidates_.size();
-	    else return reco::Jet::numberOfDaughters();
-	  }
-	}
-	return reco::Jet::numberOfDaughters();
-      }
+      virtual size_t numberOfDaughters() const;
 
       /// accessing Jet ID information
       reco::JetID const & jetID () const { return jetID_;}

--- a/DataFormats/PatCandidates/src/Jet.cc
+++ b/DataFormats/PatCandidates/src/Jet.cc
@@ -178,7 +178,41 @@ std::vector<reco::PFCandidatePtr> const & Jet::getPFConstituents () const {
   return *pfCandidatesTemp_;
 }
 
+const reco::Candidate * Jet::daughter(size_t i) const {
+  if (isCaloJet() || isJPTJet() ) {
+    if ( embeddedCaloTowers_ ) {
+      if ( caloTowersFwdPtr_.size() > 0 ) return caloTowersFwdPtr_[i].get();
+      else if ( caloTowers_.size() > 0 ) return &caloTowers_[i];
+      else return reco::Jet::daughter(i);
+    }
+  }
+  if (isPFJet()) {
+    if ( embeddedPFCandidates_ ) {
+      if ( pfCandidatesFwdPtr_.size() > 0 ) return pfCandidatesFwdPtr_[i].get();
+      else if ( pfCandidates_.size() > 0 ) return &pfCandidates_[i];
+      else return reco::Jet::daughter(i);
+    }
+  }
+  return reco::Jet::daughter(i);
+}
 
+size_t Jet::numberOfDaughters() const {
+  if (isCaloJet() || isJPTJet()) {
+    if ( embeddedCaloTowers_ ) {
+      if ( caloTowersFwdPtr_.size() > 0 ) return caloTowersFwdPtr_.size();
+      else if ( caloTowers_.size() > 0 ) return caloTowers_.size();
+      else return reco::Jet::numberOfDaughters();
+    }
+  }
+  if (isPFJet()) {
+    if ( embeddedPFCandidates_ ) {
+      if ( pfCandidatesFwdPtr_.size() > 0 ) return pfCandidatesFwdPtr_.size();
+      else if ( pfCandidates_.size() > 0 ) return pfCandidates_.size();
+      else return reco::Jet::numberOfDaughters();
+    }
+  }
+  return reco::Jet::numberOfDaughters();
+}
 
 /// return the matched generated jet
 const reco::GenJet * Jet::genJet() const {


### PR DESCRIPTION
Break virtual inline. This will make `numberOfDaughters()` and
`daughter(size_t)` symbols with GLOBAL binding. Before it was in LOCAL
binding thus breaking compilation of `testCommonToolsUtil` from
`CommonTools/Utils`. Needed for GCC 4.9.0.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
