### PR TITLE
Make getEngine() private in random service

### DIFF
--- a/FWCore/Utilities/interface/RandomNumberGenerator.h
+++ b/FWCore/Utilities/interface/RandomNumberGenerator.h
@@ -112,9 +112,6 @@ namespace edm {
     RandomNumberGenerator() {}
     virtual ~RandomNumberGenerator();
 
-    /// Use this to get the random number engine, this is the only function most users should call.
-    virtual CLHEP::HepRandomEngine& getEngine() const = 0;    
-
     virtual CLHEP::HepRandomEngine& getEngine(StreamID const&) const { return getEngine(); }
     virtual CLHEP::HepRandomEngine& getEngine(LuminosityBlockIndex const&) const { return getEngine(); }
 
@@ -140,6 +137,9 @@ namespace edm {
 
     RandomNumberGenerator(RandomNumberGenerator const&); // stop default
     RandomNumberGenerator const& operator=(RandomNumberGenerator const&); // stop default
+
+    /// Use this to get the random number engine, this is the only function most users should call.
+    virtual CLHEP::HepRandomEngine& getEngine() const = 0;
   };
 }
 #endif

--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.h
@@ -49,9 +49,6 @@ namespace edm {
       RandomNumberGeneratorService(ParameterSet const& pset, ActivityRegistry& activityRegistry);
       virtual ~RandomNumberGeneratorService();
 
-      /// Use this to get the random number engine, this is the only function most users should call.
-      virtual CLHEP::HepRandomEngine& getEngine() const;
-
       /// Exists for backward compatibility.
       virtual uint32_t mySeed() const;
 
@@ -109,6 +106,9 @@ namespace edm {
       RandomNumberGeneratorService(RandomNumberGeneratorService const&); // disallow default
 
       RandomNumberGeneratorService const& operator=(RandomNumberGeneratorService const&); // disallow default
+
+      /// Use this to get the random number engine, this is the only function most users should call.
+      virtual CLHEP::HepRandomEngine& getEngine() const;
 
       // These two functions are called internally to keep track
       // of which module is currently active

--- a/IOMC/RandomEngine/test/TestRandomNumberServiceAnalyzer.cc
+++ b/IOMC/RandomEngine/test/TestRandomNumberServiceAnalyzer.cc
@@ -89,10 +89,6 @@ TestRandomNumberServiceAnalyzer::TestRandomNumberServiceAnalyzer(edm::ParameterS
     rng->print();
     std::cout << "*** TestRandomNumberServiceAnalyzer constructor " << rng->mySeed() << "\n";
   }
-  if(rng->getEngine().name() !="RanecuEngine") {
-    //std::cout <<rng->getEngine().name()<<" "<<rng->mySeed()<<" "<<rng->getEngine().getSeed()<<std::endl;
-    assert(static_cast<long>(rng->mySeed())==rng->getEngine().getSeed());
-  }
 }
 
 TestRandomNumberServiceAnalyzer::~TestRandomNumberServiceAnalyzer() {
@@ -100,6 +96,12 @@ TestRandomNumberServiceAnalyzer::~TestRandomNumberServiceAnalyzer() {
 
 void
 TestRandomNumberServiceAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const&) {
+
+  edm::Service<edm::RandomNumberGenerator> rng;
+  if(rng->getEngine(iEvent.streamID()).name() !="RanecuEngine") {
+    assert(static_cast<long>(rng->mySeed())==rng->getEngine(iEvent.streamID()).getSeed());
+  }
+
   // Add some sleep for the different child processes in attempt
   // to ensure all the child processes get events to process.
   if(multiprocess_) {
@@ -107,7 +109,6 @@ TestRandomNumberServiceAnalyzer::analyze(edm::Event const& iEvent, edm::EventSet
   }
   ++count_;
 
-  edm::Service<edm::RandomNumberGenerator> rng;
   if(dump_) {
     std::cout << "*** TestRandomNumberServiceAnalyzer analyze " << rng->mySeed() << "\n";
   }
@@ -121,7 +122,7 @@ TestRandomNumberServiceAnalyzer::analyze(edm::Event const& iEvent, edm::EventSet
           << "/" << iEvent.eventAuxiliary().event()
           << "\n";
   outFile << rng->mySeed() << "\n";
-  outFile << rng->getEngine().name() << "\n";
+  outFile << rng->getEngine(iEvent.streamID()).name() << "\n";
   
   // Get a reference to the engine.  This call can
   // be here or it can be in the module constructor
@@ -130,7 +131,7 @@ TestRandomNumberServiceAnalyzer::analyze(edm::Event const& iEvent, edm::EventSet
   // the engine, reset the state of the engine, or try
   // to destroy the engine object.  The service takes
   // care of those actions.
-  CLHEP::HepRandomEngine& engine = rng->getEngine();
+  CLHEP::HepRandomEngine& engine = rng->getEngine(iEvent.streamID());
 
   // Generate random numbers distributed flatly between 0 and 1
   randomNumberEvent0_ = engine.flat();
@@ -165,7 +166,7 @@ TestRandomNumberServiceAnalyzer::analyze(edm::Event const& iEvent, edm::EventSet
     }
     outFile << moduleDescription().moduleLabel() << "\n";
     outFile << rng->mySeed() << "\n";
-    outFile << rng->getEngine().name() << "\n";
+    outFile << rng->getEngine(iEvent.streamID()).name() << "\n";
 
     outFile << "Event random numbers\n";
     outFile << randomNumberEvent0_ << "\n";
@@ -193,7 +194,7 @@ TestRandomNumberServiceAnalyzer::analyze(edm::Event const& iEvent, edm::EventSet
     }
     outFile << moduleDescription().moduleLabel() << "\n";
     outFile << rng->mySeed() << "\n";
-    outFile << rng->getEngine().name() << "\n";
+    outFile << rng->getEngine(iEvent.streamID()).name() << "\n";
 
     outFile << "Event random numbers\n";
     outFile << randomNumberEvent0_ << "\n";
@@ -222,7 +223,7 @@ TestRandomNumberServiceAnalyzer::analyze(edm::Event const& iEvent, edm::EventSet
     }
     outFile << moduleDescription().moduleLabel() << "\n";
     outFile << rng->mySeed() << "\n";
-    outFile << rng->getEngine().name() << "\n";
+    outFile << rng->getEngine(iEvent.streamID()).name() << "\n";
 
     outFile << "Event random numbers\n";
     outFile << randomNumberEvent0_ << "\n";
@@ -243,7 +244,6 @@ void TestRandomNumberServiceAnalyzer::beginJob() {
   edm::Service<edm::RandomNumberGenerator> rng;
   if(dump_) {
     std::cout << "*** TestRandomNumberServiceAnalyzer beginJob " << rng->mySeed() << "\n";
-    std::cout << rng->getEngine().name() << "\n";
   }
 }
 
@@ -289,9 +289,9 @@ void TestRandomNumberServiceAnalyzer::beginLuminosityBlock(edm::LuminosityBlock 
   outFile << "*** TestRandomNumberServiceAnalyzer beginLumi " << lumi.luminosityBlockAuxiliary().run()
           << "/" << lumi.luminosityBlockAuxiliary().luminosityBlock()  << "\n";
   outFile << rng->mySeed() << "\n";
-  outFile << rng->getEngine().name() << "\n";
+  outFile << rng->getEngine(lumi.index()).name() << "\n";
 
-  CLHEP::HepRandomEngine& engine = rng->getEngine();
+  CLHEP::HepRandomEngine& engine = rng->getEngine(lumi.index());
 
   // Generate random numbers distributed flatly between 0 and 1
   randomNumberLumi0_ = engine.flat();

--- a/IOMC/RandomEngine/test/unit_test_outputs/testRandomService1Dump.txt
+++ b/IOMC/RandomEngine/test/unit_test_outputs/testRandomService1Dump.txt
@@ -36,7 +36,6 @@ RandomNumberGeneratorService dump
     restoreFileName_ = 
 *** TestRandomNumberServiceAnalyzer constructor 81
 *** TestRandomNumberServiceAnalyzer beginJob 81
-HepJamesRandom
 *** TestRandomNumberServiceAnalyzer beginRun 81
 *** TestRandomNumberServiceAnalyzer beginLuminosityBlock 81
 *** TestRandomNumberServiceAnalyzer analyze 81


### PR DESCRIPTION
In the random number generator service, make the
getEngine function which takes no arguments be
private instead of public. This function is replaced
by new getEngine functions that take either a StreamID
or a LuminosityBlockIndex as an argument. This comes
after a long migration of all clients to the new
interface. The new interace is designed to work with
the multithreaded Framework.

Note this may cause some problems when automatically
merged from 7_1_X to 7_1_THREADED_X. There will be
a separate pull request to the 7_1_THREADED_X branch
soon after the automatic merge occurs which will
resolve the problems and also delete the function
entirely on that branch.
