### PR TITLE
Tk cloner

### DIFF
--- a/CalibTracker/SiStripLorentzAngle/plugins/SiStripLAProfileBooker.cc
+++ b/CalibTracker/SiStripLorentzAngle/plugins/SiStripLAProfileBooker.cc
@@ -361,13 +361,14 @@ void SiStripLAProfileBooker::analyze(const edm::Event& e, const edm::EventSetup&
 	pitch_detector=-1;       
 	HitNr = 1;    
 	
+        SiStripRecHit2D lhit;
 	TrajectoryStateOnSurface tsos=itm->updatedState();
 	const TransientTrackingRecHit::ConstRecHitPointer thit=itm->recHit();
 	if((thit->geographicalId().subdetId() == int(StripSubdetector::TIB)) ||  thit->geographicalId().subdetId()== int(StripSubdetector::TOB)){ //include only barrel
 	  const SiStripMatchedRecHit2D* matchedhit=dynamic_cast<const SiStripMatchedRecHit2D*>((*thit).hit());
 	  const ProjectedSiStripRecHit2D* phit=dynamic_cast<const ProjectedSiStripRecHit2D*>((*thit).hit());
 	  const SiStripRecHit2D* hit=dynamic_cast<const SiStripRecHit2D*>((*thit).hit());
-	  if(phit) hit=&(phit->originalHit());
+	  if(phit) {lhit = phit->originalHit(); hit = &lhit;}
 	  
 	  LocalVector trackdirection=tsos.localDirection();
 	  

--- a/CommonTools/Utils/test/testCutParser.cc
+++ b/CommonTools/Utils/test/testCutParser.cc
@@ -115,7 +115,7 @@ void testCutParser::checkAll() {
   MyDet mdet(plane);
   GeomDet *  det =  &mdet;
 
-  hitOk = SiStripRecHit2D(LocalPoint(1,1), LocalError(1,1,1), 0, 0, det, SiStripRecHit2D::ClusterRef());
+  hitOk = SiStripRecHit2D(LocalPoint(1,1), LocalError(1,1,1), 0, det, SiStripRecHit2D::ClusterRef());
 
   edm::TypeWithDict t(typeid(reco::Track));
   o = edm::ObjectWithDict(t, & trk);

--- a/CommonTools/Utils/test/testCutParser.cc
+++ b/CommonTools/Utils/test/testCutParser.cc
@@ -113,9 +113,8 @@ void testCutParser::checkAll() {
   GlobalPoint gp(0,0,0);
   BoundPlane* plane = new BoundPlane( gp, Surface::RotationType());
   MyDet mdet(plane);
-  GeomDet *  det =  &mdet;
-
-  hitOk = SiStripRecHit2D(LocalPoint(1,1), LocalError(1,1,1), 0, det, SiStripRecHit2D::ClusterRef());
+ 
+  hitOk = SiStripRecHit2D(LocalPoint(1,1), LocalError(1,1,1), mdet, SiStripRecHit2D::ClusterRef());
 
   edm::TypeWithDict t(typeid(reco::Track));
   o = edm::ObjectWithDict(t, & trk);

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -472,21 +472,21 @@ void SiStripMonitorTrack::trajectoryStudy(const edm::Ref<std::vector<Trajectory>
       GluedGeomDet * gdet=(GluedGeomDet *)tkgeom->idToDet(phit->geographicalId());
 
       GlobalVector gtrkdirup=gdet->toGlobal(updatedtsos.localMomentum());
-      const SiStripRecHit2D&  originalhit=phit->originalHit();
+      const SiStripRecHit2D  originalhit=phit->originalHit();
       const GeomDetUnit * det;
       if(!StripSubdetector(originalhit.geographicalId().rawId()).stereo()){
 	//mono side
 	LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found  MONO"<< std::endl;
 	det=gdet->monoDet();
 	statedirection=det->toLocal(gtrkdirup);
-	if(statedirection.mag() != 0) RecHitInfo<SiStripRecHit2D>(&(phit->originalHit()),statedirection,trackref,es);
+	if(statedirection.mag() != 0) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,trackref,es);
       }
       else{
 	LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found STEREO"<< std::endl;
 	//stereo side
 	det=gdet->stereoDet();
 	statedirection=det->toLocal(gtrkdirup);
-	if(statedirection.mag() != 0) RecHitInfo<SiStripRecHit2D>(&(phit->originalHit()),statedirection,trackref,es);
+	if(statedirection.mag() != 0) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,trackref,es);
       }
     }else if (hit2D){
       statedirection=updatedtsos.localMomentum();

--- a/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h
@@ -32,11 +32,10 @@ public:
 
   // no position (as in persistent)
   BaseTrackerRecHit(DetId id, trackerHitRTTI::RTTI rt) :  TrackingRecHit(id,(unsigned int)(rt)) {}
-  BaseTrackerRecHit(DetId id, GeomDet const * idet, trackerHitRTTI::RTTI rt) :  TrackingRecHit(id, idet, (unsigned int)(rt)) {}
 
   BaseTrackerRecHit( const LocalPoint& p, const LocalError&e,
-		     DetId id, GeomDet const * idet, trackerHitRTTI::RTTI rt) :  TrackingRecHit(id,idet, (unsigned int)(rt)), pos_(p), err_(e){
-    if unlikely(!hasPositionAndError()) return;
+		     GeomDet const & idet, trackerHitRTTI::RTTI rt) :  
+    TrackingRecHit(idet.geographicalId(),&idet, (unsigned int)(rt)), pos_(p), err_(e){
     LocalError lape = det()->localAlignmentError();
     if (lape.valid())
       err_ = LocalError(err_.xx()+lape.xx(),

--- a/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h
@@ -15,18 +15,23 @@ class OmniClusterRef;
 
 namespace trackerHitRTTI {
   // tracking hit can be : single (si1D, si2D, pix), projected, matched or multi
-  enum RTTI { undef=0, single=1, proj=2, match=3, multi=4};
+  enum RTTI { undef=0, single=1, projStereo=2, projMono=3, match=4, multi=5};
   inline RTTI rtti(TrackingRecHit const & hit)  { return RTTI(hit.getRTTI());}
   inline bool isUndef(TrackingRecHit const & hit) { return rtti(hit)==undef;}
   inline bool isSingle(TrackingRecHit const & hit)  { return rtti(hit)==single;}
-  inline bool isProjected(TrackingRecHit const & hit)  { return rtti(hit)==proj;}
+  inline bool isProjMono(TrackingRecHit const & hit)  { return rtti(hit)==projMono;}
+  inline bool isProjStereo(TrackingRecHit const & hit)  { return rtti(hit)==projStereo;}
+  inline bool isProjected(TrackingRecHit const & hit)  { return (rtti(hit)==projMono) | (rtti(hit)==projStereo);}
   inline bool isMatched(TrackingRecHit const & hit)  { return rtti(hit)==match;}
   inline bool isMulti(TrackingRecHit const & hit)  { return rtti(hit)==multi;}
+  inline bool isSingleType(TrackingRecHit const & hit)  { return (rtti(hit)>0) & (rtti(hit)<4) ;}
+
+  inline unsigned int  projId(TrackingRecHit const & hit) { return hit.rawId()+int(rtti(hit))-1;}
 }
 
 class BaseTrackerRecHit : public TrackingRecHit { 
 public:
-  BaseTrackerRecHit() {}
+  BaseTrackerRecHit() : qualWord_(0){}
 
   virtual ~BaseTrackerRecHit() {}
 
@@ -46,8 +51,10 @@ public:
 
   trackerHitRTTI::RTTI rtti() const { return trackerHitRTTI::rtti(*this);}
   bool isSingle() const { return trackerHitRTTI::isSingle(*this);}
-  bool isProjected() const { return trackerHitRTTI::isProjected(*this);}
   bool isMatched() const { return trackerHitRTTI::isMatched(*this);}
+  bool isProjected() const { return trackerHitRTTI::isProjected(*this);}
+  bool isProjMono() const { return trackerHitRTTI::isProjMono(*this);}
+  bool isProjSterep() const { return trackerHitRTTI::isProjStereo(*this);}
   bool isMulti() const { return trackerHitRTTI::isMulti(*this);}
 
  // used by trackMerger (to be improved)
@@ -128,6 +135,9 @@ private:
 
   LocalPoint pos_;
   LocalError err_;
+protected:
+  //this comes for free (padding)
+  unsigned int qualWord_;
 };
 
 

--- a/DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h
@@ -8,9 +8,10 @@ public:
 
   typedef BaseTrackerRecHit Base;
   ProjectedSiStripRecHit2D() {};
-  ProjectedSiStripRecHit2D( const LocalPoint& pos, const LocalError& err, const DetId& id , GeomDet const * idet,
+  ProjectedSiStripRecHit2D( const LocalPoint& pos, const LocalError& err, 
+			    GeomDet const & idet,
 			    const SiStripRecHit2D* originalHit) :
-    BaseTrackerRecHit(pos, err, id, idet, trackerHitRTTI::proj), originalHit_(*originalHit) {}
+    BaseTrackerRecHit(pos, err, idet, trackerHitRTTI::proj), originalHit_(*originalHit) {}
     
   virtual ProjectedSiStripRecHit2D* clone() const {return new ProjectedSiStripRecHit2D( *this); }
 

--- a/DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h
@@ -3,45 +3,68 @@
 
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 
-class ProjectedSiStripRecHit2D : public BaseTrackerRecHit {
-public:
+#include<iostream>
 
-  typedef BaseTrackerRecHit Base;
-  ProjectedSiStripRecHit2D() {};
+class ProjectedSiStripRecHit2D : public TrackerSingleRecHit  {
+public:
+  
+  inline static bool isMono(GeomDet const & gdet, GeomDet const & sdet) {
+    return (sdet.geographicalId()-gdet.geographicalId())==2;
+  }
+  
+  
+  typedef TrackerSingleRecHit Base;
+
+  ProjectedSiStripRecHit2D() : theOriginalDet(nullptr) {}
+
   ProjectedSiStripRecHit2D( const LocalPoint& pos, const LocalError& err, 
 			    GeomDet const & idet,
-			    const SiStripRecHit2D* originalHit) :
-    BaseTrackerRecHit(pos, err, idet, trackerHitRTTI::proj), originalHit_(*originalHit) {}
+			    SiStripRecHit2D const & originalHit) :
+    TrackerSingleRecHit(pos, err, idet, 
+			isMono(idet,*originalHit.det()) ? trackerHitRTTI::projMono: trackerHitRTTI::projStereo,
+			originalHit.omniCluster()),
+    theOriginalDet(originalHit.det()) {
+//      std::cout << getRTTI() << ' ' << originalHit.rawId() << ' ' << idet.geographicalId().rawId() << ' ' << originalId() << std::endl;
+      assert(originalId()==originalHit.rawId());
+    }
     
-  virtual ProjectedSiStripRecHit2D* clone() const {return new ProjectedSiStripRecHit2D( *this); }
+  template<typename CluRef>
+  ProjectedSiStripRecHit2D( const LocalPoint& pos, const LocalError& err, 
+			    GeomDet const & idet, GeomDet const & originalDet,
+			    CluRef const&  clus) :
+    TrackerSingleRecHit(pos, err, idet, 
+			isMono(idet,originalDet) ? trackerHitRTTI::projMono: trackerHitRTTI::projStereo,
+			clus),
+    theOriginalDet(&originalDet) {
+    assert(originalId()==originalDet.geographicalId());
+    }
 
+
+  virtual ProjectedSiStripRecHit2D* clone() const {return new ProjectedSiStripRecHit2D( *this); }
+  
   virtual int dimension() const {return 2;}
   virtual void getKfComponents( KfComponentsHolder & holder ) const { getKfComponents2D(holder); }
-
-
-  // used by trackMerger (to be improved)
-  virtual OmniClusterRef const & firstClusterRef() const { return  originalHit().firstClusterRef();}
-
-
-  const SiStripRecHit2D& originalHit() const {return originalHit_;}
-  SiStripRecHit2D& originalHit() {return originalHit_;}
-
-  virtual bool sharesInput( const TrackingRecHit* other, SharedInputType what) const {
-    return originalHit().sharesInput(other,what);
-  }
+  
+  typedef OmniClusterRef::ClusterStripRef         ClusterRef;
+  ClusterRef cluster()  const { return cluster_strip() ; }
+  const GeomDet* originalDet() const {return theOriginalDet;}
+  unsigned int originalId() const { return trackerHitRTTI::projId(*this);}
+  
+  // not useful only for backward compatibility
+  SiStripRecHit2D originalHit() const { return SiStripRecHit2D(originalId(), omniClusterRef());}
+  
+  
   virtual std::vector<const TrackingRecHit*> recHits() const{
-    std::vector<const TrackingRecHit*> rechits(1,&originalHit_);
+    std::vector<const TrackingRecHit*> rechits;
     return rechits;
   }
   virtual std::vector<TrackingRecHit*> recHits() {
-    std::vector<TrackingRecHit*> rechits(1,&originalHit_);
+    std::vector<TrackingRecHit*> rechits;
     return rechits;
   }
-
-
+  
 private:
-
-  SiStripRecHit2D originalHit_;
+  const GeomDet* theOriginalDet;
 
 };
 

--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
@@ -29,12 +29,6 @@ public:
   
   ~SiPixelRecHit() {}
   
-  SiPixelRecHit( const LocalPoint& pos , const LocalError& err,
-		 const DetId& id, GeomDet const * idet,
-		 ClusterRef const&  clus) : 
-    TrackerSingleRecHit(pos,err,id,idet, clus), 
-    qualWord_(0) 
-  {}
 
   SiPixelRecHit( const LocalPoint& pos , const LocalError& err, SiPixelRecHitQuality::QualWordType qual,
 		 const DetId& id, GeomDet const * idet,
@@ -47,7 +41,9 @@ public:
   virtual SiPixelRecHit * clone() const {return new SiPixelRecHit( * this); }
   
   ClusterRef cluster()  const { return cluster_pixel(); }
+
   void setClusterRef(ClusterRef const & ref)  {setClusterPixelRef(ref);}
+
   virtual int dimension() const {return 2;}
   virtual void getKfComponents( KfComponentsHolder & holder ) const { getKfComponents2D(holder); }
   
@@ -76,11 +72,8 @@ public:
   inline SiPixelRecHitQuality::QualWordType rawQualityWord() const { 
     return qualWord_ ; 
   }
-  inline void setRawQualityWord( SiPixelRecHitQuality::QualWordType w ) { 
-    qualWord_ = w; 
-  }
 
-
+ 
   //--- Template fit probability, in X and Y directions
   //--- These are obsolete and will be taken care of in the quality code
   inline float probabilityX() const     {
@@ -123,29 +116,6 @@ public:
   //--- Quality flag for whether the probability is filled
   inline bool hasFilledProb() const {
     return SiPixelRecHitQuality::thePacking.hasFilledProb( qualWord_ );
-  }
-  
-  //--- Setters for the above
-  inline void setProbabilityXY( float prob ) {
-    SiPixelRecHitQuality::thePacking.setProbabilityXY( prob, qualWord_ );
-  }
-  inline void setProbabilityQ( float prob ) {
-    SiPixelRecHitQuality::thePacking.setProbabilityQ( prob, qualWord_ );
-  }  
-  inline void setQBin( int qbin ) {
-    SiPixelRecHitQuality::thePacking.setQBin( qbin, qualWord_ );
-  }
-  inline void setIsOnEdge( bool flag ) {
-    SiPixelRecHitQuality::thePacking.setIsOnEdge( flag, qualWord_ );
-  }
-  inline void setHasBadPixels( bool flag ) {
-    SiPixelRecHitQuality::thePacking.setHasBadPixels( flag, qualWord_ );
-  }
-  inline void setSpansTwoROCs( bool flag ) {
-    SiPixelRecHitQuality::thePacking.setSpansTwoROCs( flag, qualWord_ );
-  }
-  inline void setHasFilledProb( bool flag ) {
-    SiPixelRecHitQuality::thePacking.setHasFilledProb( flag, qualWord_ );
   }
 
 };

--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
@@ -26,7 +26,7 @@ public:
   
   typedef edm::Ref<edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster > ClusterRef;
   
-  SiPixelRecHit(): qualWord_(0) {}
+  SiPixelRecHit(){}
   
   ~SiPixelRecHit(){}
 
@@ -34,9 +34,8 @@ public:
 		 SiPixelRecHitQuality::QualWordType qual,
 		 GeomDet const & idet,
 		 ClusterRef const&  clus) : 
-    TrackerSingleRecHit(pos,err,idet, clus), 
-    qualWord_(qual) 
-  {}
+    TrackerSingleRecHit(pos,err,idet, clus){
+    qualWord_=qual; }
 
   
   virtual SiPixelRecHit * clone() const {return new SiPixelRecHit( * this); }
@@ -56,15 +55,6 @@ private:
     return cloner(*this,tsos);
   }
   
-  //--------------------------------------------------------------------------
-  //--- Accessors of other auxiliary quantities
-  //--- Added Oct 07 by Petar for 18x.
-private:
-  // *************************************************************************
-  //
-  SiPixelRecHitQuality::QualWordType  qualWord_ ;   // unsigned int 32-bit wide
-  //
-  // *************************************************************************
   
 public:
   //--- The overall probability.  flags is the 32-bit-packed set of flags that

--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
@@ -30,10 +30,11 @@ public:
   
   ~SiPixelRecHit(){}
 
-  SiPixelRecHit( const LocalPoint& pos , const LocalError& err, SiPixelRecHitQuality::QualWordType qual,
-		 const DetId& id, GeomDet const * idet,
+  SiPixelRecHit( const LocalPoint& pos , const LocalError& err, 
+		 SiPixelRecHitQuality::QualWordType qual,
+		 GeomDet const & idet,
 		 ClusterRef const&  clus) : 
-    TrackerSingleRecHit(pos,err,id,idet, clus), 
+    TrackerSingleRecHit(pos,err,idet, clus), 
     qualWord_(qual) 
   {}
 

--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
@@ -18,6 +18,7 @@
 //! Quality word packing
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitQuality.h"
 
+#include "TkCloner.h"
 
 class SiPixelRecHit GCC11_FINAL : public TrackerSingleRecHit {
   
@@ -27,8 +28,7 @@ public:
   
   SiPixelRecHit(): qualWord_(0) {}
   
-  ~SiPixelRecHit() {}
-  
+  ~SiPixelRecHit(){}
 
   SiPixelRecHit( const LocalPoint& pos , const LocalError& err, SiPixelRecHitQuality::QualWordType qual,
 		 const DetId& id, GeomDet const * idet,
@@ -47,6 +47,13 @@ public:
   virtual int dimension() const {return 2;}
   virtual void getKfComponents( KfComponentsHolder & holder ) const { getKfComponents2D(holder); }
   
+  
+  virtual bool canImproveWithTrack() const {return true;}
+private:
+  // double dispatch
+  virtual SiPixelRecHit * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
+    return cloner(*this,tsos);
+  }
   
   //--------------------------------------------------------------------------
   //--- Accessors of other auxiliary quantities

--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
@@ -35,6 +35,14 @@ public:
     TrackerSingleRecHit(pos,err,id,idet, clus), 
     qualWord_(0) 
   {}
+
+  SiPixelRecHit( const LocalPoint& pos , const LocalError& err, SiPixelRecHitQuality::QualWordType qual,
+		 const DetId& id, GeomDet const * idet,
+		 ClusterRef const&  clus) : 
+    TrackerSingleRecHit(pos,err,id,idet, clus), 
+    qualWord_(qual) 
+  {}
+
   
   virtual SiPixelRecHit * clone() const {return new SiPixelRecHit( * this); }
   

--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHitQuality.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHitQuality.h
@@ -2,20 +2,18 @@
 #define DataFormats_SiPixelRecHitQuality_h 1
 
 //--- pow():
-#include <math.h>
+#include <cmath>
 
 //--- &&& I'm not sure why we need this. [Petar]
 #include <utility>
 
-//--- uint32_t definition:
-#include <boost/cstdint.hpp>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 
 class SiPixelRecHitQuality {
  public:
-  typedef uint32_t QualWordType;
+  typedef unsigned int QualWordType;
   
   
  public:

--- a/DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h
@@ -12,9 +12,9 @@ class SiStripMatchedRecHit2D GCC11_FINAL : public BaseTrackerRecHit {
   SiStripMatchedRecHit2D(){}
   ~SiStripMatchedRecHit2D(){}
 
-  SiStripMatchedRecHit2D( const LocalPoint& pos, const LocalError& err, const DetId& id , GeomDet const * idet,
+  SiStripMatchedRecHit2D( const LocalPoint& pos, const LocalError& err, GeomDet const & idet,
 			  const SiStripRecHit2D* rMono,const SiStripRecHit2D* rStereo):
-    BaseTrackerRecHit(pos, err, id, idet, trackerHitRTTI::match), clusterMono_(rMono->omniClusterRef()), clusterStereo_(rStereo->omniClusterRef()){}
+    BaseTrackerRecHit(pos, err, idet, trackerHitRTTI::match), clusterMono_(rMono->omniClusterRef()), clusterStereo_(rStereo->omniClusterRef()){}
 
   // by value, as they will not exists anymore...
   SiStripRecHit2D  stereoHit() const { return SiStripRecHit2D(stereoId(),stereoClusterRef()) ;}

--- a/DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h
@@ -3,6 +3,8 @@
 
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 
+#include "TkCloner.h"
+
 class SiStripMatchedRecHit2D GCC11_FINAL : public BaseTrackerRecHit {
  public:
   typedef BaseTrackerRecHit Base;
@@ -53,6 +55,14 @@ class SiStripMatchedRecHit2D GCC11_FINAL : public BaseTrackerRecHit {
   virtual std::vector<const TrackingRecHit*> recHits() const; 
 
   virtual std::vector<TrackingRecHit*> recHits(); 
+
+  virtual bool canImproveWithTrack() const {return true;}
+private:
+  // double dispatch
+  virtual SiStripMatchedRecHit2D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
+    return cloner(*this,tsos);
+  }
+ 
     
  private:
    OmniClusterRef clusterMono_, clusterStereo_;

--- a/DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h
@@ -7,6 +7,9 @@
 
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 
+#include "TkCloner.h"
+
+
 class SiStripRecHit1D GCC11_FINAL : public TrackerSingleRecHit { 
 public:
 
@@ -35,6 +38,14 @@ public:
 
   virtual int dimension() const {return 1;}
   virtual void getKfComponents( KfComponentsHolder & holder ) const {getKfComponents1D(holder);}
+
+  virtual bool canImproveWithTrack() const {return true;}
+private:
+  // double dispatch
+  virtual SiStripRecHit1D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
+    return cloner(*this,tsos);
+  }
+ 
 
  
 };

--- a/DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h
@@ -22,8 +22,8 @@ public:
 
   template<typename CluRef>
   SiStripRecHit1D( const LocalPoint& p, const LocalError& e,
-		   const DetId& id, GeomDet const * idet,
-		   CluRef const&  clus) : TrackerSingleRecHit(p,e,id,idet,clus){}
+		   GeomDet const & idet,
+		   CluRef const&  clus) : TrackerSingleRecHit(p,e,idet,clus){}
 
  
   /// method to facilitate the convesion from 2D to 1D hits

--- a/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h
@@ -22,9 +22,9 @@ public:
 
   template<typename CluRef>
   SiStripRecHit2D( const LocalPoint& pos, const LocalError& err,
-		   const DetId& id, GeomDet const * idet,
+		   GeomDet const & idet,
 		   CluRef const& clus) : 
-    TrackerSingleRecHit(pos,err,id, idet, clus) {}
+    TrackerSingleRecHit(pos,err, idet, clus) {}
  
 				
   ClusterRef cluster()  const { return cluster_strip() ; }

--- a/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h
@@ -2,6 +2,7 @@
 #define SiStripRecHit2D_H
 
 #include "DataFormats/TrackerRecHit2D/interface/TrackerSingleRecHit.h"
+#include "TkCloner.h"
 
 
 class SiStripRecHit2D GCC11_FINAL : public TrackerSingleRecHit {
@@ -34,7 +35,13 @@ public:
   virtual int dimension() const {return 2;}
   virtual void getKfComponents( KfComponentsHolder & holder ) const { getKfComponents2D(holder); }
 
-
+  virtual bool canImproveWithTrack() const {return true;}
+private:
+  // double dispatch
+  virtual SiStripRecHit2D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
+    return cloner(*this,tsos);
+  }
+ 
   
 private:
  

--- a/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h
@@ -7,7 +7,7 @@
 class SiStripRecHit2D GCC11_FINAL : public TrackerSingleRecHit {
 public:
 
-  SiStripRecHit2D(): sigmaPitch_(-1.){}
+  SiStripRecHit2D() {}
 
   ~SiStripRecHit2D() {} 
 
@@ -17,15 +17,13 @@ public:
   // no position (as in persistent)
   SiStripRecHit2D(const DetId& id,
 		  OmniClusterRef const& clus) : 
-    TrackerSingleRecHit(id, clus),
-    sigmaPitch_(-1.) {}
+    TrackerSingleRecHit(id, clus){}
 
   template<typename CluRef>
-  SiStripRecHit2D( const LocalPoint& pos, const LocalError& err, float isigmaPitch,
+  SiStripRecHit2D( const LocalPoint& pos, const LocalError& err,
 		   const DetId& id, GeomDet const * idet,
 		   CluRef const& clus) : 
-    TrackerSingleRecHit(pos,err,id, idet, clus),
-    sigmaPitch_(isigmaPitch) {}
+    TrackerSingleRecHit(pos,err,id, idet, clus) {}
  
 				
   ClusterRef cluster()  const { return cluster_strip() ; }
@@ -36,15 +34,9 @@ public:
   virtual int dimension() const {return 2;}
   virtual void getKfComponents( KfComponentsHolder & holder ) const { getKfComponents2D(holder); }
 
- 
-  float sigmaPitch() const { return sigmaPitch_;}
 
   
 private:
-
-  /// cache for the matcher....
-  float sigmaPitch_;  // transient....
-
  
 };
 

--- a/DataFormats/TrackerRecHit2D/interface/SiTrackerMultiRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiTrackerMultiRecHit.h
@@ -20,7 +20,7 @@ public:
   virtual ~SiTrackerMultiRecHit(){}	
   
   
-  SiTrackerMultiRecHit(const LocalPoint&, const LocalError&, const DetId&, GeomDet const * idet,
+  SiTrackerMultiRecHit(const LocalPoint&, const LocalError&, GeomDet const & idet,
 		       const std::vector< std::pair<const TrackingRecHit*, float> >&);
   
   virtual SiTrackerMultiRecHit* clone() const {return new SiTrackerMultiRecHit(*this);}

--- a/DataFormats/TrackerRecHit2D/interface/TkCloner.h
+++ b/DataFormats/TrackerRecHit2D/interface/TkCloner.h
@@ -8,9 +8,6 @@ class SiStripRecHit2D;
 class SiStripRecHit1D;
 class SiStripMatchedRecHit2D;
 
-class PixelClusterParameterEstimator;
-class StripClusterParameterEstimator;
-class SiStripRecHitMatcher;
 class TkCloner {
 public:
   TrackingRecHit * operator()(TrackingRecHit const & hit, TrajectoryStateOnSurface const& tsos) const {
@@ -21,12 +18,6 @@ public:
   virtual SiStripRecHit2D * operator()(SiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const=0;
   virtual SiStripRecHit1D * operator()(SiStripRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const=0;
   virtual SiStripMatchedRecHit2D * operator()(SiStripMatchedRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const=0;
-
-private:
-  const PixelClusterParameterEstimator * pixelCPE;
-  const StripClusterParameterEstimator * stripCPE;
-  const SiStripRecHitMatcher           * theMatcher;
-
 
 };
 #endif

--- a/DataFormats/TrackerRecHit2D/interface/TkCloner.h
+++ b/DataFormats/TrackerRecHit2D/interface/TkCloner.h
@@ -7,6 +7,7 @@ class SiPixelRecHit;
 class SiStripRecHit2D;
 class SiStripRecHit1D;
 class SiStripMatchedRecHit2D;
+class ProjectedSiStripRecHit2D;
 
 class TkCloner {
 public:
@@ -18,6 +19,7 @@ public:
   virtual SiStripRecHit2D * operator()(SiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const=0;
   virtual SiStripRecHit1D * operator()(SiStripRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const=0;
   virtual SiStripMatchedRecHit2D * operator()(SiStripMatchedRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const=0;
+  virtual ProjectedSiStripRecHit2D * operator()(ProjectedSiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const=0;
 
 };
 #endif

--- a/DataFormats/TrackerRecHit2D/interface/TkCloner.h
+++ b/DataFormats/TrackerRecHit2D/interface/TkCloner.h
@@ -1,0 +1,32 @@
+#ifndef TKClonerRecHit_H
+#define TKClonerRecHit_H
+
+#include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+
+class SiPixelRecHit;
+class SiStripRecHit2D;
+class SiStripRecHit1D;
+class SiStripMatchedRecHit2D;
+
+class PixelClusterParameterEstimator;
+class StripClusterParameterEstimator;
+class SiStripRecHitMatcher;
+class TkCloner {
+public:
+  TrackingRecHit * operator()(TrackingRecHit const & hit, TrajectoryStateOnSurface const& tsos) const {
+    return hit.clone(*this, tsos);
+  }
+
+  virtual SiPixelRecHit * operator()(SiPixelRecHit const & hit, TrajectoryStateOnSurface const& tsos) const=0;
+  virtual SiStripRecHit2D * operator()(SiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const=0;
+  virtual SiStripRecHit1D * operator()(SiStripRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const=0;
+  virtual SiStripMatchedRecHit2D * operator()(SiStripMatchedRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const=0;
+
+private:
+  const PixelClusterParameterEstimator * pixelCPE;
+  const StripClusterParameterEstimator * stripCPE;
+  const SiStripRecHitMatcher           * theMatcher;
+
+
+};
+#endif

--- a/DataFormats/TrackerRecHit2D/interface/TrackerSingleRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/TrackerSingleRecHit.h
@@ -33,6 +33,12 @@ public:
 		      GeomDet const & idet,
 		      CluRef const&  clus) : Base(p,e,idet, trackerHitRTTI::single), cluster_(clus){}
 
+  // for projected...
+  template<typename CluRef>
+  TrackerSingleRecHit(const LocalPoint& p, const LocalError& e,
+		      GeomDet const & idet, trackerHitRTTI::RTTI rt,
+		      CluRef const&  clus) : Base(p,e,idet, rt), cluster_(clus){}
+
 
   // a single hit is on a detunit
   const GeomDetUnit* detUnit() const {

--- a/DataFormats/TrackerRecHit2D/interface/TrackerSingleRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/TrackerSingleRecHit.h
@@ -4,6 +4,7 @@
 
 #include "DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h"
 #include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
 
 
 /*  a Hit composed by a "single" measurement
@@ -31,6 +32,12 @@ public:
   TrackerSingleRecHit(const LocalPoint& p, const LocalError& e,
 		      DetId id, GeomDet const * idet,
 		      CluRef const&  clus) : Base(p,e,id, idet, trackerHitRTTI::single), cluster_(clus){}
+
+
+  // a single hit is on a detunit
+  const GeomDetUnit* detUnit() const {
+    return static_cast<const GeomDetUnit*>(det());
+  }
 
   
   // used by trackMerger (to be improved)

--- a/DataFormats/TrackerRecHit2D/interface/TrackerSingleRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/TrackerSingleRecHit.h
@@ -30,8 +30,8 @@ public:
   
   template<typename CluRef>
   TrackerSingleRecHit(const LocalPoint& p, const LocalError& e,
-		      DetId id, GeomDet const * idet,
-		      CluRef const&  clus) : Base(p,e,id, idet, trackerHitRTTI::single), cluster_(clus){}
+		      GeomDet const & idet,
+		      CluRef const&  clus) : Base(p,e,idet, trackerHitRTTI::single), cluster_(clus){}
 
 
   // a single hit is on a detunit

--- a/DataFormats/TrackerRecHit2D/src/SiStripRecHit1D.cc
+++ b/DataFormats/TrackerRecHit2D/src/SiStripRecHit1D.cc
@@ -4,6 +4,6 @@
 SiStripRecHit1D::SiStripRecHit1D(const SiStripRecHit2D* hit2D) :
 TrackerSingleRecHit(hit2D->localPosition(),
 		    LocalError(hit2D->localPositionError().xx(),0.f,std::numeric_limits<float>::max()),
-		    hit2D->geographicalId(), hit2D->det(), hit2D->omniCluster()
+		    *hit2D->det(), hit2D->omniCluster()
 		    ){}
 

--- a/DataFormats/TrackerRecHit2D/src/SiTrackerMultiRecHit.cc
+++ b/DataFormats/TrackerRecHit2D/src/SiTrackerMultiRecHit.cc
@@ -4,9 +4,9 @@
 using namespace std;
 using namespace edm;
 
-SiTrackerMultiRecHit::SiTrackerMultiRecHit(const LocalPoint& pos, const LocalError& err, const DetId& id, GeomDet const * idet,
+SiTrackerMultiRecHit::SiTrackerMultiRecHit(const LocalPoint& pos, const LocalError& err, GeomDet const & idet,
 					   const std::vector< std::pair<const TrackingRecHit*, float> >& aHitMap):
-  BaseTrackerRecHit(pos,err,id,idet,trackerHitRTTI::multi)	
+  BaseTrackerRecHit(pos,err, idet,trackerHitRTTI::multi)	
 {
   for(std::vector<std::pair<const TrackingRecHit*, float> >::const_iterator ihit = aHitMap.begin(); ihit != aHitMap.end(); ihit++){
     theHits.push_back(ihit->first->clone());

--- a/DataFormats/TrackerRecHit2D/src/TrackerSingleRecHit.cc
+++ b/DataFormats/TrackerRecHit2D/src/TrackerSingleRecHit.cc
@@ -111,13 +111,10 @@ TrackerSingleRecHit::sharesInput( const TrackingRecHit* other,
   if (!sameDetModule(*other)) return false;
 
   // move to switch?
-  if (trackerHitRTTI::isSingle(*other)) {
+  if (trackerHitRTTI::isSingleType(*other)) {
     const TrackerSingleRecHit & otherCast = static_cast<const TrackerSingleRecHit&>(*other);
     return sharesInput(otherCast);
   } 
-
-  if (trackerHitRTTI::isProjected(*other)) 
-    return other->sharesInput(this,what);
 
   if (trackerHitRTTI::isMatched(*other) ) {
     if (what == all) return false;

--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -31,11 +31,8 @@
 
   <class name="SiStripRecHit2D"  ClassVersion="12">
    <version ClassVersion="12" checksum="2350660116"/>
-    <field name="sigmaPitch_" transient="true" />
    <version ClassVersion="11" checksum="2157674799"/>
-    <field name="sigmaPitch_" transient="true" />
    <version ClassVersion="10" checksum="4057204970"/>
-    <field name="sigmaPitch_" transient="true" />
   </class>
 
 

--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -10,7 +10,8 @@
   </class>
 
 
-  <class name="BaseTrackerRecHit" ClassVersion="10">
+  <class name="BaseTrackerRecHit" ClassVersion="11">
+    <version ClassVersion="11" checksum="135047806"/>
    <version ClassVersion="10" checksum="213945316"/>
      <field name="pos_" transient="true" />	 
      <field name="err_" transient="true" />	 
@@ -36,7 +37,9 @@
   </class>
 
 
-  <class name="ProjectedSiStripRecHit2D" ClassVersion="11">
+  <class name="ProjectedSiStripRecHit2D" ClassVersion="12">
+   <version ClassVersion="12" checksum="3025653452"/>
+   <field name="theOriginalDet" transient="true" />
    <version ClassVersion="11" checksum="1187571635"/>
    <version ClassVersion="10" checksum="1058168814"/>
   </class>
@@ -49,7 +52,8 @@
    <version ClassVersion="10" checksum="2607997209"/>
   </class>
 
-  <class name="SiPixelRecHit" ClassVersion="12">
+  <class name="SiPixelRecHit" ClassVersion="13">
+    <version ClassVersion="13" checksum="2432056380"/>
    <version ClassVersion="12" checksum="1051928582"/>
    <version ClassVersion="11" checksum="790601993"/>
    <version ClassVersion="10" checksum="414205262"/>

--- a/DataFormats/TrackingRecHit/interface/TrackingRecHit.h
+++ b/DataFormats/TrackingRecHit/interface/TrackingRecHit.h
@@ -10,9 +10,14 @@
 
 #include "DataFormats/TrackingRecHit/interface/KfComponentsHolder.h"
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+#define NO_DICT
+#endif
 
 class GeomDet;
 class GeomDetUnit;
+class TkCloner;
+class TrajectoryStateOnSurface;
 
 class TrackingRecHit {
 public:
@@ -115,6 +120,18 @@ public:
   virtual float errorGlobalRPhi() const;
 
 
+  /// Returns true if the clone( const TrajectoryStateOnSurface&) method returns an
+  /// improved hit, false if it returns an identical copy.
+  /// In order to avoid redundent copies one should call canImproveWithTrack() before 
+  /// calling clone( const TrajectoryStateOnSurface&).
+  ///this will be done inside the TkCloner itself
+  virtual bool canImproveWithTrack() const {return false;}
+private:
+  friend class  TkCloner;
+  // double dispatch
+  virtual TrackingRecHit * clone(TkCloner const&, TrajectoryStateOnSurface const&) const {
+    return clone(); // default
+  }
 
 protected:
   // used by muon...

--- a/RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h
+++ b/RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h
@@ -4,10 +4,29 @@
 #include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
 #include "RecoLocalTracker/ClusterParameterEstimator/interface/ClusterParameterEstimator.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitQuality.h"
-
+#include<tuple>
 
 class PixelClusterParameterEstimator : public  ClusterParameterEstimator<SiPixelCluster> {
   public:
+
+  
+  using ReturnType = std::tuple<LocalPoint,LocalError,SiPixelRecHitQuality::QualWordType>;
+
+  // here just to implement it in the clients;
+  // to be properly implemented in the sub-classes in order to make them thread-safe
+  virtual ReturnType getParameters(const SiPixelCluster & cl, 
+				   const GeomDetUnit    & det ) const {
+    auto lv = localParameters(cl,det);
+    return std::make_tuple(lv.first,lv.second,rawQualityWord());
+  }
+  virtual ReturnType getParameters(const SiPixelCluster & cl, 
+				   const GeomDetUnit    & det, 
+				   const LocalTrajectoryParameters & ltp ) const {
+    auto lv = localParameters(cl,det,ltp);
+    return std::make_tuple(lv.first,lv.second,rawQualityWord());
+  }
+
+
 
   PixelClusterParameterEstimator() : clusterProbComputationFlag_(0){}
 

--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEBase.h
@@ -133,14 +133,6 @@ public:
   inline bool  spansTwoRocks() const { return spansTwoROCs_ ;  }
   inline bool  hasFilledProb() const { return hasFilledProb_ ; }
   
-  //--- Flag to control how SiPixelRecHits compute clusterProbability().
-  //--- Note this is set via the configuration file, and it's simply passed
-  //--- to each TSiPixelRecHit.
-  inline unsigned int clusterProbComputationFlag() const 
-    { 
-      return clusterProbComputationFlag_ ; 
-    }
-  
   
   //-----------------------------------------------------------------------------
   //! A convenience method to fill a whole SiPixelRecHitQuality word in one shot.
@@ -212,13 +204,6 @@ public:
   mutable bool  spansTwoROCs_ ;
   mutable bool  hasFilledProb_ ;
 
-  //--- A flag that could be used to change the behavior of
-  //--- clusterProbability() in TSiPixelRecHit (the *transient* one).  
-  //--- The problem is that the transient hits are made after the CPE runs
-  //--- and they don't get the access to the PSet, so we pass it via the
-  //--- CPE itself...
-  //
-  unsigned int clusterProbComputationFlag_ ;
 
   //---------------------------
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
@@ -138,7 +138,7 @@ namespace cms
 	edm::Ref< edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster > cluster = edmNew::makeRefTo( inputhandle, clustIt);
 	// Make a RecHit and add it to the DetSet
 	// old : recHitsOnDetUnit.push_back( new SiPixelRecHit( lp, le, detIdObject, &*clustIt) );
-	SiPixelRecHit hit( lp, le, cpe_->rawQualityWord(), detIdObject, genericDet, cluster);
+	SiPixelRecHit hit( lp, le, cpe_->rawQualityWord(), *genericDet, cluster);
 	// 
 	// Now save it =================
 	recHitsOnDetUnit.push_back(hit);

--- a/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/SiPixelRecHitConverter.cc
@@ -138,9 +138,7 @@ namespace cms
 	edm::Ref< edmNew::DetSetVector<SiPixelCluster>, SiPixelCluster > cluster = edmNew::makeRefTo( inputhandle, clustIt);
 	// Make a RecHit and add it to the DetSet
 	// old : recHitsOnDetUnit.push_back( new SiPixelRecHit( lp, le, detIdObject, &*clustIt) );
-	SiPixelRecHit hit( lp, le, detIdObject, genericDet, cluster);
-	// Copy the extra stuff;
-	hit.setRawQualityWord( cpe_->rawQualityWord() );
+	SiPixelRecHit hit( lp, le, cpe_->rawQualityWord(), detIdObject, genericDet, cluster);
 	// 
 	// Now save it =================
 	recHitsOnDetUnit.push_back(hit);

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SSEMatcher.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SSEMatcher.h
@@ -203,8 +203,8 @@ void SiStripRecHitMatcher::doubleMatch(MonoIterator monoRHiter, MonoIterator mon
 	//Change NSigmaInside in the configuration file to accept more hits
 	//...and add it to the Rechit collection 
 	
-	collectorHelper.collector()(SiStripMatchedRecHit2D(LocalPoint(position), error,gluedDet->geographicalId() ,
-							   gluedDet,&monoRH,si.secondHit));
+	collectorHelper.collector()(SiStripMatchedRecHit2D(LocalPoint(position), error,
+							   *gluedDet,&monoRH,si.secondHit));
       }
       
     } // loop on cache info

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
@@ -13,6 +13,9 @@
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "TrackingTools/TransientTrackingRecHit/interface/HelpertRecHit2DLocalPos.h"
+
+
 class GluedGeomDet;
 
 #include <cfloat>
@@ -39,6 +42,16 @@ public:
   SiStripRecHitMatcher(const double theScale);
 
   bool preFilter() const { return preFilter_;}  
+
+
+  inline   
+  static float sigmaPitch(LocalPoint const& pos, LocalError const & err, 
+		   const StripTopology& topol) {
+    MeasurementError error = topol.measurementError(pos,err);
+    auto pitch=topol.localPitch(pos);
+    return error.uu()*pitch*pitch;
+  }
+
 
   // optimized matching iteration (the algo is the same, just recoded)
   template<typename MonoIterator, typename StereoIterator,  typename CollectorHelper>
@@ -177,7 +190,7 @@ void SiStripRecHitMatcher::doubleMatch(MonoIterator monoRHiter, MonoIterator mon
     
     const SiStripRecHit2D & secondHit = CollectorHelper::stereoHit(seconditer);
     
-    float sigmap22 =secondHit.sigmaPitch();
+    float sigmap22 = sigmaPitch(secondHit.localPosition(),secondHit.localPositionError(),partnertopol);
     // assert (sigmap22>=0);
     
     auto STEREOpointX=partnertopol.measurementPosition( secondHit.localPositionFast()).x();
@@ -278,8 +291,8 @@ void SiStripRecHitMatcher::doubleMatch(MonoIterator monoRHiter, MonoIterator mon
     double s1 = -m01;
     double l1 = 1./(c1*c1+s1*s1);
     
-    // FIXME: here for test...
-    float sigmap12 = monoRH.sigmaPitch();
+    float sigmap12 = sigmaPitch(monoRH.localPosition(), monoRH.localPositionError(),topol);
+    // float sigmap12 = monoRH.sigmaPitch();
     // assert(sigmap12>=0); 
 
     //float code

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
@@ -79,6 +79,15 @@ public:
   StripPosition project(const GeomDetUnit *det,const GluedGeomDet* glueddet,StripPosition strip,LocalVector trackdirection) const;
   
   
+  // needed by the obsolete version still in use on some architectures
+  void
+  match( const SiStripRecHit2D *monoRH,
+	 SimpleHitIterator begin, SimpleHitIterator end,
+	 edm::OwnVector<SiStripMatchedRecHit2D> & collector, 
+	 const GluedGeomDet* gluedDet,
+	 LocalVector trackdirection) const;
+
+
 
   void
   match( const SiStripRecHit2D *monoRH,

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
@@ -336,8 +336,8 @@ void SiStripRecHitMatcher::doubleMatch(MonoIterator monoRHiter, MonoIterator mon
 	//Change NSigmaInside in the configuration file to accept more hits
 	//...and add it to the Rechit collection 
 	
-	collectorHelper.collector()(SiStripMatchedRecHit2D(LocalPoint(position), error,gluedDet->geographicalId() ,
-							   gluedDet,&monoRH,si.secondHit));
+	collectorHelper.collector()(SiStripMatchedRecHit2D(LocalPoint(position), error,
+							   *gluedDet,&monoRH,si.secondHit));
       }
       
     } // loop on cache info

--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
@@ -65,7 +65,7 @@ public:
   SiStripMatchedRecHit2D * match(const SiStripRecHit2D *monoRH, 
 				 const SiStripRecHit2D *stereoRH,
 				 const GluedGeomDet* gluedDet,
-				 LocalVector trackdirection) const;
+				 LocalVector trackdirection, bool force=false) const;
 
   
 // this is the one used by the RecHitConverter

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
@@ -56,6 +56,7 @@ run(edm::Handle<edmNew::DetSetVector<SiStripCluster> > input, products& output)
 { run(input, output, LocalVector(0.,0.,0.)); }
 
 
+/*
 namespace {
   float sigmaPitch(LocalPoint const& pos, LocalError err, 
 		   GeomDetUnit const & stripdet) {
@@ -67,7 +68,7 @@ namespace {
     return error.uu()*pitch*pitch;
   }
 }
-
+*/
 
 void SiStripRecHitConverterAlgorithm::
 run(edm::Handle<edmNew::DetSetVector<SiStripCluster> > inputhandle, products& output, LocalVector trackdirection)
@@ -93,8 +94,7 @@ run(edm::Handle<edmNew::DetSetVector<SiStripCluster> > inputhandle, products& ou
       if(isMasked(*cluster,bad128StripBlocks)) continue;
 
       StripClusterParameterEstimator::LocalValues parameters = 	parameterestimator->localParameters(*cluster,du);
-      auto sPitch = sigmaPitch(parameters.first, parameters.second, du);
-      collector.push_back(SiStripRecHit2D( parameters.first, parameters.second, sPitch, id, &du, edmNew::makeRefTo(inputhandle,cluster) ));
+      collector.push_back(SiStripRecHit2D( parameters.first, parameters.second, id, &du, edmNew::makeRefTo(inputhandle,cluster) ));
     }
 
     if (collector.empty()) collector.abort();
@@ -135,8 +135,7 @@ run(edm::Handle<edm::RefGetter<SiStripCluster> >  refGetterhandle,
       if( !goodDet || isMasked(*icluster, bad128StripBlocks)) continue;
       GeomDetUnit const & du = *(tracker->idToDetUnit(detId));
       StripClusterParameterEstimator::LocalValues parameters = parameterestimator->localParameters(*icluster,du);
-      auto sPitch = sigmaPitch(parameters.first, parameters.second, du);
-      collector->push_back(SiStripRecHit2D( parameters.first, parameters.second, sPitch, detId, &du,  makeRefToLazyGetter(lazyGetterhandle,i) ));      
+     collector->push_back(SiStripRecHit2D( parameters.first, parameters.second, detId, &du,  makeRefToLazyGetter(lazyGetterhandle,i) ));      
     }
     if(collector->empty()) collector->abort();
   }

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitConverterAlgorithm.cc
@@ -94,7 +94,7 @@ run(edm::Handle<edmNew::DetSetVector<SiStripCluster> > inputhandle, products& ou
       if(isMasked(*cluster,bad128StripBlocks)) continue;
 
       StripClusterParameterEstimator::LocalValues parameters = 	parameterestimator->localParameters(*cluster,du);
-      collector.push_back(SiStripRecHit2D( parameters.first, parameters.second, id, &du, edmNew::makeRefTo(inputhandle,cluster) ));
+      collector.push_back(SiStripRecHit2D( parameters.first, parameters.second, du, edmNew::makeRefTo(inputhandle,cluster) ));
     }
 
     if (collector.empty()) collector.abort();
@@ -135,7 +135,7 @@ run(edm::Handle<edm::RefGetter<SiStripCluster> >  refGetterhandle,
       if( !goodDet || isMasked(*icluster, bad128StripBlocks)) continue;
       GeomDetUnit const & du = *(tracker->idToDetUnit(detId));
       StripClusterParameterEstimator::LocalValues parameters = parameterestimator->localParameters(*icluster,du);
-     collector->push_back(SiStripRecHit2D( parameters.first, parameters.second, detId, &du,  makeRefToLazyGetter(lazyGetterhandle,i) ));      
+     collector->push_back(SiStripRecHit2D( parameters.first, parameters.second, du,  makeRefToLazyGetter(lazyGetterhandle,i) ));      
     }
     if(collector->empty()) collector->abort();
   }

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
@@ -37,6 +37,22 @@ namespace {
 }
 
 
+// needed by the obsolete version still in use on some architectures
+void
+SiStripRecHitMatcher::match( const SiStripRecHit2D *monoRH,
+			     SimpleHitIterator begin, SimpleHitIterator end,
+			     edm::OwnVector<SiStripMatchedRecHit2D> & collector, 
+			     const GluedGeomDet* gluedDet,
+			     LocalVector trackdirection) const {
+
+  std::vector<SiStripMatchedRecHit2D*> result;
+  result.reserve(end-begin);
+  match(monoRH,begin,end,result,gluedDet,trackdirection);
+  for (std::vector<SiStripMatchedRecHit2D*>::iterator p=result.begin(); p!=result.end();
+       p++) collector.push_back(*p);
+}
+
+
 void
 SiStripRecHitMatcher::match( const SiStripRecHit2D *monoRH,
 			     SimpleHitIterator begin, SimpleHitIterator end,

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
@@ -234,7 +234,7 @@ SiStripRecHitMatcher::match( const SiStripRecHit2D *monoRH,
       //...and add it to the Rechit collection 
 
       const SiStripRecHit2D* secondHit = *seconditer;
-      collector(SiStripMatchedRecHit2D(position, error,gluedDet->geographicalId() ,gluedDet,
+      collector(SiStripMatchedRecHit2D(position, error,*gluedDet,
 				       monoRH,secondHit));
     }
   }
@@ -370,7 +370,7 @@ SiStripRecHitMatcher::match(const SiStripRecHit2D *monoRH,
   //if it is inside the gluedet bonds
   //Change NSigmaInside in the configuration file to accept more hits
   if(force || (gluedDet->surface()).bounds().inside(position,error,scale_)) 
-    return new SiStripMatchedRecHit2D(LocalPoint(position), error,gluedDet->geographicalId(), gluedDet, monoRH,stereoRH);
+    return new SiStripMatchedRecHit2D(LocalPoint(position), error, *gluedDet, monoRH,stereoRH);
   return nullptr;
 }
 

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
@@ -269,7 +269,7 @@ SiStripMatchedRecHit2D *
 SiStripRecHitMatcher::match(const SiStripRecHit2D *monoRH, 
 			    const SiStripRecHit2D *stereoRH,
 			    const GluedGeomDet* gluedDet,
-			    LocalVector trackdirection) const {
+			    LocalVector trackdirection, bool force) const {
   // stripdet = mono
   // partnerstripdet = stereo
   const GeomDetUnit* stripdet = gluedDet->monoDet();
@@ -347,7 +347,7 @@ SiStripRecHitMatcher::match(const SiStripRecHit2D *monoRH,
   Local2DPoint position(solution(0),solution(1));
   
 
-  if (!((gluedDet->surface()).bounds().inside(position,10.f*scale_))) return nullptr;                                                       
+  if ((!force) &&  (!((gluedDet->surface()).bounds().inside(position,10.f*scale_))) ) return nullptr;                                                       
   
 
   double c2 = -m10;
@@ -369,7 +369,7 @@ SiStripRecHitMatcher::match(const SiStripRecHit2D *monoRH,
 
   //if it is inside the gluedet bonds
   //Change NSigmaInside in the configuration file to accept more hits
-  if((gluedDet->surface()).bounds().inside(position,error,scale_)) 
+  if(force || (gluedDet->surface()).bounds().inside(position,error,scale_)) 
     return new SiStripMatchedRecHit2D(LocalPoint(position), error,gluedDet->geographicalId(), gluedDet, monoRH,stereoRH);
   return nullptr;
 }

--- a/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/src/SiStripRecHitMatcher.cc
@@ -148,7 +148,8 @@ SiStripRecHitMatcher::match( const SiStripRecHit2D *monoRH,
   double l1 = 1./(c1*c1+s1*s1);
 
  
-  auto sigmap12 = monoRH->sigmaPitch();
+  float sigmap12 = sigmaPitch(monoRH->localPosition(), monoRH->localPositionError(),topol);
+  // auto sigmap12 = monoRH->sigmaPitch();
   // assert(sigmap12>=0);
 
 
@@ -217,8 +218,8 @@ SiStripRecHitMatcher::match( const SiStripRecHit2D *monoRH,
     double s2 = -m11;
     double l2 = 1./(c2*c2+s2*s2);
 
-
-    auto sigmap22 = (*seconditer)->sigmaPitch();
+   float sigmap22 = sigmaPitch((*seconditer)->localPosition(),(*seconditer)->localPositionError(),partnertopol);
+   // auto sigmap22 = (*seconditer)->sigmaPitch();
     // assert(sigmap22>=0);
 
     double diff=(c1*s2-c2*s1);
@@ -309,8 +310,9 @@ SiStripRecHitMatcher::match(const SiStripRecHit2D *monoRH,
   double s1 = -m01;
   double l1 = 1./(c1*c1+s1*s1);
 
- 
-  auto sigmap12 = monoRH->sigmaPitch();
+
+  float sigmap12 = sigmaPitch(monoRH->localPosition(), monoRH->localPositionError(),topol);
+  // auto sigmap12 = monoRH->sigmaPitch();
   // assert(sigmap12>=0);
 
 
@@ -353,8 +355,8 @@ SiStripRecHitMatcher::match(const SiStripRecHit2D *monoRH,
   double l2 = 1./(c2*c2+s2*s2);
   
   
-
-  auto sigmap22 = stereoRH->sigmaPitch();
+  float sigmap22 = sigmaPitch(stereoRH->localPosition(),stereoRH->localPositionError(),partnertopol);
+  // auto sigmap22 = stereoRH->sigmaPitch();
   // assert (sigmap22>0);
 
   double diff=(c1*s2-c2*s1);

--- a/RecoLocalTracker/SiStripRecHitConverter/test/ReadRecHitAlgorithm.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/test/ReadRecHitAlgorithm.cc
@@ -66,8 +66,8 @@ void ReadRecHitAlgorithm::run(const SiStripMatchedRecHit2DCollection* input)
 
           auto m = iter->monoHit();
           auto s = iter->stereoHit();
-	  ProjectedSiStripRecHit2D projrechit(m.localPosition() ,m.localPositionError() , *det, &m );
-	  ProjectedSiStripRecHit2D projsrechit(s.localPosition() ,s.localPositionError() , *det, &s );
+	  ProjectedSiStripRecHit2D projrechit(m.localPosition() ,m.localPositionError() , *det, m );
+	  ProjectedSiStripRecHit2D projsrechit(s.localPosition() ,s.localPositionError() , *det, s );
 	  
 	  edm::LogVerbatim("ReadRecHit")<<"Checking shareinput\nALL:";
 	  

--- a/RecoLocalTracker/SiStripRecHitConverter/test/ReadRecHitAlgorithm.cc
+++ b/RecoLocalTracker/SiStripRecHitConverter/test/ReadRecHitAlgorithm.cc
@@ -66,8 +66,8 @@ void ReadRecHitAlgorithm::run(const SiStripMatchedRecHit2DCollection* input)
 
           auto m = iter->monoHit();
           auto s = iter->stereoHit();
-	  ProjectedSiStripRecHit2D projrechit(m.localPosition() ,m.localPositionError() , rechit.geographicalId(), det, &m );
-	  ProjectedSiStripRecHit2D projsrechit(s.localPosition() ,s.localPositionError() , rechit.geographicalId(), det, &s );
+	  ProjectedSiStripRecHit2D projrechit(m.localPosition() ,m.localPositionError() , *det, &m );
+	  ProjectedSiStripRecHit2D projsrechit(s.localPosition() ,s.localPositionError() , *det, &s );
 	  
 	  edm::LogVerbatim("ReadRecHit")<<"Checking shareinput\nALL:";
 	  

--- a/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
@@ -503,14 +503,14 @@ void GlobalTrajectoryBuilderBase::fixTEC(ConstRecHitContainer& all,
             //// to get a RecHitPointer to SiStripRecHit2D, the only  method that works is
             //// RecHitPointer MuonTransientTrackingRecHit::build(const GeomDet*,const TrackingRecHit*)
             SiStripRecHit2D* st = new SiStripRecHit2D(pos,error,
-                                                      (*lone_tec)->geographicalId().rawId(),Tstrip->detUnit(),
+                                                      *Tstrip->detUnit(),
                                                       strip->cluster());
             *lone_tec = mtt_rechit->build((*lone_tec)->det(),st);
           }
           else {
             
             SiStripRecHit2D* st = new SiStripRecHit2D(pos,error,
-                                                      (*lone_tec)->geographicalId().rawId(),Tstrip->detUnit(),
+                                                      *Tstrip->detUnit(),
                                                       strip->cluster_regional());
             *lone_tec = mtt_rechit->build((*lone_tec)->det(),st);
           }

--- a/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
@@ -498,19 +498,18 @@ void GlobalTrajectoryBuilderBase::fixTEC(ConstRecHitContainer& all,
           LocalError scaledError(rotError.xx() * scl_x * scl_x, 0, rotError.yy() * scl_y * scl_y);
           error = scaledError.rotate(-angle);
           MuonTransientTrackingRecHit* mtt_rechit;
-  	  auto sPitch = TSiStripRecHit2DLocalPos::sigmaPitch(pos,error,*Tstrip->detUnit());
           if (strip->cluster().isNonnull()) {
             //// the implemetantion below works with cloning
             //// to get a RecHitPointer to SiStripRecHit2D, the only  method that works is
             //// RecHitPointer MuonTransientTrackingRecHit::build(const GeomDet*,const TrackingRecHit*)
-            SiStripRecHit2D* st = new SiStripRecHit2D(pos,error,sPitch,
+            SiStripRecHit2D* st = new SiStripRecHit2D(pos,error,
                                                       (*lone_tec)->geographicalId().rawId(),Tstrip->detUnit(),
                                                       strip->cluster());
             *lone_tec = mtt_rechit->build((*lone_tec)->det(),st);
           }
           else {
             
-            SiStripRecHit2D* st = new SiStripRecHit2D(pos,error, sPitch,
+            SiStripRecHit2D* st = new SiStripRecHit2D(pos,error,
                                                       (*lone_tec)->geographicalId().rawId(),Tstrip->detUnit(),
                                                       strip->cluster_regional());
             *lone_tec = mtt_rechit->build((*lone_tec)->det(),st);

--- a/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
+++ b/RecoTracker/DeDx/plugins/DeDxEstimatorProducer.cc
@@ -184,14 +184,13 @@ void DeDxEstimatorProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 	   if(shapetest && !(DeDxTools::shapeSelection((DeDxTools::GetCluster(matchedHit->  monoHit()))->amplitudes()))) hits.push_back(mono);
         }else if(const ProjectedSiStripRecHit2D* projectedHit=dynamic_cast<const ProjectedSiStripRecHit2D*>(recHit)) {
            if(!useStrip) continue;
-           const SiStripRecHit2D* singleHit=&(projectedHit->originalHit());
            DeDxTools::RawHits mono;
 
            mono.trajectoryMeasurement = &(*it);
            mono.angleCosine = cosine;
-           mono.charge = getCharge(DeDxTools::GetCluster(singleHit),mono.NSaturating,singleHit->geographicalId());
-           mono.detId= singleHit->geographicalId();
-	   if(shapetest && !(DeDxTools::shapeSelection((DeDxTools::GetCluster(singleHit))->amplitudes()))) continue;
+           mono.charge = getCharge(DeDxTools::GetCluster(projectedHit->originalHit()),mono.NSaturating,projectedHit->originalId());
+           mono.detId= projectedHit->originalId();
+	   if(shapetest && !(DeDxTools::shapeSelection((DeDxTools::GetCluster(projectedHit->originalHit()))->amplitudes()))) continue;
            hits.push_back(mono);
         }else if(const SiStripRecHit2D* singleHit=dynamic_cast<const SiStripRecHit2D*>(recHit)){
            if(!useStrip) continue;

--- a/RecoTracker/DeDx/src/DeDxTools.cc
+++ b/RecoTracker/DeDx/src/DeDxTools.cc
@@ -51,18 +51,17 @@ using namespace reco;
         }else if(const ProjectedSiStripRecHit2D* projectedHit=dynamic_cast<const ProjectedSiStripRecHit2D*>(recHit)) {
            if(!useStrip) continue;
 
-           const SiStripRecHit2D* singleHit=&(projectedHit->originalHit());
            RawHits mono;
 
            mono.trajectoryMeasurement = &(*it);
 
            mono.angleCosine = cosine; 
-           const std::vector<uint8_t> & amplitudes = singleHit->cluster()->amplitudes();
+           const std::vector<uint8_t> & amplitudes = projectedHit->cluster()->amplitudes();
            mono.charge = accumulate(amplitudes.begin(), amplitudes.end(), 0);
            mono.NSaturating =0;
            for(unsigned int i=0;i<amplitudes.size();i++){if(amplitudes[i]>=254)mono.NSaturating++;}
 
-           mono.detId= singleHit->geographicalId();
+           mono.detId= projectedHit->originalId();
            hits.push_back(mono);
       
         }else if(const SiStripRecHit2D* singleHit=dynamic_cast<const SiStripRecHit2D*>(recHit)){

--- a/RecoTracker/FinalTrackSelectors/src/SimpleTrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/src/SimpleTrackListMerger.cc
@@ -58,7 +58,7 @@ namespace cms
 	pID=mhit->monoClusterRef().id();
       } else if (type == typeid(ProjectedSiStripRecHit2D)) {
 	const ProjectedSiStripRecHit2D *phit = reinterpret_cast<const ProjectedSiStripRecHit2D *>(hit);
-	pID=(&phit->originalHit())->cluster().id();
+	pID= phit->cluster().id();
       } else throw cms::Exception("Unknown RecHit Type") << "RecHit of type " << type.name() << " not supported. (use c++filt to demangle the name)";
     }
 

--- a/RecoTracker/MeasurementDet/plugins/RecHitPropagator.cc
+++ b/RecoTracker/MeasurementDet/plugins/RecHitPropagator.cc
@@ -3,7 +3,7 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHit.h"
 
 TrajectoryStateOnSurface 
-RecHitPropagator::propagate( const TransientTrackingRecHit& hit,
+RecHitPropagator::propagate( const TrackingRecHit& hit,
 			     const Plane& plane, 
 			     const TrajectoryStateOnSurface& ts) const
 {

--- a/RecoTracker/MeasurementDet/plugins/RecHitPropagator.h
+++ b/RecoTracker/MeasurementDet/plugins/RecHitPropagator.h
@@ -3,14 +3,14 @@
 
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 
-class TransientTrackingRecHit;
+class TrackingRecHit;
 class MagneticField;
 class Plane;
 
 class RecHitPropagator {
 public:
 
-  TrajectoryStateOnSurface propagate( const TransientTrackingRecHit& hit,
+  TrajectoryStateOnSurface propagate( const TrackingRecHit& hit,
 				      const Plane& plane, 
 				      const TrajectoryStateOnSurface& ts) const;
 

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.cc
@@ -207,7 +207,6 @@ TkGluedMeasurementDet::RecHitContainer
 TkGluedMeasurementDet::projectOnGluedDet( const RecHitContainer& hits,
 					  const TrajectoryStateOnSurface& ts) const
 {
-  if (hits.empty()) return hits;
   TrackingRecHitProjector<ProjectedRecHit2D> proj;
   RecHitContainer result;
   for ( RecHitContainer::const_iterator ihit = hits.begin(); ihit!=hits.end(); ihit++) {
@@ -227,6 +226,31 @@ TkGluedMeasurementDet::projectOnGluedDet( Collector& collector,
   }
 }
 
+TkGluedMeasurementDet::RecHitContainer 
+TkGluedMeasurementDet::projectOnGluedDet( std::vector<SiStripRecHit2D> const & hits,
+					  const TrajectoryStateOnSurface& ts) const
+{
+  TrackingRecHitProjector<ProjectedRecHit2D> proj;
+  RecHitContainer result;
+  for ( auto const & hit : hits)
+    result.push_back( proj.project(hit, fastGeomDet(), ts, theCPE));
+  return result;
+}
+
+template<typename Collector>
+void 
+TkGluedMeasurementDet::projectOnGluedDet( Collector& collector,
+                                          std::vector<SiStripRecHit2D> const & hits,
+                                          const GlobalVector & gdir ) const 
+{
+  for ( auto const & hit : hits)
+    collector.addProjected(hit, gdir );
+}
+
+
+
+
+
 void TkGluedMeasurementDet::checkProjection(const TrajectoryStateOnSurface& ts, 
 					    const RecHitContainer& monoHits, 
 					    const RecHitContainer& stereoHits) const
@@ -239,12 +263,12 @@ void TkGluedMeasurementDet::checkProjection(const TrajectoryStateOnSurface& ts,
   }
 }
 
-void TkGluedMeasurementDet::checkHitProjection(const TransientTrackingRecHit& hit,
+void TkGluedMeasurementDet::checkHitProjection(const TrackingRecHit& hit,
 					       const TrajectoryStateOnSurface& ts, 
 					       const GeomDet& det) const
 {
   TrackingRecHitProjector<ProjectedRecHit2D> proj;
-  TransientTrackingRecHit::RecHitPointer projectedHit = proj.project( hit, det, ts);
+  TransientTrackingRecHit::RecHitPointer projectedHit = proj.project( hit, det, ts, theCPE);
 
   RecHitPropagator prop;
   TrajectoryStateOnSurface propState = prop.propagate( hit, det.surface(), ts);
@@ -330,11 +354,11 @@ TkGluedMeasurementDet::HitCollectorForRecHits::HitCollectorForRecHits(const Geom
 }
 
 void
-TkGluedMeasurementDet::HitCollectorForRecHits::addProjected(const TransientTrackingRecHit& hit,
+TkGluedMeasurementDet::HitCollectorForRecHits::addProjected(const TrackingRecHit& hit,
                                                             const GlobalVector & gdir)
 {
     TrackingRecHitProjector<ProjectedRecHit2D> proj;
-    target_.push_back( proj.project( hit, *geomDet_, gdir));
+    target_.push_back( proj.project( hit, *geomDet_, gdir, cpe_));
 }
 
 TkGluedMeasurementDet::HitCollectorForFastMeasurements::HitCollectorForFastMeasurements
@@ -379,12 +403,12 @@ TkGluedMeasurementDet::HitCollectorForFastMeasurements::add(SiStripMatchedRecHit
 */
 
 void
-TkGluedMeasurementDet::HitCollectorForFastMeasurements::addProjected(const TransientTrackingRecHit& hit,
+TkGluedMeasurementDet::HitCollectorForFastMeasurements::addProjected(const TrackingRecHit& hit,
                                                             const GlobalVector & gdir)
 {
     // here we're ok with some extra casual new's and delete's
     TrackingRecHitProjector<ProjectedRecHit2D> proj;
-    RecHitPointer && phit = proj.project( hit, *geomDet_, gdir );
+    RecHitPointer && phit = proj.project( hit, *geomDet_, gdir,  cpe_ );
     std::pair<bool,double> diffEst = est_.estimate( stateOnThisDet_, *phit);
     if ( diffEst.first) {
       target_.add(phit, diffEst.second);

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.h
@@ -68,7 +68,7 @@ private:
 			);
       hasNewHits_ = true; 
     }
-    void addProjected(const TransientTrackingRecHit& hit,
+    void addProjected(const TrackingRecHit& hit,
 		      const GlobalVector & gdir) ;
     SiStripRecHitMatcher::Collector & collector() { return collector_; }
     bool hasNewMatchedHits() const { return hasNewHits_;  }
@@ -100,7 +100,7 @@ private:
 				    const MeasurementEstimator& est,
 				    TempMeasurements & target) ;
     void add(SiStripMatchedRecHit2D const& hit) ;
-    void addProjected(const TransientTrackingRecHit& hit,
+    void addProjected(const TrackingRecHit& hit,
 		      const GlobalVector & gdir) ;
     
     SiStripRecHitMatcher::Collector & collector() { return collector_; }
@@ -120,21 +120,32 @@ private:
     bool hasNewHits_;
   };
   
+
   
   RecHitContainer 
-  projectOnGluedDet( const RecHitContainer& hits,
+  projectOnGluedDet( const std::vector<SiStripRecHit2D>& hits,
 		     const TrajectoryStateOnSurface& ts) const dso_internal;
+  template<typename HitCollector>
+  void
+  projectOnGluedDet( HitCollector & collector,
+                     const std::vector<SiStripRecHit2D>& hits,
+                     const GlobalVector & gdir ) const  dso_internal;
 
+
+  RecHitContainer 
+    projectOnGluedDet( const RecHitContainer& hits,
+		       const TrajectoryStateOnSurface& ts) const dso_internal;
   template<typename HitCollector>
   void
   projectOnGluedDet( HitCollector & collector,
                      const RecHitContainer& hits,
                      const GlobalVector & gdir ) const  dso_internal;
 
+
   void checkProjection(const TrajectoryStateOnSurface& ts, 
 		       const RecHitContainer& monoHits, 
 		       const RecHitContainer& stereoHits) const;
-  void checkHitProjection(const TransientTrackingRecHit& hit,
+  void checkHitProjection(const TrackingRecHit& hit,
 			  const TrajectoryStateOnSurface& ts, 
 			  const GeomDet& det) const dso_internal;
 

--- a/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkPixelMeasurementDet.cc
@@ -58,7 +58,7 @@ TkPixelMeasurementDet::buildRecHit( const SiPixelClusterRef & cluster,
 {
   const GeomDetUnit& gdu( specificGeomDet());
   LocalValues lv = cpe()->localParameters( * cluster, gdu, ltp );
-  return TSiPixelRecHit::build( lv.first, lv.second, &fastGeomDet(), cluster, cpe());
+  return TSiPixelRecHit::build( lv.first, lv.second, cpe()->rawQualityWord(), &fastGeomDet(), cluster, cpe());
 }
 
 TkPixelMeasurementDet::RecHitContainer 

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
@@ -322,11 +322,11 @@ SiStripRecHit2D TkStripMeasurementDet::hit(TkStripRecHitIter const & hi ) const 
   if(!isRegional()){
     SiStripClusterRef  cluster = edmNew::makeRefTo( data.stripData().handle(), ci ); 
     LocalValues lv = cpe()->localParameters( *cluster, gdu, ltp);
-    return SiStripRecHit2D(lv.first,lv.second, TSiStripRecHit2DLocalPos::sigmaPitch(lv.first, lv.second,gdu), rawId(), &gdu, cluster);
+    return SiStripRecHit2D(lv.first,lv.second, rawId(), &gdu, cluster);
   } else {
     SiStripRegionalClusterRef cluster = edm::makeRefToLazyGetter(data.stripData().regionalHandle(),ciR);
     LocalValues lv = cpe()->localParameters( *cluster, gdu, ltp);
-    return SiStripRecHit2D(lv.first,lv.second, TSiStripRecHit2DLocalPos::sigmaPitch(lv.first, lv.second,gdu), rawId(), &gdu, cluster);
+    return SiStripRecHit2D(lv.first,lv.second, rawId(), &gdu, cluster);
   } 
 }
 

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.cc
@@ -322,11 +322,11 @@ SiStripRecHit2D TkStripMeasurementDet::hit(TkStripRecHitIter const & hi ) const 
   if(!isRegional()){
     SiStripClusterRef  cluster = edmNew::makeRefTo( data.stripData().handle(), ci ); 
     LocalValues lv = cpe()->localParameters( *cluster, gdu, ltp);
-    return SiStripRecHit2D(lv.first,lv.second, rawId(), &gdu, cluster);
+    return SiStripRecHit2D(lv.first,lv.second, gdu, cluster);
   } else {
     SiStripRegionalClusterRef cluster = edm::makeRefToLazyGetter(data.stripData().regionalHandle(),ciR);
     LocalValues lv = cpe()->localParameters( *cluster, gdu, ltp);
-    return SiStripRecHit2D(lv.first,lv.second, rawId(), &gdu, cluster);
+    return SiStripRecHit2D(lv.first,lv.second, gdu, cluster);
   } 
 }
 

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
@@ -221,7 +221,7 @@ public:
     VLocalValues const & vlv = cpe()->localParametersV( *cluster, gdu, ltp);
     bool isCompatible(false);
     for(auto vl : vlv) {
-      auto && recHit  = SiStripRecHit2D( vl.first, vl.second, TSiStripRecHit2DLocalPos::sigmaPitch(vl.first, vl.second,gdu), rawId(), &gdu, cluster);
+      auto && recHit  = SiStripRecHit2D( vl.first, vl.second, rawId(), &gdu, cluster);
       std::pair<bool,double> diffEst = est.estimate(ltp, recHit);
       LogDebug("TkStripMeasurementDet")<<" chi2=" << diffEst.second;
       if ( diffEst.first ) {
@@ -289,7 +289,7 @@ private:
     const GeomDetUnit& gdu( specificGeomDet());
     VLocalValues const & vlv = cpe()->localParametersV( *cluster, gdu, ltp);
     for(VLocalValues::const_iterator it=vlv.begin();it!=vlv.end();++it){
-      res.push_back(SiStripRecHit2D( it->first, it->second, TSiStripRecHit2DLocalPos::sigmaPitch(it->first, it->second,gdu), rawId(), &gdu, cluster));
+      res.push_back(SiStripRecHit2D( it->first, it->second, rawId(), &gdu, cluster));
     }
   }
 

--- a/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkStripMeasurementDet.h
@@ -221,7 +221,7 @@ public:
     VLocalValues const & vlv = cpe()->localParametersV( *cluster, gdu, ltp);
     bool isCompatible(false);
     for(auto vl : vlv) {
-      auto && recHit  = SiStripRecHit2D( vl.first, vl.second, rawId(), &gdu, cluster);
+      auto && recHit  = SiStripRecHit2D( vl.first, vl.second, gdu, cluster);
       std::pair<bool,double> diffEst = est.estimate(ltp, recHit);
       LogDebug("TkStripMeasurementDet")<<" chi2=" << diffEst.second;
       if ( diffEst.first ) {
@@ -289,7 +289,7 @@ private:
     const GeomDetUnit& gdu( specificGeomDet());
     VLocalValues const & vlv = cpe()->localParametersV( *cluster, gdu, ltp);
     for(VLocalValues::const_iterator it=vlv.begin();it!=vlv.end();++it){
-      res.push_back(SiStripRecHit2D( it->first, it->second, rawId(), &gdu, cluster));
+      res.push_back(SiStripRecHit2D( it->first, it->second, gdu, cluster));
     }
   }
 

--- a/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
+++ b/RecoTracker/MeasurementDet/plugins/doubleMatch.icc
@@ -15,10 +15,14 @@ namespace {
       return *reinterpret_cast<const SiStripRecHit2D*>((**monoHit).hit());
     }
     
+    inline static SiStripRecHit2D const & monoHit(std::vector<SiStripRecHit2D>::const_iterator iter) {
+      return *iter;
+    }
+    
     inline static SiStripRecHit2D const & stereoHit(std::vector<SiStripRecHit2D>::const_iterator iter) {
       return *iter;
     }
-
+    
     inline static SiStripRecHit2D const & stereoHit(TkGluedMeasurementDet::RecHitContainer::const_iterator hit) {
       return *reinterpret_cast<const SiStripRecHit2D*>((**hit).hit());
     }
@@ -32,6 +36,15 @@ namespace {
 	m_collector.addProjected( **monoHit, glbDir );
       }
     }
+
+    inline void closure(std::vector<SiStripRecHit2D>::const_iterator monoHit) {
+      if (m_collector.hasNewMatchedHits()) {
+	m_collector.clearNewMatchedHitsFlag();
+      } else {
+	m_collector.addProjected( *monoHit, glbDir );
+      }
+    }
+  
     
   };
 
@@ -64,9 +77,8 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
   // vsStereoHits.resize(simpleSteroHitsByValue.size());
   //std::transform(simpleSteroHitsByValue.begin(), simpleSteroHitsByValue.end(), vsStereoHits.begin(), take_address());
 
-  RecHitContainer monoHits;
-  RecHitContainer stereoHits;
-  std::vector<float>  diffs;
+  std::vector<SiStripRecHit2D> monoHits;
+  std::vector<SiStripRecHit2D> stereoHits;
 
   auto mf = monoHits.size();
   auto sf = stereoHits.size();
@@ -79,29 +91,28 @@ void TkGluedMeasurementDet::doubleMatch(const TrajectoryStateOnSurface& ts, cons
     emptyMono = theMonoDet->empty(data);
     if likely(!emptyMono) {
 	TrajectoryStateOnSurface mts = fastProp(ts,geomDet().surface(),theMonoDet->geomDet().surface());
-	theMonoDet->recHits(mts,collector.estimator(),data,monoHits,diffs);
+	theMonoDet->simpleRecHits(mts,collector.estimator(),data,monoHits);
       }
     // print("mono", mts,ts);
     mf = monoHits.size();
   }
   else {
-    monoHits = theMonoDet->recHits(ts, data);
+    theMonoDet->simpleRecHits(ts, data,monoHits);
     emptyMono = monoHits.empty();
   }
 
   // stereo requires "projection" for precision and change in coordinates
-  diffs.clear();
   if (collector.filter()) {
     emptyStereo = theStereoDet->empty(data);
     if likely(!emptyStereo) {
 	TrajectoryStateOnSurface pts = fastProp(ts,geomDet().surface(),theStereoDet->geomDet().surface());
-	theStereoDet->recHits(pts,collector.estimator(),data,stereoHits,diffs);
+	theStereoDet->simpleRecHits(pts,collector.estimator(),data,stereoHits);
 	// print("stereo", pts,ts);
       }
     sf = stereoHits.size();
   }
   else {
-    stereoHits= theStereoDet->recHits(ts,data);
+    theStereoDet->simpleRecHits(ts,data,stereoHits);
     emptyStereo = stereoHits.empty();
   }
 

--- a/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.icc
@@ -147,7 +147,7 @@ TrackProducerAlgorithm<T>::runWithTrack(const TrackingGeometry * theG,
 				}
 			      LocalPoint pos;//null
 			      LocalError err;//null
-			      SiStripMatchedRecHit2D rematchedH(pos,err,gluedId, builder->geometry()->idToDet(gluedId), mono,stereo);
+			      SiStripMatchedRecHit2D rematchedH(pos,err, *builder->geometry()->idToDet(gluedId), mono,stereo);
 			      hits.push_back(builder->build(&rematchedH));
 			      //the local position and error is dummy but the fitter does not need that anyways
 			      i++;

--- a/RecoTracker/TransientTrackingRecHit/interface/ProjectedRecHit2D.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/ProjectedRecHit2D.h
@@ -46,7 +46,9 @@ public:
 
   RecHitPointer clone( const TrajectoryStateOnSurface& ts) const;
 
-  const SiStripRecHit2D& originalHit() const { return static_cast<const ProjectedSiStripRecHit2D*>( hit() )->originalHit();}
+  SiStripRecHit2D originalHit() const { return static_cast<const ProjectedSiStripRecHit2D*>( hit() )->originalHit();}
+  ProjectedSiStripRecHit2D const & specificHit() const { return *static_cast<const ProjectedSiStripRecHit2D*>( hit() );}
+
 
   virtual ConstRecHitContainer 	transientHits () const;
 

--- a/RecoTracker/TransientTrackingRecHit/interface/ProjectedRecHit2D.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/ProjectedRecHit2D.h
@@ -37,6 +37,13 @@ public:
     return RecHitPointer( new ProjectedRecHit2D( pos, err, det, originaldet, originalHit));
   }
 
+  static RecHitPointer build( const LocalPoint& pos, const LocalError& err, 
+			      const GeomDet* det, const GeomDet* originaldet,
+			      const TrackingRecHit& originalHit, const StripClusterParameterEstimator* cpe ) {
+    return RecHitPointer( new ProjectedRecHit2D( pos, err, det, originaldet, originalHit, cpe));
+  }
+
+
   RecHitPointer clone( const TrajectoryStateOnSurface& ts) const;
 
   const SiStripRecHit2D& originalHit() const { return static_cast<const ProjectedSiStripRecHit2D*>( hit() )->originalHit();}
@@ -50,6 +57,11 @@ private:
   ProjectedRecHit2D( const LocalPoint& pos, const LocalError& err,
 		     const GeomDet* det, const GeomDet* originaldet, 
 		     const TransientTrackingRecHit& originalHit);
+
+  ProjectedRecHit2D( const LocalPoint& pos, const LocalError& err,
+		     const GeomDet* det, const GeomDet* originaldet, 
+		     const TrackingRecHit& originalHit, const StripClusterParameterEstimator* cpe);
+
 
   ProjectedRecHit2D( const GeomDet * geom, const GeomDet* originaldet,
 		     const ProjectedSiStripRecHit2D* rh,

--- a/RecoTracker/TransientTrackingRecHit/interface/TSiPixelRecHit.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TSiPixelRecHit.h
@@ -63,17 +63,17 @@ public:
     return RecHitPointer( new TSiPixelRecHit( geom, rh, cpe, computeCoarseLocalPosition));
   }
 
-  static RecHitPointer build( const LocalPoint& pos, const LocalError& err,
+  static RecHitPointer build( const LocalPoint& pos, const LocalError& err, SiPixelRecHitQuality::QualWordType qual,
 			      const GeomDet* det, 
 			      const clusterRef & cluster,
 			      const PixelClusterParameterEstimator* cpe) {
-    return RecHitPointer( new TSiPixelRecHit( pos, err, det, cluster, cpe));
+    return RecHitPointer( new TSiPixelRecHit( pos, err, qual, det, cluster, cpe));
   }
 
 
   //!  Probability of the compatibility of the track with the pixel cluster shape.
   virtual float clusterProbability() const {
-    return theHitData.clusterProbability( theClusterProbComputationFlag );
+    return theHitData.clusterProbability( theCPE->clusterProbComputationFlag() );
   }
 
 
@@ -81,7 +81,6 @@ public:
 private:
   const PixelClusterParameterEstimator* theCPE;
   SiPixelRecHit                         theHitData;
-  unsigned int                          theClusterProbComputationFlag;
 
 
   /// This private constructor copies the TrackingRecHit.  It should be used when the 
@@ -94,10 +93,12 @@ private:
 
   /// Another private constructor.  It creates the TrackingRecHit internally, 
   /// avoiding redundent cloning.
-  TSiPixelRecHit( const LocalPoint& pos, const LocalError& err,
+  TSiPixelRecHit( const LocalPoint& pos, const LocalError& err,SiPixelRecHitQuality::QualWordType qual,
 		  const GeomDet* det, 
 		  const clusterRef & clust,
-		  const PixelClusterParameterEstimator* cpe);
+		  const PixelClusterParameterEstimator* cpe) :
+    TValidTrackingRecHit(det), theCPE(cpe),
+    theHitData( pos, err, qual, det->geographicalId(), det, clust){}
 
 
   virtual TSiPixelRecHit * clone() const {

--- a/RecoTracker/TransientTrackingRecHit/interface/TSiPixelRecHit.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TSiPixelRecHit.h
@@ -98,7 +98,7 @@ private:
 		  const clusterRef & clust,
 		  const PixelClusterParameterEstimator* cpe) :
     TValidTrackingRecHit(det), theCPE(cpe),
-    theHitData( pos, err, qual, det->geographicalId(), det, clust){}
+    theHitData( pos, err, qual, *det, clust){}
 
 
   virtual TSiPixelRecHit * clone() const {

--- a/RecoTracker/TransientTrackingRecHit/interface/TSiStripRecHit1D.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TSiStripRecHit1D.h
@@ -102,7 +102,7 @@ private:
 		    const OmniClusterRef & clust,
 		    const StripClusterParameterEstimator* cpe) :
     TValidTrackingRecHit(det), 
-    theCPE(cpe), theHitData(pos, err, det->geographicalId(), det, clust){} 
+    theCPE(cpe), theHitData(pos, err, *det, clust){} 
 
 
   

--- a/RecoTracker/TransientTrackingRecHit/interface/TSiStripRecHit2DLocalPos.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TSiStripRecHit2DLocalPos.h
@@ -126,8 +126,7 @@ private:
     LogDebug("TSiStripRecHit2DLocalPos")<<"calculating coarse position/error.";
 
     StripClusterParameterEstimator::LocalValues lval= theCPE->localParameters(rh->stripCluster(), *gdu);
-    auto sPitch = sigmaPitch(lval.first, lval.second, *gdu);
-    theHitData = SiStripRecHit2D(lval.first, lval.second, sPitch,geom->geographicalId(), geom, rh->omniCluster());
+    theHitData = SiStripRecHit2D(lval.first, lval.second, geom->geographicalId(), geom, rh->omniCluster());
 
   }
   
@@ -137,7 +136,7 @@ private:
 			    const OmniClusterRef & clust,
 			    const StripClusterParameterEstimator* cpe) :
     TValidTrackingRecHit(idet), 
-    theCPE(cpe), theHitData(pos, err, sigmaPitch(pos, err, *static_cast<const GeomDetUnit*>(idet)), idet->geographicalId(), idet, clust) {} 
+    theCPE(cpe), theHitData(pos, err, idet->geographicalId(), idet, clust) {} 
     
   virtual TSiStripRecHit2DLocalPos* clone() const {
     return new TSiStripRecHit2DLocalPos(*this);

--- a/RecoTracker/TransientTrackingRecHit/interface/TSiStripRecHit2DLocalPos.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TSiStripRecHit2DLocalPos.h
@@ -126,7 +126,7 @@ private:
     LogDebug("TSiStripRecHit2DLocalPos")<<"calculating coarse position/error.";
 
     StripClusterParameterEstimator::LocalValues lval= theCPE->localParameters(rh->stripCluster(), *gdu);
-    theHitData = SiStripRecHit2D(lval.first, lval.second, geom->geographicalId(), geom, rh->omniCluster());
+    theHitData = SiStripRecHit2D(lval.first, lval.second, *geom, rh->omniCluster());
 
   }
   
@@ -136,7 +136,7 @@ private:
 			    const OmniClusterRef & clust,
 			    const StripClusterParameterEstimator* cpe) :
     TValidTrackingRecHit(idet), 
-    theCPE(cpe), theHitData(pos, err, idet->geographicalId(), idet, clust) {} 
+    theCPE(cpe), theHitData(pos, err, *idet, clust) {} 
     
   virtual TSiStripRecHit2DLocalPos* clone() const {
     return new TSiStripRecHit2DLocalPos(*this);

--- a/RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h
@@ -1,7 +1,7 @@
-#ifndef TKClonerRecHit_H
-#define TKClonerRecHit_H
+#ifndef TKClonerImplRecHit_H
+#define TKClonerImplRecHit_H
 
-#include "DataFormats/TrackingRecHit/interface/TKCloner.h"
+#include "DataFormats/TrackerRecHit2D/interface/TkCloner.h"
 
 
 class SiPixelRecHit;
@@ -12,7 +12,9 @@ class SiStripMatchedRecHit2D;
 class PixelClusterParameterEstimator;
 class StripClusterParameterEstimator;
 class SiStripRecHitMatcher;
-class TkClonerImpl final : public TKCloner {
+
+
+class TkClonerImpl final : public TkCloner {
 public:
 
   virtual SiPixelRecHit * operator()(SiPixelRecHit const & hit, TrajectoryStateOnSurface const& tsos) const;

--- a/RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h
@@ -17,6 +17,12 @@ class SiStripRecHitMatcher;
 class TkClonerImpl final : public TkCloner {
 public:
 
+  TkClonerImpl(const PixelClusterParameterEstimator * ipixelCPE,
+	       const StripClusterParameterEstimator * istripCPE,
+	       const SiStripRecHitMatcher           * iMatcher
+	       ): pixelCPE(ipixelCPE), stripCPE(istripCPE), theMatcher(iMatcher){}
+
+
   virtual SiPixelRecHit * operator()(SiPixelRecHit const & hit, TrajectoryStateOnSurface const& tsos) const;
   virtual SiStripRecHit2D * operator()(SiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const;
   virtual SiStripRecHit1D * operator()(SiStripRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const;

--- a/RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h
@@ -4,11 +4,6 @@
 #include "DataFormats/TrackerRecHit2D/interface/TkCloner.h"
 
 
-class SiPixelRecHit;
-class SiStripRecHit2D;
-class SiStripRecHit1D;
-class SiStripMatchedRecHit2D;
-
 class PixelClusterParameterEstimator;
 class StripClusterParameterEstimator;
 class SiStripRecHitMatcher;
@@ -27,6 +22,7 @@ public:
   virtual SiStripRecHit2D * operator()(SiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const;
   virtual SiStripRecHit1D * operator()(SiStripRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const;
   virtual SiStripMatchedRecHit2D * operator()(SiStripMatchedRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const;
+  virtual ProjectedSiStripRecHit2D * operator()(ProjectedSiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const;
 
 private:
   const PixelClusterParameterEstimator * pixelCPE;

--- a/RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h
@@ -1,0 +1,30 @@
+#ifndef TKClonerRecHit_H
+#define TKClonerRecHit_H
+
+#include "DataFormats/TrackingRecHit/interface/TKCloner.h"
+
+
+class SiPixelRecHit;
+class SiStripRecHit2D;
+class SiStripRecHit1D;
+class SiStripMatchedRecHit2D;
+
+class PixelClusterParameterEstimator;
+class StripClusterParameterEstimator;
+class SiStripRecHitMatcher;
+class TkClonerImpl final : public TKCloner {
+public:
+
+  virtual SiPixelRecHit * operator()(SiPixelRecHit const & hit, TrajectoryStateOnSurface const& tsos) const;
+  virtual SiStripRecHit2D * operator()(SiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const;
+  virtual SiStripRecHit1D * operator()(SiStripRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const;
+  virtual SiStripMatchedRecHit2D * operator()(SiStripMatchedRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const;
+
+private:
+  const PixelClusterParameterEstimator * pixelCPE;
+  const StripClusterParameterEstimator * stripCPE;
+  const SiStripRecHitMatcher           * theMatcher;
+
+
+};
+#endif

--- a/RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h
+++ b/RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h
@@ -4,7 +4,11 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
-class  SiStripRecHitMatcher;
+#include "RecoTracker/TransientTrackingRecHit/interface/TkClonerImpl.h"
+
+
+
+class SiStripRecHitMatcher;
 class PixelClusterParameterEstimator;
 class StripClusterParameterEstimator;
 
@@ -23,6 +27,9 @@ class TkTransientTrackingRecHitBuilder GCC11_FINAL : public TransientTrackingRec
   const StripClusterParameterEstimator * stripClusterParameterEstimator(){return stripCPE;}
   const SiStripRecHitMatcher           * siStripRecHitMatcher(){return theMatcher;}
   const TrackingGeometry               * geometry() const  { return tGeometry_;}
+
+  // for the time being here...
+  TkClonerImpl cloner() const { return TkClonerImpl(pixelCPE,stripCPE,theMatcher);}
 
 private:
   TransientTrackingRecHit::RecHitPointer oldbuild (const TrackingRecHit * p) const ;

--- a/RecoTracker/TransientTrackingRecHit/src/ProjectedRecHit2D.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/ProjectedRecHit2D.cc
@@ -15,6 +15,17 @@ GenericTransientTrackingRecHit( det, new ProjectedSiStripRecHit2D( pos, err, det
   theOriginalDet = originalDet;
 }
 
+ProjectedRecHit2D::ProjectedRecHit2D( const LocalPoint& pos, const LocalError& err,
+				      const GeomDet* det, const GeomDet* originalDet,
+				      const TrackingRecHit& originalHit, const StripClusterParameterEstimator* cpe) :
+GenericTransientTrackingRecHit( det, new ProjectedSiStripRecHit2D( pos, err, det->geographicalId(), det,
+								     static_cast<const SiStripRecHit2D*>(&originalHit) ) ) 
+{
+  theCPE = cpe;
+  theOriginalDet = originalDet;
+}
+
+
 ProjectedRecHit2D::RecHitPointer 
 ProjectedRecHit2D::clone( const TrajectoryStateOnSurface& ts) const
 {

--- a/RecoTracker/TransientTrackingRecHit/src/ProjectedRecHit2D.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/ProjectedRecHit2D.cc
@@ -7,7 +7,7 @@
 ProjectedRecHit2D::ProjectedRecHit2D( const LocalPoint& pos, const LocalError& err,
 				      const GeomDet* det, const GeomDet* originalDet,
 				      const TransientTrackingRecHit& originalTransientHit) :
-GenericTransientTrackingRecHit( det, new ProjectedSiStripRecHit2D( pos, err, det->geographicalId(), det,
+GenericTransientTrackingRecHit( det, new ProjectedSiStripRecHit2D( pos, err, *det,
 								     static_cast<const SiStripRecHit2D*>(originalTransientHit.hit()) ) ) 
 {
   const TSiStripRecHit2DLocalPos* specificOriginalTransientHit = static_cast<const TSiStripRecHit2DLocalPos*>(&originalTransientHit);
@@ -18,7 +18,7 @@ GenericTransientTrackingRecHit( det, new ProjectedSiStripRecHit2D( pos, err, det
 ProjectedRecHit2D::ProjectedRecHit2D( const LocalPoint& pos, const LocalError& err,
 				      const GeomDet* det, const GeomDet* originalDet,
 				      const TrackingRecHit& originalHit, const StripClusterParameterEstimator* cpe) :
-GenericTransientTrackingRecHit( det, new ProjectedSiStripRecHit2D( pos, err, det->geographicalId(), det,
+GenericTransientTrackingRecHit( det, new ProjectedSiStripRecHit2D( pos, err, *det,
 								     static_cast<const SiStripRecHit2D*>(&originalHit) ) ) 
 {
   theCPE = cpe;

--- a/RecoTracker/TransientTrackingRecHit/src/ProjectedRecHit2D.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/ProjectedRecHit2D.cc
@@ -8,7 +8,7 @@ ProjectedRecHit2D::ProjectedRecHit2D( const LocalPoint& pos, const LocalError& e
 				      const GeomDet* det, const GeomDet* originalDet,
 				      const TransientTrackingRecHit& originalTransientHit) :
 GenericTransientTrackingRecHit( det, new ProjectedSiStripRecHit2D( pos, err, *det,
-								     static_cast<const SiStripRecHit2D*>(originalTransientHit.hit()) ) ) 
+								     *static_cast<const SiStripRecHit2D*>(originalTransientHit.hit()) ) ) 
 {
   const TSiStripRecHit2DLocalPos* specificOriginalTransientHit = static_cast<const TSiStripRecHit2DLocalPos*>(&originalTransientHit);
   theCPE = specificOriginalTransientHit->cpe();
@@ -19,7 +19,7 @@ ProjectedRecHit2D::ProjectedRecHit2D( const LocalPoint& pos, const LocalError& e
 				      const GeomDet* det, const GeomDet* originalDet,
 				      const TrackingRecHit& originalHit, const StripClusterParameterEstimator* cpe) :
 GenericTransientTrackingRecHit( det, new ProjectedSiStripRecHit2D( pos, err, *det,
-								     static_cast<const SiStripRecHit2D*>(&originalHit) ) ) 
+								     *static_cast<const SiStripRecHit2D*>(&originalHit) ) ) 
 {
   theCPE = cpe;
   theOriginalDet = originalDet;
@@ -31,8 +31,8 @@ ProjectedRecHit2D::clone( const TrajectoryStateOnSurface& ts) const
 {
   if (theCPE != 0) {
     TrackingRecHitProjector<ProjectedRecHit2D> proj;
-    if(!originalHit().cluster().isNull()){
-      const SiStripCluster& clust = *(originalHit().cluster());  
+    if(!specificHit().cluster().isNull()){
+      const SiStripCluster& clust = *(specificHit().cluster());  
       
       const GeomDetUnit * gdu = reinterpret_cast<const GeomDetUnit *>(theOriginalDet);
       //if (!gdu) std::cout<<"no luck dude"<<std::endl;
@@ -41,13 +41,13 @@ ProjectedRecHit2D::clone( const TrajectoryStateOnSurface& ts) const
       
       RecHitPointer updatedOriginalHit = 
 	TSiStripRecHit2DLocalPos::build( lv.first, lv.second, theOriginalDet, 
-					 originalHit().cluster(), theCPE);
+					 specificHit().cluster(), theCPE);
       
       RecHitPointer hit = proj.project( *updatedOriginalHit, *det(), ts); 
       
     return hit;
     }else{
-      const SiStripCluster& clust = *(originalHit().cluster_regional());  
+      const SiStripCluster& clust = *(specificHit().cluster_regional());  
       
       const GeomDetUnit * gdu = reinterpret_cast<const GeomDetUnit *>(theOriginalDet);
       StripClusterParameterEstimator::LocalValues lv = 
@@ -55,7 +55,7 @@ ProjectedRecHit2D::clone( const TrajectoryStateOnSurface& ts) const
       
       RecHitPointer updatedOriginalHit = 
 	TSiStripRecHit2DLocalPos::build( lv.first, lv.second, theOriginalDet, 
-					 originalHit().cluster_regional(), theCPE);
+					 specificHit().cluster_regional(), theCPE);
       
       RecHitPointer hit = proj.project( *updatedOriginalHit, *det(), ts); 
       
@@ -70,7 +70,15 @@ ProjectedRecHit2D::clone( const TrajectoryStateOnSurface& ts) const
 TransientTrackingRecHit::ConstRecHitContainer 	
 ProjectedRecHit2D::transientHits () const {
   ConstRecHitContainer result;
-  result.push_back(TSiStripRecHit2DLocalPos::build( theOriginalDet,&originalHit(),theCPE));
+  const SiStripCluster& clust = specificHit().stripCluster();
+
+  const GeomDetUnit * gdu = reinterpret_cast<const GeomDetUnit *>(theOriginalDet);
+  //if (!gdu) std::cout<<"no luck dude"<<std::endl;
+  StripClusterParameterEstimator::LocalValues lv =
+        theCPE->localParameters( clust, *gdu);
+
+  result.push_back(TSiStripRecHit2DLocalPos::build(lv.first, lv.second, theOriginalDet,
+                                                   specificHit().omniCluster(), theCPE));
 						    
   return result;
 }
@@ -83,27 +91,27 @@ ProjectedRecHit2D::ProjectedRecHit2D( const GeomDet * geom, const GeomDet* origi
   if (computeCoarseLocalPosition){
     if (theCPE != 0) {
       TrackingRecHitProjector<ProjectedRecHit2D> proj;
-      if(!originalHit().cluster().isNull()){
-	const SiStripCluster& clust = *(originalHit().cluster());  
+      if(!specificHit().cluster().isNull()){
+	const SiStripCluster& clust = *(specificHit().cluster());  
 	
 	StripClusterParameterEstimator::LocalValues lv =
             theCPE->localParameters( clust, *reinterpret_cast<const GeomDetUnit *>(theOriginalDet));
 	
 	RecHitPointer updatedOriginalHit = 
 	  TSiStripRecHit2DLocalPos::build( lv.first, lv.second, theOriginalDet, 
-					   originalHit().cluster(), theCPE);
+					   specificHit().cluster(), theCPE);
 	
 	RecHitPointer hit = proj.project( *updatedOriginalHit, *det()); 
 	trackingRecHit_ = hit->hit()->clone();
       }else{
-	const SiStripCluster& clust = *(originalHit().cluster_regional());  
+	const SiStripCluster& clust = *(specificHit().cluster_regional());  
 	
 	StripClusterParameterEstimator::LocalValues lv =
             theCPE->localParameters( clust, *reinterpret_cast<const GeomDetUnit *>(theOriginalDet));
 	
 	RecHitPointer updatedOriginalHit = 
 	  TSiStripRecHit2DLocalPos::build( lv.first, lv.second, theOriginalDet, 
-					   originalHit().cluster_regional(), theCPE);
+					   specificHit().cluster_regional(), theCPE);
 	
 	RecHitPointer hit = proj.project( *updatedOriginalHit, *det()); 
 	trackingRecHit_ = hit->hit()->clone();

--- a/RecoTracker/TransientTrackingRecHit/src/TSiPixelRecHit.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/TSiPixelRecHit.cc
@@ -12,7 +12,7 @@ TSiPixelRecHit::RecHitPointer TSiPixelRecHit::clone (const TrajectoryStateOnSurf
     const SiPixelCluster& clust = *specificHit()->cluster();  
     PixelClusterParameterEstimator::LocalValues lv = 
       theCPE->localParameters( clust, *detUnit(), ts);
-    return TSiPixelRecHit::build( lv.first, lv.second, det(), specificHit()->cluster(), theCPE);
+    return TSiPixelRecHit::build( lv.first, lv.second, theCPE->rawQualityWord(), det(), specificHit()->cluster(), theCPE);
   }
 }
 
@@ -35,31 +35,9 @@ TSiPixelRecHit::TSiPixelRecHit(const GeomDet * geom, const SiPixelRecHit* rh,
     if (gdu){
       PixelClusterParameterEstimator::LocalValues lval= theCPE->localParameters(*rh->cluster(), *gdu);
       LogDebug("TSiPixelRecHit")<<"calculating coarse position/error.";
-      theHitData = SiPixelRecHit(lval.first, lval.second,geom->geographicalId(), geom, rh->cluster());
+      theHitData = SiPixelRecHit(lval.first, lval.second, theCPE->rawQualityWord(), geom->geographicalId(), geom, rh->cluster());
     }else{
       edm::LogError("TSiPixelRecHit") << " geomdet does not cast into geomdet unit. cannot create pixel local parameters.";
     }
   }
-
-  // Additionally, fill the SiPixeRecHitQuality from the PixelCPE.
-  theHitData.setRawQualityWord( cpe->rawQualityWord() );
-  theClusterProbComputationFlag = cpe->clusterProbComputationFlag(); 
-
 }
-
-
-
-// Another private constructor.  It creates the TrackingRecHit internally, 
-// avoiding redundent cloning.
-TSiPixelRecHit::TSiPixelRecHit( const LocalPoint& pos, const LocalError& err,
-				const GeomDet* det, 
-				clusterRef const & clust,
-				const PixelClusterParameterEstimator* cpe) :
-  TValidTrackingRecHit(det), theCPE(cpe),
-  theHitData( pos, err, det->geographicalId(), det, clust)
-{
-  // Additionally, fill the SiPixeRecHitQuality from the PixelCPE.
-  theHitData.setRawQualityWord( cpe->rawQualityWord() );
-  theClusterProbComputationFlag = cpe->clusterProbComputationFlag(); 
-}
-

--- a/RecoTracker/TransientTrackingRecHit/src/TSiPixelRecHit.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/TSiPixelRecHit.cc
@@ -35,7 +35,7 @@ TSiPixelRecHit::TSiPixelRecHit(const GeomDet * geom, const SiPixelRecHit* rh,
     if (gdu){
       PixelClusterParameterEstimator::LocalValues lval= theCPE->localParameters(*rh->cluster(), *gdu);
       LogDebug("TSiPixelRecHit")<<"calculating coarse position/error.";
-      theHitData = SiPixelRecHit(lval.first, lval.second, theCPE->rawQualityWord(), geom->geographicalId(), geom, rh->cluster());
+      theHitData = SiPixelRecHit(lval.first, lval.second, theCPE->rawQualityWord(), *geom, rh->cluster());
     }else{
       edm::LogError("TSiPixelRecHit") << " geomdet does not cast into geomdet unit. cannot create pixel local parameters.";
     }

--- a/RecoTracker/TransientTrackingRecHit/src/TSiStripMatchedRecHit.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/TSiStripMatchedRecHit.cc
@@ -56,12 +56,10 @@ TSiStripMatchedRecHit::clone( const TrajectoryStateOnSurface& ts) const
     StripClusterParameterEstimator::LocalValues lvStereo = 
       theCPE->localParameters( stereoclust, *gdet->stereoDet(), gluedToStereo(ts, gdet));
       
-    auto sPitch = TSiStripRecHit2DLocalPos::sigmaPitch(lvMono.first, lvMono.second,*gdet->monoDet());
-    SiStripRecHit2D monoHit = SiStripRecHit2D( lvMono.first, lvMono.second, sPitch,
+    SiStripRecHit2D monoHit = SiStripRecHit2D( lvMono.first, lvMono.second, 
 					       gdet->monoDet()->geographicalId(),gdet->monoDet(),
 					       orig->monoClusterRef());
-    sPitch = TSiStripRecHit2DLocalPos::sigmaPitch(lvStereo.first, lvStereo.second, *gdet->stereoDet());
-    SiStripRecHit2D stereoHit = SiStripRecHit2D( lvStereo.first, lvStereo.second, sPitch,
+    SiStripRecHit2D stereoHit = SiStripRecHit2D( lvStereo.first, lvStereo.second,
 						 gdet->stereoDet()->geographicalId(),gdet->stereoDet(),
 						 orig->stereoClusterRef());
     const SiStripMatchedRecHit2D* better =  theMatcher->match(&monoHit,&stereoHit,gdet,tkDir);
@@ -129,12 +127,10 @@ TSiStripMatchedRecHit::transientHits () const {
   StripClusterParameterEstimator::LocalValues lvStereo = 
     theCPE->localParameters( stereoclust, *gdet->stereoDet());
  
-  auto sPitch = TSiStripRecHit2DLocalPos::sigmaPitch(lvMono.first, lvMono.second,*gdet->monoDet());
-  SiStripRecHit2D monoHit = SiStripRecHit2D( lvMono.first, lvMono.second, sPitch,
+  SiStripRecHit2D monoHit = SiStripRecHit2D( lvMono.first, lvMono.second, 
 					     gdet->monoDet()->geographicalId(),gdet->monoDet(),
 					     orig->monoClusterRef());
-  sPitch = TSiStripRecHit2DLocalPos::sigmaPitch(lvStereo.first, lvStereo.second, *gdet->stereoDet());
-  SiStripRecHit2D stereoHit = SiStripRecHit2D( lvStereo.first, lvStereo.second, sPitch,
+  SiStripRecHit2D stereoHit = SiStripRecHit2D( lvStereo.first, lvStereo.second, 
 					       gdet->stereoDet()->geographicalId(),gdet->stereoDet(),
 						 orig->stereoClusterRef());
   SiStripMatchedRecHit2D* better =  theMatcher->match(&monoHit,&stereoHit,gdet,tkDir);

--- a/RecoTracker/TransientTrackingRecHit/src/TSiStripMatchedRecHit.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/TSiStripMatchedRecHit.cc
@@ -57,10 +57,10 @@ TSiStripMatchedRecHit::clone( const TrajectoryStateOnSurface& ts) const
       theCPE->localParameters( stereoclust, *gdet->stereoDet(), gluedToStereo(ts, gdet));
       
     SiStripRecHit2D monoHit = SiStripRecHit2D( lvMono.first, lvMono.second, 
-					       gdet->monoDet()->geographicalId(),gdet->monoDet(),
+					       *gdet->monoDet(),
 					       orig->monoClusterRef());
     SiStripRecHit2D stereoHit = SiStripRecHit2D( lvStereo.first, lvStereo.second,
-						 gdet->stereoDet()->geographicalId(),gdet->stereoDet(),
+						 *gdet->stereoDet(),
 						 orig->stereoClusterRef());
     const SiStripMatchedRecHit2D* better =  theMatcher->match(&monoHit,&stereoHit,gdet,tkDir);
     
@@ -128,10 +128,10 @@ TSiStripMatchedRecHit::transientHits () const {
     theCPE->localParameters( stereoclust, *gdet->stereoDet());
  
   SiStripRecHit2D monoHit = SiStripRecHit2D( lvMono.first, lvMono.second, 
-					     gdet->monoDet()->geographicalId(),gdet->monoDet(),
+					     *gdet->monoDet(),
 					     orig->monoClusterRef());
   SiStripRecHit2D stereoHit = SiStripRecHit2D( lvStereo.first, lvStereo.second, 
-					       gdet->stereoDet()->geographicalId(),gdet->stereoDet(),
+					       *gdet->stereoDet(),
 						 orig->stereoClusterRef());
   SiStripMatchedRecHit2D* better =  theMatcher->match(&monoHit,&stereoHit,gdet,tkDir);
   

--- a/RecoTracker/TransientTrackingRecHit/src/TSiStripRecHit1D.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/TSiStripRecHit1D.cc
@@ -20,11 +20,11 @@ TValidTrackingRecHit(geom), theCPE(cpe)
       if (rh->cluster().isNonnull()){
 	StripClusterParameterEstimator::LocalValues lval= theCPE->localParameters(*rh->cluster(), *gdu);
 	LocalError le(lval.second.xx(),0.,std::numeric_limits<float>::max()); //Correct??
-	theHitData = SiStripRecHit1D(lval.first, le, geom->geographicalId(),geom,rh->cluster());
+	theHitData = SiStripRecHit1D(lval.first, le, *geom,rh->cluster());
       }else{
 	StripClusterParameterEstimator::LocalValues lval= theCPE->localParameters(*rh->cluster_regional(), *gdu);
 	LocalError le(lval.second.xx(),0.,std::numeric_limits<float>::max()); //Correct??
-	theHitData = SiStripRecHit1D(lval.first, le, geom->geographicalId(),geom,rh->cluster_regional());
+	theHitData = SiStripRecHit1D(lval.first, le, *geom,rh->cluster_regional());
 	}
     }else{
       edm::LogError("TSiStripRecHit2DLocalPos")<<" geomdet does not cast into geomdet unit. cannot create strip local parameters.";

--- a/RecoTracker/TransientTrackingRecHit/src/TkClonerImpl.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/TkClonerImpl.cc
@@ -1,0 +1,39 @@
+#include "RecoTracker/TransientTrackingRecHit/interface/TKClonerImpl.h"
+
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h"
+
+#include "DataFormats/SiPixelCluster/interface/SiPixelCluster.h"
+#include "RecoLocalTracker/ClusterParameterEstimator/interface/PixelClusterParameterEstimator.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+
+
+
+SiPixelRecHit * TKClonerImpl::operator()(SiPixelRecHit const & hit, TrajectoryStateOnSurface& tsos) const {
+  const SiPixelCluster& clust = *hit.cluster();  
+  PixelClusterParameterEstimator::LocalValues lv = 
+    theCPE->localParameters( clust, hit.detUnit(), tsos);
+  return new SiPixelRecHit(lv.first, lv.second, theCPE->rawQualityWord(), hit.det()->geographicalId() hit.det(), clus());
+
+}
+
+SiStripRecHit2D * TKClonerImpl::operator()(SiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const {
+
+
+}
+
+
+
+SiStripRecHit1D * TKClonerImpl::operator()(SiStripRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const {
+
+
+}
+
+
+
+SiStripMatchedRecHit2D * TKClonerImpl::operator()(SiStripMatchedRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const {
+
+
+}

--- a/RecoTracker/TransientTrackingRecHit/src/TkClonerImpl.cc
+++ b/RecoTracker/TransientTrackingRecHit/src/TkClonerImpl.cc
@@ -23,7 +23,7 @@ SiPixelRecHit * TkClonerImpl::operator()(SiPixelRecHit const & hit, TrajectorySt
   const SiPixelCluster& clust = *hit.cluster();  
   PixelClusterParameterEstimator::LocalValues lv = 
     pixelCPE->localParameters( clust, *hit.detUnit(), tsos);
-  return new SiPixelRecHit(lv.first, lv.second, pixelCPE->rawQualityWord(), hit.det()->geographicalId(), hit.det(), hit.cluster());
+  return new SiPixelRecHit(lv.first, lv.second, pixelCPE->rawQualityWord(), *hit.det(), hit.cluster());
 
 }
 
@@ -32,7 +32,7 @@ SiStripRecHit2D * TkClonerImpl::operator()(SiStripRecHit2D const & hit, Trajecto
     const SiStripCluster&  clust = hit.stripCluster();  
     StripClusterParameterEstimator::LocalValues lv = 
       stripCPE->localParameters( clust, *hit.detUnit(), tsos);
- return new SiStripRecHit2D(lv.first, lv.second,hit.det()->geographicalId(), hit.det(), hit.cluster());
+ return new SiStripRecHit2D(lv.first, lv.second, *hit.det(), hit.cluster());
 
 }
 
@@ -44,7 +44,7 @@ SiStripRecHit1D * TkClonerImpl::operator()(SiStripRecHit1D const & hit, Trajecto
   StripClusterParameterEstimator::LocalValues lv = 
     stripCPE->localParameters( clust, *hit.detUnit(), tsos);
   LocalError le(lv.second.xx(),0.,std::numeric_limits<float>::max()); //Correct??
-  return new SiStripRecHit1D(lv.first, le, hit.det()->geographicalId(), hit.det(), hit.cluster());
+  return new SiStripRecHit1D(lv.first, le, *hit.det(), hit.cluster());
 }
 
 
@@ -93,10 +93,10 @@ SiStripMatchedRecHit2D * TkClonerImpl::operator()(SiStripMatchedRecHit2D const &
       stripCPE->localParameters( stereoclust, *gdet->stereoDet(), gluedToStereo(tsos, gdet));
       
     SiStripRecHit2D monoHit = SiStripRecHit2D( lvMono.first, lvMono.second, 
-					       gdet->monoDet()->geographicalId(),gdet->monoDet(),
+					       *gdet->monoDet(),
 					       hit.monoClusterRef());
     SiStripRecHit2D stereoHit = SiStripRecHit2D( lvStereo.first, lvStereo.second,
-						 gdet->stereoDet()->geographicalId(),gdet->stereoDet(),
+						 *gdet->stereoDet(),
 						 hit.stereoClusterRef());
     
 

--- a/RecoTracker/TransientTrackingRecHit/test/TrackerHitSizes.cpp
+++ b/RecoTracker/TransientTrackingRecHit/test/TrackerHitSizes.cpp
@@ -20,15 +20,22 @@
 
 int main() {
   std::cout << "sizes" << std::endl;
+  PSIZE(SiPixelRecHit);
+  PSIZE(SiStripRecHit1D);
+  PSIZE(SiStripRecHit2D);
+  PSIZE(SiStripMatchedRecHit2D);
+  PSIZE(ProjectedSiStripRecHit2D);
+
+  std::cout << std::endl;
+
   PSIZE(TSiStripRecHit2DLocalPos);
   PSIZE(TSiStripRecHit1D);
   PSIZE(TSiStripMatchedRecHit);
   PSIZE(TSiPixelRecHit);
   PSIZE(InvalidTransientRecHit);
-  PSIZE(SiStripMatchedRecHit2D);
-  PSIZE(ProjectedSiStripRecHit2D);
   PSIZE(ProjectedRecHit2D);
   PSIZE(GenericTransientTrackingRecHit);
+
   PSIZE(SiTrackerGSRecHit2D);
   PSIZE(SiTrackerGSMatchedRecHit2D);
 

--- a/TrackingTools/KalmanUpdators/test/KFUpdator_t.cpp
+++ b/TrackingTools/KalmanUpdators/test/KFUpdator_t.cpp
@@ -194,7 +194,7 @@ int main() {
   LocalError e(0.2,-0.05,0.1);
     
   SiStripRecHit2D dummy;
-  TrackingRecHit * hit = new SiStripMatchedRecHit2D(m, e, DetId(), det, &dummy, &dummy);
+  TrackingRecHit * hit = new SiStripMatchedRecHit2D(m, e, *det, &dummy, &dummy);
   TransientTrackingRecHit * thit = new  My2DHit(det, hit);
 
   KFUTest kt(new KFUpdator());

--- a/TrackingTools/TransientTrackingRecHit/interface/TrackingRecHitProjector.h
+++ b/TrackingTools/TransientTrackingRecHit/interface/TrackingRecHitProjector.h
@@ -4,11 +4,27 @@
 #include "TrackingTools/TransientTrackingRecHit/interface/TValidTrackingRecHit.h"
 //#include <iostream>
 
+class StripClusterParameterEstimator;
+
 template <class ResultingHit>
 class TrackingRecHitProjector {
  public:
 
   typedef  TransientTrackingRecHit::RecHitPointer      RecHitPointer;
+
+
+  RecHitPointer project( const TrackingRecHit& hit,
+			 const GeomDet& det, 
+			 const TrajectoryStateOnSurface& ts, const StripClusterParameterEstimator* cpe) const {
+    
+    GlobalVector gdir = ts.globalParameters().momentum();
+    return project(hit, det, gdir, cpe);
+  }
+  RecHitPointer project( const TrackingRecHit& hit,
+			 const GeomDet& det, const StripClusterParameterEstimator* cpe) const {
+    GlobalVector gdir = hit.globalPosition() - GlobalPoint(0,0,0);
+    return project(hit, det, gdir,cpe);
+  }
 
 
   RecHitPointer project( const TransientTrackingRecHit& hit,
@@ -55,6 +71,40 @@ class TrackingRecHitProjector {
     LocalError rotatedError = hitErr.rotate( hitXAxis.x(), hitXAxis.y());
     
     return ResultingHit::build( projectedHitPos, rotatedError, &det, hit.det(), hit);
+  }
+
+
+  RecHitPointer project( const TrackingRecHit& hit,
+			 const GeomDet& det,
+			 const GlobalVector & gdir, const StripClusterParameterEstimator* cpe) const {
+    const BoundPlane& gluedPlane = det.surface();
+    const BoundPlane& hitPlane = hit.det()->surface();
+
+    // check if the planes are parallel
+    //const float epsilon = 1.e-7; // corresponds to about 0.3 miliradian but cannot be reduced
+                                 // because of float precision
+
+    //if (fabs(gluedPlane.normalVector().dot( hitPlane.normalVector())) < 1-epsilon) {
+    //       std::cout << "TkGluedMeasurementDet plane not parallel to DetUnit plane: dot product is " 
+    // 	   << gluedPlane.normalVector().dot( hitPlane.normalVector()) << endl;
+    // FIXME: throw the appropriate exception here...
+    //throw MeasurementDetException("TkGluedMeasurementDet plane not parallel to DetUnit plane");
+    //}
+
+    double delta = gluedPlane.localZ( hitPlane.position());
+    LocalVector ldir = gluedPlane.toLocal(gdir);
+    LocalPoint lhitPos = gluedPlane.toLocal( hit.globalPosition());
+    LocalPoint projectedHitPos = lhitPos - ldir * delta/ldir.z();
+
+    LocalVector hitXAxis = gluedPlane.toLocal( hitPlane.toGlobal( LocalVector(1,0,0)));
+    LocalError hitErr = hit.localPositionError();
+    if (gluedPlane.normalVector().dot( hitPlane.normalVector()) < 0) {
+      // the two planes are inverted, and the correlation element must change sign
+      hitErr = LocalError( hitErr.xx(), -hitErr.xy(), hitErr.yy());
+    }
+    LocalError rotatedError = hitErr.rotate( hitXAxis.x(), hitXAxis.y());
+    
+    return ResultingHit::build( projectedHitPos, rotatedError, &det, hit.det(), hit, cpe);
   }
 
 };


### PR DESCRIPTION
This PR replaces 2752

From 2752

```
two technical improvements:
1) use SiStripRecHit2D in matcher instead of TTRH
1a) fix matcher for ARM
2) make PixelCPE output used in a single place
(next step will be to return all in a single call: example already in place in base class, need to be implemented in derived classes)
2) removed all setting of quality in SiPixelHit

more cleanup to come
I stop here because of 1a) and to allow work on PixelCPE

No regression observed.
No regression expected.
```

new improvements
3) cleanup of Constructors (as requested by @slava77)
4) introduction of a Cloner class to "clone' TkHits with a new track hypothesis

No regression observed.
No regression expected.

Next will be to change all Seeders to use only TkHIts (no TTRK)
