### PR TITLE
Fix another git merge error

### DIFF
--- a/CondCore/ORA/src/Object.cc
+++ b/CondCore/ORA/src/Object.cc
@@ -9,6 +9,11 @@ ora::Object::Object():
   m_type(){
 }
 
+ora::Object::Object( const void* ptr, const std::type_info& typeInfo ):
+  m_ptr( const_cast<void*>(ptr) ){
+  m_type = ClassUtils::lookupDictionary( typeInfo, true );
+}
+
 ora::Object::Object( const void* ptr, const edm::TypeWithDict& type ):
   m_ptr( const_cast<void*>(ptr) ),
   m_type( type ){  


### PR DESCRIPTION
The  ROOT6 IB CMSSW_7_1_ROOT6_X_2014-03-12-0200 had numerous compilation errors due to a git merge error in a header file that led to a missing declaration.  That was fixed, but the corresponding definition in the source file was also dropped by git, now causing numerous link errors in ROOT6 IB CMSSW_7_1_ROOT6_X_2014-03-12-1400.  This pull request adds the missing chunk to the source file, thereby fixing most, if not all, of the link errors.
Please merge immediately.
