### PR TITLE
Protection to stabilize the behavior of PFClusterAlgo

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterPS_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterPS_cfi.py
@@ -35,7 +35,7 @@ particleFlowClusterPS = cms.EDProducer("PFClusterProducer",
     # n neighbours in PS 
     nNeighbours = cms.int32(8),                                       
     # sigma of the shower in preshower     
-    showerSigma = cms.double(0.2),
+    showerSigma = cms.double(0.3),
     # n crystals for position calculation in PS
     posCalcNCrystal = cms.int32(-1),
     # use cells with common corner to build topo-clusters

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterAlgo.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterAlgo.cc
@@ -1228,7 +1228,7 @@ PFClusterAlgo::buildPFClusters( const std::vector< unsigned >& topocluster,
 	  cout<<" frac["<<ic<<"] "<<frac[ic]<<" "<<fractot<<" "<<rh<<endl;
 #endif
 
-	if( fractot ) 
+	if( fractot > 1e-20 || ( rh.detId() == curpfclusters[ic].seed() && fractot > 0.0 ) ) 
 	  frac[ic] /= fractot;
 	else { 
 #ifdef PFLOW_DEBUG

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterAlgo.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterAlgo.cc
@@ -1125,8 +1125,9 @@ PFClusterAlgo::buildPFClusters( const std::vector< unsigned >& topocluster,
       const PFLayer::Layer layer = rh.layer();
       int iring = 0;
       if (layer==PFLayer::HCAL_BARREL2 && abs(rh.positionREP().Eta())>0.34) iring= 1;
-      
-      const double rh_thresh = parameter( THRESH, layer, 0, iring );
+
+      double rh_thresh = parameter( THRESH, layer, 0, iring );
+      if( rh_thresh <= 0.0 ) rh_thresh = 1.0; // in case of zero threshold do NOT normalize rechit energies
 
       // int layer = rh.layer();
              

--- a/RecoParticleFlow/PFClusterProducer/test/BuildFile.xml
+++ b/RecoParticleFlow/PFClusterProducer/test/BuildFile.xml
@@ -6,3 +6,11 @@
   <use   name="FWCore/Utilities"/>
   <flags   EDM_PLUGIN="1"/>
 </library>
+<library   name="PFClusterAnalyzer" file="PFClusterComparator.cc">
+  <use   name="DataFormats/ParticleFlowReco"/>
+  <use   name="FWCore/Framework"/>
+  <use   name="FWCore/MessageLogger"/>
+  <use   name="FWCore/ParameterSet"/>
+  <use   name="FWCore/Utilities"/>
+  <flags   EDM_PLUGIN="1"/>
+</library>

--- a/RecoParticleFlow/PFClusterProducer/test/PFClusterComparator.cc
+++ b/RecoParticleFlow/PFClusterProducer/test/PFClusterComparator.cc
@@ -1,0 +1,184 @@
+#include "RecoParticleFlow/PFClusterProducer/test/PFClusterComparator.h"
+#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include <iomanip>
+
+using namespace std;
+using namespace edm;
+using namespace reco;
+
+PFClusterComparator::PFClusterComparator(const edm::ParameterSet& iConfig) {
+  
+
+
+  inputTagPFClusters_ 
+    = iConfig.getParameter<InputTag>("PFClusters");
+
+  inputTagPFClustersCompare_ 
+    = iConfig.getParameter<InputTag>("PFClustersCompare");
+
+  verbose_ = 
+    iConfig.getUntrackedParameter<bool>("verbose",false);
+
+  printBlocks_ = 
+    iConfig.getUntrackedParameter<bool>("printBlocks",false);
+
+
+
+  LogDebug("PFClusterComparator")
+    <<" input collection : "<<inputTagPFClusters_ ;
+   
+}
+
+
+
+PFClusterComparator::~PFClusterComparator() { }
+
+
+
+void 
+PFClusterComparator::beginRun(const edm::Run& run,
+			    const edm::EventSetup & es) { }
+
+
+void PFClusterComparator::analyze(const Event& iEvent, 
+				  const EventSetup& iSetup) {
+    
+  // get PFClusters
+
+  Handle<PFClusterCollection> pfClusters;
+  fetchCandidateCollection(pfClusters, 
+			   inputTagPFClusters_, 
+			   iEvent );
+
+  Handle<PFClusterCollection> pfClustersCompare;
+  fetchCandidateCollection(pfClustersCompare, 
+			   inputTagPFClustersCompare_, 
+			   iEvent );
+
+  // get PFClusters for isolation
+  
+  std::cout << "There are " << pfClusters->size() << " PFClusters in the original cluster collection." << std::endl;
+  std::cout << "There are " << pfClustersCompare->size() << " PFClusters in the new cluster collection." << std::endl;
+  
+  std::cout << std::flush << "---- COMPARING OLD TO NEW ----"
+	    << std::endl  << std::flush;
+
+  for( unsigned i=0; i<pfClusters->size(); i++ ) {    
+    const reco::PFCluster& cluster = pfClusters->at(i);   
+    bool foundmatch = false;
+    for( unsigned k=0; k<pfClustersCompare->size(); ++k ) {
+      const reco::PFCluster& clustercomp = pfClustersCompare->at(k);      
+      if( cluster.seed() == clustercomp.seed() ) {
+	foundmatch = true;
+	const double denergy = std::abs(cluster.energy() - 
+					clustercomp.energy());
+	const double dcenergy = std::abs(cluster.correctedEnergy() - 
+					clustercomp.correctedEnergy());
+	const double dx = std::abs(cluster.position().x() - 
+				     clustercomp.position().x());
+	const double dy = std::abs(cluster.position().y() - 
+				     clustercomp.position().y());
+	const double dz = std::abs(cluster.position().z() - 
+				     clustercomp.position().z());
+	if( denergy/std::abs(cluster.energy()) >  1e-5 ) {
+	  std::cout << "   " << cluster.seed() 
+		    << " Energies different by larger than tolerance! "
+		    << "( "<< denergy << " )"
+		    << " Old: " << std::setprecision(7) 
+		    << cluster.energy() << " GeV , New: "
+		    << clustercomp.energy() << " GeV" << std::endl;	  
+	}
+	if( dcenergy/std::abs(cluster.correctedEnergy()) >  1e-5 ) {
+	  std::cout << "   " << cluster.seed() 
+		    << " Corrected energies different by larger than tolerance! "
+		    << "( "<< denergy << " )"
+		    << " Old: " << std::setprecision(7) 
+		    << cluster.correctedEnergy() << " GeV , New: "
+		    << clustercomp.correctedEnergy() << " GeV" << std::endl;	  
+	}
+	std::cout << std::flush;
+	if( dx/std::abs(cluster.position().x()) > 1e-5 ) {
+	  std::cout << "***" << cluster.seed() 
+		    << " X's different by larger than tolerance! "
+		    << "( "<< dx << " )"
+		    << " Old: " << std::setprecision(7) 
+		    << cluster.position().x() << " , New: "
+		    << clustercomp.position().x() << std::endl;
+	}
+	std::cout << std::flush;
+	if( dy/std::abs(cluster.position().y()) > 1e-5 ) {
+	  std::cout << "---" << cluster.seed() 
+		    << " Y's different by larger than tolerance! "
+		    << "( "<< dy << " )"
+		    << " Old: " << std::setprecision(7) 
+		    << cluster.position().y() << " , New: "
+		    << clustercomp.position().y() << std::endl;
+	}
+	std::cout << std::flush;
+	if( dz/std::abs(cluster.position().z()) > 1e-5 ) {
+	  std::cout << "+++" << cluster.seed() 
+		    << " Z's different by larger than tolerance! "
+		    << "( "<< dz << " )"
+		    << " Old: " << std::setprecision(7) 
+		    << cluster.position().z() << " , New: "
+		    << clustercomp.position().z() << std::endl;
+	}
+	std::cout << std::flush;
+      }      
+    }
+    if( !foundmatch ) {      
+      std::cout << "Seed in old clusters and not new: " 
+		<< cluster << std::endl;
+    }
+  }
+   
+  std::cout << std::flush << "---- COMPARING NEW TO OLD ----"
+	    << std::endl  << std::flush;
+
+  for( unsigned i=0; i<pfClustersCompare->size(); i++ ) {    
+    const reco::PFCluster& cluster = pfClustersCompare->at(i);   
+    bool foundmatch = false;
+    for( unsigned k=0; k<pfClusters->size(); ++k ) {
+      const reco::PFCluster& clustercomp = pfClusters->at(k);      
+      if( cluster.seed() == clustercomp.seed() ) {
+	foundmatch = true;
+
+      }      
+    }
+    if( !foundmatch ) {      
+      std::cout << "Seed in new clusters and not old: " 
+		<< cluster << std::endl;
+    }
+  }
+  std::cout << std::flush;
+}
+
+
+  
+void 
+PFClusterComparator::fetchCandidateCollection(Handle<reco::PFClusterCollection>& c, 
+					    const InputTag& tag, 
+					    const Event& iEvent) const {
+  
+  bool found = iEvent.getByLabel(tag, c);
+  
+  if(!found ) {
+    ostringstream  err;
+    err<<" cannot get PFClusters: "
+       <<tag<<endl;
+    LogError("PFClusters")<<err.str();
+    throw cms::Exception( "MissingProduct", err.str());
+  }
+  
+}
+
+
+
+DEFINE_FWK_MODULE(PFClusterComparator);

--- a/RecoParticleFlow/PFClusterProducer/test/PFClusterComparator.h
+++ b/RecoParticleFlow/PFClusterProducer/test/PFClusterComparator.h
@@ -1,0 +1,61 @@
+#ifndef RecoParticleFlow_PFClusterProducer_PFClusterComparator_
+#define RecoParticleFlow_PFClusterProducer_PFClusterComparator_
+
+// system include files
+#include <memory>
+#include <string>
+#include <iostream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
+
+/**\class PFClusterAnalyzer 
+\brief test analyzer for PFClusters
+*/
+
+
+
+
+class PFClusterComparator : public edm::EDAnalyzer {
+ public:
+
+  explicit PFClusterComparator(const edm::ParameterSet&);
+
+  ~PFClusterComparator();
+  
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+
+  virtual void beginRun(const edm::Run & r, const edm::EventSetup & c);
+
+ private:
+  
+  void 
+    fetchCandidateCollection(edm::Handle<reco::PFClusterCollection>& c, 
+			     const edm::InputTag& tag, 
+			     const edm::Event& iSetup) const;
+
+/*   void printElementsInBlocks(const reco::PFCluster& cluster, */
+/* 			     std::ostream& out=std::cout) const; */
+
+
+  
+  /// PFClusters in which we'll look for pile up particles 
+  edm::InputTag   inputTagPFClusters_;
+  edm::InputTag   inputTagPFClustersCompare_;
+  
+  /// verbose ?
+  bool   verbose_;
+
+  /// print the blocks associated to a given candidate ?
+  bool   printBlocks_;
+
+};
+
+#endif


### PR DESCRIPTION
Require that the sum of rechit fractions be of reasonable size to be sure you're not adding some rechit that is far away any cluster position.

An example case of the instability is as follows:
some rechit is, at closest, ~7-8 crystals away from any cluster position. This means that the largest rechit fraction is going to be ~1e-23. The smaller fractions from clusters even farther away can be ~1e-50, which is outside of double precision when you add them together. The resulting fraction can then randomly be one or very very slightly less than one.

The means that when the fractions are normalized a rechit that is very far away from any cluster can be randomly added _in its entirety_ to a cluster it simply doesn't belong to, and it can vanish for no reason when doing the position fit in PFClusterAlgo. This makes the algorithm convergence unstable.

Requiring the rechit fraction sum to be larger than 1e-20 fixes this issue, since it ensures that at least one cluster is within about 10 shower-sigmas of the rechit. The only exception to this case are the rechit seeds, which shouldn't move very from from the cluster position on average.

Note: this can change the final positions and energies of PFClusters (especially low-energy clusters) in all sub-detectors, but should not affect higher-level physics objects.
