### PR TITLE
Fix improper use of clustersToSkip InputTag

### DIFF
--- a/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/DetachedTripletStep_cff.py
@@ -75,7 +75,6 @@ detachedTripletStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajecto
     ComponentName = 'detachedTripletStepTrajectoryBuilder',
     MeasurementTrackerName = '',
     trajectoryFilterName = 'detachedTripletStepTrajectoryFilter',
-    clustersToSkip = cms.InputTag('detachedTripletStepClusters'),
     maxCand = 3,
     alwaysUseInvalidHits = True,
     estimator = cms.string('detachedTripletStepChi2Est'),

--- a/RecoTracker/IterativeTracking/python/InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStep_cff.py
@@ -64,7 +64,6 @@ initialStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilde
     ComponentName = 'initialStepTrajectoryBuilder',
     trajectoryFilterName = 'initialStepTrajectoryFilter',
     alwaysUseInvalidHits = True,
-    clustersToSkip = cms.InputTag('initialStepClusters'),
     maxCand = 6,
     estimator = cms.string('initialStepChi2Est'),
     maxDPhiForLooperReconstruction = cms.double(2.0),


### PR DESCRIPTION
Setting this input tag into the GroupedCkfTrajectoryBuilderESProducers will have no effect and is, de facto, misleading. No changes are expected in any distribution. This pull will silent the errors recently reported while running the reco sequence.
