### PR TITLE
Migrate More to New Random Service Interface

### DIFF
--- a/IOMC/ParticleGuns/interface/BaseFlatGunProducer.h
+++ b/IOMC/ParticleGuns/interface/BaseFlatGunProducer.h
@@ -19,9 +19,6 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Run.h"
 
-#include "CLHEP/Random/JamesRandom.h"
-#include "CLHEP/Random/RandFlat.h"
-
 #include <memory>
 #include "boost/shared_ptr.hpp"
 
@@ -68,9 +65,6 @@ namespace edm
             	    	
     int              fVerbosity ;
 
-    CLHEP::HepRandomEngine& fRandomEngine ;
-    CLHEP::RandFlat*        fRandomGenerator; 
-    
     bool             fAddAntiParticle;
     
   };

--- a/IOMC/ParticleGuns/interface/ExpoRandomPtGunProducer.h
+++ b/IOMC/ParticleGuns/interface/ExpoRandomPtGunProducer.h
@@ -8,7 +8,7 @@
  ***************************************/
 
 #include "IOMC/ParticleGuns/interface/BaseFlatGunProducer.h"
-#include "CLHEP/Random/RandExponential.h"
+
 namespace edm
 {
   
@@ -30,8 +30,6 @@ namespace edm
     double            fMinPt   ;
     double            fMaxPt   ;
     double            fMeanPt ;
-    CLHEP::RandExponential * fRandomExpoGenerator;
-
   };
 } 
 

--- a/IOMC/ParticleGuns/interface/MultiParticleInConeGunProducer.h
+++ b/IOMC/ParticleGuns/interface/MultiParticleInConeGunProducer.h
@@ -8,7 +8,7 @@
  ***************************************/
 
 #include "IOMC/ParticleGuns/interface/BaseFlatGunProducer.h"
-#include "CLHEP/Random/RandExponential.h"
+
 namespace edm
 {
   

--- a/IOMC/ParticleGuns/src/BaseFlatGunProducer.cc
+++ b/IOMC/ParticleGuns/src/BaseFlatGunProducer.cc
@@ -27,10 +27,10 @@ using namespace edm;
 using namespace std;
 using namespace CLHEP;
 
-namespace {
-  CLHEP::HepRandomEngine& getEngineReference()
-  {
-
+BaseFlatGunProducer::BaseFlatGunProducer( const ParameterSet& pset ) :
+   fEvt(0)
+   // fPDGTable( new DefaultConfig::ParticleDataTable("PDG Table") )
+{
    Service<RandomNumberGenerator> rng;
    if(!rng.isAvailable()) {
     throw cms::Exception("Configuration")
@@ -38,18 +38,6 @@ namespace {
           "which appears to be absent.  Please add that service to your configuration\n"
           "or remove the modules that require it.";
    }
-
-// The Service has already instantiated an engine.  Make contact with it.
-   return (rng->getEngine());
-  }
-}
-
-BaseFlatGunProducer::BaseFlatGunProducer( const ParameterSet& pset ) :
-   fEvt(0),
-   fRandomEngine(getEngineReference()),
-   fRandomGenerator(0)
-   // fPDGTable( new DefaultConfig::ParticleDataTable("PDG Table") )
-{
 
    ParameterSet pgun_params = pset.getParameter<ParameterSet>("PGunParameters") ;
   
@@ -85,8 +73,6 @@ BaseFlatGunProducer::BaseFlatGunProducer( const ParameterSet& pset ) :
 
   fVerbosity = pset.getUntrackedParameter<int>( "Verbosity",0 ) ;
 
-// The Service has already instantiated an engine.  Use it.
-   fRandomGenerator = new CLHEP::RandFlat(fRandomEngine) ;
    fAddAntiParticle = pset.getParameter<bool>("AddAntiParticle") ;
 
    produces<GenRunInfoProduct, InRun>();
@@ -94,10 +80,6 @@ BaseFlatGunProducer::BaseFlatGunProducer( const ParameterSet& pset ) :
 
 BaseFlatGunProducer::~BaseFlatGunProducer()
 {
-  
-//if ( fRandomGenerator != NULL ) delete fRandomGenerator;
-  // do I need to delete the Engine, too ?
-  
   // no need to cleanup GenEvent memory - done in HepMCProduct
   // if (fEvt != NULL) delete fEvt ; // double check
   // delete fPDGTable;

--- a/IOMC/ParticleGuns/src/FlatRandomEGunProducer.cc
+++ b/IOMC/ParticleGuns/src/FlatRandomEGunProducer.cc
@@ -11,6 +11,10 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
+
+#include "CLHEP/Random/RandFlat.h"
 
 using namespace edm;
 using namespace std;
@@ -44,6 +48,8 @@ FlatRandomEGunProducer::~FlatRandomEGunProducer()
 
 void FlatRandomEGunProducer::produce(Event & e, const EventSetup& es) 
 {
+   edm::Service<edm::RandomNumberGenerator> rng;
+   CLHEP::HepRandomEngine* engine = &rng->getEngine(e.streamID());
 
    if ( fVerbosity > 0 )
    {
@@ -70,9 +76,9 @@ void FlatRandomEGunProducer::produce(Event & e, const EventSetup& es)
    int barcode = 1;
    for (unsigned int ip=0; ip<fPartIDs.size(); ip++)
    {
-       double energy = fRandomGenerator->fire(fMinE, fMaxE) ;
-       double eta    = fRandomGenerator->fire(fMinEta, fMaxEta) ;
-       double phi    = fRandomGenerator->fire(fMinPhi, fMaxPhi) ;
+       double energy = CLHEP::RandFlat::shoot(engine, fMinE, fMaxE) ;
+       double eta    = CLHEP::RandFlat::shoot(engine, fMinEta, fMaxEta) ;
+       double phi    = CLHEP::RandFlat::shoot(engine, fMinPhi, fMaxPhi) ;
        int PartID = fPartIDs[ip] ;
        const HepPDT::ParticleData* 
           PData = fPDGTable->particle(HepPDT::ParticleID(abs(PartID))) ;

--- a/IOMC/ParticleGuns/src/FlatRandomOneOverPtGunProducer.cc
+++ b/IOMC/ParticleGuns/src/FlatRandomOneOverPtGunProducer.cc
@@ -8,7 +8,10 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 
+#include "CLHEP/Random/RandFlat.h"
 #include "CLHEP/Units/GlobalSystemOfUnits.h"
 using namespace edm;
 
@@ -34,6 +37,9 @@ FlatRandomOneOverPtGunProducer::~FlatRandomOneOverPtGunProducer() {
 }
 
 void FlatRandomOneOverPtGunProducer::produce(Event &e, const EventSetup& es) {
+  edm::Service<edm::RandomNumberGenerator> rng;
+  CLHEP::HepRandomEngine* engine = &rng->getEngine(e.streamID());
+
 
   LogDebug("ParticleGun") << " FlatRandomOneOverPtGunProducer : Begin New Event Generation"; 
 
@@ -57,11 +63,11 @@ void FlatRandomOneOverPtGunProducer::produce(Event &e, const EventSetup& es) {
   int barcode = 1 ;
   for (unsigned int ip=0; ip<fPartIDs.size(); ++ip) {
 
-    double xx     = fRandomGenerator->fire(0.0,1.0);
+    double xx     = CLHEP::RandFlat::shoot(engine, 0.0, 1.0);
     double pt     = std::exp((1.-xx)*std::log(fMinOneOverPt)+
 			     xx*std::log(fMaxOneOverPt)) ;
-    double eta    = fRandomGenerator->fire(fMinEta, fMaxEta) ;
-    double phi    = fRandomGenerator->fire(fMinPhi, fMaxPhi) ;
+    double eta    = CLHEP::RandFlat::shoot(engine, fMinEta, fMaxEta) ;
+    double phi    = CLHEP::RandFlat::shoot(engine, fMinPhi, fMaxPhi) ;
     if (pt != 0) pt = 1./pt;
     int PartID = fPartIDs[ip] ;
     const HepPDT::ParticleData* 

--- a/IOMC/ParticleGuns/src/FlatRandomPtGunProducer.cc
+++ b/IOMC/ParticleGuns/src/FlatRandomPtGunProducer.cc
@@ -11,7 +11,10 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 
+#include "CLHEP/Random/RandFlat.h"
 
 using namespace edm;
 using namespace std;
@@ -39,6 +42,8 @@ FlatRandomPtGunProducer::~FlatRandomPtGunProducer()
 
 void FlatRandomPtGunProducer::produce(Event &e, const EventSetup& es) 
 {
+   edm::Service<edm::RandomNumberGenerator> rng;
+   CLHEP::HepRandomEngine* engine = &rng->getEngine(e.streamID());
 
    if ( fVerbosity > 0 )
    {
@@ -64,10 +69,9 @@ void FlatRandomPtGunProducer::produce(Event &e, const EventSetup& es)
    int barcode = 1 ;
    for (unsigned int ip=0; ip<fPartIDs.size(); ++ip)
    {
-
-       double pt     = fRandomGenerator->fire(fMinPt, fMaxPt) ;
-       double eta    = fRandomGenerator->fire(fMinEta, fMaxEta) ;
-       double phi    = fRandomGenerator->fire(fMinPhi, fMaxPhi) ;
+       double pt     = CLHEP::RandFlat::shoot(engine, fMinPt, fMaxPt) ;
+       double eta    = CLHEP::RandFlat::shoot(engine, fMinEta, fMaxEta) ;
+       double phi    = CLHEP::RandFlat::shoot(engine, fMinPhi, fMaxPhi) ;
        int PartID = fPartIDs[ip] ;
        const HepPDT::ParticleData* 
           PData = fPDGTable->particle(HepPDT::ParticleID(abs(PartID))) ;

--- a/IOMC/ParticleGuns/src/MultiParticleInConeGunProducer.cc
+++ b/IOMC/ParticleGuns/src/MultiParticleInConeGunProducer.cc
@@ -11,10 +11,10 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 
-// #include "FWCore/Utilities/interface/Exception.h"
-
-// #include "CLHEP/Random/RandFlat.h"
+#include "CLHEP/Random/RandFlat.h"
 
 using namespace edm;
 using namespace std;
@@ -54,6 +54,8 @@ MultiParticleInConeGunProducer::~MultiParticleInConeGunProducer()
 
 void MultiParticleInConeGunProducer::produce(Event &e, const EventSetup& es) 
 {
+   edm::Service<edm::RandomNumberGenerator> rng;
+   CLHEP::HepRandomEngine* engine = &rng->getEngine(e.streamID());
 
    if ( fVerbosity > 0 )
    {
@@ -81,9 +83,9 @@ void MultiParticleInConeGunProducer::produce(Event &e, const EventSetup& es)
    for (unsigned int ip=0; ip<fPartIDs.size(); ++ip)
    {
 
-       double pt     = fRandomGenerator->fire(fMinPt, fMaxPt) ;
-       double eta    = fRandomGenerator->fire(fMinEta, fMaxEta) ;
-       double phi    = fRandomGenerator->fire(fMinPhi, fMaxPhi) ;
+       double pt     = CLHEP::RandFlat::shoot(engine, fMinPt, fMaxPt) ;
+       double eta    = CLHEP::RandFlat::shoot(engine, fMinEta, fMaxEta) ;
+       double phi    = CLHEP::RandFlat::shoot(engine, fMinPhi, fMaxPhi) ;
        int PartID = fPartIDs[ip] ;
        const HepPDT::ParticleData* 
           PData = fPDGTable->particle(HepPDT::ParticleID(abs(PartID))) ;
@@ -110,15 +112,15 @@ void MultiParticleInConeGunProducer::produce(Event &e, const EventSetup& es)
 	 unsigned int nTry=0;
 	 while(true){
 	   //shoot flat Deltar
-	   double dR = fRandomGenerator->fire(fMinDeltaR, fMaxDeltaR);
+	   double dR = CLHEP::RandFlat::shoot(engine, fMinDeltaR, fMaxDeltaR);
 	   //shoot flat eta/phi mixing
-	   double alpha = fRandomGenerator->fire(-3.14159265358979323846, 3.14159265358979323846);
+	   double alpha = CLHEP::RandFlat::shoot(engine, -3.14159265358979323846, 3.14159265358979323846);
 	   double dEta = dR*cos(alpha);
 	   double dPhi = dR*sin(alpha);
 	   
 	   /*
 	   //shoot Energy of associated particle	 
-	   double energyIc = fRandomGenerator->fire(fMinEInCone, fMaxEInCone);
+	   double energyIc = CLHEP::RandFlat::shoot(engine, fMinEInCone, fMaxEInCone);
 	   if (mom2Ic>0){ momIC = sqrt(mom2Ic);}
 	   */
 	   //	 get kinematics
@@ -157,7 +159,7 @@ void MultiParticleInConeGunProducer::produce(Event &e, const EventSetup& es)
 	     PDataIc = fPDGTable->particle(HepPDT::ParticleID(abs(PartIDIc)));
 	   
 	   //shoot momentum ratio
-	   double momR = fRandomGenerator->fire(fMinMomRatio, fMaxMomRatio);
+	   double momR = CLHEP::RandFlat::shoot(engine, fMinMomRatio, fMaxMomRatio);
 	   double massIc= PDataIc->mass().value() ;
 	   double momIc = momR * mom;
 	   double energyIc = sqrt(momIc*momIc + massIc*massIc);


### PR DESCRIPTION
Migrate some particle gun generator code
to use the new interface of the random number generator
service designed to work with the multithreaded Framework.
(I just inadvertently missed these in the previous
pull requests.)
