### PR TITLE
Change the way how precompiled tar ball is copied to /afs/cern.ch/cms/generators/www/

### DIFF
--- a/GeneratorInterface/LHEInterface/data/create_lhe_powheg_all.sh
+++ b/GeneratorInterface/LHEInterface/data/create_lhe_powheg_all.sh
@@ -189,12 +189,8 @@ EOF
         rm -rf *.f
         cd ..
         tar chvzf ${tarball}.tar.gz ${process}
-        cp -p ${tarball}.tar.gz /afs/cern.ch/cms/generators/www/${tarballRepo}/.
-	echo "I am here 1"
-	ls  /afs/cern.ch/cms/generators/www/${tarballRepo}/
-	echo "I am here 2"
+	cp -p ${tarball}.tar.gz ${WORKDIR}/.
         cd ${process}
-	echo "I am here 3"
     fi
 
 else if [ "$precompile" == "true" ];


### PR DESCRIPTION
Previous version automatically copied precompiled powheg tarball to the directory 
 /afs/cern.ch/cms/generators/www/<scram_arch_version>/<beamenergy>TeV/powheg.

To avoid overwriting the existing tar balls, we modify the script. This version put precompiled tar ball 
in a local working directory. Then, the tar ball must be copied to the afs generator directory by the MC 
contacts. 
