### PR TITLE
Add CFCal tests to runTheMatrix

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1085,8 +1085,27 @@ steps['COPYPASTE']={'-s':'NONE',
 
 
 
-# you will need separate scenarios HERE for full and fast 
-upgradeKeys=['2017','2019','BE5D','2017Fast','BE5DFast','BE5DForwardFast','2019WithGEM','BE5DPixel10D','2017Aging','2019Aging','Extended2023','Extended2023HGCalMuon','Extended2023SHCal','Extended2023SHCal4Eta','Extended2023TTI','Extended2023Muon']
+# You will need separate scenarios HERE for full and fast. DON'T CHANGE THE ORDER, only
+# append new keys. Otherwise the numbering for the runTheMatrix tests will change.
+upgradeKeys=['2017',
+             '2019',
+             'BE5D',
+             '2017Fast',
+             'BE5DFast',
+             'BE5DForwardFast',
+             '2019WithGEM',
+             'BE5DPixel10D',
+             '2017Aging',
+             '2019Aging',
+             'Extended2023',
+             'Extended2023HGCalMuon',
+             'Extended2023SHCal',
+             'Extended2023SHCal4Eta',
+             'Extended2023TTI',
+             'Extended2023Muon',
+             'Extended2023CFCal',
+             'Extended2023CFCal4Eta'
+             ]
 upgradeGeoms={ '2017' : 'Extended2017',
                '2019' : 'Extended2019',
                '2019WithGEM' : 'Extended2019',
@@ -1102,7 +1121,9 @@ upgradeGeoms={ '2017' : 'Extended2017',
                'Extended2023SHCal' : 'Extended2023SHCal,Extended2023SHCalReco',
                'Extended2023SHCal4Eta' : 'Extended2023SHCal4Eta,Extended2023SHCalReco',
                'Extended2023TTI' : 'Extended2023TTI,Extended2023TTIReco',
-               'Extended2023Muon' : 'Extended2023Muon,Extended2023MuonReco'
+               'Extended2023Muon' : 'Extended2023Muon,Extended2023MuonReco',
+               'Extended2023CFCal' : 'Extended2023CFCal,Extended2023CFCalReco',
+               'Extended2023CFCal4Eta' : 'Extended2023CFCal4Eta,Extended2023CFCal4EtaReco'
                }
 upgradeGTs={ '2017' : 'auto:upgrade2017',
              '2019' : 'auto:upgrade2019',
@@ -1119,7 +1140,9 @@ upgradeGTs={ '2017' : 'auto:upgrade2017',
              'Extended2023SHCal' : 'auto:upgradePLS3',
              'Extended2023SHCal4Eta' : 'auto:upgradePLS3',
              'Extended2023TTI' : 'auto:upgradePLS3',
-             'Extended2023Muon' : 'auto:upgradePLS3'
+             'Extended2023Muon' : 'auto:upgradePLS3',
+             'Extended2023CFCal' : 'auto:upgradePLS3',
+             'Extended2023CFCal4Eta' : 'auto:upgradePLS3'
              }
 upgradeCustoms={ '2017' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2017',
                  '2019' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2019',
@@ -1136,7 +1159,9 @@ upgradeCustoms={ '2017' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.
                  'Extended2023SHCal' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
                  'Extended2023SHCal4Eta' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
                  'Extended2023TTI' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms_TTI.cust_phase2_BE5D',
-                 'Extended2023Muon' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023Muon'
+                 'Extended2023Muon' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023Muon',
+                 'Extended2023CFCal' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
+                 'Extended2023CFCal4Eta' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023'
                  }
 ### remember that you need to add a new step for phase 2 to include the track trigger
 ### remember that you need to add fastsim
@@ -1166,7 +1191,9 @@ upgradeScenToRun={ '2017':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023SHCal':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023SHCal4Eta':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023TTI':['GenSimFull','DigiTrkTrigFull','RecoFull','HARVESTFull'],
-                   'Extended2023Muon':['GenSimFull','DigiFull','RecoFull','HARVESTFull']
+                   'Extended2023Muon':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
+                   'Extended2023CFCal':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
+                   'Extended2023CFCal4Eta':['GenSimFull','DigiFull','RecoFull','HARVESTFull']
                    }
 
 upgradeStepDict={}


### PR DESCRIPTION
Adds tests 132xx (Extended2023CFCal) and 134xx (Extended2023CFCal4Eta) to runTheMatrix.  Currently both pass step 1 then fail in step 2 with:

```
----- Begin Fatal Exception 03-Mar-2014 16:57:37 CET-----------------------
An exception of category 'NoRecordFromDependentRecord' occurred while
   [0] Processing run: 1
   [1] Running path 'digitisation_step'
   [2] Calling beginRun for module MixingModule/'mix'
   [3] Using EventSetup component CaloGeometryBuilder/'' to make data CaloGeometry/'' in record CaloGeometryRecord
   [4] Using EventSetup component HcalHardcodeGeometryEP/'' to make data CaloSubdetectorGeometry/'HCAL' in record HcalGeometryRecord
   [5] Using EventSetup component HcalRecNumberingInitialization/'' to make data HcalDDDRecConstants/'' in record HcalRecNumberingRecord
Exception Message:
No "HcalSimNumberingRecord" record found in the dependent record "HcalRecNumberingRecord".
 Please add an ESSource or ESProducer that delivers the "HcalSimNumberingRecord" record.
----- End Fatal Exception -------------------------------------------------
```
