### PR TITLE
Fix introspection of C array data members

### DIFF
--- a/CondCore/ORA/src/ClassUtils.cc
+++ b/CondCore/ORA/src/ClassUtils.cc
@@ -436,7 +436,8 @@ edm::TypeWithDict ora::ClassUtils::containerSubType(const edm::TypeWithDict& typ
 
 edm::TypeWithDict ora::ClassUtils::resolvedType(const edm::TypeWithDict& typ){
   if (typ.isTypedef()){
-    return typ.finalType();
+    return typ.finalType().toType();
   }
   return typ;
 }
+

--- a/CondCore/ORA/src/InlineCArrayStreamer.cc
+++ b/CondCore/ORA/src/InlineCArrayStreamer.cc
@@ -25,7 +25,7 @@ ora::InlineCArrayStreamerBase::~InlineCArrayStreamerBase(){
 bool ora::InlineCArrayStreamerBase::buildDataElement(DataElement& dataElement,
                                                      IRelationalData& relationalData,
                                                      RelationalBuffer* operationBuffer){
-  m_arrayType = ClassUtils::resolvedType( m_objectType );  
+  m_arrayType = ClassUtils::resolvedType( m_objectType.toType() );  
   if ( ! m_arrayType ) {
     throwException( "Missing dictionary information for the element of array \"" +
                     m_objectType.qualifiedName() + "\"",

--- a/CondCore/ORA/src/ObjectStreamer.cc
+++ b/CondCore/ORA/src/ObjectStreamer.cc
@@ -42,7 +42,7 @@ void ora::ObjectStreamerBase::buildBaseDataMembers( DataElement& dataElement,
   
   for ( unsigned int i=0;i<ora::helper::BaseSize(objType);i++){
     edm::BaseWithDict base = ora::helper::BaseAt(objType, i);
-    edm::TypeWithDict baseType = ClassUtils::resolvedType( base.typeOf() );
+    edm::TypeWithDict baseType = ClassUtils::resolvedType( base.typeOf().toType() );
     buildBaseDataMembers( dataElement, relationalData, baseType, operationBuffer );
     for ( unsigned int j=0;j<baseType.dataMemberSize();j++){
       edm::MemberWithDict dataMember = ora::helper::DataMemberAt(baseType, j);      

--- a/CondCore/ORA/src/RelationalMapping.cc
+++ b/CondCore/ORA/src/RelationalMapping.cc
@@ -552,7 +552,7 @@ namespace ora {
     std::string className = objType.qualifiedName();
     for ( size_t i=0; i< ora::helper::BaseSize(objType); i++){
       edm::BaseWithDict base = ora::helper::BaseAt(objType, i);
-      edm::TypeWithDict baseType = ClassUtils::resolvedType( base.typeOf() ); // ?? base.toType() );
+      edm::TypeWithDict baseType = ClassUtils::resolvedType( base.typeOf().toType() );
       if(!baseType){
         throwException( "Class for base \""+base.name()+"\" is not in the dictionary.","ObjectMapping::process");
       }

--- a/DataFormats/Common/test/DictionaryTools_t.cpp
+++ b/DataFormats/Common/test/DictionaryTools_t.cpp
@@ -150,6 +150,7 @@ namespace {
     checkIt<edm::Wrapper<T> >();
     checkIt<edm::Wrapper<std::vector<T> > >();
     checkIt<T>();
+    checkIt<T[1]>();
   }
 }
 

--- a/DataFormats/TestObjects/interface/ToyProducts.h
+++ b/DataFormats/TestObjects/interface/ToyProducts.h
@@ -28,6 +28,11 @@ namespace edmtest {
   struct DummyProduct {
   };
 
+  struct ArrayProduct {
+    explicit ArrayProduct(int i = 0) : value{i} {}
+    int value[1];
+  };
+
   struct EnumProduct {
     enum TheEnumProduct {
 	TheZero = 0,

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -9,6 +9,9 @@
   <version ClassVersion="10" checksum="3025325436"/>
  </class>
  <enum name="edmtest::TheEnumProduct"/>
+ <class name="edmtest::ArrayProduct" ClassVersion="10">
+  <version ClassVersion="10" checksum="3635152897"/>
+ </class>
  <class name="edmtest::TransientIntProduct" ClassVersion="10">
   <version ClassVersion="10" checksum="304339852"/>
  </class>

--- a/DataFormats/TestObjects/test/Enum_t.cpp
+++ b/DataFormats/TestObjects/test/Enum_t.cpp
@@ -16,6 +16,8 @@ class TestDictionaries: public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(TestDictionaries);
   CPPUNIT_TEST(enum_is_valid);
   CPPUNIT_TEST(enum_by_name_is_valid);
+  CPPUNIT_TEST(enum_member_is_valid);
+  CPPUNIT_TEST(array_member_is_valid);
   CPPUNIT_TEST(demangling);
   CPPUNIT_TEST_SUITE_END();
 
@@ -27,6 +29,8 @@ class TestDictionaries: public CppUnit::TestFixture {
 
   void enum_is_valid();
   void enum_by_name_is_valid();
+  void enum_member_is_valid();
+  void array_member_is_valid();
   void demangling();
 
  private:
@@ -42,6 +46,28 @@ void TestDictionaries::enum_is_valid() {
 void TestDictionaries::enum_by_name_is_valid() {
   edm::TypeWithDict t = edm::TypeWithDict::byName("edmtest::EnumProduct::TheEnumProduct");
   CPPUNIT_ASSERT(t);
+}
+
+void TestDictionaries::enum_member_is_valid() {
+  edm::TypeWithDict t = edm::TypeWithDict::byName("edmtest::EnumProduct");
+  edm::MemberWithDict m = t.dataMemberByName("value");
+  edm::TypeWithDict t2 = m.typeOf();
+  edm::TypeWithDict t3 = edm::TypeWithDict::byName("edmtest::EnumProduct::TheEnumProduct");
+  CPPUNIT_ASSERT(t2);
+  CPPUNIT_ASSERT(t3);
+  CPPUNIT_ASSERT(t2 == t3);
+}
+
+void TestDictionaries::array_member_is_valid() {
+  edm::TypeWithDict t = edm::TypeWithDict::byName("edmtest::ArrayProduct");
+  edm::MemberWithDict m = t.dataMemberByName("value");
+  CPPUNIT_ASSERT(m.isArray());
+  edm::TypeWithDict t2 = m.typeOf();
+  edm::TypeWithDict t3 = edm::TypeWithDict::byName("int[1]");
+  CPPUNIT_ASSERT(t2);
+  CPPUNIT_ASSERT(t3);
+  CPPUNIT_ASSERT(t2.qualifiedName() == "int[1]");
+  CPPUNIT_ASSERT(t2 == t3);
 }
 
 namespace {

--- a/FWCore/Utilities/interface/MemberWithDict.h
+++ b/FWCore/Utilities/interface/MemberWithDict.h
@@ -25,6 +25,7 @@ public:
   explicit MemberWithDict(TDataMember*);
   explicit operator bool() const;
   std::string name() const;
+  bool isArray() const;
   bool isConst() const;
   bool isPublic() const;
   bool isStatic() const;

--- a/FWCore/Utilities/src/MemberWithDict.cc
+++ b/FWCore/Utilities/src/MemberWithDict.cc
@@ -2,6 +2,8 @@
 
 #include "FWCore/Utilities/interface/ObjectWithDict.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"
+#include <ostream>
+#include <sstream>
 
 namespace edm {
 
@@ -22,12 +24,27 @@ namespace edm {
 
   TypeWithDict
   MemberWithDict::typeOf() const {
+    if(isArray()) {
+      std::ostringstream name;
+      name << dataMember_->GetTypeName();
+      for(int i = 0; i < dataMember_->GetArrayDim(); ++i) {
+        name << '[';
+        name << dataMember_->GetMaxIndex(i);
+        name << ']';
+        return TypeWithDict::byName(name.str(), dataMember_->Property());
+      }
+    } 
     return TypeWithDict::byName(dataMember_->GetTypeName(), dataMember_->Property());
   }
 
   TypeWithDict
   MemberWithDict::declaringType() const {
     return TypeWithDict(dataMember_->GetClass(), dataMember_->Property());
+  }
+
+  bool
+  MemberWithDict::isArray() const {
+    return dataMember_->Property() & kIsArray;
   }
 
   bool

--- a/FWCore/Utilities/src/TypeDemangler.cc
+++ b/FWCore/Utilities/src/TypeDemangler.cc
@@ -118,10 +118,12 @@ namespace edm {
     } 
     std::string demangledName(demangled);
     free(demangled);
-    // We must use the same conventions used by REFLEX.
+    // We must use the same conventions previously used by REFLEX.
     // The order of these is important.
     // No space after comma
     replaceString(demangledName, ", ", ",");
+    // No space before opening square bracket
+    replaceString(demangledName, " [", "[");
     // Strip default allocator
     std::string const allocator(",std::allocator<");
     removeParameter(demangledName, allocator);


### PR DESCRIPTION
This pull request is fixes for three different problems involving C array data members, plus a unit test that would have found one of the problems.  These problems all caused failures in conditions code in many relval tests in the ROOT6 branch.

1)MemberWithDict::typeof(), when the member is a C array, stripped off the array information and just returned the underlying type.  The array information should not have been stripped.

2) A framework unit test is added here that would have found the above problem.

3) TypeID::className() put a space between the base type name and the opening square bracket. This is incompatible with the naming used by conditions.

4) In the ROOT6 specific code in CondCore/ORA, the C array information was not stripped off in several places where it should have been.  This pull request strips it off when needed,

Note:  Items 1, 2, and 3 are not ROOT6 specific. The fixes and tests there will be back ported to 7_1_X.
Item 1 may be backported further if offline management wants it.

Please merge this in the ROOT6 branch promptly unless there are issues.
