### PR TITLE
Remove redundant line of code

### DIFF
--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -110,7 +110,6 @@ namespace {
           (el_message.find("already in TClassTable") != std::string::npos) ||
           (el_message.find("matrix not positive definite") != std::string::npos) ||
           (el_message.find("not a TStreamerInfo object") != std::string::npos) ||
-          (el_message.find("nbins is <=0") != std::string::npos) ||
           (el_message.find("Problems declaring payload") != std::string::npos) ||
           (el_location.find("Fit") != std::string::npos) ||
           (el_location.find("TDecompChol::Solve") != std::string::npos) ||


### PR DESCRIPTION
Totally trivial.  A while back I added a line of code to the ROOT 6 to ignore a new harmless warning message from ROOT6.   Unbeknown to me, the same warning was also added to a later version of ROOT 5, so Chris Jones added effectively the same line of code in 7_1_X.  That just got carried forward into the ROOT6 branch, so it is now done twice.  This request removes the line that I added earlier to avoid doing the same thing twice, and to increase code commonality.
