### PR TITLE
Migrate L1Trigger Code to New Random Service Interface

### DIFF
--- a/L1Trigger/HardwareValidation/plugins/L1EmulBias.cc
+++ b/L1Trigger/HardwareValidation/plugins/L1EmulBias.cc
@@ -1,5 +1,9 @@
 #include "L1Trigger/HardwareValidation/plugins/L1EmulBias.h"
 
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+
 using namespace dedefs;
 
 L1EmulBias::L1EmulBias(const edm::ParameterSet& iConfig) {
@@ -92,23 +96,27 @@ L1EmulBias::L1EmulBias(const edm::ParameterSet& iConfig) {
   if(m_doSys[GLT])  produces<L1GlobalTriggerObjectMapRecord> (instName[GLT][0]);
 
   edm::Service<edm::RandomNumberGenerator> rng;
-  CLHEP::HepRandomEngine& engine = rng->getEngine();
-  rndFlat_ = new CLHEP::RandFlat  (engine, 0., 1.);
-  rndGaus_ = new CLHEP::RandGaussQ(engine, 0., 1.);
+  if(!rng.isAvailable()) {
+    throw cms::Exception("Configuration")
+      << "L1EmulBias requires the RandomNumberGeneratorService\n"
+         "which is not present in the configuration file.  You must add the service\n"
+         "in the configuration file or remove the modules that require it.";
+  }
 
   if(verbose())
     std::cout << "L1EmulBias::L1EmulBias()... done." << std::endl; 
 }
   
 L1EmulBias::~L1EmulBias() {
-  delete rndFlat_;
-  delete rndGaus_;
 }
 
 // ------------ method called to produce the data  ------------
 void
 L1EmulBias::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-  
+
+  edm::Service<edm::RandomNumberGenerator> rng;
+  CLHEP::HepRandomEngine* engine = &rng->getEngine(iEvent.streamID());
+
   if(verbose())
     std::cout << "L1EmulBias::produce...\n" << std::flush; 
 
@@ -221,30 +229,30 @@ L1EmulBias::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     std::cout << "L1EmulBias::produce - modify...\n" << std::flush; 
 
   /// fill data as modified emul collections
-  if(m_doSys[ETP]) ModifyCollection(    ecal_tp_data,    ecal_tp_emul);
-  if(m_doSys[HTP]) ModifyCollection(    hcal_tp_data,    hcal_tp_emul);
-  if(m_doSys[RCT]) ModifyCollection(     rct_em_data,     rct_em_emul);
-  if(m_doSys[RCT]) ModifyCollection(    rct_rgn_data,    rct_rgn_emul);
-  if(m_doSys[GCT]) ModifyCollection(gct_isolaem_data,gct_isolaem_emul);
-  if(m_doSys[GCT]) ModifyCollection(gct_noisoem_data,gct_noisoem_emul);
-  if(m_doSys[GCT]) ModifyCollection(gct_cenjets_data,gct_cenjets_emul);
-  if(m_doSys[GCT]) ModifyCollection(gct_forjets_data,gct_forjets_emul);
-  if(m_doSys[GCT]) ModifyCollection(gct_taujets_data,gct_taujets_emul);
-  if(m_doSys[DTP]) ModifyCollection(     dtp_ph_data,     dtp_ph_emul);
-  if(m_doSys[DTP]) ModifyCollection(     dtp_th_data,     dtp_th_emul);
-  if(m_doSys[DTF]) ModifyCollection(        dtf_data,        dtf_emul);
-  if(m_doSys[DTF]) ModifyCollection(    dtf_trk_data,    dtf_trk_emul);
-  if(m_doSys[CTP]) ModifyCollection(        ctp_data,        ctp_emul);
-  if(m_doSys[CTF]) ModifyCollection(        ctf_data,        ctf_emul);
-  if(m_doSys[CTF]) ModifyCollection(    ctf_trk_data,    ctf_trk_emul);
-  if(m_doSys[RPC]) ModifyCollection(    rpc_cen_data,    rpc_cen_emul);
-  if(m_doSys[RPC]) ModifyCollection(    rpc_for_data,    rpc_for_emul);
-  if(m_doSys[LTC]) ModifyCollection(        ltc_data,        ltc_emul);
-  if(m_doSys[GMT]) ModifyCollection(        gmt_data,        gmt_emul);
-  if(m_doSys[GMT]) ModifyCollection(    gmt_rdt_data,    gmt_rdt_emul);
-  if(m_doSys[GLT]) ModifyCollection(    glt_rdt_data,    glt_rdt_emul);
-  if(m_doSys[GLT]) ModifyCollection(    glt_evm_data,    glt_evm_emul);
-  if(m_doSys[GLT]) ModifyCollection(    glt_obj_data,    glt_obj_emul);
+  if(m_doSys[ETP]) ModifyCollection(    ecal_tp_data,    ecal_tp_emul, engine);
+  if(m_doSys[HTP]) ModifyCollection(    hcal_tp_data,    hcal_tp_emul, engine);
+  if(m_doSys[RCT]) ModifyCollection(     rct_em_data,     rct_em_emul, engine);
+  if(m_doSys[RCT]) ModifyCollection(    rct_rgn_data,    rct_rgn_emul, engine);
+  if(m_doSys[GCT]) ModifyCollection(gct_isolaem_data,gct_isolaem_emul, engine);
+  if(m_doSys[GCT]) ModifyCollection(gct_noisoem_data,gct_noisoem_emul, engine);
+  if(m_doSys[GCT]) ModifyCollection(gct_cenjets_data,gct_cenjets_emul, engine);
+  if(m_doSys[GCT]) ModifyCollection(gct_forjets_data,gct_forjets_emul, engine);
+  if(m_doSys[GCT]) ModifyCollection(gct_taujets_data,gct_taujets_emul, engine);
+  if(m_doSys[DTP]) ModifyCollection(     dtp_ph_data,     dtp_ph_emul, engine);
+  if(m_doSys[DTP]) ModifyCollection(     dtp_th_data,     dtp_th_emul, engine);
+  if(m_doSys[DTF]) ModifyCollection(        dtf_data,        dtf_emul, engine);
+  if(m_doSys[DTF]) ModifyCollection(    dtf_trk_data,    dtf_trk_emul, engine);
+  if(m_doSys[CTP]) ModifyCollection(        ctp_data,        ctp_emul, engine);
+  if(m_doSys[CTF]) ModifyCollection(        ctf_data,        ctf_emul, engine);
+  if(m_doSys[CTF]) ModifyCollection(    ctf_trk_data,    ctf_trk_emul, engine);
+  if(m_doSys[RPC]) ModifyCollection(    rpc_cen_data,    rpc_cen_emul, engine);
+  if(m_doSys[RPC]) ModifyCollection(    rpc_for_data,    rpc_for_emul, engine);
+  if(m_doSys[LTC]) ModifyCollection(        ltc_data,        ltc_emul, engine);
+  if(m_doSys[GMT]) ModifyCollection(        gmt_data,        gmt_emul, engine);
+  if(m_doSys[GMT]) ModifyCollection(    gmt_rdt_data,    gmt_rdt_emul, engine);
+  if(m_doSys[GLT]) ModifyCollection(    glt_rdt_data,    glt_rdt_emul, engine);
+  if(m_doSys[GLT]) ModifyCollection(    glt_evm_data,    glt_evm_emul, engine);
+  if(m_doSys[GLT]) ModifyCollection(    glt_obj_data,    glt_obj_emul, engine);
 
   if(verbose())
     std::cout << "L1EmulBias::produce - put...\n" << std::flush; 

--- a/L1Trigger/HardwareValidation/plugins/L1EmulBias.h
+++ b/L1Trigger/HardwareValidation/plugins/L1EmulBias.h
@@ -18,7 +18,6 @@
 #include <algorithm>
 
 // common includes
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -30,8 +29,7 @@
 #include "L1Trigger/HardwareValidation/interface/DEtrait.h"
 
 // random generation
-#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
-#include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Random/RandomEngine.h"
 #include "CLHEP/Random/RandGaussQ.h"
 
 
@@ -48,18 +46,15 @@ class L1EmulBias : public edm::EDProducer {
   virtual void endJob(void) {};
 
  public:
-  template <class T> 
-    void ModifyCollection ( std::auto_ptr<T>& data, const edm::Handle<T> emul); 
-  
+  template <class T>
+  void ModifyCollection (std::auto_ptr<T>& data, const edm::Handle<T> emul, CLHEP::HepRandomEngine*);
+
  private:
   int verbose_;
   int verbose() {return verbose_;}
   edm::InputTag m_DEsource[dedefs::DEnsys][2];
   bool m_doSys[dedefs::DEnsys];
   std::string instName[dedefs::DEnsys][5];
-  CLHEP::RandFlat   *rndFlat_;
-  CLHEP::RandGaussQ *rndGaus_;
-  
 };
 
 /* Notes:
@@ -70,13 +65,14 @@ class L1EmulBias : public edm::EDProducer {
 */
 
 template <class T> 
-void L1EmulBias::ModifyCollection(std::auto_ptr<T>& data, const edm::Handle<T> emul) {
+void L1EmulBias::ModifyCollection(std::auto_ptr<T>& data, const edm::Handle<T> emul, CLHEP::HepRandomEngine*) {
   data = (std::auto_ptr<T>)(const_cast<T*>(emul.product()));
 } 
 
 template <> inline void 
 L1EmulBias::ModifyCollection(std::auto_ptr<EcalTrigPrimDigiCollection>& data, 
-			   const edm::Handle<EcalTrigPrimDigiCollection> emul) {
+                             const edm::Handle<EcalTrigPrimDigiCollection> emul,
+                             CLHEP::HepRandomEngine*) {
   typedef EcalTrigPrimDigiCollection::const_iterator col_cit;
   for(col_cit it = emul->begin(); it!=emul->end(); it++) {
     EcalTriggerPrimitiveDigi col(*it);    
@@ -100,7 +96,8 @@ L1EmulBias::ModifyCollection(std::auto_ptr<EcalTrigPrimDigiCollection>& data,
 
 template <> inline void 
 L1EmulBias::ModifyCollection(std::auto_ptr<HcalTrigPrimDigiCollection>& data, 
-			   const edm::Handle<HcalTrigPrimDigiCollection> emul) {
+                             const edm::Handle<HcalTrigPrimDigiCollection> emul,
+                             CLHEP::HepRandomEngine*) {
   typedef HcalTrigPrimDigiCollection::const_iterator col_cit;
   for(col_cit it = emul->begin(); it!=emul->end(); it++) {
     HcalTriggerPrimitiveDigi col(*it);    
@@ -120,14 +117,15 @@ L1EmulBias::ModifyCollection(std::auto_ptr<HcalTrigPrimDigiCollection>& data,
 
 template <> inline void 
 L1EmulBias::ModifyCollection(std::auto_ptr<L1CaloEmCollection>& data, 
-			   const edm::Handle<L1CaloEmCollection> emul) {
+                             const edm::Handle<L1CaloEmCollection> emul,
+                             CLHEP::HepRandomEngine* engine) {
   typedef L1CaloEmCollection::const_iterator col_cit;
   for(col_cit it = emul->begin(); it!=emul->end(); it++) {
     unsigned crate = it->rctCrate();
     unsigned raw   = it->raw();
     bool     iso   = it->isolated();  
     unsigned rdata = raw;
-    if(crate<4*rndFlat_->fire())
+    if(crate<4*engine->flat())
       rdata = raw>>1;
     L1CaloEmCand cand(rdata,crate,iso,it->index(),it->bx(),false);    
     data->push_back(cand);
@@ -139,13 +137,14 @@ L1EmulBias::ModifyCollection(std::auto_ptr<L1CaloEmCollection>& data,
 
 template <> inline void 
 L1EmulBias::ModifyCollection(std::auto_ptr<L1CaloRegionCollection>& data, 
-			   const edm::Handle<L1CaloRegionCollection> emul) {
+                             const edm::Handle<L1CaloRegionCollection> emul,
+                             CLHEP::HepRandomEngine* engine) {
   typedef L1CaloRegionCollection::const_iterator col_cit;
   for(col_cit it = emul->begin(); it!=emul->end(); it++) {
     unsigned crate = it->rctCrate();
     unsigned raw = it->et();
     uint16_t rdata = raw;
-    if(crate<4*rndFlat_->fire())
+    if(crate<4*engine->flat())
       rdata = raw>>1;
     L1CaloRegion cand(rdata,it->gctEta(),it->gctPhi(),it->bx());    
     data->push_back(cand);
@@ -156,12 +155,13 @@ L1EmulBias::ModifyCollection(std::auto_ptr<L1CaloRegionCollection>& data,
 
 template <> inline void 
 L1EmulBias::ModifyCollection(std::auto_ptr<L1GctEmCandCollection>& data, 
-			   const edm::Handle<L1GctEmCandCollection>emul) {
+                             const edm::Handle<L1GctEmCandCollection>emul,
+                             CLHEP::HepRandomEngine* engine) {
   typedef L1GctEmCandCollection::const_iterator col_cit;
   for(col_cit it = emul->begin(); it!=emul->end(); it++) {
     unsigned raw = it->raw();
     uint16_t rdata = raw;
-    if(it->phiIndex()<4*rndFlat_->fire()) //0-17
+    if(it->phiIndex()<4*engine->flat()) //0-17
       rdata = raw>>1;
     L1GctEmCand cand(rdata,it->isolated());
     data->push_back(cand);
@@ -172,12 +172,13 @@ L1EmulBias::ModifyCollection(std::auto_ptr<L1GctEmCandCollection>& data,
 
 template <> inline void 
 L1EmulBias::ModifyCollection(std::auto_ptr<L1GctJetCandCollection>& data, 
-			   const edm::Handle<L1GctJetCandCollection> emul) {
+			     const edm::Handle<L1GctJetCandCollection> emul,
+                             CLHEP::HepRandomEngine* engine) {
   typedef L1GctJetCandCollection::const_iterator col_cit;
   for(col_cit it = emul->begin(); it!=emul->end(); it++) {
     unsigned raw = it->raw();
     uint16_t rdata = raw;
-    if(it->phiIndex()<4*rndFlat_->fire()) //0-17
+    if(it->phiIndex()<4*engine->flat()) //0-17
       rdata = raw>>1;
     L1GctJetCand cand(rdata,it->isTau(),it->isForward());
     data->push_back(cand);
@@ -187,7 +188,8 @@ L1EmulBias::ModifyCollection(std::auto_ptr<L1GctJetCandCollection>& data,
 
 template <> inline void 
 L1EmulBias::ModifyCollection ( std::auto_ptr<L1MuRegionalCandCollection>& data, 
-			     const edm::Handle<L1MuRegionalCandCollection> emul) {
+                               const edm::Handle<L1MuRegionalCandCollection> emul,
+                               CLHEP::HepRandomEngine* engine) {
   typedef L1MuRegionalCandCollection::const_iterator col_cit;
   for(col_cit it = emul->begin(); it!=emul->end(); it++) {
     L1MuRegionalCand cand(*it);    
@@ -204,12 +206,12 @@ L1EmulBias::ModifyCollection ( std::auto_ptr<L1MuRegionalCandCollection>& data,
   unsigned pt= it->pt_packed(); //0..31
   unsigned int qua = it->quality(); //0..7
   if(qua<4){cand.setPtPacked((pt>>2)&0x1f);cand.setQualityPacked((qua<<1)&0x07);}
-  double rnd = rndGaus_->fire();
+  double rnd = CLHEP::RandGaussQ::shoot(engine);
   if(rnd>0.7) {
     raw_=(raw>>1);
     cand.setDataWord(raw_);
   } else if (rnd>0.3) {
-    pt_ *= (int)(1+0.3*rndFlat_->fire());
+    pt_ *= (int)(1+0.3*engine->flat());
     cand.setPtPacked(pt_);
   } else 
     cand.reset();
@@ -224,7 +226,8 @@ L1EmulBias::ModifyCollection ( std::auto_ptr<L1MuRegionalCandCollection>& data,
 
 template <> inline void 
 L1EmulBias::ModifyCollection(std::auto_ptr<L1MuDTTrackContainer>& data, 
-			   const edm::Handle<L1MuDTTrackContainer> emul) {
+                             const edm::Handle<L1MuDTTrackContainer> emul,
+                             CLHEP::HepRandomEngine* engine) {
   typedef std::vector<L1MuDTTrackCand>  TrackContainer;
   typedef TrackContainer::const_iterator col_cit;
   TrackContainer const* tracks_in = emul->getContainer();
@@ -248,20 +251,21 @@ L1EmulBias::ModifyCollection(std::auto_ptr<L1MuDTTrackContainer>& data,
   if(2.5<fabs(it->phiValue())<3.0)
     rdata = raw>>1;
   L1MuRegionalCand cand(rdata,it->bx());    
-  double rnd    = rndFlat_->fire();
+  double rnd    = engine->flat();
   */
 }
 
 template <> inline void 
 L1EmulBias::ModifyCollection(std::auto_ptr<L1MuDTChambPhContainer>& data, 
-			   const edm::Handle<L1MuDTChambPhContainer> emul) {
+                             const edm::Handle<L1MuDTChambPhContainer> emul,
+                             CLHEP::HepRandomEngine* engine) {
   typedef std::vector<L1MuDTChambPhDigi> Phi_Container;
   typedef Phi_Container::const_iterator  col_it;
   Phi_Container const* tracks_in = emul->getContainer(); 
   Phi_Container tracks(tracks_in->size());
   int uqua;
   for(col_it it=tracks_in->begin(); it!=tracks_in->end(); it++) {
-    uqua = it->code(); // (int)(10*rndFlat_->fire());
+    uqua = it->code(); // (int)(10*engine->flat());
     uqua = (uqua<2?uqua+1:uqua);
     L1MuDTChambPhDigi 
       cand(it->bxNum(),it->whNum(),it->scNum(),it->stNum(),
@@ -273,7 +277,8 @@ L1EmulBias::ModifyCollection(std::auto_ptr<L1MuDTChambPhContainer>& data,
 
 template <> inline void 
 L1EmulBias::ModifyCollection(std::auto_ptr<L1MuDTChambThContainer>& data, 
-			   const edm::Handle<L1MuDTChambThContainer> emul) {
+                             const edm::Handle<L1MuDTChambThContainer> emul,
+                             CLHEP::HepRandomEngine*) {
   typedef std::vector<L1MuDTChambThDigi> Thi_Container;
   typedef Thi_Container::const_iterator  col_cit;
   Thi_Container const* tracks_in = emul->getContainer(); 
@@ -295,7 +300,8 @@ L1EmulBias::ModifyCollection(std::auto_ptr<L1MuDTChambThContainer>& data,
 
 template <> inline void 
 L1EmulBias::ModifyCollection(std::auto_ptr<LTCDigiCollection>& data, 
-			   const edm::Handle<LTCDigiCollection> emul) {
+                             const edm::Handle<LTCDigiCollection> emul,
+                             CLHEP::HepRandomEngine*) {
   typedef std::vector<LTCDigi>::const_iterator col_cit;
   for(col_cit it=emul->begin(); it!=emul->end(); it++) {
     data->push_back(*it);
@@ -306,7 +312,8 @@ L1EmulBias::ModifyCollection(std::auto_ptr<LTCDigiCollection>& data,
 
 template <> inline void 
 L1EmulBias::ModifyCollection(std::auto_ptr<L1MuGMTCandCollection>& data, 
-			   const edm::Handle<L1MuGMTCandCollection> emul) {
+                             const edm::Handle<L1MuGMTCandCollection> emul,
+                             CLHEP::HepRandomEngine*) {
   //typedef std::vector<L1MuGMTCand>          L1MuGMTCandCollection;
   typedef std::vector<L1MuGMTCand>::const_iterator col_cit;
   for(col_cit it=emul->begin(); it!=emul->end(); it++) {
@@ -323,7 +330,8 @@ L1EmulBias::ModifyCollection(std::auto_ptr<L1MuGMTCandCollection>& data,
 
 template <> inline void 
 L1EmulBias::ModifyCollection(std::auto_ptr<L1MuGMTReadoutCollection>& data, 
-			   const edm::Handle<L1MuGMTReadoutCollection> emul) {
+                             const edm::Handle<L1MuGMTReadoutCollection> emul,
+                             CLHEP::HepRandomEngine*) {
   typedef std::vector<L1MuGMTReadoutRecord>::const_iterator col_cit;
   std::vector<L1MuGMTReadoutRecord> col = emul->getRecords();
   for(col_cit it = col.begin(); it!=col.end(); it++) {
@@ -388,7 +396,8 @@ L1EmulBias::ModifyCollection(std::auto_ptr<L1MuGMTReadoutCollection>& data,
 
 template <> inline void 
 L1EmulBias::ModifyCollection(std::auto_ptr<CSCCorrelatedLCTDigiCollection>& data, 
-			   const edm::Handle<CSCCorrelatedLCTDigiCollection> emul) {
+                             const edm::Handle<CSCCorrelatedLCTDigiCollection> emul,
+                             CLHEP::HepRandomEngine*) {
   //typedef MuonDigiCollection<CSCDetId,CSCCorrelatedLCTDigi> CSCCorrelatedLCTDigiCollection;
   typedef CSCCorrelatedLCTDigiCollection::DigiRangeIterator mapIt;//map iterator
   typedef CSCCorrelatedLCTDigiCollection::const_iterator    vecIt;//vec iterator
@@ -418,7 +427,8 @@ L1EmulBias::ModifyCollection(std::auto_ptr<CSCCorrelatedLCTDigiCollection>& data
 }
 
 template <> inline void L1EmulBias::ModifyCollection(std::auto_ptr<L1CSCTrackCollection>& data, 
-						   const edm::Handle<L1CSCTrackCollection> emul) {
+                                                     const edm::Handle<L1CSCTrackCollection> emul,
+                                                     CLHEP::HepRandomEngine*) {
   typedef L1CSCTrackCollection::const_iterator col_cit;
   //typedef std::vector<L1CSCTrack> L1CSCTrackCollection;
   //typedef std::pair<csc::L1Track,CSCCorrelatedLCTDigiCollection> L1CSCTrack;


### PR DESCRIPTION
Migrate L1Trigger code to use the new interface
of the random number generator service designed to work
with the multithreaded Framework. The main interface
change is to require a StreamID or LuminosityBlockIndex
argument to the getEngine function. In most cases,
this required moving code from the constructor to
the event or beginLuminosityBlock method. Then a pointer
to the engine was percolated or passed in some way
to the point where it was used.
