### PR TITLE
Throw a read error and not a generic error when an LHE read fails

### DIFF
--- a/GeneratorInterface/LHEInterface/src/LHEReader.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEReader.cc
@@ -15,6 +15,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/TimeOfDay.h"
 
 #include "GeneratorInterface/LHEInterface/interface/LHEReader.h"
@@ -53,7 +54,7 @@ class LHEReader::FileSource : public LHEReader::Source {
 			                            IOFlags::OpenRead);
 
 		if (!storage)
-			throw cms::Exception("FileOpenError")
+			throw edm::Exception(edm::errors::FileOpenError)
 				<< "Could not open LHE file \""
 				<< fileURL << "\" for reading"
 				<< std::endl;


### PR DESCRIPTION
Hello,

Not sure how to get this submitted for all the different versions of CMSSW (manually?), but I guess it should be eventually.

When LHE reads fail (which happens a decent bit with xrootd), a generic CMSSW exception is thrown, which causes problems with the job retry mechanism of CRAB3. This fix throws a read error instead, which is on the whitelist of acceptable-to-retry errors.

Thanks!

@bbockelm
