### PR TITLE
Add missing iostream include

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/test/plugins/EcalUncalibRecHitDump.cc
+++ b/RecoLocalCalo/EcalRecProducers/test/plugins/EcalUncalibRecHitDump.cc
@@ -9,6 +9,8 @@
 #include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHit.h"
 #include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
+#include <iostream>
+
 class EcalUncalibRecHitDump : public edm::EDAnalyzer {
  public:
   explicit EcalUncalibRecHitDump(const edm::ParameterSet&);


### PR DESCRIPTION
A missing include of the iostream header is causing a compilation failure in the ROOT6 IB's.  This technical pull request just adds the missing include.  This is being done in the main 7_1_X branch for code commonality.
