### PR TITLE
Fix crash in HcalDigisClient for SLHC configurations

### DIFF
--- a/Validation/HcalDigis/src/HcalDigisClient.cc
+++ b/Validation/HcalDigis/src/HcalDigisClient.cc
@@ -33,13 +33,13 @@ HcalDigisClient::HcalDigisClient(const edm::ParameterSet& iConfig) {
     //dbe_->setCurrentFolder(dirName_);
     dbe_->setCurrentFolder("HcalDigisV/HcalDigiTask");
 
+    // false for regular relval and true for SLHC relval
+    doSLHC_ = iConfig.getUntrackedParameter<bool>("doSLHC", false);
+
     booking("HB");
     booking("HE");
     booking("HO");
     booking("HF");
-    // false for regular relval and true for SLHC relval
-    doSLHC_ = iConfig.getUntrackedParameter<bool>("doSLHC", false);
-
 }
 
 void HcalDigisClient::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {


### PR DESCRIPTION
Moved the initialisation of doSLHC_ to before the histograms are booked.

An extra set of histograms are booked in the "booking(...)" method if doSLHC_ is true.  If doSLHC_ is not initialised before these calls then the choice whether to book them or not is made on uninitialised memory.
