### PR TITLE
Implemented usage of streamerInfo in Root based persistency

### DIFF
--- a/CondCore/CondDB/interface/IOVProxy.h
+++ b/CondCore/CondDB/interface/IOVProxy.h
@@ -87,6 +87,8 @@ namespace cond {
       
       std::string payloadObjectType() const;
       
+      cond::SynchronizationType synchronizationType() const;
+
       cond::Time_t endOfValidity() const;
       
       cond::Time_t lastValidatedTime() const;

--- a/CondCore/CondDB/interface/KeyList.h
+++ b/CondCore/CondDB/interface/KeyList.h
@@ -42,7 +42,7 @@ namespace cond {
 	if( !m_objects[n] ){
 	  auto i = m_data.find( n );
 	  if( i != m_data.end() ){
-	    m_objects[n] = deserialize<T>( i->second.first, i->second.second, m_isOra );
+	    m_objects[n] = deserialize<T>( i->second.first, i->second.second.first, i->second.second.second, m_isOra );
 	    m_data.erase( n );
 	  } else {
 	    throwException( "Payload for index "+boost::lexical_cast<std::string>(n)+" has not been found.",
@@ -57,8 +57,8 @@ namespace cond {
     private:
       // the db session
       IOVProxy m_proxy;
-      // the key selection
-      mutable std::map<size_t,std::pair<std::string,cond::Binary> > m_data;
+      // the key selection: 
+      mutable std::map<size_t,std::pair<std::string,std::pair<cond::Binary,cond::Binary> > > m_data;
       mutable std::vector<boost::shared_ptr<void> > m_objects;
       bool m_isOra = false;
       

--- a/CondCore/CondDB/interface/Serialization.h
+++ b/CondCore/CondDB/interface/Serialization.h
@@ -22,7 +22,7 @@
 // temporarely
 #include <boost/shared_ptr.hpp>
 
-class TBufferFile;
+class RootStreamBuffer;
 
 namespace cond {
 
@@ -40,7 +40,7 @@ namespace cond {
   // output
   class RootOutputArchive {
   public:
-    explicit RootOutputArchive( std::ostream& destination );
+    RootOutputArchive( std::ostream& dataDest, std::ostream& streamerInfoDest );
 
     template <typename T>
     RootOutputArchive& operator<<( const T& instance );
@@ -49,7 +49,8 @@ namespace cond {
     void write( const std::type_info& sourceType, const void* sourceInstance);
   private:
     // here is where the write function will write on...
-    std::ostream& m_buffer;
+    std::ostream& m_dataBuffer;
+    std::ostream& m_streamerInfoBuffer;
   };
 
   template <typename T> inline RootOutputArchive& RootOutputArchive::operator<<( const T& instance ){
@@ -60,7 +61,7 @@ namespace cond {
   // input
   class RootInputArchive {
   public:
-    explicit RootInputArchive( std::istream& source );
+    RootInputArchive( std::istream& binaryData, std::istream& binaryStreamerInfo );
 
     virtual ~RootInputArchive();
 
@@ -71,8 +72,9 @@ namespace cond {
     void read( const std::type_info& destinationType, void* destinationInstance);
   private:
     // copy of the input stream. is referenced by the TBufferFile.
-    std::string m_buffer;
-    TBufferFile* m_streamer = nullptr;
+    std::string m_dataBuffer;
+    std::string m_streamerInfoBuffer;
+    RootStreamBuffer* m_streamer = nullptr;
   };
 
   template <typename T> inline RootInputArchive& RootInputArchive::operator>>( T& instance ){
@@ -85,35 +87,45 @@ namespace cond {
 
   // call for the serialization. Setting packingOnly = TRUE the data will stay in the original memory layout 
   // ( no serialization in this case ). This option is used by the ORA backend - will be dropped after the changeover
-  template <typename T> Binary serialize( const T& payload, bool packingOnly = false ){
-    Binary ret;
+  template <typename T> std::pair<Binary,Binary> serialize( const T& payload, bool packingOnly = false ){
+    std::pair<Binary,Binary> ret;
     if( !packingOnly ){
-      // save data to buffer
-      std::ostringstream buffer;
-      CondOutputArchive oa( buffer );
+      // save data to buffers
+      std::ostringstream dataBuffer;
+      std::ostringstream streamerInfoBuffer;
+      CondOutputArchive oa( dataBuffer, streamerInfoBuffer );
       oa << payload;
       //TODO: avoid (2!!) copies
-      ret.copy( buffer.str() );
+      ret.first.copy( dataBuffer.str() );
+      ret.second.copy( streamerInfoBuffer.str() );
     } else {
-      ret = Binary( payload );
+      // ORA objects case: nothing to serialize, the object is kept in memory in the original layout - the bare pointer is exchanged
+      ret.first = Binary( payload );
     }
     return ret;
   }
 
   // generates an instance of T from the binary serialized data. With unpackingOnly = true the memory is already storing the object in the final 
   // format. Only a cast is required in this case - Used by the ORA backed, will be dropped in the future.
-  template <typename T> boost::shared_ptr<T> deserialize( const std::string& payloadType, const Binary& payloadData, bool unpackingOnly = false){
+  template <typename T> boost::shared_ptr<T> deserialize( const std::string& payloadType, 
+							  const Binary& payloadData, 
+							  const Binary& streamerInfoData, 
+							  bool unpackingOnly = false){
     // for the moment we fail if types don't match... later we will check for base types...
     boost::shared_ptr<T> payload;
     if( !unpackingOnly ){
-      std::stringbuf sbuf;
-      sbuf.pubsetbuf( static_cast<char*>(const_cast<void*>(payloadData.data())), payloadData.size() );
+      std::stringbuf sdataBuf;
+      sdataBuf.pubsetbuf( static_cast<char*>(const_cast<void*>(payloadData.data())), payloadData.size() );
+      std::stringbuf sstreamerInfoBuf;
+      sstreamerInfoBuf.pubsetbuf( static_cast<char*>(const_cast<void*>(streamerInfoData.data())), streamerInfoData.size() );
 
-      std::istream buffer( &sbuf );
-      CondInputArchive ia(buffer);
+      std::istream dataBuffer( &sdataBuf );
+      std::istream streamerInfoBuffer( &sstreamerInfoBuf );
+      CondInputArchive ia( dataBuffer, streamerInfoBuffer );
       payload.reset( createPayload<T>(payloadType) );
       ia >> (*payload);
     } else {
+      // ORA objects case: nothing to de-serialize, the object is already in memory in the final layout, ready to be casted
       payload = boost::static_pointer_cast<T>(payloadData.oraObject().makeShared());
     }
     return payload;

--- a/CondCore/CondDB/interface/Session.h
+++ b/CondCore/CondDB/interface/Session.h
@@ -88,7 +88,8 @@ namespace cond {
       // read access to the iov sequence. 
       // by default ( full=false ) the iovs are lazy-loaded in groups when required, with repeatable queries ( for FronTier )
       // full=true will load the entire sequence in memory. Mainly for test/debugging.
-      IOVProxy readIov( const std::string& tag, bool full=false );//,const boost::posix_time::ptime& snapshottime )  
+      IOVProxy readIov( const std::string& tag, 
+			bool full=false );//,const boost::posix_time::ptime& snapshottime )  
       
       // 
       bool existsIov( const std::string& tag );
@@ -97,13 +98,17 @@ namespace cond {
       // the type is required for consistency with the referenced payloads.    
       // fixme: add creation time - required for the migration
       template <typename T>
-      IOVEditor createIov( const std::string& tag, cond::TimeType timeType, 
+      IOVEditor createIov( const std::string& tag, 
+			   cond::TimeType timeType, 
 			   cond::SynchronizationType synchronizationType=cond::OFFLINE );
-      IOVEditor createIov(  const std::string& payloadType, const std::string& tag, cond::TimeType timeType,
+      IOVEditor createIov( const std::string& payloadType, 
+			   const std::string& tag, 
+			   cond::TimeType timeType,
 			   cond::SynchronizationType synchronizationType=cond::OFFLINE );
 
-      IOVEditor createIovForPayload(  const Hash& payloadHash, const std::string& tag, cond::TimeType timeType,
-				      cond::SynchronizationType synchronizationType=cond::OFFLINE );
+      IOVEditor createIovForPayload( const Hash& payloadHash, 
+				     const std::string& tag, cond::TimeType timeType,
+				     cond::SynchronizationType synchronizationType=cond::OFFLINE );
       
       // update an existing iov sequence with the specified tag.
       // timeType and payloadType can't be modified.
@@ -114,9 +119,13 @@ namespace cond {
 						     const boost::posix_time::ptime& creationTime = boost::posix_time::microsec_clock::universal_time() );
       template <typename T> boost::shared_ptr<T> fetchPayload( const cond::Hash& payloadHash );
       
-      // low-level function to access the payload data as a blob. mainly used for the data migration and testing. 
-      bool fetchPayloadData( const cond::Hash& payloadHash, std::string& payloadType, cond::Binary& payloadData );
-      
+      // low-level function to access the payload data as a blob. mainly used for the data migration and testing.
+      // the version for ROOT 
+      bool fetchPayloadData( const cond::Hash& payloadHash, 
+			     std::string& payloadType, 
+			     cond::Binary& payloadData,
+			     cond::Binary& streamerInfoData );
+
       // internal functions. creates proxies without loading a specific tag.  
       IOVProxy iovProxy();
       
@@ -125,11 +134,17 @@ namespace cond {
       
       GTProxy readGlobalTag( const std::string& name );
       // essentially for the bridge. useless where ORA disappears.
-      GTProxy readGlobalTag( const std::string& name, const std::string& preFix, const std::string& postFix  );
+      GTProxy readGlobalTag( const std::string& name, 
+			     const std::string& preFix, 
+			     const std::string& postFix  );
     public:
       
-      bool checkMigrationLog( const std::string& sourceAccount, const std::string& sourceTag, std::string& destinationTag );
-      void addToMigrationLog( const std::string& sourceAccount, const std::string& sourceTag, const std::string& destinationTag );
+      bool checkMigrationLog( const std::string& sourceAccount, 
+			      const std::string& sourceTag, 
+			      std::string& destinationTag );
+      void addToMigrationLog( const std::string& sourceAccount, 
+			      const std::string& sourceTag, 
+			      const std::string& destinationTag );
 
       std::string connectionString();
 
@@ -140,7 +155,9 @@ namespace cond {
       bool isOraSession(); 
 
     private:
-      cond::Hash storePayloadData( const std::string& payloadObjectType, const cond::Binary& payloadData, const boost::posix_time::ptime& creationTime );
+      cond::Hash storePayloadData( const std::string& payloadObjectType, 
+				   const std::pair<Binary,Binary>& payloadAndStreamerInfoData, 
+				   const boost::posix_time::ptime& creationTime );
       
     private:
       
@@ -160,11 +177,12 @@ namespace cond {
     
     template <typename T> inline boost::shared_ptr<T> Session::fetchPayload( const cond::Hash& payloadHash ){
       cond::Binary payloadData;
+      cond::Binary streamerInfoData;
       std::string payloadType;
-      if(! fetchPayloadData( payloadHash, payloadType, payloadData ) ) 
+      if(! fetchPayloadData( payloadHash, payloadType, payloadData, streamerInfoData ) ) 
 	throwException( "Payload with id="+payloadHash+" has not been found in the database.",
 			"Session::fetchPayload" );
-      return deserialize<T>(  payloadType, payloadData, isOraSession() );
+      return deserialize<T>(  payloadType, payloadData, streamerInfoData, isOraSession() );
     }
 
     class TransactionScope {

--- a/CondCore/CondDB/src/IDbSchema.h
+++ b/CondCore/CondDB/src/IDbSchema.h
@@ -14,7 +14,7 @@ namespace cond {
       virtual bool exists() = 0;
       virtual void create() = 0;
       virtual bool select( const std::string& name ) = 0;
-      virtual bool select( const std::string& name, cond::TimeType& timeType, std::string& objectType, 
+      virtual bool select( const std::string& name, cond::TimeType& timeType, std::string& objectType, cond::SynchronizationType& synchronizationType,
 			   cond::Time_t& endOfValidity, std::string& description, cond::Time_t& lastValidatedTime ) = 0;
       virtual bool getMetadata( const std::string& name, std::string& description, 
 				boost::posix_time::ptime& insertionTime, boost::posix_time::ptime& modificationTime ) = 0;
@@ -32,12 +32,11 @@ namespace cond {
       virtual ~IPayloadTable(){}
       virtual bool exists() = 0;
       virtual void create() = 0;
-      virtual bool select( const cond::Hash& payloadHash, std::string& objectType, cond::Binary& payloadData ) = 0;
+      virtual bool select( const cond::Hash& payloadHash, std::string& objectType, 
+			   cond::Binary& payloadData, cond::Binary& streamerInfoData ) = 0;
       virtual bool getType( const cond::Hash& payloadHash, std::string& objectType ) = 0;
-      //virtual bool insert( const cond::Hash& payloadHash, const std::string& objectType, 
-      //			   const cond::Binary& payloadData, const boost::posix_time::ptime& insertionTime ) = 0;
       virtual cond::Hash insertIfNew( const std::string& objectType, const cond::Binary& payloadData, 
-				      const boost::posix_time::ptime& insertionTime ) = 0;
+				      const cond::Binary& streamerInfoData, const boost::posix_time::ptime& insertionTime ) = 0;
     };
 
     class IIOVTable {

--- a/CondCore/CondDB/src/IOVEditor.cc
+++ b/CondCore/CondDB/src/IOVEditor.cc
@@ -68,7 +68,8 @@ namespace cond {
     void IOVEditor::load( const std::string& tag ){
       checkTransaction( "IOVEditor::load" );
       // loads the current header data in memory
-      if( !m_session->iovSchema().tagTable().select( tag, m_data->timeType, m_data->payloadType, m_data->endOfValidity, m_data->description, m_data->lastValidatedTime ) ){
+      if( !m_session->iovSchema().tagTable().select( tag, m_data->timeType, m_data->payloadType, m_data->synchronizationType, 
+						     m_data->endOfValidity, m_data->description, m_data->lastValidatedTime ) ){
 	cond::throwException( "Tag \""+tag+"\" has not been found in the database.","IOVEditor::load");
       }
       m_data->tag = tag;

--- a/CondCore/CondDB/src/IOVProxy.cc
+++ b/CondCore/CondDB/src/IOVProxy.cc
@@ -18,6 +18,7 @@ namespace cond {
       std::string tag;
       cond::TimeType timeType;
       std::string payloadType;
+      cond::SynchronizationType synchronizationType;
       cond::Time_t endOfValidity;
       cond::Time_t lastValidatedTime;
       // iov data
@@ -126,7 +127,7 @@ namespace cond {
       
       checkTransaction( "IOVProxy::load" );
       std::string dummy;
-      if(!m_session->iovSchema().tagTable().select( tag, m_data->timeType, m_data->payloadType, 
+      if(!m_session->iovSchema().tagTable().select( tag, m_data->timeType, m_data->payloadType, m_data->synchronizationType,
 						    m_data->endOfValidity, dummy, m_data->lastValidatedTime ) ){
 	throwException( "Tag \""+tag+"\" has not been found in the database.","IOVProxy::load");
       }
@@ -170,6 +171,10 @@ namespace cond {
       return m_data.get() ? m_data->payloadType : std::string("");
     }
     
+    cond::SynchronizationType IOVProxy::synchronizationType() const {
+      return m_data.get() ? m_data->synchronizationType : cond::SYNCHRONIZATION_UNKNOWN;
+    }
+
     cond::Time_t IOVProxy::endOfValidity() const {
       return m_data.get() ? m_data->endOfValidity : cond::time::MIN_VAL;
     }

--- a/CondCore/CondDB/src/IOVSchema.h
+++ b/CondCore/CondDB/src/IOVSchema.h
@@ -29,7 +29,7 @@ namespace cond {
 	bool exists();
 	void create();
 	bool select( const std::string& name );
-	bool select( const std::string& name, cond::TimeType& timeType, std::string& objectType, 
+	bool select( const std::string& name, cond::TimeType& timeType, std::string& objectType, cond::SynchronizationType& synchronizationType,
 		     cond::Time_t& endOfValidity, std::string& description, cond::Time_t& lastValidatedTime );
 	bool getMetadata( const std::string& name, std::string& description, 
 			  boost::posix_time::ptime& insertionTime, boost::posix_time::ptime& modificationTime );
@@ -51,7 +51,6 @@ namespace cond {
       column( HASH, std::string, PAYLOAD_HASH_SIZE );
       column( OBJECT_TYPE, std::string );
       column( DATA, cond::Binary );
-      //column( STREAMER, std::string );
       column( STREAMER_INFO, cond::Binary );
       column( VERSION, std::string );
       column( INSERTION_TIME, boost::posix_time::ptime );
@@ -63,12 +62,14 @@ namespace cond {
 	bool exists();
 	void create();
 	bool select( const cond::Hash& payloadHash);
-	bool select( const cond::Hash& payloadHash, std::string& objectType, cond::Binary& payloadData);
+	bool select( const cond::Hash& payloadHash, std::string& objectType, 
+		     cond::Binary& payloadData, cond::Binary& streamerInfoData);
 	bool getType( const cond::Hash& payloadHash, std::string& objectType );
 	bool insert( const cond::Hash& payloadHash, const std::string& objectType, 
-		     const cond::Binary& payloadData, const boost::posix_time::ptime& insertionTime);
+		     const cond::Binary& payloadData, const cond::Binary& streamerInfoData, 
+		     const boost::posix_time::ptime& insertionTime);
 	cond::Hash insertIfNew( const std::string& objectType, const cond::Binary& payloadData, 
-				const boost::posix_time::ptime& insertionTime );
+				const cond::Binary& streamerInfoData, const boost::posix_time::ptime& insertionTime );
       private:
 	coral::ISchema& m_schema;
       };

--- a/CondCore/CondDB/src/KeyList.cc
+++ b/CondCore/CondDB/src/KeyList.cc
@@ -24,8 +24,9 @@ namespace cond {
 	if (keys[i]!=0) {
 	  auto p = m_proxy.find(keys[i]);
 	  if ( p!= m_proxy.end()) {
-	    auto item = m_data.insert( std::make_pair( i, std::make_pair("",cond::Binary()) ) );
-	    if( ! s.fetchPayloadData( (*p).payloadId, item.first->second.first, item.first->second.second ) )
+	    auto item = m_data.insert( std::make_pair( i, std::make_pair("",std::make_pair(cond::Binary(),cond::Binary()) ) ) );
+				       if( ! s.fetchPayloadData( (*p).payloadId, item.first->second.first, 
+								 item.first->second.second.first, item.first->second.second.second ) )
 	      cond::throwException("The Iov contains a broken payload reference.","KeyList::load");    
 	  }
 	}

--- a/CondCore/CondDB/src/OraDbSchema.cc
+++ b/CondCore/CondDB/src/OraDbSchema.cc
@@ -69,7 +69,8 @@ namespace cond {
     }
       
     bool OraTagTable::select( const std::string& name, cond::TimeType& timeType, std::string& objectType, 
-			      cond::Time_t& endOfValidity, std::string& description, cond::Time_t& lastValidatedTime ){
+			      cond::SynchronizationType&, cond::Time_t& endOfValidity, 
+			      std::string& description, cond::Time_t& lastValidatedTime ){
       if(!m_cache.load( name )) return false;
       timeType = m_cache.iovSequence().timetype();
       if( m_cache.iovSequence().payloadClasses().size()==0 ) throwException( "No payload type information found.","OraTagTable::select");
@@ -115,7 +116,11 @@ namespace cond {
       m_session( session ){
     }
 
-    bool OraPayloadTable::select( const cond::Hash& payloadHash, std::string& objectType, cond::Binary& payloadData ){
+    bool OraPayloadTable::select( const cond::Hash& payloadHash, 
+				  std::string& objectType, 
+				  cond::Binary& payloadData, 
+				  cond::Binary& //streamerInfoData
+				){
       ora::Object obj = m_session.getObject( payloadHash );
       objectType = obj.typeName();
       payloadData.fromOraObject(obj );
@@ -127,7 +132,9 @@ namespace cond {
       return true;
     }
       
-    cond::Hash OraPayloadTable::insertIfNew( const std::string& objectType, const cond::Binary& payloadData, 
+    cond::Hash OraPayloadTable::insertIfNew( const std::string& objectType, 
+					     const cond::Binary& payloadData, 
+					     const cond::Binary&, //streamerInfoData
 					     const boost::posix_time::ptime& ){
       ora::Object obj = payloadData.oraObject();
       std::string tok = m_session.storeObject( obj, objectType );

--- a/CondCore/CondDB/src/OraDbSchema.h
+++ b/CondCore/CondDB/src/OraDbSchema.h
@@ -42,7 +42,7 @@ namespace cond {
       }
 
       bool select( const std::string& name );
-      bool select( const std::string& name, cond::TimeType& timeType, std::string& objectType, 
+      bool select( const std::string& name, cond::TimeType& timeType, std::string& objectType, cond::SynchronizationType& synchronizationType,
 		   cond::Time_t& endOfValidity, std::string& description, cond::Time_t& lastValidatedTime );
       bool getMetadata( const std::string& name, std::string& description, 
 			boost::posix_time::ptime& insertionTime, boost::posix_time::ptime& modificationTime );
@@ -66,10 +66,10 @@ namespace cond {
       }
       void create(){
       }
-      bool select( const cond::Hash& payloadHash, std::string& objectType, cond::Binary& payloadData );
+      bool select( const cond::Hash& payloadHash, std::string& objectType, cond::Binary& payloadData, cond::Binary& streamerInfoData );
       bool getType( const cond::Hash& payloadHash, std::string& objectType );
       cond::Hash insertIfNew( const std::string& objectType, const cond::Binary& payloadData, 
-	       		      const boost::posix_time::ptime& insertionTime );
+			      const cond::Binary& streamerInfoData, const boost::posix_time::ptime& insertionTime );
     private:
       cond::DbSession m_session;
     };

--- a/CondCore/CondDB/src/Serialization.cc
+++ b/CondCore/CondDB/src/Serialization.cc
@@ -5,8 +5,10 @@
 //
 #include <sstream>
 // root includes 
-#include "TBufferFile.h"
+#include "TStreamerInfo.h"
 #include "TClass.h"
+#include "TList.h"
+#include "TBufferFile.h"
 #include "Cintex/Cintex.h"
 
 namespace cond {
@@ -31,23 +33,99 @@ namespace cond {
   }
 }
 
-cond::RootOutputArchive::RootOutputArchive( std::ostream& dest ):
-  m_buffer( dest ){
+class RootStreamBuffer: public TBufferFile {
+public:
+  RootStreamBuffer():
+    TBufferFile( TBufferFile::kWrite ),
+    m_streamerInfoBuff( TBufferFile::kWrite ){
+  }
+
+  RootStreamBuffer( const std::string& dataSource, const std::string& streamerInfoSource ):
+    TBufferFile( TBufferFile::kRead, dataSource.size(), const_cast<char*>( dataSource.c_str()), kFALSE ),
+    m_streamerInfoBuff( TBufferFile::kRead, streamerInfoSource.size(), const_cast<char*>( streamerInfoSource.c_str()), kFALSE ){
+  }
+
+  void ForceWriteInfo(TVirtualStreamerInfo* sinfo, Bool_t /* force */){
+    m_streamerInfo.Add( sinfo );
+  }
+
+  void TagStreamerInfo(TVirtualStreamerInfo* sinfo){
+    m_streamerInfo.Add( sinfo );
+  }
+
+  void write( const void* obj, const TClass* ptrClass ){
+    m_streamerInfo.Clear();
+    // this will populate the streamerInfo list 'behind the scenes' - calling the TagStreamerInfo method
+    StreamObject(const_cast<void*>(obj), ptrClass);    
+    // serialize the StreamerInfo
+    if(m_streamerInfo.GetEntries() ){
+      m_streamerInfoBuff.WriteObject( &m_streamerInfo );
+    }
+    m_streamerInfo.Clear();
+  }
+
+  void read( void* destinationInstance, const TClass* ptrClass ){
+    // first "load" the available streaminfo(s) 
+    // code imported from TSocket::RecvStreamerInfos
+    TList *list = (TList*)m_streamerInfoBuff.ReadObject( TList::Class() );
+    TIter next(list);
+    TStreamerInfo *info;
+    TObjLink *lnk = list->FirstLink();
+      // First call BuildCheck for regular class
+    while (lnk) {
+      info = (TStreamerInfo*)lnk->GetObject();
+      TObject *element = info->GetElements()->UncheckedAt(0);
+      Bool_t isstl = element && strcmp("This",element->GetName())==0;
+      if (!isstl) {
+	info->BuildCheck();
+      }
+      lnk = lnk->Next();
+    }
+    // Then call BuildCheck for stl class
+    lnk = list->FirstLink();
+    while (lnk) {
+      info = (TStreamerInfo*)lnk->GetObject();
+      TObject *element = info->GetElements()->UncheckedAt(0);
+      Bool_t isstl = element && strcmp("This",element->GetName())==0;
+      if (isstl) {
+	info->BuildCheck();
+      }
+      lnk = lnk->Next();
+     }
+    delete list;
+    // then read the object data
+    StreamObject(destinationInstance, ptrClass);
+  }
+
+  void copy( std::ostream& destForData, std::ostream& destForStreamerInfo ){
+    destForData.write( static_cast<const char*>(Buffer()),Length() );
+    destForStreamerInfo.write( static_cast<const char*>(m_streamerInfoBuff.Buffer()),m_streamerInfoBuff.Length() );
+  }
+  
+private:
+  TBufferFile m_streamerInfoBuff;
+  TList m_streamerInfo;
+};
+
+cond::RootOutputArchive::RootOutputArchive( std::ostream& dataDest, std::ostream& streamerInfoDest ):
+  m_dataBuffer( dataDest ),
+  m_streamerInfoBuffer( streamerInfoDest ){
 } 
 
 void cond::RootOutputArchive::write( const std::type_info& sourceType, const void* sourceInstance){
   TClass* r_class = lookUpDictionary( sourceType );
   if (!r_class) throwException( "No ROOT class registered for \"" + demangledName(sourceType)+"\"", "RootOutputArchive::write");
-  TBufferFile buffer(TBufferFile::kWrite);
+  RootStreamBuffer buffer;
   buffer.InitMap();
-  buffer.StreamObject(const_cast<void*>(sourceInstance), r_class);
-  // copy the stream into the target buffer
-  m_buffer.write( static_cast<const char*>(buffer.Buffer()), buffer.Length() ); 
+  buffer.write(sourceInstance, r_class);
+  // copy the two streams into the target buffers
+  buffer.copy( m_dataBuffer, m_streamerInfoBuffer );
 }
 
-cond::RootInputArchive::RootInputArchive( std::istream& source ):
-  m_buffer( std::istreambuf_iterator<char>(source), std::istreambuf_iterator<char>()),
-  m_streamer( new TBufferFile( TBufferFile::kRead, m_buffer.size(), const_cast<char*>(m_buffer.c_str()), kFALSE ) ){
+cond::RootInputArchive::RootInputArchive( std::istream& binaryData, std::istream& binaryStreamerInfo ):
+  m_dataBuffer( std::istreambuf_iterator<char>( binaryData ), std::istreambuf_iterator<char>()),
+  m_streamerInfoBuffer( std::istreambuf_iterator<char>( binaryStreamerInfo ), std::istreambuf_iterator<char>()),
+  m_streamer( new RootStreamBuffer( m_dataBuffer, m_streamerInfoBuffer ) ){
   m_streamer->InitMap();
 }
 
@@ -58,6 +136,6 @@ cond::RootInputArchive::~RootInputArchive(){
 void cond::RootInputArchive::read( const std::type_info& destinationType, void* destinationInstance){
   TClass* r_class = lookUpDictionary( destinationType );
   if (!r_class) throwException( "No ROOT class registered for \"" + demangledName(destinationType) +"\"","RootInputArchive::read");
-  m_streamer->StreamObject(destinationInstance, r_class);   
+  m_streamer->read( destinationInstance, r_class );
 }
 

--- a/CondCore/CondDB/src/Session.cc
+++ b/CondCore/CondDB/src/Session.cc
@@ -154,17 +154,19 @@ namespace cond {
     }
 
     cond::Hash Session::storePayloadData( const std::string& payloadObjectType, 
-					  const cond::Binary& payloadData, 
+					  const std::pair<Binary,Binary>& payloadAndStreamerInfoData,
 					  const boost::posix_time::ptime& creationTime ){
       m_session->openIovDb( SessionImpl::CREATE );
-      return m_session->iovSchema().payloadTable().insertIfNew( payloadObjectType, payloadData, creationTime );
+      return m_session->iovSchema().payloadTable().insertIfNew( payloadObjectType, payloadAndStreamerInfoData.first, 
+								payloadAndStreamerInfoData.second, creationTime );
     }
     
     bool Session::fetchPayloadData( const cond::Hash& payloadHash,
 				    std::string& payloadType, 
-				    cond::Binary& payloadData ){
+				    cond::Binary& payloadData,
+				    cond::Binary& streamerInfoData ){
       m_session->openIovDb();
-      return m_session->iovSchema().payloadTable().select( payloadHash, payloadType, payloadData );
+      return m_session->iovSchema().payloadTable().select( payloadHash, payloadType, payloadData, streamerInfoData );
     }
 
     bool Session::isOraSession(){

--- a/CondCore/DBOutputService/interface/PoolDBOutputService.h
+++ b/CondCore/DBOutputService/interface/PoolDBOutputService.h
@@ -86,6 +86,7 @@ namespace cond{
 			 const std::string& recordName,
                          bool withlogging=false){
         if( !firstPayloadObj ) throwException( "Provided payload pointer is invalid.","PoolDBOutputService::createNewIOV");
+	if (!m_dbstarted) this->initDB( false );
         createNewIOV( m_session.storePayload( *firstPayloadObj ),
 		      cond::demangledName(typeid(T)),
                       firstSinceTime,

--- a/CondCore/Utilities/bin/conddb_test_gt_load.cpp
+++ b/CondCore/Utilities/bin/conddb_test_gt_load.cpp
@@ -107,7 +107,8 @@ bool cond::UntypedPayloadProxy::get( cond::Time_t targetTime, bool debug ){
 
     std::string payloadType("");
     Binary data; 
-    loaded = m_session.fetchPayloadData( m_data->current.payloadId, payloadType, data );
+    Binary streamerInfo; 
+    loaded = m_session.fetchPayloadData( m_data->current.payloadId, payloadType, data, streamerInfo );
     m_session.transaction().commit();
     if( !loaded ){
       std::cout <<"ERROR: payload with id "<<m_data->current.payloadId<<" could not be loaded."<<std::endl;

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -18,7 +18,7 @@
 
 #define FETCH_PAYLOAD_CASE( TYPENAME ) \
   if( payloadTypeName == #TYPENAME ){ \
-    auto payload = deserialize<TYPENAME>( payloadTypeName, data ); \
+    auto payload = deserialize<TYPENAME>( payloadTypeName, data, streamerInfo );	\
     payloadPtr = payload; \
     match = true; \
   }
@@ -298,8 +298,9 @@ namespace cond {
     std::pair<std::string,boost::shared_ptr<void> > fetch( const cond::Hash& payloadId, Session& session ){
       boost::shared_ptr<void> payloadPtr;
       cond::Binary data;
+      cond::Binary streamerInfo;
       std::string payloadTypeName;
-      bool found = session.fetchPayloadData( payloadId, payloadTypeName, data );
+      bool found = session.fetchPayloadData( payloadId, payloadTypeName, data, streamerInfo );
       if( !found ) throwException( "Payload with id "+boost::lexical_cast<std::string>(payloadId)+" has not been found in the database.","fetchAndCompare" );
       //std::cout <<"--> payload type "<<payloadTypeName<<" has blob size "<<data.size()<<std::endl;
       bool match = false;
@@ -522,12 +523,12 @@ namespace cond {
 
     //   
     if( payloadTypeName == "PhysicsTools::Calibration::Histogram3D<double,double,double,double>" ){    
-      auto payload = deserialize<PhysicsTools::Calibration::Histogram3D<double,double,double,double> >(payloadTypeName, data );
+      auto payload = deserialize<PhysicsTools::Calibration::Histogram3D<double,double,double,double> >(payloadTypeName, data, streamerInfo );
       payloadPtr = payload;
       match = true;
     }
     if( payloadTypeName == "PhysicsTools::Calibration::Histogram2D<double,double,double>" ){    
-      auto payload = deserialize<PhysicsTools::Calibration::Histogram2D<double,double,double> >(payloadTypeName, data );
+      auto payload = deserialize<PhysicsTools::Calibration::Histogram2D<double,double,double> >(payloadTypeName, data, streamerInfo );
       payloadPtr = payload;
       match = true;
     }


### PR DESCRIPTION
Payloads are now stored with the relevant streamerInfo. While reading, this one is loaded and taken by root for the de-serialization. No change for the ORA-based persistency ( the current production system ).
Packages:

CondCore/CondDB
CondCore/DBOutputService
CondCore/Utilities 
