### PR TITLE
option in the matrix --revertDqmio  and HI min bias 2k

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -243,6 +243,9 @@ class MatrixReader(object):
                         if self.apply:
                             if stepIndex in self.apply or stepName in self.apply:
                                 cmd +=' '+self.addCommand
+                            if self.wm: # add top-level option
+                                cmd=cmd.replace('DQMROOT','DQM')
+                                cmd=cmd.replace('--filetype DQM','')
                         else:
                             cmd +=' '+self.addCommand
                 commands.append(cmd)
@@ -332,6 +335,8 @@ class MatrixReader(object):
                     line += ' @@@'
                 else:
                     line += ' @@@ '+commands[0]
+                # add top-level option    
+                line=line.replace('DQMROOT','DQM')
                 writtenWF+=1
                 outFile.write(line+'\n')
 
@@ -344,6 +349,8 @@ class MatrixReader(object):
                     stepIndex=index+1
                     if 'dasquery.log' in cmd: continue
                     line = 'STEP%d ++ '%(stepIndex,) +stepName + ' @@@ '+cmd
+                    # add top-level option
+                    line=line.replace('DQMROOT','DQM')
                     outFile.write(line+'\n')
                 outFile.write('\n'+'\n')
             outFile.close()

--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -20,6 +20,7 @@ class MatrixReader(object):
         self.reset(opt.what)
 
         self.wm=opt.wmcontrol
+        self.revertDqmio=opt.revertDqmio
         self.addCommand=opt.command
         self.apply=opt.apply
         self.commandLineWf=opt.workflow
@@ -243,11 +244,11 @@ class MatrixReader(object):
                         if self.apply:
                             if stepIndex in self.apply or stepName in self.apply:
                                 cmd +=' '+self.addCommand
-                            if self.wm: # add top-level option
-                                cmd=cmd.replace('DQMROOT','DQM')
-                                cmd=cmd.replace('--filetype DQM','')
-                        else:
-                            cmd +=' '+self.addCommand
+                            else:
+                                cmd +=' '+self.addCommand
+                    if self.wm and self.revertDqmio=='yes':
+                        cmd=cmd.replace('DQMROOT','DQM')
+                        cmd=cmd.replace('--filetype DQM','')
                 commands.append(cmd)
                 ranStepList.append(stepName)
                 stepIndex+=1
@@ -335,8 +336,8 @@ class MatrixReader(object):
                     line += ' @@@'
                 else:
                     line += ' @@@ '+commands[0]
-                # add top-level option    
-                line=line.replace('DQMROOT','DQM')
+                if self.revertDqmio=='yes':
+                    line=line.replace('DQMROOT','DQM')
                 writtenWF+=1
                 outFile.write(line+'\n')
 
@@ -349,8 +350,8 @@ class MatrixReader(object):
                     stepIndex=index+1
                     if 'dasquery.log' in cmd: continue
                     line = 'STEP%d ++ '%(stepIndex,) +stepName + ' @@@ '+cmd
-                    # add top-level option
-                    line=line.replace('DQMROOT','DQM')
+                    if self.revertDqmio=='yes':
+                        line=line.replace('DQMROOT','DQM')
                     outFile.write(line+'\n')
                 outFile.write('\n'+'\n')
             outFile.close()

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -765,15 +765,15 @@ steps['AMPT_PPb_5020GeV_MinimumBias']=merge([{'-n':10},step1PPbDefaults,genS('AM
 steps['AMPT_PPb_5020GeV_MinimumBiasINPUT']={'INPUT':InputInfo(dataSet='/RelValAMPT_PPb_5020GeV_MinimumBias/%s/GEN-SIM'%(baseDataSetRelease[5],),location='STD')}
 
 ## heavy ions tests
-U500by1={'--relval': '500,1'}
+U2000by1={'--relval': '2000,1'}
 U80by1={'--relval': '80,1'}
 
 hiDefaults={'--conditions':'auto:starthi_HIon',
            '--scenario':'HeavyIons'}
 
-steps['HydjetQ_MinBias_2760GeV']=merge([{'-n':1},hiDefaults,genS('Hydjet_Quenched_MinBias_2760GeV_cfi',U500by1)])
+steps['HydjetQ_MinBias_2760GeV']=merge([{'-n':1},hiDefaults,genS('Hydjet_Quenched_MinBias_2760GeV_cfi',U2000by1)])
 steps['HydjetQ_MinBias_2760GeVINPUT']={'INPUT':InputInfo(dataSet='/RelValHydjetQ_MinBias_2760GeV/%s/GEN-SIM'%(baseDataSetRelease[1],),location='STD',split=5)}
-steps['HydjetQ_MinBias_2760GeV_UP15']=merge([{'-n':1},hiDefaults,genS('Hydjet_Quenched_MinBias_2760GeV_cfi',U500by1)])
+steps['HydjetQ_MinBias_2760GeV_UP15']=merge([{'-n':1},hiDefaults,genS('Hydjet_Quenched_MinBias_2760GeV_cfi',U2000by1)])
 steps['HydjetQ_MinBias_2760GeV_UP15INPUT']={'INPUT':InputInfo(dataSet='/RelValHydjetQ_MinBias_2760GeV/%s/GEN-SIM'%(baseDataSetRelease[1],),location='STD',split=5)}
 steps['HydjetQ_B0_2760GeV']=merge([{'-n':1},hiDefaults,genS('Hydjet_Quenched_B0_2760GeV_cfi',U80by1)])
 steps['HydjetQ_B0_2760GeVINPUT']={'INPUT':InputInfo(dataSet='/RelValHydjetQ_B0_2760GeV/%s/GEN-SIM'%(baseDataSetRelease[4],),location='STD')}

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -132,6 +132,12 @@ if __name__ == '__main__':
                       dest='wmcontrol',
                       default=None,
                       )
+    parser.add_option('--revertDqmio',
+                      help='When submitting workflows to wmcontrol, force DQM outout to use pool and not DQMIO',
+                      choices=['yes','no'],
+                      dest='revertDqmio',
+                      default='no',
+                      )
     parser.add_option('--optionswm',
                       help='Specify a few things for wm injection',
                       default='',


### PR DESCRIPTION
- add --revertDqmio option to the validation matrix to revert DQM output to pool (while we test the DQMIO)
- affects only relval submission  and neither local workflows nor usage in IB's
- HI min bias sample from 500 to 2k (only relevant for production)
