### PR TITLE
RecoTauTag/RecoTau: clean -Wunused-function warnings

### DIFF
--- a/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauPiZeroStripPlugin2.cc
@@ -171,7 +171,7 @@ void markCandsInStrip(std::vector<bool>& candFlags, const std::set<size_t>& cand
 }
 
 namespace {
-  const reco::TrackBaseRef getTrack(const PFCandidate& cand) 
+  inline const reco::TrackBaseRef getTrack(const PFCandidate& cand)
   {
     if      ( cand.trackRef().isNonnull()    ) return reco::TrackBaseRef(cand.trackRef());
     else if ( cand.gsfTrackRef().isNonnull() ) return reco::TrackBaseRef(cand.gsfTrackRef());


### PR DESCRIPTION
Clean up `-Wunused-function` warnings in GCC 4.9.0 IB: https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc490/CMSSW_7_1_X_2014-02-20-0200/RecoTauTag/RecoTau

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
