### PR TITLE
Avoid playback segfault on empty file list53x

### DIFF
--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -603,7 +603,7 @@ namespace edm {
     skipBadFiles_ = false;
     if(fileIter_ == fileIterEnd_ || !rootFile_) {
       if(fileIterEnd_ == fileIterBegin_) {
-        throw Exception(errors::Configuration) << "RootInputFileSequence::readOneSequential(): no input files specified.\n";
+        throw Exception(errors::Configuration) << "RootInputFileSequence::readOneSequential(): no input files specified for secondary input source.\n";
       }
       fileIter_ = fileIterBegin_;
       initFile(false);
@@ -626,7 +626,7 @@ namespace edm {
   EventPrincipal*
   RootInputFileSequence::readOneSequentialWithID(LuminosityBlockID const& id) {
     if(fileIterEnd_ == fileIterBegin_) {
-      throw Exception(errors::Configuration) << "RootInputFileSequence::readOneSequentialWithID(): no input files specified.\n";
+      throw Exception(errors::Configuration) << "RootInputFileSequence::readOneSequentialWithID(): no input files specified for secondary input source.\n";
     }
     skipBadFiles_ = false;
     if(fileIter_ == fileIterEnd_ || !rootFile_ ||
@@ -650,13 +650,15 @@ namespace edm {
 
   EventPrincipal*
   RootInputFileSequence::readOneSpecified(EventID const& id) {
+    if(fileIterEnd_ == fileIterBegin_) {
+      throw Exception(errors::Configuration) << "RootInputFileSequence::readOneSequential(): no input files specified for secondary input source.\n";
+    }
     skipBadFiles_ = false;
     bool found = skipToItem(id.run(), id.luminosityBlock(), id.event());
     if(!found) {
       throw Exception(errors::NotFound) <<
-         "RootInputFileSequence::readOneSpecified(): Secondary Input file " <<
-         fileIter_->fileName() <<
-         " does not contain specified event:\n" << id << "\n";
+         "RootInputFileSequence::readOneSpecified(): Secondary Input files" <<
+         " do not contain specified event:\n" << id << "\n";
     }
     EventPrincipal* ep = rootFile_->clearAndReadCurrentEvent(rootFile_->secondaryEventPrincipal());
     assert(ep != 0);
@@ -666,7 +668,7 @@ namespace edm {
   EventPrincipal*
   RootInputFileSequence::readOneRandom() {
     if(fileIterEnd_ == fileIterBegin_) {
-      throw Exception(errors::Configuration) << "RootInputFileSequence::readOneRandom(): no input files specified.\n";
+      throw Exception(errors::Configuration) << "RootInputFileSequence::readOneRandom(): no input files specified for secondary input source.\n";
     }
     if(!flatDistribution_) {
       Service<RandomNumberGenerator> rng;
@@ -706,7 +708,7 @@ namespace edm {
   EventPrincipal*
   RootInputFileSequence::readOneRandomWithID(LuminosityBlockID const& id) {
     if(fileIterEnd_ == fileIterBegin_) {
-      throw Exception(errors::Configuration) << "RootInputFileSequence::readOneRandomWithID(): no input files specified.\n";
+      throw Exception(errors::Configuration) << "RootInputFileSequence::readOneRandomWithID(): no input files specified for secondary input source.\n";
     }
     if(!flatDistribution_) {
       Service<RandomNumberGenerator> rng;


### PR DESCRIPTION
When running the mixing module in playback mode, if the secondary input source is given an empty file list, a segfault resulted when attempting to throw an exception. This pull request fixes the segfault so that the exception is thrown.
This pull request also improves exception messages that occur on an empty file list for the secondary source when playback mode is not used.
This code bug has been there for a long time. This segfault has been observed as far back as 5_3_X.
Pull request requested in 5_3_X by David Lange.
