### PR TITLE
matrix option to revert DQMIO back to pool

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -243,6 +243,9 @@ class MatrixReader(object):
                         if self.apply:
                             if stepIndex in self.apply or stepName in self.apply:
                                 cmd +=' '+self.addCommand
+                            if self.wm: # add top-level option
+                                cmd=cmd.replace('DQMROOT','DQM')
+                                cmd=cmd.replace('--filetype DQM','')
                         else:
                             cmd +=' '+self.addCommand
                 commands.append(cmd)
@@ -332,6 +335,8 @@ class MatrixReader(object):
                     line += ' @@@'
                 else:
                     line += ' @@@ '+commands[0]
+                # add top-level option    
+                line=line.replace('DQMROOT','DQM')
                 writtenWF+=1
                 outFile.write(line+'\n')
 
@@ -344,6 +349,8 @@ class MatrixReader(object):
                     stepIndex=index+1
                     if 'dasquery.log' in cmd: continue
                     line = 'STEP%d ++ '%(stepIndex,) +stepName + ' @@@ '+cmd
+                    # add top-level option
+                    line=line.replace('DQMROOT','DQM')
                     outFile.write(line+'\n')
                 outFile.write('\n'+'\n')
             outFile.close()

--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -20,6 +20,7 @@ class MatrixReader(object):
         self.reset(opt.what)
 
         self.wm=opt.wmcontrol
+        self.revertDqmio=opt.revertDqmio
         self.addCommand=opt.command
         self.apply=opt.apply
         self.commandLineWf=opt.workflow
@@ -243,11 +244,11 @@ class MatrixReader(object):
                         if self.apply:
                             if stepIndex in self.apply or stepName in self.apply:
                                 cmd +=' '+self.addCommand
-                            if self.wm: # add top-level option
-                                cmd=cmd.replace('DQMROOT','DQM')
-                                cmd=cmd.replace('--filetype DQM','')
-                        else:
-                            cmd +=' '+self.addCommand
+                            else:
+                                cmd +=' '+self.addCommand
+                    if self.wm and self.revertDqmio=='yes':
+                        cmd=cmd.replace('DQMROOT','DQM')
+                        cmd=cmd.replace('--filetype DQM','')
                 commands.append(cmd)
                 ranStepList.append(stepName)
                 stepIndex+=1
@@ -335,8 +336,8 @@ class MatrixReader(object):
                     line += ' @@@'
                 else:
                     line += ' @@@ '+commands[0]
-                # add top-level option    
-                line=line.replace('DQMROOT','DQM')
+                if self.revertDqmio=='yes':
+                    line=line.replace('DQMROOT','DQM')
                 writtenWF+=1
                 outFile.write(line+'\n')
 
@@ -349,8 +350,8 @@ class MatrixReader(object):
                     stepIndex=index+1
                     if 'dasquery.log' in cmd: continue
                     line = 'STEP%d ++ '%(stepIndex,) +stepName + ' @@@ '+cmd
-                    # add top-level option
-                    line=line.replace('DQMROOT','DQM')
+                    if self.revertDqmio=='yes':
+                        line=line.replace('DQMROOT','DQM')
                     outFile.write(line+'\n')
                 outFile.write('\n'+'\n')
             outFile.close()

--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -244,8 +244,8 @@ class MatrixReader(object):
                         if self.apply:
                             if stepIndex in self.apply or stepName in self.apply:
                                 cmd +=' '+self.addCommand
-                            else:
-                                cmd +=' '+self.addCommand
+                        else:
+                            cmd +=' '+self.addCommand
                     if self.wm and self.revertDqmio=='yes':
                         cmd=cmd.replace('DQMROOT','DQM')
                         cmd=cmd.replace('--filetype DQM','')

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -132,6 +132,12 @@ if __name__ == '__main__':
                       dest='wmcontrol',
                       default=None,
                       )
+    parser.add_option('--revertDqmio',
+                      help='When submitting workflows to wmcontrol, force DQM outout to use pool and not DQMIO',
+                      choices=['yes','no'],
+                      dest='revertDqmio',
+                      default='no',
+                      )
     parser.add_option('--optionswm',
                       help='Specify a few things for wm injection',
                       default='',


### PR DESCRIPTION
- default remains DQMIO for all DQM steps and corresponding HARVEST steps
- this feature provides a clean command line option "--revertDQMIO=yes" to switch cleanly back to pool source; we'll use this as long as we're confident computing can run DQMIO in procution
