### PR TITLE
migration to "consumes" of RecoMuon/GlobalTrackingTools

### DIFF
--- a/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromL2Muon.cc
@@ -48,7 +48,8 @@ FastTSGFromL2Muon::beginRun(edm::Run const& run, edm::EventSetup const& es)
   //region builder
   edm::ParameterSet regionBuilderPSet = 
     theConfig.getParameter<edm::ParameterSet>("MuonTrackingRegionBuilder");
-  theRegionBuilder = new MuonTrackingRegionBuilder(regionBuilderPSet,theService);
+  edm::ConsumesCollector iC  = consumesCollector();
+  theRegionBuilder = new MuonTrackingRegionBuilder(regionBuilderPSet,theService,iC);
   
   /*
   if(useTFileService_) {

--- a/RecoHI/HiMuonAlgos/plugins/HIMuonTrackingRegionProducer.h
+++ b/RecoHI/HiMuonAlgos/plugins/HIMuonTrackingRegionProducer.h
@@ -27,7 +27,7 @@ class HIMuonTrackingRegionProducer : public TrackingRegionProducer {
     
     // initialize region builder
     edm::ParameterSet regionBuilderPSet   = cfg.getParameter<edm::ParameterSet>("MuonTrackingRegionBuilder");
-    theRegionBuilder                      = new MuonTrackingRegionBuilder(regionBuilderPSet);
+    theRegionBuilder                      = new MuonTrackingRegionBuilder(regionBuilderPSet,iC);
 
     // initialize muon service proxy
     edm::ParameterSet servicePSet         = cfg.getParameter<edm::ParameterSet>("ServiceParameters");

--- a/RecoMuon/GlobalMuonProducer/src/TevMuonProducer.cc
+++ b/RecoMuon/GlobalMuonProducer/src/TevMuonProducer.cc
@@ -45,14 +45,14 @@ TevMuonProducer::TevMuonProducer(const ParameterSet& parameterSet) {
 
   // the services
   theService = new MuonServiceProxy(serviceParameters);
-  
+  edm::ConsumesCollector iC  = consumesCollector();  
+
   // TrackRefitter parameters
   ParameterSet refitterParameters = parameterSet.getParameter<ParameterSet>("RefitterParameters");
-  theRefitter = new GlobalMuonRefitter(refitterParameters, theService);
+  theRefitter = new GlobalMuonRefitter(refitterParameters, theService, iC);
 
   // TrackLoader parameters
   ParameterSet trackLoaderParameters = parameterSet.getParameter<ParameterSet>("TrackLoaderParameters");
-  edm::ConsumesCollector iC  = consumesCollector();
   theTrackLoader = new MuonTrackLoader(trackLoaderParameters,iC,theService);
 
   theRefits = parameterSet.getParameter< std::vector<std::string> >("Refits");

--- a/RecoMuon/GlobalTrackFinder/src/GlobalMuonTrajectoryBuilder.cc
+++ b/RecoMuon/GlobalTrackFinder/src/GlobalMuonTrajectoryBuilder.cc
@@ -56,7 +56,7 @@ using namespace edm;
 GlobalMuonTrajectoryBuilder::GlobalMuonTrajectoryBuilder(const edm::ParameterSet& par,
 							 const MuonServiceProxy* service,
 							 edm::ConsumesCollector& iC
-							 ) : GlobalTrajectoryBuilderBase(par, service)
+							 ) : GlobalTrajectoryBuilderBase(par, service, iC)
 	   
 {
 

--- a/RecoMuon/GlobalTrackingTools/interface/ChamberSegmentUtility.h
+++ b/RecoMuon/GlobalTrackingTools/interface/ChamberSegmentUtility.h
@@ -28,13 +28,14 @@
 #include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
 #include "DataFormats/CSCRecHit/interface/CSCSegment.h"
 #include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 
 class ChamberSegmentUtility {
 
  public:
 
-  ChamberSegmentUtility(const edm::Event&, const edm::EventSetup&);
+  ChamberSegmentUtility(const edm::Event&, const edm::EventSetup&, edm::ConsumesCollector&);
 
   // Get the 4D segments in a CSC chamber
   std::vector<CSCSegment> getCSCSegmentsInChamber(CSCDetId);
@@ -61,6 +62,9 @@ class ChamberSegmentUtility {
   edm::Handle<CSCSegmentCollection> CSCSegments;
   edm::ESHandle<DTGeometry> dtGeom;
   edm::Handle<DTRecSegment4DCollection> all4DSegments;
+
+  edm::EDGetTokenT<CSCSegmentCollection> CSCSegmentsToken;
+  edm::EDGetTokenT<DTRecSegment4DCollection> all4DSegmentsToken;
 
   std::vector<DTRecSegment4D> dtseg;
   std::vector<CSCSegment> cscseg;

--- a/RecoMuon/GlobalTrackingTools/interface/ChamberSegmentUtility.h
+++ b/RecoMuon/GlobalTrackingTools/interface/ChamberSegmentUtility.h
@@ -35,7 +35,7 @@ class ChamberSegmentUtility {
 
  public:
 
-  ChamberSegmentUtility(const edm::Event&, const edm::EventSetup&, edm::ConsumesCollector&);
+  ChamberSegmentUtility();
 
   void initCSU(const edm::Handle<DTRecSegment4DCollection>&, const edm::Handle<CSCSegmentCollection>&);
 

--- a/RecoMuon/GlobalTrackingTools/interface/ChamberSegmentUtility.h
+++ b/RecoMuon/GlobalTrackingTools/interface/ChamberSegmentUtility.h
@@ -37,6 +37,8 @@ class ChamberSegmentUtility {
 
   ChamberSegmentUtility(const edm::Event&, const edm::EventSetup&, edm::ConsumesCollector&);
 
+  void initCSU(const edm::Handle<DTRecSegment4DCollection>&, const edm::Handle<CSCSegmentCollection>&);
+
   // Get the 4D segments in a CSC chamber
   std::vector<CSCSegment> getCSCSegmentsInChamber(CSCDetId);
 
@@ -63,8 +65,8 @@ class ChamberSegmentUtility {
   edm::ESHandle<DTGeometry> dtGeom;
   edm::Handle<DTRecSegment4DCollection> all4DSegments;
 
-  edm::EDGetTokenT<CSCSegmentCollection> CSCSegmentsToken;
-  edm::EDGetTokenT<DTRecSegment4DCollection> all4DSegmentsToken;
+  //  edm::EDGetTokenT<CSCSegmentCollection> CSCSegmentsToken;
+  //  edm::EDGetTokenT<DTRecSegment4DCollection> all4DSegmentsToken;
 
   std::vector<DTRecSegment4D> dtseg;
   std::vector<CSCSegment> cscseg;

--- a/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
+++ b/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
@@ -40,6 +40,7 @@
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 #include "RecoMuon/Navigation/interface/DirectMuonNavigation.h"
 #include "Alignment/MuonAlignment/interface/MuonAlignment.h"
+#include "RecoMuon/GlobalTrackingTools/interface/ChamberSegmentUtility.h"
 
 
 class DynamicTruncation {
@@ -49,7 +50,7 @@ class DynamicTruncation {
   typedef TransientTrackingRecHit::ConstRecHitPointer ConstRecHitPointer;
   typedef TransientTrackingRecHit::ConstRecHitContainer ConstRecHitContainer;
 
-  DynamicTruncation(const edm::Event&, const MuonServiceProxy&);
+  DynamicTruncation(const edm::Event&, const MuonServiceProxy&, edm::ConsumesCollector&);
 
   ~DynamicTruncation();
 
@@ -92,7 +93,7 @@ class DynamicTruncation {
   const edm::EventSetup* theSetup;
   std::vector<double> estimators;
   TrajectoryStateOnSurface currentState;
-  
+  ChamberSegmentUtility* getSegs;
   std::map<DTChamberId, GlobalError> dtApeMap;
   std::map<CSCDetId, GlobalError> cscApeMap; 
 };

--- a/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
+++ b/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
@@ -54,6 +54,11 @@ class DynamicTruncation {
 
   ~DynamicTruncation();
 
+  void setProd(const edm::Handle<DTRecSegment4DCollection>& DTSegProd, 
+	       const edm::Handle<CSCSegmentCollection>& CSCSegProd) {
+    getSegs->initCSU(DTSegProd, CSCSegProd);
+  }
+
   // Just one thr for DT and one for CSC
   void setThr(int, int, int);
   

--- a/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
+++ b/RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h
@@ -50,7 +50,7 @@ class DynamicTruncation {
   typedef TransientTrackingRecHit::ConstRecHitPointer ConstRecHitPointer;
   typedef TransientTrackingRecHit::ConstRecHitContainer ConstRecHitContainer;
 
-  DynamicTruncation(const edm::Event&, const MuonServiceProxy&, edm::ConsumesCollector&);
+  DynamicTruncation(const edm::Event&, const MuonServiceProxy&);
 
   ~DynamicTruncation();
 

--- a/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
+++ b/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
@@ -22,6 +22,7 @@
 #include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
 #include "DataFormats/DTRecHit/interface/DTRecHitCollection.h"
 #include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
 
 namespace edm {class Event;}
 namespace reco {class TransientTrack;}
@@ -162,5 +163,10 @@ class GlobalMuonRefitter {
     edm::ConsumesCollector* iC_;
     const MuonServiceProxy* theService;
     const edm::Event* theEvent;
+
+    edm::EDGetTokenT<CSCSegmentCollection> CSCSegmentsToken;
+    edm::EDGetTokenT<DTRecSegment4DCollection> all4DSegmentsToken;
+    edm::Handle<CSCSegmentCollection> CSCSegments;
+    edm::Handle<DTRecSegment4DCollection> all4DSegments;
 };
 #endif

--- a/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
+++ b/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
@@ -159,6 +159,7 @@ class GlobalMuonRefitter {
     std::string theMuonRecHitBuilderName;
     edm::ESHandle<TransientTrackingRecHitBuilder> theMuonRecHitBuilder;
 
+    edm::ConsumesCollector* iC_;
     const MuonServiceProxy* theService;
     const edm::Event* theEvent;
 };

--- a/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
+++ b/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
@@ -160,7 +160,6 @@ class GlobalMuonRefitter {
     std::string theMuonRecHitBuilderName;
     edm::ESHandle<TransientTrackingRecHitBuilder> theMuonRecHitBuilder;
 
-    edm::ConsumesCollector* iC_;
     const MuonServiceProxy* theService;
     const edm::Event* theEvent;
 

--- a/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
+++ b/RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h
@@ -11,12 +11,12 @@
  */
 
 #include "DataFormats/Common/interface/Handle.h"
-
+#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "RecoMuon/TrackingTools/interface/MuonTrajectoryBuilder.h"
 #include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
 #include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
@@ -57,7 +57,7 @@ class GlobalMuonRefitter {
   public:
 
     /// constructor with Parameter Set and MuonServiceProxy
-    GlobalMuonRefitter(const edm::ParameterSet&, const MuonServiceProxy*);
+    GlobalMuonRefitter(const edm::ParameterSet&, const MuonServiceProxy*, edm::ConsumesCollector&);
           
     /// destructor
     virtual ~GlobalMuonRefitter();
@@ -131,6 +131,8 @@ class GlobalMuonRefitter {
     edm::InputTag theCSCRecHitLabel;
     edm::Handle<DTRecHitCollection>    theDTRecHits;
     edm::Handle<CSCRecHit2DCollection> theCSCRecHits;
+    edm::EDGetTokenT<DTRecHitCollection> theDTRecHitToken;
+    edm::EDGetTokenT<CSCRecHit2DCollection> theCSCRecHitToken;
 
     int	  theSkipStation;
     int   theTrackerSkipSystem;

--- a/RecoMuon/GlobalTrackingTools/interface/GlobalTrajectoryBuilderBase.h
+++ b/RecoMuon/GlobalTrackingTools/interface/GlobalTrajectoryBuilderBase.h
@@ -24,6 +24,7 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "RecoMuon/TrackingTools/interface/MuonTrajectoryBuilder.h"
 #include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 class RectangularEtaPhiTrackingRegion;
 class TrajectoryStateOnSurface;
@@ -65,7 +66,7 @@ class GlobalTrajectoryBuilderBase : public MuonTrajectoryBuilder {
   public:
 
     /// constructor with Parameter Set and MuonServiceProxy
-    GlobalTrajectoryBuilderBase(const edm::ParameterSet&, const MuonServiceProxy*);
+    GlobalTrajectoryBuilderBase(const edm::ParameterSet&, const MuonServiceProxy*, edm::ConsumesCollector&);
           
     /// destructor
     virtual ~GlobalTrajectoryBuilderBase();

--- a/RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h
+++ b/RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h
@@ -15,6 +15,9 @@
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 class MuonServiceProxy;
 class RectangularEtaPhiTrackingRegion;
@@ -30,9 +33,10 @@ class MuonTrackingRegionBuilder {
   public:
  
     /// constructor
-    MuonTrackingRegionBuilder(const edm::ParameterSet&);
+    MuonTrackingRegionBuilder(const edm::ParameterSet&, edm::ConsumesCollector&);
     MuonTrackingRegionBuilder(const edm::ParameterSet&par,
-			      const MuonServiceProxy*service){ build(par);init(service);}
+			      const MuonServiceProxy*service,
+			      edm::ConsumesCollector& iC){ build(par, iC);init(service);}
     void init(const MuonServiceProxy*);
   
     /// destructor
@@ -48,7 +52,7 @@ class MuonTrackingRegionBuilder {
     virtual void setEvent(const edm::Event&);
 
   private:
-    void build(const edm::ParameterSet&);
+    void build(const edm::ParameterSet&, edm::ConsumesCollector&);
 
     edm::InputTag theBeamSpotTag;   // beam spot
     edm::InputTag theVertexCollTag; // vertex collection
@@ -76,5 +80,7 @@ class MuonTrackingRegionBuilder {
 
     double theOnDemand;
     std::string theMeasurementTrackerName;
+    edm::EDGetTokenT<reco::BeamSpot> bsHandleToken;
+    edm::EDGetTokenT<reco::VertexCollection> vertexCollectionToken;
 };
 #endif

--- a/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
+++ b/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
@@ -21,10 +21,6 @@
 
 #include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
-#include "DataFormats/MuonReco/interface/MuonQuality.h"
-#include "DataFormats/MuonReco/interface/MuonTrackLinks.h"
-#include "DataFormats/MuonReco/interface/MuonFwd.h"
-
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
@@ -46,7 +42,10 @@ GlobalTrackQualityProducer::GlobalTrackQualityProducer(const edm::ParameterSet& 
   double maxChi2 = iConfig.getParameter<double>("MaxChi2");
   double nSigma = iConfig.getParameter<double>("nSigma");
   theEstimator = new Chi2MeasurementEstimator(maxChi2,nSigma);
- 
+
+  glbMuonsToken=consumes<reco::TrackCollection>(inputCollection_);
+  linkCollectionToken=consumes<reco::MuonTrackLinksCollection>(inputLinksCollection_);
+
   produces<edm::ValueMap<reco::MuonQuality> >();
 }
 
@@ -70,10 +69,10 @@ GlobalTrackQualityProducer::produce(edm::Event& iEvent, const edm::EventSetup& i
 
   // Take the GLB muon container(s)
   edm::Handle<reco::TrackCollection> glbMuons;
-  iEvent.getByLabel(inputCollection_,glbMuons);
+  iEvent.getByToken(glbMuonsToken,glbMuons);
   
   edm::Handle<reco::MuonTrackLinksCollection>    linkCollectionHandle;
-  iEvent.getByLabel(inputLinksCollection_, linkCollectionHandle);
+  iEvent.getByToken(linkCollectionToken,linkCollectionHandle);
 
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHand;

--- a/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
+++ b/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.cc
@@ -36,8 +36,9 @@ GlobalTrackQualityProducer::GlobalTrackQualityProducer(const edm::ParameterSet& 
   theService = new MuonServiceProxy(serviceParameters);     
   
   // TrackRefitter parameters
+  edm::ConsumesCollector iC  = consumesCollector();
   edm::ParameterSet refitterParameters = iConfig.getParameter<edm::ParameterSet>("RefitterParameters");
-  theGlbRefitter = new GlobalMuonRefitter(refitterParameters, theService);
+  theGlbRefitter = new GlobalMuonRefitter(refitterParameters, theService, iC);
 
   edm::ParameterSet trackMatcherPSet = iConfig.getParameter<edm::ParameterSet>("GlobalMuonTrackMatcher");
   theGlbMatcher = new GlobalMuonTrackMatcher(trackMatcherPSet,theService);

--- a/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.h
+++ b/RecoMuon/GlobalTrackingTools/plugins/GlobalTrackQualityProducer.h
@@ -13,11 +13,12 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-
+#include "DataFormats/MuonReco/interface/MuonQuality.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
 #include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h"
 #include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonTrackMatcher.h"
-
+#include "DataFormats/MuonReco/interface/MuonTrackLinks.h"
 #include "TrackingTools/DetLayers/interface/MeasurementEstimator.h"
 #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
 
@@ -37,6 +38,8 @@ class GlobalTrackQualityProducer : public edm::EDProducer {
  
   edm::InputTag inputCollection_;
   edm::InputTag inputLinksCollection_;
+  edm::EDGetTokenT<reco::TrackCollection> glbMuonsToken;
+  edm::EDGetTokenT<reco::MuonTrackLinksCollection> linkCollectionToken;
   MuonServiceProxy* theService;
   GlobalMuonRefitter* theGlbRefitter;
   GlobalMuonTrackMatcher* theGlbMatcher;

--- a/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
@@ -28,8 +28,6 @@ GlobalMuonRefitter = cms.PSet(
     # second int --> CSC threshold
     #  third int --> if 1 APEs are used
     DYTthrs = cms.vint32(25, 10, 1),
-    DTSegs  = cms.InputTag("dt1DRecHits"),
-    CSCSegs = cms.InputTag("csc2DRecHits"),
     
     # muon station to be skipped
     SkipStation		= cms.int32(-1),

--- a/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
+++ b/RecoMuon/GlobalTrackingTools/python/GlobalMuonRefitter_cff.py
@@ -28,7 +28,9 @@ GlobalMuonRefitter = cms.PSet(
     # second int --> CSC threshold
     #  third int --> if 1 APEs are used
     DYTthrs = cms.vint32(25, 10, 1),
-
+    DTSegs  = cms.InputTag("dt1DRecHits"),
+    CSCSegs = cms.InputTag("csc2DRecHits"),
+    
     # muon station to be skipped
     SkipStation		= cms.int32(-1),
 

--- a/RecoMuon/GlobalTrackingTools/src/ChamberSegmentUtility.cc
+++ b/RecoMuon/GlobalTrackingTools/src/ChamberSegmentUtility.cc
@@ -37,13 +37,23 @@ ChamberSegmentUtility::ChamberSegmentUtility(const edm::Event& Event,
 					     const edm::EventSetup& Setup,
 					     edm::ConsumesCollector& iC)
 {
-  Setup.get<MuonGeometryRecord>().get(cscGeometry);
-  CSCSegmentsToken=iC.consumes<CSCSegmentCollection>(InputTag("cscSegments"));
-  Event.getByToken(CSCSegmentsToken, CSCSegments);
+}
+
+void ChamberSegmentUtility::initCSU(const edm::Handle<DTRecSegment4DCollection>& DTSegProd,
+				    const edm::Handle<CSCSegmentCollection>& CSCSegProd) {
   
-  Setup.get<MuonGeometryRecord>().get(dtGeom);
-  all4DSegmentsToken=iC.consumes<DTRecSegment4DCollection>(InputTag("dt4DSegments"));
-  Event.getByToken(all4DSegmentsToken, all4DSegments);
+  all4DSegments = DTSegProd;
+  CSCSegments   = CSCSegProd;
+  //  CSCSegmentsToken=iC.consumes<CSCSegmentCollection>(InputTag("cscSegments",""));
+  //  all4DSegmentsToken=iC.consumes<DTRecSegment4DCollection>(InputTag("dt4DSegments",""));
+
+  //  cout << "SONO QUI" << endl;
+
+  //  Event.getByToken(all4DSegmentsToken, all4DSegments);
+  //  Event.getByToken(CSCSegmentsToken, CSCSegments);
+
+  //  Setup.get<MuonGeometryRecord>().get(cscGeometry);
+  //  Setup.get<MuonGeometryRecord>().get(dtGeom);
 
   unsigned int index = 0;
   for (  CSCSegmentCollection::id_iterator chamberId = CSCSegments->id_begin();
@@ -76,8 +86,6 @@ ChamberSegmentUtility::ChamberSegmentUtility(const edm::Event& Event,
       if ((*chamberIdIt).station() == 4) dtsegMap[4].push_back(*segment);
     }
   }
-
-
 }
 
 

--- a/RecoMuon/GlobalTrackingTools/src/ChamberSegmentUtility.cc
+++ b/RecoMuon/GlobalTrackingTools/src/ChamberSegmentUtility.cc
@@ -33,27 +33,14 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
-ChamberSegmentUtility::ChamberSegmentUtility(const edm::Event& Event, 
-					     const edm::EventSetup& Setup,
-					     edm::ConsumesCollector& iC)
-{
-}
+ChamberSegmentUtility::ChamberSegmentUtility()
+{}
 
 void ChamberSegmentUtility::initCSU(const edm::Handle<DTRecSegment4DCollection>& DTSegProd,
 				    const edm::Handle<CSCSegmentCollection>& CSCSegProd) {
   
   all4DSegments = DTSegProd;
   CSCSegments   = CSCSegProd;
-  //  CSCSegmentsToken=iC.consumes<CSCSegmentCollection>(InputTag("cscSegments",""));
-  //  all4DSegmentsToken=iC.consumes<DTRecSegment4DCollection>(InputTag("dt4DSegments",""));
-
-  //  cout << "SONO QUI" << endl;
-
-  //  Event.getByToken(all4DSegmentsToken, all4DSegments);
-  //  Event.getByToken(CSCSegmentsToken, CSCSegments);
-
-  //  Setup.get<MuonGeometryRecord>().get(cscGeometry);
-  //  Setup.get<MuonGeometryRecord>().get(dtGeom);
 
   unsigned int index = 0;
   for (  CSCSegmentCollection::id_iterator chamberId = CSCSegments->id_begin();
@@ -79,7 +66,6 @@ void ChamberSegmentUtility::initCSU(const edm::Handle<DTRecSegment4DCollection>&
 
     for (DTRecSegment4DCollection::const_iterator segment = range.first;
          segment!=range.second; ++segment){
-      
       if ((*chamberIdIt).station() == 1) dtsegMap[1].push_back(*segment);
       if ((*chamberIdIt).station() == 2) dtsegMap[2].push_back(*segment);
       if ((*chamberIdIt).station() == 3) dtsegMap[3].push_back(*segment);

--- a/RecoMuon/GlobalTrackingTools/src/ChamberSegmentUtility.cc
+++ b/RecoMuon/GlobalTrackingTools/src/ChamberSegmentUtility.cc
@@ -33,13 +33,17 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
-ChamberSegmentUtility::ChamberSegmentUtility(const edm::Event& Event, const edm::EventSetup& Setup)
+ChamberSegmentUtility::ChamberSegmentUtility(const edm::Event& Event, 
+					     const edm::EventSetup& Setup,
+					     edm::ConsumesCollector& iC)
 {
-
   Setup.get<MuonGeometryRecord>().get(cscGeometry);
-  Event.getByLabel("cscSegments", CSCSegments);
+  CSCSegmentsToken=iC.consumes<CSCSegmentCollection>(InputTag("cscSegments"));
+  Event.getByToken(CSCSegmentsToken, CSCSegments);
+  
   Setup.get<MuonGeometryRecord>().get(dtGeom);
-  Event.getByLabel("dt4DSegments", all4DSegments);
+  all4DSegmentsToken=iC.consumes<DTRecSegment4DCollection>(InputTag("dt4DSegments"));
+  Event.getByToken(all4DSegmentsToken, all4DSegments);
 
   unsigned int index = 0;
   for (  CSCSegmentCollection::id_iterator chamberId = CSCSegments->id_begin();

--- a/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
@@ -15,7 +15,6 @@
 #include "RecoMuon/GlobalTrackingTools/interface/DynamicTruncation.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "TrackingTools/TrackFitters/interface/RecHitLessByDet.h"
-#include "RecoMuon/GlobalTrackingTools/interface/ChamberSegmentUtility.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
 #include "RecoMuon/DetLayers/interface/MuonDetLayerGeometry.h"
 #include "RecoMuon/Records/interface/MuonRecoGeometryRecord.h"
@@ -27,7 +26,6 @@
 #include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
 #include "DataFormats/TrackingRecHit/interface/AlignmentPositionError.h"
 #include "DataFormats/GeometryCommonDetAlgo/interface/ErrorFrameTransformer.h"
-
 #include "CondFormats/Alignment/interface/Alignments.h"
 #include "CondFormats/Alignment/interface/AlignTransform.h"
 #include "CondFormats/AlignmentRecord/interface/DTAlignmentRcd.h"
@@ -44,7 +42,7 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
-DynamicTruncation::DynamicTruncation(const edm::Event& event, const MuonServiceProxy& theService):
+DynamicTruncation::DynamicTruncation(const edm::Event& event, const MuonServiceProxy& theService, edm::ConsumesCollector& iC):
   DTThr(0), CSCThr(0), useAPE(false) 
 {
   theEvent = &event;
@@ -58,6 +56,7 @@ DynamicTruncation::DynamicTruncation(const edm::Event& event, const MuonServiceP
   theService.eventSetup().get<MuonRecoGeometryRecord>().get(navMuon);
   theService.eventSetup().get<IdealMagneticFieldRecord>().get(magfield);
   navigation = new DirectMuonNavigation(theService.detLayerGeometry());
+  getSegs = new ChamberSegmentUtility(*theEvent, *theSetup, iC);
 }
 
 
@@ -203,7 +202,6 @@ void DynamicTruncation::compatibleDets(TrajectoryStateOnSurface& tsos, map<int, 
 
 
 void DynamicTruncation::filteringAlgo(map<int, std::vector<DetId> >& detMap) {
-  ChamberSegmentUtility getSegs(*theEvent, *theSetup);
   for (unsigned int iDet = 0; iDet < detMap.size(); ++iDet) {
     double bestLayerValue = MAX_THR;
     bool isDTorCSC = false;
@@ -218,8 +216,8 @@ void DynamicTruncation::filteringAlgo(map<int, std::vector<DetId> >& detMap) {
 	DTChamberId DTid(id);
 
 	std::vector<DTRecSegment4D> allDTsegs;
-	std::map<int, std::vector<DTRecSegment4D> >::const_iterator dtIter = getSegs.getDTlist().find(DTid.station());
-	if (dtIter != getSegs.getDTlist().end()){
+	std::map<int, std::vector<DTRecSegment4D> >::const_iterator dtIter = getSegs->getDTlist().find(DTid.station());
+	if (dtIter != getSegs->getDTlist().end()){
 	  allDTsegs = dtIter->second;
 	}
 	std::vector<DTRecSegment4D>::size_type sz = allDTsegs.size();
@@ -241,7 +239,7 @@ void DynamicTruncation::filteringAlgo(map<int, std::vector<DetId> >& detMap) {
 	  if (bestChamberValue >= DTThr || bestChamberValue > bestLayerValue) continue; 
 	  layerRH.clear(); layerSEG.clear();
 	  layerSEG.push_back(theMuonRecHitBuilder->build(&bestDTSeg));
-	  std::vector<DTRecHit1D> DTrh = getSegs.getDTRHmap(bestDTSeg);
+	  std::vector<DTRecHit1D> DTrh = getSegs->getDTRHmap(bestDTSeg);
 	  for (std::vector<DTRecHit1D>::iterator it = DTrh.begin(); it != DTrh.end(); it++) {
 	    layerRH.push_back(theMuonRecHitBuilder->build(&*it));
 	  }
@@ -252,8 +250,8 @@ void DynamicTruncation::filteringAlgo(map<int, std::vector<DetId> >& detMap) {
         CSCDetId CSCid(id);
 	
 	std::vector<CSCSegment> allCSCsegs;
-	std::map<int, std::vector<CSCSegment> >::const_iterator cscIter = getSegs.getCSClist().find(CSCid.station()); 
-	if (cscIter != getSegs.getCSClist().end()){
+	std::map<int, std::vector<CSCSegment> >::const_iterator cscIter = getSegs->getCSClist().find(CSCid.station()); 
+	if (cscIter != getSegs->getCSClist().end()){
 	  allCSCsegs = cscIter->second;
 	}
 	
@@ -276,7 +274,7 @@ void DynamicTruncation::filteringAlgo(map<int, std::vector<DetId> >& detMap) {
 	  if (bestChamberValue >= CSCThr || bestChamberValue > bestLayerValue) continue;
 	  layerRH.clear(); layerSEG.clear();
 	  layerSEG.push_back(theMuonRecHitBuilder->build(&bestCSCSeg));
-	  std::vector<CSCRecHit2D> CSCrh = getSegs.getCSCRHmap(bestCSCSeg);
+	  std::vector<CSCRecHit2D> CSCrh = getSegs->getCSCRHmap(bestCSCSeg);
 	  for (std::vector<CSCRecHit2D>::iterator it = CSCrh.begin(); it != CSCrh.end(); ++it) {
 	    layerRH.push_back(theMuonRecHitBuilder->build(&*it));
 	  }

--- a/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
@@ -42,7 +42,7 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
-DynamicTruncation::DynamicTruncation(const edm::Event& event, const MuonServiceProxy& theService, edm::ConsumesCollector& iC):
+DynamicTruncation::DynamicTruncation(const edm::Event& event, const MuonServiceProxy& theService):
   DTThr(0), CSCThr(0), useAPE(false) 
 {
   theEvent = &event;
@@ -56,7 +56,7 @@ DynamicTruncation::DynamicTruncation(const edm::Event& event, const MuonServiceP
   theService.eventSetup().get<MuonRecoGeometryRecord>().get(navMuon);
   theService.eventSetup().get<IdealMagneticFieldRecord>().get(magfield);
   navigation = new DirectMuonNavigation(theService.detLayerGeometry());
-  getSegs = new ChamberSegmentUtility(*theEvent, *theSetup, iC);
+  getSegs = new ChamberSegmentUtility();
 }
 
 

--- a/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
@@ -115,7 +115,6 @@ GlobalMuonRefitter::GlobalMuonRefitter(const edm::ParameterSet& par,
     theRescaleErrorFactor = 1000.;
 
   theCacheId_TRH = 0;
-  iC_ = &iC;
   theDTRecHitToken=iC.consumes<DTRecHitCollection>(theDTRecHitLabel);
   theCSCRecHitToken=iC.consumes<CSCRecHit2DCollection>(theCSCRecHitLabel);
   CSCSegmentsToken = iC.consumes<CSCSegmentCollection>(InputTag("cscSegments"));
@@ -243,7 +242,7 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
     if (theMuonHitsOption == 4 ) {
       // here we use the single thr per subdetector (better performance can be obtained using thr as function of eta)
 	
-      DynamicTruncation dytRefit(*theEvent,*theService, *iC_);
+      DynamicTruncation dytRefit(*theEvent,*theService);
       dytRefit.setThr(theDYTthrs.at(0),theDYTthrs.at(1),theDYTthrs.at(2));                                
       dytRefit.setProd(all4DSegments, CSCSegments);
       DYTRecHits = dytRefit.filter(globalTraj.front());

--- a/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
@@ -114,6 +114,7 @@ GlobalMuonRefitter::GlobalMuonRefitter(const edm::ParameterSet& par,
   else
     theRescaleErrorFactor = 1000.;
 
+  iC_ = &iC;
   theDTRecHitToken=iC.consumes<DTRecHitCollection>(theDTRecHitLabel);
   theCSCRecHitToken=iC.consumes<CSCRecHit2DCollection>(theCSCRecHitLabel);
   theCacheId_TRH = 0;
@@ -239,7 +240,7 @@ vector<Trajectory> GlobalMuonRefitter::refit(const reco::Track& globalTrack,
     if (theMuonHitsOption == 4 ) {
       // here we use the single thr per subdetector (better performance can be obtained using thr as function of eta)
 	
-      DynamicTruncation dytRefit(*theEvent,*theService);
+      DynamicTruncation dytRefit(*theEvent,*theService, *iC_);
       dytRefit.setThr(theDYTthrs.at(0),theDYTthrs.at(1),theDYTthrs.at(2));                                
       DYTRecHits = dytRefit.filter(globalTraj.front());
       //vector<double> est = dytRefit.getEstimators();

--- a/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalMuonRefitter.cc
@@ -50,7 +50,6 @@
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
-
 #include "RecoMuon/MeasurementDet/interface/MuonDetLayerMeasurements.h"
 #include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHitBuilder.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"
@@ -67,7 +66,8 @@ using namespace edm;
 //----------------
 
 GlobalMuonRefitter::GlobalMuonRefitter(const edm::ParameterSet& par,
-				       const MuonServiceProxy* service) : 
+				       const MuonServiceProxy* service,
+				       edm::ConsumesCollector& iC) : 
   theCosmicFlag(par.getParameter<bool>("PropDirForCosmics")),
   theDTRecHitLabel(par.getParameter<InputTag>("DTRecSegmentLabel")),
   theCSCRecHitLabel(par.getParameter<InputTag>("CSCRecSegmentLabel")),
@@ -113,8 +113,9 @@ GlobalMuonRefitter::GlobalMuonRefitter(const edm::ParameterSet& par,
   }
   else
     theRescaleErrorFactor = 1000.;
-  
 
+  theDTRecHitToken=iC.consumes<DTRecHitCollection>(theDTRecHitLabel);
+  theCSCRecHitToken=iC.consumes<CSCRecHit2DCollection>(theCSCRecHitLabel);
   theCacheId_TRH = 0;
 
 }
@@ -133,8 +134,8 @@ GlobalMuonRefitter::~GlobalMuonRefitter() {
 void GlobalMuonRefitter::setEvent(const edm::Event& event) {
 
   theEvent = &event;
-  event.getByLabel(theDTRecHitLabel, theDTRecHits);
-  event.getByLabel(theCSCRecHitLabel, theCSCRecHits);
+  event.getByToken(theDTRecHitToken, theDTRecHits);
+  event.getByToken(theCSCRecHitToken, theCSCRecHits);   
 }
 
 

--- a/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
@@ -102,7 +102,7 @@ GlobalTrajectoryBuilderBase::GlobalTrajectoryBuilderBase(const edm::ParameterSet
 
   ParameterSet regionBuilderPSet = par.getParameter<ParameterSet>("MuonTrackingRegionBuilder");
 
-  theRegionBuilder = new MuonTrackingRegionBuilder(regionBuilderPSet,theService);
+  theRegionBuilder = new MuonTrackingRegionBuilder(regionBuilderPSet,theService,iC);
 
   // TrackRefitter parameters
   ParameterSet refitterParameters = par.getParameter<ParameterSet>("GlbRefitterParameters");

--- a/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
@@ -85,7 +85,8 @@ using namespace edm;
 // Constructors --
 //----------------
 GlobalTrajectoryBuilderBase::GlobalTrajectoryBuilderBase(const edm::ParameterSet& par,
-                                                         const MuonServiceProxy* service) : 
+                                                         const MuonServiceProxy* service,
+							 edm::ConsumesCollector& iC) : 
   theTrackMatcher(0),theLayerMeasurements(0),theTrackTransformer(0),theRegionBuilder(0), theService(service),theGlbRefitter(0) {
 
   theCategory = par.getUntrackedParameter<string>("Category", "Muon|RecoMuon|GlobalMuon|GlobalTrajectoryBuilderBase");
@@ -105,7 +106,7 @@ GlobalTrajectoryBuilderBase::GlobalTrajectoryBuilderBase(const edm::ParameterSet
 
   // TrackRefitter parameters
   ParameterSet refitterParameters = par.getParameter<ParameterSet>("GlbRefitterParameters");
-  theGlbRefitter = new GlobalMuonRefitter(refitterParameters, theService);
+  theGlbRefitter = new GlobalMuonRefitter(refitterParameters, theService, iC);
 
   theMuonHitsOption = refitterParameters.getParameter<int>("MuonHitsOption");
 

--- a/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionBuilder.cc
+++ b/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionBuilder.cc
@@ -26,8 +26,6 @@
 #include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/PatternTools/interface/TSCPBuilderNoMaterial.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -38,11 +36,11 @@ using namespace std;
 //
 
 void MuonTrackingRegionBuilder::init(const MuonServiceProxy* service) { theService= service;}
-MuonTrackingRegionBuilder::MuonTrackingRegionBuilder(const edm::ParameterSet& par)
+MuonTrackingRegionBuilder::MuonTrackingRegionBuilder(const edm::ParameterSet& par, edm::ConsumesCollector& iC)
 {
-  build(par);
+  build(par, iC);
 }
-void MuonTrackingRegionBuilder::build(const edm::ParameterSet& par){
+void MuonTrackingRegionBuilder::build(const edm::ParameterSet& par, edm::ConsumesCollector& iC){
   // vertex Collection and Beam Spot
   theBeamSpotTag = par.getParameter<edm::InputTag>("beamSpot");
   theVertexCollTag = par.getParameter<edm::InputTag>("vertexCollection");
@@ -72,9 +70,11 @@ void MuonTrackingRegionBuilder::build(const edm::ParameterSet& par){
   theDeltaR = par.getParameter<double>("DeltaR");
 
   // perigee reference point
-
   theOnDemand = par.getParameter<double>("OnDemand");
   theMeasurementTrackerName = par.getParameter<std::string>("MeasurementTrackerName");
+
+  bsHandleToken=iC.consumes<reco::BeamSpot>(theBeamSpotTag);
+  vertexCollectionToken=iC.consumes<reco::VertexCollection>(theVertexCollTag);
 }
 
 
@@ -128,7 +128,7 @@ MuonTrackingRegionBuilder::region(const reco::Track& staTrack) const {
 
   // retrieve beam spot information
   edm::Handle<reco::BeamSpot> bsHandle;
-  bool bsHandleFlag = theEvent->getByLabel(theBeamSpotTag, bsHandle);
+  bool bsHandleFlag = theEvent->getByToken(bsHandleToken, bsHandle);
   // check the validity, otherwise vertexing
   // inizialization of BS
 
@@ -138,7 +138,7 @@ MuonTrackingRegionBuilder::region(const reco::Track& staTrack) const {
   } else {
     // get originZPos from list of reconstructed vertices (first or all)
     edm::Handle<reco::VertexCollection> vertexCollection;
-    bool vtxHandleFlag = theEvent->getByLabel(theVertexCollTag,vertexCollection);
+    bool vtxHandleFlag = theEvent->getByToken(vertexCollectionToken, vertexCollection);
     // check if there exists at least one reconstructed vertex
     if ( vtxHandleFlag && !vertexCollection->empty() ) {
       // use the first vertex in the collection and assume it is the primary event vertex 

--- a/RecoMuon/L3TrackFinder/src/L3MuonTrajectoryBuilder.cc
+++ b/RecoMuon/L3TrackFinder/src/L3MuonTrajectoryBuilder.cc
@@ -71,7 +71,7 @@ using namespace edm;
 
 L3MuonTrajectoryBuilder::L3MuonTrajectoryBuilder(const edm::ParameterSet& par,
 						 const MuonServiceProxy* service,
-						 edm::ConsumesCollector& iC) : GlobalTrajectoryBuilderBase(par, service) {
+						 edm::ConsumesCollector& iC) : GlobalTrajectoryBuilderBase(par, service, iC) {
 
   theTrajectoryCleaner = new TrajectoryCleanerBySharedHits();    
 

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.cc
@@ -13,11 +13,13 @@ TSGFromL2Muon::TSGFromL2Muon(const edm::ParameterSet& cfg)
 
   theL2CollectionLabel = cfg.getParameter<edm::InputTag>("MuonCollectionLabel");
 
+  edm::ConsumesCollector iC  = consumesCollector();
+
   //region builder
   edm::ParameterSet regionBuilderPSet = theConfig.getParameter<edm::ParameterSet>("MuonTrackingRegionBuilder");
   //ability to no define a region
   if (!regionBuilderPSet.empty()){
-    theRegionBuilder = new MuonTrackingRegionBuilder(regionBuilderPSet);
+    theRegionBuilder = new MuonTrackingRegionBuilder(regionBuilderPSet, iC);
   }
 
   //seed generator
@@ -26,7 +28,6 @@ TSGFromL2Muon::TSGFromL2Muon(const edm::ParameterSet& cfg)
   edm::ParameterSet seedGenPSet = theConfig.getParameter<edm::ParameterSet>("TkSeedGenerator");
   std::string seedGenName = seedGenPSet.getParameter<std::string>("ComponentName");
 
-  edm::ConsumesCollector iC  = consumesCollector();
   theTkSeedGenerator = TrackerSeedGeneratorFactory::get()->create(seedGenName, seedGenPSet,iC);  
   
   //seed cleaner


### PR DESCRIPTION
This PR is for the migration to "consumes" of RecoMuon/GlobalTrackingTools. Dependencies on other modules have also been resolved.
