### PR TITLE
Two more root6 relval fixes

### DIFF
--- a/CondCore/ORA/src/InlineCArrayStreamer.cc
+++ b/CondCore/ORA/src/InlineCArrayStreamer.cc
@@ -32,7 +32,7 @@ bool ora::InlineCArrayStreamerBase::buildDataElement(DataElement& dataElement,
                     "InlineCArrayStreamerBase::buildDataElement" );
   }
   // Loop over the elements of the array.
-  for ( unsigned int i=0;i<m_objectType.size();i++){
+  for ( unsigned int i=0;i<m_objectType.arrayLength();i++){
 
     // Form the element name
     std::string arrayElementLabel = MappingRules::variableNameForArrayIndex( m_mapping.variableName(),i);

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -536,7 +536,6 @@ namespace edm {
 
   TypeWithDict
   TypeWithDict::toType() const {
-    TypeWithDict ret;
     if (type_ == nullptr) {
       return *this;
     }

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -538,18 +538,17 @@ namespace edm {
   TypeWithDict::toType() const {
     TypeWithDict ret;
     if (type_ == nullptr) {
-      return ret;
+      return *this;
     }
     TType* ty = gInterpreter->Type_ToType(type_);
     if (ty == nullptr) {
-      return ret;
+      return *this;
     }
     std::type_info const* ti = gInterpreter->Type_TypeInfo(ty);
     if (ti == nullptr) {
-      return ret;
+      return *this;
     }
-    ret = TypeWithDict(*ti);
-    return ret;
+    return TypeWithDict(*ti);
   }
 
   std::string


### PR DESCRIPTION
This is a fix for two ROOT6 specific bugs causing relval failures.
1) TypeWithDict::typeOf()  is used to strip off array and pointer information to get the underlying type.
It was written returning a dummy type if the original type is not an array or pointer.  This is not in itself a bug, because the analogous Reflex function did the same.  However,the conditions  code as written for ROOT6 assumes that the original type will be returned if the type is not an array or a pointer.  The easiest way to fix this for now is to have toType() return the original type.
2) The conditions code assumed incorrectly that TypeWithDict::size() returns the number of elements in the array if the type is an array.  It does not. The correct function to call is TypeWithDict::arrayLength().
This pull request changes the call to use arrayLength().
Please merge this promptly unless there are problems.
