### PR TITLE
Updated GTs for 710_pre3

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -1,20 +1,20 @@
 autoCond = { 
     # GlobalTag for MC production with perfectly aligned and calibrated detector
-    'mc'                :   'MC_70_V4::All',
+    'mc'                :   'MC_71_V1::All',
     # GlobalTag for MC production with realistic alignment and calibrations
-    'startup'           :   'START70_V6::All',
+    'startup'           :   'START71_V1::All',
     # GlobalTag for MC production of Heavy Ions events with realistic alignment and calibrations
-    'starthi'           :   'STARTHI70_V7::All',
+    'starthi'           :   'STARTHI71_V1::All',
     # GlobalTag for MC production of p-Pb events with realistic alignment and calibrations
-    'startpa'           :   'STARTHI70_V8::All',
+    'startpa'           :   'STARTHI71_V2::All',
     # GlobalTag for data reprocessing: this should always be the GR_R tag
-    'com10'             :   'GR_R_70_V1::All',
+    'com10'             :   'GR_R_71_V1::All',
     # GlobalTag for running HLT on recent data: this should be the GR_P (prompt reco) global tag until a compatible GR_H tag is available, 
     # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
-    'hltonline'         :   'GR_H_V33::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
+    'hltonline'         :   'GR_H_V34::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for POSTLS1 upgrade studies:
-    'upgradePLS1'       :   'POSTLS170_V3::All',
-    'upgradePLS150ns'   :   'POSTLS170_V4::All',
+    'upgradePLS1'       :   'POSTLS171_V1::All',
+    'upgradePLS150ns'   :   'POSTLS171_V2::All',
     'upgrade2017'       :   'DES17_70_V2::All', # placeholder (GT not meant for standard RelVal)
     'upgrade2019'       :   'DES19_70_V2::All', # placeholder (GT not meant for standard RelVal)
     'upgradePLS3'       :   'POSTLS262_V1::All' # placeholder (GT not meant for standard RelVal)


### PR DESCRIPTION
This updates the release GT in autocond.py:
- keeping into account the ECAL pull request https://github.com/cms-sw/cmssw/pull/2397 , updating MC and data GT with the new TimeBias corrections
- updating SiPixelQuality (new list of bad modules) and Templates tags for MC (postLs1) and DATA GT for run2
