### PR TITLE
Increment version number of AssociationVector template

### DIFF
--- a/DataFormats/Common/interface/AssociationVector.h
+++ b/DataFormats/Common/interface/AssociationVector.h
@@ -100,7 +100,7 @@ namespace edm {
     const_iterator end() const { return transientVector().end(); }
 
     //Used by ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(11)
 
   private:
     enum CacheState { kUnset, kFilling, kSet };


### PR DESCRIPTION
In pull request #2434, already merged, a bug was fixed where the transientVector_ data member of the AssociationVector template was not declared transient in the dictionary specification of one instance of this template, although it should have been.  That pull request fixed a ROOT6 error.
Since this was just one instance of a template, there is no declared ROOT version number associated with the instance.  Rather, there is a version number for the entire template.  That version number should have been incremented in #2434, because making a member transient affects the checksum, but was not.  This pull request increments the ROOT version of the template. This fixes the fatal exception seen by Vincenzo Innocente when reading a file containing the older version of the class.
