### PR TITLE
migrate SiStripDCSStatus to getByToken

### DIFF
--- a/CalibTracker/SiStripCommon/BuildFile.xml
+++ b/CalibTracker/SiStripCommon/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ServiceRegistry"/>
+<use   name="FWCore/Utilities"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="Geometry/Records"/>

--- a/CalibTracker/SiStripCommon/interface/ShallowClustersProducer.h
+++ b/CalibTracker/SiStripCommon/interface/ShallowClustersProducer.h
@@ -4,7 +4,11 @@
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "DataFormats/Common/interface/DetSetVector.h"
+
+#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
+
 class SiStripClusterInfo;
 class SiStripProcessedRawDigi;
 class TrackerTopology;
@@ -37,6 +41,9 @@ class ShallowClustersProducer : public edm::EDProducer {
     float outsideasymm() const {return (last-first)/(last+first);}
   };
 
+  edm::EDGetTokenT<edm::DetSetVector<SiStripCluster> >          theClustersToken_;
+  edm::EDGetTokenT<edm::DetSetVector<SiStripProcessedRawDigi> > theDigisToken_;
+  
 };
 
 #endif

--- a/CalibTracker/SiStripCommon/interface/SiStripDCSStatus.h
+++ b/CalibTracker/SiStripCommon/interface/SiStripDCSStatus.h
@@ -7,6 +7,8 @@
 #include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "DataFormats/Scalers/interface/DcsStatus.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+
  
 class SiStripDCSStatus {
  public:
@@ -26,7 +28,8 @@ class SiStripDCSStatus {
   bool rawdataAbsent;
   bool initialised;
 
-  edm::EDGetTokenT<DcsStatusCollection> dcsStatusToken_;
+  edm::EDGetTokenT<DcsStatusCollection>  dcsStatusToken_;
+  edm::EDGetTokenT<FEDRawDataCollection> rawDataToken_;
 
 };
 

--- a/CalibTracker/SiStripCommon/interface/SiStripDCSStatus.h
+++ b/CalibTracker/SiStripCommon/interface/SiStripDCSStatus.h
@@ -3,10 +3,15 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
+#include "DataFormats/Scalers/interface/DcsStatus.h"
  
 class SiStripDCSStatus {
  public:
-  SiStripDCSStatus();
+  SiStripDCSStatus(edm::ConsumesCollector && iC) : SiStripDCSStatus( iC ) {};
+  SiStripDCSStatus(edm::ConsumesCollector & iC);
  ~SiStripDCSStatus();
 
   bool getStatus(edm::Event const& e, edm::EventSetup const& eSetup);
@@ -20,6 +25,9 @@ class SiStripDCSStatus {
   bool trackerAbsent;
   bool rawdataAbsent;
   bool initialised;
+
+  edm::EDGetTokenT<DcsStatusCollection> dcsStatusToken_;
+
 };
 
 #endif

--- a/CalibTracker/SiStripCommon/plugins/ShallowClustersProducer.cc
+++ b/CalibTracker/SiStripCommon/plugins/ShallowClustersProducer.cc
@@ -11,8 +11,7 @@
 #include "boost/foreach.hpp"
 
 ShallowClustersProducer::ShallowClustersProducer(const edm::ParameterSet& iConfig) 
-  : theClustersLabel(iConfig.getParameter<edm::InputTag>("Clusters")),
-    Prefix(iConfig.getParameter<std::string>("Prefix") )
+  : Prefix(iConfig.getParameter<std::string>("Prefix") )
 {
   produces <std::vector<unsigned> >    ( Prefix + "number"       );
   produces <std::vector<unsigned> >    ( Prefix + "width"        );
@@ -51,6 +50,8 @@ ShallowClustersProducer::ShallowClustersProducer(const edm::ParameterSet& iConfi
   produces <std::vector<int> >         ( Prefix + "petal"         );
   produces <std::vector<int> >         ( Prefix + "stereo"        );
 
+  theClustersToken_ = consumes<edm::DetSetVector<SiStripCluster> >          (iConfig.getParameter<edm::InputTag>("Clusters"));
+  theDigisToken_    = consumes<edm::DetSetVector<SiStripProcessedRawDigi> > (edm::InputTag("siStripProcessedRawDigis", ""));
 }
 
 void ShallowClustersProducer::
@@ -98,10 +99,12 @@ produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   std::auto_ptr<std::vector<int> >            stereo         ( new std::vector<int>());
 
   edm::Handle<edmNew::DetSetVector<SiStripCluster> > clusters;
-  iEvent.getByLabel(theClustersLabel, clusters);
+  //  iEvent.getByLabel(theClustersLabel, clusters);
+  iEvent.getByToken(theClustersToken_, clusters);
   
   edm::Handle<edm::DetSetVector<SiStripProcessedRawDigi> > rawProcessedDigis;
-  iEvent.getByLabel("siStripProcessedRawDigis", "", rawProcessedDigis);
+  //  iEvent.getByLabel("siStripProcessedRawDigis", "", rawProcessedDigis);
+  iEvent.getByToken(theDigisToken_,rawProcessedDigis);
  
   edmNew::DetSetVector<SiStripCluster>::const_iterator itClusters=clusters->begin();
   for(;itClusters!=clusters->end();++itClusters){

--- a/CalibTracker/SiStripCommon/plugins/SiStripDCSFilter.cc
+++ b/CalibTracker/SiStripCommon/plugins/SiStripDCSFilter.cc
@@ -22,7 +22,7 @@ class SiStripDCSFilter : public edm::EDFilter {
 // -- Constructor
 //
 SiStripDCSFilter::SiStripDCSFilter( const edm::ParameterSet & pset ) {
-  dcsStatus_ = new SiStripDCSStatus(); 
+  dcsStatus_ = new SiStripDCSStatus(consumesCollector()); 
 }
 //
 // -- Destructor

--- a/CalibTracker/SiStripCommon/src/SiStripDCSStatus.cc
+++ b/CalibTracker/SiStripCommon/src/SiStripDCSStatus.cc
@@ -4,7 +4,6 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 
 #include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/Scalers/interface/DcsStatus.h"
 
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
@@ -24,7 +23,7 @@
 //
 // -- Constructor
 //
-SiStripDCSStatus::SiStripDCSStatus() :
+SiStripDCSStatus::SiStripDCSStatus(edm::ConsumesCollector & iC) :
   TIBTIDinDAQ(false),
   TOBinDAQ(false),
   TECFinDAQ(false),
@@ -32,6 +31,8 @@ SiStripDCSStatus::SiStripDCSStatus() :
   trackerAbsent(false),
   rawdataAbsent(true),
   initialised(false) {
+
+  dcsStatusToken_ = iC.consumes<DcsStatusCollection>(edm::InputTag("scalersRawToDigi"));
 }
 //
 // -- Destructor
@@ -47,7 +48,8 @@ bool SiStripDCSStatus::getStatus(edm::Event const& e, edm::EventSetup const& eSe
   if (!initialised) initialise(e, eSetup);
 
   edm::Handle<DcsStatusCollection> dcsStatus;
-  e.getByLabel("scalersRawToDigi", dcsStatus);
+  //  e.getByLabel("scalersRawToDigi", dcsStatus);
+  e.getByToken(dcsStatusToken_, dcsStatus);
   if ( trackerAbsent || !dcsStatus.isValid())  return retVal;
   if ((*dcsStatus).size() == 0) return retVal;
 

--- a/CalibTracker/SiStripCommon/src/SiStripDCSStatus.cc
+++ b/CalibTracker/SiStripCommon/src/SiStripDCSStatus.cc
@@ -5,7 +5,6 @@
 
 #include "DataFormats/Common/interface/Handle.h"
 
-#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
@@ -33,6 +32,7 @@ SiStripDCSStatus::SiStripDCSStatus(edm::ConsumesCollector & iC) :
   initialised(false) {
 
   dcsStatusToken_ = iC.consumes<DcsStatusCollection>(edm::InputTag("scalersRawToDigi"));
+  rawDataToken_   = iC.consumes<FEDRawDataCollection>(edm::InputTag("source"));
 }
 //
 // -- Destructor
@@ -109,7 +109,8 @@ void SiStripDCSStatus::initialise(edm::Event const& e, edm::EventSetup const& eS
   auto connectedFEDs = fedCabling_->fedIds();
 
   edm::Handle<FEDRawDataCollection> rawDataHandle;
-  e.getByLabel("source", rawDataHandle);
+  //  e.getByLabel("source", rawDataHandle);
+  e.getByToken(rawDataToken_, rawDataHandle);
 
   if ( !rawDataHandle.isValid() ) {
     rawdataAbsent = true;

--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
@@ -188,7 +188,7 @@ SiStripMonitorCluster::SiStripMonitorCluster(const edm::ParameterSet& iConfig)
   apvPhaseProducerToken_ = consumes<APVCyclePhaseCollection>(conf_.getParameter<edm::InputTag>("ApvPhaseProducer") );
   // Create DCS Status
   bool checkDCS    = conf_.getParameter<bool>("UseDCSFiltering");
-  if (checkDCS) dcsStatus_ = new SiStripDCSStatus();
+  if (checkDCS) dcsStatus_ = new SiStripDCSStatus(consumesCollector());
   else dcsStatus_ = 0;
 
 }

--- a/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
@@ -176,7 +176,7 @@ SiStripMonitorDigi::SiStripMonitorDigi(const edm::ParameterSet& iConfig) :
 
   // Create DCS Status
   bool checkDCS    = conf_.getParameter<bool>("UseDCSFiltering");
-  if (checkDCS) dcsStatus_ = new SiStripDCSStatus();
+  if (checkDCS) dcsStatus_ = new SiStripDCSStatus(consumesCollector());
   else dcsStatus_ = 0; 
 
   //initialize boolean for the data-presence check (needed for TotalNumberOfDigisFailure histogram)

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -53,7 +53,7 @@ SiStripMonitorTrack::SiStripMonitorTrack(const edm::ParameterSet& conf):
 
   // Create DCS Status
   bool checkDCS    = conf_.getParameter<bool>("UseDCSFiltering");
-  if (checkDCS) dcsStatus_ = new SiStripDCSStatus();
+  if (checkDCS) dcsStatus_ = new SiStripDCSStatus(consumesCollector());
   else dcsStatus_ = 0;
 }
 


### PR DESCRIPTION
migrate SiStripDCSStatus and Strip DQM files which make use of it to getByToken
# modified:   CalibTracker/SiStripCommon/BuildFile.xml
# modified:   CalibTracker/SiStripCommon/interface/ShallowClustersProducer.h
# modified:   CalibTracker/SiStripCommon/interface/SiStripDCSStatus.h
# modified:   CalibTracker/SiStripCommon/plugins/ShallowClustersProducer.cc
# modified:   CalibTracker/SiStripCommon/plugins/SiStripDCSFilter.cc
# modified:   CalibTracker/SiStripCommon/src/SiStripDCSStatus.cc
# modified:   DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
# modified:   DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
# modified:   DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
