### PR TITLE
Fixed thread-safety issues with PixelToFEDAssociateFromAscii

### DIFF
--- a/CalibTracker/SiPixelConnectivity/interface/PixelToFEDAssociateFromAscii.h
+++ b/CalibTracker/SiPixelConnectivity/interface/PixelToFEDAssociateFromAscii.h
@@ -24,17 +24,17 @@ public:
   PixelToFEDAssociateFromAscii(const std::string & fileName);
 
   /// FED id for module
-  virtual int operator()(const PixelModuleName &) const;
+  virtual int operator()(const PixelModuleName &) const override;
 
   /// version
-  virtual std::string version() const;
+  virtual std::string version() const override;
 
 
   /// FED id to which barrel modul (identified by name) should be assigned 
-  virtual int operator()(const PixelBarrelName &) const;
+  int operator()(const PixelBarrelName &) const;
 
   /// FED id to which endcape modul (identified by name) should be assigned 
-  virtual int operator()(const PixelEndcapName &) const;
+  int operator()(const PixelEndcapName &) const;
 
 private:
   /// initialisatin (read file)
@@ -53,8 +53,8 @@ private:
 
   typedef std::vector< std::pair< int, std::vector<Bdu> > > BarrelConnections;
   typedef std::vector< std::pair< int, std::vector<Edu> > > EndcapConnections;
-  static BarrelConnections theBarrel;
-  static EndcapConnections theEndcap;
+  BarrelConnections theBarrel;
+  EndcapConnections theEndcap;
 
 private:
 
@@ -62,7 +62,7 @@ private:
 
   /// initialisation (read input file)
   void send (std::pair< int, std::vector<Bdu> > & , 
-      std::pair< int, std::vector<Edu> > & ) const;
+      std::pair< int, std::vector<Edu> > & ) ;
   Bdu getBdu( std::string ) const;
   Edu getEdu( std::string ) const;
   Range readRange( const std::string &) const;

--- a/CalibTracker/SiPixelConnectivity/src/PixelToFEDAssociateFromAscii.cc
+++ b/CalibTracker/SiPixelConnectivity/src/PixelToFEDAssociateFromAscii.cc
@@ -11,12 +11,6 @@
 using namespace std;
 
 
-PixelToFEDAssociateFromAscii::BarrelConnections PixelToFEDAssociateFromAscii::theBarrel
-   = PixelToFEDAssociateFromAscii::BarrelConnections();
-PixelToFEDAssociateFromAscii::EndcapConnections PixelToFEDAssociateFromAscii::theEndcap
-   = PixelToFEDAssociateFromAscii::EndcapConnections();
-
-
 PixelToFEDAssociateFromAscii::PixelToFEDAssociateFromAscii(const string & fn) {
   init(fn);
 }
@@ -169,7 +163,7 @@ void PixelToFEDAssociateFromAscii::init(const string & cfg_name)
 }
 
 void PixelToFEDAssociateFromAscii::send(
-    pair<int,vector<Bdu> > & b, pair<int,vector<Edu> > & e) const 
+    pair<int,vector<Bdu> > & b, pair<int,vector<Edu> > & e)
 {
   if (b.second.size() > 0) theBarrel.push_back(b);
   if (e.second.size() > 0) theEndcap.push_back(e);


### PR DESCRIPTION
Changed the class statics to be member data. This avoids potential
thread-safety issues. The additional minor changes were to support
this change or to make mainentance easier. The exact functionality
of this class was unchanged.
