### PR TITLE
Set Global cache at beginStream time for Stream modules

### DIFF
--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptor.h
@@ -99,7 +99,11 @@ namespace edm {
       typedef CallGlobalLuminosityBlockSummary<T> MyGlobalLuminosityBlockSummary;
       
       void setupStreamModules() override final {
-        this->createStreamModules([this] () -> EDAnalyzerBase* {return impl::makeStreamModule<T>(*m_pset,m_global.get());});
+        this->createStreamModules([this] () -> EDAnalyzerBase* {
+          auto tmp = impl::makeStreamModule<T>(*m_pset,m_global.get());
+          MyGlobal::set(tmp,m_global.get());
+          return tmp;
+        });
         m_pset= nullptr;
       }
 
@@ -107,7 +111,6 @@ namespace edm {
         MyGlobal::endJob(m_global.get());
       }
       void setupRun(EDAnalyzerBase* iProd, RunIndex iIndex) override final {
-        MyGlobal::set(iProd,m_global.get());
         MyGlobalRun::set(iProd, m_runs[iIndex].get());
       }
       void streamEndRunSummary(EDAnalyzerBase* iProd,

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptor.h
@@ -92,7 +92,11 @@ namespace edm {
       typedef CallEndLuminosityBlockProduce<T> MyEndLuminosityBlockProduce;
       
       void setupStreamModules() override final {
-        this->createStreamModules([this] () -> M* {return impl::makeStreamModule<T>(*m_pset,m_global.get());});
+        this->createStreamModules([this] () -> M* {
+          auto tmp = impl::makeStreamModule<T>(*m_pset,m_global.get());
+          MyGlobal::set(tmp,m_global.get());
+          return tmp;
+        });
         m_pset= nullptr;
       }
 
@@ -100,7 +104,6 @@ namespace edm {
         MyGlobal::endJob(m_global.get());
       }
       void setupRun(M* iProd, RunIndex iIndex) override final {
-        MyGlobal::set(iProd,m_global.get());
         MyGlobalRun::set(iProd, m_runs[iIndex].get());
       }
       void streamEndRunSummary(M* iProd,


### PR DESCRIPTION
Bug fix: originally the setGlobal wasn’t done until beginRun. However, if there was an exception between beginStream and beginRun time, the endStream method of the stream module would be called and if globalCache() is called, it would be given a nullptr.
