### PR TITLE
restore class definition using PF information

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -219,7 +219,7 @@ class GsfElectronAlgo {
     void displayInternalElectrons( const std::string & title ) const ;
     void clonePreviousElectrons() ;
     void completeElectrons() ; // do not redo cloned electrons done previously
-    void addPflowInfo() ;
+    void addPflowInfo() ; // now deprecated
     void setAmbiguityData( bool ignoreNotPreselected = true ) ;
     void removeNotPreselectedElectrons() ;
     void removeAmbiguousElectrons() ;

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -875,6 +875,8 @@ void GsfElectronAlgo::clonePreviousElectrons()
    }
  }
 
+
+// now deprecated
 void GsfElectronAlgo::addPflowInfo()
  {
   bool found ;
@@ -1369,16 +1371,24 @@ void GsfElectronAlgo::createElectron()
   if (electronData_->innMom.mag()>0.)
    { ele->setTrackFbrem((electronData_->innMom.mag()-electronData_->outMom.mag())/electronData_->innMom.mag()) ; }
 
+  // the supercluster is the refined one The seed is not necessarily the first cluster
+  // hence the use of the electronCluster
   SuperClusterRef sc = ele->superCluster() ;
   if (!(sc.isNull()))
    {
     CaloClusterPtr cl = ele->electronCluster() ;
     if (sc->clustersSize()>1)
-     { ele->setSuperClusterFbrem( ( sc->energy() - cl->energy() ) / sc->energy() ) ; }
+     { 
+       float pf_fbrem =( sc->energy() - cl->energy() ) / sc->energy();
+       ele->setSuperClusterFbrem( pf_fbrem ) ;
+       ele->setPfSuperClusterFbrem( pf_fbrem) ;
+     }
     else
-     { ele->setSuperClusterFbrem(0) ; }
+      { 
+	ele->setSuperClusterFbrem(0) ; 
+	ele->setPfSuperClusterFbrem(0);
+      }
    }
-
 
   //====================================================
   // classification and corrections
@@ -1386,7 +1396,7 @@ void GsfElectronAlgo::createElectron()
   // classification
   ElectronClassification theClassifier ;
   theClassifier.classify(*ele) ;
-
+  theClassifier.refineWithPflow(*ele) ;
   // ecal energy
   ElectronEnergyCorrector theEnCorrector(generalData_->crackCorrectionFunction) ;
   if (generalData_->strategyCfg.useEcalRegression) // new 


### PR DESCRIPTION
Restore the so-called "Bad-track" class which disappeared during the migration to GED. The electrons which end up in this category were previously in the "showering class". 
The plots below have been made with RelValZEE 710pre3 samples.
The migration from one class to the other can be seen here:
![h_ele_classes](https://f.cloud.github.com/assets/4553043/2421583/bb597660-ab83-11e3-9cf3-117ee1c8fdd6.gif)
(red is new, blue is default 710pre3; the entries <10 are in the barrel; >=10 in the endcaps)

Even though the regression is using the class and was trained before the fix, it seems that it won't be necessary to retrain it. 
![h_ele_poptrue_showering_barrel](https://f.cloud.github.com/assets/4553043/2421607/25bbff6e-ab84-11e3-9b5f-e7bfc004932d.gif)
![h_ele_poptrue_showering_endcaps](https://f.cloud.github.com/assets/4553043/2421608/25bf4106-ab84-11e3-81c9-904d5b30ad93.gif)
The resolution is actually slightly improved. The statistics have decreased between the two cases, which is normal. 

There are no validation plots for the "badTrack" class, but the inclusive plots is essentially unchanged.
![h_ele_poptrue](https://f.cloud.github.com/assets/4553043/2421621/53dcbc9e-ab84-11e3-981c-b0aff2a015e1.gif)
