### PR TITLE
switch back to use associator for track validation

### DIFF
--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -9,11 +9,10 @@ from Validation.RecoTrack.PostProcessorTracker_cfi import *
 import PhysicsTools.RecoAlgos.recoTrackSelector_cfi
 
 from SimTracker.TrackerHitAssociation.clusterTpAssociationProducer_cfi import *
-from SimTracker.TrackAssociation.trackingParticleRecoTrackAsssociation_cfi import *
 
 TrackAssociatorByHitsRecoDenom= SimTracker.TrackAssociation.quickTrackAssociatorByHits_cfi.quickTrackAssociatorByHits.clone(
     ComponentName = cms.string('TrackAssociatorByHitsRecoDenom'),  
-    )#actually not used but needed to have proper folder names
+    )
 
 # Validation iterative steps
 cutsRecoTracksZero = PhysicsTools.RecoAlgos.recoTrackSelector_cfi.recoTrackSelector.clone()
@@ -83,7 +82,7 @@ cutsRecoTracksTenthHp = PhysicsTools.RecoAlgos.recoTrackSelector_cfi.recoTrackSe
 cutsRecoTracksTenthHp.algorithm=cms.vstring("iter10")
 cutsRecoTracksTenthHp.quality=cms.vstring("highPurity")
 
-trackValidator= Validation.RecoTrack.MultiTrackValidator_cfi.multiTrackValidator.clone(UseAssociators = cms.bool(False))
+trackValidator= Validation.RecoTrack.MultiTrackValidator_cfi.multiTrackValidator.clone()
 
 trackValidator.label=cms.VInputTag(cms.InputTag("generalTracks"),
                                    cms.InputTag("cutsRecoTracksHp"),
@@ -134,6 +133,6 @@ tracksValidationSelectors = cms.Sequence( cutsRecoTracksHp*
                                 cutsRecoTracksTenthHp )
 
 # selectors go into separate "prevalidation" sequence
-tracksValidation = cms.Sequence( tpClusterProducer * trackingParticleRecoTrackAsssociation * trackValidator)
+tracksValidation = cms.Sequence( tpClusterProducer * trackValidator)
 tracksValidationFS = cms.Sequence( trackValidator )
 

--- a/Validation/RecoVertex/python/VertexValidation_cff.py
+++ b/Validation/RecoVertex/python/VertexValidation_cff.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
+from SimTracker.TrackAssociation.trackingParticleRecoTrackAsssociation_cfi import *
 from Validation.RecoVertex.v0validator_cfi import *
 
-vertexValidation = cms.Sequence(v0Validator)
+vertexValidation = cms.Sequence(trackingParticleRecoTrackAsssociation * v0Validator)


### PR DESCRIPTION
Fix problem in track validation which was introduced with my recent PR (validation worked ok only for generalTracks).
Go back to use of associators on the fly for track validation.
Main speedup for trackingParticleRecoTrackAsssociation will still be there.
Doing PR for 71Xs, 70X and 62XSLHC.
This one for 71X.
