### PR TITLE
Avoid segfault in relval 50102 for gcc4.9.0

### DIFF
--- a/DQMOffline/Trigger/src/TopSingleLeptonHLTOfflineDQM.cc
+++ b/DQMOffline/Trigger/src/TopSingleLeptonHLTOfflineDQM.cc
@@ -18,6 +18,8 @@
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
+#include <cassert>
+
 /*Originally from DQM/Physics by R. Wolf and J. Andrea*/
 using namespace std;
 namespace HLTOfflineDQMTopSingleLepton {
@@ -514,6 +516,10 @@ namespace HLTOfflineDQMTopSingleLepton {
         unsigned int kElec=0;
         unsigned int kMuon=0;
         unsigned int kJet=0;
+        // FIXME: This assert is needed to avoid a segfault when moduleIndex is >= the size of moduleLabels.
+        // This does happen in relval 50102 for gcc4.9.0, and the problem needs to be fixed.
+        // The assert does not fire for gcc4.8.1. The difference is not understood.
+        assert(moduleIndex < moduleLabels.size());
         for (unsigned int k=0; k<=moduleIndex; ++k) {
           const string& moduleLabel(moduleLabels[k]);
           const string  moduleType(hltConfig.moduleType(moduleLabel));


### PR DESCRIPTION
Relval test 50102 segfaults in gcc4.9.0 IB's.  This segfault was traced to DQMOffline/Trigger/src/TopSingleLeptonHLTOfflineDQM.cc, where a vector subscript is way out of bounds (not an off-by-one error).
This pull request simply adds an assert to check for this and avoid the segfault.  It is up to the package owners to fix the underlying problem.
Note that there is no segfault in relval 50102 in gcc4.8.1 IB's. Also, this assert does not fire in relval 50102 in gcc4.8.1 IB's.  I did not investigate the difference.  But again, the package owners need to diagnose and fix the problem before there can be releases using gcc4.9.0.
