### PR TITLE
Must set process history ID in runs, lumis, and events

### DIFF
--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.h
@@ -6,6 +6,7 @@
 
 #include "boost/filesystem.hpp"
 
+#include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 #include "DataFormats/Provenance/interface/Timestamp.h"
 #include "FWCore/Sources/interface/RawInputSource.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
@@ -68,6 +69,7 @@ private:
   boost::filesystem::path openFile_;
   FILE* fileStream_;
   edm::EventID eventID_;
+  edm::ProcessHistoryID processHistoryID_;
 
   unsigned int currentLumiSection_;
   boost::filesystem::path currentInputJson_;


### PR DESCRIPTION
The new FedRawDataInputSource did not inject the process history ID into runs, lumis, and events.  This caused problems in retrieving products.  This pull request fixes this problem for 7_0_X.
The problem will be fixed in 7_1_X by Srecko Morovic, because he needs to merge this fix with some other changes for 7_1_X.
