### PR TITLE
Re matcher

### DIFF
--- a/CommonTools/Utils/test/testCutParser.cc
+++ b/CommonTools/Utils/test/testCutParser.cc
@@ -115,7 +115,7 @@ void testCutParser::checkAll() {
   MyDet mdet(plane);
   GeomDet *  det =  &mdet;
 
-  hitOk = SiStripRecHit2D(LocalPoint(1,1), LocalError(1,1,1), 0, 0, det, SiStripRecHit2D::ClusterRef());
+  hitOk = SiStripRecHit2D(LocalPoint(1,1), LocalError(1,1,1), 0, det, SiStripRecHit2D::ClusterRef());
 
   edm::TypeWithDict t(typeid(reco::Track));
   o = edm::ObjectWithDict(t, & trk);

--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
@@ -29,12 +29,6 @@ public:
   
   ~SiPixelRecHit() {}
   
-  SiPixelRecHit( const LocalPoint& pos , const LocalError& err,
-		 const DetId& id, GeomDet const * idet,
-		 ClusterRef const&  clus) : 
-    TrackerSingleRecHit(pos,err,id,idet, clus), 
-    qualWord_(0) 
-  {}
 
   SiPixelRecHit( const LocalPoint& pos , const LocalError& err, SiPixelRecHitQuality::QualWordType qual,
 		 const DetId& id, GeomDet const * idet,
@@ -47,7 +41,9 @@ public:
   virtual SiPixelRecHit * clone() const {return new SiPixelRecHit( * this); }
   
   ClusterRef cluster()  const { return cluster_pixel(); }
+
   void setClusterRef(ClusterRef const & ref)  {setClusterPixelRef(ref);}
+
   virtual int dimension() const {return 2;}
   virtual void getKfComponents( KfComponentsHolder & holder ) const { getKfComponents2D(holder); }
   
@@ -76,11 +72,8 @@ public:
   inline SiPixelRecHitQuality::QualWordType rawQualityWord() const { 
     return qualWord_ ; 
   }
-  inline void setRawQualityWord( SiPixelRecHitQuality::QualWordType w ) { 
-    qualWord_ = w; 
-  }
 
-
+ 
   //--- Template fit probability, in X and Y directions
   //--- These are obsolete and will be taken care of in the quality code
   inline float probabilityX() const     {
@@ -123,29 +116,6 @@ public:
   //--- Quality flag for whether the probability is filled
   inline bool hasFilledProb() const {
     return SiPixelRecHitQuality::thePacking.hasFilledProb( qualWord_ );
-  }
-  
-  //--- Setters for the above
-  inline void setProbabilityXY( float prob ) {
-    SiPixelRecHitQuality::thePacking.setProbabilityXY( prob, qualWord_ );
-  }
-  inline void setProbabilityQ( float prob ) {
-    SiPixelRecHitQuality::thePacking.setProbabilityQ( prob, qualWord_ );
-  }  
-  inline void setQBin( int qbin ) {
-    SiPixelRecHitQuality::thePacking.setQBin( qbin, qualWord_ );
-  }
-  inline void setIsOnEdge( bool flag ) {
-    SiPixelRecHitQuality::thePacking.setIsOnEdge( flag, qualWord_ );
-  }
-  inline void setHasBadPixels( bool flag ) {
-    SiPixelRecHitQuality::thePacking.setHasBadPixels( flag, qualWord_ );
-  }
-  inline void setSpansTwoROCs( bool flag ) {
-    SiPixelRecHitQuality::thePacking.setSpansTwoROCs( flag, qualWord_ );
-  }
-  inline void setHasFilledProb( bool flag ) {
-    SiPixelRecHitQuality::thePacking.setHasFilledProb( flag, qualWord_ );
   }
 
 };

--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
@@ -35,6 +35,14 @@ public:
     TrackerSingleRecHit(pos,err,id,idet, clus), 
     qualWord_(0) 
   {}
+
+  SiPixelRecHit( const LocalPoint& pos , const LocalError& err, SiPixelRecHitQuality::QualWordType qual,
+		 const DetId& id, GeomDet const * idet,
+		 ClusterRef const&  clus) : 
+    TrackerSingleRecHit(pos,err,id,idet, clus), 
+    qualWord_(qual) 
+  {}
+
   
   virtual SiPixelRecHit * clone() const {return new SiPixelRecHit( * this); }
   

--- a/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h
@@ -7,7 +7,7 @@
 class SiStripRecHit2D GCC11_FINAL : public TrackerSingleRecHit {
 public:
 
-  SiStripRecHit2D(): sigmaPitch_(-1.){}
+  SiStripRecHit2D() {}
 
   ~SiStripRecHit2D() {} 
 
@@ -17,15 +17,13 @@ public:
   // no position (as in persistent)
   SiStripRecHit2D(const DetId& id,
 		  OmniClusterRef const& clus) : 
-    TrackerSingleRecHit(id, clus),
-    sigmaPitch_(-1.) {}
+    TrackerSingleRecHit(id, clus){}
 
   template<typename CluRef>
-  SiStripRecHit2D( const LocalPoint& pos, const LocalError& err, float isigmaPitch,
+  SiStripRecHit2D( const LocalPoint& pos, const LocalError& err,
 		   const DetId& id, GeomDet const * idet,
 		   CluRef const& clus) : 
-    TrackerSingleRecHit(pos,err,id, idet, clus),
-    sigmaPitch_(isigmaPitch) {}
+    TrackerSingleRecHit(pos,err,id, idet, clus) {}
  
 				
   ClusterRef cluster()  const { return cluster_strip() ; }
@@ -36,15 +34,9 @@ public:
   virtual int dimension() const {return 2;}
   virtual void getKfComponents( KfComponentsHolder & holder ) const { getKfComponents2D(holder); }
 
- 
-  float sigmaPitch() const { return sigmaPitch_;}
 
   
 private:
-
-  /// cache for the matcher....
-  float sigmaPitch_;  // transient....
-
  
 };
 

--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -31,11 +31,8 @@
 
   <class name="SiStripRecHit2D"  ClassVersion="12">
    <version ClassVersion="12" checksum="2350660116"/>
-    <field name="sigmaPitch_" transient="true" />
    <version ClassVersion="11" checksum="2157674799"/>
-    <field name="sigmaPitch_" transient="true" />
    <version ClassVersion="10" checksum="4057204970"/>
-    <field name="sigmaPitch_" transient="true" />
   </class>
 
 

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h
@@ -4,10 +4,29 @@
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitQuality.h"
-
+#include<tuple>
 
 class PixelClusterParameterEstimator : public  ClusterParameterEstimator<SiPixelCluster> {
   public:
+
+  
+  using ReturnType = std::tuple<LocalPoint,LocalError,SiPixelRecHitQuality::QualWordType>;
+
+  // here just to implement it in the clients;
+  // to be properly implemented in the sub-classes in order to make them thread-safe
+  virtual ReturnType getParameters(const SiPixelCluster & cl, 
+				   const GeomDetUnit    & det ) const {
+    auto lv = localParameters(cl,det);
+    return std::make_tuple(lv.first,lv.second,rawQualityWord());
+  }
+  virtual ReturnType getParameters(const SiPixelCluster & cl, 
+				   const GeomDetUnit    & det, 
+				   const LocalTrajectoryParameters & ltp ) const {
+    auto lv = localParameters(cl,det,ltp);
+    return std::make_tuple(lv.first,lv.second,rawQualityWord());
+  }
+
+
 
   PixelClusterParameterEstimator() : clusterProbComputationFlag_(0){}
 

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -133,14 +133,6 @@ public:
   inline bool  spansTwoRocks() const { return spansTwoROCs_ ;  }
   inline bool  hasFilledProb() const { return hasFilledProb_ ; }
   
-  //--- Flag to control how SiPixelRecHits compute clusterProbability().
-  //--- Note this is set via the configuration file, and it's simply passed
-  //--- to each TSiPixelRecHit.
-  inline unsigned int clusterProbComputationFlag() const 
-    { 
-      return clusterProbComputationFlag_ ; 
-    }
-  
   
   //-----------------------------------------------------------------------------
   //! A convenience method to fill a whole SiPixelRecHitQuality word in one shot.
@@ -212,13 +204,6 @@ public:
   mutable bool  spansTwoROCs_ ;
   mutable bool  hasFilledProb_ ;
 
-  //--- A flag that could be used to change the behavior of
-  //--- clusterProbability() in TSiPixelRecHit (the *transient* one).  
-  //--- The problem is that the transient hits are made after the CPE runs
-  //--- and they don't get the access to the PSet, so we pass it via the
-  //--- CPE itself...
-  //
-  unsigned int clusterProbComputationFlag_ ;
 
   //---------------------------
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
@@ -138,9 +138,7 @@ namespace cms
 	edm::Ref< edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster > cluster = edmNew::makeRefTo( inputhandle, clustIt);
 	// Make a RecHit and add it to the DetSet
 	// old : recHitsOnDetUnit.push_back( new SiPixelRecHit( lp, le, detIdObject, &*clustIt) );
-	SiPixelRecHit hit( lp, le, detIdObject, genericDet, cluster);
-	// Copy the extra stuff;
-	hit.setRawQualityWord( cpe_->rawQualityWord() );
+	SiPixelRecHit hit( lp, le, cpe_->rawQualityWord(), detIdObject, genericDet, cluster);
 	// 
 	// Now save it =================
 	recHitsOnDetUnit.push_back(hit);

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
@@ -13,6 +13,9 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "TrackingTools/TransientTrackingRecHit/interface/HelpertRecHit2DLocalPos.h"
+
+
 class GluedGeomDet;
 
 #include <cfloat>
@@ -39,6 +42,16 @@ public:
   SiStripRecHitMatcher(const double theScale);
 
   bool preFilter() const { return preFilter_;}  
+
+
+  inline   
+  static float sigmaPitch(LocalPoint const& pos, LocalError const & err, 
+		   const StripTopology& topol) {
+    MeasurementError error = topol.measurementError(pos,err);
+    auto pitch=topol.localPitch(pos);
+    return error.uu()*pitch*pitch;
+  }
+
 
   // optimized matching iteration (the algo is the same, just recoded)
   template<typename MonoIterator, typename StereoIterator,  typename CollectorHelper>
@@ -177,7 +190,7 @@ void SiStripRecHitMatcher::doubleMatch(MonoIterator monoRHiter, MonoIterator mon
     
     const SiStripRecHit2D & secondHit = CollectorHelper::stereoHit(seconditer);
     
-    float sigmap22 =secondHit.sigmaPitch();
+    float sigmap22 = sigmaPitch(secondHit.localPosition(),secondHit.localPositionError(),partnertopol);
     // assert (sigmap22>=0);
     
     auto STEREOpointX=partnertopol.measurementPosition( secondHit.localPositionFast()).x();
@@ -278,8 +291,8 @@ void SiStripRecHitMatcher::doubleMatch(MonoIterator monoRHiter, MonoIterator mon
     double s1 = -m01;
     double l1 = 1./(c1*c1+s1*s1);
     
-    // FIXME: here for test...
-    float sigmap12 = monoRH.sigmaPitch();
+    float sigmap12 = sigmaPitch(monoRH.localPosition(), monoRH.localPositionError(),topol);
+    // float sigmap12 = monoRH.sigmaPitch();
     // assert(sigmap12>=0); 
 
     //float code

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
@@ -79,6 +79,15 @@ public:
   StripPosition project(const GeomDetUnit *det,const GluedGeomDet* glueddet,StripPosition strip,LocalVector trackdirection) const;
   
   
+  // needed by the obsolete version still in use on some architectures
+  void
+  match( const SiStripRecHit2D *monoRH,
+	 SimpleHitIterator begin, SimpleHitIterator end,
+	 edm::OwnVector<SiStripMatchedRecHit2D> & collector, 
+	 const GluedGeomDet* gluedDet,
+	 LocalVector trackdirection) const;
+
+
 
   void
   match( const SiStripRecHit2D *monoRH,

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
@@ -56,6 +56,7 @@ run(edm::Handle<edmNew::DetSetVector<SiStripCluster> > input, products& output)
 { run(input, output, LocalVector(0.,0.,0.)); }
 
 
+/*
 namespace {
   float sigmaPitch(LocalPoint const& pos, LocalError err, 
 		   GeomDetUnit const & stripdet) {
@@ -67,7 +68,7 @@ namespace {
     return error.uu()*pitch*pitch;
   }
 }
-
+*/
 
 void SiStripRecHitConverterAlgorithm::
 run(edm::Handle<edmNew::DetSetVector<SiStripCluster> > inputhandle, products& output, LocalVector trackdirection)
@@ -93,8 +94,7 @@ run(edm::Handle<edmNew::DetSetVector<SiStripCluster> > inputhandle, products& ou
       if(isMasked(*cluster,bad128StripBlocks)) continue;
 
       StripClusterParameterEstimator::LocalValues parameters = 	parameterestimator->localParameters(*cluster,du);
-      auto sPitch = sigmaPitch(parameters.first, parameters.second, du);
-      collector.push_back(SiStripRecHit2D( parameters.first, parameters.second, sPitch, id, &du, edmNew::makeRefTo(inputhandle,cluster) ));
+      collector.push_back(SiStripRecHit2D( parameters.first, parameters.second, id, &du, edmNew::makeRefTo(inputhandle,cluster) ));
     }
 
     if (collector.empty()) collector.abort();
@@ -135,8 +135,7 @@ run(edm::Handle<edm::RefGetter<SiStripCluster> >  refGetterhandle,
       if( !goodDet || isMasked(*icluster, bad128StripBlocks)) continue;
       GeomDetUnit const & du = *(tracker->idToDetUnit(detId));
       StripClusterParameterEstimator::LocalValues parameters = parameterestimator->localParameters(*icluster,du);
-      auto sPitch = sigmaPitch(parameters.first, parameters.second, du);
-      collector->push_back(SiStripRecHit2D( parameters.first, parameters.second, sPitch, detId, &du,  makeRefToLazyGetter(lazyGetterhandle,i) ));      
+     collector->push_back(SiStripRecHit2D( parameters.first, parameters.second, detId, &du,  makeRefToLazyGetter(lazyGetterhandle,i) ));      
     }
     if(collector->empty()) collector->abort();
   }

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
@@ -37,6 +37,22 @@ namespace {
 }
 
 
+// needed by the obsolete version still in use on some architectures
+void
+SiStripRecHitMatcher::match( const SiStripRecHit2D *monoRH,
+			     SimpleHitIterator begin, SimpleHitIterator end,
+			     edm::OwnVector<SiStripMatchedRecHit2D> & collector, 
+			     const GluedGeomDet* gluedDet,
+			     LocalVector trackdirection) const {
+
+  std::vector<SiStripMatchedRecHit2D*> result;
+  result.reserve(end-begin);
+  match(monoRH,begin,end,result,gluedDet,trackdirection);
+  for (std::vector<SiStripMatchedRecHit2D*>::iterator p=result.begin(); p!=result.end();
+       p++) collector.push_back(*p);
+}
+
+
 void
 SiStripRecHitMatcher::match( const SiStripRecHit2D *monoRH,
 			     SimpleHitIterator begin, SimpleHitIterator end,

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
@@ -148,7 +148,8 @@ SiStripRecHitMatcher::match( const SiStripRecHit2D *monoRH,
   double l1 = 1./(c1*c1+s1*s1);
 
  
-  auto sigmap12 = monoRH->sigmaPitch();
+  float sigmap12 = sigmaPitch(monoRH->localPosition(), monoRH->localPositionError(),topol);
+  // auto sigmap12 = monoRH->sigmaPitch();
   // assert(sigmap12>=0);
 
 
@@ -217,8 +218,8 @@ SiStripRecHitMatcher::match( const SiStripRecHit2D *monoRH,
     double s2 = -m11;
     double l2 = 1./(c2*c2+s2*s2);
 
-
-    auto sigmap22 = (*seconditer)->sigmaPitch();
+   float sigmap22 = sigmaPitch((*seconditer)->localPosition(),(*seconditer)->localPositionError(),partnertopol);
+   // auto sigmap22 = (*seconditer)->sigmaPitch();
     // assert(sigmap22>=0);
 
     double diff=(c1*s2-c2*s1);
@@ -309,8 +310,9 @@ SiStripRecHitMatcher::match(const SiStripRecHit2D *monoRH,
   double s1 = -m01;
   double l1 = 1./(c1*c1+s1*s1);
 
- 
-  auto sigmap12 = monoRH->sigmaPitch();
+
+  float sigmap12 = sigmaPitch(monoRH->localPosition(), monoRH->localPositionError(),topol);
+  // auto sigmap12 = monoRH->sigmaPitch();
   // assert(sigmap12>=0);
 
 
@@ -353,8 +355,8 @@ SiStripRecHitMatcher::match(const SiStripRecHit2D *monoRH,
   double l2 = 1./(c2*c2+s2*s2);
   
   
-
-  auto sigmap22 = stereoRH->sigmaPitch();
+  float sigmap22 = sigmaPitch(stereoRH->localPosition(),stereoRH->localPositionError(),partnertopol);
+  // auto sigmap22 = stereoRH->sigmaPitch();
   // assert (sigmap22>0);
 
   double diff=(c1*s2-c2*s1);

--- a/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
@@ -498,19 +498,18 @@ void GlobalTrajectoryBuilderBase::fixTEC(ConstRecHitContainer& all,
           LocalError scaledError(rotError.xx() * scl_x * scl_x, 0, rotError.yy() * scl_y * scl_y);
           error = scaledError.rotate(-angle);
           MuonTransientTrackingRecHit* mtt_rechit;
-  	  auto sPitch = TSiStripRecHit2DLocalPos::sigmaPitch(pos,error,*Tstrip->detUnit());
           if (strip->cluster().isNonnull()) {
             //// the implemetantion below works with cloning
             //// to get a RecHitPointer to SiStripRecHit2D, the only  method that works is
             //// RecHitPointer MuonTransientTrackingRecHit::build(const GeomDet*,const TrackingRecHit*)
-            SiStripRecHit2D* st = new SiStripRecHit2D(pos,error,sPitch,
+            SiStripRecHit2D* st = new SiStripRecHit2D(pos,error,
                                                       (*lone_tec)->geographicalId().rawId(),Tstrip->detUnit(),
                                                       strip->cluster());
             *lone_tec = mtt_rechit->build((*lone_tec)->det(),st);
           }
           else {
             
-            SiStripRecHit2D* st = new SiStripRecHit2D(pos,error, sPitch,
+            SiStripRecHit2D* st = new SiStripRecHit2D(pos,error,
                                                       (*lone_tec)->geographicalId().rawId(),Tstrip->detUnit(),
                                                       strip->cluster_regional());
             *lone_tec = mtt_rechit->build((*lone_tec)->det(),st);

--- a/RecoTracker/MeasurementDet/plugins/RecHitPropagator.cc
+++ b/RecoTracker/MeasurementDet/plugins/RecHitPropagator.cc
@@ -3,7 +3,7 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
 TrajectoryStateOnSurface 
-RecHitPropagator::propagate( const TransientTrackingRecHit& hit,
+RecHitPropagator::propagate( const TrackingRecHit& hit,
 			     const Plane& plane, 
 			     const TrajectoryStateOnSurface& ts) const
 {

--- a/RecoTracker/MeasurementDet/plugins/RecHitPropagator.h
+++ b/RecoTracker/MeasurementDet/plugins/RecHitPropagator.h
@@ -3,14 +3,14 @@
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
-class TransientTrackingRecHit;
+class TrackingRecHit;
 class MagneticField;
 class Plane;
 
 class RecHitPropagator {
 public:
 
-  TrajectoryStateOnSurface propagate( const TransientTrackingRecHit& hit,
+  TrajectoryStateOnSurface propagate( const TrackingRecHit& hit,
 				      const Plane& plane, 
 				      const TrajectoryStateOnSurface& ts) const;
 

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
@@ -207,7 +207,6 @@ TkGluedMeasurementDet::RecHitContainer
 TkGluedMeasurementDet::projectOnGluedDet( const RecHitContainer& hits,
 					  const TrajectoryStateOnSurface& ts) const
 {
-  if (hits.empty()) return hits;
   TrackingRecHitProjector<ProjectedRecHit2D> proj;
   RecHitContainer result;
   for ( RecHitContainer::const_iterator ihit = hits.begin(); ihit!=hits.end(); ihit++) {
@@ -227,6 +226,31 @@ TkGluedMeasurementDet::projectOnGluedDet( Collector& collector,
   }
 }
 
+TkGluedMeasurementDet::RecHitContainer 
+TkGluedMeasurementDet::projectOnGluedDet( std::vector<SiStripRecHit2D> const & hits,
+					  const TrajectoryStateOnSurface& ts) const
+{
+  TrackingRecHitProjector<ProjectedRecHit2D> proj;
+  RecHitContainer result;
+  for ( auto const & hit : hits)
+    result.push_back( proj.project(hit, fastGeomDet(), ts, theCPE));
+  return result;
+}
+
+template<typename Collector>
+void 
+TkGluedMeasurementDet::projectOnGluedDet( Collector& collector,
+                                          std::vector<SiStripRecHit2D> const & hits,
+                                          const GlobalVector & gdir ) const 
+{
+  for ( auto const & hit : hits)
+    collector.addProjected(hit, gdir );
+}
+
+
+
+
+
 void TkGluedMeasurementDet::checkProjection(const TrajectoryStateOnSurface& ts, 
 					    const RecHitContainer& monoHits, 
 					    const RecHitContainer& stereoHits) const
@@ -239,12 +263,12 @@ void TkGluedMeasurementDet::checkProjection(const TrajectoryStateOnSurface& ts,
   }
 }
 
-void TkGluedMeasurementDet::checkHitProjection(const TransientTrackingRecHit& hit,
+void TkGluedMeasurementDet::checkHitProjection(const TrackingRecHit& hit,
 					       const TrajectoryStateOnSurface& ts, 
 					       const GeomDet& det) const
 {
   TrackingRecHitProjector<ProjectedRecHit2D> proj;
-  TransientTrackingRecHit::RecHitPointer projectedHit = proj.project( hit, det, ts);
+  TransientTrackingRecHit::RecHitPointer projectedHit = proj.project( hit, det, ts, theCPE);
 
   RecHitPropagator prop;
   TrajectoryStateOnSurface propState = prop.propagate( hit, det.surface(), ts);
@@ -330,11 +354,11 @@ TkGluedMeasurementDet::HitCollectorForRecHits::HitCollectorForRecHits(const Geom
 }
 
 void
-TkGluedMeasurementDet::HitCollectorForRecHits::addProjected(const TransientTrackingRecHit& hit,
+TkGluedMeasurementDet::HitCollectorForRecHits::addProjected(const TrackingRecHit& hit,
                                                             const GlobalVector & gdir)
 {
     TrackingRecHitProjector<ProjectedRecHit2D> proj;
-    target_.push_back( proj.project( hit, *geomDet_, gdir));
+    target_.push_back( proj.project( hit, *geomDet_, gdir, cpe_));
 }
 
 TkGluedMeasurementDet::HitCollectorForFastMeasurements::HitCollectorForFastMeasurements
@@ -379,12 +403,12 @@ TkGluedMeasurementDet::HitCollectorForFastMeasurements::add(SiStripMatchedRecHit
 */
 
 void
-TkGluedMeasurementDet::HitCollectorForFastMeasurements::addProjected(const TransientTrackingRecHit& hit,
+TkGluedMeasurementDet::HitCollectorForFastMeasurements::addProjected(const TrackingRecHit& hit,
                                                             const GlobalVector & gdir)
 {
     // here we're ok with some extra casual new's and delete's
     TrackingRecHitProjector<ProjectedRecHit2D> proj;
-    RecHitPointer && phit = proj.project( hit, *geomDet_, gdir );
+    RecHitPointer && phit = proj.project( hit, *geomDet_, gdir,  cpe_ );
     std::pair<bool,double> diffEst = est_.estimate( stateOnThisDet_, *phit);
     if ( diffEst.first) {
       target_.add(phit, diffEst.second);

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.h
@@ -68,7 +68,7 @@ private:
 			);
       hasNewHits_ = true; 
     }
-    void addProjected(const TransientTrackingRecHit& hit,
+    void addProjected(const TrackingRecHit& hit,
 		      const GlobalVector & gdir) ;
     SiStripRecHitMatcher::Collector & collector() { return collector_; }
     bool hasNewMatchedHits() const { return hasNewHits_;  }
@@ -100,7 +100,7 @@ private:
 				    const MeasurementEstimator& est,
 				    TempMeasurements & target) ;
     void add(SiStripMatchedRecHit2D const& hit) ;
-    void addProjected(const TransientTrackingRecHit& hit,
+    void addProjected(const TrackingRecHit& hit,
 		      const GlobalVector & gdir) ;
     
     SiStripRecHitMatcher::Collector & collector() { return collector_; }
@@ -120,21 +120,32 @@ private:
     bool hasNewHits_;
   };
   
+
   
   RecHitContainer 
-  projectOnGluedDet( const RecHitContainer& hits,
+  projectOnGluedDet( const std::vector<SiStripRecHit2D>& hits,
 		     const TrajectoryStateOnSurface& ts) const dso_internal;
+  template<typename HitCollector>
+  void
+  projectOnGluedDet( HitCollector & collector,
+                     const std::vector<SiStripRecHit2D>& hits,
+                     const GlobalVector & gdir ) const  dso_internal;
 
+
+  RecHitContainer 
+    projectOnGluedDet( const RecHitContainer& hits,
+		       const TrajectoryStateOnSurface& ts) const dso_internal;
   template<typename HitCollector>
   void
   projectOnGluedDet( HitCollector & collector,
                      const RecHitContainer& hits,
                      const GlobalVector & gdir ) const  dso_internal;
 
+
   void checkProjection(const TrajectoryStateOnSurface& ts, 
 		       const RecHitContainer& monoHits, 
 		       const RecHitContainer& stereoHits) const;
-  void checkHitProjection(const TransientTrackingRecHit& hit,
+  void checkHitProjection(const TrackingRecHit& hit,
 			  const TrajectoryStateOnSurface& ts, 
 			  const GeomDet& det) const dso_internal;
 

--- a/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
@@ -58,7 +58,7 @@ TkPixelMeasurementDet::buildRecHit( const SiPixelClusterRef & cluster,
 {
   const GeomDetUnit& gdu( specificGeomDet());
   LocalValues lv = cpe()->localParameters( * cluster, gdu, ltp );
-  return TSiPixelRecHit::build( lv.first, lv.second, &fastGeomDet(), cluster, cpe());
+  return TSiPixelRecHit::build( lv.first, lv.second, cpe()->rawQualityWord(), &fastGeomDet(), cluster, cpe());
 }
 
 TkPixelMeasurementDet::RecHitContainer 

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
@@ -322,11 +322,11 @@ SiStripRecHit2D TkStripMeasurementDet::hit(TkStripRecHitIter const & hi ) const 
   if(!isRegional()){
     SiStripClusterRef  cluster = edmNew::makeRefTo( data.stripData().handle(), ci ); 
     LocalValues lv = cpe()->localParameters( *cluster, gdu, ltp);
-    return SiStripRecHit2D(lv.first,lv.second, TSiStripRecHit2DLocalPos::sigmaPitch(lv.first, lv.second,gdu), rawId(), &gdu, cluster);
+    return SiStripRecHit2D(lv.first,lv.second, rawId(), &gdu, cluster);
   } else {
     SiStripRegionalClusterRef cluster = edm::makeRefToLazyGetter(data.stripData().regionalHandle(),ciR);
     LocalValues lv = cpe()->localParameters( *cluster, gdu, ltp);
-    return SiStripRecHit2D(lv.first,lv.second, TSiStripRecHit2DLocalPos::sigmaPitch(lv.first, lv.second,gdu), rawId(), &gdu, cluster);
+    return SiStripRecHit2D(lv.first,lv.second, rawId(), &gdu, cluster);
   } 
 }
 

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
@@ -221,7 +221,7 @@ public:
     VLocalValues const & vlv = cpe()->localParametersV( *cluster, gdu, ltp);
     bool isCompatible(false);
     for(auto vl : vlv) {
-      auto && recHit  = SiStripRecHit2D( vl.first, vl.second, TSiStripRecHit2DLocalPos::sigmaPitch(vl.first, vl.second,gdu), rawId(), &gdu, cluster);
+      auto && recHit  = SiStripRecHit2D( vl.first, vl.second, rawId(), &gdu, cluster);
       std::pair<bool,double> diffEst = est.estimate(ltp, recHit);
       LogDebug("TkStripMeasurementDet")<<" chi2=" << diffEst.second;
       if ( diffEst.first ) {
@@ -289,7 +289,7 @@ private:
     const GeomDetUnit& gdu( specificGeomDet());
     VLocalValues const & vlv = cpe()->localParametersV( *cluster, gdu, ltp);
     for(VLocalValues::const_iterator it=vlv.begin();it!=vlv.end();++it){
-      res.push_back(SiStripRecHit2D( it->first, it->second, TSiStripRecHit2DLocalPos::sigmaPitch(it->first, it->second,gdu), rawId(), &gdu, cluster));
+      res.push_back(SiStripRecHit2D( it->first, it->second, rawId(), &gdu, cluster));
     }
   }
 

--- a/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
+++ b/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
@@ -15,10 +15,14 @@ namespace {
       return *reinterpret_cast<const SiStripRecHit2D*>((**monoHit).hit());
     }
     
+    inline static SiStripRecHit2D const & monoHit(std::vector<SiStripRecHit2D>::const_iterator iter) {
+      return *iter;
+    }
+    
     inline static SiStripRecHit2D const & stereoHit(std::vector<SiStripRecHit2D>::const_iterator iter) {
       return *iter;
     }
-
+    
     inline static SiStripRecHit2D const & stereoHit(TkGluedMeasurementDet::RecHitContainer::const_iterator hit) {
       return *reinterpret_cast<const SiStripRecHit2D*>((**hit).hit());
     }
@@ -32,6 +36,15 @@ namespace {
 	m_collector.addProjected( **monoHit, glbDir );
       }
     }
+
+    inline void closure(std::vector<SiStripRecHit2D>::const_iterator monoHit) {
+      if (m_collector.hasNewMatchedHits()) {
+	m_collector.clearNewMatchedHitsFlag();
+      } else {
+	m_collector.addProjected( *monoHit, glbDir );
+      }
+    }
+  
     
   };
 
@@ -64,9 +77,8 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
   // vsStereoHits.resize(simpleSteroHitsByValue.size());
   //std::transform(simpleSteroHitsByValue.begin(), simpleSteroHitsByValue.end(), vsStereoHits.begin(), take_address());
 
-  RecHitContainer monoHits;
-  RecHitContainer stereoHits;
-  std::vector<float>  diffs;
+  std::vector<SiStripRecHit2D> monoHits;
+  std::vector<SiStripRecHit2D> stereoHits;
 
   auto mf = monoHits.size();
   auto sf = stereoHits.size();
@@ -79,29 +91,28 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
     emptyMono = theMonoDet->empty(data);
     if likely(!emptyMono) {
 	TrajectoryStateOnSurface mts = fastProp(ts,geomDet().surface(),theMonoDet->geomDet().surface());
-	theMonoDet->recHits(mts,collector.estimator(),data,monoHits,diffs);
+	theMonoDet->simpleRecHits(mts,collector.estimator(),data,monoHits);
       }
     // print("mono", mts,ts);
     mf = monoHits.size();
   }
   else {
-    monoHits = theMonoDet->recHits(ts, data);
+    theMonoDet->simpleRecHits(ts, data,monoHits);
     emptyMono = monoHits.empty();
   }
 
   // stereo requires "projection" for precision and change in coordinates
-  diffs.clear();
   if (collector.filter()) {
     emptyStereo = theStereoDet->empty(data);
     if likely(!emptyStereo) {
 	TrajectoryStateOnSurface pts = fastProp(ts,geomDet().surface(),theStereoDet->geomDet().surface());
-	theStereoDet->recHits(pts,collector.estimator(),data,stereoHits,diffs);
+	theStereoDet->simpleRecHits(pts,collector.estimator(),data,stereoHits);
 	// print("stereo", pts,ts);
       }
     sf = stereoHits.size();
   }
   else {
-    stereoHits= theStereoDet->recHits(ts,data);
+    theStereoDet->simpleRecHits(ts,data,stereoHits);
     emptyStereo = stereoHits.empty();
   }
 

--- a/RecoTracker/TransientTrackingRecHit/interface/ProjectedRecHit2D.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/ProjectedRecHit2D.h
@@ -37,6 +37,13 @@ public:
     return RecHitPointer( new ProjectedRecHit2D( pos, err, det, originaldet, originalHit));
   }
 
+  static RecHitPointer build( const LocalPoint& pos, const LocalError& err, 
+			      const GeomDet* det, const GeomDet* originaldet,
+			      const TrackingRecHit& originalHit, const StripClusterParameterEstimator* cpe ) {
+    return RecHitPointer( new ProjectedRecHit2D( pos, err, det, originaldet, originalHit, cpe));
+  }
+
+
   RecHitPointer clone( const TrajectoryStateOnSurface& ts) const;
 
   const SiStripRecHit2D& originalHit() const { return static_cast<const ProjectedSiStripRecHit2D*>( hit() )->originalHit();}
@@ -50,6 +57,11 @@ private:
   ProjectedRecHit2D( const LocalPoint& pos, const LocalError& err,
 		     const GeomDet* det, const GeomDet* originaldet, 
 		     const TransientTrackingRecHit& originalHit);
+
+  ProjectedRecHit2D( const LocalPoint& pos, const LocalError& err,
+		     const GeomDet* det, const GeomDet* originaldet, 
+		     const TrackingRecHit& originalHit, const StripClusterParameterEstimator* cpe);
+
 
   ProjectedRecHit2D( const GeomDet * geom, const GeomDet* originaldet,
 		     const ProjectedSiStripRecHit2D* rh,

--- a/RecoTracker/TransientTrackingRecHit/interface/TSiPixelRecHit.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TSiPixelRecHit.h
@@ -63,17 +63,17 @@ public:
     return RecHitPointer( new TSiPixelRecHit( geom, rh, cpe, computeCoarseLocalPosition));
   }
 
-  static RecHitPointer build( const LocalPoint& pos, const LocalError& err,
+  static RecHitPointer build( const LocalPoint& pos, const LocalError& err, SiPixelRecHitQuality::QualWordType qual,
 			      const GeomDet* det, 
 			      const clusterRef & cluster,
 			      const PixelClusterParameterEstimator* cpe) {
-    return RecHitPointer( new TSiPixelRecHit( pos, err, det, cluster, cpe));
+    return RecHitPointer( new TSiPixelRecHit( pos, err, qual, det, cluster, cpe));
   }
 
 
   //!  Probability of the compatibility of the track with the pixel cluster shape.
   virtual float clusterProbability() const {
-    return theHitData.clusterProbability( theClusterProbComputationFlag );
+    return theHitData.clusterProbability( theCPE->clusterProbComputationFlag() );
   }
 
 
@@ -81,7 +81,6 @@ public:
 private:
   const PixelClusterParameterEstimator* theCPE;
   SiPixelRecHit                         theHitData;
-  unsigned int                          theClusterProbComputationFlag;
 
 
   /// This private constructor copies the TrackingRecHit.  It should be used when the 
@@ -94,10 +93,12 @@ private:
 
   /// Another private constructor.  It creates the TrackingRecHit internally, 
   /// avoiding redundent cloning.
-  TSiPixelRecHit( const LocalPoint& pos, const LocalError& err,
+  TSiPixelRecHit( const LocalPoint& pos, const LocalError& err,SiPixelRecHitQuality::QualWordType qual,
 		  const GeomDet* det, 
 		  const clusterRef & clust,
-		  const PixelClusterParameterEstimator* cpe);
+		  const PixelClusterParameterEstimator* cpe) :
+    TValidTrackingRecHit(det), theCPE(cpe),
+    theHitData( pos, err, qual, det->geographicalId(), det, clust){}
 
 
   virtual TSiPixelRecHit * clone() const {

--- a/RecoTracker/TransientTrackingRecHit/interface/TSiStripRecHit2DLocalPos.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TSiStripRecHit2DLocalPos.h
@@ -126,8 +126,7 @@ private:
     LogDebug("TSiStripRecHit2DLocalPos")<<"calculating coarse position/error.";
 
     StripClusterParameterEstimator::LocalValues lval= theCPE->localParameters(rh->stripCluster(), *gdu);
-    auto sPitch = sigmaPitch(lval.first, lval.second, *gdu);
-    theHitData = SiStripRecHit2D(lval.first, lval.second, sPitch,geom->geographicalId(), geom, rh->omniCluster());
+    theHitData = SiStripRecHit2D(lval.first, lval.second, geom->geographicalId(), geom, rh->omniCluster());
 
   }
   
@@ -137,7 +136,7 @@ private:
 			    const OmniClusterRef & clust,
 			    const StripClusterParameterEstimator* cpe) :
     TValidTrackingRecHit(idet), 
-    theCPE(cpe), theHitData(pos, err, sigmaPitch(pos, err, *static_cast<const GeomDetUnit*>(idet)), idet->geographicalId(), idet, clust) {} 
+    theCPE(cpe), theHitData(pos, err, idet->geographicalId(), idet, clust) {} 
     
   virtual TSiStripRecHit2DLocalPos* clone() const {
     return new TSiStripRecHit2DLocalPos(*this);

--- a/RecoTracker/TransientTrackingRecHit/src/ProjectedRecHit2D.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/ProjectedRecHit2D.cc
@@ -15,6 +15,17 @@ GenericTransientTrackingRecHit( det, new ProjectedSiStripRecHit2D( pos, err, det
   theOriginalDet = originalDet;
 }
 
+ProjectedRecHit2D::ProjectedRecHit2D( const LocalPoint& pos, const LocalError& err,
+				      const GeomDet* det, const GeomDet* originalDet,
+				      const TrackingRecHit& originalHit, const StripClusterParameterEstimator* cpe) :
+GenericTransientTrackingRecHit( det, new ProjectedSiStripRecHit2D( pos, err, det->geographicalId(), det,
+								     static_cast<const SiStripRecHit2D*>(&originalHit) ) ) 
+{
+  theCPE = cpe;
+  theOriginalDet = originalDet;
+}
+
+
 ProjectedRecHit2D::RecHitPointer 
 ProjectedRecHit2D::clone( const TrajectoryStateOnSurface& ts) const
 {

--- a/RecoTracker/TransientTrackingRecHit/src/TSiPixelRecHit.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/TSiPixelRecHit.cc
@@ -12,7 +12,7 @@ TSiPixelRecHit::RecHitPointer TSiPixelRecHit::clone (const TrajectoryStateOnSurf
     const SiPixelCluster& clust = *specificHit()->cluster();  
     PixelClusterParameterEstimator::LocalValues lv = 
       theCPE->localParameters( clust, *detUnit(), ts);
-    return TSiPixelRecHit::build( lv.first, lv.second, det(), specificHit()->cluster(), theCPE);
+    return TSiPixelRecHit::build( lv.first, lv.second, theCPE->rawQualityWord(), det(), specificHit()->cluster(), theCPE);
   }
 }
 
@@ -35,31 +35,9 @@ TSiPixelRecHit::TSiPixelRecHit(const GeomDet * geom, const SiPixelRecHit* rh,
     if (gdu){
       PixelClusterParameterEstimator::LocalValues lval= theCPE->localParameters(*rh->cluster(), *gdu);
       LogDebug("TSiPixelRecHit")<<"calculating coarse position/error.";
-      theHitData = SiPixelRecHit(lval.first, lval.second,geom->geographicalId(), geom, rh->cluster());
+      theHitData = SiPixelRecHit(lval.first, lval.second, theCPE->rawQualityWord(), geom->geographicalId(), geom, rh->cluster());
     }else{
       edm::LogError("TSiPixelRecHit") << " geomdet does not cast into geomdet unit. cannot create pixel local parameters.";
     }
   }
-
-  // Additionally, fill the SiPixeRecHitQuality from the PixelCPE.
-  theHitData.setRawQualityWord( cpe->rawQualityWord() );
-  theClusterProbComputationFlag = cpe->clusterProbComputationFlag(); 
-
 }
-
-
-
-// Another private constructor.  It creates the TrackingRecHit internally, 
-// avoiding redundent cloning.
-TSiPixelRecHit::TSiPixelRecHit( const LocalPoint& pos, const LocalError& err,
-				const GeomDet* det, 
-				clusterRef const & clust,
-				const PixelClusterParameterEstimator* cpe) :
-  TValidTrackingRecHit(det), theCPE(cpe),
-  theHitData( pos, err, det->geographicalId(), det, clust)
-{
-  // Additionally, fill the SiPixeRecHitQuality from the PixelCPE.
-  theHitData.setRawQualityWord( cpe->rawQualityWord() );
-  theClusterProbComputationFlag = cpe->clusterProbComputationFlag(); 
-}
-

--- a/RecoTracker/TransientTrackingRecHit/src/TSiStripMatchedRecHit.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/TSiStripMatchedRecHit.cc
@@ -56,12 +56,10 @@ TSiStripMatchedRecHit::clone( const TrajectoryStateOnSurface& ts) const
     StripClusterParameterEstimator::LocalValues lvStereo = 
       theCPE->localParameters( stereoclust, *gdet->stereoDet(), gluedToStereo(ts, gdet));
       
-    auto sPitch = TSiStripRecHit2DLocalPos::sigmaPitch(lvMono.first, lvMono.second,*gdet->monoDet());
-    SiStripRecHit2D monoHit = SiStripRecHit2D( lvMono.first, lvMono.second, sPitch,
+    SiStripRecHit2D monoHit = SiStripRecHit2D( lvMono.first, lvMono.second, 
 					       gdet->monoDet()->geographicalId(),gdet->monoDet(),
 					       orig->monoClusterRef());
-    sPitch = TSiStripRecHit2DLocalPos::sigmaPitch(lvStereo.first, lvStereo.second, *gdet->stereoDet());
-    SiStripRecHit2D stereoHit = SiStripRecHit2D( lvStereo.first, lvStereo.second, sPitch,
+    SiStripRecHit2D stereoHit = SiStripRecHit2D( lvStereo.first, lvStereo.second,
 						 gdet->stereoDet()->geographicalId(),gdet->stereoDet(),
 						 orig->stereoClusterRef());
     const SiStripMatchedRecHit2D* better =  theMatcher->match(&monoHit,&stereoHit,gdet,tkDir);
@@ -129,12 +127,10 @@ TSiStripMatchedRecHit::transientHits () const {
   StripClusterParameterEstimator::LocalValues lvStereo = 
     theCPE->localParameters( stereoclust, *gdet->stereoDet());
  
-  auto sPitch = TSiStripRecHit2DLocalPos::sigmaPitch(lvMono.first, lvMono.second,*gdet->monoDet());
-  SiStripRecHit2D monoHit = SiStripRecHit2D( lvMono.first, lvMono.second, sPitch,
+  SiStripRecHit2D monoHit = SiStripRecHit2D( lvMono.first, lvMono.second, 
 					     gdet->monoDet()->geographicalId(),gdet->monoDet(),
 					     orig->monoClusterRef());
-  sPitch = TSiStripRecHit2DLocalPos::sigmaPitch(lvStereo.first, lvStereo.second, *gdet->stereoDet());
-  SiStripRecHit2D stereoHit = SiStripRecHit2D( lvStereo.first, lvStereo.second, sPitch,
+  SiStripRecHit2D stereoHit = SiStripRecHit2D( lvStereo.first, lvStereo.second, 
 					       gdet->stereoDet()->geographicalId(),gdet->stereoDet(),
 						 orig->stereoClusterRef());
   SiStripMatchedRecHit2D* better =  theMatcher->match(&monoHit,&stereoHit,gdet,tkDir);

--- a/TrackingTools/TransientTrackingRecHit/interface/TrackingRecHitProjector.h
+++ b/TrackingTools/TransientTrackingRecHit/interface/TrackingRecHitProjector.h
@@ -4,11 +4,27 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TValidTrackingRecHit.h"
 //#include <iostream>
 
+class StripClusterParameterEstimator;
+
 template <class ResultingHit>
 class TrackingRecHitProjector {
  public:
 
   typedef  TransientTrackingRecHit::RecHitPointer      RecHitPointer;
+
+
+  RecHitPointer project( const TrackingRecHit& hit,
+			 const GeomDet& det, 
+			 const TrajectoryStateOnSurface& ts, const StripClusterParameterEstimator* cpe) const {
+    
+    GlobalVector gdir = ts.globalParameters().momentum();
+    return project(hit, det, gdir, cpe);
+  }
+  RecHitPointer project( const TrackingRecHit& hit,
+			 const GeomDet& det, const StripClusterParameterEstimator* cpe) const {
+    GlobalVector gdir = hit.globalPosition() - GlobalPoint(0,0,0);
+    return project(hit, det, gdir,cpe);
+  }
 
 
   RecHitPointer project( const TransientTrackingRecHit& hit,
@@ -55,6 +71,40 @@ class TrackingRecHitProjector {
     LocalError rotatedError = hitErr.rotate( hitXAxis.x(), hitXAxis.y());
     
     return ResultingHit::build( projectedHitPos, rotatedError, &det, hit.det(), hit);
+  }
+
+
+  RecHitPointer project( const TrackingRecHit& hit,
+			 const GeomDet& det,
+			 const GlobalVector & gdir, const StripClusterParameterEstimator* cpe) const {
+    const BoundPlane& gluedPlane = det.surface();
+    const BoundPlane& hitPlane = hit.det()->surface();
+
+    // check if the planes are parallel
+    //const float epsilon = 1.e-7; // corresponds to about 0.3 miliradian but cannot be reduced
+                                 // because of float precision
+
+    //if (fabs(gluedPlane.normalVector().dot( hitPlane.normalVector())) < 1-epsilon) {
+    //       std::cout << "TkGluedMeasurementDet plane not parallel to DetUnit plane: dot product is " 
+    // 	   << gluedPlane.normalVector().dot( hitPlane.normalVector()) << endl;
+    // FIXME: throw the appropriate exception here...
+    //throw MeasurementDetException("TkGluedMeasurementDet plane not parallel to DetUnit plane");
+    //}
+
+    double delta = gluedPlane.localZ( hitPlane.position());
+    LocalVector ldir = gluedPlane.toLocal(gdir);
+    LocalPoint lhitPos = gluedPlane.toLocal( hit.globalPosition());
+    LocalPoint projectedHitPos = lhitPos - ldir * delta/ldir.z();
+
+    LocalVector hitXAxis = gluedPlane.toLocal( hitPlane.toGlobal( LocalVector(1,0,0)));
+    LocalError hitErr = hit.localPositionError();
+    if (gluedPlane.normalVector().dot( hitPlane.normalVector()) < 0) {
+      // the two planes are inverted, and the correlation element must change sign
+      hitErr = LocalError( hitErr.xx(), -hitErr.xy(), hitErr.yy());
+    }
+    LocalError rotatedError = hitErr.rotate( hitXAxis.x(), hitXAxis.y());
+    
+    return ResultingHit::build( projectedHitPos, rotatedError, &det, hit.det(), hit, cpe);
   }
 
 };


### PR DESCRIPTION
Two technical improvements:
1) use SiStripRecHit2D in matcher instead of TTRH
1a) fix matcher for ARM
2) make PixelCPE output used in a single place
(next step will be to return all in a single call: example already in place in base class, need to be implemented in derived classes)
2) removed all setting of quality in SiPixelHit

more cleanup to come
I stop here because of 1a) and to allow work on PixelCPE

No regression observed.
No regression expected.
