### PR TITLE
add missing include of iostream

### DIFF
--- a/DQM/EcalCommon/plugins/EcalMonitorPrescaler.cc
+++ b/DQM/EcalCommon/plugins/EcalMonitorPrescaler.cc
@@ -8,6 +8,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include <cmath>
+#include <iostream>
 
 uint32_t EcalMonitorPrescaler::filterBits_[EcalMonitorPrescaler::nPrescalers] = {
   (1 << EcalDCCHeaderBlock::MTCC) |


### PR DESCRIPTION
EcalMonitorPrescaler.cc does not compile in the latest ROOT6 IB due to a missing #incude of iostream.
This request adds the missing include.
