### PR TITLE
Fix compilation error in CondCore/ORA

### DIFF
--- a/CondCore/ORA/src/Container.cc
+++ b/CondCore/ORA/src/Container.cc
@@ -77,8 +77,8 @@ const std::string& ora::Container::className(){
 }
 
 std::string ora::Container::realClassName(){
-  Reflex::Type type = ClassUtils::lookupDictionary( className() );
-  std::string ret = ClassUtils::demangledName( type.TypeInfo() ); 
+  edm::TypeWithDict type = ClassUtils::lookupDictionary( className() );
+  std::string ret = ClassUtils::demangledName( type.typeInfo() );
   ret.erase( std::remove( ret.begin(), ret.end(), ' ' ), ret.end() ); 
   return ret;
 }


### PR DESCRIPTION
Reflex was reintroduced via a carry-froward of a change in 7_1_X, causing a compilation error in CondCore/ORA.
This is the fix for the compilation error. Please merge promptly.  Since the file now does not compile, this request is a sure thing.
