### PR TITLE
Consumes migration

### DIFF
--- a/EventFilter/CastorRawToDigi/plugins/CastorDigiToRaw.cc
+++ b/EventFilter/CastorRawToDigi/plugins/CastorDigiToRaw.cc
@@ -19,6 +19,7 @@ CastorDigiToRaw::CastorDigiToRaw(edm::ParameterSet const& conf) :
   usingctdc_(conf.getUntrackedParameter<bool>("CastorCtdc",false))
 
 {
+  tok_input_ = consumes<CastorDigiCollection>(castorTag_);
   produces<FEDRawDataCollection>();
 }
 
@@ -33,7 +34,7 @@ void CastorDigiToRaw::produce(edm::Event& e, const edm::EventSetup& es)
   // Step A: Get Inputs 
   edm::Handle<CastorDigiCollection> castor;
   if (!castorTag_.label().empty()) {
-    e.getByLabel(castorTag_,castor);
+    e.getByToken(tok_input_,castor);
     colls.castorCont=castor.product();	
   }
   // get the mapping

--- a/EventFilter/CastorRawToDigi/plugins/CastorDigiToRaw.h
+++ b/EventFilter/CastorRawToDigi/plugins/CastorDigiToRaw.h
@@ -35,6 +35,7 @@ private:
   CastorCtdcPacker ctdcpacker_;
   edm::InputTag castorTag_, calibTag_, trigTag_;
   bool usingctdc_;
+  edm::EDGetTokenT<CastorDigiCollection> tok_input_;
 
 };
 

--- a/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
+++ b/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
@@ -49,8 +49,7 @@ CastorRawToDigi::CastorRawToDigi(edm::ParameterSet const& conf):
   if (unpackTTP_)
     produces<HcalTTPDigiCollection>();
 
-//  if (unpackCalib_)
-//    produces<HcalCalibDigiCollection>();
+  tok_input_ = consumes<FEDRawDataCollection>(dataTag_);
 
 }
 
@@ -62,7 +61,7 @@ void CastorRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
 {
   // Step A: Get Inputs 
   edm::Handle<FEDRawDataCollection> rawraw;  
-  e.getByLabel(dataTag_,rawraw);
+  e.getByToken(tok_input_,rawraw);
   // get the mapping
   edm::ESHandle<CastorDbService> pSetup;
   es.get<CastorDbRecord>().get( pSetup );

--- a/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.h
+++ b/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.h
@@ -17,6 +17,7 @@
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -47,6 +48,7 @@ private:
   bool silent_;
   bool usenominalOrbitMessageTime_;
   int expectedOrbitMessageTime_;
+  edm::EDGetTokenT<FEDRawDataCollection> tok_input_;
 
 };
 


### PR DESCRIPTION
Migration to consumes usage for the CastorRawToDigi and CastorDigiToRaw modules. The changes are quickly tested by running a full MC chain (Step1: GEN-SIM-DIGI-RAW and Step2: RAW-DIGI-RECO) that uses both modules. The output file showed correctly filled Castor objects. Tested in CMSSW_7_1_0_pre4.
