### PR TITLE
Patch hierarchyconstraints to CMSSW_6_2_X_SHLC

### DIFF
--- a/Alignment/CommonAlignmentParametrization/interface/FrameToFrameDerivative.h
+++ b/Alignment/CommonAlignmentParametrization/interface/FrameToFrameDerivative.h
@@ -6,7 +6,10 @@
 
 /// \class FrameToFrameDerivative
 ///
-/// class for calculating derivatives between different frames
+/// Class for calculating the jacobian d_object/d_composedObject
+/// for the rigid body parametrisation of both, i.e. the derivatives
+/// expressing the influence of u, v, w, alpha, beta, gamma of the
+/// composedObject on u, v, w, alpha, beta, gamma of its component 'object'.
 ///
 ///  $Date: 2010/12/14 01:02:34 $
 ///  $Revision: 1.7 $
@@ -18,12 +21,25 @@ class FrameToFrameDerivative
 {
   public:
 
-  /// Return the derivative DeltaFrame(object)/DeltaFrame(composedobject) 
+  /// Return the derivative DeltaFrame(object)/DeltaFrame(composedObject),
+  /// i.e. a 6x6 matrix:
+  ///
+  /// / du/du_c du/dv_c du/dw_c du/da_c du/db_c du/dg_c |
+  /// | dv/du_c dv/dv_c dv/dw_c dv/da_c dv/db_c dv/dg_c |
+  /// | dw/du_c dw/dv_c dw/dw_c dw/da_c dw/db_c dw/dg_c |
+  /// | da/du_c da/dv_c da/dw_c da/da_c da/db_c da/dg_c |
+  /// | db/du_c db/dv_c db/dw_c db/da_c db/db_c db/dg_c |
+  /// \ dg/du_c dg/dv_c dg/dw_c dg/da_c dg/db_c dg/dg_c /
+  ///
+  /// where u, v, w, a, b, g are shifts and rotations of the object
+  /// and u_c, v_c, w_c, a_c, b_c, g_c those of the composed object.
+
   AlgebraicMatrix frameToFrameDerivative(const Alignable* object,
 					 const Alignable* composedObject) const;
 
   /// Calculates derivatives DeltaFrame(object)/DeltaFrame(composedobject) 
-  /// using their positions and orientations.
+  /// using their positions and orientations, see method frameToFrameDerivative(..)
+  /// for definition.
   /// As a new method it gets a new interface avoiding CLHEP that should anyway be
   /// replaced by SMatrix at some point...
   AlgebraicMatrix66 getDerivative(const align::RotationType &objectRot,

--- a/Alignment/CommonAlignmentParametrization/interface/KarimakiAlignmentDerivatives.h
+++ b/Alignment/CommonAlignmentParametrization/interface/KarimakiAlignmentDerivatives.h
@@ -17,7 +17,15 @@ class KarimakiAlignmentDerivatives
 {
 public:
   
-  /// Returns 6x2 jacobian matrix
+  /// Returns 6x2 jacobian matrix of derivatives of residuals in x and y
+  /// with respect to rigid body aligment parameters:
+  ///
+  /// / dr_x/du  dr_y/du |
+  /// | dr_x/dv  dr_y/dv |
+  /// | dr_x/dw  dr_y/dw |
+  /// | dr_x/da  dr_y/da |
+  /// | dr_x/db  dr_y/db |
+  /// \ dr_x/dg  dr_y/dg /
   AlgebraicMatrix operator()(const TrajectoryStateOnSurface &tsos) const;
   
 };

--- a/Alignment/CommonAlignmentParametrization/interface/ParametersToParametersDerivatives.h
+++ b/Alignment/CommonAlignmentParametrization/interface/ParametersToParametersDerivatives.h
@@ -3,11 +3,33 @@
 
 /// \class ParametersToParametersDerivatives
 ///
-/// Class for calculating derivatives for hierarchies between different kind
-/// of alignment parameters (note that not all combinations might be supported!),
-/// needed e.g. to formulate constraints to remove the additional degrees of
-/// freedom introduced if larger structure and their components are aligned
-/// simultaneously.
+/// Class for getting the jacobian d_mother/d_component for various kinds
+/// of alignment parametrisations, i.e. the derivatives expressing the influence
+/// of the parameters of the 'component' on the parameters of its 'mother'.
+/// This is needed e.g. to formulate constraints to remove the additional
+/// degrees of freedom introduced if larger structures and their components
+/// are aligned simultaneously.
+/// The jacobian matrix is
+///
+/// / dp1_l/dp1_i dp1_l/dp2_i  ...  dp1_l/dpn_i |
+/// | dp2_l/dp1_i dp2_l/dp2_i  ...  dp2_l/dpn_i |
+/// |      .           .                 .      |
+/// |      .           .                 .      |
+/// |      .           .                 .      |
+/// \ dpm_l/dpm_i dpm_l/dpm_i  ...  dpm_l/dpn_i /
+///
+/// where 
+/// p1_l, p2_l, ..., pn_l are the n parameters of the composite 'mother' object
+/// and
+/// p1_i, p2_i, ..., pm_i are the m parameters of its component.
+///
+/// Note that not all combinations of parameters are supported:
+/// Please check method isOK() before accessing the derivatives via 
+/// operator(unsigned int indParMother, unsigned int indParComp).
+///
+/// Currently these parameters are supported:
+/// - mother: rigid body parameters,
+/// - component: rigid body, bowed surface or two bowed surfaces parameters.
 ///
 ///  $Date: 2010/12/14 01:08:25 $
 ///  $Revision: 1.2 $
@@ -26,8 +48,9 @@ class ParametersToParametersDerivatives
   /// Indicate whether able to provide the derivatives.
   bool isOK() const { return isOK_;}
 
-  /// Return the derivative DeltaParam(object)/DeltaParam(composedobject), indices start with 0.
-  /// But check isOK() first!
+  /// Return the derivative DeltaParam(mother)/DeltaParam(component).
+  /// Indices start with 0 - but check isOK() first!
+  /// See class description about matrix.
   double operator() (unsigned int indParMother, unsigned int indParComp) const; 
 
   // Not this - would make the internals public:
@@ -45,8 +68,10 @@ class ParametersToParametersDerivatives
   bool init2BowedRigid(const Alignable &component, const Alignable &mother);
 
   typedef ROOT::Math::SMatrix<double,6,9,ROOT::Math::MatRepStd<double,6,9> > AlgebraicMatrix69;
-  AlgebraicMatrix69 dBowed_dRigid(const AlgebraicMatrix66 &f2f,
-				  double halfWidth, double halfLength) const;
+  /// from d(rigid_mother)/d(rigid_component) to d(rigid_mother)/d(bowed_component)
+  /// for bad input (length or width zero), set object to invalid: isOK_ = false
+  AlgebraicMatrix69 dRigid_dBowed(const AlgebraicMatrix66 &dRigidM2dRigidC,
+				  double halfWidth, double halfLength);
 
   /// data members
   bool            isOK_; /// can we provide the desired?

--- a/Alignment/CommonAlignmentParametrization/src/BeamSpotAlignmentParameters.cc
+++ b/Alignment/CommonAlignmentParametrization/src/BeamSpotAlignmentParameters.cc
@@ -10,7 +10,6 @@
 #include "Alignment/CommonAlignment/interface/Utilities.h"
 #include "Alignment/CommonAlignment/interface/Alignable.h"
 #include "Alignment/CommonAlignment/interface/AlignableDetOrUnitPtr.h"
-#include "Alignment/CommonAlignmentParametrization/interface/FrameToFrameDerivative.h"
 #include "Alignment/CommonAlignmentParametrization/interface/BeamSpotAlignmentDerivatives.h"
 #include "Alignment/CommonAlignmentParametrization/interface/AlignmentParametersFactory.h"
 #include "CondFormats/Alignment/interface/Definitions.h"
@@ -97,10 +96,11 @@ BeamSpotAlignmentParameters::derivatives( const TrajectoryStateOnSurface &tsos,
 
   if (ali == alidet) { // same alignable => same frame
     return BeamSpotAlignmentDerivatives()(tsos);
-  } else { // different alignable => transform into correct frame
-    const AlgebraicMatrix deriv = BeamSpotAlignmentDerivatives()(tsos);
-    FrameToFrameDerivative ftfd;
-    return ftfd.frameToFrameDerivative(alidet, ali) * deriv;
+  } else {
+    throw cms::Exception("MisMatch")
+      << "BeamSpotAlignmentParameters::derivatives: The hit alignable must match the "
+      << "aligned one, i.e. these parameters make only sense for AlignableBeamSpot.\n";
+    return AlgebraicMatrix(N_PARAM, 2); // please compiler
   }
 }
 

--- a/Alignment/CommonAlignmentParametrization/src/FrameToFrameDerivative.cc
+++ b/Alignment/CommonAlignmentParametrization/src/FrameToFrameDerivative.cc
@@ -96,8 +96,7 @@ FrameToFrameDerivative::getDerivative(const align::RotationType &objectRot,
   derivative[5][4] = derivBB[2][1];
   derivative[5][5] = derivBB[2][2];
   
-  return(derivative.T());
-
+  return derivative;
 }
 
 

--- a/Alignment/CommonAlignmentParametrization/src/RigidBodyAlignmentParameters.cc
+++ b/Alignment/CommonAlignmentParametrization/src/RigidBodyAlignmentParameters.cc
@@ -93,7 +93,7 @@ RigidBodyAlignmentParameters::derivatives( const TrajectoryStateOnSurface &tsos,
   } else { // different alignable => transform into correct frame
     const AlgebraicMatrix deriv = KarimakiAlignmentDerivatives()(tsos);
     FrameToFrameDerivative ftfd;
-    return ftfd.frameToFrameDerivative(alidet, ali) * deriv;
+    return ftfd.frameToFrameDerivative(alidet, ali).T() * deriv;
   }
 }
 

--- a/Alignment/CommonAlignmentParametrization/src/RigidBodyAlignmentParameters4D.cc
+++ b/Alignment/CommonAlignmentParametrization/src/RigidBodyAlignmentParameters4D.cc
@@ -29,7 +29,7 @@ RigidBodyAlignmentParameters4D::derivatives( const TrajectoryStateOnSurface &tso
   } else { // different alignable => transform into correct frame
     const AlgebraicMatrix deriv = SegmentAlignmentDerivatives4D()(tsos);
     FrameToFrameDerivative ftfd;
-    return ftfd.frameToFrameDerivative(alidet, ali) * deriv;
+    return ftfd.frameToFrameDerivative(alidet, ali).T() * deriv;
   }
 }
 


### PR DESCRIPTION
This is a backport to 70X of pull request #2370. Notes from there:

> This patch has been prepared by Gero Flucke some time ago, see https://twiki.cern.ch/twiki/bin/viewauth/CMS/TkAlignmentLegacyThoughts, first topic. Testing happened on CMSSW_4_4_5. Results were presented in the alignment meeting of Oct 31, 2013, where the modifications got blessed. See https://twiki.cern.ch/twiki/bin/viewauth/CMS/TkAlPullReq201401 for more details and link to the presentation.
> This is an outstanding issue since months that was not put into git.

For consistency, this needs to be put into earlier releases as well.
