### PR TITLE
Reduced the number of threads used for testing from 8 to 4

### DIFF
--- a/FWCore/Concurrency/python/dropNonMTSafe.py
+++ b/FWCore/Concurrency/python/dropNonMTSafe.py
@@ -24,7 +24,7 @@ def dropNonMTSafe(process):
   _dropFromPaths(process,"SiStripMonitorTrackCommon")
   _dropFromPaths(process,"SiStripMonitorTrack_hi")
 
-  process.options = cms.untracked.PSet(numberOfThreads = cms.untracked.uint32(8),
+  process.options = cms.untracked.PSet(numberOfThreads = cms.untracked.uint32(4),
                                        sizeOfStackForThreadsInKB = cms.untracked.uint32(10*1024),
                                        numberOfStreams = cms.untracked.uint32(0))
                                        


### PR DESCRIPTION
Given the present highly serialized nature of the available modules, running 8 threads is a complete waste of resource. Dropping to 4 should still give us more than we need but hopefully free more resources for the IB RelVal tests.
