### PR TITLE
Castor consumes migrations + Parameter cleanup

### DIFF
--- a/EventFilter/CastorRawToDigi/plugins/CastorDigiToRaw.cc
+++ b/EventFilter/CastorRawToDigi/plugins/CastorDigiToRaw.cc
@@ -19,6 +19,7 @@ CastorDigiToRaw::CastorDigiToRaw(edm::ParameterSet const& conf) :
   usingctdc_(conf.getUntrackedParameter<bool>("CastorCtdc",false))
 
 {
+  tok_input_ = consumes<CastorDigiCollection>(castorTag_);
   produces<FEDRawDataCollection>();
 }
 
@@ -33,7 +34,7 @@ void CastorDigiToRaw::produce(edm::Event& e, const edm::EventSetup& es)
   // Step A: Get Inputs 
   edm::Handle<CastorDigiCollection> castor;
   if (!castorTag_.label().empty()) {
-    e.getByLabel(castorTag_,castor);
+    e.getByToken(tok_input_,castor);
     colls.castorCont=castor.product();	
   }
   // get the mapping

--- a/EventFilter/CastorRawToDigi/plugins/CastorDigiToRaw.cc
+++ b/EventFilter/CastorRawToDigi/plugins/CastorDigiToRaw.cc
@@ -13,10 +13,8 @@
 using namespace std;
 
 CastorDigiToRaw::CastorDigiToRaw(edm::ParameterSet const& conf) :
-  castorTag_(conf.getUntrackedParameter("CASTOR",edm::InputTag())),
-  calibTag_(conf.getUntrackedParameter("CALIB",edm::InputTag())),
-  trigTag_(conf.getUntrackedParameter("TRIG",edm::InputTag())),
-  usingctdc_(conf.getUntrackedParameter<bool>("CastorCtdc",false))
+  castorTag_(conf.getParameter<edm::InputTag>("CASTOR")),
+  usingctdc_(conf.getParameter<bool>("CastorCtdc"))
 
 {
   tok_input_ = consumes<CastorDigiCollection>(castorTag_);

--- a/EventFilter/CastorRawToDigi/plugins/CastorDigiToRaw.h
+++ b/EventFilter/CastorRawToDigi/plugins/CastorDigiToRaw.h
@@ -33,7 +33,7 @@ public:
 private:
   CastorPacker packer_;
   CastorCtdcPacker ctdcpacker_;
-  edm::InputTag castorTag_, calibTag_, trigTag_;
+  edm::InputTag castorTag_;
   bool usingctdc_;
   edm::EDGetTokenT<CastorDigiCollection> tok_input_;
 

--- a/EventFilter/CastorRawToDigi/plugins/CastorDigiToRaw.h
+++ b/EventFilter/CastorRawToDigi/plugins/CastorDigiToRaw.h
@@ -35,6 +35,7 @@ private:
   CastorCtdcPacker ctdcpacker_;
   edm::InputTag castorTag_, calibTag_, trigTag_;
   bool usingctdc_;
+  edm::EDGetTokenT<CastorDigiCollection> tok_input_;
 
 };
 

--- a/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
+++ b/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
@@ -14,21 +14,17 @@ using namespace std;
 
 CastorRawToDigi::CastorRawToDigi(edm::ParameterSet const& conf):
   dataTag_(conf.getParameter<edm::InputTag>("InputLabel")),
-  unpacker_(conf.getUntrackedParameter<int>("CastorFirstFED",FEDNumbering::MINCASTORFEDID),conf.getParameter<int>("firstSample"),conf.getParameter<int>("lastSample")),
-  ctdcunpacker_(conf.getUntrackedParameter<int>("CastorFirstFED",FEDNumbering::MINCASTORFEDID),conf.getParameter<int>("firstSample"),conf.getParameter<int>("lastSample")),
-  filter_(conf.getParameter<bool>("FilterDataQuality"),conf.getParameter<bool>("FilterDataQuality"),
-	  false,
-	  0, 0, 
-	  -1),
-  fedUnpackList_(conf.getUntrackedParameter<std::vector<int> >("FEDs", std::vector<int>())),
-  firstFED_(conf.getUntrackedParameter<int>("CastorFirstFED",FEDNumbering::MINCASTORFEDID)),
-//  unpackCalib_(conf.getUntrackedParameter<bool>("UnpackCalib",false)),
+  unpacker_(conf.getParameter<int>("CastorFirstFED"),conf.getParameter<int>("firstSample"),conf.getParameter<int>("lastSample")),
+  ctdcunpacker_(conf.getParameter<int>("CastorFirstFED"),conf.getParameter<int>("firstSample"),conf.getParameter<int>("lastSample")),
+  filter_(conf.getParameter<bool>("FilterDataQuality"),conf.getParameter<bool>("FilterDataQuality"),false,0,0,-1),
+  fedUnpackList_(conf.getUntrackedParameter<std::vector<int> >("FEDs",std::vector<int>())),
+  firstFED_(conf.getParameter<int>("CastorFirstFED")),
   complainEmptyData_(conf.getUntrackedParameter<bool>("ComplainEmptyData",false)),
-  usingctdc_(conf.getUntrackedParameter<bool>("CastorCtdc",false)),
-  unpackTTP_(conf.getUntrackedParameter<bool>("UnpackTTP",false)),
+  usingctdc_(conf.getParameter<bool>("CastorCtdc")),
+  unpackTTP_(conf.getParameter<bool>("UnpackTTP")),
   silent_(conf.getUntrackedParameter<bool>("silent",true)),
-  usenominalOrbitMessageTime_(conf.getUntrackedParameter<bool>("UseNominalOrbitMessageTime",true)),
-  expectedOrbitMessageTime_(conf.getUntrackedParameter<int>("ExpectedOrbitMessageTime",-1))
+  usenominalOrbitMessageTime_(conf.getParameter<bool>("UseNominalOrbitMessageTime")),
+  expectedOrbitMessageTime_(conf.getParameter<int>("ExpectedOrbitMessageTime"))
 
 {
   if (fedUnpackList_.empty()) {
@@ -78,7 +74,6 @@ void CastorRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   colls.castorCont=&castor;
   if (unpackTTP_) colls.ttp=&ttp;
   colls.tpCont=&htp;
-  //colls.calibCont=&hc;
  
   // Step C: unpack all requested FEDs
   for (std::vector<int>::const_iterator i=fedUnpackList_.begin(); i!=fedUnpackList_.end(); i++) {
@@ -131,13 +126,6 @@ void CastorRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   e.put(castor_prod);
   e.put(htp_prod);
 
-  /// calib
-//  if (unpackCalib_) {
-//    std::auto_ptr<CastorCalibDigiCollection> hc_prod(new CastorCalibDigiCollection());
-//    hc_prod->swap_contents(hc);
-//    hc_prod->sort();
-//    e.put(hc_prod);
-//  }
   if (unpackTTP_) {
     std::auto_ptr<HcalTTPDigiCollection> prod(new HcalTTPDigiCollection());
     prod->swap_contents(ttp);

--- a/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
+++ b/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.cc
@@ -49,8 +49,7 @@ CastorRawToDigi::CastorRawToDigi(edm::ParameterSet const& conf):
   if (unpackTTP_)
     produces<HcalTTPDigiCollection>();
 
-//  if (unpackCalib_)
-//    produces<HcalCalibDigiCollection>();
+  tok_input_ = consumes<FEDRawDataCollection>(dataTag_);
 
 }
 
@@ -62,7 +61,7 @@ void CastorRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
 {
   // Step A: Get Inputs 
   edm::Handle<FEDRawDataCollection> rawraw;  
-  e.getByLabel(dataTag_,rawraw);
+  e.getByToken(tok_input_,rawraw);
   // get the mapping
   edm::ESHandle<CastorDbService> pSetup;
   es.get<CastorDbRecord>().get( pSetup );

--- a/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.h
+++ b/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.h
@@ -41,7 +41,6 @@ private:
   CastorDataFrameFilter filter_;
   std::vector<int> fedUnpackList_;
   int firstFED_;
-  // bool unpackCalib_;
   bool complainEmptyData_;
   bool usingctdc_;
   bool unpackTTP_;

--- a/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.h
+++ b/EventFilter/CastorRawToDigi/plugins/CastorRawToDigi.h
@@ -17,6 +17,7 @@
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -47,6 +48,7 @@ private:
   bool silent_;
   bool usenominalOrbitMessageTime_;
   int expectedOrbitMessageTime_;
+  edm::EDGetTokenT<FEDRawDataCollection> tok_input_;
 
 };
 

--- a/EventFilter/CastorRawToDigi/python/CastorDigiToRaw_cfi.py
+++ b/EventFilter/CastorRawToDigi/python/CastorDigiToRaw_cfi.py
@@ -1,5 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 castorRawData = cms.EDProducer("CastorDigiToRaw",
-    CASTOR = cms.untracked.InputTag("simCastorDigis"),
+    CASTOR = cms.InputTag("simCastorDigis"),
+    CastorCtdc = cms.bool(False)
 )

--- a/EventFilter/CastorRawToDigi/python/CastorRawToDigi_cfi.py
+++ b/EventFilter/CastorRawToDigi/python/CastorRawToDigi_cfi.py
@@ -7,7 +7,7 @@ castorDigis = cms.EDProducer("CastorRawToDigi",
     FilterDataQuality = cms.bool(True),
     # Number of the first CASTOR FED.  If this is not specified, the
     # default from FEDNumbering is used.
-    CastorFirstFED = cms.untracked.int32(690),
+    CastorFirstFED = cms.int32(690),
     # FED numbers to unpack.  If this is not specified, all FEDs from
     # FEDNumbering will be unpacked.
     FEDs = cms.untracked.vint32( 690, 691, 692 ),
@@ -21,9 +21,12 @@ castorDigis = cms.EDProducer("CastorRawToDigi",
     firstSample = cms.int32(0),
     lastSample = cms.int32(9),
     # castor technical trigger processor
-    UnpackTTP = cms.untracked.bool(True),
+    UnpackTTP = cms.bool(True),
     # report errors
     silent = cms.untracked.bool(False),
     #
-    InputLabel = cms.InputTag("rawDataCollector")
+    InputLabel = cms.InputTag("rawDataCollector"),
+    CastorCtdc = cms.bool(False),
+    UseNominalOrbitMessageTime = cms.bool(True),
+    ExpectedOrbitMessageTime = cms.int32(-1)
 )


### PR DESCRIPTION
In addition to the consumes migration, further improvements are done:
- make most important parameters tracked
- remove obsolete parameters
- cleanup of some commented code

Code is quickly tested running full MC chain applying the DigiToRaw and RawToDigi modules, done in CMSSW_7_1_0_pre4.
