### PR TITLE
first attempt be5d + extended Pixel reco (be5d+ext tracking code)

### DIFF
--- a/RecoTracker/Configuration/python/RecoTrackerPhase2BEPixel10D_cff.py
+++ b/RecoTracker/Configuration/python/RecoTrackerPhase2BEPixel10D_cff.py
@@ -1,0 +1,32 @@
+import FWCore.ParameterSet.Config as cms
+
+# Iterative steps
+#from RecoTracker.IterativeTracking.iterativeTk_cff import *
+from RecoTracker.IterativeTracking.Phase2BEPixel10D_iterativeTk_cff import *
+from RecoTracker.IterativeTracking.Phase1PU140_ElectronSeeds_cff import *
+
+
+import copy
+
+#dEdX reconstruction
+from RecoTracker.DeDx.dedxEstimators_cff import *
+
+#BeamHalo tracking
+from RecoTracker.Configuration.RecoTrackerBHM_cff import *
+
+
+#special sequences, such as pixel-less
+from RecoTracker.Configuration.RecoTrackerNotStandard_cff import *
+
+ckftracks_woBH = cms.Sequence(iterTracking*electronSeedsSeq*doAlldEdXEstimators)
+ckftracks = ckftracks_woBH.copy() #+ beamhaloTracksSeq) # temporarily out, takes too much resources
+
+ckftracks_wodEdX = ckftracks.copy()
+ckftracks_wodEdX.remove(doAlldEdXEstimators)
+
+
+ckftracks_plus_pixelless = cms.Sequence(ckftracks*ctfTracksPixelLess)
+
+
+from RecoJets.JetAssociationProducers.trackExtrapolator_cfi import *
+trackingGlobalReco = cms.Sequence(ckftracks*trackExtrapolator)

--- a/RecoTracker/IterativeTracking/python/Phase2BEPixel10D_iterativeTk_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase2BEPixel10D_iterativeTk_cff.py
@@ -1,0 +1,27 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoTracker.IterativeTracking.Phase1PU140_InitialStep_cff import *
+from RecoTracker.IterativeTracking.Phase2PU140Pixel10D_HighPtTripletStep_cff import *
+from RecoTracker.IterativeTracking.Phase2PU140Pixel10D_LowPtQuadStep_cff import *
+from RecoTracker.IterativeTracking.Phase2PU140Pixel10D_LowPtTripletStep_cff import *
+from RecoTracker.IterativeTracking.Phase2PU140Pixel10D_DetachedQuadStep_cff import *
+from RecoTracker.IterativeTracking.Phase2PU140Pixel10D_PixelPairStep_cff import *
+from RecoTracker.FinalTrackSelectors.Phase1PU140_earlyGeneralTracks_cfi import *
+from RecoTracker.IterativeTracking.Phase2BE_MuonSeededStep_cff import *
+from RecoTracker.FinalTrackSelectors.Phase2BE_preDuplicateMergingGeneralTracks_cfi import *
+from RecoTracker.FinalTrackSelectors.MergeTrackCollections_cff import *
+from RecoTracker.ConversionSeedGenerators.Phase2BE_ConversionStep_cff import *
+
+iterTracking = cms.Sequence(InitialStep*
+                            HighPtTripletStep*
+                            LowPtQuadStep*
+                            LowPtTripletStep*
+                            DetachedQuadStep*
+                            PixelPairStep*
+                            earlyGeneralTracks*
+                            muonSeededStep*
+                            preDuplicateMergingGeneralTracks*
+                            generalTracksSequence*
+                            ConvStep*
+                            conversionStepTracks
+                            )

--- a/RecoTracker/IterativeTracking/python/Phase2PU140Pixel10D_DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase2PU140Pixel10D_DetachedQuadStep_cff.py
@@ -1,0 +1,262 @@
+import FWCore.ParameterSet.Config as cms
+
+###############################################
+# Low pT and detached tracks from pixel triplets
+###############################################
+
+# REMOVE HITS ASSIGNED TO GOOD TRACKS FROM PREVIOUS ITERATIONS
+
+detachedQuadStepClusters = cms.EDProducer("TrackClusterRemover",
+    clusterLessSolution = cms.bool(True),
+    oldClusterRemovalInfo = cms.InputTag("lowPtTripletStepClusters"),
+    trajectories = cms.InputTag("lowPtTripletStepTracks"),
+    overrideTrkQuals = cms.InputTag('lowPtTripletStepSelector','lowPtTripletStep'),
+    TrackQuality = cms.string('highPurity'),
+    minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
+    pixelClusters = cms.InputTag("siPixelClusters"),
+    stripClusters = cms.InputTag("siStripClusters"),
+    Common = cms.PSet(
+        maxChi2 = cms.double(9.0)
+    )
+)
+
+# SEEDING LAYERS
+import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
+detachedQuadStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.pixellayertriplets.clone(
+    ComponentName = cms.string('detachedQuadStepSeedLayers'),
+    layerList = cms.vstring('BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
+                            'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
+                            'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
+                            'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
+                            'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
+                            'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
+                            'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
+#ale
+                            'BPix1+FPix1_pos+FPix3_pos',
+                            'BPix1+FPix1_neg+FPix3_neg',
+                            'BPix1+FPix2_pos+FPix3_pos',
+                            'BPix1+FPix2_neg+FPix3_neg',
+                            'BPix1+FPix3_pos+FPix4_pos',
+                            'BPix1+FPix3_neg+FPix4_neg',
+                            'FPix3_pos+FPix4_pos+FPix5_pos',
+                            'FPix3_neg+FPix4_neg+FPix5_neg',
+                            'FPix4_pos+FPix5_pos+FPix6_pos',
+                            'FPix4_neg+FPix5_neg+FPix6_neg',
+                            'FPix5_pos+FPix6_pos+FPix7_pos',
+                            'FPix5_neg+FPix6_neg+FPix7_neg',
+                            'FPix6_pos+FPix7_pos+FPix9_pos',
+                            'FPix6_neg+FPix7_neg+FPix9_neg',
+                            'FPix6_pos+FPix7_pos+FPix10_pos',
+                            'FPix6_neg+FPix7_neg+FPix10_neg',
+                            'FPix7_pos+FPix9_pos+FPix10_pos',
+                            'FPix7_neg+FPix9_neg+FPix10_neg'
+                            )
+    )
+detachedQuadStepSeedLayers.BPix.skipClusters = cms.InputTag('detachedQuadStepClusters')
+detachedQuadStepSeedLayers.FPix.skipClusters = cms.InputTag('detachedQuadStepClusters')
+
+# SEEDS
+from RecoPixelVertexing.PixelTriplets.PixelTripletLargeTipGenerator_cfi import *
+PixelTripletLargeTipGenerator.extraHitRZtolerance = 0.0
+PixelTripletLargeTipGenerator.extraHitRPhitolerance = 0.0
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
+from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock
+detachedQuadStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone(
+    RegionFactoryPSet = RegionPsetFomBeamSpotBlock.clone(
+        ComponentName = cms.string('GlobalRegionProducerFromBeamSpot'),
+        RegionPSet = RegionPsetFomBeamSpotBlock.RegionPSet.clone(
+            ptMin = 0.5,
+            originRadius = 0.5,
+            nSigmaZ = 4.0
+            )
+    ),
+    SeedMergerPSet = cms.PSet(
+        layerListName = cms.string('PixelSeedMergerQuadruplets'),
+	addRemainingTriplets = cms.bool(False),
+	mergeTriplets = cms.bool(True),
+	ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
+    )
+)
+detachedQuadStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'detachedQuadStepSeedLayers'
+detachedQuadStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet = cms.PSet(PixelTripletLargeTipGenerator)
+detachedQuadStepSeeds.SeedCreatorPSet.ComponentName = 'SeedFromConsecutiveHitsTripletOnlyCreator'
+detachedQuadStepSeeds.SeedComparitorPSet = cms.PSet(
+        ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
+        FilterAtHelixStage = cms.bool(False),
+        FilterPixelHits = cms.bool(True),
+        FilterStripHits = cms.bool(False),
+        ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter')
+    )
+detachedQuadStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False)
+detachedQuadStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(0)
+
+# QUALITY CUTS DURING TRACK BUILDING
+import TrackingTools.TrajectoryFiltering.TrajectoryFilterESProducer_cfi
+detachedQuadStepStandardTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilterESProducer_cfi.trajectoryFilterESProducer.clone(
+    ComponentName = 'detachedQuadStepStandardTrajectoryFilter',
+    filterPset = TrackingTools.TrajectoryFiltering.TrajectoryFilterESProducer_cfi.trajectoryFilterESProducer.filterPset.clone(
+    maxLostHitsFraction = cms.double(1./10.),
+    constantValueForLostHitsFractionFilter = cms.double(0.301),
+    minimumNumberOfHits = 3,
+    minPt = 0.075
+    )
+    )
+
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeTrajectoryFilterESProducer_cfi import *
+# Composite filter
+import TrackingTools.TrajectoryFiltering.CompositeTrajectoryFilterESProducer_cfi
+detachedQuadStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.CompositeTrajectoryFilterESProducer_cfi.compositeTrajectoryFilterESProducer.clone(
+    ComponentName = cms.string('detachedQuadStepTrajectoryFilter'),
+    filterNames   = cms.vstring('detachedQuadStepStandardTrajectoryFilter',
+                                'clusterShapeTrajectoryFilter')
+    )
+
+import TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi
+detachedQuadStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName = cms.string('detachedQuadStepChi2Est'),
+    nSigma = cms.double(3.0),
+    MaxChi2 = cms.double(9.0)
+)
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderESProducer_cfi
+detachedQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderESProducer_cfi.GroupedCkfTrajectoryBuilder.clone(
+    ComponentName = 'detachedQuadStepTrajectoryBuilder',
+    MeasurementTrackerName = '',
+    trajectoryFilterName = 'detachedQuadStepTrajectoryFilter',
+    clustersToSkip = cms.InputTag('detachedQuadStepClusters'),
+    maxCand = 2,
+    alwaysUseInvalidHits = False,
+    estimator = cms.string('detachedQuadStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    maxPtForLooperReconstruction = cms.double(0.7) 
+    )
+
+# MAKING OF TRACK CANDIDATES
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+detachedQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('detachedQuadStepSeeds'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    TrajectoryBuilder = 'detachedQuadStepTrajectoryBuilder',
+    doSeedingRegionRebuilding = True,
+    useHitsSplitting = True
+    )
+
+from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
+detachedQuadStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
+        ComponentName = cms.string('detachedQuadStepTrajectoryCleanerBySharedHits'),
+            fractionShared = cms.double(0.09),
+            allowSharedFirstHit = cms.bool(True)
+            )
+detachedQuadStepTrackCandidates.TrajectoryCleaner = 'detachedQuadStepTrajectoryCleanerBySharedHits'
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+detachedQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    AlgorithmName = cms.string('iter4'),
+    src = 'detachedQuadStepTrackCandidates',
+    Fitter = cms.string('FlexibleKFFittingSmoother'),
+    TTRHBuilder=cms.string('WithTrackAngle')
+    )
+
+# TRACK SELECTION AND QUALITY FLAG SETTING.
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+detachedQuadStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src='detachedQuadStepTracks',
+    trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'detachedQuadStepVtxLoose',
+            chi2n_par = 0.9,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            d0_par1 = ( 0.9, 3.0 ),
+            dz_par1 = ( 0.9, 3.0 ),
+            d0_par2 = ( 1.0, 3.0 ),
+            dz_par2 = ( 1.0, 3.0 )
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'detachedQuadStepTrkLoose',
+            chi2n_par = 0.5,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            d0_par1 = ( 1.3, 4.0 ),
+            dz_par1 = ( 1.3, 4.0 ),
+            d0_par2 = ( 1.3, 4.0 ),
+            dz_par2 = ( 1.3, 4.0 )
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'detachedQuadStepVtxTight',
+            preFilterName = 'detachedQuadStepVtxLoose',
+            chi2n_par = 0.9,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.9, 3.0 ),
+            dz_par1 = ( 0.9, 3.0 ),
+            d0_par2 = ( 0.9, 3.0 ),
+            dz_par2 = ( 0.9, 3.0 )
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'detachedQuadStepTrkTight',
+            preFilterName = 'detachedQuadStepTrkLoose',
+            chi2n_par = 0.35,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 4,
+            d0_par1 = ( 1.1, 4.0 ),
+            dz_par1 = ( 1.1, 4.0 ),
+            d0_par2 = ( 1.1, 4.0 ),
+            dz_par2 = ( 1.1, 4.0 )
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'detachedQuadStepVtx',
+            preFilterName = 'detachedQuadStepVtxTight',
+            chi2n_par = 0.8,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.8, 3.0 ),
+            dz_par1 = ( 0.8, 3.0 ),
+            d0_par2 = ( 0.8, 3.0 ),
+            dz_par2 = ( 0.8, 3.0 )
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'detachedQuadStepTrk',
+            preFilterName = 'detachedQuadStepTrkTight',
+            chi2n_par = 0.2,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 0,
+            minNumber3DLayers = 4,
+            d0_par1 = ( 0.8, 4.0 ),
+            dz_par1 = ( 0.8, 4.0 ),
+            d0_par2 = ( 0.7, 4.0 ),
+            dz_par2 = ( 0.7, 4.0 )
+            )
+        ) #end of vpset
+    ) #end of clone
+
+import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
+detachedQuadStep = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
+    TrackProducers = cms.VInputTag(cms.InputTag('detachedQuadStepTracks'),
+                                   cms.InputTag('detachedQuadStepTracks')),
+    hasSelector=cms.vint32(1,1),
+    shareFrac = cms.double(0.095),
+    indivShareFrac=cms.vdouble(0.095,0.095),
+    selectedTrackQuals = cms.VInputTag(cms.InputTag("detachedQuadStepSelector","detachedQuadStepVtx"),
+                                       cms.InputTag("detachedQuadStepSelector","detachedQuadStepTrk")),
+    setsToMerge = cms.VPSet(cms.PSet( tLists=cms.vint32(0,1), pQual=cms.bool(True) )),
+    writeOnlyTrkQuals=cms.bool(True)
+)
+
+DetachedQuadStep = cms.Sequence(detachedQuadStepClusters*
+                                               detachedQuadStepSeeds*
+                                               detachedQuadStepTrackCandidates*
+                                               detachedQuadStepTracks*
+                                               detachedQuadStepSelector*
+                                               detachedQuadStep)

--- a/RecoTracker/IterativeTracking/python/Phase2PU140Pixel10D_HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase2PU140Pixel10D_HighPtTripletStep_cff.py
@@ -1,0 +1,187 @@
+import FWCore.ParameterSet.Config as cms
+
+# NEW CLUSTERS (remove previously used clusters)
+highPtTripletStepClusters = cms.EDProducer("TrackClusterRemover",
+    clusterLessSolution= cms.bool(True),
+    trajectories = cms.InputTag("initialStepTracks"),
+    overrideTrkQuals = cms.InputTag('initialStepSelector','initialStep'),
+    TrackQuality = cms.string('highPurity'),
+    minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
+    pixelClusters = cms.InputTag("siPixelClusters"),
+    stripClusters = cms.InputTag("siStripClusters"),
+    doStripChargeCheck = cms.bool(True),
+    stripRecHits = cms.string('siStripMatchedRecHits'),
+    Common = cms.PSet(
+        maxChi2 = cms.double(9.0),
+        minGoodStripCharge = cms.double(50.0)
+    )
+)
+
+# SEEDING LAYERS
+import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
+highPtTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.pixellayertriplets.clone(
+    ComponentName = cms.string('highPtTripletStepSeedLayers'),
+    layerList = cms.vstring('BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
+                            'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
+                            'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
+                            'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
+                            'BPix1+BPix3+FPix1_pos', 'BPix1+BPix3+FPix1_neg',
+                            'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
+                            'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
+                            'BPix1+BPix2+FPix2_pos', 'BPix1+BPix2+FPix2_neg',
+                            'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
+                            'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',
+                            'BPix1+FPix1_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix3_neg',
+#ale
+                            'BPix1+FPix3_pos+FPix4_pos',
+                            'BPix1+FPix3_neg+FPix4_neg',
+                            'FPix3_pos+FPix4_pos+FPix5_pos',
+                            'FPix3_neg+FPix4_neg+FPix5_neg',
+                            'FPix4_pos+FPix5_pos+FPix6_pos',
+                            'FPix4_neg+FPix5_neg+FPix6_neg',
+                            'FPix5_pos+FPix6_pos+FPix7_pos',
+                            'FPix5_neg+FPix6_neg+FPix7_neg',
+                            'FPix6_pos+FPix7_pos+FPix9_pos',
+                            'FPix6_neg+FPix7_neg+FPix9_neg',
+                            'FPix6_pos+FPix7_pos+FPix10_pos',
+                            'FPix6_neg+FPix7_neg+FPix10_neg',
+                            'FPix7_pos+FPix9_pos+FPix10_pos',
+                            'FPix7_neg+FPix9_neg+FPix10_neg'
+                            )
+    )
+highPtTripletStepSeedLayers.BPix.skipClusters = cms.InputTag('highPtTripletStepClusters')
+highPtTripletStepSeedLayers.FPix.skipClusters = cms.InputTag('highPtTripletStepClusters')
+
+# SEEDS
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
+from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock
+highPtTripletStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone(
+    RegionFactoryPSet = RegionPsetFomBeamSpotBlock.clone(
+    ComponentName = cms.string('GlobalRegionProducerFromBeamSpot'),
+    RegionPSet = RegionPsetFomBeamSpotBlock.RegionPSet.clone(
+    ptMin = 0.9,
+    originRadius = 0.02,
+    nSigmaZ = 4.0
+    )
+    )
+    )
+highPtTripletStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'highPtTripletStepSeedLayers'
+
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+highPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet.ComponentName = 'LowPtClusterShapeSeedComparitor'
+highPtTripletStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False)
+highPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(0)
+
+# QUALITY CUTS DURING TRACK BUILDING
+import TrackingTools.TrajectoryFiltering.TrajectoryFilterESProducer_cfi
+highPtTripletStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilterESProducer_cfi.trajectoryFilterESProducer.clone(
+    ComponentName = 'highPtTripletStepTrajectoryFilter',
+    filterPset = TrackingTools.TrajectoryFiltering.TrajectoryFilterESProducer_cfi.trajectoryFilterESProducer.filterPset.clone(
+    minimumNumberOfHits = 3,
+    minPt = 0.2
+    )
+    )
+
+import TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi
+highPtTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName = cms.string('highPtTripletStepChi2Est'),
+    nSigma = cms.double(3.0),
+    MaxChi2 = cms.double(30.0)
+)
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderESProducer_cfi
+highPtTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderESProducer_cfi.GroupedCkfTrajectoryBuilder.clone(
+    ComponentName = 'highPtTripletStepTrajectoryBuilder',
+    MeasurementTrackerName = '',
+    trajectoryFilterName = 'highPtTripletStepTrajectoryFilter',
+    clustersToSkip = cms.InputTag('highPtTripletStepClusters'),
+    maxCand = 4,
+    estimator = cms.string('highPtTripletStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
+    # of the outermost Tracker barrel layer (with B=3.8T)
+    maxPtForLooperReconstruction = cms.double(0.7) 
+    )
+
+# MAKING OF TRACK CANDIDATES
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+highPtTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('highPtTripletStepSeeds'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    TrajectoryBuilder = 'highPtTripletStepTrajectoryBuilder',
+    doSeedingRegionRebuilding = True,
+    useHitsSplitting = True
+)
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+highPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src = 'highPtTripletStepTrackCandidates',
+    AlgorithmName = cms.string('iter1'),
+    Fitter = cms.string('FlexibleKFFittingSmoother'),
+    TTRHBuilder=cms.string('WithTrackAngle')
+    )
+
+from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
+highPtTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
+        ComponentName = cms.string('highPtTripletStepTrajectoryCleanerBySharedHits'),
+            fractionShared = cms.double(0.16),
+            allowSharedFirstHit = cms.bool(True)
+            )
+highPtTripletStepTrackCandidates.TrajectoryCleaner = 'highPtTripletStepTrajectoryCleanerBySharedHits'
+
+# Final selection
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+highPtTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src='highPtTripletStepTracks',
+    trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'highPtTripletStepLoose',
+            chi2n_par = 2.0,
+            res_par = ( 0.003, 0.002 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 3,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.7, 4.0 ),
+            dz_par1 = ( 0.8, 4.0 ),
+            d0_par2 = ( 0.4, 4.0 ),
+            dz_par2 = ( 0.6, 4.0 )
+            ), #end of pset
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'highPtTripletStepTight',
+            preFilterName = 'highPtTripletStepLoose',
+            chi2n_par = 1.0,
+            res_par = ( 0.003, 0.002 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.6, 4.0 ),
+            dz_par1 = ( 0.7, 4.0 ),
+            d0_par2 = ( 0.35, 4.0 ),
+            dz_par2 = ( 0.5, 4.0 )
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'highPtTripletStep',
+            preFilterName = 'highPtTripletStepTight',
+            chi2n_par = 0.7,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.5, 4.0 ),
+            dz_par1 = ( 0.7, 4.0 ),
+            d0_par2 = ( 0.25, 4.0 ),
+            dz_par2 = ( 0.4, 4.0 )
+            ),
+        ) #end of vpset
+    ) #end of clone
+
+# Final sequence
+HighPtTripletStep = cms.Sequence(highPtTripletStepClusters*
+                                highPtTripletStepSeeds*
+                                highPtTripletStepTrackCandidates*
+                                highPtTripletStepTracks*
+                                highPtTripletStepSelector)

--- a/RecoTracker/IterativeTracking/python/Phase2PU140Pixel10D_LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase2PU140Pixel10D_LowPtQuadStep_cff.py
@@ -1,0 +1,202 @@
+import FWCore.ParameterSet.Config as cms
+
+# NEW CLUSTERS (remove previously used clusters)
+lowPtQuadStepClusters = cms.EDProducer("TrackClusterRemover",
+    clusterLessSolution= cms.bool(True),
+    trajectories = cms.InputTag("highPtTripletStepTracks"),
+    overrideTrkQuals = cms.InputTag('highPtTripletStepSelector','highPtTripletStep'),
+    TrackQuality = cms.string('highPurity'),
+    minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
+    pixelClusters = cms.InputTag("siPixelClusters"),
+    stripClusters = cms.InputTag("siStripClusters"),
+    doStripChargeCheck = cms.bool(True),
+    stripRecHits = cms.string('siStripMatchedRecHits'),
+    Common = cms.PSet(
+        maxChi2 = cms.double(9.0),
+        minGoodStripCharge = cms.double(60.0)
+    )
+)
+
+# SEEDING LAYERS
+import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
+lowPtQuadStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.pixellayertriplets.clone(
+    ComponentName = cms.string('lowPtQuadStepSeedLayers'),
+    layerList = cms.vstring('BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
+                            'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
+                            'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
+                            'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
+                            'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
+                            'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
+                            'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
+#ale
+                            'BPix1+FPix1_pos+FPix3_pos',
+                            'BPix1+FPix1_neg+FPix3_neg',
+                            'BPix1+FPix2_pos+FPix3_pos',
+                            'BPix1+FPix2_neg+FPix3_neg',
+                            'BPix1+FPix3_pos+FPix4_pos',
+                            'BPix1+FPix3_neg+FPix4_neg',
+                            'FPix3_pos+FPix4_pos+FPix5_pos',
+                            'FPix3_neg+FPix4_neg+FPix5_neg',
+                            'FPix4_pos+FPix5_pos+FPix6_pos',
+                            'FPix4_neg+FPix5_neg+FPix6_neg',
+                            'FPix5_pos+FPix6_pos+FPix7_pos',
+                            'FPix5_neg+FPix6_neg+FPix7_neg',
+                            'FPix6_pos+FPix7_pos+FPix9_pos',
+                            'FPix6_neg+FPix7_neg+FPix9_neg',
+                            'FPix6_pos+FPix7_pos+FPix10_pos',
+                            'FPix6_neg+FPix7_neg+FPix10_neg',
+                            'FPix7_pos+FPix9_pos+FPix10_pos',
+                            'FPix7_neg+FPix9_neg+FPix10_neg'
+                            )
+    )
+lowPtQuadStepSeedLayers.BPix.skipClusters = cms.InputTag('lowPtQuadStepClusters')
+lowPtQuadStepSeedLayers.FPix.skipClusters = cms.InputTag('lowPtQuadStepClusters')
+
+# SEEDS
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
+from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock
+lowPtQuadStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone(
+    RegionFactoryPSet = RegionPsetFomBeamSpotBlock.clone(
+        ComponentName = cms.string('GlobalRegionProducerFromBeamSpot'),
+        RegionPSet = RegionPsetFomBeamSpotBlock.RegionPSet.clone(
+            ptMin = 0.35,
+            originRadius = 0.02,
+            nSigmaZ = 4.0
+            )
+    ),
+    SeedMergerPSet = cms.PSet(
+        layerListName = cms.string('PixelSeedMergerQuadruplets'),
+	addRemainingTriplets = cms.bool(False),
+	mergeTriplets = cms.bool(True),
+	ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
+    )
+)
+lowPtQuadStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'lowPtQuadStepSeedLayers'
+
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+lowPtQuadStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet.ComponentName = 'LowPtClusterShapeSeedComparitor'
+lowPtQuadStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False)
+lowPtQuadStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(0)
+
+# QUALITY CUTS DURING TRACK BUILDING
+import TrackingTools.TrajectoryFiltering.TrajectoryFilterESProducer_cfi
+lowPtQuadStepStandardTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilterESProducer_cfi.trajectoryFilterESProducer.clone(
+    ComponentName = 'lowPtQuadStepStandardTrajectoryFilter',
+    filterPset = TrackingTools.TrajectoryFiltering.TrajectoryFilterESProducer_cfi.trajectoryFilterESProducer.filterPset.clone(
+    minimumNumberOfHits = 3,
+    minPt = 0.075
+    )
+    )
+
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeTrajectoryFilterESProducer_cfi import *
+# Composite filter
+import TrackingTools.TrajectoryFiltering.CompositeTrajectoryFilterESProducer_cfi
+lowPtQuadStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.CompositeTrajectoryFilterESProducer_cfi.compositeTrajectoryFilterESProducer.clone(
+    ComponentName = cms.string('lowPtQuadStepTrajectoryFilter'),
+    filterNames   = cms.vstring('lowPtQuadStepStandardTrajectoryFilter',
+                                'clusterShapeTrajectoryFilter')
+    )
+
+import TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi
+lowPtQuadStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName = cms.string('lowPtQuadStepChi2Est'),
+    nSigma = cms.double(3.0),
+    MaxChi2 = cms.double(25.0)
+)
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderESProducer_cfi
+lowPtQuadStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderESProducer_cfi.GroupedCkfTrajectoryBuilder.clone(
+    ComponentName = 'lowPtQuadStepTrajectoryBuilder',
+    MeasurementTrackerName = '',
+    trajectoryFilterName = 'lowPtQuadStepTrajectoryFilter',
+    clustersToSkip = cms.InputTag('lowPtQuadStepClusters'),
+    maxCand = 4,
+    estimator = cms.string('lowPtQuadStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
+    # of the outermost Tracker barrel layer (with B=3.8T)
+    maxPtForLooperReconstruction = cms.double(0.7) 
+    )
+
+# MAKING OF TRACK CANDIDATES
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+lowPtQuadStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('lowPtQuadStepSeeds'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    TrajectoryBuilder = 'lowPtQuadStepTrajectoryBuilder',
+    doSeedingRegionRebuilding = True,
+    useHitsSplitting = True
+)
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+lowPtQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src = 'lowPtQuadStepTrackCandidates',
+    AlgorithmName = cms.string('iter2'),
+    Fitter = cms.string('FlexibleKFFittingSmoother'),
+    TTRHBuilder=cms.string('WithTrackAngle')
+    )
+
+from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
+lowPtQuadStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
+        ComponentName = cms.string('lowPtQuadStepTrajectoryCleanerBySharedHits'),
+            fractionShared = cms.double(0.095),
+            allowSharedFirstHit = cms.bool(True)
+            )
+lowPtQuadStepTrackCandidates.TrajectoryCleaner = 'lowPtQuadStepTrajectoryCleanerBySharedHits'
+
+# Final selection
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+lowPtQuadStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src='lowPtQuadStepTracks',
+    trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'lowPtQuadStepLoose',
+            chi2n_par = 2.0,
+            res_par = ( 0.003, 0.002 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.8, 4.0 ),
+            dz_par1 = ( 0.7, 4.0 ),
+            d0_par2 = ( 0.5, 4.0 ),
+            dz_par2 = ( 0.5, 4.0 )
+            ), #end of pset
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'lowPtQuadStepTight',
+            preFilterName = 'lowPtQuadStepLoose',
+            chi2n_par = 1.3,
+            res_par = ( 0.003, 0.002 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.7, 4.0 ),
+            dz_par1 = ( 0.6, 4.0 ),
+            d0_par2 = ( 0.4, 4.0 ),
+            dz_par2 = ( 0.4, 4.0 )
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'lowPtQuadStep',
+            preFilterName = 'lowPtQuadStepTight',
+            chi2n_par = 1.0,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.6, 4.0 ),
+            dz_par1 = ( 0.5, 4.0 ),
+            d0_par2 = ( 0.3, 4.0 ),
+            dz_par2 = ( 0.4, 4.0 )
+            ),
+        ) #end of vpset
+    ) #end of clone
+
+# Final sequence
+LowPtQuadStep = cms.Sequence(lowPtQuadStepClusters*
+                                lowPtQuadStepSeeds*
+                                lowPtQuadStepTrackCandidates*
+                                lowPtQuadStepTracks*
+                                lowPtQuadStepSelector)

--- a/RecoTracker/IterativeTracking/python/Phase2PU140Pixel10D_LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase2PU140Pixel10D_LowPtTripletStep_cff.py
@@ -1,0 +1,193 @@
+import FWCore.ParameterSet.Config as cms
+
+# NEW CLUSTERS (remove previously used clusters)
+lowPtTripletStepClusters = cms.EDProducer("TrackClusterRemover",
+    clusterLessSolution= cms.bool(True),
+    trajectories = cms.InputTag("lowPtQuadStepTracks"),
+    overrideTrkQuals = cms.InputTag('lowPtQuadStepSelector','lowPtQuadStep'),
+    TrackQuality = cms.string('highPurity'),
+    minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
+    pixelClusters = cms.InputTag("siPixelClusters"),
+    stripClusters = cms.InputTag("siStripClusters"),
+    Common = cms.PSet(
+        maxChi2 = cms.double(9.0)
+    )
+)
+
+# SEEDING LAYERS
+import RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi
+lowPtTripletStepSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerTriplets_cfi.pixellayertriplets.clone(
+    ComponentName = cms.string('lowPtTripletStepSeedLayers'),
+    layerList = cms.vstring('BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
+                            'BPix1+BPix3+BPix4', 'BPix1+BPix2+BPix4',
+                            'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
+                            'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
+                            'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
+                            'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
+                            'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
+#ale
+                            'BPix1+FPix1_pos+FPix3_pos',
+                            'BPix1+FPix1_neg+FPix3_neg',
+                            'BPix1+FPix2_pos+FPix3_pos',
+                            'BPix1+FPix2_neg+FPix3_neg',
+                            'BPix1+FPix3_pos+FPix4_pos',
+                            'BPix1+FPix3_neg+FPix4_neg',
+                            'FPix3_pos+FPix4_pos+FPix5_pos',
+                            'FPix3_neg+FPix4_neg+FPix5_neg',
+                            'FPix4_pos+FPix5_pos+FPix6_pos',
+                            'FPix4_neg+FPix5_neg+FPix6_neg',
+                            'FPix5_pos+FPix6_pos+FPix7_pos',
+                            'FPix5_neg+FPix6_neg+FPix7_neg',
+                            'FPix6_pos+FPix7_pos+FPix9_pos',
+                            'FPix6_neg+FPix7_neg+FPix9_neg',
+                            'FPix6_pos+FPix7_pos+FPix10_pos',
+                            'FPix6_neg+FPix7_neg+FPix10_neg',
+                            'FPix7_pos+FPix9_pos+FPix10_pos',
+                            'FPix7_neg+FPix9_neg+FPix10_neg'
+                            )
+    )
+lowPtTripletStepSeedLayers.BPix.skipClusters = cms.InputTag('lowPtTripletStepClusters')
+lowPtTripletStepSeedLayers.FPix.skipClusters = cms.InputTag('lowPtTripletStepClusters')
+
+# SEEDS
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
+from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import RegionPsetFomBeamSpotBlock
+lowPtTripletStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone(
+    RegionFactoryPSet = RegionPsetFomBeamSpotBlock.clone(
+    ComponentName = cms.string('GlobalRegionProducerFromBeamSpot'),
+    RegionPSet = RegionPsetFomBeamSpotBlock.RegionPSet.clone(
+    ptMin = 0.45,
+    originRadius = 0.015,
+    nSigmaZ = 4.0
+    )
+    )
+    )
+lowPtTripletStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'lowPtTripletStepSeedLayers'
+
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+lowPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet.ComponentName = 'LowPtClusterShapeSeedComparitor'
+lowPtTripletStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False)
+lowPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(0)
+
+# QUALITY CUTS DURING TRACK BUILDING
+import TrackingTools.TrajectoryFiltering.TrajectoryFilterESProducer_cfi
+lowPtTripletStepStandardTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilterESProducer_cfi.trajectoryFilterESProducer.clone(
+    ComponentName = 'lowPtTripletStepStandardTrajectoryFilter',
+    filterPset = TrackingTools.TrajectoryFiltering.TrajectoryFilterESProducer_cfi.trajectoryFilterESProducer.filterPset.clone(
+    minimumNumberOfHits = 3,
+    minPt = 0.075
+    )
+    )
+
+from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeTrajectoryFilterESProducer_cfi import *
+# Composite filter
+import TrackingTools.TrajectoryFiltering.CompositeTrajectoryFilterESProducer_cfi
+lowPtTripletStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.CompositeTrajectoryFilterESProducer_cfi.compositeTrajectoryFilterESProducer.clone(
+    ComponentName = cms.string('lowPtTripletStepTrajectoryFilter'),
+    filterNames   = cms.vstring('lowPtTripletStepStandardTrajectoryFilter',
+                                'clusterShapeTrajectoryFilter')
+    )
+
+import TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi
+lowPtTripletStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName = cms.string('lowPtTripletStepChi2Est'),
+    nSigma = cms.double(3.0),
+    MaxChi2 = cms.double(9.0)
+)
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderESProducer_cfi
+lowPtTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderESProducer_cfi.GroupedCkfTrajectoryBuilder.clone(
+    ComponentName = 'lowPtTripletStepTrajectoryBuilder',
+    MeasurementTrackerName = '',
+    trajectoryFilterName = 'lowPtTripletStepTrajectoryFilter',
+    clustersToSkip = cms.InputTag('lowPtTripletStepClusters'),
+    maxCand = 4,
+    estimator = cms.string('lowPtTripletStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    # 0.63 GeV is the maximum pT for a charged particle to loop within the 1.1m radius
+    # of the outermost Tracker barrel layer (with B=3.8T)
+    maxPtForLooperReconstruction = cms.double(0.7) 
+    )
+
+# MAKING OF TRACK CANDIDATES
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+lowPtTripletStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('lowPtTripletStepSeeds'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True),
+    TrajectoryBuilder = 'lowPtTripletStepTrajectoryBuilder',
+    doSeedingRegionRebuilding = True,
+    useHitsSplitting = True
+)
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+lowPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    src = 'lowPtTripletStepTrackCandidates',
+    AlgorithmName = cms.string('iter3'),
+    Fitter = cms.string('FlexibleKFFittingSmoother'),
+    TTRHBuilder=cms.string('WithTrackAngle')
+    )
+
+from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
+lowPtTripletStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
+        ComponentName = cms.string('lowPtTripletStepTrajectoryCleanerBySharedHits'),
+            fractionShared = cms.double(0.09),
+            allowSharedFirstHit = cms.bool(True)
+            )
+lowPtTripletStepTrackCandidates.TrajectoryCleaner = 'lowPtTripletStepTrajectoryCleanerBySharedHits'
+
+# Final selection
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+lowPtTripletStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src='lowPtTripletStepTracks',
+    trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'lowPtTripletStepLoose',
+            chi2n_par = 1.2,
+            res_par = ( 0.003, 0.002 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.7, 4.0 ),
+            dz_par1 = ( 0.6, 4.0 ),
+            d0_par2 = ( 0.5, 4.0 ),
+            dz_par2 = ( 0.5, 4.0 )
+            ), #end of pset
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'lowPtTripletStepTight',
+            preFilterName = 'lowPtTripletStepLoose',
+            chi2n_par = 0.7,
+            res_par = ( 0.003, 0.002 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.6, 4.0 ),
+            dz_par1 = ( 0.5, 4.0 ),
+            d0_par2 = ( 0.4, 4.0 ),
+            dz_par2 = ( 0.4, 4.0 )
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'lowPtTripletStep',
+            preFilterName = 'lowPtTripletStepTight',
+            chi2n_par = 0.4,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.5, 4.0 ),
+            dz_par1 = ( 0.4, 4.0 ),
+            d0_par2 = ( 0.3, 4.0 ),
+            dz_par2 = ( 0.35, 4.0 )
+            ),
+        ) #end of vpset
+    ) #end of clone
+
+# Final sequence
+LowPtTripletStep = cms.Sequence(lowPtTripletStepClusters*
+                                lowPtTripletStepSeeds*
+                                lowPtTripletStepTrackCandidates*
+                                lowPtTripletStepTracks*
+                                lowPtTripletStepSelector)

--- a/RecoTracker/IterativeTracking/python/Phase2PU140Pixel10D_PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase2PU140Pixel10D_PixelPairStep_cff.py
@@ -1,0 +1,186 @@
+import FWCore.ParameterSet.Config as cms
+
+
+# NEW CLUSTERS (remove previously used clusters)
+pixelPairStepClusters = cms.EDProducer("TrackClusterRemover",
+    clusterLessSolution = cms.bool(True),
+    oldClusterRemovalInfo = cms.InputTag("detachedQuadStepClusters"),
+    trajectories = cms.InputTag("detachedQuadStepTracks"),
+    overrideTrkQuals = cms.InputTag('detachedQuadStep'),
+    TrackQuality = cms.string('highPurity'),
+    minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
+    pixelClusters = cms.InputTag("siPixelClusters"),
+    stripClusters = cms.InputTag("siStripClusters"),
+    Common = cms.PSet(
+        maxChi2 = cms.double(9.0)
+    )
+)
+
+# SEEDING LAYERS
+pixelPairStepSeedLayers = cms.ESProducer("SeedingLayersESProducer",
+    ComponentName = cms.string('pixelPairStepSeedLayers'),
+    layerList = cms.vstring('BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3',
+                            'BPix2+BPix4', 'BPix3+BPix4',
+                            'BPix1+FPix1_pos', 'BPix1+FPix1_neg',
+                            'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
+                            'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg',
+                            'FPix2_pos+FPix3_pos', 'FPix2_neg+FPix3_neg'
+#ale
+                            'FPix3_pos+FPix4_pos', 'FPix3_neg+FPix4_neg',
+                            'FPix4_pos+FPix5_pos', 'FPix4_neg+FPix5_neg',
+                            'FPix5_pos+FPix6_pos', 'FPix5_neg+FPix6_neg',
+                            'FPix6_pos+FPix7_pos', 'FPix6_neg+FPix7_neg',
+                            'FPix7_pos+FPix8_pos', 'FPix7_neg+FPix8_neg',
+                            'FPix7_pos+FPix9_pos', 'FPix7_neg+FPix9_neg',
+                            'FPix7_pos+FPix10_pos', 'FPix7_neg+FPix10_neg',
+                            'FPix8_pos+FPix9_pos', 'FPix8_neg+FPix9_neg',
+                            'FPix8_pos+FPix10_pos', 'FPix7_neg+FPix10_neg',
+                            'FPix9_pos+FPix10_pos', 'FPix9_neg+FPix10_neg'
+                            ),
+    BPix = cms.PSet(
+        useErrorsFromParam = cms.bool(True),
+        hitErrorRPhi = cms.double(0.0027),
+        hitErrorRZ = cms.double(0.006),
+        TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
+        HitProducer = cms.string('siPixelRecHits'),
+        skipClusters = cms.InputTag('pixelPairStepClusters')
+    ),
+    FPix = cms.PSet(
+        useErrorsFromParam = cms.bool(True),
+        hitErrorRPhi = cms.double(0.0051),
+        hitErrorRZ = cms.double(0.0036),
+        TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
+        HitProducer = cms.string('siPixelRecHits'),
+        skipClusters = cms.InputTag('pixelPairStepClusters')
+    )
+)
+
+# SEEDS
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromPairsWithVertices_cff
+pixelPairStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromPairsWithVertices_cff.globalSeedsFromPairsWithVertices.clone()
+pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.ptMin = 1.5
+pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.originRadius = 0.015
+pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.fixedError = 0.03
+pixelPairStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = cms.string('pixelPairStepSeedLayers')
+
+pixelPairStepSeeds.SeedComparitorPSet = cms.PSet(
+        ComponentName = cms.string('PixelClusterShapeSeedComparitor'),
+        FilterAtHelixStage = cms.bool(True),
+        FilterPixelHits = cms.bool(True),
+        FilterStripHits = cms.bool(False),
+        ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter')
+    )
+pixelPairStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False)
+pixelPairStepSeeds.OrderedHitsFactoryPSet.maxElement =  cms.uint32(0)
+
+# QUALITY CUTS DURING TRACK BUILDING
+import TrackingTools.TrajectoryFiltering.TrajectoryFilterESProducer_cfi
+pixelPairStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilterESProducer_cfi.trajectoryFilterESProducer.clone(
+    ComponentName = 'pixelPairStepTrajectoryFilter',
+    filterPset = TrackingTools.TrajectoryFiltering.TrajectoryFilterESProducer_cfi.trajectoryFilterESProducer.filterPset.clone(
+    maxLostHitsFraction = cms.double(1./10.),
+    constantValueForLostHitsFractionFilter = cms.double(0.701),
+    minimumNumberOfHits = 3,
+    minPt = 0.1
+    )
+    )
+
+import TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi
+pixelPairStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName = cms.string('pixelPairStepChi2Est'),
+    nSigma = cms.double(3.0),
+    MaxChi2 = cms.double(9.0)
+)
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderESProducer_cfi
+pixelPairStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilderESProducer_cfi.GroupedCkfTrajectoryBuilder.clone(
+    ComponentName = 'pixelPairStepTrajectoryBuilder',
+    MeasurementTrackerName = '',
+    trajectoryFilterName = 'pixelPairStepTrajectoryFilter',
+    clustersToSkip = cms.InputTag('pixelPairStepClusters'),
+    maxCand = 3,
+    estimator = cms.string('pixelPairStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    maxPtForLooperReconstruction = cms.double(0.7) 
+    )
+
+# MAKING OF TRACK CANDIDATES
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+pixelPairStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('pixelPairStepSeeds'),
+    TrajectoryBuilder = 'pixelPairStepTrajectoryBuilder',
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    numHitsForSeedCleaner = cms.int32(50),
+    onlyPixelHitsForSeedCleaner = cms.bool(True)
+)
+
+from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits
+pixelPairStepTrajectoryCleanerBySharedHits = trajectoryCleanerBySharedHits.clone(
+        ComponentName = cms.string('pixelPairStepTrajectoryCleanerBySharedHits'),
+            fractionShared = cms.double(0.09),
+            allowSharedFirstHit = cms.bool(True)
+            )
+pixelPairStepTrackCandidates.TrajectoryCleaner = 'pixelPairStepTrajectoryCleanerBySharedHits'
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+pixelPairStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    AlgorithmName = cms.string('iter5'),
+    src = 'pixelPairStepTrackCandidates',
+    Fitter = cms.string('FlexibleKFFittingSmoother'),
+    TTRHBuilder=cms.string('WithTrackAngle')
+    )
+
+# Final selection
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+pixelPairStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+    src='pixelPairStepTracks',
+    trackSelectors= cms.VPSet(
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'pixelPairStepLoose',
+            chi2n_par = 0.7,
+            res_par = ( 0.003, 0.002 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.3, 4.0 ),
+            dz_par1 = ( 0.35, 4.0 ),
+            d0_par2 = ( 0.35, 4.0 ),
+            dz_par2 = ( 0.35, 4.0 )
+            ), #end of pset
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+            name = 'pixelPairStepTight',
+            preFilterName = 'pixelPairStepLoose',
+            chi2n_par = 0.5,
+            res_par = ( 0.003, 0.002 ),
+            minNumberLayers = 4,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.2, 4.0 ),
+            dz_par1 = ( 0.25, 4.0 ),
+            d0_par2 = ( 0.25, 4.0 ),
+            dz_par2 = ( 0.25, 4.0 )
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'pixelPairStep',
+            preFilterName = 'pixelPairStepTight',
+            chi2n_par = 0.25,
+            res_par = ( 0.003, 0.001 ),
+            minNumberLayers = 5,
+            maxNumberLostLayers = 1,
+            minNumber3DLayers = 4,
+            d0_par1 = ( 0.15, 4.0 ),
+            dz_par1 = ( 0.2, 4.0 ),
+            d0_par2 = ( 0.2, 4.0 ),
+            dz_par2 = ( 0.2, 4.0 )
+            ),
+        ) #end of vpset
+    ) #end of clone
+
+# Final sequence
+PixelPairStep = cms.Sequence(pixelPairStepClusters*
+                         pixelPairStepSeeds*
+                         pixelPairStepTrackCandidates*
+                         pixelPairStepTracks*
+                         pixelPairStepSelector)


### PR DESCRIPTION
New files for the reco (very first attempt)  of the trackerBe5D+ExtendedPixels (Alessia, Carlo, Kevin et al.) 
Tested with cmsdriver commands below [1]
Next step is to test within the 2023 scenario (looking at that right now..)

tested with cmsDriver.py FourMuPt_1_200_cfi --conditions auto:upgradePLS3 -n 10 --eventcontent FEVTDEBUG --relval 9000, 00 -s GEN,SIM --datatier GEN-SIM --beamspot Gauss --customise SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_phase2_BE5DPixel10D --geometry ExtendedPhase2TkBE5DPixel10D --magField 38T_PostLS1 --fileout file:step1.root

cmsDriver.py step2 -s DIGI:pdigi_valid,L1,DIGI2RAW --conditions auto:upgradePLS3 -n 10 --eventcontent FEVTDEBUG  --datatier GEN-SIM-DIGI-RAW --beamspot Gauss --customise SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_phase2_BE5DPixel10D --geometry ExtendedPhase2TkBE5DPixel10D --magField 38T_PostLS1 --filein file:step1.root

 cmsDriver.py step3 -s RAW2DIGI,L1Reco,RECO,EI,VALIDATION,DQM --conditions auto:upgradePLS3 -n 10 --eventcontent FEVTDEBUG,DQM  --datatier GEN-SIM-RECO,DQM  --customise SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_phase2_BE5DPixel10D --geometry ExtendedPhase2TkBE5DPixel10D --magField 38T_PostLS1 --filein file:step2_DIGI_L1_DIGI2RAW.root

cmsDriver.py step4 -s HARVESTING:validationHarvesting+dqmHarvesting --conditions auto:upgradePLS3 -n 1  --customise SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_phase2_BE5DPixel10D --geometry ExtendedPhase2TkBE5DPixel10D --magField 38T_PostLS1 --filein file:step3_RAW2DIGI_L1Reco_RECO_EI_VALIDATION_DQM.root 
