### PR TITLE
Modified PhysicsTools/Utilities/scripts/edmPickEvents.py

### DIFF
--- a/PhysicsTools/Utilities/scripts/edmPickEvents.py
+++ b/PhysicsTools/Utilities/scripts/edmPickEvents.py
@@ -166,10 +166,11 @@ def setupCrabDict (options):
     crab['email']         = options.email
     if options.crabCondor:
         crab['scheduler'] = 'condor'
-        crab['useServer'] = ''
+#        crab['useServer'] = ''
     else:
-        crab['scheduler'] = 'glite'
-        crab['useServer'] = 'use_server              = 1'
+        crab['scheduler'] = 'remoteGlidein'
+#        crab['useServer'] = 'use_server              = 1'
+    crab['useServer'] = ''
     return crab
 
 
@@ -217,7 +218,9 @@ jobtype                 = cmssw
 
 if __name__ == "__main__":
     email = guessEmail()
-    parser = optparse.OptionParser ("Usage: %prog [options] dataset events_or_events.txt", description='''This program facilitates picking specific events from a data set.  For full details, please visit https://twiki.cern.ch/twiki/bin/view/CMS/PickEvents ''')
+    parser = optparse.OptionParser ("Usage: %prog [options] dataset events_or_events.txt", description='''This program 
+facilitates picking specific events from a data set.  For full details, please visit 
+https://twiki.cern.ch/twiki/bin/view/CMS/PickEvents ''')
     parser.add_option ('--output', dest='base', type='string',
                        default='pickevents',
                        help='Base name to use for output files (root, JSON, run and event list, etc.; default "%default")')
@@ -323,3 +326,4 @@ if __name__ == "__main__":
         print "\n%s" % command
         if options.runInteractive and not options.printInteractive:
             os.system (command)
+


### PR DESCRIPTION
The grid scheduler condor does not exist anymore. We have moved to scheduler remoteGlidein. The script edmPickEvents.py is used to quickly pick events from datasets if they are available  locally OR run a grid job if they are not available locally. Hence this modification was needed. I have tested the script and it works fine. Kindly accept the request and make incorporate it in other releases.

The details are as follows:
I have changed the python script PhysicsTools/Utilities/scripts/edmPickEvents.py to replace scheduler from "condor" to "remoteGlidein" and moved the reference to useServer outside the "if" loop. 
