### PR TITLE
Add missing include of iostream

### DIFF
--- a/Mixing/Base/interface/BMixingModule.h
+++ b/Mixing/Base/interface/BMixingModule.h
@@ -59,14 +59,14 @@ namespace edm {
       // Should 'poisson' return 0 or 1 if there is no mixing? See also averageNumber above.
       bool poisson() const {return inputSources_[0] ? inputSources_[0]->poisson() : 0.0 ;}
 
-      virtual void createnewEDProduct() {std::cout << "BMixingModule::createnewEDProduct must be overwritten!" << std::endl;}
-      virtual void checkSignal(const edm::Event &e) {std::cout << "BMixingModule::checkSignal must be overwritten!" << std::endl;}
+      virtual void createnewEDProduct();
+      virtual void checkSignal(const edm::Event &e);
       virtual void addSignals(const edm::Event &e,const edm::EventSetup& c) {;}
       virtual void addPileups(const int bcr, EventPrincipal *ep, unsigned int eventId,unsigned int worker, const edm::EventSetup& c) {;}
-      virtual void setBcrOffset () {std::cout << "BMixingModule::setBcrOffset must be overwritten!" << std::endl;} //FIXME: LogWarning
-      virtual void setSourceOffset (const unsigned int s) {std::cout << "BMixingModule::setSourceOffset must be overwritten!" << std::endl;}
+      virtual void setBcrOffset ();
+      virtual void setSourceOffset (const unsigned int s);
       virtual void put(edm::Event &e,const edm::EventSetup& c) {;}
-      virtual void doPileUp(edm::Event &e, const edm::EventSetup& c) {std::cout << "BMixingModule::doPileUp must be overwritten!" << std::endl;}
+      virtual void doPileUp(edm::Event &e, const edm::EventSetup& c);
       virtual void setEventStartInfo(const unsigned int s) {;} //to be set in CF
       virtual void getEventStartInfo(edm::Event & e,const unsigned int source) {;} //to be set locally
 

--- a/Mixing/Base/src/BMixingModule.cc
+++ b/Mixing/Base/src/BMixingModule.cc
@@ -16,7 +16,7 @@
 
 #include "TFile.h"
 #include "TH1F.h"
-
+#include <iostream>
 const unsigned int edm::BMixingModule::maxNbSources_ =4;
 
 namespace
@@ -282,5 +282,15 @@ namespace edm {
       if(inputSources_[endIdx]) inputSources_[endIdx]->endJob();
     }
   }
+
+  void BMixingModule::createnewEDProduct() {std::cout << "BMixingModule::createnewEDProduct must be overwritten!" << std::endl;}
+
+  void BMixingModule::checkSignal(const edm::Event &e) {std::cout << "BMixingModule::checkSignal must be overwritten!" << std::endl;}
+
+  void BMixingModule::setBcrOffset () {std::cout << "BMixingModule::setBcrOffset must be overwritten!" << std::endl;} //FIXME: LogWarning
+
+  void BMixingModule::setSourceOffset (const unsigned int s) {std::cout << "BMixingModule::setSourceOffset must be overwritten!" << std::endl;}
+
+  void BMixingModule::doPileUp(edm::Event &e, const edm::EventSetup& c) {std::cout << "BMixingModule::doPileUp must be overwritten!" << std::endl;}
 
 } //edm


### PR DESCRIPTION
Fix compilation errors in ROOT6 IB by adding missing include of iostream. To avoid adding an include of iostream in a header, the functions using std::cout were moved into the .cc file. Since these are called in error cases only, there is no performance impact.
