### PR TITLE
Removed FileInPath::isLocal to avoid user confusion

### DIFF
--- a/FWCore/ParameterSet/interface/FileInPath.h
+++ b/FWCore/ParameterSet/interface/FileInPath.h
@@ -97,9 +97,6 @@ namespace edm
     /// Where was the file found?
     LocationCode location() const;
 
-    /// Was the file found under the "local" area?
-    bool isLocal() const;
-
     /// Return a string that can be used to open the referenced
     /// file. 
     ///

--- a/FWCore/ParameterSet/src/FileInPath.cc
+++ b/FWCore/ParameterSet/src/FileInPath.cc
@@ -161,12 +161,6 @@ namespace edm
     return location_;
   }
 
-  bool
-  FileInPath::isLocal() const
-  {
-    return Local == location_;
-  }
-
   std::string
   FileInPath::fullPath() const
   {

--- a/FWCore/PythonParameterSet/src/PythonModule.h
+++ b/FWCore/PythonParameterSet/src/PythonModule.h
@@ -62,7 +62,6 @@ BOOST_PYTHON_MODULE(libFWCoreParameterSet)
   boost::python::class_<edm::FileInPath>("FileInPath", boost::python::init<std::string>())
       .def("fullPath",     &edm::FileInPath::fullPath)
       .def("relativePath", &edm::FileInPath::relativePath)
-      .def("isLocal",      &edm::FileInPath::isLocal)
   ;
 
   boost::python::class_<edm::LuminosityBlockRange>("LuminosityBlockRange", boost::python::init<unsigned int, unsigned int, unsigned int, unsigned int>())

--- a/FWCore/PythonParameterSet/test/makepset_t.cppunit.cc
+++ b/FWCore/PythonParameterSet/test/makepset_t.cppunit.cc
@@ -207,7 +207,7 @@ void testmakepset::fileinpathAux() {
   char *releaseBase = getenv("CMSSW_RELEASE_BASE");
   bool localArea = (releaseBase != 0 && strlen(releaseBase) != 0);
   if(localArea) {
-    CPPUNIT_ASSERT(fip.isLocal() == true);
+    CPPUNIT_ASSERT(fip.location() == edm::FileInPath::Local);
   }
   CPPUNIT_ASSERT(fip.relativePath()  == "FWCore/ParameterSet/python/Config.py");
   CPPUNIT_ASSERT(ufip.relativePath() == "FWCore/ParameterSet/python/Types.py");
@@ -220,7 +220,7 @@ void testmakepset::fileinpathAux() {
   std::string tmpout = fullpath.substr(0, fullpath.find("FWCore/ParameterSet/python/Config.py")) + "tmp.py";
 
   edm::FileInPath topo = innerps.getParameter<edm::FileInPath>("topo");
-  CPPUNIT_ASSERT(topo.isLocal() == false);
+  CPPUNIT_ASSERT(topo.location() != edm::FileInPath::Local);
   CPPUNIT_ASSERT(topo.relativePath() == "Geometry/TrackerSimData/data/trackersens.xml");
   fullpath = topo.fullPath();
   CPPUNIT_ASSERT(!fullpath.empty());
@@ -261,7 +261,7 @@ void testmakepset::fileinpathAux() {
   edm::ParameterSet const& innerps2 = ps2->getParameterSet("main");
   edm::FileInPath fip2 = innerps2.getParameter<edm::FileInPath>("fip2");
   if (localArea) {
-    CPPUNIT_ASSERT(fip2.isLocal() == true);
+    CPPUNIT_ASSERT(fip2.location() == edm::FileInPath::Local);
   }
   CPPUNIT_ASSERT(fip2.relativePath() == "tmp.py");
   std::string fullpath2 = fip2.fullPath();


### PR DESCRIPTION
Several users thought FileInPath::isLocal would tell them if the file was found at all rather than just stating that the last time the file was found (say in a different job) it was found in the user’s work area. Given this was only used in a couple of places we decided it was better to just remove the method all together and require users to call FileInPath::location() if they wanted to get the same information.
