### PR TITLE
setNewRun() and setNewLumi() should work always

### DIFF
--- a/FWCore/Sources/src/ProducerSourceBase.cc
+++ b/FWCore/Sources/src/ProducerSourceBase.cc
@@ -148,7 +148,7 @@ namespace edm {
     }
     bool newFile = (fileIndex() > index);
     setEventCached();
-    if(eventID_.run() != oldEventID.run()) {
+    if(newRun() || eventID_.run() != oldEventID.run()) {
       // New Run
       setNewRun();
       setNewLumi();
@@ -161,7 +161,7 @@ namespace edm {
       return newFile ? IsFile : IsLumi;
     }
     // Same Run
-    if (eventID_.luminosityBlock() != oldEventID.luminosityBlock()) {
+    if (newLumi() || eventID_.luminosityBlock() != oldEventID.luminosityBlock()) {
       // New Lumi
       setNewLumi();
       return newFile ? IsFile : IsLumi;


### PR DESCRIPTION
The classes ProducerSourceBase and ProducerSourceFiles provide a setNewRun call and a setNewLumi call
for input sources derived from these classes to indicate a new run or lumi.  However, these calls do not work if called from setRunAndLumiInfo(), unless the run or lumi number changed, in which case the call is not needed.
This pull request ensures that a call to setNewRun() or setNewLumi() will cause a new run or new lumi transition.
This fix is needed by LHESource to process LHE input files with different headers in the same job.
This pull request needs normal testing and signature requirements.
