### PR TITLE
Mixing save pileup info for digitizers

### DIFF
--- a/SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h
+++ b/SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h
@@ -20,6 +20,9 @@
 
 // system include files
 #include <vector>
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupMixingContent.h"
+
+
 
 // user include files
 
@@ -73,10 +76,21 @@ class DigiAccumulatorMixMod {
     virtual void beginLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) {}
     virtual void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) {}
 
+
+    void StorePileupInformation( std::vector<int> &numInteractionList,
+				 std::vector<int> &bunchCrossingList,
+				 std::vector<float> &TrueInteractionList){
+      PileupInfo_ = new PileupMixingContent(numInteractionList, bunchCrossingList, TrueInteractionList);
+    }
+
+    PileupMixingContent* getEventPileupInfo() { return PileupInfo_; }
+
   private:
     DigiAccumulatorMixMod(DigiAccumulatorMixMod const&); // stop default
 
     DigiAccumulatorMixMod const& operator=(DigiAccumulatorMixMod const&); // stop default
+
+    PileupMixingContent* PileupInfo_;
 
     // ---------- member data --------------------------------
 };

--- a/SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h
+++ b/SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h
@@ -77,20 +77,22 @@ class DigiAccumulatorMixMod {
     virtual void endLuminosityBlock(edm::LuminosityBlock const& lumi, edm::EventSetup const& setup) {}
 
 
-    void StorePileupInformation( std::vector<int> &numInteractionList,
+    virtual void StorePileupInformation( std::vector<int> &numInteractionList,
 				 std::vector<int> &bunchCrossingList,
-				 std::vector<float> &TrueInteractionList){
-      PileupInfo_ = new PileupMixingContent(numInteractionList, bunchCrossingList, TrueInteractionList);
-    }
+				 std::vector<float> &TrueInteractionList){ }
 
-    PileupMixingContent* getEventPileupInfo() { return PileupInfo_; }
+    virtual PileupMixingContent* getEventPileupInfo() { 
+      std::cout << " You must override the virtual functions in DigiAccumulatorMixMod in\n" << "order to access PileupInformation.  Returning empty object." << std::endl;
+
+      PileupMixingContent* dummyPileupObject = new PileupMixingContent();
+      
+      return dummyPileupObject;      
+    }
 
   private:
     DigiAccumulatorMixMod(DigiAccumulatorMixMod const&); // stop default
 
     DigiAccumulatorMixMod const& operator=(DigiAccumulatorMixMod const&); // stop default
-
-    PileupMixingContent* PileupInfo_;
 
     // ---------- member data --------------------------------
 };

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -434,6 +434,12 @@ namespace edm {
       }
     }
 
+    for(Accumulators::const_iterator accItr = digiAccumulators_.begin(), accEnd = digiAccumulators_.end(); accItr != accEnd; ++accItr) {
+      (*accItr)->StorePileupInformation( bunchCrossingList,
+					 numInteractionList,
+					 TrueInteractionList);
+    }
+
 
     PileupMixing_ = std::auto_ptr<PileupMixingContent>(new PileupMixingContent(bunchCrossingList,
                                                                                numInteractionList,

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
@@ -58,6 +58,15 @@ namespace cms {
     virtual void finalizeEvent(edm::Event& e, edm::EventSetup const& c) override;
 
     virtual void beginJob() {}
+
+    virtual void StorePileupInformation( std::vector<int> &numInteractionList,
+				 std::vector<int> &bunchCrossingList,
+				 std::vector<float> &TrueInteractionList){
+      PileupInfo_ = new PileupMixingContent(numInteractionList, bunchCrossingList, TrueInteractionList);
+    }
+
+    virtual PileupMixingContent* getEventPileupInfo() { return PileupInfo_; }
+
   private:
     void accumulatePixelHits(edm::Handle<std::vector<PSimHit> >, CLHEP::HepRandomEngine*);
     CLHEP::HepRandomEngine* randomEngine(edm::StreamID const& streamID);
@@ -72,6 +81,8 @@ namespace cms {
     edm::ESHandle<MagneticField> pSetup;
     std::map<unsigned int, PixelGeomDetUnit*> detectorUnits;
     std::vector<CLHEP::HepRandomEngine*> randomEngines_;
+
+    PileupMixingContent* PileupInfo_;
 
     // infrastructure to reject dead pixels as defined in db (added by F.Blekman)
   };


### PR DESCRIPTION
Allow digitizers to access pileup information for a given event so that luminosity-dependent characteristics can be modeled properly. (e.g. data loss in pixels).
