### PR TITLE
Forced to take ROOT internal mutex lock to avoid deadlock

### DIFF
--- a/FWCore/PluginManager/BuildFile.xml
+++ b/FWCore/PluginManager/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="boost"/>
 <use   name="tbb"/>
+<use   name="rootcint"/>
 <use   name="boost_filesystem"/>
 <use   name="FWCore/Utilities"/>
 <export>

--- a/FWCore/PluginManager/src/PluginManager.cc
+++ b/FWCore/PluginManager/src/PluginManager.cc
@@ -19,6 +19,10 @@
 #include <fstream>
 #include <set>
 
+// TEMPORARY
+#include "TInterpreter.h"
+#include "TVirtualMutex.h"
+
 // user include files
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/PluginFactoryBase.h"
@@ -241,7 +245,13 @@ PluginManager::load(const std::string& iCategory,
       goingToLoad_(p);
       Sentry s(loadingLibraryNamed_(), p.string());
       //boost::filesystem::path native(p.string());
-      boost::shared_ptr<SharedLibrary> ptr( new SharedLibrary(p) );
+      boost::shared_ptr<SharedLibrary> ptr;
+      {
+	//TEMPORARY: to avoid possible deadlocks from ROOT, we must
+	// take the lock ourselves
+	R__LOCKGUARD(gCINTMutex);
+	ptr.reset( new SharedLibrary(p) );
+      }
       loadables_[p]=ptr;
       justLoaded_(*ptr);
       return *ptr;
@@ -275,7 +285,13 @@ PluginManager::tryToLoad(const std::string& iCategory,
       goingToLoad_(p);
       Sentry s(loadingLibraryNamed_(), p.string());
       //boost::filesystem::path native(p.string());
-      boost::shared_ptr<SharedLibrary> ptr( new SharedLibrary(p) );
+      boost::shared_ptr<SharedLibrary> ptr;
+      {
+	//TEMPORARY: to avoid possible deadlocks from ROOT, we must
+	// take the lock ourselves
+	R__LOCKGUARD(gCINTMutex);
+	ptr.reset( new SharedLibrary(p) );
+      }
       loadables_[p]=ptr;
       justLoaded_(*ptr);
       return ptr.get();


### PR DESCRIPTION
ROOT locks the same mutex before loading a shared library and in
statics embedded in shared libaries. In the middle the operating
system takes a lock to protect the shared library data structures.
Therefore to avoid deadlock problems we must take the same ROOT lock
before loading any shared libraries since we do not know apriori
if the shared library being loaded links to a library which will
take the lock at load time.
