### PR TITLE
Migrate Calibration Code to New Random Service Interface

### DIFF
--- a/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.h
+++ b/CalibMuon/DTCalibration/test/DBTools/FakeTTrig.h
@@ -16,10 +16,6 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-namespace CLHEP {
-  class RandGaussQ;
-}
-
 #include <string>
 class DTGeometry;
 class DTSuperLayer;
@@ -35,6 +31,7 @@ public:
 
   // Operations
   virtual void beginRun(const edm::Run& run, const edm::EventSetup& setup );
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   virtual void analyze(const edm::Event& event, const edm::EventSetup& setup){}
   virtual void endJob();
 
@@ -61,8 +58,6 @@ private:
   // Get the tTrigMap
   edm::ESHandle<DTTtrig> tTrigMapRef;
 
-  // the random generator
-  CLHEP::RandGaussQ* theGaussianDistribution;
-
+  bool dataBaseWriteWasDone;
 };
 #endif

--- a/CalibMuon/DTCalibration/test/FakeTTrig_cfg.py
+++ b/CalibMuon/DTCalibration/test/FakeTTrig_cfg.py
@@ -36,10 +36,9 @@ process.calibDB = cms.ESSource("PoolDBESSource",
 #)
 
 process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
-    moduleSeeds = cms.PSet(
-        FaketTrig = cms.untracked.uint32(563)
-    ),
-    sourceSeed = cms.untracked.uint32(98765)
+    FaketTrig = cms.PSet(
+        initialSeed = cms.untracked.uint32(563)
+    )
 )
  
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",


### PR DESCRIPTION
Migrate Calibration code to use the new interface
of the random number generator service designed to work
with the multithreaded Framework. The main interface
change is to require a StreamID or LuminosityBlockIndex
argument to the getEngine function. These objects are only
available during the event or beginLuminosityBlock method.

There is only one calibration module using the random
number interface. I do not know how to test this module
as nothing else in CMSSW references it.
