### PR TITLE
Restore chunk lost in git merge error

### DIFF
--- a/CondCore/ORA/interface/Object.h
+++ b/CondCore/ORA/interface/Object.h
@@ -13,6 +13,9 @@ namespace ora {
   class Object {
     public:
     Object();
+    template <typename T>
+    explicit Object( const T& obj );
+    Object( const void* ptr, const std::type_info& typeInfo );
     Object( const void* ptr, const edm::TypeWithDict& type );
     Object( const void* ptr, const std::string& typeName );
     Object( const Object& rhs);


### PR DESCRIPTION
When the latest changes in 7_1_X were merged into 7_1_ROOT6_X, one chunk of code in CondCore/ORA/interface/Object.h was mysteriously dropped, causing numerous (119) compilation errors.
This very urgent pull request restores the dropped chunk and fixes most, if not all, of the compilation errors.
Please merge immediately.
