### PR TITLE
Fix crash in HcalDigisClient (again)

### DIFF
--- a/Validation/HcalDigis/src/HcalDigisClient.cc
+++ b/Validation/HcalDigis/src/HcalDigisClient.cc
@@ -33,12 +33,12 @@ HcalDigisClient::HcalDigisClient(const edm::ParameterSet& iConfig) {
     //dbe_->setCurrentFolder(dirName_);
     dbe_->setCurrentFolder("HcalDigisV/HcalDigiTask");
 
+    // false for regular relval and true for SLHC relval
+    doSLHC_ = iConfig.getUntrackedParameter<bool>("doSLHC", true);
     booking("HB");
     booking("HE");
     booking("HO");
     booking("HF");
-    // false for regular relval and true for SLHC relval
-    doSLHC_ = iConfig.getUntrackedParameter<bool>("doSLHC", true);
 
 }
 


### PR DESCRIPTION
This bug shows up as a seg fault in HcalDigisClient during harvesting:

```
#5  0x00002b7c734c1a74 in MonitorElement::Fill(double, double) () from /afs/cern.ch/cms/sw/ReleaseCandidates/vol0/slc5_amd64_gcc472/cms/cmssw/CMSSW_6_2_X_SLHC_2014-03-18-0200/lib/slc5_amd64_gcc472/libDQMServicesCore.so
#6  0x00002b7c831fbcb4 in HcalDigisClient::HcalDigisEndjob(std::vector<MonitorElement*, std::allocator<MonitorElement*> > const&, std::string) () from /afs/cern.ch/cms/sw/ReleaseCandidates/vol0/slc5_amd64_gcc472/cms/cmssw/CMSSW_6_2_X_SLHC_2014-03-18-0200/lib/slc5_amd64_gcc472/pluginValidationHcalDigis.so
#7  0x00002b7c831fc8d8 in HcalDigisClient::runClient() () from /afs/cern.ch/cms/sw/ReleaseCandidates/vol0/slc5_amd64_gcc472/cms/cmssw/CMSSW_6_2_X_SLHC_2014-03-18-0200/lib/slc5_amd64_gcc472/pluginValidationHcalDigis.so
#8  0x00002b7c64b7d330 in edm::EDAnalyzer::doEndRun(edm::RunPrincipal const&, edm::EventSetup const&, edm::CurrentProcessingContext const*) () from /afs/cern.ch/cms/sw/ReleaseCandidates/vol0/slc5_amd64_gcc472/cms/cmssw/CMSSW_6_2_X_SLHC_2014-03-18-0200/lib/slc5_amd64_gcc472/libFWCoreFramework.so
```

Histograms are only booked if an un-intialised boolean is true.  The histograms are filled if the boolean is true, but this is after the variable has been properly initialised.  Hence there is a 50/50 chance that the code will either run as expected or seg fault, depending on the previous memory contents of the variable.
This was previously fixed in #2483 but was then broken again by #2833.
