### PR TITLE
Ignore new ROOT error message about TH1 nbins <=0

### DIFF
--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -116,7 +116,8 @@ namespace {
           (el_location.find("TDecompChol::Solve") != std::string::npos) ||
           (el_location.find("THistPainter::PaintInit") != std::string::npos) ||
           (el_location.find("TUnixSystem::SetDisplay") != std::string::npos) ||
-          (el_location.find("TGClient::GetFontByName") != std::string::npos)) {
+          (el_location.find("TGClient::GetFontByName") != std::string::npos) ||
+          (el_message.find("nbins is <=0 - set to nbins = 1") != std::string::npos)) {
         el_severity = SeverityLevel::kInfo;
       }
 


### PR DESCRIPTION
When we switched to ROOT 5.34.17 a new warning message appeared
when TH1 is passed nbins <= 0. Since ROOT already sets the value
to nbins=1 we can ignore this warning.
