### PR TITLE
move the default HLT menu for relvals to the development one

### DIFF
--- a/Configuration/HLT/python/autoHLT.py
+++ b/Configuration/HLT/python/autoHLT.py
@@ -2,6 +2,7 @@
 #   cmsDiver.py hlt -s HLT:@relval
 
 autoHLT = {
-  'relval'     : '2013',
+  'relval'     : 'GRun',
   'test'       : 'GRun',
+  'frozen'     : '2013',
 }


### PR DESCRIPTION
Move the default HLT menu for relvals to the development one (GRun) in 71X, so that the release validations can be based on it and check changes to the development menu
