### PR TITLE
DB connection handling upgraded to support sqlite fip and new frontier c...

### DIFF
--- a/CondCore/CondDB/interface/Binary.h
+++ b/CondCore/CondDB/interface/Binary.h
@@ -1,6 +1,8 @@
 #ifndef CondCore_CondDB_Binary_h
 #define CondCore_CondDB_Binary_h
 
+// for the old system, this will go away
+#include "CondCore/ORA/interface/Object.h"
 #include <string>
 #include <memory>
 // temporarely
@@ -13,18 +15,11 @@ namespace coral {
 
 namespace cond {
 
-  struct Nodelete {
-    Nodelete(){}
-    void operator()( void* ptr ){}
-  };
-  
   class Binary {
   public:
     Binary();
 
     template <typename T> explicit Binary( const T& object );
-
-    explicit Binary( const boost::shared_ptr<void>& objectPtr );
 
     Binary( const void* data, size_t size  );
 
@@ -44,16 +39,19 @@ namespace cond {
 
     size_t size() const;
 
-    boost::shared_ptr<void> share() const;
+    ora::Object oraObject() const;
+
+    void fromOraObject( const ora::Object& object );
 
   private:
     std::shared_ptr<coral::Blob> m_data;
     //
-    boost::shared_ptr<void> m_object;
+    // workaround to support the non-streamed, packed objects ( the old system )
+    ora::Object m_object;
   };
 
   template <typename T> Binary::Binary( const T& object ):
-    m_object( &const_cast<T&>(object), Nodelete() ){
+    m_object( object ){
   }
 }
 

--- a/CondCore/CondDB/interface/ConnectionPool.h
+++ b/CondCore/CondDB/interface/ConnectionPool.h
@@ -39,14 +39,14 @@ namespace cond {
       bool isLoggingEnabled() const;
       void setParameters( const edm::ParameterSet& connectionPset );
       void configure();
-      Session createSession( const std::string& connectionString, bool writeCapable=false, BackendType backType=ORA_DB );
+      Session createSession( const std::string& connectionString, bool writeCapable=false, BackendType backType=DEFAULT_DB );
       Session createReadOnlySession( const std::string& connectionString, const std::string& transactionId );
       
     private:
       Session createSession( const std::string& connectionString, 
 			     const std::string& transactionId, 
 			     bool writeCapable=false, 
-			     BackendType backType=ORA_DB );
+			     BackendType backType=DEFAULT_DB );
       void configure( coral::IConnectionServiceConfiguration& coralConfig);
     private:
       std::string m_authPath;
@@ -55,7 +55,6 @@ namespace cond {
       bool m_loggingEnabled = false;
       // this one has to be moved!
       cond::CoralServiceManager* m_pluginManager = 0; 
-      std::vector<std::string> m_refreshtablelist;
       std::map<std::string,int> m_dbTypes;
     };
   }

--- a/CondCore/CondDB/interface/GTProxy.h
+++ b/CondCore/CondDB/interface/GTProxy.h
@@ -21,6 +21,9 @@ namespace cond {
 
   namespace persistency {
 
+    // required in the "bridge" mode, to be removed with the ORA based code after the transition
+    std::pair<std::string,std::string> parseTag( const std::string& tag );
+
     class SessionImpl;
     class GTProxyData;
 

--- a/CondCore/CondDB/interface/Serialization.h
+++ b/CondCore/CondDB/interface/Serialization.h
@@ -114,7 +114,7 @@ namespace cond {
       payload.reset( createPayload<T>(payloadType) );
       ia >> (*payload);
     } else {
-      payload = boost::static_pointer_cast<T>(payloadData.share());
+      payload = boost::static_pointer_cast<T>(payloadData.oraObject().makeShared());
     }
     return payload;
   }

--- a/CondCore/CondDB/src/Binary.cc
+++ b/CondCore/CondDB/src/Binary.cc
@@ -12,10 +12,6 @@ cond::Binary::Binary():
   m_data( new coral::Blob(0) ){
 }
 
-cond::Binary::Binary( const boost::shared_ptr<void>& objectPtr ):
-  m_object( objectPtr ){
-}
-
 cond::Binary::Binary( const void* data, size_t size  ):
   m_data( new coral::Blob( size ) ){
   ::memcpy( m_data->startingAddress(), data, size );
@@ -46,7 +42,7 @@ const coral::Blob& cond::Binary::get() const {
 void cond::Binary::copy( const std::string& source ){
   m_data.reset( new coral::Blob( source.size() ) );
   ::memcpy( m_data->startingAddress(), source.c_str(), source.size() );
-  m_object.reset();
+  m_object = ora::Object();
 }
 
 const void* cond::Binary::data() const {
@@ -63,10 +59,13 @@ size_t cond::Binary::size() const {
   return m_data->size();
 }
     
-boost::shared_ptr<void> cond::Binary::share() const {
+ora::Object cond::Binary::oraObject() const {
   return m_object;
 }
 
-
+void cond::Binary::fromOraObject( const ora::Object& object ){
+  m_object = object;
+  m_data.reset();
+}
 
 

--- a/CondCore/CondDB/src/DbConnectionString.cc
+++ b/CondCore/CondDB/src/DbConnectionString.cc
@@ -2,12 +2,14 @@
 #include "CondCore/CondDB/interface/Utils.h"
 #include "DbConnectionString.h"
 //
+#include "CondCore/DBCommon/interface/FipProtocolParser.h"
 #include "FWCore/Catalog/interface/SiteLocalConfig.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 
 namespace cond {
 
   namespace persistency {
+
 
     unsigned int
     countslash(const std::string& input) {
@@ -24,52 +26,48 @@ namespace cond {
       return count;
     }
 
-    std::pair<std::string,std::string> makeFrontierConnectionString( const std::string& initialConnection, 
-					      const std::string& transactionId ){
-      std::string realConn = initialConnection;
-      std::string proto("frontier://");
-      std::string::size_type fpos=initialConnection.find(proto);
-      unsigned int nslash=countslash(initialConnection.substr(proto.size(),initialConnection.size()-fpos));
-      if(nslash==1){
-	edm::Service<edm::SiteLocalConfig> localconfservice;
-	if( !localconfservice.isAvailable() ){
-	  throwException("SiteLocalConfigService is not available","cond::makeRealConnectString");       
+    std::pair<std::string,std::string> getConnectionParams( const std::string& connectionString, 
+							    const std::string& transactionId ){
+      if( connectionString.empty() ) throwException( "The connection string is empty.","getConnectionParams"); 
+      std::string protocol = getConnectionProtocol( connectionString );
+      std::string finalConn = connectionString;
+      std::string refreshConn("");
+      if( protocol == "frontier" ){
+	std::string protocol("frontier://");
+	std::string::size_type fpos=connectionString.find(protocol);
+	unsigned int nslash=countslash(connectionString.substr(protocol.size(),connectionString.size()-fpos));
+	if(nslash==1){
+	  edm::Service<edm::SiteLocalConfig> localconfservice;
+	  if( !localconfservice.isAvailable() ){
+	    throwException("edm::SiteLocalConfigService is not available","getConnectionParams");       
+	  }
+	  finalConn=localconfservice->lookupCalibConnect(connectionString);
 	}
-	realConn=localconfservice->lookupCalibConnect(initialConnection);
-      }
-      if (!transactionId.empty()) {
-	size_t l = realConn.rfind('/');
-	realConn.insert(l,"(freshkey="+transactionId+')');
-      }
-      
-      std::string refreshConnect;
-      std::string::size_type startRefresh = realConn.find("://");
-      if (startRefresh != std::string::npos){
-	startRefresh += 3;
-      }
-      std::string::size_type endRefresh=realConn.rfind("/", std::string::npos);
-      if (endRefresh == std::string::npos){
-	refreshConnect = realConn;
-      }else{
-	refreshConnect = realConn.substr(startRefresh, endRefresh-startRefresh);
-	if(refreshConnect.substr(0,1) != "("){
-	  //if the connect string is not a complicated parenthesized string,
-	  // an http:// needs to be at the beginning of it
-	  refreshConnect.insert(0, "http://");
+	if (!transactionId.empty()) {
+	  size_t l = finalConn.rfind('/');
+	  finalConn.insert(l,"(freshkey="+transactionId+')');
 	}
+
+	std::string::size_type startRefresh = finalConn.find("://");
+	if (startRefresh != std::string::npos){
+	  startRefresh += 3;
+	}
+	std::string::size_type endRefresh=finalConn.rfind("/", std::string::npos);
+	if (endRefresh == std::string::npos){
+	  refreshConn = finalConn;
+	} else{
+	  refreshConn = finalConn.substr(startRefresh, endRefresh-startRefresh);
+	  if(refreshConn.substr(0,1) != "("){
+	    //if the connect string is not a complicated parenthesized string,
+	    // an http:// needs to be at the beginning of it
+	    refreshConn.insert(0, "http://");
+	  }
+	}
+      } else if ( protocol == "sqlite_fip" ){
+	cond::FipProtocolParser parser;
+	finalConn = parser.getRealConnect( connectionString ); 
       }
-      return std::make_pair(realConn,refreshConnect);
-    }
-    
-    std::pair<std::string,std::string> getRealConnectionString( const std::string& initialConnection ){
-      return getRealConnectionString( initialConnection, "" );
-    }
-    
-    std::pair<std::string,std::string> getRealConnectionString( const std::string& initialConnection, 
-								const std::string& transId ){
-      auto connData = parseConnectionString( initialConnection );
-      if( std::get<0>(connData) == "frontier" ) return makeFrontierConnectionString(  initialConnection, transId );    
-      return std::make_pair(initialConnection,"");
+      return std::make_pair( finalConn, refreshConn ); 
     }
 
   }

--- a/CondCore/CondDB/src/DbConnectionString.h
+++ b/CondCore/CondDB/src/DbConnectionString.h
@@ -1,6 +1,7 @@
 #ifndef CondCore_CondDB_DbConnectionString_h
 #define CondCore_CondDB_DbConnectionString_h
 
+#include "CondCore/CondDB/interface/Utils.h"
 //
 #include <string>
 
@@ -8,9 +9,7 @@ namespace cond {
 
   namespace persistency {
 
-    std::pair<std::string,std::string> getRealConnectionString( const std::string& initialConnection );
-
-    std::pair<std::string,std::string> getRealConnectionString( const std::string& initialConnection, const std::string& transId );
+    std::pair<std::string,std::string> getConnectionParams( const std::string& initialConnection, const std::string& transId );
 
   }
 

--- a/CondCore/CondDB/src/GTProxy.cc
+++ b/CondCore/CondDB/src/GTProxy.cc
@@ -5,6 +5,19 @@ namespace cond {
 
   namespace persistency {
 
+    std::pair<std::string,std::string> parseTag( const std::string& tag ){
+      std::string pfn("");
+      std::string t(tag);
+      size_t pos = tag.rfind('@');
+      if( pos != std::string::npos && tag.size() >= pos+3 ){
+	if( tag[pos+1]=='[' && tag[tag.size()-1]==']' ) {
+	  pfn = tag.substr( pos+2,tag.size()-pos-3 ); 
+	  t = tag.substr( 0, pos );
+	}
+      }
+      return std::make_pair( t, pfn );
+    }
+
     // implementation details...
     // only hosting data in this case
     class GTProxyData {

--- a/CondCore/CondDB/src/OraDbSchema.cc
+++ b/CondCore/CondDB/src/OraDbSchema.cc
@@ -118,7 +118,7 @@ namespace cond {
     bool OraPayloadTable::select( const cond::Hash& payloadHash, std::string& objectType, cond::Binary& payloadData ){
       ora::Object obj = m_session.getObject( payloadHash );
       objectType = obj.typeName();
-      payloadData = cond::Binary( obj.makeShared() );
+      payloadData.fromOraObject(obj );
       return true;
     }
 
@@ -129,8 +129,7 @@ namespace cond {
       
     cond::Hash OraPayloadTable::insertIfNew( const std::string& objectType, const cond::Binary& payloadData, 
 					     const boost::posix_time::ptime& ){
-      void* ptr = payloadData.share().get();
-      ora::Object obj( ptr, objectType );
+      ora::Object obj = payloadData.oraObject();
       std::string tok = m_session.storeObject( obj, objectType );
       m_session.flush();
       return tok;

--- a/CondCore/DBCommon/plugins/RelationalAuthenticationService.cc
+++ b/CondCore/DBCommon/plugins/RelationalAuthenticationService.cc
@@ -60,9 +60,11 @@ cond::RelationalAuthenticationService::RelationalAuthenticationService::credenti
   } 
   creds = m_cache.get( connectionString );
   if( ! creds ){
-    std::string msg("No Authentication available for connection=\"");
-    msg += connectionString + "\".";
-    throw coral::AuthenticationServiceException( msg, "cond::RelationalAuthenticationService::RelationalAuthenticationService::credentials", "");
+    std::string msg("Connection to \"");
+    msg += connectionString + "\"";
+    msg += " with role \"COND_DEFAULT_ROLE\" is not available for ";
+    msg +=m_db.keyPrincipalName();
+    cond::throwException( msg, "cond::RelationalAuthenticationService::RelationalAuthenticationService::credentials" );
   }
   return *creds;
 }
@@ -80,10 +82,11 @@ cond::RelationalAuthenticationService::RelationalAuthenticationService::credenti
   } 
   creds = m_cache.get( connectionString, role );
   if( ! creds ){
-    std::string msg("No Authentication available for connection=\"");
-    msg += connectionString + "\".";
-    msg += " and role=\"" + role + "\".";
-    throw coral::AuthenticationServiceException( msg, "cond::RelationalAuthenticationService::RelationalAuthenticationService::credentials","");
+    std::string msg("Connection to \"");
+    msg += connectionString + "\"";
+    msg += " with role \"" + role + "\" is not available for ";
+    msg +=m_db.keyPrincipalName();
+    cond::throwException( msg, "cond::RelationalAuthenticationService::RelationalAuthenticationService::credentials" );
   }
   return *creds;
 }

--- a/CondCore/DBCommon/src/DecodingKey.cc
+++ b/CondCore/DBCommon/src/DecodingKey.cc
@@ -179,7 +179,7 @@ size_t cond::DecodingKey::init( const std::string& keyFileName, const std::strin
 	}
       }
     } else {
-      std::string msg = "Provided Key File \""+m_fileName+"\" is invalid.";
+      std::string msg = "Required Key File \""+m_fileName+"\" is missing or unreadable.";
       throwException(msg,"DecodingKey::init");      
     }
   }

--- a/CondCore/DBOutputService/src/PoolDBOutputService.cc
+++ b/CondCore/DBOutputService/src/PoolDBOutputService.cc
@@ -55,7 +55,8 @@ cond::service::PoolDBOutputService::PoolDBOutputService(const edm::ParameterSet 
   connection.setParameters( connectionPset );
   connection.configure();
   std::string connectionString = iConfig.getParameter<std::string>("connect");
-  BackendType backType = (BackendType) iConfig.getUntrackedParameter<int>("dbFormat", DEFAULT_DB);
+  BackendType backType = (BackendType) iConfig.getUntrackedParameter<int>("dbFormat", DEFAULT_DB );
+  if( backType == UNKNOWN_DB )  backType = DEFAULT_DB;
   m_session = connection.createSession( connectionString, true, backType ); 
   
   //if( iConfig.exists("logconnect") ){

--- a/CondCore/DBOutputService/test/python/testIOVPayloadAnalyzer_example_oracle_cfg.py
+++ b/CondCore/DBOutputService/test/python/testIOVPayloadAnalyzer_example_oracle_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("TEST")
 process.load("CondCore.CondDB.CondDB_cfi")
 process.CondDB.connect = 'oracle://cms_orcoff_prep/CMS_COND_WEB'
-process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb/test'
+process.CondDB.DBParameters.authenticationPath = '/afs/cern.ch/cms/DB/conddb'
 #process.CondDB.DBParameters.messageLevel = cms.untracked.int32(3)
 
 process.source = cms.Source("EmptyIOVSource",

--- a/CondCore/DBOutputService/test/stubs/writeKeyed.cc
+++ b/CondCore/DBOutputService/test/stubs/writeKeyed.cc
@@ -40,6 +40,7 @@ writeKeyed::endJob() {
   edm::Service<cond::service::PoolDBOutputService> outdb;
 
 
+  std::map<cond::Time_t, cond::BaseKeyed*> keys;
   // populated with the keyed payloads (configurations)
   for ( size_t i=0; i<dict.size(); ++i)
     for (size_t j=0;j<7; ++j) {
@@ -51,9 +52,15 @@ writeKeyed::endJob() {
 			   bk = new condex::ConfF(dict[i]+nums[j],i+0.1*j),      
 			   dict[i]+nums[j]);
       std::cout << k.m_skey << " " << k.m_key << std::endl;
-      outdb->writeOne(k.m_obj,k.m_key,confcont);
+      
+      keys.insert( std::make_pair( k.m_key, k.m_obj ) );
+      //outdb->writeOne(k.m_obj,k.m_key,confcont);
     }
 
+  std::cout <<"# uploading keys..."<<std::endl;
+  for( auto k : keys )outdb->writeOne( k.second, k.first,confcont ); 
+
+  std::cout <<"# uploading master payloads..."<<std::endl;
   // populate the master payload
   int run=10;
   for (size_t j=0;j<7; ++j) {

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -41,20 +41,6 @@ namespace {
     return iRecordName + std::string( "@" ) + iLabelName;
   }
 
-  // required in the "bridge" mode, to be removed with the ORA based code after the transition
-  std::pair<std::string,std::string> parseTag( const std::string& tag ){
-    std::string pfn("");
-    std::string t(tag);
-    size_t pos = tag.rfind('@');
-    if( pos != std::string::npos && tag.size() >= pos+3 ){
-      if( tag[pos+1]=='[' && tag[tag.size()-1]==']' ) {
-	pfn = tag.substr( pos+2,tag.size()-pos-3 ); 
-	t = tag.substr( 0, pos );
-      }
-    }
-    return std::make_pair( t, pfn );
-  }
-
   /* utility class to return a IOVs associated to a given "name"
      This implementation return the IOV associated to a record...
      It is essentialy a workaround to get the full IOV out of the tag colector
@@ -211,7 +197,7 @@ CondDBESSource::CondDBESSource( const edm::ParameterSet& iConfig ) :
   for(it=itBeg;it!=itEnd;++it){
     std::string connStr = m_connectionString;
     std::string tag = it->second.tagName();
-    std::pair<std::string,std::string> tagParams = parseTag( it->second.tagName() );
+    std::pair<std::string,std::string> tagParams = cond::persistency::parseTag( it->second.tagName() );
     if( !tagParams.second.empty() ) {
       connStr =  tagParams.second;
       tag = tagParams.first;
@@ -407,7 +393,7 @@ CondDBESSource::setIntervalFor( const edm::eventsetup::EventSetupRecordKey& iKey
 	//transId << "long" << m_lastRun;
 	transId << m_lastRun;
 	std::string connStr = m_connectionString;
-	std::pair<std::string,std::string> tagParams = parseTag( tcIter->second.tagName() );
+	std::pair<std::string,std::string> tagParams = cond::persistency::parseTag( tcIter->second.tagName() );
 	if( !tagParams.second.empty() ) connStr =  tagParams.second;
 	std::map<std::string,std::pair<cond::persistency::Session,std::string> >::iterator iSess = m_sessionPool.find( connStr );
 	bool reopen = false;

--- a/CondCore/ORA/interface/Object.h
+++ b/CondCore/ORA/interface/Object.h
@@ -12,6 +12,9 @@ namespace ora {
   class Object {
     public:
     Object();
+    template <typename T>
+    explicit Object( const T& obj );
+    Object( const void* ptr, const std::type_info& typeInfo );
     Object( const void* ptr, const Reflex::Type& type );
     Object( const void* ptr, const std::string& typeName );
     Object( const Object& rhs);
@@ -30,6 +33,20 @@ namespace ora {
     void* m_ptr;
     Reflex::Type m_type;
   };
+
+  template<> 
+  inline
+  Object::Object( const Object& rhs ):
+    m_ptr( rhs.m_ptr ),
+    m_type( rhs.m_type ){
+  }
+
+}
+
+template <typename T>
+inline
+ora::Object::Object( const T& obj ):
+  Object( &obj, typeid(obj) ){
 }
 
 template <typename T>

--- a/CondCore/ORA/src/Database.cc
+++ b/CondCore/ORA/src/Database.cc
@@ -46,7 +46,7 @@ namespace ora {
         contHandle = session.createContainer( name, contType );
       } else {
         throwException("Container \""+name+"\" does not exist in the database.",
-                       "Database::insertItem");
+                       "Database::getContainerFromSession");
       }
     }
 
@@ -301,7 +301,7 @@ ora::Object ora::Database::fetchItem(const OId& oid){
 
 ora::OId ora::Database::insertItem(const std::string& containerName,
                                    const Object& dataObject ){
-  open( true );
+  open( true );  
   Container cont  = getContainerFromSession( containerName, dataObject.type(), *m_impl->m_session );
   int itemId = cont.insertItem( dataObject );
   return OId( cont.id(), itemId );

--- a/CondCore/ORA/src/Object.cc
+++ b/CondCore/ORA/src/Object.cc
@@ -9,14 +9,19 @@ ora::Object::Object():
   m_type(){
 }
 
+ora::Object::Object( const void* ptr, const std::type_info& typeInfo ):
+  m_ptr( const_cast<void*>(ptr) ){
+  m_type = ClassUtils::lookupDictionary( typeInfo, true );
+}
+
 ora::Object::Object( const void* ptr, const Reflex::Type& type ):
   m_ptr( const_cast<void*>(ptr) ),
-  m_type( type ){
+  m_type( type ){  
 }
 
 ora::Object::Object( const void* ptr, const std::string& typeName ):
-  m_ptr( const_cast<void*>(ptr) ),
-  m_type(Reflex::Type::ByName( typeName )){
+  m_ptr( const_cast<void*>(ptr) ){
+  m_type = ClassUtils::lookupDictionary( typeName, true );
 }
 
 ora::Object::Object( const Object& rhs):
@@ -65,8 +70,12 @@ void* ora::Object::cast( const std::type_info& typeInfo ) const{
   return ClassUtils::upCast( m_type, m_ptr, castType );
 }
 
-boost::shared_ptr<void> ora::Object::makeShared() const {
-  return boost::shared_ptr<void>( m_ptr, RflxDeleter( m_type ) );
+boost::shared_ptr<void> ora::Object::makeShared( ) const {
+  boost::shared_ptr<void> ret;
+  if( m_ptr ) {
+    ret = boost::shared_ptr<void>( m_ptr, RflxDeleter( m_type ) );
+  }
+  return ret;
 }
 
 void ora::Object::destruct() {

--- a/CondCore/Utilities/bin/conddb_migrate.cpp
+++ b/CondCore/Utilities/bin/conddb_migrate.cpp
@@ -5,6 +5,7 @@
 #include "CondCore/DBCommon/interface/Auth.h"
 
 #include "CondCore/CondDB/interface/ConnectionPool.h"
+#include "CondCore/CondDB/interface/Utils.h"
 #include "CondCore/CondDB/interface/IOVEditor.h"
 #include "CondCore/CondDB/interface/IOVProxy.h"
 
@@ -56,7 +57,7 @@ int cond::MigrateUtilities::execute(){
   std::string destConnect = getOptionValue<std::string>("destConnect" );
 
   std::string sourceConnect = getOptionValue<std::string>("sourceConnect");
-  std::tuple<std::string,std::string,std::string> connPars = parseConnectionString( sourceConnect );
+  std::tuple<std::string,std::string,std::string> connPars = persistency::parseConnectionString( sourceConnect );
   if( std::get<0>( connPars ) == "frontier" ) throwException("Cannot migrate data from FronTier cache.","MigrateUtilities::execute");
 
   std::cout <<"# Connecting to source database on "<<sourceConnect<<std::endl;

--- a/CondCore/Utilities/bin/conddb_migrate_gt.cpp
+++ b/CondCore/Utilities/bin/conddb_migrate_gt.cpp
@@ -142,7 +142,7 @@ int cond::MigrateGTUtilities::execute(){
     std::string connectionString = std::get<4>( gtitem );
     
     std::cout <<"--> Processing tag "<<tag<<" (objectType: "<<payloadTypeName<<") on account "<<connectionString<<std::endl;
-    auto connectionData = parseConnectionString( connectionString );
+    auto connectionData = persistency::parseConnectionString( connectionString );
     std::string account = std::get<2>( connectionData );
     if( std::get<1>( connectionData )=="FrontierArc" ) {
       size_t len = account.size()-5;

--- a/CondCore/Utilities/bin/conddb_test_gt_load.cpp
+++ b/CondCore/Utilities/bin/conddb_test_gt_load.cpp
@@ -19,8 +19,6 @@ namespace cond {
 
     void load( const std::string& tag );
 
-    void reload();
-
     void reset();
 
     TimeType timeType() const;
@@ -52,9 +50,7 @@ namespace cond {
 }
 
 cond::UntypedPayloadProxy::UntypedPayloadProxy( Session& session ):
-  m_session( session ),
-  m_iov( session.iovProxy() ),
-  m_data(){
+  m_session( session ){
   m_data.reset( new pimpl );
   m_data->current.clear();
 }
@@ -74,12 +70,9 @@ cond::UntypedPayloadProxy& cond::UntypedPayloadProxy::operator=( const cond::Unt
 
 void cond::UntypedPayloadProxy::load( const std::string& tag ){
   m_data->current.clear();
-  m_iov.load( tag );
-}
-
-void cond::UntypedPayloadProxy::reload(){
-  m_data->current.clear();
-  m_iov.reload();
+  m_session.transaction().start();
+  m_iov = m_session.readIov( tag );
+  m_session.transaction().commit();
 }
 
 void cond::UntypedPayloadProxy::reset(){
@@ -105,6 +98,8 @@ bool cond::UntypedPayloadProxy::get( cond::Time_t targetTime, bool debug ){
 
     // a new payload is required!
     if( debug )std::cout <<" Searching tag "<<m_iov.tag()<<" for a valid payload for time="<<targetTime<<std::endl;
+    m_session.transaction().start();
+
     auto iIov = m_iov.find( targetTime );
     if(iIov == m_iov.end() ) cond::throwException(std::string("Tag ")+m_iov.tag()+": No iov available for the target time:"+boost::lexical_cast<std::string>(targetTime),"UntypedPayloadProxy::get");
     m_data->current = *iIov;
@@ -113,10 +108,14 @@ bool cond::UntypedPayloadProxy::get( cond::Time_t targetTime, bool debug ){
     std::string payloadType("");
     Binary data; 
     loaded = m_session.fetchPayloadData( m_data->current.payloadId, payloadType, data );
+    m_session.transaction().commit();
     if( !loaded ){
       std::cout <<"ERROR: payload with id "<<m_data->current.payloadId<<" could not be loaded."<<std::endl;
     }else {
-      if( debug ) std::cout <<"Loaded payload of type \""<< payloadType <<"\" ("<<data.size()<<" bytes)"<<std::endl;  
+      std::stringstream sz;
+      if( data.oraObject().address()==0 ) sz << data.size();
+      else sz <<"?";
+      if( debug ) std::cout <<"Loaded payload of type \""<< payloadType <<"\" ("<<sz.str()<<" bytes)"<<std::endl;  
     }
   } else {
     event <<"Target time "<<targetTime<<" is within range for payloads available in cache: ["<<m_data->current.since<<" - "<<m_data->current.till<<"]";
@@ -173,21 +172,31 @@ int cond::TestGTLoad::execute(){
 
   ConnectionPool connPool;
   if( hasDebug() ) connPool.setMessageVerbosity( coral::Debug );
+  connPool.configure();
   Session session = connPool.createSession( connect );
   session.transaction().start();
   
   std::cout <<"Loading Global Tag "<<gtag<<std::endl;
   GTProxy gt = session.readGlobalTag( gtag );
 
+  session.transaction().commit();
+
   std::cout <<"Loading "<<gt.size()<<" tags..."<<std::endl;
   std::vector<UntypedPayloadProxy> proxies;
   std::map<std::string,size_t> requests;
   for( auto t: gt ){
-    UntypedPayloadProxy p( session );
+    std::pair<std::string,std::string> tagParams = parseTag( t.tagName() );
+    std::string tagConnStr = connect;
+    Session tagSession = session; 
+    if( !tagParams.second.empty() ) {
+      tagConnStr = tagParams.second;
+      tagSession = connPool.createSession( tagConnStr );
+    }
+    UntypedPayloadProxy p( tagSession );
     try{
-      p.load( t.tagName() );
+      p.load( tagParams.first );
       proxies.push_back( p );
-      requests.insert( std::make_pair( t.tagName(), 0 ) );
+      requests.insert( std::make_pair( tagParams.first, 0 ) );
     } catch ( const cond::Exception& e ){
       std::cout <<"ERROR: "<<e.what()<<std::endl;
     }
@@ -204,26 +213,26 @@ int cond::TestGTLoad::execute(){
       bool loaded = false;
       time::TimeType ttype = p.timeType();
       auto r = requests.find( p.tag() );
-      try{
-	if( ttype==runnumber ){
-	  p.get( run, hasDebug() );	
-	  r->second++;
-	} else if( ttype==lumiid ){
-	  p.get( lumi, hasDebug() );
-	  r->second++;
-	} else if( ttype==timestamp){
-	  p.get( ts, hasDebug() );
-	  r->second++;
-	} else {
-	  std::cout <<"WARNING: iov request on tag "<<p.tag()<<" (timeType="<<time::timeTypeName(p.timeType())<<") has been skipped."<<std::endl;
+      if( r != requests.end() ){
+	try{
+	  if( ttype==runnumber ){
+	    p.get( run, hasDebug() );	
+	    r->second++;
+	  } else if( ttype==lumiid ){
+	    p.get( lumi, hasDebug() );
+	    r->second++;
+	  } else if( ttype==timestamp){
+	    p.get( ts, hasDebug() );
+	    r->second++;
+	  } else {
+	    std::cout <<"WARNING: iov request on tag "<<p.tag()<<" (timeType="<<time::timeTypeName(p.timeType())<<") has been skipped."<<std::endl;
+	  }
+	} catch ( const cond::Exception& e ){
+	  std::cout <<"ERROR:"<<e.what()<<std::endl;
 	}
-      } catch ( const cond::Exception& e ){
-	std::cout <<"ERROR:"<<e.what()<<std::endl;
       }
     }
   }
-
-  session.transaction().commit();
 
   std::cout <<std::endl;
   std::cout <<"*** End of job."<<std::endl;
@@ -231,10 +240,12 @@ int cond::TestGTLoad::execute(){
   std::cout<<std::endl;
   for( auto p: proxies ){
     auto r = requests.find( p.tag() );
-    std::cout <<"*** Tag: "<<p.tag()<<" Requests processed:"<<r->second<<" Queries:"<<p.numberOfQueries()<<std::endl;
-    if( verbose ){
-      const std::vector<std::string>& hist = p.history();
-      for( auto e: p.history() ) std::cout <<"    "<<e<<std::endl;
+    if( r != requests.end() ){
+      std::cout <<"*** Tag: "<<p.tag()<<" Requests processed:"<<r->second<<" Queries:"<<p.numberOfQueries()<<std::endl;
+      if( verbose ){
+	const std::vector<std::string>& hist = p.history();
+	for( auto e: p.history() ) std::cout <<"    "<<e<<std::endl;
+      }
     }
   }
 


### PR DESCRIPTION
...aching for payloads + other fixes

The connection handling for old and new database has been cleaned. Support for sqlite_fip has been re-added in both old and new systems. For fronTier the caching policy has been set up using the new functions, allowing the never-expiring for payloads. 
In additions, fixes for dictionary auto-loading ( old system ) and extensions of test_gt_load to old database flavor.

Packages:
CondCore/CondDB
CondCore/DBCommon
CondCore/DBOutputService
CondCore/ESSources
CondCore/ORA
CondCore/Utilities
