### PR TITLE
Migrate to New Random Service Interface

### DIFF
--- a/EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibrator.h
+++ b/EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibrator.h
@@ -14,6 +14,10 @@ using std::ifstream;
 using std::istringstream;
 using std::cout;
 
+namespace edm {
+  class StreamID;
+}
+
 struct correctionValues
 {
     double nRunMin;
@@ -68,7 +72,7 @@ class ElectronEnergyCalibrator
 		    init();
     	}
 
-        void calibrate(SimpleElectron &electron);
+        void calibrate(SimpleElectron &electron, edm::StreamID const&);
         void correctLinearity(SimpleElectron &electron);
 
     private:

--- a/EgammaAnalysis/ElectronTools/plugins/CalibratedElectronProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/CalibratedElectronProducer.cc
@@ -289,7 +289,7 @@ void CalibratedElectronProducer::produce( edm::Event & event, const edm::EventSe
             // energy calibration for ecalDriven electrons
             if ( ele.core()->ecalDrivenSeed() || correctionsType==2 || combinationType==3 )
             {
-                theEnCorrector->calibrate(mySimpleElectron);
+                theEnCorrector->calibrate(mySimpleElectron, event.streamID());
 
                 // E-p combination
 

--- a/EgammaAnalysis/ElectronTools/plugins/CalibratedPatElectronProducer.cc
+++ b/EgammaAnalysis/ElectronTools/plugins/CalibratedPatElectronProducer.cc
@@ -244,7 +244,7 @@ void CalibratedPatElectronProducer::produce( edm::Event & event, const edm::Even
             // energy calibration for ecalDriven electrons
             if ( ele->core()->ecalDrivenSeed() || correctionsType==2 || combinationType==3 )
             {
-                theEnCorrector->calibrate(mySimpleElectron);
+                theEnCorrector->calibrate(mySimpleElectron, event.streamID());
 
                 // E-p combination
 

--- a/EgammaAnalysis/ElectronTools/src/ElectronEnergyCalibrator.cc
+++ b/EgammaAnalysis/ElectronTools/src/ElectronEnergyCalibrator.cc
@@ -167,7 +167,7 @@ double ElectronEnergyCalibrator::stringToDouble(const string &str)
 	return val;
 }
 
-void ElectronEnergyCalibrator::calibrate(SimpleElectron &electron)
+void ElectronEnergyCalibrator::calibrate(SimpleElectron &electron, edm::StreamID const& streamID)
 {
     double scale = 1.0;
     double dsigMC=0.; 
@@ -299,7 +299,7 @@ void ElectronEnergyCalibrator::calibrate(SimpleElectron &electron)
                     }
                 } else 
                 {
-                    CLHEP::RandFlat flatRandom(rng->getEngine());	
+                    CLHEP::RandFlat flatRandom(rng->getEngine(streamID));
 	                double rn = flatRandom.fire();
                 	if ( rn > lumiRatio_ ) 
                     {
@@ -411,7 +411,7 @@ void ElectronEnergyCalibrator::calibrate(SimpleElectron &electron)
 
     if ( isMC_ ) 
     {
-        CLHEP::RandGaussQ gaussDistribution(rng->getEngine(), 1.,dsigMC);
+        CLHEP::RandGaussQ gaussDistribution(rng->getEngine(streamID), 1.,dsigMC);
         corrMC = gaussDistribution.fire();
         if ( verbose_ ) 
         {


### PR DESCRIPTION
Migrate ElectronEnergyCalibrator to use the
new interface of the random number generator
service designed to work with the multithreaded
Framework.
