### PR TITLE
Use correct ROOT6 name in all cases

### DIFF
--- a/CondCore/ORA/src/ClassUtils.cc
+++ b/CondCore/ORA/src/ClassUtils.cc
@@ -80,6 +80,7 @@ bool ora::ClassUtils::checkMappedType( const edm::TypeWithDict& type,
   replaceString(typeName, "unsigned long long", "ULong64_t");
   replaceString(typeName, "long long", "Long64_t");
   replaceString(typeName, "std::basic_string<char> ", "std::string");
+  replaceString(typeName, "std::basic_string<char>", "std::string");
   return (type.qualifiedName() == typeName );
 }
 


### PR DESCRIPTION
In ROOT 6, the normalized name for a C++ string is "std::string".  In ROOT 5. std::basic_string is used.
In the conditions code, the ROOT 5 name must be converted to the ROOT 6 name.  This was done before, but only for those cases where the ROOT 5 name was followed by a space.  This causes relval failures.
This pull request does the conversion in those cases where the ROOT 5 name is not followed by a space.
Please merge this promptly unless there is a problem.
