### PR TITLE
Fix segfault in PixelTrackReconstruction

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackReconstruction.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackReconstruction.h
@@ -34,8 +34,8 @@ private:
   std::unique_ptr<PixelTrackFilter> theFilter;
   PixelTrackCleaner * theCleaner;
   std::unique_ptr<OrderedHitsGenerator> theGenerator;
-  TrackingRegionProducer* theRegionProducer;
-  QuadrupletSeedMerger *theMerger_;
+  std::unique_ptr<TrackingRegionProducer> theRegionProducer;
+  std::unique_ptr<QuadrupletSeedMerger> theMerger_;
 };
 #endif
 


### PR DESCRIPTION
Fixes the segfault reported by Giulio in https://hypernews.cern.ch/HyperNews/CMS/get/swReleases/4012.html. The problem was a spurious delete of `theRegionProducer` in `halt()` (called from `PixelTrackProducer::endRun()`), while it is constructed now in the PixelTrackReconstruction constructor. The bug was introduced in 4f569be1 (probably by mistake in rebase or something).

The `theMerger_` would have suffered from the same problem, so I changed it too to `std:unique_ptr`.
