### PR TITLE
Fix long64 issues in ROOT 6 Conditions code

### DIFF
--- a/CondCore/ORA/src/CArrayStreamer.cc
+++ b/CondCore/ORA/src/CArrayStreamer.cc
@@ -46,7 +46,7 @@ bool ora::CArrayWriter::build( DataElement& offset,
   // Check the component type
   if ( ! arrayType || !arrayResolvedType ) {
     throwException( "Missing dictionary information for the element type of the array \"" +
-                    m_objectType.qualifiedName() + "\"",
+                    m_objectType.cppName() + "\"",
                     "CArrayWriter::build" );
   }
   
@@ -198,7 +198,7 @@ bool ora::CArrayReader::build( DataElement& offset,
   // Check the component type
   if ( ! arrayType || !arrayResolvedType ) {
     throwException( "Missing dictionary information for the element type of the array \"" +
-                    m_objectType.qualifiedName() + "\"",
+                    m_objectType.cppName() + "\"",
                     "CArrayReader::build" );
   }
 

--- a/CondCore/ORA/src/ClassUtils.cc
+++ b/CondCore/ORA/src/ClassUtils.cc
@@ -72,16 +72,14 @@ bool ora::ClassUtils::checkMappedType( const edm::TypeWithDict& type,
     return mappedTypeName=="int";
   } else if ( isTypeOraVector( type ) ){
     return isTypeNameOraVector( mappedTypeName );
-  } else if ( type.qualifiedName() == mappedTypeName ) {
+  } else if ( type.cppName() == mappedTypeName ) {
     return true;
   }
   // ROOT 6 uses these typedefs in names.
   std::string typeName(mappedTypeName); 
-  replaceString(typeName, "unsigned long long", "ULong64_t");
-  replaceString(typeName, "long long", "Long64_t");
   replaceString(typeName, "std::basic_string<char> ", "std::string");
   replaceString(typeName, "std::basic_string<char>", "std::string");
-  return (type.qualifiedName() == typeName );
+  return (type.cppName() == typeName );
 }
 
 bool ora::ClassUtils::findBaseType( edm::TypeWithDict& type, edm::TypeWithDict& baseType, size_t& func ){
@@ -155,7 +153,7 @@ edm::TypeWithDict ora::ClassUtils::lookupDictionary( const std::string& classNam
 
 void* ora::ClassUtils::constructObject( const edm::TypeWithDict& typ ){
   void* ptr = 0;
-  if( typ.qualifiedName()=="std::string"){
+  if( typ.cppName()=="std::string"){
     ptr = new std::string("");
   } else {
     ptr = typ.construct().address();
@@ -164,7 +162,7 @@ void* ora::ClassUtils::constructObject( const edm::TypeWithDict& typ ){
 }
 
 bool ora::ClassUtils::isTypeString(const edm::TypeWithDict& typ){
-  std::string name = typ.qualifiedName();
+  std::string name = typ.cppName();
   return ( name == "std::string" ||
            name == "std::basic_string<char>" );
 }

--- a/CondCore/ORA/src/ContainerSchema.cc
+++ b/CondCore/ORA/src/ContainerSchema.cc
@@ -53,7 +53,7 @@ ora::ContainerSchema::ContainerSchema( int containerId,
                                        DatabaseSession& session ):
   m_containerId( containerId ),
   m_containerName( containerName ),
-  m_className( containerType.qualifiedName( ) ),
+  m_className( containerType.cppName( ) ),
   m_classDict( containerType ),
   m_session( session ),
   m_loaded( false ),
@@ -172,7 +172,7 @@ void ora::ContainerSchema::evolve(){
   MappingGenerator mapGen( m_session.schema().storageSchema() );
   // retrieve the base mapping
   MappingTree baseMapping;
-  if( !m_session.mappingDatabase().getBaseMappingForContainer( m_classDict.qualifiedName(), m_containerId, baseMapping )){
+  if( !m_session.mappingDatabase().getBaseMappingForContainer( m_classDict.cppName(), m_containerId, baseMapping )){
     throwException("Base mapping has not been found in the database.",
                    "ContainerSchema::evolve");
   }
@@ -187,12 +187,12 @@ void ora::ContainerSchema::evolve(){
 }
 
 void ora::ContainerSchema::evolve( const edm::TypeWithDict& dependentClass, MappingTree& baseMapping ){
-  std::string className = dependentClass.qualifiedName();
+  std::string className = dependentClass.cppName();
   MappingGenerator mapGen( m_session.schema().storageSchema() );
   std::map<std::string,MappingTree*>::iterator iDep =
     m_dependentMappings.insert( std::make_pair( className, new MappingTree ) ).first;
-  if( baseMapping.className() != dependentClass.qualifiedName() ){
-    throwException("Provided base mapping does not map class \""+dependentClass.qualifiedName()+"\".",
+  if( baseMapping.className() != dependentClass.cppName() ){
+    throwException("Provided base mapping does not map class \""+dependentClass.cppName()+"\".",
                    "ContainerSchema::evolve");    
   }
   mapGen.createNewDependentMapping( dependentClass, m_mapping, baseMapping, *iDep->second );
@@ -247,7 +247,7 @@ ora::MappingTree& ora::ContainerSchema::mapping( bool writeEnabled ){
 bool ora::ContainerSchema::loadMappingForDependentClass( const edm::TypeWithDict& dependentClassDict ){
   if( !dependentClassDict ) throwException("The dependent class has not been found in the dictionary.",
 					   "ContainerSchema::loadMappingForDependentClass");
-  std::string className = dependentClassDict.qualifiedName();
+  std::string className = dependentClassDict.cppName();
   std::map<std::string,MappingTree*>::iterator iDep = m_dependentMappings.find( className );
   if( iDep ==  m_dependentMappings.end() ){
     // not in cache, search the database...
@@ -264,7 +264,7 @@ bool ora::ContainerSchema::loadMappingForDependentClass( const edm::TypeWithDict
 }
 
 void ora::ContainerSchema::create( const edm::TypeWithDict& dependentClassDict ){
-  std::string className = dependentClassDict.qualifiedName();
+  std::string className = dependentClassDict.cppName();
   std::map<std::string,MappingTree*>::iterator iDep =
     m_dependentMappings.insert( std::make_pair( className, new MappingTree ) ).first;
   MappingGenerator mapGen( m_session.schema().storageSchema() );
@@ -279,7 +279,7 @@ void ora::ContainerSchema::create( const edm::TypeWithDict& dependentClassDict )
 }
 
 void ora::ContainerSchema::extend( const edm::TypeWithDict& dependentClassDict ){
-  std::string className = dependentClassDict.qualifiedName();
+  std::string className = dependentClassDict.cppName();
   MappingTree baseMapping;
   if( !m_session.mappingDatabase().getBaseMappingForContainer( className,
                                                                m_containerId, baseMapping ) ){
@@ -300,7 +300,7 @@ bool ora::ContainerSchema::extendIfRequired( const edm::TypeWithDict& dependentC
 
 ora::MappingElement& ora::ContainerSchema::mappingForDependentClass( const edm::TypeWithDict& dependentClassDict,
                                                                      bool writeEnabled ){
-  std::string className = dependentClassDict.qualifiedName();
+  std::string className = dependentClassDict.cppName();
   if( ! loadMappingForDependentClass( dependentClassDict ) ){
     if( writeEnabled ){
       // check if a base is available:

--- a/CondCore/ORA/src/Database.cc
+++ b/CondCore/ORA/src/Database.cc
@@ -35,7 +35,7 @@ namespace ora {
   };
   
   std::string nameFromClass( const edm::TypeWithDict& contType ){
-    return contType.qualifiedName();
+    return contType.cppName();
   }
   
   Container getContainerFromSession( const std::string& name, const edm::TypeWithDict& contType, DatabaseSession& session ){

--- a/CondCore/ORA/src/DatabaseContainer.cc
+++ b/CondCore/ORA/src/DatabaseContainer.cc
@@ -41,11 +41,11 @@ namespace ora {
 	  InsertOperation* topLevelInsert = &operationBuffer.newInsert( topLevelMapping.tableName() );
 	  topLevelInsert->addId(  topLevelMapping.columnNames()[ 0 ] );
 	  const edm::TypeWithDict& type = m_contSchema.type();
-	  MappingElement::iterator iMap = topLevelMapping.find( type.qualifiedName() );
+	  MappingElement::iterator iMap = topLevelMapping.find( type.cppName() );
 	  // the first inner mapping is the relevant...
 	  if( iMap == topLevelMapping.end()){
 	    throwException("Could not find a mapping element for class \""+
-			   type.qualifiedName()+"\"",
+			   type.cppName()+"\"",
 			   "WriteBuffer::flush");
 	  }
 	  MappingElement& mapping = iMap->second;
@@ -106,11 +106,11 @@ namespace ora {
 	  topLevelUpdate->addId(  topLevelMapping.columnNames()[ 0 ] );
 	  topLevelUpdate->addWhereId(  topLevelMapping.columnNames()[ 0 ] );
 	  const edm::TypeWithDict& type = m_contSchema.type();
-	  MappingElement::iterator iMap = topLevelMapping.find( type.qualifiedName() );
+	  MappingElement::iterator iMap = topLevelMapping.find( type.cppName() );
 	  // the first inner mapping is the relevant...
 	  if( iMap == topLevelMapping.end()){
 	    throwException("Could not find a mapping element for class \""+
-			   type.qualifiedName()+"\"",
+			   type.cppName()+"\"",
 			   "UpdateBuffer::flush");
 	  }
 	  MappingElement& mapping = iMap->second;
@@ -151,11 +151,11 @@ namespace ora {
 
         MappingElement& topLevelMapping = contSchema.mapping().topElement();
         m_topLevelQuery.addWhereId(  topLevelMapping.columnNames()[ 0 ] );
-        MappingElement::iterator iMap = topLevelMapping.find( m_type.qualifiedName() );
+        MappingElement::iterator iMap = topLevelMapping.find( m_type.cppName() );
         // the first inner mapping is the good one ...
         if( iMap == topLevelMapping.end()){
           throwException("Could not find a mapping element for class \""+
-                         m_type.qualifiedName()+"\"",
+                         m_type.cppName()+"\"",
                          "ReadBuffer::ReadBuffer");
         }
         MappingElement& mapping = iMap->second;
@@ -282,7 +282,7 @@ void* ora::IteratorBuffer::getItem(){
 
 void* ora::IteratorBuffer::getItemAsType( const edm::TypeWithDict& asType ){
   if( !ClassUtils::isType( type(), asType ) ){
-    throwException("Provided output object type \""+asType.qualifiedName()+"\" does not match with the container type \""+type().qualifiedName(), 
+    throwException("Provided output object type \""+asType.cppName()+"\" does not match with the container type \""+type().cppName(), 
 		   "ora::IteratorBuffer::getItemsAsType" );
   } 
   return getItem();
@@ -419,7 +419,7 @@ void* ora::DatabaseContainer::fetchItemAsType(int itemId,
     m_readBuffer.reset( new ReadBuffer( *m_schema ) );
   }
   if( !ClassUtils::isType( type(), asType ) ){
-    throwException("Provided output object type \""+asType.qualifiedName()+"\" does not match with the container type \""+type().qualifiedName(), 
+    throwException("Provided output object type \""+asType.cppName()+"\" does not match with the container type \""+type().cppName(), 
 		   "ora::DatabaseContainer::fetchItemAsType" );
   } 
   return m_readBuffer->read( itemId );

--- a/CondCore/ORA/src/InlineCArrayStreamer.cc
+++ b/CondCore/ORA/src/InlineCArrayStreamer.cc
@@ -28,7 +28,7 @@ bool ora::InlineCArrayStreamerBase::buildDataElement(DataElement& dataElement,
   m_arrayType = ClassUtils::resolvedType( m_objectType.toType() );  
   if ( ! m_arrayType ) {
     throwException( "Missing dictionary information for the element of array \"" +
-                    m_objectType.qualifiedName() + "\"",
+                    m_objectType.cppName() + "\"",
                     "InlineCArrayStreamerBase::buildDataElement" );
   }
   // Loop over the elements of the array.

--- a/CondCore/ORA/src/MappingDatabase.cc
+++ b/CondCore/ORA/src/MappingDatabase.cc
@@ -1,4 +1,5 @@
 #include "CondCore/ORA/interface/Exception.h"
+#include "ClassUtils.h"
 #include "MappingDatabase.h"
 #include "IDatabaseSchema.h"
 #include "MappingTree.h"
@@ -12,7 +13,7 @@
 
 std::string
 ora::MappingDatabase::versionOfClass( const edm::TypeWithDict& dictionary ){
-  std::string className = dictionary.qualifiedName();
+  std::string className = dictionary.cppName();
   Reflex::PropertyList classProps = ora::helper::Properties(dictionary);
   std::string classVersion = MappingRules::defaultClassVersion(className);
   if(classProps.HasProperty(MappingRules::classVersionPropertyNameInDictionary())){
@@ -273,7 +274,7 @@ void ora::MappingDatabase::insertClassVersion( const edm::TypeWithDict& dictiona
                                                int containerId,
                                                const std::string& mappingVersion,
                                                bool asBase  ){
-  std::string className = dictionaryEntry.qualifiedName();
+  std::string className = dictionaryEntry.cppName();
   std::string classVersion = versionOfClass( dictionaryEntry );
   insertClassVersion( className, classVersion, depIndex, containerId, mappingVersion, asBase );
 }
@@ -282,7 +283,7 @@ void ora::MappingDatabase::setMappingVersionForClass( const edm::TypeWithDict& d
                                                       int containerId,
                                                       const std::string& mappingVersion,
                                                       bool dependency ){
-  std::string className = dictionaryEntry.qualifiedName();
+  std::string className = dictionaryEntry.cppName();
   std::string classVersion = versionOfClass( dictionaryEntry );
   std::string classId = MappingRules::classId( className, classVersion );
   std::string mv("");

--- a/CondCore/ORA/src/MappingGenerator.cc
+++ b/CondCore/ORA/src/MappingGenerator.cc
@@ -16,7 +16,7 @@ ora::MappingGenerator::~MappingGenerator(){}
 void ora::MappingGenerator::createNewMapping( const std::string& containerName,
                                               const edm::TypeWithDict& classDictionary,
                                               MappingTree& destination ){
-  std::string className = classDictionary.qualifiedName();
+  std::string className = classDictionary.cppName();
 
   size_t sz = RelationalMapping::sizeInColumns( classDictionary );
   if(sz > MappingRules::MaxColumnsPerTable){
@@ -58,7 +58,7 @@ void ora::MappingGenerator::createNewMapping( const std::string& containerName,
 void ora::MappingGenerator::createNewDependentMapping( const edm::TypeWithDict& classDictionary,
                                                        const MappingTree& parentClassMapping,
                                                        MappingTree& destination ){
-  std::string className = classDictionary.qualifiedName();
+  std::string className = classDictionary.cppName();
   
   size_t sz = RelationalMapping::sizeInColumns( classDictionary );
   if(sz > MappingRules::MaxColumnsPerTable){

--- a/CondCore/ORA/src/Object.cc
+++ b/CondCore/ORA/src/Object.cc
@@ -52,7 +52,7 @@ const edm::TypeWithDict& ora::Object::type() const {
 }
 
 std::string ora::Object::typeName() const {
-  return m_type.qualifiedName();
+  return m_type.cppName();
 }
 
 void* ora::Object::cast( const std::type_info& typeInfo ) const{

--- a/CondCore/ORA/src/ObjectStreamer.cc
+++ b/CondCore/ORA/src/ObjectStreamer.cc
@@ -56,13 +56,13 @@ void ora::ObjectStreamerBase::buildBaseDataMembers( DataElement& dataElement,
       if ( ! dataMemberType ) {
         throwException( "Missing dictionary information for data member \"" +
                         dataMember.name() + "\" of class \"" +
-                        baseType.qualifiedName() + "\"",
+                        baseType.cppName() + "\"",
                         "ObjectStreamerBase::buildBaseDataMembers" );
       }
       
       // check if the member is from a class in the inheritance tree
       edm::TypeWithDict declaringType = ClassUtils::resolvedType( dataMember.declaringType());
-      std::string scope = declaringType.qualifiedName();
+      std::string scope = declaringType.cppName();
       // Get the data member name
       std::string dataMemberName = MappingRules::scopedVariableName( dataMember.name(), scope );
       // Retrieve the relevant mapping element
@@ -70,7 +70,7 @@ void ora::ObjectStreamerBase::buildBaseDataMembers( DataElement& dataElement,
       if ( iDataMemberMapping != m_mapping.end() ) {
         MappingElement& dataMemberMapping = iDataMemberMapping->second;
 	if( !ClassUtils::checkMappedType(dataMemberType,dataMemberMapping.variableType()) ){
-	  throwException( "Data member \""+dataMemberName +"\" type \"" + dataMemberType.qualifiedName() +
+	  throwException( "Data member \""+dataMemberName +"\" type \"" + dataMemberType.cppName() +
 			  "\" does not match with the expected type in the mapping \""+dataMemberMapping.variableType()+"\".",
 			  "ObjectStreamerBase::buildBaseDataMembers" );
 	}
@@ -113,7 +113,7 @@ bool ora::ObjectStreamerBase::buildDataMembers( DataElement& dataElement,
     if ( ! dataMemberType ) {
       throwException( "Missing dictionary information for data member \"" +
                       dataMember.name() + "\" of class \"" +
-                      m_objectType.qualifiedName() + "\"",
+                      m_objectType.cppName() + "\"",
                       "ObjectStreamerBase::buildDataMembers" );
     }
       
@@ -127,7 +127,7 @@ bool ora::ObjectStreamerBase::buildDataMembers( DataElement& dataElement,
     if ( idataMemberMapping != m_mapping.end() ) {
       MappingElement& dataMemberMapping = idataMemberMapping->second;
       if( !ClassUtils::checkMappedType(dataMemberType,dataMemberMapping.variableType())){
-        throwException( "Data member  \""+dataMemberName +"\" type \"" + dataMemberType.qualifiedName() +
+        throwException( "Data member  \""+dataMemberName +"\" type \"" + dataMemberType.cppName() +
                         "\" does not match with the expected type in the mapping \""+dataMemberMapping.variableType()+"\".",
                         "ObjectStreamerBase::buildDataMembers" );
       }

--- a/CondCore/ORA/src/OraPtrStreamer.cc
+++ b/CondCore/ORA/src/OraPtrStreamer.cc
@@ -44,7 +44,7 @@ namespace ora {
         // Check the component type
         if ( ! ptrType || !ptrResolvedType ) {
           throwException( "Missing dictionary information for the type of the pointer \"" +
-                          m_objectType.qualifiedName() + "\"",
+                          m_objectType.cppName() + "\"",
                           "OraPtrReadBuffer::build" );
         }
 
@@ -165,7 +165,7 @@ bool ora::OraPtrWriter::build(DataElement& dataElement,
   // Check the component type
   if ( ! ptrType || !ptrResolvedType ) {
     throwException( "Missing dictionary information for the type of the pointer \"" +
-                    m_objectType.qualifiedName() + "\"",
+                    m_objectType.cppName() + "\"",
                     "OraPtrWriter::build" );
   }
 
@@ -230,7 +230,7 @@ bool ora::OraPtrUpdater::build(DataElement& dataElement,
   // Check the component type
   if ( ! ptrType || !ptrResolvedType ) {
     throwException( "Missing dictionary information for the type of the pointer \"" +
-                    m_objectType.qualifiedName() + "\"",
+                    m_objectType.cppName() + "\"",
                     "OraPtrUpdater::build" );
   }
 

--- a/CondCore/ORA/src/OraReferenceStreamer.cc
+++ b/CondCore/ORA/src/OraReferenceStreamer.cc
@@ -39,7 +39,7 @@ bool ora::OraReferenceStreamerBase::buildDataElement(DataElement& dataElement,
   if( m_objectType != refType ){
     bool foundRef = ClassUtils::findBaseType( m_objectType, refType, baseOffsetFunc );
     if(!foundRef){
-      throwException("Type \""+m_objectType.qualifiedName()+"\" is not an Ora Reference.",
+      throwException("Type \""+m_objectType.cppName()+"\" is not an Ora Reference.",
                      "OraReferenceStreamerBase::buildDataElement");
     } 
   }

--- a/CondCore/ORA/src/PVectorHandler.cc
+++ b/CondCore/ORA/src/PVectorHandler.cc
@@ -61,12 +61,12 @@ ora::PVectorHandler::PVectorHandler( const edm::TypeWithDict& dictionary ):
 {
   edm::MemberWithDict privateVectorAttribute = m_type.dataMemberByName("m_vec");
   if(privateVectorAttribute){
-    assert(!strcmp("ora::PVector<cond::IOVElement>",m_type.qualifiedName().c_str()));
+    assert(!strcmp("ora::PVector<cond::IOVElement>",m_type.cppName().c_str()));
     m_vecAttributeOffset = privateVectorAttribute.offset();
     ROOT::TCollectionProxyInfo* collProxyPtr = ROOT::TCollectionProxyInfo::Generate(ROOT::TCollectionProxyInfo::Pushback<std::vector<cond::IOVElement> >());
     m_collProxy.reset( collProxyPtr );
     if(! m_collProxy.get() ){
-      throwException( "Cannot find \"createTCollectionProxyInfo\" function for type \""+m_type.qualifiedName()+"\"",
+      throwException( "Cannot find \"createTCollectionProxyInfo\" function for type \""+m_type.cppName()+"\"",
                       "PVectorHandler::PVectorHandler");
     }
   }
@@ -110,7 +110,7 @@ ora::IArrayIteratorHandler*
 ora::PVectorHandler::iterate( const void* address ){
   if ( ! m_iteratorReturnType ) {
     throwException( "Missing the dictionary information for the value_type member of the container \"" +
-                    m_type.qualifiedName() + "\"",
+                    m_type.cppName() + "\"",
                     "PVectorHandler" );
   }
   m_collEnv.fObject = static_cast<char*>(const_cast<void*>(address))+m_vecAttributeOffset;

--- a/CondCore/ORA/src/QueryableVectorStreamer.cc
+++ b/CondCore/ORA/src/QueryableVectorStreamer.cc
@@ -83,7 +83,7 @@ namespace ora {
         edm::TypeWithDict storeBaseType = ClassUtils::containerSubType(m_objectType,"range_store_base_type");
         if( !storeBaseType ){
           throwException( "Missing dictionary information for the range store base type of the container \"" +
-                          m_objectType.qualifiedName() + "\"",
+                          m_objectType.cppName() + "\"",
                           "QVQueryMaker::build" );          
         }
         
@@ -94,7 +94,7 @@ namespace ora {
         // Check the component type
         if ( ! valueType ||!valueResolvedType ) {
           throwException( "Missing dictionary information for the content type of the container \"" +
-                          m_objectType.qualifiedName() + "\"",
+                          m_objectType.cppName() + "\"",
                           "QVQueryMaker::build" );
         }
         std::string valueName = valueType.name();
@@ -226,13 +226,13 @@ namespace ora {
         edm::MemberWithDict firstMember = iteratorDereferenceReturnType.dataMemberByName( "first" );
         if ( ! firstMember ) {
           throwException( "Could not retrieve the data member \"first\" of the class \"" +
-                          iteratorDereferenceReturnType.qualifiedName() + "\"",
+                          iteratorDereferenceReturnType.cppName() + "\"",
                           "QVQueryMakerAndLoad::read" );
         }
         edm::MemberWithDict secondMember = iteratorDereferenceReturnType.dataMemberByName( "second" );
         if ( ! secondMember ) {
           throwException( "Could not retrieve the data member \"second\" of the class \"" +
-                          iteratorDereferenceReturnType.qualifiedName() + "\"",
+                          iteratorDereferenceReturnType.cppName() + "\"",
                           "QVQueryMakerAndLoad::read" );
         }
 
@@ -262,7 +262,7 @@ namespace ora {
           iteratorDereferenceReturnType.destruct( objectData );
           if ( !inserted ) {
             throwException( "Could not insert a new element in the array type \"" +
-                            m_objectType.qualifiedName() + "\"",
+                            m_objectType.cppName() + "\"",
                             "QVQueryMakerAndLoad::executeAndLoad" );
           }
           ++i;

--- a/CondCore/ORA/src/RelationalMapping.cc
+++ b/CondCore/ORA/src/RelationalMapping.cc
@@ -212,7 +212,7 @@ void ora::BlobMapping::process( MappingElement& parentElement,
                                 const std::string& attributeName,
                                 const std::string& attributeNameForSchema,
                                 const std::string& scopeNameForSchema ){
-  std::string className = m_type.qualifiedName();
+  std::string className = m_type.cppName();
   processLeafElement(parentElement,
                      ora::MappingElement::blobMappingElementType(),
                      className,
@@ -233,7 +233,7 @@ void ora::OraReferenceMapping::process( MappingElement& parentElement,
                                         const std::string& attributeName,
                                         const std::string& attributeNameForSchema,
                                         const std::string& scopeNameForSchema ){
-  std::string className = m_type.qualifiedName();
+  std::string className = m_type.cppName();
   std::string elementType = ora::MappingElement::OraReferenceMappingElementType();
   if(!m_tableRegister.checkTable( parentElement.tableName())){
     throwException("Table \""+parentElement.tableName()+"\" has not been allocated.",
@@ -268,7 +268,7 @@ void ora::UniqueReferenceMapping::process( MappingElement& parentElement,
                                            const std::string& attributeNameForSchema,
                                            const std::string& scopeNameForSchema ){
     
-  std::string typeName = m_type.qualifiedName();
+  std::string typeName = m_type.cppName();
   if(!m_tableRegister.checkTable( parentElement.tableName())){
     throwException("Table \""+parentElement.tableName()+"\" has not been allocated.",
                    "UniqueReferenceMapping::process");
@@ -311,7 +311,7 @@ void ora::OraPtrMapping::process( MappingElement& parentElement,
                                   const std::string& attributeNameForSchema,
                                   const std::string& scopeNameForSchema ){
   
-  std::string typeName = m_type.qualifiedName();
+  std::string typeName = m_type.cppName();
   ora::MappingElement& me = parentElement.appendSubElement( ora::MappingElement::OraPointerMappingElementType(), attributeName, typeName, parentElement.tableName() );
   me.setColumnNames( parentElement.columnNames() );
 
@@ -335,7 +335,7 @@ void ora::NamedRefMapping::process( MappingElement& parentElement,
                                     const std::string& attributeName,
                                     const std::string& attributeNameForSchema, 
                                     const std::string& scopeNameForSchema ){
-  std::string typeName = m_type.qualifiedName();
+  std::string typeName = m_type.cppName();
   ora::MappingElement& me = parentElement.appendSubElement( ora::MappingElement::namedReferenceMappingElementType(), attributeName, typeName, parentElement.tableName() );
 
   std::vector< std::string > cols;
@@ -375,7 +375,7 @@ void ora::ArrayMapping::process( MappingElement& parentElement,
   }
   m_tableRegister.insertTable(arrayTable);
 
-  std::string className = m_type.qualifiedName();
+  std::string className = m_type.cppName();
 
   std::string elementType = ora::MappingElement::arrayMappingElementType();
   if(ora::ClassUtils::isTypePVector(m_type) || ora::ClassUtils::isTypeQueryableVector(m_type)){
@@ -420,18 +420,18 @@ void ora::ArrayMapping::process( MappingElement& parentElement,
     contentType = ClassUtils::containerDataType( m_type );
     keyType = ClassUtils::containerKeyType( m_type );
     if( !keyType || !ClassUtils::resolvedType(keyType) ){
-      throwException( "Cannot not resolve the type of the key item of container \""+m_type.qualifiedName()+"\".",
+      throwException( "Cannot not resolve the type of the key item of container \""+m_type.cppName()+"\".",
                       "ArrayMapping::process");
     }
   }
   else {
     // Not supported container
-      throwException( "Container type=\""+m_type.qualifiedName()+"\".is not supported.",
+      throwException( "Container type=\""+m_type.cppName()+"\".is not supported.",
                       "ArrayMapping::process");    
   }
 
   if( !contentType || !ClassUtils::resolvedType(contentType) ){
-      throwException( "Cannot not resolve the type of the content item of container \""+m_type.qualifiedName()+"\".",
+      throwException( "Cannot not resolve the type of the content item of container \""+m_type.cppName()+"\".",
                       "ArrayMapping::process");
   }
   RelationalMappingFactory mappingFactory( m_tableRegister );
@@ -460,7 +460,7 @@ void ora::CArrayMapping::process( MappingElement& parentElement,
                                   const std::string& scopeNameForSchema ){
   edm::TypeWithDict arrayElementType = m_type.toType();
   if( !arrayElementType || !ClassUtils::resolvedType( arrayElementType ) ){
-    throwException("Cannot resolve the type of the content of the array \""+m_type.qualifiedName()+"\".",
+    throwException("Cannot resolve the type of the content of the array \""+m_type.cppName()+"\".",
                    "CArrayMapping::process");
   }
 
@@ -468,7 +468,7 @@ void ora::CArrayMapping::process( MappingElement& parentElement,
     throwException("Table \""+parentElement.tableName()+"\" has not been allocated.",
                    "CArrayMapping::process");
   }
-  std::string className = m_type.qualifiedName();
+  std::string className = m_type.cppName();
   RelationalMappingFactory mappingFactory( m_tableRegister );
 
   std::string arrayScopeNameForSchema = scopeNameForSchema;
@@ -550,7 +550,7 @@ namespace ora {
                            const edm::TypeWithDict& objType,
                            const std::string& scopeNameForSchema,
                            TableRegister& tableRegister ){
-    std::string className = objType.qualifiedName();
+    std::string className = objType.cppName();
     edm::TypeBases bases(objType);
     for (auto const & b : bases) {
       edm::BaseWithDict base(b);
@@ -569,7 +569,7 @@ namespace ora {
         // Retrieve the data member type
         edm::TypeWithDict type = ClassUtils::resolvedType( baseMember.typeOf() );
         edm::TypeWithDict declaringType = ClassUtils::resolvedType( baseMember.declaringType());
-        std::string scope = declaringType.qualifiedName();
+        std::string scope = declaringType.cppName();
         // Retrieve the field name
         std::string objectMemberName = ora::MappingRules::scopedVariableName( baseMember.name(), scope );
         std::string objectMemberNameForSchema = ora::MappingRules::scopedVariableForSchemaObjects( baseMember.name(), scope );
@@ -593,7 +593,7 @@ void ora::ObjectMapping::process( MappingElement& parentElement,
                                   const std::string& attributeName,
                                   const std::string& attributeNameForSchema,
                                   const std::string& scopeNameForSchema ){
-  std::string className = m_type.qualifiedName();
+  std::string className = m_type.cppName();
   std::string elementType = ora::MappingElement::objectMappingElementType();
   ora::MappingElement& me = parentElement.appendSubElement( elementType, attributeName, className, parentElement.tableName() );
   me.setColumnNames( parentElement.columnNames() );

--- a/CondCore/ORA/src/STLContainerHandler.cc
+++ b/CondCore/ORA/src/STLContainerHandler.cc
@@ -75,7 +75,7 @@ ora::STLContainerHandler::STLContainerHandler( const edm::TypeWithDict& dictiona
   TClass* cl = dictionary.getClass();
   m_collProxy = cl->GetCollectionProxy();
   if( !m_collProxy ){
-    throwException( "Cannot create \"TVirtualCollectionProxy\" for type \""+m_type.qualifiedName()+"\"",
+    throwException( "Cannot create \"TVirtualCollectionProxy\" for type \""+m_type.cppName()+"\"",
                     "STLContainerHandler::STLContainerHandler");
   }
 
@@ -101,7 +101,7 @@ ora::IArrayIteratorHandler*
 ora::STLContainerHandler::iterate( const void* address ){
   if ( ! m_iteratorReturnType ) {
     throwException( "Missing the dictionary information for the value_type member of the container \"" +
-                    m_type.qualifiedName() + "\"",
+                    m_type.cppName() + "\"",
                     "STLContainerHandler::iterate" );
   }
   void *addr = const_cast<void*>(address);
@@ -140,7 +140,7 @@ ora::SpecialSTLContainerHandler::SpecialSTLContainerHandler( const edm::TypeWith
     edm::TypeWithDict fieldType = field.typeOf();
     if ( ! fieldType ) {
       throwException( "The dictionary of the underlying container of \"" +
-                      dictionary.qualifiedName() + "\" is not available",
+                      dictionary.cppName() + "\" is not available",
                       "SpecialSTLContainerHandler" );
     }
     if ( ClassUtils::isTypeContainer(fieldType) ) {
@@ -151,7 +151,7 @@ ora::SpecialSTLContainerHandler::SpecialSTLContainerHandler( const edm::TypeWith
   }
   if ( !m_containerHandler.get() ) {
     throwException( "Could not retrieve the underlying container of \"" +
-                    dictionary.qualifiedName() + "\" is not available",
+                    dictionary.cppName() + "\" is not available",
                     "SpecialSTLContainerHandler" );
   }
 }

--- a/CondCore/ORA/src/STLContainerStreamer.cc
+++ b/CondCore/ORA/src/STLContainerStreamer.cc
@@ -40,7 +40,7 @@ bool ora::STLContainerWriter::build( DataElement& offset,
                                      RelationalBuffer& operationBuffer ){
   if( !m_objectType ){
     throwException( "Missing dictionary information for the type of the container \"" +
-                    m_objectType.qualifiedName() + "\"",
+                    m_objectType.cppName() + "\"",
                     "STLContainerWriter::build" );
   }
   m_localElement.clear();
@@ -72,7 +72,7 @@ bool ora::STLContainerWriter::build( DataElement& offset,
     edm::TypeWithDict keyResolvedType = ClassUtils::resolvedType(keyType);
     if ( ! keyType || !keyResolvedType ) {
       throwException( "Missing dictionary information for the key type of the container \"" +
-                      m_objectType.qualifiedName() + "\"",
+                      m_objectType.cppName() + "\"",
                       "STLContainerWriter::build" );
     }
     std::string keyName("key_type");
@@ -94,7 +94,7 @@ bool ora::STLContainerWriter::build( DataElement& offset,
   // Check the component type
   if ( ! valueType || !valueResolvedType ) {
     throwException( "Missing dictionary information for the content type of the container \"" +
-                    m_objectType.qualifiedName() + "\"",
+                    m_objectType.cppName() + "\"",
                     "STLContainerWriter::build" );
   }
 
@@ -149,13 +149,13 @@ void ora::STLContainerWriter::write( int oid,
     firstMember = iteratorReturnType.dataMemberByName( "first" );
     if ( ! firstMember ) {
       throwException( "Could not find the data member \"first\" for the class \"" +
-                      iteratorReturnType.qualifiedName() + "\"",
+                      iteratorReturnType.cppName() + "\"",
                       "STLContainerWriter::write" );
     }
     secondMember = iteratorReturnType.dataMemberByName( "second" );
     if ( ! secondMember ) {
       throwException( "Could not retrieve the data member \"second\" for the class \"" +
-                      iteratorReturnType.qualifiedName() + "\"",
+                      iteratorReturnType.cppName() + "\"",
                       "STLContainerWriter::write" );
     }
   }
@@ -283,7 +283,7 @@ bool ora::STLContainerReader::build( DataElement& offset, IRelationalData& ){
 
     if ( ! keyType ||!keyResolvedType ) {
       throwException( "Missing dictionary information for the key type of the container \"" +
-                      m_objectType.qualifiedName() + "\"",
+                      m_objectType.cppName() + "\"",
                       "STLContainerReader::build" );
     }
 
@@ -307,7 +307,7 @@ bool ora::STLContainerReader::build( DataElement& offset, IRelationalData& ){
   // Check the component type
   if ( ! valueType ||!valueResolvedType ) {
     throwException( "Missing dictionary information for the content type of the container \"" +
-                    m_objectType.qualifiedName() + "\"",
+                    m_objectType.cppName() + "\"",
                     "STLContainerReader::build" );
   }
 
@@ -370,13 +370,13 @@ void ora::STLContainerReader::read( void* destinationData ) {
     firstMember = iteratorReturnType.dataMemberByName( "first" );
     if ( ! firstMember ) {
       throwException("Could not retrieve the data member \"first\" of the class \"" +
-                     iteratorReturnType.qualifiedName() + "\"",
+                     iteratorReturnType.cppName() + "\"",
                      "STLContainerReader::read" );
     }
     secondMember = iteratorReturnType.dataMemberByName( "second" );
     if ( ! secondMember ) {
       throwException( "Could not retrieve the data member \"second\" of the class \"" +
-                      iteratorReturnType.qualifiedName() + "\"",
+                      iteratorReturnType.cppName() + "\"",
                       "STLContainerReader::read" );
     }
   }
@@ -418,7 +418,7 @@ void ora::STLContainerReader::read( void* destinationData ) {
     bool inserted = m_arrayHandler->size( address )>prevSize;
     if ( !inserted ) {
       throwException( "Could not insert a new element in the array type \"" +
-                      m_objectType.qualifiedName() + "\"",
+                      m_objectType.cppName() + "\"",
                       "STLContainerReader::read" );
     }
     ++i;

--- a/CondCore/ORA/src/UniqueRefStreamer.cc
+++ b/CondCore/ORA/src/UniqueRefStreamer.cc
@@ -33,11 +33,11 @@ namespace ora {
           m_depInsert->addId( *iC );
         }
 
-        MappingElement::iterator iMe = mapping.find( objectType.qualifiedName() );
+        MappingElement::iterator iMe = mapping.find( objectType.cppName() );
         // the first inner mapping is the relevant...
         if( iMe == mapping.end()){
           throwException("Could not find a mapping element for class \""+
-                         objectType.qualifiedName()+"\"",
+                         objectType.cppName()+"\"",
                          "DependentClassWriter::write");
         }
         RelationalStreamerFactory streamerFactory( contSchema );
@@ -85,11 +85,11 @@ namespace ora {
         m_type = objectType;
         m_depQuery.reset( new SelectOperation( depMapping.tableName(), contSchema.storageSchema()));
         m_depQuery->addWhereId(  depMapping.columnNames()[ 1 ] );
-        MappingElement::iterator iMap = depMapping.find( m_type.qualifiedName() );
+        MappingElement::iterator iMap = depMapping.find( m_type.cppName() );
         // the first inner mapping is the good one ...
         if( iMap == depMapping.end()){
           throwException("Could not find a mapping element for class \""+
-                         m_type.qualifiedName()+"\"",
+                         m_type.cppName()+"\"",
                          "DependentClassReadBuffer::ReadBuffer");
         }
         MappingElement& mapping = iMap->second;
@@ -238,7 +238,7 @@ void ora::UniqueRefWriter::write( int oid,
     refObj.typeOf().functionMemberByName("typeInfo").invoke(refObj, &refTIObj);
     
     edm::TypeWithDict refType = ClassUtils::lookupDictionary( *refTypeInfo );
-    className = refType.qualifiedName();
+    className = refType.cppName();
 
     // building the dependent buffer
     MappingElement& depMapping =  m_schema.mappingForDependentClass( refType, true );    

--- a/FWCore/Utilities/interface/TypeDemangler.h
+++ b/FWCore/Utilities/interface/TypeDemangler.h
@@ -6,5 +6,7 @@
 namespace edm {
   std::string
   typeDemangle(char const* mangledName);
+  void
+  replaceString(std::string& demangledName, std::string const& from, std::string const& to);
 }
 #endif

--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -83,6 +83,7 @@ public:
   bool isTypedef() const;
   bool isVirtual() const;
   std::string qualifiedName() const;
+  std::string cppName() const;
   std::string unscopedName() const;
   std::string name() const;
   std::string unscopedNameWithTypedef() const;

--- a/FWCore/Utilities/src/TypeDemangler.cc
+++ b/FWCore/Utilities/src/TypeDemangler.cc
@@ -72,16 +72,6 @@ namespace {
   } 
 
   void
-  replaceString(std::string& demangledName, std::string const& from, std::string const& to) {
-    // from must not be a substring of to.
-    std::string::size_type length = from.size(); 
-    std::string::size_type pos = 0;
-    while((pos = demangledName.find(from, pos)) != std::string::npos) {
-       demangledName.replace(pos, length, to); 
-    }
-  }
-
-  void
   constBeforeIdentifier(std::string& demangledName) {
     std::string const toBeMoved(" const");
     std::string::size_type const asize = toBeMoved.size();
@@ -105,6 +95,16 @@ namespace {
 }
 
 namespace edm {
+  void
+  replaceString(std::string& demangledName, std::string const& from, std::string const& to) {
+    // from must not be a substring of to.
+    std::string::size_type length = from.size(); 
+    std::string::size_type pos = 0;
+    while((pos = demangledName.find(from, pos)) != std::string::npos) {
+       demangledName.replace(pos, length, to); 
+    }
+  }
+
   std::string
   typeDemangle(char const* mangledName) {
     int status = 0;

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -361,6 +361,15 @@ namespace edm {
   }
 
   std::string
+  TypeWithDict::cppName() const {
+    std::string cName = qualifiedName();
+    // Get rid of silly ROOT typedefs
+    replaceString(cName, "ULong64_t", "unsigned long long");
+    replaceString(cName, "Long64_t", "long long");
+    return cName;
+  }
+
+  std::string
   TypeWithDict::qualifiedName() const {
     if (type_ == nullptr) {
       return "undefined";


### PR DESCRIPTION
Many (102) relvals in ROOT6 fail in the conditons code because of a name mismatch between "(unsigned) long long", used by Reflex and the Conditons database, and "(U)Long64_t", used by ROOT.  I have fixed a few of these before, but they keep cropping up.  So,this pull request is a comprehensive fix for these issues, once and for all.  It adds a new member function to TypeWithDict that will return "long long" as the name, rather than "Long64_t", and changes the conditions code to use this new function 
Note:  because of the new member function, this request causes 829 packages to rebuild.
The only header change is a new function declaration.  No existing interfaces were changed.
Please merge this promptly, so I won't have to keep rebuilding 829 packages.
Note: With this fix, the 102 tests still fail, but later for a different reason.  The next failure is a segfault,
but this request should still be merged.
