### PR TITLE
Putting the input jet collection into single config

### DIFF
--- a/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
+++ b/RecoTauTag/Configuration/python/HPSPFTaus_cff.py
@@ -22,6 +22,12 @@ from RecoTauTag.RecoTau.RecoTauDiscriminantCutMultiplexer_cfi import *
 # Load helper functions to change the source of the discriminants
 from RecoTauTag.RecoTau.TauDiscriminatorTools import *
 
+# Load PFjet input parameters
+from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
+
+# deltaBeta correction factor calculated for taus from ak5PFJets (Run I)
+ak5dBetaCorrection=0.0772/0.1687 
+
 # Select those taus that pass the HPS selections
 #  - pt > 15, mass cuts, tauCone cut
 from RecoTauTag.RecoTau.PFRecoTauDiscriminationByHPSSelection_cfi import hpsSelectionDiscriminator, decayMode_1Prong0Pi0, decayMode_1Prong1Pi0, decayMode_1Prong2Pi0, decayMode_3Prong0Pi0
@@ -108,6 +114,7 @@ hpsPFTauDiscriminationByLooseIsolationDBSumPtCorr = hpsPFTauDiscriminationByLoos
     deltaBetaFactor = "%0.4f"%(0.0123/0.1687),
     applyOccupancyCut = False,
     applySumPtCut = True,
+    customOuterCone = PFRecoTauPFJetInputs.isolationConeSize
 )
 hpsPFTauDiscriminationByLooseIsolationDBSumPtCorr.maximumSumPtCut=hpsPFTauDiscriminationByLooseIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt
 
@@ -118,6 +125,7 @@ hpsPFTauDiscriminationByMediumIsolationDBSumPtCorr = hpsPFTauDiscriminationByMed
     deltaBetaFactor = "%0.4f"%(0.0462/0.1687),
     applyOccupancyCut = False,
     applySumPtCut = True,
+    customOuterCone = PFRecoTauPFJetInputs.isolationConeSize
 )
 hpsPFTauDiscriminationByMediumIsolationDBSumPtCorr.maximumSumPtCut=hpsPFTauDiscriminationByMediumIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt
 
@@ -128,6 +136,7 @@ hpsPFTauDiscriminationByTightIsolationDBSumPtCorr = hpsPFTauDiscriminationByTigh
     deltaBetaFactor = "%0.4f"%(0.0772/0.1687),
     applyOccupancyCut = False,
     applySumPtCut = True,
+    customOuterCone = PFRecoTauPFJetInputs.isolationConeSize
 )
 hpsPFTauDiscriminationByTightIsolationDBSumPtCorr.maximumSumPtCut=hpsPFTauDiscriminationByTightIsolationDBSumPtCorr.qualityCuts.isolationQualityCuts.minGammaEt
 
@@ -153,7 +162,7 @@ hpsPFTauDiscriminationByVLooseCombinedIsolationDBSumPtCorr.qualityCuts.isolation
 hpsPFTauDiscriminationByLooseCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminationByLooseIsolationDBSumPtCorr.clone(
     ApplyDiscriminationByTrackerIsolation = True,
     ApplyDiscriminationByECALIsolation = True,
-    deltaBetaFactor = "%0.4f"%(0.0772/0.1687),
+    deltaBetaFactor = "%0.4f"%(ak5dBetaCorrection),
     applyOccupancyCut = False,
     applySumPtCut = True,
     maximumSumPtCut = 2.0,
@@ -182,7 +191,7 @@ hpsPFTauDiscriminationByRawGammaIsolationDBSumPtCorr = hpsPFTauDiscriminationByL
 hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminationByMediumIsolationDBSumPtCorr.clone(
     ApplyDiscriminationByTrackerIsolation = True,
     ApplyDiscriminationByECALIsolation = True,
-    deltaBetaFactor = "%0.4f"%(0.0772/0.1687),
+    deltaBetaFactor = "%0.4f"%(ak5dBetaCorrection),
     applyOccupancyCut = False,
     applySumPtCut = True,
     maximumSumPtCut = 1.0,
@@ -194,7 +203,7 @@ hpsPFTauDiscriminationByMediumCombinedIsolationDBSumPtCorr.qualityCuts.isolation
 hpsPFTauDiscriminationByTightCombinedIsolationDBSumPtCorr = hpsPFTauDiscriminationByTightIsolationDBSumPtCorr.clone(
     ApplyDiscriminationByTrackerIsolation = True,
     ApplyDiscriminationByECALIsolation = True,
-    deltaBetaFactor = "%0.4f"%(0.0772/0.1687),
+    deltaBetaFactor = "%0.4f"%(ak5dBetaCorrection),
     applyOccupancyCut = False,
     applySumPtCut = True,
     maximumSumPtCut = 0.8,
@@ -587,7 +596,7 @@ hpsPFTauMVA3IsolationChargedIsoPtSum = hpsPFTauDiscriminationByLooseCombinedIsol
     applyDeltaBetaCorrection = cms.bool(False),
     storeRawSumPt = cms.bool(True),
     storeRawPUsumPt = cms.bool(False),
-    customOuterCone = cms.double(0.5),
+    customOuterCone = PFRecoTauPFJetInputs.isolationConeSize,
     isoConeSizeForDeltaBeta = cms.double(0.8),
     verbosity = cms.int32(0)
 )

--- a/RecoTauTag/Configuration/python/RecoPFTauTag_cff.py
+++ b/RecoTauTag/Configuration/python/RecoPFTauTag_cff.py
@@ -81,11 +81,8 @@ recoTauPileUpVertices = cms.EDFilter(
     minTrackSumPt = cms.double(5),
     filter = cms.bool(False),
 )
-# import jet filtering sequence
-from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import tauInputJets
 
 recoTauCommonSequence = cms.Sequence(
-    tauInputJets *
     ak5PFJetTracksAssociatorAtVertex *
     recoTauAK5PFJets08Region*
     recoTauPileUpVertices*

--- a/RecoTauTag/Configuration/python/RecoPFTauTag_cff.py
+++ b/RecoTauTag/Configuration/python/RecoPFTauTag_cff.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
+
 #-------------------------------------------------------------------------------
 #------------------ Jet Production and Preselection-----------------------------
 #-------------------------------------------------------------------------------
@@ -19,7 +21,7 @@ import FWCore.ParameterSet.Config as cms
 from RecoTauTag.RecoTau.RecoTauJetRegionProducer_cfi import \
       RecoTauJetRegionProducer
 recoTauAK5PFJets08Region=RecoTauJetRegionProducer.clone(
-    src = cms.InputTag("ak5PFJets")
+    src = PFRecoTauPFJetInputs.inputJetCollection
 )
 
 
@@ -27,7 +29,7 @@ recoTauAK5PFJets08Region=RecoTauJetRegionProducer.clone(
 # Reconstruct the pi zeros in our pre-selected jets.
 from RecoTauTag.RecoTau.RecoTauPiZeroProducer_cfi import \
          ak5PFJetsLegacyHPSPiZeros
-ak5PFJetsLegacyHPSPiZeros.jetSrc = cms.InputTag("ak5PFJets")
+ak5PFJetsLegacyHPSPiZeros.jetSrc = PFRecoTauPFJetInputs.inputJetCollection
 # import charged hadrons
 from RecoTauTag.RecoTau.PFRecoTauChargedHadronProducer_cfi import \
           ak5PFJetsRecoTauChargedHadrons
@@ -42,7 +44,7 @@ from RecoTauTag.RecoTau.PFRecoTauChargedHadronProducer_cfi import \
 from RecoTauTag.RecoTau.RecoTauCombinatoricProducer_cfi import \
         combinatoricRecoTaus
 
-combinatoricRecoTaus.jetSrc = cms.InputTag("ak5PFJets")
+combinatoricRecoTaus.jetSrc = PFRecoTauPFJetInputs.inputJetCollection
 
 
 #-------------------------------------------------------------------------------
@@ -62,7 +64,8 @@ from RecoTauTag.RecoTau.PFRecoTauTagInfoProducer_cfi import \
 from RecoJets.JetAssociationProducers.ic5PFJetTracksAssociatorAtVertex_cfi \
         import ic5PFJetTracksAssociatorAtVertex
 ak5PFJetTracksAssociatorAtVertex = ic5PFJetTracksAssociatorAtVertex.clone()
-ak5PFJetTracksAssociatorAtVertex.jets = cms.InputTag("ak5PFJets")
+ak5PFJetTracksAssociatorAtVertex.jets = PFRecoTauPFJetInputs.inputJetCollection
+ak5PFJetTracksAssociatorAtVertex.coneSize = PFRecoTauPFJetInputs.jetConeSize
 tautagInfoModifer = cms.PSet(
     name = cms.string("TTIworkaround"),
     plugin = cms.string("RecoTauTagInfoWorkaroundModifer"),

--- a/RecoTauTag/Configuration/python/RecoPFTauTag_cff.py
+++ b/RecoTauTag/Configuration/python/RecoPFTauTag_cff.py
@@ -81,9 +81,11 @@ recoTauPileUpVertices = cms.EDFilter(
     minTrackSumPt = cms.double(5),
     filter = cms.bool(False),
 )
-
+# import jet filtering sequence
+from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import tauInputJets
 
 recoTauCommonSequence = cms.Sequence(
+    tauInputJets *
     ak5PFJetTracksAssociatorAtVertex *
     recoTauAK5PFJets08Region*
     recoTauPileUpVertices*

--- a/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
+++ b/RecoTauTag/RecoTau/plugins/PFRecoTauDiscriminationByIsolation.cc
@@ -74,10 +74,18 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
 	<< " These options are mutually exclusive.";
     }
 
+    if ( pset.exists("baselineConeSize") ) {
+      baselineCone_ = pset.getParameter<double>("baselineConeSize");
+    } else {
+      baselineCone_ = 0.5;
+    }
+
     if ( pset.exists("customOuterCone") ) {
       customIsoCone_ = pset.getParameter<double>("customOuterCone");
+      coneSizeCorrection_=customIsoCone_*customIsoCone_/(baselineCone_*baselineCone_);
     } else {
       customIsoCone_ = -1;
+      coneSizeCorrection_=1.0;
     }
 
     // Get the quality cuts specific to the isolation region
@@ -169,7 +177,9 @@ class PFRecoTauDiscriminationByIsolation : public PFTauDiscriminationProducerBas
   bool applyRelativeSumPtCut_;
   double maximumRelativeSumPt_;
   double customIsoCone_;
-  
+  double baselineCone_;
+  double coneSizeCorrection_;
+
   // Options to store the raw value in the discriminator instead of boolean pass/fail flag
   bool storeRawOccupancy_;
   bool storeRawSumPt_;
@@ -237,6 +247,7 @@ void PFRecoTauDiscriminationByIsolation::beginEvent(const edm::Event& event, con
     event.getByToken(vertex_token, vertices);
     size_t nVtxThisEvent = vertices->size();
     deltaBetaFactorThisEvent_ = deltaBetaFormula_->Eval(nVtxThisEvent);
+    if (customIsoCone_ >= 0.) deltaBetaFactorThisEvent_*=coneSizeCorrection_;
   }
 
   if ( applyRhoCorrection_ ) {

--- a/RecoTauTag/RecoTau/python/PFRecoTauChargedHadronProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauChargedHadronProducer_cfi.py
@@ -4,9 +4,10 @@ import RecoTauTag.RecoTau.PFRecoTauChargedHadronBuilderPlugins_cfi as builders
 import RecoTauTag.RecoTau.PFRecoTauChargedHadronQualityPlugins_cfi as ranking
 
 from RecoTauTag.RecoTau.PFRecoTauQualityCuts_cfi import PFTauQualityCuts
+from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
 
 ak5PFJetsRecoTauChargedHadrons = cms.EDProducer("PFRecoTauChargedHadronProducer",
-    jetSrc = cms.InputTag("ak5PFJets"),
+    jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     jetRegionSrc = cms.InputTag("recoTauAK5PFJets08Region"),
     outputSelection = cms.string('pt > %1.1f' % PFTauQualityCuts.signalQualityCuts.minTrackPt.value()), # CV: apply minimum Pt cut as sanity check
     builders = cms.VPSet(

--- a/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByHPSSelection_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByHPSSelection_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoTauTag.RecoTau.TauDiscriminatorTools import noPrediscriminants
+from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
 
 decayMode_1Prong0Pi0 = cms.PSet(
     nCharged = cms.uint32(1),
@@ -63,7 +64,7 @@ hpsSelectionDiscriminator = cms.EDProducer(
     "PFRecoTauDiscriminationByHPSSelection",
     PFTauProducer = cms.InputTag('combinatoricRecoTaus'),
     Prediscriminants = noPrediscriminants,
-    matchingCone = cms.double(0.5),
+    matchingCone = PFRecoTauPFJetInputs.jetConeSize,
     minTauPt = cms.double(0.0),
     coneSizeFormula = cms.string("max(min(0.1, 3.0/pt()), 0.05)"),
     decayModes = cms.VPSet(

--- a/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByIsolation_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauDiscriminationByIsolation_cfi.py
@@ -34,6 +34,8 @@ pfRecoTauDiscriminationByIsolation = cms.EDProducer("PFRecoTauDiscriminationByIs
     # This must correspond to the cone size of the algorithm which built the
     # tau. (or if customOuterCone option is used, the custom cone size)
     isoConeSizeForDeltaBeta = cms.double(0.5),
+    customOuterCone = cms.double(0.5),
+    baselineConeSize = cms.double(0.5),
     # The delta beta factor maps the expected neutral contribution in the
     # isolation cone from the observed PU charged contribution.  This factor can
     # optionally be a function (use 'x') of the number of vertices in the event

--- a/RecoTauTag/RecoTau/python/PFRecoTauPFJetInputs_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauPFJetInputs_cfi.py
@@ -1,7 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
+from CommonTools.RecoAlgos.pfJetSelector_cfi import pfJetSelector
+
+tauInputJets = pfJetSelector.clone(
+    src = cms.InputTag("ak5PFJets"),
+    filter = cms.bool( True ),
+    cut = cms.string ( "pt > 20 && abs(eta) < 2.5")
+)
+
 PFRecoTauPFJetInputs = cms.PSet (
-    inputJetCollection = cms.InputTag("ak5PFJets"),
+    inputJetCollection = cms.InputTag("tauInputJets"),
     jetConeSize = cms.double(0.5),
     isolationConeSize = cms.double(0.5)
 )

--- a/RecoTauTag/RecoTau/python/PFRecoTauPFJetInputs_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauPFJetInputs_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+PFRecoTauPFJetInputs = cms.PSet (
+    inputJetCollection = cms.InputTag("ak5PFJets"),
+    jetConeSize = cms.double(0.5),
+    isolationConeSize = cms.double(0.5)
+)

--- a/RecoTauTag/RecoTau/python/PFRecoTauPFJetInputs_cfi.py
+++ b/RecoTauTag/RecoTau/python/PFRecoTauPFJetInputs_cfi.py
@@ -1,15 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from CommonTools.RecoAlgos.pfJetSelector_cfi import pfJetSelector
-
-tauInputJets = pfJetSelector.clone(
-    src = cms.InputTag("ak5PFJets"),
-    filter = cms.bool( True ),
-    cut = cms.string ( "pt > 20 && abs(eta) < 2.5")
-)
-
 PFRecoTauPFJetInputs = cms.PSet (
-    inputJetCollection = cms.InputTag("tauInputJets"),
+    inputJetCollection = cms.InputTag("ak5PFJets"),
     jetConeSize = cms.double(0.5),
     isolationConeSize = cms.double(0.5)
 )

--- a/RecoTauTag/RecoTau/python/RecoTauCombinatoricProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauCombinatoricProducer_cfi.py
@@ -2,7 +2,7 @@
 import FWCore.ParameterSet.Config as cms
 from RecoTauTag.RecoTau.PFRecoTauQualityCuts_cfi import PFTauQualityCuts
 from RecoTauTag.RecoTau.PFRecoTauEnergyAlgorithmPlugin_cfi import pfTauEnergyAlgorithmPlugin
-
+from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
 '''
 
 Configuration for combinatoric PFTau producer plugins.
@@ -74,7 +74,7 @@ _combinatoricTauConfig = cms.PSet(
     name = cms.string("combinatoric"),
     plugin = cms.string("RecoTauBuilderCombinatoricPlugin"),
     pfCandSrc = cms.InputTag("particleFlow"),
-    isolationConeSize = cms.double(0.5),
+    isolationConeSize = PFRecoTauPFJetInputs.isolationConeSize,
     qualityCuts = PFTauQualityCuts,
     decayModes = cms.VPSet(
         combinatoricDecayModeConfigs.config1prong0pi0,
@@ -87,7 +87,7 @@ _combinatoricTauConfig = cms.PSet(
 )
 
 combinatoricRecoTaus = cms.EDProducer("RecoTauProducer",
-    jetSrc = cms.InputTag("ak5PFJets"),
+    jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     jetRegionSrc = cms.InputTag("recoTauAK5PFJets08Region"),
     chargedHadronSrc = cms.InputTag('ak5PFJetsRecoTauChargedHadrons'),                                
     piZeroSrc = cms.InputTag("ak5PFJetsRecoTauPiZeros"),

--- a/RecoTauTag/RecoTau/python/RecoTauJetRegionProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauJetRegionProducer_cfi.py
@@ -1,9 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
+
 RecoTauJetRegionProducer = cms.EDProducer(
         "RecoTauJetRegionProducer",
             deltaR = cms.double(0.8),
-            src = cms.InputTag("ak5PFJets"),
+            src = PFRecoTauPFJetInputs.inputJetCollection,
             pfCandSrc = cms.InputTag("particleFlow"),
             pfCandAssocMapSrc = cms.InputTag("")
         )

--- a/RecoTauTag/RecoTau/python/RecoTauPiZeroProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauPiZeroProducer_cfi.py
@@ -2,10 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 import RecoTauTag.RecoTau.RecoTauPiZeroBuilderPlugins_cfi as builders
 import RecoTauTag.RecoTau.RecoTauPiZeroQualityPlugins_cfi as ranking
+from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
+
 
 ak5PFJetsRecoTauGreedyPiZeros = cms.EDProducer(
     "RecoTauPiZeroProducer",
-    jetSrc = cms.InputTag("ak5PFJets"),
+    jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     massHypothesis = cms.double(0.136),
     outputSelection = cms.string('pt > 1.5'),
     builders = cms.VPSet(
@@ -18,7 +20,7 @@ ak5PFJetsRecoTauGreedyPiZeros = cms.EDProducer(
 
 ak5PFJetsRecoTauPiZeros = cms.EDProducer(
     "RecoTauPiZeroProducer",
-    jetSrc = cms.InputTag("ak5PFJets"),
+    jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     massHypothesis = cms.double(0.136),
     outputSelection = cms.string('pt > 1.5'),
     builders = cms.VPSet(
@@ -35,7 +37,7 @@ ak5PFJetsRecoTauPiZeros = cms.EDProducer(
 
 ak5PFJetsLegacyTaNCPiZeros = cms.EDProducer(
     "RecoTauPiZeroProducer",
-    jetSrc = cms.InputTag("ak5PFJets"),
+    jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     massHypothesis = cms.double(0.136),
     outputSelection = cms.string('pt > 1.5'),
     builders = cms.VPSet(
@@ -49,7 +51,7 @@ ak5PFJetsLegacyTaNCPiZeros = cms.EDProducer(
 
 ak5PFJetsLegacyHPSPiZeros = cms.EDProducer(
     "RecoTauPiZeroProducer",
-    jetSrc = cms.InputTag("ak5PFJets"),
+    jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     massHypothesis = cms.double(0.136),
     outputSelection = cms.string('pt > 0'),
     builders = cms.VPSet(

--- a/RecoTauTag/RecoTau/python/RecoTauShrinkingConeProducer_cfi.py
+++ b/RecoTauTag/RecoTau/python/RecoTauShrinkingConeProducer_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 from RecoTauTag.RecoTau.PFRecoTauQualityCuts_cfi import PFTauQualityCuts
-
+from RecoTauTag.RecoTau.PFRecoTauPFJetInputs_cfi import PFRecoTauPFJetInputs
 '''
 
 Configuration for 'shrinkingCone' PFTau Producer
@@ -28,7 +28,7 @@ _shrinkingConeRecoTausConfig = cms.PSet(
 
 shrinkingConeRecoTaus = cms.EDProducer(
     "RecoTauProducer",
-    jetSrc = cms.InputTag("ak5PFJets"),
+    jetSrc = PFRecoTauPFJetInputs.inputJetCollection,
     piZeroSrc = cms.InputTag("ak5PFJetsRecoTauPiZeros"),
     jetRegionSrc = cms.InputTag("recoTauAK5PFJets08Region"),
     builders = cms.VPSet(


### PR DESCRIPTION
In anticipation of the possible change of the default jet collection, the input jet collection for the tau reco is now defined in a single config file to allow to change default change collection consistently at one place

@veelken and @monicava are for sure interested in this request as well
