### PR TITLE
Making Quark-Gluon likelihood conditions DB object

### DIFF
--- a/CondCore/JetMETPlugins/src/plugins.cc
+++ b/CondCore/JetMETPlugins/src/plugins.cc
@@ -1,7 +1,14 @@
 #include "CondCore/PluginSystem/interface/registration_macros.h"
 
+#include "CondFormats/JetMETObjects/interface/QGLikelihoodObject.h"
+#include "CondFormats/DataRecord/interface/QGLikelihoodRcd.h"
+
 #include "CondFormats/JetMETObjects/interface/FFTJetCorrectorParameters.h"
 #include "CondFormats/DataRecord/interface/FFTJetCorrectorParametersRcdTypes.h"
+
+
+
+REGISTER_PLUGIN(QGLikelihoodRcd, QGLikelihoodObject);
 
 REGISTER_PLUGIN(FFTBasicJetCorrectorParametersRcd, FFTJetCorrectorParameters);
 REGISTER_PLUGIN(FFTGenJetCorrectorParametersRcd, FFTJetCorrectorParameters);

--- a/CondFormats/DataRecord/interface/QGLikelihoodRcd.h
+++ b/CondFormats/DataRecord/interface/QGLikelihoodRcd.h
@@ -1,0 +1,25 @@
+#ifndef QGLikelihoodRcd_QGLikelihoodRcd_h
+#define QGLikelihoodRcd_QGLikelihoodRcd_h
+// -*- C++ -*-
+//
+// Package:     CondFormats/JetMETObjects
+// Class  :     QGLikelihoodRcd
+// 
+/**\class QGLikelihoodRcd QGLikelihoodRcd.h CondFormats/JetMETObjects/interface/QGLikelihoodRcd.h
+
+ Description: [one line class summary]
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:      Salvatore Rappoccio
+// Created:     Thu, 13 Mar 2014 15:14:40 GMT
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class QGLikelihoodRcd : public edm::eventsetup::EventSetupRecordImplementation<QGLikelihoodRcd> {};
+
+#endif

--- a/CondFormats/DataRecord/src/QGLikelihoodRcd.cc
+++ b/CondFormats/DataRecord/src/QGLikelihoodRcd.cc
@@ -1,0 +1,15 @@
+// -*- C++ -*-
+//
+// Package:     CondFormats/JetMETObjects
+// Class  :     QGLikelihoodRcd
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Author:      Salvatore Rappoccio
+// Created:     Thu, 13 Mar 2014 15:14:40 GMT
+
+#include "CondFormats/DataRecord/interface/QGLikelihoodRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(QGLikelihoodRcd);

--- a/CondFormats/JetMETObjects/BuildFile.xml
+++ b/CondFormats/JetMETObjects/BuildFile.xml
@@ -5,6 +5,7 @@
 <use   name="rootmath"/>
 <use   name="rootrflx"/>
 <use   name="clhep"/>
+<use   name="CondFormats/PhysicsToolsObjects"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/JetMETObjects/interface/QGLikelihoodObject.h
+++ b/CondFormats/JetMETObjects/interface/QGLikelihoodObject.h
@@ -1,0 +1,35 @@
+#ifndef QGLikelihoodObject_h
+#define QGLikelihoodObject_h
+
+#include "CondFormats/BTauObjects/interface/CombinedSVCategoryData.h"
+#include "CondFormats/PhysicsToolsObjects/interface/Histogram.h"
+
+
+
+#include <vector>
+
+
+struct QGLikelihoodCategory {
+  float RhoVal, PtMin, PtMax;
+  int EtaBin;  
+  int QGIndex;
+  int VarIndex;
+};
+
+
+
+struct QGLikelihoodObject
+{
+  typedef PhysicsTools::Calibration::HistogramF Histogram;
+
+  struct Entry
+  {
+    QGLikelihoodCategory category;
+    Histogram histogram;
+  };
+
+ std::vector<Entry> data;
+  
+};
+
+#endif //QGLikelihoodObject_h

--- a/CondFormats/JetMETObjects/src/QGLikelihoodObject.cc
+++ b/CondFormats/JetMETObjects/src/QGLikelihoodObject.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/JetMETObjects/interface/QGLikelihoodObject.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(QGLikelihoodObject);

--- a/CondFormats/JetMETObjects/src/classes.h
+++ b/CondFormats/JetMETObjects/src/classes.h
@@ -5,6 +5,7 @@
 #include "CondFormats/JetMETObjects/interface/SimpleJetCorrector.h"
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 #include "CondFormats/JetMETObjects/interface/FFTJetCorrectorParameters.h"
+#include "CondFormats/JetMETObjects/interface/QGLikelihoodObject.h"
 
 #include <vector>
 
@@ -20,5 +21,10 @@ namespace CondFormats_JetMETObjects {
     JetCorrectorParametersCollection::collection_type colltype;
     std::vector<JetCorrectorParametersCollection> collv;
     FFTJetCorrectorParameters fftcorr;
+    QGLikelihoodCategory qgcat;
+    QGLikelihoodObject qgobj;
+    QGLikelihoodObject::Entry qgentry;
+    std::vector< QGLikelihoodObject::Entry > qgentryv;
+
   };
 }

--- a/CondFormats/JetMETObjects/src/classes_def.xml
+++ b/CondFormats/JetMETObjects/src/classes_def.xml
@@ -16,5 +16,16 @@
   <class name="FFTJetCorrectorParameters" class_version="0">
      <field name="m_buffer" mapping="blob"/>
   </class>
+
+  <class name="QGLikelihoodCategory"/>
+  <class name="QGLikelihoodObject" class_version="0">
+     <field name="data" mapping="blob"/>
+  </class>
+
+  <class name="QGLikelihoodObject::Entry"/>
+  <class name="std::vector<QGLikelihoodObject::Entry>"/>     
+
+
+
 </selection>
 </lcgdict>

--- a/JetMETCorrections/Modules/BuildFile.xml
+++ b/JetMETCorrections/Modules/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="CondCore/PluginSystem"/>
 <use   name="CondFormats/DataRecord"/>
+<use   name="CondFormats/JetMETObjects"/>
 <use   name="CondCore/DBCommon"/>
 <use   name="CondCore/DBOutputService"/>
 <use   name="CommonTools/Utils"/>

--- a/JetMETCorrections/Modules/interface/QGLikelihoodESProducer.h
+++ b/JetMETCorrections/Modules/interface/QGLikelihoodESProducer.h
@@ -52,10 +52,10 @@ class QGLikelihoodESProducer : public edm::ESProducer { //, public  edm::EventSe
 
       ReturnType produce(const QGLikelihoodRcd&);
 
-      // /// set validity interval
-      // void setIntervalFor( const edm::eventsetup::EventSetupRecordKey &,
-      // 			   const edm::IOVSyncValue &,
-      // 			   edm::ValidityInterval & );
+      /// set validity interval
+      void setIntervalFor( const edm::eventsetup::EventSetupRecordKey &,
+      			   const edm::IOVSyncValue &,
+      			   edm::ValidityInterval & );
    private:
       // ----------member data ---------------------------
       std::string mAlgo;

--- a/JetMETCorrections/Modules/interface/QGLikelihoodESProducer.h
+++ b/JetMETCorrections/Modules/interface/QGLikelihoodESProducer.h
@@ -1,0 +1,65 @@
+#ifndef JetMETCorrections_Modules_QGLikelihoodESProducer_h
+#define JetMETCorrections_Modules_QGLikelihoodESProducer_h
+
+// -*- C++ -*-
+//
+// Package:    JetMETCorrections/QGLikelihoodESProducer
+// Class:      QGLikelihoodESProducer
+// 
+/**\class QGLikelihoodESProducer QGLikelihoodESProducer.h JetMETCorrections/QGLikelihoodESProducer/plugins/QGLikelihoodESProducer.cc
+
+ Description: ESProducer to get the quark-gluon likelihood object "QGLikelihoodObject"
+              from record "QGLikelihoodRcd". 
+
+ Implementation:
+     Completely trivial, simply returns the QGLikelihoodObject to the user. There is only
+     one QGLikelihoodObject object in each record. 
+*/
+//
+// Original Author:  Salvatore Rappoccio
+//         Created:  Thu, 13 Mar 2014 15:02:39 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+#include <iostream>
+#include "boost/shared_ptr.hpp"
+
+// user include files
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/EventSetupRecordIntervalFinder.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/Framework/interface/ESProducts.h"
+#include "CondFormats/JetMETObjects/interface/QGLikelihoodObject.h"
+#include "CondFormats/DataRecord/interface/QGLikelihoodRcd.h"
+
+
+//
+// class declaration
+//
+
+class QGLikelihoodESProducer : public edm::ESProducer { //, public  edm::EventSetupRecordIntervalFinder {
+   public:
+      QGLikelihoodESProducer(const edm::ParameterSet&);
+      ~QGLikelihoodESProducer();
+
+      typedef boost::shared_ptr<QGLikelihoodObject> ReturnType;
+
+      ReturnType produce(const QGLikelihoodRcd&);
+
+      // /// set validity interval
+      // void setIntervalFor( const edm::eventsetup::EventSetupRecordKey &,
+      // 			   const edm::IOVSyncValue &,
+      // 			   edm::ValidityInterval & );
+   private:
+      // ----------member data ---------------------------
+      std::string mAlgo;
+};
+
+#endif 
+

--- a/JetMETCorrections/Modules/plugins/BuildFile.xml
+++ b/JetMETCorrections/Modules/plugins/BuildFile.xml
@@ -1,11 +1,13 @@
 <library   file="*.cc" name="JetMETCorrectionsModulesPlugins">
   <use   name="CondCore/PluginSystem"/>
   <use   name="CondFormats/DataRecord"/>
+  <use   name="CondFormats/JetMETObjects"/>
   <use   name="CondCore/DBCommon"/>
   <use   name="CondCore/DBOutputService"/>
   <use   name="DataFormats/JetReco"/>
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/PluginManager"/>
+  <use   name="FWCore/ServiceRegistry"/>
   <use   name="JetMETCorrections/Algorithms"/>
   <use   name="JetMETCorrections/Objects"/>
   <use   name="JetMETCorrections/Modules"/>

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBReader.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBReader.cc
@@ -66,13 +66,13 @@ QGLikelihoodDBReader::~QGLikelihoodDBReader()
 
 void QGLikelihoodDBReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  std::cout << "Getting QGL objects from DB" << std::endl;
+  edm::LogInfo   ("UserOutput") <<  "Getting QGL objects from DB" << std::endl;
   edm::ESHandle<QGLikelihoodObject> QGLParamsColl;
-  std::cout <<"Inspecting QGLikelihood payload with label: "<< mPayloadName <<std::endl;
+  edm::LogInfo   ("UserOutput") << "Inspecting QGLikelihood payload with label: "<< mPayloadName <<std::endl;
   QGLikelihoodRcd const & rcdhandle = iSetup.get<QGLikelihoodRcd>();
   rcdhandle.get(mPayloadName,QGLParamsColl);
   std::vector<QGLikelihoodObject::Entry> const & data = QGLParamsColl->data;
-  std::cout << "There are " << data.size() << " objects in this payload" << std::endl;
+  edm::LogInfo   ("UserOutput") <<  "There are " << data.size() << " objects in this payload" << std::endl;
   for ( auto ibegin = data.begin(),
 	  iend = data.end(), idata = ibegin; idata != iend; ++idata ) {    
     int varIndex = idata->category.VarIndex;
@@ -84,7 +84,7 @@ void QGLikelihoodDBReader::analyze(const edm::Event& iEvent, const edm::EventSet
     // Print out for debugging
     char buff[1000];
     sprintf( buff, "var=%1d, eta=%1d, qg=%1d, ptMin=%8.2f, ptMax=%8.2f, rhoVal=%6.2f", varIndex, etaBin, qgBin, ptMin, ptMax, rhoVal );
-    std::cout << buff << std::endl;
+    edm::LogVerbatim   ("UserOutput") << buff << std::endl;
     
   }
 }

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBReader.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBReader.cc
@@ -70,14 +70,11 @@ void QGLikelihoodDBReader::analyze(const edm::Event& iEvent, const edm::EventSet
   edm::ESHandle<QGLikelihoodObject> QGLParamsColl;
   std::cout <<"Inspecting QGLikelihood payload with label: "<< mPayloadName <<std::endl;
   QGLikelihoodRcd const & rcdhandle = iSetup.get<QGLikelihoodRcd>();
-  std::cout << "Got the record handle, now getting the payload" << std::endl;
   rcdhandle.get(mPayloadName,QGLParamsColl);
-  std::cout << "Got payload from the DB" << std::endl;
   std::vector<QGLikelihoodObject::Entry> const & data = QGLParamsColl->data;
   std::cout << "There are " << data.size() << " objects in this payload" << std::endl;
   for ( auto ibegin = data.begin(),
 	  iend = data.end(), idata = ibegin; idata != iend; ++idata ) {    
-    std::cout << "Looping..." << std::endl;
     int varIndex = idata->category.VarIndex;
     int qgBin = idata->category.QGIndex;
     int etaBin = idata->category.EtaBin;

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBReader.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBReader.cc
@@ -1,0 +1,106 @@
+// -*- C++ -*-
+//
+// Package:    QGLikelihoodDBReader
+// Class:      
+// 
+/**\class QGLikelihoodDBReader
+
+ Description: <one line class summary>
+
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author:  Salvatore Rappoccio
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "CondFormats/JetMETObjects/interface/QGLikelihoodObject.h"
+#include "JetMETCorrections/Objects/interface/JetCorrectionsRecord.h"
+#include "CondFormats/DataRecord/interface/QGLikelihoodRcd.h"
+//
+// class declaration
+//
+
+class QGLikelihoodDBReader : public edm::EDAnalyzer {
+public:
+  explicit QGLikelihoodDBReader(const edm::ParameterSet&);
+  ~QGLikelihoodDBReader();
+  
+  
+private:
+  virtual void beginJob() override ;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override ;
+ 
+  std::string mPayloadName;
+  bool mCreateTextFile,mPrintScreen;
+};
+
+
+QGLikelihoodDBReader::QGLikelihoodDBReader(const edm::ParameterSet& iConfig)
+{
+  mPayloadName    = iConfig.getUntrackedParameter<std::string>("payloadName");
+  mPrintScreen    = iConfig.getUntrackedParameter<bool>("printScreen");
+  mCreateTextFile = iConfig.getUntrackedParameter<bool>("createTextFile");
+}
+
+
+QGLikelihoodDBReader::~QGLikelihoodDBReader()
+{
+ 
+}
+
+void QGLikelihoodDBReader::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  std::cout << "Getting QGL objects from DB" << std::endl;
+  edm::ESHandle<QGLikelihoodObject> QGLParamsColl;
+  std::cout <<"Inspecting QGLikelihood payload with label: "<< mPayloadName <<std::endl;
+  QGLikelihoodRcd const & rcdhandle = iSetup.get<QGLikelihoodRcd>();
+  std::cout << "Got the record handle, now getting the payload" << std::endl;
+  rcdhandle.get(mPayloadName,QGLParamsColl);
+  std::cout << "Got payload from the DB" << std::endl;
+  std::vector<QGLikelihoodObject::Entry> const & data = QGLParamsColl->data;
+  std::cout << "There are " << data.size() << " objects in this payload" << std::endl;
+  for ( auto ibegin = data.begin(),
+	  iend = data.end(), idata = ibegin; idata != iend; ++idata ) {    
+    std::cout << "Looping..." << std::endl;
+    int varIndex = idata->category.VarIndex;
+    int qgBin = idata->category.QGIndex;
+    int etaBin = idata->category.EtaBin;
+    double rhoVal = idata->category.RhoVal;
+    double ptMin = idata->category.PtMin;
+    double ptMax = idata->category.PtMax;
+    // Print out for debugging
+    char buff[1000];
+    sprintf( buff, "var=%1d, eta=%1d, qg=%1d, ptMin=%8.2f, ptMax=%8.2f, rhoVal=%6.2f", varIndex, etaBin, qgBin, ptMin, ptMax, rhoVal );
+    std::cout << buff << std::endl;
+    
+  }
+}
+
+void 
+QGLikelihoodDBReader::beginJob()
+{
+}
+
+void 
+QGLikelihoodDBReader::endJob() 
+{
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(QGLikelihoodDBReader);

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -53,7 +53,7 @@ void QGLikelihoodDBWriter::beginJob()
   QGLikelihoodObject *payload = new QGLikelihoodObject();
   payload->data.clear();
 
-  TFile * f = TFile::Open(edm::FileInPath(inputRootFile.c_str()));
+  TFile * f = TFile::Open(edm::FileInPath(inputRootFile.c_str()).fullPath().c_str());
   
   // For easy keeping, here are the various strings in the histogram name. 
   std::string varName0 = "nPFCand_QC_ptCutJet0";

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -23,7 +23,7 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
 #include "CondFormats/JetMETObjects/interface/QGLikelihoodObject.h"
-
+#include "FWCore/ParameterSet/interface/FileInPath.h"
 
 class  QGLikelihoodDBWriter : public edm::EDAnalyzer
 {
@@ -53,7 +53,7 @@ void QGLikelihoodDBWriter::beginJob()
   QGLikelihoodObject *payload = new QGLikelihoodObject();
   payload->data.clear();
 
-  TFile * f = TFile::Open(inputRootFile.c_str());
+  TFile * f = TFile::Open(edm::FileInPath(inputRootFile.c_str()));
   
   // For easy keeping, here are the various strings in the histogram name. 
   std::string varName0 = "nPFCand_QC_ptCutJet0";

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -70,7 +70,7 @@ void QGLikelihoodDBWriter::beginJob()
   // subdirectories. Need to traverse through them and add the histograms. 
   TList * keys = f->GetListOfKeys();
   if ( !keys ) {
-    std::cout << "No keys." << std::endl;
+    edm::LogError  ("NoKeys") << "There are no keys in the input file." << std::endl;
     return;
   }
 
@@ -125,7 +125,7 @@ void QGLikelihoodDBWriter::beginJob()
 	ptFirstPos += varName3.size();
       }
       else {
-	std::cout << "Cannot find the variable name, bummer." << std::endl;
+	edm::LogError  ("NoName") << "Cannot find the variable name " << std::endl;
 	return;
       }
 
@@ -150,7 +150,8 @@ void QGLikelihoodDBWriter::beginJob()
 	qgBin = 1;
 	ptFirstPos += etaName1.size() + gluonName.size();
       } else {
-	std::cout << "Cannot find eta, qg and pt bins, bummer." << std::endl;
+	edm::LogError  ("NoBins") << "Cannot find eta, qg and pt bins." << std::endl;
+	return;
       }
 
       // Access the pt information
@@ -165,10 +166,10 @@ void QGLikelihoodDBWriter::beginJob()
       srhoVal >> rhoVal;
        
 
-      // Print out for debugging
+      // Print out for debugging      
       char buff[1000];
       sprintf( buff, "%50s : var=%1d, eta=%1d, qg=%1d, ptMin=%8.2f, ptMax=%8.2f, rhoVal=%6.2f", histname.c_str(), varIndex, etaBin, qgBin, ptMin, ptMax, rhoVal );
-      std::cout << buff << std::endl;
+      edm::LogVerbatim   ("HistName") << buff << std::endl;
 
       // Create the new QGLikelihoodCategory and add to the list. 
       TObject * objhist = keyhist->ReadObj();
@@ -203,20 +204,19 @@ void QGLikelihoodDBWriter::beginJob()
    
   
 
-  
-  std::cout << "Opening PoolDBOutputService" << std::endl;
+  edm::LogInfo   ("UserOutput") << "Opening PoolDBOutputService" << std::endl;
 
   // now write it into the DB
   edm::Service<cond::service::PoolDBOutputService> s;
   if (s.isAvailable()) 
     {
-      std::cout << "Setting up payload with " << payload->data.size() <<  " entries and tag " << payloadTag << std::endl;
+      edm::LogInfo   ("UserOutput") <<  "Setting up payload with " << payload->data.size() <<  " entries and tag " << payloadTag << std::endl;
       if (s->isNewTagRequest(payloadTag)) 
 	s->createNewIOV<QGLikelihoodObject>(payload, s->beginOfTime(), s->endOfTime(), payloadTag);
       else 
 	s->appendSinceTime<QGLikelihoodObject>(payload, 111, payloadTag);
     }
-  std::cout << "Wrote in CondDB QGLikelihood payload label: " << payloadTag << std::endl;
+  edm::LogInfo   ("UserOutput") <<  "Wrote in CondDB QGLikelihood payload label: " << payloadTag << std::endl;
 }
 
 

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -1,0 +1,224 @@
+// Author: Benedikt Hegner
+// Email:  benedikt.hegner@cern.ch
+
+#include "TFile.h"
+#include "TList.h"
+#include "TString.h"
+#include "TKey.h"
+#include "TH1.h"
+#include <sstream>
+#include <vector>
+#include <iterator>
+#include <algorithm>
+#include <sstream>
+#include <memory>
+#include <string>
+#include <fstream>
+#include <iostream>
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CondFormats/JetMETObjects/interface/QGLikelihoodObject.h"
+
+
+class  QGLikelihoodDBWriter : public edm::EDAnalyzer
+{
+ public:
+  QGLikelihoodDBWriter(const edm::ParameterSet&);
+  virtual void beginJob() override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override {}
+  virtual void endJob() override {}
+  ~QGLikelihoodDBWriter() {}
+
+ private:
+  std::string inputRootFile;
+  std::string payloadTag;
+};
+
+// Constructor
+QGLikelihoodDBWriter::QGLikelihoodDBWriter(const edm::ParameterSet& pSet)
+{
+  inputRootFile    = pSet.getParameter<std::string>("src");
+  payloadTag       = pSet.getParameter<std::string>("payload");
+}
+
+// Begin Job
+void QGLikelihoodDBWriter::beginJob()
+{
+
+  QGLikelihoodObject *payload = new QGLikelihoodObject();
+  payload->data.clear();
+
+  TFile * f = TFile::Open(inputRootFile.c_str());
+  
+  // For easy keeping, here are the various strings in the histogram name. 
+  std::string varName0 = "nPFCand_QC_ptCutJet0";
+  std::string varName1 = "ptD_QCJet0";
+  std::string varName2 = "axis1_QCJet0";
+  std::string varName3 = "axis2_QCJet0";
+  std::string etaName0 = "_F";
+  std::string etaName1 = "";
+  std::string quarkName= "_quark_";
+  std::string gluonName= "_gluon_";
+  std::string rhoName  = "_rho";
+
+  // The structure of the root file is that it is in a bunch of 
+  // subdirectories. Need to traverse through them and add the histograms. 
+  TList * keys = f->GetListOfKeys();
+  if ( !keys ) {
+    std::cout << "No keys." << std::endl;
+    return;
+  }
+
+
+  TIter nextdir(keys);
+  TKey *keydir;
+  while ((keydir = (TKey*)nextdir())) {
+    TDirectory * dir = (TDirectory*)keydir->ReadObj() ;
+    TIter nexthist(dir->GetListOfKeys());
+    TKey * keyhist;
+    while ( (keyhist = (TKey*)nexthist())) {
+
+      double ptMin=0.0, ptMax=0.0, rhoVal=-99.99;
+      int etaBin=-1;
+      int varIndex=-1;
+      int qgBin=-1;
+
+      std::string histname = keyhist->GetName();
+
+      // Histogram names encode the binning. Examples: 
+      //     nPFCand_QC_ptCutJet0_gluon_pt40_51_rho0
+      //     ptD_QCJet0_gluon_pt40_51_rho0
+      //     axis1_QCJet0_gluon_pt40_51_rho0
+      //     axis2_QCJet0_gluon_pt40_51_rho0
+      size_t varName0Pos = histname.find( varName0 );
+      size_t varName1Pos = histname.find( varName1 );
+      size_t varName2Pos = histname.find( varName2 );
+      size_t varName3Pos = histname.find( varName3 );
+      size_t eta_qg_0Pos = histname.find( etaName0 + quarkName );
+      size_t eta_qg_1Pos = histname.find( etaName1 + quarkName );
+      size_t eta_qg_2Pos = histname.find( etaName0 + gluonName );
+      size_t eta_qg_3Pos = histname.find( etaName1 + gluonName );
+      size_t rhoPos      = histname.find( rhoName );
+      size_t ptFirstPos  = 0;
+
+
+      // First check the variable name, and offset the first position of the "pt" substring
+      if ( varName0Pos != std::string::npos ) {
+	varIndex = 0;
+	ptFirstPos += varName0.size();
+      }
+      else if ( varName1Pos != std::string::npos ) {
+	varIndex = 1;
+	ptFirstPos += varName1.size();
+      }
+      else if ( varName2Pos != std::string::npos ) {
+	varIndex = 2;
+	ptFirstPos += varName2.size();
+      }
+      else if ( varName3Pos != std::string::npos ) {
+	varIndex = 3;
+	ptFirstPos += varName3.size();
+      }
+      else {
+	std::cout << "Cannot find the variable name, bummer." << std::endl;
+	return;
+      }
+
+      // Next check central vs. forward eta, q vs g, and get the offest of the position where the pt is stored
+      if ( eta_qg_0Pos != std::string::npos ) {
+	etaBin = 0;
+	qgBin = 0;
+	ptFirstPos += etaName0.size() + quarkName.size();
+      }
+      else if ( eta_qg_1Pos != std::string::npos ) {
+	etaBin = 1;
+	qgBin = 0;
+	ptFirstPos += etaName1.size() + quarkName.size();
+      }
+      else if ( eta_qg_2Pos != std::string::npos ) {
+	etaBin = 0;
+	qgBin = 1;
+	ptFirstPos += etaName0.size() + gluonName.size();
+      }
+      else if ( eta_qg_3Pos != std::string::npos ) {
+	etaBin = 1;
+	qgBin = 1;
+	ptFirstPos += etaName1.size() + gluonName.size();
+      } else {
+	std::cout << "Cannot find eta, qg and pt bins, bummer." << std::endl;
+      }
+
+      // Access the pt information
+      ptFirstPos += 2;
+      char junk('_');
+      std::stringstream sptVal ( histname.substr( ptFirstPos, rhoPos ) );
+      sptVal >> ptMin >> junk >> ptMax;
+
+      // Access the rho information
+      size_t rhoEndPos = rhoPos + rhoName.size();
+      std::stringstream srhoVal ( histname.substr( rhoEndPos, histname.size() ) );
+      srhoVal >> rhoVal;
+       
+
+      // Print out for debugging
+      char buff[1000];
+      sprintf( buff, "%50s : var=%1d, eta=%1d, qg=%1d, ptMin=%8.2f, ptMax=%8.2f, rhoVal=%6.2f", histname.c_str(), varIndex, etaBin, qgBin, ptMin, ptMax, rhoVal );
+      std::cout << buff << std::endl;
+
+      // Create the new QGLikelihoodCategory and add to the list. 
+      TObject * objhist = keyhist->ReadObj();
+      TH1* th1hist = (TH1*)objhist;
+      
+
+
+      QGLikelihoodCategory category;
+      category.RhoVal = rhoVal;
+      category.PtMin = ptMin;
+      category.PtMax = ptMax;
+      category.EtaBin = etaBin;
+      category.QGIndex = qgBin;
+      category.VarIndex = varIndex;
+      QGLikelihoodObject::Histogram histogram (th1hist->GetNbinsX(), 
+					       th1hist->GetXaxis()->GetBinLowEdge(0), 
+					       th1hist->GetXaxis()->GetBinUpEdge( th1hist->GetNbinsX() - 1)
+					       );
+      for ( int ibin = 0; ibin < th1hist->GetNbinsX(); ++ibin ) {
+	histogram.setBinContent( ibin, th1hist->GetBinContent( ibin-1 ) ); // ROOT TH1 indexing off-by-one
+      }
+
+      QGLikelihoodObject::Entry entry;
+      entry.category = category;
+      entry.histogram = histogram; 
+      payload->data.push_back( entry );
+
+    }
+
+  }
+
+   
+  
+
+  
+  std::cout << "Opening PoolDBOutputService" << std::endl;
+
+  // now write it into the DB
+  edm::Service<cond::service::PoolDBOutputService> s;
+  if (s.isAvailable()) 
+    {
+      std::cout << "Setting up payload with " << payload->data.size() <<  " entries and tag " << payloadTag << std::endl;
+      if (s->isNewTagRequest(payloadTag)) 
+	s->createNewIOV<QGLikelihoodObject>(payload, s->beginOfTime(), s->endOfTime(), payloadTag);
+      else 
+	s->appendSinceTime<QGLikelihoodObject>(payload, 111, payloadTag);
+    }
+  std::cout << "Wrote in CondDB QGLikelihood payload label: " << payloadTag << std::endl;
+}
+
+
+DEFINE_FWK_MODULE(QGLikelihoodDBWriter);
+

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -184,11 +184,11 @@ void QGLikelihoodDBWriter::beginJob()
       category.QGIndex = qgBin;
       category.VarIndex = varIndex;
       QGLikelihoodObject::Histogram histogram (th1hist->GetNbinsX(), 
-					       th1hist->GetXaxis()->GetBinLowEdge(0), 
-					       th1hist->GetXaxis()->GetBinUpEdge( th1hist->GetNbinsX() - 1)
+					       th1hist->GetXaxis()->GetBinLowEdge(1), 
+					       th1hist->GetXaxis()->GetBinUpEdge( th1hist->GetNbinsX() )
 					       );
       for ( int ibin = 0; ibin < th1hist->GetNbinsX(); ++ibin ) {
-	histogram.setBinContent( ibin, th1hist->GetBinContent( ibin-1 ) ); // ROOT TH1 indexing off-by-one
+	histogram.setBinContent( ibin, th1hist->GetBinContent( ibin+1 ) ); // ROOT TH1 indexing off-by-one
       }
 
       QGLikelihoodObject::Entry entry;

--- a/JetMETCorrections/Modules/python/qglESProducer_cfi.py
+++ b/JetMETCorrections/Modules/python/qglESProducer_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+QGLikelihoodESProducer_AK5PF = cms.ESProducer("QGLikelihoodESProducer",
+# this is what it makes available
+    algo = cms.string('QGL_AK5PF')
+)
+QGLikelihoodESProducer_AK5PFchs = cms.ESProducer("QGLikelihoodESProducer",
+# this is what it makes available
+    algo = cms.string('QGL_AK5PFchs')
+)

--- a/JetMETCorrections/Modules/src/QGLikelihoodESProducer.cc
+++ b/JetMETCorrections/Modules/src/QGLikelihoodESProducer.cc
@@ -36,17 +36,15 @@ QGLikelihoodESProducer::QGLikelihoodESProducer(const edm::ParameterSet& iConfig)
 {
    //the following line is needed to tell the framework what
    // data is being produced
+   std::string label(iConfig.getParameter<std::string>("@module_label"));
    mAlgo             = iConfig.getParameter<std::string>("algo");
-   setWhatProduced(this, mAlgo);
-   // findingRecordWithKey<QGLikelihoodRcd>();
-
-   std::cout << "QGLikelihoodESProducer is called on " << mAlgo << ", I am " << this << std::endl;
+   setWhatProduced(this, label);
+   //findingRecordWithKey<QGLikelihoodRcd>();
 }
 
 
 QGLikelihoodESProducer::~QGLikelihoodESProducer()
 {
-  std::cout << "Destructed " << this << std::endl;
 }
 
 
@@ -54,28 +52,27 @@ QGLikelihoodESProducer::~QGLikelihoodESProducer()
 // member functions
 //
 
-// void 
-// QGLikelihoodESProducer::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
-// 				       const edm::IOVSyncValue&,
-// 				       edm::ValidityInterval& oInterval ) {
-//   // the same PDF's is valid for any time
-//   oInterval = edm::ValidityInterval (edm::IOVSyncValue::beginOfTime (), 
-//                                      edm::IOVSyncValue::endOfTime ()) ;
-// }
+void 
+QGLikelihoodESProducer::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+				       const edm::IOVSyncValue&,
+				       edm::ValidityInterval& oInterval ) {
+  // the same PDF's is valid for any time
+  oInterval = edm::ValidityInterval (edm::IOVSyncValue::beginOfTime (), 
+                                     edm::IOVSyncValue::endOfTime ()) ;
+}
 
 // ------------ method called to produce the data  ------------
 QGLikelihoodESProducer::ReturnType
 QGLikelihoodESProducer::produce(const QGLikelihoodRcd& iRecord)
 {
-  std::cout << "QGLProducer producing on " << this << std::endl;
    using namespace edm::es;
+   // boost::shared_ptr<QGLikelihoodObject> pQGLikelihoodObject;
+   // return products(pQGLikelihoodObject);   
+
    edm::ESHandle<QGLikelihoodObject> qglObj;
-   std::cout << "Getting algo " << mAlgo << std::endl;
    iRecord.get(mAlgo, qglObj);
-   std::cout << "Done." << std::endl;
 
    boost::shared_ptr<QGLikelihoodObject> pMyType( new QGLikelihoodObject(*qglObj) );
-   std::cout << "Returning" << std::endl;
    return pMyType;
 
 }

--- a/JetMETCorrections/Modules/src/QGLikelihoodESProducer.cc
+++ b/JetMETCorrections/Modules/src/QGLikelihoodESProducer.cc
@@ -1,0 +1,81 @@
+// -*- C++ -*-
+//
+// Package:    JetMETCorrections/QGLikelihoodESProducer
+// Class:      QGLikelihoodESProducer
+// 
+/**\class QGLikelihoodESProducer QGLikelihoodESProducer.h JetMETCorrections/QGLikelihoodESProducer/plugins/QGLikelihoodESProducer.cc
+
+ Description: ESProducer to get the quark-gluon likelihood object "QGLikelihoodObject"
+              from record "QGLikelihoodRcd". 
+
+ Implementation:
+     Completely trivial, simply returns the QGLikelihoodObject to the user. There is only
+     one QGLikelihoodObject object in each record. 
+*/
+//
+// Original Author:  Salvatore Rappoccio
+//         Created:  Thu, 13 Mar 2014 15:02:39 GMT
+//
+//
+
+
+#include "JetMETCorrections/Modules/interface/QGLikelihoodESProducer.h"
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+QGLikelihoodESProducer::QGLikelihoodESProducer(const edm::ParameterSet& iConfig)
+{
+   //the following line is needed to tell the framework what
+   // data is being produced
+   mAlgo             = iConfig.getParameter<std::string>("algo");
+   setWhatProduced(this, mAlgo);
+   // findingRecordWithKey<QGLikelihoodRcd>();
+
+   std::cout << "QGLikelihoodESProducer is called on " << mAlgo << ", I am " << this << std::endl;
+}
+
+
+QGLikelihoodESProducer::~QGLikelihoodESProducer()
+{
+  std::cout << "Destructed " << this << std::endl;
+}
+
+
+//
+// member functions
+//
+
+// void 
+// QGLikelihoodESProducer::setIntervalFor(const edm::eventsetup::EventSetupRecordKey&,
+// 				       const edm::IOVSyncValue&,
+// 				       edm::ValidityInterval& oInterval ) {
+//   // the same PDF's is valid for any time
+//   oInterval = edm::ValidityInterval (edm::IOVSyncValue::beginOfTime (), 
+//                                      edm::IOVSyncValue::endOfTime ()) ;
+// }
+
+// ------------ method called to produce the data  ------------
+QGLikelihoodESProducer::ReturnType
+QGLikelihoodESProducer::produce(const QGLikelihoodRcd& iRecord)
+{
+  std::cout << "QGLProducer producing on " << this << std::endl;
+   using namespace edm::es;
+   edm::ESHandle<QGLikelihoodObject> qglObj;
+   std::cout << "Getting algo " << mAlgo << std::endl;
+   iRecord.get(mAlgo, qglObj);
+   std::cout << "Done." << std::endl;
+
+   boost::shared_ptr<QGLikelihoodObject> pMyType( new QGLikelihoodObject(*qglObj) );
+   std::cout << "Returning" << std::endl;
+   return pMyType;
+
+}

--- a/JetMETCorrections/Modules/src/SealModule.cc
+++ b/JetMETCorrections/Modules/src/SealModule.cc
@@ -9,6 +9,7 @@
 #include "JetMETCorrections/Modules/interface/JetCorrectionESSource.h"
 #include "JetMETCorrections/Modules/interface/JetCorrectionESChain.h"
 #include "JetMETCorrections/Modules/interface/JetCorrectionProducer.h"
+#include "JetMETCorrections/Modules/interface/QGLikelihoodESProducer.h"
 #include "JetMETCorrections/Algorithms/interface/LXXXCorrector.h"
 #include "JetMETCorrections/Algorithms/interface/L1OffsetCorrector.h"
 #include "JetMETCorrections/Algorithms/interface/L1JPTOffsetCorrector.h"
@@ -20,8 +21,11 @@
 #include "DataFormats/JetReco/interface/TrackJet.h"
 #include "DataFormats/JetReco/interface/GenJet.h"
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
+#include "CondFormats/JetMETObjects/interface/QGLikelihoodObject.h"
+
 
 REGISTER_PLUGIN(JetCorrectionsRecord,JetCorrectorParametersCollection);
+
 using namespace cms;
 using namespace reco;
 
@@ -41,6 +45,10 @@ typedef JetCorrectionProducer<GenJet> GenJetCorrectionProducer;
 DEFINE_FWK_MODULE(GenJetCorrectionProducer);
 
 DEFINE_FWK_EVENTSETUP_MODULE(JetCorrectionESChain);
+
+
+DEFINE_FWK_EVENTSETUP_MODULE(QGLikelihoodESProducer);
+
 
 //--------------- Generic LX corrections --------------------
 DEFINE_JET_CORRECTION_ESSOURCE (LXXXCorrector, LXXXCorrectionESSource);

--- a/JetMETCorrections/Modules/test/QGLikelihoodDBWriter_cfg.py
+++ b/JetMETCorrections/Modules/test/QGLikelihoodDBWriter_cfg.py
@@ -1,5 +1,16 @@
 import FWCore.ParameterSet.Config as cms 
-process = cms.Process('qgldb') 
+process = cms.Process('qgldb')
+
+process.MessageLogger = cms.Service("MessageLogger",
+            destinations = cms.untracked.vstring(
+                    'cout'
+            ),
+            cout = cms.untracked.PSet(
+                    threshold = cms.untracked.string( 'INFO' )
+            ),
+)
+
+
 process.load('CondCore.DBCommon.CondDBCommon_cfi') 
 process.CondDBCommon.connect = 'sqlite_file:QGL_V1.db' 
 process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1)) 

--- a/JetMETCorrections/Modules/test/QGLikelihoodDBWriter_cfg.py
+++ b/JetMETCorrections/Modules/test/QGLikelihoodDBWriter_cfg.py
@@ -1,0 +1,36 @@
+import FWCore.ParameterSet.Config as cms 
+process = cms.Process('qgldb') 
+process.load('CondCore.DBCommon.CondDBCommon_cfi') 
+process.CondDBCommon.connect = 'sqlite_file:QGL_V1.db' 
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1)) 
+process.source = cms.Source('EmptySource') 
+process.PoolDBOutputService = cms.Service('PoolDBOutputService', 
+   process.CondDBCommon, 
+   toPut = cms.VPSet( 
+      cms.PSet(
+         record = cms.string('QGL_AK5PF'), 
+         tag    = cms.string('QGLikelihoodObject_V1_AK5PF'), 
+         label  = cms.string('QGL_AK5PF') 
+      ),
+      cms.PSet(
+         record = cms.string('QGL_AK5PFchs'), 
+         tag    = cms.string('QGLikelihoodObject_V1_AK5PFchs'), 
+         label  = cms.string('QGL_AK5PFchs') 
+      ),
+   ) 
+) 
+
+process.dbWriterAK5PF = cms.EDAnalyzer('QGLikelihoodDBWriter', 
+   src    = cms.string('CondFormats/JetMETObjects/data/ReducedHisto_2012.root'),  
+   payload= cms.string('QGL_AK5PF') 
+) 
+process.dbWriterAK5PFchs = cms.EDAnalyzer('QGLikelihoodDBWriter', 
+   src    = cms.string('CondFormats/JetMETObjects/data/ReducedHisto_2012_CHS.root'),  
+   payload= cms.string('QGL_AK5PFchs') 
+) 
+
+
+process.p = cms.Path( 
+process.dbWriterAK5PF *
+process.dbWriterAK5PFchs
+) 

--- a/JetMETCorrections/Modules/test/QGLikelihoodLocalDBReader_cfg.py
+++ b/JetMETCorrections/Modules/test/QGLikelihoodLocalDBReader_cfg.py
@@ -2,6 +2,16 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("myprocess")
 #process.load("CondCore.DBCommon.CondDBCommon_cfi")
+
+process.MessageLogger = cms.Service("MessageLogger",
+            destinations = cms.untracked.vstring(
+                    'cout'
+            ),
+            cout = cms.untracked.PSet(
+                    threshold = cms.untracked.string( 'INFO' )
+            ),
+)
+
 process.load('Configuration.StandardSequences.Services_cff')
 
 process.load("JetMETCorrections.Modules.qglESProducer_cfi")

--- a/JetMETCorrections/Modules/test/QGLikelihoodLocalDBReader_cfg.py
+++ b/JetMETCorrections/Modules/test/QGLikelihoodLocalDBReader_cfg.py
@@ -1,0 +1,47 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("myprocess")
+#process.load("CondCore.DBCommon.CondDBCommon_cfi")
+process.load('Configuration.StandardSequences.Services_cff')
+
+process.load("JetMETCorrections.Modules.qglESProducer_cfi")
+
+from CondCore.DBCommon.CondDBSetup_cfi import *
+
+process.maxEvents = cms.untracked.PSet(
+        input = cms.untracked.int32(1)
+        )
+
+process.source = cms.Source("EmptySource")
+
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+      CondDBSetup,
+      toGet = cms.VPSet(
+      cms.PSet(
+            record = cms.string('QGLikelihoodRcd'),
+            tag    = cms.string('QGLikelihoodObject_V1_AK5PF'),
+            label  = cms.untracked.string('QGL_AK5PF')
+            ),
+      cms.PSet(
+            record = cms.string('QGLikelihoodRcd'),
+            tag    = cms.string('QGLikelihoodObject_V1_AK5PFchs'),
+            label  = cms.untracked.string('QGL_AK5PFchs')
+            ),
+        ),
+      connect = cms.string('sqlite:QGL_V1.db')
+)
+
+
+process.demo1 = cms.EDAnalyzer('QGLikelihoodDBReader', 
+        payloadName    = cms.untracked.string('QGL_AK5PF'),
+        printScreen    = cms.untracked.bool(False),
+        createTextFile = cms.untracked.bool(True)
+)
+
+process.demo2 = cms.EDAnalyzer('QGLikelihoodDBReader', 
+        payloadName    = cms.untracked.string('QGL_AK5PFchs'),
+        printScreen    = cms.untracked.bool(False),
+        createTextFile = cms.untracked.bool(True)
+)
+
+process.p = cms.Path(process.demo1 * process.demo2 )


### PR DESCRIPTION
This is the first attempt at translating static ROOT files (which the authors wanted to ship with CMSSW) into CondDB objects. They will be stored in QGLikelihoodObject objects. There will be further test configurations once the objects are actually in the database, but for now the only test is writing to local sqlite files and reading again. This replaces ad-hoc functionality from #2820 with a more robust strategy. 
