### PR TITLE
Fast match

### DIFF
--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
@@ -98,7 +98,7 @@ public:
   
   
   float scale_;
-  
+  bool  preFilter_=false;
 };
 
 

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
@@ -37,7 +37,8 @@ public:
 
   SiStripRecHitMatcher(const edm::ParameterSet& conf);
   SiStripRecHitMatcher(const double theScale);
-  
+
+  bool preFilter() const { return preFilter_;}  
 
   // optimized matching iteration (the algo is the same, just recoded)
   template<typename MonoIterator, typename StereoIterator,  typename CollectorHelper>

--- a/RecoLocalTracker/SiStripRecHitConverter/python/SiStripRecHitMatcher_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/SiStripRecHitMatcher_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 SiStripRecHitMatcherESProducer = cms.ESProducer("SiStripRecHitMatcherESProducer",
     ComponentName = cms.string('StandardMatcher'),
     NSigmaInside = cms.double(3.0),
-    PreFilter = cms.untracked.bool(False)
+    PreFilter = cms.untracked.bool(True)
 )
 
 

--- a/RecoLocalTracker/SiStripRecHitConverter/python/SiStripRecHitMatcher_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/SiStripRecHitMatcher_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 SiStripRecHitMatcherESProducer = cms.ESProducer("SiStripRecHitMatcherESProducer",
     ComponentName = cms.string('StandardMatcher'),
     NSigmaInside = cms.double(3.0),
-    PreFilter = cms.untracked.bool(False)
+    PreFilter = cms.bool(True)
 )
 
 

--- a/RecoLocalTracker/SiStripRecHitConverter/python/SiStripRecHitMatcher_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/SiStripRecHitMatcher_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 SiStripRecHitMatcherESProducer = cms.ESProducer("SiStripRecHitMatcherESProducer",
     ComponentName = cms.string('StandardMatcher'),
     NSigmaInside = cms.double(3.0),
-    PreFilter = cms.bool(True)
+    PreFilter = cms.bool(False)
 )
 
 

--- a/RecoLocalTracker/SiStripRecHitConverter/python/SiStripRecHitMatcher_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/SiStripRecHitMatcher_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 SiStripRecHitMatcherESProducer = cms.ESProducer("SiStripRecHitMatcherESProducer",
     ComponentName = cms.string('StandardMatcher'),
     NSigmaInside = cms.double(3.0),
-    PreFilter = cms.untracked.bool(True)
+    PreFilter = cms.untracked.bool(False)
 )
 
 

--- a/RecoLocalTracker/SiStripRecHitConverter/python/SiStripRecHitMatcher_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/SiStripRecHitMatcher_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 SiStripRecHitMatcherESProducer = cms.ESProducer("SiStripRecHitMatcherESProducer",
     ComponentName = cms.string('StandardMatcher'),
     NSigmaInside = cms.double(3.0),
-    PreFilter = cms.untracked.bool(Fals)
+    PreFilter = cms.untracked.bool(False)
 )
 
 

--- a/RecoLocalTracker/SiStripRecHitConverter/python/SiStripRecHitMatcher_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/SiStripRecHitMatcher_cfi.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 SiStripRecHitMatcherESProducer = cms.ESProducer("SiStripRecHitMatcherESProducer",
     ComponentName = cms.string('StandardMatcher'),
-    NSigmaInside = cms.double(3.0)
+    NSigmaInside = cms.double(3.0),
+    PreFilter = cms.untracked.bool(Fals)
 )
 
 

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
@@ -17,7 +17,7 @@
 
 SiStripRecHitMatcher::SiStripRecHitMatcher(const edm::ParameterSet& conf):
   scale_(conf.getParameter<double>("NSigmaInside")),
-  preFilter_(conf.getUntrackedParameter<bool>("PreFilter",false))  
+  preFilter_(conf.existsAs<bool>("PreFilter") ? conf.getParameter<bool>("PreFilter") : false)  
   {}
 
 SiStripRecHitMatcher::SiStripRecHitMatcher(const double theScale):

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
@@ -15,13 +15,14 @@
 
 
 
-SiStripRecHitMatcher::SiStripRecHitMatcher(const edm::ParameterSet& conf){   
-  scale_=conf.getParameter<double>("NSigmaInside");  
-}
+SiStripRecHitMatcher::SiStripRecHitMatcher(const edm::ParameterSet& conf):
+  scale_(conf.getParameter<double>("NSigmaInside")),
+  preFilter_(conf.getUntrackedParameter<bool>("PreFilter",false))  
+  {}
 
-SiStripRecHitMatcher::SiStripRecHitMatcher(const double theScale){   
-  scale_=theScale;  
-}
+SiStripRecHitMatcher::SiStripRecHitMatcher(const double theScale):
+  scale_(theScale){}  
+
 
 
 namespace {

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.h
@@ -106,7 +106,7 @@ private:
     SiStripRecHitMatcher::Collector & collector() { return collector_; }
     bool hasNewMatchedHits() const { return hasNewHits_;  }
     void clearNewMatchedHitsFlag() { hasNewHits_ = false; }
-    static bool filter() { return false;}   // if true mono-colection will been filter using the estimator before matching  
+    bool filter() const { return matcher_->preFilter();}   // if true mono-colection will been filter using the estimator before matching  
     size_t size() const { return target_.size();}
     const MeasurementEstimator  & estimator() { return est_;}
   private: 

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
@@ -24,11 +24,11 @@ TkStripMeasurementDet::TkStripMeasurementDet( const GeomDet* gdet, StMeasurement
 
 // fast check if the det contains any useful cluster
 bool TkStripMeasurementDet::empty(const MeasurementTrackerEvent & data) const {
-  if unlikely( (!isActive(data)) || isEmpty(data.stripData())) return false;
+  if unlikely( (!isActive(data)) || isEmpty(data.stripData())) return true;
 
-  if(!isRegional()){//old implemetation with DetSet
+  if(!isRegional()){// standard implemetation with DetSet
     const detset & detSet = data.stripData().detSet(index()); 
-    for ( new_const_iterator ci = detSet.begin(); ci != detSet.end(); ++ ci ) {
+    for ( auto ci = detSet.begin(); ci != detSet.end(); ++ ci ) {
       if (isMasked(*ci)) continue;
       SiStripClusterRef  cluster = edmNew::makeRefTo( data.stripData().handle(), ci ); 
       if (accept(cluster, data.stripClustersToSkip()))

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
@@ -21,11 +21,38 @@ TkStripMeasurementDet::TkStripMeasurementDet( const GeomDet* gdet, StMeasurement
     }
   }
 
+
+// fast check if the det contains any useful cluster
+bool TkStripMeasurementDet::empty(const MeasurementTrackerEvent & data) const {
+  if unlikely( (!isActive(data)) || isEmpty(data.stripData())) return false;
+
+  if(!isRegional()){//old implemetation with DetSet
+    const detset & detSet = data.stripData().detSet(index()); 
+    for ( new_const_iterator ci = detSet.begin(); ci != detSet.end(); ++ ci ) {
+      if (isMasked(*ci)) continue;
+      SiStripClusterRef  cluster = edmNew::makeRefTo( data.stripData().handle(), ci ); 
+      if (accept(cluster, data.stripClustersToSkip()))
+	return false;
+    }
+    return true;
+  }
+  // on demand
+  unsigned int ci = beginClusterI(data.stripData()), ce = endClusterI(data.stripData()); 
+  for (; ci != ce; ++ci){
+    SiStripRegionalClusterRef clusterRef = edm::makeRefToLazyGetter(data.stripData().regionalHandle(),ci);
+    if (isMasked(*clusterRef)) continue;
+    if (accept(clusterRef, data.stripClustersToSkip()))
+      return false;
+  }
+  return true;  
+}
+
+
 TkStripMeasurementDet::RecHitContainer 
 TkStripMeasurementDet::recHits( const TrajectoryStateOnSurface& ts, const MeasurementTrackerEvent & data) const
 {
   RecHitContainer result;
-  if ( (!isActive(data)) || isEmpty(data.stripData())) return result;
+  if unlikely( (!isActive(data)) || isEmpty(data.stripData())) return result;
   if(!isRegional()){//old implemetation with DetSet
     const detset & detSet = data.stripData().detSet(index()); 
     result.reserve(detSet.size());
@@ -56,7 +83,7 @@ TkStripMeasurementDet::recHits( const TrajectoryStateOnSurface& ts, const Measur
 bool
 TkStripMeasurementDet::recHits( const TrajectoryStateOnSurface& stateOnThisDet, const MeasurementEstimator& est, const MeasurementTrackerEvent & data, 
 				RecHitContainer & result, std::vector<float> & diffs ) const {
-  if ( (!isActive(data)) || isEmpty(data.stripData())) return false;
+  if unlikely( (!isActive(data)) || isEmpty(data.stripData())) return false;
 
   auto oldSize = result.size();
 

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
@@ -155,6 +155,7 @@ public:
   virtual RecHitContainer recHits( const TrajectoryStateOnSurface&, const MeasurementTrackerEvent & data) const;
 
 
+  bool empty(const MeasurementTrackerEvent & data) const;
 
   void simpleRecHits( const TrajectoryStateOnSurface& ts, const MeasurementTrackerEvent & data, std::vector<SiStripRecHit2D> &result) const ;
   

--- a/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
+++ b/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
@@ -42,6 +42,7 @@ namespace {
 #include "DataFormats/GeometrySurface/interface/LocalError.h" 
 
 namespace {
+  inline
   void print(const char* where, const TrajectoryStateOnSurface& t1,const TrajectoryStateOnSurface& t2) {
     std::cout << where<< std::endl;
     std::cout <<  t1.localParameters().vector() << std::endl;
@@ -50,8 +51,6 @@ namespace {
     std::cout <<  t2.localError().positionError() << std::endl;
 
   }
-
-
 }
 
 

--- a/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
+++ b/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
@@ -126,7 +126,7 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
     }
 
 
-  if ((!emptyMono) &  (!emptyStereo) ) {
+  if ((!monoHits.empty()) &  (!stereoHits.empty()) ) {
     
     const GluedGeomDet* gluedDet = &specificGeomDet();
     LocalVector trdir = (ts.isValid() ? ts.localDirection() : surface().toLocal( position()-GlobalPoint(0,0,0)));

--- a/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
+++ b/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
@@ -72,28 +72,39 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
   auto mf = monoHits.size();
   auto sf = stereoHits.size();
   
-  // mono does not require "projection"
+  bool emptyMono = false;
+  bool emptyStereo = false;
+
+  // mono does require "projection" for precise estimate
   if (collector.filter()) {
-    //TrajectoryStateOnSurface mts = fastProp(ts,geomDet().surface(),theMonoDet->geomDet().surface());
-    theMonoDet->recHits(ts,collector.estimator(),data,monoHits,diffs); 
+    emptyMono = theMonoDet->empty(data);
+    if likely(!emptyMono) {
+	TrajectoryStateOnSurface mts = fastProp(ts,geomDet().surface(),theMonoDet->geomDet().surface());
+	theMonoDet->recHits(mts,collector.estimator(),data,monoHits,diffs);
+      }
     // print("mono", mts,ts);
     mf = monoHits.size();
   }
-  else
+  else {
     monoHits = theMonoDet->recHits(ts, data);
+    emptyMono = monoHits.empty();
+  }
 
-  // stereo in principle requires "projection"
-  TrajectoryStateOnSurface pts = ts;
+  // stereo requires "projection" for precision and change in coordinates
   diffs.clear();
   if (collector.filter()) {
-    TrajectoryStateOnSurface pts = fastProp(ts,geomDet().surface(),theStereoDet->geomDet().surface());
-    theStereoDet->recHits(pts,collector.estimator(),data,stereoHits,diffs);
-    // print("stereo", pts,ts);
+    emptyStereo = theStereoDet->empty(data);
+    if likely(!emptyStereo) {
+	TrajectoryStateOnSurface pts = fastProp(ts,geomDet().surface(),theStereoDet->geomDet().surface());
+	theStereoDet->recHits(pts,collector.estimator(),data,stereoHits,diffs);
+	// print("stereo", pts,ts);
+      }
     sf = stereoHits.size();
   }
-  else
-    stereoHits= theStereoDet->recHits(pts,data);
-
+  else {
+    stereoHits= theStereoDet->recHits(ts,data);
+    emptyStereo = stereoHits.empty();
+  }
 
   if (collector.filter()) {
     auto mh = monoHits.size();
@@ -101,26 +112,22 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
     stat(mh,sh,mf,sf);
   }
 
-  if (stereoHits.empty()&&monoHits.empty()) return;
+  if unlikely( emptyMono &  emptyStereo) return;
 
-  if( (!theStereoDet->isActive(data)) ||
-       ((!collector.filter())&&stereoHits.empty())
-      ) {
-    // make mono TTRHs and project them
-    projectOnGluedDet( collector, monoHits, glbDir);
-    return;
-  }
+  if unlikely(emptyStereo) {
+      // make mono TTRHs and project them
+      projectOnGluedDet( collector, monoHits, glbDir);
+      return;
+    }
   
-  if (  (!theMonoDet->isActive(data)) ||
-	((!collector.filter())&&monoHits.empty())
-	) {
-    // make stereo TTRHs and project them
+  if unlikely( emptyMono ) {
+      // make stereo TTRHs and project them
     projectOnGluedDet( collector, stereoHits, glbDir);
     return;
-  }
+    }
 
 
-  if ((!stereoHits.empty())&&(!monoHits.empty())) {
+  if ((!emptyMono) &  (!emptyStereo) ) {
     
     const GluedGeomDet* gluedDet = &specificGeomDet();
     LocalVector trdir = (ts.isValid() ? ts.localDirection() : surface().toLocal( position()-GlobalPoint(0,0,0)));


### PR DESCRIPTION
these modification enable the possibility to study a "faster" version of the hit matcher
that preselects the hits to match based on the track parameters
The selection is controlled by a parameter of the Matcher "PreFilter"
default is false.
to set to true just

```
--- a/RecoLocalTracker/SiStripRecHitConverter/python/SiStripRecHitMatcher_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/SiStripRecHitMatcher_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 SiStripRecHitMatcherESProducer = cms.ESProducer("SiStripRecHitMatcherESProducer",
     ComponentName = cms.string('StandardMatcher'),
     NSigmaInside = cms.double(3.0),
-    PreFilter = cms.untracked.bool(False)
+    PreFilter = cms.untracked.bool(True)
 )
```

the speed up obtained depends on occupancy and track density in each det-unit.
At high pileup it is expected to be significant.
for a typical JetHT sample from 2012C one saves about 25% of the time in the matcher itself
corresponding to about a 6% speed up of the total CkfTrackCandidateMakerBase.

the cost is a small inefficiency caused by a loss of about 10% of the hits on the track, as it can be seen in
the standard MTV plots for TTBar
http://innocent.home.cern.ch/innocent/FastMatchMTV/

this loss in not present al all in single particle events and seems to be constant with the increase of the pileup

The use of this optimization shall be therefore reviewed in light of the final configuration for Run 2
including cluster-charge cuts and new setup for the iterative-tracking

I have of course verified that the modifications with default configuration do not produce any regression
