### PR TITLE
Don't fail on harmless warnings

### DIFF
--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -110,6 +110,8 @@ namespace {
           (el_message.find("already in TClassTable") != std::string::npos) ||
           (el_message.find("matrix not positive definite") != std::string::npos) ||
           (el_message.find("not a TStreamerInfo object") != std::string::npos) ||
+          (el_message.find("nbins is <=0") != std::string::npos) ||
+          (el_message.find("Problems declaring payload") != std::string::npos) ||
           (el_location.find("Fit") != std::string::npos) ||
           (el_location.find("TDecompChol::Solve") != std::string::npos) ||
           (el_location.find("THistPainter::PaintInit") != std::string::npos) ||


### PR DESCRIPTION
CMSSW intentionally converts ROOT warning messages to fatal exceptions except for specific warnings that are white listed. Many relvals in the ROOT6 branch are failing because of two harmless warning messages that are new for ROOT6.
This pull request avoids exceptions for these two messages.
