### PR TITLE
compilation error fix: added missing std::

### DIFF
--- a/EgammaAnalysis/ElectronTools/interface/EGammaCutBasedEleId.h
+++ b/EgammaAnalysis/ElectronTools/interface/EGammaCutBasedEleId.h
@@ -14,6 +14,7 @@
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #endif
+#include "EgammaAnalysis/ElectronTools/interface/ElectronEffectiveArea.h"
 
 #include <vector>
 
@@ -79,7 +80,8 @@ bool PassWP(const WorkingPoint workingPoint,
     const double &iso_ch,
     const double &iso_em,
     const double &iso_nh,
-    const double &rho);
+    const double &rho,
+    ElectronEffectiveArea::ElectronEffectiveAreaTarget EAtarget);
 
 
 bool PassWP(const WorkingPoint workingPoint,
@@ -90,7 +92,8 @@ bool PassWP(const WorkingPoint workingPoint,
     const double &iso_ch,
     const double &iso_em,
     const double &iso_nh,
-    const double &rho);
+    const double &rho,
+    ElectronEffectiveArea::ElectronEffectiveAreaTarget EAtarget);
 
 
 bool PassTriggerCuts(const TriggerWorkingPoint triggerWorkingPoint, const reco::GsfElectronRef &ele);
@@ -109,7 +112,8 @@ unsigned int TestWP(const WorkingPoint workingPoint,
     const double &iso_ch,
     const double &iso_em,
     const double &iso_nh,
-    const double &rho);
+    const double &rho,
+    ElectronEffectiveArea::ElectronEffectiveAreaTarget EAtarget);
 
 unsigned int TestWP(const WorkingPoint workingPoint,
     const reco::GsfElectron &ele,
@@ -119,7 +123,8 @@ unsigned int TestWP(const WorkingPoint workingPoint,
     const double &iso_ch,
     const double &iso_em,
     const double &iso_nh,
-    const double &rho);
+    const double &rho,
+    ElectronEffectiveArea::ElectronEffectiveAreaTarget EAtarget);
 
 #endif
 
@@ -132,7 +137,7 @@ unsigned int TestWP(const WorkingPoint workingPoint,
 bool PassWP(WorkingPoint workingPoint, const bool isEB, const float pt, const float eta,
     const float dEtaIn, const float dPhiIn, const float sigmaIEtaIEta, const float hoe,
     const float ooemoop, const float d0vtx, const float dzvtx, const float iso_ch, const float iso_em, const float iso_nh, 
-    const bool vtxFitConversion, const unsigned int mHits, const double rho);
+    const bool vtxFitConversion, const unsigned int mHits, const double rho, ElectronEffectiveArea::ElectronEffectiveAreaTarget EAtarget);
 
 bool PassTriggerCuts(const TriggerWorkingPoint triggerWorkingPoint, const bool isEB, const float pt, 
     const float dEtaIn, const float dPhiIn, const float sigmaIEtaIEta, const float hoe,
@@ -143,7 +148,7 @@ bool PassEoverPCuts(const float eta, const float eopin, const float fbrem);
 unsigned int TestWP(WorkingPoint workingPoint, const bool isEB, const float pt, const float eta,
     const float dEtaIn, const float dPhiIn, const float sigmaIEtaIEta, const float hoe,
     const float ooemoop, const float d0vtx, const float dzvtx, const float iso_ch, const float iso_em, const float iso_nh, 
-    const bool vtxFitConversion, const unsigned int mHits, const double rho);
+    const bool vtxFitConversion, const unsigned int mHits, const double rho, ElectronEffectiveArea::ElectronEffectiveAreaTarget EAtarget);
 
 // print the bit mask
 void PrintDebug(unsigned int mask);

--- a/EgammaAnalysis/ElectronTools/interface/ElectronEffectiveArea.h
+++ b/EgammaAnalysis/ElectronTools/interface/ElectronEffectiveArea.h
@@ -20,7 +20,7 @@
 #ifndef STANDALONE
 #endif
 
-using namespace std;
+//using namespace std;
 
 class ElectronEffectiveArea{
  public:

--- a/EgammaAnalysis/ElectronTools/src/EGammaCutBasedEleId.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaCutBasedEleId.cc
@@ -302,7 +302,7 @@ unsigned int EgammaCutBasedEleId::TestWP(WorkingPoint workingPoint, const bool i
     unsigned int idx = isEB ? 0 : 1;
 
     // effective area for isolation
-    float AEff = ElectronEffectiveArea::GetElectronEffectiveArea(ElectronEffectiveArea::kEleGammaAndNeutralHadronIso03, eta, ElectronEffectiveArea::kEleEAData2011);
+    float AEff = ElectronEffectiveArea::GetElectronEffectiveArea(ElectronEffectiveArea::kEleGammaAndNeutralHadronIso03, eta, ElectronEffectiveArea::kEleEAData2012);
 
     // apply to neutrals
     double rhoPrime = std::max(rho, 0.0);

--- a/EgammaAnalysis/ElectronTools/src/EGammaCutBasedEleId.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaCutBasedEleId.cc
@@ -14,11 +14,12 @@ bool EgammaCutBasedEleId::PassWP(WorkingPoint workingPoint,
     const double &iso_ch,
     const double &iso_em,
     const double &iso_nh,
-    const double &rho)
+    const double &rho,
+    ElectronEffectiveArea::ElectronEffectiveAreaTarget EAtarget)
 {
 
     // get the mask
-    unsigned int mask = TestWP(workingPoint, ele, conversions, beamspot, vtxs, iso_ch, iso_em, iso_nh, rho);
+    unsigned int mask = TestWP(workingPoint, ele, conversions, beamspot, vtxs, iso_ch, iso_em, iso_nh, rho, EAtarget);
 
     // check if the desired WP passed
     if ((mask & PassAll) == PassAll) return true;
@@ -33,9 +34,10 @@ bool EgammaCutBasedEleId::PassWP(WorkingPoint workingPoint,
     const double &iso_ch,
     const double &iso_em,
     const double &iso_nh,
-    const double &rho)
+    const double &rho,
+    ElectronEffectiveArea::ElectronEffectiveAreaTarget EAtarget)
 {
-  return PassWP(workingPoint,*ele,conversions,beamspot,vtxs,iso_ch,iso_em,iso_nh,rho);
+  return PassWP(workingPoint,*ele,conversions,beamspot,vtxs,iso_ch,iso_em,iso_nh,rho, EAtarget);
 }
 
 bool EgammaCutBasedEleId::PassTriggerCuts(TriggerWorkingPoint triggerWorkingPoint, const reco::GsfElectron &ele)
@@ -88,7 +90,8 @@ unsigned int EgammaCutBasedEleId::TestWP(WorkingPoint workingPoint,
     const double &iso_ch,
     const double &iso_em,
     const double &iso_nh,
-    const double &rho)
+    const double &rho,
+    ElectronEffectiveArea::ElectronEffectiveAreaTarget EAtarget)
 {
 
     // get the ID variables from the electron object
@@ -123,7 +126,7 @@ unsigned int EgammaCutBasedEleId::TestWP(WorkingPoint workingPoint,
 
     // get the mask value
     unsigned int mask = EgammaCutBasedEleId::TestWP(workingPoint, isEB, pt, eta, dEtaIn, dPhiIn,
-        sigmaIEtaIEta, hoe, ooemoop, d0vtx, dzvtx, iso_ch, iso_em, iso_nh, vtxFitConversion, mHits, rho);
+        sigmaIEtaIEta, hoe, ooemoop, d0vtx, dzvtx, iso_ch, iso_em, iso_nh, vtxFitConversion, mHits, rho, EAtarget);
 
     // return the mask value
     return mask;
@@ -138,8 +141,9 @@ unsigned int EgammaCutBasedEleId::TestWP(WorkingPoint workingPoint,
 					 const double &iso_ch,
 					 const double &iso_em,
 					 const double &iso_nh,
-					 const double &rho) {
-  return TestWP(workingPoint,*ele,conversions,beamspot,vtxs,iso_ch,iso_em,iso_nh,rho);
+					 const double &rho,
+					 ElectronEffectiveArea::ElectronEffectiveAreaTarget EAtarget) {
+  return TestWP(workingPoint,*ele,conversions,beamspot,vtxs,iso_ch,iso_em,iso_nh,rho, EAtarget);
 }
 
 
@@ -148,10 +152,10 @@ unsigned int EgammaCutBasedEleId::TestWP(WorkingPoint workingPoint,
 bool EgammaCutBasedEleId::PassWP(WorkingPoint workingPoint, const bool isEB, const float pt, const float eta,
     const float dEtaIn, const float dPhiIn, const float sigmaIEtaIEta, const float hoe,
     const float ooemoop, const float d0vtx, const float dzvtx, const float iso_ch, const float iso_em, const float iso_nh, 
-    const bool vtxFitConversion, const unsigned int mHits, const double rho)
+    const bool vtxFitConversion, const unsigned int mHits, const double rho, ElectronEffectiveArea::ElectronEffectiveAreaTarget EAtarget)
 {
     unsigned int mask = EgammaCutBasedEleId::TestWP(workingPoint, isEB, pt, eta, dEtaIn, dPhiIn,
-        sigmaIEtaIEta, hoe, ooemoop, d0vtx, dzvtx, iso_ch, iso_em, iso_nh, vtxFitConversion, mHits, rho);
+        sigmaIEtaIEta, hoe, ooemoop, d0vtx, dzvtx, iso_ch, iso_em, iso_nh, vtxFitConversion, mHits, rho, EAtarget);
 
     if ((mask & PassAll) == PassAll) return true;
     return false;
@@ -216,7 +220,7 @@ bool EgammaCutBasedEleId::PassEoverPCuts(const float eta, const float eopin, con
 unsigned int EgammaCutBasedEleId::TestWP(WorkingPoint workingPoint, const bool isEB, const float pt, const float eta,
     const float dEtaIn, const float dPhiIn, const float sigmaIEtaIEta, const float hoe, 
     const float ooemoop, const float d0vtx, const float dzvtx, const float iso_ch, const float iso_em, const float iso_nh, 
-    const bool vtxFitConversion, const unsigned int mHits, const double rho)
+    const bool vtxFitConversion, const unsigned int mHits, const double rho, ElectronEffectiveArea::ElectronEffectiveAreaTarget EAtarget)
 {
 
     unsigned int mask = 0;
@@ -302,7 +306,7 @@ unsigned int EgammaCutBasedEleId::TestWP(WorkingPoint workingPoint, const bool i
     unsigned int idx = isEB ? 0 : 1;
 
     // effective area for isolation
-    float AEff = ElectronEffectiveArea::GetElectronEffectiveArea(ElectronEffectiveArea::kEleGammaAndNeutralHadronIso03, eta, ElectronEffectiveArea::kEleEAData2012);
+    float AEff = ElectronEffectiveArea::GetElectronEffectiveArea(ElectronEffectiveArea::kEleGammaAndNeutralHadronIso03, eta, EAtarget);
 
     // apply to neutrals
     double rhoPrime = std::max(rho, 0.0);

--- a/EgammaAnalysis/ElectronTools/src/EGammaCutBasedEleIdAnalyzer.cc
+++ b/EgammaAnalysis/ElectronTools/src/EGammaCutBasedEleIdAnalyzer.cc
@@ -35,6 +35,7 @@ Implementation:
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/RecoCandidate/interface/IsoDeposit.h"
 #include "EgammaAnalysis/ElectronTools/interface/EGammaCutBasedEleId.h"
+#include "EgammaAnalysis/ElectronTools/interface/ElectronEffectiveArea.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CommonTools/UtilAlgos/interface/TFileService.h"
 
@@ -52,6 +53,7 @@ class EGammaCutBasedEleIdAnalyzer : public edm::EDAnalyzer {
 
         static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
+	ElectronEffectiveArea::ElectronEffectiveAreaTarget EAtarget;
 
     private:
         virtual void beginJob() ;
@@ -73,6 +75,7 @@ class EGammaCutBasedEleIdAnalyzer : public edm::EDAnalyzer {
         edm::InputTag               primaryVertexInputTag_;
         std::vector<edm::InputTag>  isoValInputTags_;
 
+	std::string EAtargetToken_;
         // debug
         bool printDebug_;
 
@@ -112,6 +115,7 @@ EGammaCutBasedEleIdAnalyzer::EGammaCutBasedEleIdAnalyzer(const edm::ParameterSet
     primaryVertexInputTag_  = iConfig.getParameter<edm::InputTag>("primaryVertexInputTag");
     isoValInputTags_        = iConfig.getParameter<std::vector<edm::InputTag> >("isoValInputTags");
 
+    EAtargetToken_	= iConfig.getParameter<std::string>("EAtarget");//EleEANoCorr, EleEAData2011, EleEASummer11MC,EleEAFall11MC, EleEAData2012/ 
     // debug
     printDebug_             = iConfig.getParameter<bool>("printDebug");
 
@@ -194,10 +198,10 @@ EGammaCutBasedEleIdAnalyzer::analyze(const edm::Event& iEvent, const edm::EventS
         //
 
         // working points
-        bool veto       = EgammaCutBasedEleId::PassWP(EgammaCutBasedEleId::VETO, ele, conversions_h, beamSpot, vtx_h, iso_ch, iso_em, iso_nh, rhoIso);
-        bool loose      = EgammaCutBasedEleId::PassWP(EgammaCutBasedEleId::LOOSE, ele, conversions_h, beamSpot, vtx_h, iso_ch, iso_em, iso_nh, rhoIso);
-        bool medium     = EgammaCutBasedEleId::PassWP(EgammaCutBasedEleId::MEDIUM, ele, conversions_h, beamSpot, vtx_h, iso_ch, iso_em, iso_nh, rhoIso);
-        bool tight      = EgammaCutBasedEleId::PassWP(EgammaCutBasedEleId::TIGHT, ele, conversions_h, beamSpot, vtx_h, iso_ch, iso_em, iso_nh, rhoIso);
+        bool veto       = EgammaCutBasedEleId::PassWP(EgammaCutBasedEleId::VETO, ele, conversions_h, beamSpot, vtx_h, iso_ch, iso_em, iso_nh, rhoIso, EAtarget);
+        bool loose      = EgammaCutBasedEleId::PassWP(EgammaCutBasedEleId::LOOSE, ele, conversions_h, beamSpot, vtx_h, iso_ch, iso_em, iso_nh, rhoIso, EAtarget);
+        bool medium     = EgammaCutBasedEleId::PassWP(EgammaCutBasedEleId::MEDIUM, ele, conversions_h, beamSpot, vtx_h, iso_ch, iso_em, iso_nh, rhoIso, EAtarget);
+        bool tight      = EgammaCutBasedEleId::PassWP(EgammaCutBasedEleId::TIGHT, ele, conversions_h, beamSpot, vtx_h, iso_ch, iso_em, iso_nh, rhoIso, EAtarget);
 
         // eop/fbrem cuts for extra tight ID
         bool fbremeopin = EgammaCutBasedEleId::PassEoverPCuts(ele);
@@ -244,6 +248,18 @@ EGammaCutBasedEleIdAnalyzer::analyze(const edm::Event& iEvent, const edm::EventS
     void 
 EGammaCutBasedEleIdAnalyzer::beginJob()
 {
+  if( EAtargetToken_ == "EleEANoCorr")
+    EAtarget  =ElectronEffectiveArea::kEleEANoCorr;
+  else if( EAtargetToken_ == "EleEAData2011")
+    EAtarget  =ElectronEffectiveArea::kEleEAData2011;
+  else if( EAtargetToken_ == "EleEASummer11MC")
+    EAtarget  =ElectronEffectiveArea::kEleEASummer11MC;
+  else if( EAtargetToken_ == "EleEAFall11MC")
+    EAtarget  =ElectronEffectiveArea::kEleEAFall11MC;
+  else if( EAtargetToken_ == "EleEAData2012")
+    EAtarget  =ElectronEffectiveArea::kEleEAData2012;
+  else
+    EAtarget  =ElectronEffectiveArea::kEleEAData2012;
 }
 
 // ------------ method called once each job just after ending the event loop  ------------

--- a/PhysicsTools/SelectorUtils/interface/PFElectronSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/PFElectronSelector.h
@@ -119,7 +119,7 @@ class PFElectronSelector : public Selector<pat::Electron> {
     double chIso = electron.userIsolation(pat::PfChargedHadronIso);
     double nhIso = electron.userIsolation(pat::PfNeutralHadronIso);
     double phIso  = electron.userIsolation(pat::PfGammaIso);
-    double pfIso = ( chIso + max(0.0, nhIso + phIso - rhoIso*AEff) )/ electron.ecalDrivenMomentum().pt();
+    double pfIso = ( chIso + std::max(0.0, nhIso + phIso - rhoIso*AEff) )/ electron.ecalDrivenMomentum().pt();
     int mHits  =  electron.gsfTrack()->trackerExpectedHitsInner().numberOfHits();   
     double mva = electron.electronID("mvaTrigV0");
     //Electron Selection for e+jets


### PR DESCRIPTION
#2376 has cleaned up header and removed using namespace std. this caused compilation error PhysicsTools/SelectorUtils. This pull request fixes the error (just added missing std::)
