### PR TITLE
Fixed thread-safety issues with ElectronLikelihood

### DIFF
--- a/RecoEgamma/ElectronIdentification/interface/ElectronLikelihood.h
+++ b/RecoEgamma/ElectronIdentification/interface/ElectronLikelihood.h
@@ -58,10 +58,26 @@ class ElectronLikelihood {
                     std::vector<float> &measuremnts, 
                     const EcalClusterLazyTools&) const ;
 
+  //Class to enforce that we only call const functions on LikelihoodPdfProduct
+  // when we are in const functions of ElectronLikelihood
+  class LikelihoodPdfProductPtr {
+  public:
+    LikelihoodPdfProductPtr(): m_ptr(nullptr) {}
+    LikelihoodPdfProductPtr( LikelihoodPdfProduct* iPtr): m_ptr(iPtr) {}
+
+    LikelihoodPdfProduct* operator->() { return m_ptr;}
+    const LikelihoodPdfProduct* operator->() const { return m_ptr;}
+
+    LikelihoodPdfProduct* get() { return m_ptr;}
+
+  private:
+    LikelihoodPdfProduct* m_ptr;
+  };
+
   //! likelihood below 15GeV/c
-  LikelihoodPdfProduct *_EB0lt15lh, *_EB1lt15lh, *_EElt15lh;
+  LikelihoodPdfProductPtr _EB0lt15lh, _EB1lt15lh, _EElt15lh;
   //! likelihood above 15GeV/c
-  LikelihoodPdfProduct *_EB0gt15lh, *_EB1gt15lh, *_EEgt15lh;
+  LikelihoodPdfProductPtr _EB0gt15lh, _EB1gt15lh, _EEgt15lh;
 
   //! general parameters of all the ele id algorithms
   LikelihoodSwitches m_eleIDSwitches ;

--- a/RecoEgamma/ElectronIdentification/interface/LikelihoodPdf.h
+++ b/RecoEgamma/ElectronIdentification/interface/LikelihoodPdf.h
@@ -25,19 +25,19 @@ class LikelihoodPdf {
   void split(const std::map<std::string,float>& splitFractions, bool splitPdf = false);
 
   //! get Value of pdf at point x for class catName
-  float getVal(float x, std::string catName="NOSPLIT", bool normalized = true);
+  float getVal(float x, std::string const& catName="NOSPLIT", bool normalized = true) const;
 
   //! get PDF name
-  std::string getName() { return _name; }
+  std::string const& getName() const { return _name; }
 
   //! get PDF species
-  std::string getSpecies() { return _species; }
+  std::string const& getSpecies() const { return _species; }
 
 
 
  private:
 
-  float normalization(const PhysicsTools::Calibration::HistogramF *thePdf);
+  float normalization(const PhysicsTools::Calibration::HistogramF *thePdf) const;
   
   std::string _name;
   std::string _species;

--- a/RecoEgamma/ElectronIdentification/interface/LikelihoodPdfProduct.h
+++ b/RecoEgamma/ElectronIdentification/interface/LikelihoodPdfProduct.h
@@ -27,11 +27,11 @@ class LikelihoodPdfProduct {
   void setSplitFrac(const char* specname, const char* catName, float frac=1.0);
 
   //! get the likelihood ratio p(a priori) * L(specName) / L_tot
-  float getRatio(const char* specName, const std::vector<float>& measurements, std::string);
+  float getRatio(const char* specName, const std::vector<float>& measurements, const std::string&) const;
 
  private:
 
-  float getSpeciesProb(const char* specName, const std::vector<float>& measurements, std::string gsfClass);
+  float getSpeciesProb(const char* specName, const std::vector<float>& measurements, const std::string& gsfClass) const;
   std::string _name;
   const ElectronLikelihoodCalibration *_calibration;
   std::vector<LikelihoodSpecies*> _specList;

--- a/RecoEgamma/ElectronIdentification/interface/LikelihoodSpecies.h
+++ b/RecoEgamma/ElectronIdentification/interface/LikelihoodSpecies.h
@@ -15,18 +15,18 @@ class LikelihoodSpecies {
 
   // modifiers
   void setName(const char* name);
-  void addPdf(LikelihoodPdf* pdf);
+  void addPdf(const LikelihoodPdf* pdf);
   void setPrior(float prior);
   void setSplitFraction(std::pair<std::string,float> splitfrac);
 
   // methods
-  std::vector<LikelihoodPdf*> getListOfPdfs();
-  const char* getName();
-  float getPrior();
-  std::map<std::string,float> getSplitFractions();
+  std::vector<const LikelihoodPdf*> const& getListOfPdfs() const;
+  const char* getName() const;
+  float getPrior() const;
+  std::map<std::string,float> const& getSplitFractions() const;
 
  private:
-  std::vector<LikelihoodPdf*> _pdfList;
+  std::vector<const LikelihoodPdf*> _pdfList;
   std::string _name;
   float _prior;
   std::map<std::string,float> _splitFractions;

--- a/RecoEgamma/ElectronIdentification/src/ElectronLikelihood.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronLikelihood.cc
@@ -37,12 +37,12 @@ ElectronLikelihood::ElectronLikelihood (const ElectronLikelihoodCalibration *cal
 
 
 ElectronLikelihood::~ElectronLikelihood () {
-  delete _EB0lt15lh ;
-  delete _EB1lt15lh ;
-  delete _EElt15lh ;
-  delete _EB0gt15lh ;
-  delete _EB1gt15lh ;
-  delete _EEgt15lh ;
+  delete _EB0lt15lh.get() ;
+  delete _EB1lt15lh.get() ;
+  delete _EElt15lh.get() ;
+  delete _EB0gt15lh.get() ;
+  delete _EB1gt15lh.get() ;
+  delete _EEgt15lh.get() ;
 }
 
 

--- a/RecoEgamma/ElectronIdentification/src/LikelihoodPdf.cc
+++ b/RecoEgamma/ElectronIdentification/src/LikelihoodPdf.cc
@@ -82,8 +82,8 @@ LikelihoodPdf::initFromDB(const ElectronLikelihoodCalibration *calibration) {
 
 
 float 
-LikelihoodPdf::getVal(float x, std::string gsfClass, 
-		      bool normalized) {
+LikelihoodPdf::getVal(float x, std::string const& gsfClass, 
+		      bool normalized) const {
   const PhysicsTools::Calibration::HistogramF *thePdf=0;
   if(_splitPdf.size()>1) {
     edm::LogInfo("LikelihoodPdf") << "The PDF " << _name
@@ -121,7 +121,7 @@ LikelihoodPdf::getVal(float x, std::string gsfClass,
 
 // Histogram::normalization() gives the integral excluding the over-underflow...
 float
-LikelihoodPdf::normalization(const PhysicsTools::Calibration::HistogramF *thePdf) {
+LikelihoodPdf::normalization(const PhysicsTools::Calibration::HistogramF *thePdf) const {
   int nBins = thePdf->numberOfBins();
   float sum=0.;
   for(int i=0; i<=nBins+1; i++) {

--- a/RecoEgamma/ElectronIdentification/src/LikelihoodPdfProduct.cc
+++ b/RecoEgamma/ElectronIdentification/src/LikelihoodPdfProduct.cc
@@ -79,14 +79,14 @@ LikelihoodPdfProduct::setSplitFrac(const char* specname,
 float 
 LikelihoodPdfProduct::getRatio(const char* specname, 
 			       const std::vector<float>& measurements, 
-			       std::string gsfClass) 
+			       const std::string& gsfClass) const
 {
   float sigProb=0, bkgProb=0;
   std::vector<LikelihoodSpecies*>::const_iterator specItr;
   for(specItr=_specList.begin();specItr!=_specList.end();specItr++) {
-    LikelihoodSpecies* species = *specItr;
-    std::map<std::string,float> splitFractions = species->getSplitFractions();
-    std::map<std::string,float>::iterator iter = splitFractions.find(gsfClass);
+    const LikelihoodSpecies* species = *specItr;
+    std::map<std::string,float> const& splitFractions = species->getSplitFractions();
+    std::map<std::string,float>::const_iterator iter = splitFractions.find(gsfClass);
     //! if the pdf is not splitted, assign the split fraction = 1
     float splitFr= (splitFractions.size()==0) ? 1. : iter->second;
     if(strcmp(species->getName(),specname)==0) {
@@ -107,16 +107,16 @@ LikelihoodPdfProduct::getRatio(const char* specname,
 float 
 LikelihoodPdfProduct::getSpeciesProb(const char* specName, 
 				     const std::vector<float>& measurements, 
-				     std::string gsfClass) 
+				     const std::string& gsfClass)  const
 {
   float bareProb=1.;
   float priorWeight=1.;
   std::vector<LikelihoodSpecies*>::const_iterator specItr;
   for(specItr=_specList.begin();specItr!=_specList.end();specItr++) {
-    LikelihoodSpecies* species = *specItr;
+    const LikelihoodSpecies* species = *specItr;
     if(strcmp(species->getName(),specName)==0) {
       for(unsigned int ipdf=0; ipdf< species->getListOfPdfs().size(); ipdf++) {
-        bareProb*=species->getListOfPdfs().at(ipdf)->getVal(measurements.at(ipdf),gsfClass);
+        bareProb*=species->getListOfPdfs()[ipdf]->getVal(measurements.at(ipdf),gsfClass);
       }
       priorWeight=species->getPrior();
       break;

--- a/RecoEgamma/ElectronIdentification/src/LikelihoodSpecies.cc
+++ b/RecoEgamma/ElectronIdentification/src/LikelihoodSpecies.cc
@@ -6,7 +6,7 @@ LikelihoodSpecies::LikelihoodSpecies(const char* name, float prior) {
 }
 
 LikelihoodSpecies::~LikelihoodSpecies() {
-  std::vector<LikelihoodPdf*>::iterator pdfItr;
+  std::vector<const LikelihoodPdf*>::iterator pdfItr;
   for(pdfItr=_pdfList.begin(); pdfItr!=_pdfList.end(); pdfItr++) {
     delete *pdfItr;
   }
@@ -16,7 +16,7 @@ void LikelihoodSpecies::setName(const char* name) {
   _name = std::string(name);
 }
 
-void LikelihoodSpecies::addPdf(LikelihoodPdf* pdf) {
+void LikelihoodSpecies::addPdf(const LikelihoodPdf* pdf) {
   _pdfList.push_back(pdf);
 }
 
@@ -28,19 +28,19 @@ void LikelihoodSpecies::setSplitFraction(std::pair<std::string,float> splitfrac)
   _splitFractions.insert(splitfrac);
 }
 
-std::vector<LikelihoodPdf*> LikelihoodSpecies::getListOfPdfs() {
+std::vector<const LikelihoodPdf*> const& LikelihoodSpecies::getListOfPdfs() const {
   return _pdfList;
 }
 
-const char* LikelihoodSpecies::getName() {
+const char* LikelihoodSpecies::getName() const {
   return _name.c_str();
 }
 
-float LikelihoodSpecies::getPrior() {
+float LikelihoodSpecies::getPrior() const {
   return _prior;
 }
 
-std::map<std::string,float> LikelihoodSpecies::getSplitFractions() {
+std::map<std::string,float> const& LikelihoodSpecies::getSplitFractions() const {
   return _splitFractions;
 }
 


### PR DESCRIPTION
Fixed const correctness problems with object directly and indirectly
held by ElectronLikelihood. Then enforced that only const functions
of the direct and indirect objects are called from const member functions
of ElectronLikelihood. This guarantees thread-safety.
