### PR TITLE
Use correct name for key and value

### DIFF
--- a/CondCore/ORA/src/STLContainerStreamer.cc
+++ b/CondCore/ORA/src/STLContainerStreamer.cc
@@ -75,7 +75,7 @@ bool ora::STLContainerWriter::build( DataElement& offset,
                       m_objectType.qualifiedName() + "\"",
                       "STLContainerWriter::build" );
     }
-    std::string keyName = keyType.name();
+    std::string keyName("key_type");
     // Retrieve the relevant mapping element
     MappingElement::iterator iMe = m_mappingElement.find( keyName );
     if ( iMe == m_mappingElement.end() ) {
@@ -98,13 +98,13 @@ bool ora::STLContainerWriter::build( DataElement& offset,
                     "STLContainerWriter::build" );
   }
 
-  std::string valueName = valueType.name();
+  std::string valueName("value_type");
   // Retrieve the relevant mapping element
   MappingElement::iterator iMe = m_mappingElement.find( valueName );
   if ( iMe == m_mappingElement.end() ) {
     // Try again with the name of a possible typedef
-    valueName = valueType.unscopedNameWithTypedef();
-    iMe = m_mappingElement.find( valueName );
+    std::string valueName2 = valueType.unscopedNameWithTypedef();
+    iMe = m_mappingElement.find( valueName2 );
     if ( iMe == m_mappingElement.end() ) {
       throwException( "Item for \"" + valueName + "\" not found in the mapping element",
                       "STLContainerWriter::build" );
@@ -287,7 +287,7 @@ bool ora::STLContainerReader::build( DataElement& offset, IRelationalData& ){
                       "STLContainerReader::build" );
     }
 
-    std::string keyName = keyType.name();
+    std::string keyName("key_type");
     // Retrieve the relevant mapping element
     MappingElement::iterator iMe = m_mappingElement.find( keyName );
     if ( iMe == m_mappingElement.end() ) {
@@ -311,13 +311,13 @@ bool ora::STLContainerReader::build( DataElement& offset, IRelationalData& ){
                     "STLContainerReader::build" );
   }
 
-  std::string valueName = valueType.name();
+  std::string valueName("value_type");
   // Retrieve the relevant mapping element
   MappingElement::iterator iMe = m_mappingElement.find( valueName );
   if ( iMe == m_mappingElement.end() ) {
     // Try again with the name of a possible typedef
-    valueName = valueType.unscopedNameWithTypedef();
-    iMe = m_mappingElement.find( valueName );
+    std::string valueName2 = valueType.unscopedNameWithTypedef();
+    iMe = m_mappingElement.find( valueName2 );
     if ( iMe == m_mappingElement.end() ) {
       throwException( "Item for \"" + valueName + "\" not found in the mapping element",
                       "STLContainerReader::build" );

--- a/FWCore/Utilities/src/MemberWithDict.cc
+++ b/FWCore/Utilities/src/MemberWithDict.cc
@@ -31,8 +31,8 @@ namespace edm {
         name << '[';
         name << dataMember_->GetMaxIndex(i);
         name << ']';
-        return TypeWithDict::byName(name.str(), dataMember_->Property());
       }
+      return TypeWithDict::byName(name.str(), dataMember_->Property());
     } 
     return TypeWithDict::byName(dataMember_->GetTypeName(), dataMember_->Property());
   }


### PR DESCRIPTION
This pull request is a fix for a fatal problem for about half of the relval tests in the ROOT6 IB.
The conditions code uses a complicated code to determine the names "key_type" and "value_type",
(typedefs of data members of STL collections), which never change.  Unfortunately, the new framework code returns the name of the underlying type rather than the name of the typedef.  Since the names returned never change, the easiest way to fix this is simply to hard code the the strings "key_type" and "value_type".
Also in this pull request is a fix for multidimensioned C arrays.  All but the first index were dropped due to s simple bug in MemberWithDict, which is fixed in this request.
 Please merge this promptly unless there are issues.
