### PR TITLE
Removed mutable from HcalGeometry

### DIFF
--- a/Geometry/HcalTowerAlgo/interface/HcalGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalGeometry.h
@@ -129,7 +129,7 @@ private:
   mutable edm::AtomicPtrCache<std::vector<DetId>> m_hoIds ;
   mutable edm::AtomicPtrCache<std::vector<DetId>> m_hfIds ;
   mutable edm::AtomicPtrCache<std::vector<DetId>> m_emptyIds ;
-  mutable CaloSubdetectorGeometry::IVec m_dins;  
+  CaloSubdetectorGeometry::IVec m_dins;  
 
   HBCellVec m_hbCellVec ;
   HECellVec m_heCellVec ;


### PR DESCRIPTION
One of the mutable member data of HcalGeometry did not need to be
mutable. This avoids thread-safety issues.
