### PR TITLE
Fixed configuration typo for Extended2023TTI (tests 128xx)

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1135,7 +1135,7 @@ upgradeCustoms={ '2017' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.
                  'Extended2023HGCalMuon' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
                  'Extended2023SHCal' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
                  'Extended2023SHCal4Eta' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
-                 'Extended2023TTI' : 'SLHCUpgradeSimulations/Configuration/combinedCustomsTTI.cust_phase2_BE5D',
+                 'Extended2023TTI' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms_TTI.cust_phase2_BE5D',
                  'Extended2023Muon' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023Muon'
                  }
 ### remember that you need to add a new step for phase 2 to include the track trigger


### PR DESCRIPTION
Allows the 128xx tests to run GEN-SIM.  Now fails in step 2.
