### PR TITLE
Finish consumes for valid muoncscdigis

### DIFF
--- a/Validation/MuonCSCDigis/src/CSCWireDigiValidation.cc
+++ b/Validation/MuonCSCDigis/src/CSCWireDigiValidation.cc
@@ -1,7 +1,6 @@
 #include "Validation/MuonCSCDigis/src/CSCWireDigiValidation.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/CSCDigi/interface/CSCWireDigiCollection.h"
 
 #include "Geometry/CSCGeometry/interface/CSCLayerGeometry.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
@@ -11,7 +10,7 @@
 
 CSCWireDigiValidation::CSCWireDigiValidation(DQMStore* dbe,
                                              const edm::InputTag & inputTag,
-                                             edm::ConsumesCollector && /* iC */,
+                                             edm::ConsumesCollector && iC,
                                              bool doSim)
 : CSCBaseValidation(dbe, inputTag),
   theDoSimFlag(doSim),
@@ -19,6 +18,8 @@ CSCWireDigiValidation::CSCWireDigiValidation(DQMStore* dbe,
   theNDigisPerLayerPlots(),
   theNDigisPerEventPlot( dbe_->book1D("CSCWireDigisPerEvent", "CSC Wire Digis per event", 100, 0, 100) )
 {
+  wires_Token_ = iC.consumes<CSCWireDigiCollection>(inputTag);
+
   for(int i = 0; i < 10; ++i)
   {
     char title1[200], title2[200], title3[200];
@@ -50,7 +51,8 @@ void CSCWireDigiValidation::analyze(const edm::Event&e, const edm::EventSetup&)
 {
   edm::Handle<CSCWireDigiCollection> wires;
 
-  e.getByLabel(theInputTag, wires);
+  e.getByToken(wires_Token_, wires);
+
   if (!wires.isValid()) {
     edm::LogError("CSCDigiDump") << "Cannot get wires by label " << theInputTag.encode();
   }

--- a/Validation/MuonCSCDigis/src/CSCWireDigiValidation.h
+++ b/Validation/MuonCSCDigis/src/CSCWireDigiValidation.h
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/CSCDigi/interface/CSCWireDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCWireDigiCollection.h"
 #include "Validation/MuonCSCDigis/interface/CSCBaseValidation.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
@@ -13,7 +14,7 @@ class CSCWireDigiValidation : public CSCBaseValidation
 public:
   CSCWireDigiValidation(DQMStore* dbe,
                         const edm::InputTag & inputTag,
-                        edm::ConsumesCollector && /* iC */,
+                        edm::ConsumesCollector && iC,
                         bool doSim);
   ~CSCWireDigiValidation();
   void analyze(const edm::Event&, const edm::EventSetup&);
@@ -22,6 +23,7 @@ public:
                       const CSCLayer * layer, int chamberType);
 
 private:
+  edm::EDGetTokenT<CSCWireDigiCollection> wires_Token_;
   bool theDoSimFlag;
   MonitorElement* theTimeBinPlots[10];
   MonitorElement* theNDigisPerLayerPlots[10];


### PR DESCRIPTION
This completes consumes interface for Validation/MuonCSCDigis. Seemed to have been almost done by Marco R. a few months ago. This compiles and builds but has not been tested because I don't know how to.
