### PR TITLE
71X - consumes migration IIa

### DIFF
--- a/FWCore/Framework/interface/InputTagMatch.h
+++ b/FWCore/Framework/interface/InputTagMatch.h
@@ -1,0 +1,48 @@
+#ifndef FWCore_Framework_InputTagMatch_h
+#define FWCore_Framework_InputTagMatch_h
+
+/** \class edm::InputTagMatch
+
+This is intended to be used with the class GetterOfProducts.
+See comments in the file GetterOfProducts.h for a description.
+
+\author V. Adler
+
+*/
+
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DataFormats/Provenance/interface/BranchDescription.h"
+
+#include <string>
+
+namespace edm {
+
+   class InputTagMatch {
+   public:
+
+      InputTagMatch(std::string const& encodedInputTag) : inputTag_(encodedInputTag) { }
+
+      bool operator()(edm::BranchDescription const& branchDescription) {
+         bool result(true);
+         bool match(false);
+         if (!inputTag_.label().empty()) {
+           match = true;
+           result = (result && branchDescription.moduleLabel() == inputTag_.label());
+         }
+         if (!inputTag_.instance().empty()) {
+           match = true;
+           result = (result && branchDescription.productInstanceName() == inputTag_.instance());
+         }
+         if (!inputTag_.process().empty()) {
+           match = true;
+           result = (result && branchDescription.processName() == inputTag_.process());
+         }
+         if (match) return result;
+         return false;
+      }
+
+   private:
+      edm::InputTag inputTag_;
+   };
+}
+#endif

--- a/FWCore/Framework/interface/InputTagMatch.h
+++ b/FWCore/Framework/interface/InputTagMatch.h
@@ -20,7 +20,7 @@ namespace edm {
    class InputTagMatch {
    public:
 
-      InputTagMatch(std::string const& encodedInputTag) : inputTag_(encodedInputTag) { }
+      InputTagMatch(edm::InputTag const& inputTag) : inputTag_(inputTag) { }
 
       bool operator()(edm::BranchDescription const& branchDescription) {
          bool result(true);

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.cc
@@ -48,7 +48,7 @@ PATTriggerEventProducer::PATTriggerEventProducer( const ParameterSet & iConfig )
 {
 
   if ( iConfig.exists( "triggerResults" ) ) tagTriggerResults_ = iConfig.getParameter< InputTag >( "triggerResults" );
-  triggerResultsGetter_ = edm::GetterOfProducts< edm::TriggerResults >( edm::InputTagMatch( InputTag( tagTriggerResults_.label(), tagTriggerResults_.instance() ) ), this);
+  triggerResultsGetter_ = GetterOfProducts< TriggerResults >( InputTagMatch( InputTag( tagTriggerResults_.label(), tagTriggerResults_.instance() ) ), this);
   if ( iConfig.exists( "triggerEvent" ) )       tagTriggerEvent_    = iConfig.getParameter< InputTag >( "triggerEvent" );
   if ( iConfig.exists( "patTriggerProducer" ) ) tagTriggerProducer_ = iConfig.getParameter< InputTag >( "patTriggerProducer" );
   triggerAlgorithmCollectionToken_ = mayConsume< TriggerAlgorithmCollection >( tagTriggerProducer_ );
@@ -65,9 +65,9 @@ PATTriggerEventProducer::PATTriggerEventProducer( const ParameterSet & iConfig )
   if ( iConfig.exists( "l1GtTag" ) ) tagL1Gt_ = iConfig.getParameter< InputTag >( "l1GtTag" );
   l1GtToken_ = mayConsume< L1GlobalTriggerReadoutRecord >( tagL1Gt_ );
   if ( iConfig.exists( "patTriggerMatches" ) ) tagsTriggerMatcher_ = iConfig.getParameter< std::vector< InputTag > >( "patTriggerMatches" );
-  triggerMatcherTokens_ = vector_transform( tagsTriggerMatcher_, [this](edm::InputTag const & tag) { return mayConsume< TriggerObjectStandAloneMatch >( tag ); } );
+  triggerMatcherTokens_ = vector_transform( tagsTriggerMatcher_, [this](InputTag const & tag) { return mayConsume< TriggerObjectStandAloneMatch >( tag ); } );
 
-  callWhenNewProductsRegistered( [ this, &iConfig ]( edm::BranchDescription const& bd ) {
+  callWhenNewProductsRegistered( [ this, &iConfig ]( BranchDescription const& bd ) {
     triggerResultsGetter_( bd );
   } );
 

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.cc
@@ -8,6 +8,8 @@
 
 #include "FWCore/Utilities/interface/transform.h"
 
+#include "FWCore/Framework/interface/InputTagMatch.h"
+
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/HLTReco/interface/TriggerEvent.h"
 #include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
@@ -45,7 +47,10 @@ PATTriggerEventProducer::PATTriggerEventProducer( const ParameterSet & iConfig )
   gtCondLumiInit_( false )
 {
 
-  if ( iConfig.exists( "triggerResults" ) )     tagTriggerResults_  = iConfig.getParameter< InputTag >( "triggerResults" );
+  if ( iConfig.exists( "triggerResults" ) ) tagTriggerResults_ = iConfig.getParameter< InputTag >( "triggerResults" );
+  InputTag tagTriggerResultsTmp( tagTriggerResults_.label(), tagTriggerResults_.instance() );
+  triggerResultsGetter_ = edm::GetterOfProducts< edm::TriggerResults >( edm::InputTagMatch( tagTriggerResultsTmp.encode() ), this);
+  callWhenNewProductsRegistered( triggerResultsGetter_ );
   if ( iConfig.exists( "triggerEvent" ) )       tagTriggerEvent_    = iConfig.getParameter< InputTag >( "triggerEvent" );
   if ( iConfig.exists( "patTriggerProducer" ) ) tagTriggerProducer_ = iConfig.getParameter< InputTag >( "patTriggerProducer" );
   triggerAlgorithmCollectionToken_ = mayConsume< TriggerAlgorithmCollection >( tagTriggerProducer_ );
@@ -107,7 +112,6 @@ void PATTriggerEventProducer::beginRun(const Run & iRun, const EventSetup & iSet
   } else if ( tagTriggerEvent_.process() != nameProcess_ ) {
     LogWarning( "triggerResultsTag" ) << "TriggerResults process name '" << tagTriggerResults_.process() << "' differs from HLT process name '" << nameProcess_ << "'";
   }
-//   triggerResultsToken_ = mayConsume< TriggerResults >( tagTriggerResults_ ); // FIXME: This works only in the c'tor!
   if ( tagTriggerEvent_.process().empty() || tagTriggerEvent_.process()   == "*" ) {
     tagTriggerEvent_ = InputTag( tagTriggerEvent_.label(), tagTriggerEvent_.instance(), nameProcess_ );
   } else if ( tagTriggerEvent_.process() != nameProcess_ ) {

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.cc
@@ -48,8 +48,7 @@ PATTriggerEventProducer::PATTriggerEventProducer( const ParameterSet & iConfig )
 {
 
   if ( iConfig.exists( "triggerResults" ) ) tagTriggerResults_ = iConfig.getParameter< InputTag >( "triggerResults" );
-  InputTag tagTriggerResultsTmp( tagTriggerResults_.label(), tagTriggerResults_.instance() );
-  triggerResultsGetter_ = edm::GetterOfProducts< edm::TriggerResults >( edm::InputTagMatch( tagTriggerResultsTmp.encode() ), this);
+  triggerResultsGetter_ = edm::GetterOfProducts< edm::TriggerResults >( edm::InputTagMatch( InputTag( tagTriggerResults_.label(), tagTriggerResults_.instance() ) ), this);
   if ( iConfig.exists( "triggerEvent" ) )       tagTriggerEvent_    = iConfig.getParameter< InputTag >( "triggerEvent" );
   if ( iConfig.exists( "patTriggerProducer" ) ) tagTriggerProducer_ = iConfig.getParameter< InputTag >( "patTriggerProducer" );
   triggerAlgorithmCollectionToken_ = mayConsume< TriggerAlgorithmCollection >( tagTriggerProducer_ );

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.cc
@@ -50,7 +50,6 @@ PATTriggerEventProducer::PATTriggerEventProducer( const ParameterSet & iConfig )
   if ( iConfig.exists( "triggerResults" ) ) tagTriggerResults_ = iConfig.getParameter< InputTag >( "triggerResults" );
   InputTag tagTriggerResultsTmp( tagTriggerResults_.label(), tagTriggerResults_.instance() );
   triggerResultsGetter_ = edm::GetterOfProducts< edm::TriggerResults >( edm::InputTagMatch( tagTriggerResultsTmp.encode() ), this);
-  callWhenNewProductsRegistered( triggerResultsGetter_ );
   if ( iConfig.exists( "triggerEvent" ) )       tagTriggerEvent_    = iConfig.getParameter< InputTag >( "triggerEvent" );
   if ( iConfig.exists( "patTriggerProducer" ) ) tagTriggerProducer_ = iConfig.getParameter< InputTag >( "patTriggerProducer" );
   triggerAlgorithmCollectionToken_ = mayConsume< TriggerAlgorithmCollection >( tagTriggerProducer_ );
@@ -68,6 +67,10 @@ PATTriggerEventProducer::PATTriggerEventProducer( const ParameterSet & iConfig )
   l1GtToken_ = mayConsume< L1GlobalTriggerReadoutRecord >( tagL1Gt_ );
   if ( iConfig.exists( "patTriggerMatches" ) ) tagsTriggerMatcher_ = iConfig.getParameter< std::vector< InputTag > >( "patTriggerMatches" );
   triggerMatcherTokens_ = vector_transform( tagsTriggerMatcher_, [this](edm::InputTag const & tag) { return mayConsume< TriggerObjectStandAloneMatch >( tag ); } );
+
+  callWhenNewProductsRegistered( [ this, &iConfig ]( edm::BranchDescription const& bd ) {
+    triggerResultsGetter_( bd );
+  } );
 
   for ( size_t iMatch = 0; iMatch < tagsTriggerMatcher_.size(); ++iMatch ) {
     produces< TriggerObjectMatch >( tagsTriggerMatcher_.at( iMatch ).label() );

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.h
@@ -30,6 +30,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/GetterOfProducts.h"
 
 #include <string>
 #include <vector>
@@ -76,7 +77,7 @@ namespace pat {
       HLTConfigProvider            hltConfig_;
       bool                         hltConfigInit_;
       edm::InputTag                tagTriggerResults_;  // configuration (optional with default)
-//       edm::EDGetTokenT< edm::TriggerResults > triggerResultsToken_;
+      edm::GetterOfProducts< edm::TriggerResults > triggerResultsGetter_;
       edm::InputTag                tagTriggerEvent_;    // configuration (optional with default)
       // Conditions
       edm::InputTag                tagCondGt_;          // configuration (optional with default)

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
@@ -91,7 +91,6 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
     }
     InputTag tagL1ExtraMuTmp( tagL1ExtraMu_.label(), tagL1ExtraMu_.instance() );
     l1ExtraMuGetter_ = edm::GetterOfProducts< l1extra::L1MuonParticleCollection >( edm::InputTagMatch( tagL1ExtraMuTmp.encode() ), this);
-    callWhenNewProductsRegistered( l1ExtraMuGetter_ );
   }
   if ( iConfig.exists( "l1ExtraNoIsoEG" ) ) {
     tagL1ExtraNoIsoEG_ = iConfig.getParameter< InputTag >( "l1ExtraNoIsoEG" );
@@ -101,7 +100,6 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
     }
     InputTag tagL1ExtraNoIsoEGTmp( tagL1ExtraNoIsoEG_.label(), tagL1ExtraNoIsoEG_.instance() );
     l1ExtraNoIsoEGGetter_ = edm::GetterOfProducts< l1extra::L1EmParticleCollection >( edm::InputTagMatch( tagL1ExtraNoIsoEGTmp.encode() ), this);
-    callWhenNewProductsRegistered( l1ExtraNoIsoEGGetter_ );
   }
   if ( iConfig.exists( "l1ExtraIsoEG" ) ) {
     tagL1ExtraIsoEG_ = iConfig.getParameter< InputTag >( "l1ExtraIsoEG" );
@@ -111,7 +109,6 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
     }
     InputTag tagL1ExtraIsoEGTmp( tagL1ExtraIsoEG_.label(), tagL1ExtraIsoEG_.instance() );
     l1ExtraIsoEGGetter_ = edm::GetterOfProducts< l1extra::L1EmParticleCollection >( edm::InputTagMatch( tagL1ExtraIsoEGTmp.encode() ), this);
-    callWhenNewProductsRegistered( l1ExtraIsoEGGetter_ );
   }
   if ( iConfig.exists( "l1ExtraCenJet" ) ) {
     tagL1ExtraCenJet_ = iConfig.getParameter< InputTag >( "l1ExtraCenJet" );
@@ -121,7 +118,6 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
     }
     InputTag tagL1ExtraCenJetTmp( tagL1ExtraCenJet_.label(), tagL1ExtraCenJet_.instance() );
     l1ExtraCenJetGetter_ = edm::GetterOfProducts< l1extra::L1JetParticleCollection >( edm::InputTagMatch( tagL1ExtraCenJetTmp.encode() ), this);
-    callWhenNewProductsRegistered( l1ExtraCenJetGetter_ );
   }
   if ( iConfig.exists( "l1ExtraForJet" ) ) {
     tagL1ExtraForJet_ = iConfig.getParameter< InputTag >( "l1ExtraForJet" );
@@ -131,7 +127,6 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
     }
     InputTag tagL1ExtraForJetTmp( tagL1ExtraForJet_.label(), tagL1ExtraForJet_.instance() );
     l1ExtraForJetGetter_ = edm::GetterOfProducts< l1extra::L1JetParticleCollection >( edm::InputTagMatch( tagL1ExtraForJetTmp.encode() ), this);
-    callWhenNewProductsRegistered( l1ExtraForJetGetter_ );
   }
   if ( iConfig.exists( "l1ExtraTauJet" ) ) {
     tagL1ExtraTauJet_ = iConfig.getParameter< InputTag >( "l1ExtraTauJet" );
@@ -141,7 +136,6 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
     }
     InputTag tagL1ExtraTauJetTmp( tagL1ExtraTauJet_.label(), tagL1ExtraTauJet_.instance() );
     l1ExtraTauJetGetter_ = edm::GetterOfProducts< l1extra::L1JetParticleCollection >( edm::InputTagMatch( tagL1ExtraTauJetTmp.encode() ), this);
-    callWhenNewProductsRegistered( l1ExtraTauJetGetter_ );
   }
   if ( iConfig.exists( "l1ExtraETM" ) ) {
     tagL1ExtraETM_ = iConfig.getParameter< InputTag >( "l1ExtraETM" );
@@ -151,7 +145,6 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
     }
     InputTag tagL1ExtraETMTmp( tagL1ExtraETM_.label(), tagL1ExtraETM_.instance() );
     l1ExtraETMGetter_ = edm::GetterOfProducts< l1extra::L1EtMissParticleCollection >( edm::InputTagMatch( tagL1ExtraETMTmp.encode() ), this);
-    callWhenNewProductsRegistered( l1ExtraETMGetter_ );
   }
   if ( iConfig.exists( "l1ExtraHTM" ) ) {
     tagL1ExtraHTM_ = iConfig.getParameter< InputTag >( "l1ExtraHTM" );
@@ -161,7 +154,6 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
     }
     InputTag tagL1ExtraHTMTmp( tagL1ExtraHTM_.label(), tagL1ExtraHTM_.instance() );
     l1ExtraHTMGetter_ = edm::GetterOfProducts< l1extra::L1EtMissParticleCollection >( edm::InputTagMatch( tagL1ExtraHTMTmp.encode() ), this);
-    callWhenNewProductsRegistered( l1ExtraHTMGetter_ );
   }
   if ( iConfig.exists( "mainBxOnly" ) ) mainBxOnly_ = iConfig.getParameter< bool >( "mainBxOnly" );
   if ( iConfig.exists( "saveL1Refs" ) ) saveL1Refs_ = iConfig.getParameter< bool >( "saveL1Refs" );
@@ -170,27 +162,40 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
   if ( iConfig.exists( "triggerResults" ) ) tagTriggerResults_ = iConfig.getParameter< InputTag >( "triggerResults" );
   InputTag tagTriggerResultsTmp( tagTriggerResults_.label(), tagTriggerResults_.instance() );
   triggerResultsGetter_ = edm::GetterOfProducts< edm::TriggerResults >( edm::InputTagMatch( tagTriggerResultsTmp.encode() ), this);
-  callWhenNewProductsRegistered( triggerResultsGetter_ );
   if ( iConfig.exists( "triggerEvent" ) ) tagTriggerEvent_ = iConfig.getParameter< InputTag >( "triggerEvent" );
   InputTag tagTriggerEventTmp( tagTriggerEvent_.label(), tagTriggerEvent_.instance() );
   triggerEventGetter_ = edm::GetterOfProducts< trigger::TriggerEvent >( edm::InputTagMatch( tagTriggerEventTmp.encode() ), this);
-  callWhenNewProductsRegistered( triggerResultsGetter_ );
   if ( iConfig.exists( "hltPrescaleLabel" ) )    hltPrescaleLabel_      = iConfig.getParameter< std::string >( "hltPrescaleLabel" );
   if ( iConfig.exists( "hltPrescaleTable" ) ) {
     labelHltPrescaleTable_ = iConfig.getParameter< std::string >( "hltPrescaleTable" );
     InputTag tagHltPrescaleTableRunTmp( labelHltPrescaleTable_, "Run" );
     hltPrescaleTableRunGetter_ = edm::GetterOfProducts< trigger::HLTPrescaleTable >( edm::InputTagMatch( tagHltPrescaleTableRunTmp.encode() ), this, InRun );
-    callWhenNewProductsRegistered( hltPrescaleTableRunGetter_ );
     InputTag tagHltPrescaleTableLumiTmp( labelHltPrescaleTable_, "Lumi" );
     hltPrescaleTableLumiGetter_ = edm::GetterOfProducts< trigger::HLTPrescaleTable >( edm::InputTagMatch( tagHltPrescaleTableLumiTmp.encode() ), this, InLumi );
-    callWhenNewProductsRegistered( hltPrescaleTableLumiGetter_ );
     InputTag tagHltPrescaleTableEventTmp( labelHltPrescaleTable_, "Event" );
     hltPrescaleTableEventGetter_ = edm::GetterOfProducts< trigger::HLTPrescaleTable >( edm::InputTagMatch( tagHltPrescaleTableEventTmp.encode() ), this );
-    callWhenNewProductsRegistered( hltPrescaleTableEventGetter_ );
   }
-  if ( iConfig.exists( "addPathModuleLabels" ) ) addPathModuleLabels_   = iConfig.getParameter< bool >( "addPathModuleLabels" );
+  if ( iConfig.exists( "addPathModuleLabels" ) ) addPathModuleLabels_ = iConfig.getParameter< bool >( "addPathModuleLabels" );
   exludeCollections_.clear();
-  if ( iConfig.exists( "exludeCollections" )  ) exludeCollections_      = iConfig.getParameter< std::vector< std::string > >( "exludeCollections" );
+  if ( iConfig.exists( "exludeCollections" )  ) exludeCollections_ = iConfig.getParameter< std::vector< std::string > >( "exludeCollections" );
+
+  callWhenNewProductsRegistered( [ this, &iConfig ]( edm::BranchDescription const& bd ) {
+    if ( iConfig.exists( "l1ExtraMu" ) ) l1ExtraMuGetter_( bd );
+    if ( iConfig.exists( "l1ExtraNoIsoEG" ) ) l1ExtraNoIsoEGGetter_( bd );
+    if ( iConfig.exists( "l1ExtraIsoEG" ) ) l1ExtraIsoEGGetter_( bd );
+    if ( iConfig.exists( "l1ExtraCenJet" ) ) l1ExtraCenJetGetter_( bd );
+    if ( iConfig.exists( "l1ExtraForJet" ) ) l1ExtraForJetGetter_( bd );
+    if ( iConfig.exists( "l1ExtraTauJet" ) ) l1ExtraTauJetGetter_( bd );
+    if ( iConfig.exists( "l1ExtraETM" ) ) l1ExtraETMGetter_( bd );
+    if ( iConfig.exists( "l1ExtraHTM" ) ) l1ExtraHTMGetter_( bd );
+    triggerResultsGetter_( bd );
+    triggerEventGetter_( bd );
+    if ( iConfig.exists( "hltPrescaleTable" ) ) {
+      hltPrescaleTableRunGetter_( bd );
+      hltPrescaleTableLumiGetter_( bd );
+      hltPrescaleTableEventGetter_( bd );
+    }
+  } );
 
   if ( ! onlyStandAlone_ ) {
     produces< TriggerAlgorithmCollection >();

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
@@ -10,6 +10,8 @@
 #include <cassert>
 #include <string>
 
+#include "FWCore/Framework/interface/InputTagMatch.h"
+
 #include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
 #include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -87,6 +89,9 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraMu_ = true;
       else                    tagL1ExtraMu_ = InputTag( tagL1ExtraMu_.label(), tagL1ExtraMu_.instance(), nameProcess_ );
     }
+    InputTag tagL1ExtraMuTmp( tagL1ExtraMu_.label(), tagL1ExtraMu_.instance() );
+    l1ExtraMuGetter_ = edm::GetterOfProducts< l1extra::L1MuonParticleCollection >( edm::InputTagMatch( tagL1ExtraMuTmp.encode() ), this);
+    callWhenNewProductsRegistered( l1ExtraMuGetter_ );
   }
   if ( iConfig.exists( "l1ExtraNoIsoEG" ) ) {
     tagL1ExtraNoIsoEG_ = iConfig.getParameter< InputTag >( "l1ExtraNoIsoEG" );
@@ -94,6 +99,9 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraNoIsoEG_ = true;
       else                    tagL1ExtraNoIsoEG_ = InputTag( tagL1ExtraNoIsoEG_.label(), tagL1ExtraNoIsoEG_.instance(), nameProcess_ );
     }
+    InputTag tagL1ExtraNoIsoEGTmp( tagL1ExtraNoIsoEG_.label(), tagL1ExtraNoIsoEG_.instance() );
+    l1ExtraNoIsoEGGetter_ = edm::GetterOfProducts< l1extra::L1EmParticleCollection >( edm::InputTagMatch( tagL1ExtraNoIsoEGTmp.encode() ), this);
+    callWhenNewProductsRegistered( l1ExtraNoIsoEGGetter_ );
   }
   if ( iConfig.exists( "l1ExtraIsoEG" ) ) {
     tagL1ExtraIsoEG_ = iConfig.getParameter< InputTag >( "l1ExtraIsoEG" );
@@ -101,6 +109,9 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraIsoEG_ = true;
       else                    tagL1ExtraIsoEG_ = InputTag( tagL1ExtraIsoEG_.label(), tagL1ExtraIsoEG_.instance(), nameProcess_ );
     }
+    InputTag tagL1ExtraIsoEGTmp( tagL1ExtraIsoEG_.label(), tagL1ExtraIsoEG_.instance() );
+    l1ExtraIsoEGGetter_ = edm::GetterOfProducts< l1extra::L1EmParticleCollection >( edm::InputTagMatch( tagL1ExtraIsoEGTmp.encode() ), this);
+    callWhenNewProductsRegistered( l1ExtraIsoEGGetter_ );
   }
   if ( iConfig.exists( "l1ExtraCenJet" ) ) {
     tagL1ExtraCenJet_ = iConfig.getParameter< InputTag >( "l1ExtraCenJet" );
@@ -108,6 +119,9 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraCenJet_ = true;
       else                    tagL1ExtraCenJet_ = InputTag( tagL1ExtraCenJet_.label(), tagL1ExtraCenJet_.instance(), nameProcess_ );
     }
+    InputTag tagL1ExtraCenJetTmp( tagL1ExtraCenJet_.label(), tagL1ExtraCenJet_.instance() );
+    l1ExtraCenJetGetter_ = edm::GetterOfProducts< l1extra::L1JetParticleCollection >( edm::InputTagMatch( tagL1ExtraCenJetTmp.encode() ), this);
+    callWhenNewProductsRegistered( l1ExtraCenJetGetter_ );
   }
   if ( iConfig.exists( "l1ExtraForJet" ) ) {
     tagL1ExtraForJet_ = iConfig.getParameter< InputTag >( "l1ExtraForJet" );
@@ -115,6 +129,9 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraForJet_ = true;
       else                    tagL1ExtraForJet_ = InputTag( tagL1ExtraForJet_.label(), tagL1ExtraForJet_.instance(), nameProcess_ );
     }
+    InputTag tagL1ExtraForJetTmp( tagL1ExtraForJet_.label(), tagL1ExtraForJet_.instance() );
+    l1ExtraForJetGetter_ = edm::GetterOfProducts< l1extra::L1JetParticleCollection >( edm::InputTagMatch( tagL1ExtraForJetTmp.encode() ), this);
+    callWhenNewProductsRegistered( l1ExtraForJetGetter_ );
   }
   if ( iConfig.exists( "l1ExtraTauJet" ) ) {
     tagL1ExtraTauJet_ = iConfig.getParameter< InputTag >( "l1ExtraTauJet" );
@@ -122,6 +139,9 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraTauJet_ = true;
       else                    tagL1ExtraTauJet_ = InputTag( tagL1ExtraTauJet_.label(), tagL1ExtraTauJet_.instance(), nameProcess_ );
     }
+    InputTag tagL1ExtraTauJetTmp( tagL1ExtraTauJet_.label(), tagL1ExtraTauJet_.instance() );
+    l1ExtraTauJetGetter_ = edm::GetterOfProducts< l1extra::L1JetParticleCollection >( edm::InputTagMatch( tagL1ExtraTauJetTmp.encode() ), this);
+    callWhenNewProductsRegistered( l1ExtraTauJetGetter_ );
   }
   if ( iConfig.exists( "l1ExtraETM" ) ) {
     tagL1ExtraETM_ = iConfig.getParameter< InputTag >( "l1ExtraETM" );
@@ -129,6 +149,9 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraETM_ = true;
       else                    tagL1ExtraETM_ = InputTag( tagL1ExtraETM_.label(), tagL1ExtraETM_.instance(), nameProcess_ );
     }
+    InputTag tagL1ExtraETMTmp( tagL1ExtraETM_.label(), tagL1ExtraETM_.instance() );
+    l1ExtraETMGetter_ = edm::GetterOfProducts< l1extra::L1EtMissParticleCollection >( edm::InputTagMatch( tagL1ExtraETMTmp.encode() ), this);
+    callWhenNewProductsRegistered( l1ExtraETMGetter_ );
   }
   if ( iConfig.exists( "l1ExtraHTM" ) ) {
     tagL1ExtraHTM_ = iConfig.getParameter< InputTag >( "l1ExtraHTM" );
@@ -136,15 +159,35 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraHTM_ = true;
       else                    tagL1ExtraHTM_ = InputTag( tagL1ExtraHTM_.label(), tagL1ExtraHTM_.instance(), nameProcess_ );
     }
+    InputTag tagL1ExtraHTMTmp( tagL1ExtraHTM_.label(), tagL1ExtraHTM_.instance() );
+    l1ExtraHTMGetter_ = edm::GetterOfProducts< l1extra::L1EtMissParticleCollection >( edm::InputTagMatch( tagL1ExtraHTMTmp.encode() ), this);
+    callWhenNewProductsRegistered( l1ExtraHTMGetter_ );
   }
   if ( iConfig.exists( "mainBxOnly" ) ) mainBxOnly_ = iConfig.getParameter< bool >( "mainBxOnly" );
   if ( iConfig.exists( "saveL1Refs" ) ) saveL1Refs_ = iConfig.getParameter< bool >( "saveL1Refs" );
 
   // HLT configuration parameters
-  if ( iConfig.exists( "triggerResults" ) )      tagTriggerResults_     = iConfig.getParameter< InputTag >( "triggerResults" );
-  if ( iConfig.exists( "triggerEvent" ) )        tagTriggerEvent_       = iConfig.getParameter< InputTag >( "triggerEvent" );
+  if ( iConfig.exists( "triggerResults" ) ) tagTriggerResults_ = iConfig.getParameter< InputTag >( "triggerResults" );
+  InputTag tagTriggerResultsTmp( tagTriggerResults_.label(), tagTriggerResults_.instance() );
+  triggerResultsGetter_ = edm::GetterOfProducts< edm::TriggerResults >( edm::InputTagMatch( tagTriggerResultsTmp.encode() ), this);
+  callWhenNewProductsRegistered( triggerResultsGetter_ );
+  if ( iConfig.exists( "triggerEvent" ) ) tagTriggerEvent_ = iConfig.getParameter< InputTag >( "triggerEvent" );
+  InputTag tagTriggerEventTmp( tagTriggerEvent_.label(), tagTriggerEvent_.instance() );
+  triggerEventGetter_ = edm::GetterOfProducts< trigger::TriggerEvent >( edm::InputTagMatch( tagTriggerEventTmp.encode() ), this);
+  callWhenNewProductsRegistered( triggerResultsGetter_ );
   if ( iConfig.exists( "hltPrescaleLabel" ) )    hltPrescaleLabel_      = iConfig.getParameter< std::string >( "hltPrescaleLabel" );
-  if ( iConfig.exists( "hltPrescaleTable" ) )    labelHltPrescaleTable_ = iConfig.getParameter< std::string >( "hltPrescaleTable" );
+  if ( iConfig.exists( "hltPrescaleTable" ) ) {
+    labelHltPrescaleTable_ = iConfig.getParameter< std::string >( "hltPrescaleTable" );
+    InputTag tagHltPrescaleTableRunTmp( labelHltPrescaleTable_, "Run" );
+    hltPrescaleTableRunGetter_ = edm::GetterOfProducts< trigger::HLTPrescaleTable >( edm::InputTagMatch( tagHltPrescaleTableRunTmp.encode() ), this, InRun );
+    callWhenNewProductsRegistered( hltPrescaleTableRunGetter_ );
+    InputTag tagHltPrescaleTableLumiTmp( labelHltPrescaleTable_, "Lumi" );
+    hltPrescaleTableLumiGetter_ = edm::GetterOfProducts< trigger::HLTPrescaleTable >( edm::InputTagMatch( tagHltPrescaleTableLumiTmp.encode() ), this, InLumi );
+    callWhenNewProductsRegistered( hltPrescaleTableLumiGetter_ );
+    InputTag tagHltPrescaleTableEventTmp( labelHltPrescaleTable_, "Event" );
+    hltPrescaleTableEventGetter_ = edm::GetterOfProducts< trigger::HLTPrescaleTable >( edm::InputTagMatch( tagHltPrescaleTableEventTmp.encode() ), this );
+    callWhenNewProductsRegistered( hltPrescaleTableEventGetter_ );
+  }
   if ( iConfig.exists( "addPathModuleLabels" ) ) addPathModuleLabels_   = iConfig.getParameter< bool >( "addPathModuleLabels" );
   exludeCollections_.clear();
   if ( iConfig.exists( "exludeCollections" )  ) exludeCollections_      = iConfig.getParameter< std::vector< std::string > >( "exludeCollections" );
@@ -195,38 +238,25 @@ void PATTriggerProducer::beginRun(const Run & iRun, const EventSetup & iSetup )
     }
     LogInfo( "autoProcessName" ) << "HLT process name' " << nameProcess_ << "' used for PAT trigger information";
   }
-//   hltPrescaleTableRunToken_   = mayConsume< trigger::HLTPrescaleTable, InRun >( InputTag( labelHltPrescaleTable_, "Run", nameProcess_ ) ); // FIXME: This works only in the c'tor!
-//   hltPrescaleTableLumiToken_  = mayConsume< trigger::HLTPrescaleTable, InLumi >( InputTag( labelHltPrescaleTable_, "Lumi", nameProcess_ ) ); // FIXME: This works only in the c'tor!
-//   hltPrescaleTableEventToken_ = mayConsume< trigger::HLTPrescaleTable >( InputTag( labelHltPrescaleTable_, "Event", nameProcess_ ) ); // FIXME: This works only in the c'tor!
   // adapt configuration of used input tags
   if ( tagTriggerResults_.process().empty() || tagTriggerResults_.process() == "*" ) {
     tagTriggerResults_ = InputTag( tagTriggerResults_.label(), tagTriggerResults_.instance(), nameProcess_ );
   } else if ( tagTriggerEvent_.process() != nameProcess_ ) {
     LogWarning( "inputTags" ) << "TriggerResults process name '" << tagTriggerResults_.process() << "' differs from HLT process name '" << nameProcess_ << "'";
   }
-//   triggerResultsToken_ = mayConsume< edm::TriggerResults >( tagTriggerResults_ ); // FIXME: This works only in the c'tor!
   if ( tagTriggerEvent_.process().empty() || tagTriggerEvent_.process()   == "*" ) {
     tagTriggerEvent_ = InputTag( tagTriggerEvent_.label(), tagTriggerEvent_.instance(), nameProcess_ );
   } else if ( tagTriggerEvent_.process() != nameProcess_ ) {
     LogWarning( "inputTags" ) << "TriggerEvent process name '" << tagTriggerEvent_.process() << "' differs from HLT process name '" << nameProcess_ << "'";
   }
-//   triggerEventToken_ = mayConsume< trigger::TriggerEvent >( tagTriggerEvent_ ); // FIXME: This works only in the c'tor!
   if ( autoProcessNameL1ExtraMu_ )      tagL1ExtraMu_      = InputTag( tagL1ExtraMu_.label()     , tagL1ExtraMu_.instance()     , nameProcess_ );
-//   l1ExtraMuToken_ = mayConsume< l1extra::L1MuonParticleCollection >( tagL1ExtraMu_ ); // FIXME: This works only in the c'tor!
   if ( autoProcessNameL1ExtraNoIsoEG_ ) tagL1ExtraNoIsoEG_ = InputTag( tagL1ExtraNoIsoEG_.label(), tagL1ExtraNoIsoEG_.instance(), nameProcess_ );
-//   l1ExtraNoIsoEGToken_ = mayConsume< l1extra::L1EmParticleCollection >( tagL1ExtraNoIsoEG_ ); // FIXME: This works only in the c'tor!
   if ( autoProcessNameL1ExtraIsoEG_ )   tagL1ExtraIsoEG_   = InputTag( tagL1ExtraIsoEG_.label()  , tagL1ExtraIsoEG_.instance()  , nameProcess_ );
-//   l1ExtraIsoEGToken_ = mayConsume< l1extra::L1EmParticleCollection >( tagL1ExtraIsoEG_ ); // FIXME: This works only in the c'tor!
   if ( autoProcessNameL1ExtraCenJet_ )  tagL1ExtraCenJet_  = InputTag( tagL1ExtraCenJet_.label() , tagL1ExtraCenJet_.instance() , nameProcess_ );
-//   l1ExtraCenJetToken_ = mayConsume< l1extra::L1JetParticleCollection >( tagL1ExtraCenJet_ ); // FIXME: This works only in the c'tor!
   if ( autoProcessNameL1ExtraForJet_ )  tagL1ExtraForJet_  = InputTag( tagL1ExtraForJet_.label() , tagL1ExtraForJet_.instance() , nameProcess_ );
-//   l1ExtraForJetToken_ = mayConsume< l1extra::L1JetParticleCollection >( tagL1ExtraForJet_ ); // FIXME: This works only in the c'tor!
   if ( autoProcessNameL1ExtraTauJet_ )  tagL1ExtraTauJet_  = InputTag( tagL1ExtraTauJet_.label() , tagL1ExtraTauJet_.instance() , nameProcess_ );
-//   l1ExtraTauJetToken_ = mayConsume< l1extra::L1JetParticleCollection >( tagL1ExtraTauJet_ ); // FIXME: This works only in the c'tor!
   if ( autoProcessNameL1ExtraETM_ )     tagL1ExtraETM_     = InputTag( tagL1ExtraETM_.label()    , tagL1ExtraETM_.instance()    , nameProcess_ );
-//   l1ExtraETMToken_ = mayConsume< l1extra::L1EtMissParticleCollection >( tagL1ExtraETM_ ); // FIXME: This works only in the c'tor!
   if ( autoProcessNameL1ExtraHTM_ )     tagL1ExtraHTM_     = InputTag( tagL1ExtraHTM_.label()    , tagL1ExtraHTM_.instance()    , nameProcess_ );
-//   l1ExtraHTMToken_ = mayConsume< l1extra::L1EtMissParticleCollection >( tagL1ExtraHTM_ ); // FIXME: This works only in the c'tor!
 
   // Initialize HLTConfigProvider
   bool changed( true );
@@ -247,7 +277,6 @@ void PATTriggerProducer::beginRun(const Run & iRun, const EventSetup & iSetup )
     if ( ! labelHltPrescaleTable_.empty() ) {
       Handle< trigger::HLTPrescaleTable > handleHltPrescaleTable;
       iRun.getByLabel( InputTag( labelHltPrescaleTable_, "Run", nameProcess_ ), handleHltPrescaleTable );
-//       iRun.getByToken( hltPrescaleTableRunToken_, handleHltPrescaleTable );
       if ( handleHltPrescaleTable.isValid() ) {
         hltPrescaleTableRun_ = trigger::HLTPrescaleTable( handleHltPrescaleTable->set(), handleHltPrescaleTable->labels(), handleHltPrescaleTable->table() );
       }
@@ -271,7 +300,6 @@ void PATTriggerProducer::beginLuminosityBlock(const LuminosityBlock & iLuminosit
     if ( ! labelHltPrescaleTable_.empty() ) {
       Handle< trigger::HLTPrescaleTable > handleHltPrescaleTable;
       iLuminosityBlock.getByLabel( InputTag( labelHltPrescaleTable_, "Lumi", nameProcess_ ), handleHltPrescaleTable );
-//       iLuminosityBlock.getByToken( hltPrescaleTableLumiToken_, handleHltPrescaleTable );
       if ( handleHltPrescaleTable.isValid() ) {
         hltPrescaleTableLumi_ = trigger::HLTPrescaleTable( handleHltPrescaleTable->set(), handleHltPrescaleTable->labels(), handleHltPrescaleTable->table() );
       }
@@ -295,10 +323,8 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   // Get and check HLT event data
   Handle< trigger::TriggerEvent > handleTriggerEvent;
   iEvent.getByLabel( tagTriggerEvent_, handleTriggerEvent );
-//   iEvent.getByToken( triggerEventToken_, handleTriggerEvent );
   Handle< TriggerResults > handleTriggerResults;
   iEvent.getByLabel( tagTriggerResults_, handleTriggerResults );
-//   iEvent.getByToken( triggerResultsToken_, handleTriggerResults );
   bool goodHlt( hltConfigInit_ );
   if ( goodHlt ) {
     if( ! handleTriggerResults.isValid() ) {
@@ -323,7 +349,6 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
     if ( ! labelHltPrescaleTable_.empty() ) {
       Handle< trigger::HLTPrescaleTable > handleHltPrescaleTable;
       iEvent.getByLabel( InputTag( labelHltPrescaleTable_, "Event", nameProcess_ ), handleHltPrescaleTable );
-//       iEvent.getByToken( hltPrescaleTableEventToken_, handleHltPrescaleTable );
       if ( handleHltPrescaleTable.isValid() ) {
         hltPrescaleTable = trigger::HLTPrescaleTable( handleHltPrescaleTable->set(), handleHltPrescaleTable->labels(), handleHltPrescaleTable->table() );
       }
@@ -545,7 +570,6 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   if ( ! tagL1ExtraMu_.label().empty() ) {
     Handle< l1extra::L1MuonParticleCollection > handleL1ExtraMu;
     iEvent.getByLabel( tagL1ExtraMu_, handleL1ExtraMu );
-//     iEvent.getByToken( l1ExtraMuToken_, handleL1ExtraMu );
     if ( handleL1ExtraMu.isValid() ) {
       std::vector< unsigned > muKeys;
       for ( size_t l1Mu = 0; l1Mu < handleL1ExtraMu->size(); ++l1Mu ) {
@@ -571,7 +595,6 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   if ( ! tagL1ExtraNoIsoEG_.label().empty() ) {
     Handle< l1extra::L1EmParticleCollection > handleL1ExtraNoIsoEG;
     iEvent.getByLabel( tagL1ExtraNoIsoEG_, handleL1ExtraNoIsoEG );
-//     iEvent.getByToken( l1ExtraNoIsoEGToken_, handleL1ExtraNoIsoEG );
     if ( handleL1ExtraNoIsoEG.isValid() ) {
       std::vector< unsigned > noIsoEGKeys;
       for ( size_t l1NoIsoEG = 0; l1NoIsoEG < handleL1ExtraNoIsoEG->size(); ++l1NoIsoEG ) {
@@ -597,7 +620,6 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   if ( ! tagL1ExtraIsoEG_.label().empty() ) {
     Handle< l1extra::L1EmParticleCollection > handleL1ExtraIsoEG;
     iEvent.getByLabel( tagL1ExtraIsoEG_, handleL1ExtraIsoEG );
-//     iEvent.getByToken( l1ExtraIsoEGToken_, handleL1ExtraIsoEG );
     if ( handleL1ExtraIsoEG.isValid() ) {
       std::vector< unsigned > isoEGKeys;
       for ( size_t l1IsoEG = 0; l1IsoEG < handleL1ExtraIsoEG->size(); ++l1IsoEG ) {
@@ -623,7 +645,6 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   if ( ! tagL1ExtraCenJet_.label().empty() ) {
     Handle< l1extra::L1JetParticleCollection > handleL1ExtraCenJet;
     iEvent.getByLabel( tagL1ExtraCenJet_, handleL1ExtraCenJet );
-//     iEvent.getByToken( l1ExtraCenJetToken_, handleL1ExtraCenJet );
     if ( handleL1ExtraCenJet.isValid() ) {
       std::vector< unsigned > cenJetKeys;
       for ( size_t l1CenJet = 0; l1CenJet < handleL1ExtraCenJet->size(); ++l1CenJet ) {
@@ -649,7 +670,6 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   if ( ! tagL1ExtraForJet_.label().empty() ) {
     Handle< l1extra::L1JetParticleCollection > handleL1ExtraForJet;
     iEvent.getByLabel( tagL1ExtraForJet_, handleL1ExtraForJet );
-//     iEvent.getByToken( l1ExtraForJetToken_, handleL1ExtraForJet );
     if ( handleL1ExtraForJet.isValid() ) {
       std::vector< unsigned > forJetKeys;
       for ( size_t l1ForJet = 0; l1ForJet < handleL1ExtraForJet->size(); ++l1ForJet ) {
@@ -675,7 +695,6 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   if ( ! tagL1ExtraTauJet_.label().empty() ) {
     Handle< l1extra::L1JetParticleCollection > handleL1ExtraTauJet;
     iEvent.getByLabel( tagL1ExtraTauJet_, handleL1ExtraTauJet );
-//     iEvent.getByToken( l1ExtraTauJetToken_, handleL1ExtraTauJet );
     if ( handleL1ExtraTauJet.isValid() ) {
       std::vector< unsigned > tauJetKeys;
       for ( size_t l1TauJet = 0; l1TauJet < handleL1ExtraTauJet->size(); ++l1TauJet ) {
@@ -701,7 +720,6 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   if ( ! tagL1ExtraETM_ .label().empty()) {
     Handle< l1extra::L1EtMissParticleCollection > handleL1ExtraETM;
     iEvent.getByLabel( tagL1ExtraETM_, handleL1ExtraETM );
-//     iEvent.getByToken( l1ExtraETMToken_, handleL1ExtraETM );
     if ( handleL1ExtraETM.isValid() ) {
       std::vector< unsigned > etmKeys;
       for ( size_t l1ETM = 0; l1ETM < handleL1ExtraETM->size(); ++l1ETM ) {
@@ -727,7 +745,6 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
   if ( ! tagL1ExtraHTM_.label().empty() ) {
     Handle< l1extra::L1EtMissParticleCollection > handleL1ExtraHTM;
     iEvent.getByLabel( tagL1ExtraHTM_, handleL1ExtraHTM );
-//     iEvent.getByToken( l1ExtraHTMToken_, handleL1ExtraHTM );
     if ( handleL1ExtraHTM.isValid() ) {
       std::vector< unsigned > htmKeys;
       for ( size_t l1HTM = 0; l1HTM < handleL1ExtraHTM->size(); ++l1HTM ) {

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
@@ -89,8 +89,7 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraMu_ = true;
       else                    tagL1ExtraMu_ = InputTag( tagL1ExtraMu_.label(), tagL1ExtraMu_.instance(), nameProcess_ );
     }
-    InputTag tagL1ExtraMuTmp( tagL1ExtraMu_.label(), tagL1ExtraMu_.instance() );
-    l1ExtraMuGetter_ = edm::GetterOfProducts< l1extra::L1MuonParticleCollection >( edm::InputTagMatch( tagL1ExtraMuTmp.encode() ), this);
+    l1ExtraMuGetter_ = edm::GetterOfProducts< l1extra::L1MuonParticleCollection >( edm::InputTagMatch( InputTag( tagL1ExtraMu_.label(), tagL1ExtraMu_.instance() ) ), this);
   }
   if ( iConfig.exists( "l1ExtraNoIsoEG" ) ) {
     tagL1ExtraNoIsoEG_ = iConfig.getParameter< InputTag >( "l1ExtraNoIsoEG" );
@@ -98,8 +97,7 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraNoIsoEG_ = true;
       else                    tagL1ExtraNoIsoEG_ = InputTag( tagL1ExtraNoIsoEG_.label(), tagL1ExtraNoIsoEG_.instance(), nameProcess_ );
     }
-    InputTag tagL1ExtraNoIsoEGTmp( tagL1ExtraNoIsoEG_.label(), tagL1ExtraNoIsoEG_.instance() );
-    l1ExtraNoIsoEGGetter_ = edm::GetterOfProducts< l1extra::L1EmParticleCollection >( edm::InputTagMatch( tagL1ExtraNoIsoEGTmp.encode() ), this);
+    l1ExtraNoIsoEGGetter_ = edm::GetterOfProducts< l1extra::L1EmParticleCollection >( edm::InputTagMatch( InputTag( tagL1ExtraNoIsoEG_.label(), tagL1ExtraNoIsoEG_.instance() ) ), this);
   }
   if ( iConfig.exists( "l1ExtraIsoEG" ) ) {
     tagL1ExtraIsoEG_ = iConfig.getParameter< InputTag >( "l1ExtraIsoEG" );
@@ -107,8 +105,7 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraIsoEG_ = true;
       else                    tagL1ExtraIsoEG_ = InputTag( tagL1ExtraIsoEG_.label(), tagL1ExtraIsoEG_.instance(), nameProcess_ );
     }
-    InputTag tagL1ExtraIsoEGTmp( tagL1ExtraIsoEG_.label(), tagL1ExtraIsoEG_.instance() );
-    l1ExtraIsoEGGetter_ = edm::GetterOfProducts< l1extra::L1EmParticleCollection >( edm::InputTagMatch( tagL1ExtraIsoEGTmp.encode() ), this);
+    l1ExtraIsoEGGetter_ = edm::GetterOfProducts< l1extra::L1EmParticleCollection >( edm::InputTagMatch( InputTag( tagL1ExtraIsoEG_.label(), tagL1ExtraIsoEG_.instance() ) ), this);
   }
   if ( iConfig.exists( "l1ExtraCenJet" ) ) {
     tagL1ExtraCenJet_ = iConfig.getParameter< InputTag >( "l1ExtraCenJet" );
@@ -116,8 +113,7 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraCenJet_ = true;
       else                    tagL1ExtraCenJet_ = InputTag( tagL1ExtraCenJet_.label(), tagL1ExtraCenJet_.instance(), nameProcess_ );
     }
-    InputTag tagL1ExtraCenJetTmp( tagL1ExtraCenJet_.label(), tagL1ExtraCenJet_.instance() );
-    l1ExtraCenJetGetter_ = edm::GetterOfProducts< l1extra::L1JetParticleCollection >( edm::InputTagMatch( tagL1ExtraCenJetTmp.encode() ), this);
+    l1ExtraCenJetGetter_ = edm::GetterOfProducts< l1extra::L1JetParticleCollection >( edm::InputTagMatch( InputTag( tagL1ExtraCenJet_.label(), tagL1ExtraCenJet_.instance() ) ), this);
   }
   if ( iConfig.exists( "l1ExtraForJet" ) ) {
     tagL1ExtraForJet_ = iConfig.getParameter< InputTag >( "l1ExtraForJet" );
@@ -125,8 +121,7 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraForJet_ = true;
       else                    tagL1ExtraForJet_ = InputTag( tagL1ExtraForJet_.label(), tagL1ExtraForJet_.instance(), nameProcess_ );
     }
-    InputTag tagL1ExtraForJetTmp( tagL1ExtraForJet_.label(), tagL1ExtraForJet_.instance() );
-    l1ExtraForJetGetter_ = edm::GetterOfProducts< l1extra::L1JetParticleCollection >( edm::InputTagMatch( tagL1ExtraForJetTmp.encode() ), this);
+    l1ExtraForJetGetter_ = edm::GetterOfProducts< l1extra::L1JetParticleCollection >( edm::InputTagMatch( InputTag( tagL1ExtraForJet_.label(), tagL1ExtraForJet_.instance() ) ), this);
   }
   if ( iConfig.exists( "l1ExtraTauJet" ) ) {
     tagL1ExtraTauJet_ = iConfig.getParameter< InputTag >( "l1ExtraTauJet" );
@@ -134,8 +129,7 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraTauJet_ = true;
       else                    tagL1ExtraTauJet_ = InputTag( tagL1ExtraTauJet_.label(), tagL1ExtraTauJet_.instance(), nameProcess_ );
     }
-    InputTag tagL1ExtraTauJetTmp( tagL1ExtraTauJet_.label(), tagL1ExtraTauJet_.instance() );
-    l1ExtraTauJetGetter_ = edm::GetterOfProducts< l1extra::L1JetParticleCollection >( edm::InputTagMatch( tagL1ExtraTauJetTmp.encode() ), this);
+    l1ExtraTauJetGetter_ = edm::GetterOfProducts< l1extra::L1JetParticleCollection >( edm::InputTagMatch( InputTag( tagL1ExtraTauJet_.label(), tagL1ExtraTauJet_.instance() ) ), this);
   }
   if ( iConfig.exists( "l1ExtraETM" ) ) {
     tagL1ExtraETM_ = iConfig.getParameter< InputTag >( "l1ExtraETM" );
@@ -143,8 +137,7 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraETM_ = true;
       else                    tagL1ExtraETM_ = InputTag( tagL1ExtraETM_.label(), tagL1ExtraETM_.instance(), nameProcess_ );
     }
-    InputTag tagL1ExtraETMTmp( tagL1ExtraETM_.label(), tagL1ExtraETM_.instance() );
-    l1ExtraETMGetter_ = edm::GetterOfProducts< l1extra::L1EtMissParticleCollection >( edm::InputTagMatch( tagL1ExtraETMTmp.encode() ), this);
+    l1ExtraETMGetter_ = edm::GetterOfProducts< l1extra::L1EtMissParticleCollection >( edm::InputTagMatch( InputTag( tagL1ExtraETM_.label(), tagL1ExtraETM_.instance() ) ), this);
   }
   if ( iConfig.exists( "l1ExtraHTM" ) ) {
     tagL1ExtraHTM_ = iConfig.getParameter< InputTag >( "l1ExtraHTM" );
@@ -152,28 +145,22 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraHTM_ = true;
       else                    tagL1ExtraHTM_ = InputTag( tagL1ExtraHTM_.label(), tagL1ExtraHTM_.instance(), nameProcess_ );
     }
-    InputTag tagL1ExtraHTMTmp( tagL1ExtraHTM_.label(), tagL1ExtraHTM_.instance() );
-    l1ExtraHTMGetter_ = edm::GetterOfProducts< l1extra::L1EtMissParticleCollection >( edm::InputTagMatch( tagL1ExtraHTMTmp.encode() ), this);
+    l1ExtraHTMGetter_ = edm::GetterOfProducts< l1extra::L1EtMissParticleCollection >( edm::InputTagMatch( InputTag( tagL1ExtraHTM_.label(), tagL1ExtraHTM_.instance() ) ), this);
   }
   if ( iConfig.exists( "mainBxOnly" ) ) mainBxOnly_ = iConfig.getParameter< bool >( "mainBxOnly" );
   if ( iConfig.exists( "saveL1Refs" ) ) saveL1Refs_ = iConfig.getParameter< bool >( "saveL1Refs" );
 
   // HLT configuration parameters
   if ( iConfig.exists( "triggerResults" ) ) tagTriggerResults_ = iConfig.getParameter< InputTag >( "triggerResults" );
-  InputTag tagTriggerResultsTmp( tagTriggerResults_.label(), tagTriggerResults_.instance() );
-  triggerResultsGetter_ = edm::GetterOfProducts< edm::TriggerResults >( edm::InputTagMatch( tagTriggerResultsTmp.encode() ), this);
+  triggerResultsGetter_ = edm::GetterOfProducts< edm::TriggerResults >( edm::InputTagMatch( InputTag( tagTriggerResults_.label(), tagTriggerResults_.instance() ) ), this);
   if ( iConfig.exists( "triggerEvent" ) ) tagTriggerEvent_ = iConfig.getParameter< InputTag >( "triggerEvent" );
-  InputTag tagTriggerEventTmp( tagTriggerEvent_.label(), tagTriggerEvent_.instance() );
-  triggerEventGetter_ = edm::GetterOfProducts< trigger::TriggerEvent >( edm::InputTagMatch( tagTriggerEventTmp.encode() ), this);
+  triggerEventGetter_ = edm::GetterOfProducts< trigger::TriggerEvent >( edm::InputTagMatch( InputTag( tagTriggerEvent_.label(), tagTriggerEvent_.instance() ) ), this);
   if ( iConfig.exists( "hltPrescaleLabel" ) )    hltPrescaleLabel_      = iConfig.getParameter< std::string >( "hltPrescaleLabel" );
   if ( iConfig.exists( "hltPrescaleTable" ) ) {
     labelHltPrescaleTable_ = iConfig.getParameter< std::string >( "hltPrescaleTable" );
-    InputTag tagHltPrescaleTableRunTmp( labelHltPrescaleTable_, "Run" );
-    hltPrescaleTableRunGetter_ = edm::GetterOfProducts< trigger::HLTPrescaleTable >( edm::InputTagMatch( tagHltPrescaleTableRunTmp.encode() ), this, InRun );
-    InputTag tagHltPrescaleTableLumiTmp( labelHltPrescaleTable_, "Lumi" );
-    hltPrescaleTableLumiGetter_ = edm::GetterOfProducts< trigger::HLTPrescaleTable >( edm::InputTagMatch( tagHltPrescaleTableLumiTmp.encode() ), this, InLumi );
-    InputTag tagHltPrescaleTableEventTmp( labelHltPrescaleTable_, "Event" );
-    hltPrescaleTableEventGetter_ = edm::GetterOfProducts< trigger::HLTPrescaleTable >( edm::InputTagMatch( tagHltPrescaleTableEventTmp.encode() ), this );
+    hltPrescaleTableRunGetter_ = edm::GetterOfProducts< trigger::HLTPrescaleTable >( edm::InputTagMatch( InputTag( labelHltPrescaleTable_, "Run" ) ), this, InRun );
+    hltPrescaleTableLumiGetter_ = edm::GetterOfProducts< trigger::HLTPrescaleTable >( edm::InputTagMatch( InputTag( labelHltPrescaleTable_, "Lumi" ) ), this, InLumi );
+    hltPrescaleTableEventGetter_ = edm::GetterOfProducts< trigger::HLTPrescaleTable >( edm::InputTagMatch( InputTag( labelHltPrescaleTable_, "Event" ) ), this );
   }
   if ( iConfig.exists( "addPathModuleLabels" ) ) addPathModuleLabels_ = iConfig.getParameter< bool >( "addPathModuleLabels" );
   exludeCollections_.clear();

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
@@ -89,7 +89,7 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraMu_ = true;
       else                    tagL1ExtraMu_ = InputTag( tagL1ExtraMu_.label(), tagL1ExtraMu_.instance(), nameProcess_ );
     }
-    l1ExtraMuGetter_ = edm::GetterOfProducts< l1extra::L1MuonParticleCollection >( edm::InputTagMatch( InputTag( tagL1ExtraMu_.label(), tagL1ExtraMu_.instance() ) ), this);
+    l1ExtraMuGetter_ = GetterOfProducts< l1extra::L1MuonParticleCollection >( InputTagMatch( InputTag( tagL1ExtraMu_.label(), tagL1ExtraMu_.instance() ) ), this);
   }
   if ( iConfig.exists( "l1ExtraNoIsoEG" ) ) {
     tagL1ExtraNoIsoEG_ = iConfig.getParameter< InputTag >( "l1ExtraNoIsoEG" );
@@ -97,7 +97,7 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraNoIsoEG_ = true;
       else                    tagL1ExtraNoIsoEG_ = InputTag( tagL1ExtraNoIsoEG_.label(), tagL1ExtraNoIsoEG_.instance(), nameProcess_ );
     }
-    l1ExtraNoIsoEGGetter_ = edm::GetterOfProducts< l1extra::L1EmParticleCollection >( edm::InputTagMatch( InputTag( tagL1ExtraNoIsoEG_.label(), tagL1ExtraNoIsoEG_.instance() ) ), this);
+    l1ExtraNoIsoEGGetter_ = GetterOfProducts< l1extra::L1EmParticleCollection >( InputTagMatch( InputTag( tagL1ExtraNoIsoEG_.label(), tagL1ExtraNoIsoEG_.instance() ) ), this);
   }
   if ( iConfig.exists( "l1ExtraIsoEG" ) ) {
     tagL1ExtraIsoEG_ = iConfig.getParameter< InputTag >( "l1ExtraIsoEG" );
@@ -105,7 +105,7 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraIsoEG_ = true;
       else                    tagL1ExtraIsoEG_ = InputTag( tagL1ExtraIsoEG_.label(), tagL1ExtraIsoEG_.instance(), nameProcess_ );
     }
-    l1ExtraIsoEGGetter_ = edm::GetterOfProducts< l1extra::L1EmParticleCollection >( edm::InputTagMatch( InputTag( tagL1ExtraIsoEG_.label(), tagL1ExtraIsoEG_.instance() ) ), this);
+    l1ExtraIsoEGGetter_ = GetterOfProducts< l1extra::L1EmParticleCollection >( InputTagMatch( InputTag( tagL1ExtraIsoEG_.label(), tagL1ExtraIsoEG_.instance() ) ), this);
   }
   if ( iConfig.exists( "l1ExtraCenJet" ) ) {
     tagL1ExtraCenJet_ = iConfig.getParameter< InputTag >( "l1ExtraCenJet" );
@@ -113,7 +113,7 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraCenJet_ = true;
       else                    tagL1ExtraCenJet_ = InputTag( tagL1ExtraCenJet_.label(), tagL1ExtraCenJet_.instance(), nameProcess_ );
     }
-    l1ExtraCenJetGetter_ = edm::GetterOfProducts< l1extra::L1JetParticleCollection >( edm::InputTagMatch( InputTag( tagL1ExtraCenJet_.label(), tagL1ExtraCenJet_.instance() ) ), this);
+    l1ExtraCenJetGetter_ = GetterOfProducts< l1extra::L1JetParticleCollection >( InputTagMatch( InputTag( tagL1ExtraCenJet_.label(), tagL1ExtraCenJet_.instance() ) ), this);
   }
   if ( iConfig.exists( "l1ExtraForJet" ) ) {
     tagL1ExtraForJet_ = iConfig.getParameter< InputTag >( "l1ExtraForJet" );
@@ -121,7 +121,7 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraForJet_ = true;
       else                    tagL1ExtraForJet_ = InputTag( tagL1ExtraForJet_.label(), tagL1ExtraForJet_.instance(), nameProcess_ );
     }
-    l1ExtraForJetGetter_ = edm::GetterOfProducts< l1extra::L1JetParticleCollection >( edm::InputTagMatch( InputTag( tagL1ExtraForJet_.label(), tagL1ExtraForJet_.instance() ) ), this);
+    l1ExtraForJetGetter_ = GetterOfProducts< l1extra::L1JetParticleCollection >( InputTagMatch( InputTag( tagL1ExtraForJet_.label(), tagL1ExtraForJet_.instance() ) ), this);
   }
   if ( iConfig.exists( "l1ExtraTauJet" ) ) {
     tagL1ExtraTauJet_ = iConfig.getParameter< InputTag >( "l1ExtraTauJet" );
@@ -129,7 +129,7 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraTauJet_ = true;
       else                    tagL1ExtraTauJet_ = InputTag( tagL1ExtraTauJet_.label(), tagL1ExtraTauJet_.instance(), nameProcess_ );
     }
-    l1ExtraTauJetGetter_ = edm::GetterOfProducts< l1extra::L1JetParticleCollection >( edm::InputTagMatch( InputTag( tagL1ExtraTauJet_.label(), tagL1ExtraTauJet_.instance() ) ), this);
+    l1ExtraTauJetGetter_ = GetterOfProducts< l1extra::L1JetParticleCollection >( InputTagMatch( InputTag( tagL1ExtraTauJet_.label(), tagL1ExtraTauJet_.instance() ) ), this);
   }
   if ( iConfig.exists( "l1ExtraETM" ) ) {
     tagL1ExtraETM_ = iConfig.getParameter< InputTag >( "l1ExtraETM" );
@@ -137,7 +137,7 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraETM_ = true;
       else                    tagL1ExtraETM_ = InputTag( tagL1ExtraETM_.label(), tagL1ExtraETM_.instance(), nameProcess_ );
     }
-    l1ExtraETMGetter_ = edm::GetterOfProducts< l1extra::L1EtMissParticleCollection >( edm::InputTagMatch( InputTag( tagL1ExtraETM_.label(), tagL1ExtraETM_.instance() ) ), this);
+    l1ExtraETMGetter_ = GetterOfProducts< l1extra::L1EtMissParticleCollection >( InputTagMatch( InputTag( tagL1ExtraETM_.label(), tagL1ExtraETM_.instance() ) ), this);
   }
   if ( iConfig.exists( "l1ExtraHTM" ) ) {
     tagL1ExtraHTM_ = iConfig.getParameter< InputTag >( "l1ExtraHTM" );
@@ -145,28 +145,28 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
       if ( autoProcessName_ ) autoProcessNameL1ExtraHTM_ = true;
       else                    tagL1ExtraHTM_ = InputTag( tagL1ExtraHTM_.label(), tagL1ExtraHTM_.instance(), nameProcess_ );
     }
-    l1ExtraHTMGetter_ = edm::GetterOfProducts< l1extra::L1EtMissParticleCollection >( edm::InputTagMatch( InputTag( tagL1ExtraHTM_.label(), tagL1ExtraHTM_.instance() ) ), this);
+    l1ExtraHTMGetter_ = GetterOfProducts< l1extra::L1EtMissParticleCollection >( InputTagMatch( InputTag( tagL1ExtraHTM_.label(), tagL1ExtraHTM_.instance() ) ), this);
   }
   if ( iConfig.exists( "mainBxOnly" ) ) mainBxOnly_ = iConfig.getParameter< bool >( "mainBxOnly" );
   if ( iConfig.exists( "saveL1Refs" ) ) saveL1Refs_ = iConfig.getParameter< bool >( "saveL1Refs" );
 
   // HLT configuration parameters
   if ( iConfig.exists( "triggerResults" ) ) tagTriggerResults_ = iConfig.getParameter< InputTag >( "triggerResults" );
-  triggerResultsGetter_ = edm::GetterOfProducts< edm::TriggerResults >( edm::InputTagMatch( InputTag( tagTriggerResults_.label(), tagTriggerResults_.instance() ) ), this);
+  triggerResultsGetter_ = GetterOfProducts< TriggerResults >( InputTagMatch( InputTag( tagTriggerResults_.label(), tagTriggerResults_.instance() ) ), this);
   if ( iConfig.exists( "triggerEvent" ) ) tagTriggerEvent_ = iConfig.getParameter< InputTag >( "triggerEvent" );
-  triggerEventGetter_ = edm::GetterOfProducts< trigger::TriggerEvent >( edm::InputTagMatch( InputTag( tagTriggerEvent_.label(), tagTriggerEvent_.instance() ) ), this);
+  triggerEventGetter_ = GetterOfProducts< trigger::TriggerEvent >( InputTagMatch( InputTag( tagTriggerEvent_.label(), tagTriggerEvent_.instance() ) ), this);
   if ( iConfig.exists( "hltPrescaleLabel" ) )    hltPrescaleLabel_      = iConfig.getParameter< std::string >( "hltPrescaleLabel" );
   if ( iConfig.exists( "hltPrescaleTable" ) ) {
     labelHltPrescaleTable_ = iConfig.getParameter< std::string >( "hltPrescaleTable" );
-    hltPrescaleTableRunGetter_ = edm::GetterOfProducts< trigger::HLTPrescaleTable >( edm::InputTagMatch( InputTag( labelHltPrescaleTable_, "Run" ) ), this, InRun );
-    hltPrescaleTableLumiGetter_ = edm::GetterOfProducts< trigger::HLTPrescaleTable >( edm::InputTagMatch( InputTag( labelHltPrescaleTable_, "Lumi" ) ), this, InLumi );
-    hltPrescaleTableEventGetter_ = edm::GetterOfProducts< trigger::HLTPrescaleTable >( edm::InputTagMatch( InputTag( labelHltPrescaleTable_, "Event" ) ), this );
+    hltPrescaleTableRunGetter_ = GetterOfProducts< trigger::HLTPrescaleTable >( InputTagMatch( InputTag( labelHltPrescaleTable_, "Run" ) ), this, InRun );
+    hltPrescaleTableLumiGetter_ = GetterOfProducts< trigger::HLTPrescaleTable >( InputTagMatch( InputTag( labelHltPrescaleTable_, "Lumi" ) ), this, InLumi );
+    hltPrescaleTableEventGetter_ = GetterOfProducts< trigger::HLTPrescaleTable >( InputTagMatch( InputTag( labelHltPrescaleTable_, "Event" ) ), this );
   }
   if ( iConfig.exists( "addPathModuleLabels" ) ) addPathModuleLabels_ = iConfig.getParameter< bool >( "addPathModuleLabels" );
   exludeCollections_.clear();
   if ( iConfig.exists( "exludeCollections" )  ) exludeCollections_ = iConfig.getParameter< std::vector< std::string > >( "exludeCollections" );
 
-  callWhenNewProductsRegistered( [ this, &iConfig ]( edm::BranchDescription const& bd ) {
+  callWhenNewProductsRegistered( [ this, &iConfig ]( BranchDescription const& bd ) {
     if ( iConfig.exists( "l1ExtraMu" ) ) l1ExtraMuGetter_( bd );
     if ( iConfig.exists( "l1ExtraNoIsoEG" ) ) l1ExtraNoIsoEGGetter_( bd );
     if ( iConfig.exists( "l1ExtraIsoEG" ) ) l1ExtraIsoEGGetter_( bd );

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.h
@@ -38,6 +38,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/GetterOfProducts.h"
 
 #include <string>
 
@@ -78,21 +79,21 @@ namespace pat {
       edm::InputTag       tagL1GlobalTriggerObjectMaps_;  // configuration (optional with default)
       edm::EDGetTokenT< L1GlobalTriggerObjectMaps > l1GlobalTriggerObjectMapsToken_;
       edm::InputTag       tagL1ExtraMu_;                  // configuration (optional)
-//       edm::EDGetTokenT< l1extra::L1MuonParticleCollection > l1ExtraMuToken_;
+      edm::GetterOfProducts< l1extra::L1MuonParticleCollection > l1ExtraMuGetter_;
       edm::InputTag       tagL1ExtraNoIsoEG_;             // configuration (optional)
-//       edm::EDGetTokenT< l1extra::L1EmParticleCollection > l1ExtraNoIsoEGToken_;
+      edm::GetterOfProducts< l1extra::L1EmParticleCollection > l1ExtraNoIsoEGGetter_;
       edm::InputTag       tagL1ExtraIsoEG_;               // configuration (optional)
-//       edm::EDGetTokenT< l1extra::L1EmParticleCollection > l1ExtraIsoEGToken_;
+      edm::GetterOfProducts< l1extra::L1EmParticleCollection > l1ExtraIsoEGGetter_;
       edm::InputTag       tagL1ExtraCenJet_;              // configuration (optional)
-//       edm::EDGetTokenT< l1extra::L1JetParticleCollection > l1ExtraCenJetToken_;
+      edm::GetterOfProducts< l1extra::L1JetParticleCollection > l1ExtraCenJetGetter_;
       edm::InputTag       tagL1ExtraForJet_;              // configuration (optional)
-//       edm::EDGetTokenT< l1extra::L1JetParticleCollection > l1ExtraForJetToken_;
+      edm::GetterOfProducts< l1extra::L1JetParticleCollection > l1ExtraForJetGetter_;
       edm::InputTag       tagL1ExtraTauJet_;              // configuration (optional)
-//       edm::EDGetTokenT< l1extra::L1JetParticleCollection > l1ExtraTauJetToken_;
+      edm::GetterOfProducts< l1extra::L1JetParticleCollection > l1ExtraTauJetGetter_;
       edm::InputTag       tagL1ExtraETM_;                 // configuration (optional)
-//       edm::EDGetTokenT< l1extra::L1EtMissParticleCollection > l1ExtraETMToken_;
+      edm::GetterOfProducts< l1extra::L1EtMissParticleCollection > l1ExtraETMGetter_;
       edm::InputTag       tagL1ExtraHTM_;                 // configuration (optional)
-//       edm::EDGetTokenT< l1extra::L1EtMissParticleCollection > l1ExtraHTMToken_;
+      edm::GetterOfProducts< l1extra::L1EtMissParticleCollection > l1ExtraHTMGetter_;
       bool                autoProcessNameL1ExtraMu_;
       bool                autoProcessNameL1ExtraNoIsoEG_;
       bool                autoProcessNameL1ExtraIsoEG_;
@@ -107,14 +108,14 @@ namespace pat {
       HLTConfigProvider         hltConfig_;
       bool                      hltConfigInit_;
       edm::InputTag             tagTriggerResults_;     // configuration (optional with default)
-//       edm::EDGetTokenT< edm::TriggerResults > triggerResultsToken_;
+      edm::GetterOfProducts< edm::TriggerResults > triggerResultsGetter_;
       edm::InputTag             tagTriggerEvent_;       // configuration (optional with default)
-//       edm::EDGetTokenT< trigger::TriggerEvent > triggerEventToken_;
+      edm::GetterOfProducts< trigger::TriggerEvent > triggerEventGetter_;
       std::string               hltPrescaleLabel_;      // configuration (optional)
       std::string               labelHltPrescaleTable_; // configuration (optional)
-//       edm::EDGetTokenT< trigger::HLTPrescaleTable > hltPrescaleTableRunToken_;
-//       edm::EDGetTokenT< trigger::HLTPrescaleTable > hltPrescaleTableLumiToken_;
-//       edm::EDGetTokenT< trigger::HLTPrescaleTable > hltPrescaleTableEventToken_;
+      edm::GetterOfProducts< trigger::HLTPrescaleTable > hltPrescaleTableRunGetter_;
+      edm::GetterOfProducts< trigger::HLTPrescaleTable > hltPrescaleTableLumiGetter_;
+      edm::GetterOfProducts< trigger::HLTPrescaleTable > hltPrescaleTableEventGetter_;
       trigger::HLTPrescaleTable hltPrescaleTableRun_;
       trigger::HLTPrescaleTable hltPrescaleTableLumi_;
       bool                       addPathModuleLabels_;  // configuration (optional with default)


### PR DESCRIPTION
PAT trigger `consumes` migration, using `edm::GetterOfProducts`.
`getByLabel` is still used.
A new predicate to match InputTags is added.
