### PR TITLE
Implement configurable DT hit uncertainties from DB

### DIFF
--- a/CalibMuon/DTCalibration/test/DBTools/DumpDBToFile.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpDBToFile.cc
@@ -26,9 +26,13 @@
 #include "CondFormats/DTObjects/interface/DTDeadFlag.h"
 #include "CondFormats/DataRecord/interface/DTReadOutMappingRcd.h"
 #include "CondFormats/DTObjects/interface/DTReadOutMapping.h"
+#include "CondFormats/DataRecord/interface/DTRecoUncertaintiesRcd.h"
+#include "CondFormats/DTObjects/interface/DTRecoUncertainties.h"
 
 #include <iostream>
 #include <fstream>
+#include <algorithm>
+#include <iterator>
 
 using namespace edm;
 using namespace std;
@@ -77,6 +81,11 @@ void DumpDBToFile::beginRun(const edm::Run&, const EventSetup& setup) {
     ESHandle<DTReadOutMapping> channels;
     setup.get<DTReadOutMappingRcd>().get(channels);
     channelsMap = &*channels;
+  } else if (dbToDump == "RecoUncertDB") {
+    ESHandle<DTRecoUncertainties> uncerts;
+    setup.get<DTRecoUncertaintiesRcd>().get(uncerts);
+    uncertMap = &*uncerts;
+    
   }
 }
 
@@ -251,7 +260,34 @@ void DumpDBToFile::endJob() {
 	   << "layer "   << roLink->layerId << ' ' 
 	   << "wire "    << roLink->cellId << ' '<<endl;
     }
+  }  else if(dbToDump == "RecoUncertDB") {
+      for(DTRecoUncertainties::const_iterator wireAndUncerts = uncertMap->begin();
+	  wireAndUncerts != uncertMap->end(); wireAndUncerts++) {
+	DTWireId wireId((*wireAndUncerts).first);
+	vector<float> values = (*wireAndUncerts).second;
+	
+	cout << wireId;
+	copy(values.begin(), values.end(), ostream_iterator<char>(cout, " um, "));
+	cout << endl;
+
+	vector<float> consts;
+	consts.push_back(-1);
+	consts.push_back(-1);
+	consts.push_back(-1);
+	consts.push_back(-1);
+	consts.push_back(-1);
+	consts.push_back(-9999999);      
+	consts.push_back(-9999999);
+	consts.push_back(-1);
+	consts.insert(consts.end(), values.begin(), values.end());
+
+	theCalibFile->addCell(wireId, consts);
+	
+      } 
+    //Write constants into file
+    theCalibFile->writeConsts(theOutputFileName);
   }
+
 
 }
 

--- a/CalibMuon/DTCalibration/test/DBTools/DumpDBToFile.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpDBToFile.cc
@@ -228,7 +228,7 @@ void DumpDBToFile::endJob() {
 	theCalibFile->addCell(wireId, consts);
       }
     } else if(dbToDump == "RecoUncertDB") {
-      cout << "RecoUncertDB type: " << uncertMap->type() << endl;
+      cout << "RecoUncertDB version: " << uncertMap->version() << endl;
       for(DTRecoUncertainties::const_iterator wireAndUncerts = uncertMap->begin();
 	  wireAndUncerts != uncertMap->end(); wireAndUncerts++) {
 	DTWireId wireId((*wireAndUncerts).first);

--- a/CalibMuon/DTCalibration/test/DBTools/DumpDBToFile.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpDBToFile.cc
@@ -45,7 +45,7 @@ DumpDBToFile::DumpDBToFile(const ParameterSet& pset) {
   dbLabel  = pset.getUntrackedParameter<string>("dbLabel", "");
 
   if(dbToDump != "VDriftDB" && dbToDump != "TTrigDB" && dbToDump != "TZeroDB" 
-     && dbToDump != "NoiseDB" && dbToDump != "DeadDB" && dbToDump != "ChannelsDB")
+     && dbToDump != "NoiseDB" && dbToDump != "DeadDB" && dbToDump != "ChannelsDB" && dbToDump != "RecoUncertDB")
     cout << "[DumpDBToFile] *** Error: parameter dbToDump is not valid, check the cfg file" << endl;
 }
 
@@ -227,7 +227,31 @@ void DumpDBToFile::endJob() {
 
 	theCalibFile->addCell(wireId, consts);
       }
-    } 
+    } else if(dbToDump == "RecoUncertDB") {
+      cout << "RecoUncertDB type: " << uncertMap->type() << endl;
+      for(DTRecoUncertainties::const_iterator wireAndUncerts = uncertMap->begin();
+	  wireAndUncerts != uncertMap->end(); wireAndUncerts++) {
+	DTWireId wireId((*wireAndUncerts).first);
+	vector<float> values = (*wireAndUncerts).second;
+	
+	cout << wireId;
+	copy(values.begin(), values.end(), ostream_iterator<float>(cout, " cm, "));
+	cout << endl;
+
+	vector<float> consts;
+	consts.push_back(-1);
+	consts.push_back(-1);
+	consts.push_back(-1);
+	consts.push_back(-1);
+	consts.push_back(-1);
+	consts.push_back(-9999999);      
+	consts.push_back(-9999999);
+	consts.push_back(-1);
+	consts.insert(consts.end(), values.begin(), values.end());
+
+	theCalibFile->addCell(wireId, consts);
+      }
+    }
     //Write constants into file
     theCalibFile->writeConsts(theOutputFileName);
   }
@@ -260,32 +284,6 @@ void DumpDBToFile::endJob() {
 	   << "layer "   << roLink->layerId << ' ' 
 	   << "wire "    << roLink->cellId << ' '<<endl;
     }
-  }  else if(dbToDump == "RecoUncertDB") {
-      for(DTRecoUncertainties::const_iterator wireAndUncerts = uncertMap->begin();
-	  wireAndUncerts != uncertMap->end(); wireAndUncerts++) {
-	DTWireId wireId((*wireAndUncerts).first);
-	vector<float> values = (*wireAndUncerts).second;
-	
-	cout << wireId;
-	copy(values.begin(), values.end(), ostream_iterator<char>(cout, " um, "));
-	cout << endl;
-
-	vector<float> consts;
-	consts.push_back(-1);
-	consts.push_back(-1);
-	consts.push_back(-1);
-	consts.push_back(-1);
-	consts.push_back(-1);
-	consts.push_back(-9999999);      
-	consts.push_back(-9999999);
-	consts.push_back(-1);
-	consts.insert(consts.end(), values.begin(), values.end());
-
-	theCalibFile->addCell(wireId, consts);
-	
-      } 
-    //Write constants into file
-    theCalibFile->writeConsts(theOutputFileName);
   }
 
 

--- a/CalibMuon/DTCalibration/test/DBTools/DumpDBToFile.h
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpDBToFile.h
@@ -21,6 +21,7 @@ class DTStatusFlag;
 class DTDeadFlag;
 class DTCalibrationMap;
 class DTReadOutMapping;
+class DTRecoUncertainties;
 
 class DumpDBToFile : public edm::EDAnalyzer {
 public:
@@ -46,6 +47,7 @@ private:
   const DTStatusFlag *statusMap;
   const DTDeadFlag *deadMap;
   const DTReadOutMapping *channelsMap;
+  const DTRecoUncertainties *uncertMap;
 
   DTCalibrationMap *theCalibFile;
 

--- a/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.cc
@@ -243,8 +243,8 @@ void DumpFileToDB::endJob() {
     // Create the object to be written to DB
     DTRecoUncertainties* uncert = new DTRecoUncertainties();
 
-    // FIXME: should come from the configuration
-    uncert->setType("uniform2steps");
+    // FIXME: should come from the configuration; to be changed whenever a new schema for values is introduced.
+    uncert->setType("uniformPerStep"); // Uniform uncertainties per SL and step; parameters 0-3 are for steps 1-4.
 
     // Loop over file entries
     for(DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();

--- a/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.cc
@@ -243,22 +243,22 @@ void DumpFileToDB::endJob() {
     // Create the object to be written to DB
     DTRecoUncertainties* uncert = new DTRecoUncertainties();
 
+    // FIXME: should come from the configuration
+    uncert->setType("uniform2steps");
+
     // Loop over file entries
     for(DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
 	keyAndCalibs != theCalibFile->keyAndConsts_end();
 	++keyAndCalibs) {
 
-      DTSuperLayerId slId = (*keyAndCalibs).first.superlayerId();
+      //DTSuperLayerId slId = (*keyAndCalibs).first.superlayerId();
       
       vector<float> values = (*keyAndCalibs).second;
 
-      cout << "key: " << slId;
-      int others = 8; // the first 8 positions in the map are already allocated to other DT conditions
-      for(int index = 0; index <=4; ++index) {
-	float value = values[index+others];
-	cout << " step: " << index << " value " << value << " cm ";
-	uncert->set((*keyAndCalibs).first, (DTRecoUncertainties::Type)index, value);
-      }
+      vector<float> uncerts(values.begin()+8, values.end());
+
+      uncert->set((*keyAndCalibs).first, uncerts);
+
       cout << endl;
       
 

--- a/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.cc
@@ -244,7 +244,7 @@ void DumpFileToDB::endJob() {
     DTRecoUncertainties* uncert = new DTRecoUncertainties();
 
     // FIXME: should come from the configuration; to be changed whenever a new schema for values is introduced.
-    uncert->setType("uniformPerStep"); // Uniform uncertainties per SL and step; parameters 0-3 are for steps 1-4.
+    uncert->setVersion(1); // Uniform uncertainties per SL and step; parameters 0-3 are for steps 1-4.
 
     // Loop over file entries
     for(DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();

--- a/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.cc
+++ b/CalibMuon/DTCalibration/test/DBTools/DumpFileToDB.cc
@@ -23,7 +23,7 @@
 #include "CondFormats/DTObjects/interface/DTStatusFlag.h"
 #include "CondFormats/DTObjects/interface/DTDeadFlag.h"
 #include "CondFormats/DTObjects/interface/DTReadOutMapping.h"
-
+#include "CondFormats/DTObjects/interface/DTRecoUncertainties.h"
 #include "CalibMuon/DTCalibration/interface/DTCalibDBUtils.h"
 
 using namespace edm;
@@ -38,8 +38,13 @@ DumpFileToDB::DumpFileToDB(const ParameterSet& pset) {
 
   mapFileName = pset.getUntrackedParameter<ParameterSet>("calibFileConfig").getUntrackedParameter<string>("calibConstFileName", "dummy.txt");
 
-  if(dbToDump != "VDriftDB" && dbToDump != "TTrigDB" && dbToDump != "TZeroDB" && 
-     dbToDump != "NoiseDB" && dbToDump != "DeadDB" && dbToDump != "ChannelsDB")
+  if(dbToDump != "VDriftDB" &&
+     dbToDump != "TTrigDB" &&
+     dbToDump != "TZeroDB" && 
+     dbToDump != "NoiseDB" &&
+     dbToDump != "DeadDB" &&
+     dbToDump != "ChannelsDB" &&
+     dbToDump != "RecoUncertDB")
     cout << "[DumpFileToDB] *** Error: parameter dbToDump is not valid, check the cfg file" << endl;
 
   diffMode = pset.getUntrackedParameter<bool>("differentialMode", false);
@@ -233,11 +238,42 @@ void DumpFileToDB::endJob() {
     }
     string record = "DTReadOutMappingRcd";
     DTCalibDBUtils::writeToDB<DTReadOutMapping>(record, ro_map);
+  } else if(dbToDump == "RecoUncertDB") { // Write the Uncertainties
+
+    // Create the object to be written to DB
+    DTRecoUncertainties* uncert = new DTRecoUncertainties();
+
+    // Loop over file entries
+    for(DTCalibrationMap::const_iterator keyAndCalibs = theCalibFile->keyAndConsts_begin();
+	keyAndCalibs != theCalibFile->keyAndConsts_end();
+	++keyAndCalibs) {
+
+      DTSuperLayerId slId = (*keyAndCalibs).first.superlayerId();
+      
+      vector<float> values = (*keyAndCalibs).second;
+
+      cout << "key: " << slId;
+      int others = 8; // the first 8 positions in the map are already allocated to other DT conditions
+      for(int index = 0; index <=4; ++index) {
+	float value = values[index+others];
+	cout << " step: " << index << " value " << value << " cm ";
+	uncert->set((*keyAndCalibs).first, (DTRecoUncertainties::Type)index, value);
+      }
+      cout << endl;
+      
+
+    }
+
+    cout << "[DumpFileToDB]Writing RecoUncertainties object to DB!" << endl;
+    string record = "DTRecoUncertaintiesRcd";
+    DTCalibDBUtils::writeToDB<DTRecoUncertainties>(record, uncert);
   }
 }
 
+
+
   
-vector <int> DumpFileToDB::readChannelsMap (stringstream &linestr){
+vector <int> DumpFileToDB::readChannelsMap (stringstream &linestr) {
   //The hardware channel
   int ddu_id = 0;
   int ros_id = 0;

--- a/CondCore/DTPlugins/src/plugin.cc
+++ b/CondCore/DTPlugins/src/plugin.cc
@@ -38,7 +38,8 @@
 #include "CondFormats/DataRecord/interface/DTLVStatusRcd.h"
 #include "CondFormats/Common/interface/BaseKeyed.h"
 #include "CondCore/CondDB/interface/KeyListProxy.h"
-
+#include "CondFormats/DTObjects/interface/DTRecoUncertainties.h"
+#include "CondFormats/DataRecord/interface/DTRecoUncertaintiesRcd.h"
 
 //
 #include "CondCore/CondDB/interface/Serialization.h"
@@ -68,6 +69,7 @@ REGISTER_PLUGIN(DTHVStatusRcd,DTHVStatus);
 REGISTER_PLUGIN(DTLVStatusRcd,DTLVStatus);
 REGISTER_PLUGIN(DTKeyedConfigContainerRcd, cond::BaseKeyed);
 REGISTER_KEYLIST_PLUGIN(DTKeyedConfigListRcd,cond::persistency::KeyList,DTKeyedConfigContainerRcd);
+REGISTER_PLUGIN(DTRecoUncertaintiesRcd, DTRecoUncertainties);
 
 
 

--- a/CondFormats/DTObjects/interface/DTRecoUncertainties.h
+++ b/CondFormats/DTObjects/interface/DTRecoUncertainties.h
@@ -40,6 +40,12 @@ public:
   void set(const DTWireId& wireid, const std::vector<float>& values);
   
 
+
+  /// Access methods to data
+  typedef std::map<uint32_t, std::vector<float> >::const_iterator const_iterator;
+  const_iterator begin() const;
+  const_iterator end() const;
+
 private:
   
   // map of uncertainties per SL Id. The position in the vector is determined by the 

--- a/CondFormats/DTObjects/interface/DTRecoUncertainties.h
+++ b/CondFormats/DTObjects/interface/DTRecoUncertainties.h
@@ -25,14 +25,14 @@ public:
   /// Destructor
   virtual ~DTRecoUncertainties();
 
-  void setType(const std::string& tt) {
-    theType = tt;
-  };
+  void setVersion(int version) {
+    theVersion = version;
+  }
   
   /// Label specifying the structure of the payload; currently supported:
   /// "uniformPerStep" (uniform uncertainties per SL and step; index 0-3 = uncertainties for steps 1-4 in cm)
-  const std::string& type() const {
-    return theType;
+  int version() const {
+    return theVersion;
   }
 
   /// get the uncertainties for the SL correspoding to the given WireId and for the correct step as defined by the algorithm
@@ -50,11 +50,11 @@ public:
 
 private:
   
-  // map of uncertainties per SL Id. The position in the vector is determined by the 
-  // DTRecoUncertainties::Type as it depends on the Reco algorithm e=being used.
+  // map of uncertainties per SL Id. The position in the vector depends on 
+  // version() as it depends on the Reco algorithm being used.
   std::map<uint32_t, std::vector<float> > payload;
   
-  std::string theType;
+  int theVersion;
 
 };
 #endif

--- a/CondFormats/DTObjects/interface/DTRecoUncertainties.h
+++ b/CondFormats/DTObjects/interface/DTRecoUncertainties.h
@@ -29,7 +29,9 @@ public:
     theType = tt;
   };
   
-  std::string type() const {
+  /// Label specifying the structure of the payload; currently supported:
+  /// "uniformPerStep" (uniform uncertainties per SL and step; index 0-3 = uncertainties for steps 1-4 in cm)
+  const std::string& type() const {
     return theType;
   }
 

--- a/CondFormats/DTObjects/interface/DTRecoUncertainties.h
+++ b/CondFormats/DTObjects/interface/DTRecoUncertainties.h
@@ -12,6 +12,7 @@
 
 #include <map>
 #include <vector>
+#include <string>
 #include <stdint.h>
 
 class DTWireId;
@@ -24,30 +25,28 @@ public:
   /// Destructor
   virtual ~DTRecoUncertainties();
 
-  // Operations
-  enum Type {
-    ldStep1 = 0,
-    ldStep3 = 1
+  void setType(const std::string& tt) {
+    theType = tt;
   };
-
-
+  
+  std::string type() const {
+    return theType;
+  }
 
   /// get the uncertainties for the SL correspoding to the given WireId and for the correct step as defined by the algorithm
-  float get(const DTWireId& wireid, DTRecoUncertainties::Type) const;
+  float get(const DTWireId& wireid, unsigned int index) const;
   
   /// fills the map
-  void set(const DTWireId& wireid, DTRecoUncertainties::Type type, float value);
-
+  void set(const DTWireId& wireid, const std::vector<float>& values);
   
 
 private:
-
-
   
   // map of uncertainties per SL Id. The position in the vector is determined by the 
   // DTRecoUncertainties::Type as it depends on the Reco algorithm e=being used.
   std::map<uint32_t, std::vector<float> > payload;
   
+  std::string theType;
 
 };
 #endif

--- a/CondFormats/DTObjects/interface/DTRecoUncertainties.h
+++ b/CondFormats/DTObjects/interface/DTRecoUncertainties.h
@@ -2,10 +2,8 @@
 #define CondFormats_DTObjects_DTRecoUncertainties_H
 
 /** \class DTRecoUncertainties
- *  No description available.
+ *  DB object for storing DT hit uncertatinties.
  *
- *  $Date: $
- *  $Revision: $
  *  \author G. Cerminara - CERN
  */
 

--- a/CondFormats/DTObjects/interface/DTRecoUncertainties.h
+++ b/CondFormats/DTObjects/interface/DTRecoUncertainties.h
@@ -1,0 +1,54 @@
+#ifndef CondFormats_DTObjects_DTRecoUncertainties_H
+#define CondFormats_DTObjects_DTRecoUncertainties_H
+
+/** \class DTRecoUncertainties
+ *  No description available.
+ *
+ *  $Date: $
+ *  $Revision: $
+ *  \author G. Cerminara - CERN
+ */
+
+
+#include <map>
+#include <vector>
+#include <stdint.h>
+
+class DTWireId;
+
+class DTRecoUncertainties {
+public:
+  /// Constructor
+  DTRecoUncertainties();
+
+  /// Destructor
+  virtual ~DTRecoUncertainties();
+
+  // Operations
+  enum Type {
+    ldStep1 = 0,
+    ldStep3 = 1
+  };
+
+
+
+  /// get the uncertainties for the SL correspoding to the given WireId and for the correct step as defined by the algorithm
+  float get(const DTWireId& wireid, DTRecoUncertainties::Type) const;
+  
+  /// fills the map
+  void set(const DTWireId& wireid, DTRecoUncertainties::Type type, float value);
+
+  
+
+private:
+
+
+  
+  // map of uncertainties per SL Id. The position in the vector is determined by the 
+  // DTRecoUncertainties::Type as it depends on the Reco algorithm e=being used.
+  std::map<uint32_t, std::vector<float> > payload;
+  
+
+};
+#endif
+

--- a/CondFormats/DTObjects/src/DTRecoUncertainties.cc
+++ b/CondFormats/DTObjects/src/DTRecoUncertainties.cc
@@ -46,3 +46,10 @@ void DTRecoUncertainties::set(const DTWireId& wireid, const std::vector<float>& 
 }
 
 
+DTRecoUncertainties::const_iterator DTRecoUncertainties::begin() const {
+  return payload.begin();
+}
+
+DTRecoUncertainties::const_iterator DTRecoUncertainties::end() const {
+  return payload.end();
+}

--- a/CondFormats/DTObjects/src/DTRecoUncertainties.cc
+++ b/CondFormats/DTObjects/src/DTRecoUncertainties.cc
@@ -22,7 +22,7 @@ DTRecoUncertainties::DTRecoUncertainties(){}
 DTRecoUncertainties::~DTRecoUncertainties(){}
 
 
-float DTRecoUncertainties::get(const DTWireId& wireid, DTRecoUncertainties::Type type) const {
+float DTRecoUncertainties::get(const DTWireId& wireid, unsigned int index) const {
   // FIXME: what to do in case the superlayerId is not found in the map?
   // FIXME: any check on the type?
   map<uint32_t, vector<float> >::const_iterator slIt = payload.find(wireid.superlayerId().rawId());
@@ -30,28 +30,19 @@ float DTRecoUncertainties::get(const DTWireId& wireid, DTRecoUncertainties::Type
     cout << "[DTRecoUncertainties]***Error: the SLId: " << wireid.superlayerId() << " is not in the paylaod map!" << endl;
     // FIXME: what to do here???
     return -1.;
-  } else if(vector<float>::size_type(type) >= (*slIt).second.size()) {
-    cout << "[DTRecoUncertainties]***Error: requesting parameter index: " << type << " for vector of size " << (*slIt).second.size() << endl;
+  } else if(vector<float>::size_type(index) >= (*slIt).second.size()) {
+    cout << "[DTRecoUncertainties]***Error: requesting parameter index: " << index << " for vector of size " << (*slIt).second.size() << endl;
     // FIXME: what to do here???
     return -1.;
   }
   
 
-  return (*slIt).second[type];
+  return (*slIt).second[index];
 }
-  
-void DTRecoUncertainties::set(const DTWireId& wireid, DTRecoUncertainties::Type type, float value) {
-  map<uint32_t, vector<float> >::iterator slIt = payload.find(wireid.superlayerId().rawId());
-  if(slIt == payload.end()) {
-    // in this case the vector of values needs to be initialized
-    // FIXME: the max numbr of parameters should be coded in the algorithm somehow and not harcoded here!
-    vector<float> slPayload(4, 0.);
-    slPayload[type] = value;
-    payload[wireid.superlayerId().rawId()] = slPayload;
-    
-  } else {
-    (*slIt).second[type] = value;
-  }
+
+
+void DTRecoUncertainties::set(const DTWireId& wireid, const std::vector<float>& values) {
+  payload[wireid.superlayerId()] = values;
 }
 
 

--- a/CondFormats/DTObjects/src/DTRecoUncertainties.cc
+++ b/CondFormats/DTObjects/src/DTRecoUncertainties.cc
@@ -1,0 +1,56 @@
+
+/*
+ *  See header file for a description of this class.
+ *
+ *  $Date: $
+ *  $Revision: $
+ *  \author G. Cerminara - CERN
+ */
+
+#include "CondFormats/DTObjects/interface/DTRecoUncertainties.h"
+#include "DataFormats/MuonDetId/src/DTWireId.cc"
+#include <iostream>
+
+using std::map;
+using std::vector;
+using std::cout;
+using std::endl;
+
+
+DTRecoUncertainties::DTRecoUncertainties(){}
+
+DTRecoUncertainties::~DTRecoUncertainties(){}
+
+
+float DTRecoUncertainties::get(const DTWireId& wireid, DTRecoUncertainties::Type type) const {
+  // FIXME: what to do in case the superlayerId is not found in the map?
+  // FIXME: any check on the type?
+  map<uint32_t, vector<float> >::const_iterator slIt = payload.find(wireid.superlayerId().rawId());
+  if(slIt == payload.end()) {
+    cout << "[DTRecoUncertainties]***Error: the SLId: " << wireid.superlayerId() << " is not in the paylaod map!" << endl;
+    // FIXME: what to do here???
+    return -1.;
+  } else if(vector<float>::size_type(type) >= (*slIt).second.size()) {
+    cout << "[DTRecoUncertainties]***Error: requesting parameter index: " << type << " for vector of size " << (*slIt).second.size() << endl;
+    // FIXME: what to do here???
+    return -1.;
+  }
+  
+  return (*slIt).second[type];
+}
+  
+void DTRecoUncertainties::set(const DTWireId& wireid, DTRecoUncertainties::Type type, float value) {
+  map<uint32_t, vector<float> >::iterator slIt = payload.find(wireid.superlayerId().rawId());
+  if(slIt == payload.end()) {
+    // in this case the vector of values needs to be initialized
+    // FIXME: the max numbr of parameters should be coded in the algorithm somehow and not harcoded here!
+    vector<float> slPayload(4, 0.);
+    slPayload[type] = value;
+    payload[wireid.superlayerId().rawId()] = slPayload;
+    
+  } else {
+    (*slIt).second[type] = value;
+  }
+}
+
+

--- a/CondFormats/DTObjects/src/DTRecoUncertainties.cc
+++ b/CondFormats/DTObjects/src/DTRecoUncertainties.cc
@@ -36,6 +36,7 @@ float DTRecoUncertainties::get(const DTWireId& wireid, DTRecoUncertainties::Type
     return -1.;
   }
   
+
   return (*slIt).second[type];
 }
   

--- a/CondFormats/DTObjects/src/DTRecoUncertainties.cc
+++ b/CondFormats/DTObjects/src/DTRecoUncertainties.cc
@@ -2,8 +2,6 @@
 /*
  *  See header file for a description of this class.
  *
- *  $Date: $
- *  $Revision: $
  *  \author G. Cerminara - CERN
  */
 

--- a/CondFormats/DTObjects/src/T_EventSetup_DTRecoUncertainties.cc
+++ b/CondFormats/DTObjects/src/T_EventSetup_DTRecoUncertainties.cc
@@ -1,0 +1,5 @@
+// user include files
+#include "CondFormats/DTObjects/interface/DTRecoUncertainties.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(DTRecoUncertainties);

--- a/CondFormats/DTObjects/src/classes.h
+++ b/CondFormats/DTObjects/src/classes.h
@@ -75,8 +75,9 @@ namespace CondFormats_DTObjects {
 //    std::vector< std::pair<DTMtimeId,DTMtimeData> > blah4;
 //    std::vector< std::pair<DTStatusFlagId,DTStatusFlagData> > blah5;
 
+    
+    std::pair<uint32_t, std::vector<float> > p_payload;
     std::map<uint32_t, std::vector<float> > payload;
-
 
   };
 }

--- a/CondFormats/DTObjects/src/classes.h
+++ b/CondFormats/DTObjects/src/classes.h
@@ -26,6 +26,7 @@
 #include "CondFormats/DTObjects/interface/DTCCBConfig.h"
 #include "CondFormats/DTObjects/interface/DTKeyedConfig.h"
 #include "CondFormats/DTObjects/interface/DTTPGParameters.h"
+#include "CondFormats/DTObjects/interface/DTRecoUncertainties.h"
 
 namespace CondFormats_DTObjects {
   struct dictionary {
@@ -73,6 +74,10 @@ namespace CondFormats_DTObjects {
 //    std::vector< std::pair<DTTtrigId,DTTtrigData> > blah3;
 //    std::vector< std::pair<DTMtimeId,DTMtimeData> > blah4;
 //    std::vector< std::pair<DTStatusFlagId,DTStatusFlagData> > blah5;
+
+    std::map<uint32_t, std::vector<float> > payload;
+
+
   };
 }
 

--- a/CondFormats/DTObjects/src/classes_def.xml
+++ b/CondFormats/DTObjects/src/classes_def.xml
@@ -91,6 +91,10 @@
   <class name="std::vector<std::pair<DTTPGParametersId,DTTPGParametersData> >"/>
   <class name="DTTPGParametersId" id="D0D7107B-C7C5-DD11-AA5A-000E0C5CE282"/>
   <class name="DTTPGParametersData" id="5EEE8E7B-C7C5-DD11-A18E-000E0C5CE282"/>
+
+ <class name="DTRecoUncertainties" class_version="0">
+   <field name="payload" mapping="blob" />
+ </class>
 <!-- comment -->
 </lcgdict>
 

--- a/CondFormats/DTObjects/src/classes_def.xml
+++ b/CondFormats/DTObjects/src/classes_def.xml
@@ -91,10 +91,11 @@
   <class name="std::vector<std::pair<DTTPGParametersId,DTTPGParametersData> >"/>
   <class name="DTTPGParametersId" id="D0D7107B-C7C5-DD11-AA5A-000E0C5CE282"/>
   <class name="DTTPGParametersData" id="5EEE8E7B-C7C5-DD11-A18E-000E0C5CE282"/>
-
- <class name="DTRecoUncertainties" class_version="0">
-   <field name="payload" mapping="blob" />
- </class>
+  <class name="std::map<uint32_t, std::vector<float> >"/> 
+  <class name="DTRecoUncertainties" class_version="0">
+    <field name="payload" mapping="blob" />
+    <field name="theType" mapping="blob" />
+  </class>
 <!-- comment -->
 </lcgdict>
 

--- a/CondFormats/DTObjects/src/classes_def.xml
+++ b/CondFormats/DTObjects/src/classes_def.xml
@@ -95,7 +95,6 @@
   <class name="std::map<uint32_t, std::vector<float> >"/> 
   <class name="DTRecoUncertainties" class_version="10">
     <field name="payload" mapping="blob" />
-    <field name="theVersion" mapping="blob" />
   </class>
 <!-- comment -->
 </lcgdict>

--- a/CondFormats/DTObjects/src/classes_def.xml
+++ b/CondFormats/DTObjects/src/classes_def.xml
@@ -95,7 +95,7 @@
   <class name="std::map<uint32_t, std::vector<float> >"/> 
   <class name="DTRecoUncertainties" class_version="10">
     <field name="payload" mapping="blob" />
-    <field name="theType" mapping="blob" />
+    <field name="theVersion" mapping="blob" />
   </class>
 <!-- comment -->
 </lcgdict>

--- a/CondFormats/DTObjects/src/classes_def.xml
+++ b/CondFormats/DTObjects/src/classes_def.xml
@@ -91,8 +91,9 @@
   <class name="std::vector<std::pair<DTTPGParametersId,DTTPGParametersData> >"/>
   <class name="DTTPGParametersId" id="D0D7107B-C7C5-DD11-AA5A-000E0C5CE282"/>
   <class name="DTTPGParametersData" id="5EEE8E7B-C7C5-DD11-A18E-000E0C5CE282"/>
+  <class name="std::pair<uint32_t, std::vector<float> >"/> 
   <class name="std::map<uint32_t, std::vector<float> >"/> 
-  <class name="DTRecoUncertainties" class_version="0">
+  <class name="DTRecoUncertainties" class_version="10">
     <field name="payload" mapping="blob" />
     <field name="theType" mapping="blob" />
   </class>

--- a/CondFormats/DataRecord/interface/DTRecoUncertaintiesRcd.h
+++ b/CondFormats/DataRecord/interface/DTRecoUncertaintiesRcd.h
@@ -1,0 +1,26 @@
+#ifndef CondFormats_DTRecoUncertaintiesRcd_h
+#define CondFormats_DTRecoUncertaintiesRcd_h
+// -*- C++ -*-
+//
+// Package:     CondFormats
+// Class  :     DTRecoUncertaintiesRcd
+// 
+/**\class DTRecoUncertaintiesRcd DTRecoUncertaintiesRcd.h src/CondFormats/interface/DTRecoUncertaintiesRcd.h
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:      
+// Created:     Wed Feb 23 11:26:01 CET 2011
+// $Id: DTRecoUncertaintiesRcd.h,v 1.1 2011/02/25 14:20:28 cerminar Exp $
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class DTRecoUncertaintiesRcd : public edm::eventsetup::EventSetupRecordImplementation<DTRecoUncertaintiesRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/src/DTRecoUncertaintiesRcd.cc
+++ b/CondFormats/DataRecord/src/DTRecoUncertaintiesRcd.cc
@@ -1,0 +1,16 @@
+// -*- C++ -*-
+//
+// Package:     CondFormats
+// Class  :     DTRecoUncertaintiesRcd
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Author:      
+// Created:     Wed Feb 23 11:26:01 CET 2011
+// $Id: DTRecoUncertaintiesRcd.cc,v 1.1 2011/02/25 14:20:28 cerminar Exp $
+
+#include "CondFormats/DataRecord//interface/DTRecoUncertaintiesRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(DTRecoUncertaintiesRcd);

--- a/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.cc
+++ b/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.cc
@@ -50,16 +50,16 @@ void DTLinearDriftFromDBAlgo::setES(const EventSetup& setup) {
   setup.get<DTMtimeRcd>().get(mTimeHandle);
   mTimeMap = &*mTimeHandle;
   
-  ESHandle<DTRecoUncertainties> uncerts;
-  setup.get<DTRecoUncertaintiesRcd>().get(uncerts);
-  uncertMap = &*uncerts;
+//   ESHandle<DTRecoUncertainties> uncerts;
+//   setup.get<DTRecoUncertaintiesRcd>().get(uncerts);
+//   uncertMap = &*uncerts;
 
   // check uncertainty map type
-  if (uncerts->version()>1) edm::LogError("NotImplemented") << "DT Uncertainty DB version unknown: " << uncerts->version();
+//  if (uncerts->version()>1) edm::LogError("NotImplemented") << "DT Uncertainty DB version unknown: " << uncerts->version();
 
   if(debug) {
     cout << "[DTLinearDriftFromDBAlgo] meanTimer version: " << mTimeMap->version()<<endl;
-    cout << "                          uncertDB  version: " << uncerts->version()<<endl;
+//    cout << "                          uncertDB  version: " << uncerts->version()<<endl;
   }
   
 }
@@ -150,15 +150,15 @@ bool DTLinearDriftFromDBAlgo::compute(const DTLayer* layer,
 
   // Read the vDrift and reso for this wire
   float vDrift = 0;
-  float hitMTResolution = 0; // Value from vdrift DB; obsolete.
+  float hitResolution = 0; 
   // vdrift is cm/ns , resolution is cm
   mTimeMap->get(wireId.superlayerId(),
 	        vDrift,
-	        hitMTResolution,
+	        hitResolution,  // Value from vdrift DB; obsolete.
 	        DTVelocityUnits::cm_per_ns);
 
   // Read the uncertainty from the DB for the given channel and step
-  float hitResolution = uncertMap->get(wireId, step-1);
+  //  float hitResolution = uncertMap->get(wireId, step-1);
 
   //only in step 3
   if(doVdriftCorr && step == 3){

--- a/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.cc
+++ b/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.cc
@@ -14,6 +14,9 @@
 #include "FWCore/Utilities/interface/Exception.h"
 #include "CondFormats/DTObjects/interface/DTMtime.h"
 #include "CondFormats/DataRecord/interface/DTMtimeRcd.h"
+#include "CondFormats/DTObjects/interface/DTRecoUncertainties.h"
+#include "CondFormats/DataRecord/interface/DTRecoUncertaintiesRcd.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 using namespace std;
 using namespace edm;
@@ -47,8 +50,17 @@ void DTLinearDriftFromDBAlgo::setES(const EventSetup& setup) {
   setup.get<DTMtimeRcd>().get(mTimeHandle);
   mTimeMap = &*mTimeHandle;
   
+  ESHandle<DTRecoUncertainties> uncerts;
+  setup.get<DTRecoUncertaintiesRcd>().get(uncerts);
+  uncertMap = &*uncerts;
+
+  // check uncertainty map type
+  if (uncerts->type()!="uniformPerStep") edm::LogError("NotImplemented") << "Uncertainty type unknown: " << uncerts->type();
+
   if(debug) 
     cout << "[DTLinearDriftFromDBAlgo] meanTimer version: " << mTimeMap->version()<<endl;
+    cout << "                          uncertDB  version: " << uncerts->type()<<endl;
+
 }
 
 
@@ -137,12 +149,15 @@ bool DTLinearDriftFromDBAlgo::compute(const DTLayer* layer,
 
   // Read the vDrift and reso for this wire
   float vDrift = 0;
-  float hitResolution = 0;//FIXME: should use this!
+  float hitMTResolution = 0; // Value from vdrift DB; obsolete.
   // vdrift is cm/ns , resolution is cm
   mTimeMap->get(wireId.superlayerId(),
 	        vDrift,
-	        hitResolution,
+	        hitMTResolution,
 	        DTVelocityUnits::cm_per_ns);
+
+  // Read the uncertainty from the DB for the given channel and step
+  float hitResolution = uncertMap->get(wireId, step-1);
 
   //only in step 3
   if(doVdriftCorr && step == 3){

--- a/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.cc
+++ b/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.cc
@@ -55,12 +55,13 @@ void DTLinearDriftFromDBAlgo::setES(const EventSetup& setup) {
   uncertMap = &*uncerts;
 
   // check uncertainty map type
-  if (uncerts->type()!="uniformPerStep") edm::LogError("NotImplemented") << "Uncertainty type unknown: " << uncerts->type();
+  if (uncerts->version()>1) edm::LogError("NotImplemented") << "DT Uncertainty DB version unknown: " << uncerts->version();
 
-  if(debug) 
+  if(debug) {
     cout << "[DTLinearDriftFromDBAlgo] meanTimer version: " << mTimeMap->version()<<endl;
-    cout << "                          uncertDB  version: " << uncerts->type()<<endl;
-
+    cout << "                          uncertDB  version: " << uncerts->version()<<endl;
+  }
+  
 }
 
 

--- a/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.h
+++ b/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.h
@@ -12,6 +12,7 @@
 #include "RecoLocalMuon/DTRecHit/interface/DTRecHitBaseAlgo.h"
 
 class DTMtime;
+class DTRecoUncertainties;
 
 class DTLinearDriftFromDBAlgo : public DTRecHitBaseAlgo {
  public:
@@ -81,6 +82,9 @@ class DTLinearDriftFromDBAlgo : public DTRecHitBaseAlgo {
 
   //Map of meantimes
   const DTMtime *mTimeMap;
+
+  // Map of hit uncertainties
+  const DTRecoUncertainties *uncertMap;
  
   // Times below MinTime (ns) are considered as coming from previous BXs.
   const float minTime;

--- a/Validation/DTRecHits/test/DTValidation_RelVal_fromRECO_local_cfg.py
+++ b/Validation/DTRecHits/test/DTValidation_RelVal_fromRECO_local_cfg.py
@@ -10,6 +10,8 @@ reReco = False         # Set this to True to re-reconstruct hits
 skipDeltaSuppr = False # Skip DRR (only when reReco=True)
 step2FromDigi = False  # Remake step-2 hits instead of bypassing step-2; useful when re-fitting segments from hits since hits in 2D segments are otherwise non updated. 
 
+# Optional DB for DT uncertainties, es.  "DTRecoUncertainties.db"
+uncertDB = ""
 
 doAngleCorr = False
 
@@ -32,11 +34,12 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
 
 ## Uncertainty DB
-#process.GlobalTag.toGet = cms.VPSet(
-#    cms.PSet(record = cms.string("DTRecoUncertaintiesRcd"),
-#             tag = cms.string("DTRecoUncertainties_test"),
-#             connect = cms.untracked.string("sqlite_file:DTRecoUncertainties.db"))
-#)
+if uncertDB != "" : 
+    process.GlobalTag.toGet = cms.VPSet(
+        cms.PSet(record = cms.string("DTRecoUncertaintiesRcd"),
+                 tag = cms.string("DTRecoUncertainties_test"),
+                 connect = cms.untracked.string("sqlite_file:"+uncertDB))
+        )
 
 
 

--- a/Validation/DTRecHits/test/DTValidation_RelVal_fromRECO_local_cfg.py
+++ b/Validation/DTRecHits/test/DTValidation_RelVal_fromRECO_local_cfg.py
@@ -6,8 +6,9 @@ import FWCore.ParameterSet.Config as cms
 #
 # Configurable options:
 
-reReco = True         # Set this to True to re-reconstruct hits
-skipDeltaSuppr = True # Skip DRR (only when reReco=True)
+reReco = False         # Set this to True to re-reconstruct hits
+skipDeltaSuppr = False # Skip DRR (only when reReco=True)
+step2FromDigi = False  # Remake step-2 hits instead of bypassing step-2; useful when re-fitting segments from hits since hits in 2D segments are otherwise non updated. 
 
 
 doAngleCorr = False
@@ -28,6 +29,16 @@ process.maxEvents = cms.untracked.PSet(
 
 ## Conditions
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+
+
+## Uncertainty DB
+#process.GlobalTag.toGet = cms.VPSet(
+#    cms.PSet(record = cms.string("DTRecoUncertaintiesRcd"),
+#             tag = cms.string("DTRecoUncertainties_test"),
+#             connect = cms.untracked.string("sqlite_file:DTRecoUncertainties.db"))
+#)
+
+
 
 process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("Configuration.Geometry.GeometryIdeal_cff")
@@ -178,6 +189,11 @@ if (skipDeltaSuppr) :
 if (doAngleCorr) :
     process.dt4DSegments.Reco4DAlgoConfig.recAlgoConfig.doAngleCorr = True;
     process.dt4DSegments.Reco4DAlgoConfig.Reco2DAlgoConfig.doAngleCorr = True; #Note: hit recomputation @step2 is not activated anyhow!
+
+if (step2FromDigi) :
+    process.dt4DSegments.Reco4DAlgoConfig.recAlgoConfig.stepTwoFromDigi = True;
+    process.dt4DSegments.Reco4DAlgoConfig.Reco2DAlgoConfig.recAlgoConfig.stepTwoFromDigi = True;
+
 
 if (reReco) :
     #add  process.dt2DSegments if needed

--- a/Validation/DTRecHits/test/plotAllWStrue.r
+++ b/Validation/DTRecHits/test/plotAllWStrue.r
@@ -1,0 +1,240 @@
+void plotAllWStrue(TString filename, int sector, int sl){
+  
+
+  if (! TString(gSystem->GetLibraries()).Contains("Histograms_h")) {
+    gROOT->LoadMacro("$CMSSW_BASE/src/Validation/DTRecHits/test/Histograms.h+"); 
+     gROOT->LoadMacro("macros.C");
+     gROOT->LoadMacro("ranges.C+");
+     gROOT->LoadMacro("summaryPlot.C+");
+  }
+
+  
+  bool doRes = true;
+  bool doResVsDist = true;
+  bool doResVsAngle = true;
+  bool doResVsX = true;
+  bool doResVsY = true;
+  bool doAngleDist = true;
+
+  TStyle * style = getStyle("tdr");
+  style->cd();
+  gStyle->SetCanvasDefW(1375); // Set larger canvas
+  gStyle->SetCanvasDefH(800);  
+  gStyle->SetTitleSize(0.05,"XYZ"); // Set larger axis titles
+  gStyle->SetTitleOffset(1.5,"Y");
+  gStyle->SetOptTitle(0); // remove histogram titles
+  
+  setPalette();
+  opt2Dplot = "col";
+  
+ float nsigma = 2;
+ 
+ TFile *file = new TFile(filename);
+  
+  TString canvbasename = filename;
+  canvbasename = canvbasename.Replace(canvbasename.Length()-5,5,"") + TString("_Se") + (long) sector + "_SL" + (long) sl; 
+
+  HRes1DHit* hRes1D[5][3]; // W, S;  
+  HRes4DHit* hRes4D[5][3];
+  
+  
+  for (int wheel = -2; wheel<=2; ++wheel) {
+    for (int station = 1; station<=3; ++station) {
+      
+      int iW = wheel+2;
+      int iSt= station-1;
+      hRes1D[iW][iSt] = new HRes1DHit(file,wheel,station,sl,"S3");
+      hRes4D[iW][iSt] = new HRes4DHit(file,wheel,station,0);
+      
+    }
+
+  }
+  
+  
+  if(doRes){
+    TCanvas* c0= new TCanvas(canvbasename+"_AllWSRes", canvbasename+"_AllWSRes");    
+    
+    c0->Divide(5,3,0.0005,0.0005);
+
+    for (int wheel = -2; wheel<=2; ++wheel) {
+      for (int station = 1; station<=3; ++station) {
+	int iW = wheel+2;
+	int iSt= station-1;
+
+	int ipad=iW+1 +(2-iSt)*5;
+	c0->cd(ipad); ++ipad;
+	
+	if(wheel<0) continue;
+
+	TH1F* h = hRes1D[iW][iSt]->hRes;
+	
+	TF1* fres=drawGFit(h, nsigma, -0.4, 0.4);
+	
+	
+      }
+    }
+  }
+ 
+  if(doResVsDist){
+    TCanvas* c0= new TCanvas(canvbasename+"_AllWSResVsDist", canvbasename+"_AllWSResVsDist");    
+    c0->Divide(5,3,0.0005,0.0005);
+        
+    for (int wheel = -2; wheel<=2; ++wheel) {
+      for (int station = 1; station<=3; ++station) {
+	int iW = wheel+2;
+	int iSt= station-1;
+	int ipad=iW+1 + (2-iSt)*5;
+	
+	c0->cd(ipad); ++ipad;
+	if(wheel<0) continue;
+	
+	plotAndProfileX(hRes1D[iW][iSt]->hResVsPos,2,1,1,-.1, .1, 0., 2.1);
+	
+      }
+    }
+  }
+ 
+  if(doResVsAngle){
+    SummaryPlot hs_p0("p0");
+    SummaryPlot hs_p1("p1");
+
+    TCanvas* c0= new TCanvas(canvbasename+"_AllWSResVsAngle", canvbasename+"_AllWSResVsAngle");    
+    c0->Divide(5,3,0.0005,0.0005);
+    
+    for (int wheel = -2; wheel<=2; ++wheel) {
+      for (int station = 1; station<=3; ++station) {
+	  
+	  int iW = wheel+2;
+	  int iSt= station-1;
+	  int ipad=iW+1 + (2-iSt)*5;
+	  
+	  c0->cd(ipad); ++ipad;
+	  if(wheel<0) continue;
+	  
+	  float min;
+	  float max;
+	  
+	  rangeAngle(wheel, station, sl, min, max);
+	  
+	  TH1F* hprof = plotAndProfileX(hRes1D[iW][iSt]->hResVsAngle,1,1,1,-0.04, 0.04, min-0.03, max+0.03);
+	  TF1 *angleDep= new TF1("angleDep","[0]*cos(x+[2])+[1]", min, max);
+	  //TF1 *angleDep= new TF1("angleDep","[0]*x*x+[2]*x+[1]", min, max);
+	  angleDep->SetParameters(0.01,0.001, 0.1);
+	  
+	  if(sl == 2 || (sl == 1 && (iSt!=0 ||(iSt==0 && iW==2)))) angleDep->FixParameter(2,0.);
+
+	  if(sl == 1 && (iW == 3 ||iW == 0) && iSt == 0)  angleDep->SetParameter(2,-0.12);
+	  
+	  hprof->Fit(angleDep,"RQN"); 
+	  
+	  if(sl == 2 && (iW == 0 || iW == 4) && (iSt == 0 || iSt == 1)) continue;
+	  
+	  angleDep->Draw("same");
+	  float p0 = angleDep->GetParameter(0);
+	  float p1 = angleDep->GetParameter(1);
+	  float p2 = angleDep->GetParameter(2);
+	  
+       	cout << "Wh:" <<wheel<< " St:"<<station << " SL:" <<sl << " "<< p0 << " " << p1 << " " << p2 << endl;
+	
+	  hs_p0.Fill(wheel, station, sector, p0);
+	  hs_p1.Fill(wheel, station, sector, p1);
+	
+      }
+    }
+  // Summary plot (still being developed)
+    TCanvas* c6= new TCanvas(canvbasename+"_AllWSAngleCorr_p0", canvbasename+"_AllWSAngleCorr_p0");    
+    hs_p0.hsumm->GetYaxis()->SetRangeUser(0.5,0.5);
+    hs_p0.hsumm->Draw("p");
+    
+    
+    float p0_m[3][3];
+    float p1_m[3][3];
+    
+    for (int wheel = 0; wheel<=2; ++wheel) {
+      for (int station = 1; station<=3; ++station) {
+	
+	float p0_n = hs_p0.hsumm->GetBinContent(hs_p0.bin(-wheel,station,0));
+	float p0_p = hs_p0.hsumm->GetBinContent(hs_p0.bin(wheel,station,0));
+	float p1_n = hs_p1.hsumm->GetBinContent(hs_p1.bin(-wheel,station,0));
+	float p1_p = hs_p1.hsumm->GetBinContent(hs_p1.bin(wheel,station,0));
+	p0_m[wheel][station] = (p0_n + p0_p)/2;
+	p1_m[wheel][station] = (p1_n + p1_p)/2;
+	//	cout << wheel << "   "   << station << "   " <<  p0_m[wheel][station] <<  "   "<<p1_m[wheel][station] <<endl;
+      }
+      
+    }
+    
+ }
+ 
+
+  //  if (doResVsX) {
+//     TCanvas* c0=new TCanvas(canvbasename+"_AllWSResVsX", canvbasename+"_AllWSResVsX");    
+    
+//     c0->Divide(5,3);
+
+//     for (int wheel = 0; wheel<=2; ++wheel) {
+//       for (int station = 0; station<=2; ++station) {
+
+// 	int ipad=wheel+3 + (2-station)*5;
+// 	c0->cd(ipad); ++ipad;
+// 	plotAndProfileX(hRes1D[wheel][station]->hResDistVsX,2,1,1,-0.05, 0.05, -150, 150); // FIXME
+//       }
+//     }
+//   }
+
+//  if (doResVsY) {
+
+//    TCanvas* c0=new TCanvas(canvbasename+"_AllWSResVsY", canvbasename+"_AllWSResVsY");    
+     
+//     c0->Divide(5,3);
+
+//     for (int wheel = 0; wheel<=2; ++wheel) {
+//       for (int station = 0; station<=2; ++station) {
+
+// 	int ipad=wheel+3 + (2-station)*5;
+// 	c0->cd(ipad); ++ipad;
+// 	plotAndProfileX(hRes1D[wheel][station]->hResDistVsY,2,1,1,-0.05, 0.05, -150, 150); // FIXME
+//       }
+//     }
+//   }
+
+ if(doAngleDist){
+   TCanvas* c0= new TCanvas(canvbasename+"_AllWSAngleDist", canvbasename+"_AllWSAngleDist");
+   c0->Divide(5,3,0.0005,0.0005);
+   
+   for (int wheel = -2; wheel<=2; ++wheel) {
+     for (int station = 1; station<=3; ++station) {
+       int iW = wheel+2;
+       int iSt= station-1;
+       // DTDetId detId(wheel, station, sector, sl, 0, 0);
+       int ipad=iW+1 + (2-iSt)*5;
+       
+       c0->cd(ipad); ++ipad;
+       if(wheel<0) continue;
+
+       float min;
+       float max;
+              
+       rangeAngle(wheel, station, sl, min, max);
+      //  cout << "min" << min << endl;
+//        cout << "max" << max << endl;
+
+       TH1F* hAngle = hRes4D[iW][iSt]->hSimAlpha;
+       hAngle->Sumw2();       
+
+       if(sl==2){
+	 TH1F* hAngle = hRes4D[iW][iSt]->hSimBeta; 
+	 hAngle->Sumw2();       
+       }
+
+       hAngle->GetXaxis()->SetRangeUser(-1.2,1.2);
+       hAngle->Draw();
+
+     }
+   }
+}
+ 
+}
+
+   
+

--- a/Validation/DTRecHits/test/plotValidation.r
+++ b/Validation/DTRecHits/test/plotValidation.r
@@ -45,6 +45,7 @@ void plotValidation(TString filename, int wheel, int station) {
   bool doSegPull = true;
   bool doAngularDeps = true;
   bool doEff4D = true;
+  bool doNSeg = true;
 
 
   //----------------------------------------------------------------------
@@ -370,6 +371,28 @@ void plotValidation(TString filename, int wheel, int station) {
 //     drawGFit(hRes4D->hPullBeta, nsigma, -10.,10.);  
 
 
+  }
+
+  //-------------------- #segments
+  if (doNSeg) {
+    TCanvas* c1= new TCanvas;
+    c1->SetTitle(canvbasename+"_NSeg");   
+    c1->SetName(canvbasename+"_NSeg");
+    // c1->Divide(2,2);
+//     c1->cd(1);
+    
+    TH1F* hNs =  hEff4D->hNSeg;
+ 
+    hNs->SetXTitle("#segments");
+    hNs->Draw();
+
+    double int_1 = hNs->Integral(2,21);
+    double int_2 = hNs->Integral(3,21);
+    
+    double ratio = int_2/int_1;
+    
+    cout << "int_1: " << int_1 <<" int_2: " << int_2 << " ratio: " << ratio << endl;
+    
   }
 
 

--- a/Validation/DTRecHits/test/ranges.C
+++ b/Validation/DTRecHits/test/ranges.C
@@ -1,0 +1,74 @@
+
+
+#include <map>
+#include <cmath>
+
+using namespace std;
+
+void rangeAngle(int wheel, int station, int sl, float& min, float& max) {
+
+  
+  //   W       St
+  map<int, map<int, float> > m_min;
+  map<int, map<int, float> > m_max;
+
+// map<float, map<float, float> > m_min;
+//  map<float, map<float, float> > m_max;
+
+  if (sl !=2 ) { // phi
+    m_min[2][3] = -0.18;
+    m_min[2][2] = -0.26;
+    m_min[2][1] = -0.1;
+    m_min[1][3] = -0.2;
+    m_min[1][2] = -0.25;
+    m_min[1][1] = -0.1;
+    m_min[0][3] = -0.2;
+    m_min[0][2] = -0.2;
+    m_min[0][1] = -0.2;
+   
+
+    m_max[2][3] = 0.22;
+    m_max[2][2] = 0.16;
+    m_max[2][1] = 0.28;
+    m_max[1][3] = 0.25;
+    m_max[1][2] = 0.18;
+    m_max[1][1] = 0.28;
+    m_max[0][3] = 0.2;
+    m_max[0][2] = 0.2;
+    m_max[0][1] = 0.2;
+   
+
+  } else { //theta
+    
+    m_min[0][1] = -0.25;
+    m_min[0][2] = -0.2;
+    m_min[0][3] = -0.18;
+    m_min[1][1] =  0.36;
+    m_min[1][2] =  0.3;
+    m_min[1][3] =  0.25;
+    m_min[2][1] =  0.78;
+    m_min[2][2] =  0.7;
+    m_min[2][3] =  0.6;
+
+    m_max[0][1] = 0.25;
+    m_max[0][2] = 0.2;
+    m_max[0][3] = 0.18;
+    m_max[1][1] = 0.7;
+    m_max[1][2] = 0.63;
+    m_max[1][3] = 0.55;
+    m_max[2][1] = 0.96;
+    m_max[2][2] = 0.88;
+    m_max[2][3] = 0.79;
+
+ 
+ }
+ 
+    min = m_min[wheel][station];
+    max = m_max[wheel][station];
+    
+
+  //  std::cout << "min" << min << endl;
+  //std::cout << "max" << max << endl;
+
+}
+

--- a/Validation/DTRecHits/test/summaryPlot.gnu
+++ b/Validation/DTRecHits/test/summaryPlot.gnu
@@ -7,7 +7,7 @@ reset
 set macro
 
 #Set the input file here
-myfile =  '"<sort -gs -k 2 True_RelValZMM5312_BP7X_noDRR_summary.txt"'
+myfile =  '"<sort -gs -k 2 RelValZMM5312_BP7X_noDRR_summary.txt "'
 
 
 #Set this to 1 to print plots to png files
@@ -152,3 +152,27 @@ set label 99 "Segment Position Pull Width" rotate right at screen 0.02,0.97
 plot \
 @myfile using (($3)==1&&int($4)==1?$15:1/0) title '{/Symbol f} SLs' w p pt  5 ps 1.4 lc 4, \
 @myfile using (($3)==1&&int($4)==2?$15:1/0) title '{/Symbol q} SLs' w p pt 13 ps 1.5 lc 13
+
+### Number of segment ratio
+if (print) {set output "TrueNSegRatio.png"}
+set yrange [0:0.15]
+set label 99 "(ev with more than 2 seg)/(ev with more than 1 seg) " rotate right at screen 0.02,0.97
+plot \
+@myfile using (($3)==1&&int($4)==1?$18:1/0) title '4D segment' w p pt  5 ps 1.4 lc 4
+
+
+### p0
+if (print) {set output "TrueP0.png"}
+set yrange [0:0.8]
+set label 99 "p0" rotate right at screen 0.02,0.97
+plot \
+@myfile using (($3)==1&&int($4)==1?$19:1/0) title '{/Symbol f} SLs' w p pt  5 ps 1.4 lc 4, \
+@myfile using (($3)==1&&int($4)==2?$19:1/0) title '{/Symbol q} SLs' w p pt 13 ps 1.5 lc 13
+
+### p1
+if (print) {set output "TrueP1.png"}
+set yrange [-1:1]
+set label 99 "p0" rotate right at screen 0.02,0.97
+plot \
+@myfile using (($3)==1&&int($4)==1?$20:1/0) title '{/Symbol f} SLs' w p pt  5 ps 1.4 lc 4, \
+@myfile using (($3)==1&&int($4)==2?$20:1/0) title '{/Symbol q} SLs' w p pt 13 ps 1.5 lc 13


### PR DESCRIPTION
First version of object definition, dictionary and tools for storing and using configurable DT hit uncertainties from the DB. In this initial version, the reconstruction code does not access the DB yet, so there is no change in reconstruction. Please accept this PR so we can proceed with populating the DB.
