### PR TITLE
Thread safety issues

### DIFF
--- a/MagneticField/Engine/interface/MagneticField.h
+++ b/MagneticField/Engine/interface/MagneticField.h
@@ -59,7 +59,7 @@ private:
   //nominal field value 
   virtual int computeNominalValue() const;
   mutable std::atomic<char> nominalValueCompiuted;
-  mutable int theNominalValue;
+  [[cms::thread_guard("nominalValueCompiuted")]] mutable int theNominalValue;
   enum FooStates {kUnset, kSetting, kSet};
 };
 


### PR DESCRIPTION
Mark mutable so static analyzer knows it is protected
by atomic.  Fix thread safety issue in the copy constructor.
Use default memory behavior in the atomic functions.
