### PR TITLE
Don't call TClass::New for each container element

### DIFF
--- a/CondCore/ORA/src/STLContainerStreamer.cc
+++ b/CondCore/ORA/src/STLContainerStreamer.cc
@@ -387,18 +387,18 @@ void ora::STLContainerReader::read( void* destinationData ) {
 
   size_t cursorSize = m_query->selectionSize(m_recordId, m_recordId.size()-1);
   unsigned int i=0;
+  // Create a new element for the array
+  void* objectData = 0;
+  if(isElementFundamental){
+    objectData = &primitiveStub;
+  } else {
+    objectData = iteratorReturnType.construct().address();
+  }
+
   while ( i< cursorSize ){
 
     m_recordId[m_recordId.size()-1] = (int)i;
     m_query->selectRow( m_recordId );
-
-    // Create a new element for the array
-    void* objectData = 0;
-    if(isElementFundamental){
-      objectData = &primitiveStub;
-    } else {
-      objectData = iteratorReturnType.construct().address();
-    }
 
     void* componentData = objectData;
     void* keyData = 0;
@@ -416,15 +416,15 @@ void ora::STLContainerReader::read( void* destinationData ) {
     size_t prevSize = m_arrayHandler->size( address );
     m_arrayHandler->appendNewElement( address, objectData );
     bool inserted = m_arrayHandler->size( address )>prevSize;
-    if ( ! ( iteratorReturnType.isFundamental() ) ) {
-      iteratorReturnType.destruct( objectData );
-    }
     if ( !inserted ) {
       throwException( "Could not insert a new element in the array type \"" +
                       m_objectType.qualifiedName() + "\"",
                       "STLContainerReader::read" );
     }
     ++i;
+  }
+  if ( ! ( iteratorReturnType.isFundamental() ) ) {
+    iteratorReturnType.destruct( objectData );
   }
 
   m_arrayHandler->finalize( address );


### PR DESCRIPTION
This fixes the huge time consumption for the ROOT6 relvals,
In the conditions code, TClass::New was called for each element of a collection, which is not a good idea for over 100K emements.  This fix calls it once for each container and reuses the memory.
This is a HUGE time savings.
Please merge ASAP, and the ROOT6 IB's should actually finish in a finite amount of time.
