### PR TITLE
HLTTau producers migrated to consume

### DIFF
--- a/RecoTauTag/HLTProducers/interface/CaloTowerCreatorForTauHLT.h
+++ b/RecoTauTag/HLTProducers/interface/CaloTowerCreatorForTauHLT.h
@@ -17,8 +17,10 @@
  */
 
 #include "FWCore/Framework/interface/EDProducer.h"
+#include "DataFormats/CaloTowers/interface/CaloTower.h"
+#include "DataFormats/L1Trigger/interface/L1JetParticle.h"
+#include "DataFormats/L1Trigger/interface/L1JetParticleFwd.h"
 #include <string>
-#include "FWCore/Utilities/interface/InputTag.h"
 
 namespace edm {
   class ParameterSet;
@@ -37,13 +39,13 @@ class CaloTowerCreatorForTauHLT : public edm::EDProducer {
   /// verbosity
   int mVerbose;
   /// label of source collection
- edm::InputTag mtowers;
+  edm::EDGetTokenT<CaloTowerCollection> mtowers_token;
   /// use only towers in cone mCone around L1 candidate for regional jet reco
   double mCone;
   /// label of tau trigger type analysis
-  edm::InputTag mTauTrigger;
+  edm::EDGetTokenT<l1extra::L1JetParticleCollection> mTauTrigger_token;
   /// imitator of L1 seeds
-  edm::InputTag ml1seeds;
+  //edm::InputTag ml1seeds;
   /// ET threshold
   double mEtThreshold;
   /// E threshold

--- a/RecoTauTag/HLTProducers/interface/L2TauJetsMerger.h
+++ b/RecoTauTag/HLTProducers/interface/L2TauJetsMerger.h
@@ -25,7 +25,9 @@ class L2TauJetsMerger: public edm::EDProducer {
  private:
     
   typedef std::vector<edm::InputTag> vtag;
+  typedef std::vector<edm::EDGetTokenT<reco::CaloJetCollection> > vtoken_cjets;
   vtag jetSrc;
+  vtoken_cjets jetSrc_token;
   double mEt_Min;
   std::map<int, const reco::CaloJet> myL2L1JetsMap; //first is # L1Tau , second is L2 jets
 

--- a/RecoTauTag/HLTProducers/interface/L2TauPixelIsoTagProducer.h
+++ b/RecoTauTag/HLTProducers/interface/L2TauPixelIsoTagProducer.h
@@ -5,6 +5,10 @@
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/JetReco/interface/Jet.h"
 
 /** \class L2TauPixelIsoTagProducer
  * Producer of a JetTagCollection where tag is defined as # of pixel tracks
@@ -28,10 +32,10 @@ public:
 
 private:
 
-  edm::InputTag m_jetSrc;
-  edm::InputTag m_vertexSrc;
-  edm::InputTag m_trackSrc;
-  edm::InputTag m_beamSpotSrc;
+  edm::EDGetTokenT<edm::View<reco::Jet> > m_jetSrc_token;
+  edm::EDGetTokenT<reco::VertexCollection> m_vertexSrc_token;
+  edm::EDGetTokenT<reco::TrackCollection> m_trackSrc_token;
+  edm::EDGetTokenT<reco::BeamSpot> m_beamSpotSrc_token;
 
   int m_maxNumberPV;
 

--- a/RecoTauTag/HLTProducers/interface/TauJetSelectorForHLTTrackSeeding.h
+++ b/RecoTauTag/HLTProducers/interface/TauJetSelectorForHLTTrackSeeding.h
@@ -14,6 +14,13 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "DataFormats/JetReco/interface/CaloJet.h"
+#include "DataFormats/JetReco/interface/CaloJetCollection.h"
+#include "DataFormats/JetReco/interface/TrackJet.h"
+#include "DataFormats/JetReco/interface/TrackJetCollection.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
 class TauJetSelectorForHLTTrackSeeding : public edm::EDProducer {
 
 public:
@@ -27,9 +34,9 @@ private:
       
   // ----------member data ---------------------------
 
-  const edm::InputTag inputTrackJetTag_;
-  const edm::InputTag inputCaloJetTag_;
-  const edm::InputTag inputTrackTag_;
+  edm::EDGetTokenT<reco::TrackJetCollection> inputTrackJetToken_;
+  edm::EDGetTokenT<reco::CaloJetCollection> inputCaloJetToken_;
+  edm::EDGetTokenT<reco::TrackCollection> inputTrackToken_;
   const double ptMinCaloJet_;
   const double etaMinCaloJet_;
   const double etaMaxCaloJet_;

--- a/RecoTauTag/HLTProducers/src/CaloTowerCreatorForTauHLT.cc
+++ b/RecoTauTag/HLTProducers/src/CaloTowerCreatorForTauHLT.cc
@@ -2,15 +2,12 @@
 // original author: L.Lista INFN, modifyed by: F.Ratnikov UMd 
 // Author for regionality A. Nikitenko
 // Modified by S. Gennai
-#include <cmath>
+
 #include "DataFormats/RecoCandidate/interface/RecoCaloTowerCandidate.h"
-#include "DataFormats/CaloTowers/interface/CaloTower.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "RecoTauTag/HLTProducers/interface/CaloTowerCreatorForTauHLT.h"
-#include "DataFormats/L1Trigger/interface/L1JetParticle.h"
-#include "DataFormats/L1Trigger/interface/L1JetParticleFwd.h"
 // Math
 #include "Math/GenVector/VectorUtil.h"
 #include <cmath>
@@ -23,14 +20,14 @@ using namespace l1extra ;
 CaloTowerCreatorForTauHLT::CaloTowerCreatorForTauHLT( const ParameterSet & p ) 
   :
   mVerbose (p.getUntrackedParameter<int> ("verbose", 0)),
-  mtowers (p.getParameter<InputTag> ("towers")),
   mCone (p.getParameter<double> ("UseTowersInCone")),
-  mTauTrigger (p.getParameter<InputTag> ("TauTrigger")),
-//  ml1seeds (p.getParameter<InputTag> ("l1seeds")),
   mEtThreshold (p.getParameter<double> ("minimumEt")),
   mEThreshold (p.getParameter<double> ("minimumE")),
   mTauId (p.getParameter<int> ("TauId"))
 {
+  mtowers_token = consumes<CaloTowerCollection>(p.getParameter<InputTag>("towers") );
+  mTauTrigger_token = consumes<L1JetParticleCollection>(p.getParameter<InputTag>("TauTrigger") );
+
   produces<CaloTowerCollection>();
 }
 
@@ -39,11 +36,12 @@ CaloTowerCreatorForTauHLT::~CaloTowerCreatorForTauHLT() {
 
 void CaloTowerCreatorForTauHLT::produce( Event& evt, const EventSetup& ) {
   edm::Handle<CaloTowerCollection> caloTowers;
-  evt.getByLabel( mtowers, caloTowers );
+  evt.getByToken( mtowers_token, caloTowers );
 
   // imitate L1 seeds
   edm::Handle<L1JetParticleCollection> jetsgen;
-  evt.getByLabel(mTauTrigger, jetsgen);
+  evt.getByToken( mTauTrigger_token, jetsgen);
+
   std::auto_ptr<CaloTowerCollection> cands( new CaloTowerCollection );
   cands->reserve( caloTowers->size() );
   

--- a/RecoTauTag/HLTProducers/src/L2TauJetsMerger.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauJetsMerger.cc
@@ -1,7 +1,5 @@
 #include "RecoTauTag/HLTProducers/interface/L2TauJetsMerger.h"
 #include "Math/GenVector/VectorUtil.h"
-#include "DataFormats/L1Trigger/interface/L1JetParticle.h"
-#include "DataFormats/L1Trigger/interface/L1JetParticleFwd.h"
 #include "DataFormats/HLTReco/interface/TriggerTypeDefs.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 //
@@ -10,14 +8,14 @@
 using namespace reco;
 using namespace std;
 using namespace edm;
-using namespace l1extra;
 
 L2TauJetsMerger::L2TauJetsMerger(const edm::ParameterSet& iConfig)
 {
   jetSrc = iConfig.getParameter<vtag>("JetSrc");
-  //l1ParticlesTau = iConfig.getParameter<InputTag>("L1ParticlesTau");
-  //l1ParticlesJet = iConfig.getParameter<InputTag>("L1ParticlesJet");
-  //tauTrigger = iConfig.getParameter<InputTag>("L1TauTrigger");
+  for(vtag::const_iterator it = jetSrc.begin(); it != jetSrc.end(); ++it) {
+    edm::EDGetTokenT<CaloJetCollection> aToken = consumes<CaloJetCollection>(*it);
+    jetSrc_token.push_back(aToken);
+  }
   mEt_Min = iConfig.getParameter<double>("EtMin");
   
   produces<CaloJetCollection>();
@@ -42,10 +40,10 @@ void L2TauJetsMerger::produce(edm::Event& iEvent, const edm::EventSetup& iES)
  myTmpJets.clear();
 
  int iL1Jet = 0;
- for( vtag::const_iterator s = jetSrc.begin(); s != jetSrc.end(); ++ s ) {
+ for( vtoken_cjets::const_iterator s = jetSrc_token.begin(); s != jetSrc_token.end(); ++ s ) {
    edm::Handle<CaloJetCollection> tauJets;
-   iEvent.getByLabel( * s, tauJets );
-   for(CaloJetCollection::const_iterator iTau = tauJets->begin();iTau !=tauJets->end();iTau++)
+   iEvent.getByToken( * s, tauJets );
+   for(CaloJetCollection::const_iterator iTau = tauJets->begin(); iTau !=tauJets->end(); ++iTau)
      { 
      //Create a Map to associate to every Jet its L1SeedId, i.e. 0,1,2 or 3
        if(iTau->et() > mEt_Min) {

--- a/RecoTauTag/HLTProducers/src/L2TauPixelIsoTagProducer.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauPixelIsoTagProducer.cc
@@ -12,17 +12,14 @@
 
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/BTauReco/interface/JetTag.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
 
 L2TauPixelIsoTagProducer::L2TauPixelIsoTagProducer(const edm::ParameterSet& conf)
 {
-  m_jetSrc      = conf.getParameter<edm::InputTag>("JetSrc");
-  m_vertexSrc   = conf.getParameter<edm::InputTag>("VertexSrc");
-  m_trackSrc    = conf.getParameter<edm::InputTag>("TrackSrc");  // for future use (now tracks are taken directly from PV)
-  m_beamSpotSrc = conf.getParameter<edm::InputTag>("BeamSpotSrc");
+  m_jetSrc_token      = consumes<edm::View<reco::Jet> >(conf.getParameter<edm::InputTag>("JetSrc") );
+  m_vertexSrc_token   = consumes<reco::VertexCollection>(conf.getParameter<edm::InputTag>("VertexSrc") );
+  m_trackSrc_token    = consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("TrackSrc") );  // for future use (now tracks are taken directly from PV)
+  m_beamSpotSrc_token = consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("BeamSpotSrc") );
 
   m_maxNumberPV = conf.getParameter<int>("MaxNumberPV"); // for future use, now is assumed to be = 1
 
@@ -30,7 +27,7 @@ L2TauPixelIsoTagProducer::L2TauPixelIsoTagProducer(const edm::ParameterSet& conf
   m_trackMaxDxy   = conf.getParameter<double>("TrackMaxDxy");
   m_trackMaxNChi2 = conf.getParameter<double>("TrackMaxNChi2");
   m_trackMinNHits = conf.getParameter<int>("TrackMinNHits");
-  m_trackPVMaxDZ    = conf.getParameter<double>("TrackPVMaxDZ"); // for future use with tracks not from PV
+  m_trackPVMaxDZ  = conf.getParameter<double>("TrackPVMaxDZ"); // for future use with tracks not from PV
 
   m_isoCone2Min  = std::pow(conf.getParameter<double>("IsoConeMin"), 2);
   m_isoCone2Max  = std::pow(conf.getParameter<double>("IsoConeMax"), 2);
@@ -44,15 +41,15 @@ void L2TauPixelIsoTagProducer::produce(edm::Event& ev, const edm::EventSetup& es
   using namespace reco;
   using namespace std;
   using namespace edm;
-  m_trackSrc.encode();
+  //m_trackSrc.encode();
 
   edm::Handle<BeamSpot> bs;
-  ev.getByLabel( m_beamSpotSrc, bs);
+  ev.getByToken( m_beamSpotSrc_token, bs);
 
 
   // Get jets
   Handle< View<Jet> > jets_h;
-  ev.getByLabel (m_jetSrc, jets_h);
+  ev.getByToken (m_jetSrc_token, jets_h);
   vector<RefToBase<Jet> > jets;
   jets.reserve (jets_h->size());
   for (size_t i = 0; i < jets_h->size(); ++i)  jets.push_back( jets_h->refAt(i) );
@@ -74,7 +71,7 @@ void L2TauPixelIsoTagProducer::produce(edm::Event& ev, const edm::EventSetup& es
 
   // Get pixel vertices (their x,y positions are already supposed to be defined from the BeamSpot)
   Handle<VertexCollection> vertices;
-  ev.getByLabel(m_vertexSrc, vertices);
+  ev.getByToken(m_vertexSrc_token, vertices);
 
   // find the primary vertex (the 1st valid non-fake vertex in the collection)
   const Vertex *pv = 0;

--- a/RecoTauTag/HLTProducers/src/TauJetSelectorForHLTTrackSeeding.cc
+++ b/RecoTauTag/HLTProducers/src/TauJetSelectorForHLTTrackSeeding.cc
@@ -1,18 +1,9 @@
 #include "RecoTauTag/HLTProducers/interface/TauJetSelectorForHLTTrackSeeding.h"
 
 #include "DataFormats/Math/interface/deltaPhi.h"
-#include "DataFormats/JetReco/interface/CaloJet.h"
-#include "DataFormats/JetReco/interface/CaloJetCollection.h"
-#include "DataFormats/JetReco/interface/TrackJet.h"
-#include "DataFormats/JetReco/interface/TrackJetCollection.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 
 TauJetSelectorForHLTTrackSeeding::TauJetSelectorForHLTTrackSeeding(const edm::ParameterSet& iConfig):
-  inputTrackJetTag_(iConfig.getParameter< edm::InputTag > ("inputTrackJetTag")),
-  inputCaloJetTag_(iConfig.getParameter< edm::InputTag > ("inputCaloJetTag")),
-  inputTrackTag_(iConfig.getParameter< edm::InputTag > ("inputTrackTag")),
   ptMinCaloJet_(iConfig.getParameter< double > ("ptMinCaloJet")),
   etaMinCaloJet_(iConfig.getParameter< double > ("etaMinCaloJet")),
   etaMaxCaloJet_(iConfig.getParameter< double > ("etaMaxCaloJet")),
@@ -24,6 +15,10 @@ TauJetSelectorForHLTTrackSeeding::TauJetSelectorForHLTTrackSeeding(const edm::Pa
   nTrkMaxInCaloCone_(iConfig.getParameter< int > ("nTrkMaxInCaloCone"))
 {
    //now do what ever initialization is needed
+  inputTrackJetToken_ = consumes< reco::TrackJetCollection >(iConfig.getParameter< edm::InputTag > ("inputTrackJetTag"));
+  inputCaloJetToken_  = consumes< reco::CaloJetCollection >(iConfig.getParameter< edm::InputTag > ("inputCaloJetTag"));
+  inputTrackToken_    = consumes< reco::TrackCollection >(iConfig.getParameter< edm::InputTag > ("inputTrackTag"));
+
   produces<reco::TrackJetCollection>();
 }
 
@@ -48,7 +43,7 @@ TauJetSelectorForHLTTrackSeeding::produce(edm::Event& iEvent, const edm::EventSe
    std::auto_ptr< reco::TrackJetCollection > augmentedTrackJets (new reco::TrackJetCollection);
 
    edm::Handle<reco::TrackJetCollection> trackjets;
-   iEvent.getByLabel(inputTrackJetTag_, trackjets);
+   iEvent.getByToken(inputTrackJetToken_, trackjets);
 
    for (reco::TrackJetCollection::const_iterator trackjet = trackjets->begin();
 	  trackjet != trackjets->end(); trackjet++) {
@@ -56,10 +51,10 @@ TauJetSelectorForHLTTrackSeeding::produce(edm::Event& iEvent, const edm::EventSe
    }
 
    edm::Handle<reco::TrackCollection> tracks;
-   iEvent.getByLabel(inputTrackTag_,tracks);
+   iEvent.getByToken(inputTrackToken_,tracks);
 
    edm::Handle<reco::CaloJetCollection> calojets;
-   iEvent.getByLabel(inputCaloJetTag_,calojets);
+   iEvent.getByToken(inputCaloJetToken_,calojets);
 
    const double tauConeSize2       = tauConeSize_ * tauConeSize_;
    const double isolationConeSize2 = isolationConeSize_ * isolationConeSize_;


### PR DESCRIPTION
The following modules are migrated to consumes:
RecoTauTag/HLTProducers
-> CaloTowerCreatorForTauHLT
-> L2TauJetsMerger
-> L2TauPixelIsoTagProducer
-> TauJetSelectorForHLTTrackSeeding

Tested with 'frozen 2013' HLT table at CMSSW_7_1_0_pre3
