### PR TITLE
Fix OverFlow bin in muon isolation histos

### DIFF
--- a/DQMOffline/Muon/src/MuonIsolationDQM.cc
+++ b/DQMOffline/Muon/src/MuonIsolationDQM.cc
@@ -770,19 +770,11 @@ void MuonIsolationDQM::FillHistos(int numPV){
 #ifdef DEBUG
   cout << "FillHistos( "<< numPV <<" )"<< endl;
 #endif  
-  int overFlowBin;
-  double overFlow = 0;
   
   //----------Fill 1D histograms---------------
   for(int var=0; var<NUM_VARS; var++){  
     h_1D[var]->Fill(theData[var]);
     //    cd_plots[var]->Fill(theData[var]);//right now, this is a regular PDF (just like h_1D)
-    if (theData[var] > param[var][2]) {
-      // fill the overflow bin
-      overFlowBin = (int) param[var][0] + 1;
-      overFlow = GetTH1FromMonitorElement(h_1D[var])->GetBinContent(overFlowBin);
-      GetTH1FromMonitorElement(h_1D[var])->SetBinContent(overFlowBin, overFlow + 1);
-    }
   }//Finish 1D
   
   for (int var=0; var<NUM_VARS_2D; var++){


### PR DESCRIPTION
Remove double counting in overflow bin on muon isolation histograms.
