### PR TITLE
Update version numbers for ROOT6

### DIFF
--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -57,10 +57,11 @@
    <version ClassVersion="11" checksum="9999999999"/>
    <version ClassVersion="10" checksum="2078425999"/>
   </class>
-  <class name="reco::MuonPFIsolation" ClassVersion="15">
+  <class name="reco::MuonPFIsolation" ClassVersion="16">
    <version ClassVersion="13" checksum="893633899"/>
    <version ClassVersion="14" checksum="3941472816"/>
    <version ClassVersion="15" checksum="838139830"/>
+   <version ClassVersion="16" checksum="9999999999"/>
   </class>
 
   <class name="reco::Muon::MuonTrackRefMap"/>

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -1,10 +1,11 @@
 <lcgdict>
 
-   <class name="reco::PFCandidate" ClassVersion="13">
+   <class name="reco::PFCandidate" ClassVersion="14">
     <version ClassVersion="10" checksum="536762407"/>
     <version ClassVersion="11" checksum="2503588164"/>
     <version ClassVersion="12" checksum="2782366916"/>
     <version ClassVersion="13" checksum="3911979988"/>
+    <version ClassVersion="14" checksum="9999999999"/>
      <field name="elementsInBlocks_" transient="true"/>
      <field name="getter_" transient="true"/>
      <field name="refsCollectionCache_" transient="true"/>

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -57,7 +57,8 @@
   <class name="edm::Ref< std::vector<reco::Track>, reco::Track, edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >"/>
 -->  
 
-  <class name="reco::PFTrajectoryPoint" ClassVersion="11">
+  <class name="reco::PFTrajectoryPoint" ClassVersion="12">
+   <version ClassVersion="12" checksum="9999999999"/>
    <version ClassVersion="11" checksum="2337677018"/>
 <!-- Removed by Patrick: avoid many useless PFTrack copies (memory+CPU) and costless for RECO/AOD
     <field name="posrep_" transient="true"/>

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -4,8 +4,9 @@
 	<class name="HepMC::GenEvent" ClassVersion="10">
   <version ClassVersion="10" checksum="2993730389"/>
  </class>
-	<class name="HepMC::GenVertex" ClassVersion="10">
+	<class name="HepMC::GenVertex" ClassVersion="11">
   <version ClassVersion="10" checksum="1541111972"/>
+  <version ClassVersion="11" checksum="9999999999"/>
  </class>
 	<class name="HepMC::GenParticle" ClassVersion="10">
   <version ClassVersion="10" checksum="3138667414"/>
@@ -15,10 +16,11 @@
     <class name="HepMC::GenCrossSection" ClassVersion="10">
      <version ClassVersion="10" checksum="920043842"/>
     </class>
-	<class name="HepMC::WeightContainer" ClassVersion="12">
+	<class name="HepMC::WeightContainer" ClassVersion="13">
   <version ClassVersion="10" checksum="2163093401"/>
   <version ClassVersion="11" checksum="376377869"/>
   <version ClassVersion="12" checksum="2537869863"/>
+  <version ClassVersion="13" checksum="9999999999"/>
   </class>
 	<class name="HepMC::FourVector" ClassVersion="10">
   <version ClassVersion="10" checksum="3279825169"/>


### PR DESCRIPTION
This pull request updates the version numbers of five more classes for which the checksum has changed between ROOT5 and ROOT6.  This fixes some fatal errors in the relval tests in the ROOT6 branch.
The values of the checksums in ROOT6 are placeholders for now.

Please merge promptly unless something is wrong.
