### PR TITLE
Delta R overlap filter for Candidates

### DIFF
--- a/CommonTools/UtilAlgos/plugins/BuildFile.xml
+++ b/CommonTools/UtilAlgos/plugins/BuildFile.xml
@@ -5,4 +5,5 @@
   <use   name="FWCore/ParameterSet"/>
   <use   name="CommonTools/UtilAlgos"/>
   <use   name="FWCore/ServiceRegistry"/>
+  <use   name="DataFormats/Candidate"/>
 </library>

--- a/CommonTools/UtilAlgos/plugins/DeltaROverlapExclusionSelector.h
+++ b/CommonTools/UtilAlgos/plugins/DeltaROverlapExclusionSelector.h
@@ -1,0 +1,12 @@
+#include "CommonTools/UtilAlgos/interface/MatchByDR.h"
+#include "CommonTools/UtilAlgos/interface/SingleObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/OverlapExclusionSelector.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+
+typedef SingleObjectSelector<
+  edm::View<reco::Candidate> ,
+  OverlapExclusionSelector<edm::View<reco::Candidate> ,
+                           reco::Candidate, 
+                           reco::MatchByDR<reco::Candidate, reco::Candidate> >
+  > DeltaROverlapExclusionSelector;
+

--- a/CommonTools/UtilAlgos/plugins/SealModule.cc
+++ b/CommonTools/UtilAlgos/plugins/SealModule.cc
@@ -1,0 +1,5 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "CommonTools/UtilAlgos/plugins/DeltaROverlapExclusionSelector.h"
+
+DEFINE_FWK_MODULE(DeltaROverlapExclusionSelector);

--- a/DataFormats/ParticleFlowCandidate/src/classes.h
+++ b/DataFormats/ParticleFlowCandidate/src/classes.h
@@ -29,7 +29,7 @@
 #include "DataFormats/Common/interface/OneToManyWithQualityGeneric.h"
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
-
+#include "DataFormats/Common/interface/RefVectorHolder.h"
 
 namespace DataFormats_ParticleFlowCandidate {
   struct dictionary {
@@ -48,6 +48,7 @@ namespace DataFormats_ParticleFlowCandidate {
     std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > bla335;
     edm::Wrapper<edm::ValueMap<std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > > > valueMap_iso_wr;
     edm::ValueMap<std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > >  valueMap_iso; 
+    edm::reftobase::RefVectorHolder<reco::PFCandidateRefVector > bla3351;
 
     edm::Wrapper<edm::ValueMap<edm::Ptr<reco::PFCandidate> > > bla336;
     edm::ValueMap<edm::Ptr<std::vector<reco::PFCandidate> > >  bla337;

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -38,7 +38,7 @@
   <class name="edm::ValueMap<edm::Ptr<std::vector<reco::PFCandidate> > >"/>
   <class name="std::vector<edm::Ptr<std::vector<reco::PFCandidate> > >"/>
   <class name="edm::ValueMap<edm::Ptr<reco::PFCandidate> >"/>
-
+  <class name="edm::reftobase::RefVectorHolder<reco::PFCandidateRefVector >"/>
 
   <class name="reco::IsolatedPFCandidate"  ClassVersion="10">
    <version ClassVersion="10" checksum="1426765407"/>


### PR DESCRIPTION
Adds a filter that runs on a collection of Cands and removes those that overlap in deltaR with another collection.  Also adds dictionary for output of this module when running on PFCandidates.

The use case is for L3 muons in HLT paths with PF iso, which are seen to occasionally overlap with PF Hadrons. Hopefully going to be a temporary fix until the PF behavior there is fully understood.

The implementation was discussed on the physTools hn:
https://hypernews.cern.ch/HyperNews/CMS/get/physTools/3163/1/1/1/1/1/2/1/1/1.html

Would also like to backport this to 70X if possible.
