### PR TITLE
Change depthCor* static members to static std::atomic --thread safety

### DIFF
--- a/DataFormats/ParticleFlowReco/interface/PFCluster.h
+++ b/DataFormats/ParticleFlowReco/interface/PFCluster.h
@@ -13,7 +13,9 @@
 
 #include <iostream>
 #include <vector>
-
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+#include <atomic>
+#endif
 
 
 class PFClusterAlgo;
@@ -141,7 +143,22 @@ namespace reco {
     
     /// cluster position: rho, eta, phi (transient)
     REPPoint            posrep_;
-    
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+     /// \todo move to PFClusterTools
+    static std::atomic<int>    depthCorMode_;
+
+    /// \todo move to PFClusterTools
+    static std::atomic<double> depthCorA_;
+
+    /// \todo move to PFClusterTools
+    static std::atomic<double> depthCorB_ ;
+
+    /// \todo move to PFClusterTools
+    static std::atomic<double> depthCorAp_;
+
+    /// \todo move to PFClusterTools
+    static std::atomic<double> depthCorBp_;
+#else
     
     /// \todo move to PFClusterTools
     static int    depthCorMode_;
@@ -157,6 +174,7 @@ namespace reco {
     
     /// \todo move to PFClusterTools
     static double depthCorBp_;
+#endif
     
     static const math::XYZPoint dummyVtx_;
 

--- a/DataFormats/ParticleFlowReco/src/PFCluster.cc
+++ b/DataFormats/ParticleFlowReco/src/PFCluster.cc
@@ -4,12 +4,20 @@
 using namespace std;
 using namespace reco;
 
-
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+std::atomic<int>    PFCluster::depthCorMode_{0};
+std::atomic<double> PFCluster::depthCorA_{0.89};
+std::atomic<double> PFCluster::depthCorB_{7.3};
+std::atomic<double> PFCluster::depthCorAp_{0.89};
+std::atomic<double> PFCluster::depthCorBp_{4.0};
+#else
 int    PFCluster::depthCorMode_ = 0;
 double PFCluster::depthCorA_ = 0.89;
 double PFCluster::depthCorB_ = 7.3;
 double PFCluster::depthCorAp_ = 0.89;
 double PFCluster::depthCorBp_ = 4.0;
+#endif
+
 
 const math::XYZPoint PFCluster::dummyVtx_(0,0,0);
 


### PR DESCRIPTION
These parameters are set once in the PFCluster constructor from parameter set
or set once to default values in PFCluster.cc. After that they are only read.
Put ifdefs around std::atomic definitions so that reflex can work.
