### PR TITLE
Fix/silence warnings in tau trigger DQM

### DIFF
--- a/DQMOffline/Trigger/src/HLTTauDQMPath.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPath.cc
@@ -327,7 +327,7 @@ bool HLTTauDQMPath::beginRun(const HLTConfigProvider& HLTCP) {
         ss << ",";
       ss << iRegex->str();
     }
-    edm::LogWarning("HLTTauDQMOffline") << "HLTTauDQMPath::beginRun(): did not find any paths matching to regexes " << ss.str();
+    edm::LogInfo("HLTTauDQMOffline") << "HLTTauDQMPath::beginRun(): did not find any paths matching to regexes " << ss.str();
     return false;
   }
 

--- a/DQMOffline/Trigger/src/HLTTauDQMPath.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPath.cc
@@ -209,7 +209,7 @@ namespace {
         n.tau = getParameterSafe(HLTCP, filterName, "MinJets");
       }
     }
-    else if(moduleType == "HLT1PFTau") {
+    else if(moduleType == "HLT1Tau" || moduleType == "HLT1PFTau") {
       //n.tau = HLTCP.modulePSet(filterName).getParameter<int>("MinN");
       n.tau = getParameterSafe(HLTCP, filterName, "MinN");
     }
@@ -229,7 +229,7 @@ namespace {
       n.tau = num;
       n.electron = num;
     }
-    else if(moduleType == "HLT2MuonPFTau") {
+    else if(moduleType == "HLT2MuonTau" || moduleType == "HLT2MuonPFTau") {
       //int num = HLTCP.modulePSet(filterName).getParameter<int>("MinN");
       int num = getParameterSafe(HLTCP, filterName, "MinN");
       n.tau = num;

--- a/DQMOffline/Trigger/test/HLTTauOfflineDQMTest_cfg.py
+++ b/DQMOffline/Trigger/test/HLTTauOfflineDQMTest_cfg.py
@@ -19,7 +19,7 @@ process.source = cms.Source("PoolSource",
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 100
-#process.MessageLogger.categories.append("HLTTauDQMOffline")
+process.MessageLogger.categories.append("HLTTauDQMOffline")
 process.load("Configuration.StandardSequences.Geometry_cff")
 process.load("Geometry.CaloEventSetup.CaloTopology_cfi")
 


### PR DESCRIPTION
Fixes/silences the warnings reported by Giulio in https://hypernews.cern.ch/HyperNews/CMS/get/swReleases/4012.html. The filter types `HLT1Tau` and `HLT2MuonTau` used in 2011 HLT menu were not recognized (an oversight by me). The other warning about "not finding any paths matching to regex" I silenced by decreasing the message level to LogInfo. We will probably anyway move in the near future to monitor all tau paths in a generic way, making this regex-path matching (and the now-LogInfo message) obsolete.

FYI @mbluj
