### PR TITLE
Make static DCCDataUnpacker::silentMode_ std::atomic

### DIFF
--- a/EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h
+++ b/EventFilter/EcalRawToDigi/interface/DCCDataUnpacker.h
@@ -23,6 +23,7 @@
 #include <map>
 #include <stdio.h>                     
 #include <stdint.h>
+#include <atomic>
 
 //DATA DECODER
 
@@ -223,7 +224,7 @@ public :
   */
   DCCEventBlock * currentEvent(){ return currentEvent_;}
 
-  static bool silentMode_; 
+  static std::atomic<bool> silentMode_; 
  
 protected :
 

--- a/EventFilter/EcalRawToDigi/src/DCCDataUnpacker.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCDataUnpacker.cc
@@ -6,7 +6,7 @@
 #include "EventFilter/EcalRawToDigi/interface/EcalElectronicsMapper.h"
 #include <set>
 
-bool DCCDataUnpacker::silentMode_ = false;
+std::atomic<bool> DCCDataUnpacker::silentMode_(false);
 
 DCCDataUnpacker::DCCDataUnpacker( 
   EcalElectronicsMapper * mapper, bool hU, bool srpU, bool tccU, bool feU , bool memU, bool syncCheck, bool feIdCheck, bool forceToKeepFRdata


### PR DESCRIPTION
Given that DCCDatdaUnpacker::silentMode_ is a public global and
could be modified by any thread, this had to be changed to an
std::atomic<bool>.
