### PR TITLE
Properly get bin edge info from TH2F in PFClient

### DIFF
--- a/DQMOffline/PFTau/plugins/PFClient.cc
+++ b/DQMOffline/PFTau/plugins/PFClient.cc
@@ -133,7 +133,7 @@ void PFClient::createResolutionPlots(std::string& folder, std::string& name) {
     std::string ytit = th->GetYaxis()->GetTitle();
     float* xbins = new float[nbinx+1];
     for (size_t ix = 1; ix < nbinx+1; ++ix) {
-       xbins[ix-1] = th->GetBinLowEdge(ix);
+       xbins[ix-1] = th->GetXaxis()->GetBinLowEdge(ix);
        if (ix == nbinx) xbins[ix] = th->GetXaxis()->GetBinUpEdge(ix);
     }
     std::string tit_new = ";"+xtit+";"+ytit;
@@ -193,7 +193,7 @@ void PFClient::createProjectionPlots(std::string& folder, std::string& name) {
     std::string ytit = th->GetYaxis()->GetTitle();
     float* xbins = new float[nbinx+1];
     for (size_t ix = 1; ix < nbinx+1; ++ix) {
-       xbins[ix-1] = th->GetBinLowEdge(ix);
+       xbins[ix-1] = th->GetXaxis()->GetBinLowEdge(ix);
        if (ix == nbinx) xbins[ix] = th->GetXaxis()->GetBinUpEdge(ix);
     }    
 
@@ -236,7 +236,7 @@ void PFClient::createProfilePlots(std::string& folder, std::string& name) {
     std::string ytit = th->GetYaxis()->GetTitle();
     double* xbins = new double[nbinx+1];
     for (size_t ix = 1; ix < nbinx+1; ++ix) {
-       xbins[ix-1] = th->GetBinLowEdge(ix);
+       xbins[ix-1] = th->GetXaxis()->GetBinLowEdge(ix);
        if (ix == nbinx) xbins[ix] = th->GetXaxis()->GetBinUpEdge(ix);
     }    
 


### PR DESCRIPTION
ROOT 5.34.17 gives an error (which is converted to an exception) if
GetBinLowEdge called directly on a TH2F. The correct way is to call
that method on the result of TH2F::GetXaxis().
