### PR TITLE
Overriding the cache to avoid high xrootd failure rates in pileup dataset reads

### DIFF
--- a/Utilities/XrdAdaptor/src/XrdFile.cc
+++ b/Utilities/XrdAdaptor/src/XrdFile.cc
@@ -136,6 +136,8 @@ XrdFile::open (const char *name,
 
   m_name = name;
   m_client = new XrdClient(name);
+  m_client->UseCache(false); // Hack from Prof. Bockelman
+
   if (! m_client->Open(perms, openflags)
       || m_client->LastServerResp()->status != kXR_ok) {
     edm::Exception ex(edm::errors::FileOpenError);


### PR DESCRIPTION
This appears to fix a problem with intermittent failures observed in production while reading pileup datasets via xrootd.  FNAL uses local xrootd reads by default and this is starting to happen at the ~10% order.  See:

https://savannah.cern.ch/support/?141988

We need to get this into a 62x prerelease to scale test the fix, then if that is workable will probably need this ported to all production releases.
