### PR TITLE
Remove TYPELOOKUP_DATA_REG(SeedingLayerSetsBuilder)

### DIFF
--- a/RecoTracker/TkSeedingLayers/src/module.cc
+++ b/RecoTracker/TkSeedingLayers/src/module.cc
@@ -1,9 +1,0 @@
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/ModuleFactory.h"
-#include "FWCore/Framework/interface/ESProducer.h"
-#include "FWCore/Utilities/interface/typelookup.h"
-#include "RecoTracker/TkSeedingLayers/interface/SeedingLayerSetsBuilder.h"
-
-TYPELOOKUP_DATA_REG(SeedingLayerSetsBuilder);
-


### PR DESCRIPTION
Leftover from #2378, I forgot to remove the use of this macro when the SeedingLayersESProducer was removed.

@Dr15Jones This should remove SeedingLayerSetsBuilder from your list of thread-unsafe ES products (as it is not such anymore)
