### PR TITLE
Add header needed for clang compilation

### DIFF
--- a/FWCore/Utilities/interface/ConvertException.h
+++ b/FWCore/Utilities/interface/ConvertException.h
@@ -4,10 +4,7 @@
 #include <string>
 #include <exception>
 #include <functional>
-
-namespace cms {
-  class Exception;
-}
+#include "FWCore/Utilities/interface/Exception.h"
 
 namespace edm {
   namespace convertException {


### PR DESCRIPTION
Clang requires the full declaration of cms::Exception before the implementation of wrap.
