### PR TITLE
Adding CSA14 GTs and enabling pre-mixing in autoCond.py

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -14,7 +14,7 @@ autoCond = {
     'hltonline'         :   'GR_H_V33::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for POSTLS1 upgrade studies:
     'upgradePLS1'       :   'POSTLS170_V7::All',
-    'upgradePLS150ns'   :   'POSTLS170_V4::All',
+    'upgradePLS150ns'   :   'POSTLS170_V6::All',
     'upgrade2017'       :   'DES17_70_V2::All', # placeholder (GT not meant for standard RelVal)
     'upgrade2019'       :   'DES19_70_V2::All', # placeholder (GT not meant for standard RelVal)
     'upgradePLS3'       :   'POSTLS262_V1::All' # placeholder (GT not meant for standard RelVal)

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -13,7 +13,7 @@ autoCond = {
     # then it should point to the GR_H tag and override the connection string and pfnPrefix for use offline
     'hltonline'         :   'GR_H_V33::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for POSTLS1 upgrade studies:
-    'upgradePLS1'       :   'POSTLS170_V5::All',
+    'upgradePLS1'       :   'POSTLS170_V7::All',
     'upgradePLS150ns'   :   'POSTLS170_V4::All',
     'upgrade2017'       :   'DES17_70_V2::All', # placeholder (GT not meant for standard RelVal)
     'upgrade2019'       :   'DES19_70_V2::All', # placeholder (GT not meant for standard RelVal)


### PR DESCRIPTION
Updates autoCond.py by adding the GTs for the pessimistic scenario (aka 50 ns) in CSA14, and changing the GT for the optimistic scenario (aka 25 ns) in CSA14.
- POSTLS170_V6 GT
  - updated AlCa conditions for the 50 ns CSA14 scenario
  - technical fixes (a.k.a. migrations of the accounts in prod)
  - enabling Ecal full readout for pre-mixing
  - adding SiStrip offsets for APV cycle phase producers.
- POSTLS170_V7 GT
  - enabling Ecal full readout for pre-mixing
  - adding SiStrip offsets for APV cycle phase producers.
