### PR TITLE
Use edm::convertException::wrap to handle conversion of exceptions

### DIFF
--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -130,7 +130,7 @@ int main(int argc, char* argv[]) {
   EventProcessorWithSentry proc;
 
   try {
-    try {
+    returnCode = edm::convertException::wrap([&]()->int {
 
       // NOTE: MacOs X has a lower rlimit for opened file descriptor than Linux (256
       // in Snow Leopard vs 512 in SLC5). This is a problem for some of the workflows
@@ -358,26 +358,8 @@ int main(int argc, char* argv[]) {
 
       context = "Calling endJob";
       proc->endJob();
-    }
-    catch (cms::Exception& e) {
-      throw;
-    }
-    // The functions in the following catch blocks throw an edm::Exception
-    catch(std::bad_alloc& bda) {
-      edm::convertException::badAllocToEDM();
-    }
-    catch (std::exception& e) {
-      edm::convertException::stdToEDM(e);
-    }
-    catch(std::string& s) {
-      edm::convertException::stringToEDM(s);
-    }
-    catch(char const* c) {
-      edm::convertException::charPtrToEDM(c);
-    }
-    catch (...) {
-      edm::convertException::unknownToEDM();
-    }
+      return returnCode;
+    });
   }
   // All exceptions which are not handled before propagating
   // into main will get caught here.

--- a/FWCore/Framework/interface/ComponentFactory.h
+++ b/FWCore/Framework/interface/ComponentFactory.h
@@ -89,15 +89,9 @@ template<typename T>
          }
          
          try {
-           try {
+           return convertException::wrap([&]() -> boost::shared_ptr<base_type> {
              return it->second->addTo(esController, iProvider, iConfiguration, replaceExisting);
-           }
-           catch (cms::Exception& e) { throw; }
-           catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-           catch (std::exception& e) { convertException::stdToEDM(e); }
-           catch(std::string& s) { convertException::stringToEDM(s); }
-           catch(char const* c) { convertException::charPtrToEDM(c); }
-           catch (...) { convertException::unknownToEDM(); }
+           });
          }
          catch(cms::Exception & iException) {
            std::string edmtype = iConfiguration.template getParameter<std::string>("@module_edm_type");

--- a/FWCore/Framework/interface/ExceptionHelpers.h
+++ b/FWCore/Framework/interface/ExceptionHelpers.h
@@ -53,15 +53,9 @@ namespace edm {
                                    bool disablePrint = false) {
 
     try {
-      try {
+      return convertException::wrap([iFunc]() {
         return iFunc();
-      }
-      catch (cms::Exception& e) { throw; }
-      catch (std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-      catch (std::exception& e) { convertException::stdToEDM(e); }
-      catch (std::string& s) { convertException::stringToEDM(s); }
-      catch (char const* c) { convertException::charPtrToEDM(c); }
-      catch (...) { convertException::unknownToEDM(); }
+      });
     }
     catch(cms::Exception& ex) {
       addContextAndPrintException(context, ex, disablePrint);

--- a/FWCore/Framework/interface/WorkerManager.h
+++ b/FWCore/Framework/interface/WorkerManager.h
@@ -98,7 +98,7 @@ namespace edm {
     this->resetAll();
 
     try {
-      try {
+      convertException::wrap([&]() {
         try {
           if (T::isEvent_) {
             setupOnDemandSystem(dynamic_cast<EventPrincipal&>(ep), es);
@@ -117,13 +117,7 @@ namespace edm {
             throw;
           }
         }
-      }
-      catch (cms::Exception& e) { throw; }
-      catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-      catch (std::exception& e) { convertException::stdToEDM(e); }
-      catch(std::string& s) { convertException::stringToEDM(s); }
-      catch(char const* c) { convertException::charPtrToEDM(c); }
-      catch (...) { convertException::unknownToEDM(); }
+      });
     }
     catch(cms::Exception& ex) {
       if (ex.context().empty()) {

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -113,15 +113,9 @@ namespace edm {
     filler->fill(descriptions);
 
     try {
-      try {
+      convertException::wrap([&]() {
         descriptions.validate(*main_input, std::string("source"));
-      }
-      catch (cms::Exception& e) { throw; }
-      catch (std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-      catch (std::exception& e) { convertException::stdToEDM(e); }
-      catch (std::string& s) { convertException::stringToEDM(s); }
-      catch (char const* c) { convertException::charPtrToEDM(c); }
-      catch (...) { convertException::unknownToEDM(); }
+      });
     }
     catch (cms::Exception & iException) {
       std::ostringstream ost;
@@ -150,15 +144,9 @@ namespace edm {
     try {
       //even if we have an exception, send the signal
       std::shared_ptr<int> sentry(nullptr,[areg,&md](void*){areg->postSourceConstructionSignal_(md);});
-      try {
+      convertException::wrap([&]() {
         input = std::unique_ptr<InputSource>(InputSourceFactory::get()->makeInputSource(*main_input, isdesc).release());
-      }
-      catch (cms::Exception& e) { throw; }
-      catch (std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-      catch (std::exception& e) { convertException::stdToEDM(e); }
-      catch (std::string& s) { convertException::stringToEDM(s); }
-      catch (char const* c) { convertException::charPtrToEDM(c); }
-      catch (...) { convertException::unknownToEDM(); }
+      });
     }
     catch (cms::Exception& iException) {
       std::ostringstream ost;
@@ -583,15 +571,9 @@ namespace edm {
     //   looper_->beginOfJob(es);
     //}
     try {
-      try {
+      convertException::wrap([&]() {
         input_->doBeginJob();
-      }
-      catch (cms::Exception& e) { throw; }
-      catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-      catch (std::exception& e) { convertException::stdToEDM(e); }
-      catch(std::string& s) { convertException::stringToEDM(s); }
-      catch(char const* c) { convertException::charPtrToEDM(c); }
-      catch (...) { convertException::unknownToEDM(); }
+      });
     }
     catch(cms::Exception& ex) {
       ex.addContext("Calling beginJob for the source");
@@ -1272,7 +1254,7 @@ namespace edm {
       nextItemTypeFromProcessingEvents_=InputSource::IsEvent;
       asyncStopRequestedWhileProcessingEvents_=false;
       try {
-        try {
+        convertException::wrap([&]() {
           
           InputSource::ItemType itemType;
           
@@ -1339,13 +1321,7 @@ namespace edm {
               break;
             }
           }  // End of loop over state machine events
-        } // Try block
-        catch (cms::Exception& e) { throw; }
-        catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-        catch (std::exception& e) { convertException::stdToEDM(e); }
-        catch(std::string& s) { convertException::stringToEDM(s); }
-        catch(char const* c) { convertException::charPtrToEDM(c); }
-        catch (...) { convertException::unknownToEDM(); }
+        }); // convertException::wrap
       } // Try block
       // Some comments on exception handling related to the boost state machine:
       //

--- a/FWCore/Framework/src/EventSetupProviderMaker.cc
+++ b/FWCore/Framework/src/EventSetupProviderMaker.cc
@@ -153,15 +153,9 @@ namespace edm {
       ConfigurationDescriptions descriptions(filler->baseType());
       filler->fill(descriptions);
       try {
-        try {
+        edm::convertException::wrap([&]() {
           descriptions.validate(pset, moduleLabel);
-        }
-        catch (cms::Exception& e) { throw; }
-        catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-        catch (std::exception& e) { convertException::stdToEDM(e); }
-        catch(std::string& s) { convertException::stringToEDM(s); }
-        catch(char const* c) { convertException::charPtrToEDM(c); }
-        catch (...) { convertException::unknownToEDM(); }
+        });
       }
       catch (cms::Exception & iException) {
         std::ostringstream ost;

--- a/FWCore/Framework/src/EventSetupRecord.cc
+++ b/FWCore/Framework/src/EventSetupRecord.cc
@@ -180,16 +180,10 @@ EventSetupRecord::getFromProxy(DataKey const & iKey ,
    
    if(0!=proxy) {
       try {
-         try {
+        convertException::wrap([&]() {
             hold = proxy->get(*this, iKey,iTransientAccessOnly);
             iDesc = proxy->providerDescription(); 
-         }
-         catch (cms::Exception& e) { throw; }
-         catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-         catch (std::exception& e) { convertException::stdToEDM(e); }
-         catch(std::string& s) { convertException::stringToEDM(s); }
-         catch(char const* c) { convertException::charPtrToEDM(c); }
-         catch (...) { convertException::unknownToEDM(); }
+        });
       }
       catch(cms::Exception& e) {
          addTraceInfoToCmsException(e,iKey.name().value(),proxy->providerDescription(), iKey);
@@ -216,15 +210,9 @@ EventSetupRecord::doGet(const DataKey& aKey, bool aGetTransiently) const {
    const DataProxy* proxy = find(aKey);
    if(0 != proxy) {
       try {
-         try {
+         convertException::wrap([&]() {
             proxy->doGet(*this, aKey, aGetTransiently);
-         }
-         catch (cms::Exception& e) { throw; }
-         catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-         catch (std::exception& e) { convertException::stdToEDM(e); }
-         catch(std::string& s) { convertException::stringToEDM(s); }
-         catch(char const* c) { convertException::charPtrToEDM(c); }
-         catch (...) { convertException::unknownToEDM(); }
+         });
       }
       catch( cms::Exception& e) {
          addTraceInfoToCmsException(e,aKey.name().value(),proxy->providerDescription(), aKey);

--- a/FWCore/Framework/src/GlobalSchedule.h
+++ b/FWCore/Framework/src/GlobalSchedule.h
@@ -155,15 +155,9 @@ namespace edm {
     workerManager_.processOneOccurrence<T>(ep, es, StreamID::invalidStreamID(), &globalContext, &globalContext, cleaningUpAfterException);
 
     try {
-      try {
+      convertException::wrap([&]() {
         runNow<T>(ep,es,&globalContext);
-      }
-      catch (cms::Exception& e) { throw; }
-      catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-      catch (std::exception& e) { convertException::stdToEDM(e); }
-      catch(std::string& s) { convertException::stringToEDM(s); }
-      catch(char const* c) { convertException::charPtrToEDM(c); }
-      catch (...) { convertException::unknownToEDM(); }
+      });
     }
     catch(cms::Exception& ex) {
       if (ex.context().empty()) {

--- a/FWCore/Framework/src/Path.h
+++ b/FWCore/Framework/src/Path.h
@@ -193,19 +193,13 @@ namespace edm {
           ++i) {
       ++nwrwue;
       try {
-        try {
+        convertException::wrap([&]() {
           if(T::isEvent_) {
             should_continue = i->runWorker<T>(ep, es, streamID, context);
           } else {
             should_continue = i->runWorker<T>(ep, es, streamID, context);
           }
-        }
-        catch (cms::Exception& e) { throw; }
-        catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-        catch (std::exception& e) { convertException::stdToEDM(e); }
-        catch(std::string& s) { convertException::stringToEDM(s); }
-        catch(char const* c) { convertException::charPtrToEDM(c); }
-        catch (...) { convertException::unknownToEDM(); }
+        });
       }
       catch(cms::Exception& ex) {
         // handleWorkerFailure may throw a new exception.

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -366,7 +366,7 @@ namespace edm {
 
     ++total_events_;
     try {
-      try {
+      convertException::wrap([&]() {
         try {
           if (runTriggerPaths<T>(ep, es, &streamContext_)) {
             ++total_passed_;
@@ -400,13 +400,7 @@ namespace edm {
 
         if (endpathsAreActive_) runEndPaths<T>(ep, es, &streamContext_);
         resetEarlyDelete();
-      }
-      catch (cms::Exception& e) { throw; }
-      catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-      catch (std::exception& e) { convertException::stdToEDM(e); }
-      catch(std::string& s) { convertException::stringToEDM(s); }
-      catch(char const* c) { convertException::charPtrToEDM(c); }
-      catch (...) { convertException::unknownToEDM(); }
+      });
     }
     catch(cms::Exception& ex) {
       if (ex.context().empty()) {
@@ -433,17 +427,11 @@ namespace edm {
     workerManager_.processOneOccurrence<T>(ep, es, streamID_, &streamContext_, &streamContext_, cleaningUpAfterException);
 
     try {
-      try {
+      convertException::wrap([&]() {
         runTriggerPaths<T>(ep, es, &streamContext_);
 
         if (endpathsAreActive_) runEndPaths<T>(ep, es, &streamContext_);
-      }
-      catch (cms::Exception& e) { throw; }
-      catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-      catch (std::exception& e) { convertException::stdToEDM(e); }
-      catch(std::string& s) { convertException::stringToEDM(s); }
-      catch(char const* c) { convertException::charPtrToEDM(c); }
-      catch (...) { convertException::unknownToEDM(); }
+      });
     }
     catch(cms::Exception& ex) {
       if (ex.context().empty()) {

--- a/FWCore/Framework/src/Worker.cc
+++ b/FWCore/Framework/src/Worker.cc
@@ -110,16 +110,10 @@ private:
 
   void Worker::beginJob() {
     try {
-      try {
+      convertException::wrap([&]() {
         ModuleBeginJobSignalSentry cpp(actReg_.get(), description());
         implBeginJob();
-      }
-      catch (cms::Exception& e) { throw; }
-      catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-      catch (std::exception& e) { convertException::stdToEDM(e); }
-      catch(std::string& s) { convertException::stringToEDM(s); }
-      catch(char const* c) { convertException::charPtrToEDM(c); }
-      catch (...) { convertException::unknownToEDM(); }
+      });
     }
     catch(cms::Exception& ex) {
       state_ = Exception;
@@ -132,16 +126,10 @@ private:
   
   void Worker::endJob() {
     try {
-      try {
+      convertException::wrap([&]() {
         ModuleEndJobSignalSentry cpp(actReg_.get(), description());
         implEndJob();
-      }
-      catch (cms::Exception& e) { throw; }
-      catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-      catch (std::exception& e) { convertException::stdToEDM(e); }
-      catch(std::string& s) { convertException::stringToEDM(s); }
-      catch(char const* c) { convertException::charPtrToEDM(c); }
-      catch (...) { convertException::unknownToEDM(); }
+      });
     }
     catch(cms::Exception& ex) {
       state_ = Exception;
@@ -154,7 +142,7 @@ private:
 
   void Worker::beginStream(StreamID id, StreamContext& streamContext) {
     try {
-      try {
+      convertException::wrap([&]() {
         streamContext.setTransition(StreamContext::Transition::kBeginStream);
         streamContext.setEventID(EventID(0, 0, 0));
         streamContext.setRunIndex(RunIndex::invalidRunIndex());
@@ -165,13 +153,7 @@ private:
         moduleCallingContext_.setState(ModuleCallingContext::State::kRunning);
         ModuleBeginStreamSignalSentry beginSentry(actReg_.get(), streamContext, moduleCallingContext_);
         implBeginStream(id);
-      }
-      catch (cms::Exception& e) { throw; }
-      catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-      catch (std::exception& e) { convertException::stdToEDM(e); }
-      catch(std::string& s) { convertException::stringToEDM(s); }
-      catch(char const* c) { convertException::charPtrToEDM(c); }
-      catch (...) { convertException::unknownToEDM(); }
+      });
     }
     catch(cms::Exception& ex) {
       state_ = Exception;
@@ -184,7 +166,7 @@ private:
   
   void Worker::endStream(StreamID id, StreamContext& streamContext) {
     try {
-      try {
+      convertException::wrap([&]() {
         streamContext.setTransition(StreamContext::Transition::kEndStream);
         streamContext.setEventID(EventID(0, 0, 0));
         streamContext.setRunIndex(RunIndex::invalidRunIndex());
@@ -195,13 +177,7 @@ private:
         moduleCallingContext_.setState(ModuleCallingContext::State::kRunning);
         ModuleEndStreamSignalSentry endSentry(actReg_.get(), streamContext, moduleCallingContext_);
         implEndStream(id);
-      }
-      catch (cms::Exception& e) { throw; }
-      catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-      catch (std::exception& e) { convertException::stdToEDM(e); }
-      catch(std::string& s) { convertException::stringToEDM(s); }
-      catch(char const* c) { convertException::charPtrToEDM(c); }
-      catch (...) { convertException::unknownToEDM(); }
+      });
     }
     catch(cms::Exception& ex) {
       state_ = Exception;

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -377,7 +377,7 @@ namespace edm {
     ModuleContextSentry moduleContextSentry(&moduleCallingContext_, parentContext);
 
     try {
-      try {
+      convertException::wrap([&]() {
 
         if (T::isEvent_) {
           ++timesRun_;
@@ -404,13 +404,7 @@ namespace edm {
           state_ = Fail;
           if (T::isEvent_) ++timesFailed_;
         }
-      }
-      catch (cms::Exception& e) { throw; }
-      catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-      catch (std::exception& e) { convertException::stdToEDM(e); }
-      catch(std::string& s) { convertException::stringToEDM(s); }
-      catch(char const* c) { convertException::charPtrToEDM(c); }
-      catch (...) { convertException::unknownToEDM(); }
+      });
     }
     catch(cms::Exception& ex) {
 

--- a/FWCore/Framework/src/WorkerMaker.cc
+++ b/FWCore/Framework/src/WorkerMaker.cc
@@ -67,16 +67,10 @@ namespace edm {
     ConfigurationDescriptions descriptions(baseType());
     fillDescriptions(descriptions);
     try {
-      try {
+      convertException::wrap([&]() {
         descriptions.validate(*p.pset_, p.pset_->getParameter<std::string>("@module_label"));
         validateEDMType(baseType(), p);
-      }
-      catch (cms::Exception& e) { throw; }
-      catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-      catch (std::exception& e) { convertException::stdToEDM(e); }
-      catch(std::string& s) { convertException::stringToEDM(s); }
-      catch(char const* c) { convertException::charPtrToEDM(c); }
-      catch (...) { convertException::unknownToEDM(); }
+      });
     }
     catch (cms::Exception & iException) {
       throwValidationException(p, iException);
@@ -87,7 +81,7 @@ namespace edm {
     std::shared_ptr<maker::ModuleHolder> module;
     bool postCalled = false;
     try {
-      try {
+      convertException::wrap([&]() {
         pre(md);
         module = makeModule(*(p.pset_));
         module->setModuleDescription(md);
@@ -96,13 +90,7 @@ namespace edm {
         // if exception then post will be called in the catch block
         postCalled = true;
         post(md);
-      }
-      catch (cms::Exception& e) { throw; }
-      catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-      catch (std::exception& e) { convertException::stdToEDM(e); }
-      catch(std::string& s) { convertException::stringToEDM(s); }
-      catch(char const* c) { convertException::charPtrToEDM(c); }
-      catch (...) { convertException::unknownToEDM(); }
+      });
     }
     catch(cms::Exception & iException){
       if(!postCalled) {

--- a/FWCore/Framework/src/WorkerManager.cc
+++ b/FWCore/Framework/src/WorkerManager.cc
@@ -80,16 +80,10 @@ namespace edm {
   void WorkerManager::endJob(ExceptionCollector& collector) {
     for(auto& worker : allWorkers_) {
       try {
-        try {
+        convertException::wrap([&]() {
           worker->endJob();
-        }
-        catch (cms::Exception& e) { throw; }
-        catch (std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-        catch (std::exception& e) { convertException::stdToEDM(e); }
-        catch (std::string& s) { convertException::stringToEDM(s); }
-        catch (char const* c) { convertException::charPtrToEDM(c); }
-        catch (...) { convertException::unknownToEDM(); }
-      }      
+        });
+      }
       catch (cms::Exception const& ex) {
         collector.addException(ex);
       }

--- a/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
+++ b/FWCore/ParameterSet/bin/edmWriteConfigs.cpp
@@ -87,15 +87,9 @@ namespace {
     edm::ConfigurationDescriptions descriptions(filler->baseType());
 
     try {
-      try {
+      edm::convertException::wrap([&]() {
         filler->fill(descriptions);
-      }
-      catch (cms::Exception& e) { throw; }
-      catch(std::bad_alloc& bda) { edm::convertException::badAllocToEDM(); }
-      catch (std::exception& e) { edm::convertException::stdToEDM(e); }
-      catch(std::string& s) { edm::convertException::stringToEDM(s); }
-      catch(char const* c) { edm::convertException::charPtrToEDM(c); }
-      catch (...) { edm::convertException::unknownToEDM(); }
+      });
     }
     catch(cms::Exception& e) {
       std::ostringstream ost;
@@ -105,15 +99,9 @@ namespace {
     }
 
     try {
-      try {
+      edm::convertException::wrap([&]() {
         descriptions.writeCfis(baseType, pluginName);
-      }
-      catch (cms::Exception& e) { throw; }
-      catch(std::bad_alloc& bda) { edm::convertException::badAllocToEDM(); }
-      catch (std::exception& e) { edm::convertException::stdToEDM(e); }
-      catch(std::string& s) { edm::convertException::stringToEDM(s); }
-      catch(char const* c) { edm::convertException::charPtrToEDM(c); }
-      catch (...) { edm::convertException::unknownToEDM(); }
+      });
     }
     catch(cms::Exception& e) {
       std::ostringstream ost;
@@ -201,7 +189,7 @@ try {
   std::string library;
 
   try {
-    try {
+    edm::convertException::wrap([&]() {
 
       if(vm.count(kLibraryOpt)) {
         library = vm[kLibraryOpt].as<std::string>();
@@ -229,7 +217,7 @@ try {
         CatToInfos::const_iterator itPlugins = catToInfos.find(factory->category());
 
         // No plugins in this category at all
-        if(itPlugins == catToInfos.end() ) return 0;
+        if(itPlugins == catToInfos.end() ) return;
 
         std::vector<edmplugin::PluginInfo> const& infos = itPlugins->second;
         std::string previousName;
@@ -272,7 +260,7 @@ try {
                       << "The executable will return success (0) so scram will continue,\n"
                       << "but no cfi files will be written.\n"
                       << iException.what() << std::endl;
-            return 0;
+            return;
           }
           else {
             throw;
@@ -293,13 +281,7 @@ try {
       edm::for_all(pluginNames, boost::bind(&writeCfisForPlugin,
                                             _1,
                                             factory));
-    }
-    catch (cms::Exception& e) { throw; }
-    catch(std::bad_alloc& bda) { edm::convertException::badAllocToEDM(); }
-    catch (std::exception& e) { edm::convertException::stdToEDM(e); }
-    catch(std::string& s) { edm::convertException::stringToEDM(s); }
-    catch(char const* c) { edm::convertException::charPtrToEDM(c); }
-    catch (...) { edm::convertException::unknownToEDM(); }
+    });
   }
   catch (cms::Exception & iException) {
     std::ostringstream ost;

--- a/FWCore/ServiceRegistry/src/ServicesManager.cc
+++ b/FWCore/ServiceRegistry/src/ServicesManager.cc
@@ -299,15 +299,9 @@ namespace edm {
              filler->fill(descriptions);
 
              try {
-               try {
+               convertException::wrap([&]() {
                  descriptions.validate(*(itMaker->second.pset_), serviceType);
-               }
-               catch (cms::Exception& e) { throw; }
-               catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-               catch (std::exception& e) { convertException::stdToEDM(e); }
-               catch(std::string& s) { convertException::stringToEDM(s); }
-               catch(char const* c) { convertException::charPtrToEDM(c); }
-               catch (...) { convertException::unknownToEDM(); }
+               });
              }
              catch (cms::Exception & iException) {
                std::ostringstream ost;
@@ -316,16 +310,10 @@ namespace edm {
                throw;
              }
              try {
-               try {
+               convertException::wrap([&]() {
                  // This creates the service
                  itMaker->second.add(*this);
-               }
-               catch (cms::Exception& e) { throw; }
-               catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-               catch (std::exception& e) { convertException::stdToEDM(e); }
-               catch(std::string& s) { convertException::stringToEDM(s); }
-               catch(char const* c) { convertException::charPtrToEDM(c); }
-               catch (...) { convertException::unknownToEDM(); }
+               });
              }
              catch (cms::Exception & iException) {
                std::ostringstream ost;

--- a/FWCore/Utilities/interface/ConvertException.h
+++ b/FWCore/Utilities/interface/ConvertException.h
@@ -3,6 +3,11 @@
 
 #include <string>
 #include <exception>
+#include <functional>
+
+namespace cms {
+  class Exception;
+}
 
 namespace edm {
   namespace convertException {
@@ -11,6 +16,22 @@ namespace edm {
     void stringToEDM(std::string& s);
     void charPtrToEDM(char const* c);
     void unknownToEDM();
+
+    template<typename F>
+    auto wrap(F iFunc) -> decltype( iFunc() ) {
+      try {
+        return iFunc();
+      }
+      catch (cms::Exception& e) { throw; }
+      catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
+      catch (std::exception& e) { convertException::stdToEDM(e); }
+      catch(std::string& s) { convertException::stringToEDM(s); }
+      catch(char const* c) { convertException::charPtrToEDM(c); }
+      catch (...) { convertException::unknownToEDM(); }
+      //Never gets here
+      typedef decltype(iFunc()) ReturnType;      
+      return ReturnType();
+    }
   }
 }
 

--- a/FWCore/Utilities/src/ExceptionCollector.cc
+++ b/FWCore/Utilities/src/ExceptionCollector.cc
@@ -34,16 +34,10 @@ namespace edm {
   void
   ExceptionCollector::call(boost::function<void(void)> f) {
     try {
-      try {
+      convertException::wrap([&f]() {
         f();
-      }
-      catch (cms::Exception& e) { throw; }
-      catch (std::bad_alloc& bda) { convertException::badAllocToEDM(); }
-      catch (std::exception& e) { convertException::stdToEDM(e); }
-      catch (std::string& s) { convertException::stringToEDM(s); }
-      catch (char const* c) { convertException::charPtrToEDM(c); }
-      catch (...) { convertException::unknownToEDM(); }
-    }      
+      });
+    }
     catch (cms::Exception const& ex) {
       ++nExceptions_;
       if (nExceptions_ == 1) {


### PR DESCRIPTION
Passing a C++11 lambda to this function allows us to simplify handling the conversion
of exceptions to cms::Exceptions via a reusable function.
