### PR TITLE
String returned by value must be stored

### DIFF
--- a/CommonTools/Utils/src/returnType.cc
+++ b/CommonTools/Utils/src/returnType.cc
@@ -38,7 +38,8 @@ namespace reco {
   TypeCode typeCode(const edm::TypeWithDict & t) {
 
     typedef std::pair<const char*const, method::TypeCode> Values;
-    const char* name = t.name().c_str();
+    std::string const theName(t.name());
+    char const* name = theName.c_str();
     auto f = std::equal_range(retTypeVec.begin(),retTypeVec.end(),Values{name,enumType},
                               [] ( Values const& iLHS, Values const& iRHS) -> bool{
        return std::strcmp(iLHS.first,iRHS.first)<0;


### PR DESCRIPTION
This is a fix for a valgrind error discovered by Vincenzo Innocente.  The function TypeWithDict::name() returns a string by value.  A caller of this function, the free function typeCode(), saved the value of the char\* to the embedded C string without saving the string itself.  In those cases where TypeWithDict returns a temporary (as it will when the type is a pointer), the stored char\* gets used after the temporary string is reclaimed.  The fault is in the caller.  This pull request has the caller save the returned string on the stack so that it does not get prematurely reclaimed.
This problem was introduced in 7_0_X.  A separate pull request will be issued for 7_0_X.
