### PR TITLE
Pre mixing modifications for 7 0 x

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -861,11 +861,15 @@ class ConfigBuilder(object):
             self.DIGI2RAWDefaultCFF="Configuration/StandardSequences/DigiToRawDM_cff"
             self.L1EMDefaultCFF='Configuration/StandardSequences/SimL1EmulatorDM_cff'
 
+	if "DIGIPREMIX" in self.stepMap.keys():
+            self.DIGIDefaultCFF="Configuration/StandardSequences/Digi_PreMix_cff"
+
         self.ALCADefaultSeq=None
 	self.LHEDefaultSeq='externalLHEProducer'
         self.GENDefaultSeq='pgen'
         self.SIMDefaultSeq='psim'
         self.DIGIDefaultSeq='pdigi'
+	self.DIGIPREMIXDefaultSeq='pdigi'
         self.DATAMIXDefaultSeq=None
         self.DIGI2RAWDefaultSeq='DigiToRaw'
         self.HLTDefaultSeq='GRun'
@@ -1356,6 +1360,17 @@ class ConfigBuilder(object):
 
         if sequence == 'pdigi_valid':
             self.executeAndRemember("process.mix.digitizers = cms.PSet(process.theDigitizersValid)")
+
+	self.scheduleSequence(sequence.split('.')[-1],'digitisation_step')
+        return
+
+    def prepare_DIGIPREMIX(self, sequence = None):
+        """ Enrich the schedule with the digitisation step"""
+        self.loadDefaultOrSpecifiedCFF(sequence,self.DIGIDefaultCFF)
+
+	self.loadAndRemember("SimGeneral/MixingModule/digi_noNoise_cfi")
+	self.executeAndRemember("process.mix.digitizers = cms.PSet(process.theDigitizersNoNoise)")
+
 
 	self.scheduleSequence(sequence.split('.')[-1],'digitisation_step')
         return

--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -83,6 +83,7 @@ def OptionsFromItems(items):
                  "SIM":"GEN",
                  "reSIM":"SIM",
                  "DIGI":"SIM",
+                 "DIGIPREMIX":"SIM",
                  "reDIGI":"DIGI",
                  "L1REPACK":"RAW",
                  "HLT":"RAW",
@@ -203,6 +204,8 @@ def OptionsFromItems(items):
         if 'CFWRITER' in options.trimmedStep:
             options.isMC=True
         if 'DIGI' in options.trimmedStep:
+            options.isMC=True
+        if 'DIGI2RAW' in options.trimmedStep:
             options.isMC=True
         if (not (options.eventcontent == None)) and 'SIM' in options.eventcontent:
             options.isMC=True

--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -20,6 +20,9 @@ import FWCore.ParameterSet.Config as cms
 #  PREMIX
 #    special Digi collections for pre-mixing minbias events for pileup simulation
 #
+#  PREMIXRAW
+#    extension of GENRAW for pre-mixing minbias events for pileup simulation.  Raw2Digi step is done.
+#
 #  RAWDEBUG(RAWSIM+ALL_SIM_INFO), RAWDEBUGHLT(RAWDEBUG+HLTDEBUG)
 #
 #  RAWSIMHLT (RAWSIM + HLTDEBUG)
@@ -405,6 +408,15 @@ MIXINGMODULEEventContent = cms.PSet(
     eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
     )
 
+# PREMIXRAW Data Tier definition
+#
+#
+PREMIXRAWEventContent = cms.PSet(
+    outputCommands = cms.untracked.vstring('drop *'),
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize=cms.untracked.int32(5*1024*1024)
+)
+
 #
 #
 ## RAW repacked event content definition
@@ -520,6 +532,11 @@ GENRAWEventContent.outputCommands.extend(MEtoEDMConverterFEVT.outputCommands)
 GENRAWEventContent.outputCommands.extend(IOMCRAW.outputCommands)
 GENRAWEventContent.outputCommands.extend(DigiToRawFEVT.outputCommands)
 GENRAWEventContent.outputCommands.extend(CommonEventContent.outputCommands)
+
+PREMIXRAWEventContent.outputCommands.extend(GENRAWEventContent.outputCommands)
+PREMIXRAWEventContent.outputCommands.append('keep CrossingFramePlaybackInfoExtended_*_*_*')
+PREMIXRAWEventContent.outputCommands.append('drop CrossingFramePlaybackInfoExtended_mix_*_*')
+PREMIXRAWEventContent.outputCommands.append('drop PileupSummaryInfos_addPileupInfo_*_*')            
 
 REPACKRAWSIMEventContent.outputCommands.extend(REPACKRAWEventContent.outputCommands)
 REPACKRAWSIMEventContent.outputCommands.extend(SimG4CoreRAW.outputCommands)

--- a/Configuration/StandardSequences/python/DigiToRawDM_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRawDM_cff.py
@@ -27,5 +27,8 @@ cscpacker.comparatorDigiTag = cms.InputTag("mixData","MuonCSCComparatorDigisDM")
 dtpacker.digiColl = cms.InputTag('mixData')
 #dtpacker.digiColl = cms.InputTag('simMuonDTDigis')
 rpcpacker.InputLabel = cms.InputTag("mixData")
-castorRawData.CASTOR = cms.untracked.InputTag("castorDigis")
+
+DigiToRaw.remove(castorRawData)
+
+#castorRawData.CASTOR = cms.untracked.InputTag("castorDigis")
 #

--- a/Configuration/StandardSequences/python/Digi_PreMix_cff.py
+++ b/Configuration/StandardSequences/python/Digi_PreMix_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+# fragment to turn off ZS in Hcal:
+from Configuration.StandardSequences.DigiNZS_cff import *
+
+# modifications to the digi sequences defined above (DigiNZS imports the central Digi_cff)
+
+simMuonCSCDigis.strips.doNoise = False
+simMuonCSCDigis.wires.doNoise = False
+simMuonDTDigis.onlyMuHits = True
+simMuonRPCDigis.Noise = False
+
+# Note: the other noise is turned of in the DigitizersNoNoise sequence defined in the MixingModule
+# because the MM holds/controls all of the other digitizers.
+
+# Turn off SR in Ecal
+simEcalDigis.UseFullReadout = cms.bool(True)
+
+                                

--- a/SimCalorimetry/EcalSelectiveReadoutProducers/interface/EcalSelectiveReadoutProducer.h
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/interface/EcalSelectiveReadoutProducer.h
@@ -144,6 +144,12 @@ private:
    */
   bool useCondDb_;
 
+
+  /**  Special switch to turn off SR entirely using special DB entries 
+   */
+
+  bool useFullReadout_;
+
   /** Used when settings_ is imported from configuration file. Just used
    * for memory management. Used settings_ to access to the object
    */

--- a/SimCalorimetry/EcalSelectiveReadoutProducers/python/ecalDigis_cfi.py
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/python/ecalDigis_cfi.py
@@ -25,6 +25,12 @@ simEcalDigis = cms.EDProducer("EcalSelectiveReadoutProducer",
     # Switch for reading SRP settings from condition database
     configFromCondDB = cms.bool(True),
 
+    # Switch to turn off SRP altogether using special DB payload
+    UseFullReadout = cms.bool(True),
+
+    # ES label?
+    # NZSLabel = cms.ESInputTag(' '),
+
     # Label name of input ECAL trigger primitive collection
     trigPrimProducer = cms.string('simEcalTriggerPrimitiveDigis'),
 

--- a/SimCalorimetry/EcalSelectiveReadoutProducers/python/ecalDigis_cfi.py
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/python/ecalDigis_cfi.py
@@ -26,7 +26,7 @@ simEcalDigis = cms.EDProducer("EcalSelectiveReadoutProducer",
     configFromCondDB = cms.bool(True),
 
     # Switch to turn off SRP altogether using special DB payload
-    UseFullReadout = cms.bool(True),
+    UseFullReadout = cms.bool(False),
 
     # ES label?
     # NZSLabel = cms.ESInputTag(' '),

--- a/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSelectiveReadoutProducer.cc
+++ b/SimCalorimetry/EcalSelectiveReadoutProducers/src/EcalSelectiveReadoutProducer.cc
@@ -65,6 +65,9 @@ EcalSelectiveReadoutProducer::EcalSelectiveReadoutProducer(const edm::ParameterS
     produces<EESrFlagCollection>(eeSrFlagCollection_);
   }
 
+  useFullReadout_ = false;
+  useFullReadout_ = params.getParameter<bool>("UseFullReadout");
+
   theGeometry = 0;
   theTriggerTowerMap = 0;
   theElecMap = 0;
@@ -82,7 +85,13 @@ EcalSelectiveReadoutProducer::produce(edm::Event& event, const edm::EventSetup& 
   if(useCondDb_){
     //getting selective readout configuration:
     edm::ESHandle<EcalSRSettings> hSr;
-    eventSetup.get<EcalSRSettingsRcd>().get(hSr);
+
+    if(useFullReadout_){
+      eventSetup.get<EcalSRSettingsRcd>().get("fullReadout",hSr);
+    }
+    else{
+      eventSetup.get<EcalSRSettingsRcd>().get(hSr);
+    }
     settings_ = hSr.product();
   }
   

--- a/SimGeneral/DataMixingModule/python/mixOne_simraw_on_sim_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_simraw_on_sim_cfi.py
@@ -9,18 +9,48 @@ import EventFilter.CSCRawToDigi.cscUnpacker_cfi
 import EventFilter.SiStripRawToDigi.SiStripDigis_cfi
 import EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi
 
+# content from Configuration/StandardSequences/DigiToRaw_cff.py
+
+ecalDigis = EventFilter.EcalRawToDigi.EcalUnpackerData_cfi.ecalEBunpacker.clone()
+
+ecalPreshowerDigis = EventFilter.ESRawToDigi.esRawToDigi_cfi.esRawToDigi.clone()
+
+hcalDigis = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone()
+
+muonCSCDigis = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis.clone()
+
+muonDTDigis = EventFilter.DTRawToDigi.dtunpacker_cfi.muonDTDigis.clone()
+
+muonRPCDigis = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker.clone()
+
+#castorDigis = EventFilter.CastorRawToDigi.CastorRawToDigi_cfi.castorDigis.clone( FEDs = cms.untracked.vint32(690,691,692) )
+
+siStripDigis = EventFilter.SiStripRawToDigi.SiStripDigis_cfi.siStripDigis.clone()
+
+siPixelDigis = EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi.siPixelDigis.clone()
+
+siPixelDigis.InputLabel = 'rawDataCollector'
+ecalDigis.InputLabel = 'rawDataCollector'
+ecalPreshowerDigis.sourceTag = 'rawDataCollector'
+hcalDigis.InputLabel = 'rawDataCollector'
+muonCSCDigis.InputObjects = 'rawDataCollector'
+muonDTDigis.inputLabel = 'rawDataCollector'
+muonRPCDigis.InputLabel = 'rawDataCollector'
+#castorDigis.InputLabel = 'rawDataCollector'
+
+
 mixData = cms.EDProducer("DataMixingModule",
           hcalSimBlock,
     input = cms.SecSource("PoolSource",
         producers = cms.VPSet(cms.convertToVPSet(
-                                             ecalEBunpacker = EventFilter.EcalRawToDigi.EcalUnpackerData_cfi.ecalEBunpacker,
-                                             esRawToDigi = EventFilter.ESRawToDigi.esRawToDigi_cfi.esRawToDigi,
-                                             hcalDigis = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis,
-                                             muonDTDigis = EventFilter.DTRawToDigi.dtunpacker_cfi.muonDTDigis,
-                                             rpcunpacker = EventFilter.RPCRawToDigi.rpcUnpacker_cfi.rpcunpacker,
-                                             muonCSCDigis = EventFilter.CSCRawToDigi.cscUnpacker_cfi.muonCSCDigis,
-                                             siStripDigis = EventFilter.SiStripRawToDigi.SiStripDigis_cfi.siStripDigis,
-                                             siPixelDigis = EventFilter.SiPixelRawToDigi.SiPixelRawToDigi_cfi.siPixelDigis
+                                             ecalDigis = ecalDigis,
+                                             ecalPreshowerDigis = ecalPreshowerDigis,
+                                             hcalDigis = hcalDigis,
+                                             muonDTDigis = muonDTDigis,
+                                             muonRPCDigis = muonRPCDigis,
+                                             muonCSCDigis = muonCSCDigis,
+                                             siStripDigis = siStripDigis,
+                                             siPixelDigis = siPixelDigis,
                              )),
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(1.0)

--- a/SimGeneral/MixingModule/python/digi_noNoise_cfi.py
+++ b/SimGeneral/MixingModule/python/digi_noNoise_cfi.py
@@ -1,10 +1,39 @@
 import FWCore.ParameterSet.Config as cms
 
-process.mix.hcal.doNoise = cms.bool(False)
-process.mix.hcal.doEmpty = cms.bool(False)
-process.mix.hcal.doHPDNoise = cms.bool(False)
-process.mix.hcal.doIonFeedback = cms.bool(False)
-process.mix.hcal.doThermalNoise = cms.bool(False)
-process.mix.ecal.doNoise = cms.bool(False)
-process.mix.pixel.AddNoise = cms.bool(False)
-process.mix.strip.AddNoise = cms.bool(False)
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.aliases_cfi import *
+from SimGeneral.MixingModule.pixelDigitizer_cfi import *
+from SimGeneral.MixingModule.stripDigitizer_cfi import *
+from SimGeneral.MixingModule.ecalDigitizer_cfi import *
+from SimGeneral.MixingModule.hcalDigitizer_cfi import *
+from SimGeneral.MixingModule.castorDigitizer_cfi import *
+from SimGeneral.MixingModule.trackingTruthProducer_cfi import *
+
+theDigitizersNoNoise = cms.PSet(
+  pixel = cms.PSet(
+    pixelDigitizer
+  ),
+  strip = cms.PSet(
+    stripDigitizer
+  ),
+  ecal = cms.PSet(
+    ecalDigitizer
+  ),
+  hcal = cms.PSet(
+    hcalDigitizer
+  ),
+  castor  = cms.PSet(
+    castorDigitizer
+  )
+)
+
+
+theDigitizersNoNoise.hcal.doNoise = cms.bool(False)
+theDigitizersNoNoise.hcal.doEmpty = cms.bool(False)
+theDigitizersNoNoise.hcal.doHPDNoise = cms.bool(False)
+theDigitizersNoNoise.hcal.doIonFeedback = cms.bool(False)
+theDigitizersNoNoise.hcal.doThermalNoise = cms.bool(False)
+theDigitizersNoNoise.ecal.doNoise = cms.bool(False)
+theDigitizersNoNoise.pixel.AddNoise = cms.bool(False)
+theDigitizersNoNoise.strip.AddNoise = cms.bool(False)
+

--- a/SimGeneral/MixingModule/python/digi_noNoise_cfi.py
+++ b/SimGeneral/MixingModule/python/digi_noNoise_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+process.mix.hcal.doNoise = cms.bool(False)
+process.mix.hcal.doEmpty = cms.bool(False)
+process.mix.hcal.doHPDNoise = cms.bool(False)
+process.mix.hcal.doIonFeedback = cms.bool(False)
+process.mix.hcal.doThermalNoise = cms.bool(False)
+process.mix.ecal.doNoise = cms.bool(False)
+process.mix.pixel.AddNoise = cms.bool(False)
+process.mix.strip.AddNoise = cms.bool(False)


### PR DESCRIPTION
Modifications on top of 7_0_0 for premixing.  Changes include:
- full integration of a new DIGIPREMIX step into cmsDriver to get rid of customisation fragments
- use of label to pull proper payload out of the database to turn off Selective Readout in Ecal
- new sequence Digi_PreMix in Configuration/Standard sequences for digi options, to remove customisations
- new EventContent PREMIXRAW, again to remove customisation fragments

I will update the Twiki documentation for the PreMixing recipes.
