### PR TITLE
Don't try to update empty process history ID

### DIFF
--- a/FWCore/Sources/src/DaqProvenanceHelper.cc
+++ b/FWCore/Sources/src/DaqProvenanceHelper.cc
@@ -104,6 +104,7 @@ namespace edm {
 
   void
   DaqProvenanceHelper::fixMetaData(std::vector<ProcessConfiguration>& pcv, std::vector<ProcessHistory>& phv) {
+    phv.push_back(ProcessHistory()); // For new processHistory, containing only processConfiguration_
     std::vector<ProcessConfiguration> newPCs;
     for(auto const& pc : pcv) {
        if(pc.processName() == oldProcessName_) {
@@ -118,7 +119,7 @@ namespace edm {
     // update existing process histories
     for(auto& ph : phv) {
       for(auto const& newPC : newPCs) {
-        if(matchProcesses(newPC, ph)) {
+        if(ph.empty() || matchProcesses(newPC, ph)) {
           ProcessHistoryID oldPHID = ph.id();
           ph.push_front(newPC);
           ProcessHistoryID newPHID = ph.id();


### PR DESCRIPTION
This is a fix for a bug that has  been in place since CMSSW_6_2_0.
The problem was hit by Erik Butz when he tried to read a file written with CMSSW_3_2_5.
For files written in CMSSW_5_0_0 and later, actual FED raw data is recorded as having been created in a process called "LHC" with a module label of "rawDataCollector".  If a file written prior to CMSSW_5_0_0 is read in CMSSW_5_0_0 or later, this "LHC" process is added retroactively, which affects the process history.  The process history must then be retroactively modified.
This worked fine until CMSSW_6_2_0, when a bug was introduced.  There is a map used to map the old process history to the new.  In 6_2_0, the entry for an empty old process history was incorrectly omitted from the map.  Real raw data prior to CMSSW_5_0_0 had an empty process history.  So, the process history ID for real raw data was not found in the map. and a fatal assert fired.
The fix is to simply add the missing entry to the map.
