### PR TITLE
Remove getEngine() function from random service

### DIFF
--- a/FWCore/Utilities/interface/RandomNumberGenerator.h
+++ b/FWCore/Utilities/interface/RandomNumberGenerator.h
@@ -151,22 +151,24 @@ namespace edm {
 
     /// Use the next 2 functions to get the random number engine.
     /// These are the only functions most modules should call.
+
     /// Use this engine in event methods
     virtual CLHEP::HepRandomEngine& getEngine(StreamID const&) const = 0;
+
     /// Use this engine in the global begin luminosity block method
     virtual CLHEP::HepRandomEngine& getEngine(LuminosityBlockIndex const&) const = 0;
 
-    /// THIS IS DEPRECATED AND WILL BE DELETED SOON. IT ALWAYS RETURNS THE ENGINE
-    /// FOR ALL STREAMS and will result in data races if used with multiple threads
-    /// and streams. "One" type modules can use it without data races, but even then
-    /// replay will be broken. Multiple forked processes will not work properly either.
-    virtual CLHEP::HepRandomEngine& getEngine() const = 0;
-
-    /// This returns the first seed from the configuration. In general this is not needed
-    /// but is available for backward compatibility and debugging. Note that use of
-    /// this to seed engines constructed in modules is not recommended and unless done
-    /// carefully will create duplicate sequences in different threads and/or data races.
-    /// THIS MAY ALSO BE DELETED AT SOME POINT.
+    /// This returns the seed from the configuration. In the unusual case where an
+    /// an engine type takes multiple seeds to initialize a sequence, this function
+    /// only returns the first. As a general rule, this function should not be used,
+    /// but is available for backward compatibility and debugging. It might be useful
+    /// for some types of tests. Using this to seed engines constructed in modules is
+    /// not recommended because (unless done very carefully) it will create duplicate
+    /// sequences in different threads and/or data races. Also, if engines are created
+    /// by modules the replay mechanism will be broken.
+    /// Because it is dangerous and could be misused, this function might be deleted
+    /// someday if we ever find time to delete all uses of it in CMSSW. There are of
+    /// order 10 last time I checked ...
     virtual std::uint32_t mySeed() const = 0;
 
     // The following functions should not be used by general users.  They

--- a/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
+++ b/IOMC/RandomEngine/src/RandomNumberGeneratorService.cc
@@ -56,8 +56,8 @@ namespace edm {
     const std::uint32_t RandomNumberGeneratorService::maxSeedHepJames =  900000000U;
     const std::uint32_t RandomNumberGeneratorService::maxSeedTRandom3 = 4294967295U;
 
-    // This supports the no argument getEngine function and the mySeed function
-    // DELETE THIS WHEN/IF both those functions are deleted.
+    // This supports the mySeed function
+    // DELETE THIS WHEN/IF that functions is deleted.
     thread_local std::string RandomNumberGeneratorService::moduleLabel_;
 
     RandomNumberGeneratorService::RandomNumberGeneratorService(ParameterSet const& pset,
@@ -202,41 +202,8 @@ namespace edm {
         activityRegistry.watchPostModuleStreamEndLumi(this, &RandomNumberGeneratorService::postModuleStreamEndLumi);
       }
 
-      // The following for loop and the code it contains support the no argument getEngine function
-      // DELETE IT when/if that function is deleted.
-      for(auto const& i : seedsAndNameMap_) {
-        std::string const& label = i.first;
-        std::string const& name = i.second.engineName();
-        VUint32 const& seeds = i.second.seeds();
-
-        if(name == "RanecuEngine") {
-          std::shared_ptr<CLHEP::HepRandomEngine> engine(new CLHEP::RanecuEngine());
-          long int seedL[2];
-          seedL[0] = static_cast<long int>(seeds[0]);
-          seedL[1] = static_cast<long int>(seeds[1]);
-          engine->setSeeds(seedL,0);
-          oldEngineMap_[label] = engine;
-        }
-        // For the other engines, one seed is required
-        else {
-          long int seedL = static_cast<long int>(seeds[0]);
-
-          if(name == "HepJamesRandom") {
-            std::shared_ptr<CLHEP::HepRandomEngine> engine(new CLHEP::HepJamesRandom(seedL));
-            oldEngineMap_[label] = engine;
-          } else { // TRandom3, currently the only other possibility
-
-            std::uint32_t seedu32 = static_cast<std::uint32_t>(seedL);
-            assert(seeds[0] == seedu32);
-
-            std::shared_ptr<CLHEP::HepRandomEngine> engine(new TRandomAdaptor(seedL));
-            oldEngineMap_[label] = engine;
-          }
-        }
-      }
-
-      // The next 5 lines support the no argument getEngine function and the mySeed function
-      // DELETE THEM when/if both functions are deleted.
+      // The next 5 lines support the mySeed function
+      // DELETE THEM when/if that function is deleted.
       activityRegistry.watchPostModuleConstruction(this, &RandomNumberGeneratorService::postModuleConstruction);
       activityRegistry.watchPreModuleBeginJob(this, &RandomNumberGeneratorService::preModuleBeginJob);
       activityRegistry.watchPostModuleBeginJob(this, &RandomNumberGeneratorService::postModuleBeginJob);
@@ -321,45 +288,6 @@ namespace edm {
       return *iter->labelAndEngine()->engine();
     }
 
-    // TO BE DELETED, THIS CAN ONLY BE USED WITH TYPE "ONE" MODULES.
-    // REPLAY DOES NOT WORK WITH THIS VERSION OF GETENGINE.
-    CLHEP::HepRandomEngine&
-    RandomNumberGeneratorService::getEngine() const {
-      std::string label;
-      ModuleCallingContext const* mcc = CurrentModuleOnThread::getCurrentModuleOnThread();
-      if(mcc == nullptr) {
-        if(!moduleLabel_.empty()) {
-          label = moduleLabel_;
-        }
-        else {
-          throw Exception(errors::LogicError)
-            << "RandomNumberGeneratorService::getEngine()\n"
-               "Requested a random number engine from the RandomNumberGeneratorService\n"
-               "when no module was active. ModuleCallingContext is null\n";
-        }
-      } else {
-        label = mcc->moduleDescription()->moduleLabel();
-      }
-      std::map<std::string, std::shared_ptr<CLHEP::HepRandomEngine> >::const_iterator iter = oldEngineMap_.find(label);
-      if(iter == oldEngineMap_.end()) {
-        throw Exception(errors::Configuration)
-          << "The module with label \""
-          << label
-          << "\" requested a random number engine from the \n"
-             "RandomNumberGeneratorService, but that module was not configured\n"
-             "for random numbers.  An engine is created only if a seed(s) is provided\n"
-             "in the configuration file.  Please add the following PSet to the\n"
-             "configuration file for the RandomNumberGeneratorService:\n\n"
-             "  " << label << " = cms.PSet(\n"
-             "    initialSeed = cms.untracked.uint32(your_seed),\n"
-             "    engineName = cms.untracked.string('TRandom3')\n"
-             "  )\n"
-             "where you replace \"your_seed\" with a number and add a comma if necessary\n"
-            "The \"engineName\" parameter is optional. If absent the default is \"HepJamesRandom\".\n";
-      }
-      return *iter->second;
-    }
-
     // PROBABLY TO BE DELETED, This returns the configured seed without
     // any of the modifications for streams, forking, or the offset configuration
     // parameter. Maybe useful to use for debugging/checks, but dangerous if one tries
@@ -438,13 +366,13 @@ namespace edm {
       if(iter != seedsAndNameMap_.end()) {
         iter->second.setModuleID(description.id());
       }
-      // The next line supports the no argument getEngine function and the mySeed function
-      // DELETE IT when/if both functions are deleted.
+      // The next line supports the mySeed function
+      // DELETE IT when/if that function is deleted.
       moduleLabel_ = description.moduleLabel();
     }
 
-    // The next 5 functions support the no argument getEngine function and the mySeed function
-    // DELETE THEM when/if both functions are deleted.
+    // The next 5 functions support the mySeed function
+    // DELETE THEM when/if that function is deleted.
     void
     RandomNumberGeneratorService::postModuleConstruction(ModuleDescription const& description) {
       moduleLabel_.clear();

--- a/IOMC/RandomEngine/test/TestRandomNumberServiceAnalyzer.cc
+++ b/IOMC/RandomEngine/test/TestRandomNumberServiceAnalyzer.cc
@@ -93,11 +93,6 @@ TestRandomNumberServiceAnalyzer::~TestRandomNumberServiceAnalyzer() {
 void
 TestRandomNumberServiceAnalyzer::analyze(edm::Event const& iEvent, edm::EventSetup const&) {
 
-  edm::Service<edm::RandomNumberGenerator> rng;
-  if(rng->getEngine(iEvent.streamID()).name() !="RanecuEngine") {
-    assert(static_cast<long>(rng->mySeed())==rng->getEngine(iEvent.streamID()).getSeed());
-  }
-
   // Add some sleep for the different child processes in attempt
   // to ensure all the child processes get events to process.
   if(multiprocess_) {

--- a/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
+++ b/IOMC/RandomEngine/test/TestRandomNumberServiceGlobal.cc
@@ -167,7 +167,6 @@ TestRandomNumberServiceGlobal::TestRandomNumberServiceGlobal(edm::ParameterSet c
   if(dump_) {
     edm::Service<edm::RandomNumberGenerator> rng;
     std::cout << "*** TestRandomNumberServiceGlobal constructor " << rng->mySeed() << "\n";
-    std::cout << rng->getEngine().name() << "\n";
   }
 }
 
@@ -185,7 +184,7 @@ TestRandomNumberServiceGlobal::analyze(edm::StreamID streamID, edm::Event const&
   if(dump_) {
     edm::Service<edm::RandomNumberGenerator> rng;
     std::cout << "*** TestRandomNumberServiceGlobal analyze " << rng->mySeed() << "\n";
-    std::cout << rng->getEngine().name() << "\n";
+    std::cout << rng->getEngine(streamID).name() << "\n";
   }
 
   TestRandomNumberServiceStreamCache* cache = streamCache(streamID);
@@ -287,7 +286,6 @@ void TestRandomNumberServiceGlobal::beginJob() {
   if(dump_) {
     edm::Service<edm::RandomNumberGenerator> rng;
     std::cout << "*** TestRandomNumberServiceGlobal beginJob " << rng->mySeed() << "\n";
-    std::cout << rng->getEngine().name() << "\n";
   }
 }
 
@@ -295,7 +293,6 @@ void TestRandomNumberServiceGlobal::endJob() {
   if(dump_) {
     edm::Service<edm::RandomNumberGenerator> rng;
     std::cout << "*** TestRandomNumberServiceGlobal endJob " << rng->mySeed() << "\n";
-    std::cout << rng->getEngine().name() << "\n";
   }
 }
 
@@ -306,7 +303,7 @@ TestRandomNumberServiceGlobal::globalBeginLuminosityBlock(edm::LuminosityBlock c
   if(dump_) {
     edm::Service<edm::RandomNumberGenerator> rng;
     std::cout << "*** TestRandomNumberServiceGlobal beginLuminosityBlock " << rng->mySeed() << "\n";
-    std::cout << rng->getEngine().name() << "\n";
+    std::cout << rng->getEngine(lumi.index()).name() << "\n";
   }
 
   std::shared_ptr<TestRandomNumberServiceLumiCache> lumiCache(new TestRandomNumberServiceLumiCache);

--- a/IOMC/RandomEngine/test/unit_test_outputs/testRandomService1Dump.txt
+++ b/IOMC/RandomEngine/test/unit_test_outputs/testRandomService1Dump.txt
@@ -1,5 +1,4 @@
 *** TestRandomNumberServiceGlobal constructor 83
-TRandom3
 
 
 RandomNumberGeneratorService dump
@@ -35,7 +34,6 @@ RandomNumberGeneratorService dump
         t3 84 TRandom3  engine does not know seeds
         t4 85 HepJamesRandom  85
 *** TestRandomNumberServiceGlobal beginJob 83
-TRandom3
 *** TestRandomNumberServiceGlobal beginLuminosityBlock 83
 TRandom3
 *** TestRandomNumberServiceGlobal analyze 83
@@ -51,4 +49,3 @@ TRandom3
 *** TestRandomNumberServiceGlobal analyze 83
 TRandom3
 *** TestRandomNumberServiceGlobal endJob 83
-TRandom3


### PR DESCRIPTION
In the random number generator service, remove the
getEngine function which takes no arguments. This function
is replaced by new getEngine functions that take either
a StreamID or a LuminosityBlockIndex as an argument. This
comes after a long migration of all clients to the new
interface. The new interace is designed to work with
the multithreaded Framework.

(Note that this also fixes a compilation error that resulted
after a similar pull request was automatically merged from
7_1_X)
