### PR TITLE
Migrate Code to New Random Service Interface

### DIFF
--- a/FastSimulation/MaterialEffects/interface/NuclearInteractionSimulator.h
+++ b/FastSimulation/MaterialEffects/interface/NuclearInteractionSimulator.h
@@ -97,6 +97,8 @@ class NuclearInteractionSimulator : public MaterialEffectsSimulator
   std::ofstream myOutputFile;
   unsigned myOutputBuffer;
 
+  bool currentValuesWereSet;
+
   //  DaqMonitorBEInterface * dbe;
   //  MonitorElement* hAfter;
   //  MonitorElement* hAfter2;

--- a/FastSimulation/PileUpProducer/plugins/PileUpProducer.h
+++ b/FastSimulation/PileUpProducer/plugins/PileUpProducer.h
@@ -9,9 +9,13 @@
 #include <fstream>
 #include "TH1F.h"
 
-class ParameterSet;
-class Event;
-class EventSetup;
+namespace edm {
+  class Event;
+  class EventSetup;
+  class LuminosityBlock;
+  class ParameterSet;
+  class Run;
+}
 
 class TFile;
 class TTree;
@@ -28,6 +32,7 @@ class PileUpProducer : public edm::EDProducer
   explicit PileUpProducer(edm::ParameterSet const & p);
   virtual ~PileUpProducer();
   virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void produce(edm::Event & e, const edm::EventSetup & c) override;
 
@@ -66,6 +71,8 @@ class PileUpProducer : public edm::EDProducer
   std::vector<double> dataProb;
   int varSize;
   int probSize;
+
+  bool currentValuesWereSet;
 };
 
 #endif

--- a/FastSimulation/Utilities/interface/RandomEngineAndDistribution.h
+++ b/FastSimulation/Utilities/interface/RandomEngineAndDistribution.h
@@ -22,12 +22,6 @@ class RandomEngineAndDistribution {
   RandomEngineAndDistribution(edm::StreamID const&);
   RandomEngineAndDistribution(edm::LuminosityBlockIndex const&);
 
-  // This is strongly deprecated, it exists for backward compatibility
-  // for cases where the above two functions cannot be used easily.
-  // It is the intent fix all those cases and delete this function
-  // as soon as possible.
-  RandomEngineAndDistribution();
-
   ~RandomEngineAndDistribution();
 
   CLHEP::HepRandomEngine& theEngine() const { return *engine_; }

--- a/FastSimulation/Utilities/src/RandomEngineAndDistribution.cc
+++ b/FastSimulation/Utilities/src/RandomEngineAndDistribution.cc
@@ -41,22 +41,5 @@ RandomEngineAndDistribution::RandomEngineAndDistribution(edm::LuminosityBlockInd
     rootEngine_ = ( (edm::TRandomAdaptor*) engine_ )->getRootEngine();
 }
 
-RandomEngineAndDistribution::RandomEngineAndDistribution() :
-  engine_(nullptr),
-  rootEngine_(nullptr) {
-  edm::Service<edm::RandomNumberGenerator> rng;
-  if ( ! rng.isAvailable() ) {
-    throw cms::Exception("Configuration") <<
-      "RandomNumberGenerator service is not available.\n"
-      "You must add the service in the configuration file\n"
-      "or remove the module that requires it.";
-  }
-  engine_ = &rng->getEngine();
-
-  // Get the TRandom3 egine, to benefit from Root functional random generation
-  if ( engine_->name() == "TRandom3" )
-    rootEngine_ = ( (edm::TRandomAdaptor*) engine_ )->getRootEngine();
-}
-
 RandomEngineAndDistribution::~RandomEngineAndDistribution() {
 }


### PR DESCRIPTION
Migrate FastSimulation code to use the new interface
of the random number generator service designed to work
with the multithreaded Framework. The main interface
change is to require a StreamID or LuminosityBlockIndex
argument to the getEngine function. These objects are only
available during the event or beginLuminosityBlock method.
