### PR TITLE
Removed empty/unused functions from DBService

### DIFF
--- a/RecoLuminosity/LumiProducer/interface/DBService.h
+++ b/RecoLuminosity/LumiProducer/interface/DBService.h
@@ -1,7 +1,7 @@
 #ifndef RecoLuminosity_LumiProducer_DBService_h
 #define RecoLuminosity_LumiProducer_DBService_h
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+
 #include <string>
 namespace coral{
   class ISessionProxy;
@@ -12,20 +12,12 @@ namespace lumi{
   namespace service{
     class DBService{
     public:
-      DBService(const edm::ParameterSet& iConfig, 
-		edm::ActivityRegistry& iAR);
+      DBService(const edm::ParameterSet& iConfig);
       ~DBService();
-      void postEndJob();
-      void preEventProcessing( const edm::EventID & evtID, 
-      			       const edm::Timestamp & iTime );
-      void preModule(const edm::ModuleDescription& desc);
-      void postModule(const edm::ModuleDescription& desc);
-      void preBeginLumi(const edm::LuminosityBlockID&, 
-			const edm::Timestamp& );
+
       coral::ISessionProxy* connectReadOnly( const std::string& connectstring );
       void disconnect( coral::ISessionProxy* session );
-      lumi::DBConfig&  DBConfig();
-      void setupWebCache();
+
     private:
       coral::ConnectionService* m_svc;
       lumi::DBConfig* m_dbconfig;

--- a/RecoLuminosity/LumiProducer/plugins/Module.cc
+++ b/RecoLuminosity/LumiProducer/plugins/Module.cc
@@ -1,4 +1,5 @@
 #include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 #include "RecoLuminosity/LumiProducer/interface/DBService.h"
 using lumi::service::DBService;
-DEFINE_FWK_SERVICE(DBService);
+typedef edm::serviceregistry::ParameterSetMaker<DBService> DBServiceMaker;
+DEFINE_FWK_SERVICE_MAKER(DBService,DBServiceMaker);

--- a/RecoLuminosity/LumiProducer/src/DBService.cc
+++ b/RecoLuminosity/LumiProducer/src/DBService.cc
@@ -6,8 +6,7 @@
 #include "RelationalAccess/AccessMode.h"
 
 #include <iostream>
-lumi::service::DBService::DBService(const edm::ParameterSet& iConfig,
-				    edm::ActivityRegistry& iAR){
+lumi::service::DBService::DBService(const edm::ParameterSet& iConfig){
   m_svc=new coral::ConnectionService;
   m_dbconfig= new lumi::DBConfig(*m_svc);
   std::string authpath=iConfig.getUntrackedParameter<std::string>("authPath","");
@@ -20,24 +19,6 @@ lumi::service::DBService::~DBService(){
   delete m_svc;
 }
 
-void 
-lumi::service::DBService::postEndJob(){
-}
-void 
-lumi::service::DBService::preEventProcessing(const edm::EventID& iEvtid, 
-					     const edm::Timestamp& iTime){
-}
-void
-lumi::service::DBService::preModule(const edm::ModuleDescription& desc){
-}
-void 
-lumi::service::DBService::preBeginLumi(const edm::LuminosityBlockID& iLumiid,  
-				       const edm::Timestamp& iTime ){
-}
-void
-lumi::service::DBService::postModule(const edm::ModuleDescription& desc){
-}
-
 coral::ISessionProxy* 
 lumi::service::DBService::connectReadOnly( const std::string& connectstring ){
   return m_svc->connect(connectstring, coral::ReadOnly);
@@ -46,10 +27,4 @@ void
 lumi::service::DBService::disconnect( coral::ISessionProxy* session ){
   delete session;
 }
-lumi::DBConfig&
-lumi::service::DBService::DBConfig(){
-  return *m_dbconfig;
-}
-void
-lumi::service::DBService::setupWebCache(){
-}
+


### PR DESCRIPTION
To make future maintenance easier and avoid possible thread-safety
issues I removed empty functions and the one unused function
which returned a pointer to the internals of the Service.
