### PR TITLE
Consumes for valid cscrechits

### DIFF
--- a/Validation/CSCRecHits/src/CSCRecHit2DValidation.cc
+++ b/Validation/CSCRecHits/src/CSCRecHit2DValidation.cc
@@ -1,14 +1,15 @@
 #include "Validation/CSCRecHits/src/CSCRecHit2DValidation.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
 
 
-CSCRecHit2DValidation::CSCRecHit2DValidation(DQMStore* dbe, const edm::InputTag & inputTag)
+CSCRecHit2DValidation::CSCRecHit2DValidation(DQMStore* dbe, const edm::InputTag & inputTag, edm::ConsumesCollector && iC)
 : CSCBaseValidation(dbe, inputTag),
   theNPerEventPlot( dbe_->book1D("CSCRecHitsPerEvent", "Number of CSC Rec Hits per event", 100, 0, 500) )
 {
+   rechits_Token_ = iC.consumes<CSCRecHit2DCollection>(inputTag);
+
    dbe_->setCurrentFolder("CSCRecHitsV/CSCRecHitTask");
 
    for(int i = 0; i < 10; ++i)
@@ -52,7 +53,7 @@ void CSCRecHit2DValidation::analyze(const edm::Event&e, const edm::EventSetup& e
 {
   // get the collection of CSCRecHrecHitItrD
   edm::Handle<CSCRecHit2DCollection> hRecHits;
-  e.getByLabel(theInputTag, hRecHits);
+  e.getByToken(rechits_Token_, hRecHits);
   const CSCRecHit2DCollection * cscRecHits = hRecHits.product();
 
   unsigned nPerEvent = 0;

--- a/Validation/CSCRecHits/src/CSCRecHit2DValidation.h
+++ b/Validation/CSCRecHits/src/CSCRecHit2DValidation.h
@@ -3,6 +3,8 @@
 
 #include "Validation/MuonCSCDigis/interface/CSCBaseValidation.h"
 #include "DataFormats/CSCRecHit/interface/CSCRecHit2D.h"
+#include "DataFormats/CSCRecHit/interface/CSCRecHit2DCollection.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "Geometry/CSCGeometry/interface/CSCLayer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
@@ -10,13 +12,15 @@
 class CSCRecHit2DValidation : public CSCBaseValidation
 {
 public:
-  CSCRecHit2DValidation(DQMStore* dbe, const edm::InputTag & inputTag);
+  CSCRecHit2DValidation(DQMStore* dbe, const edm::InputTag & inputTag, edm::ConsumesCollector && iC);
 
-  // print out RMSes
   virtual ~CSCRecHit2DValidation();
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
  private:
+
+  edm::EDGetTokenT<CSCRecHit2DCollection> rechits_Token_;
+
   void plotResolution(const PSimHit & simHit, const CSCRecHit2D & recHit,
                       const CSCLayer * layer, int chamberType);
 

--- a/Validation/CSCRecHits/src/CSCRecHitValidation.cc
+++ b/Validation/CSCRecHits/src/CSCRecHitValidation.cc
@@ -13,15 +13,19 @@ CSCRecHitValidation::CSCRecHitValidation(const edm::ParameterSet & ps)
   theOutputFile( ps.getParameter<std::string>("outputFile") ),
   theSimHitMap(ps.getParameter<edm::InputTag>("simHitsTag")),
   theCSCGeometry(0),
-  the2DValidation(dbe_, ps.getParameter<edm::InputTag>("recHitLabel") ),
-  theSegmentValidation(dbe_, ps.getParameter<edm::InputTag>("segmentLabel") )
+  the2DValidation(0),
+  theSegmentValidation(0)
 {
+  the2DValidation = new CSCRecHit2DValidation(dbe_, ps.getParameter<edm::InputTag>("recHitLabel"), consumesCollector() );
+  theSegmentValidation = new CSCSegmentValidation(dbe_, ps.getParameter<edm::InputTag>("segmentLabel"), consumesCollector() );
 }
 
 
 CSCRecHitValidation::~CSCRecHitValidation()
 {
   if ( theOutputFile.size() != 0 && dbe_ ) dbe_->save(theOutputFile);
+  delete the2DValidation;
+  delete theSegmentValidation;
 }
 
 
@@ -39,12 +43,13 @@ void CSCRecHitValidation::analyze(const edm::Event&e, const edm::EventSetup& eve
   eventSetup.get<MuonGeometryRecord>().get( hGeom );
   theCSCGeometry = &*hGeom;
 
-  the2DValidation.setGeometry(theCSCGeometry);
-  the2DValidation.setSimHitMap(&theSimHitMap);
-  theSegmentValidation.setGeometry(theCSCGeometry);
-  theSegmentValidation.setSimHitMap(&theSimHitMap);
+  the2DValidation->setGeometry(theCSCGeometry);
+  the2DValidation->setSimHitMap(&theSimHitMap);
 
-  the2DValidation.analyze(e, eventSetup);
-  theSegmentValidation.analyze(e, eventSetup);
+  theSegmentValidation->setGeometry(theCSCGeometry);
+  theSegmentValidation->setSimHitMap(&theSimHitMap);
+
+  the2DValidation->analyze(e, eventSetup);
+  theSegmentValidation->analyze(e, eventSetup);
 
 }

--- a/Validation/CSCRecHits/src/CSCRecHitValidation.h
+++ b/Validation/CSCRecHits/src/CSCRecHitValidation.h
@@ -32,8 +32,8 @@ public:
   PSimHitMap theSimHitMap;
   const CSCGeometry * theCSCGeometry;
 
-  CSCRecHit2DValidation the2DValidation;
-  CSCSegmentValidation theSegmentValidation;
+  CSCRecHit2DValidation * the2DValidation;
+  CSCSegmentValidation * theSegmentValidation;
 };
 
 #endif

--- a/Validation/CSCRecHits/src/CSCSegmentValidation.cc
+++ b/Validation/CSCRecHits/src/CSCSegmentValidation.cc
@@ -1,11 +1,10 @@
 #include "Validation/CSCRecHits/src/CSCSegmentValidation.h"
-#include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
 #include <algorithm>
 #include "DQMServices/Core/interface/DQMStore.h"
 
 
 
-CSCSegmentValidation::CSCSegmentValidation(DQMStore* dbe, const edm::InputTag & inputTag)
+CSCSegmentValidation::CSCSegmentValidation(DQMStore* dbe, const edm::InputTag & inputTag, edm::ConsumesCollector && iC)
 : CSCBaseValidation(dbe, inputTag),
   theLayerHitsPerChamber(),
   theChamberSegmentMap(),
@@ -26,6 +25,8 @@ CSCSegmentValidation::CSCSegmentValidation(DQMStore* dbe, const edm::InputTag & 
   theTypePlot6HitsShower( dbe_->book1D("CSCSegments6HitsShower", "", 100, 0, 10) ),
   theTypePlot6HitsShowerSeg( dbe_->book1D("CSCSegments6HitsShowerSeg", "", 100, 0, 10) )
 {
+   segments_Token_ = iC.consumes<CSCSegmentCollection>(inputTag);
+
    dbe_->setCurrentFolder("CSCRecHitsV/CSCRecHitTask");
    for(int i = 0; i < 10; ++i)
   {
@@ -57,7 +58,7 @@ void CSCSegmentValidation::analyze(const edm::Event&e, const edm::EventSetup& ev
 {
   // get the collection of CSCRecHsegmentItrD
   edm::Handle<CSCSegmentCollection> hRecHits;
-  e.getByLabel(theInputTag, hRecHits);
+  e.getByToken(segments_Token_, hRecHits);
   const CSCSegmentCollection * cscRecHits = hRecHits.product();
 
   theChamberSegmentMap.clear();

--- a/Validation/CSCRecHits/src/CSCSegmentValidation.h
+++ b/Validation/CSCRecHits/src/CSCSegmentValidation.h
@@ -3,6 +3,8 @@
 
 #include "Validation/MuonCSCDigis/interface/CSCBaseValidation.h"
 #include "DataFormats/CSCRecHit/interface/CSCSegment.h"
+#include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "Geometry/CSCGeometry/interface/CSCLayer.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
@@ -10,7 +12,7 @@
 class CSCSegmentValidation : public CSCBaseValidation
 {
 public:
-  CSCSegmentValidation(DQMStore* dbe, const edm::InputTag & inputTag);
+  CSCSegmentValidation(DQMStore* dbe, const edm::InputTag & inputTag, edm::ConsumesCollector && iC);
 
   virtual ~CSCSegmentValidation() {}
   virtual void analyze(const edm::Event&, const edm::EventSetup&);
@@ -21,6 +23,8 @@ public:
 
   bool hasSegment(int chamberId) const;
   static int whatChamberType(int detId);
+
+  edm::EDGetTokenT<CSCSegmentCollection> segments_Token_;
 
   // map to count how many layers are hit.  First index is chamber detId, second is layers
   // that have hits

--- a/Validation/MuonCSCDigis/src/CSCWireDigiValidation.cc
+++ b/Validation/MuonCSCDigis/src/CSCWireDigiValidation.cc
@@ -1,7 +1,6 @@
 #include "Validation/MuonCSCDigis/src/CSCWireDigiValidation.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/CSCDigi/interface/CSCWireDigiCollection.h"
 
 #include "Geometry/CSCGeometry/interface/CSCLayerGeometry.h"
 #include "Geometry/CSCGeometry/interface/CSCGeometry.h"
@@ -11,7 +10,7 @@
 
 CSCWireDigiValidation::CSCWireDigiValidation(DQMStore* dbe,
                                              const edm::InputTag & inputTag,
-                                             edm::ConsumesCollector && /* iC */,
+                                             edm::ConsumesCollector && iC,
                                              bool doSim)
 : CSCBaseValidation(dbe, inputTag),
   theDoSimFlag(doSim),
@@ -19,6 +18,8 @@ CSCWireDigiValidation::CSCWireDigiValidation(DQMStore* dbe,
   theNDigisPerLayerPlots(),
   theNDigisPerEventPlot( dbe_->book1D("CSCWireDigisPerEvent", "CSC Wire Digis per event", 100, 0, 100) )
 {
+  wires_Token_ = iC.consumes<CSCWireDigiCollection>(inputTag);
+
   for(int i = 0; i < 10; ++i)
   {
     char title1[200], title2[200], title3[200];
@@ -50,7 +51,8 @@ void CSCWireDigiValidation::analyze(const edm::Event&e, const edm::EventSetup&)
 {
   edm::Handle<CSCWireDigiCollection> wires;
 
-  e.getByLabel(theInputTag, wires);
+  e.getByToken(wires_Token_, wires);
+
   if (!wires.isValid()) {
     edm::LogError("CSCDigiDump") << "Cannot get wires by label " << theInputTag.encode();
   }

--- a/Validation/MuonCSCDigis/src/CSCWireDigiValidation.h
+++ b/Validation/MuonCSCDigis/src/CSCWireDigiValidation.h
@@ -4,6 +4,7 @@
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/CSCDigi/interface/CSCWireDigi.h"
+#include "DataFormats/CSCDigi/interface/CSCWireDigiCollection.h"
 #include "Validation/MuonCSCDigis/interface/CSCBaseValidation.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
@@ -13,7 +14,7 @@ class CSCWireDigiValidation : public CSCBaseValidation
 public:
   CSCWireDigiValidation(DQMStore* dbe,
                         const edm::InputTag & inputTag,
-                        edm::ConsumesCollector && /* iC */,
+                        edm::ConsumesCollector && iC,
                         bool doSim);
   ~CSCWireDigiValidation();
   void analyze(const edm::Event&, const edm::EventSetup&);
@@ -22,6 +23,7 @@ public:
                       const CSCLayer * layer, int chamberType);
 
 private:
+  edm::EDGetTokenT<CSCWireDigiCollection> wires_Token_;
   bool theDoSimFlag;
   MonitorElement* theTimeBinPlots[10];
   MonitorElement* theNDigisPerLayerPlots[10];


### PR DESCRIPTION
Add consumes interface to Validation/CSCRecHits. Compiles and builds but has not been tested because I don't know how to. This branch incorporates the branch finish_consumes_for_valid_muoncscdigis because it needs those changes in Validation/MuonCSCDigis too, and I don't know how to keep the branches independent.
