### PR TITLE
Add additional info to exception messages from FWLiteESRecordWriterAnalyzer

### DIFF
--- a/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
+++ b/PhysicsTools/CondLiteIO/plugins/FWLiteESRecordWriterAnalyzer.cc
@@ -79,7 +79,8 @@ namespace edm {
          
          const void* pValue = this->getFromProxy(dataKey,iDesc,iTransientAccessOnly);
          if(0==pValue) {
-            throw cms::Exception("NoProxyException");
+	   throw cms::Exception("NoProxyException")<<"No data of type \""<<iData->m_tag->name()<<"\" with label \""<<
+	     iName<<"\" in record \""<<this->key().name()<<"\"";
          }
          iData->m_data = pValue;
       }


### PR DESCRIPTION
When data is not found, the exception now states the type, label and record for
the missing data.
