### PR TITLE
Force boost spirit to be thread-safe

### DIFF
--- a/CommonTools/Utils/BuildFile.xml
+++ b/CommonTools/Utils/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="FWCore/Utilities"/>
-<use   name="boost"/>
+<use   name="boost_header"/>
 <use   name="roothistmatrix"/>
 <use   name="roottmva"/>
 <export>

--- a/CommonTools/Utils/src/Grammar.h
+++ b/CommonTools/Utils/src/Grammar.h
@@ -10,6 +10,10 @@
  * \version $Revision: 1.13 $
  *
  */
+
+#define BOOST_SPIRIT_THREADSAFE 1
+#define PHOENIX_THREADSAFE 1
+
 #include "boost/spirit/include/classic_core.hpp"
 #include "boost/spirit/include/classic_grammar_def.hpp"
 #include "boost/spirit/include/classic_chset.hpp"


### PR DESCRIPTION
It appears that in order for parsers based on boost spirit to be
thread-safe one has to set specific CPP defines. This change sets
those defines (based on how parts of boost which use spirit set
it to be thread-safe).
