### PR TITLE
Check for unrunnable schedules

### DIFF
--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -73,6 +73,9 @@ namespace edm {
     };
     void labelsForToken(EDGetToken iToken, Labels& oLabels) const;
     
+    void modulesDependentUpon(const std::string& iProcessName,
+                              std::vector<const char*>& oModuleLabels) const;
+    
   protected:
     friend class ConsumesCollector;
     template<typename T> friend class WillGetIfMatch;

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -235,6 +235,9 @@ namespace edm {
 
   private:
 
+    /// Check that the schedule is actually runable
+    void checkForCorrectness() const;
+    
     void limitOutput(ParameterSet const& proc_pset, BranchIDLists const& branchIDLists);
 
     std::shared_ptr<TriggerResultInserter> resultsInserter_;

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -84,6 +84,9 @@ namespace edm {
                         ProductHolderIndexHelper const&);
       
       const EDConsumerBase* consumer() const;
+      
+      void modulesDependentUpon(const std::string& iProcessName,
+                                std::vector<const char*>& oModuleLabels) const;
     private:
       EDAnalyzerAdaptorBase(const EDAnalyzerAdaptorBase&); // stop default
       

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -76,6 +76,9 @@ namespace edm {
       void updateLookup(BranchType iBranchType,
                         ProductHolderIndexHelper const&);
 
+      void modulesDependentUpon(const std::string& iProcessName,
+                                std::vector<const char*>& oModuleLabels) const;
+
 
     protected:
       template<typename F> void createStreamModules(F iFunc) {

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -106,6 +106,7 @@ namespace edm {
     virtual void updateLookup(BranchType iBranchType,
                       ProductHolderIndexHelper const&) = 0;
 
+    virtual void modulesDependentUpon(std::vector<const char*>& oModuleLabels) const = 0;
     
     virtual Types moduleType() const =0;
 

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -98,11 +98,15 @@ namespace edm {
                                                unsigned int iNumberOfChildren) override;
     virtual std::string workerType() const override;
 
-    virtual void itemsToGet(BranchType branchType, std::vector<ProductHolderIndexAndSkipBit>& indexes) const {
+    virtual void modulesDependentUpon(std::vector<const char*>& oModuleLabels) const override {
+      module_->modulesDependentUpon(module_->moduleDescription().processName(),oModuleLabels);
+    }
+
+    virtual void itemsToGet(BranchType branchType, std::vector<ProductHolderIndexAndSkipBit>& indexes) const override {
       module_->itemsToGet(branchType, indexes);
     }
 
-    virtual void itemsMayGet(BranchType branchType, std::vector<ProductHolderIndexAndSkipBit>& indexes) const {
+    virtual void itemsMayGet(BranchType branchType, std::vector<ProductHolderIndexAndSkipBit>& indexes) const override {
       module_->itemsMayGet(branchType, indexes);
     }
 

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -111,6 +111,12 @@ EDAnalyzerAdaptorBase::consumer() const {
   return m_streamModules[0];
 }
 
+void
+EDAnalyzerAdaptorBase::modulesDependentUpon(const std::string& iProcessName,
+                                            std::vector<const char*>& oModuleLabels) const {
+  assert(not m_streamModules.empty());
+  return m_streamModules[0]->modulesDependentUpon(iProcessName, oModuleLabels);
+}
 
 bool
 EDAnalyzerAdaptorBase::doEvent(EventPrincipal& ep, EventSetup const& c,

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -105,6 +105,14 @@ namespace edm {
 
     template< typename T>
     void
+    ProducingModuleAdaptorBase<T>::modulesDependentUpon(const std::string& iProcessName,
+                                                        std::vector<const char*>& oModuleLabels) const {
+      assert(not m_streamModules.empty());
+      return m_streamModules[0]->modulesDependentUpon(iProcessName, oModuleLabels);
+    }
+
+    template< typename T>
+    void
     ProducingModuleAdaptorBase<T>::updateLookup(BranchType iType,
                                         ProductHolderIndexHelper const& iHelper) {
       for(auto mod: m_streamModules) {


### PR DESCRIPTION
Using data dependencies between modules and the order in which modules must run because of Path declarations, we determine if the configuration is unrunnable (a module would never  get the data it wants because the Path order is wrong) or indeterminate if run in the threaded framework. The indeterminate nature could be because one Path has modules in the proper data dependency order while a second Path has them in the wrong order. Depending on which Path runs first you could get a different answer.
