### PR TITLE
Fix exception to action table lifetime

### DIFF
--- a/Mixing/Base/src/PileUp.cc
+++ b/Mixing/Base/src/PileUp.cc
@@ -62,7 +62,7 @@ namespace edm {
 
     if(pset.existsAs<std::vector<ParameterSet> >("producers", true)) {
       std::vector<ParameterSet> producers = pset.getParameter<std::vector<ParameterSet> >("producers");
-      provider_.reset(new SecondaryEventProvider(producers, *productRegistry_, ExceptionToActionTable(), processConfiguration_));
+      provider_.reset(new SecondaryEventProvider(producers, *productRegistry_, processConfiguration_));
     }
 
     productRegistry_->setFrozen();

--- a/Mixing/Base/src/SecondaryEventProvider.cc
+++ b/Mixing/Base/src/SecondaryEventProvider.cc
@@ -1,4 +1,5 @@
 #include "Mixing/Base/src/SecondaryEventProvider.h"
+#include "FWCore/Framework/interface/ExceptionActions.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/StreamID.h"
@@ -6,9 +7,9 @@
 namespace edm {
   SecondaryEventProvider::SecondaryEventProvider(std::vector<ParameterSet>& psets,
                      ProductRegistry& preg,
-                     ExceptionToActionTable const& actions,
                      boost::shared_ptr<ProcessConfiguration> processConfiguration) :
-    workerManager_(boost::shared_ptr<ActivityRegistry>(new ActivityRegistry), actions) {
+    exceptionToActionTable_(new ExceptionToActionTable),
+    workerManager_(boost::shared_ptr<ActivityRegistry>(new ActivityRegistry), *exceptionToActionTable_) {
     std::vector<std::string> shouldBeUsedLabels;
     std::set<std::string> unscheduledLabels;
     const PreallocationConfiguration preallocConfig;

--- a/Mixing/Base/src/SecondaryEventProvider.h
+++ b/Mixing/Base/src/SecondaryEventProvider.h
@@ -2,11 +2,11 @@
 #define Mixing_Base_SecondaryEventProvider_h
 
 #include "FWCore/Framework/interface/WorkerManager.h"
-
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
 #include "boost/shared_ptr.hpp"
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -17,7 +17,6 @@ namespace edm {
   public:
     SecondaryEventProvider(std::vector<ParameterSet>& psets,
              ProductRegistry& pregistry,
-             ExceptionToActionTable const& actions,
              boost::shared_ptr<ProcessConfiguration> processConfiguration);
 
     void beginRun(RunPrincipal& run, const edm::EventSetup& setup, ModuleCallingContext const*);
@@ -32,6 +31,7 @@ namespace edm {
     void endJob() {workerManager_.endJob();}
 
   private:
+    std::unique_ptr<ExceptionToActionTable> exceptionToActionTable_;
     WorkerManager workerManager_;
   };
 }


### PR DESCRIPTION
This is a purely technical fix for a segmentation fault observed by Mike Hildreth when running workflows using data premixing.
An ExceptionToActionTable object is used to determine the course of action after an exception is caught.
Unfortunately, in the class that handles processing premixed data, an ExceptionToActionTable was constructed as a temporary on the stack whose lifetime was over before it was used.
This fix allocates it on the heap, held by a std::unique_ptr, making it's lifetime the same as the containing class.
This problem does not exist prior to 7_0_X as the affected code was new for 7_0_X.
