### PR TITLE
Huge performance improvement

### DIFF
--- a/CondCore/ORA/src/ObjectStreamer.cc
+++ b/CondCore/ORA/src/ObjectStreamer.cc
@@ -40,12 +40,14 @@ void ora::ObjectStreamerBase::buildBaseDataMembers( DataElement& dataElement,
                                                     const edm::TypeWithDict& objType,
                                                     RelationalBuffer* operationBuffer ){
   
-  for ( unsigned int i=0;i<ora::helper::BaseSize(objType);i++){
-    edm::BaseWithDict base = ora::helper::BaseAt(objType, i);
+  edm::TypeBases bases(objType);
+  for (auto const & b : bases) {
+    edm::BaseWithDict base(b);
     edm::TypeWithDict baseType = ClassUtils::resolvedType( base.typeOf().toType() );
     buildBaseDataMembers( dataElement, relationalData, baseType, operationBuffer );
-    for ( unsigned int j=0;j<baseType.dataMemberSize();j++){
-      edm::MemberWithDict dataMember = ora::helper::DataMemberAt(baseType, j);      
+    edm::TypeDataMembers members(baseType);
+    for (auto const & member : members) {
+      edm::MemberWithDict dataMember(member);
       DataElement& dataMemberElement = dataElement.addChild( dataMember.offset(), /*base.offsetFP()*/ base.offset() );
       // Ignore the transients and the statics (how to deal with non-const statics?)
       if ( dataMember.isTransient() || dataMember.isStatic() ) continue;
@@ -93,9 +95,9 @@ bool ora::ObjectStreamerBase::buildDataMembers( DataElement& dataElement,
                                                 RelationalBuffer* operationBuffer ){
   buildBaseDataMembers( dataElement, relationalData, m_objectType, operationBuffer );
     // Loop over the data members of the class.
-  for ( unsigned int i=0;i<m_objectType.dataMemberSize();i++){
-
-    edm::MemberWithDict dataMember = ora::helper::DataMemberAt(m_objectType, i);
+  edm::TypeDataMembers members(m_objectType);
+  for (auto const & member : members) {
+    edm::MemberWithDict dataMember(member);
     DataElement& dataMemberElement = dataElement.addChild( dataMember.offset(), 0 );
 
     edm::TypeWithDict declaringType = ClassUtils::resolvedType( dataMember.declaringType());

--- a/CondCore/ORA/src/RelationalMapping.cc
+++ b/CondCore/ORA/src/RelationalMapping.cc
@@ -60,8 +60,9 @@ ora::RelationalMapping::_sizeInColumns(const edm::TypeWithDict& topLevelClassTyp
       // loop over the data members
       //-ap ignore for now:  typ.UpdateMembers();
       //std::vector<edm::TypeWithDict> carrays;
-      for ( size_t i=0; i< typ.dataMemberSize(); i++){
-        edm::MemberWithDict objMember = ora::helper::DataMemberAt(typ,i);
+      edm::TypeDataMembers members(typ);
+      for (auto const & member : members) {
+        edm::MemberWithDict objMember(member);
 
         // Skip the transient ones
         if ( objMember.isTransient() ) continue;
@@ -550,8 +551,9 @@ namespace ora {
                            const std::string& scopeNameForSchema,
                            TableRegister& tableRegister ){
     std::string className = objType.qualifiedName();
-    for ( size_t i=0; i< ora::helper::BaseSize(objType); i++){
-      edm::BaseWithDict base = ora::helper::BaseAt(objType, i);
+    edm::TypeBases bases(objType);
+    for (auto const & b : bases) {
+      edm::BaseWithDict base(b);
       edm::TypeWithDict baseType = ClassUtils::resolvedType( base.typeOf().toType() );
       if(!baseType){
         throwException( "Class for base \""+base.name()+"\" is not in the dictionary.","ObjectMapping::process");
@@ -559,8 +561,9 @@ namespace ora {
 
       // TO BE FIXED:: here there is still to fix the right scopeName to pass 
       processBaseClasses( mappingElement, baseType, scopeNameForSchema, tableRegister );
-      for ( size_t j=0; j< baseType.dataMemberSize(); j++){
-        edm::MemberWithDict baseMember = ora::helper::DataMemberAt(baseType, j);
+      edm::TypeDataMembers members(baseType);
+      for (auto const & member : members) {
+        edm::MemberWithDict baseMember(member);
         // Skip the transient and the static ones
         if ( baseMember.isTransient() || baseMember.isStatic() || isLoosePersistencyOnWriting( baseMember ) ) continue;
         // Retrieve the data member type
@@ -606,9 +609,9 @@ void ora::ObjectMapping::process( MappingElement& parentElement,
   objectScopeNameForSchema += attributeNameForSchema;
 
   // loop over the data members 
-  for ( size_t i=0; i< objectType.dataMemberSize(); i++){
-
-    edm::MemberWithDict objectMember = ora::helper::DataMemberAt(m_type, i);
+  edm::TypeDataMembers members(objectType);
+  for (auto const & member : members) {
+    edm::MemberWithDict objectMember(member);
     // Skip the transient and the static ones
     if ( objectMember.isTransient() || objectMember.isStatic() || isLoosePersistencyOnWriting( objectMember )) continue;
 

--- a/CondCore/ORA/src/STLContainerHandler.cc
+++ b/CondCore/ORA/src/STLContainerHandler.cc
@@ -134,9 +134,9 @@ ora::SpecialSTLContainerHandler::SpecialSTLContainerHandler( const edm::TypeWith
 {
   // update dictionary to include base classes members
   //-ap ignore for now:  dictionary.UpdateMembers();
-  for ( unsigned int i=0;i<dictionary.dataMemberSize();i++){
-
-    edm::MemberWithDict field = ora::helper::DataMemberAt(dictionary, i);
+  edm::TypeDataMembers members(dictionary);
+  for (auto const & member : members) {
+    edm::MemberWithDict field(member);
     edm::TypeWithDict fieldType = field.typeOf();
     if ( ! fieldType ) {
       throwException( "The dictionary of the underlying container of \"" +


### PR DESCRIPTION
I have long been aware of some inefficiencies in the ROOT6 conditions code due to unnecessary nested loops,
I finally got around to fixing this today, and there was a factor of 15 speedup, i.e. more than an order of magnitude.
I should have done this months ago!
Please merge this a few months ago-).  If that is not possible, immediately would be acceptable.
