### PR TITLE
Update version numbers

### DIFF
--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -40,9 +40,10 @@
    <version ClassVersion="10" checksum="3308689624"/>
    <version ClassVersion="11" checksum="3649971983"/>
   </class>
-  <class name="reco::Photon::PflowIsolationVariables"  ClassVersion="12">
+  <class name="reco::Photon::PflowIsolationVariables"  ClassVersion="13">
    <version ClassVersion="11" checksum="3200292660"/>
    <version ClassVersion="12" checksum="114160170"/>
+   <version ClassVersion="13" checksum="9999999999"/>
   </class>
   <class name="reco::Photon::PflowIDVariables"  ClassVersion="-1">
    <version ClassVersion="-1" checksum="2819734289"/>


### PR DESCRIPTION
Update the version number for one more class whose checksum has changed between ROOT5 and ROOT6.
Please merge promptly unless there is a problem.
The ROOT6 checksum is a placeholder.
