### PR TITLE
Removed unnecessary beginJob/endJob methods

### DIFF
--- a/CommonTools/ParticleFlow/plugins/PFPileUp.cc
+++ b/CommonTools/ParticleFlow/plugins/PFPileUp.cc
@@ -50,9 +50,6 @@ PFPileUp::~PFPileUp() { }
 
 
 
-void PFPileUp::beginJob() { }
-
-
 void PFPileUp::produce(Event& iEvent,
 			  const EventSetup& iSetup) {
 

--- a/CommonTools/ParticleFlow/plugins/PFPileUp.h
+++ b/CommonTools/ParticleFlow/plugins/PFPileUp.h
@@ -42,9 +42,7 @@ class PFPileUp : public edm::EDProducer {
 
   ~PFPileUp();
 
-  virtual void produce(edm::Event&, const edm::EventSetup&);
-
-  virtual void beginJob();
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
  private:
 

--- a/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseProducerFromL1TS.cc
+++ b/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseProducerFromL1TS.cc
@@ -58,10 +58,8 @@ class APVCyclePhaseProducerFromL1TS : public edm::EDProducer {
       ~APVCyclePhaseProducerFromL1TS();
 
 private:
-  virtual void beginJob() override ;
   virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override ;
 
   bool isBadRun(const unsigned int) const;
   
@@ -322,17 +320,6 @@ APVCyclePhaseProducerFromL1TS::produce(edm::Event& iEvent, const edm::EventSetup
 
   iEvent.put(apvphases);
 
-}
-
-// ------------ method called once each job just before starting event loop  ------------
-void 
-APVCyclePhaseProducerFromL1TS::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-APVCyclePhaseProducerFromL1TS::endJob() {
 }
 
 bool 

--- a/DPGAnalysis/SiStripTools/plugins/EventWithHistoryProducerFromL1ABC.cc
+++ b/DPGAnalysis/SiStripTools/plugins/EventWithHistoryProducerFromL1ABC.cc
@@ -46,11 +46,9 @@ class EventWithHistoryProducerFromL1ABC : public edm::EDProducer {
       ~EventWithHistoryProducerFromL1ABC();
 
    private:
-      virtual void beginJob() override ;
       virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
       virtual void endRun(const edm::Run&, const edm::EventSetup&) override;
-      virtual void endJob() override ;
       
       // ----------member data ---------------------------
 
@@ -166,12 +164,6 @@ EventWithHistoryProducerFromL1ABC::produce(edm::Event& iEvent, const edm::EventS
    }
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void 
-EventWithHistoryProducerFromL1ABC::beginJob()
-{
-}
-
 void 
 EventWithHistoryProducerFromL1ABC::beginRun(const edm::Run&, const edm::EventSetup&)
 {
@@ -192,11 +184,6 @@ EventWithHistoryProducerFromL1ABC::endRun(const edm::Run&, const edm::EventSetup
     edm::LogVerbatim("AbsoluteBXOffsetSummary") << offset->first << " " << offset->second;
   }
 
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-EventWithHistoryProducerFromL1ABC::endJob() {
 }
 
 //define this as a plug-in

--- a/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GlobalTriggerEvmRawToDigi.h
+++ b/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GlobalTriggerEvmRawToDigi.h
@@ -54,9 +54,7 @@ public:
 
 private:
 
-    virtual void beginJob();
-
-    virtual void produce(edm::Event&, const edm::EventSetup&);
+    virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
     /// block unpackers
 
@@ -71,9 +69,6 @@ private:
 
     /// dump FED raw data
     void dumpFedRawData(const unsigned char*, int, std::ostream&);
-
-    ///
-    virtual void endJob();
 
 private:
 

--- a/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GlobalTriggerRawToDigi.h
+++ b/EventFilter/L1GlobalTriggerRawToDigi/interface/L1GlobalTriggerRawToDigi.h
@@ -59,9 +59,7 @@ public:
 
 private:
 
-    virtual void beginJob();
-
-    virtual void produce(edm::Event&, const edm::EventSetup&);
+    virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
     /// block unpackers
 
@@ -88,8 +86,6 @@ private:
     /// dump FED raw data
     void dumpFedRawData(const unsigned char*, int, std::ostream&);
 
-    ///
-    virtual void endJob();
 
 private:
 

--- a/EventFilter/L1GlobalTriggerRawToDigi/src/L1GlobaTriggerEvmRawToDigi.cc
+++ b/EventFilter/L1GlobalTriggerRawToDigi/src/L1GlobaTriggerEvmRawToDigi.cc
@@ -132,12 +132,6 @@ L1GlobalTriggerEvmRawToDigi::~L1GlobalTriggerEvmRawToDigi() {
 
 // member functions
 
-void L1GlobalTriggerEvmRawToDigi::beginJob() {
-
-    // empty now
-
-}
-
 // method called to produce the data
 void L1GlobalTriggerEvmRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& evSetup) {
 
@@ -822,12 +816,6 @@ void L1GlobalTriggerEvmRawToDigi::dumpFedRawData(
                 << payload[i] << std::dec << std::setfill(' ') << std::endl;
     }
 
-}
-
-//
-void L1GlobalTriggerEvmRawToDigi::endJob() {
-
-    // empty now
 }
 
 // static class members

--- a/EventFilter/L1GlobalTriggerRawToDigi/src/L1GlobaTriggerRawToDigi.cc
+++ b/EventFilter/L1GlobalTriggerRawToDigi/src/L1GlobaTriggerRawToDigi.cc
@@ -142,10 +142,6 @@ L1GlobalTriggerRawToDigi::~L1GlobalTriggerRawToDigi() {
 
 // member functions
 
-void L1GlobalTriggerRawToDigi::beginJob() {
-    // empty
-}
-
 // method called to produce the data
 void L1GlobalTriggerRawToDigi::produce(edm::Event& iEvent, const edm::EventSetup& evSetup) {
 
@@ -1051,12 +1047,6 @@ void L1GlobalTriggerRawToDigi::dumpFedRawData(
                 << payload[i] << std::dec << std::setfill(' ') << std::endl;
     }
 
-}
-
-//
-void L1GlobalTriggerRawToDigi::endJob() {
-
-    // empty now
 }
 
 // static class members

--- a/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
+++ b/EventFilter/SiPixelRawToDigi/plugins/SiPixelRawToDigi.h
@@ -31,12 +31,8 @@ public:
   /// dtor
   virtual ~SiPixelRawToDigi();
 
-
-  /// dummy end of job 
-  virtual void endJob() {}
-
   /// get data, convert to digis attach againe to Event
-  virtual void produce( edm::Event&, const edm::EventSetup& );
+  virtual void produce( edm::Event&, const edm::EventSetup& ) override;
 
 private:
 

--- a/L1Trigger/L1ExtraFromDigis/interface/L1ExtraParticlesProd.h
+++ b/L1Trigger/L1ExtraFromDigis/interface/L1ExtraParticlesProd.h
@@ -44,9 +44,7 @@ class L1ExtraParticlesProd : public edm::EDProducer {
       ~L1ExtraParticlesProd();
 
    private:
-      virtual void beginJob() ;
-      virtual void produce(edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+      virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
       //      math::XYZTLorentzVector gctLorentzVector( const double& et,
       math::PtEtaPhiMLorentzVector gctLorentzVector( const double& et,

--- a/L1Trigger/L1ExtraFromDigis/src/L1ExtraParticlesProd.cc
+++ b/L1Trigger/L1ExtraFromDigis/src/L1ExtraParticlesProd.cc
@@ -1086,16 +1086,5 @@ L1ExtraParticlesProd::gctLorentzVector( const double& et,
 					0. ) ;
 }     
 
-// ------------ method called once each job just before starting event loop  ------------
-void 
-L1ExtraParticlesProd::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-L1ExtraParticlesProd::endJob() {
-}
-
 //define this as a plug-in
 DEFINE_FWK_MODULE(L1ExtraParticlesProd);

--- a/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.cc
@@ -34,8 +34,6 @@ TauGenJetProducer::TauGenJetProducer(const edm::ParameterSet& iConfig)
 
 TauGenJetProducer::~TauGenJetProducer() { }
 
-void TauGenJetProducer::beginJob() { }
-
 void TauGenJetProducer::produce(Event& iEvent,
 				const EventSetup& iSetup) {
 

--- a/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.h
+++ b/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.h
@@ -29,9 +29,7 @@ class TauGenJetProducer : public edm::EDProducer {
 
   ~TauGenJetProducer();
 
-  virtual void produce(edm::Event&, const edm::EventSetup&);
-
-  virtual void beginJob();
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
  private:
 

--- a/RecoEcal/EgammaClusterProducers/interface/Multi5x5SuperClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/Multi5x5SuperClusterProducer.h
@@ -25,8 +25,8 @@ class Multi5x5SuperClusterProducer : public edm::EDProducer
 
       ~Multi5x5SuperClusterProducer();
 
-      virtual void produce(edm::Event&, const edm::EventSetup&);
-      virtual void endJob();
+      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+      virtual void endJob() override;
 
    private:
 

--- a/RecoEcal/EgammaClusterProducers/src/InterestingTrackEcalDetIdProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/InterestingTrackEcalDetIdProducer.cc
@@ -52,9 +52,7 @@ class InterestingTrackEcalDetIdProducer : public edm::EDProducer {
       ~InterestingTrackEcalDetIdProducer();
 
    private:
-      virtual void beginJob() override ;
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override ;
       void beginRun(edm::Run const&, const edm::EventSetup&) override;
 
       
@@ -160,17 +158,6 @@ void InterestingTrackEcalDetIdProducer::beginRun(edm::Run const& run, const edm:
   edm::ESHandle<CaloTopology> theCaloTopology;
   iSetup.get<CaloTopologyRecord>().get(theCaloTopology);
   caloTopology_ = &(*theCaloTopology); 
-}
-
-// ------------ method called once each job just before starting event loop  ------------
-void 
-InterestingTrackEcalDetIdProducer::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-InterestingTrackEcalDetIdProducer::endJob() {
 }
 
 //define this as a plug-in

--- a/RecoJets/JetAssociationProducers/interface/TrackExtrapolator.h
+++ b/RecoJets/JetAssociationProducers/interface/TrackExtrapolator.h
@@ -61,9 +61,8 @@ class TrackExtrapolator : public edm::EDProducer {
       ~TrackExtrapolator();
 
    private:
-      virtual void beginJob() ;
-      virtual void produce(edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+
       
       // ----------member data ---------------------------
 

--- a/RecoJets/JetAssociationProducers/src/TrackExtrapolator.cc
+++ b/RecoJets/JetAssociationProducers/src/TrackExtrapolator.cc
@@ -82,20 +82,6 @@ TrackExtrapolator::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.put( extrapolations );
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void 
-TrackExtrapolator::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-TrackExtrapolator::endJob() {
-}
-
-
-
-
 // -----------------------------------------------------------------------------
 //
 bool TrackExtrapolator::propagateTrackToVolume( const reco::Track& fTrack,

--- a/RecoJets/JetPlusTracks/plugins/JetPlusTrackProducer.cc
+++ b/RecoJets/JetPlusTracks/plugins/JetPlusTrackProducer.cc
@@ -282,16 +282,5 @@ JetPlusTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void 
-JetPlusTrackProducer::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-JetPlusTrackProducer::endJob() {
-}
-
 //define this as a plug-in
 //DEFINE_FWK_MODULE(JetPlusTrackProducer);

--- a/RecoJets/JetPlusTracks/plugins/JetPlusTrackProducer.h
+++ b/RecoJets/JetPlusTracks/plugins/JetPlusTrackProducer.h
@@ -44,9 +44,7 @@ class JetPlusTrackProducer : public edm::EDProducer {
    public:
       explicit JetPlusTrackProducer(const edm::ParameterSet&);
       ~JetPlusTrackProducer();
-      virtual void beginJob();
-      virtual void produce(edm::Event&, const edm::EventSetup&);
-      virtual void endJob();
+      virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
    // ---------- private data members ---------------------------
    private:

--- a/RecoJets/JetProducers/plugins/CastorJetIDProducer.cc
+++ b/RecoJets/JetProducers/plugins/CastorJetIDProducer.cc
@@ -84,16 +84,5 @@ CastorJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.put( castorjetIdValueMap );
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void 
-CastorJetIDProducer::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-CastorJetIDProducer::endJob() {
-}
-
 //define this as a plug-in
 DEFINE_FWK_MODULE(CastorJetIDProducer);

--- a/RecoJets/JetProducers/plugins/CastorJetIDProducer.h
+++ b/RecoJets/JetProducers/plugins/CastorJetIDProducer.h
@@ -45,9 +45,7 @@ class CastorJetIDProducer : public edm::EDProducer {
       ~CastorJetIDProducer();
 
    private:
-      virtual void beginJob() ;
-      virtual void produce(edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+      virtual void produce(edm::Event&, const edm::EventSetup&) override;
       
       // ----------member data ---------------------------
       edm::InputTag                 src_;          // input jet source

--- a/RecoJets/JetProducers/plugins/JetIDProducer.cc
+++ b/RecoJets/JetProducers/plugins/JetIDProducer.cc
@@ -104,16 +104,5 @@ JetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.put( jetIdValueMap );
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void 
-JetIDProducer::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-JetIDProducer::endJob() {
-}
-
 //define this as a plug-in
 DEFINE_FWK_MODULE(JetIDProducer);

--- a/RecoJets/JetProducers/plugins/JetIDProducer.h
+++ b/RecoJets/JetProducers/plugins/JetIDProducer.h
@@ -49,9 +49,7 @@ class JetIDProducer : public edm::EDProducer {
       ~JetIDProducer();
 
    private:
-      virtual void beginJob() ;
-      virtual void produce(edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
+      virtual void produce(edm::Event&, const edm::EventSetup&) override;
       
       // ----------member data ---------------------------
       edm::InputTag                 src_;         // input jet source

--- a/RecoLocalCalo/Castor/src/CastorTowerProducer.cc
+++ b/RecoLocalCalo/Castor/src/CastorTowerProducer.cc
@@ -54,9 +54,7 @@ class CastorTowerProducer : public edm::EDProducer {
       ~CastorTowerProducer();
 
    private:
-      virtual void beginJob() override ;
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override ;
       virtual void ComputeTowerVariable(const edm::RefVector<edm::SortedCollection<CastorRecHit> >& usedRecHits, double&  Ehot, double& depth);
       
       // member data
@@ -266,18 +264,6 @@ void CastorTowerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
   iEvent.put(OutputTowers);
 } 
 
-
-// ------------ method called once each job just before starting event loop  ------------
-void CastorTowerProducer::beginJob() {
-  LogDebug("CastorTowerProducer")
-    <<"Starting CastorTowerProducer";
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void CastorTowerProducer::endJob() {
-  LogDebug("CastorTowerProducer")
-    <<"Ending CastorTowerProducer";
-}
 
 void CastorTowerProducer::ComputeTowerVariable(const edm::RefVector<edm::SortedCollection<CastorRecHit> >& usedRecHits, double&  Ehot, double& depth) {
 

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitSelection.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitSelection.cc
@@ -49,9 +49,7 @@ class HcalHitSelection : public edm::EDProducer {
       ~HcalHitSelection();
 
    private:
-      virtual void beginJob() override ;
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override ;
   
   edm::InputTag hbheTag,hoTag,hfTag;
   edm::EDGetTokenT<HBHERecHitCollection> tok_hbhe_;
@@ -185,17 +183,6 @@ HcalHitSelection::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   skim(ho,ho_out,hoSeverityLevel);
   iEvent.put(ho_out,hoTag.label());
   
-}
-
-// ------------ method called once each job just before starting event loop  ------------
-void 
-HcalHitSelection::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-HcalHitSelection::endJob() {
 }
 
 //define this as a plug-in

--- a/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelClusterProducer.h
+++ b/RecoLocalTracker/SiPixelClusterizer/interface/SiPixelClusterProducer.h
@@ -63,11 +63,10 @@ namespace cms
     void setupClusterizer();
 
     // Begin Job
-    //virtual void beginJob( const edm::EventSetup& );
-    virtual void beginJob( );
+    virtual void beginJob( ) override;
 
     //--- The top-level event method.
-    virtual void produce(edm::Event& e, const edm::EventSetup& c);
+    virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
 
     //--- Execute the algorithm(s).
     void run(const edm::DetSetVector<PixelDigi>   & input,

--- a/RecoLocalTracker/SiPixelRecHits/interface/SiPixelRecHitConverter.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/SiPixelRecHitConverter.h
@@ -75,11 +75,7 @@ namespace cms
     //--- realistic use case...
 
     //--- The top-level event method.
-    virtual void produce(edm::Event& e, const edm::EventSetup& c);
-
-    // Begin Job
-    //virtual void beginJob();
-    virtual void beginJob();
+    virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
 
     //--- Execute the position estimator algorithm(s).
     //--- New interface with DetSetVector

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
@@ -55,14 +55,6 @@ namespace cms
   }  
   
   //---------------------------------------------------------------------------
-  // Begin job: get magnetic field
-  //---------------------------------------------------------------------------
-  //void SiPixelRecHitConverter::beginJob() 
-  void SiPixelRecHitConverter::beginJob() 
-  {
-  }
-  
-  //---------------------------------------------------------------------------
   //! The "Event" entrypoint: gets called by framework for every event
   //---------------------------------------------------------------------------
   void SiPixelRecHitConverter::produce(edm::Event& e, const edm::EventSetup& es)

--- a/RecoLocalTracker/SubCollectionProducers/interface/ClusterSummaryProducer.h
+++ b/RecoLocalTracker/SubCollectionProducers/interface/ClusterSummaryProducer.h
@@ -70,8 +70,8 @@ class ClusterSummaryProducer : public edm::EDProducer {
       ~ClusterSummaryProducer(){};
 
    private:
-      virtual void beginJob() ;
-      virtual void produce(edm::Event&, const edm::EventSetup&);
+      virtual void beginJob() override;
+      virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
       void decodeInput(std::vector<std::string> &, std::string );
       

--- a/RecoMET/METProducers/interface/MuonMETValueMapProducer.h
+++ b/RecoMET/METProducers/interface/MuonMETValueMapProducer.h
@@ -43,9 +43,7 @@ public:
   ~MuonMETValueMapProducer() { }
 
 private:
-  virtual void beginJob() { }
-  virtual void produce(edm::Event&, const edm::EventSetup&);
-  virtual void endJob() { }
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
   void determine_deltax_deltay(double& deltax, double& deltay, const reco::Muon& muon, double bfield, edm::Event& iEvent, const edm::EventSetup& iSetup);
   reco::MuonMETCorrectionData::Type decide_correction_type(const reco::Muon& muon, const math::XYZPoint &beamSpotPosition);

--- a/RecoMET/METProducers/interface/MuonTCMETValueMapProducer.h
+++ b/RecoMET/METProducers/interface/MuonTCMETValueMapProducer.h
@@ -47,9 +47,8 @@ public:
 
 
 private:
-  virtual void beginJob() ;
-  virtual void produce(edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  virtual void beginJob() override;
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
       
   edm::Handle<reco::MuonCollection>    muons_;
   edm::Handle<reco::BeamSpot>          beamSpot_;

--- a/RecoMET/METProducers/src/MuonTCMETValueMapProducer.cc
+++ b/RecoMET/METProducers/src/MuonTCMETValueMapProducer.cc
@@ -196,12 +196,6 @@ void MuonTCMETValueMapProducer::beginJob()
 }
 
 //____________________________________________________________________________||
-void MuonTCMETValueMapProducer::endJob()
-{
-
-}
-
-//____________________________________________________________________________||
 bool MuonTCMETValueMapProducer::isGoodMuon( const reco::Muon* muon )
 {
   double d0    = -999;

--- a/RecoParticleFlow/PFTracking/interface/ElectronSeedMerger.h
+++ b/RecoParticleFlow/PFTracking/interface/ElectronSeedMerger.h
@@ -16,9 +16,7 @@ class ElectronSeedMerger : public edm::EDProducer {
       ~ElectronSeedMerger();
   
    private:
-      virtual void beginJob(){} ;
-      virtual void produce(edm::Event&, const edm::EventSetup&);
-      virtual void endJob(){}
+      virtual void produce(edm::Event&, const edm::EventSetup&) override;
  
 
       edm::ParameterSet conf_;

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
@@ -123,12 +123,6 @@ void  DeDxEstimatorProducer::beginRun(edm::Run const& run, const edm::EventSetup
    MakeCalibrationMap();
 }
 
-// ------------ method called once each job just after ending the event loop  ------------
-void  DeDxEstimatorProducer::endJob(){
-   MODsColl.clear();
-}
-
-
 
 
 void DeDxEstimatorProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.h
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.h
@@ -41,7 +41,6 @@ public:
 private:
   virtual void beginRun(edm::Run const& run, const edm::EventSetup&) override;
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() ;
 
   int    getCharge(const SiStripCluster*   Cluster, int& Saturating_Strips,const uint32_t &);
 //  int    getCharge(const SiStripRecHit2D* sistripsimplehit, int& Saturating_Strips);

--- a/RecoVertex/V0Producer/interface/V0Producer.h
+++ b/RecoVertex/V0Producer/interface/V0Producer.h
@@ -45,10 +45,7 @@ public:
   ~V0Producer();
 
 private:
-  //virtual void beginJob() ;
-  virtual void beginJob();
-  virtual void produce(edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
   edm::ParameterSet theParams;
   V0Fitter * theVees;      

--- a/RecoVertex/V0Producer/src/V0Producer.cc
+++ b/RecoVertex/V0Producer/src/V0Producer.cc
@@ -81,14 +81,6 @@ void V0Producer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 }
 
 
-//void V0Producer::beginJob() {
-void V0Producer::beginJob() {
-}
-
-
-void V0Producer::endJob() {
-}
-
 //define this as a plug-in
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 

--- a/SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h
+++ b/SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h
@@ -24,9 +24,7 @@ public:
   static bool simHitTPAssociationListGreater(SimHitTPPair i,SimHitTPPair j) { return (i.first.key()>j.first.key()); }
 
 private:
-  virtual void beginJob() {}
-  virtual void produce(edm::Event&, const edm::EventSetup&);
-  virtual void endJob() {}
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
   std::vector<edm::InputTag> _simHitSrc;
   edm::InputTag _trackingParticleSrc;

--- a/Validation/RecoTau/plugins/CollectionFromZLegProducer.cc
+++ b/Validation/RecoTau/plugins/CollectionFromZLegProducer.cc
@@ -26,7 +26,6 @@ public:
   virtual ~CollectionFromZLegProducer();
   
   void produce(edm::Event& iEvent,const edm::EventSetup& iSetup) override;
-  void endJob() override;
 
 private:  
   // member data
@@ -93,10 +92,6 @@ void CollectionFromZLegProducer::produce(edm::Event& iEvent,const edm::EventSetu
   } 
   iEvent.put(theTagLeg  , "theTagLeg"   ) ;
   iEvent.put(theProbeLeg, "theProbeLeg" ) ;
-}
-
-void CollectionFromZLegProducer::endJob()
-{
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/Validation/RecoTau/plugins/ElectronFromPVSelector.cc
+++ b/Validation/RecoTau/plugins/ElectronFromPVSelector.cc
@@ -37,7 +37,6 @@ public:
   
   // member functions
   void produce(edm::Event& iEvent,const edm::EventSetup& iSetup) override;
-  void endJob() override;
 
 private:  
   // member data
@@ -105,10 +104,6 @@ void GsfElectronFromPVSelector::produce(edm::Event& iEvent,const edm::EventSetup
   
   iEvent.put(goodGsfElectrons);
   
-}
-
-void GsfElectronFromPVSelector::endJob()
-{
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/Validation/RecoTau/plugins/IsoTracks.cc
+++ b/Validation/RecoTau/plugins/IsoTracks.cc
@@ -27,7 +27,6 @@ public:
   
   // member functions
   void produce(edm::Event& iEvent,const edm::EventSetup& iSetup) override;
-  void endJob() override;
 
 private:  
   // member data
@@ -94,10 +93,6 @@ void IsoTracks::produce(edm::Event& iEvent,const edm::EventSetup& iSetup)
 	}
   }
   iEvent.put(IsoTracks);
-}
-
-void IsoTracks::endJob()
-{
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/Validation/RecoTau/plugins/MuonFromPVSelector.cc
+++ b/Validation/RecoTau/plugins/MuonFromPVSelector.cc
@@ -31,7 +31,6 @@ public:
   
   // member functions
   void produce(edm::Event& iEvent,const edm::EventSetup& iSetup) override;
-  void endJob() override;
 
 private:  
   // member data
@@ -97,10 +96,6 @@ void MuonFromPVSelector::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
   
   iEvent.put(goodMuons);
   
-}
-
-void MuonFromPVSelector::endJob()
-{
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/Validation/RecoTau/plugins/TrackFromPVSelector.cc
+++ b/Validation/RecoTau/plugins/TrackFromPVSelector.cc
@@ -31,7 +31,6 @@ public:
   
   // member functions
   void produce(edm::Event& iEvent,const edm::EventSetup& iSetup) override;
-  void endJob() override;
 
 private:  
   // member data
@@ -95,10 +94,6 @@ void TrackFromPVSelector::produce(edm::Event& iEvent,const edm::EventSetup& iSet
   
   iEvent.put(goodTracks);
   
-}
-
-void TrackFromPVSelector::endJob()
-{
 }
 
 #include "FWCore/Framework/interface/MakerMacros.h"


### PR DESCRIPTION
In order to facilitate possible conversion of the modules to stream based
modules, we must remove the beginJob/endJob methods (since they are
not supported by the default stream implementation). This commit removed
empty/unnecessary beginJob/endJob methods. In the cases where the methods
were being used, they were left alone but the 'override' declaration was
added to ensure that if the module were converted to a stream module the
compiler could catch the fact that beginJob/endJob are not defined in the
new base class.
