### PR TITLE
move delete of energy corrector in destructor

### DIFF
--- a/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/PhotonProducer.cc
@@ -141,7 +141,7 @@ PhotonProducer::PhotonProducer(const edm::ParameterSet& config) :
 
 PhotonProducer::~PhotonProducer() 
 {
-
+  delete thePhotonEnergyCorrector_;
   //delete energyCorrectionF;
 }
 
@@ -162,7 +162,6 @@ void  PhotonProducer::endRun (edm::Run const& r, edm::EventSetup const & theEven
 
   delete thePhotonIsolationCalculator_;
   delete thePhotonMIPHaloTagger_;
-  delete thePhotonEnergyCorrector_;
 }
 
 


### PR DESCRIPTION
I had moved the new from beginRun to constructor without moving consistently the delete, this was causing the crash as the Run was changing.
