### PR TITLE
Have GeometricDet::bounds() return std::unique_ptr<Bounds>

### DIFF
--- a/Geometry/TrackerGeometryBuilder/src/PlaneBuilderFromGeometricDet.cc
+++ b/Geometry/TrackerGeometryBuilder/src/PlaneBuilderFromGeometricDet.cc
@@ -22,7 +22,7 @@
 
 PlaneBuilderFromGeometricDet::ResultType PlaneBuilderFromGeometricDet::plane(const GeometricDet* gd) const {
    // gd->bounds() returns a pointer owned by the caller!                                                  
-  return ResultType( new Plane( gd->positionBounds(), gd->rotationBounds(), gd->bounds())); 
+  return ResultType( new Plane( gd->positionBounds(), gd->rotationBounds(), gd->bounds().release())); 
 }	      
 
 

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeomBuilderFromGeometricDet.cc
@@ -100,7 +100,7 @@ void TrackerGeomBuilderFromGeometricDet::buildPixel(std::vector<const GeometricD
 
     std::string const & detName = gdv[i]->name().fullname();
     if (thePixelDetTypeMap.find(detName) == thePixelDetTypeMap.end()) {
-      std::auto_ptr<const Bounds> bounds(gdv[i]->bounds());
+      std::unique_ptr<const Bounds> bounds(gdv[i]->bounds());
       
       PixelTopology* t = 
 	  PixelTopologyBuilder().build(&*bounds,
@@ -136,7 +136,7 @@ void TrackerGeomBuilderFromGeometricDet::buildSilicon(std::vector<const Geometri
 
     std::string const & detName = gdv[i]->name().fullname();
     if (theStripDetTypeMap.find(detName) == theStripDetTypeMap.end()) {
-       std::auto_ptr<const Bounds> bounds(gdv[i]->bounds());
+       std::unique_ptr<const Bounds> bounds(gdv[i]->bounds());
        StripTopology* t =
 	   StripTopologyBuilder().build(&*bounds,
 				       gdv[i]->siliconAPVNum(),

--- a/Geometry/TrackerNumberingBuilder/interface/GeometricDet.h
+++ b/Geometry/TrackerNumberingBuilder/interface/GeometricDet.h
@@ -11,6 +11,7 @@
 #include "DataFormats/DetId/interface/DetId.h"
 
 #include <vector>
+#include <memory>
 #include "FWCore/ParameterSet/interface/types.h"
 
 #include <ext/pool_allocator.h>
@@ -219,7 +220,7 @@ class GeometricDet {
   /**
    *bounds() returns the Bounds.
    */
-   Bounds * bounds() const; 
+  std::unique_ptr<Bounds> bounds() const; 
 #ifdef GEOMETRICDETDEBUG
   int copyno() const {
     //std::cout<<"copyno"<<std::endl;

--- a/Geometry/TrackerNumberingBuilder/src/GeometricDet.cc
+++ b/Geometry/TrackerNumberingBuilder/src/GeometricDet.cc
@@ -335,10 +335,10 @@ GeometricDet::Rotation GeometricDet::rotationBounds() const{
   return _rotation;
 }
 
-Bounds * GeometricDet::bounds() const{
+std::unique_ptr<Bounds> GeometricDet::bounds() const{
   //std::cout << "bounds" << std::endl;
   const std::vector<double>& par = _params;
   TrackerShapeToBounds shapeToBounds;
-  return shapeToBounds.buildBounds(_shape,par);
+  return std::unique_ptr<Bounds>(shapeToBounds.buildBounds(_shape,par));
 }
 


### PR DESCRIPTION
Before GeometricDet::bounds() returned a pointer to a new'ed Bounds.
However, returning a non-const pointer from a const function can make
the static analyzer think there is a threading problem. By switching
to returning a std::unique_ptr<Bounds> by value, the static analyzer
no longer complains and it makes callers of the routine take explicit
ownership of the pointer (which they should have done all along).
There were only minor changes to other code to deal with this change.
