### PR TITLE
Fixes for C array data member introspection

### DIFF
--- a/DataFormats/Common/test/DictionaryTools_t.cpp
+++ b/DataFormats/Common/test/DictionaryTools_t.cpp
@@ -152,6 +152,7 @@ namespace {
     checkIt<edm::Wrapper<T> >();
     checkIt<edm::Wrapper<std::vector<T> > >();
     checkIt<T>();
+    checkIt<T[1]>();
   }
 }
 

--- a/DataFormats/TestObjects/interface/ToyProducts.h
+++ b/DataFormats/TestObjects/interface/ToyProducts.h
@@ -28,6 +28,11 @@ namespace edmtest {
   struct DummyProduct {
   };
 
+  struct ArrayProduct {
+    explicit ArrayProduct(int i = 0) : value() {value[0] = i;}
+    int value[1];
+  };
+
   struct EnumProduct {
     enum TheEnumProduct {
 	TheZero = 0,

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -9,6 +9,9 @@
   <version ClassVersion="10" checksum="3025325436"/>
  </class>
  <enum name="edmtest::TheEnumProduct"/>
+ <class name="edmtest::ArrayProduct" ClassVersion="10">
+  <version ClassVersion="10" checksum="3635152897"/>
+ </class>
  <class name="edmtest::TransientIntProduct" ClassVersion="10">
   <version ClassVersion="10" checksum="304339852"/>
  </class>

--- a/DataFormats/TestObjects/test/Enum_t.cpp
+++ b/DataFormats/TestObjects/test/Enum_t.cpp
@@ -2,6 +2,7 @@
 
 
 #include "FWCore/Utilities/interface/DictionaryTools.h"
+#include "FWCore/Utilities/interface/MemberWithDict.h"
 #include "FWCore/Utilities/interface/TypeDemangler.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
@@ -16,6 +17,8 @@ class TestDictionaries: public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE(TestDictionaries);
   CPPUNIT_TEST(enum_is_valid);
   CPPUNIT_TEST(enum_by_name_is_valid);
+  CPPUNIT_TEST(enum_member_is_valid);
+  CPPUNIT_TEST(array_member_is_valid);
   CPPUNIT_TEST(demangling);
   CPPUNIT_TEST_SUITE_END();
 
@@ -27,6 +30,8 @@ class TestDictionaries: public CppUnit::TestFixture {
 
   void enum_is_valid();
   void enum_by_name_is_valid();
+  void enum_member_is_valid();
+  void array_member_is_valid();
   void demangling();
 
  private:
@@ -42,6 +47,28 @@ void TestDictionaries::enum_is_valid() {
 void TestDictionaries::enum_by_name_is_valid() {
   edm::TypeWithDict t = edm::TypeWithDict::byName("edmtest::EnumProduct::TheEnumProduct");
   CPPUNIT_ASSERT(t);
+}
+
+void TestDictionaries::enum_member_is_valid() {
+  edm::TypeWithDict t = edm::TypeWithDict::byName("edmtest::EnumProduct");
+  edm::MemberWithDict m = t.dataMemberByName("value");
+  edm::TypeWithDict t2 = m.typeOf();
+  edm::TypeWithDict t3 = edm::TypeWithDict::byName("edmtest::EnumProduct::TheEnumProduct");
+  CPPUNIT_ASSERT(t2);
+  CPPUNIT_ASSERT(t3);
+  CPPUNIT_ASSERT(t2 == t3);
+}
+
+void TestDictionaries::array_member_is_valid() {
+  edm::TypeWithDict t = edm::TypeWithDict::byName("edmtest::ArrayProduct");
+  edm::MemberWithDict m = t.dataMemberByName("value");
+  CPPUNIT_ASSERT(m.isArray());
+  edm::TypeWithDict t2 = m.typeOf();
+  edm::TypeWithDict t3 = edm::TypeWithDict::byName("int[1]");
+  CPPUNIT_ASSERT(t2);
+  CPPUNIT_ASSERT(t3);
+  CPPUNIT_ASSERT(t2.qualifiedName() == "int[1]");
+  CPPUNIT_ASSERT(t2 == t3);
 }
 
 namespace {

--- a/FWCore/Utilities/interface/MemberWithDict.h
+++ b/FWCore/Utilities/interface/MemberWithDict.h
@@ -32,6 +32,8 @@ namespace edm {
 
     TypeWithDict typeOf() const;
 
+    bool isArray() const;
+
     bool isConst() const;
 
     bool isPublic() const;

--- a/FWCore/Utilities/src/MemberWithDict.cc
+++ b/FWCore/Utilities/src/MemberWithDict.cc
@@ -2,6 +2,8 @@
 #include "FWCore/Utilities/interface/MemberWithDict.h"
 #include "FWCore/Utilities/interface/ObjectWithDict.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"
+#include <ostream>
+#include <sstream>
 
 namespace edm {
 
@@ -30,12 +32,27 @@ namespace edm {
 
   TypeWithDict
   MemberWithDict::typeOf() const {
+    if(isArray()) {
+      std::ostringstream name;
+      name << dataMember_->GetTypeName();
+      for(int i = 0; i < dataMember_->GetArrayDim(); ++i) {
+        name << '[';
+        name << dataMember_->GetMaxIndex(i);
+        name << ']';
+        return TypeWithDict::byName(name.str(), dataMember_->Property());
+      }
+    } 
     return TypeWithDict::byName(dataMember_->GetTypeName(), dataMember_->Property());
   }
 
   TypeWithDict
   MemberWithDict::declaringType() const {
     return TypeWithDict(dataMember_->GetClass(), dataMember_->Property());
+  }
+
+  bool
+  MemberWithDict::isArray() const {
+    return dataMember_->Property() & kIsArray;
   }
 
   bool

--- a/FWCore/Utilities/src/TypeDemangler.cc
+++ b/FWCore/Utilities/src/TypeDemangler.cc
@@ -118,10 +118,12 @@ namespace edm {
     } 
     std::string demangledName(demangled);
     free(demangled);
-    // We must use the same conventions used by REFLEX.
+    // We must use the same conventions previously used by REFLEX.
     // The order of these is important.
     // No space after comma
     replaceString(demangledName, ", ", ",");
+    // No space before opening square bracket
+    replaceString(demangledName, " [", "[");
     // Strip default allocator
     std::string const allocator(",std::allocator<");
     removeParameter(demangledName, allocator);


### PR DESCRIPTION
This pull request is fixes for two different problems involving C array data members, plus a unit test that would have found one of the problems. These problems all caused failures in conditions code in many relval tests in the ROOT6 branch.  However, the fixes in this pull request are for the ROOT 5 version, which also has the bugs.  The bugs did not affect the relvals in ROOT 5 because the conditions code uses Reflex in ROOT 5, and this bypasses the problem.

1)MemberWithDict::typeof(), when the member is a C array, stripped off the array information and just returned the underlying type. The array information should not have been stripped.

2) A framework unit test is added here that would have found the above problem.

3) TypeID::className() put a space between the base type name and the opening square bracket. This is incompatible with the naming used by conditions.

Since this request is for the main 7_1_X branch, it is not urgent.
