### PR TITLE
Don't look at base classes of STL containers

### DIFF
--- a/CondCore/ORA/src/ObjectStreamer.cc
+++ b/CondCore/ORA/src/ObjectStreamer.cc
@@ -40,6 +40,10 @@ void ora::ObjectStreamerBase::buildBaseDataMembers( DataElement& dataElement,
                                                     const edm::TypeWithDict& objType,
                                                     RelationalBuffer* operationBuffer ){
   
+  // Don't look for base classes of std:: stuff
+  if(objType.name().substr(0,5) == "std::") {
+    return;
+  } 
   edm::TypeBases bases(objType);
   for (auto const & b : bases) {
     edm::BaseWithDict base(b);


### PR DESCRIPTION
This is a fix for a segfault that is now causing many relvals in the ROOT6 IB to fail.
The conditions code searches for base classes of each class that is used in conditions, and attempts to construct a TypeWithDict from the base class.  However, if the class in question is an instance of an STL container, the base classes, if any, do not have dictionaries, and a segfault results due to a null pointer dereference.
This pull request simply suppresses the search for base classes of STL containers.  This search was unnecessary anyway, since ROOT understands STL containers.
