### PR TITLE
first version of TrackTriggerObjects for 620_SLHC9

### DIFF
--- a/DataFormats/L1TrackTrigger/BuildFile.xml
+++ b/DataFormats/L1TrackTrigger/BuildFile.xml
@@ -4,6 +4,11 @@
 <use   name="FWCore/ParameterSet"/>
 <use   name="DataFormats/Math"/>
 <use   name="DataFormats/SiPixelDetId"/>
+<!-- Addition for the L1TrackTriggerObjects -->
+<use   name="DataFormats/Candidate"/>
+<use   name="DataFormats/Common"/>
+<use   name="DataFormats/L1GlobalMuonTrigger"/>
+<!--  -->
 <use   name="boost"/>
 <use   name="rootrflx"/>
 <use   name="clhep"/>

--- a/DataFormats/L1TrackTrigger/interface/L1TkElectronParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkElectronParticle.h
@@ -1,0 +1,65 @@
+#ifndef L1TkTrigger_L1ElectronParticle_h
+#define L1TkTrigger_L1ElectronParticle_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkEmParticle
+// 
+
+#include "DataFormats/Candidate/interface/LeafCandidate.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/Ptr.h"
+
+#include "DataFormats/L1Trigger/interface/L1EmParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h"
+
+//#include "SimDataFormats/SLHC/interface/L1TkTrack.h"
+#include "SimDataFormats/SLHC/interface/StackedTrackerTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+
+namespace l1extra {
+         
+   class L1TkElectronParticle : public L1TkEmParticle
+   {     
+         
+      public:
+
+   typedef TTTrack< Ref_PixelDigi_ >  L1TkTrackType;
+   typedef std::vector< L1TkTrackType >   L1TkTrackCollectionType;
+
+           
+         L1TkElectronParticle();
+
+	 L1TkElectronParticle( const LorentzVector& p4,
+			    const edm::Ref< L1EmParticleCollection >& egRef,
+			    const edm::Ptr< L1TkTrackType >& trkPtr,
+			    float tkisol = -999. );
+
+	virtual ~L1TkElectronParticle() {}
+
+         // ---------- const member functions ---------------------
+
+         const edm::Ptr< L1TkTrackType >& getTrkPtr() const
+         { return trkPtr_ ; }
+
+ 	 float getTrkzVtx() const { return TrkzVtx_ ; }
+
+
+         // ---------- member functions ---------------------------
+
+	 void setTrkzVtx(float TrkzVtx)  { TrkzVtx_ = TrkzVtx ; }
+
+      private:
+
+         edm::Ptr< L1TkTrackType > trkPtr_ ;
+	 float TrkzVtx_ ;
+
+    };
+}
+
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkElectronParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkElectronParticleFwd.h
@@ -1,0 +1,28 @@
+#ifndef L1TkTrigger_L1ElectronParticleFwd_h
+#define L1TkTrigger_L1ElectronParticleFwd_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkElectronParticleFwd
+// 
+
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+
+namespace l1extra {
+
+   class L1TkElectronParticle ;
+
+   typedef std::vector< L1TkElectronParticle > L1TkElectronParticleCollection ;
+
+   typedef edm::Ref< L1TkElectronParticleCollection > L1TkElectronParticleRef ;
+   typedef edm::RefVector< L1TkElectronParticleCollection > L1TkElectronParticleRefVector ;
+   typedef std::vector< L1TkElectronParticleRef > L1TkElectronParticleVectorRef ;
+}
+
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h
@@ -1,0 +1,59 @@
+#ifndef L1TkTrigger_L1EmParticle_h
+#define L1TkTrigger_L1EmParticle_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkEmParticle
+// 
+
+#include "DataFormats/Candidate/interface/LeafCandidate.h"
+#include "DataFormats/Common/interface/Ref.h"
+
+#include "DataFormats/L1Trigger/interface/L1EmParticleFwd.h"
+#include "DataFormats/L1Trigger/interface/L1EmParticle.h"
+
+#include "SimDataFormats/SLHC/interface/StackedTrackerTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+
+namespace l1extra {
+         
+   class L1TkEmParticle : public reco::LeafCandidate
+   {     
+         
+      public:
+           
+         L1TkEmParticle();
+
+	 L1TkEmParticle( const LorentzVector& p4,
+			    const edm::Ref< L1EmParticleCollection >& egRef,
+			    float tkisol = -999. );
+
+	virtual ~L1TkEmParticle() {}
+
+         // ---------- const member functions ---------------------
+
+	 const edm::Ref< L1EmParticleCollection >& getEGRef() const
+	 { return egRef_ ; }
+
+	 float getTrkIsol() const { return TrkIsol_ ; } 
+
+
+         // ---------- member functions ---------------------------
+
+	 void setTrkIsol(float TrkIsol)  { TrkIsol_ = TrkIsol ; }
+
+	 int bx() const;
+
+      private:
+
+	 edm::Ref< L1EmParticleCollection > egRef_ ;
+	 float TrkIsol_;
+
+    };
+}
+
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkEmParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkEmParticleFwd.h
@@ -1,0 +1,28 @@
+#ifndef L1TkTrigger_L1EmParticleFwd_h
+#define L1TkTrigger_L1EmParticleFwd_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkEmParticleFwd
+// 
+
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+
+namespace l1extra {
+
+   class L1TkEmParticle ;
+
+   typedef std::vector< L1TkEmParticle > L1TkEmParticleCollection ;
+
+   typedef edm::Ref< L1TkEmParticleCollection > L1TkEmParticleRef ;
+   typedef edm::RefVector< L1TkEmParticleCollection > L1TkEmParticleRefVector ;
+   typedef std::vector< L1TkEmParticleRef > L1TkEmParticleVectorRef ;
+}
+
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkEtMissParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkEtMissParticle.h
@@ -1,0 +1,100 @@
+#ifndef L1TkTrigger_L1TkEtMissParticle_h
+#define L1TkTrigger_L1TkEtMissParticle_h
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkEtMissParticle
+// 
+/**\class L1TkEtMissParticle 
+
+ Description: L1Extra particle class for EtMiss object.
+*/
+//
+// Original Author:  E. Perez
+//         Created:  Nov 14, 2013
+//      
+        
+// system include files
+        
+// user include files
+#include "DataFormats/Candidate/interface/LeafCandidate.h"
+#include "DataFormats/Common/interface/Ref.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkPrimaryVertex.h"
+
+
+
+namespace l1extra {
+
+  class L1TkEtMissParticle : public reco::LeafCandidate
+    { 
+    public:
+      
+      enum EtMissType{ kMET, kMHT, kNumTypes } ;
+
+      L1TkEtMissParticle();
+
+      L1TkEtMissParticle(
+        const LorentzVector& p4,
+        EtMissType type,
+        const double& etTotal,
+	const double& etMissPU,
+	const double& etTotalPU,
+        const edm::Ref< L1TkPrimaryVertexCollection >& aVtxRef = edm::Ref< L1TkPrimaryVertexCollection >(),
+        int bx = 0 ) ;
+
+
+
+      // ---------- const member functions ---------------------
+
+      EtMissType type() const { return type_ ; }  // kET or kHT
+
+      // For type = kET, this is |MET|; for type = kHT, this is |MHT|
+      double etMiss() const
+        { return et() ; }
+
+      // For type = kET, this is total ET; for type = kHT, this is total HT
+      const double& etTotal() const
+        { return etTot_ ; }
+
+	// EtMiss and EtTot from PU vertices
+	double etMissPU() const
+	  { return etMissPU_ ; }
+	double etTotalPU() const 
+	  { return etTotalPU_ ; }
+
+      int bx() const
+        { return bx_ ; }
+
+      const edm::Ref< L1TkPrimaryVertexCollection >& getVtxRef() const
+        { return vtxRef_ ; }
+
+
+      // ---------- member functions ---------------------------
+      void setEtTotal( const double& etTotal )
+        { etTot_ = etTotal ; }
+
+      void setBx( int bx )
+        { bx_ = bx ; }
+
+    private:
+
+      // ---------- member data --------------------------------
+
+      EtMissType type_ ;
+      double etTot_ ;
+      double etMissPU_ ;
+      double etTotalPU_ ;
+
+      edm::Ref< L1TkPrimaryVertexCollection > vtxRef_ ;
+
+      int bx_ ;
+
+   };
+
+}
+
+#endif
+
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkEtMissParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkEtMissParticleFwd.h
@@ -1,0 +1,32 @@
+#ifndef L1TkTrigger_L1TkEtMissParticleFwd_h
+#define L1TkTrigger_L1TkEtMissParticleFwd_h
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkEtMissParticleFwd
+// 
+
+// system include files
+
+// user include files
+
+// forward declarations
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+
+namespace l1extra {
+
+   class L1TkEtMissParticle ;
+
+   //typedef edm::RefProd< L1TkEtMissParticle > L1TkEtMissParticleRefProd ;
+
+   typedef std::vector< L1TkEtMissParticle > L1TkEtMissParticleCollection ;
+
+   //typedef edm::Ref< L1TkEtMissParticleCollection > L1TkEtMissParticleRef ;
+   //typedef edm::RefVector< L1TkEtMissParticleCollection > L1TkEtMissParticleRefVector ;
+   //typedef std::vector< L1TkEtMissParticleRef > L1TkEtMissParticleVectorRef ;
+}
+
+#endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkHTMissParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkHTMissParticle.h
@@ -1,0 +1,119 @@
+#ifndef L1TkTrigger_L1TkHTMissParticle_h
+#define L1TkTrigger_L1TkHTMissParticle_h
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkHTMissParticle
+// 
+/**\class L1TkHTMissParticle 
+
+ Description: L1Extra particle class for HTMiss object.
+*/
+//
+// Original Author:  E. Perez
+//         Created:  Nov 14, 2013
+//      
+        
+// system include files
+        
+// user include files
+#include "DataFormats/Candidate/interface/LeafCandidate.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefProd.h"
+#include "DataFormats/Common/interface/Ref.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkPrimaryVertex.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkJetParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkJetParticleFwd.h"
+
+
+
+
+namespace l1extra {
+
+  class L1TkHTMissParticle : public reco::LeafCandidate
+    { 
+    public:
+      
+      L1TkHTMissParticle();
+
+      L1TkHTMissParticle(
+        const LorentzVector& p4,
+        const double& EtTotal,
+        const edm::RefProd< L1TkJetParticleCollection >& jetCollRef = edm::RefProd< L1TkJetParticleCollection >(),
+        const edm::Ref< L1TkPrimaryVertexCollection >& aVtxRef = edm::Ref< L1TkPrimaryVertexCollection >(),
+        int bx = 0 ) ;
+
+
+
+      // ---------- const member functions ---------------------
+
+
+      double EtMiss() const
+        { return et() ; }	// HTM (missing HT)
+
+      const double& EtTotal() const
+        { return EtTot_ ; }	
+
+	// HTM and HT from PU vertices
+	double EtMissPU() const
+	  { return EtMissPU_ ; }
+
+	double EtTotalPU() const 
+	  { return EtTotalPU_ ; }
+
+      int bx() const
+        { return bx_ ; }
+
+      float getVtx()  const 
+	{ return zvtx_ ; }
+
+      const edm::RefProd< L1TkJetParticleCollection >& getjetCollectionRef() const
+        { return jetCollectionRef_ ; }
+
+      const edm::Ref< L1TkPrimaryVertexCollection >& getVtxRef() const
+	{ return vtxRef_ ;}
+
+      // ---------- member functions ---------------------------
+      void setEtTotal( const double& EtTotal )
+        { EtTot_ = EtTotal ; }
+
+      void setEtTotalPU( const double& EtTotalPU )
+	{ EtTotalPU_ = EtTotalPU ; }
+
+      void setEtMissPU( const double& EtMissPU ) 
+	{ EtMissPU_ = EtMissPU ; }
+
+      void setVtx( const float& zvtx )
+	{ zvtx_ = zvtx ; }
+
+      void setBx( int bx )
+        { bx_ = bx ; }
+
+    private:
+
+      // ---------- member data --------------------------------
+
+      float zvtx_;		// zvtx used to constrain the jets
+      double EtTot_ ;		// HT
+      double EtMissPU_ ;	// HTM form jets that don't come from zvtx
+      double EtTotalPU_ ;	// HT from jets that don't come from zvtx
+
+	// reference to the collection of L1TkJets used to calculate HT and HTM :
+      edm::RefProd< L1TkJetParticleCollection > jetCollectionRef_ ;
+
+	// optional. In case the TkJets are constrained to the event primary vertex,
+	// instead of using the jet vertices.
+      edm::Ref< L1TkPrimaryVertexCollection > vtxRef_ ;
+
+
+      int bx_ ;
+
+   };
+
+}
+
+#endif
+
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkHTMissParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkHTMissParticleFwd.h
@@ -1,0 +1,32 @@
+#ifndef L1TkTrigger_L1TkHTMissParticleFwd_h
+#define L1TkTrigger_L1TkHTMissParticleFwd_h
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkHTMissParticleFwd
+// 
+
+// system include files
+
+// user include files
+
+// forward declarations
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+
+namespace l1extra {
+
+   class L1TkHTMissParticle ;
+
+   //typedef edm::RefProd< L1TkHTMissParticle > L1TkHTMissParticleRefProd ;
+
+   typedef std::vector< L1TkHTMissParticle > L1TkHTMissParticleCollection ;
+
+   //typedef edm::Ref< L1TkHTMissParticleCollection > L1TkHTMissParticleRef ;
+   //typedef edm::RefVector< L1TkHTMissParticleCollection > L1TkHTMissParticleRefVector ;
+   //typedef std::vector< L1TkHTMissParticleRef > L1TkHTMissParticleVectorRef ;
+}
+
+#endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkJetParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkJetParticle.h
@@ -1,0 +1,56 @@
+#ifndef L1TkTrigger_L1JetParticle_h
+#define L1TkTrigger_L1JetParticle_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkJetParticle
+// 
+
+#include "DataFormats/Candidate/interface/LeafCandidate.h"
+#include "DataFormats/Common/interface/Ref.h"
+
+#include "DataFormats/L1Trigger/interface/L1JetParticleFwd.h"
+#include "DataFormats/L1Trigger/interface/L1JetParticle.h"
+
+//#include "SimDataFormats/SLHC/interface/StackedTrackerTypes.h"
+
+
+namespace l1extra {
+
+   class L1TkJetParticle : public reco::LeafCandidate
+   {
+
+      public:
+
+         L1TkJetParticle();
+
+         L1TkJetParticle( const LorentzVector& p4,
+                            const edm::Ref< L1JetParticleCollection >& jetRef,
+			    float jetvtx = -999. );
+
+        virtual ~L1TkJetParticle() {}
+
+         // ---------- const member functions ---------------------
+
+         const edm::Ref< L1JetParticleCollection >& getJetRef() const
+         { return jetRef_ ; }
+
+	 float getJetVtx() const  { return JetVtx_ ; }
+
+
+         // ---------- member functions ---------------------------
+
+	 void setJetVtx(float JetVtx) { JetVtx_ = JetVtx ; }
+
+         int bx() const;
+
+      private:
+         edm::Ref< L1JetParticleCollection > jetRef_ ;
+	 float JetVtx_ ;
+
+    };
+}
+
+#endif
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkJetParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkJetParticleFwd.h
@@ -1,0 +1,30 @@
+#ifndef L1TkTrigger_L1JetParticleFwd_h
+#define L1TkTrigger_L1JetParticleFwd_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkJetParticleFwd
+// 
+
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+
+namespace l1extra {
+
+   class L1TkJetParticle ;
+
+   typedef edm::RefProd< L1TkJetParticle > L1TkJetParticleRefProd ;
+
+   typedef std::vector< L1TkJetParticle > L1TkJetParticleCollection ;
+
+   typedef edm::Ref< L1TkJetParticleCollection > L1TkJetParticleRef ;
+   typedef edm::RefVector< L1TkJetParticleCollection > L1TkJetParticleRefVector ;
+   typedef std::vector< L1TkJetParticleRef > L1TkJetParticleVectorRef ;
+}
+
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkMuonParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkMuonParticle.h
@@ -1,0 +1,86 @@
+#ifndef L1TkTrigger_L1MuonParticle_h
+#define L1TkTrigger_L1MuonParticle_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkEmParticle
+// 
+
+#include "DataFormats/Candidate/interface/LeafCandidate.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/Ptr.h"
+
+#include "DataFormats/L1Trigger/interface/L1EmParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h"
+
+#include "SimDataFormats/SLHC/interface/StackedTrackerTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+#include "DataFormats/L1Trigger/interface/L1MuonParticle.h"
+#include "DataFormats/L1Trigger/interface/L1MuonParticleFwd.h"
+
+// PL :include PierLuigi's class
+// #include "....."
+
+namespace l1extra {
+         
+   class L1TkMuonParticle : public reco::LeafCandidate
+   {     
+         
+      public:
+
+   typedef TTTrack< Ref_PixelDigi_ >  L1TkTrackType;
+   typedef std::vector< L1TkTrackType >   L1TkTrackCollectionType;
+           
+         L1TkMuonParticle();
+
+	 L1TkMuonParticle( const LorentzVector& p4,
+			    // const edm::Ref< XXXCollection >& muRef,     // reference to PL's object
+			     const edm::Ref< L1MuonParticleCollection >& muRef,
+			    const edm::Ptr< L1TkTrackType >& trkPtr,
+			    float tkisol = -999. );
+
+	virtual ~L1TkMuonParticle() {}
+
+         // ---------- const member functions ---------------------
+
+         const edm::Ptr< L1TkTrackType >& getTrkPtr() const
+         { return trkPtr_ ; }
+
+	// PL :
+         // const edm::Ref< XXXCollection >& getMuRef() const
+         // { return muRef_ ; }
+
+ 	 float getTrkzVtx() const { return TrkzVtx_ ; }
+         float getTrkIsol() const { return TrkIsol_ ; }
+
+
+         // ---------- member functions ---------------------------
+
+	 void setTrkzVtx(float TrkzVtx)  { TrkzVtx_ = TrkzVtx ; }
+         void setTrkIsol(float TrkIsol)  { TrkIsol_ = TrkIsol ; }
+         int bx() const;
+
+	  //void setDeltaR(float dr) { DeltaR_ = dr ; }
+
+      private:
+
+	// PL
+         // edm::Ref< XXXCollection > muRef_ ;
+	 edm::Ref< L1MuonParticleCollection > muRef_ ;
+
+         edm::Ptr< L1TkTrackType > trkPtr_ ;
+
+         float TrkIsol_;
+	 float TrkzVtx_ ;
+	
+	 //float DeltaR_ ;	// temporary
+
+    };
+}
+
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkMuonParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkMuonParticleFwd.h
@@ -1,0 +1,28 @@
+#ifndef L1TkTrigger_L1MuonParticleFwd_h
+#define L1TkTrigger_L1MuonParticleFwd_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkMuonParticleFwd
+// 
+
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+
+namespace l1extra {
+
+   class L1TkMuonParticle ;
+
+   typedef std::vector< L1TkMuonParticle > L1TkMuonParticleCollection ;
+
+   typedef edm::Ref< L1TkMuonParticleCollection > L1TkMuonParticleRef ;
+   typedef edm::RefVector< L1TkMuonParticleCollection > L1TkMuonParticleRefVector ;
+   typedef std::vector< L1TkMuonParticleRef > L1TkMuonParticleVectorRef ;
+}
+
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkPrimaryVertex.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkPrimaryVertex.h
@@ -1,0 +1,33 @@
+#ifndef L1TkTrigger_L1TkPrimaryVertex_h
+#define L1TkTrigger_L1TkPrimaryVertex_h
+
+
+// Nov 12, 2013
+// First version of a class for L1-zvertex
+
+class L1TkPrimaryVertex {
+
+ public:
+
+ L1TkPrimaryVertex() : zvertex(-999), sum(-999) {}
+
+ ~L1TkPrimaryVertex() { }
+
+ L1TkPrimaryVertex(float z, float s) : zvertex(z), sum(s) { }
+
+
+    float getZvertex() const { return zvertex ; } 
+    float getSum() const { return sum ; }
+
+ private:
+   float zvertex;
+   float sum;
+
+};
+
+#include <vector>
+
+typedef std::vector<L1TkPrimaryVertex> L1TkPrimaryVertexCollection ;
+
+
+#endif

--- a/DataFormats/L1TrackTrigger/interface/L1TkTauParticle.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkTauParticle.h
@@ -1,0 +1,85 @@
+#ifndef L1TkTrigger_L1TauParticle_h
+#define L1TkTrigger_L1TauParticle_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkTauParticle
+//
+
+#include "DataFormats/Candidate/interface/LeafCandidate.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/Ptr.h"
+
+#include "DataFormats/L1Trigger/interface/L1EmParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h"
+
+#include "SimDataFormats/SLHC/interface/StackedTrackerTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+#include "DataFormats/L1Trigger/interface/L1JetParticle.h"
+#include "DataFormats/L1Trigger/interface/L1JetParticleFwd.h"
+
+
+namespace l1extra {
+         
+   class L1TkTauParticle : public reco::LeafCandidate
+   {     
+         
+      public:
+
+   typedef TTTrack< Ref_PixelDigi_ >  L1TkTrackType;
+   typedef std::vector< L1TkTrackType >   L1TkTrackCollectionType;
+           
+         L1TkTauParticle();
+
+	 L1TkTauParticle( const LorentzVector& p4,
+			    const edm::Ref< L1JetParticleCollection >& tauCaloRef,   // null for stand-alone TkTaus
+			    const edm::Ptr< L1TkTrackType >& trkPtr,
+                            const edm::Ptr< L1TkTrackType >& trkPtr2,	// null for tau -> 1 prong
+                            const edm::Ptr< L1TkTrackType >& trkPtr3,	// null for tau -> 1 prong
+			    float tkisol = -999. );
+
+	virtual ~L1TkTauParticle() {}
+
+         // ---------- const member functions ---------------------
+
+         const edm::Ref< L1JetParticleCollection >& gettauCaloRef() const
+	  { return tauCaloRef_  ; }
+
+         const edm::Ptr< L1TkTrackType >& getTrkPtr() const
+         { return trkPtr_ ; }
+
+         const edm::Ptr< L1TkTrackType >& getTrkPtr2() const
+         { return trkPtr2_ ; }
+         const edm::Ptr< L1TkTrackType >& getTrkPtr3() const
+         { return trkPtr3_ ; }
+
+ 	 float getTrkzVtx() const { return TrkzVtx_ ; }
+         float getTrkIsol() const { return TrkIsol_ ; }
+
+
+         // ---------- member functions ---------------------------
+
+	 void setTrkzVtx(float TrkzVtx)  { TrkzVtx_ = TrkzVtx ; }
+         void setTrkIsol(float TrkIsol)  { TrkIsol_ = TrkIsol ; }
+         int bx() const;
+
+      private:
+
+	 edm::Ref< L1JetParticleCollection > tauCaloRef_ ;
+
+         edm::Ptr< L1TkTrackType > trkPtr_ ;
+         edm::Ptr< L1TkTrackType > trkPtr2_ ;
+         edm::Ptr< L1TkTrackType > trkPtr3_ ;
+
+         float TrkIsol_;
+	 float TrkzVtx_ ;
+	
+    };
+}
+
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/interface/L1TkTauParticleFwd.h
+++ b/DataFormats/L1TrackTrigger/interface/L1TkTauParticleFwd.h
@@ -1,0 +1,28 @@
+#ifndef L1TkTrigger_L1TauParticleFwd_h
+#define L1TkTrigger_L1TaunParticleFwd_h
+
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkTauParticleFwd
+// 
+
+#include <vector>
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/RefVector.h"
+
+
+namespace l1extra {
+
+   class L1TkTauParticle ;
+
+   typedef std::vector< L1TkTauParticle > L1TkTauParticleCollection ;
+
+   typedef edm::Ref< L1TkTauParticleCollection > L1TkTauParticleRef ;
+   typedef edm::RefVector< L1TkTauParticleCollection > L1TkTauParticleRefVector ;
+   typedef std::vector< L1TkTauParticleRef > L1TkTauParticleVectorRef ;
+}
+
+#endif
+
+

--- a/DataFormats/L1TrackTrigger/src/L1TkElectronParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkElectronParticle.cc
@@ -1,0 +1,33 @@
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkEmParticle
+// 
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkElectronParticle.h"
+
+
+using namespace l1extra ;
+
+
+L1TkElectronParticle::L1TkElectronParticle()
+{
+}
+
+L1TkElectronParticle::L1TkElectronParticle( const LorentzVector& p4,
+         const edm::Ref< L1EmParticleCollection >& egRef,
+         const edm::Ptr< L1TkTrackType >& trkPtr,
+	 float tkisol )
+   : L1TkEmParticle( p4, egRef, tkisol) ,
+     trkPtr_ ( trkPtr )
+
+{
+
+ if ( trkPtr_.isNonnull() ) {
+	float z = getTrkPtr() -> getPOCA().z();
+	setTrkzVtx( z );
+ }
+}
+
+
+

--- a/DataFormats/L1TrackTrigger/src/L1TkEmParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkEmParticle.cc
@@ -1,0 +1,44 @@
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkEmParticle
+// 
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h"
+
+
+using namespace l1extra ;
+
+
+L1TkEmParticle::L1TkEmParticle()
+{
+}
+
+L1TkEmParticle::L1TkEmParticle( const LorentzVector& p4,
+         const edm::Ref< L1EmParticleCollection >& egRef,
+	 float tkisol )
+   : LeafCandidate( ( char ) 0, p4 ),
+     egRef_ ( egRef ),
+     TrkIsol_ ( tkisol ) 
+{
+
+}
+
+
+int L1TkEmParticle::bx() const {
+ int dummy = -999;
+ if ( egRef_.isNonnull() ) {
+	return (getEGRef() -> bx()) ;
+ }
+ else {
+	return dummy;
+
+ }
+}
+
+
+
+
+
+
+

--- a/DataFormats/L1TrackTrigger/src/L1TkEtMissParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkEtMissParticle.cc
@@ -1,0 +1,27 @@
+#include "DataFormats/L1TrackTrigger/interface/L1TkEtMissParticle.h"
+
+using namespace l1extra ;
+
+L1TkEtMissParticle::L1TkEtMissParticle()
+{
+}
+
+L1TkEtMissParticle::L1TkEtMissParticle(
+        const LorentzVector& p4,
+        EtMissType type,
+        const double& etTotal,
+        const double& etMissPU,
+        const double& etTotalPU,
+        const edm::Ref< L1TkPrimaryVertexCollection >& avtxRef,
+        int bx )
+   : LeafCandidate( ( char ) 0, p4 ),
+     type_( type ),
+     etTot_( etTotal ),
+     etMissPU_ ( etMissPU ),
+     etTotalPU_ ( etTotalPU ),
+     vtxRef_( avtxRef ),
+     bx_( bx )
+{
+}
+
+

--- a/DataFormats/L1TrackTrigger/src/L1TkHTMissParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkHTMissParticle.cc
@@ -1,0 +1,29 @@
+#include "DataFormats/L1TrackTrigger/interface/L1TkHTMissParticle.h"
+
+using namespace l1extra ;
+
+L1TkHTMissParticle::L1TkHTMissParticle()
+{
+}
+
+L1TkHTMissParticle::L1TkHTMissParticle(
+        const LorentzVector& p4,
+        const double& etTotal,
+	const edm::RefProd< L1TkJetParticleCollection >& jetCollRef,
+        const edm::Ref< L1TkPrimaryVertexCollection >& avtxRef,
+        int bx )
+   : LeafCandidate( ( char ) 0, p4 ),
+     EtTot_( etTotal ),
+     jetCollectionRef_( jetCollRef ),
+     vtxRef_( avtxRef ),
+     bx_( bx )
+{
+
+   if ( vtxRef_.isNonnull() ) {
+	float z = getVtxRef() -> getZvertex() ;
+	setVtx( z );
+   }
+
+}
+
+

--- a/DataFormats/L1TrackTrigger/src/L1TkJetParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkJetParticle.cc
@@ -1,0 +1,38 @@
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkJetParticle
+// 
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkJetParticle.h"
+
+
+using namespace l1extra ;
+
+
+L1TkJetParticle::L1TkJetParticle()
+{
+}
+
+L1TkJetParticle::L1TkJetParticle( const LorentzVector& p4,
+         const edm::Ref< L1JetParticleCollection >& jetRef,
+         float jetvtx )
+   : LeafCandidate( ( char ) 0, p4 ),
+     jetRef_ ( jetRef ),
+     JetVtx_ ( jetvtx )
+{
+
+}
+
+
+int L1TkJetParticle::bx() const {
+ int dummy = -999;
+ if ( jetRef_.isNonnull() ) {
+        return (getJetRef() -> bx()) ;
+ }
+ else {
+        return dummy;
+
+ }
+}
+

--- a/DataFormats/L1TrackTrigger/src/L1TkMuonParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkMuonParticle.cc
@@ -1,0 +1,52 @@
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkEmParticle
+// 
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkMuonParticle.h"
+
+
+using namespace l1extra ;
+
+
+L1TkMuonParticle::L1TkMuonParticle()
+{
+}
+
+L1TkMuonParticle::L1TkMuonParticle( const LorentzVector& p4,
+         // const edm::Ref< XXXCollection >& muRef,  // PL
+	 const edm::Ref< L1MuonParticleCollection > &muRef,
+         const edm::Ptr< L1TkTrackType >& trkPtr,
+	 float tkisol )
+   : LeafCandidate( ( char ) 0, p4 ),
+     muRef_ ( muRef ) ,		// PL uncomment
+     trkPtr_ ( trkPtr ) ,
+     TrkIsol_ ( tkisol )
+
+{
+
+ if ( trkPtr_.isNonnull() ) {
+	float z = getTrkPtr() -> getPOCA().z();
+	setTrkzVtx( z );
+ }
+}
+
+int L1TkMuonParticle::bx() const {
+ int dummy = -999;
+	// PL.  In case Pierluigi's objects have a bx
+/*
+ if ( muRef_.isNonnull() ) {
+        return (getMuRef() -> bx()) ;
+ }
+ else {
+        return dummy;
+ 
+ }
+*/
+        return dummy;
+}
+
+
+
+

--- a/DataFormats/L1TrackTrigger/src/L1TkTauParticle.cc
+++ b/DataFormats/L1TrackTrigger/src/L1TkTauParticle.cc
@@ -1,0 +1,45 @@
+// -*- C++ -*-
+//
+// Package:     L1Trigger
+// Class  :     L1TkEmParticle
+// 
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkTauParticle.h"
+
+
+using namespace l1extra ;
+
+
+L1TkTauParticle::L1TkTauParticle()
+{
+}
+
+L1TkTauParticle::L1TkTauParticle( const LorentzVector& p4,
+	 const edm::Ref< L1JetParticleCollection > &tauCaloRef,
+         const edm::Ptr< L1TkTrackType >& trkPtr,
+         const edm::Ptr< L1TkTrackType >& trkPtr2,
+         const edm::Ptr< L1TkTrackType >& trkPtr3,
+	 float tkisol )
+   : LeafCandidate( ( char ) 0, p4 ),
+     tauCaloRef_ ( tauCaloRef ) ,
+     trkPtr_ ( trkPtr ) ,
+     trkPtr2_ ( trkPtr2 ) ,
+     trkPtr3_ ( trkPtr3 ) ,
+     TrkIsol_ ( tkisol )
+
+{
+
+ if ( trkPtr_.isNonnull() ) {
+	float z = getTrkPtr() -> getPOCA().z();
+	setTrkzVtx( z );
+ }
+}
+
+int L1TkTauParticle::bx() const {
+ int dummy = 0;
+ return dummy;
+}
+
+
+
+

--- a/DataFormats/L1TrackTrigger/src/classes.h
+++ b/DataFormats/L1TrackTrigger/src/classes.h
@@ -11,6 +11,34 @@
 #include "DataFormats/Common/interface/DetSetVectorNew.h"
 #include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
 
+// includes needed for the L1TrackTriggerObjects
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkPrimaryVertex.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkEtMissParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkEtMissParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkEmParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkElectronParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkElectronParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkJetParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkJetParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkHTMissParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkHTMissParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkMuonParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkMuonParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkTauParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkTauParticleFwd.h"
+#include "DataFormats/Common/interface/RefVector.h"
+#include "DataFormats/Common/interface/RefProd.h"
+
+
+
 namespace
 {
   namespace
@@ -57,4 +85,71 @@ namespace
 
   }
 }
+
+
+
+//  L1TrackTriggerObjects stuff :
+
+namespace {
+  struct dictionary {
+
+
+        // L1 Primary Vertex
+     L1TkPrimaryVertex trzvtx;
+     edm::Wrapper<L1TkPrimaryVertexCollection> trzvtxColl;
+     edm::Ref< L1TkPrimaryVertexCollection > trkvtxRef ;
+
+
+        // L1TkEtMiss... following L1EtMiss...
+     l1extra::L1TkEtMissParticle TketMiss ;
+     l1extra::L1TkEtMissParticleCollection TketMissColl ;
+     edm::Wrapper<l1extra::L1TkEtMissParticle> w_TketMiss;
+     edm::Wrapper<l1extra::L1TkEtMissParticleCollection> w_TketMissColl;
+     //l1extra::L1TkEtMissParticleRef refTkEtMiss ;
+     //l1extra::L1TkEtMissParticleRefVector refTkVecEtMiss ;
+     //l1extra::L1TkEtMissParticleVectorRef vecTkRefEtMissColl ;
+     //l1extra::L1TkEtMissParticleRefProd refTkProdEtMiss ;
+     //edm::reftobase::Holder<reco::Candidate, l1extra::L1TkEtMissParticleRef> rtbTkm1;
+     //edm::reftobase::Holder<reco::Candidate, l1extra::L1TkEtMissParticleRefProd> rtbTkm2;
+        
+        // L1TkEmParticle
+     l1extra::L1TkEmParticleCollection trkemColl ;
+     edm::Wrapper<l1extra::L1TkEmParticleCollection> w_trkemColl;
+     l1extra::L1TkEmParticleRef reftrkEm ;
+     //l1extra::L1TkEmParticleRefVector refVectrkEmColl ;
+     //l1extra::L1TkEmParticleVectorRef vecReftrkEmColl ;
+     //edm::reftobase::Holder<reco::Candidate, l1extra::L1TkEmParticleRef> rtbtrke;
+        
+        // L1TkElectronParticle
+     l1extra::L1TkElectronParticleCollection trkeleColl ;
+     edm::Wrapper<l1extra::L1TkElectronParticleCollection> w_trkeleColl;
+     l1extra::L1TkElectronParticleRef reftrkEle ;
+        
+        // L1TkJetParticle
+     l1extra::L1TkJetParticleCollection trkjetColl ;
+     edm::Wrapper<l1extra::L1TkJetParticleCollection> w_trkjetColl;
+     l1extra::L1TkJetParticleRef reftrkJet ;
+     l1extra::L1TkJetParticleRefProd refTkProdJet ;
+
+        // L1TkHTMissParticle
+     l1extra::L1TkHTMissParticle TkHTMiss ;
+     l1extra::L1TkHTMissParticleCollection TkHTMissColl ;
+     edm::Wrapper<l1extra::L1TkHTMissParticle> w_TkHTMiss;
+     edm::Wrapper<l1extra::L1TkHTMissParticleCollection> w_TkHTMissColl;
+        
+        // L1TkMuonParticle
+     l1extra::L1TkMuonParticleCollection trkmuColl ;
+     edm::Wrapper<l1extra::L1TkMuonParticleCollection> w_trkmuColl;
+     l1extra::L1TkMuonParticleRef reftrkMu ;
+        
+        // L1TkTauParticle
+     l1extra::L1TkTauParticleCollection trktauColl ;
+     edm::Wrapper<l1extra::L1TkTauParticleCollection> w_trktauColl;
+     l1extra::L1TkTauParticleRef reftrkTau ;
+
+  
+  };
+
+}
+
 

--- a/DataFormats/L1TrackTrigger/src/classes_def.xml
+++ b/DataFormats/L1TrackTrigger/src/classes_def.xml
@@ -40,5 +40,63 @@
   <class pattern="edm::Wrapper<edm::Ptr<TTTrack<*>>>" />
   <class pattern="edm::Wrapper<std::vector<edm::Ptr<TTTrack<*>>>>" />
 
+ <class name="L1TkPrimaryVertex" ClassVersion="11">
+  <version ClassVersion="11" checksum="863057557"/>
+ </class>
+ <class name="std::vector<L1TkPrimaryVertex>"/>
+ <class name="edm::Wrapper<std::vector<L1TkPrimaryVertex> >"/>
+  <class name="edm::Ref<std::vector<L1TkPrimaryVertex>,L1TkPrimaryVertex,edm::refhelper::FindUsingAdvance<std::vector<L1TkPrimaryVertex>,L1TkPrimaryVertex> >"/>
+
+  <class name="l1extra::L1TkEtMissParticle" ClassVersion="11">
+   <version ClassVersion="11" checksum="950167147"/>
+  </class>
+  <class name="std::vector<l1extra::L1TkEtMissParticle>"/>
+ <class name="edm::Wrapper<l1extra::L1TkEtMissParticle>"/>
+  <class name="edm::Wrapper<std::vector<l1extra::L1TkEtMissParticle> >"/>
+
+  <class name="l1extra::L1TkEmParticle" ClassVersion="10">
+   <version ClassVersion="10" checksum="4061452071"/>
+  </class>
+  <class name="std::vector<l1extra::L1TkEmParticle>"/>
+  <class name="edm::Wrapper<std::vector<l1extra::L1TkEmParticle> >"/>
+  <class name="edm::Ref<std::vector<l1extra::L1TkEmParticle>,l1extra::L1TkEmParticle,edm::refhelper::FindUsingAdvance<std::vector<l1extra::L1TkEmParticle>,l1extra::L1TkEmParticle> >"/>
+
+  <class name="l1extra::L1TkElectronParticle" ClassVersion="10">
+   <version ClassVersion="10" checksum="1448523362"/>
+  </class>
+  <class name="std::vector<l1extra::L1TkElectronParticle>"/>
+  <class name="edm::Wrapper<std::vector<l1extra::L1TkElectronParticle> >"/>
+  <class name="edm::Ref<std::vector<l1extra::L1TkElectronParticle>,l1extra::L1TkElectronParticle,edm::refhelper::FindUsingAdvance<std::vector<l1extra::L1TkElectronParticle>,l1extra::L1TkElectronParticle> >"/>
+
+  <class name="l1extra::L1TkJetParticle" ClassVersion="10">
+   <version ClassVersion="10" checksum="2684897040"/>
+  </class>
+  <class name="std::vector<l1extra::L1TkJetParticle>"/>
+  <class name="edm::Wrapper<std::vector<l1extra::L1TkJetParticle> >"/>
+  <class name="edm::Ref<std::vector<l1extra::L1TkJetParticle>,l1extra::L1TkJetParticle,edm::refhelper::FindUsingAdvance<std::vector<l1extra::L1TkJetParticle>,l1extra::L1TkJetParticle> >"/>
+
+  <class name="edm::RefProd< std::vector<l1extra::L1TkJetParticle> >"/>
+  
+  <class name="l1extra::L1TkHTMissParticle" ClassVersion="11">
+   <version ClassVersion="11" checksum="4141571377"/>
+  </class>
+  <class name="std::vector<l1extra::L1TkHTMissParticle>"/>
+  <class name="edm::Wrapper<l1extra::L1TkHTMissParticle>"/>
+  <class name="edm::Wrapper<std::vector<l1extra::L1TkHTMissParticle> >"/>
+
+  <class name="l1extra::L1TkMuonParticle" ClassVersion="10">
+   <version ClassVersion="10" checksum="1626250068"/>
+  </class>
+  <class name="std::vector<l1extra::L1TkMuonParticle>"/>
+  <class name="edm::Wrapper<std::vector<l1extra::L1TkMuonParticle> >"/>
+  <class name="edm::Ref<std::vector<l1extra::L1TkMuonParticle>,l1extra::L1TkMuonParticle,edm::refhelper::FindUsingAdvance<std::vector<l1extra::L1TkMuonParticle>,l1extra::L1TkMuonParticle> >"/>
+
+  <class name="l1extra::L1TkTauParticle" ClassVersion="10">
+   <version ClassVersion="10" checksum="755577729"/>
+  </class>
+  <class name="std::vector<l1extra::L1TkTauParticle>"/>
+  <class name="edm::Wrapper<std::vector<l1extra::L1TkTauParticle> >"/>
+  <class name="edm::Ref<std::vector<l1extra::L1TkTauParticle>,l1extra::L1TkTauParticle,edm::refhelper::FindUsingAdvance<std::vector<l1extra::L1TkTauParticle>,l1extra::L1TkTauParticle> >"/>
+
 </lcgdict>
 

--- a/SLHCUpgradeSimulations/L1TrackTrigger/interface/L1TkElectronEtComparator.h
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/interface/L1TkElectronEtComparator.h
@@ -1,0 +1,19 @@
+#ifndef L1TkElectronEtComparator_HH
+#define L1TkElectronEtComparator_HH
+#include "DataFormats/L1Trigger/interface/L1EmParticle.h"
+#include "DataFormats/L1Trigger/interface/L1EmParticleFwd.h"
+
+namespace L1TkElectron{
+  class EtComparator {
+  public:
+    bool operator()(const l1extra::L1EmParticle& a, const l1extra::L1EmParticle& b) const {
+      double et_a = 0.0;
+      double et_b = 0.0;    
+      if (cosh(a.eta()) > 0.0) et_a = a.energy()/cosh(a.eta());
+      if (cosh(b.eta()) > 0.0) et_b = b.energy()/cosh(b.eta());
+      
+      return et_a > et_b;
+    }
+  };
+}
+#endif

--- a/SLHCUpgradeSimulations/L1TrackTrigger/interface/L1TkElectronTrackMatchAlgo.h
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/interface/L1TkElectronTrackMatchAlgo.h
@@ -1,0 +1,22 @@
+#ifndef L1TkElectronTrackMatchAlgo_HH
+#define L1TkElectronTrackMatchAlgo_HH
+
+#include "DataFormats/L1Trigger/interface/L1EmParticle.h"
+#include "DataFormats/L1Trigger/interface/L1EmParticleFwd.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+//#include "SimDataFormats/SLHC/interface/StackedTrackerTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+namespace L1TkElectronTrackMatchAlgo {
+   typedef TTTrack< Ref_PixelDigi_ >  L1TkTrackType;
+   typedef std::vector< L1TkTrackType >    L1TkTrackCollectionType ;
+  void doMatch(l1extra::L1EmParticleCollection::const_iterator egIter, const edm::Ptr< L1TkTrackType >& pTrk, double&  dph, double&  dr, double& deta);
+  void doMatch(const GlobalPoint& epos, const edm::Ptr< L1TkTrackType >& pTrk, double& dph, double&  dr, double& deta);
+
+  double deltaR(const GlobalPoint& epos, const edm::Ptr< L1TkTrackType >& pTrk);
+  double deltaPhi(const GlobalPoint& epos, const edm::Ptr< L1TkTrackType >& pTrk);
+  double deltaEta(const GlobalPoint& epos, const edm::Ptr< L1TkTrackType >& pTrk);
+  GlobalPoint calorimeterPosition(double phi, double eta, double e);
+
+}  
+#endif

--- a/SLHCUpgradeSimulations/L1TrackTrigger/plugins/BuildFile.xml
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/plugins/BuildFile.xml
@@ -6,6 +6,9 @@
   <use   name="SimDataFormats/GeneratorProducts"/>
   <use   name="PhysicsTools/UtilAlgos"/>
   <use   name="CommonTools/UtilAlgos"/>
+<use name="SLHCUpgradeSimulations/L1CaloTrigger"/>
+<use name="DataFormats/JetReco"/>
+<use name="DataFormats/L1TrackTrigger"/>
   <use   name="hepmc"/>
   <use   name="root"/>
   <flags   EDM_PLUGIN="1"/>

--- a/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1JetsFromHIHLTJets.cc
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1JetsFromHIHLTJets.cc
@@ -1,0 +1,185 @@
+// -*- C++ -*-
+//
+//
+// Produces a collection of L1JetParticles starting from a
+// collection of reco:CaloJets, as created by the HLT
+// Heavy Ion jet algorithm.
+// 
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1Trigger/interface/L1JetParticle.h"
+#include "DataFormats/L1Trigger/interface/L1JetParticleFwd.h"
+
+#include "Math/LorentzVector.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+#include "DataFormats/JetReco/interface/CaloJet.h"
+
+#include <string>
+#include "TMath.h"
+
+
+using namespace l1extra ;
+using namespace math;
+using namespace reco;
+
+//
+// class declaration
+//
+
+class L1JetsFromHIHLTJets : public edm::EDProducer {
+   public:
+
+      explicit L1JetsFromHIHLTJets(const edm::ParameterSet&);
+      ~L1JetsFromHIHLTJets();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      virtual void beginJob() ;
+      virtual void produce(edm::Event&, const edm::EventSetup&);
+      virtual void endJob() ;
+
+      //virtual void beginRun(edm::Run&, edm::EventSetup const&);
+      //virtual void endRun(edm::Run&, edm::EventSetup const&);
+      //virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+      //virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+
+      // ----------member data ---------------------------
+	
+	 edm::InputTag HIJetsInputTag;
+
+	 float ETAMIN;
+	 float ETAMAX;
+
+
+} ;
+
+
+//
+// constructors and destructor
+//
+L1JetsFromHIHLTJets::L1JetsFromHIHLTJets(const edm::ParameterSet& iConfig)
+{
+
+   HIJetsInputTag = iConfig.getParameter<edm::InputTag>("HIJetsInputTag");
+
+   ETAMIN = (float)iConfig.getParameter<double>("ETAMIN");
+   ETAMAX = (float)iConfig.getParameter<double>("ETAMAX");
+
+   produces<L1JetParticleCollection>();
+}
+
+L1JetsFromHIHLTJets::~L1JetsFromHIHLTJets() {
+}
+
+// ------------ method called to produce the data  ------------
+void
+L1JetsFromHIHLTJets::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+   using namespace std;
+
+ std::auto_ptr<L1JetParticleCollection> result(new L1JetParticleCollection);
+
+ edm::Handle< vector<reco::CaloJet> > HLTJetsHandle;
+ iEvent.getByLabel(HIJetsInputTag,HLTJetsHandle);
+
+ vector<reco::CaloJet>::const_iterator hltIterj;
+
+  for (hltIterj = HLTJetsHandle->begin(); hltIterj != HLTJetsHandle->end(); ++hltIterj) {
+
+   float etajet = hltIterj -> eta();
+   if (fabs(etajet) < ETAMIN || fabs(etajet) > ETAMAX)  continue;
+
+   //LorentzVector P4 = hltIterj -> detectorP4();
+
+   edm::Ref< L1GctJetCandCollection > dummyRef;
+
+   int bx = 0;
+   L1JetParticle jet( hltIterj -> detectorP4() , dummyRef, bx); 
+   result -> push_back( jet );
+
+ }
+
+ iEvent.put( result );
+
+}
+
+// --------------------------------------------------------------------------------------
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void
+L1JetsFromHIHLTJets::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void
+L1JetsFromHIHLTJets::endJob() {
+}
+
+// ------------ method called when starting to processes a run  ------------
+/*
+void
+L1JetsFromHIHLTJets::beginRun(edm::Run& iRun, edm::EventSetup const& iSetup)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a run  ------------
+/*
+void
+L1JetsFromHIHLTJets::endRun(edm::Run&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void
+L1JetsFromHIHLTJets::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void
+L1JetsFromHIHLTJets::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+L1JetsFromHIHLTJets::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1JetsFromHIHLTJets);
+
+
+

--- a/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1TkElectronStubsProducer.cc
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1TkElectronStubsProducer.cc
@@ -1,0 +1,208 @@
+// -*- C++ -*-
+//
+//
+// Producer of a L1TkElectronParticle, for the algorithm matching a L1Track to the L1EG object.
+// 	The code here is dummy, just to show how to create an L1TkElectronParticle
+//	without a reference to a L1Track  
+//      (e.g. when matching the L1EGamma with stubs and not tracks :
+//
+// The proper producer will be provided by Suchandra & Atanu.
+// 
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkElectronParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkElectronParticleFwd.h"
+
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+
+// for L1Tracks:
+#include "SimDataFormats/SLHC/interface/StackedTrackerTypes.h"
+
+#include <string>
+#include "TMath.h"
+
+
+using namespace l1extra ;
+
+//
+// class declaration
+//
+
+class L1TkElectronStubsProducer : public edm::EDProducer {
+   public:
+
+   typedef TTTrack< Ref_PixelDigi_ >  L1TkTrackType;
+   typedef std::vector< L1TkTrackType >  L1TkTrackCollectionType;
+
+      explicit L1TkElectronStubsProducer(const edm::ParameterSet&);
+      ~L1TkElectronStubsProducer();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      virtual void beginJob() ;
+      virtual void produce(edm::Event&, const edm::EventSetup&);
+      virtual void endJob() ;
+
+      //virtual void beginRun(edm::Run&, edm::EventSetup const&);
+      //virtual void endRun(edm::Run&, edm::EventSetup const&);
+      //virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+      //virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+
+      // ----------member data ---------------------------
+	edm::InputTag L1EGammaInputTag;
+	edm::InputTag L1TrackInputTag;
+	std::string label;
+
+} ;
+
+
+//
+// constructors and destructor
+//
+L1TkElectronStubsProducer::L1TkElectronStubsProducer(const edm::ParameterSet& iConfig)
+{
+
+   L1EGammaInputTag = iConfig.getParameter<edm::InputTag>("L1EGammaInputTag") ;
+   L1TrackInputTag = iConfig.getParameter<edm::InputTag>("L1TrackInputTag");
+   label = iConfig.getParameter<std::string>("label");
+   
+
+   produces<L1TkElectronParticleCollection>(label);
+}
+
+L1TkElectronStubsProducer::~L1TkElectronStubsProducer() {
+}
+
+// ------------ method called to produce the data  ------------
+void
+L1TkElectronStubsProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+
+ std::auto_ptr<L1TkElectronParticleCollection> result(new L1TkElectronParticleCollection);
+
+ edm::Handle<L1EmParticleCollection> EGammaHandle;
+ iEvent.getByLabel(L1EGammaInputTag,EGammaHandle);
+ std::vector<L1EmParticle>::const_iterator egIter ;
+
+ edm::Handle<L1TkTrackCollectionType> L1TkTrackHandle;
+ iEvent.getByLabel(L1TrackInputTag, L1TkTrackHandle);
+ L1TkTrackCollectionType::const_iterator trackIter;
+ if( !EGammaHandle.isValid() )
+        {
+          LogError("L1TkElectronStubsProducer")
+            << "\nWarning: L1EmParticleCollection with " << L1EGammaInputTag
+            << "\nrequested in configuration, but not found in the event. Exit"
+            << std::endl;
+           return;
+        }
+
+ int ieg = 0;
+ for (egIter = EGammaHandle->begin();  egIter != EGammaHandle->end(); ++egIter) {
+
+    edm::Ref< L1EmParticleCollection > EGammaRef( EGammaHandle, ieg );
+    ieg ++;
+
+    int ibx = egIter -> bx();
+    if (ibx != 0) continue;
+
+        float trkisol = -999;       // dummy
+        const math::XYZTLorentzVector P4 = egIter -> p4() ;
+
+           edm::Ptr< L1TkTrackType > L1TrackPtrNull;     //  null pointer
+           L1TkElectronParticle trkEm( P4,
+                                 EGammaRef,
+                                 L1TrackPtrNull,  
+                                 trkisol );
+
+           	// then one can set the "z" of the electron, as determined by the 
+           	// algorithm, via :
+	   float z = -999; 	// dummy
+           trkEm.setTrkzVtx( z );
+
+	   result -> push_back( trkEm );
+
+
+ }  // end loop over EGamma objects
+
+ iEvent.put( result, label );
+
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void
+L1TkElectronStubsProducer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void
+L1TkElectronStubsProducer::endJob() {
+}
+
+// ------------ method called when starting to processes a run  ------------
+/*
+void
+L1TkElectronStubsProducer::beginRun(edm::Run& iRun, edm::EventSetup const& iSetup)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a run  ------------
+/*
+void
+L1TkElectronStubsProducer::endRun(edm::Run&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void
+L1TkElectronStubsProducer::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void
+L1TkElectronStubsProducer::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+L1TkElectronStubsProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TkElectronStubsProducer);
+
+
+

--- a/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1TkElectronTrackProducer.cc
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1TkElectronTrackProducer.cc
@@ -1,0 +1,327 @@
+// -*- C++ -*-
+//
+// Package:    L1TrackTrigger
+// Class:      L1TkElectronTrackMatchAlgo
+// 
+/**\class L1TkElectronTrackMatchAlgo 
+
+ Description: Producer of a L1TkElectronParticle, for the algorithm matching a L1Track to the L1EG object
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  S. Dutta and A. Modak
+//         Created:  Wed Dec 4 12 11:55:35 CET 2013
+// $Id$
+//
+//
+// -*- C++ -*-
+//
+//
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkElectronParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkElectronParticleFwd.h"
+
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+
+// for L1Tracks:
+#include "SimDataFormats/SLHC/interface/StackedTrackerTypes.h"
+
+// Matching Algorithm
+#include "SLHCUpgradeSimulations/L1TrackTrigger/interface/L1TkElectronTrackMatchAlgo.h"
+//#include "SLHCUpgradeSimulations/L1TrackTrigger/interface/L1TkElectronEtComparator.h"
+
+#include "DataFormats/Math/interface/deltaPhi.h"
+
+#include <string>
+#include "TMath.h"
+
+
+using namespace l1extra ;
+
+//
+// class declaration
+//
+
+class L1TkElectronTrackProducer : public edm::EDProducer {
+   public:
+
+   typedef TTTrack< Ref_PixelDigi_ >  L1TkTrackType;                  
+   typedef std::vector< L1TkTrackType >  L1TkTrackCollectionType;
+
+      explicit L1TkElectronTrackProducer(const edm::ParameterSet&);
+      ~L1TkElectronTrackProducer();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      virtual void beginJob() ;
+      virtual void produce(edm::Event&, const edm::EventSetup&);
+      virtual void endJob() ;
+
+      //virtual void beginRun(edm::Run&, edm::EventSetup const&);
+      //virtual void endRun(edm::Run&, edm::EventSetup const&);
+      //virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+      //virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+
+      float isolation(const edm::Handle<L1TkTrackCollectionType> & trkHandle, int match_index);
+
+      // ----------member data ---------------------------
+	edm::InputTag L1EGammaInputTag;
+	edm::InputTag L1TrackInputTag;
+	std::string label;
+         
+	float ETmin; 	// min ET in GeV of L1EG objects
+
+	float DRmin;
+	float DRmax;
+	float PTMINTRA;
+	bool PrimaryVtxConstrain;	// use the primary vertex (default = false)
+	float DeltaZ;      	// | z_track - z_ref_track | < DeltaZ in cm. 
+				// Used only when PrimaryVtxConstrain = True.
+	float IsoCut;
+	bool RelativeIsolation;
+
+        float trkQualityChi2;
+        float trkQualityPtMin; 
+        float dPhiCutoff;
+        float dRCutoff;
+        float dEtaCutoff;
+} ;
+
+
+//
+// constructors and destructor
+//
+L1TkElectronTrackProducer::L1TkElectronTrackProducer(const edm::ParameterSet& iConfig)
+{
+
+   label = iConfig.getParameter<std::string>("label");  // label of the collection produced
+							// e.g. EG or IsoEG if all objects are kept
+							// EGIsoTrk or IsoEGIsoTrk if only the EG or IsoEG
+							// objects that pass a cut RelIso < IsoCut are written
+							// in the new collection.
+
+   L1EGammaInputTag = iConfig.getParameter<edm::InputTag>("L1EGammaInputTag") ;
+   L1TrackInputTag = iConfig.getParameter<edm::InputTag>("L1TrackInputTag");
+
+   ETmin = (float)iConfig.getParameter<double>("ETmin");
+
+   // parameters for the calculation of the isolation :
+   PTMINTRA = (float)iConfig.getParameter<double>("PTMINTRA");
+   DRmin = (float)iConfig.getParameter<double>("DRmin");
+   DRmax = (float)iConfig.getParameter<double>("DRmax");
+   DeltaZ = (float)iConfig.getParameter<double>("DeltaZ");
+
+   // cut applied on the isolation (if this number is <= 0, no cut is applied)
+   IsoCut = (float)iConfig.getParameter<double>("IsoCut");
+   RelativeIsolation = iConfig.getParameter<bool>("RelativeIsolation");
+
+   // parameters to select tracks to match with L1EG
+   trkQualityChi2  = (float)iConfig.getParameter<double>("TrackChi2");
+   trkQualityPtMin = (float)iConfig.getParameter<double>("TrackMinPt");
+   dPhiCutoff      = (float)iConfig.getParameter<double>("TrackEGammaDeltaPhi"); 
+   dRCutoff        = (float)iConfig.getParameter<double>("TrackEGammaDeltaR"); 
+   dEtaCutoff      = (float)iConfig.getParameter<double>("TrackEGammaDeltaEta"); 
+
+   produces<L1TkElectronParticleCollection>(label);
+}
+
+L1TkElectronTrackProducer::~L1TkElectronTrackProducer() {
+}
+
+// ------------ method called to produce the data  ------------
+void
+L1TkElectronTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+  std::auto_ptr<L1TkElectronParticleCollection> result(new L1TkElectronParticleCollection);
+  
+  edm::Handle<L1EmParticleCollection> EGammaHandle;
+  iEvent.getByLabel(L1EGammaInputTag,EGammaHandle);
+  l1extra::L1EmParticleCollection eGammaCollection = (*EGammaHandle.product());
+  //  sort(eGammaCollection.begin(), eGammaCollection.end(), L1TkElectron::EtComparator());
+  l1extra::L1EmParticleCollection::const_iterator egIter;
+  edm::Handle<L1TkTrackCollectionType> L1TkTrackHandle;
+  iEvent.getByLabel(L1TrackInputTag, L1TkTrackHandle);
+  L1TkTrackCollectionType::const_iterator trackIter;
+  
+  if( !EGammaHandle.isValid() ) {
+    edm::LogError("L1TkElectronTrackProducer")
+      << "\nWarning: L1EmParticleCollection with " << L1EGammaInputTag
+      << "\nrequested in configuration, but not found in the event. Exit"
+      << std::endl;
+    return;
+  }
+  if (!L1TkTrackHandle.isValid() ) {
+    edm::LogError("L1TkEmParticleProducer")
+      << "\nWarning: L1TkTrackCollectionType with " << L1TrackInputTag
+      << "\nrequested in configuration, but not found in the event. Exit."
+      << std::endl;
+    return;
+  }
+
+  int ieg = 0;
+  for (egIter = eGammaCollection.begin();  egIter != eGammaCollection.end(); ++egIter) {
+    edm::Ref< L1EmParticleCollection > EGammaRef( EGammaHandle, ieg );
+    ieg ++; 
+
+    int ibx = egIter -> bx();
+    if (ibx != 0) continue;
+
+    float e_ele   = egIter->energy();
+    float eta_ele = egIter->eta();
+    float et_ele = 0;
+    if (cosh(eta_ele) > 0.0) et_ele = e_ele/cosh(eta_ele);
+    else et_ele = -1.0;
+    if (fabs(eta_ele) > 2.5) continue;
+    if (ETmin > 0.0 && et_ele <= ETmin) continue;
+    // match the L1EG object with a L1Track
+    float drmin = 999;
+    int itr = 0;
+    int itrack = -1;
+    for (trackIter = L1TkTrackHandle->begin(); trackIter != L1TkTrackHandle->end(); ++trackIter) {
+      edm::Ptr< L1TkTrackType > L1TrackPtr( L1TkTrackHandle, itr) ;
+      if ( trackIter->getMomentum().perp() > trkQualityPtMin && trackIter->getChi2() < trkQualityChi2) {
+	double dPhi = 99.;
+	double dR = 99.;
+	double dEta = 99.;   
+	L1TkElectronTrackMatchAlgo::doMatch(egIter, L1TrackPtr, dPhi, dR, dEta); 
+
+	if (fabs(dPhi) < dPhiCutoff && dR < dRCutoff && fabs(dEta) < dEtaCutoff && dR < drmin) {
+	  drmin = dR;
+	  itrack = itr;
+	}
+      }
+      itr++;
+    }
+    if (itrack >= 0)  {
+      edm::Ptr< L1TkTrackType > matchedL1TrackPtr(L1TkTrackHandle, itrack);      
+      
+      const math::XYZTLorentzVector P4 = egIter -> p4() ;      
+      float trkisol = isolation(L1TkTrackHandle, itrack);
+      if (RelativeIsolation && et_ele > 0.0) {   // relative isolation
+	trkisol = trkisol  / et_ele;
+      }
+      
+      L1TkElectronParticle trkEm( P4, 
+				  EGammaRef,
+				  matchedL1TrackPtr, 
+				  trkisol );
+      
+      if (IsoCut <= 0) {
+	// write the L1TkEm particle to the collection, 
+	// irrespective of its relative isolation
+	result -> push_back( trkEm );
+      }	else {
+	// the object is written to the collection only
+	// if it passes the isolation cut
+	if (trkisol <= IsoCut) result -> push_back( trkEm );
+      }
+     
+    }
+   
+  } // end loop over EGamma objects
+  
+  iEvent.put( result, label );
+
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void
+L1TkElectronTrackProducer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void
+L1TkElectronTrackProducer::endJob() {
+}
+
+// ------------ method called when starting to processes a run  ------------
+/*
+void
+L1TkElectronTrackProducer::beginRun(edm::Run& iRun, edm::EventSetup const& iSetup)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a run  ------------
+/*
+void
+L1TkElectronTrackProducer::endRun(edm::Run&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void
+L1TkElectronTrackProducer::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void
+L1TkElectronTrackProducer::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+L1TkElectronTrackProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+// method to calculate isolation
+float 
+L1TkElectronTrackProducer::isolation(const edm::Handle<L1TkTrackCollectionType> & trkHandle, int match_index) {
+  edm::Ptr< L1TkTrackType > matchedTrkPtr (trkHandle, match_index) ; 
+  L1TkTrackCollectionType::const_iterator trackIter;
+
+  float sumPt = 0.0;
+  int itr = 0;
+  for (trackIter = trkHandle->begin(); trackIter != trkHandle->end(); ++trackIter) {
+    if (itr == match_index) continue;
+    float dZ = fabs(trackIter->getPOCA().z() - matchedTrkPtr->getPOCA().z() );
+    
+    float dPhi = reco::deltaPhi(trackIter->getMomentum().phi(), matchedTrkPtr->getMomentum().phi());
+    float dEta = (trackIter->getMomentum().eta() - matchedTrkPtr->getMomentum().eta());
+    float dR =  sqrt(dPhi*dPhi + dEta*dEta);
+
+     if (dR > DRmin && dR < DRmax && dZ < DeltaZ && trackIter->getMomentum().perp() > PTMINTRA && itr != match_index) sumPt += trackIter->getMomentum().perp();
+
+    itr ++;
+
+  }
+  return sumPt;
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TkElectronTrackProducer);
+
+
+
+

--- a/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1TkEmParticleProducer.cc
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1TkEmParticleProducer.cc
@@ -1,0 +1,381 @@
+// -*- C++ -*-
+//
+//
+// dummy producer for a L1TkEmParticle
+// 
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkEmParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkPrimaryVertex.h"
+
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+
+// for L1Tracks:
+//#include "SimDataFormats/SLHC/interface/StackedTrackerTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+#include <string>
+#include "TMath.h"
+
+
+using namespace l1extra ;
+
+//
+// class declaration
+//
+
+class L1TkEmParticleProducer : public edm::EDProducer {
+   public:
+
+   typedef TTTrack< Ref_PixelDigi_ >  L1TkTrackType;
+   typedef std::vector< L1TkTrackType >  L1TkTrackCollectionType;
+
+      explicit L1TkEmParticleProducer(const edm::ParameterSet&);
+      ~L1TkEmParticleProducer();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+      float DeltaPhi(float phi1, float phi2) ;
+      float deltaR(float eta1, float eta2, float phi1, float phi2) ;
+      float CorrectedEta(float eta, float zv);
+
+
+   private:
+      virtual void beginJob() ;
+      virtual void produce(edm::Event&, const edm::EventSetup&);
+      virtual void endJob() ;
+
+      //virtual void beginRun(edm::Run&, edm::EventSetup const&);
+      //virtual void endRun(edm::Run&, edm::EventSetup const&);
+      //virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+      //virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+
+      // ----------member data ---------------------------
+	edm::InputTag L1EGammaInputTag;
+	edm::InputTag L1TrackInputTag;
+        edm::InputTag L1VertexInputTag; // used only when PrimaryVtxConstrain = True.
+
+	std::string label;
+
+	float ETmin; 	// min ET in GeV of L1EG objects
+
+	float ZMAX;		// |z_track| < ZMAX in cm
+	float CHI2MAX;		
+	float DRmin;
+	float DRmax;
+	float PTMINTRA;
+	bool PrimaryVtxConstrain;	// use the primary vertex (default = false)
+	float DeltaZMax;	// | z_track - z_primaryvtx | < DeltaZMax in cm. 
+				// Used only when PrimaryVtxConstrain = True.
+	float IsoCut;
+	bool RelativeIsolation;
+} ;
+
+
+//
+// constructors and destructor
+//
+L1TkEmParticleProducer::L1TkEmParticleProducer(const edm::ParameterSet& iConfig)
+{
+
+   label = iConfig.getParameter<std::string>("label");  // label of the collection produced
+							// e.g. EG or IsoEG if all objects are kept
+							// EGIsoTrk or IsoEGIsoTrk if only the EG or IsoEG
+							// objects that pass a cut RelIso < IsoCut are written
+							// in the new collection.
+
+   L1EGammaInputTag = iConfig.getParameter<edm::InputTag>("L1EGammaInputTag") ;
+   L1TrackInputTag = iConfig.getParameter<edm::InputTag>("L1TrackInputTag");
+   L1VertexInputTag = iConfig.getParameter<edm::InputTag>("L1VertexInputTag");	// only used when PrimaryVtxConstrain = true
+
+   ETmin = (float)iConfig.getParameter<double>("ETmin");
+
+	// parameters for the calculation of the isolation :
+   ZMAX = (float)iConfig.getParameter<double>("ZMAX");
+   CHI2MAX = (float)iConfig.getParameter<double>("CHI2MAX");
+   PTMINTRA = (float)iConfig.getParameter<double>("PTMINTRA");
+   DRmin = (float)iConfig.getParameter<double>("DRmin");
+   DRmax = (float)iConfig.getParameter<double>("DRmax");
+   PrimaryVtxConstrain = iConfig.getParameter<bool>("PrimaryVtxConstrain");
+   DeltaZMax = (float)iConfig.getParameter<double>("DeltaZMax");
+	// cut applied on the isolation (if this number is <= 0, no cut is applied)
+   IsoCut = (float)iConfig.getParameter<double>("IsoCut");
+   RelativeIsolation = iConfig.getParameter<bool>("RelativeIsolation");
+
+   produces<L1TkEmParticleCollection>(label);
+}
+
+L1TkEmParticleProducer::~L1TkEmParticleProducer() {
+}
+
+// ------------ method called to produce the data  ------------
+void
+L1TkEmParticleProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+
+ std::auto_ptr<L1TkEmParticleCollection> result(new L1TkEmParticleCollection);
+
+	// the L1EGamma objects
+ edm::Handle<L1EmParticleCollection> EGammaHandle;
+ iEvent.getByLabel(L1EGammaInputTag,EGammaHandle);
+ std::vector<L1EmParticle>::const_iterator egIter ;
+
+	// the L1Tracks
+ edm::Handle<L1TkTrackCollectionType> L1TkTrackHandle;
+ iEvent.getByLabel(L1TrackInputTag, L1TkTrackHandle);
+ L1TkTrackCollectionType::const_iterator trackIter;
+
+	// the primary vertex (used only if PrimaryVtxConstrain = true)
+ float zvtxL1tk = -999;
+ if (PrimaryVtxConstrain) {
+ 	edm::Handle<L1TkPrimaryVertexCollection> L1VertexHandle;
+	iEvent.getByLabel(L1VertexInputTag,L1VertexHandle);
+	if (!L1VertexHandle.isValid() ) {
+	   LogWarning("L1TkEmParticleProducer")
+            << "\nWarning: L1TkPrimaryVertexCollection with " << L1VertexInputTag
+            << "\nrequested in configuration, but not found in the event. Won't use any PrimaryVertex constraint."
+            << std::endl;
+	    PrimaryVtxConstrain = false;
+	}
+	else {
+	    std::vector<L1TkPrimaryVertex>::const_iterator vtxIter = L1VertexHandle->begin();
+	       // by convention, the first vertex in the collection is the one that should
+	       // be used by default
+	    zvtxL1tk = vtxIter -> getZvertex();
+	}
+ }
+
+ if (!L1TkTrackHandle.isValid() ) {
+          LogError("L1TkEmParticleProducer")
+            << "\nWarning: L1TkTrackCollectionType with " << L1TrackInputTag
+            << "\nrequested in configuration, but not found in the event. Exit."
+            << std::endl;
+           return;
+ }
+
+	// Now loop over the L1EGamma objects
+
+ if( !EGammaHandle.isValid() )
+        {
+          LogError("L1TkEmParticleProducer")
+            << "\nWarning: L1EmParticleCollection with " << L1EGammaInputTag
+            << "\nrequested in configuration, but not found in the event. Exit."
+            << std::endl;
+	   return;
+        }
+
+ int ieg = 0;
+ for (egIter = EGammaHandle->begin();  egIter != EGammaHandle->end(); ++egIter) {
+
+    edm::Ref< L1EmParticleCollection > EGammaRef( EGammaHandle, ieg );
+    ieg ++;
+
+    int bx = egIter -> bx() ;
+
+    if (bx == 0) {
+
+	float eta = egIter -> eta();
+	if (PrimaryVtxConstrain) {
+		// The eta of the L1EG object is seen from (0,0,0).
+		// if PrimaryVtxConstrain = true, use the zvtxL1tk to correct the eta(L1EG)
+		// that is used in the calculation of DeltaR.
+	   eta = CorrectedEta( (float)eta, zvtxL1tk);
+	}
+	float phi = egIter -> phi();
+	float et = egIter -> et();
+
+	if (et < ETmin) continue;
+
+	// calculate the isolation of the L1EG object with
+	// respect to L1Tracks.
+
+	float trkisol = -999;
+	float sumPt = 0;
+
+	//std::cout << " here an EG w et = " << et << std::endl;
+
+	for (trackIter = L1TkTrackHandle->begin(); trackIter != L1TkTrackHandle->end(); ++trackIter) {
+
+	   float Pt = trackIter->getMomentum().perp();
+	   float Eta = trackIter->getMomentum().eta();
+	   float Phi = trackIter->getMomentum().phi();
+	   float z  = trackIter->getPOCA().z();
+	   if (fabs(z) > ZMAX) continue;
+    	   if (Pt < PTMINTRA) continue;
+	   float chi2 = trackIter->getChi2();
+	   if (chi2 > CHI2MAX) continue;
+
+	   if (PrimaryVtxConstrain) {
+	     if ( zvtxL1tk > -999 && fabs( z - zvtxL1tk) >= DeltaZMax) continue;
+	   }
+
+	   float dr = deltaR(Eta, eta, Phi,phi);
+	   if (dr < DRmax && dr >= DRmin)  {
+		//std::cout << " a track in the cone, z Pt = " << z << " " << Pt << std::endl;
+		sumPt += Pt;
+	   }
+
+	}  // end loop over tracks
+
+	if (RelativeIsolation) {
+	    if (et > 0) trkisol = sumPt / et;	// relative isolation
+        }
+        else {	// absolute isolation
+	    trkisol = sumPt ;
+	}
+
+    	const math::XYZTLorentzVector P4 = egIter -> p4() ;
+	L1TkEmParticle trkEm(  P4,
+				EGammaRef,
+				trkisol );
+    
+        if (IsoCut <= 0) {
+		// write the L1TkEm particle to the collection, 
+		// irrespective of its relative isolation
+		result -> push_back( trkEm );
+	}
+	else {
+		// the object is written to the collection only
+		// if it passes the isolation cut
+		if (trkisol <= IsoCut) result -> push_back( trkEm );
+	}
+
+     }  // endif bx==0
+
+ }  // end loop over EGamma objects
+
+ iEvent.put( result, label );
+
+}
+
+// --------------------------------------------------------------------------------------
+
+float L1TkEmParticleProducer::CorrectedEta(float eta, float zv)  {
+
+// Correct the eta of the L1EG object once we know the zvertex
+
+bool IsBarrel = ( fabs(eta) < 1.479 );
+float REcal = 129. ;
+float ZEcal = 315.4 ;
+
+float theta = 2. * TMath::ATan( TMath::Exp( - eta ) );
+if (theta < 0) theta = theta + TMath::Pi();
+float tantheta = TMath::Tan( theta );
+
+float delta;
+if (IsBarrel) {
+        delta = REcal / tantheta ;
+}
+else {
+        if (theta > 0) delta =  ZEcal;
+        if (theta < 0) delta = -ZEcal;
+}
+
+float tanthetaprime = delta * tantheta / (delta - zv );
+
+float thetaprime = TMath::ATan( tanthetaprime );
+if (thetaprime < 0) thetaprime = thetaprime + TMath::Pi();
+
+float etaprime = -TMath::Log( TMath::Tan( thetaprime / 2.) );
+return etaprime;
+
+}
+
+// --------------------------------------------------------------------------------------
+
+float L1TkEmParticleProducer::DeltaPhi(float phi1, float phi2) {
+// dPhi between 0 and Pi
+   float dphi = phi1 - phi2;
+   if (dphi < 0) dphi = dphi + 2.*TMath::Pi();
+   if (dphi > TMath::Pi()) dphi = 2.*TMath::Pi() - dphi;
+  return dphi;
+}
+
+// --------------------------------------------------------------------------------------
+
+float L1TkEmParticleProducer::deltaR(float eta1, float eta2, float phi1, float phi2) {
+    float deta = eta1 - eta2;
+    float dphi = DeltaPhi(phi1, phi2);
+    float DR= sqrt( deta*deta + dphi*dphi );
+    return DR;
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void
+L1TkEmParticleProducer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void
+L1TkEmParticleProducer::endJob() {
+}
+
+// ------------ method called when starting to processes a run  ------------
+/*
+void
+L1TkEmParticleProducer::beginRun(edm::Run& iRun, edm::EventSetup const& iSetup)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a run  ------------
+/*
+void
+L1TkEmParticleProducer::endRun(edm::Run&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void
+L1TkEmParticleProducer::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void
+L1TkEmParticleProducer::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+L1TkEmParticleProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TkEmParticleProducer);
+
+
+

--- a/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1TkEtMissProducer.cc
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1TkEtMissProducer.cc
@@ -1,0 +1,350 @@
+// -*- C++ -*-
+//
+//
+// Original Author:  Emmanuelle Perez,40 1-A28,+41227671915,
+//         Created:  Tue Nov 12 17:03:19 CET 2013
+// $Id$
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+//#include "SimDataFormats/SLHC/interface/StackedTrackerTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+////////////////////////////
+// DETECTOR GEOMETRY HEADERS
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelTopologyBuilder.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+
+#include "Geometry/Records/interface/StackedTrackerGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StackedTrackerGeometry.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StackedTrackerDetUnit.h"
+#include "DataFormats/SiPixelDetId/interface/StackedTrackerDetId.h"
+
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkEtMissParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkEtMissParticleFwd.h"
+
+
+using namespace l1extra;
+
+//
+// class declaration
+//
+
+class L1TkEtMissProducer : public edm::EDProducer {
+   public:
+
+   typedef TTTrack< Ref_PixelDigi_ >  L1TkTrackType;
+   typedef std::vector< L1TkTrackType >  L1TkTrackCollectionType;
+
+      explicit L1TkEtMissProducer(const edm::ParameterSet&);
+      ~L1TkEtMissProducer();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+   private:
+      virtual void beginJob() ;
+      virtual void produce(edm::Event&, const edm::EventSetup&);
+      virtual void endJob() ;
+      
+      virtual void beginRun(edm::Run&, edm::EventSetup const&);
+      //virtual void endRun(edm::Run&, edm::EventSetup const&);
+      //virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+      //virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+
+      // ----------member data ---------------------------
+
+        edm::InputTag L1VertexInputTag;
+        edm::InputTag L1TrackInputTag;
+
+	float ZMAX;	// in cm
+	float DeltaZ;	// in cm
+	float CHI2MAX;
+	float PTMINTRA;	// in GeV
+        int nStubsmin;
+        int nStubsPSmin ;       // minimum number of stubs in PS modules 
+
+
+        //const StackedTrackerGeometry*                   theStackedGeometry;
+
+};
+
+//
+// constants, enums and typedefs
+//
+
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+L1TkEtMissProducer::L1TkEtMissProducer(const edm::ParameterSet& iConfig)
+{
+   //register your products
+/* Examples
+   produces<ExampleData2>();
+
+   //if do put with a label
+   produces<ExampleData2>("label");
+ 
+   //if you want to put into the Run
+   produces<ExampleData2,InRun>();
+*/
+   //now do what ever other initialization is needed
+  
+  L1VertexInputTag = iConfig.getParameter<edm::InputTag>("L1VertexInputTag") ;
+  L1TrackInputTag = iConfig.getParameter<edm::InputTag>("L1TrackInputTag");
+
+
+  ZMAX = (float)iConfig.getParameter<double>("ZMAX");
+  DeltaZ = (float)iConfig.getParameter<double>("DeltaZ");
+  CHI2MAX = (float)iConfig.getParameter<double>("CHI2MAX");
+  PTMINTRA = (float)iConfig.getParameter<double>("PTMINTRA");
+  nStubsmin = iConfig.getParameter<int>("nStubsmin");
+  nStubsPSmin = iConfig.getParameter<int>("nStubsPSmin");
+
+  produces<L1TkEtMissParticleCollection>("MET");
+
+}
+
+
+L1TkEtMissProducer::~L1TkEtMissProducer()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void
+L1TkEtMissProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+
+  /// Geometry handles etc
+  edm::ESHandle<TrackerGeometry>                               geometryHandle;
+  edm::ESHandle<StackedTrackerGeometry>           stackedGeometryHandle;
+  const StackedTrackerGeometry*                   theStackedGeometry;
+  StackedTrackerGeometry::StackContainerIterator  StackedTrackerIterator;
+  /// Geometry setup
+  /// Set pointers to Geometry
+  iSetup.get<TrackerDigiGeometryRecord>().get(geometryHandle);
+  iSetup.get<StackedTrackerGeometryRecord>().get(stackedGeometryHandle);
+  theStackedGeometry = stackedGeometryHandle.product();
+
+ 
+ std::auto_ptr<L1TkEtMissParticleCollection> result(new L1TkEtMissParticleCollection);
+
+ edm::Handle<L1TkPrimaryVertexCollection> L1VertexHandle;
+ iEvent.getByLabel(L1VertexInputTag,L1VertexHandle);
+ std::vector<L1TkPrimaryVertex>::const_iterator vtxIter;
+
+ edm::Handle<L1TkTrackCollectionType> L1TkTrackHandle;
+ iEvent.getByLabel(L1TrackInputTag, L1TkTrackHandle);
+ L1TkTrackCollectionType::const_iterator trackIter;
+
+
+ if( !L1VertexHandle.isValid() )
+        {
+          LogError("L1TkEtMissProducer")
+            << "\nWarning: L1TkPrimaryVertexCollection with " << L1VertexInputTag
+            << "\nrequested in configuration, but not found in the event. Exit"
+            << std::endl;
+	   return;
+        }
+
+ if( !L1TkTrackHandle.isValid() )
+        {
+          LogError("L1TkEtMissProducer")
+            << "\nWarning: L1TkTrackCollectionType with " << L1TrackInputTag
+            << "\nrequested in configuration, but not found in the event. Exit"
+            << std::endl;
+           return;
+        }
+
+
+ int ivtx = 0;
+
+ for (vtxIter = L1VertexHandle->begin(); vtxIter != L1VertexHandle->end(); ++vtxIter) {
+
+    float zVTX = vtxIter -> getZvertex();
+    edm::Ref< L1TkPrimaryVertexCollection > vtxRef( L1VertexHandle, ivtx );
+    ivtx ++;
+
+    float sumPx = 0;
+    float sumPy = 0;
+    float etTot = 0;
+
+    double sumPx_PU = 0;
+    double sumPy_PU = 0;
+    double etTot_PU = 0;
+
+  	for (trackIter = L1TkTrackHandle->begin(); trackIter != L1TkTrackHandle->end(); ++trackIter) {
+ 
+    	    float pt = trackIter->getMomentum().perp();
+    	    float chi2 = trackIter->getChi2();
+    	    float ztr  = trackIter->getPOCA().z();
+	
+    	    if (pt < PTMINTRA) continue;
+    	    if (fabs(ztr) > ZMAX ) continue;
+    	    if (chi2 > CHI2MAX) continue;
+                
+            int nstubs = 0;
+	    float nPS = 0.;     // number of stubs in PS modules
+
+	    std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_PixelDigi_ > >, TTStub< Ref_PixelDigi_ > > >  theStubs = trackIter -> getStubRefs() ;
+
+            int tmp_trk_nstub = (int) theStubs.size();
+            if ( tmp_trk_nstub < 0) continue;
+            // loop over the stubs
+            for (unsigned int istub=0; istub<(unsigned int)theStubs.size(); istub++) {
+                  nstubs ++;
+           	  StackedTrackerDetId detIdStub( theStubs.at(istub)->getDetId() );
+                  bool isPS = theStackedGeometry -> isPSModule( detIdStub );
+           	  if (isPS) nPS ++;
+            }
+            if (nstubs < nStubsmin) continue;
+            if (nPS < nStubsPSmin) continue;
+
+            if ( fabs(ztr - zVTX) <= DeltaZ) {   // eg DeltaZ = 1 mm
+
+	    	sumPx += trackIter->getMomentum().x();
+	    	sumPy += trackIter->getMomentum().y();
+	    	etTot += pt ;
+	    }
+	    else   {	// PU sums
+                sumPx_PU += trackIter->getMomentum().x();
+                sumPy_PU += trackIter->getMomentum().y();
+                etTot_PU += pt ;
+	    }
+
+
+    	} // end loop over tracks
+     float et = sqrt( sumPx*sumPx + sumPy*sumPy );
+     math::XYZTLorentzVector missingEt( -sumPx, -sumPy, 0, et);
+
+     double etmiss_PU = sqrt( sumPx_PU*sumPx_PU + sumPy_PU*sumPy_PU );
+
+     int ibx = 0;
+     result -> push_back(  L1TkEtMissParticle( missingEt,
+				 L1TkEtMissParticle::kMET,
+				 etTot,
+				 etmiss_PU,
+				 etTot_PU,
+				 vtxRef,
+				 ibx )
+		         ) ;
+
+
+ } // end loop over vertices
+
+ iEvent.put( result, "MET");
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+L1TkEtMissProducer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+L1TkEtMissProducer::endJob() {
+}
+
+// ------------ method called when starting to processes a run  ------------
+void
+L1TkEtMissProducer::beginRun(edm::Run& iRun, edm::EventSetup const& iSetup)
+{
+
+/*
+  /// Geometry handles etc
+  edm::ESHandle<TrackerGeometry>                               geometryHandle;
+  //const TrackerGeometry*                                       theGeometry;
+  edm::ESHandle<StackedTrackerGeometry>           stackedGeometryHandle;
+
+  /// Geometry setup
+  /// Set pointers to Geometry
+  iSetup.get<TrackerDigiGeometryRecord>().get(geometryHandle);
+  //theGeometry = &(*geometryHandle);
+  /// Set pointers to Stacked Modules
+  iSetup.get<StackedTrackerGeometryRecord>().get(stackedGeometryHandle);
+  theStackedGeometry = stackedGeometryHandle.product(); /// Note this is different 
+                                                        /// from the "global" geometry
+  if (theStackedGeometry == 0) cout << " theStackedGeometry = 0 " << endl;      // for compil when not used...
+*/
+
+}
+ 
+// ------------ method called when ending the processing of a run  ------------
+/*
+void
+L1TkEtMissProducer::endRun(edm::Run&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void
+L1TkEtMissProducer::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void
+L1TkEtMissProducer::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+L1TkEtMissProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TkEtMissProducer);

--- a/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1TkHTMissProducer.cc
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1TkHTMissProducer.cc
@@ -1,0 +1,264 @@
+// -*- C++ -*-
+//
+//
+// Original Author:  Emmanuelle Perez,40 1-A28,+41227671915,
+//         Created:  Tue Nov 12 17:03:19 CET 2013
+// $Id$
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkHTMissParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkHTMissParticleFwd.h"
+
+
+using namespace l1extra;
+
+//
+// class declaration
+//
+
+class L1TkHTMissProducer : public edm::EDProducer {
+   public:
+
+      explicit L1TkHTMissProducer(const edm::ParameterSet&);
+      ~L1TkHTMissProducer();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+   private:
+      virtual void beginJob() ;
+      virtual void produce(edm::Event&, const edm::EventSetup&);
+      virtual void endJob() ;
+      
+      virtual void beginRun(edm::Run&, edm::EventSetup const&);
+      //virtual void endRun(edm::Run&, edm::EventSetup const&);
+      //virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+      //virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+
+      // ----------member data ---------------------------
+
+        edm::InputTag L1TkJetInputTag;
+
+	bool PrimaryVtxConstrain;
+        edm::InputTag L1VertexInputTag; // used only when PrimaryVtxConstrain = True.
+
+	float DeltaZ;
+
+
+};
+
+//
+// constants, enums and typedefs
+//
+
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+L1TkHTMissProducer::L1TkHTMissProducer(const edm::ParameterSet& iConfig)
+{
+   //register your products
+   //now do what ever other initialization is needed
+  
+  L1TkJetInputTag = iConfig.getParameter<edm::InputTag>("L1TkJetInputTag");
+  DeltaZ = (float)iConfig.getParameter<double>("DeltaZ");
+
+  L1VertexInputTag = iConfig.getParameter<edm::InputTag>("L1VertexInputTag") ;
+  PrimaryVtxConstrain = iConfig.getParameter<bool>("PrimaryVtxConstrain");
+
+  produces<L1TkHTMissParticleCollection>();
+
+}
+
+
+L1TkHTMissProducer::~L1TkHTMissProducer()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void
+L1TkHTMissProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+ 
+ std::auto_ptr<L1TkHTMissParticleCollection> result(new L1TkHTMissParticleCollection);
+
+ edm::Handle<L1TkPrimaryVertexCollection> L1VertexHandle;
+ iEvent.getByLabel(L1VertexInputTag,L1VertexHandle);
+ std::vector<L1TkPrimaryVertex>::const_iterator vtxIter;
+
+ edm::Handle<L1TkJetParticleCollection> L1TkJetsHandle;
+ iEvent.getByLabel(L1TkJetInputTag,L1TkJetsHandle);
+ std::vector<L1TkJetParticle>::const_iterator jetIter;
+
+
+ if ( ! L1TkJetsHandle.isValid() ) {
+          LogError("L1TkHTMissProducer")
+            << "\nWarning: L1TkJetParticleCollection with " << L1TkJetInputTag
+            << "\nrequested in configuration, but not found in the event. Exit"
+            << std::endl;
+           return;
+ }
+
+ float zvtx = -999;
+
+ edm::Ref< L1TkPrimaryVertexCollection > L1VtxRef; 	// null reference
+
+ if ( PrimaryVtxConstrain ) {
+     if( !L1VertexHandle.isValid() )
+            {
+              LogError("L1TkHTMissProducer")
+                << "\nWarning: L1TkPrimaryVertexCollection with " << L1VertexInputTag
+                << "\nrequested in configuration, but not found in the event. Exit."
+                << std::endl;
+	       return ;
+            }
+      else {
+                std::vector<L1TkPrimaryVertex>::const_iterator vtxIter = L1VertexHandle->begin();
+                   // by convention, the first vertex in the collection is the one that should
+                   // be used by default
+                zvtx = vtxIter -> getZvertex();
+	        int ivtx = 0;
+	        edm::Ref< L1TkPrimaryVertexCollection > vtxRef( L1VertexHandle, ivtx );
+	        L1VtxRef = vtxRef;
+      }
+ }  //endif PrimaryVtxConstrain
+
+
+    float sumPx = 0;
+    float sumPy = 0;
+    float etTot = 0;	// HT
+
+ for (jetIter = L1TkJetsHandle->begin(); jetIter != L1TkJetsHandle->end(); ++jetIter) {
+
+    int ibx = jetIter -> bx();
+    if (ibx != 0) continue;
+
+    float px = jetIter -> px();
+    float py = jetIter -> py();
+    float et = jetIter -> et();
+    float jetVtx = jetIter -> getJetVtx();
+    
+	// vertex consistency requirement :
+	// here I use the zvtx from the primary vertex
+    bool VtxRequirement = fabs( jetVtx - zvtx ) < DeltaZ ;
+
+    if (VtxRequirement) {
+	sumPx += px;
+	sumPy += py;
+	etTot += et;
+    }
+ }  // end loop over jets
+
+     float et = sqrt( sumPx*sumPx + sumPy*sumPy );	// HTM
+     math::XYZTLorentzVector missingEt( -sumPx, -sumPy, 0, et); 
+
+     edm::RefProd<L1TkJetParticleCollection> jetCollRef(L1TkJetsHandle) ;
+
+     L1TkHTMissParticle tkHTM( missingEt,
+				etTot,
+                                jetCollRef,
+                                L1VtxRef );
+
+/*
+	// in case no primary vtx is used, need to set the zvtx that was
+	// used in the consistency requirement (e.g. the zvtx of the
+	// leading jet) 
+
+     if (! PrimaryVtxConstrain) {
+	tkHTM -> setVtx ( zvtx_used );
+     }
+*/
+
+  result -> push_back(  tkHTM );
+
+  iEvent.put( result);
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+L1TkHTMissProducer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+L1TkHTMissProducer::endJob() {
+}
+
+// ------------ method called when starting to processes a run  ------------
+void
+L1TkHTMissProducer::beginRun(edm::Run& iRun, edm::EventSetup const& iSetup)
+{
+
+
+}
+ 
+// ------------ method called when ending the processing of a run  ------------
+/*
+void
+L1TkHTMissProducer::endRun(edm::Run&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void
+L1TkHTMissProducer::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void
+L1TkHTMissProducer::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+L1TkHTMissProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TkHTMissProducer);

--- a/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1TkJetProducer.cc
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1TkJetProducer.cc
@@ -1,0 +1,202 @@
+// -*- C++ -*-
+//
+//
+// Producer of a L1TkJetParticle.
+// Dummy code below. To be filled by Louise.
+// 
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkJetParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkJetParticleFwd.h"
+
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+
+// for L1Tracks:
+//#include "SimDataFormats/SLHC/interface/StackedTrackerTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+#include <string>
+#include "TMath.h"
+
+
+using namespace l1extra ;
+
+//
+// class declaration
+//
+
+class L1TkJetProducer : public edm::EDProducer {
+   public:
+
+   typedef TTTrack< Ref_PixelDigi_ >  L1TkTrackType;
+   typedef std::vector< L1TkTrackType >    L1TkTrackCollectionType;
+
+      explicit L1TkJetProducer(const edm::ParameterSet&);
+      ~L1TkJetProducer();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      virtual void beginJob() ;
+      virtual void produce(edm::Event&, const edm::EventSetup&);
+      virtual void endJob() ;
+
+      //virtual void beginRun(edm::Run&, edm::EventSetup const&);
+      //virtual void endRun(edm::Run&, edm::EventSetup const&);
+      //virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+      //virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+
+      // ----------member data ---------------------------
+	edm::InputTag L1CentralJetInputTag;
+	edm::InputTag L1TrackInputTag;
+
+} ;
+
+
+//
+// constructors and destructor
+//
+L1TkJetProducer::L1TkJetProducer(const edm::ParameterSet& iConfig)
+{
+
+   L1CentralJetInputTag = iConfig.getParameter<edm::InputTag>("L1CentralJetInputTag") ;
+   L1TrackInputTag = iConfig.getParameter<edm::InputTag>("L1TrackInputTag");
+   
+   produces<L1TkJetParticleCollection>("Central");
+
+}
+
+L1TkJetProducer::~L1TkJetProducer() {
+}
+
+// ------------ method called to produce the data  ------------
+void
+L1TkJetProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+
+ std::auto_ptr<L1TkJetParticleCollection> cenTkJets(new L1TkJetParticleCollection);
+
+ edm::Handle<L1JetParticleCollection> CentralJetHandle;
+ iEvent.getByLabel(L1CentralJetInputTag,CentralJetHandle);
+ std::vector<L1JetParticle>::const_iterator jetIter ;
+
+ edm::Handle<L1TkTrackCollectionType> L1TkTrackHandle;
+ iEvent.getByLabel(L1TrackInputTag, L1TkTrackHandle);
+ L1TkTrackCollectionType::const_iterator trackIter;
+
+	// central jets (i.e. |eta| < 3)
+
+ if( !CentralJetHandle.isValid() )
+	{
+	  LogError("L1TkJetProducer")
+	    << "\nWarning: L1JetParticleCollection with " << L1CentralJetInputTag
+	    << "\nrequested in configuration, but not found in the event."
+	    << std::endl;
+	}
+ else {
+
+    int ijet = 0;
+    for (jetIter = CentralJetHandle->begin();  jetIter != CentralJetHandle->end(); ++jetIter) {
+
+       edm::Ref< L1JetParticleCollection > JetRef( CentralJetHandle, ijet );
+       ijet ++;
+
+       int ibx = jetIter -> bx();
+       if (ibx != 0) continue;
+
+	   // calculate the vertex of the jet. Here dummy.
+	   float jetvtx = -999;
+
+           const math::XYZTLorentzVector P4 = jetIter -> p4() ;
+           L1TkJetParticle trkJet(  P4,
+                                   JetRef,
+				   jetvtx );
+
+	       cenTkJets -> push_back( trkJet );
+
+    }  // end loop over Jet objects
+ } // endif CentralJetHandle.isValid()
+
+
+
+ iEvent.put( cenTkJets, "Central" );
+
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void
+L1TkJetProducer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void
+L1TkJetProducer::endJob() {
+}
+
+// ------------ method called when starting to processes a run  ------------
+/*
+void
+L1TkJetProducer::beginRun(edm::Run& iRun, edm::EventSetup const& iSetup)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a run  ------------
+/*
+void
+L1TkJetProducer::endRun(edm::Run&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void
+L1TkJetProducer::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void
+L1TkJetProducer::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+L1TkJetProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TkJetProducer);
+
+
+

--- a/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1TkMuonProducer.cc
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1TkMuonProducer.cc
@@ -1,0 +1,354 @@
+// -*- C++ -*-
+//
+//
+// dummy producer for a L1TkMuonParticle
+// This is just an interface, taking the muon objects created
+// by PierLuigi's code, and putting them into a collection of
+// L1TkMuonParticle.
+// 
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkMuonParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkMuonParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkPrimaryVertex.h"
+
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+
+// for L1Tracks:
+//#include "SimDataFormats/SLHC/interface/StackedTrackerTypes.h"
+
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
+#include <string>
+#include "TMath.h"
+
+
+using namespace l1extra ;
+
+//
+// class declaration
+//
+
+class L1TkMuonParticleProducer : public edm::EDProducer {
+   public:
+
+   typedef TTTrack< Ref_PixelDigi_ >  L1TkTrackType;
+   typedef std::vector< L1TkTrackType >  L1TkTrackCollectionType;
+
+      explicit L1TkMuonParticleProducer(const edm::ParameterSet&);
+      ~L1TkMuonParticleProducer();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      virtual void beginJob() ;
+      virtual void produce(edm::Event&, const edm::EventSetup&);
+      virtual void endJob() ;
+
+      //virtual void beginRun(edm::Run&, edm::EventSetup const&);
+      //virtual void endRun(edm::Run&, edm::EventSetup const&);
+      //virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+      //virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+
+      // ----------member data ---------------------------
+	
+	 //edm::InputTag L1PLInputTag;  // inputTag for PierLuigi's objects
+
+	 edm::InputTag L1MuonsInputTag;
+	 edm::InputTag L1TrackInputTag;	 
+
+	 float ETAMIN;
+	 float ETAMAX;
+        float ZMAX;             // |z_track| < ZMAX in cm
+        float CHI2MAX;
+        float PTMINTRA;
+        float DRmax;
+
+        int nStubsmin ;         // minimum number of stubs 
+
+	bool closest ;
+
+
+} ;
+
+
+//
+// constructors and destructor
+//
+L1TkMuonParticleProducer::L1TkMuonParticleProducer(const edm::ParameterSet& iConfig)
+{
+
+   //L1PLInputTag = iConfig.getParameter<edm::InputTag>("L1PLInputTag");
+
+   L1MuonsInputTag = iConfig.getParameter<edm::InputTag>("L1MuonsInputTag");
+   L1TrackInputTag = iConfig.getParameter<edm::InputTag>("L1TrackInputTag");
+
+   ETAMIN = (float)iConfig.getParameter<double>("ETAMIN");
+   ETAMAX = (float)iConfig.getParameter<double>("ETAMAX");
+   ZMAX = (float)iConfig.getParameter<double>("ZMAX");
+   CHI2MAX = (float)iConfig.getParameter<double>("CHI2MAX");
+   PTMINTRA = (float)iConfig.getParameter<double>("PTMINTRA");
+   DRmax = (float)iConfig.getParameter<double>("DRmax");
+  nStubsmin = iConfig.getParameter<int>("nStubsmin");
+  closest = iConfig.getParameter<bool>("closest");
+
+   produces<L1TkMuonParticleCollection>();
+}
+
+L1TkMuonParticleProducer::~L1TkMuonParticleProducer() {
+}
+
+// ------------ method called to produce the data  ------------
+void
+L1TkMuonParticleProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+   using namespace std;
+
+
+ std::auto_ptr<L1TkMuonParticleCollection> result(new L1TkMuonParticleCollection);
+
+ // dummy code. I loop over the L1Muons and pick up the L1Track that is closest
+ // in DeltaR.
+
+  edm::Handle< vector<l1extra::L1MuonParticle>  > MuonHandle;
+  iEvent.getByLabel(L1MuonsInputTag,MuonHandle);
+  vector<l1extra::L1MuonParticle>::const_iterator l1MuIter;
+
+ edm::Handle<L1TkTrackCollectionType> L1TkTrackHandle;
+ iEvent.getByLabel(L1TrackInputTag, L1TkTrackHandle);
+ L1TkTrackCollectionType::const_iterator trackIter;
+
+
+  int imu = 0;
+  for (l1MuIter = MuonHandle->begin(); l1MuIter != MuonHandle->end(); ++l1MuIter) {
+
+    edm::Ref< L1MuonParticleCollection > MuRef( MuonHandle, imu );
+    imu ++;
+
+        float drmin = 999;
+        float ptmax = -1;
+	if (ptmax < 0) ptmax = -1;	// dummy
+
+      float eta = l1MuIter -> eta();
+      float phi = l1MuIter -> phi();
+
+      float feta = fabs( eta );
+      if (feta < ETAMIN) continue;
+      if (feta > ETAMAX) continue;
+
+      L1MuGMTExtendedCand cand = l1MuIter -> gmtMuonCand();
+      unsigned int quality = cand.quality();
+      int bx = l1MuIter -> bx() ;
+      if (bx != 0 ) continue;
+      if (quality < 3) continue;
+
+	// match the L1Muons with L1Tracks
+
+        int itr = -1;
+        int itrack = -1;
+        for (trackIter = L1TkTrackHandle->begin(); trackIter != L1TkTrackHandle->end(); ++trackIter) {
+	   itr ++ ;
+           float Pt = trackIter->getMomentum().perp();
+           float z  = trackIter->getPOCA().z();
+           if (fabs(z) > ZMAX) continue;
+           if (Pt < PTMINTRA) continue;
+           float chi2 = trackIter->getChi2();
+           if (chi2 > CHI2MAX) continue;
+
+	   std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_PixelDigi_ > >, TTStub< Ref_PixelDigi_ > > >  theStubs = trackIter -> getStubRefs() ;
+      	   int tmp_trk_nstub = (int) theStubs.size();
+      	   if ( tmp_trk_nstub < nStubsmin) continue;
+
+                float Eta = trackIter->getMomentum().eta();
+                float Phi = trackIter->getMomentum().phi();
+                float deta = eta - Eta;
+                float dphi = phi - Phi;
+                if (dphi < 0) dphi = dphi + 2.*TMath::Pi();
+                if (dphi > TMath::Pi()) dphi = 2.*TMath::Pi() - dphi;
+                float dR = sqrt( deta*deta + dphi*dphi );
+
+		if (closest) {
+			// take the closest track:
+                if (dR < drmin) {
+                  drmin = dR;
+                  itrack = itr;
+                }
+		}
+		else {
+			// or take the leading track within a cone 
+		if (dR < DRmax) {
+		  if (Pt > ptmax) {
+			ptmax = Pt;
+			itrack = itr;
+			drmin = dR;
+		  }
+		}
+		}
+
+        }  // end loop over the tracks
+
+        if (drmin < DRmax ) {     // found a L1Track matched to the L1Muon object
+
+            edm::Ptr< L1TkTrackType > L1TrackPtr( L1TkTrackHandle, itrack) ;
+
+            float px = L1TrackPtr -> getMomentum().x();
+            float py = L1TrackPtr -> getMomentum().y();
+            float pz = L1TrackPtr -> getMomentum().z(); 
+            float e = sqrt( px*px + py*py + pz*pz );    // massless particle
+            math::XYZTLorentzVector TrackP4(px,py,pz,e);
+            
+            float trkisol = -999;       // dummy
+            
+            L1TkMuonParticle trkMu( TrackP4,
+                                 MuRef,
+                                 L1TrackPtr,
+                                 trkisol );
+
+	    //trkMu.setDeltaR ( drmin ) ;
+            
+            result -> push_back( trkMu );
+
+        
+         }  // endif drmin < DRmax
+
+
+   }  // end loop over the L1Muons
+
+	// PL: the muon objects from PierLuigi
+/*
+ edm::Handle<XXXCollection> XXXHandle;
+ iEvent.getByLabel(L1PLInputTag,XXXHandle);
+ std::vector<XXX>::const_iterator muIter ;
+
+ if (!XXXHandle.isValid() ) {
+          LogError("L1TkMuonParticleProducer")
+            << "\nWarning: L1XXXCollectionType with " << L1PLInputTag
+            << "\nrequested in configuration, but not found in the event. Exit."
+            << std::endl;
+           return;
+ }
+
+	// Now loop over the muons of Pierluigi 
+
+ int imu = 0;
+ for (muIter = XXXHandle->begin();  muIter != XXXHandle->end(); ++muIter) {
+
+    edm::Ref< XXXCollection > muRef( XXXHandle, imu );
+    imu ++;
+
+    // int bx = egIter -> bx() ;	// if PL's objects have a bx method
+    int bx = 0;    // else...
+
+    if (bx == 0) {
+
+	edm::Ptr< L1TkTrackType > L1TrackPtr ;
+
+	// PL : get the matched L1Track from PL's object
+	// L1TrackPtr  = muRef -> getRefToTheL1Track() ;
+	
+            float px = L1TrackPtr -> getMomentum().x();
+            float py = L1TrackPtr -> getMomentum().y();
+            float pz = L1TrackPtr -> getMomentum().z();
+            float e = sqrt( px*px + py*py + pz*pz );    // massless particle
+            math::XYZTLorentzVector TrackP4(px,py,pz,e);
+
+	// the code may calculate a tracker-based isolation variable,
+	// or pick it up from PL's object if it is there.
+	// for the while, dummy.
+	float trkisol = -999;
+
+
+	L1TkMuonParticle trkMu(  P4,
+				// muRef,  
+				L1TrackPtr,	
+				trkisol );
+    
+     }  // endif bx==0
+
+ }  // end loop over Pierluigi's objects
+*/
+
+ iEvent.put( result );
+
+}
+
+// --------------------------------------------------------------------------------------
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void
+L1TkMuonParticleProducer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void
+L1TkMuonParticleProducer::endJob() {
+}
+
+// ------------ method called when starting to processes a run  ------------
+/*
+void
+L1TkMuonParticleProducer::beginRun(edm::Run& iRun, edm::EventSetup const& iSetup)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a run  ------------
+/*
+void
+L1TkMuonParticleProducer::endRun(edm::Run&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void
+L1TkMuonParticleProducer::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void
+L1TkMuonParticleProducer::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+L1TkMuonParticleProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TkMuonParticleProducer);
+
+
+

--- a/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1TkPrimaryVertexProducer.cc
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1TkPrimaryVertexProducer.cc
@@ -1,0 +1,366 @@
+// -*- C++ -*-
+//
+//
+// Original Author:  Emmanuelle Perez,40 1-A28,+41227671915,
+//         Created:  Tue Nov 12 17:03:19 CET 2013
+// $Id$
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+
+//#include "SimDataFormats/SLHC/interface/StackedTrackerTypes.h"
+//#include "SimDataFormats/SLHC/interface/slhcevent.hh"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+////////////////////////////
+// DETECTOR GEOMETRY HEADERS
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelTopologyBuilder.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetType.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+
+#include "Geometry/Records/interface/StackedTrackerGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StackedTrackerGeometry.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StackedTrackerDetUnit.h"
+#include "DataFormats/SiPixelDetId/interface/StackedTrackerDetId.h"
+
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkPrimaryVertex.h"
+
+
+//
+// class declaration
+//
+
+class L1TkPrimaryVertexProducer : public edm::EDProducer {
+   public:
+
+   typedef TTTrack< Ref_PixelDigi_ >  L1TkTrackType;
+   typedef std::vector< L1TkTrackType >  L1TkTrackCollectionType;
+
+      explicit L1TkPrimaryVertexProducer(const edm::ParameterSet&);
+      ~L1TkPrimaryVertexProducer();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+      float MaxPtVertex(const edm::Handle<L1TkTrackCollectionType> & L1TkTrackHandle,
+                float& sum,
+                int nmin, int nPSmin, float ptmin, int imode,
+		const StackedTrackerGeometry* theStackedGeometry) ;
+
+      float SumPtVertex(const edm::Handle<L1TkTrackCollectionType> & L1TkTrackHandle,
+                float z, int nmin, int nPSmin, float ptmin, int imode,
+		const StackedTrackerGeometry* theStackedGeometry ) ;
+
+
+   private:
+      virtual void beginJob() ;
+      virtual void produce(edm::Event&, const edm::EventSetup&);
+      virtual void endJob() ;
+      
+      virtual void beginRun(edm::Run&, edm::EventSetup const&);
+      //virtual void endRun(edm::Run&, edm::EventSetup const&);
+      //virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+      //virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+
+      // ----------member data ---------------------------
+
+        edm::InputTag L1TrackInputTag;
+
+	float ZMAX;	// in cm
+	float DeltaZ;	// in cm
+	float CHI2MAX;
+	float PTMINTRA ; 	// in GeV
+
+	int nStubsmin ;		// minimum number of stubs 
+	int nStubsPSmin ;	// minimum number of stubs in PS modules 
+	bool SumPtSquared;
+
+        //const StackedTrackerGeometry*                   theStackedGeometry;
+
+};
+
+//
+// constants, enums and typedefs
+//
+
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+L1TkPrimaryVertexProducer::L1TkPrimaryVertexProducer(const edm::ParameterSet& iConfig)
+{
+   //register your products
+   //now do what ever other initialization is needed
+  
+  L1TrackInputTag = iConfig.getParameter<edm::InputTag>("L1TrackInputTag");
+
+  ZMAX = (float)iConfig.getParameter<double>("ZMAX");
+  DeltaZ = (float)iConfig.getParameter<double>("DeltaZ");
+  CHI2MAX = (float)iConfig.getParameter<double>("CHI2MAX");
+  PTMINTRA = (float)iConfig.getParameter<double>("PTMINTRA");
+
+  nStubsmin = iConfig.getParameter<int>("nStubsmin");
+  nStubsPSmin = iConfig.getParameter<int>("nStubsPSmin");
+
+  SumPtSquared = iConfig.getParameter<bool>("SumPtSquared");
+
+  produces<L1TkPrimaryVertexCollection>();
+
+}
+
+
+L1TkPrimaryVertexProducer::~L1TkPrimaryVertexProducer()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void
+L1TkPrimaryVertexProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+
+ std::auto_ptr<L1TkPrimaryVertexCollection> result(new L1TkPrimaryVertexCollection);
+
+  /// Geometry handles etc
+  edm::ESHandle<TrackerGeometry>                               geometryHandle;
+  //const TrackerGeometry*                                       theGeometry;
+  edm::ESHandle<StackedTrackerGeometry>           stackedGeometryHandle;
+  const StackedTrackerGeometry*                   theStackedGeometry;
+  StackedTrackerGeometry::StackContainerIterator  StackedTrackerIterator;
+  
+  /// Geometry setup
+  /// Set pointers to Geometry
+  iSetup.get<TrackerDigiGeometryRecord>().get(geometryHandle);
+  //theGeometry = &(*geometryHandle);
+  /// Set pointers to Stacked Modules
+  iSetup.get<StackedTrackerGeometryRecord>().get(stackedGeometryHandle);
+  theStackedGeometry = stackedGeometryHandle.product(); 
+  
+  ////////////////////////
+  // GET MAGNETIC FIELD //
+  edm::ESHandle<MagneticField> magneticFieldHandle;
+  iSetup.get<IdealMagneticFieldRecord>().get(magneticFieldHandle);
+  const MagneticField* theMagneticField = magneticFieldHandle.product();
+  double mMagneticFieldStrength = theMagneticField->inTesla(GlobalPoint(0,0,0)).z();
+  if ( mMagneticFieldStrength < 0) std::cout << "mMagneticFieldStrength < 0 " << std::endl;  // for compil when not used
+
+
+
+  edm::Handle<L1TkTrackCollectionType> L1TkTrackHandle;
+  //iEvent.getByLabel("L1Tracks","Level1TkTracks",L1TkTrackHandle);
+ iEvent.getByLabel(L1TrackInputTag, L1TkTrackHandle);   
+
+
+ if( !L1TkTrackHandle.isValid() )
+        {
+          LogError("L1TkPrimaryVertexProducer")
+            << "\nWarning: L1TkTrackCollection with " << L1TrackInputTag
+            << "\nrequested in configuration, but not found in the event. Exit"
+            << std::endl;
+ 	    return;
+        }
+
+
+
+   float sum1 = -999;
+   int nmin = nStubsmin;
+   int nPSmin = nStubsPSmin ;
+   float ptmin = PTMINTRA ;
+   int imode = 2;	// max(Sum PT2)
+   if (! SumPtSquared)  imode = 1;   // max(Sum PT)
+
+   float z1 = MaxPtVertex( L1TkTrackHandle, sum1, nmin, nPSmin, ptmin, imode, theStackedGeometry );
+   L1TkPrimaryVertex vtx1( z1, sum1 );
+
+ result -> push_back( vtx1 );
+
+ iEvent.put( result);
+}
+
+
+float L1TkPrimaryVertexProducer::MaxPtVertex(const edm::Handle<L1TkTrackCollectionType> & L1TkTrackHandle,
+ 		float& Sum,
+		int nmin, int nPSmin, float ptmin, int imode,
+		const StackedTrackerGeometry*                   theStackedGeometry) {
+        // return the zvtx corresponding to the max(SumPT)
+        // of tracks with at least nPSmin stubs in PS modules
+   
+      float sumMax = 0;
+      float zvtxmax = -999;
+      int nIter = (int)(ZMAX * 10. * 2.) ;
+      for (int itest = 0; itest <= nIter; itest ++) {
+	
+        //float z = -100 + itest;         // z in mm
+	float z = -ZMAX * 10 + itest ;  	// z in mm
+        z = z/10.  ;   // z in cm
+        float sum = SumPtVertex(L1TkTrackHandle, z, nmin, nPSmin, ptmin, imode, theStackedGeometry);
+        if (sumMax >0 && sum == sumMax) {
+          //cout << " Note: Several vertices have the same sum " << zvtxmax << " " << z << " " << sumMax << endl;
+        }
+   
+        if (sum > sumMax) {
+           sumMax = sum;
+           zvtxmax = z;
+        }
+       }  // end loop over tested z 
+   
+ Sum = sumMax;
+ return zvtxmax;
+}  
+
+
+float L1TkPrimaryVertexProducer::SumPtVertex(const edm::Handle<L1TkTrackCollectionType> & L1TkTrackHandle,
+		float z, int nmin, int nPSmin, float ptmin, int imode,
+		const StackedTrackerGeometry*                   theStackedGeometry) {
+
+        // sumPT of tracks with >= nPSmin stubs in PS modules
+        // z in cm
+ float sumpt = 0;
+
+
+  L1TkTrackCollectionType::const_iterator trackIter;
+
+  for (trackIter = L1TkTrackHandle->begin(); trackIter != L1TkTrackHandle->end(); ++trackIter) {
+
+    float pt = trackIter->getMomentum().perp();
+    float chi2 = trackIter->getChi2();
+    float ztr  = trackIter->getPOCA().z();
+
+    if (pt < ptmin) continue;
+    if (fabs(ztr) > ZMAX ) continue;
+    if (chi2 > CHI2MAX) continue;
+    if ( fabs(ztr - z) > DeltaZ) continue;   // eg DeltaZ = 1 mm
+
+
+	// get the number of stubs and the number of stubs in PS layers
+    float nPS = 0.;     // number of stubs in PS modules
+    float nstubs = 0;
+
+      // get pointers to stubs associated to the L1 track
+      std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_PixelDigi_ > >, TTStub< Ref_PixelDigi_ > > >  theStubs = trackIter -> getStubRefs() ;
+
+      int tmp_trk_nstub = (int) theStubs.size();
+      if ( tmp_trk_nstub < 0) {
+	std::cout << " ... could not retrieve the vector of stubs in L1TkPrimaryVertexProducer::SumPtVertex " << std::endl;
+	continue;
+      }
+
+      // loop over the stubs
+      for (unsigned int istub=0; istub<(unsigned int)theStubs.size(); istub++) {
+        //bool genuine = theStubs.at(istub)->isGenuine();
+        //if (genuine) {
+           nstubs ++;
+           StackedTrackerDetId detIdStub( theStubs.at(istub)->getDetId() );
+           bool isPS = theStackedGeometry -> isPSModule( detIdStub );
+           //if (isPS) cout << " this is a stub in a PS module " << endl;
+           if (isPS) nPS ++;
+	//} // endif genuine
+       } // end loop over stubs
+
+        if (imode == 1 || imode == 2 ) {
+            if (nPS < nPSmin) continue;
+        }
+	if ( nstubs < nmin) continue;
+
+        if (imode == 2) sumpt += pt*pt;
+        if (imode == 1) sumpt += pt;
+
+  } // end loop over the tracks
+
+ return sumpt;
+
+}
+
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+L1TkPrimaryVertexProducer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+L1TkPrimaryVertexProducer::endJob() {
+}
+
+// ------------ method called when starting to processes a run  ------------
+void
+L1TkPrimaryVertexProducer::beginRun(edm::Run& iRun, edm::EventSetup const& iSetup)
+{
+
+
+}
+ 
+// ------------ method called when ending the processing of a run  ------------
+/*
+void
+L1TkPrimaryVertexProducer::endRun(edm::Run&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void
+L1TkPrimaryVertexProducer::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void
+L1TkPrimaryVertexProducer::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+L1TkPrimaryVertexProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TkPrimaryVertexProducer);

--- a/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1TkTauFromCalo.cc
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/plugins/L1TkTauFromCalo.cc
@@ -1,0 +1,281 @@
+// -*- C++ -*-
+//
+//
+// dummy producer for a L1TkTauParticle
+// The code simply match the L1CaloTaus with the closest L1Track.
+// 
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkTauParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkTauParticleFwd.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkPrimaryVertex.h"
+
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+
+// for L1Tracks:
+//#include "SimDataFormats/SLHC/interface/StackedTrackerTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
+#include <string>
+#include "TMath.h"
+
+
+using namespace l1extra ;
+
+//
+// class declaration
+//
+
+class L1TkTauFromCaloProducer : public edm::EDProducer {
+   public:
+
+   typedef TTTrack< Ref_PixelDigi_ >  L1TkTrackType;
+   typedef std::vector< L1TkTrackType >  L1TkTrackCollectionType;
+
+      explicit L1TkTauFromCaloProducer(const edm::ParameterSet&);
+      ~L1TkTauFromCaloProducer();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+   private:
+      virtual void beginJob() ;
+      virtual void produce(edm::Event&, const edm::EventSetup&);
+      virtual void endJob() ;
+
+      //virtual void beginRun(edm::Run&, edm::EventSetup const&);
+      //virtual void endRun(edm::Run&, edm::EventSetup const&);
+      //virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+      //virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
+
+      // ----------member data ---------------------------
+	
+	 //edm::InputTag L1PLInputTag;  // inputTag for PierLuigi's objects
+
+	 edm::InputTag L1TausInputTag;
+	 edm::InputTag L1TrackInputTag;	 
+
+        float ZMAX;             // |z_track| < ZMAX in cm
+        float CHI2MAX;
+        float PTMINTRA;
+        float DRmax;
+
+        int nStubsmin ;         // minimum number of stubs 
+
+	bool closest ;
+
+
+} ;
+
+
+//
+// constructors and destructor
+//
+L1TkTauFromCaloProducer::L1TkTauFromCaloProducer(const edm::ParameterSet& iConfig)
+{
+
+   L1TausInputTag = iConfig.getParameter<edm::InputTag>("L1TausInputTag");
+   L1TrackInputTag = iConfig.getParameter<edm::InputTag>("L1TrackInputTag");
+
+   ZMAX = (float)iConfig.getParameter<double>("ZMAX");
+   CHI2MAX = (float)iConfig.getParameter<double>("CHI2MAX");
+   PTMINTRA = (float)iConfig.getParameter<double>("PTMINTRA");
+   DRmax = (float)iConfig.getParameter<double>("DRmax");
+   nStubsmin = iConfig.getParameter<int>("nStubsmin");
+
+   produces<L1TkTauParticleCollection>();
+}
+
+L1TkTauFromCaloProducer::~L1TkTauFromCaloProducer() {
+}
+
+// ------------ method called to produce the data  ------------
+void
+L1TkTauFromCaloProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+   using namespace std;
+
+
+ std::auto_ptr<L1TkTauParticleCollection> result(new L1TkTauParticleCollection);
+
+ // dummy code. I loop over the L1Taus and pick up the L1Track that is closest
+ // in DeltaR.
+
+  edm::Handle< vector<l1extra::L1JetParticle>  > TauHandle;
+  iEvent.getByLabel(L1TausInputTag,TauHandle);
+  vector<l1extra::L1JetParticle>::const_iterator l1TauIter;
+
+ edm::Handle<L1TkTrackCollectionType> L1TkTrackHandle;
+ iEvent.getByLabel(L1TrackInputTag, L1TkTrackHandle);
+ L1TkTrackCollectionType::const_iterator trackIter;
+
+
+  int itau = 0;
+  for (l1TauIter = TauHandle->begin(); l1TauIter != TauHandle->end(); ++l1TauIter) {
+
+    edm::Ref< L1JetParticleCollection > tauCaloRef( TauHandle, itau );
+    itau ++;
+
+        float drmin = 999;
+
+      float eta = l1TauIter -> eta();
+      float phi = l1TauIter -> phi();
+
+      int bx = l1TauIter -> bx() ;
+      if (bx != 0 ) continue;
+
+	// match the L1Taus with L1Tracks
+
+        int itr = -1;
+        int itrack = -1;
+        for (trackIter = L1TkTrackHandle->begin(); trackIter != L1TkTrackHandle->end(); ++trackIter) {
+	   itr ++ ;
+           float Pt = trackIter->getMomentum().perp();
+           float z  = trackIter->getPOCA().z();
+           if (fabs(z) > ZMAX) continue;
+           if (Pt < PTMINTRA) continue;
+           float chi2 = trackIter->getChi2();
+           if (chi2 > CHI2MAX) continue;
+
+	   std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_PixelDigi_ > >, TTStub< Ref_PixelDigi_ > > >  theStubs = trackIter -> getStubRefs() ;
+
+      	   int tmp_trk_nstub = (int) theStubs.size();
+      	   if ( tmp_trk_nstub < nStubsmin) continue;
+
+                float Eta = trackIter->getMomentum().eta();
+                float Phi = trackIter->getMomentum().phi();
+                float deta = eta - Eta;
+                float dphi = phi - Phi;
+                if (dphi < 0) dphi = dphi + 2.*TMath::Pi();
+                if (dphi > TMath::Pi()) dphi = 2.*TMath::Pi() - dphi;
+                float dR = sqrt( deta*deta + dphi*dphi );
+
+			// take the closest track:
+                if (dR < drmin) {
+                  drmin = dR;
+                  itrack = itr;
+                }
+
+        }  // end loop over the tracks
+
+        if (drmin < DRmax ) {     // found a L1Track matched to the L1Tau object
+
+            edm::Ptr< L1TkTrackType > L1TrackPtr( L1TkTrackHandle, itrack) ;
+
+            float px = L1TrackPtr -> getMomentum().x();
+            float py = L1TrackPtr -> getMomentum().y();
+            float pz = L1TrackPtr -> getMomentum().z(); 
+            float e = sqrt( px*px + py*py + pz*pz );    // massless particle
+            math::XYZTLorentzVector TrackP4(px,py,pz,e);
+		// TrackP4 should be the 4-vector of what you define
+		// as the tau kinematics. Here I just pick up the PT of
+		// the matched track and set m=0. That's certainly no what you would 
+		// do e.g. for a 3-prong decay !
+            
+            float trkisol = -999;       // dummy
+            
+	    edm::Ptr< L1TkTrackType > L1TrackPtrNull2;     //  null pointer
+            edm::Ptr< L1TkTrackType > L1TrackPtrNull3;     //  null pointer
+
+            L1TkTauParticle trkTau( TrackP4,
+                                 tauCaloRef,
+                                 L1TrackPtr,
+				 L1TrackPtrNull2,
+				 L1TrackPtrNull3,
+                                 trkisol );
+
+	    //trkMu.setDeltaR ( drmin ) ;
+            
+            result -> push_back( trkTau );
+
+        
+         }  // endif drmin < DRmax
+
+
+   }  // end loop over the L1Taus
+
+ iEvent.put( result );
+
+}
+
+// --------------------------------------------------------------------------------------
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void
+L1TkTauFromCaloProducer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void
+L1TkTauFromCaloProducer::endJob() {
+}
+
+// ------------ method called when starting to processes a run  ------------
+/*
+void
+L1TkTauFromCaloProducer::beginRun(edm::Run& iRun, edm::EventSetup const& iSetup)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a run  ------------
+/*
+void
+L1TkTauFromCaloProducer::endRun(edm::Run&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void
+L1TkTauFromCaloProducer::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void
+L1TkTauFromCaloProducer::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+L1TkTauFromCaloProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TkTauFromCaloProducer);
+
+
+

--- a/SLHCUpgradeSimulations/L1TrackTrigger/python/L1TkElectronTrackProducer_cfi.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/python/L1TkElectronTrackProducer_cfi.py
@@ -1,0 +1,36 @@
+import FWCore.ParameterSet.Config as cms
+
+L1TkElectrons = cms.EDProducer("L1TkElectronTrackProducer",
+	label = cms.string("EG"),	# labels the collection of L1TkEmParticleProducer that is produced.
+					# (not really needed actually)
+        L1EGammaInputTag = cms.InputTag("SLHCL1ExtraParticlesNewClustering","EGamma"),      # input EGamma collection
+					# When the standard sequences are used :
+                                                #   - for the Run-1 algo, use ("l1extraParticles","NonIsolated")
+                                                #     or ("l1extraParticles","Isolated")
+                                                #   - for the "old stage-2" algo (2x2 clustering), use 
+                                                #     ("SLHCL1ExtraParticles","EGamma") or ("SLHCL1ExtraParticles","IsoEGamma")
+                                                #   - for the new clustering algorithm of Jean-Baptiste et al,
+                                                #     use ("SLHCL1ExtraParticlesNewClustering","IsoEGamma") or
+                                                #     ("SLHCL1ExtraParticlesNewClustering","EGamma").
+        ETmin = cms.double( -1.0 ),             # Only the L1EG objects that have ET > ETmin in GeV
+                                                # are considered. ETmin < 0 means that no cut is applied.
+     	L1TrackInputTag = cms.InputTag("TTTracksFromPixelDigis","Level1TTTracks"),
+        # Quality cuts on Track and Track L1EG matching criteria                                
+        TrackChi2           = cms.double(100.0), # minimum Chi2 to select tracks
+        TrackMinPt          = cms.double(12.0), # minimum Pt to select tracks                                     
+        TrackEGammaDeltaPhi = cms.double(0.05), # Delta Phi cutoff to match Track with L1EG objects
+        TrackEGammaDeltaR = cms.double(0.08),   # Delta R cutoff to match Track with L1EG objects
+        TrackEGammaDeltaEta = cms.double(0.08), # Delta Eta cutoff to match Track with L1EG objects
+                                                # are considered. 
+	RelativeIsolation = cms.bool( True ),	# default = True. The isolation variable is relative if True,
+						# else absolute.
+        IsoCut = cms.double( -0.15 ), 		# Cut on the (Trk-based) isolation: only the L1TkEmParticle for which
+                                                # the isolation is below RelIsoCut are written into
+                                                # the output collection. When RelIsoCut < 0, no cut is applied.
+						# When RelativeIsolation = False, IsoCut is in GeV.
+        # Determination of the isolation w.r.t. L1Tracks :
+        PTMINTRA = cms.double( 2. ),	# in GeV
+	DRmin = cms.double( 0.03),
+	DRmax = cms.double( 0.2 ),
+	DeltaZ = cms.double( 0.6 )    # in cm. Used for tracks to be used isolation calculation
+)

--- a/SLHCUpgradeSimulations/L1TrackTrigger/python/L1TkEmParticleProducer_cfi.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/python/L1TkEmParticleProducer_cfi.py
@@ -1,0 +1,36 @@
+import FWCore.ParameterSet.Config as cms
+
+L1TkPhotons = cms.EDProducer("L1TkEmParticleProducer",
+        label = cms.string("EG"), 	# labels the collection of L1TkEmParticleProducer that is produced
+					# (not really needed actually)
+        L1EGammaInputTag = cms.InputTag("SLHCL1ExtraParticlesNewClustering","EGamma"),      # input L1EG collection
+                                                # When the standard sequences are used :
+                                                #   - for the Run-1 algo, use ("l1extraParticles","NonIsolated")
+                                                #     or ("l1extraParticles","Isolated")
+                                                #   - for the "old stage-2" algo (2x2 clustering), use 
+                                                #     ("SLHCL1ExtraParticles","EGamma") or ("SLHCL1ExtraParticles","IsoEGamma")
+                                                #   - for the new clustering algorithm of Jean-Baptiste et al,
+                                                #     use ("SLHCL1ExtraParticlesNewClustering","IsoEGamma") or
+                                                #     ("SLHCL1ExtraParticlesNewClustering","EGamma").
+        ETmin = cms.double( -1 ),               # Only the L1EG objects that have ET > ETmin in GeV
+                                                # are considered. ETmin < 0 means that no cut is applied.
+        RelativeIsolation = cms.bool( True ),   # default = True. The isolation variable is relative if True,
+                                                # else absolute.
+        IsoCut = cms.double( 0.1 ),             # Cut on the (Trk-based) isolation: only the L1TkEmParticle for which
+                                                # the isolation is below RelIsoCut are written into
+                                                # the output collection. When RelIsoCut < 0, no cut is applied.
+                                                # When RelativeIsolation = False, IsoCut is in GeV.
+           # Determination of the isolation w.r.t. L1Tracks :
+        L1TrackInputTag = cms.InputTag("TTTracksFromPixelDigis","Level1TTTracks"),
+        ZMAX = cms.double( 25. ),       # in cm
+        CHI2MAX = cms.double( 100. ),
+        PTMINTRA = cms.double( 2. ),    # in GeV
+        DRmin = cms.double( 0.07),
+        DRmax = cms.double( 0.30 ),
+        PrimaryVtxConstrain = cms.bool( False ),  # default = False
+						  # if set to True, the L1TkPrimaryVertex is used to constrain
+						  # the tracks entering in the calculation of the isolatiom.
+        DeltaZMax = cms.double( 999. ),    # in cm. Used only when PrimaryVtxConstrain = True
+        L1VertexInputTag = cms.InputTag("NotUsed"),     # Used only when PrimaryVtxConstrain = True
+)
+

--- a/SLHCUpgradeSimulations/L1TrackTrigger/python/L1TkEtMissProducer_cfi.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/python/L1TkEtMissProducer_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+L1TkEtMiss = cms.EDProducer('L1TkEtMissProducer',
+     L1TrackInputTag = cms.InputTag("TTTracksFromPixelDigis","Level1TTTracks"),
+     L1VertexInputTag = cms.InputTag("L1TkPrimaryVertex"),
+     ZMAX = cms.double ( 25. ) ,        # in cm
+     CHI2MAX = cms.double( 100. ),
+     PTMINTRA = cms.double( 2. ),       # in GeV
+     DeltaZ = cms.double( 1. ),       # in cm
+     nStubsmin = cms.int32( 4 ),      # min number of stubs for the tracks to enter in TrkMET calculation
+     nStubsPSmin = cms.int32( 0)      # min number of stubs in the PS Modules
+)
+
+

--- a/SLHCUpgradeSimulations/L1TrackTrigger/python/L1TkMuonProducer_cfi.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/python/L1TkMuonProducer_cfi.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+L1TkMuons = cms.EDProducer("L1TkMuonParticleProducer",
+        L1MuonsInputTag = cms.InputTag("l1extraParticles"),
+        L1TrackInputTag = cms.InputTag("TTTracksFromPixelDigis","Level1TTTracks"),
+        ETAMIN = cms.double(0),
+        ETAMAX = cms.double(5.),        # no cut
+        ZMAX = cms.double( 25. ),       # in cm
+        CHI2MAX = cms.double( 100. ),
+        PTMINTRA = cms.double( 2. ),    # in GeV
+        DRmax = cms.double( 0.5 ),
+        nStubsmin = cms.int32( 5 ),        # minimum number of stubs
+        closest = cms.bool( True )
+)
+

--- a/SLHCUpgradeSimulations/L1TrackTrigger/python/L1TkPrimaryVertexProducer_cfi.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/python/L1TkPrimaryVertexProducer_cfi.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+L1TkPrimaryVertex = cms.EDProducer('L1TkPrimaryVertexProducer',
+     L1TrackInputTag = cms.InputTag("TTTracksFromPixelDigis","Level1TTTracks"),
+     ZMAX = cms.double ( 25. ) ,        # in cm
+     CHI2MAX = cms.double( 100. ),
+     DeltaZ = cms.double( 0.1 ),        # in cm.   
+     PTMINTRA = cms.double( 2.),        # PTMIN of L1Tracks, in GeV
+     nStubsmin = cms.int32( 4 ) ,       # minimum number of stubs
+     nStubsPSmin = cms.int32( 3 ),      # minimum number of stubs in PS modules 
+     SumPtSquared = cms.bool( True )    # maximizes SumPT^2 or SumPT
+)
+

--- a/SLHCUpgradeSimulations/L1TrackTrigger/src/L1TkElectronTrackMatchAlgo.cc
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/src/L1TkElectronTrackMatchAlgo.cc
@@ -1,0 +1,109 @@
+// -*- C++ -*-
+//
+// Package:    L1TrackTrigger
+// Class:      L1TkElectronTrackMatchAlgo
+// 
+/**\class L1TkElectronTrackMatchAlgo 
+
+ Description: Algorithm to match L1EGamma oject with L1Track candidates
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  S. Dutta and A. Modak
+//         Created:  Wed Dec 4 12 11:55:35 CET 2013
+// $Id$
+//
+//
+
+
+// system include files
+#include <memory>
+#include <cmath>
+
+#include "DataFormats/Math/interface/deltaPhi.h"
+#include "SLHCUpgradeSimulations/L1TrackTrigger/interface/L1TkElectronTrackMatchAlgo.h"
+namespace L1TkElectronTrackMatchAlgo {
+  // ------------ match EGamma and Track
+  void doMatch(l1extra::L1EmParticleCollection::const_iterator egIter, const edm::Ptr< L1TkTrackType > & pTrk, double& dph, double&  dr, double& deta) {
+    GlobalPoint egPos = L1TkElectronTrackMatchAlgo::calorimeterPosition(egIter->phi(), egIter->eta(), egIter->energy());
+    dph  = L1TkElectronTrackMatchAlgo::deltaPhi(egPos, pTrk);
+    dr   = L1TkElectronTrackMatchAlgo::deltaR(egPos, pTrk);
+    deta = L1TkElectronTrackMatchAlgo::deltaEta(egPos, pTrk);
+  }
+  // ------------ match EGamma and Track
+  void doMatch(const GlobalPoint& epos, const edm::Ptr< L1TkTrackType > & pTrk, double& dph, double&  dr, double& deta) {
+    dph  = L1TkElectronTrackMatchAlgo::deltaPhi(epos, pTrk);
+    dr   = L1TkElectronTrackMatchAlgo::deltaR(epos, pTrk);
+    deta = L1TkElectronTrackMatchAlgo::deltaEta(epos, pTrk);
+  }
+  // --------------- calculate deltaR between Track and EGamma object
+  double deltaPhi(const GlobalPoint& epos, const edm::Ptr< L1TkTrackType > & pTrk){
+    double er = epos.perp();
+
+    // Using track fit curvature
+    //  double curv = 0.003 * magnetStrength * trk->getCharge()/ trk->getMomentum().perp(); 
+    double curv = pTrk->getRInv();
+    double x1 = (asin(er*curv/(2.0)));
+    double phi1 = reco::deltaPhi(pTrk->getMomentum().phi(), epos.phi());
+
+    double dif1 = phi1 - x1;
+    double dif2 = phi1 + x1; 
+
+    if (fabs(dif1) < fabs(dif2)) return dif1;
+    else return dif2; 
+  
+  }
+// --------------- calculate deltaPhi between Track and EGamma object                 
+  double deltaR(const GlobalPoint& epos, const edm::Ptr< L1TkTrackType > & pTrk){
+    double dPhi = fabs(reco::deltaPhi(epos.phi(), pTrk->getMomentum().phi()));
+    double dEta = deltaEta(epos, pTrk);
+    return sqrt(dPhi*dPhi + dEta*dEta);
+  }
+  // --------------- calculate deltaEta between Track and EGamma object                 
+  double deltaEta(const GlobalPoint& epos, const edm::Ptr< L1TkTrackType > & pTrk){
+    double corr_eta = 999.0;
+    double er = epos.perp();
+    double ez = epos.z();
+    double z0 = pTrk->getPOCA().z()  ;
+    double theta = 0.0;
+    if (ez >= 0) theta = atan(er/fabs(ez-z0));
+    else theta = M_PI - atan(er/fabs(ez-z0));
+    corr_eta = -1.0 * log(tan(theta/2.0));
+    double deleta = (corr_eta - pTrk->getMomentum().eta());
+    return deleta;
+  }
+  // -------------- get Calorimeter position
+  GlobalPoint calorimeterPosition(double phi, double eta, double e) {
+    double x = 0.; 
+    double y = 0.;
+    double z = 0.;
+    double depth = 0.89*(7.7+ log(e) );
+    double theta = 2*atan(exp(-1*eta));
+    double r = 0;
+    if( fabs(eta) > 1.479 ) 
+      { 
+	double ecalZ = 315.4*fabs(eta)/eta;
+	
+	r = ecalZ / cos( 2*atan( exp( -1*eta ) ) ) + depth;
+	x = r * cos( phi ) * sin( theta );
+	y = r * sin( phi ) * sin( theta );
+	z = r * cos( theta );
+      }
+    else
+      {
+	double rperp = 129.0;
+	double zface =  sqrt( cos( theta ) * cos( theta ) /
+			     ( 1 - cos( theta ) * cos( theta ) ) * 
+			     rperp * rperp ) * fabs( eta ) / eta;  
+	r = sqrt( rperp * rperp + zface * zface ) + depth;
+	x = r * cos( phi ) * sin( theta );
+	y = r * sin( phi ) * sin( theta );
+	z = r * cos( theta );
+      }
+    GlobalPoint pos(x,y,z);
+    return pos;
+  }
+
+}

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/BuildFile.xml
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/BuildFile.xml
@@ -41,6 +41,8 @@
     <use   name="CondFormats/DataRecord"/>
     <use   name="RecoTauTag/TauTagTools"/>
     <use   name="RecoTracker/TkSeedGenerator"/>
+<use name="DataFormats/L1TrackTrigger"/>
+  <use   name="CommonTools/UtilAlgos"/>
     <flags   CXXFLAGS="-g -O0"/>
   </library>
 </environment>

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/L1TrackTriggerObjectsAnalyzer.cc
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/L1TrackTriggerObjectsAnalyzer.cc
@@ -1,0 +1,429 @@
+// -*- C++ -*-
+//
+// Package:    L1TrackTriggerObjectsAnalyzer
+// Class:      L1TrackTriggerObjectsAnalyzer
+// 
+/**\class L1TrackTriggerObjectsAnalyzer L1TrackTriggerObjectsAnalyzer.cc SLHCUpgradeSimulations/L1TrackTriggerObjectsAnalyzer/src/L1TrackTriggerObjectsAnalyzer.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Emmanuelle Perez,40 1-A28,+41227671915,
+//         Created:  Thu Nov 14 11:22:13 CET 2013
+// $Id$
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+
+// Gen-level stuff:
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+
+#include "DataFormats/L1TrackTrigger/interface/L1TkPrimaryVertex.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkEtMissParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkEtMissParticleFwd.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkEmParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkEmParticleFwd.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkElectronParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkElectronParticleFwd.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkJetParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkJetParticleFwd.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkHTMissParticle.h"
+#include "DataFormats/L1TrackTrigger/interface/L1TkHTMissParticleFwd.h"
+
+#include "TFile.h"
+#include "TH1F.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+
+using namespace l1extra;
+
+
+
+//
+// class declaration
+//
+
+class L1TrackTriggerObjectsAnalyzer : public edm::EDAnalyzer {
+   public:
+
+   typedef TTTrack< Ref_PixelDigi_ >  L1TkTrackType;
+   typedef std::vector< L1TkTrackType >  L1TkTrackCollectionType;
+
+      explicit L1TrackTriggerObjectsAnalyzer(const edm::ParameterSet&);
+      ~L1TrackTriggerObjectsAnalyzer();
+
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+
+   private:
+      virtual void beginJob() ;
+      virtual void analyze(const edm::Event&, const edm::EventSetup&);
+      virtual void endJob() ;
+
+      //virtual void beginRun(edm::Run const&, edm::EventSetup const&);
+      //virtual void endRun(edm::Run const&, edm::EventSetup const&);
+      //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+      //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+
+      // ----------member data ---------------------------
+
+	// to test the L1TkPrimaryVertex :
+	edm::InputTag L1VtxInputTag;
+
+	// for L1TrackEtmiss:
+	edm::InputTag L1TkEtMissInputTag;
+
+	// for L1TkEmParticles
+        edm::InputTag L1TkPhotonsInputTag;
+	edm::InputTag L1TkElectronsInputTag;
+
+	// for L1TkJetParticles
+        edm::InputTag L1TkJetsInputTag;
+
+	// for L1TkHTMParticle
+	edm::InputTag L1TkHTMInputTag;
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+L1TrackTriggerObjectsAnalyzer::L1TrackTriggerObjectsAnalyzer(const edm::ParameterSet& iConfig)
+
+{
+   //now do what ever initialization is needed
+
+  L1VtxInputTag = iConfig.getParameter<edm::InputTag>("L1VtxInputTag") ;
+  L1TkEtMissInputTag = iConfig.getParameter<edm::InputTag>("L1TkEtMissInputTag");
+  L1TkElectronsInputTag = iConfig.getParameter<edm::InputTag>("L1TkElectronsInputTag");
+  L1TkPhotonsInputTag = iConfig.getParameter<edm::InputTag>("L1TkPhotonsInputTag");
+  L1TkJetsInputTag = iConfig.getParameter<edm::InputTag>("L1TkJetsInputTag");
+  L1TkHTMInputTag = iConfig.getParameter<edm::InputTag>("L1TkHTMInputTag");
+}
+
+
+L1TrackTriggerObjectsAnalyzer::~L1TrackTriggerObjectsAnalyzer()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called for each event  ------------
+void
+L1TrackTriggerObjectsAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+
+   std::cout << " ----  a new event ----- " << std::endl;
+
+	// First, retrieve the generated primary vertex
+
+
+  edm::Handle<edm::HepMCProduct> HepMCEvt;
+  iEvent.getByLabel("generator",HepMCEvt);
+
+     const HepMC::GenEvent* MCEvt = HepMCEvt->GetEvent();
+     const double mm=0.1;
+
+     float zvtx_gen = -999;
+     for ( HepMC::GenEvent::vertex_const_iterator ivertex = MCEvt->vertices_begin(); ivertex != MCEvt->vertices_end(); ++ivertex )
+         {
+             bool hasParentVertex = false;
+ 
+             // Loop over the parents looking to see if they are coming from a production vertex
+             for (
+                 HepMC::GenVertex::particle_iterator iparent = (*ivertex)->particles_begin(HepMC::parents);
+                 iparent != (*ivertex)->particles_end(HepMC::parents);
+                 ++iparent
+             )
+                 if ( (*iparent)->production_vertex() )
+                 {
+                     hasParentVertex = true;
+                     break;
+                }
+ 
+             // Reject those vertices with parent vertices
+             if (hasParentVertex) continue;
+ 
+             // Get the position of the vertex
+             HepMC::FourVector pos = (*ivertex)->position();
+	     zvtx_gen = pos.z()*mm; 
+
+	     break;  // there should be one single primary vertex
+
+          }  // end loop over gen vertices
+
+     std::cout << " Generated zvertex : " << zvtx_gen << std::endl;
+
+
+
+	// ----------------------------------------------------------------------
+	//
+        // retrieve the L1 vertices
+        
+ edm::Handle<L1TkPrimaryVertexCollection> L1VertexHandle;
+ iEvent.getByLabel(L1VtxInputTag,L1VertexHandle);
+ std::vector<L1TkPrimaryVertex>::const_iterator vtxIter;
+ 
+ if ( L1VertexHandle.isValid() ) {
+     std::cout << " -----  L1TkPrimaryVertex objects   ----- " << std::endl;
+     int ivtx = 0;
+	// several algorithms have been run in the L1TkPrimaryVertexProducer
+	// hence there is a collection of L1 primary vertices.
+	// the first one is probably the most reliable.
+
+     for (vtxIter = L1VertexHandle->begin(); vtxIter != L1VertexHandle->end(); ++vtxIter) {
+        float z = vtxIter -> getZvertex();
+        float sum = vtxIter -> getSum();
+        std::cout << " a vertex with  z = sum " << z << " " << sum << std::endl;
+        ivtx ++;
+     }  
+ }
+
+	//
+        // ----------------------------------------------------------------------
+	// retrieve the EtMiss objects
+	//
+
+ edm::Handle<L1TkEtMissParticleCollection> L1TkEtMissHandle;
+ iEvent.getByLabel(L1TkEtMissInputTag, L1TkEtMissHandle);
+ std::vector<L1TkEtMissParticle>::const_iterator etmIter;
+
+ if (L1TkEtMissHandle.isValid() ) {
+    std::cout << " -----  L1TkEtMiss objects  -----  " << std::endl; 
+    for (etmIter = L1TkEtMissHandle -> begin(); etmIter != L1TkEtMissHandle->end(); ++etmIter) {
+	float etmis = etmIter -> et();
+	const edm::Ref< L1TkPrimaryVertexCollection > vtxRef = etmIter -> getVtxRef();
+	float zvtx = vtxRef -> getZvertex();
+        float etMissPU = etmIter -> etMissPU();
+	std::cout << " ETmiss = " << etmis << " for zvtx = " << zvtx << " and ETmiss from PU = " << etMissPU << std::endl;
+    }
+ }
+
+
+        //
+        // ----------------------------------------------------------------------
+        // retrieve the L1TkJetParticle objects
+        //
+        
+ edm::Handle<L1TkJetParticleCollection> L1TkJetsHandle;
+ iEvent.getByLabel(L1TkJetsInputTag, L1TkJetsHandle);
+ std::vector<L1TkJetParticle>::const_iterator jetIter ;
+
+ if ( L1TkJetsHandle.isValid() ) {
+    std::cout << " -----   L1TkJetParticle  objects -----  " << std::endl;
+    for (jetIter = L1TkJetsHandle -> begin(); jetIter != L1TkJetsHandle->end(); ++jetIter) {
+        float et = jetIter -> pt();
+        float phi = jetIter -> phi();
+        float eta = jetIter -> eta();
+        int bx = jetIter -> bx() ;
+	float jetvtx = jetIter -> getJetVtx();
+        const edm::Ref< L1JetParticleCollection > Jetref = jetIter -> getJetRef();
+        float et_L1Jet = Jetref -> et();
+	L1JetParticle::JetType type = Jetref -> type();
+
+        std::cout << " a Jet candidate ET eta phi zvertex " << et << " " << eta << " " << phi << " " << jetvtx  << std::endl;
+        std::cout << "                Calo  ET, typ " << et_L1Jet << " " << type << std::endl;
+        std::cout << "                bx = " << bx << std::endl;
+    }
+ }
+
+        //
+        // ----------------------------------------------------------------------
+        // retrieve HT and HTM
+	//
+
+ edm::Handle<L1TkHTMissParticleCollection> L1TkHTMHandle;
+ iEvent.getByLabel(L1TkHTMInputTag, L1TkHTMHandle);
+
+ if ( L1TkHTMHandle.isValid() ) {
+	std::cout << " -----  L1TkHTMissParticle: size (should be 1) = " << L1TkHTMHandle -> size() << std::endl;
+	std::vector<L1TkHTMissParticle>::const_iterator HTMIter = L1TkHTMHandle -> begin();
+	float HTT = HTMIter -> EtTotal();
+	float HTM = HTMIter -> EtMiss();
+	//float HTM_the_same = HTMIter -> et();
+
+	// phi of the HTM vector :
+	float phi = HTMIter -> phi();
+	std::cout << " HTT = " << HTT << " HTM = " << HTM << " " << "phi(HTM) = " << phi << std::endl;
+	 
+	// access the L1TkJets used to build HT and HTM :
+	const edm::RefProd< L1TkJetParticleCollection > jetCollRef = HTMIter -> getjetCollectionRef();
+ 	std::vector<L1TkJetParticle>::const_iterator jet = jetCollRef -> begin();
+	std::cout << " ET of the first L1TkJet = " << jet -> et() << std::endl;
+ }
+ else {
+    std::cout << L1TkHTMInputTag << " is non valid." << std::endl;
+ }
+
+
+        //
+        // ----------------------------------------------------------------------
+        // retrieve the L1TkEmParticle objects
+	//
+
+ edm::Handle<L1TkEmParticleCollection> L1TkPhotonsHandle;
+ iEvent.getByLabel(L1TkPhotonsInputTag, L1TkPhotonsHandle);
+ std::vector<L1TkEmParticle>::const_iterator phoIter ;
+
+ if ( L1TkPhotonsHandle.isValid() ) {
+    std::cout << " -----   L1TkEmParticle  objects -----  " << std::endl;
+    for (phoIter = L1TkPhotonsHandle -> begin(); phoIter != L1TkPhotonsHandle->end(); ++phoIter) {
+	float et = phoIter -> pt();
+	float phi = phoIter -> phi();
+	float eta = phoIter -> eta();
+	int bx = phoIter -> bx() ;
+        float trkisol = phoIter -> getTrkIsol() ;
+	const edm::Ref< L1EmParticleCollection > EGref = phoIter -> getEGRef();
+	float et_L1Calo = EGref -> et();
+	float eta_calo = EGref -> eta();
+	float phi_calo = EGref -> phi();
+
+	std::cout << " a photon candidate ET eta phi trkisol " << et << " " << eta << " " << phi << " " << trkisol << std::endl;
+	std::cout << "                Calo  ET eta phi " << et_L1Calo << " " << eta_calo << " " << phi_calo << std::endl; 
+	std::cout << "                bx = " << bx << std::endl;
+    }
+ }
+
+
+        //
+        // ----------------------------------------------------------------------
+        // retrieve the L1TkElectronParticle objects
+        //
+
+ edm::Handle<L1TkElectronParticleCollection> L1TkElectronsHandle;
+ iEvent.getByLabel(L1TkElectronsInputTag, L1TkElectronsHandle);
+ std::vector<L1TkElectronParticle>::const_iterator eleIter ;
+
+ if ( L1TkElectronsHandle.isValid() ) {
+    std::cout << " -----   L1TkElectronParticle  objects -----  " << std::endl;
+    for (eleIter = L1TkElectronsHandle -> begin(); eleIter != L1TkElectronsHandle->end(); ++eleIter) {
+        float et = eleIter -> pt();
+        float phi = eleIter -> phi();
+        float eta = eleIter -> eta();
+	int bx = eleIter -> bx();
+    	float trkisol = eleIter -> getTrkIsol() ;
+	float ztr = eleIter -> getTrkzVtx() ;
+        std::cout << "an electron candidate ET eta phi bx trkisol ztr " << et << " " << eta << " " << phi << " " << bx << " " << trkisol << " " << ztr << std::endl;
+
+        const edm::Ref< L1EmParticleCollection > EGref = eleIter -> getEGRef();
+        if ( EGref.isNonnull() ) {
+           float et_L1Calo = EGref -> et();
+           float eta_calo = EGref -> eta();
+           float phi_calo = EGref -> phi();
+           std::cout << "                Calo  ET eta phi " << et_L1Calo << " " << eta_calo << " " << phi_calo << std::endl;
+	}
+	else {
+	    std::cout << " .... edm::Ref to EGamma is unvalid !! ?  " << std::endl;
+	}
+
+        const edm::Ptr< L1TkTrackType > TrkRef = eleIter -> getTrkPtr();
+	if ( TrkRef.isNonnull() ) {
+            float pt_track = TrkRef -> getMomentum().perp();
+            float phi_track = TrkRef -> getMomentum().phi();
+            float eta_track = TrkRef -> getMomentum().eta();
+            float ztrack = TrkRef -> getPOCA().z();
+            std::cout << "                Track PT eta phi ztr " << pt_track << " " << eta_track << " " << phi_track << " " << ztrack << std::endl;
+	}
+	else {
+	    std::cout << " ... edm::Ptr to L1Tracks is unvalid (e.g. electron was matched to stubs) " << std::endl;
+	}
+    }
+ }
+
+
+}
+
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+L1TrackTriggerObjectsAnalyzer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+L1TrackTriggerObjectsAnalyzer::endJob() 
+{
+}
+
+// ------------ method called when starting to processes a run  ------------
+/*
+void 
+L1TrackTriggerObjectsAnalyzer::beginRun(edm::Run const&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a run  ------------
+/*
+void 
+L1TrackTriggerObjectsAnalyzer::endRun(edm::Run const&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void 
+L1TrackTriggerObjectsAnalyzer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void 
+L1TrackTriggerObjectsAnalyzer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+*/
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+L1TrackTriggerObjectsAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(L1TrackTriggerObjectsAnalyzer);

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/runL1Tracks.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/runL1Tracks.py
@@ -1,0 +1,99 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("TRA")
+
+
+#
+# This runs over a DIGI file (that contains clusters and stubs)
+# and runs the tracklet-based L1Tracking.
+# Note that the tracklet-L1Tracks are already present on the
+# DIGI produced in SLHC8 - but you may want to rerun it, to
+# benefit from the latest updates of the L1Tracking code.
+# 
+# For running over a SLHC6 DIGI file: the file must contain the
+# tracker digis (they are present by default in SLHC6 DIGI files).
+# If you run over the centrally produced files, you need to redo
+# the stubs, see below and uncomment the corresponding lines.
+#
+
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
+
+
+process.source = cms.Source("PoolSource",
+    #fileNames = singleElectronFiles
+    #fileNames = ttbarFiles_p1
+    #fileNames = cms.untracked.vstring('/store/group/comm_trigger/L1TrackTrigger/BE5D_620_SLHC6/singleMu/PU140/SingleMuMinus_BE5D_PU140.root')
+     fileNames = cms.untracked.vstring('file:/afs/cern.ch/user/e/eperez/public/step2.root')
+)
+
+
+# ---- Global Tag :
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+
+
+# ---------------------------------------------------------------------------
+#
+# ---- Run the L1Tracking :
+
+# ---- redo the stubs in case you run over a 620_SLHC6 file.
+#      Stubs were produced during the central production
+#      and are present on the DIGI files, but the "z-matching" condition
+#      was enforced. Here we redo the stubs without the z-matching.
+#      This leads to better tracking efficiencies.
+ 
+#process.load('Configuration.StandardSequences.L1TrackTrigger_cff')
+#process.pStubs = cms.Path( process.L1TkStubsFromPixelDigis )
+
+# --- now we run the L1Track producer :
+
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedGauss_cfi')
+
+process.load('Configuration.Geometry.GeometryExtendedPhase2TkBE5DReco_cff')
+process.load('Configuration.Geometry.GeometryExtendedPhase2TkBE5D_cff')
+process.load('Geometry.TrackerGeometryBuilder.StackedTrackerGeometry_cfi')
+
+process.BeamSpotFromSim =cms.EDProducer("BeamSpotFromSimProducer")
+
+process.load("SLHCUpgradeSimulations.L1TrackTrigger.L1TTrack_cfi")
+process.L1Tracks.geometry = cms.untracked.string('BE5D')
+
+process.pL1Tracks = cms.Path( process.BeamSpotFromSim*process.L1Tracks )
+
+#
+# ---------------------------------------------------------------------------
+
+
+process.Out = cms.OutputModule( "PoolOutputModule",
+    fileName = cms.untracked.string( "example_w_Tracks.root" ),
+    fastCloning = cms.untracked.bool( False ),
+    outputCommands = cms.untracked.vstring( 'drop *')
+)
+
+process.Out.outputCommands.append( 'keep *_*_*_TRA' )
+process.Out.outputCommands.append('keep *_generator_*_*')
+process.Out.outputCommands.append('keep *_*gen*_*_*')
+process.Out.outputCommands.append('keep *_*Gen*_*_*')
+process.Out.outputCommands.append('keep *_rawDataCollector_*_*')
+
+process.Out.outputCommands.append('keep *_TTStubsFromPixelDigis_ClusterAccepted_*')
+process.Out.outputCommands.append('keep *_TTClusterAssociatorFromPixelDigis_ClusterAccepted_*')
+
+process.Out.outputCommands.append('keep *_TTStubAssociatorFromPixelDigis_StubAccepted_*')
+process.Out.outputCommands.append('keep *_TTStubsFromPixelDigis_StubAccepted_*')
+
+process.Out.outputCommands.append('keep *_TTTracksFromPixelDigis_Level1TTTracks_*')
+process.Out.outputCommands.append('keep *_TTTrackAssociatorFromPixelDigis_Level1TTTracks_*')
+
+
+
+process.FEVToutput_step = cms.EndPath(process.Out)
+
+
+
+

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/test_L1TkEGamma.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/test_L1TkEGamma.py
@@ -1,0 +1,190 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("ALL")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
+
+#
+# This runs over a file that already contains the L1Tracks.
+#
+# It produces the following objects :
+#    - L1EG objects obtained by running the SLHCCaloTrigger sequence
+#	- this produces both the "old stage-2" and the "new stage-2" objects
+#    - collection of L1TkEmParticles  - produces Trk-based isolated "photons"
+#    - collection of L1TkElectrons from L1TkElectronTrackProducer 
+#
+#
+# It also runs a trivial analyzer than prints the objects
+# that have been created. 
+
+
+process.source = cms.Source("PoolSource",
+     fileNames = cms.untracked.vstring(
+         '/store/group/comm_trigger/L1TrackTrigger/620_SLHC8/BE5D/SingleEle_NoPU.root'
+     )
+)
+
+
+# ---- Global Tag :
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+
+
+
+# ---------------------------------------------------------------------------
+#
+# --- Produces the L1EG objects 
+#
+	# To produce L1EG objects corresponding to the "stage-2" algorithms:
+	# one runs the SLHCCaloTrigger sequence. This produces both the
+	# "old stage-2" objects (2x2 clustering) and the "new stage-2"
+	# objects (new clustering from JB Sauvan et al). Note that the
+	# efficiency of the latter is currently poor at very high PU.
+
+process.load('Configuration.Geometry.GeometryExtendedPhase2TkBE5D_cff')
+process.load('Configuration.Geometry.GeometryExtendedPhase2TkBE5DReco_cff')
+
+process.load('Configuration/StandardSequences/L1HwVal_cff')
+process.load('Configuration.StandardSequences.RawToDigi_cff')
+process.load("SLHCUpgradeSimulations.L1CaloTrigger.SLHCCaloTrigger_cff")
+
+
+	# The sequence SLHCCaloTrigger is broken in SLHC8 because of the
+	# L1Jets stuff (should be fixed in SLHC9).
+	# Hence, in the "remove" lines below, I hack the sequence such that
+	# we can run the L1EGamma stuff.
+
+process.SLHCCaloTrigger.remove( process.L1TowerJetProducer )
+process.SLHCCaloTrigger.remove( process.L1TowerJetFilter1D )
+process.SLHCCaloTrigger.remove( process.L1TowerJetFilter2D )
+process.SLHCCaloTrigger.remove( process.L1TowerJetPUEstimator )
+process.SLHCCaloTrigger.remove( process.L1TowerJetPUSubtractedProducer )
+process.SLHCCaloTrigger.remove( process.L1CalibFilterTowerJetProducer )
+process.SLHCCaloTrigger.remove( process.L1CaloJetExpander )
+
+# bug fix for missing HCAL TPs in MC RAW
+from SimCalorimetry.HcalTrigPrimProducers.hcaltpdigi_cff import HcalTPGCoderULUT
+HcalTPGCoderULUT.LUTGenerationMode = cms.bool(True)
+process.valRctDigis.hcalDigis             = cms.VInputTag(cms.InputTag('valHcalTriggerPrimitiveDigis'))
+process.L1CaloTowerProducer.HCALDigis =  cms.InputTag("valHcalTriggerPrimitiveDigis")
+
+process.slhccalo = cms.Path( process.RawToDigi + process.valHcalTriggerPrimitiveDigis+process.SLHCCaloTrigger)
+
+
+	# To produce L1EG objects corresponding
+	# to the Run-1 L1EG algorithm, one just needs to run
+	# L1Reco. The (Run-1) L1EG algorithm has already been
+	# run in the DIGI step of the production. 
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.L1Reco = cms.Path( process.l1extraParticles )
+
+#
+# ---------------------------------------------------------------------------
+
+
+
+# ---------------------------------------------------------------------------
+
+# Now we produce L1TkEmParticles and L1TkElectrons
+
+
+# ----  "photons" isolated w.r.t. L1Tracks :
+
+process.load("SLHCUpgradeSimulations.L1TrackTrigger.L1TkEmParticleProducer_cfi")
+process.pL1TkPhotons = cms.Path( process.L1TkPhotons )
+
+# ----  "electrons" from L1Tracks. Inclusive electrons :
+
+process.load("SLHCUpgradeSimulations.L1TrackTrigger.L1TkElectronTrackProducer_cfi")
+process.pElectrons = cms.Path( process.L1TkElectrons )
+
+# ----  L1TkElectrons that are isolated w.r.t. L1Tracks :
+
+process.L1TkIsoElectrons = process.L1TkElectrons.clone()
+process.L1TkIsoElectrons.IsoCut = cms.double(0.1)
+process.pElectronsTkIso = cms.Path( process.L1TkIsoElectrons )
+
+# ----  L1TkElectrons made from L1IsoEG objects, i.e. from L1EG objects that 
+#       are isolated in the calorimeter :
+
+process.L1TkElectronsIsoEG = process.L1TkElectrons.clone()
+process.L1TkElectronsIsoEG.L1EGammaInputTag = cms.InputTag("SLHCL1ExtraParticlesNewClustering","IsoEGamma")
+process.pElectronsIsoEG = cms.Path( process.L1TkElectronsIsoEG )
+
+# ----  "electrons" from stubs  	- not implemented yet.
+#                                               
+#process.L1TkElectronsStubs = cms.EDProducer("L1TkElectronStubsProducer",
+#)                                              
+#process.pElectronsStubs = cms.Path( process.L1TkElectronsStubs )
+
+
+
+# ---------------------------------------------------------------------------
+
+
+# Run a trivial analyzer that prints the objects
+
+process.ana = cms.EDAnalyzer( 'L1TrackTriggerObjectsAnalyzer' ,
+    L1VtxInputTag = cms.InputTag("L1TkPrimaryVertex"),
+    L1TkEtMissInputTag = cms.InputTag("L1TkEtMiss","MET"),
+    L1TkElectronsInputTag = cms.InputTag("L1TkElectronsTrack","EG"),
+    L1TkPhotonsInputTag = cms.InputTag("L1TkPhotons","EG"),
+    L1TkJetsInputTag = cms.InputTag("L1TkJets","Central"),
+    L1TkHTMInputTag = cms.InputTag("L1TkHTMiss")
+)
+
+process.pAna = cms.Path( process.ana )
+
+
+
+# ---------------------------------------------------------------------------
+
+# --- Output module :
+
+
+process.Out = cms.OutputModule( "PoolOutputModule",
+    fileName = cms.untracked.string( "test_L1TrackTriggerObjects.root" ),
+    fastCloning = cms.untracked.bool( False ),
+    outputCommands = cms.untracked.vstring( 'drop *')
+)
+
+
+	# gen-level information
+process.Out.outputCommands.append('keep *_generator_*_*')
+process.Out.outputCommands.append('keep *_*gen*_*_*')
+process.Out.outputCommands.append('keep *_*Gen*_*_*')
+process.Out.outputCommands.append('keep *_rawDataCollector_*_*')
+
+	# the L1Tracks, clusters and stubs
+process.Out.outputCommands.append('keep *_TTStubsFromPixelDigis_ClusterAccepted_*')
+process.Out.outputCommands.append('keep *_TTClusterAssociatorFromPixelDigis_ClusterAccepted_*')
+process.Out.outputCommands.append('keep *_TTStubAssociatorFromPixelDigis_StubAccepted_*')
+process.Out.outputCommands.append('keep *_TTStubsFromPixelDigis_StubAccepted_*')
+process.Out.outputCommands.append('keep *_TTTracksFromPixelDigis_Level1TTTracks_*')
+process.Out.outputCommands.append('keep *_TTTrackAssociatorFromPixelDigis_Level1TTTracks_*')
+
+	# the L1EG objects
+process.Out.outputCommands.append('keep *_SLHCL1ExtraParticles_*_*' )
+process.Out.outputCommands.append('keep *_SLHCL1ExtraParticlesNewClustering_*_*')
+process.Out.outputCommands.append('keep l1extraL1Em*_l1extraParticles_*_*')
+
+	# the L1TkEmParticles
+process.Out.outputCommands.append('keep *_L1TkPhotons_*_*')
+
+	# the L1TkElectrons
+process.Out.outputCommands.append('keep *_L1TkElectrons_*_*')
+process.Out.outputCommands.append('keep *_L1TkElectronsIsoEG_*_*')
+process.Out.outputCommands.append('keep *_L1TkIsoElectrons_*_*')
+
+
+process.FEVToutput_step = cms.EndPath(process.Out)
+
+
+
+
+
+
+

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/test_L1TkEtMiss.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/test_L1TkEtMiss.py
@@ -1,0 +1,99 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("ALL")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(5) )
+
+#
+# This runs over a file that already contains the L1Tracks.
+#
+# It produces the following objects :
+#    - L1TkPrimaryVertex  - note that the clusters and stubs must
+#	   have been kept on the event. See the event content of
+#	   the example runL1Tracks.py
+#    - collection of L1TkEmParticles  - produces Trk-based isolated "photons"
+#    - collection of L1TkElectrons from L1TkElectronTrackProducer 
+#    - L1TkEtMiss
+#    - collection of L1TkMuons
+ 
+# This runs the L1EG algorithms (stage-2 and new clustering), and 
+# creates L1TkEmParticles, L1TkElectrons, L1TrkMET.
+#
+# It also unpacks the L1Jets (Run-1 algorithm) that have been created
+# during the centrakl production. They are used to create L1TkJets and
+# L1TkHTMiss - these are just technical templates so far.
+#
+
+
+process.source = cms.Source("PoolSource",
+     fileNames = cms.untracked.vstring('file:/afs/cern.ch/user/e/eperez/public/step2.root')
+)
+
+
+# ---- Global Tag :
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+
+
+
+# --- Produce the Primary Vertex
+
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.Geometry.GeometryExtendedPhase2TkBE5DReco_cff')
+process.load('Configuration.Geometry.GeometryExtendedPhase2TkBE5D_cff')
+process.load('Geometry.TrackerGeometryBuilder.StackedTrackerGeometry_cfi')
+
+process.load("SLHCUpgradeSimulations.L1TrackTrigger.L1TkPrimaryVertexProducer_cfi")
+process.pL1TkPrimaryVertex = cms.Path( process.L1TkPrimaryVertex )
+
+# --- Produce the L1TrkMET
+process.load("SLHCUpgradeSimulations.L1TrackTrigger.L1TkEtMissProducer_cfi")
+process.pL1TrkMET = cms.Path( process.L1TkEtMiss )
+
+
+
+# ---------------------------------------------------------------------------
+
+# --- Output module :
+
+
+process.Out = cms.OutputModule( "PoolOutputModule",
+    fileName = cms.untracked.string( "test_L1TrackTriggerObjects.root" ),
+    fastCloning = cms.untracked.bool( False ),
+    outputCommands = cms.untracked.vstring( 'drop *')
+)
+
+
+	# genlevel information
+process.Out.outputCommands.append('keep *_generator_*_*')
+process.Out.outputCommands.append('keep *_*gen*_*_*')
+process.Out.outputCommands.append('keep *_*Gen*_*_*')
+process.Out.outputCommands.append('keep *_rawDataCollector_*_*')
+
+        # the L1Tracks, clusters and stubs
+process.Out.outputCommands.append('keep *_TTStubsFromPixelDigis_ClusterAccepted_*')
+process.Out.outputCommands.append('keep *_TTClusterAssociatorFromPixelDigis_ClusterAccepted_*')
+process.Out.outputCommands.append('keep *_TTStubAssociatorFromPixelDigis_StubAccepted_*')
+process.Out.outputCommands.append('keep *_TTStubsFromPixelDigis_StubAccepted_*')
+process.Out.outputCommands.append('keep *_TTTracksFromPixelDigis_Level1TTTracks_*')
+process.Out.outputCommands.append('keep *_TTTrackAssociatorFromPixelDigis_Level1TTTracks_*')
+
+	# the L1TkPrimaryVertex
+process.Out.outputCommands.append('keep *_L1TkPrimaryVertex_*_*')
+
+	# the TrkMET
+process.Out.outputCommands.append('keep *_L1TkEtMiss_*_*')
+
+
+
+process.FEVToutput_step = cms.EndPath(process.Out)
+
+
+
+
+
+
+

--- a/SLHCUpgradeSimulations/L1TrackTrigger/test/test_L1TkMuon.py
+++ b/SLHCUpgradeSimulations/L1TrackTrigger/test/test_L1TkMuon.py
@@ -1,0 +1,87 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("Muo")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+
+# initialize MessageLogger and output report
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32(500),
+    limit = cms.untracked.int32(10000000)
+)
+
+#
+# This runs over a file that already contains the L1Tracks.
+#
+# Creates L1TkMuons starting from the Run-1 L1Muons.
+#
+
+process.source = cms.Source("PoolSource",
+    # replace 'myfile.root' with the source file you want to use
+     fileNames = cms.untracked.vstring(
+        '/store/group/comm_trigger/L1TrackTrigger/620_SLHC8/BE5D/SingleMu_NoPU.root'
+     )
+)
+
+
+process.load('Configuration.Geometry.GeometryExtendedPhase2TkBE5DReco_cff')
+process.load('Configuration.Geometry.GeometryExtendedPhase2TkBE5D_cff')
+
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+
+
+# --- creates l1extra objects for L1Muons 
+
+        # raw2digi to get the GT digis
+process.load('Configuration.StandardSequences.RawToDigi_cff')
+process.p0 = cms.Path( process.RawToDigi )
+	# run L1Reco
+process.load('Configuration.StandardSequences.L1Reco_cff')
+process.L1Reco = cms.Path( process.l1extraParticles )
+
+
+# ---  Produces the L1TkMuons :
+
+process.load("SLHCUpgradeSimulations.L1TrackTrigger.L1TkMuonProducer_cfi")
+process.pMuons = cms.Path( process.L1TkMuons )
+
+
+
+
+# ---------------------------------------------------------------------------
+
+# --- Output module :
+
+
+process.Out = cms.OutputModule( "PoolOutputModule",
+    fileName = cms.untracked.string( "test_L1TrackTriggerObjects.root" ),
+    fastCloning = cms.untracked.bool( False ),
+    outputCommands = cms.untracked.vstring( 'drop *')
+)
+
+
+        # genlevel information
+process.Out.outputCommands.append('keep *_generator_*_*')
+process.Out.outputCommands.append('keep *_*gen*_*_*')
+process.Out.outputCommands.append('keep *_*Gen*_*_*')
+process.Out.outputCommands.append('keep *_rawDataCollector_*_*')
+
+        # the L1Tracks, clusters and stubs
+process.Out.outputCommands.append('keep *_TTStubsFromPixelDigis_ClusterAccepted_*')
+process.Out.outputCommands.append('keep *_TTClusterAssociatorFromPixelDigis_ClusterAccepted_*')
+process.Out.outputCommands.append('keep *_TTStubAssociatorFromPixelDigis_StubAccepted_*')
+process.Out.outputCommands.append('keep *_TTStubsFromPixelDigis_StubAccepted_*')
+process.Out.outputCommands.append('keep *_TTTracksFromPixelDigis_Level1TTTracks_*')
+process.Out.outputCommands.append('keep *_TTTrackAssociatorFromPixelDigis_Level1TTTracks_*')
+
+        # the L1TkMuon
+process.Out.outputCommands.append('keep *_L1TkMuons_*_*')
+
+
+process.FEVToutput_step = cms.EndPath(process.Out)
+


### PR DESCRIPTION
Added classes into DataFormats/L1TrackTrigger and various producers and test examples in SLHCUpgradeSImulations/L1TrackTrigger, to produce the "L1TrackTriggerObjects" that are used e.g. in L1Menu studies.
