### PR TITLE
Consumes for csctriggerprimitives

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
@@ -23,8 +23,8 @@
 #include "L1Trigger/CSCCommonTrigger/interface/CSCTriggerGeometry.h"
 #include "CondFormats/DataRecord/interface/CSCBadChambersRcd.h"
 
-#include "DataFormats/CSCDigi/interface/CSCComparatorDigiCollection.h"
-#include "DataFormats/CSCDigi/interface/CSCWireDigiCollection.h"
+//#include "DataFormats/CSCDigi/interface/CSCComparatorDigiCollection.h"
+//#include "DataFormats/CSCDigi/interface/CSCWireDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCALCTDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigiCollection.h"
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigiCollection.h"
@@ -45,6 +45,9 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
   checkBadChambers_ = conf.getUntrackedParameter<bool>("checkBadChambers", true);
 
   lctBuilder_ = new CSCTriggerPrimitivesBuilder(conf); // pass on the conf
+
+  wire_token_ = consumes<CSCWireDigiCollection>(wireDigiProducer_);
+  comp_token_ = consumes<CSCComparatorDigiCollection>(compDigiProducer_);
 
   // register what this produces
   produces<CSCALCTDigiCollection>();
@@ -99,8 +102,10 @@ void CSCTriggerPrimitivesProducer::produce(edm::Event& ev,
   // Get the collections of comparator & wire digis from event.
   edm::Handle<CSCComparatorDigiCollection> compDigis;
   edm::Handle<CSCWireDigiCollection>       wireDigis;
-  ev.getByLabel(compDigiProducer_.label(), compDigiProducer_.instance(), compDigis);
-  ev.getByLabel(wireDigiProducer_.label(), wireDigiProducer_.instance(), wireDigis);
+  //  ev.getByLabel(compDigiProducer_.label(), compDigiProducer_.instance(), compDigis);
+  //  ev.getByLabel(wireDigiProducer_.label(), wireDigiProducer_.instance(), wireDigis);
+  ev.getByToken(comp_token_, compDigis);
+  ev.getByToken(wire_token_, wireDigis);
 
   // Create empty collections of ALCTs, CLCTs, and correlated LCTs upstream
   // and downstream of MPC.

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
@@ -20,6 +20,9 @@
  *
  */
 
+#include "DataFormats/CSCDigi/interface/CSCComparatorDigiCollection.h"
+#include "DataFormats/CSCDigi/interface/CSCWireDigiCollection.h"
+#include <FWCore/Framework/interface/ConsumesCollector.h>
 #include <FWCore/Framework/interface/Frameworkfwd.h>
 #include <FWCore/Framework/interface/one/EDProducer.h>
 #include <FWCore/Framework/interface/Event.h>
@@ -39,9 +42,13 @@ class CSCTriggerPrimitivesProducer : public edm::one::EDProducer<edm::one::Share
 
  private:
   int iev; // event number
+ 
   edm::InputTag compDigiProducer_;
   edm::InputTag wireDigiProducer_;
-  // swich to force the use of parameters from config file rather then from DB
+  edm::EDGetTokenT<CSCComparatorDigiCollection> comp_token_;
+  edm::EDGetTokenT<CSCWireDigiCollection> wire_token_;
+ 
+  // switch to force the use of parameters from config file rather then from DB
   bool debugParameters_;
   // switch to for enabling checking against the list of bad chambers
   bool checkBadChambers_;

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesDQM.h
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesDQM.h
@@ -12,6 +12,7 @@
  *
  */
 
+#include <FWCore/Utilities/interface/EDGetToken.h>
 #include <FWCore/Framework/interface/Frameworkfwd.h>
 #include <FWCore/Framework/interface/EDAnalyzer.h>
 #include <FWCore/Framework/interface/Event.h>
@@ -96,6 +97,19 @@ class CSCTriggerPrimitivesDQM : public edm::EDAnalyzer
   edm::InputTag simHitProducer_;
   edm::InputTag wireDigiProducer_;
   edm::InputTag compDigiProducer_;
+
+  edm::EDGetTokenT<edm::PSimHitContainer> simHit_token_;
+  edm::EDGetTokenT<CSCWireDigiCollection> wireDigi_token_;
+  edm::EDGetTokenT<CSCComparatorDigiCollection> compDigi_token_;
+
+  edm::EDGetTokenT<CSCALCTDigiCollection> alcts_d_token_;
+  edm::EDGetTokenT<CSCCLCTDigiCollection> clcts_d_token_;
+  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> lcts_tmb_d_token_;
+  edm::EDGetTokenT<CSCALCTDigiCollection> alcts_e_token_;
+  edm::EDGetTokenT<CSCCLCTDigiCollection> clcts_e_token_;
+  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> lcts_tmb_e_token_;
+  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> lcts_mpc_e_token_;
+
   std::vector<std::string> bad_chambers;
   std::vector<std::string> bad_wires;
   std::vector<std::string> bad_strips;

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.h
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.h
@@ -11,6 +11,7 @@
  *
  */
 
+#include <FWCore/Utilities/interface/EDGetToken.h>
 #include <FWCore/Framework/interface/Frameworkfwd.h>
 #include <FWCore/Framework/interface/EDAnalyzer.h>
 #include <FWCore/Framework/interface/Event.h>
@@ -91,6 +92,18 @@ class CSCTriggerPrimitivesReader : public edm::EDAnalyzer
   edm::InputTag simHitProducer_;
   edm::InputTag wireDigiProducer_;
   edm::InputTag compDigiProducer_;
+
+  edm::EDGetTokenT<edm::PSimHitContainer> simHit_token_;
+  edm::EDGetTokenT<CSCWireDigiCollection> wireDigi_token_;
+  edm::EDGetTokenT<CSCComparatorDigiCollection> compDigi_token_;
+
+  edm::EDGetTokenT<CSCALCTDigiCollection> alcts_d_token_;
+  edm::EDGetTokenT<CSCCLCTDigiCollection> clcts_d_token_;
+  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> lcts_tmb_d_token_;
+  edm::EDGetTokenT<CSCALCTDigiCollection> alcts_e_token_;
+  edm::EDGetTokenT<CSCCLCTDigiCollection> clcts_e_token_;
+  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> lcts_tmb_e_token_;
+  edm::EDGetTokenT<CSCCorrelatedLCTDigiCollection> lcts_mpc_e_token_;
 
   // a prefix for results ps files
   std::string   resultsFileNamesPrefix_;


### PR DESCRIPTION
This adds the consumes interface to L1Trigger/CSCTriggerPrimitives. Done on behalf of Slave Valuev who doesn't have the time right now. Compiles and builds OK. But untested. Slava will test perhaps next week. 
