### PR TITLE
New PostLS3 GT containing RPC conditions for digitization.

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -1,7 +1,7 @@
 autoCond = { 
     'upgrade2017'       :   'DES17_62_V8::All', # 
     'upgrade2019'       :   'DES19_62_V8::All', # 
-    'upgradePLS3'       :   'DES19_62_V8::All' # 
+    'upgradePLS3'       :   'DES23_62_V1::All' # 
 }
 
 aliases = {


### PR DESCRIPTION
Update of the GT in autoCond.py:
- New RPC conditions for digitization in the PhaseII upgrade, to be used for all simulations with cmsExtended2023 geometries. They have been included in the new PostLS3 GT.
