### PR TITLE
Migrate to new random service interface

### DIFF
--- a/IOMC/RandomEngine/src/RandomFilter.h
+++ b/IOMC/RandomEngine/src/RandomFilter.h
@@ -20,12 +20,6 @@ type and name is "untracked double acceptRate".
 
 #include "FWCore/Framework/interface/EDFilter.h"
 
-#include "boost/shared_ptr.hpp"
-
-namespace CLHEP {
-  class RandFlat;
-}
-
 namespace edm {
   class ParameterSet;
   class Event;
@@ -42,7 +36,5 @@ namespace edm {
 
     // value between 0 and 1
     double acceptRate_;
-
-    boost::shared_ptr<CLHEP::RandFlat> flatDistribution_;
   };
 }


### PR DESCRIPTION
Migrate the RandomFilter module to the new random
service interface designed for multithreading.
