### PR TITLE
Add default ctors

### DIFF
--- a/CondFormats/HcalObjects/interface/HcalCondObjectContainer.h
+++ b/CondFormats/HcalObjects/interface/HcalCondObjectContainer.h
@@ -14,6 +14,7 @@ class HcalTopology;
 
 class HcalCondObjectContainerBase {
 public:
+  HcalCondObjectContainerBase() : topo_(nullptr) {}
   const HcalTopology* topo() const { return topo_; }
   int getCreatorPackedIndexVersion() const { return packedIndexVersion_; }
   void setTopo(const HcalTopology* topo) const;
@@ -33,6 +34,7 @@ template<class Item>
 class HcalCondObjectContainer : public HcalCondObjectContainerBase {
 public:
   // default constructor
+  HcalCondObjectContainer() : HcalCondObjectContainerBase() {}
   HcalCondObjectContainer(const HcalTopology* topo) : HcalCondObjectContainerBase(topo) { }
 
   // destructor:


### PR DESCRIPTION
Work around a ROOT limitation that is causing fatal errors in relvals in the ROOT6 branch.
A JIRA ticket has been opened against ROOT for the problem, but in the meantime we can avoid the errors by simply adding otherwise unnecessary public default constructors to two classes that do not have them.
