### PR TITLE
Don't try to update empty process history ID

### DIFF
--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -1234,11 +1234,13 @@ namespace edm {
       lumiTree_.fillAux<LuminosityBlockAux>(pLumiAux);
       conversion(lumiAux, *lumiAuxiliary);
     }
-    if(provenanceAdaptor_) {
-      lumiAuxiliary->setProcessHistoryID(provenanceAdaptor_->convertID(lumiAuxiliary->processHistoryID()));
-    }
-    if(daqProvenanceHelper_) {
-      lumiAuxiliary->setProcessHistoryID(daqProvenanceHelper_->mapProcessHistoryID(lumiAuxiliary->processHistoryID()));
+    if(fileFormatVersion().processHistorySameWithinRun()) {
+      if(provenanceAdaptor_) {
+        lumiAuxiliary->setProcessHistoryID(provenanceAdaptor_->convertID(lumiAuxiliary->processHistoryID()));
+      }
+      if(daqProvenanceHelper_) {
+        lumiAuxiliary->setProcessHistoryID(daqProvenanceHelper_->mapProcessHistoryID(lumiAuxiliary->processHistoryID()));
+      }
     }
     if(lumiAuxiliary->luminosityBlock() == 0 && !fileFormatVersion().runsAndLumis()) {
       lumiAuxiliary->id() = LuminosityBlockID(RunNumber_t(1), LuminosityBlockNumber_t(1));
@@ -1258,11 +1260,13 @@ namespace edm {
       runTree_.fillAux<RunAux>(pRunAux);
       conversion(runAux, *runAuxiliary);
     }
-    if(provenanceAdaptor_) {
-      runAuxiliary->setProcessHistoryID(provenanceAdaptor_->convertID(runAuxiliary->processHistoryID()));
-    }
-    if(daqProvenanceHelper_) {
-      runAuxiliary->setProcessHistoryID(daqProvenanceHelper_->mapProcessHistoryID(runAuxiliary->processHistoryID()));
+    if(fileFormatVersion().processHistorySameWithinRun()) {
+      if(provenanceAdaptor_) {
+        runAuxiliary->setProcessHistoryID(provenanceAdaptor_->convertID(runAuxiliary->processHistoryID()));
+      }
+      if(daqProvenanceHelper_) {
+        runAuxiliary->setProcessHistoryID(daqProvenanceHelper_->mapProcessHistoryID(runAuxiliary->processHistoryID()));
+      }
     }
     return runAuxiliary;
   }


### PR DESCRIPTION
This is a fix for a bug that has actually been in place since CMSSW_3_0_0, but did not show any symptoms until CMSSW_6_2_0.
The problem was hit by Erik Butz when he tried to read a file written with CMSSW_3_2_5.
When an old format file is read, the process history ID's may change, and must then be converted to new values. However, prior to release 3_8_0, process history ID's existed only for events, and not for runs and lumis. The bug is that, when a file written before release 3_8_0 is read, the code attempts to convert the non-existent (default constructed) process history ID's of runs and lumis to the new values.  These values are never used, so this is almost harmless, except for some unnecessary code running.
However, to do the conversion, the process history ID must be looked up in a map.  An assert occurs if the ID is not found.  Apparently, prior to 6_2_0, the default ID was found in the map.  Beginning in 6_2_X , it is not.
The fix is simply that if a file is read that predates the presence of process history ID's in runs and lumis,
don't try to convert the non-existent ID's, which are not used anyway.
