### PR TITLE
RecoVertex/MultiVertexFit: clean -Wunused-function warnings

### DIFF
--- a/RecoVertex/MultiVertexFit/src/LinTrackCache.cc
+++ b/RecoVertex/MultiVertexFit/src/LinTrackCache.cc
@@ -5,7 +5,7 @@ using namespace std;
 
 namespace
 {
-  int verbose()
+  inline int verbose()
   {
     static const int ret = 0; /* SimpleConfigurable<int>
       (0, "LinTrackCache:Debug").value(); */

--- a/RecoVertex/MultiVertexFit/src/MultiVertexBSeeder.cc
+++ b/RecoVertex/MultiVertexFit/src/MultiVertexBSeeder.cc
@@ -31,7 +31,7 @@ namespace {
     return ret;
   }
 
-  int verbose()
+  inline int verbose()
   {
     return 0;
   }
@@ -48,7 +48,7 @@ namespace {
     return a;
   }
 
-  bool element ( const reco::TransientTrack & rt, const TransientVertex & rv )
+  inline bool element ( const reco::TransientTrack & rt, const TransientVertex & rv )
   {
     const vector < reco::TransientTrack > trks = rv.originalTracks();
     for ( vector< reco::TransientTrack >::const_iterator i=trks.begin(); i!=trks.end() ; ++i )
@@ -151,7 +151,7 @@ namespace {
     return pts;
   }
 
-  GlobalPoint computePos ( const GlobalTrajectoryParameters & jet,
+  inline GlobalPoint computePos ( const GlobalTrajectoryParameters & jet,
       double s )
   {
     GlobalPoint ret = jet.position();

--- a/RecoVertex/MultiVertexFit/src/MultiVertexReconstructor.cc
+++ b/RecoVertex/MultiVertexFit/src/MultiVertexReconstructor.cc
@@ -10,7 +10,7 @@ namespace {
     return 0;
   }
 
-  void remove ( vector < TransientVertex > & vtces,
+  inline void remove ( vector < TransientVertex > & vtces,
                 const vector < reco::TransientTrack > & trks )
   {
     cout << "[MultiVertexReconstructor] fixme remove not yet implemented" << endl;


### PR DESCRIPTION
Cleans GCC 4.9.0 -Wunused-function warnings.

Also in `RecoVertex/MultiVertexFit/src/MultiVertexReconstructor.cc` there is a method `inline void remove (...)`, which uses `std::cout`. Maybe that should be converted?

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
