### PR TITLE
GE1/1 geometry customization bugfix

### DIFF
--- a/Geometry/MuonCommonData/data/PhaseII/v2/muonNumbering.xml
+++ b/Geometry/MuonCommonData/data/PhaseII/v2/muonNumbering.xml
@@ -489,7 +489,7 @@
    <Parameter name="CopyNoOffset" value="2*[super]"/>
   </SpecPar>
   <SpecPar name="MuonGEMSector">
-   <PartSelector path="//GEMBox11"/>
+   <PartSelector path="//GEMBox11."/>
    <PartSelector path="//GEMBox21"/>
    <PartSelector path="//GEMBox21L"/>
    <Parameter name="CopyNoTag" value="[mg_sector]"/>

--- a/Geometry/MuonCommonData/data/PhaseII/v3/muonNumbering.xml
+++ b/Geometry/MuonCommonData/data/PhaseII/v3/muonNumbering.xml
@@ -491,7 +491,7 @@
    <Parameter name="CopyNoOffset" value="2*[super]"/>
   </SpecPar>
   <SpecPar name="MuonGEMSector">
-   <PartSelector path="//GEMBox11"/>
+   <PartSelector path="//GEMBox11."/>
    <PartSelector path="//GEMBox21"/>
    <PartSelector path="//GEMBox21L"/>
    <Parameter name="CopyNoTag" value="[mg_sector]"/>

--- a/Geometry/MuonCommonData/data/v2/gem11.xml
+++ b/Geometry/MuonCommonData/data/v2/gem11.xml
@@ -137,7 +137,7 @@
 
   <Trd1 name="GB11" dz="[dzGB11]" dy1="[dyGB11]" dy2="[dyGB11]" dx1="[dxBotGB11]" dx2="[dxTopGB11]" />
   <Trd1 name="GA11" dz="[dzGA11]" dy1="[dyGA11]" dy2="[dyGA11]" dx1="[dxBotGA11]" dx2="[dxTopGA11]" />
-  <UnionSolid name="GEMBox11">
+  <UnionSolid name="GEMBox11S">
     <rSolid name="GB11"/>
     <rSolid name="GA11"/>
     <Translation x="0.0*fm" y="([dyGB11]+[dyGA11])" z="([dzGB11]-[dzGA11])"/>
@@ -214,8 +214,8 @@
     <rSolid name="GE11"/>
     <rMaterial name="materials:ME_free_space"/>
   </LogicalPart>
-  <LogicalPart name="GEMBox11" category="unspecified">
-    <rSolid name="GEMBox11"/>
+  <LogicalPart name="GEMBox11S" category="unspecified">
+    <rSolid name="GEMBox11S"/>
     <rMaterial name="materials:Aluminium"/>
   </LogicalPart>
   <LogicalPart name="GMAX11" category="unspecified">
@@ -446,7 +446,7 @@
     <Translation x="0*fm" y="0*fm" z="5.686*m" />
   </PosPart>
   <PosPart copyNumber="1">
-    <rParent name="gem11:GEMBox11"/>
+    <rParent name="gem11:GEMBox11S"/>
     <rChild name="gem11:GMAX11"/>
     <Translation x="0*fm" y="[ypGM11]" z="0*fm" />
   </PosPart>
@@ -851,7 +851,7 @@
 
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11P"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="2"/>
@@ -864,7 +864,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11P"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="1"/>
@@ -877,7 +877,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11P"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="53"/>
@@ -890,7 +890,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11P"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="52"/>
@@ -903,7 +903,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11N"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="2"/>
@@ -916,7 +916,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11N"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="1"/>
@@ -929,7 +929,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11N"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="53"/>
@@ -942,7 +942,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11N"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="52"/>

--- a/Geometry/MuonCommonData/data/v2/muonGemNumbering.xml
+++ b/Geometry/MuonCommonData/data/v2/muonGemNumbering.xml
@@ -415,12 +415,12 @@
  </SpecParSection>
  <SpecParSection label="muonGEMnumbering" eval="true">
   <SpecPar name="MuonGEMEndcap">
-   <PartSelector path="//GEMDisk.*"/>
+   <PartSelector path="//GEMDisk11.*"/>
    <Parameter name="CopyNoTag" value="[mg_ring]"/>
    <Parameter name="CopyNoOffset" value="1*[super]"/>
   </SpecPar>
   <SpecPar name="MuonGEMSector">
-   <PartSelector path="//GEMBox.*"/>
+   <PartSelector path="//GEMBox11."/>
    <Parameter name="CopyNoTag" value="[mg_sector]"/>
    <Parameter name="CopyNoOffset" value="3*[super]"/>
   </SpecPar>

--- a/Geometry/MuonCommonData/data/v3/gem11.xml
+++ b/Geometry/MuonCommonData/data/v3/gem11.xml
@@ -153,7 +153,7 @@
 
   <Trd1 name="GB11" dz="[dzGB11]" dy1="[dyGB11]" dy2="[dyGB11]" dx1="[dxBotGB11]" dx2="[dxTopGB11]" />
   <Trd1 name="GA11" dz="[dzGA11]" dy1="[dyGA11]" dy2="[dyGA11]" dx1="[dxBotGA11]" dx2="[dxTopGA11]" />
-  <UnionSolid name="GEMBox11">
+  <UnionSolid name="GEMBox11S">
     <rSolid name="GB11"/>
     <rSolid name="GA11"/>
     <Translation x="0.0*fm" y="([dyGB11]+[dyGA11])" z="([dzGB11]-[dzGA11])"/>
@@ -242,8 +242,8 @@
     <rSolid name="GE11"/>
     <rMaterial name="materials:ME_free_space"/>
   </LogicalPart>
-  <LogicalPart name="GEMBox11" category="unspecified">
-    <rSolid name="GEMBox11"/>
+  <LogicalPart name="GEMBox11S" category="unspecified">
+    <rSolid name="GEMBox11S"/>
     <rMaterial name="materials:Aluminium"/>
   </LogicalPart>
   <LogicalPart name="GMAX11" category="unspecified">
@@ -493,7 +493,7 @@
     <Translation x="0*fm" y="0*fm" z="5.686*m" />
   </PosPart>
   <PosPart copyNumber="1">
-    <rParent name="gem11:GEMBox11"/>
+    <rParent name="gem11:GEMBox11S"/>
     <rChild name="gem11:GMAX11"/>
     <Translation x="0*fm" y="[ypGM11]" z="0*fm" />
   </PosPart>
@@ -958,7 +958,7 @@
 
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11P"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="2"/>
@@ -971,7 +971,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11P"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="1"/>
@@ -984,7 +984,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11P"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="53"/>
@@ -997,7 +997,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11P"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="52"/>
@@ -1010,7 +1010,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11N"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="2"/>
@@ -1023,7 +1023,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11N"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="1"/>
@@ -1036,7 +1036,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11N"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="53"/>
@@ -1049,7 +1049,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11N"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="52"/>

--- a/Geometry/MuonCommonData/data/v5/gem11.xml
+++ b/Geometry/MuonCommonData/data/v5/gem11.xml
@@ -145,7 +145,7 @@
 
   <Trd1 name="GB11" dz="[dzGB11]" dy1="[dyGB11]" dy2="[dyGB11]" dx1="[dxBotGB11]" dx2="[dxTopGB11]" />
   <Trd1 name="GA11" dz="[dzGA11]" dy1="[dyGA11]" dy2="[dyGA11]" dx1="[dxBotGA11]" dx2="[dxTopGA11]" />
-  <UnionSolid name="GEMBox11">
+  <UnionSolid name="GEMBox11S">
     <rSolid name="GB11"/>
     <rSolid name="GA11"/>
     <Translation x="0.0*fm" y="([dyGB11]+[dyGA11])" z="([dzGB11]-[dzGA11])"/>
@@ -228,8 +228,8 @@
     <rSolid name="GE11"/>
     <rMaterial name="materials:ME_free_space"/>
   </LogicalPart>
-  <LogicalPart name="GEMBox11" category="unspecified">
-    <rSolid name="GEMBox11"/>
+  <LogicalPart name="GEMBox11S" category="unspecified">
+    <rSolid name="GEMBox11S"/>
     <rMaterial name="materials:Aluminium"/>
   </LogicalPart>
   <LogicalPart name="GMAX11" category="unspecified">
@@ -455,7 +455,7 @@
     <Translation x="0*fm" y="0*fm" z="5.686*m" />
   </PosPart>
   <PosPart copyNumber="1">
-    <rParent name="gem11:GEMBox11"/>
+    <rParent name="gem11:GEMBox11S"/>
     <rChild name="gem11:GMAX11"/>
     <Translation x="0*fm" y="[ypGM11]" z="0*fm" />
   </PosPart>
@@ -890,7 +890,7 @@
 
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11P"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="2"/>
@@ -903,7 +903,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11P"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="1"/>
@@ -916,7 +916,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11P"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="53"/>
@@ -929,7 +929,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11P"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="52"/>
@@ -942,7 +942,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11N"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="2"/>
@@ -955,7 +955,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11N"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="1"/>
@@ -968,7 +968,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11N"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="53"/>
@@ -981,7 +981,7 @@
 </Algorithm>
 <Algorithm name="muon:DDGEMAngular">
     <rParent name="gem11:GEMDisk11N"/>
-    <String name="ChildName" value="GEMBox11"/>
+    <String name="ChildName" value="GEMBox11S"/>
     <String name="RotNameSpace" value="gemf"/>
     <Numeric name="n" value="18"/>
     <Numeric name="startCopyNo" value="52"/>


### PR DESCRIPTION
I noticed that when I tried to run 

<PRE>
cmsDriver.py SingleMuPt100_cfi -s GEN,SIM --conditions auto:upgradePLS3 --magField 38T_PostLS1 --datatier GEN-SIM --geometry Extended2023Muon --customise Geometry/GEMGeometry/gemGeometryCustoms.custom_GE11_9and10partitions_v1 --eventcontent FEVTDEBUG -n 10 --fileout out_sim.root
</PRE>


on a fresh SLHC9 checkout I got this bug

<PRE>
We have determined that this is simulation (if not, rerun cmsDriver.py with --data)
Step: GEN Spec:
Loading generator fragment from Configuration.Generator.SingleMuPt100_cfi
Step: SIM Spec:
Step: ENDJOB Spec:
globaltag = DES23_62_V1::All
customising the process with custom_GE11_9and10partitions_v1 from Geometry/GEMGeometry/gemGeometryCustoms
Starting  cmsRun  SingleMuPt100_cfi_GEN_SIM.py
globaltag = DES23_62_V1::All
271 DQMStore::DQMStore
HcalTopologyIdealEP::HcalTopologyIdealEP
%MSG-e Specific:  OscarProducer:g4SimHits@beginRun 14-Mar-2014 23:44:58 CET  Run: 1
Could not process q-name of a DDLogicalPart, reason:
No regex-match for namespace=  name=GEMBox11

SpecPar selection is:
//GEMBox11

%MSG
%
</PRE>


The GEMBox error message disappears after including the fix. The HFFibre error message still remains though.

<PRE>
[dildick@cmslpc26 src]$ cmsDriver.py SingleMuPt100_cfi -s GEN,SIM --conditions auto:upgradePLS3 --magField 38T_PostLS1 --datatier GEN-SIM --geometry Extended2023Muon --customise Geometry/GEMGeometry/gemGeometryCustoms.custom_GE11_9and10partitions_v1 --eventcontent FEVTDEBUG -n 10 --fileout out_sim.root
GEN,SIM,ENDJOB
We have determined that this is simulation (if not, rerun cmsDriver.py with --data)
Step: GEN Spec: 
Loading generator fragment from Configuration.Generator.SingleMuPt100_cfi
Step: SIM Spec: 
Step: ENDJOB Spec: 
globaltag = DES23_62_V1::All
customising the process with custom_GE11_9and10partitions_v1 from Geometry/GEMGeometry/gemGeometryCustoms
Starting  cmsRun  SingleMuPt100_cfi_GEN_SIM.py
globaltag = DES23_62_V1::All
271 DQMStore::DQMStore 
HcalTopologyIdealEP::HcalTopologyIdealEP
%MSG-e Specific:  OscarProducer:g4SimHits@beginRun 15-Mar-2014 04:02:10 CDT  Run: 1
Could not process q-name of a DDLogicalPart, reason:
No regex-match for namespace=  name=HFFibre.*

SpecPar selection is:
//HFFibre.*

%MSG
Set Driver verbosity to -2
 New QGSP_FTFP_BERT physics list, replaces LEP with FTF/P for p/n/pi (/K?)  Thresholds: 
    1) between BERT  and FTF/P over the interval 6 to 8 GeV. 
    2) between FTF/P and QGS/P over the interval 12 to 25 GeV. 
  -- quasiElastic was asked to be 1
     Changed to 1 for QGS  and to 0 (must be false) for FTF
</PRE>
