### PR TITLE
Change the way how precompiled tar ball is copied to /afs/cern.ch/cms/generators/www/

### DIFF
--- a/GeneratorInterface/LHEInterface/data/create_lhe_powheg_all.sh
+++ b/GeneratorInterface/LHEInterface/data/create_lhe_powheg_all.sh
@@ -189,12 +189,8 @@ EOF
         rm -rf *.f
         cd ..
         tar chvzf ${tarball}.tar.gz ${process}
-        cp -p ${tarball}.tar.gz /afs/cern.ch/cms/generators/www/${tarballRepo}/.
-	echo "I am here 1"
-	ls  /afs/cern.ch/cms/generators/www/${tarballRepo}/
-	echo "I am here 2"
+	cp -p ${tarball}.tar.gz ${WORKDIR}/.
         cd ${process}
-	echo "I am here 3"
     fi
 
 else if [ "$precompile" == "true" ];


### PR DESCRIPTION
Instead of doing automatic copy of precompiled powheg tar ball to the directory 
/afs/cern.ch/cms/generators/www/<scram_arch_version>/<beamenergy>TeV/powheg, now the precompiled 
tar ball is put in a local working directory after running the script create_lhe_powheg_all.sh. 
The MC contacts must put the tar balls in the afs directory by hand before running LHE production.
