### PR TITLE
Point electron producers at the updated Feb 7th Soft Electron MVA

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
@@ -160,7 +160,7 @@ gedGsfElectronsTmp = cms.EDProducer("GEDGsfElectronProducer",
    # Iso Values 
    useIsolationValues = cms.bool(False),
  SoftElecMVAFilesString = cms.vstring(
-    "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_27Jan2014.weights.xml"
+    "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_7Feb2014.weights.xml"
                                 ),
 )
 

--- a/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
@@ -329,7 +329,7 @@ gsfElectrons = cms.EDProducer("GsfElectronProducer",
            edSumNeutralHadronEt= cms.InputTag('elEDIsoValueNeutral04')),
 
    SoftElecMVAFilesString = cms.vstring(
-    "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_9Dec2013.weights.xml"
+    "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_7Feb2014.weights.xml"
                                 ),
 )
 


### PR DESCRIPTION
Follow up to #2558 and #2717. Plots are in the former.

This PR updates the weight files locations in the producers to use the Feb7th training of the soft electron MVA.

@cmsbuild You will need to run the standard build testing on this manually, using the file in the download.url patch in #2558.
