### PR TITLE
Add PhysicsTGraphPayload as a serializable class

### DIFF
--- a/CondFormats/PhysicsToolsObjects/interface/PhysicsTGraphPayload.h
+++ b/CondFormats/PhysicsToolsObjects/interface/PhysicsTGraphPayload.h
@@ -11,6 +11,8 @@
  *
  */
 
+#include "CondFormats/Serialization/interface/Serializable.h"
+
 #include "TGraph.h"
 
 #include <vector>
@@ -37,6 +39,8 @@ class PhysicsTGraphPayload
   int numPoints_;
   std::vector<float> x_;
   std::vector<float> y_;
+
+  COND_SERIALIZABLE;
 };
 
 #endif

--- a/CondFormats/PhysicsToolsObjects/src/Serialization.cc
+++ b/CondFormats/PhysicsToolsObjects/src/Serialization.cc
@@ -81,6 +81,16 @@ void PhysicsTFormulaPayload::serialize(Archive & ar, const unsigned int)
 COND_SERIALIZATION_INSTANTIATE(PhysicsTFormulaPayload);
 
 template <class Archive>
+void PhysicsTGraphPayload::serialize(Archive & ar, const unsigned int)
+{
+    ar & BOOST_SERIALIZATION_NVP(name_);
+    ar & BOOST_SERIALIZATION_NVP(numPoints_);
+    ar & BOOST_SERIALIZATION_NVP(x_);
+    ar & BOOST_SERIALIZATION_NVP(y_);
+}
+COND_SERIALIZATION_INSTANTIATE(PhysicsTGraphPayload);
+
+template <class Archive>
 void PhysicsTools::Calibration::BitSet::serialize(Archive & ar, const unsigned int)
 {
     ar & BOOST_SERIALIZATION_NVP(store);

--- a/CondFormats/PhysicsToolsObjects/src/headers.h
+++ b/CondFormats/PhysicsToolsObjects/src/headers.h
@@ -12,3 +12,5 @@
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromBinnedTFormula.h"
 #include "CondFormats/PhysicsToolsObjects/interface/PhysicsTFormulaPayload.h"
+
+#include "CondFormats/PhysicsToolsObjects/interface/PhysicsTGraphPayload.h"

--- a/CondFormats/PhysicsToolsObjects/test/testSerializationPhysicsToolsObjects.cpp
+++ b/CondFormats/PhysicsToolsObjects/test/testSerializationPhysicsToolsObjects.cpp
@@ -13,6 +13,7 @@ int main()
     testSerialization<PerformanceWorkingPoint>();
     testSerialization<PhysicsPerformancePayload>();
     testSerialization<PhysicsTFormulaPayload>();
+    testSerialization<PhysicsTGraphPayload>();
     testSerialization<PhysicsTools::Calibration::BitSet>();
     testSerialization<PhysicsTools::Calibration::Histogram2D<double,double,double>>();
     testSerialization<PhysicsTools::Calibration::Histogram2D<float,float,float>>();
@@ -47,6 +48,7 @@ int main()
     testSerialization<std::vector<BinningVariables::BinningVariablesType>>();
     testSerialization<std::vector<PerformanceResult::ResultType>>();
     testSerialization<std::vector<PhysicsTFormulaPayload>>();
+    testSerialization<std::vector<PhysicsTGraphPayload>>();
     testSerialization<std::vector<PhysicsTools::Calibration::HistogramD2D>>();
     testSerialization<std::vector<PhysicsTools::Calibration::HistogramD3D>>();
     testSerialization<std::vector<PhysicsTools::Calibration::HistogramD>>();


### PR DESCRIPTION
Fixes the BOOSTIO IB, which was broken due to the merge of PR #2536
