### PR TITLE
Use R__LOCKGUARD2 instead of R__LOCKGUARD

### DIFF
--- a/FWCore/PluginManager/src/PluginManager.cc
+++ b/FWCore/PluginManager/src/PluginManager.cc
@@ -249,7 +249,7 @@ PluginManager::load(const std::string& iCategory,
       {
 	//TEMPORARY: to avoid possible deadlocks from ROOT, we must
 	// take the lock ourselves
-	R__LOCKGUARD(gCINTMutex);
+	R__LOCKGUARD2(gCINTMutex);
 	ptr.reset( new SharedLibrary(p) );
       }
       loadables_[p]=ptr;


### PR DESCRIPTION
To avoid having the first lock order incorrect because the Cint lock
is not yet created when PluginManager first calls R__LOCKGUARD, I
switched to R__LOCKGUARD2 which will create that Cint lock if ROOT
has decided that locks should be made but hasn't yet made them.
This will make helgrind happy although it has no other real need.
