### PR TITLE
Make DTRecoUncertainties Boost-serializable

### DIFF
--- a/CondFormats/DTObjects/interface/DTRecoUncertainties.h
+++ b/CondFormats/DTObjects/interface/DTRecoUncertainties.h
@@ -8,6 +8,8 @@
  */
 
 
+#include "CondFormats/Serialization/interface/Serializable.h"
+
 #include <map>
 #include <vector>
 #include <string>
@@ -54,6 +56,7 @@ private:
   
   int theVersion;
 
+  COND_SERIALIZABLE;
 };
 #endif
 

--- a/CondFormats/DTObjects/src/Serialization.cc
+++ b/CondFormats/DTObjects/src/Serialization.cc
@@ -247,6 +247,14 @@ void DTReadOutMapping::serialize(Archive & ar, const unsigned int)
 COND_SERIALIZATION_INSTANTIATE(DTReadOutMapping);
 
 template <class Archive>
+void DTRecoUncertainties::serialize(Archive & ar, const unsigned int)
+{
+    ar & BOOST_SERIALIZATION_NVP(payload);
+    ar & BOOST_SERIALIZATION_NVP(theVersion);
+}
+COND_SERIALIZATION_INSTANTIATE(DTRecoUncertainties);
+
+template <class Archive>
 void DTStatusFlag::serialize(Archive & ar, const unsigned int)
 {
     ar & BOOST_SERIALIZATION_NVP(dataVersion);

--- a/CondFormats/DTObjects/src/headers.h
+++ b/CondFormats/DTObjects/src/headers.h
@@ -26,3 +26,4 @@
 #include "CondFormats/DTObjects/interface/DTCCBConfig.h"
 #include "CondFormats/DTObjects/interface/DTKeyedConfig.h"
 #include "CondFormats/DTObjects/interface/DTTPGParameters.h"
+#include "CondFormats/DTObjects/interface/DTRecoUncertainties.h"

--- a/CondFormats/DTObjects/test/testSerializationDTObjects.cpp
+++ b/CondFormats/DTObjects/test/testSerializationDTObjects.cpp
@@ -29,6 +29,7 @@ int main()
     testSerialization<DTRangeT0Id>();
     testSerialization<DTReadOutGeometryLink>();
     testSerialization<DTReadOutMapping>();
+    testSerialization<DTRecoUncertainties>();
     testSerialization<DTStatusFlag>();
     testSerialization<DTStatusFlagData>();
     testSerialization<DTStatusFlagId>();


### PR DESCRIPTION
Required due to the merge of #2835.
