### PR TITLE
initialize variables not to have random loops

### DIFF
--- a/DQM/RPCMonitorDigi/src/RPCMonitorDigi.cc
+++ b/DQM/RPCMonitorDigi/src/RPCMonitorDigi.cc
@@ -16,7 +16,11 @@
 
 const std::string RPCMonitorDigi::regionNames_[3] =  {"Endcap-", "Barrel", "Endcap+"};
 
-RPCMonitorDigi::RPCMonitorDigi( const edm::ParameterSet& pset ):counter(0){
+RPCMonitorDigi::RPCMonitorDigi( const edm::ParameterSet& pset )
+ : counter(0),
+   dcs_(false),
+   numberOfDisks_(0),
+   numberOfInnerRings_(0){
 
   saveRootFile  = pset.getUntrackedParameter<bool>("SaveRootFile", false); 
   RootFileName  = pset.getUntrackedParameter<std::string>("RootFileName", "RPCMonitorDigiDQM.root"); 
@@ -50,31 +54,6 @@ void RPCMonitorDigi::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const 
 
   edm::LogInfo ("rpcmonitordigi") <<"[RPCMonitorDigi]: Begin Run " ;
   
-  
-  //Book 
-  this->bookRegionME(ibooker,noiseFolder_, regionNoiseCollection);
-  this->bookSectorRingME(ibooker,noiseFolder_, sectorRingNoiseCollection);
-  this->bookWheelDiskME(ibooker,noiseFolder_, wheelDiskNoiseCollection);
-
-  std::string currentFolder = subsystemFolder_ +"/"+noiseFolder_;
-  ibooker.setCurrentFolder(currentFolder);
- 
-  noiseRPCEvents_ = ibooker.book1D("RPCEvents","RPCEvents", 1, 0.5, 1.5);
-  
-  if(useMuonDigis_ ){
-    this->bookRegionME(ibooker, muonFolder_, regionMuonCollection);
-    this->bookSectorRingME(ibooker, muonFolder_, sectorRingMuonCollection);
-    this->bookWheelDiskME(ibooker, muonFolder_, wheelDiskMuonCollection);
-    
-    currentFolder = subsystemFolder_ +"/"+muonFolder_;
-    ibooker.setCurrentFolder(currentFolder); 
-   
-    muonRPCEvents_ =  ibooker.book1D("RPCEvents", "RPCEvents", 1, 0.5, 1.5);
-    NumberOfMuon_ = ibooker.book1D("NumberOfMuons", "Number of Muons", 11, -0.5, 10.5);
-    NumberOfRecHitMuon_ = ibooker.book1D("NumberOfRecHitMuons", "Number of RPC RecHits per Muon", 8, -0.5, 7.5);
-  }
-   
-
   std::set<int> disk_set, ring_set;
   edm::ESHandle<RPCGeometry> rpcGeo;
   iSetup.get<MuonGeometryRecord>().get(rpcGeo);
@@ -117,7 +96,30 @@ void RPCMonitorDigi::bookHistograms(DQMStore::IBooker & ibooker, edm::Run const 
 
   numberOfDisks_ = disk_set.size();
   numberOfInnerRings_ = (*ring_set.begin());
+  
+  //Book 
+  this->bookRegionME(ibooker,noiseFolder_, regionNoiseCollection);
+  this->bookSectorRingME(ibooker,noiseFolder_, sectorRingNoiseCollection);
+  this->bookWheelDiskME(ibooker,noiseFolder_, wheelDiskNoiseCollection);
 
+  std::string currentFolder = subsystemFolder_ +"/"+noiseFolder_;
+  ibooker.setCurrentFolder(currentFolder);
+ 
+  noiseRPCEvents_ = ibooker.book1D("RPCEvents","RPCEvents", 1, 0.5, 1.5);
+  
+  if(useMuonDigis_ ){
+    this->bookRegionME(ibooker, muonFolder_, regionMuonCollection);
+    this->bookSectorRingME(ibooker, muonFolder_, sectorRingMuonCollection);
+    this->bookWheelDiskME(ibooker, muonFolder_, wheelDiskMuonCollection);
+    
+    currentFolder = subsystemFolder_ +"/"+muonFolder_;
+    ibooker.setCurrentFolder(currentFolder); 
+   
+    muonRPCEvents_ =  ibooker.book1D("RPCEvents", "RPCEvents", 1, 0.5, 1.5);
+    NumberOfMuon_ = ibooker.book1D("NumberOfMuons", "Number of Muons", 11, -0.5, 10.5);
+    NumberOfRecHitMuon_ = ibooker.book1D("NumberOfRecHitMuons", "Number of RPC RecHits per Muon", 8, -0.5, 7.5);
+  }
+   
   //Clear flags;
   dcs_ = true;
 }

--- a/DQMServices/Core/python/test/dqm_testMultiThread_DQMIO_cfg.py
+++ b/DQMServices/Core/python/test/dqm_testMultiThread_DQMIO_cfg.py
@@ -64,6 +64,7 @@ process.options = cms.untracked.PSet(
 # Enable MultiThread DQM
 process.dqmSaver.enableMultiThread = cms.untracked.bool(True)
 process.DQMoutput.enableMultiThread = cms.untracked.bool(True)
+process.DQMStore.enableMultiThread = cms.untracked.bool(True)
 
 
 #process.Tracer = cms.Service('Tracer')


### PR DESCRIPTION
initialise numberOfDisks_ and numberOfInnerRings_ not to have random loops and random booking of histograms. should fix the huge increase in memory when running WFs in THREADED releases.
