### PR TITLE
option to use fake vertex in GlobalTrackingRegionWithVerticesProducer

### DIFF
--- a/RecoTracker/TkTrackingRegions/plugins/GlobalTrackingRegionWithVerticesProducer.h
+++ b/RecoTracker/TkTrackingRegions/plugins/GlobalTrackingRegionWithVerticesProducer.h
@@ -31,7 +31,7 @@ public:
     theFixedError       = regionPSet.getParameter<double>("fixedError");
 
     theUseFoundVertices = regionPSet.getParameter<bool>("useFoundVertices");
-    theUseFakeVertices  = regionPSet.getParameter<bool>("useFakeVertices");
+    theUseFakeVertices  = regionPSet.existsAs<bool>("useFakeVertices") ? regionPSet.getParameter<bool>("useFakeVertices") : false;
     theUseFixedError    = regionPSet.getParameter<bool>("useFixedError");
     token_vertex      = iC.consumes<reco::VertexCollection>(regionPSet.getParameter<edm::InputTag>("VertexCollection"));
   }   

--- a/RecoTracker/TkTrackingRegions/plugins/GlobalTrackingRegionWithVerticesProducer.h
+++ b/RecoTracker/TkTrackingRegions/plugins/GlobalTrackingRegionWithVerticesProducer.h
@@ -31,6 +31,7 @@ public:
     theFixedError       = regionPSet.getParameter<double>("fixedError");
 
     theUseFoundVertices = regionPSet.getParameter<bool>("useFoundVertices");
+    theUseFakeVertices  = regionPSet.getParameter<bool>("useFakeVertices");
     theUseFixedError    = regionPSet.getParameter<bool>("useFixedError");
     token_vertex      = iC.consumes<reco::VertexCollection>(regionPSet.getParameter<edm::InputTag>("VertexCollection"));
   }   
@@ -60,7 +61,8 @@ public:
       ev.getByToken(token_vertex,vertexCollection);
 
       for(reco::VertexCollection::const_iterator iV=vertexCollection->begin(); iV != vertexCollection->end() ; iV++) {
-          if (iV->isFake() || !iV->isValid()) continue;
+          if (!iV->isValid()) continue;
+          if (iV->isFake() && !(theUseFakeVertices && theUseFixedError)) continue;
 	  GlobalPoint theOrigin_       = GlobalPoint(iV->x(),iV->y(),iV->z());
 	  double theOriginHalfLength_ = (theUseFixedError ? theFixedError : (iV->zError())*theSigmaZVertex); 
 	  result.push_back( new GlobalTrackingRegion(thePtMin, theOrigin_, theOriginRadius, theOriginHalfLength_, thePrecise) );
@@ -90,6 +92,7 @@ private:
   bool thePrecise;
   
   bool theUseFoundVertices;
+  bool theUseFakeVertices;
   bool theUseFixedError;
   edm::EDGetTokenT<reco::VertexCollection> 	 token_vertex; 
   edm::EDGetTokenT<reco::BeamSpot> 	 token_beamSpot; 

--- a/RecoTracker/TkTrackingRegions/python/GlobalTrackingRegionWithVertices_cfi.py
+++ b/RecoTracker/TkTrackingRegions/python/GlobalTrackingRegionWithVertices_cfi.py
@@ -29,6 +29,7 @@ RegionPSetWithVerticesBlock = cms.PSet(
         VertexCollection = cms.InputTag("pixelVertices"),
         ptMin = cms.double(0.9),
         useFoundVertices = cms.bool(True),
+        useFakeVertices = cms.bool(False),
         nSigmaZ = cms.double(4.0)
     )
 )


### PR DESCRIPTION
Adds an option to allow use of fake vertices in GlobalTrackingRegionWithVerticesProducer.  The use case is for the HLT to create a tracking region using a fake vertex with the Z0 of a lepton.

The option is turned off by default to preserve the existing behavior.
