### PR TITLE
Fixed thread-safety issues with GeometricDetExtra

### DIFF
--- a/Geometry/TrackerNumberingBuilder/interface/GeometricDetExtra.h
+++ b/Geometry/TrackerNumberingBuilder/interface/GeometricDetExtra.h
@@ -58,7 +58,7 @@ class GeometricDetExtra {
   /**
    * set or add or clear components
    */
-  void setGeographicalId(DetId id) const {
+  void setGeographicalId(DetId id) {
     _geographicalId = id; 
     //std::cout <<"setGeographicalId " << int(id) << std::endl;
   }
@@ -108,8 +108,7 @@ class GeometricDetExtra {
   /** Data members **/
 
   GeometricDet const* _mygd;  
-  //FIXME WHY? FROM GeometricDet comment 
-  mutable DetId _geographicalId;
+  DetId _geographicalId;
   GeoHistory _parents;
   double _volume;
   double _density;


### PR DESCRIPTION
The unused method setGeomgraphicalId was const and was used to change
a mutable. By changing the method to non-const we could get rid of the
mutable and solve the thread-safety issue. No other code is affected
by this change.
