### PR TITLE
Consumes Migration for Particle Flow

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/EFilter.cc
+++ b/RecoParticleFlow/PFProducer/plugins/EFilter.cc
@@ -26,7 +26,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 // #include "SimDataFormats/HepMCProduct/interface/HepMCProduct.h"
 
-#include "DataFormats/ParticleFlowReco/interface/PFSimParticle.h"
 
 using namespace edm;
 using namespace std;
@@ -34,7 +33,7 @@ using namespace std;
 EFilter::EFilter(const edm::ParameterSet& iConfig) {
   //now do what ever initialization is needed
 
-  inputTagParticles_ = iConfig.getParameter<InputTag>("particles");
+  inputTagParticles_ = consumes<std::vector<reco::PFSimParticle> >(iConfig.getParameter<InputTag>("particles"));
 
   minE_ = iConfig.getUntrackedParameter<double>("minE",-1);
   maxE_ = iConfig.getUntrackedParameter<double>("maxE",999999);
@@ -64,15 +63,7 @@ EFilter::filter(edm::Event& iEvent,
 
 
   Handle<std::vector<reco::PFSimParticle> > particles;
-  bool found = iEvent.getByLabel(inputTagParticles_, particles);
-  //    cout<<"n particles = "<<particles->size()<<endl;
-  
-  if (! found) {
-    LogError("PFSimParticle")<<"cannot find particles: "
-			     <<inputTagParticles_<<endl;
-    return false;
-  }
-  
+  iEvent.getByToken(inputTagParticles_, particles);
 
   if( !particles->empty() ) {
     // take first trajectory point of first particle (the mother)

--- a/RecoParticleFlow/PFProducer/plugins/EFilter.h
+++ b/RecoParticleFlow/PFProducer/plugins/EFilter.h
@@ -2,6 +2,8 @@
 #define RecoParticleFlow_PFProducer_EFilter_h_
 
 #include "FWCore/Framework/interface/EDFilter.h"
+#include "DataFormats/ParticleFlowReco/interface/PFSimParticle.h"
+
 // #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 
@@ -39,7 +41,7 @@ class EFilter : public edm::EDFilter {
 /*   FSimEvent* mySimEvent; */
   // std::string hepMCModuleLabel_;
 
-  edm::InputTag  inputTagParticles_;
+  edm::EDGetTokenT<std::vector<reco::PFSimParticle> > inputTagParticles_;
 
   double minE_;
   double maxE_;

--- a/RecoParticleFlow/PFProducer/plugins/PFBlockProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFBlockProducer.cc
@@ -3,18 +3,6 @@
 #include "RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h"
 #include "RecoParticleFlow/PFClusterTools/interface/PFEnergyResolution.h"
 
-#include "DataFormats/ParticleFlowReco/interface/PFLayer.h"
-#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
-#include "DataFormats/ParticleFlowReco/interface/PFRecTrack.h" 
-#include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexFwd.h"
-#include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertex.h"
-#include "DataFormats/ParticleFlowReco/interface/PFConversionFwd.h"
-#include "DataFormats/ParticleFlowReco/interface/PFConversion.h"
-#include "DataFormats/ParticleFlowReco/interface/PFV0Fwd.h"
-#include "DataFormats/ParticleFlowReco/interface/PFV0.h"
-
-#include "DataFormats/EgammaCandidates/interface/Photon.h"
-#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"
 
@@ -32,69 +20,53 @@ using namespace std;
 using namespace edm;
 
 PFBlockProducer::PFBlockProducer(const edm::ParameterSet& iConfig) {
-  
 
   // use configuration file to setup input/output collection names
-  inputTagRecTracks_ 
-    = iConfig.getParameter<InputTag>("RecTracks");
+  inputTagRecTracks_ =consumes<reco::PFRecTrackCollection>(iConfig.getParameter<InputTag>("RecTracks"));
 
-  inputTagGsfRecTracks_ 
-    = iConfig.getParameter<InputTag>("GsfRecTracks");
 
-    inputTagConvBremGsfRecTracks_ 
-    = iConfig.getParameter<InputTag>("ConvBremGsfRecTracks");
+  inputTagGsfRecTracks_ =consumes<reco::GsfPFRecTrackCollection>(iConfig.getParameter<InputTag>("GsfRecTracks"));
 
-  inputTagRecMuons_ 
-    = iConfig.getParameter<InputTag>("RecMuons");
+  inputTagConvBremGsfRecTracks_ =consumes<reco::GsfPFRecTrackCollection>(iConfig.getParameter<InputTag>("ConvBremGsfRecTracks"));
 
-  inputTagPFNuclear_ 
-    = iConfig.getParameter<InputTag>("PFNuclear");
+  inputTagRecMuons_ =consumes<reco::MuonCollection>(iConfig.getParameter<InputTag>("RecMuons"));
 
-  inputTagPFConversions_ 
-    = iConfig.getParameter<InputTag>("PFConversions");
+  inputTagPFNuclear_ =consumes<reco::PFDisplacedTrackerVertexCollection>(iConfig.getParameter<InputTag>("PFNuclear"));
 
-  inputTagPFV0_ 
-    = iConfig.getParameter<InputTag>("PFV0");
+  inputTagPFConversions_ =consumes<reco::PFConversionCollection>(iConfig.getParameter<InputTag>("PFConversions"));
 
-  inputTagPFClustersECAL_ 
-    = iConfig.getParameter<InputTag>("PFClustersECAL");
+  inputTagPFV0_ =consumes<reco::PFV0Collection>(iConfig.getParameter<InputTag>("PFV0"));
 
-  inputTagPFClustersHCAL_ 
-    = iConfig.getParameter<InputTag>("PFClustersHCAL");
+  inputTagPFClustersECAL_ =consumes<reco::PFClusterCollection>(iConfig.getParameter<InputTag>("PFClustersECAL"));
 
-  inputTagPFClustersHO_ 
-    = iConfig.getParameter<InputTag>("PFClustersHO");
+  inputTagPFClustersHCAL_ =consumes<reco::PFClusterCollection>(iConfig.getParameter<InputTag>("PFClustersHCAL"));
 
-  inputTagPFClustersHFEM_ 
-    = iConfig.getParameter<InputTag>("PFClustersHFEM");
+  inputTagPFClustersHO_ =consumes<reco::PFClusterCollection>(iConfig.getParameter<InputTag>("PFClustersHO"));
 
-  inputTagPFClustersHFHAD_ 
-    = iConfig.getParameter<InputTag>("PFClustersHFHAD");
+  inputTagPFClustersHFEM_ =consumes<reco::PFClusterCollection>(iConfig.getParameter<InputTag>("PFClustersHFEM"));
 
-  inputTagPFClustersPS_ 
-    = iConfig.getParameter<InputTag>("PFClustersPS");
+  inputTagPFClustersHFHAD_ =consumes<reco::PFClusterCollection>(iConfig.getParameter<InputTag>("PFClustersHFHAD"));
+
+  inputTagPFClustersPS_ =consumes<reco::PFClusterCollection>(iConfig.getParameter<InputTag>("PFClustersPS"));
 
   useEGPhotons_ = iConfig.getParameter<bool>("useEGPhotons");
   
   if(useEGPhotons_) {
-    inputTagEGPhotons_
-      = iConfig.getParameter<InputTag>("EGPhotons");         
+    inputTagEGPhotons_=consumes<reco::PhotonCollection>(iConfig.getParameter<InputTag>("EGPhotons"));         
   }
   
   useSuperClusters_ = iConfig.existsAs<bool>("useSuperClusters") ? iConfig.getParameter<bool>("useSuperClusters") : false;
   
   if (useSuperClusters_) {
-    inputTagSCBarrel_
-      = iConfig.getParameter<InputTag>("SCBarrel");      
-    inputTagSCEndcap_
-      = iConfig.getParameter<InputTag>("SCEndcap");     
+    inputTagSCBarrel_=consumes<reco::SuperClusterCollection>(iConfig.getParameter<InputTag>("SCBarrel"));      
+    inputTagSCEndcap_=consumes<reco::SuperClusterCollection>(iConfig.getParameter<InputTag>("SCEndcap"));     
   }
   
   //default value = false (for compatibility with old HLT configs)
   superClusterMatchByRef_ = iConfig.existsAs<bool>("SuperClusterMatchByRef") ? iConfig.getParameter<bool>("SuperClusterMatchByRef") : false;
   
   if (superClusterMatchByRef_) {
-    inputTagPFClusterAssociationEBEE_ = iConfig.getParameter<InputTag>("PFClusterAssociationEBEE");
+    inputTagPFClusterAssociationEBEE_ =consumes<edm::ValueMap<reco::CaloClusterPtr> >(iConfig.getParameter<InputTag>("PFClusterAssociationEBEE"));
   }
   
   verbose_ = 
@@ -197,89 +169,47 @@ void
 PFBlockProducer::produce(Event& iEvent, 
 			 const EventSetup& iSetup) {
   
-  LogDebug("PFBlockProducer")<<"START event: "<<iEvent.id().event()
-			     <<" in run "<<iEvent.id().run()<<endl;
-  
-  
   // get rectracks
   
   Handle< reco::PFRecTrackCollection > recTracks;
   
   // LogDebug("PFBlockProducer")<<"get reco tracks"<<endl;
-  bool found = iEvent.getByLabel(inputTagRecTracks_, recTracks);
-    
-  if(!found )
-    LogError("PFBlockProducer")<<" cannot get rectracks: "
-			       <<inputTagRecTracks_<<endl;
-
-
+   iEvent.getByToken(inputTagRecTracks_, recTracks);
+ 
 
   // get GsfTracks 
   Handle< reco::GsfPFRecTrackCollection > GsfrecTracks;
 
-  if(!usePFatHLT_) {
-    found = iEvent.getByLabel(inputTagGsfRecTracks_,GsfrecTracks);
-
-    if(!found )
-      LogError("PFBlockProducer")<<" cannot get Gsfrectracks: "
-				 << inputTagGsfRecTracks_ <<endl;
-  }
+  if(!usePFatHLT_) 
+    iEvent.getByToken(inputTagGsfRecTracks_,GsfrecTracks);
 
   // get ConvBremGsfTracks 
   Handle< reco::GsfPFRecTrackCollection > convBremGsfrecTracks;
 
-  if(useConvBremGsfTracks_) {
-    found = iEvent.getByLabel(inputTagConvBremGsfRecTracks_,convBremGsfrecTracks);
+  if(useConvBremGsfTracks_) 
+    iEvent.getByToken(inputTagConvBremGsfRecTracks_,convBremGsfrecTracks);
 
-    if(!found )
-      LogError("PFBlockProducer")<<" cannot get ConvBremGsfrectracks: "
-				 << inputTagConvBremGsfRecTracks_ <<endl;
-  }
 
   // get recmuons
   Handle< reco::MuonCollection > recMuons;
 
-  // LogDebug("PFBlockProducer")<<"get reco muons"<<endl;
-  //if(!usePFatHLT_) {
-  found = iEvent.getByLabel(inputTagRecMuons_, recMuons);
-  
-    //if(!found )
-    //  LogError("PFBlockProducer")<<" cannot get recmuons: "
-    //			 <<inputTagRecMuons_<<endl;
-
-  // get PFNuclearInteractions
-  //}
-  //---------- Gouzevitch
-  //  Handle< reco::PFNuclearInteractionCollection > pfNuclears; 
+  iEvent.getByToken(inputTagRecMuons_, recMuons);
   Handle< reco::PFDisplacedTrackerVertexCollection > pfNuclears; 
 
   if( useNuclear_ ) {
-
-    found = iEvent.getByLabel(inputTagPFNuclear_, pfNuclears);
-    if(!found )
-      LogError("PFBlockProducer")<<" cannot get PFNuclearInteractions : "
-                               <<inputTagPFNuclear_<<endl;
+    iEvent.getByToken(inputTagPFNuclear_, pfNuclears);
   }
  
   // get conversions
   Handle< reco::PFConversionCollection > pfConversions;
   if( useConversions_ ) {
-    found = iEvent.getByLabel(inputTagPFConversions_, pfConversions);
-    
-    if(!found )
-      LogError("PFBlockProducer")<<" cannot get PFConversions : "
-				 <<inputTagPFConversions_<<endl;
+    iEvent.getByToken(inputTagPFConversions_, pfConversions);
   }
-  
 
   // get V0s
   Handle< reco::PFV0Collection > pfV0;
   if( useV0_ ) {
-    found = iEvent.getByLabel(inputTagPFV0_, pfV0);
-    
-    if(!found )
-      LogError("PFBlockProducer")<<" cannot get PFV0 : "
-				 <<inputTagPFV0_<<endl;
+    iEvent.getByToken(inputTagPFV0_, pfV0);
   }
 
 
@@ -288,93 +218,51 @@ PFBlockProducer::produce(Event& iEvent,
   
   
   Handle< reco::PFClusterCollection > clustersECAL;
-  found = iEvent.getByLabel(inputTagPFClustersECAL_, 
+  iEvent.getByToken(inputTagPFClustersECAL_, 
 			    clustersECAL);      
-  if(!found )
-    LogError("PFBlockProducer")<<" cannot get ECAL clusters: "
-			       <<inputTagPFClustersECAL_<<endl;
     
-  
   Handle< reco::PFClusterCollection > clustersHCAL;
-  found = iEvent.getByLabel(inputTagPFClustersHCAL_, 
+  iEvent.getByToken(inputTagPFClustersHCAL_, 
 			    clustersHCAL);      
-  if(!found )
-    LogError("PFBlockProducer")<<" cannot get HCAL clusters: "
-			       <<inputTagPFClustersHCAL_<<endl;
-    
+      
   Handle< reco::PFClusterCollection > clustersHO;
   if (useHO_) {
-    found = iEvent.getByLabel(inputTagPFClustersHO_, 
+    iEvent.getByToken(inputTagPFClustersHO_, 
 			      clustersHO);      
-    if(!found )
-      LogError("PFBlockProducer")<<" cannot get HO clusters: "
-				 <<inputTagPFClustersHO_<<endl;
   }
 
   Handle< reco::PFClusterCollection > clustersHFEM;
-  found = iEvent.getByLabel(inputTagPFClustersHFEM_, 
+  iEvent.getByToken(inputTagPFClustersHFEM_, 
 			    clustersHFEM);      
-  if(!found )
-    LogError("PFBlockProducer")<<" cannot get HFEM clusters: "
-			       <<inputTagPFClustersHFEM_<<endl;
-    
+      
   Handle< reco::PFClusterCollection > clustersHFHAD;
-  found = iEvent.getByLabel(inputTagPFClustersHFHAD_, 
+  iEvent.getByToken(inputTagPFClustersHFHAD_, 
 			    clustersHFHAD);      
-  if(!found )
-    LogError("PFBlockProducer")<<" cannot get HFHAD clusters: "
-			       <<inputTagPFClustersHFHAD_<<endl;
-    
 
   Handle< reco::PFClusterCollection > clustersPS;
-  found = iEvent.getByLabel(inputTagPFClustersPS_, 
+  iEvent.getByToken(inputTagPFClustersPS_, 
 			    clustersPS);      
-  if(!found )
-    LogError("PFBlockProducer")<<" cannot get PS clusters: "
-			       <<inputTagPFClustersPS_<<endl;
-
-  // dummy. Not used in the full framework 
+   // dummy. Not used in the full framework 
   Handle< reco::PFRecTrackCollection > nuclearRecTracks;
-
   
   Handle< reco::PhotonCollection >  egPhotons;
-  found = iEvent.getByLabel(inputTagEGPhotons_,
+  iEvent.getByToken(inputTagEGPhotons_,
 			    egPhotons);
-
-  if(!found && useEGPhotons_ )
-    LogError("PFBlockProducer")<<" cannot get photons" 
-			       << inputTagEGPhotons_ << endl;
-			       
+  			       
   Handle< reco::SuperClusterCollection >  sceb;
   Handle< reco::SuperClusterCollection >  scee;
   
   if (useSuperClusters_) {
-    found = iEvent.getByLabel(inputTagSCBarrel_,
+    iEvent.getByToken(inputTagSCBarrel_,
 			      sceb);
-
-    if(!found)
-      LogError("PFBlockProducer")<<" cannot get sceb" 
-				<< inputTagSCBarrel_ << endl;
-	  
-				
-    
-    found = iEvent.getByLabel(inputTagSCEndcap_,
+    iEvent.getByToken(inputTagSCEndcap_,
 			      scee);
-
-    if(!found)
-      LogError("PFBlockProducer")<<" cannot get scee" 
-				<< inputTagSCEndcap_ << endl;				       
-								
   }
   
   Handle<edm::ValueMap<reco::CaloClusterPtr> > pfclusterassoc;
   if (superClusterMatchByRef_) {
-    found = iEvent.getByLabel(inputTagPFClusterAssociationEBEE_,
+    iEvent.getByToken(inputTagPFClusterAssociationEBEE_,
                               pfclusterassoc);
-
-    if(!found)
-      LogError("PFBlockProducer")<<" cannot get PFCluster Association" 
-                                << inputTagPFClusterAssociationEBEE_ << endl;
   }
 
   if( usePFatHLT_  ) {
@@ -419,7 +307,5 @@ PFBlockProducer::produce(Event& iEvent,
     pOutputBlockCollection( pfBlockAlgo_.transferBlocks() ); 
   
   iEvent.put(pOutputBlockCollection);
-
-  LogDebug("PFBlockProducer")<<"STOP event: "<<iEvent.id().event()
-			     <<" in run "<<iEvent.id().run()<<endl;
+    
 }

--- a/RecoParticleFlow/PFProducer/plugins/PFBlockProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFBlockProducer.cc
@@ -246,7 +246,8 @@ PFBlockProducer::produce(Event& iEvent,
   Handle< reco::PFRecTrackCollection > nuclearRecTracks;
   
   Handle< reco::PhotonCollection >  egPhotons;
-  iEvent.getByToken(inputTagEGPhotons_,
+  if (useEGPhotons_)
+    iEvent.getByToken(inputTagEGPhotons_,
 			    egPhotons);
   			       
   Handle< reco::SuperClusterCollection >  sceb;

--- a/RecoParticleFlow/PFProducer/plugins/PFBlockProducer.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFBlockProducer.h
@@ -15,6 +15,19 @@
 
 #include "RecoParticleFlow/PFProducer/interface/PFBlockAlgo.h"
 
+#include "DataFormats/ParticleFlowReco/interface/PFLayer.h"
+#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
+#include "DataFormats/ParticleFlowReco/interface/PFRecTrack.h" 
+#include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexFwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertex.h"
+#include "DataFormats/ParticleFlowReco/interface/PFConversionFwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFConversion.h"
+#include "DataFormats/ParticleFlowReco/interface/PFV0Fwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFV0.h"
+
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
+
 
 /**\class PFBlockProducer 
 \brief Producer for particle flow blocks
@@ -44,23 +57,23 @@ class PFBlockProducer : public edm::EDProducer {
 
   
 
-  edm::InputTag   inputTagRecTracks_;
-  edm::InputTag   inputTagGsfRecTracks_;
-  edm::InputTag   inputTagConvBremGsfRecTracks_;
-  edm::InputTag   inputTagRecMuons_;
-  edm::InputTag   inputTagPFNuclear_;
-  edm::InputTag   inputTagPFClustersECAL_;
-  edm::InputTag   inputTagPFClustersHCAL_;
-  edm::InputTag   inputTagPFClustersHO_;
-  edm::InputTag   inputTagPFClustersHFEM_;
-  edm::InputTag   inputTagPFClustersHFHAD_;
-  edm::InputTag   inputTagPFClustersPS_;
-  edm::InputTag   inputTagPFConversions_;
-  edm::InputTag   inputTagPFV0_;
-  edm::InputTag   inputTagEGPhotons_;
-  edm::InputTag   inputTagSCBarrel_;
-  edm::InputTag   inputTagSCEndcap_;  
-  edm::InputTag   inputTagPFClusterAssociationEBEE_;
+  edm::EDGetTokenT<reco::PFRecTrackCollection>  inputTagRecTracks_;
+  edm::EDGetTokenT<reco::GsfPFRecTrackCollection>  inputTagGsfRecTracks_;
+  edm::EDGetTokenT<reco::GsfPFRecTrackCollection>  inputTagConvBremGsfRecTracks_;
+  edm::EDGetTokenT<reco::MuonCollection>  inputTagRecMuons_;
+  edm::EDGetTokenT<reco::PFDisplacedTrackerVertexCollection> inputTagPFNuclear_;
+  edm::EDGetTokenT<reco::PFClusterCollection> inputTagPFClustersECAL_;
+  edm::EDGetTokenT<reco::PFClusterCollection> inputTagPFClustersHCAL_;
+  edm::EDGetTokenT<reco::PFClusterCollection> inputTagPFClustersHO_;
+  edm::EDGetTokenT<reco::PFClusterCollection> inputTagPFClustersHFEM_;
+  edm::EDGetTokenT<reco::PFClusterCollection> inputTagPFClustersHFHAD_;
+  edm::EDGetTokenT<reco::PFClusterCollection> inputTagPFClustersPS_;
+  edm::EDGetTokenT<reco::PFConversionCollection> inputTagPFConversions_;
+  edm::EDGetTokenT<reco::PFV0Collection>   inputTagPFV0_;
+  edm::EDGetTokenT<reco::PhotonCollection>  inputTagEGPhotons_;
+  edm::EDGetTokenT<reco::SuperClusterCollection>  inputTagSCBarrel_;
+  edm::EDGetTokenT<reco::SuperClusterCollection>  inputTagSCEndcap_;
+  edm::EDGetTokenT<edm::ValueMap<reco::CaloClusterPtr> > inputTagPFClusterAssociationEBEE_;
   
   // Link track and HCAL clusters to HO clusters ?
   bool useHO_;

--- a/RecoParticleFlow/PFProducer/plugins/PFLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFLinker.cc
@@ -21,8 +21,8 @@ PFLinker::PFLinker(const edm::ParameterSet & iConfig) {
 
   
   muonTag_ = iConfig.getParameter<edm::InputTag>("Muons");
-  inputTagMuons_=consumes<reco::MuonCollection>(muonTag_.label());
-  inputTagMuonMap_=consumes<reco::MuonToMuonMap>(muonTag_.label());
+  inputTagMuons_=consumes<reco::MuonCollection>(muonTag_);
+  inputTagMuonMap_=consumes<reco::MuonToMuonMap>(muonTag_);
   
   nameOutputPF_ 
     = iConfig.getParameter<std::string>("OutputPF");

--- a/RecoParticleFlow/PFProducer/plugins/PFLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFLinker.cc
@@ -21,7 +21,7 @@ PFLinker::PFLinker(const edm::ParameterSet & iConfig) {
 
   
   muonTag_ = iConfig.getParameter<edm::InputTag>("Muons");
-  inputTagMuons_=consumes<reco::MuonCollection>(muonTag_);
+  inputTagMuons_=consumes<reco::MuonCollection>(edm::InputTag(muonTag_.label()));
   inputTagMuonMap_=consumes<reco::MuonToMuonMap>(muonTag_);
   
   nameOutputPF_ 
@@ -53,7 +53,7 @@ PFLinker::PFLinker(const edm::ParameterSet & iConfig) {
   produces<edm::ValueMap<reco::PFCandidatePtr> > (nameOutputElectronsPF_);
   produces<edm::ValueMap<reco::PFCandidatePtr> > (nameOutputPhotonsPF_);
   produces<edm::ValueMap<reco::PFCandidatePtr> > (nameOutputMergedPF_);
-  if(fillMuonRefs_)  produces<edm::ValueMap<reco::PFCandidatePtr> > ((muonTag_.label()));
+  if(fillMuonRefs_)  produces<edm::ValueMap<reco::PFCandidatePtr> > (muonTag_.label());
 
 }
 
@@ -65,6 +65,8 @@ void PFLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     pfCandidates_p(new reco::PFCandidateCollection);
   
   edm::Handle<reco::GsfElectronCollection> gsfElectrons;
+  iEvent.getByToken(inputTagGsfElectrons_,gsfElectrons);
+
   std::map<reco::GsfElectronRef,reco::PFCandidatePtr> electronCandidateMap;  
 
 

--- a/RecoParticleFlow/PFProducer/plugins/PFLinker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFLinker.cc
@@ -1,10 +1,5 @@
 #include "RecoParticleFlow/PFProducer/plugins/PFLinker.h"
 
-#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
-#include "DataFormats/MuonReco/interface/MuonToMuonMap.h"
-#include "DataFormats/MuonReco/interface/Muon.h"
-#include "DataFormats/MuonReco/interface/MuonFwd.h"
 
 #include "RecoParticleFlow/PFProducer/interface/GsfElectronEqual.h"
 #include "RecoParticleFlow/PFProducer/interface/PhotonEqual.h"
@@ -13,14 +8,21 @@
 
 PFLinker::PFLinker(const edm::ParameterSet & iConfig) {
   // vector of InputTag; more than 1 is not for RECO, it is for analysis
-  inputTagPFCandidates_ 
-    = iConfig.getParameter<std::vector<edm::InputTag> >("PFCandidate");
-  inputTagGsfElectrons_
-    = iConfig.getParameter<edm::InputTag>("GsfElectrons");
-  inputTagPhotons_
-    = iConfig.getParameter<edm::InputTag>("Photons");
-  inputTagMuons_
-    = iConfig.getParameter<edm::InputTag>("Muons");
+  
+    std::vector<edm::InputTag> tags  = iConfig.getParameter<std::vector<edm::InputTag> >("PFCandidate");
+  for (unsigned int i=0;i<tags.size();++i)
+    inputTagPFCandidates_.push_back(consumes<reco::PFCandidateCollection>(tags[i]));   
+  
+
+  inputTagGsfElectrons_=consumes<reco::GsfElectronCollection>(
+	      iConfig.getParameter<edm::InputTag>("GsfElectrons"));
+
+  inputTagPhotons_=consumes<reco::PhotonCollection>(iConfig.getParameter<edm::InputTag>("Photons"));
+
+  
+  muonTag_ = iConfig.getParameter<edm::InputTag>("Muons");
+  inputTagMuons_=consumes<reco::MuonCollection>(muonTag_.label());
+  inputTagMuonMap_=consumes<reco::MuonToMuonMap>(muonTag_.label());
   
   nameOutputPF_ 
     = iConfig.getParameter<std::string>("OutputPF");
@@ -51,7 +53,7 @@ PFLinker::PFLinker(const edm::ParameterSet & iConfig) {
   produces<edm::ValueMap<reco::PFCandidatePtr> > (nameOutputElectronsPF_);
   produces<edm::ValueMap<reco::PFCandidatePtr> > (nameOutputPhotonsPF_);
   produces<edm::ValueMap<reco::PFCandidatePtr> > (nameOutputMergedPF_);
-  if(fillMuonRefs_)  produces<edm::ValueMap<reco::PFCandidatePtr> > (inputTagMuons_.label());
+  if(fillMuonRefs_)  produces<edm::ValueMap<reco::PFCandidatePtr> > ((muonTag_.label()));
 
 }
 
@@ -63,56 +65,25 @@ void PFLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     pfCandidates_p(new reco::PFCandidateCollection);
   
   edm::Handle<reco::GsfElectronCollection> gsfElectrons;
-  bool status=fetchCollection<reco::GsfElectronCollection>(gsfElectrons,
-						      inputTagGsfElectrons_,
-						      iEvent );
   std::map<reco::GsfElectronRef,reco::PFCandidatePtr> electronCandidateMap;  
-
-  if(!status) {
-    std::ostringstream err;
-    err << " Problem in PFLinker: no electron collection called " << inputTagGsfElectrons_ << std::endl;
-    edm::LogError("PFLinker") << err.str();
-  }
 
 
   edm::Handle<reco::PhotonCollection> photons;
-  status=fetchCollection<reco::PhotonCollection>(photons,
-						 inputTagPhotons_,
-						 iEvent );
-  if(!status) {
-    std::ostringstream err;
-    err << " Problem in PFLinker: no photon collection called " << inputTagPhotons_ << std::endl;
-    edm::LogError("PFLinker") << err.str();
-  }
-
-
+  iEvent.getByToken(inputTagPhotons_,photons);
   std::map<reco::PhotonRef,reco::PFCandidatePtr> photonCandidateMap;
 
 
   edm::Handle<reco::MuonToMuonMap> muonMap;
   if(fillMuonRefs_)
-    status=fetchCollection<reco::MuonToMuonMap>(muonMap,
-						inputTagMuons_,
-						iEvent);
+    iEvent.getByToken(inputTagMuonMap_,muonMap);
   std::map<reco::MuonRef,reco::PFCandidatePtr> muonCandidateMap;
   
   unsigned nColPF=inputTagPFCandidates_.size();
   
-  if(!status) {
-    std::ostringstream err;
-    err << " Problem in PFLinker: no muon collection called " << inputTagMuons_ << std::endl;
-    edm::LogError("PFLinker") << err.str();
-  }
-
-  
   edm::Handle<reco::PFCandidateCollection> pfCandidates;
   for(unsigned icol=0;icol<nColPF;++icol) {
-    
-    bool status=fetchCollection<reco::PFCandidateCollection>(pfCandidates, 
-							     inputTagPFCandidates_[icol], 
-							     iEvent );
-    
-    unsigned ncand=(status)?pfCandidates->size():0;
+    iEvent.getByToken(inputTagPFCandidates_[icol],pfCandidates);
+    unsigned ncand=pfCandidates->size();
     
     for( unsigned i=0; i<ncand; ++i) {
       edm::Ptr<reco::PFCandidate> candPtr(pfCandidates,i);
@@ -195,10 +166,10 @@ void PFLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 
   if(fillMuonRefs_){
     edm::Handle<reco::MuonCollection> muons; 
-    iEvent.getByLabel(inputTagMuons_.label(), muons);
+    iEvent.getByToken(inputTagMuons_, muons);
     
     pfMapMuons = fillValueMap<reco::MuonCollection>(iEvent, 
-						    inputTagMuons_.label(), 
+						    muonTag_.label(), 
 						    muons, 
 						    muonCandidateMap,
 						    pfCandidateRefProd);
@@ -213,22 +184,6 @@ void PFLinker::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   if(fillMuonRefs_) *pfMapMerged += pfMapMuons;
   
   iEvent.put(pfMapMerged,nameOutputMergedPF_);
-}
-
-template<typename T>
-bool PFLinker::fetchCollection(edm::Handle<T>& c, 
-			       const edm::InputTag& tag, 
-			       const edm::Event& iEvent) const {  
-
-  bool found = iEvent.getByLabel(tag, c);
-  
-  if(!found )
-    {
-      std::ostringstream  err;
-      err<<" cannot get " <<tag<<std::endl;
-      edm::LogError("PFLinker")<<err.str();
-    }
-  return found;
 }
 
 

--- a/RecoParticleFlow/PFProducer/plugins/PFLinker.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFLinker.h
@@ -23,6 +23,11 @@
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/MuonReco/interface/MuonToMuonMap.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
 
 #include <string>
 
@@ -36,12 +41,6 @@ class PFLinker : public edm::EDProducer {
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
  private:
-
-  template<typename T>
-    bool fetchCollection(edm::Handle<T>& c, 
-			 const edm::InputTag& tag, 
-			 const edm::Event& iEvent) const ;
-  
   template<typename TYPE>
     edm::ValueMap<reco::PFCandidatePtr> fillValueMap(edm::Event & event,
 						     std::string label,
@@ -52,17 +51,18 @@ class PFLinker : public edm::EDProducer {
  private:
  
   /// Input PFCandidates
-  std::vector<edm::InputTag>       inputTagPFCandidates_;
+  std::vector<edm::EDGetTokenT<reco::PFCandidateCollection> >       inputTagPFCandidates_;
 
   /// Input GsfElectrons
-  edm::InputTag       inputTagGsfElectrons_;
+  edm::EDGetTokenT<reco::GsfElectronCollection>    inputTagGsfElectrons_;
 
   /// Input Photons
-  edm::InputTag       inputTagPhotons_;
+  edm::EDGetTokenT<reco::PhotonCollection>         inputTagPhotons_;
 
   /// Input Muons
-  edm::InputTag       inputTagMuons_;
-
+  edm::InputTag muonTag_;
+  edm::EDGetTokenT<reco::MuonCollection>      inputTagMuons_;
+  edm::EDGetTokenT<reco::MuonToMuonMap> inputTagMuonMap_;
   /// name of output collection of PFCandidate
   std::string nameOutputPF_;
 

--- a/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
@@ -10,13 +10,6 @@
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"
 #include "CondFormats/DataRecord/interface/PFCalibrationRcd.h"
 #include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
-#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
-#include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
-#include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
-#include "DataFormats/ParticleFlowReco/interface/PFBlockElementSuperClusterFwd.h"
-#include "DataFormats/ParticleFlowReco/interface/PFBlockElementSuperCluster.h"
-#include "DataFormats/Common/interface/ValueMap.h"
 
 #include <sstream>
 
@@ -49,12 +42,10 @@ PFProducer::PFProducer(const edm::ParameterSet& iConfig) {
     thepfEnergyCalibrationHF ( new PFEnergyCalibrationHF(calibHF_use,calibHF_eta_step,calibHF_a_EMonly,calibHF_b_HADonly,calibHF_a_EMHAD,calibHF_b_EMHAD) ) ;
   //-----------------
 
-  inputTagBlocks_ 
-    = iConfig.getParameter<InputTag>("blocks");
-
+  inputTagBlocks_ = consumes<reco::PFBlockCollection>(iConfig.getParameter<InputTag>("blocks"));
+  
   //Post cleaning of the muons
-  inputTagMuons_ 
-    = iConfig.getParameter<InputTag>("muons");
+  inputTagMuons_ = consumes<reco::MuonCollection>(iConfig.getParameter<InputTag>("muons"));
   postMuonCleaning_
     = iConfig.getParameter<bool>("postMuonCleaning");
 
@@ -91,7 +82,7 @@ PFProducer::PFProducer(const edm::ParameterSet& iConfig) {
     = iConfig.getParameter<bool>("useEGammaElectrons");    
 
   if(  useEGammaElectrons_) {
-    inputTagEgammaElectrons_ = iConfig.getParameter<edm::InputTag>("egammaElectrons");
+    inputTagEgammaElectrons_ = consumes<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("egammaElectrons"));
   }
 
   electronOutputCol_
@@ -222,9 +213,9 @@ PFProducer::PFProducer(const edm::ParameterSet& iConfig) {
  if(use_EGammaFilters_) {
    ele_iso_mvaWeightFile = iConfig.getParameter<string>("isolatedElectronID_mvaWeightFile");
    ele_iso_path_mvaWeightFile  = edm::FileInPath ( ele_iso_mvaWeightFile.c_str() ).fullPath();
-   inputTagPFEGammaCandidates_ = iConfig.getParameter<edm::InputTag>("PFEGammaCandidates");
-   inputTagValueMapGedElectrons_ = iConfig.getParameter<edm::InputTag>("GedElectronValueMap"); 
-   inputTagValueMapGedPhotons_ = iConfig.getParameter<edm::InputTag>("GedPhotonValueMap"); 
+   inputTagPFEGammaCandidates_ = consumes<edm::View<reco::PFCandidate> >((iConfig.getParameter<edm::InputTag>("PFEGammaCandidates")));
+   inputTagValueMapGedElectrons_ = consumes<edm::ValueMap<reco::GsfElectronRef>>(iConfig.getParameter<edm::InputTag>("GedElectronValueMap")); 
+   inputTagValueMapGedPhotons_ = consumes<edm::ValueMap<reco::PhotonRef> >(iConfig.getParameter<edm::InputTag>("GedPhotonValueMap")); 
    ele_iso_pt = iConfig.getParameter<double>("electron_iso_pt");
    ele_iso_mva_barrel  = iConfig.getParameter<double>("electron_iso_mva_barrel");
    ele_iso_mva_endcap = iConfig.getParameter<double>("electron_iso_mva_endcap");
@@ -386,11 +377,11 @@ PFProducer::PFProducer(const edm::ParameterSet& iConfig) {
 				       minDeltaMet);
 
   // Input tags for HF cleaned rechits
-  inputTagCleanedHF_ 
-    = iConfig.getParameter< std::vector<edm::InputTag> >("cleanedHF");
-
+  std::vector<edm::InputTag> tags =iConfig.getParameter< std::vector<edm::InputTag> >("cleanedHF");
+  for (unsigned int i=0;i<tags.size();++i)
+    inputTagCleanedHF_.push_back(consumes<reco::PFRecHitCollection>(tags[i])); 
   //MIKE: Vertex Parameters
-  vertices_ = iConfig.getParameter<edm::InputTag>("vertexCollection");
+  vertices_ = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexCollection"));
   useVerticesForNeutral_ = iConfig.getParameter<bool>("useVerticesForNeutral");
 
   // Use HO clusters and links in the PF reconstruction
@@ -507,7 +498,7 @@ PFProducer::produce(Event& iEvent,
   // Get The vertices from the event
   // and assign dynamic vertex parameters
   edm::Handle<reco::VertexCollection> vertices;
-  bool gotVertices = iEvent.getByLabel(vertices_,vertices);
+  bool gotVertices = iEvent.getByToken(vertices_,vertices);
   if(!gotVertices) {
     ostringstream err;
     err<<"Cannot find vertices for this event.Continuing Without them ";
@@ -521,17 +512,7 @@ PFProducer::produce(Event& iEvent,
 
   Handle< reco::PFBlockCollection > blocks;
 
-  LogDebug("PFProducer")<<"getting blocks"<<endl;
-  bool found = iEvent.getByLabel( inputTagBlocks_, blocks );  
-
-  if(!found ) {
-
-    ostringstream err;
-    err<<"cannot find blocks: "<<inputTagBlocks_;
-    LogError("PFProducer")<<err.str()<<endl;
-    
-    throw cms::Exception( "MissingProduct", err.str());
-  }
+  iEvent.getByToken( inputTagBlocks_, blocks );  
 
   // get the collection of muons 
 
@@ -539,34 +520,13 @@ PFProducer::produce(Event& iEvent,
 
   if ( postMuonCleaning_ ) {
 
-    LogDebug("PFProducer")<<"getting muons"<<endl;
-    found = iEvent.getByLabel( inputTagMuons_, muons );  
+    iEvent.getByToken( inputTagMuons_, muons );  
     pfAlgo_->setMuonHandle(muons);
-    if(!found) {
-      ostringstream err;
-      err<<"cannot find muons: "<<inputTagMuons_;
-      LogError("PFProducer")<<err.str()<<endl;
-    
-      throw cms::Exception( "MissingProduct", err.str());
-
-    }
-
   }
 
   if (useEGammaElectrons_) {
     Handle < reco::GsfElectronCollection > egelectrons;
-    
-    LogDebug("PFProducer")<<" Reading e/gamma electrons activated "<<endl;
-    found = iEvent.getByLabel( inputTagEgammaElectrons_, egelectrons );  
-    
-    if(!found) {
-      ostringstream err;
-      err<<"cannot find electrons: "<<inputTagEgammaElectrons_;
-      LogError("PFProducer")<<err.str()<<endl;
-    
-      throw cms::Exception( "MissingProduct", err.str());
-    }
-    
+    iEvent.getByToken( inputTagEgammaElectrons_, egelectrons );  
     pfAlgo_->setEGElectronCollection(*egelectrons);
   }
 
@@ -575,41 +535,15 @@ PFProducer::produce(Event& iEvent,
     // Read PFEGammaCandidates
 
     edm::Handle<edm::View<reco::PFCandidate> > pfEgammaCandidates;
+    iEvent.getByToken(inputTagPFEGammaCandidates_,pfEgammaCandidates);
 
-    found=iEvent.getByLabel(inputTagPFEGammaCandidates_,pfEgammaCandidates);
-
-    if(!found ) {
-      std::ostringstream err;
-      err<<" cannot get PFEGammaCandidates: "
-	 << inputTagPFEGammaCandidates_ <<std::endl;
-      edm::LogError("PFProducer")<<err.str();
-      throw cms::Exception( "MissingProduct", err.str());
-    }
-    
     // Get the value maps
     
     edm::Handle<edm::ValueMap<reco::GsfElectronRef> > valueMapGedElectrons;
-    found = iEvent.getByLabel(inputTagValueMapGedElectrons_,valueMapGedElectrons);
-
-    if(!found ) {
-      std::ostringstream err;
-      err<<" cannot get valueMapGedElectrons: "
-	 << inputTagValueMapGedElectrons_ <<std::endl;
-      edm::LogError("PFProducer")<<err.str();
-      throw cms::Exception( "MissingProduct", err.str());
-    }
-
+    iEvent.getByToken(inputTagValueMapGedElectrons_,valueMapGedElectrons);
 
     edm::Handle<edm::ValueMap<reco::PhotonRef> > valueMapGedPhotons;
-    found = iEvent.getByLabel(inputTagValueMapGedPhotons_,valueMapGedPhotons);
-
-    if(!found ) {
-      std::ostringstream err;
-      err<<" cannot get valueMapGedPhotons: "
-	 << inputTagValueMapGedPhotons_ <<std::endl;
-      edm::LogError("PFProducer")<<err.str();
-      throw cms::Exception( "MissingProduct", err.str());
-    }
+    iEvent.getByToken(inputTagValueMapGedPhotons_,valueMapGedPhotons);
 
     pfAlgo_->setEGammaCollections(*pfEgammaCandidates,
     				  *valueMapGedElectrons,
@@ -618,7 +552,6 @@ PFProducer::produce(Event& iEvent,
   }
 
 
-  
   LogDebug("PFProducer")<<"particle flow is starting"<<endl;
 
   assert( blocks.isValid() );
@@ -678,7 +611,7 @@ PFProducer::produce(Event& iEvent,
   reco::PFRecHitCollection hfCopy;
   for ( unsigned ihf=0; ihf<inputTagCleanedHF_.size(); ++ihf ) {
     Handle< reco::PFRecHitCollection > hfCleaned;
-    bool foundHF = iEvent.getByLabel( inputTagCleanedHF_[ihf], hfCleaned );  
+    bool foundHF = iEvent.getByToken( inputTagCleanedHF_[ihf], hfCleaned );  
     if (!foundHF) continue;
     for ( unsigned jhf=0; jhf<(*hfCleaned).size(); ++jhf ) { 
       hfCopy.push_back( (*hfCleaned)[jhf] );

--- a/RecoParticleFlow/PFProducer/plugins/PFProducer.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFProducer.h
@@ -13,6 +13,18 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
+#include "DataFormats/ParticleFlowReco/interface/PFBlockElementSuperClusterFwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFBlockElementSuperCluster.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFBlockFwd.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 
 class PFAlgo;
 class PFEnergyCalibrationHF;
@@ -36,20 +48,22 @@ class PFProducer : public edm::EDProducer {
   virtual void beginRun(const edm::Run &, const edm::EventSetup &) override;
 
  private:
+  edm::EDGetTokenT<reco::PFBlockCollection>  inputTagBlocks_;
+  edm::EDGetTokenT<reco::MuonCollection>     inputTagMuons_;
+  edm::EDGetTokenT<reco::VertexCollection>   vertices_;
+  edm::EDGetTokenT<reco::GsfElectronCollection> inputTagEgammaElectrons_;
 
-  edm::InputTag  inputTagBlocks_;
-  edm::InputTag  inputTagMuons_;
-  edm::InputTag  vertices_;
-  edm::InputTag  inputTagEgammaElectrons_;
-  std::vector<edm::InputTag>  inputTagCleanedHF_;
+
+  std::vector<edm::EDGetTokenT<reco::PFRecHitCollection> >  inputTagCleanedHF_;
   std::string electronOutputCol_;
   std::string electronExtraOutputCol_;
   std::string photonExtraOutputCol_;
 
   // NEW EGamma Filters
-  edm::InputTag inputTagValueMapGedElectrons_;
-  edm::InputTag inputTagValueMapGedPhotons_;
-  edm::InputTag inputTagPFEGammaCandidates_;
+  edm::EDGetTokenT<edm::ValueMap<reco::GsfElectronRef> >inputTagValueMapGedElectrons_;
+  edm::EDGetTokenT<edm::ValueMap<reco::PhotonRef> > inputTagValueMapGedPhotons_;
+  edm::EDGetTokenT<edm::View<reco::PFCandidate> > inputTagPFEGammaCandidates_;
+
   bool use_EGammaFilters_;
 
 

--- a/RecoParticleFlow/PFTracking/interface/ElectronSeedMerger.h
+++ b/RecoParticleFlow/PFTracking/interface/ElectronSeedMerger.h
@@ -9,6 +9,7 @@
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 
 class ElectronSeedMerger : public edm::EDProducer {
    public:
@@ -22,9 +23,8 @@ class ElectronSeedMerger : public edm::EDProducer {
       edm::ParameterSet conf_;
 
       ///SEED COLLECTIONS
-      edm::InputTag ecalBasedSeeds_;
-      edm::InputTag tkBasedSeeds_;
-
+      edm::EDGetTokenT<reco::ElectronSeedCollection> ecalSeedToken_;
+      edm::EDGetTokenT<reco::ElectronSeedCollection> tkSeedToken_;
 
 };
 #endif

--- a/RecoParticleFlow/PFTracking/interface/GoodSeedProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/GoodSeedProducer.h
@@ -135,10 +135,10 @@ class GoodSeedProducer : public edm::EDProducer {
 
       // ----------access to event data
       edm::ParameterSet conf_;
-      edm::InputTag pfCLusTagPSLabel_;
-      edm::InputTag pfCLusTagECLabel_;
-      edm::InputTag pfCLusTagHCLabel_;
-      std::vector<edm::InputTag> tracksContainers_;
+      edm::EDGetTokenT<reco::PFClusterCollection> pfCLusTagPSLabel_;
+      edm::EDGetTokenT<reco::PFClusterCollection> pfCLusTagECLabel_;
+      edm::EDGetTokenT<reco::PFClusterCollection> pfCLusTagHCLabel_;
+      std::vector<edm::EDGetTokenT<reco::TrackCollection> > tracksContainers_;
       
 
       std::string fitterName_;

--- a/RecoParticleFlow/PFTracking/interface/GoodSeedProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/GoodSeedProducer.h
@@ -19,6 +19,8 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "TMVA/Reader.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "TrackingTools/PatternTools/interface/Trajectory.h"
 /// \brief Abstract
 /*!
 \author Michele Pioppi
@@ -138,7 +140,8 @@ class GoodSeedProducer : public edm::EDProducer {
       edm::EDGetTokenT<reco::PFClusterCollection> pfCLusTagPSLabel_;
       edm::EDGetTokenT<reco::PFClusterCollection> pfCLusTagECLabel_;
       edm::EDGetTokenT<reco::PFClusterCollection> pfCLusTagHCLabel_;
-      std::vector<edm::EDGetTokenT<reco::TrackCollection> > tracksContainers_;
+      std::vector<edm::EDGetTokenT<std::vector<Trajectory> > > trajContainers_;
+      std::vector<edm::EDGetTokenT<reco::TrackCollection > > tracksContainers_;
       
 
       std::string fitterName_;

--- a/RecoParticleFlow/PFTracking/interface/LightPFTrackProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/LightPFTrackProducer.h
@@ -7,6 +7,8 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
 class PFTrackTransformer;
 class LightPFTrackProducer : public edm::EDProducer {
 public:
@@ -26,7 +28,7 @@ private:
   
   ///PFTrackTransformer
   PFTrackTransformer *pfTransformer_; 
-  std::vector<edm::InputTag> tracksContainers_;
+  std::vector<edm::EDGetTokenT<reco::TrackCollection> > tracksContainers_;
   ///TRACK QUALITY
     bool useQuality_;
     reco::TrackBase::TrackQuality trackQuality_;

--- a/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
@@ -1,5 +1,8 @@
 #ifndef PFElecTkProducer_H
 #define PFElecTkProducer_H
+#include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertex.h"
+#include "DataFormats/ParticleFlowReco/interface/PFConversion.h"
+#include "DataFormats/ParticleFlowReco/interface/PFV0.h"
 
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -15,6 +18,12 @@
 #include "DataFormats/EgammaReco/interface/ElectronSeed.h"
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexFwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFConversionFwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFV0Fwd.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFDisplacedTrackerVertex.h"
 
 class PFTrackTransformer;
 class GsfTrack;
@@ -96,13 +105,13 @@ class PFElecTkProducer : public edm::EDProducer {
       reco::GsfPFRecTrack pftrack_;
       reco::GsfPFRecTrack secpftrack_;
       edm::ParameterSet conf_;
-      edm::InputTag gsfTrackLabel_;
-      edm::InputTag pfTrackLabel_;
-      edm::InputTag primVtxLabel_;
-      edm::InputTag pfEcalClusters_;
-      edm::InputTag pfNuclear_;
-      edm::InputTag pfConv_;
-      edm::InputTag pfV0_;
+      edm::EDGetTokenT<reco::GsfTrackCollection> gsfTrackLabel_;
+      edm::EDGetTokenT<reco::PFRecTrackCollection> pfTrackLabel_;
+      edm::EDGetTokenT<reco::VertexCollection> primVtxLabel_;
+      edm::EDGetTokenT<reco::PFClusterCollection> pfEcalClusters_;
+      edm::EDGetTokenT<reco::PFDisplacedTrackerVertexCollection>  pfNuclear_;
+      edm::EDGetTokenT<reco::PFConversionCollection> pfConv_;
+      edm::EDGetTokenT<reco::PFV0Collection>  pfV0_;
       bool useNuclear_;
       bool useConversions_;
       bool useV0_;

--- a/RecoParticleFlow/PFTracking/interface/PFNuclearProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFNuclearProducer.h
@@ -6,6 +6,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFNuclearInteraction.h"
 
 class PFTrackTransformer;
 class PFNuclearProducer : public edm::EDProducer {
@@ -27,6 +28,6 @@ private:
   ///PFTrackTransformer
   PFTrackTransformer *pfTransformer_; 
   double likelihoodCut_;
-  std::vector<edm::InputTag> nuclearContainers_;
+  std::vector<edm::EDGetTokenT<reco::NuclearInteractionCollection> > nuclearContainers_;
 };
 #endif

--- a/RecoParticleFlow/PFTracking/interface/PFTrackProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFTrackProducer.h
@@ -7,6 +7,12 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
+
 /// \brief Abstract
 /*!
 \author Daniele Benedetti
@@ -35,10 +41,10 @@ private:
   
   ///PFTrackTransformer
   PFTrackTransformer *pfTransformer_; 
-  std::vector<edm::InputTag> tracksContainers_;
-  edm::InputTag gsfTrackLabel_;  
-  edm::InputTag muonColl_;
-  edm::InputTag vtx_h;
+  std::vector<edm::EDGetTokenT<reco::TrackCollection> > tracksContainers_;
+  edm::EDGetTokenT<reco::GsfTrackCollection> gsfTrackLabel_;  
+  edm::EDGetTokenT<reco::MuonCollection> muonColl_;
+  edm::EDGetTokenT<reco::VertexCollection> vtx_h;
   ///TRACK QUALITY
   bool useQuality_;
   reco::TrackBase::TrackQuality trackQuality_;

--- a/RecoParticleFlow/PFTracking/plugins/ElectronSeedMerger.cc
+++ b/RecoParticleFlow/PFTracking/plugins/ElectronSeedMerger.cc
@@ -9,7 +9,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeed.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeed.h"
-#include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 #include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h"  
 #include <string>
@@ -24,10 +23,10 @@ ElectronSeedMerger::ElectronSeedMerger(const ParameterSet& iConfig):
 {
   LogInfo("ElectronSeedMerger")<<"Electron SeedMerger  started  ";
   
-  
-  ecalBasedSeeds_=iConfig.getParameter<InputTag>("EcalBasedSeeds");
-  tkBasedSeeds_=iConfig.getParameter<InputTag>("TkBasedSeeds");
- 
+
+  ecalSeedToken_ = consumes<ElectronSeedCollection>(iConfig.getParameter<InputTag>("EcalBasedSeeds"));
+  tkSeedToken_ = consumes<ElectronSeedCollection>(iConfig.getParameter<InputTag>("TkBasedSeeds"));
+   
   produces<ElectronSeedCollection>();
 
 }
@@ -55,11 +54,11 @@ ElectronSeedMerger::produce(Event& iEvent, const EventSetup& iSetup)
 
   //HANDLE THE INPUT SEED COLLECTIONS
   Handle<ElectronSeedCollection> EcalBasedSeeds;
-  iEvent.getByLabel(ecalBasedSeeds_,EcalBasedSeeds);
+  iEvent.getByToken(ecalSeedToken_,EcalBasedSeeds);
   ElectronSeedCollection ESeed = *(EcalBasedSeeds.product());
 
   Handle<ElectronSeedCollection> TkBasedSeeds;
-  iEvent.getByLabel(tkBasedSeeds_,TkBasedSeeds);
+  iEvent.getByToken(tkSeedToken_,TkBasedSeeds);
   ElectronSeedCollection TSeed = *(TkBasedSeeds.product());
 
 

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
@@ -46,15 +46,17 @@ GoodSeedProducer::GoodSeedProducer(const ParameterSet& iConfig):
   
   //now do what ever initialization is needed
  
-  tracksContainers_ = 
-    iConfig.getParameter< vector < InputTag > >("TkColList");
+  std::vector<edm::InputTag> tags =   iConfig.getParameter< vector < InputTag > >("TkColList");
+  for(unsigned int i=0;i<tags.size();++i)
+    tracksContainers_.push_back(consumes<reco::TrackCollection>(tags[i]));
+
   
   minPt_=iConfig.getParameter<double>("MinPt");
   maxPt_=iConfig.getParameter<double>("MaxPt");
   maxEta_=iConfig.getParameter<double>("MaxEta");
 
 
-  //ISOLATION REQUEST AS DONE IN THE TAU GROUP
+  //ISOLATION REQUEST AS DONE IN THE TAU GROUP(Michalis: Do we still need this crazy stuff??)
   applyIsolation_ =iConfig.getParameter<bool>("ApplyIsolation");
   HcalIsolWindow_                       =iConfig.getParameter<double>("HcalWindow");
   EcalStripSumE_minClusEnergy_ = iConfig.getParameter<double>("EcalStripSumE_minClusEnergy");
@@ -65,14 +67,11 @@ GoodSeedProducer::GoodSeedProducer(const ParameterSet& iConfig):
    maxHoverP_= iConfig.getParameter<double>("HOverPLead_maxValue");
  
   //
-  pfCLusTagECLabel_=
-    iConfig.getParameter<InputTag>("PFEcalClusterLabel");
+   pfCLusTagECLabel_=consumes<reco::PFClusterCollection>(iConfig.getParameter<InputTag>("PFEcalClusterLabel"));
 
-  pfCLusTagHCLabel_=
-   iConfig.getParameter<InputTag>("PFHcalClusterLabel");  
+   pfCLusTagHCLabel_=consumes<reco::PFClusterCollection>(iConfig.getParameter<InputTag>("PFHcalClusterLabel"));  
 
-  pfCLusTagPSLabel_=
-    iConfig.getParameter<InputTag>("PFPSClusterLabel");
+   pfCLusTagPSLabel_=consumes<reco::PFClusterCollection>(iConfig.getParameter<InputTag>("PFPSClusterLabel"));
   
   preidgsf_ = iConfig.getParameter<string>("PreGsfLabel");
   preidckf_ = iConfig.getParameter<string>("PreCkfLabel");
@@ -177,7 +176,7 @@ GoodSeedProducer::produce(Event& iEvent, const EventSetup& iSetup)
   //Handle input collections
   //ECAL clusters	      
   Handle<PFClusterCollection> theECPfClustCollection;
-  iEvent.getByLabel(pfCLusTagECLabel_,theECPfClustCollection);
+  iEvent.getByToken(pfCLusTagECLabel_,theECPfClustCollection);
   
   vector<PFCluster> basClus;
   vector<PFCluster>::const_iterator iklus;
@@ -189,11 +188,11 @@ GoodSeedProducer::produce(Event& iEvent, const EventSetup& iSetup)
 
   //HCAL clusters
   Handle<PFClusterCollection> theHCPfClustCollection;
-  iEvent.getByLabel(pfCLusTagHCLabel_,theHCPfClustCollection);
+  iEvent.getByToken(pfCLusTagHCLabel_,theHCPfClustCollection);
   
   //PS clusters
   Handle<PFClusterCollection> thePSPfClustCollection;
-  iEvent.getByLabel(pfCLusTagPSLabel_,thePSPfClustCollection);
+  iEvent.getByToken(pfCLusTagPSLabel_,thePSPfClustCollection);
   
   ps1Clus.clear();
   ps2Clus.clear();
@@ -212,12 +211,12 @@ GoodSeedProducer::produce(Event& iEvent, const EventSetup& iSetup)
     
     //Track collection
     Handle<TrackCollection> tkRefCollection;
-    iEvent.getByLabel(tracksContainers_[istr], tkRefCollection);
+    iEvent.getByToken(tracksContainers_[istr], tkRefCollection);
     const TrackCollection&  Tk=*(tkRefCollection.product());
     
     //Trajectory collection
     Handle<vector<Trajectory> > tjCollection;
-    iEvent.getByLabel(tracksContainers_[istr], tjCollection);
+    iEvent.getByToken(tracksContainers_[istr], tjCollection);
     vector<Trajectory> Tj=*(tjCollection.product());
     
     
@@ -486,7 +485,7 @@ GoodSeedProducer::produce(Event& iEvent, const EventSetup& iSetup)
       if(tracksContainers_.size()==1)
 	{
 	  Handle<TrackCollection> tkRefCollection ;
-	  iEvent.getByLabel(tracksContainers_[0],tkRefCollection);
+	  iEvent.getByToken(tracksContainers_[0],tkRefCollection);
 	  fillPreIdRefValueMap(tkRefCollection,preIdRefProd,mapFiller);
 	  mapFiller.fill();
 	  iEvent.put(preIdMap_p,preidname_);

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
@@ -47,9 +47,10 @@ GoodSeedProducer::GoodSeedProducer(const ParameterSet& iConfig):
   //now do what ever initialization is needed
  
   std::vector<edm::InputTag> tags =   iConfig.getParameter< vector < InputTag > >("TkColList");
-  for(unsigned int i=0;i<tags.size();++i)
+  for(unsigned int i=0;i<tags.size();++i) {
+    trajContainers_.push_back(consumes<vector<Trajectory> >(tags[i]));
     tracksContainers_.push_back(consumes<reco::TrackCollection>(tags[i]));
-
+  }
   
   minPt_=iConfig.getParameter<double>("MinPt");
   maxPt_=iConfig.getParameter<double>("MaxPt");
@@ -216,7 +217,7 @@ GoodSeedProducer::produce(Event& iEvent, const EventSetup& iSetup)
     
     //Trajectory collection
     Handle<vector<Trajectory> > tjCollection;
-    iEvent.getByToken(tracksContainers_[istr], tjCollection);
+    iEvent.getByToken(trajContainers_[istr], tjCollection);
     vector<Trajectory> Tj=*(tjCollection.product());
     
     

--- a/RecoParticleFlow/PFTracking/plugins/LightPFTrackProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/LightPFTrackProducer.cc
@@ -4,7 +4,6 @@
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrack.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
@@ -17,9 +16,13 @@ LightPFTrackProducer::LightPFTrackProducer(const ParameterSet& iConfig):
 {
   produces<reco::PFRecTrackCollection>();
 
-  tracksContainers_ = 
+
+  
+  std::vector<InputTag>  tags = 
     iConfig.getParameter< vector < InputTag > >("TkColList");
 
+  for (unsigned int i=0;i<tags.size();++i)
+    tracksContainers_.push_back(consumes<reco::TrackCollection>(tags[i]));
 
   useQuality_   = iConfig.getParameter<bool>("UseQuality");
   trackQuality_=reco::TrackBase::qualityByName(iConfig.getParameter<std::string>("TrackQuality"));
@@ -43,7 +46,7 @@ LightPFTrackProducer::produce(Event& iEvent, const EventSetup& iSetup)
     
     //Track collection
     Handle<reco::TrackCollection> tkRefCollection;
-    iEvent.getByLabel(tracksContainers_[istr], tkRefCollection);
+    iEvent.getByToken(tracksContainers_[istr], tkRefCollection);
     reco::TrackCollection  Tk=*(tkRefCollection.product());
     for(unsigned int i=0;i<Tk.size();i++){
       if (useQuality_ &&

--- a/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.cc
@@ -1,9 +1,6 @@
 #include <memory>
 #include "RecoParticleFlow/PFTracking/plugins/PFConversionProducer.h"
 #include "RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h"
-#include "DataFormats/ParticleFlowReco/interface/PFConversionFwd.h"
-#include "DataFormats/ParticleFlowReco/interface/PFConversion.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -28,9 +25,9 @@ PFConversionProducer::PFConversionProducer(const ParameterSet& iConfig):
   produces<reco::PFRecTrackCollection>();
   produces<reco::PFConversionCollection>();
 
-  pfConversionContainer_ = 
-    iConfig.getParameter< InputTag >("conversionCollection");
-  vtx_h=iConfig.getParameter<edm::InputTag>("PrimaryVertexLabel");
+  pfConversionContainer_ =consumes<reco::ConversionCollection>(iConfig.getParameter< InputTag >("conversionCollection")); 
+
+  vtx_h=consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("PrimaryVertexLabel"));
 }
 
 PFConversionProducer::~PFConversionProducer()
@@ -53,14 +50,12 @@ PFConversionProducer::produce(Event& iEvent, const EventSetup& iSetup)
   TransientTrackBuilder thebuilder = *(builder.product());
   reco::PFRecTrackRefProd pfTrackRefProd = iEvent.getRefBeforePut<reco::PFRecTrackCollection>();
   Handle<reco::ConversionCollection> convCollH;
-  iEvent.getByLabel(pfConversionContainer_, convCollH);
+  iEvent.getByToken(pfConversionContainer_, convCollH);
   
   const reco::ConversionCollection& convColl = *(convCollH.product());
   
-  Handle<reco::TrackCollection> trackColl;
-  iEvent.getByLabel(pfTrackContainer_, trackColl);
   Handle<reco::VertexCollection> vertex;
-  iEvent.getByLabel(vtx_h, vertex);
+  iEvent.getByToken(vtx_h, vertex);
   //Find PV for IP calculation, if there is no PV in collection than use dummy 
   reco::Vertex dummy;
   const reco::Vertex* pv=&dummy;    

--- a/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFConversionProducer.h
@@ -6,6 +6,9 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFConversion.h"
+#include "DataFormats/ParticleFlowReco/interface/PFConversionFwd.h"
 
 class PFTrackTransformer;
 class PFConversionProducer : public edm::EDProducer {
@@ -26,8 +29,8 @@ private:
   
   ///PFTrackTransformer
   PFTrackTransformer *pfTransformer_; 
-  edm::InputTag pfConversionContainer_;
-  edm::InputTag pfTrackContainer_;
-  edm::InputTag vtx_h;
+  edm::EDGetTokenT<reco::ConversionCollection> pfConversionContainer_;
+  edm::EDGetTokenT<reco::VertexCollection> vtx_h;
+  
 };
 #endif

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.cc
@@ -1,7 +1,6 @@
 #include <memory>
 #include "RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.h"
 #include "RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h"
-#include "DataFormats/ParticleFlowReco/interface/PFDisplacedTrackerVertex.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
@@ -14,11 +13,11 @@ PFDisplacedTrackerVertexProducer::PFDisplacedTrackerVertexProducer(const Paramet
   produces<reco::PFRecTrackCollection>();
   produces<reco::PFDisplacedTrackerVertexCollection>();
 
-  pfDisplacedVertexContainer_ = 
-    iConfig.getParameter< InputTag >("displacedTrackerVertexColl");
+  pfDisplacedVertexContainer_ = consumes<reco::PFDisplacedVertexCollection>(									    iConfig.getParameter< InputTag >("displacedTrackerVertexColl"));
 
-  pfTrackContainer_ =
-    iConfig.getParameter< InputTag >("trackColl");
+
+  pfTrackContainer_ =consumes<reco::TrackCollection>(
+    iConfig.getParameter< InputTag >("trackColl"));
 
 }
 
@@ -42,11 +41,11 @@ PFDisplacedTrackerVertexProducer::produce(Event& iEvent, const EventSetup& iSetu
 
     
   Handle<reco::PFDisplacedVertexCollection> nuclCollH;
-  iEvent.getByLabel(pfDisplacedVertexContainer_, nuclCollH);
+  iEvent.getByToken(pfDisplacedVertexContainer_, nuclCollH);
   const reco::PFDisplacedVertexCollection& nuclColl = *(nuclCollH.product());
 
   Handle<reco::TrackCollection> trackColl;
-  iEvent.getByLabel(pfTrackContainer_, trackColl);
+  iEvent.getByToken(pfTrackContainer_, trackColl);
 
   int idx = 0;
 

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedTrackerVertexProducer.h
@@ -6,6 +6,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFDisplacedTrackerVertex.h"
 
 class PFTrackTransformer;
 class PFDisplacedTrackerVertexProducer : public edm::EDProducer {
@@ -26,8 +27,8 @@ private:
   
   ///PFTrackTransformer
   PFTrackTransformer *pfTransformer_; 
-  edm::InputTag pfDisplacedVertexContainer_;
-  edm::InputTag pfTrackContainer_;
+  edm::EDGetTokenT<reco::PFDisplacedVertexCollection> pfDisplacedVertexContainer_;
+  edm::EDGetTokenT<reco::TrackCollection> pfTrackContainer_;
 
 };
 #endif

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.cc
@@ -11,8 +11,6 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
-#include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexCandidateFwd.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 #include <set>
 
@@ -22,14 +20,11 @@ using namespace edm;
 PFDisplacedVertexCandidateProducer::PFDisplacedVertexCandidateProducer(const edm::ParameterSet& iConfig) {
   
   // --- Setup input collection names --- //
-  inputTagTracks_ 
-    = iConfig.getParameter<InputTag>("trackCollection");
+  inputTagTracks_ = consumes<reco::TrackCollection>(iConfig.getParameter<InputTag>("trackCollection"));
 
-  inputTagMainVertex_ 
-    = iConfig.getParameter<InputTag>("mainVertexLabel");
+  inputTagMainVertex_=consumes<reco::VertexCollection>(iConfig.getParameter<InputTag>("mainVertexLabel"));
 
-  inputTagBeamSpot_ 
-    = iConfig.getParameter<InputTag>("offlineBeamSpotLabel");
+  inputTagBeamSpot_ =consumes<reco::BeamSpot>(iConfig.getParameter<InputTag>("offlineBeamSpotLabel"));
 
   verbose_ = 
     iConfig.getUntrackedParameter<bool>("verbose");
@@ -82,13 +77,13 @@ PFDisplacedVertexCandidateProducer::produce(Event& iEvent,
   const MagneticField* theMagField = magField.product();
 
   Handle <reco::TrackCollection> trackCollection;
-  iEvent.getByLabel(inputTagTracks_, trackCollection);
+  iEvent.getByToken(inputTagTracks_, trackCollection);
     
   Handle< reco::VertexCollection > mainVertexHandle;
-  iEvent.getByLabel(inputTagMainVertex_, mainVertexHandle);
+  iEvent.getByToken(inputTagMainVertex_, mainVertexHandle);
 
   Handle< reco::BeamSpot > beamSpotHandle;
-  iEvent.getByLabel(inputTagBeamSpot_, beamSpotHandle);
+  iEvent.getByToken(inputTagBeamSpot_, beamSpotHandle);
 
   pfDisplacedVertexCandidateFinder_.setPrimaryVertex(mainVertexHandle, beamSpotHandle);
   pfDisplacedVertexCandidateFinder_.setInput( trackCollection, theMagField );

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexCandidateProducer.h
@@ -10,6 +10,8 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "RecoParticleFlow/PFTracking/interface/PFDisplacedVertexCandidateFinder.h"
+#include "DataFormats/ParticleFlowReco/interface/PFDisplacedVertexCandidateFwd.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 /**\class PFDisplacedVertexCandidateProducer 
 \brief Producer for DisplacedVertices 
@@ -34,11 +36,11 @@ class PFDisplacedVertexCandidateProducer : public edm::EDProducer {
  private:
 
   /// Reco Tracks used to spot the nuclear interactions
-  edm::InputTag   inputTagTracks_;
+  edm::EDGetTokenT<reco::TrackCollection>   inputTagTracks_;
  
   /// Input tag for main vertex to cut of dxy of secondary tracks
-  edm::InputTag   inputTagMainVertex_; 
-  edm::InputTag   inputTagBeamSpot_;
+  edm::EDGetTokenT<reco::VertexCollection>  inputTagMainVertex_; 
+  edm::EDGetTokenT<reco::BeamSpot>    inputTagBeamSpot_;
   
   /// verbose ?
   bool   verbose_;

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.cc
@@ -28,14 +28,12 @@ PFDisplacedVertexProducer::PFDisplacedVertexProducer(const edm::ParameterSet& iC
   
   // --- Setup input collection names --- //
 
-  inputTagVertexCandidates_ 
-    = iConfig.getParameter<InputTag>("vertexCandidatesLabel");
+  inputTagVertexCandidates_= consumes<reco::PFDisplacedVertexCandidateCollection>(iConfig.getParameter<InputTag>("vertexCandidatesLabel"));
 
-  inputTagMainVertex_ 
-    = iConfig.getParameter<InputTag>("mainVertexLabel");
+  inputTagMainVertex_ = consumes<reco::VertexCollection>(iConfig.getParameter<InputTag>("mainVertexLabel"));
 
-  inputTagBeamSpot_ 
-    = iConfig.getParameter<InputTag>("offlineBeamSpotLabel");
+
+  inputTagBeamSpot_ =consumes<reco::BeamSpot> (iConfig.getParameter<InputTag>("offlineBeamSpotLabel"));
 
   verbose_ = 
     iConfig.getUntrackedParameter<bool>("verbose");
@@ -123,13 +121,13 @@ PFDisplacedVertexProducer::produce(Event& iEvent,
   iSetup.get<TrackerDigiGeometryRecord>().get(tkerGeomHandle);
 
   Handle<reco::PFDisplacedVertexCandidateCollection> vertexCandidates;
-  iEvent.getByLabel(inputTagVertexCandidates_, vertexCandidates);
+  iEvent.getByToken(inputTagVertexCandidates_, vertexCandidates);
 
   Handle< reco::VertexCollection > mainVertexHandle;
-  iEvent.getByLabel(inputTagMainVertex_, mainVertexHandle);
+  iEvent.getByToken(inputTagMainVertex_, mainVertexHandle);
 
   Handle< reco::BeamSpot > beamSpotHandle;
-  iEvent.getByLabel(inputTagBeamSpot_, beamSpotHandle);
+  iEvent.getByToken(inputTagBeamSpot_, beamSpotHandle);
 
   // Fill useful event information for the Finder
   pfDisplacedVertexFinder_.setEdmParameters(theMagField, globTkGeomHandle, tkerGeomHandle); 

--- a/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFDisplacedVertexProducer.h
@@ -35,11 +35,12 @@ class PFDisplacedVertexProducer : public edm::EDProducer {
 
   /// Collection of DisplacedVertex Candidates used as input for
   /// the Displaced VertexFinder.
-  edm::InputTag   inputTagVertexCandidates_;
+  edm::EDGetTokenT<reco::PFDisplacedVertexCandidateCollection>   inputTagVertexCandidates_;
 
   /// Input tag for main vertex to cut of dxy of secondary tracks
-  edm::InputTag   inputTagMainVertex_; 
-  edm::InputTag   inputTagBeamSpot_;
+
+  edm::EDGetTokenT<reco::VertexCollection>   inputTagMainVertex_; 
+  edm::EDGetTokenT<reco::BeamSpot>   inputTagBeamSpot_;
   
   /// verbose ?
   bool   verbose_;

--- a/RecoParticleFlow/PFTracking/plugins/PFNuclearProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFNuclearProducer.cc
@@ -1,7 +1,6 @@
 #include <memory>
 #include "RecoParticleFlow/PFTracking/interface/PFNuclearProducer.h"
 #include "RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h"
-#include "DataFormats/ParticleFlowReco/interface/PFNuclearInteraction.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
@@ -14,8 +13,12 @@ PFNuclearProducer::PFNuclearProducer(const ParameterSet& iConfig):
   produces<reco::PFRecTrackCollection>();
   produces<reco::PFNuclearInteractionCollection>();
 
-  nuclearContainers_ = 
+  std::vector<edm::InputTag> tags= 
     iConfig.getParameter< vector < InputTag > >("nuclearColList");
+
+  for (unsigned int i=0;i<tags.size();++i) 
+    nuclearContainers_.push_back(consumes<reco::NuclearInteractionCollection>(tags[i]));
+
   likelihoodCut_
      = iConfig.getParameter<double>("likelihoodCut");
 }
@@ -43,7 +46,7 @@ PFNuclearProducer::produce(Event& iEvent, const EventSetup& iSetup)
   for (unsigned int istr=0; istr<nuclearContainers_.size();istr++){
     
     Handle<reco::NuclearInteractionCollection> nuclCollH;
-    iEvent.getByLabel(nuclearContainers_[istr], nuclCollH);
+    iEvent.getByToken(nuclearContainers_[istr], nuclCollH);
     const reco::NuclearInteractionCollection& nuclColl = *(nuclCollH.product());
 
     // loop on all NuclearInteraction 

--- a/RecoParticleFlow/PFTracking/plugins/PFV0Producer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFV0Producer.cc
@@ -2,7 +2,6 @@
 #include "RecoParticleFlow/PFTracking/plugins/PFV0Producer.h"
 #include "DataFormats/ParticleFlowReco/interface/PFV0.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecTrackFwd.h"
-#include "DataFormats/ParticleFlowReco/interface/PFV0Fwd.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "RecoParticleFlow/PFTracking/interface/PFTrackTransformer.h"
@@ -21,8 +20,10 @@ PFV0Producer::PFV0Producer(const ParameterSet& iConfig):
   produces<reco::PFV0Collection>();
   produces<reco::PFRecTrackCollection>();
 
-  V0list_ = 
-    iConfig.getParameter< vector < InputTag > >("V0List");
+  std::vector<edm::InputTag> tags =     iConfig.getParameter< vector < InputTag > >("V0List");
+
+  for (unsigned int i=0;i<tags.size();++i)
+    V0list_.push_back(consumes<reco::PFV0Collection>(tags[i])); 
 }
 
 PFV0Producer::~PFV0Producer()
@@ -46,7 +47,7 @@ PFV0Producer::produce(Event& iEvent, const EventSetup& iSetup)
 
   for (unsigned int il=0; il<V0list_.size(); il++){
     Handle<VertexCompositeCandidateCollection> V0coll;
-    iEvent.getByLabel(V0list_[il],V0coll);
+    iEvent.getByToken(V0list_[il],V0coll);
     LogDebug("PFV0Producer")<<V0list_[il]<<" contains "<<V0coll->size()<<" V0 candidates ";
     for (unsigned int iv=0;iv<V0coll->size();iv++){
       VertexCompositeCandidateRef V0(V0coll, iv);

--- a/RecoParticleFlow/PFTracking/plugins/PFV0Producer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFV0Producer.cc
@@ -8,7 +8,6 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-#include "DataFormats/Candidate/interface/VertexCompositeCandidate.h"
 
 using namespace std;
 using namespace edm;
@@ -23,7 +22,7 @@ PFV0Producer::PFV0Producer(const ParameterSet& iConfig):
   std::vector<edm::InputTag> tags =     iConfig.getParameter< vector < InputTag > >("V0List");
 
   for (unsigned int i=0;i<tags.size();++i)
-    V0list_.push_back(consumes<reco::PFV0Collection>(tags[i])); 
+    V0list_.push_back(consumes<reco::VertexCompositeCandidateCollection>(tags[i])); 
 }
 
 PFV0Producer::~PFV0Producer()

--- a/RecoParticleFlow/PFTracking/plugins/PFV0Producer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFV0Producer.h
@@ -6,6 +6,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFV0Fwd.h"
 
 
 class PFTrackTransformer;
@@ -27,7 +28,7 @@ private:
 
   ///PFTrackTransformer
   PFTrackTransformer *pfTransformer_; 
-  std::vector < edm::InputTag > V0list_;
+  std::vector < edm::EDGetTokenT<reco::PFV0Collection> > V0list_;
 
 };
 #endif

--- a/RecoParticleFlow/PFTracking/plugins/PFV0Producer.h
+++ b/RecoParticleFlow/PFTracking/plugins/PFV0Producer.h
@@ -7,6 +7,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFV0Fwd.h"
+#include "DataFormats/Candidate/interface/VertexCompositeCandidate.h"
 
 
 class PFTrackTransformer;
@@ -28,7 +29,7 @@ private:
 
   ///PFTrackTransformer
   PFTrackTransformer *pfTransformer_; 
-  std::vector < edm::EDGetTokenT<reco::PFV0Collection> > V0list_;
+  std::vector < edm::EDGetTokenT<reco::VertexCompositeCandidateCollection> > V0list_;
 
 };
 #endif


### PR DESCRIPTION
Hi ,
I finalized the consumes migration for all the modules.
This PR contains all the changes except the PFClusterProducer module which is already 
migrated and queued in #2730 

-Checked that there are no more modules under RecoParticleFlow that need migration
-The development is done on CMSSW_7_1_X_2014-03-13-0200

I would appreciate if you can  have a quick look for any major issues/request  because I will be in Moriond EWK next week and the response is expected to be slower
Cheers
Michalis
