### PR TITLE
Updated soft electron MVA (Feb7th training)

### DIFF
--- a/RecoEgamma/ElectronIdentification/data/download.url
+++ b/RecoEgamma/ElectronIdentification/data/download.url
@@ -1,2 +1,3 @@
 http://cmsdoc.cern.ch/cms/data/CMSSW/RecoEgamma/ElectronIdentification/data/TMVA_BDTSimpleCat_17Feb2011.weights.xml
 http://cmsdoc.cern.ch/cms/data/CMSSW/RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_27Jan2014.weights.xml
+http://cmsdoc.cern.ch/cms/data/CMSSW/RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_7Feb2014.weights.xml


### PR DESCRIPTION
This is the latest training from Simon and should come after the bug fix in #2558.
(plots are attached in that PR)

@ktf @slava77 This needs an associated CMSDIST update. Hopefully we don't encounter weird file corruptions issues as last time. The new weight is already in the directory.
