### PR TITLE
Added the possibility to configure APVCyclePhaseProducerFromL1TS with a DB object

### DIFF
--- a/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondDBWriter.h
+++ b/CalibTracker/SiStripESProducers/plugins/DBWriter/DummyCondDBWriter.h
@@ -48,6 +48,7 @@ template< typename TObject , typename TObjectO ,typename TRecord >
 void DummyCondDBWriter<TObject,TObjectO,TRecord>::endRun(const edm::Run & run, const edm::EventSetup & es){
 
   std::string rcdName=iConfig_.getParameter<std::string>("record");
+  std::string labelName=iConfig_.getUntrackedParameter<std::string>("label","");
 
   if( cacheID == es.get<TRecord>().cacheIdentifier()){
       edm::LogInfo("DummyCondDBWriter") << "not needed to store objects with Record "<< rcdName << " at run " << run.run() << std::endl;    return;
@@ -55,7 +56,7 @@ void DummyCondDBWriter<TObject,TObjectO,TRecord>::endRun(const edm::Run & run, c
   cacheID = es.get<TRecord>().cacheIdentifier();
 
   edm::ESHandle<TObject> esobj;
-  es.get<TRecord>().get( esobj );
+  es.get<TRecord>().get( labelName, esobj );
   TObjectO *obj= new TObjectO(*(esobj.product()));
   cond::Time_t Time_;  
   

--- a/CalibTracker/SiStripESProducers/src/SiStripConfObjectGenerator.cc
+++ b/CalibTracker/SiStripESProducers/src/SiStripConfObjectGenerator.cc
@@ -24,8 +24,17 @@ SiStripConfObject* SiStripConfObjectGenerator::createObject()
     else if( parIt->getParameter<std::string>("ParameterType") == "double" ) {
       obj->put(parIt->getParameter<std::string>("ParameterName"), parIt->getParameter<double>("ParameterValue"));
     }
-    if( parIt->getParameter<std::string>("ParameterType") == "string" ) {
+    else if( parIt->getParameter<std::string>("ParameterType") == "string" ) {
       obj->put(parIt->getParameter<std::string>("ParameterName"), parIt->getParameter<std::string>("ParameterValue"));
+    }
+    else if( parIt->getParameter<std::string>("ParameterType") == "bool" ) {
+      obj->put(parIt->getParameter<std::string>("ParameterName"), parIt->getParameter<bool>("ParameterValue"));
+    }
+    else if( parIt->getParameter<std::string>("ParameterType") == "vint32" ) {
+      obj->put(parIt->getParameter<std::string>("ParameterName"), parIt->getParameter<std::vector<int> >("ParameterValue"));
+    }
+    else if( parIt->getParameter<std::string>("ParameterType") == "vstring" ) {
+      obj->put(parIt->getParameter<std::string>("ParameterName"), parIt->getParameter<std::vector<std::string> >("ParameterValue"));
     }
   }
   return obj;

--- a/CondFormats/SiStripObjects/interface/SiStripConfObject.h
+++ b/CondFormats/SiStripObjects/interface/SiStripConfObject.h
@@ -38,6 +38,7 @@ class SiStripConfObject
     return false;
   }
 
+
   /// Updating the value stored as 'name' with 'inputValue'. 
   /// False if parameter 'name' does not exist (and nothing is done then - use put(..) instead!),
   /// otherwise true.
@@ -73,6 +74,7 @@ class SiStripConfObject
     return returnValue;
   }
 
+
   bool isParameter( const std::string & name ) const
   {
     return( parameters.find(name) != parameters.end() );
@@ -87,5 +89,19 @@ class SiStripConfObject
 
   parMap parameters;
 };
+
+template <>
+bool SiStripConfObject::put<std::vector<int> >( const std::string & name, const std::vector<int> & inputValue );
+template <>
+bool SiStripConfObject::update<std::vector<int> >( const std::string & name, const std::vector<int> & inputValue );
+template <>
+std::vector<int> SiStripConfObject::get<std::vector<int> >( const std::string & name ) const;
+template <>
+bool SiStripConfObject::put<std::vector<std::string> >( const std::string & name, const std::vector<std::string> & inputValue );
+template <>
+bool SiStripConfObject::update<std::vector<std::string> >( const std::string & name, const std::vector<std::string> & inputValue );
+template <>
+std::vector<std::string> SiStripConfObject::get<std::vector<std::string> >( const std::string & name ) const;
+
 
 #endif

--- a/CondFormats/SiStripObjects/src/SiStripConfObject.cc
+++ b/CondFormats/SiStripObjects/src/SiStripConfObject.cc
@@ -1,5 +1,98 @@
 #include "CondFormats/SiStripObjects/interface/SiStripConfObject.h"
 
+template <>
+bool SiStripConfObject::put<std::vector<int> >( const std::string & name, const std::vector<int> & inputValue )
+{
+  std::stringstream ss;
+  for(std::vector<int>::const_iterator elem=inputValue.begin();elem!=inputValue.end();++elem) {
+    ss << *elem << " ";
+  }
+  if( parameters.insert(std::make_pair(name, ss.str())).second ) return true;
+  return false;
+}
+
+template <>
+bool SiStripConfObject::update<std::vector<int> >( const std::string & name, const std::vector<int> & inputValue )
+{
+  parMap::iterator it = parameters.find(name);
+  if (it == parameters.end()) {
+    std::cout << "WARNING in SiStripConfObject::update: parameter " << name << " not found, "
+	      << "so cannot be updated to the vector of int of size'" << inputValue.size() << "'." << std::endl;
+    return false;
+  } else {
+    std::stringstream ss;
+    for(std::vector<int>::const_iterator elem=inputValue.begin();elem!=inputValue.end();++elem) {
+      ss << *elem << " ";
+    }
+    it->second = ss.str();
+    return true;
+  }
+}
+
+template <>
+std::vector<int> SiStripConfObject::get<std::vector<int> >( const std::string & name ) const
+{
+  std::vector<int> returnValue;
+  parMap::const_iterator it = parameters.find(name);
+  std::stringstream ss;
+  if( it != parameters.end() ) {
+    ss << it->second;
+    int elem;
+    while(ss >> elem) returnValue.push_back(elem);
+  }
+  else {
+    std::cout << "WARNING: parameter " << name << " not found. Returning default value" << std::endl;
+  }
+  return returnValue;
+}
+
+template <>
+bool SiStripConfObject::put<std::vector<std::string> >( const std::string & name, const std::vector<std::string> & inputValue )
+{
+  std::stringstream ss;
+  for(std::vector<std::string>::const_iterator elem=inputValue.begin();elem!=inputValue.end();++elem) {
+    ss << *elem << " ";
+  }
+  if( parameters.insert(std::make_pair(name, ss.str())).second ) return true;
+  return false;
+}
+
+template <>
+bool SiStripConfObject::update<std::vector<std::string> >( const std::string & name, const std::vector<std::string> & inputValue )
+{
+  parMap::iterator it = parameters.find(name);
+  if (it == parameters.end()) {
+    std::cout << "WARNING in SiStripConfObject::update: parameter " << name << " not found, "
+	      << "so cannot be updated to the vector of std::string of size'" << inputValue.size() << "'." << std::endl;
+    return false;
+  } else {
+    std::stringstream ss;
+    for(std::vector<std::string>::const_iterator elem=inputValue.begin();elem!=inputValue.end();++elem) {
+      ss << *elem << " ";
+    }
+    it->second = ss.str();
+    return true;
+  }
+}
+
+template <>
+std::vector<std::string> SiStripConfObject::get<std::vector<std::string> >( const std::string & name ) const
+{
+  std::vector<std::string> returnValue;
+  parMap::const_iterator it = parameters.find(name);
+  std::stringstream ss;
+  if( it != parameters.end() ) {
+    ss << it->second;
+    std::string elem;
+    while(ss >> elem) returnValue.push_back(elem);
+  }
+  else {
+    std::cout << "WARNING: parameter " << name << " not found. Returning default value" << std::endl;
+  }
+  return returnValue;
+}
+
+
 void SiStripConfObject::printSummary(std::stringstream & ss) const
 {
   parMap::const_iterator it = parameters.begin();

--- a/DPGAnalysis/SiStripTools/plugins/BuildFile.xml
+++ b/DPGAnalysis/SiStripTools/plugins/BuildFile.xml
@@ -8,6 +8,8 @@
 <use   name="FWCore/Utilities"/>
 <use   name="CommonTools/Utils"/>
 <use   name="CommonTools/UtilAlgos"/>
+<use   name="CondFormats/SiStripObjects"/>
+<use   name="CondFormats/DataRecords"/>
 <use   name="DataFormats/SiStripDigi"/>
 <use   name="DataFormats/SiStripCluster"/>
 <use   name="DataFormats/SiPixelCluster"/>

--- a/DPGAnalysis/SiStripTools/python/SiStripConfObjectAPVPhaseOffsetsFakeESSource_cfi.py
+++ b/DPGAnalysis/SiStripTools/python/SiStripConfObjectAPVPhaseOffsetsFakeESSource_cfi.py
@@ -1,0 +1,38 @@
+import FWCore.ParameterSet.Config as cms
+
+from CalibTracker.SiStripESProducers.services.SiStripConfObjectGeneratorService_cfi import *
+
+SiStripConfObjectGenerator.Parameters = cms.VPSet(
+    cms.PSet(
+        ParameterName = cms.string("defaultPartitionNames"),
+        ParameterType = cms.string("vstring"),
+        ParameterValue = cms.vstring("TI","TO","TP","TM"),
+    ),
+    cms.PSet(
+        ParameterName = cms.string("defaultPhases"),
+        ParameterType = cms.string("vint32"),
+        ParameterValue = cms.vint32(48,48,48,48),
+    ),
+    cms.PSet(
+        ParameterName = cms.string("useEC0"),
+        ParameterType = cms.string("bool"),
+        ParameterValue = cms.bool(False),
+    ),
+    cms.PSet(
+        ParameterName = cms.string("badRun"),
+        ParameterType = cms.string("bool"),
+        ParameterValue = cms.bool(False),
+    ),
+    cms.PSet(
+        ParameterName = cms.string("magicOffset"),
+        ParameterType = cms.string("int"),
+        ParameterValue = cms.int32(11),
+    ),
+)
+
+siStripConfObjectAPVPhaseOffsetsFakeESSource = cms.ESSource("SiStripConfObjectFakeESSource",
+                                                            appendToDataLabel = cms.string('apvphaseoffsets')
+                                                            )
+
+
+

--- a/DPGAnalysis/SiStripTools/python/apvcyclephaseproducerfroml1ts2011_cfi.py
+++ b/DPGAnalysis/SiStripTools/python/apvcyclephaseproducerfroml1ts2011_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 APVPhases = cms.EDProducer('APVCyclePhaseProducerFromL1TS',
+                           ignoreDB = cms.untracked.bool(True),
                            defaultPartitionNames = cms.vstring("TI",
                                                                "TO",
                                                                "TP",

--- a/DPGAnalysis/SiStripTools/python/apvcyclephaseproducerfroml1ts2013_cfi.py
+++ b/DPGAnalysis/SiStripTools/python/apvcyclephaseproducerfroml1ts2013_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 APVPhases = cms.EDProducer('APVCyclePhaseProducerFromL1TS',
+                           ignoreDB = cms.untracked.bool(True),
                            defaultPartitionNames = cms.vstring("TI",
                                                                "TO",
                                                                "TP",

--- a/DPGAnalysis/SiStripTools/python/apvcyclephaseproducerfroml1tsDB_cfi.py
+++ b/DPGAnalysis/SiStripTools/python/apvcyclephaseproducerfroml1tsDB_cfi.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 APVPhases = cms.EDProducer('APVCyclePhaseProducerFromL1TS',
-                           ignoreDB = cms.untracked.bool(True),
                            defaultPartitionNames = cms.vstring("TI",
                                                                "TO",
                                                                "TP",

--- a/DPGAnalysis/SiStripTools/python/apvcyclephaseproducerfroml1ts_cfi.py
+++ b/DPGAnalysis/SiStripTools/python/apvcyclephaseproducerfroml1ts_cfi.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 APVPhases = cms.EDProducer('APVCyclePhaseProducerFromL1TS',
+                           ignoreDB = cms.untracked.bool(True),
                            defaultPartitionNames = cms.vstring("TI",
                                                                "TO",
                                                                "TP",

--- a/DPGAnalysis/SiStripTools/test/CondDBWriter_SiStripConfObjectAPVPhaseOffsets_cfg.py
+++ b/DPGAnalysis/SiStripTools/test/CondDBWriter_SiStripConfObjectAPVPhaseOffsets_cfg.py
@@ -1,0 +1,50 @@
+# The following comments couldn't be translated into the new config version:
+
+# upload to database 
+
+#string timetype = "timestamp"    
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("CondDBWriterAPVPhaseOffsets")
+
+process.MessageLogger = cms.Service(
+    "MessageLogger",
+    debugModules = cms.untracked.vstring('siStripConfObjectDummyDBWriter'),
+    threshold = cms.untracked.string('INFO'),
+    destinations = cms.untracked.vstring('ConfObjectBuilder.log')
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+process.source = cms.Source("EmptySource",
+    numberEventsInRun = cms.untracked.uint32(1),
+    firstRun = cms.untracked.uint32(1),
+)
+
+process.load("DPGAnalysis.SiStripTools.SiStripConfObjectAPVPhaseOffsetsFakeESSource_cfi")
+process.load("CalibTracker.SiStripESProducers.DBWriter.SiStripConfObjectDummyDBWriter_cfi")
+
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+    DBParameters = cms.PSet(
+        messageLevel = cms.untracked.int32(2),
+        authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
+    ),
+    timetype = cms.untracked.string('runnumber'),
+    connect = cms.string('sqlite_file:apvphaseoffsets.db'),
+    toPut = cms.VPSet(cms.PSet(
+        record = cms.string('SiStripConfObjectRcd'),
+        tag = cms.string('SiStripAPVPhaseOffsets_real_v1')
+    ))
+)
+
+process.siStripConfObjectDummyDBWriter.record=process.PoolDBOutputService.toPut[0].record 
+process.siStripConfObjectDummyDBWriter.label=cms.untracked.string("apvphaseoffsets")
+
+# This specifies the IOV, not the EmptySource (to see why look at the DummyDBWriter code)
+process.siStripConfObjectDummyDBWriter.OpenIovAt = ""
+process.siStripConfObjectDummyDBWriter.OpenIovAtTime = 206510
+
+process.p1 = cms.Path(process.siStripConfObjectDummyDBWriter)

--- a/DPGAnalysis/SiStripTools/test/apvcyclephaseproducer_test_dbfile_cfg.py
+++ b/DPGAnalysis/SiStripTools/test/apvcyclephaseproducer_test_dbfile_cfg.py
@@ -1,0 +1,79 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("APVCyclePhaseProducerTestDBfile")
+
+process.load("FWCore.MessageService.MessageLogger_cfi")
+
+process.MessageLogger.infos.placeholder = cms.untracked.bool(False)
+process.MessageLogger.infos.threshold = cms.untracked.string("INFO")
+process.MessageLogger.infos.default = cms.untracked.PSet(
+    limit = cms.untracked.int32(10000000)
+    )
+process.MessageLogger.infos.FwkReport = cms.untracked.PSet(
+    reportEvery = cms.untracked.int32(10000)
+    )
+process.MessageLogger.cerr.threshold = cms.untracked.string("WARNING")
+
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+
+process.source = cms.Source("PoolSource",
+                    fileNames = cms.untracked.vstring(
+        "/store/data/Run2012A/Jet/RAW/v1/000/191/226/0AFA4854-0986-E111-881D-5404A640A639.root",
+        "/store/data/Run2012A/SingleElectron/RAW/v1/000/193/621/B2087C58-9F98-E111-90BD-002481E0D646.root",
+        "/store/data/Run2012A/SingleElectron/RAW/v1/000/193/648/9AEA9A92-F498-E111-98EB-001D09F23A20.root",
+        "/store/data/Run2012C/MinimumBias/RAW/v1/000/199/812/007E76FB-9ED8-E111-8986-003048D2BE12.root",
+        "/store/data/Run2012C/MinimumBias2/RAW/v1/000/198/603/346E0D4C-6FCA-E111-AE04-002481E0D958.root",
+        "/store/data/Run2012C/MinimumBias/RAW/v1/000/203/002/50D2F56A-5700-E211-9636-5404A63886AE.root",
+        "/store/data/Run2012D/MinimumBias/RAW/v1/000/207/454/0428CA7D-B830-E211-8481-485B3977172C.root",
+        "/store/data/Commissioning2013/Cosmics/RAW/v1/00000/74845390-8D47-E311-9701-003048CFB390.root"
+#        "/store/data/Commissioning2013/Cosmics/RAW/v1/00000/007C8D94-9A46-E311-9596-003048F0E594.root",
+#        "/store/data/Commissioning2013/Cosmics/RAW/v1/00000/06631F08-9A45-E311-9BFD-003048F17496.root"
+),
+#                    skipBadFiles = cms.untracked.bool(True),
+                    inputCommands = cms.untracked.vstring("keep *", "drop *_MEtoEDMConverter_*_*")
+                    )
+
+
+#process.source = cms.Source("EmptySource",
+#                            firstRun = cms.untracked.uint32(216322),
+#                            numberEventsInRun = cms.untracked.uint32(10)
+#                            )
+
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.GlobalTag.globaltag = "GR_R_70_V1::All"
+#-------------------------------------------------------------------------
+process.poolDBESSource = cms.ESSource("PoolDBESSource",
+   BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService'),
+   DBParameters = cms.PSet(
+        messageLevel = cms.untracked.int32(1),
+        authenticationPath = cms.untracked.string('/afs/cern.ch/cms/DB/conddb')
+    ),
+    timetype = cms.untracked.string('runnumber'),
+    connect = cms.string('sqlite_file:apvphaseoffsets.db'),
+    appendToDataLabel = cms.string("apvphaseoffsets"),
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string('SiStripConfObjectRcd'),
+        tag = cms.string('SiStripAPVPhaseOffsets_real_v1')
+    ))
+)
+#-------------------------------------------------------------------------
+
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.Reconstruction_cff")
+
+#process.load("DPGAnalysis.SiStripTools.configurableapvcyclephaseproducer_GR09_withdefault_cff")
+process.load("DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1tsDB_cfi")
+
+#process.APVPhases.ignoreDB = cms.untracked.bool(True)
+
+process.load("DPGAnalysis.SiStripTools.apvcyclephasemonitor_cfi")
+
+process.TFileService = cms.Service('TFileService',
+                                   fileName = cms.string('apvcyclephaseproducer_test_dbfile.root')
+                                   )
+
+process.p0 = cms.Path(process.scalersRawToDigi + process.APVPhases +
+                      process.apvcyclephasemonitor )
+

--- a/DPGAnalysis/SiStripTools/test/apvcyclephaseproducer_test_fakesource_cfg.py
+++ b/DPGAnalysis/SiStripTools/test/apvcyclephaseproducer_test_fakesource_cfg.py
@@ -14,17 +14,36 @@ process.MessageLogger.infos.FwkReport = cms.untracked.PSet(
     )
 process.MessageLogger.cerr.threshold = cms.untracked.string("WARNING")
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(40) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(10) )
 
-process.source = cms.Source("EmptySource",
-                            firstRun = cms.untracked.uint32(70414),
-                            numberEventsInRun = cms.untracked.uint32(10)
-                            )
+process.source = cms.Source("PoolSource",
+                    fileNames = cms.untracked.vstring("/store/data/Commissioning2013/Cosmics/RAW/v1/00000/007C8D94-9A46-E311-9596-003048F0E594.root",
+                                                      "/store/data/Commissioning2013/Cosmics/RAW/v1/00000/06631F08-9A45-E311-9BFD-003048F17496.root"
+),
+#                    skipBadFiles = cms.untracked.bool(True),
+                    inputCommands = cms.untracked.vstring("keep *", "drop *_MEtoEDMConverter_*_*")
+                    )
 
+
+#process.source = cms.Source("EmptySource",
+#                            firstRun = cms.untracked.uint32(216322),
+#                            numberEventsInRun = cms.untracked.uint32(10)
+#                            )
+
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.GlobalTag.globaltag = "GR_R_70_V1::All"
+#-------------------------------------------------------------------------
+process.load("DPGAnalysis.SiStripTools.SiStripConfObjectAPVPhaseOffsetsFakeESSource_cfi")
 #-------------------------------------------------------------------------
 
+process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
+process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
+process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.Reconstruction_cff")
+
 #process.load("DPGAnalysis.SiStripTools.configurableapvcyclephaseproducer_GR09_withdefault_cff")
-process.load("DPGAnalysis.SiStripTools.configurableapvcyclephaseproducer_CRAFT08_cfi")
+process.load("DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1tsDB_cfi")
+#process.APVPhases.recordLabel = cms.untracked.string("")
 
 process.load("DPGAnalysis.SiStripTools.apvcyclephasemonitor_cfi")
 
@@ -32,6 +51,6 @@ process.TFileService = cms.Service('TFileService',
                                    fileName = cms.string('apvcyclephaseproducer_test_fakesource.root')
                                    )
 
-process.p0 = cms.Path(process.APVPhases +
+process.p0 = cms.Path(process.scalersRawToDigi + process.APVPhases +
                       process.apvcyclephasemonitor )
 

--- a/DPGAnalysis/SiStripTools/test/apvphaseproducertest_cfg.py
+++ b/DPGAnalysis/SiStripTools/test/apvphaseproducertest_cfg.py
@@ -86,9 +86,10 @@ process.load("DPGAnalysis.SiStripTools.eventwithhistoryproducerfroml1abc_cfi")
 
 #process.load("DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1ts_cfi")
 
-import DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1ts2011_cfi 
+import DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1tsDB_cfi 
+process.APVPhases = DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1tsDB_cfi.APVPhases 
+#import DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1ts2011_cfi 
 #process.APVPhases2011 = DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1ts2011_cfi.APVPhases 
-process.APVPhases = DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1ts2011_cfi.APVPhases 
 #import DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1ts2010_cfi 
 #process.APVPhases2010 = DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1ts2010_cfi.APVPhases 
 

--- a/DPGAnalysis/SiStripTools/test/apvshotanalyzer_cfg.py
+++ b/DPGAnalysis/SiStripTools/test/apvshotanalyzer_cfg.py
@@ -62,7 +62,7 @@ process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.froml1abcHEs = cms.EDProducer("EventWithHistoryProducerFromL1ABC",
                                       l1ABCCollection=cms.InputTag("scalersRawToDigi")
                                       )
-process.load("DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1ts2011_cfi")
+process.load("DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1tsDB_cfi")
 process.load("DPGAnalysis.SiStripTools.eventtimedistribution_cfi")
 process.eventtimedistribution.historyProduct = cms.InputTag("froml1abcHEs")
 

--- a/DPGAnalysis/SiStripTools/test/eventwithhistoryfiltertest_cfg.py
+++ b/DPGAnalysis/SiStripTools/test/eventwithhistoryfiltertest_cfg.py
@@ -77,7 +77,7 @@ process.source.fileNames = cms.untracked.vstring(options.inputFiles)
 
 process.load("DPGAnalysis.SiStripTools.eventwithhistoryproducerfroml1abc_cfi")
 
-process.load("DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1ts2011_cfi")
+process.load("DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1tsDB_cfi")
 
 process.load("DPGAnalysis.SiStripTools.filters.Potential_TIBTEC_HugeEvents_AlCaReco_cfi")
 

--- a/DPGAnalysis/SiStripTools/test/manyfederrors_cfg.py
+++ b/DPGAnalysis/SiStripTools/test/manyfederrors_cfg.py
@@ -62,7 +62,7 @@ process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.froml1abcHEs = cms.EDProducer("EventWithHistoryProducerFromL1ABC",
                                       l1ABCCollection=cms.InputTag("scalersRawToDigi")
                                       )
-process.load("DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1ts2011_cfi")
+process.load("DPGAnalysis.SiStripTools.apvcyclephaseproducerfroml1tsDB_cfi")
 process.APVPhases.wantHistos = cms.untracked.bool(True)
 
 process.load("DPGAnalysis.SiStripTools.eventtimedistribution_cfi")


### PR DESCRIPTION
This pull request requires a new tag in the Global Tag to work properly. ALCA managers are informed. The tag will be needed for sure when the clients of the EDProducer APVCyclePhaseProducerFromL1TS will switch to the new configuration which uses the DB input to configure it.
