### PR TITLE
IVF in the RECO sequence + trackJetPt as taggingvariable

### DIFF
--- a/DataFormats/BTauReco/interface/TaggingVariable.h
+++ b/DataFormats/BTauReco/interface/TaggingVariable.h
@@ -19,6 +19,7 @@ namespace reco {
     enum TaggingVariableName {
       jetEnergy = 0,                            // jet energy
       jetPt,                                    // jet transverse momentum
+      trackJetPt,                               // track-based jet transverse momentum
       jetEta,                                   // jet pseudorapidity
       jetPhi,                                   // jet polar angle
       jetNTracks,                               // tracks associated to jet

--- a/DataFormats/BTauReco/src/TaggingVariable.cc
+++ b/DataFormats/BTauReco/src/TaggingVariable.cc
@@ -11,6 +11,7 @@ namespace reco {
 const char* TaggingVariableDescription[] = {
   /* [jetEnergy]                                = */ "jet energy",
   /* [jetPt]                                    = */ "jet transverse momentum",
+  /* [trackJetPt]                               = */ "track-based jet transverse momentum",
   /* [jetEta]                                   = */ "jet pseudorapidity",
   /* [jetPhi]                                   = */ "jet polar angle",
   /* [jetNTracks]                               = */ "tracks associated to jet",
@@ -88,6 +89,7 @@ const char* TaggingVariableDescription[] = {
 const char* TaggingVariableTokens[] = {
   /* [jetEnergy]                                = */ "jetEnergy",
   /* [jetPt]                                    = */ "jetPt",
+  /* [trackJetPt]                               = */ "trackJetPt",
   /* [jetEta]                                   = */ "jetEta",
   /* [jetPhi]                                   = */ "jetPhi",
   /* [jetNTracks]                               = */ "jetNTracks",

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -292,7 +292,7 @@ class AddJetCollection(ConfigToolBase):
             if 'inclusiveSecondaryVertexFinderFilteredTagInfos' in acceptedTagInfos:
                 if not hasattr( process, 'inclusiveVertexing' ):
                     process.load( 'RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff' )
-                if not hasattr( process, 'inclusiveMergedVerticesFiltered' ):
+                if not hasattr( process, 'inclusiveVerticesFiltered' ):
                     process.load( 'RecoBTag.SecondaryVertex.secondaryVertex_cff' )
                 if not hasattr( process, 'bToCharmDecayVertexMerged' ):
                     process.load( 'RecoBTag.SecondaryVertex.bToCharmDecayVertexMerger_cfi' )

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -292,7 +292,7 @@ class AddJetCollection(ConfigToolBase):
             if 'inclusiveSecondaryVertexFinderFilteredTagInfos' in acceptedTagInfos:
                 if not hasattr( process, 'inclusiveVertexing' ):
                     process.load( 'RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff' )
-                if not hasattr( process, 'inclusiveVerticesFiltered' ):
+                if not hasattr( process, 'inclusiveSecondaryVerticesFiltered' ):
                     process.load( 'RecoBTag.SecondaryVertex.secondaryVertex_cff' )
                 if not hasattr( process, 'bToCharmDecayVertexMerged' ):
                     process.load( 'RecoBTag.SecondaryVertex.bToCharmDecayVertexMerger_cfi' )

--- a/RecoBTag/SecondaryVertex/python/bToCharmDecayVertexMerger_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/bToCharmDecayVertexMerger_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 bToCharmDecayVertexMerged = cms.EDProducer("BtoCharmDecayVertexMerger",
       primaryVertices  = cms.InputTag("offlinePrimaryVertices"),
-      secondaryVertices = cms.InputTag("inclusiveVerticesFiltered"),
+      secondaryVertices = cms.InputTag("inclusiveSecondaryVerticesFiltered"),
       minDRUnique = cms.untracked.double(0.4),
       minvecSumIMifsmallDRUnique = cms.untracked.double(5.5),
       minCosPAtomerge = cms.untracked.double(0.99),

--- a/RecoBTag/SecondaryVertex/python/bToCharmDecayVertexMerger_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/bToCharmDecayVertexMerger_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 bToCharmDecayVertexMerged = cms.EDProducer("BtoCharmDecayVertexMerger",
       primaryVertices  = cms.InputTag("offlinePrimaryVertices"),
-      secondaryVertices = cms.InputTag("inclusiveMergedVerticesFiltered"),
+      secondaryVertices = cms.InputTag("inclusiveVerticesFiltered"),
       minDRUnique = cms.untracked.double(0.4),
       minvecSumIMifsmallDRUnique = cms.untracked.double(5.5),
       minCosPAtomerge = cms.untracked.double(0.99),

--- a/RecoBTag/SecondaryVertex/python/inclusiveSecondaryVertexFinderTagInfos_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/inclusiveSecondaryVertexFinderTagInfos_cfi.py
@@ -5,7 +5,7 @@ from RecoBTag.SecondaryVertex.secondaryVertexTagInfos_cfi import *
 inclusiveSecondaryVertexFinderTagInfos = secondaryVertexTagInfos.clone()
 
 # use external SV collection made from IVF
-inclusiveSecondaryVertexFinderTagInfos.extSVCollection     = cms.InputTag('inclusiveMergedVertices')
+inclusiveSecondaryVertexFinderTagInfos.extSVCollection     = cms.InputTag('inclusiveVertices')
 inclusiveSecondaryVertexFinderTagInfos.extSVDeltaRToJet    = cms.double(0.3)
 inclusiveSecondaryVertexFinderTagInfos.useExternalSV = cms.bool(True)
 inclusiveSecondaryVertexFinderTagInfos.vertexCuts.fracPV = 0.79 ## 4 out of 5 is discarded

--- a/RecoBTag/SecondaryVertex/python/inclusiveSecondaryVertexFinderTagInfos_cfi.py
+++ b/RecoBTag/SecondaryVertex/python/inclusiveSecondaryVertexFinderTagInfos_cfi.py
@@ -5,7 +5,7 @@ from RecoBTag.SecondaryVertex.secondaryVertexTagInfos_cfi import *
 inclusiveSecondaryVertexFinderTagInfos = secondaryVertexTagInfos.clone()
 
 # use external SV collection made from IVF
-inclusiveSecondaryVertexFinderTagInfos.extSVCollection     = cms.InputTag('inclusiveVertices')
+inclusiveSecondaryVertexFinderTagInfos.extSVCollection     = cms.InputTag('inclusiveSecondaryVertices')
 inclusiveSecondaryVertexFinderTagInfos.extSVDeltaRToJet    = cms.double(0.3)
 inclusiveSecondaryVertexFinderTagInfos.useExternalSV = cms.bool(True)
 inclusiveSecondaryVertexFinderTagInfos.vertexCuts.fracPV = 0.79 ## 4 out of 5 is discarded

--- a/RecoBTag/SecondaryVertex/python/secondaryVertex_cff.py
+++ b/RecoBTag/SecondaryVertex/python/secondaryVertex_cff.py
@@ -20,9 +20,9 @@ from RecoBTag.SecondaryVertex.inclusiveSecondaryVertexFinderTagInfos_cfi import 
 from RecoBTag.SecondaryVertex.combinedInclusiveSecondaryVertexBJetTags_cfi import *
 #from RecoBTag.SecondaryVertex.combinedIVFES_cfi import * #not yet using dedicated training, share CSV ones
 from RecoBTag.SecondaryVertex.bVertexFilter_cfi import *
-inclusiveVerticesFiltered = bVertexFilter.clone()
-inclusiveVerticesFiltered.vertexFilter.multiplicityMin = 2
-inclusiveVerticesFiltered.secondaryVertices = cms.InputTag("inclusiveVertices")
+inclusiveSecondaryVerticesFiltered = bVertexFilter.clone()
+inclusiveSecondaryVerticesFiltered.vertexFilter.multiplicityMin = 2
+inclusiveSecondaryVerticesFiltered.secondaryVertices = cms.InputTag("inclusiveSecondaryVertices")
 
 from RecoBTag.SecondaryVertex.bToCharmDecayVertexMerger_cfi import *
 from RecoBTag.SecondaryVertex.simpleInclusiveSecondaryVertexBJetTags_cfi import *

--- a/RecoBTag/SecondaryVertex/python/secondaryVertex_cff.py
+++ b/RecoBTag/SecondaryVertex/python/secondaryVertex_cff.py
@@ -20,9 +20,9 @@ from RecoBTag.SecondaryVertex.inclusiveSecondaryVertexFinderTagInfos_cfi import 
 from RecoBTag.SecondaryVertex.combinedInclusiveSecondaryVertexBJetTags_cfi import *
 #from RecoBTag.SecondaryVertex.combinedIVFES_cfi import * #not yet using dedicated training, share CSV ones
 from RecoBTag.SecondaryVertex.bVertexFilter_cfi import *
-inclusiveMergedVerticesFiltered = bVertexFilter.clone()
-inclusiveMergedVerticesFiltered.vertexFilter.multiplicityMin = 2
-inclusiveMergedVerticesFiltered.secondaryVertices = cms.InputTag("inclusiveMergedVertices")
+inclusiveVerticesFiltered = bVertexFilter.clone()
+inclusiveVerticesFiltered.vertexFilter.multiplicityMin = 2
+inclusiveVerticesFiltered.secondaryVertices = cms.InputTag("inclusiveVertices")
 
 from RecoBTag.SecondaryVertex.bToCharmDecayVertexMerger_cfi import *
 from RecoBTag.SecondaryVertex.simpleInclusiveSecondaryVertexBJetTags_cfi import *

--- a/RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitratration.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/TrackVertexArbitratration.h
@@ -61,4 +61,10 @@ class TrackVertexArbitration{
         double					distCut;
         double					sigCut;
 	double					dLenFraction;
+	double 					fitterSigmacut; // = 3.0;
+	double 					fitterTini; // = 256.;
+	double 					fitterRatio;//    = 0.25;
+	int 					trackMinLayers;
+	double					trackMinPt;
+	int					trackMinPixels;   
 };

--- a/RecoVertex/AdaptiveVertexFinder/interface/TracksClusteringFromDisplacedSeed.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/TracksClusteringFromDisplacedSeed.h
@@ -48,7 +48,7 @@ class TracksClusteringFromDisplacedSeed {
         double 					min3DIPValue;
         double 					clusterMaxDistance;
         double 					clusterMaxSignificance;
-        double 					clusterScale;
+        double 					distanceRatio;
         double 					clusterMinAngleCosine;
 
 

--- a/RecoVertex/AdaptiveVertexFinder/interface/TracksClusteringFromDisplacedSeed.h
+++ b/RecoVertex/AdaptiveVertexFinder/interface/TracksClusteringFromDisplacedSeed.h
@@ -44,6 +44,8 @@ class TracksClusteringFromDisplacedSeed {
         std::pair<std::vector<reco::TransientTrack>,GlobalPoint> nearTracks(const reco::TransientTrack &seed, const std::vector<reco::TransientTrack> & tracks, const reco::Vertex & primaryVertex) const;
 
 //	unsigned int				maxNTracks;
+        double 					max3DIPSignificance;
+        double 					max3DIPValue;
         double 					min3DIPSignificance;
         double 					min3DIPValue;
         double 					clusterMaxDistance;

--- a/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexFinder_cfi.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexFinder_cfi.py
@@ -10,6 +10,8 @@ inclusiveVertexFinder  = cms.EDProducer("InclusiveVertexFinder",
        maxNTracks = cms.uint32(30),
 
        clusterizer = cms.PSet(
+           seedMax3DIPSignificance = cms.double(9999.),
+					 seedMax3DIPValue = cms.double(5),
            seedMin3DIPSignificance = cms.double(1.2),
            seedMin3DIPValue = cms.double(0.005),
            clusterMaxDistance = cms.double(0.05), #500um

--- a/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexFinder_cfi.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexFinder_cfi.py
@@ -14,13 +14,18 @@ inclusiveVertexFinder  = cms.EDProducer("InclusiveVertexFinder",
            seedMin3DIPValue = cms.double(0.005),
            clusterMaxDistance = cms.double(0.05), #500um
            clusterMaxSignificance = cms.double(4.5), #4.5 sigma
-           clusterScale = cms.double(1), 
+           distanceRatio = cms.double(20), # was cluster scale = 1 / density factor =0.05 
            clusterMinAngleCosine = cms.double(0.5), # only forward decays
        ),
 
        vertexMinAngleCosine = cms.double(0.95), # scalar prod direction of tracks and flight dir
        vertexMinDLen2DSig = cms.double(2.5), #2.5 sigma
        vertexMinDLenSig = cms.double(0.5), #0.5 sigma
+       fitterSigmacut =  cms.double(3),
+       fitterTini = cms.double(256),
+       fitterRatio = cms.double(0.25),
+       useDirectVertexFitter = cms.bool(True),
+       useVertexReco  = cms.bool(True),
        vertexReco = cms.PSet(
                finder = cms.string('avr'),
                primcut = cms.double(1.0),

--- a/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexFinder_cfi.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexFinder_cfi.py
@@ -11,7 +11,7 @@ inclusiveVertexFinder  = cms.EDProducer("InclusiveVertexFinder",
 
        clusterizer = cms.PSet(
            seedMax3DIPSignificance = cms.double(9999.),
-					 seedMax3DIPValue = cms.double(5),
+           seedMax3DIPValue = cms.double(9999.),
            seedMin3DIPSignificance = cms.double(1.2),
            seedMin3DIPValue = cms.double(0.005),
            clusterMaxDistance = cms.double(0.05), #500um

--- a/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexing_cff.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexing_cff.py
@@ -4,10 +4,10 @@ from RecoVertex.AdaptiveVertexFinder.inclusiveVertexFinder_cfi import *
 from RecoVertex.AdaptiveVertexFinder.vertexMerger_cfi import *
 from RecoVertex.AdaptiveVertexFinder.trackVertexArbitrator_cfi import *
 
-inclusiveMergedVertices = vertexMerger.clone()
-inclusiveMergedVertices.secondaryVertices = cms.InputTag("trackVertexArbitrator")
-inclusiveMergedVertices.maxFraction = 0.2
-inclusiveMergedVertices.minSignificance = 10.
+inclusiveVertices = vertexMerger.clone()
+inclusiveVertices.secondaryVertices = cms.InputTag("trackVertexArbitrator")
+inclusiveVertices.maxFraction = 0.2
+inclusiveVertices.minSignificance = 10.
 
-inclusiveVertexing = cms.Sequence(inclusiveVertexFinder*vertexMerger*trackVertexArbitrator*inclusiveMergedVertices)
+inclusiveVertexing = cms.Sequence(inclusiveVertexFinder*vertexMerger*trackVertexArbitrator*inclusiveVertices)
 

--- a/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexing_cff.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/inclusiveVertexing_cff.py
@@ -4,10 +4,10 @@ from RecoVertex.AdaptiveVertexFinder.inclusiveVertexFinder_cfi import *
 from RecoVertex.AdaptiveVertexFinder.vertexMerger_cfi import *
 from RecoVertex.AdaptiveVertexFinder.trackVertexArbitrator_cfi import *
 
-inclusiveVertices = vertexMerger.clone()
-inclusiveVertices.secondaryVertices = cms.InputTag("trackVertexArbitrator")
-inclusiveVertices.maxFraction = 0.2
-inclusiveVertices.minSignificance = 10.
+inclusiveSecondaryVertices = vertexMerger.clone()
+inclusiveSecondaryVertices.secondaryVertices = cms.InputTag("trackVertexArbitrator")
+inclusiveSecondaryVertices.maxFraction = 0.2
+inclusiveSecondaryVertices.minSignificance = 10.
 
-inclusiveVertexing = cms.Sequence(inclusiveVertexFinder*vertexMerger*trackVertexArbitrator*inclusiveVertices)
+inclusiveVertexing = cms.Sequence(inclusiveVertexFinder*vertexMerger*trackVertexArbitrator*inclusiveSecondaryVertices)
 

--- a/RecoVertex/AdaptiveVertexFinder/python/trackVertexArbitrator_cfi.py
+++ b/RecoVertex/AdaptiveVertexFinder/python/trackVertexArbitrator_cfi.py
@@ -8,7 +8,14 @@ trackVertexArbitrator = cms.EDProducer("TrackVertexArbitrator",
        dLenFraction = cms.double(0.333),
        dRCut = cms.double(0.4),
        distCut = cms.double(0.04),
-       sigCut = cms.double(5)
+       sigCut = cms.double(5),
+       fitterSigmacut =  cms.double(3),
+       fitterTini = cms.double(256),
+       fitterRatio = cms.double(0.25),
+       trackMinLayers = cms.int32(4),
+       trackMinPt = cms.double(0.4),
+       trackMinPixels = cms.int32(1)
+
 )
 
 

--- a/RecoVertex/AdaptiveVertexFinder/src/TrackVertexArbitratration.cc
+++ b/RecoVertex/AdaptiveVertexFinder/src/TrackVertexArbitratration.cc
@@ -10,18 +10,24 @@ TrackVertexArbitration::TrackVertexArbitration(const edm::ParameterSet &params) 
 	dRCut                     (params.getParameter<double>("dRCut")),
 	distCut                   (params.getParameter<double>("distCut")),
 	sigCut                    (params.getParameter<double>("sigCut")),
-	dLenFraction              (params.getParameter<double>("dLenFraction"))
+	dLenFraction              (params.getParameter<double>("dLenFraction")),
+	fitterSigmacut            (params.getParameter<double>("fitterSigmacut")),
+	fitterTini                (params.getParameter<double>("fitterTini")),
+	fitterRatio               (params.getParameter<double>("fitterRatio")),
+	trackMinLayers            (params.getParameter<int32_t>("trackMinLayers")),
+	trackMinPt                (params.getParameter<double>("trackMinPt")),
+	trackMinPixels            (params.getParameter<int32_t>("trackMinPixels"))
 {
 	
 }
 
 bool TrackVertexArbitration::trackFilterArbitrator(const reco::TrackRef &track) const
 {
-        if (track->hitPattern().trackerLayersWithMeasurement() < 4)
+        if (track->hitPattern().trackerLayersWithMeasurement() < trackMinLayers)
                 return false;
-        if (track->pt() < 0.4 )
+        if (track->pt() < trackMinPt)
                 return false;
-        if (track->hitPattern().numberOfValidPixelHits() < 1)
+        if (track->hitPattern().numberOfValidPixelHits() < trackMinPixels)
                 return false;
 
         return true;
@@ -40,15 +46,10 @@ reco::VertexCollection  TrackVertexArbitration::trackVertexArbitrator(
 {
 	using namespace reco;
 
-	     //std::cout << "PV: " << pv.position() << std::endl;
+	//std::cout << "PV: " << pv.position() << std::endl;
         VertexDistance3D dist;
-
-  double sigmacut = 3.0;
-  double Tini     = 256.;
-  double ratio    = 0.25;
-
-  AdaptiveVertexFitter theAdaptiveFitter(
-                                            GeometricAnnealing(sigmacut, Tini, ratio),
+  	AdaptiveVertexFitter theAdaptiveFitter(
+                                            GeometricAnnealing(fitterSigmacut, fitterTini, fitterRatio),
                                             DefaultLinearizationPointFinder(),
                                             KalmanVertexUpdator<5>(),
                                             KalmanVertexTrackCompatibilityEstimator<5>(),
@@ -57,8 +58,7 @@ reco::VertexCollection  TrackVertexArbitration::trackVertexArbitrator(
 
 
 	reco::VertexCollection recoVertices;
-
-       VertexDistance3D vdist;
+        VertexDistance3D vdist;
 
 for(std::vector<reco::Vertex>::const_iterator sv = secondaryVertices.begin();
 	    sv != secondaryVertices.end(); ++sv) {

--- a/RecoVertex/AdaptiveVertexFinder/src/TrackVertexArbitratration.cc
+++ b/RecoVertex/AdaptiveVertexFinder/src/TrackVertexArbitratration.cc
@@ -93,6 +93,7 @@ reco::VertexCollection  TrackVertexArbitration::trackVertexArbitrator(
 		} else {
 	 	                std::pair<bool,Measurement1D> ipvp = IPTools::absoluteImpactParameter3D(tt,pv);
 				cachedIP[itrack]=ipvp.second;
+				ipv=ipvp.second;
 		}
                 std::pair<bool,Measurement1D> isv = IPTools::absoluteImpactParameter3D(tt,*sv);
 		float dR = Geom::deltaR(flightDir,tt.track()); //.eta(), flightDir.phi(), tt.track().eta(), tt.track().phi());

--- a/RecoVertex/AdaptiveVertexFinder/src/TracksClusteringFromDisplacedSeed.cc
+++ b/RecoVertex/AdaptiveVertexFinder/src/TracksClusteringFromDisplacedSeed.cc
@@ -8,7 +8,7 @@ TracksClusteringFromDisplacedSeed::TracksClusteringFromDisplacedSeed(const edm::
 	min3DIPValue(params.getParameter<double>("seedMin3DIPValue")),
 	clusterMaxDistance(params.getParameter<double>("clusterMaxDistance")),
         clusterMaxSignificance(params.getParameter<double>("clusterMaxSignificance")), //3
-        clusterScale(params.getParameter<double>("clusterScale")),//10.
+        distanceRatio(params.getParameter<double>("distanceRatio")),//was clusterScale/densityFactor
         clusterMinAngleCosine(params.getParameter<double>("clusterMinAngleCosine")) //0.0
 
 {
@@ -25,8 +25,6 @@ std::pair<std::vector<reco::TransientTrack>,GlobalPoint> TracksClusteringFromDis
       float sumWeights=0;
       std::pair<bool,Measurement1D> ipSeed = IPTools::absoluteImpactParameter3D(seed,primaryVertex);
       float pvDistance = ipSeed.second.value();
-//      float densityFactor = 2./sqrt(20.*tracks.size()); // assuming all tracks being in 2 narrow jets of cone 0.3
-      float densityFactor = 2./sqrt(20.*80); // assuming 80 tracks being in 2 narrow jets of cone 0.3
       for(std::vector<reco::TransientTrack>::const_iterator tt = tracks.begin();tt!=tracks.end(); ++tt )   {
 
        if(*tt==seed) continue;
@@ -57,7 +55,7 @@ std::pair<std::vector<reco::TransientTrack>,GlobalPoint> TracksClusteringFromDis
                     dotprodTrack > clusterMinAngleCosine && //Angles between PV-PCAonTrack vectors and track directions
 //                    dotprodTrackSeed2D > clusterMinAngleCosine && //Angle between track and seed
         //      distance*clusterScale*tracks.size() < (distanceFromPV+pvDistance)*(distanceFromPV+pvDistance)/pvDistance && // cut scaling with track density
-                   distance*clusterScale < densityFactor*distanceFromPV && // cut scaling with track density
+                   distance*distanceRatio < distanceFromPV && // cut scaling with track density
                     distance < clusterMaxDistance);  // absolute distance cut
 
 #ifdef VTXDEBUG
@@ -65,7 +63,7 @@ std::pair<std::vector<reco::TransientTrack>,GlobalPoint> TracksClusteringFromDis
                     dotprodSeed  << " > " <<  clusterMinAngleCosine << "  && " << 
                     dotprodTrack  << " > " <<  clusterMinAngleCosine << "  && " << 
                     dotprodTrackSeed2D  << " > " <<  clusterMinAngleCosine << "  &&  "  << 
-                    distance*clusterScale  << " < " <<  densityFactor*distanceFromPV << "  crossingtoPV: " << distanceFromPV << " dis*scal " <<  distance*clusterScale << "  <  " << densityFactor*distanceFromPV << " dist: " << distance << " < " << clusterMaxDistance <<  std::endl; // cut scaling with track density
+                    distance*distanceRatio  << " < " <<  distanceFromPV << "  crossingtoPV: " << distanceFromPV << " dis*scal " <<  distance*distanceRatio << "  <  " << distanceFromPV << " dist: " << distance << " < " << clusterMaxDistance <<  std::endl; // cut scaling with track density
 #endif           
                  if(selected)
                  {

--- a/RecoVertex/AdaptiveVertexFinder/src/TracksClusteringFromDisplacedSeed.cc
+++ b/RecoVertex/AdaptiveVertexFinder/src/TracksClusteringFromDisplacedSeed.cc
@@ -4,6 +4,8 @@
 
 TracksClusteringFromDisplacedSeed::TracksClusteringFromDisplacedSeed(const edm::ParameterSet &params) :
 //	maxNTracks(params.getParameter<unsigned int>("maxNTracks")),
+	max3DIPSignificance(params.getParameter<double>("seedMax3DIPSignificance")),
+	max3DIPValue(params.getParameter<double>("seedMax3DIPValue")),
 	min3DIPSignificance(params.getParameter<double>("seedMin3DIPSignificance")),
 	min3DIPValue(params.getParameter<double>("seedMin3DIPValue")),
 	clusterMaxDistance(params.getParameter<double>("clusterMaxDistance")),
@@ -92,7 +94,7 @@ std::vector<TracksClusteringFromDisplacedSeed::Cluster> TracksClusteringFromDisp
 	std::vector<TransientTrack> seeds;
 	for(std::vector<TransientTrack>::const_iterator it = selectedTracks.begin(); it != selectedTracks.end(); it++){
                 std::pair<bool,Measurement1D> ip = IPTools::absoluteImpactParameter3D(*it,pv);
-                if(ip.first && ip.second.value() >= min3DIPValue && ip.second.significance() >= min3DIPSignificance)
+                if(ip.first && ip.second.value() >= min3DIPValue && ip.second.significance() >= min3DIPSignificance && ip.second.value() <= max3DIPValue && ip.second.significance() <= max3DIPSignificance)
                   { 
 #ifdef VTXDEBUG
                     std::cout << "new seed " <<  it-selectedTracks.begin() << " ref " << it->trackBaseRef().key()  << " " << ip.second.value() << " " << ip.second.significance() << " " << it->track().hitPattern().trackerLayersWithMeasurement() << " " << it->track().pt() << " " << it->track().eta() << std::endl;

--- a/RecoVertex/AdaptiveVertexFinder/src/TracksClusteringFromDisplacedSeed.cc
+++ b/RecoVertex/AdaptiveVertexFinder/src/TracksClusteringFromDisplacedSeed.cc
@@ -31,7 +31,6 @@ std::pair<std::vector<reco::TransientTrack>,GlobalPoint> TracksClusteringFromDis
 
        if(*tt==seed) continue;
 
-       std::pair<bool,Measurement1D> ip = IPTools::absoluteImpactParameter3D(*tt,primaryVertex);
        if(dist.calculate(tt->impactPointState(),seed.impactPointState()))
             {
 		 GlobalPoint ttPoint          = dist.points().first;

--- a/RecoVertex/AdaptiveVertexFinder/test/sequenceTest.py
+++ b/RecoVertex/AdaptiveVertexFinder/test/sequenceTest.py
@@ -44,7 +44,8 @@ process.FEVT = cms.OutputModule("PoolOutputModule",
 )
 
 # Other statements
-process.GlobalTag.globaltag = 'POSTLS162_V1::All'
+process.GlobalTag.globaltag = 'POSTLS161_V15::All'
+#process.GlobalTag.globaltag = 'POSTLS162_V5::All'
 #process.GlobalTag.globaltag = 'START53_V26::All'
 
 

--- a/RecoVertex/AdaptiveVertexFinder/test/sequenceTest.py
+++ b/RecoVertex/AdaptiveVertexFinder/test/sequenceTest.py
@@ -2,6 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process('RECO2')
 
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+
 # import of standard configurations
 
 process.load('Configuration/StandardSequences/Geometry_cff')
@@ -19,11 +22,20 @@ process.options = cms.untracked.PSet(
 )
 # Input source
 process.source = cms.Source("PoolSource",
-    skipEvents = cms.untracked.uint32(51), 
+#    skipEvents = cms.untracked.uint32(51), 
     fileNames = cms.untracked.vstring( 
 #'file:/data1/arizzi/CMSSW_3_5_6/src/MCQCD80120START_C07EAA09-2D2C-DF11-87E7-002618943886.root'
-'/store/relval/CMSSW_7_0_0/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS170_V4-v2/00000/265B9219-FF98-E311-BF4A-02163E00EA95.root'
+#'/store/relval/CMSSW_7_0_0/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS170_V4-v2/00000/265B9219-FF98-E311-BF4A-02163E00EA95.root'
+#'/store/mc/Summer12_DR53X/TTJets_MassiveBinDECAY_TuneZ2star_8TeV-madgraph-tauola/AODSIM/PU_S10_START53_V7A-v1/0000/001C868B-B2E1-E111-9BE3-003048D4DCD8.root'
+#'/store/mc/Fall13dr/EWKZjj_mqq120_mll50_13TeV_madgraph-pythia8/AODSIM/tsg_PU20bx25_POSTLS162_V2-v1/00000/0087CB53-3576-E311-BB3D-848F69FD5027.root'
+#'/store/mc/Fall13dr/EWKZjj_mqq120_mll50_13TeV_madgraph-pythia8/AODSIM/tsg_PU40bx25_POSTLS162_V2-v1/00000/00A356DA-0C76-E311-B789-7845C4FC364D.root'
+'/store/mc/Fall13dr/EWKZjj_mqq120_mll50_13TeV_madgraph-pythia8/AODSIM/tsg_PU40bx50_POSTLS162_V2-v1/00000/16C169C2-C475-E311-8BEE-7845C4FC3A2B.root'
+#'/store/mc/Summer13dr53X/QCD_Pt-80to120_TuneZ2star_13TeV-pythia6/AODSIM/PU25bx25_START53_V19D-v1/20000/006F508D-3AE4-E211-B654-90E6BA0D09D4.root'
     )
+)
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1000)
 )
 
 # Output definition
@@ -33,6 +45,7 @@ process.FEVT = cms.OutputModule("PoolOutputModule",
 
 # Other statements
 process.GlobalTag.globaltag = 'POSTLS162_V1::All'
+#process.GlobalTag.globaltag = 'START53_V26::All'
 
 
 process.p = cms.Path(process.inclusiveVertexing)

--- a/RecoVertex/AdaptiveVertexFinder/test/sequenceTest.py
+++ b/RecoVertex/AdaptiveVertexFinder/test/sequenceTest.py
@@ -4,13 +4,13 @@ process = cms.Process('RECO2')
 
 # import of standard configurations
 
-process.load('Configuration/StandardSequences/GeometryExtended_cff')
+process.load('Configuration/StandardSequences/Geometry_cff')
 process.load('Configuration/StandardSequences/MagneticField_38T_cff')
 process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
 process.load('Configuration/StandardSequences/Reconstruction_cff')
 process.load('Configuration/EventContent/EventContent_cff')
 
-process.load('RecoVertex/AdaptiveVertexFinder/inclusiveVertexing_cff')
+#process.load('RecoVertex/AdaptiveVertexFinder/inclusiveVertexing_cff')
 
 
 process.options = cms.untracked.PSet(
@@ -22,7 +22,7 @@ process.source = cms.Source("PoolSource",
     skipEvents = cms.untracked.uint32(51), 
     fileNames = cms.untracked.vstring( 
 #'file:/data1/arizzi/CMSSW_3_5_6/src/MCQCD80120START_C07EAA09-2D2C-DF11-87E7-002618943886.root'
-'/store/relval/CMSSW_3_5_4/RelValQCD_Pt_3000_3500/GEN-SIM-RECO/MC_3XY_V24-v1/0003/561FC9E7-9A2B-DF11-9CE2-001A92971B12.root'
+'/store/relval/CMSSW_7_0_0/RelValTTbar_13/GEN-SIM-RECO/PU50ns_POSTLS170_V4-v2/00000/265B9219-FF98-E311-BF4A-02163E00EA95.root'
     )
 )
 
@@ -32,7 +32,7 @@ process.FEVT = cms.OutputModule("PoolOutputModule",
 )
 
 # Other statements
-process.GlobalTag.globaltag = 'MC_3XY_V21::All'
+process.GlobalTag.globaltag = 'POSTLS162_V1::All'
 
 
 process.p = cms.Path(process.inclusiveVertexing)

--- a/RecoVertex/Configuration/python/RecoVertex_EventContent_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_EventContent_cff.py
@@ -5,7 +5,8 @@ RecoVertexFEVT = cms.PSet(
         'keep  *_offlinePrimaryVerticesWithBS_*_*',
         'keep  *_offlinePrimaryVerticesFromCosmicTracks_*_*',
         'keep  *_nuclearInteractionMaker_*_*',
-        'keep *_generalV0Candidates_*_*')
+        'keep *_generalV0Candidates_*_*',
+	'keep *_inclusiveVertices_*_*')
 )
 #RECO content
 RecoVertexRECO = cms.PSet(
@@ -13,7 +14,8 @@ RecoVertexRECO = cms.PSet(
         'keep  *_offlinePrimaryVerticesWithBS_*_*',
         'keep  *_offlinePrimaryVerticesFromCosmicTracks_*_*',
         'keep  *_nuclearInteractionMaker_*_*',
-        'keep *_generalV0Candidates_*_*')
+        'keep *_generalV0Candidates_*_*',
+	'keep *_inclusiveVertices_*_*')
 )
 #AOD content
 RecoVertexAOD = cms.PSet(
@@ -21,6 +23,7 @@ RecoVertexAOD = cms.PSet(
         'keep  *_offlinePrimaryVerticesWithBS_*_*',
         'keep  *_offlinePrimaryVerticesFromCosmicTracks_*_*',
         'keep  *_nuclearInteractionMaker_*_*',
-        'keep *_generalV0Candidates_*_*')                                           
+        'keep *_generalV0Candidates_*_*',                                           
+	'keep *_inclusiveVertices_*_*')
 )
 

--- a/RecoVertex/Configuration/python/RecoVertex_EventContent_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_EventContent_cff.py
@@ -6,7 +6,7 @@ RecoVertexFEVT = cms.PSet(
         'keep  *_offlinePrimaryVerticesFromCosmicTracks_*_*',
         'keep  *_nuclearInteractionMaker_*_*',
         'keep *_generalV0Candidates_*_*',
-	'keep *_inclusiveVertices_*_*')
+	'keep *_inclusiveSecondaryVertices_*_*')
 )
 #RECO content
 RecoVertexRECO = cms.PSet(
@@ -15,7 +15,7 @@ RecoVertexRECO = cms.PSet(
         'keep  *_offlinePrimaryVerticesFromCosmicTracks_*_*',
         'keep  *_nuclearInteractionMaker_*_*',
         'keep *_generalV0Candidates_*_*',
-	'keep *_inclusiveVertices_*_*')
+	'keep *_inclusiveSecondaryVertices_*_*')
 )
 #AOD content
 RecoVertexAOD = cms.PSet(
@@ -24,6 +24,6 @@ RecoVertexAOD = cms.PSet(
         'keep  *_offlinePrimaryVerticesFromCosmicTracks_*_*',
         'keep  *_nuclearInteractionMaker_*_*',
         'keep *_generalV0Candidates_*_*',                                           
-	'keep *_inclusiveVertices_*_*')
+	'keep *_inclusiveSecondaryVertices_*_*')
 )
 

--- a/RecoVertex/Configuration/python/RecoVertex_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_cff.py
@@ -6,6 +6,7 @@ from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
 from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVertices_cfi import *
 from RecoVertex.PrimaryVertexProducer.OfflinePrimaryVerticesWithBS_cfi import *
 from RecoVertex.V0Producer.generalV0Candidates_cff import *
+from RecoVertex.AdaptiveVertexFinder.inclusiveVertexing_cff import *
 
-vertexreco = cms.Sequence(offlinePrimaryVertices*offlinePrimaryVerticesWithBS*generalV0Candidates)
+vertexreco = cms.Sequence(offlinePrimaryVertices*offlinePrimaryVerticesWithBS*generalV0Candidates*inclusiveVertexing)
 


### PR DESCRIPTION
1) placeholder for track-based jet pt in TaggingVariable 
- announced: 
  - https://twiki.cern.ch/twiki/bin/viewauth/CMS/CMSSW_7_1_0
  - https://twiki.cern.ch/twiki/bin/viewauth/CMS/BTagSoftware#Revise_the_jet_pT_definition_for
- discussed in various BTV meetings:
  - slide 4 of https://indico.cern.ch/event/300388/session/0/contribution/0/material/slides/0.pdf
  - slide 14 of https://indico.cern.ch/event/302907/contribution/3/material/slides/0.pdf
  - slide 5 of https://indico.cern.ch/event/303434/session/0/contribution/0/material/slides/0.pdf

2) IVF in the RECO sequence 
- announced here https://twiki.cern.ch/twiki/bin/viewauth/CMS/CMSSW_7_1_0
- discussed in meetings:
  - slide 5 of https://indico.cern.ch/event/303434/session/0/contribution/0/material/slides/0.pdf
  - https://indico.cern.ch/event/307998/
