### PR TITLE
Update version number for ROOT 6

### DIFF
--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -163,7 +163,8 @@
   <class name="reco::GsfElectron::ChargeInfo" ClassVersion="10">
    <version ClassVersion="10" checksum="1415326811"/>
   </class>
-  <class name="reco::GsfElectron::PflowIsolationVariables" ClassVersion="11">
+  <class name="reco::GsfElectron::PflowIsolationVariables" ClassVersion="12">
+   <version ClassVersion="12" checksum="9999999999"/>
    <version ClassVersion="11" checksum="2389048798"/>
    <version ClassVersion="10" checksum="4270399196"/>
   <ioread sourceClass="reco::GsfElectron::PflowIsolationVariables" version="[1-10]" source="float chargedHadronIso" targetClass="reco::GsfElectron::PflowIsolationVariables" target="sumChargedHadronPt">


### PR DESCRIPTION
Update the version number of one more class whose checksum is different in ROOT6 than in ROOT5.
The ROOT6 checksum used is a placeholder.
This will fix a fatal error in one of the "other" tests in the IB.
Please merge promptly unless there is a problem.
