### PR TITLE
Ignore new nbinsy warning from ROOT

### DIFF
--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -117,7 +117,8 @@ namespace {
           (el_location.find("THistPainter::PaintInit") != std::string::npos) ||
           (el_location.find("TUnixSystem::SetDisplay") != std::string::npos) ||
           (el_location.find("TGClient::GetFontByName") != std::string::npos) ||
-          (el_message.find("nbins is <=0 - set to nbins = 1") != std::string::npos)) {
+          (el_message.find("nbins is <=0 - set to nbins = 1") != std::string::npos) ||
+          (el_message.find("nbinsy is <=0 - set to nbinsy = 1") != std::string::npos)) {
         el_severity = SeverityLevel::kInfo;
       }
 


### PR DESCRIPTION
ROOT 5.34.17 has added additional warnings which we convert to exceptions. The warning about nbinsy <=0 is irrelevant since ROOT has a reasonable behavior in this case. Therefore, we want to ignore it.
