### PR TITLE
Fix provenance of electrons

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronFinalizer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronFinalizer.cc
@@ -17,7 +17,7 @@ using namespace reco;
 GEDGsfElectronFinalizer::GEDGsfElectronFinalizer( const edm::ParameterSet & cfg )
  {   
    previousGsfElectrons_ = consumes<reco::GsfElectronCollection>(cfg.getParameter<edm::InputTag>("previousGsfElectronsTag"));
-   pfCandidates_ = consumes<reco::PFCandidateCollection>(cfg.getParameter<edm::InputTag>("PFCandidatesTag"));
+   pfCandidates_ = consumes<reco::PFCandidateCollection>(cfg.getParameter<edm::InputTag>("pfCandidatesTag"));
    outputCollectionLabel_ = cfg.getParameter<std::string>("outputCollectionLabel");
    edm::ParameterSet pfIsoVals(cfg.getParameter<edm::ParameterSet> ("pfIsolationValues"));
    
@@ -88,7 +88,8 @@ void GEDGsfElectronFinalizer::produce( edm::Event & event, const edm::EventSetup
      newElectron.setPfIsolationVariables(isoVariables);
 
      // now set a status if not already done (in GEDGsfElectronProducer.cc)
-     if(newElectron.mvaOutput().status==0) {
+     std::cout << " previous status " << newElectron.mvaOutput().status << std::endl;
+     if(newElectron.mvaOutput().status<=0) { 
        std::map<reco::GsfTrackRef, const  reco::PFCandidate * >::const_iterator itcheck=gsfPFMap.find(newElectron.gsfTrack());
        reco::GsfElectron::MvaOutput myMvaOutput(newElectron.mvaOutput());
        if(itcheck!=gsfPFMap.end()) {

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronFinalizer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronFinalizer.cc
@@ -69,7 +69,8 @@ void GEDGsfElectronFinalizer::produce( edm::Event & event, const edm::EventSetup
    for(;it!=itend;++it) {
      // First check that the GsfTrack is non null
      if( it->gsfTrackRef().isNonnull()) {
-       gsfPFMap[it->gsfTrackRef()]=&(*it);
+       if(abs(it->pdgId())==11) // consider only the electrons 
+	 gsfPFMap[it->gsfTrackRef()]=&(*it);
      }
    }
 
@@ -88,7 +89,7 @@ void GEDGsfElectronFinalizer::produce( edm::Event & event, const edm::EventSetup
      newElectron.setPfIsolationVariables(isoVariables);
 
      // now set a status if not already done (in GEDGsfElectronProducer.cc)
-     std::cout << " previous status " << newElectron.mvaOutput().status << std::endl;
+     //     std::cout << " previous status " << newElectron.mvaOutput().status << std::endl;
      if(newElectron.mvaOutput().status<=0) { 
        std::map<reco::GsfTrackRef, const  reco::PFCandidate * >::const_iterator itcheck=gsfPFMap.find(newElectron.gsfTrack());
        reco::GsfElectron::MvaOutput myMvaOutput(newElectron.mvaOutput());

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronFinalizer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronFinalizer.h
@@ -1,27 +1,29 @@
 
-#ifndef PFIsolationFiller_h
-#define PFIsolationFiller_h
+#ifndef GEDGsfElectronFinalizer_h
+#define GEDGsfElectronFinalizer_h
 
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 
 #include <string>
 #include <vector>
 
-class PFIsolationFiller : public edm::EDProducer
+class GEDGsfElectronFinalizer : public edm::EDProducer
 {
  public:
-  explicit PFIsolationFiller (const edm::ParameterSet &);
-  ~PFIsolationFiller(); 
+  explicit GEDGsfElectronFinalizer (const edm::ParameterSet &);
+  ~GEDGsfElectronFinalizer(); 
   
   virtual void produce(edm::Event &, const edm::EventSetup&);
 
  private:
   edm::EDGetTokenT<reco::GsfElectronCollection> previousGsfElectrons_;
+  edm::EDGetTokenT<reco::PFCandidateCollection> pfCandidates_;
   std::string outputCollectionLabel_;
   std::vector<edm::EDGetTokenT<edm::ValueMap<double> > > tokenElectronIsoVals_;
   unsigned nDeps_;

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.cc
@@ -125,7 +125,7 @@ void GEDGsfElectronProducer::matchWithPFCandidates(edm::Event & event)
       reco::GsfElectron::MvaOutput myMvaOutput;
       myMvaOutput.mva = it->mva_e_pi();
       // at the moment, undefined
-      myMvaOutput.status = 0;
+      myMvaOutput.status = it->egammaExtraRef()->electronStatus() ;
       gsfMVAOutputMap_[it->gsfTrackRef()] = myMvaOutput;
 
       reco::GsfElectron::MvaInput myMvaInput;

--- a/RecoEgamma/EgammaElectronProducers/plugins/SealModule.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/SealModule.cc
@@ -16,7 +16,7 @@
 
 #include "GEDGsfElectronCoreProducer.h"
 #include "GEDGsfElectronProducer.h"
-#include "PFIsolationFiller.h"
+#include "GEDGsfElectronFinalizer.h"
 
 DEFINE_FWK_MODULE(SiStripElectronProducer);
 DEFINE_FWK_MODULE(SiStripElectronAssociator);
@@ -30,4 +30,4 @@ DEFINE_FWK_MODULE(GsfElectronProducer);
 DEFINE_FWK_MODULE(SiStripElectronSeedProducer);
 DEFINE_FWK_MODULE(GEDGsfElectronCoreProducer);
 DEFINE_FWK_MODULE(GEDGsfElectronProducer);
-DEFINE_FWK_MODULE(PFIsolationFiller);
+DEFINE_FWK_MODULE(GEDGsfElectronFinalizer);

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectronFinalizer_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectronFinalizer_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-gedGsfElectrons = cms.EDProducer("PFIsolationFiller",
+gedGsfElectrons = cms.EDProducer("GEDGsfElectronFinalizer",
                                  previousGsfElectronsTag = cms.InputTag("gedGsfElectronsTmp"),
                                  pfCandidatesTag = cms.InputTag("particleFlowTmp"),
                                  pfIsolationValues = cms.PSet(

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectronFinalizer_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectronFinalizer_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 gedGsfElectrons = cms.EDProducer("PFIsolationFiller",
                                  previousGsfElectronsTag = cms.InputTag("gedGsfElectronsTmp"),
+                                 pfCandidatesTag = cms.InputTag("particleFlowTmp"),
                                  pfIsolationValues = cms.PSet(
                                        pfSumChargedHadronPt = cms.InputTag('gedElPFIsoValueCharged03'),
                                        pfSumPhotonEt = cms.InputTag('gedElPFIsoValueGamma03'),

--- a/RecoEgamma/EgammaElectronProducers/python/pfBasedElectronIso_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/pfBasedElectronIso_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 from CommonTools.ParticleFlow.pfParticleSelection_cff import *
 from RecoEgamma.EgammaElectronProducers.electronPFIsolationDeposits_cff import *
 from RecoEgamma.EgammaElectronProducers.electronPFIsolationValues_cff import *
-from RecoEgamma.EgammaElectronProducers.pfIsolationFiller_cfi import *
+from RecoEgamma.EgammaElectronProducers.gedGsfElectronFinalizer_cfi import *
 
 # The following should be removed up to  <--- when moving to GED only
 pfBasedElectronIsoSequence = cms.Sequence(


### PR DESCRIPTION
Hello

as requested by Lindsey & Daniele, fixed the transmission of the provenance from the PFlow to the GsfElectron (variable MvaOutput.status) The change has been implemented in the producer previously called "PFIsolationFiller" which has been renamed into GEDGsfElectronFinalizer. 
For the time being, the provenance is recomputed by checking the presence of the PFCandidate of type electron with the same GsfTrack. In the future, more information could be provided through the status flag of the PFEgammaExtra. When it is done, the present code will just keep it and no longer recompute it. 

F.
