### PR TITLE
Array and class version fixes

### DIFF
--- a/CondCore/ORA/src/InlineCArrayStreamer.cc
+++ b/CondCore/ORA/src/InlineCArrayStreamer.cc
@@ -32,7 +32,7 @@ bool ora::InlineCArrayStreamerBase::buildDataElement(DataElement& dataElement,
                     "InlineCArrayStreamerBase::buildDataElement" );
   }
   // Loop over the elements of the array.
-  for ( unsigned int i=0;i<m_objectType.arrayLength();i++){
+  for ( size_t i=0;i<m_objectType.maximumIndex(0U);++i){
 
     // Form the element name
     std::string arrayElementLabel = MappingRules::variableNameForArrayIndex( m_mapping.variableName(),i);

--- a/DataFormats/DetId/src/classes_def.xml
+++ b/DataFormats/DetId/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-  <class name="DetId" ClassVersion="10">
+  <class name="DetId" ClassVersion="11">
+   <version ClassVersion="11" checksum="9999999999"/>
    <version ClassVersion="10" checksum="1024501242"/>
   </class>
   <class name="std::vector<DetId>"/>

--- a/DataFormats/L1GlobalTrigger/src/classes_def.xml
+++ b/DataFormats/L1GlobalTrigger/src/classes_def.xml
@@ -100,7 +100,8 @@
   </class>
   <class name="std::vector<L1GtLogicParser::OperandToken> "/>
 
-  <class name="L1GtLogicParser::TokenRPN" ClassVersion="10">
+  <class name="L1GtLogicParser::TokenRPN" ClassVersion="11">
+   <version ClassVersion="11" checksum="999999999"/>
    <version ClassVersion="10" checksum="535147936"/>
   </class>
   <class name="std::vector<L1GtLogicParser::TokenRPN> "/>

--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -92,6 +92,8 @@ public:
   std::string templateName() const;
   size_t size() const;
   size_t arrayLength() const;
+  size_t arrayDimension() const;
+  size_t maximumIndex(size_t dim) const;
   size_t dataMemberSize() const;
   size_t functionMemberSize() const;
   MemberWithDict dataMemberByName(std::string const&) const;

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -443,6 +443,22 @@ namespace edm {
   }
 
   size_t
+  TypeWithDict::arrayDimension() const {
+    if (type_ == nullptr) {
+      return 0;
+    }
+    return gInterpreter->Type_ArrayDim(type_);
+  }
+
+  size_t
+  TypeWithDict::maximumIndex(size_t dim) const {
+    if (type_ == nullptr) {
+      return 0;
+    }
+    return gInterpreter->Type_MaxIndex(type_, dim);
+  }
+
+  size_t
   TypeWithDict::dataMemberSize() const {
     if (class_ != nullptr) {
       return class_->GetListOfDataMembers()->GetSize();


### PR DESCRIPTION
Fixes for some more fatal relval errors in the ROOT6 IBs.
1)Incremented the version numbers for two more classes whose checksums have changed between ROOT 5 and ROOT 6.
2) Added functions to TypeWithDict to get the number of dimensions oc a C style array, and the maximum index value for each dimension.  Call the new function maximumIndex() in  InlineCArrayStreamer.cc to fix a bug where arrayLength() was used instead. arrayLength() is the product of the maximum indices for each dimension, so for multidimensional arrays we would run off the end of the array.
Note:  These fixes will not be visible in the results of the relvals in the IB's because another error is hit first. I am using a workaround for the other error in my tests.  I have not pull requested the workaround because it requires a root file of more than 100MB.
Please merge this request promptly unless there are problems.
