### PR TITLE
Made GeometricDet thread-safe

### DIFF
--- a/Geometry/TrackerNumberingBuilder/interface/GeometricDet.h
+++ b/Geometry/TrackerNumberingBuilder/interface/GeometricDet.h
@@ -33,7 +33,7 @@ class GeometricDet {
   typedef DDExpandedView::NavRange NavRange;
 
   typedef std::vector< GeometricDet const *>  ConstGeometricDetContainer;
-  typedef std::vector< GeometricDet const *>  GeometricDetContainer;
+  typedef std::vector< GeometricDet *>  GeometricDetContainer;
 
 #ifdef PoolAlloc  
   typedef std::vector< DDExpandedNode, PoolAlloc<DDExpandedNode> > GeoHistory;
@@ -71,7 +71,7 @@ class GeometricDet {
   /**
    * set or add or clear components
    */
-  void setGeographicalID(DetId id) const {
+  void setGeographicalID(DetId id) {
     _geographicalID = id; 
     //std::cout <<"setGeographicalID " << int(id) << std::endl;
   }
@@ -82,6 +82,7 @@ class GeometricDet {
   }
 #endif
   void addComponents(GeometricDetContainer const & cont);
+  void addComponents(ConstGeometricDetContainer const & cont);
   void addComponent(GeometricDet*);
   /**
    * clearComponents() only empties the container, the components are not deleted!
@@ -102,6 +103,10 @@ class GeometricDet {
     return _container.empty(); 
   }
   
+  GeometricDet* component(size_t index) {
+    return const_cast<GeometricDet*>(_container[index]);
+  }
+
   /**
    * Access methods
    */
@@ -160,11 +165,11 @@ class GeometricDet {
    * components() returns explicit components; please note that in case of a leaf 
    * GeometricDet it returns nothing (an empty vector)
    */
-  GeometricDetContainer & components() {
+  ConstGeometricDetContainer & components() {
     //std::cout << "components1" <<std::endl;
     return _container;
   }  
-  GeometricDetContainer const & components() const {
+  ConstGeometricDetContainer const & components() const {
     //std::cout<<"const components2 "<<std::endl;
     return _container;
   }
@@ -175,7 +180,7 @@ class GeometricDet {
    */
 
   ConstGeometricDetContainer deepComponents() const;
-  void deepComponents(GeometricDetContainer & cont) const;
+  void deepComponents(ConstGeometricDetContainer & cont) const;
 
 #ifdef GEOMETRICDETDEBUG
   //rr
@@ -289,7 +294,7 @@ class GeometricDet {
 
  private:
 
-  GeometricDetContainer _container;
+  ConstGeometricDetContainer _container;
   DDTranslation _trans;
   double _phi;
   double _rho;
@@ -299,8 +304,8 @@ class GeometricDet {
   DDName _ddname;
   GeometricEnumType _type;
   std::vector<double> _params;
-  //FIXME
-  mutable DetId _geographicalID;
+
+  DetId _geographicalID;
 #ifdef GEOMETRICDETDEBUG
   GeoHistory _parents;
   double _volume;

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerBuilder.cc
@@ -49,13 +49,13 @@ CmsTrackerBuilder::buildComponent( DDFilteredView& fv, GeometricDet* g, std::str
 void
 CmsTrackerBuilder::sortNS( DDFilteredView& fv, GeometricDet* det )
 {  
-  GeometricDet::GeometricDetContainer & comp = det->components();
+  GeometricDet::ConstGeometricDetContainer & comp = det->components();
   std::stable_sort( comp.begin(), comp.end(), subDetByType());
   
   for( uint32_t i = 0; i < comp.size(); i++ )
   {
     uint32_t temp= comp[i]->type();
-    comp[i]->setGeographicalID(temp);
+    det->component(i)->setGeographicalID(temp);
   }
 }
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerDetIdBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerDetIdBuilder.cc
@@ -24,7 +24,7 @@ CmsTrackerDetIdBuilder::buildId( GeometricDet* tracker )
 }
 
 void
-CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int ID )
+CmsTrackerDetIdBuilder::iterate( GeometricDet *in, int level, unsigned int ID )
 {
   std::bitset<32> binary_ID(ID);
 
@@ -41,10 +41,11 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
     {  
       for( uint32_t i = 0; i<(in)->components().size(); i++ )
       {
-	uint32_t jSubDet = ((in)->components())[i]->geographicalID().rawId();
+	GeometricDet* component = in->component(i);
+	uint32_t jSubDet = component->geographicalID().rawId();
 	uint32_t temp = ID;
 	temp |= (jSubDet<<25);
-	((in)->components())[i]->setGeographicalID(temp);	
+	component->setGeographicalID(temp);	
 	
 	switch( jSubDet )
 	{ 
@@ -52,7 +53,7 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
 	case 2:
 	  {
 	    // SubDetector Side start bit is 23 [3 unused and Side length is 2 bit]
-	    if(((in)->components())[i]->translation().z()<0. )
+	    if(component->translation().z()<0. )
 	    {
 	      temp |= (1<<23); // PXF-
 	    }
@@ -66,7 +67,7 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
 	case 4:
 	  {
 	    temp|= (0<<15); // SubDetector Side start bit is 13 [10 unused and Side length is 2 bit]
-	    if((((in)->components())[i])->components()[0]->translation().z()<0. )
+	    if((component)->components()[0]->translation().z()<0. )
 	    {
 	      temp |= (1<<13); // TIDB = TID-
 	    }
@@ -80,7 +81,7 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
 	case 6:
 	  {
 	    temp |= (0<<20); // SubDetector Side start bit is 18 [5 unused and Side length is 2 bit]
-	    if(((in)->components())[i]->translation().z()<0. )
+	    if(component->translation().z()<0. )
 	    {
 	      temp |= (1<<18); // TEC-
 	    }
@@ -98,10 +99,10 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
 	  // SubDetector switch ends
 	}
 	
-	((in)->components())[i]->setGeographicalID(DetId(temp));	
+	component->setGeographicalID(DetId(temp));	
 	
 	// next level
-	iterate(((in)->components())[i],level+1,((in)->components())[i]->geographicalID().rawId());
+	iterate(component,level+1,component->geographicalID().rawId());
       }
       break;
     }
@@ -110,6 +111,7 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
     {
       for( uint32_t i = 0; i < (in)->components().size(); i++ )
       {
+	auto component = in->component(i);
 	uint32_t temp = ID;
       
 	switch( iSubDet )
@@ -117,40 +119,40 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
 	// PXB
 	case 1:
 	  {
-	    temp |= (((in)->components())[i]->geographicalID().rawId() << m_layerNumberPXB ); // Layer Number start bit is 16 [5 unused]
+	    temp |= (component->geographicalID().rawId() << m_layerNumberPXB ); // Layer Number start bit is 16 [5 unused]
 	    break;
 	  }
 	// PXF
 	case 2:
 	  {
-	    temp |= (((in)->components())[i]->geographicalID().rawId() << 16 ); // Disk Number start bit is 16
+	    temp |= (component->geographicalID().rawId() << 16 ); // Disk Number start bit is 16
 	    break;
 	  }
 	// TIB
 	case 3:
 	  {
-	    temp |= (((in)->components())[i]->geographicalID().rawId() << 14); // Layer Number start bit is 14 [8 unused]
+	    temp |= (component->geographicalID().rawId() << 14); // Layer Number start bit is 14 [8 unused]
 	    break;
 	  }
 	
 	// TID
 	case 4:
 	  {
-	    temp |= (((in)->components())[i]->geographicalID().rawId() << 11); // Disk (Wheel) Number start bit is 11
+	    temp |= (component->geographicalID().rawId() << 11); // Disk (Wheel) Number start bit is 11
 	    break;
 	  }
 	
 	// TOB
 	case 5:
 	  {
-	    temp |= (((in)->components())[i]->geographicalID().rawId() << 14); // Layer Number start bit is 14 [8 unused]
+	    temp |= (component->geographicalID().rawId() << 14); // Layer Number start bit is 14 [8 unused]
 	    break;
 	  }
 	
 	// TEC
 	case 6:
 	  {
-	    temp |= (((in)->components())[i]->geographicalID().rawId() << 14); // Wheel Number start bit is 14
+	    temp |= (component->geographicalID().rawId() << 14); // Wheel Number start bit is 14
 	    break;
 	  }
       
@@ -163,10 +165,10 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
 	// SubDetector switch ends
 	}
       
-	((in)->components())[i]->setGeographicalID( temp );
+	component->setGeographicalID( temp );
       
 	// next level
-	iterate(((in)->components())[i],level+1,((in)->components())[i]->geographicalID().rawId());      
+	iterate(component,level+1,component->geographicalID().rawId());      
       }
     
       break; 
@@ -175,7 +177,8 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
   case 2: {
     
     for (uint32_t i=0;i<(in)->components().size();i++) {
-	
+      auto component = in->component(i);
+
       switch (iSubDet) {
 
 	// PXB
@@ -183,8 +186,8 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
 	{
 	  uint32_t temp = ID;
 	  // Ladder Starting bit = 2 (last unused) + 6 (Module Number) = 8
-	  temp |= (((in)->components())[i]->geographicalID().rawId()<<8);
-	  ((in)->components())[i]->setGeographicalID(temp);
+	  temp |= (component->geographicalID().rawId()<<8);
+	  component->setGeographicalID(temp);
 	  break;
 	}
 	
@@ -193,8 +196,8 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
 	{
 	  uint32_t temp = ID;
 	  // Blade Starting bit = 1 (last unused) + 5 (Module Number) + 2 (Plaquette part) = 8
-	  temp |= (((in)->components())[i]->geographicalID().rawId()<<8);
-	  ((in)->components())[i]->setGeographicalID(temp);
+	  temp |= (component->geographicalID().rawId()<<8);
+	  component->setGeographicalID(temp);
 	  break;
 	}
 	
@@ -203,8 +206,8 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
 	{
 	  uint32_t temp = ID;
 	  // Side+Part+String Starting bit = 2 (Module Type) + 2 (Module Number) = 4
-	  temp |= (((in)->components())[i]->geographicalID().rawId()<<4);
-	  ((in)->components())[i]->setGeographicalID(temp);
+	  temp |= (component->geographicalID().rawId()<<4);
+	  component->setGeographicalID(temp);
 	  break;
 	}
 	
@@ -213,8 +216,8 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
 	{
 	  uint32_t temp = ID;
 	  // Ring+Part Starting bit = 2 (Module Type) + 5 (Module Number) + 2 (Disk Part)= 9
-	  temp |= (((in)->components())[i]->geographicalID().rawId()<<9);
-	  ((in)->components())[i]->setGeographicalID(DetId(temp));
+	  temp |= (component->geographicalID().rawId()<<9);
+	  component->setGeographicalID(DetId(temp));
 	  break;
 	}
 	
@@ -223,8 +226,8 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
 	{
 	  uint32_t temp = ID;
 	  // Side+Rod Starting bit = 2 (Module Type) + 3 (Module Number) = 5
-	  temp |= (((in)->components())[i]->geographicalID().rawId()<<5);
-	  ((in)->components())[i]->setGeographicalID(temp);
+	  temp |= (component->geographicalID().rawId()<<5);
+	  component->setGeographicalID(temp);
 	  break;
 	}
 	
@@ -233,8 +236,8 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
 	{
 	  uint32_t temp = ID;
 	  // Petal+Part Starting bit = 2 (Module Type) + 3 (Module Number) + 3 (Ring Number) = 8
-	  temp |= (((in)->components())[i]->geographicalID().rawId()<<8);
-	  ((in)->components())[i]->setGeographicalID(temp);
+	  temp |= (component->geographicalID().rawId()<<8);
+	  component->setGeographicalID(temp);
 	  break;
 	}
 	
@@ -248,7 +251,7 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
       }
 
       // next level
-      iterate(((in)->components())[i],level+1,((in)->components())[i]->geographicalID().rawId());
+      iterate(component,level+1,component->geographicalID().rawId());
     }
     
     break;    
@@ -258,7 +261,8 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
   case 3:
     {
       for (uint32_t i=0;i<(in)->components().size();i++) {
-	
+	auto component = in->component(i);
+
 	switch (iSubDet) {
 	  
 	  // TEC
@@ -266,8 +270,8 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
 	  {
 	    // Ring Starting bit = 2 (Module Type) + 3 (Module Number)
 	    uint32_t temp = ID;
-	    temp |= (((in)->components())[i]->geographicalID().rawId()<<5);
-	    ((in)->components())[i]->setGeographicalID(temp);
+	    temp |= (component->geographicalID().rawId()<<5);
+	    component->setGeographicalID(temp);
 	    break;
 	  }
 	  
@@ -275,15 +279,15 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
 	default:
 	  {
 	    uint32_t temp = ID;
-	    temp |= (((in)->components())[i]->geographicalID().rawId()<<2); // Starting bit = 2 (Module Type)
-	    ((in)->components())[i]->setGeographicalID(temp);
+	    temp |= (component->geographicalID().rawId()<<2); // Starting bit = 2 (Module Type)
+	    component->setGeographicalID(temp);
 	  }
 	  
 	  // SubDetector switch ends
 	}
 	
 	// next level
-	iterate(((in)->components())[i],level+1,((in)->components())[i]->geographicalID().rawId());
+	iterate(component,level+1,component->geographicalID().rawId());
 	
       }
       
@@ -303,10 +307,11 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
 	  {
 	    // Module Number bit = 2 (Module Type)
 	    uint32_t temp = ID;
-	    temp |= (((in)->components())[i]->geographicalID().rawId()<<2);
-	    ((in)->components())[i]->setGeographicalID(temp);
+	    auto component = in->component(i);
+	    temp |= (component->geographicalID().rawId()<<2);
+	    component->setGeographicalID(temp);
 	    // next level
-	    iterate(((in)->components())[i],level+1,((in)->components())[i]->geographicalID().rawId());
+	    iterate(component,level+1,component->geographicalID().rawId());
 	    break;
 	  }
 	  
@@ -315,8 +320,9 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
 	  {
 	    for (uint32_t i=0;i<(in)->components().size();i++) {
 	      uint32_t temp = ID;
-	      temp |= (((in)->components())[i]->geographicalID().rawId());
-	      ((in)->components())[i]->setGeographicalID(temp);
+	      auto component = in->component(i);
+	      temp |= (component->geographicalID().rawId());
+	      component->setGeographicalID(temp);
 	    }
 	  }
 	  
@@ -334,8 +340,9 @@ CmsTrackerDetIdBuilder::iterate( GeometricDet const *in, int level, unsigned int
       // TEC Module Type (only TEC arrives here)
       for (uint32_t i=0;i<(in)->components().size();i++) {
 	uint32_t temp = ID;
-	temp |= (((in)->components())[i]->geographicalID().rawId());
-	((in)->components())[i]->setGeographicalID(temp);
+	auto component = in->component(i);
+	temp |= (component->geographicalID().rawId());
+	component->setGeographicalID(temp);
       }
       break;
     }

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerDetIdBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerDetIdBuilder.h
@@ -16,7 +16,7 @@ public:
   CmsTrackerDetIdBuilder( unsigned int layerNumberPXB );
   GeometricDet* buildId( GeometricDet *det );  
 protected:
-  void iterate( GeometricDet const *det, int level, unsigned int ID );
+  void iterate( GeometricDet *det, int level, unsigned int ID );
   
 private:
   // This is the map between detid and navtype to restore backward compatibility between 12* and 13* series

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerDiskBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerDiskBuilder.cc
@@ -22,44 +22,44 @@ PhiSort( const GeometricDet* Panel1, const GeometricDet* Panel2 )
 }
 
 void
-CmsTrackerDiskBuilder::PhiPosNegSplit_innerOuter( std::vector< GeometricDet const *>::iterator begin,
-						  std::vector< GeometricDet const *>::iterator end )
+CmsTrackerDiskBuilder::PhiPosNegSplit_innerOuter( GeometricDet::ConstGeometricDetContainer::iterator begin,
+						  GeometricDet::ConstGeometricDetContainer::iterator end )
 {
   // first sort in phi, lowest first (-pi to +pi)
   std::sort( begin, end, PhiSort );
 
   // now put positive phi (in order) ahead of negative phi as in std geometry
-  std::vector<const GeometricDet*> theCompsPosNeg;
+  GeometricDet::ConstGeometricDetContainer theCompsPosNeg;
   theCompsPosNeg.empty();
   theCompsPosNeg.clear();
   // also find the average radius (used to split inner and outer disk panels)
   double theRmin = (**begin).rho();
   double theRmax = theRmin;
-  for(vector<const GeometricDet*>::const_iterator it=begin;
+  for(GeometricDet::ConstGeometricDetContainer::const_iterator it=begin;
       it!=end;it++){
     if((**it).phi() >= 0) theCompsPosNeg.push_back(*it);
     theRmin = std::min( theRmin, (**it).rho());
     theRmax = std::max( theRmax, (**it).rho());
   }
-  for(vector<const GeometricDet*>::const_iterator it=begin;
+  for(GeometricDet::ConstGeometricDetContainer::const_iterator it=begin;
       it!=end;it++){
     if((**it).phi() < 0) theCompsPosNeg.push_back(*it);
   }
 
   // now put inner disk panels first
   double radius_split = 0.5 * (theRmin + theRmax);
-  std::vector<const GeometricDet*> theCompsInnerOuter;
+  GeometricDet::ConstGeometricDetContainer theCompsInnerOuter;
   theCompsInnerOuter.empty();
   theCompsInnerOuter.clear();
   //unsigned int num_inner = 0;
-  for(vector<const GeometricDet*>::const_iterator it=theCompsPosNeg.begin();
+  for(GeometricDet::ConstGeometricDetContainer::const_iterator it=theCompsPosNeg.begin();
       it!=theCompsPosNeg.end();it++){
     if((**it).rho() <= radius_split) {
       theCompsInnerOuter.push_back(*it);
       //num_inner++;
     }
   }
-  for(vector<const GeometricDet*>::const_iterator it=theCompsPosNeg.begin();
+  for(GeometricDet::ConstGeometricDetContainer::const_iterator it=theCompsPosNeg.begin();
       it!=theCompsPosNeg.end();it++){
     if((**it).rho() > radius_split) theCompsInnerOuter.push_back(*it);
   }
@@ -87,7 +87,7 @@ CmsTrackerDiskBuilder::buildComponent( DDFilteredView& fv, GeometricDet* g, std:
 void
 CmsTrackerDiskBuilder::sortNS( DDFilteredView& fv, GeometricDet* det )
 {
-  GeometricDet::GeometricDetContainer & comp = det->components();
+  GeometricDet::ConstGeometricDetContainer & comp = det->components();
 
   switch( det->components().front()->type())
   {
@@ -114,14 +114,14 @@ CmsTrackerDiskBuilder::sortNS( DDFilteredView& fv, GeometricDet* det )
   {
     if( fabs( comp[2*j]->translation().z()) > fabs( comp[ 2*j +1 ]->translation().z()))
     {
-      zmaxpanels.push_back( comp[2*j] );
-      zminpanels.push_back( comp[2*j+1] );
+      zmaxpanels.push_back( det->component(2*j) );
+      zminpanels.push_back( det->component(2*j+1) );
 
     }
     else if( fabs( comp[2*j]->translation().z()) < fabs( comp[ 2*j +1 ]->translation().z()))
     {
-      zmaxpanels.push_back( comp[2*j+1] );
-      zminpanels.push_back( comp[2*j] );
+      zmaxpanels.push_back( det->component(2*j+1) );
+      zminpanels.push_back( det->component(2*j) );
     }
     else
     {

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerDiskBuilder.h
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerDiskBuilder.h
@@ -17,8 +17,8 @@ private:
   virtual void sortNS( DDFilteredView& , GeometricDet* );
   virtual void buildComponent( DDFilteredView& , GeometricDet*, std::string );
   
-  void PhiPosNegSplit_innerOuter( std::vector< GeometricDet const *>::iterator begin,
-				  std::vector< GeometricDet const *>::iterator end );
+  void PhiPosNegSplit_innerOuter( GeometricDet::ConstGeometricDetContainer::iterator begin,
+				  GeometricDet::ConstGeometricDetContainer::iterator end );
   unsigned int m_totalBlade;
 };
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLadderBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLadderBuilder.cc
@@ -14,7 +14,7 @@ void CmsTrackerLadderBuilder::buildComponent(DDFilteredView& fv, GeometricDet* g
 }
 
 void CmsTrackerLadderBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
-  GeometricDet::GeometricDetContainer & comp = det->components();
+  GeometricDet::ConstGeometricDetContainer & comp = det->components();
 
   if (comp.front()->type()==GeometricDet::DetUnit) 
     std::sort(comp.begin(),comp.end(),LessZ());
@@ -23,7 +23,7 @@ void CmsTrackerLadderBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
   
  
   for(uint32_t i=0; i<comp.size();i++){
-    comp[i]->setGeographicalID(i+1);
+    det->component(i)->setGeographicalID(i+1);
   } 
  
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLayerBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerLayerBuilder.cc
@@ -39,14 +39,14 @@ void CmsTrackerLayerBuilder::buildComponent(DDFilteredView& fv, GeometricDet* g,
 
 void CmsTrackerLayerBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
 
-  GeometricDet::GeometricDetContainer comp = det->components();
+  GeometricDet::ConstGeometricDetContainer& comp = det->components();
 
   // TIB
   // SubDetector Side: 2 bits [TIB-:1 TIB+:2]
   // Layer Part      : 2 bits [internal:1 external:0]
   // String Number   : 6 bits [1,...,56 (at most)]
   //
-  if(det->components().front()->type()== GeometricDet::strng){
+  if(comp.front()->type()== GeometricDet::strng){
     float layerRadius = (det->params()[2]+det->params()[1])/2.;
 
     GeometricDet::GeometricDetContainer neg;
@@ -62,12 +62,12 @@ void CmsTrackerLayerBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
     extpos.clear();
     intpos.clear();
 
-
-    for(GeometricDet::GeometricDetContainer::iterator i=comp.begin();i!=comp.end();i++){
-      if((*i)->translation().z()<0.){
-	neg.push_back(*i);
+    for(size_t i = 0; i< comp.size(); ++i) {
+      auto component = det->component(i);
+      if(component->translation().z()<0.){
+	neg.push_back(component);
       }else{
-	pos.push_back(*i);
+	pos.push_back(component);
       }
     }
 
@@ -129,17 +129,18 @@ void CmsTrackerLayerBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
     det->addComponents(intpos);
     det->addComponents(extpos);
     
-  }else if(det->components().front()->type()== GeometricDet::rod){
+  }else if(comp.front()->type()== GeometricDet::rod){
     GeometricDet::GeometricDetContainer neg;
     GeometricDet::GeometricDetContainer pos;
     neg.clear();
     pos.clear();
     
-    for(GeometricDet::GeometricDetContainer::iterator i=comp.begin();i!=comp.end();i++){
-      if((*i)->translation().z()<0.){
-	neg.push_back(*i);
+    for(size_t i=0; i<comp.size(); ++i) {
+      auto component = det->component(i);
+      if(component->translation().z()<0.){
+	neg.push_back(component);
       }else{
-	pos.push_back(*i);
+	pos.push_back(component);
       }
     }
 
@@ -167,11 +168,9 @@ void CmsTrackerLayerBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
     TrackerStablePhiSort(comp.begin(), comp.end(), ExtractPhi());
 	
     for(uint32_t i=0; i<comp.size();i++){
-      comp[i]->setGeographicalID(DetId(i+1));
+      det->component(i)->setGeographicalID(DetId(i+1));
     }    
-    
-    det->clearComponents();
-    det->addComponents(comp);
+
   }else{
     edm::LogError("CmsTrackerLayerBuilder")<<"ERROR - wrong SubDet to sort..... "<<det->components().front()->type();
   }

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPanelBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPanelBuilder.cc
@@ -22,7 +22,7 @@ void CmsTrackerPanelBuilder::buildComponent(DDFilteredView& fv, GeometricDet* g,
 }
 
 void CmsTrackerPanelBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
- GeometricDet::GeometricDetContainer & comp = det->components();
+ GeometricDet::ConstGeometricDetContainer & comp = det->components();
 
  if (comp.front()->type()==GeometricDet::DetUnit) 
    std::sort(comp.begin(),comp.end(),LessR()); 
@@ -30,7 +30,7 @@ void CmsTrackerPanelBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
    edm::LogError("CmsTrackerPanelBuilder")<<"ERROR - wrong SubDet to sort..... "<<det->components().front()->type(); 
 
   for(uint32_t i=0; i<comp.size();i++){
-    comp[i]->setGeographicalID(i+1);
+    det->component(i)->setGeographicalID(i+1);
   } 
  
 }

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPetalBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerPetalBuilder.cc
@@ -19,7 +19,7 @@ void CmsTrackerPetalBuilder::buildComponent(DDFilteredView& fv, GeometricDet* g,
 }
 
 void CmsTrackerPetalBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
-  GeometricDet::GeometricDetContainer & comp = det->components();
+  GeometricDet::ConstGeometricDetContainer & comp = det->components();
 
   if (comp.front()->type()==GeometricDet::ring)
     std::sort(comp.begin(),comp.end(),LessR_module());
@@ -33,7 +33,7 @@ void CmsTrackerPetalBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
   uint32_t startring = 8 - comp.size();
   
   for(uint32_t i=0; i<comp.size(); i++){
-    comp[i]->setGeographicalID(startring+i);
+    det->component(i)->setGeographicalID(startring+i);
   }
 }
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerRingBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerRingBuilder.cc
@@ -16,7 +16,7 @@ void CmsTrackerRingBuilder::buildComponent(DDFilteredView& fv, GeometricDet* g, 
 }
 
 void CmsTrackerRingBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
-  GeometricDet::GeometricDetContainer & comp = det->components();
+  GeometricDet::ConstGeometricDetContainer & comp = det->components();
   fv.firstChild(); 
   GeometricDet::GeometricDetContainer compfw;
   GeometricDet::GeometricDetContainer compbw;
@@ -54,7 +54,7 @@ void CmsTrackerRingBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
     }
 
     for(uint32_t i=0; i<comp.size();i++)
-      comp[i]->setGeographicalID(i+1);
+      det->component(i)->setGeographicalID(i+1);
 
   } else {
     // TID
@@ -63,9 +63,9 @@ void CmsTrackerRingBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
     //
     for(uint32_t i=0; i<comp.size();i++){
       if(fabs(comp[i]->translation().z())<fabs(det->translation().z())){      
-	compfw.push_back(comp[i]);
+	compfw.push_back(det->component(i));
       } else {
-	compbw.push_back(comp[i]);
+	compbw.push_back(det->component(i));
       }
     }
     

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerRodBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerRodBuilder.cc
@@ -14,12 +14,12 @@ void CmsTrackerRodBuilder::buildComponent(DDFilteredView& fv, GeometricDet* g, s
 }
 
 void CmsTrackerRodBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
-  GeometricDet::GeometricDetContainer & comp = det->components();
+  GeometricDet::ConstGeometricDetContainer & comp = det->components();
 
   std::stable_sort(comp.begin(),comp.end(),LessModZ()); 	
 
   for(uint32_t i=0; i<comp.size();i++){
-     comp[i]->setGeographicalID(i+1);
+    det->component(i)->setGeographicalID(i+1);
   }
     
   if (comp.empty() ){

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerStringBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerStringBuilder.cc
@@ -14,16 +14,14 @@ void CmsTrackerStringBuilder::buildComponent(DDFilteredView& fv, GeometricDet* g
 }
 
 void CmsTrackerStringBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
-  GeometricDet::GeometricDetContainer comp = det->components();
+  GeometricDet::ConstGeometricDetContainer& comp = det->components();
 
   std::stable_sort(comp.begin(),comp.end(),LessModZ()); 
   
   if(comp.size()){
     for(uint32_t i=0; i<comp.size();i++){
-      comp[i]->setGeographicalID(DetId(i+1));
+      det->component(i)->setGeographicalID(DetId(i+1));
     }
-    det->clearComponents();
-    det->addComponents(comp);
   }else{
        edm::LogError("CmsTrackerStringBuilder")<<"Where are the String's modules?";
   }

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerSubStrctBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerSubStrctBuilder.cc
@@ -46,7 +46,7 @@ CmsTrackerSubStrctBuilder::buildComponent( DDFilteredView& fv, GeometricDet* g, 
 void
 CmsTrackerSubStrctBuilder::sortNS( DDFilteredView& fv, GeometricDet* det )
 {
-  GeometricDet::GeometricDetContainer & comp = det->components();
+  GeometricDet::ConstGeometricDetContainer & comp = det->components();
 
   switch( comp.front()->type())
   {
@@ -65,7 +65,7 @@ CmsTrackerSubStrctBuilder::sortNS( DDFilteredView& fv, GeometricDet* det )
   
   for( uint32_t i = 0; i < comp.size(); i++ )
   {
-    comp[i]->setGeographicalID(i+1); // Every subdetector: Layer/Disk/Wheel Number
+    det->component(i)->setGeographicalID(i+1); // Every subdetector: Layer/Disk/Wheel Number
   }
 }
 

--- a/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerWheelBuilder.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/CmsTrackerWheelBuilder.cc
@@ -30,7 +30,7 @@ void CmsTrackerWheelBuilder::buildComponent(DDFilteredView& fv, GeometricDet* g,
 }
 
 void CmsTrackerWheelBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
-  GeometricDet::GeometricDetContainer comp = det->components();
+  GeometricDet::ConstGeometricDetContainer& comp = det->components();
        
   if(comp.size()){
     if(comp.front()->type()==GeometricDet::petal){
@@ -40,9 +40,9 @@ void CmsTrackerWheelBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
       compbw.clear();
       for(uint32_t i=0; i<comp.size();i++){
 	if(fabs(comp[i]->translation().z())<fabs(det->translation().z())){
-	  compfw.push_back(comp[i]);
+	  compfw.push_back(det->component(i));
 	}else{
-	  compbw.push_back(comp[i]);      
+	  compbw.push_back(det->component(i));      
 	}
       }    
       
@@ -75,11 +75,8 @@ void CmsTrackerWheelBuilder::sortNS(DDFilteredView& fv, GeometricDet* det){
       // TID
       // Disk Number: 2 bits [1,2,3]
       for(uint32_t i=0; i<comp.size(); i++){
-	comp[i]->setGeographicalID(DetId(i+1));
+	det->component(i)->setGeographicalID(DetId(i+1));
       }
-      
-      det->clearComponents();
-      det->addComponents(comp);
     }
   }else{
     edm::LogError("CmsTrackerWheelBuilder")<<"Where are the Petals or Rings?";

--- a/Geometry/TrackerNumberingBuilder/src/GeometricDet.cc
+++ b/Geometry/TrackerNumberingBuilder/src/GeometricDet.cc
@@ -275,27 +275,29 @@ GeometricDet::ConstGeometricDetContainer GeometricDet::deepComponents() const {
   return _temp;
 }
 
-void GeometricDet::deepComponents(GeometricDetContainer & cont) const {
+void GeometricDet::deepComponents(ConstGeometricDetContainer & cont) const {
   //std::cout << "const deepComponents2" << std::endl;
   if (isLeaf())
-    cont.push_back(const_cast<GeometricDet*>(this));
+    cont.push_back(this);
   else 
     std::for_each(_container.begin(),_container.end(), 
-		  boost::bind(&GeometricDet::deepComponents,_1,boost::ref(cont))
+		  [&](const GeometricDet* iDet) {
+		    iDet->deepComponents(cont);
+		  }
 		  );
 }
 
-
 void GeometricDet::addComponents(GeometricDetContainer const & cont){
   //std::cout << "addComponents" << std::endl;
-  if (_container.empty()) {
-    _container=cont;
-    return;
-  }
   _container.reserve(_container.size()+cont.size());
   std::copy(cont.begin(), cont.end(), back_inserter(_container));
 }
 
+void GeometricDet::addComponents(ConstGeometricDetContainer const & cont){
+  //std::cout << "addComponents" << std::endl;
+  _container.reserve(_container.size()+cont.size());
+  std::copy(cont.begin(), cont.end(), back_inserter(_container));
+}
 
 void GeometricDet::addComponent(GeometricDet* det){
   //std::cout << "deepComponent" << std::endl;


### PR DESCRIPTION
GeometricDet::setGeographicalID is now non-const. To allow children
of a GeometricDet to have their geomgraphicalID set we added a
component(size_t) method which gives non-const access to a child.
All classes which were modifying the GeometricDet have been updated
to support the new interface.
